### PR TITLE
Add conditions check in VirtualMachinePublishRequest controller

### DIFF
--- a/api/v1alpha1/condition_consts.go
+++ b/api/v1alpha1/condition_consts.go
@@ -125,3 +125,53 @@ const (
 	// is not in ready state.
 	VirtualMachineImageProviderNotReadyReason = "VirtualMachineImageProviderNotReady"
 )
+
+// Condition.Reason for Conditions related to VirtualMachinePublishRequest.
+const (
+	// SourceVirtualMachineNotExistReason documents that the source VM of
+	// the VirtualMachinePublishRequest doesn't exist.
+	SourceVirtualMachineNotExistReason = "SourceVirtualMachineNotExist"
+
+	// SourceVirtualMachineNotCreatedReason documents that the source VM of
+	// the VirtualMachinePublishRequest hasn't been created.
+	SourceVirtualMachineNotCreatedReason = "SourceVirtualMachineNotCreated"
+
+	// TargetContentLibraryNotExistReason documents that the target content
+	// library of the VirtualMachinePublishRequest doesn't exist.
+	TargetContentLibraryNotExistReason = "TargetContentLibraryNotExist"
+
+	// TargetContentLibraryNotWritableReason documents that the target content
+	// library of the VirtualMachinePublishRequest isn't writable.
+	TargetContentLibraryNotWritableReason = "TargetContentLibraryNotWritable"
+
+	// TargetItemAlreadyExistsReason documents that in the target content
+	// library, there is already an item, which has the same name with the
+	// VirtualMachinePublishRequest's target item.
+	TargetItemAlreadyExistsReason = "TargetItemAlreadyExists"
+
+	// TargetVirtualMachineImageNotFoundReason documents that the expected
+	// VirtualMachineImage resource which is corresponding to VirtualMachinePublishRequest
+	// target item is not found in the cluster.
+	TargetVirtualMachineImageNotFoundReason = "VirtualMachineImageNotFound"
+
+	// UploadTaskQueuedReason documents that the VM publish task is in queued status.
+	UploadTaskQueuedReason = "Queued"
+
+	// UploadingReason documents that the VM publish task is in running status
+	// and the published item is uploading to the target location.
+	UploadingReason = "Uploading"
+
+	// UploadFailureReason documents that uploading published item to the
+	// target location failed.
+	UploadFailureReason = "UploadFailure"
+
+	// HasNotBeenUploadedReason documents that the VirtualMachinePublishRequest
+	// hasn't completed because the published item hasn't been uploaded
+	// to the target location.
+	HasNotBeenUploadedReason = "HasNotBeenUploaded"
+
+	// ImageUnavailableReason documents that the VirtualMachinePublishRequest
+	// hasn't been completed because the expected VirtualMachineImage resource
+	// hasn't been available yet.
+	ImageUnavailableReason = "ImageUnavailable"
+)

--- a/api/v1alpha1/virtualmachinepublishrequest_types.go
+++ b/api/v1alpha1/virtualmachinepublishrequest_types.go
@@ -196,6 +196,7 @@ type VirtualMachinePublishRequestSpec struct {
 	// resource is eligible for deletion immediately after it finishes.
 	//
 	// +optional
+	// +kubebuilder:validation:Minimum=0
 	TTLSecondsAfterFinished *int64 `json:"ttlSecondsAfterFinished,omitempty"`
 }
 
@@ -369,7 +370,7 @@ func (vmpr *VirtualMachinePublishRequest) markCondition(
 	}
 	if reason == "" && status == corev1.ConditionTrue {
 		reason = VirtualMachinePublishRequestConditionSuccess
-	} else {
+	} else if reason == "" {
 		reason = string(status)
 	}
 

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachinepublishrequests.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachinepublishrequests.yaml
@@ -132,6 +132,7 @@ spec:
                   the request resource is eligible for deletion immediately after
                   it finishes."
                 format: int64
+                minimum: 0
                 type: integer
             type: object
           status:

--- a/controllers/contentlibrary/contentlibraryitem/contentlibraryitem_controller_suite_test.go
+++ b/controllers/contentlibrary/contentlibraryitem/contentlibraryitem_controller_suite_test.go
@@ -28,8 +28,7 @@ var suite = builder.NewTestSuiteForControllerWithFSS(
 )
 
 func TestContentLibraryItem(t *testing.T) {
-	_ = intgTests
-	suite.Register(t, "ContentLibraryItem controller suite", nil, unitTests)
+	suite.Register(t, "ContentLibraryItem controller suite", intgTests, unitTests)
 }
 
 var _ = BeforeSuite(suite.BeforeSuite)

--- a/controllers/virtualmachinepublishrequest/virtualmachinepublishrequest_controller.go
+++ b/controllers/virtualmachinepublishrequest/virtualmachinepublishrequest_controller.go
@@ -11,6 +11,11 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
 	"github.com/pkg/errors"
 
 	corev1 "k8s.io/api/core/v1"
@@ -43,6 +48,13 @@ const (
 	// - content library service hasn't processed far enough to submit and register this task. (Most common case)
 	// Wait for 30 seconds to eliminate the last case in a best-effort manner.
 	waitForTaskTimeout = 30 * time.Second
+
+	clibItemPrefix = "clibitem-"
+)
+
+var (
+	// DefaultRequeueDelaySeconds represents the default requeue delay seconds when reconcile.
+	DefaultRequeueDelaySeconds = 60
 )
 
 // AddToManager adds this package's controller to the provided manager.
@@ -62,11 +74,51 @@ func AddToManager(ctx *context.ControllerManagerContext, mgr manager.Manager) er
 		ctx.VMProvider,
 	)
 
