### PR TITLE
Use APIReader client to Get() VirtualMachinePublishRequest

### DIFF
--- a/controllers/virtualmachinepublishrequest/virtualmachinepublishrequest_controller_unit_test.go
+++ b/controllers/virtualmachinepublishrequest/virtualmachinepublishrequest_controller_unit_test.go
@@ -67,6 +67,7 @@ func unitTestsReconcile() {
 		ctx = suite.NewUnitTestContextForController(initObjects...)
 		reconciler = virtualmachinepublishrequest.NewReconciler(
 			ctx.Client,
+			ctx.Client,
 			ctx.Logger,
 			ctx.Recorder,
 			ctx.VMProvider,

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -26,7 +26,6 @@ import (
 	netopv1alpha1 "github.com/vmware-tanzu/vm-operator/external/net-operator/api/v1alpha1"
 	cnsv1alpha1 "github.com/vmware-tanzu/vm-operator/external/vsphere-csi-driver/pkg/syncer/cnsoperator/apis/cnsnodevmattachment/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
-	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 	"github.com/vmware-tanzu/vm-operator/pkg/record"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere"
 )
@@ -57,13 +56,6 @@ func New(opts Options) (Manager, error) {
 	// This can cause VM operator pod to be OOM killed. To avoid that, we by-pass
 	// the cache for ConfigMaps and Secrets so they are looked up from API sever directly.
 	cacheDisabledObjects := []client.Object{&corev1.ConfigMap{}, &corev1.Secret{}}
-
-	// Look up VirtualMachinePublishRequest resources from API server directly to avoid get stale objects from cache,
-	// We kind of rely on the up-to-date status when sending publish VM requests during reconciling VMPublishRequests.
-	// Update stale object will be rejected by API server and result in unnecessary reconciles.
-	if lib.IsWCPVMImageRegistryEnabled() {
-		cacheDisabledObjects = append(cacheDisabledObjects, &vmopv1.VirtualMachinePublishRequest{})
-	}
 
 	// Build the controller manager.
 	mgr, err := ctrlmgr.New(opts.KubeConfig, ctrlmgr.Options{


### PR DESCRIPTION
Unlike ConfigMaps and Secrets which we cannot cache because their quantity and size will exceed our container's memory limit, the pub req shouldn't be cached because of how the controller is implemented so make that explicit in the controller.