### PR TITLE
Add VM publish related metrics in virtualmachinepublishrequest controller

### DIFF
--- a/pkg/metrics/vmpub_metrics.go
+++ b/pkg/metrics/vmpub_metrics.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"sync"
+
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type PublishResult int
+
+const (
+	PublishFailed     PublishResult = -1
+	PublishInProgress PublishResult = 0
+	PublishSucceeded  PublishResult = 1
+)
+
+var (
+	vmPubMetricsOnce sync.Once
+	vmPubMetrics     *VMPublishMetrics
+)
+
+type VMPublishMetrics struct {
+	vmPubRequest *prometheus.GaugeVec
+}
+
+// NewVMPublishMetrics initializes a singleton and registers all the defined metrics.
+func NewVMPublishMetrics() *VMPublishMetrics {
+	vmPubMetricsOnce.Do(func() {
+		vmPubMetrics = &VMPublishMetrics{
+			vmPubRequest: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+				Namespace: metricsNamespace,
+				Subsystem: "vm",
+				Name:      "publish_request",
+				Help:      "VirtualMachine publish request result",
+			}, []string{
+				"name",
+				"namespace",
+			}),
+		}
+
+		metrics.Registry.MustRegister(
+			vmPubMetrics.vmPubRequest,
+		)
+	})
+
+	return vmPubMetrics
+}
+
+// RegisterVMPublishRequest registers VM publish request metrics with the given value.
+func (m *VMPublishMetrics) RegisterVMPublishRequest(logger logr.Logger, reqName, ns string, val PublishResult) {
+	labels := getVMPubRequestLabels(reqName, ns)
+	m.vmPubRequest.With(labels).Set(float64(val))
+
+	logger.V(5).WithValues("labels", labels, "result", val).Info("Set metrics for VM publish request")
+}
+
+// DeleteMetrics deletes all the related VM publish request metrics from the given name and namespace.
+func (m *VMPublishMetrics) DeleteMetrics(logger logr.Logger, reqName, ns string) {
+	labels := getVMPubRequestLabels(reqName, ns)
+	deleted := m.vmPubRequest.Delete(labels)
+
+	logger.V(5).WithValues("labels", labels, "deleted", deleted).Info("Delete VM publish request metrics")
+}
+
+func getVMPubRequestLabels(name, ns string) prometheus.Labels {
+	return prometheus.Labels{
+		"name":      name,
+		"namespace": ns,
+	}
+}


### PR DESCRIPTION
This PR adds a new `pkg/metrics/vmpub_metrics.go` file which introduces `vm_publish_request` metrics registered in the `virtualmachinepublishrequest` controller. This will give us better visibility on VM publish request results and the ability to measure the percentage of successful publish requests.

Testing Done:
- Metrics registration
```console
$ curl -s localhost:8083/metrics | grep vm_publish
# HELP vmservice_vm_publish_request VirtualMachine publish request result
# TYPE vmservice_vm_publish_request gauge
vmservice_vm_publish_request{name="packer-vsphere-supervisor-crrhw",namespace="sdiliyaer-test"} 0
vmservice_vm_publish_request{name="test-ubuntu",namespace="sdiliyaer-test"} 0
vmservice_vm_publish_request{name="vmpub-test-metrics",namespace="yijiang-ns"} -1
```
- Metrics deletion
```console
$ curl -s localhost:8083/metrics  | grep vm_publish
# HELP vmservice_vm_publish_request VirtualMachine publish request result
# TYPE vmservice_vm_publish_request gauge
vmservice_vm_publish_request{name="metrics-test",namespace="sdiliyaer-test"} 0
$ kubectl delete vmpub -n sdiliyaer-test metrics-test
virtualmachinepublishrequest.vmoperator.vmware.com "metrics-test" deleted
$ curl -s localhost:8083/metrics  | grep vm_publish
$
``` 