### PR TITLE
Fix e-mail link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ Please see the [documentation](https://vm-operator.rtfd.io) for more information
 ## Community
 - Find us on Slack at [#ug-vmware](https://kubernetes.slack.com/messages/ug-vmware)
 - Regular working group [meetings](https://docs.google.com/document/d/1B2oUAuNbYc8nXjRrN353Pt-mDPtwyLrBO3cok7BfV4s/edit?usp=sharing)
-- Reach out directly via VMware liaison [Ellen Mei](meie@vmware.com)
+- Reach out directly via VMware liaison [Ellen Mei](mailto:meie@vmware.com)


### PR DESCRIPTION
This change fixes a minor link typo in `README.md`. Previously, the link for Ellen Mei would point to https://github.com/vmware-tanzu/vm-operator/blob/main/meie@vmware.com, which does not exist.