### PR TITLE
Removed internalID from required field

### DIFF
--- a/api/v1alpha1/virtualmachineimage_types.go
+++ b/api/v1alpha1/virtualmachineimage_types.go
@@ -109,7 +109,7 @@ type VirtualMachineImageStatus struct {
 	Uuid string `json:"uuid,omitempty"` //nolint:revive,stylecheck
 
 	// Deprecated
-	InternalId string `json:"internalId"` //nolint:revive,stylecheck
+	InternalId string `json:"internalId,omitempty"` //nolint:revive,stylecheck
 
 	// Deprecated
 	PowerState string `json:"powerState,omitempty"`

--- a/config/crd/bases/vmoperator.vmware.com_clustervirtualmachineimages.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_clustervirtualmachineimages.yaml
@@ -268,8 +268,6 @@ spec:
               uuid:
                 description: Deprecated
                 type: string
-            required:
-            - internalId
             type: object
         type: object
     served: true

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachineimages.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachineimages.yaml
@@ -269,8 +269,6 @@ spec:
               uuid:
                 description: Deprecated
                 type: string
-            required:
-            - internalId
             type: object
         type: object
     served: true


### PR DESCRIPTION
This change removed internalID from required fields in VMI/CVMI Status since it's already deprecated.