-	// TODO: . Watch VirtualMachineImage resources.
 	return ctrl.NewControllerManagedBy(mgr).
 		For(controlledType).
 		WithOptions(controller.Options{MaxConcurrentReconciles: ctx.MaxConcurrentReconciles}).
+		Watches(&source.Kind{Type: &vmopv1alpha1.VirtualMachineImage{}},
+			handler.EnqueueRequestsFromMapFunc(vmiToVMPubMapperFn(ctx, r.Client))).
 		Complete(r)
+}
+
+// vmiToVMPubMapperFn returns a mapper function that can be used to queue reconcile request
+// for the VirtualMachinePublishRequests in response to an event on the VirtualMachineImage resource.
+// Note: Only when WCP_VM_Image_Registry FSS is enabled, this controller will be added to the controller manager.
+// In this case, the VirtualMachineImage is a namespace scoped resource.
+func vmiToVMPubMapperFn(ctx *context.ControllerManagerContext, c client.Client) func(o client.Object) []reconcile.Request {
+	// For a given VirtualMachineImage, return reconcile requests
+	// for those VirtualMachinePublishRequests with corresponding VirtualMachinesImage as the target item.
+	return func(o client.Object) []reconcile.Request {
+		vmi := o.(*vmopv1alpha1.VirtualMachineImage)
+		logger := ctx.Logger.WithValues("name", vmi.Name, "namespace", vmi.Namespace)
+
+		logger.V(4).Info("Reconciling all VirtualMachinePublishRequests referencing a target item name same " +
+			"with this VirtualMachineImage display name")
+
+		vmPubList := &vmopv1alpha1.VirtualMachinePublishRequestList{}
+		if err := c.List(ctx, vmPubList, client.InNamespace(vmi.Namespace)); err != nil {
+			logger.Error(err, "Failed to list VirtualMachinePublishRequests for reconciliation due to VirtualMachineImage watch")
+			return nil
+		}
+
+		// Populate reconcile requests for vmpubs
+		var reconcileRequests []reconcile.Request
+		for _, vmPub := range vmPubList.Items {
+			if vmPub.Status.TargetRef == nil {
+				continue
+			}
+
+			if vmPub.Status.TargetRef.Item.Name == vmi.Status.ImageName {
+				key := client.ObjectKey{Namespace: vmPub.Namespace, Name: vmPub.Name}
+				reconcileRequests = append(reconcileRequests, reconcile.Request{NamespacedName: key})
+			}
+		}
+
+		logger.V(4).Info("Returning VirtualMachinePublishRequest reconcile requests due to VirtualMachineImage watch",
+			"requests", reconcileRequests)
+		return reconcileRequests
+	}
 }
 
 func NewReconciler(
@@ -91,9 +143,17 @@ type Reconciler struct {
 	VMProvider vmprovider.VirtualMachineProviderInterface
 }
 
-func requeueDelay(_ *context.VirtualMachinePublishRequestContext) time.Duration {
-	// TODO: update requeue delay based on publish request conditions
-	return time.Minute
+func requeueDelay(ctx *context.VirtualMachinePublishRequestContext) time.Duration {
+	vmPubReq := ctx.VMPublishRequest
+	// Skip checking other conditions.
+	// If ImageAvailable is true, Uploaded must be true. This also marks Condition Complete to true,
+	// we will never reach this function.
+	if vmPubReq.IsUploaded() {
+		return 10 * time.Second
+	}
+
+	// VM Publish request is still in progress, requeue after one minute.
+	return time.Duration(DefaultRequeueDelaySeconds) * time.Second
 }
 
 // +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachinepublishrequests,verbs=get;list;watch;create;update;patch;delete
@@ -150,8 +210,86 @@ func (r *Reconciler) updateSourceAndTargetRef(ctx *context.VirtualMachinePublish
 	}
 }
 
-// checkIsSourceValid function checks if the source VM is valid.
-// It is invalid if the VM k8s resource doesn't exist, or is not in Created phase.
+// publishVirtualMachine checks if source VM and target is valid. Publish a VM if all requirements are met.
+// Returns
+// - A boolean value represents if the following Patch should be skipped.
+// - error.
+func (r *Reconciler) publishVirtualMachine(ctx *context.VirtualMachinePublishRequestContext) (bool, error) {
+	vmPublishReq := ctx.VMPublishRequest
+	// Check if the source and target is valid
+	if err := r.checkIsSourceValid(ctx); err != nil {
+		ctx.Logger.Error(err, "failed to check if source is valid")
+		return false, err
+	}
+
+	if err := r.checkIsTargetValid(ctx); err != nil {
+		ctx.Logger.Error(err, "failed to check if target is valid")
+		return false, err
+	}
+
+	if vmPublishReq.IsSourceValid() && vmPublishReq.IsTargetValid() {
+		vmPublishReq.Status.Attempts++
+		vmPublishReq.Status.LastAttemptTime = metav1.Now()
+
+		// Update VirtualMachinePublishRequest object to avoid conflict.
+		// API server will reject the Update request if updating to a stale object, so that we can always
+		// set the correct number of attempts in the status to avoid running into a situation where we end
+		// up sending multiple publish requests with the same actID.
+		//
+		// Patch a stale object won't fail even when the resourceVersion doesn't match. In this case, we
+		// may set .status.attempts to a same number multiple times using Patch.
+		// Use Update instead and skip Patch in the ReconcileNormal defer function.
+		if err := r.Client.Status().Update(ctx, vmPublishReq); err != nil {
+			ctx.Logger.Error(err, "update VirtualMachinePublishRequest status failed")
+			return true, err
+		}
+
+		go func() {
+			actID := getPublishRequestActID(vmPublishReq)
+			itemID, pubErr := r.VMProvider.PublishVirtualMachine(ctx, ctx.VM, vmPublishReq, ctx.ContentLibrary, actID)
+			if pubErr != nil {
+				ctx.Logger.Error(pubErr, "failed to publish VM")
+			} else {
+				ctx.Logger.Info("created an OVF from VM", "itemID", itemID)
+			}
+			r.Recorder.EmitEvent(vmPublishReq, "Publish", pubErr, false)
+		}()
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (r *Reconciler) removeVMPubResourceFromCluster(ctx *context.VirtualMachinePublishRequestContext) (requeueAfter time.Duration,
+	deleted bool, err error) {
+	vmPublishReq := ctx.VMPublishRequest
+	ttlSecondsAfterFinished := vmPublishReq.Spec.TTLSecondsAfterFinished
+	if ttlSecondsAfterFinished == nil {
+		// Skip auto clean up
+		return
+	}
+
+	if *ttlSecondsAfterFinished > 0 {
+		completeTime := vmPublishReq.Status.CompletionTime.Time
+		if time.Since(completeTime) < time.Duration(*ttlSecondsAfterFinished)*time.Second {
+			targetTime := completeTime.Add(time.Duration(*ttlSecondsAfterFinished) * time.Second)
+			return time.Until(targetTime), false, nil
+		}
+	}
+
+	// TTLSecondsAfterFinished elapsed, delete the resource
+	ctx.Logger.Info("deleting VM Publish Request")
+	deleted = true
+	if err = r.Delete(ctx, vmPublishReq); err != nil {
+		deleted = false
+		ctx.Logger.Error(err, "failed to delete vm publish requests")
+	}
+
+	return
+}
+
+// checkIsSourceValid function checks if the source VM is valid. It is invalid if the VM k8s resource
+// doesn't exist, or is not in Created phase.
 func (r *Reconciler) checkIsSourceValid(ctx *context.VirtualMachinePublishRequestContext) error {
 	vmPubReq := ctx.VMPublishRequest
 	vm := &vmopv1alpha1.VirtualMachine{}
@@ -160,15 +298,22 @@ func (r *Reconciler) checkIsSourceValid(ctx *context.VirtualMachinePublishReques
 	if err != nil {
 		ctx.Logger.Error(err, "failed to get VirtualMachine", "vm", objKey)
 		if apiErrors.IsNotFound(err) {
-			vmPubReq.MarkSourceValid(corev1.ConditionFalse, "SourceVmNotExist", err.Error())
+			// If not found the source VM, no need to requeue to cause another reconcile. Set error to nil.
+			// Ideally this won't happen because we have a validation webhook to check source VM existence.
+			errMsg := fmt.Sprintf("%s, a new VirtualMachinePublishRequest is needed to continue publishing.", err.Error())
+			vmPubReq.MarkSourceValid(corev1.ConditionFalse, vmopv1alpha1.SourceVirtualMachineNotExistReason, errMsg)
 			err = nil
 		}
 		return err
 	}
 	ctx.VM = vm
 
-	// TODO: . Add more check.
-	// VM is in created phase and .Status.UniqueID is not empty.
+	if vm.Status.UniqueID == "" {
+		err = fmt.Errorf("VM hasn't been created, phase: %s, unique ID: %s", vm.Status.Phase, vm.Status.UniqueID)
+		vmPubReq.MarkSourceValid(corev1.ConditionFalse, vmopv1alpha1.SourceVirtualMachineNotCreatedReason, err.Error())
+		return err
+	}
+
 	vmPubReq.MarkSourceValid(corev1.ConditionTrue)
 	return nil
 }
@@ -178,22 +323,110 @@ func (r *Reconciler) checkIsSourceValid(ctx *context.VirtualMachinePublishReques
 // or another vmpub request with the same name is in progress.
 func (r *Reconciler) checkIsTargetValid(ctx *context.VirtualMachinePublishRequestContext) error {
 	vmPubReq := ctx.VMPublishRequest
-	targetLocationName := vmPubReq.Spec.Target.Location.Name
 	contentLibrary := &imgregv1a1.ContentLibrary{}
+	targetLocationName := vmPubReq.Spec.Target.Location.Name
+	targetItemName := vmPubReq.Spec.Target.Item.Name
 	objKey := client.ObjectKey{Name: targetLocationName, Namespace: vmPubReq.Namespace}
 	if err := r.Get(ctx, objKey, contentLibrary); err != nil {
 		ctx.Logger.Error(err, "failed to get ContentLibrary", "cl", objKey)
 		if apiErrors.IsNotFound(err) {
-			vmPubReq.MarkTargetValid(corev1.ConditionFalse, "TargetContentLibraryNotExist", err.Error())
+			// If not found the target CL, no need to requeue to cause another reconcile. Set error to nil.
+			// Ideally this won't happen because we have a validation webhook to check target CL existence.
+			errMsg := fmt.Sprintf("%s, a new VirtualMachinePublishRequest is needed to continue publishing.", err.Error())
+			vmPubReq.MarkTargetValid(corev1.ConditionFalse, vmopv1alpha1.TargetContentLibraryNotExistReason, errMsg)
 			err = nil
 		}
 		return err
 	}
-	ctx.ContentLibrary = contentLibrary
 
-	// TODO: . Add more check.
+	if !contentLibrary.Spec.Writable {
+		err := fmt.Errorf("target location %s is not writable", contentLibrary.Status.Name)
+		vmPubReq.MarkTargetValid(corev1.ConditionFalse, vmopv1alpha1.TargetContentLibraryNotWritableReason,
+			err.Error())
+		return err
+	}
+
+	ctx.ContentLibrary = contentLibrary
+	exist, err := r.VMProvider.DoesItemExistInContentLibrary(ctx, contentLibrary, targetItemName)
+	if err != nil {
+		ctx.Logger.Error(err, "failed to find item", "cl", objKey, "item name", targetItemName)
+		return err
+	}
+	if exist {
+		err = fmt.Errorf("item with name %s already exists in the content library %s", targetItemName, contentLibrary.Status.Name)
+		vmPubReq.MarkTargetValid(corev1.ConditionFalse, vmopv1alpha1.TargetItemAlreadyExistsReason, err.Error())
+		return err
+	}
+
 	vmPubReq.MarkTargetValid(corev1.ConditionTrue)
 	return nil
+}
+
+// checkIsImageAvailable checks if the published VirtualMachineImage resource is available in the cluster.
+func (r *Reconciler) checkIsImageAvailable(ctx *context.VirtualMachinePublishRequestContext, itemID string) error {
+	if !ctx.VMPublishRequest.IsUploaded() {
+		return nil
+	}
+
+	if itemID == "" {
+		id, err := r.getUploadedItemID(ctx)
+		if err != nil {
+			ctx.Logger.Error(err, "failed to get uploaded item UUID")
+			return err
+		}
+		itemID = id
+	}
+
+	vmiList := &vmopv1alpha1.VirtualMachineImageList{}
+	if err := r.Client.List(ctx, vmiList, client.InNamespace(ctx.VMPublishRequest.Namespace)); err != nil {
+		ctx.Logger.Error(err, "failed to list VirtualMachineImage")
+		return err
+	}
+
+	found := false
+	for _, vmi := range vmiList.Items {
+		if vmi.Spec.ImageID == itemID {
+			found = true
+			ctx.VMPublishRequest.Status.ImageName = vmi.Name
+			ctx.VMPublishRequest.MarkImageAvailable(corev1.ConditionTrue)
+			ctx.Logger.Info("VirtualMachineImage is available", "vmiName", vmi.Name)
+			break
+		}
+	}
+
+	if !found {
+		ctx.VMPublishRequest.MarkImageAvailable(corev1.ConditionFalse,
+			vmopv1alpha1.TargetVirtualMachineImageNotFoundReason, "VirtualMachineImage not found")
+	}
+
+	return nil
+}
+
+// checkIsComplete checks if condition Complete can be marked to true.
+// The condition's status is set to true only when all other conditions present on the resource have a truthy status.
+func (r *Reconciler) checkIsComplete(ctx *context.VirtualMachinePublishRequestContext) bool {
+	if ctx.VMPublishRequest.IsComplete() {
+		return true
+	}
+
+	if !ctx.VMPublishRequest.IsUploaded() {
+		ctx.VMPublishRequest.MarkComplete(corev1.ConditionFalse, vmopv1alpha1.HasNotBeenUploadedReason,
+			"item hasn't been uploaded yet.")
+		return false
+	}
+
+	if !ctx.VMPublishRequest.IsImageAvailable() {
+		ctx.VMPublishRequest.MarkComplete(corev1.ConditionFalse, vmopv1alpha1.ImageUnavailableReason,
+			"VirtualMachineImage is not available")
+		return false
+	}
+
+	ctx.VMPublishRequest.MarkComplete(corev1.ConditionTrue)
+	ctx.VMPublishRequest.Status.Ready = true
+	ctx.VMPublishRequest.Status.CompletionTime = metav1.Now()
+	ctx.Logger.Info("VM publish request completed", "time", ctx.VMPublishRequest.Status.CompletionTime)
+
+	return true
 }
 
 // getPublishRequestTask gets task with description id com.vmware.ovfs.LibraryItem.capture and specified actid in taskManager.
@@ -225,15 +458,23 @@ func (r *Reconciler) getPublishRequestTask(ctx *context.VirtualMachinePublishReq
 	return publishTask, nil
 }
 
-// checkPublishRequestStatus gets VM Publish task from task manager and checks its status.
-// - If this task is queued/running, then we should return early.
-// - task succeeded, update related conditions. (Uploaded/ImageAvailable)
-// - task failed, clear previous status and retry the operation.
-// Return true if a publish request should be sent, otherwise return false.
-func (r *Reconciler) checkPublishRequestStatus(ctx *context.VirtualMachinePublishRequestContext) (bool, error) {
+// checkPublishRequestStatus checks the publish request task status and mark Uploaded condition.
+// Returns
+// - if a following publish task is needed (true if a publish request should be sent, otherwise return false.),
+// - the uploaded item UUID
+// - error
+// It filters VM Publish task from VC task manager by activation ID and checks its status.
+// - If this task is queued/running, then we should mark Uploaded to false and no need to retry VM publish.
+// - task succeeded, mark Uploaded to true and return the uploaded item ID.
+// - task failed, mark Uploaded to false and retry the operation.
+func (r *Reconciler) checkPublishRequestStatus(ctx *context.VirtualMachinePublishRequestContext) (string, bool, error) {
 	if ctx.VMPublishRequest.Status.Attempts == 0 {
 		// no VM publish task has been attempted. return immediately.
-		return true, nil
+		return "", true, nil
+	}
+
+	if ctx.VMPublishRequest.IsUploaded() {
+		return "", false, nil
 	}
 
 	actID := getPublishRequestActID(ctx.VMPublishRequest)
@@ -242,7 +483,7 @@ func (r *Reconciler) checkPublishRequestStatus(ctx *context.VirtualMachinePublis
 	task, err := r.getPublishRequestTask(ctx)
 	if err != nil {
 		// Failed to get task from taskManager, return early and retry in next reconcile loop.
-		return false, err
+		return "", false, err
 	}
 
 	// If we can not find a relevant task, probably due to:
@@ -260,41 +501,103 @@ func (r *Reconciler) checkPublishRequestStatus(ctx *context.VirtualMachinePublis
 	// backoff in case 3, and we are not submitting requests over and over when this publish task is actually running.
 	if task == nil {
 		if time.Since(ctx.VMPublishRequest.Status.LastAttemptTime.Time) > waitForTaskTimeout {
-			// CreateOvf API failed to submit this task for some reason. In this case, retry VM publish and return error.
-			return true, fmt.Errorf("failed to create task: %s, last attempt time: %s",
+			// CreateOvf API failed to submit this task for some reason. In this case, retry VM publish.
+			// Also return error here to goes into exponential backoff in case it is not transient.
+			return "", true, fmt.Errorf("failed to create task: %s, last attempt time: %s",
 				TaskDescriptionID, ctx.VMPublishRequest.Status.LastAttemptTime.String())
 		}
 
 		// CreateOvf request has been sent but the task com.vmware.ovfs.LibraryItem.capture hasn't been
 		// submitted to the task manager yet. retry taskManager query at later reconcile.
-		return false, nil
+		return "", false, nil
 	}
 
 	switch task.State {
 	case vimtypes.TaskInfoStateQueued:
 		logger.V(5).Info("VM Publish task is queued but hasn't started")
-		return false, nil
+		ctx.VMPublishRequest.MarkUploaded(corev1.ConditionFalse, vmopv1alpha1.UploadTaskQueuedReason, "VM Publish task is queued.")
+		return "", false, nil
 	case vimtypes.TaskInfoStateRunning:
 		// CreateOVF is still in progress
+		// TODO: VCLCO-2927 Add task Progress info.
 		logger.V(5).Info("VM Publish is still in progress", "progress", task.Progress)
-		return false, nil
+		ctx.VMPublishRequest.MarkUploaded(corev1.ConditionFalse, vmopv1alpha1.UploadingReason, "Uploading item to content library.")
+		return "", false, nil
 	case vimtypes.TaskInfoStateSuccess:
-		// Publish request succeeds. requeue
-		// TODO: . Update conditions.
-		// TODO: . Watch ContentLibraryItem resources and create vm image resources.
+		// Publish request succeeds. Update Uploaded condition.
+		ctx.VMPublishRequest.MarkUploaded(corev1.ConditionTrue)
 		logger.Info("VM Publish succeeded", "result", task.Result)
-		return false, nil
+		itemID, err := parseItemIDFromTaskResult(task.Result)
+		if err != nil {
+			// Only log this error. We can retry this operation when checking if VMI is available.
+			logger.Error(err, "failed to get uploaded item UUID")
+		}
+		return itemID, false, nil
 	case vimtypes.TaskInfoStateError:
-		err = fmt.Errorf("VM publish failed, err: %v", task.Error)
-		logger.Error(err, "VM Publish failed, will retry this operation")
-		return true, err
+		errMsg := "failed to publish source VM"
+		if task.Error != nil {
+			errMsg = task.Error.LocalizedMessage
+		}
+
+		logger.Error(err, "VM Publish failed, will retry this operation", "actID",
+			task.ActivationId, "descriptionID", task.DescriptionId)
+		ctx.VMPublishRequest.MarkUploaded(corev1.ConditionFalse, vmopv1alpha1.UploadFailureReason, errMsg)
+		return "", true, fmt.Errorf(errMsg)
 	}
-	return true, nil
+
+	return "", true, nil
+}
+
+// getUploadedItemID returns the uploaded content library item ID.
+func (r *Reconciler) getUploadedItemID(ctx *context.VirtualMachinePublishRequestContext) (string, error) {
+	task, err := r.getPublishRequestTask(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	if task == nil {
+		return "", fmt.Errorf("VM publish task doesn't exist in the task manager, actID: %s",
+			getPublishRequestActID(ctx.VMPublishRequest))
+	}
+
+	return parseItemIDFromTaskResult(task.Result)
+}
+
+// getPublishRequestActID returns the activation ID we pass down to the content library vAPI.
+// Append .status.attempts to the vmpublishrequest uuid to generate an activation ID.
+// VC doesn't prevent duplicate activation IDs for different requests, but we can have problems
+// when doing the query, i.e. not returned all the tasks.
+// So we need a unique string, which is also under track to be the actID for a later query.
+func getPublishRequestActID(vmPub *vmopv1alpha1.VirtualMachinePublishRequest) string {
+	return fmt.Sprintf("%s-%d", string(vmPub.UID), vmPub.Status.Attempts)
+}
+
+// parseItemIDFromTaskResult returns the content library item UUID from the task result.
+func parseItemIDFromTaskResult(result vimtypes.AnyType) (string, error) {
+	clItem, ok := result.(vimtypes.ManagedObjectReference)
+	if !ok {
+		return "", fmt.Errorf("failed to cast task result to ManagedObjectReference")
+	}
+
+	if clItem.Type != "ContentLibraryItem" {
+		return "", fmt.Errorf("expect task result type to be ContentLibraryItem, get %s instead", clItem.Type)
+	}
+
+	if len(clItem.Value) <= len(clibItemPrefix) {
+		return "", fmt.Errorf("content library item UUID is invalid")
+	}
+	return clItem.Value[len(clibItemPrefix):], nil
 }
 
 func (r *Reconciler) ReconcileNormal(ctx *context.VirtualMachinePublishRequestContext) (_ ctrl.Result, reterr error) {
 	ctx.Logger.Info("Reconciling VirtualMachinePublishRequest")
 	vmPublishReq := ctx.VMPublishRequest
+
+	// In case the .spec.ttlSecondsAfterFinished is not set, we can return early and no need to do any reconcile.
+	if vmPublishReq.IsComplete() {
+		requeueAfter, _, err := r.removeVMPubResourceFromCluster(ctx)
+		return ctrl.Result{RequeueAfter: requeueAfter}, err
+	}
 
 	skipPatch := false
 	patchHelper, err := patch.NewHelper(vmPublishReq, r.Client)
@@ -302,7 +605,12 @@ func (r *Reconciler) ReconcileNormal(ctx *context.VirtualMachinePublishRequestCo
 		return ctrl.Result{}, errors.Wrapf(err, "failed to init patch helper for %s", fmt.Sprintf("%s/%s", vmPublishReq.Namespace, vmPublishReq.Name))
 	}
 
+	var savedErr error
 	defer func() {
+		if reterr == nil && savedErr != nil {
+			reterr = savedErr
+		}
+
 		if skipPatch {
 			return
 		}
@@ -315,76 +623,46 @@ func (r *Reconciler) ReconcileNormal(ctx *context.VirtualMachinePublishRequestCo
 		}
 	}()
 
-	if vmPublishReq.IsComplete() {
-		// TODO: . fulfill the logic when VM publish request is completed.
-		ctx.Logger.Info("VM Publish completed", "time", vmPublishReq.Status.CompletionTime)
-		return ctrl.Result{}, nil
-	}
-
 	if vmPublishReq.Status.StartTime.IsZero() {
 		vmPublishReq.Status.StartTime = metav1.Now()
 	}
 
 	r.updateSourceAndTargetRef(ctx)
 
-	shouldPublish, err := r.checkPublishRequestStatus(ctx)
-	reterr = err
-	if !shouldPublish {
-		return ctrl.Result{}, reterr
+	itemID, shouldPublish, err := r.checkPublishRequestStatus(ctx)
+	if err != nil {
+		// Save this error and return it in defer func().
+		// If there is something wrong with VC, i.e. we can never find a task from VC task manager, this can help
+		// fall into exponential backoff instead of sending publish VM requests over and over.
+		savedErr = err
 	}
 
-	// Check if the source and target is valid
-	if err := r.checkIsSourceValid(ctx); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	if err := r.checkIsTargetValid(ctx); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	if vmPublishReq.IsSourceValid() && vmPublishReq.IsTargetValid() {
-		vmPublishReq.Status.Attempts++
-		vmPublishReq.Status.LastAttemptTime = metav1.Now()
-		skipPatch = true
-
-		// Update VirtualMachinePublishRequest object to avoid conflict.
-		// API server will reject the Update request if updating to a stale object, so that we can always
-		// set the correct number of attempts in the status to avoid running into a situation where we end
-		// up sending multiple publish requests with the same actID.
-		//
-		// Patch a stale object won't fail even when the resourceVersion doesn't match. In this case, we
-		// may set .status.attempts to a same number multiple times using Patch.
-		// Use Update instead and skip Patch in the defer function.
-		if err = r.Client.Status().Update(ctx, vmPublishReq); err != nil {
-			ctx.Logger.Error(err, "update failed")
-			return ctrl.Result{}, err
+	if shouldPublish {
+		skipPatch, err = r.publishVirtualMachine(ctx)
+		if err != nil {
+			ctx.Logger.Error(err, "failed to publish VirtualMachine")
+			return ctrl.Result{}, errors.Wrapf(err, "failed to publish VirtualMachine")
 		}
-
-		go func() {
-			actID := getPublishRequestActID(vmPublishReq)
-			itemID, pubErr := r.VMProvider.PublishVirtualMachine(ctx, ctx.VM, vmPublishReq, ctx.ContentLibrary, actID)
-			if pubErr != nil {
-				ctx.Logger.Error(pubErr, "failed to publish VM")
-			} else {
-				ctx.Logger.Info("created an OVF from VM", "itemID", itemID)
-			}
-			r.Recorder.EmitEvent(vmPublishReq, "Publish", pubErr, false)
-		}()
+		return ctrl.Result{RequeueAfter: requeueDelay(ctx)}, nil
 	}
 
-	return ctrl.Result{RequeueAfter: requeueDelay(ctx)}, reterr
+	if err = r.checkIsImageAvailable(ctx, itemID); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if r.checkIsComplete(ctx) {
+		// remove VirtualMachinePublishRequest from the cluster if ttlSecondsAfterFinished is set.
+		requeueAfter, deleted, err := r.removeVMPubResourceFromCluster(ctx)
+		if deleted {
+			skipPatch = true
+		}
+		return ctrl.Result{RequeueAfter: requeueAfter}, err
+	}
+
+	return ctrl.Result{RequeueAfter: requeueDelay(ctx)}, nil
 }
 
 func (r *Reconciler) ReconcileDelete(_ *context.VirtualMachinePublishRequestContext) (ctrl.Result, error) {
 	// no op
 	return ctrl.Result{}, nil
-}
-
-// getPublishRequestActID returns the activation ID we pass down to the content library vAPI.
-// Append .status.attempts to the vmpublishrequest uuid to generate an activation ID.
-// VC doesn't prevent duplicate activation IDs for different requests, but we can have problems
-// when doing the query, i.e. not returned all the tasks.
-// So we need a unique string, which is also under track to be the actID for a later query.
-func getPublishRequestActID(vmPub *vmopv1alpha1.VirtualMachinePublishRequest) string {
-	return fmt.Sprintf("%s-%d", string(vmPub.UID), vmPub.Status.Attempts)
 }

--- a/controllers/virtualmachinepublishrequest/virtualmachinepublishrequest_controller_suite_test.go
+++ b/controllers/virtualmachinepublishrequest/virtualmachinepublishrequest_controller_suite_test.go
@@ -12,18 +12,20 @@ import (
 
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachinepublishrequest"
 	ctrlContext "github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 	providerfake "github.com/vmware-tanzu/vm-operator/pkg/vmprovider/fake"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 var intgFakeVMProvider = providerfake.NewVMProvider()
 
-var suite = builder.NewTestSuiteForController(
+var suite = builder.NewTestSuiteForControllerWithFSS(
 	virtualmachinepublishrequest.AddToManager,
 	func(ctx *ctrlContext.ControllerManagerContext, _ ctrlmgr.Manager) error {
 		ctx.VMProvider = intgFakeVMProvider
 		return nil
 	},
+	map[string]bool{lib.VMImageRegistryFSS: true},
 )
 
 func TestVirtualMachinePublishRequest(t *testing.T) {

--- a/pkg/vmprovider/interface.go
+++ b/pkg/vmprovider/interface.go
@@ -37,6 +37,7 @@ type VirtualMachineProviderInterface interface {
 	GetVirtualMachineImageFromContentLibrary(ctx context.Context, contentLibrary *v1alpha1.ContentLibraryProvider, itemID string,
 		currentCLImages map[string]v1alpha1.VirtualMachineImage) (*v1alpha1.VirtualMachineImage, error)
 	SyncVirtualMachineImage(ctx context.Context, itemID string, vmi client.Object) error
+	DoesItemExistInContentLibrary(ctx context.Context, contentLibrary *imgregv1a1.ContentLibrary, itemName string) (bool, error)
 
 	GetTasksByActID(ctx context.Context, actID string) (tasksInfo []vimTypes.TaskInfo, retErr error)
 }

--- a/pkg/vmprovider/providers/vsphere/contentlibrary/content_library_provider.go
+++ b/pkg/vmprovider/providers/vsphere/contentlibrary/content_library_provider.go
@@ -33,6 +33,7 @@ type Provider interface {
 	GetLibraryItems(ctx context.Context, clUUID string) ([]library.Item, error)
 	GetLibraryItem(ctx context.Context, clUUID, itemName string) (*library.Item, error)
 	ListLibraryItems(ctx context.Context, libraryUUID string) ([]string, error)
+	GetLibraryItemIDsByName(ctx context.Context, libraryUUID, itemName string) ([]string, error)
 	RetrieveOvfEnvelopeFromLibraryItem(ctx context.Context, item *library.Item) (*ovf.Envelope, error)
 	SyncVirtualMachineImage(ctx context.Context, itemID string, vmi client.Object) error
 
@@ -140,6 +141,15 @@ func (cs *provider) GetLibraryItem(ctx context.Context, libraryUUID, itemName st
 	}
 
 	return item, nil
+}
+
+func (cs *provider) GetLibraryItemIDsByName(ctx context.Context, libraryUUID, itemName string) ([]string, error) {
+	itemIDs, err := cs.libMgr.FindLibraryItems(ctx, library.FindItem{LibraryID: libraryUUID, Name: itemName})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to find image: %s", itemName)
+	}
+
+	return itemIDs, nil
 }
 
 // RetrieveOvfEnvelopeFromLibraryItem downloads the supported file from content library.

--- a/webhooks/virtualmachinepublishrequest/validation/virtualmachinepublishrequest_validator_intg_test.go
+++ b/webhooks/virtualmachinepublishrequest/validation/virtualmachinepublishrequest_validator_intg_test.go
@@ -60,14 +60,14 @@ func intgTestsValidateCreate() {
 		}
 		ctx = newIntgValidatingWebhookContext()
 
-		err = ctx.Client.Create(ctx, ctx.vm)
-		Expect(err).ToNot(HaveOccurred())
-
-		err = ctx.Client.Create(ctx, ctx.cl)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(ctx.Client.Create(ctx, ctx.vm)).To(Succeed())
+		Expect(ctx.Client.Create(ctx, ctx.cl)).To(Succeed())
 	})
 
 	AfterEach(func() {
+		Expect(ctx.Client.Delete(ctx, ctx.vm)).To(Succeed())
+		Expect(ctx.Client.Delete(ctx, ctx.cl)).To(Succeed())
+
 		lib.IsWCPVMImageRegistryEnabled = ctx.oldIsWCPVMImageRegistryEnabledFunc
 		err = nil
 		ctx = nil
@@ -105,14 +105,9 @@ func intgTestsValidateUpdate() {
 	BeforeEach(func() {
 		ctx = newIntgValidatingWebhookContext()
 
-		err = ctx.Client.Create(ctx, ctx.vm)
-		Expect(err).ToNot(HaveOccurred())
-
-		err = ctx.Client.Create(ctx, ctx.cl)
-		Expect(err).ToNot(HaveOccurred())
-
-		err = ctx.Client.Create(ctx, ctx.vmPub)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(ctx.Client.Create(ctx, ctx.vm)).To(Succeed())
+		Expect(ctx.Client.Create(ctx, ctx.cl)).To(Succeed())
+		Expect(ctx.Client.Create(ctx, ctx.vmPub)).To(Succeed())
 	})
 
 	JustBeforeEach(func() {
@@ -120,6 +115,10 @@ func intgTestsValidateUpdate() {
 	})
 
 	AfterEach(func() {
+		Expect(ctx.Client.Delete(ctx, ctx.vm)).To(Succeed())
+		Expect(ctx.Client.Delete(ctx, ctx.cl)).To(Succeed())
+		Expect(ctx.Client.Delete(ctx, ctx.vmPub)).To(Succeed())
+
 		err = nil
 		ctx = nil
 	})
@@ -152,14 +151,9 @@ func intgTestsValidateDelete() {
 	BeforeEach(func() {
 		ctx = newIntgValidatingWebhookContext()
 
-		err = ctx.Client.Create(ctx, ctx.vm)
-		Expect(err).ToNot(HaveOccurred())
-
-		err = ctx.Client.Create(ctx, ctx.cl)
-		Expect(err).ToNot(HaveOccurred())
-
-		err = ctx.Client.Create(ctx, ctx.vmPub)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(ctx.Client.Create(ctx, ctx.vm)).To(Succeed())
+		Expect(ctx.Client.Create(ctx, ctx.cl)).To(Succeed())
+		Expect(ctx.Client.Create(ctx, ctx.vmPub)).To(Succeed())
 	})
 
 	JustBeforeEach(func() {
@@ -167,6 +161,9 @@ func intgTestsValidateDelete() {
 	})
 
 	AfterEach(func() {
+		Expect(ctx.Client.Delete(ctx, ctx.vm)).To(Succeed())
+		Expect(ctx.Client.Delete(ctx, ctx.cl)).To(Succeed())
+
 		err = nil
 		ctx = nil
 	})


### PR DESCRIPTION
This change includes:
- Add VirtualMachinePublishRequest condition reasons to API.
- Add more details to SourceValid/TargetValid check.
  - Source VM should be created.
  - Target item name should be unique in the CL.
  - Target CL should be writable.
- Add condition Upload implementation.
  - VM publish succeeded, mark Uploaded to true. Otherwise, mark to false.
- Add condition ImageAvailable implementation.
  - If a namespace scoped VMI is created, mark ImageAvailable to true.
- Add condition Complete implementation. Remove vmpub resource if ttlSecondsAfterFinished is set.
- Fix update VMI scope in integration tests and re-enable ContentLibraryItem intg tests.

Test done:
- Create a VirtualMachinePublishRequest with invalid source VM.
```
Status:
  Conditions:
    Last Transition Time:  2022-11-30T01:29:45Z
    Message:               VM hasn't been created, phase: , unique ID:
    Reason:                SourceVirtualMachineNotCreated
    Status:                False
    Type:                  SourceValid
```
- Create a VirtualMachinePublishRequest with invalid target.
```
Status:
  Conditions:
    ...
    Last Transition Time:  2022-11-30T01:32:02Z
    Message:               item with name image-3 already exists in the content library cl-1
    Reason:                TargetItemAlreadyExists
    Status:                False
    Type:                  TargetValid
```
- Create a VirtualMachinePublishRequest without ttlSecondsAfterFinished.
```
root@4228bec44fd208899d1d24c732ff40dd [ ~ ]# k describe vmpub yijiang-vmpub -n yijiang-ns
Name:         yijiang-vmpub
Namespace:    yijiang-ns
Labels:       <none>
Annotations:  <none>
API Version:  vmoperator.vmware.com/v1alpha1
Kind:         VirtualMachinePublishRequest
Metadata:
  Creation Timestamp:  2022-11-29T22:27:02Z
  Generation:          1
  ...
  UID:               b732dedd-4c27-47ad-af93-7b9dbe9c6b54
Spec:
  Source:
    API Version:  vmoperator.vmware.com/v1alpha1
    Kind:         VirtualMachine
    Name:         yijiang-vm
  Target:
    Item:
      Name:  image-1
    Location:
      API Version:  imageregistry.vmware.com/v1alpha1
      Kind:         ContentLibrary
      Name:         cl-oujy6gsf5zdpjhau4rwtrgdkhm
Status:
  Attempts:         1
  Completion Time:  2022-11-29T22:28:24Z
  Conditions:
    Last Transition Time:  2022-11-29T22:27:02Z
    Reason:                Success
    Status:                True
    Type:                  SourceValid
    Last Transition Time:  2022-11-29T22:27:02Z
    Reason:                Success
    Status:                True
    Type:                  TargetValid
    Last Transition Time:  2022-11-29T22:27:46Z
    Reason:                Success
    Status:                True
    Type:                  Uploaded
    Last Transition Time:  2022-11-29T22:28:24Z
    Reason:                Success
    Status:                True
    Type:                  ImageAvailable
    Last Transition Time:  2022-11-29T22:28:24Z
    Reason:                Success
    Status:                True
    Type:                  Complete
  Image Name:              vmi-odtihnzsqffjbek2vfeqewq4w4
  Last Attempt Time:       2022-11-29T22:27:42Z
  Ready:                   true
  Source Ref:
    API Version:  vmoperator.vmware.com/v1alpha1
    Kind:         VirtualMachine
    Name:         yijiang-vm
  Start Time:     2022-11-29T22:27:02Z
  Target Ref:
    Item:
      Name:  image-1
    Location:
      API Version:  imageregistry.vmware.com/v1alpha1
      Kind:         ContentLibrary
      Name:         cl-oujy6gsf5zdpjhau4rwtrgdkhm
Events:             <none>
```
- Create a VirtualMachinePublishRequest with ttlSecondsAfterFinished.
```
root@4228bec44fd208899d1d24c732ff40dd [ ~ ]# k describe vmpub yijiang-vmpub-ttl -n yijiang-ns
Error from server (NotFound): virtualmachinepublishrequests.vmoperator.vmware.com "yijiang-vmpub-ttl" not found
```