### PR TITLE
Add golangci-lint config file

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,38 @@
+# This file contains the rules for golangci-lint
+
+# options for analysis running
+run:
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  deadline: 5m
+
+  # which dirs to skip: they won't be analyzed;
+  # can use regexp here: generated.*, regexp is applied on full path;
+  # default value is empty list, but next dirs are always skipped independently
+  # from this option's value:
+  #   	vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
+  skip-files:
+   - ".*generated.*\\.go"
+
+# override defaults
+linters-settings:
+  gocyclo:
+    # minimal code complexity to report
+    min-complexity: 18
+
+# linters to enable in addition to the default linters
+linters:
+  enable:
+    - dupl
+    - gosec
+    - goconst
+    - gocyclo
+    - gofmt
+    - goimports
+    - interfacer
+    - misspell
+    - nakedret
+    - scopelint
+    #- stylecheck (too much existing code fails)
+    - unconvert
+    - unused
+  disable-all: false


### PR DESCRIPTION
Add a lint config file. Will fix the current issue with `make manager` where it fails with a linter error. 

This config file skips over `*generated*` files. 