### PR TITLE
Update VMClass.Spec.ConfigSpec to be RawMessage

### DIFF
--- a/api/v1alpha1/virtualmachineclass_types.go
+++ b/api/v1alpha1/virtualmachineclass_types.go
@@ -1,12 +1,13 @@
-// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2019-2023 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package v1alpha1
 
 import (
+	"encoding/json"
+
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // VGPUDevice contains the configuration corresponding to a vGPU device.
@@ -105,7 +106,10 @@ type VirtualMachineClassSpec struct {
 	// field "_typeName" to preserve type information.
 	//
 	// +optional
-	ConfigSpec *runtime.RawExtension `json:"configSpec,omitempty"`
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:validation:Type=object
+	// +kubebuilder:pruning:PreserveUnknownFields
+	ConfigSpec json.RawMessage `json:"configSpec,omitempty"`
 }
 
 // VirtualMachineClassStatus defines the observed state of VirtualMachineClass.  VirtualMachineClasses are immutable,

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -9,6 +9,7 @@
 package v1alpha1
 
 import (
+	"encoding/json"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -1003,8 +1004,8 @@ func (in *VirtualMachineClassSpec) DeepCopyInto(out *VirtualMachineClassSpec) {
 	in.Policies.DeepCopyInto(&out.Policies)
 	if in.ConfigSpec != nil {
 		in, out := &in.ConfigSpec, &out.ConfigSpec
-		*out = new(runtime.RawExtension)
-		(*in).DeepCopyInto(*out)
+		*out = make(json.RawMessage, len(*in))
+		copy(*out, *in)
 	}
 }
 

--- a/docs/user-guide/apis/v1alpha1.md
+++ b/docs/user-guide/apis/v1alpha1.md
@@ -679,7 +679,7 @@ _Appears in:_
 | `hardware` _[VirtualMachineClassHardware](#virtualmachineclasshardware)_ | Hardware describes the configuration of the VirtualMachineClass attributes related to virtual hardware.  The configuration specified in this field is used to customize the virtual hardware characteristics of any VirtualMachine associated with this VirtualMachineClass. |
 | `policies` _[VirtualMachineClassPolicies](#virtualmachineclasspolicies)_ | Policies describes the configuration of the VirtualMachineClass attributes related to virtual infrastructure policy.  The configuration specified in this field is used to customize various policies related to infrastructure resource consumption. |
 | `description` _string_ | Description describes the configuration of the VirtualMachineClass which is not related to virtual hardware or infrastructure policy. This field is used to address remaining specs about this VirtualMachineClass. |
-| `configSpec` _RawExtension_ | ConfigSpec describes additional configuration information for a VirtualMachine. 
+| `configSpec` _integer array_ | ConfigSpec describes additional configuration information for a VirtualMachine. 
  The contents of this field are the VirtualMachineConfigSpec data object (https://bit.ly/3HDtiRu) marshaled to JSON using the discriminator field "_typeName" to preserve type information. |
 
 

--- a/pkg/vmprovider/providers/vsphere/vmprovider_vm_test.go
+++ b/pkg/vmprovider/providers/vsphere/vmprovider_vm_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package vsphere_test
@@ -21,7 +21,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -168,9 +167,7 @@ func vmTests() {
 					// Update the VM Class with the XML.
 					vmClass := &vmopv1alpha1.VirtualMachineClass{}
 					Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: vm.Spec.ClassName}, vmClass)).To(Succeed())
-					vmClass.Spec.ConfigSpec = &runtime.RawExtension{
-						Raw: w.Bytes(),
-					}
+					vmClass.Spec.ConfigSpec = w.Bytes()
 					Expect(ctx.Client.Update(ctx, vmClass)).To(Succeed())
 				}
 

--- a/pkg/vmprovider/providers/vsphere/vmprovider_vm_utils.go
+++ b/pkg/vmprovider/providers/vsphere/vmprovider_vm_utils.go
@@ -1,13 +1,13 @@
-// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package vsphere
 
 import (
+	"encoding/json"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/google/uuid"
@@ -316,11 +316,11 @@ func AddInstanceStorageVolumes(
 	return nil
 }
 
-func GetVMClassConfigSpec(raw *runtime.RawExtension) (*types.VirtualMachineConfigSpec, error) {
-	if raw == nil {
+func GetVMClassConfigSpec(raw json.RawMessage) (*types.VirtualMachineConfigSpec, error) {
+	if len(raw) == 0 {
 		return nil, nil
 	}
-	classConfigSpec, err := util.UnmarshalConfigSpecFromJSON(raw.Raw)
+	classConfigSpec, err := util.UnmarshalConfigSpecFromJSON(raw)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This patch updates the `VirtualMachineClass.Spec.ConfigSpec` to be `json.RawMessage`, which is similar to `runtime.RawExtension`, but has no opinion about being a `runtime.Object`.
    
Per https://github.com/kubernetes-sigs/controller-tools/issues/637, it was necessary to decorate the field with the following kubebuilder annotations to force the wire protocol to be an object:

```go
// +kubebuilder:validation:Schemaless
// +kubebuilder:validation:Type=object
// +kubebuilder:pruning:PreserveUnknownFields
```