### PR TITLE
Update MaxDeployThreads to be configurable

### DIFF
--- a/controllers/virtualmachine/virtualmachine_controller_unit_test.go
+++ b/controllers/virtualmachine/virtualmachine_controller_unit_test.go
@@ -70,6 +70,7 @@ func unitTestsReconcile() {
 			ctx.Recorder,
 			ctx.VMProvider,
 			fakeProbeManagerIf,
+			16,
 		)
 		fakeVMProvider = ctx.VMProvider.(*providerfake.VMProvider)
 		fakeProbeManager = fakeProbeManagerIf.(*proberfake.ProberManager)

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -1,0 +1,13 @@
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package context
+
+// Key is used to store/retrieve information in/from a VM Operator context.
+type Key uint
+
+const (
+	// MaxDeployThreadsContextKey is the context key that stores the maximum
+	// number of threads allowed used to deploy a VM.
+	MaxDeployThreadsContextKey Key = iota
+)

--- a/pkg/lib/env.go
+++ b/pkg/lib/env.go
@@ -108,9 +108,9 @@ var IsWCPVMImageRegistryEnabled = func() bool {
 	return os.Getenv(VMImageRegistryFSS) == trueString
 }
 
-// MaxConcurrentCreateVMsOnProvider returns the percentage of reconciler threads that can be used to create VMs on the provider
-// concurrently. The default is 80.
-// TODO: Remove the env lookup once we have tuned this value from system tests.
+// MaxConcurrentCreateVMsOnProvider returns the percentage of reconciler
+// threads that can be used to create VMs on the provider concurrently. The
+// default is 80.
 var MaxConcurrentCreateVMsOnProvider = func() int {
 	v := os.Getenv(MaxCreateVMsOnProviderEnv)
 	if v == "" {

--- a/pkg/vmprovider/providers/vsphere/vmprovider_vm_test.go
+++ b/pkg/vmprovider/providers/vsphere/vmprovider_vm_test.go
@@ -5,6 +5,7 @@ package vsphere_test
 
 import (
 	"bytes"
+	goctx "context"
 	"encoding/json"
 	"fmt"
 	"math/rand"
@@ -28,6 +29,7 @@ import (
 	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
+	"github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/topology"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere"
@@ -56,6 +58,7 @@ func vmTests() {
 
 	JustBeforeEach(func() {
 		ctx = suite.NewTestContextForVCSim(testConfig, initObjects...)
+		ctx.Context = goctx.WithValue(ctx.Context, context.MaxDeployThreadsContextKey, 16)
 		vmProvider = vsphere.NewVSphereVMProviderFromClient(ctx.Client, ctx.Recorder)
 		nsInfo = ctx.CreateWorkloadNamespace()
 	})

--- a/pkg/vmprovider/providers/vsphere/vmprovider_vm_utils_test.go
+++ b/pkg/vmprovider/providers/vsphere/vmprovider_vm_utils_test.go
@@ -39,7 +39,7 @@ func vmUtilTests() {
 		vm := builder.DummyBasicVirtualMachine("test-vm", "dummy-ns")
 
 		vmCtx = context.VirtualMachineContext{
-			Context: goctx.Background(),
+			Context: goctx.WithValue(goctx.Background(), context.MaxDeployThreadsContextKey, 16),
 			Logger:  suite.GetLogger().WithValues("vmName", vm.Name),
 			VM:      vm,
 		}


### PR DESCRIPTION
This patch updates the way VM Operator handles `MaxDeployThreads`. The value used to be hardcoded as `80%` of the `MaxConcurrentReconciles`, which is `20`. However, `MaxConcurrentReconciles` is configurable via the VM Operator deployment, so `80%` of `20`, which is `16`, should increase or decrease if `MaxConcurrentReconciles` does as well. This patch now derives `MaxDeployThreads` by looking at the environment variable `MAX_CREATE_VMS_ON_PROVIDER` which is expected to be a whole number that represents the percentage of the `MaxConcurrentReconciles` that equals `MaxDeployThreads`. `MaxDeployThreads` is then calculated by `MaxConcurrentReconciles / (100 / MaxDeployThreadsEnvVarValue)`. If the env var is not set then it defaults to `80`.