### PR TITLE
Temporarily disable a CLS IT

### DIFF
--- a/controllers/contentlibrary/contentlibraryitem/contentlibraryitem_controller_suite_test.go
+++ b/controllers/contentlibrary/contentlibraryitem/contentlibraryitem_controller_suite_test.go
@@ -28,7 +28,8 @@ var suite = builder.NewTestSuiteForControllerWithFSS(
 )
 
 func TestContentLibraryItem(t *testing.T) {
-	suite.Register(t, "ContentLibraryItem controller suite", intgTests, unitTests)
+	_ = intgTests
+	suite.Register(t, "ContentLibraryItem controller suite", nil, unitTests)
 }
 
 var _ = BeforeSuite(suite.BeforeSuite)


### PR DESCRIPTION
This patch temporarily disables an IT related to the CLS controller that is going away anyway.