### PR TITLE
Propagate TKG labels to cvmi

### DIFF
--- a/controllers/contentlibrary/clustercontentlibraryitem/clustercontentlibraryitem_controller.go
+++ b/controllers/contentlibrary/clustercontentlibraryitem/clustercontentlibraryitem_controller.go
@@ -202,6 +202,17 @@ func (r *Reconciler) setUpCVMIFromCCLItem(cvmi *vmopv1a1.ClusterVirtualMachineIm
 		return err
 	}
 
+	if cvmi.Labels == nil {
+		cvmi.Labels = make(map[string]string)
+	}
+
+	// Only watch for service type labels from ClusterContentLibraryItem
+	for label := range cclItem.Labels {
+		if strings.HasPrefix(label, "type.services.vmware.com/") {
+			cvmi.Labels[label] = ""
+		}
+	}
+
 	// Do not initialize the Spec or Status directly as it might overwrite the existing fields.
 	cvmi.Spec.Type = string(cclItem.Status.Type)
 	cvmi.Spec.ImageID = cclItem.Spec.UUID

--- a/controllers/contentlibrary/clustercontentlibraryitem/clustercontentlibraryitem_controller_unit_test.go
+++ b/controllers/contentlibrary/clustercontentlibraryitem/clustercontentlibraryitem_controller_unit_test.go
@@ -170,6 +170,7 @@ func unitTestsReconcile() {
 					utils.PopulateRuntimeFieldsTo(expectedCVMI, &createdCVMI)
 
 					Expect(createdCVMI.Name).To(Equal(expectedCVMI.Name))
+					Expect(createdCVMI.Labels).To(Equal(expectedCVMI.Labels))
 					Expect(createdCVMI.OwnerReferences).To(Equal(expectedCVMI.OwnerReferences))
 					Expect(createdCVMI.Spec).To(Equal(expectedCVMI.Spec))
 					Expect(createdCVMI.Status).To(Equal(expectedCVMI.Status))
@@ -203,6 +204,7 @@ func unitTestsReconcile() {
 					utils.PopulateRuntimeFieldsTo(expectedCVMI, &updatedCVMI)
 
 					Expect(updatedCVMI.Name).To(Equal(expectedCVMI.Name))
+					Expect(updatedCVMI.Labels).To(Equal(expectedCVMI.Labels))
 					Expect(updatedCVMI.OwnerReferences).To(Equal(expectedCVMI.OwnerReferences))
 					Expect(updatedCVMI.Spec).To(Equal(expectedCVMI.Spec))
 					Expect(updatedCVMI.Status).To(Equal(expectedCVMI.Status))
@@ -232,6 +234,7 @@ func unitTestsReconcile() {
 					utils.PopulateRuntimeFieldsTo(expectedCVMI, &currentCVMI)
 
 					Expect(currentCVMI.Name).To(Equal(expectedCVMI.Name))
+					Expect(currentCVMI.Labels).To(Equal(expectedCVMI.Labels))
 					Expect(currentCVMI.OwnerReferences).To(Equal(expectedCVMI.OwnerReferences))
 					Expect(currentCVMI.Spec.HardwareVersion).To(BeZero())
 					Expect(currentCVMI.Status.ImageSupported).To(BeNil())


### PR DESCRIPTION
After below discussion, image registry will use the label `servicetype.iaas.vmware.com/tkg` for TKG ClusterContentLibrary and ClusterContentLibraryItem in order to distinguish them from the other cluster scoped content library and content library item resources.

This change propagates the label to ClusterVirtualMachineImage resources corresponding to the TKG content library items as well.

Test done:
```
# k get cvmi --show-labels
NAME                    PROVIDER-NAME              CONTENT-LIBRARY-NAME   IMAGE-NAME                                                                  VERSION                           OS-TYPE               FORMAT   AGE   LABELS
vmi-0b5e4855a0f850ba8   clitem-0b5e4855a0f850ba8   cl-cbe1f4d63cf1d1877   ob-17861429-photon-3-k8s-v1.20.2---vmware.1-tkg.1.1d4f79a                                                                           Ovf      20h   type.services.vmware.com/tkg=
```
