### PR TITLE
Introduce VirtualMachineImage Firmware status field and utilize with deployment Config Spec

### DIFF
--- a/api/v1alpha1/virtualmachineimage_types.go
+++ b/api/v1alpha1/virtualmachineimage_types.go
@@ -136,7 +136,12 @@ type VirtualMachineImageStatus struct {
 	// ContentVersion describes the observed content version of this VirtualMachineImage that was last successfully
 	// synced with the vSphere content library item.
 	// +optional
-	ContentVersion string `json:"contentVersion"`
+	ContentVersion string `json:"contentVersion,omitempty"`
+
+	// Firmware describe the firmware type used by this VirtualMachineImage.
+	// eg: bios, efi.
+	// +optional
+	Firmware string `json:"firmware,omitempty"`
 }
 
 func (vmImage *VirtualMachineImage) GetConditions() Conditions {

--- a/config/crd/bases/vmoperator.vmware.com_clustervirtualmachineimages.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_clustervirtualmachineimages.yaml
@@ -251,6 +251,10 @@ spec:
                   of this VirtualMachineImage that was last successfully synced with
                   the vSphere content library item.
                 type: string
+              firmware:
+                description: 'Firmware describe the firmware type used by this VirtualMachineImage.
+                  eg: bios, efi.'
+                type: string
               imageName:
                 description: ImageName describes the display name of this VirtualMachineImage.
                 type: string

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachineimages.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachineimages.yaml
@@ -252,6 +252,10 @@ spec:
                   of this VirtualMachineImage that was last successfully synced with
                   the vSphere content library item.
                 type: string
+              firmware:
+                description: 'Firmware describe the firmware type used by this VirtualMachineImage.
+                  eg: bios, efi.'
+                type: string
               imageName:
                 description: ImageName describes the display name of this VirtualMachineImage.
                 type: string

--- a/docs/user-guide/apis/v1alpha1.md
+++ b/docs/user-guide/apis/v1alpha1.md
@@ -766,6 +766,7 @@ _Appears in:_
 | `conditions` _[Condition](#condition) array_ | Conditions describes the current condition information of the VirtualMachineImage object. e.g. if the OS type is supported or image is supported by VMService |
 | `contentLibraryRef` _[TypedLocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#typedlocalobjectreference-v1-core)_ | ContentLibraryRef is a reference to the source ContentLibrary/ClusterContentLibrary resource. |
 | `contentVersion` _string_ | ContentVersion describes the observed content version of this VirtualMachineImage that was last successfully synced with the vSphere content library item. |
+| `firmware` _string_ | Firmware describe the firmware type used by this VirtualMachineImage. eg: bios, efi. |
 
 ### VirtualMachineMetadata
 

--- a/images/ttylinux-pc_i486-16.1.ovf
+++ b/images/ttylinux-pc_i486-16.1.ovf
@@ -83,6 +83,7 @@
         <rasd:ResourceSubType>vmware.vmci</rasd:ResourceSubType>
         <rasd:ResourceType>1</rasd:ResourceType>
       </Item>
+      <vmw:Config ovf:required="false" vmw:key="firmware" vmw:value="efi"/>
       <vmw:Config ovf:required="false" vmw:key="powerOpInfo.powerOffType" vmw:value="soft"/>
       <vmw:Config ovf:required="false" vmw:key="powerOpInfo.resetType" vmw:value="soft"/>
       <vmw:Config ovf:required="false" vmw:key="powerOpInfo.suspendType" vmw:value="soft"/>

--- a/pkg/vmprovider/providers/vsphere/contentlibrary/content_library_provider.go
+++ b/pkg/vmprovider/providers/vsphere/contentlibrary/content_library_provider.go
@@ -430,6 +430,11 @@ func (cs *provider) SyncVirtualMachineImage(ctx context.Context, itemID string, 
 		}
 		// Set Status.ImageSupported to combined compatibility of OVF compatibility or WCP_UNIFIED_TKG FSS state.
 		status.ImageSupported = pointer.BoolPtr(isImageSupported(vmi, ovfEnvelope.VirtualSystem, ovfSystemProps))
+
+		// Set Status Firmware from the envelope's virtual hardware section
+		if virtualHwSection := ovfEnvelope.VirtualSystem.VirtualHardware; len(virtualHwSection) > 0 {
+			status.Firmware = getFirmwareType(virtualHwSection[0])
+		}
 	}
 
 	return nil

--- a/pkg/vmprovider/providers/vsphere/contentlibrary/content_library_test.go
+++ b/pkg/vmprovider/providers/vsphere/contentlibrary/content_library_test.go
@@ -86,6 +86,7 @@ func clTests() {
 					Expect(image.Name).To(Equal(ctx.ContentLibraryImageName))
 					Expect(image.Spec.Type).To(Equal("ovf"))
 					Expect(image.Status.ImageName).To(Equal(ctx.ContentLibraryImageName))
+					Expect(image.Status.Firmware).To(Equal("efi"))
 				})
 
 				It("Returns cached VirtualMachineImage from map", func() {

--- a/pkg/vmprovider/providers/vsphere/virtualmachine/configspec.go
+++ b/pkg/vmprovider/providers/vsphere/virtualmachine/configspec.go
@@ -20,6 +20,7 @@ func CreateConfigSpec(
 	name string,
 	vmClassSpec *v1alpha1.VirtualMachineClassSpec,
 	minFreq uint64,
+	imageFirmware string,
 	vmClassConfigSpec *vimtypes.VirtualMachineConfigSpec) *vimtypes.VirtualMachineConfigSpec {
 
 	var configSpec *vimtypes.VirtualMachineConfigSpec
@@ -80,6 +81,11 @@ func CreateConfigSpec(
 		configSpec.MemoryAllocation.Limit = &lim
 	}
 
+	// Use firmware type from the image if config spec doesn't have it.
+	if configSpec.Firmware == "" && imageFirmware != "" {
+		configSpec.Firmware = imageFirmware
+	}
+
 	return configSpec
 }
 
@@ -90,9 +96,10 @@ func CreateConfigSpecForPlacement(
 	vmClassSpec *v1alpha1.VirtualMachineClassSpec,
 	minFreq uint64,
 	storageClassesToIDs map[string]string,
+	imageFirmware string,
 	vmClassConfigSpec *vimtypes.VirtualMachineConfigSpec) *vimtypes.VirtualMachineConfigSpec {
 
-	configSpec := CreateConfigSpec(vmCtx.VM.Name, vmClassSpec, minFreq, vmClassConfigSpec)
+	configSpec := CreateConfigSpec(vmCtx.VM.Name, vmClassSpec, minFreq, imageFirmware, vmClassConfigSpec)
 
 	// Add a dummy disk for placement: PlaceVmsXCluster expects there to always be at least one disk.
 	// Until we're in a position to have the OVF envelope here, add a dummy disk satisfy it.

--- a/pkg/vmprovider/providers/vsphere/virtualmachine/configspec_test.go
+++ b/pkg/vmprovider/providers/vsphere/virtualmachine/configspec_test.go
@@ -27,6 +27,7 @@ var _ = Describe("CreateConfigSpec", func() {
 	var (
 		vmClassSpec     *vmopv1.VirtualMachineClassSpec
 		minCPUFreq      uint64
+		firmware        string
 		configSpec      *vimtypes.VirtualMachineConfigSpec
 		classConfigSpec *vimtypes.VirtualMachineConfigSpec
 		err             error
@@ -36,6 +37,7 @@ var _ = Describe("CreateConfigSpec", func() {
 		vmClass := builder.DummyVirtualMachineClass()
 		vmClassSpec = &vmClass.Spec
 		minCPUFreq = 2500
+		firmware = "efi"
 	})
 
 	It("Basic ConfigSpec assertions", func() {
@@ -43,6 +45,7 @@ var _ = Describe("CreateConfigSpec", func() {
 			vmName,
 			vmClassSpec,
 			minCPUFreq,
+			firmware,
 			nil)
 		Expect(configSpec).ToNot(BeNil())
 		Expect(err).To(BeNil())
@@ -52,6 +55,7 @@ var _ = Describe("CreateConfigSpec", func() {
 		Expect(configSpec.MemoryMB).To(BeEquivalentTo(4 * 1024))
 		Expect(configSpec.CpuAllocation).ToNot(BeNil())
 		Expect(configSpec.MemoryAllocation).ToNot(BeNil())
+		Expect(configSpec.Firmware).To(Equal(firmware))
 	})
 
 	Context("Use VM Class ConfigSpec", func() {
@@ -79,6 +83,7 @@ var _ = Describe("CreateConfigSpec", func() {
 				vmName,
 				vmClassSpec,
 				minCPUFreq,
+				firmware,
 				classConfigSpec)
 			Expect(configSpec).ToNot(BeNil())
 		})
@@ -91,6 +96,7 @@ var _ = Describe("CreateConfigSpec", func() {
 			Expect(configSpec.MemoryMB).To(BeEquivalentTo(4 * 1024))
 			Expect(configSpec.CpuAllocation).ToNot(BeNil())
 			Expect(configSpec.MemoryAllocation).ToNot(BeNil())
+			Expect(configSpec.Firmware).To(Equal(firmware))
 			Expect(configSpec.DeviceChange).To(HaveLen(1))
 			dSpec := configSpec.DeviceChange[0].GetVirtualDeviceConfigSpec()
 			_, ok := dSpec.Device.(*vimtypes.VirtualE1000)
@@ -106,6 +112,7 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 		vmCtx               context.VirtualMachineContext
 		vmClassSpec         *vmopv1.VirtualMachineClassSpec
 		minCPUFreq          uint64
+		firmware            string
 		storageClassesToIDs map[string]string
 		configSpec          *vimtypes.VirtualMachineConfigSpec
 		classConfigSpec     *vimtypes.VirtualMachineConfigSpec
@@ -115,6 +122,7 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 		vmClass := builder.DummyVirtualMachineClass()
 		vmClassSpec = &vmClass.Spec
 		minCPUFreq = 2500
+		firmware = "efi"
 		storageClassesToIDs = map[string]string{}
 
 		vm := builder.DummyVirtualMachine()
@@ -131,6 +139,7 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 			vmClassSpec,
 			minCPUFreq,
 			storageClassesToIDs,
+			firmware,
 			classConfigSpec)
 		Expect(configSpec).ToNot(BeNil())
 	})
@@ -186,6 +195,7 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 			Expect(configSpec.MemoryMB).To(BeEquivalentTo(4 * 1024))
 			Expect(configSpec.CpuAllocation).ToNot(BeNil())
 			Expect(configSpec.MemoryAllocation).ToNot(BeNil())
+			Expect(configSpec.Firmware).To(Equal(firmware))
 			Expect(configSpec.DeviceChange).To(HaveLen(2))
 			dSpec := configSpec.DeviceChange[0].GetVirtualDeviceConfigSpec()
 			_, ok := dSpec.Device.(*vimtypes.VirtualPCIPassthrough)

--- a/pkg/vmprovider/providers/vsphere/vmprovider_vm.go
+++ b/pkg/vmprovider/providers/vsphere/vmprovider_vm.go
@@ -590,6 +590,7 @@ func (vs *vSphereVMProvider) vmCreateGenConfigSpec(
 		vmCtx.VM.Name,
 		&createArgs.VMClass.Spec,
 		createArgs.MinCPUFreq,
+		createArgs.VMImageStatus.Firmware,
 		vmClassConfigSpec)
 
 	createArgs.PlacementConfigSpec = virtualmachine.CreateConfigSpecForPlacement(
@@ -597,6 +598,7 @@ func (vs *vSphereVMProvider) vmCreateGenConfigSpec(
 		&createArgs.VMClass.Spec,
 		createArgs.MinCPUFreq,
 		createArgs.StorageClassesToIDs,
+		createArgs.VMImageStatus.Firmware,
 		vmClassConfigSpec)
 }
 
@@ -702,6 +704,7 @@ func (vs *vSphereVMProvider) vmUpdateGetArgs(
 		vmCtx.VM.Name,
 		&updateArgs.VMClass.Spec,
 		updateArgs.MinCPUFreq,
+		updateArgs.VMImageStatus.Firmware,
 		updateArgs.ClassConfigSpec)
 
 	return updateArgs, nil


### PR DESCRIPTION
The firmware status field for a virtualmachineimage gets populated when creating the vmi. The firmware config string if populated in the ovf image will be consumed when the vm class config spec does not specify firmware type.

This helps prevent issues with deploying images that don't support a specific type of firmware (ie) efi,bios and default to the image as the baseline unless otherwise specified by the vi admin via the vmclass.

Testing: 
- make test
- Manual testing with centos marketplace using OvfEnv transport