### PR TITLE
Fix issues when target item name is not set.

### DIFF
--- a/controllers/virtualmachinepublishrequest/virtualmachinepublishrequest_controller.go
+++ b/controllers/virtualmachinepublishrequest/virtualmachinepublishrequest_controller.go
@@ -198,12 +198,13 @@ func (r *Reconciler) updateSourceAndTargetRef(ctx *context.VirtualMachinePublish
 	if vmPubReq.Status.TargetRef == nil {
 		targetItemName := vmPubReq.Spec.Target.Item.Name
 		if targetItemName == "" {
-			targetItemName = fmt.Sprintf("%s-image", vmPubReq.Name)
+			targetItemName = fmt.Sprintf("%s-image", vmPubReq.Status.SourceRef.Name)
 		}
 
 		vmPubReq.Status.TargetRef = &vmopv1alpha1.VirtualMachinePublishRequestTarget{
 			Item: vmopv1alpha1.VirtualMachinePublishRequestTargetItem{
-				Name: targetItemName,
+				Name:        targetItemName,
+				Description: vmPubReq.Spec.Target.Item.Description,
 			},
 			Location: vmPubReq.Spec.Target.Location,
 		}
@@ -325,7 +326,7 @@ func (r *Reconciler) checkIsTargetValid(ctx *context.VirtualMachinePublishReques
 	vmPubReq := ctx.VMPublishRequest
 	contentLibrary := &imgregv1a1.ContentLibrary{}
 	targetLocationName := vmPubReq.Spec.Target.Location.Name
-	targetItemName := vmPubReq.Spec.Target.Item.Name
+	targetItemName := vmPubReq.Status.TargetRef.Item.Name
 	objKey := client.ObjectKey{Name: targetLocationName, Namespace: vmPubReq.Namespace}
 	if err := r.Get(ctx, objKey, contentLibrary); err != nil {
 		ctx.Logger.Error(err, "failed to get ContentLibrary", "cl", objKey)

--- a/controllers/virtualmachinepublishrequest/virtualmachinepublishrequest_controller_intg_test.go
+++ b/controllers/virtualmachinepublishrequest/virtualmachinepublishrequest_controller_intg_test.go
@@ -86,9 +86,11 @@ func virtualMachinePublishRequestReconcile() {
 				UniqueID: "dummy-unique-id",
 			}
 			Expect(ctx.Client.Status().Update(ctx, vmObj)).To(Succeed())
-
 			Expect(ctx.Client.Create(ctx, cl)).To(Succeed())
-			Expect(ctx.Client.Create(ctx, vmpub)).To(Succeed())
+
+			Eventually(func() error {
+				return ctx.Client.Create(ctx, vmpub)
+			}).Should(Succeed())
 
 			defaultRequeueDelay := int64(virtualmachinepublishrequest.DefaultRequeueDelaySeconds)
 			atomic.StoreInt64(&defaultRequeueDelay, 1)

--- a/controllers/virtualmachinepublishrequest/virtualmachinepublishrequest_controller_unit_test.go
+++ b/controllers/virtualmachinepublishrequest/virtualmachinepublishrequest_controller_unit_test.go
@@ -260,7 +260,7 @@ func unitTestsReconcile() {
 
 						By("Should set sourceRef/targetRef")
 						Expect(vmpub.Status.SourceRef.Name).To(Equal(vm.Name))
-						Expect(vmpub.Status.TargetRef.Item.Name).To(Equal("dummy-vmpub-image"))
+						Expect(vmpub.Status.TargetRef.Item.Name).To(Equal("dummy-vm-image"))
 						Expect(vmpub.Status.TargetRef.Location).To(Equal(vmpub.Spec.Target.Location))
 					})
 				})

--- a/pkg/vmprovider/providers/vsphere/virtualmachine/publish.go
+++ b/pkg/vmprovider/providers/vsphere/virtualmachine/publish.go
@@ -26,8 +26,8 @@ const (
 func CreateOVF(vmCtx context.VirtualMachineContext, client *rest.Client,
 	vmPubReq *vmopv1alpha1.VirtualMachinePublishRequest, cl *imgregv1a1.ContentLibrary, actID string) (string, error) {
 	createSpec := vcenter.CreateSpec{
-		Name:        vmPubReq.Spec.Target.Item.Name,
-		Description: vmPubReq.Spec.Target.Item.Description,
+		Name:        vmPubReq.Status.TargetRef.Item.Name,
+		Description: vmPubReq.Status.TargetRef.Item.Description,
 	}
 
 	vm := vmCtx.VM

--- a/pkg/vmprovider/providers/vsphere/virtualmachine/publish_test.go
+++ b/pkg/vmprovider/providers/vsphere/virtualmachine/publish_test.go
@@ -43,6 +43,8 @@ func publishTests() {
 		cl = builder.DummyContentLibrary("dummy-cl", "dummy-ns", ctx.ContentLibraryID)
 		vmPub = builder.DummyVirtualMachinePublishRequest("dummy-vmpub", "dummy-ns",
 			vcVM.Name(), "dummy-item-name", "dummy-cl")
+		vmPub.Status.SourceRef = &vmPub.Spec.Source
+		vmPub.Status.TargetRef = &vmPub.Spec.Target
 		vmCtx = context.VirtualMachineContext{
 			Context: ctx,
 			Logger:  suite.GetLogger().WithValues("vmName", vcVM.Name()),

--- a/webhooks/virtualmachinepublishrequest/validation/virtualmachinepublishrequest_validator.go
+++ b/webhooks/virtualmachinepublishrequest/validation/virtualmachinepublishrequest_validator.go
@@ -32,9 +32,6 @@ import (
 
 const (
 	webHookName = "default"
-
-	APIVersionNotSupported = "API version %s isn't supported"
-	KindNotSupported       = "kind %s isn't supported"
 )
 
 // +kubebuilder:webhook:verbs=create;update,path=/default-validate-vmoperator-vmware-com-v1alpha1-virtualmachinepublishrequest,mutating=false,failurePolicy=fail,groups=vmoperator.vmware.com,resources=virtualmachinepublishrequests,versions=v1alpha1,name=default.validating.virtualmachinepublishrequest.vmoperator.vmware.com,sideEffects=None,admissionReviewVersions=v1;v1beta1

--- a/webhooks/virtualmachinepublishrequest/validation/virtualmachinepublishrequest_validator_intg_test.go
+++ b/webhooks/virtualmachinepublishrequest/validation/virtualmachinepublishrequest_validator_intg_test.go
@@ -74,11 +74,10 @@ func intgTestsValidateCreate() {
 	})
 
 	When("WCP_VM_Image_Registry is enabled: create is performed", func() {
-		BeforeEach(func() {
-			err = ctx.Client.Create(ctx, ctx.vmPub)
-		})
 		It("should allow the request", func() {
-			Expect(err).ToNot(HaveOccurred())
+			Eventually(func() error {
+				return ctx.Client.Create(ctx, ctx.vmPub)
+			}).Should(Succeed())
 		})
 	})
 
@@ -91,7 +90,12 @@ func intgTestsValidateCreate() {
 		})
 
 		It("should deny the request", func() {
-			Expect(err).To(HaveOccurred())
+			Eventually(func() string {
+				if err = ctx.Client.Create(ctx, ctx.vmPub); err != nil {
+					return err.Error()
+				}
+				return ""
+			}).Should(ContainSubstring("WCP_VM_Image_Registry feature not enabled"))
 		})
 	})
 }
@@ -107,7 +111,11 @@ func intgTestsValidateUpdate() {
 
 		Expect(ctx.Client.Create(ctx, ctx.vm)).To(Succeed())
 		Expect(ctx.Client.Create(ctx, ctx.cl)).To(Succeed())
-		Expect(ctx.Client.Create(ctx, ctx.vmPub)).To(Succeed())
+
+		// Use Eventually to create vmPub In case VM or CL is not available yet.
+		Eventually(func() error {
+			return ctx.Client.Create(ctx, ctx.vmPub)
+		}).Should(Succeed())
 	})
 
 	JustBeforeEach(func() {
@@ -153,7 +161,10 @@ func intgTestsValidateDelete() {
 
 		Expect(ctx.Client.Create(ctx, ctx.vm)).To(Succeed())
 		Expect(ctx.Client.Create(ctx, ctx.cl)).To(Succeed())
-		Expect(ctx.Client.Create(ctx, ctx.vmPub)).To(Succeed())
+
+		Eventually(func() error {
+			return ctx.Client.Create(ctx, ctx.vmPub)
+		}).Should(Succeed())
 	})
 
 	JustBeforeEach(func() {


### PR DESCRIPTION
The VirtualMachinePublishRequest .spec.target.item.name is optional and we will set a default name if it is empty, which is <source vm name> + image. We will not mutate target item name in the spec, but instead update targetRef in the status. In other words, we will always set targetRef item information in the status no matter if .spec.target.item.name is set or not. Use .status.targetRef.item.name can guarantee that we use the right item name when publishing VMs.
This change includes:
- when target item name is not set, use <source-vm>-image as default target item name.
- Use .status.targetRef.item as the publish VM info
- Also fix VirtualMachinePublishRequest webhook and controller integration tests.

Test done:
 - Manually deployed to a WCP testbed.
```
apiVersion: vmoperator.vmware.com/v1alpha1
kind: VirtualMachinePublishRequest
metadata:
  name: source-vm-1
  namespace: test-ns
spec:
  target:
    item:
      description: test
    location:
      name: cl-ujgvg6meibek5bim5jxgsu24eu
```
After created in the cluster
```
apiVersion: vmoperator.vmware.com/v1alpha1
kind: VirtualMachinePublishRequest
metadata:
...
  name: source-vm-1
  namespace: test-ns
spec:
  target:
    item:
      description: test
    location:
      apiVersion: imageregistry.vmware.com/v1alpha1
      kind: ContentLibrary
      name: cl-ujgvg6meibek5bim5jxgsu24eu
status:
  attempts: 1
  ...
  sourceRef:
    apiVersion: vmoperator.vmware.com/v1alpha1
    kind: VirtualMachine
    name: source-vm-1
  startTime: "2022-12-15T09:01:01Z"
  targetRef:
    item:
      description: test
      name: source-vm-1-image
    location:
      apiVersion: imageregistry.vmware.com/v1alpha1
      kind: ContentLibrary
      name: cl-ujgvg6meibek5bim5jxgsu24eu
 ```