### PR TITLE
Implement caching for download of virtual machine images

### DIFF
--- a/controllers/contentlibrary/clustercontentlibraryitem/clustercontentlibraryitem_controller.go
+++ b/controllers/contentlibrary/clustercontentlibraryitem/clustercontentlibraryitem_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package clustercontentlibraryitem
@@ -260,7 +260,7 @@ func (r *Reconciler) syncImageContent(ctx goctx.Context,
 		return nil
 	}
 
-	err := r.VMProvider.SyncVirtualMachineImage(ctx, cclItem.Spec.UUID, cvmi)
+	err := r.VMProvider.SyncVirtualMachineImage(ctx, cclItem, cvmi)
 	if err != nil {
 		conditions.MarkFalse(cvmi,
 			vmopv1a1.VirtualMachineImageSyncedCondition,

--- a/controllers/contentlibrary/clustercontentlibraryitem/clustercontentlibraryitem_controller_intg_test.go
+++ b/controllers/contentlibrary/clustercontentlibraryitem/clustercontentlibraryitem_controller_intg_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package clustercontentlibraryitem_test
@@ -65,8 +65,8 @@ func cclItemReconcile() {
 		ctx = suite.NewIntegrationTestContext()
 		intgFakeVMProvider.Lock()
 		defer intgFakeVMProvider.Unlock()
-		intgFakeVMProvider.SyncVirtualMachineImageFn = func(ctx context.Context,
-			itemID string, cvmiObj client.Object) error {
+		intgFakeVMProvider.SyncVirtualMachineImageFn = func(
+			_ context.Context, _, cvmiObj client.Object) error {
 			// Change a random spec and status field to verify the provider function is called.
 			cvmi := cvmiObj.(*vmopv1a1.ClusterVirtualMachineImage)
 			cvmi.Spec.HardwareVersion = 123

--- a/controllers/contentlibrary/clustercontentlibraryitem/clustercontentlibraryitem_controller_unit_test.go
+++ b/controllers/contentlibrary/clustercontentlibraryitem/clustercontentlibraryitem_controller_unit_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package clustercontentlibraryitem_test
@@ -56,8 +56,8 @@ func unitTestsReconcile() {
 			ctx.VMProvider,
 		)
 		fakeVMProvider = ctx.VMProvider.(*providerfake.VMProvider)
-		fakeVMProvider.SyncVirtualMachineImageFn = func(_ context.Context, _ string,
-			cvmiObj client.Object) error {
+		fakeVMProvider.SyncVirtualMachineImageFn = func(
+			_ context.Context, _, cvmiObj client.Object) error {
 			cvmi := cvmiObj.(*vmopv1a1.ClusterVirtualMachineImage)
 			// Change a random spec and status field to verify the provider function is called.
 			cvmi.Spec.HardwareVersion = 123

--- a/controllers/contentlibrary/contentlibraryitem/contentlibraryitem_controller.go
+++ b/controllers/contentlibrary/contentlibraryitem/contentlibraryitem_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package contentlibraryitem
@@ -255,10 +255,7 @@ func (r *Reconciler) syncImageContent(ctx goctx.Context,
 		return nil
 	}
 
-	// TODO: .
-	// We should use cache here to avoid downloading from VC for every single VM image under every namespaces and
-	// cluster VMI with the same item ID.
-	err := r.VMProvider.SyncVirtualMachineImage(ctx, clItem.Spec.UUID, vmi)
+	err := r.VMProvider.SyncVirtualMachineImage(ctx, clItem, vmi)
 	if err != nil {
 		conditions.MarkFalse(vmi,
 			vmopv1alpha1.VirtualMachineImageSyncedCondition,

--- a/controllers/contentlibrary/contentlibraryitem/contentlibraryitem_controller_intg_test.go
+++ b/controllers/contentlibrary/contentlibraryitem/contentlibraryitem_controller_intg_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package contentlibraryitem_test
@@ -60,8 +60,8 @@ func clItemReconcile() {
 
 		intgFakeVMProvider.Lock()
 		defer intgFakeVMProvider.Unlock()
-		intgFakeVMProvider.SyncVirtualMachineImageFn = func(ctx context.Context,
-			itemID string, vmiObj client.Object) error {
+		intgFakeVMProvider.SyncVirtualMachineImageFn = func(
+			_ context.Context, _, vmiObj client.Object) error {
 			vmi := vmiObj.(*vmopv1a1.VirtualMachineImage)
 			// Change a random spec and status field to verify the provider function is called.
 			vmi.Spec.HardwareVersion = 123

--- a/controllers/contentlibrary/contentlibraryitem/contentlibraryitem_controller_unit_test.go
+++ b/controllers/contentlibrary/contentlibraryitem/contentlibraryitem_controller_unit_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package contentlibraryitem_test
@@ -55,8 +55,7 @@ func unitTestsReconcile() {
 			ctx.VMProvider,
 		)
 		fakeVMProvider = ctx.VMProvider.(*providerfake.VMProvider)
-		fakeVMProvider.SyncVirtualMachineImageFn = func(_ context.Context, _ string,
-			vmi client.Object) error {
+		fakeVMProvider.SyncVirtualMachineImageFn = func(_ context.Context, _, vmi client.Object) error {
 			vmiObj := vmi.(*vmopv1a1.VirtualMachineImage)
 			// Change a random spec and status field to verify the provider function is called.
 			vmiObj.Spec.HardwareVersion = 123

--- a/controllers/contentlibrary/utils/test_utils.go
+++ b/controllers/contentlibrary/utils/test_utils.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package utils
@@ -105,7 +105,7 @@ func GetServiceTypeLabels(labels map[string]string) map[string]string {
 }
 
 func GetExpectedCVMIFrom(cclItem imgregv1a1.ClusterContentLibraryItem,
-	providerFunc func(context.Context, string, crtlclient.Object) error) *vmopv1a1.ClusterVirtualMachineImage {
+	providerFunc func(context.Context, crtlclient.Object, crtlclient.Object) error) *vmopv1a1.ClusterVirtualMachineImage {
 
 	cvmi := &vmopv1a1.ClusterVirtualMachineImage{
 		ObjectMeta: metav1.ObjectMeta{
@@ -152,14 +152,14 @@ func GetExpectedCVMIFrom(cclItem imgregv1a1.ClusterContentLibraryItem,
 	}
 
 	if providerFunc != nil {
-		_ = providerFunc(nil, "", cvmi)
+		_ = providerFunc(nil, nil, cvmi)
 	}
 
 	return cvmi
 }
 
 func GetExpectedVMIFrom(clItem imgregv1a1.ContentLibraryItem,
-	providerFunc func(context.Context, string, crtlclient.Object) error) *vmopv1a1.VirtualMachineImage {
+	providerFunc func(context.Context, crtlclient.Object, crtlclient.Object) error) *vmopv1a1.VirtualMachineImage {
 
 	vmi := &vmopv1a1.VirtualMachineImage{
 		ObjectMeta: metav1.ObjectMeta{
@@ -206,7 +206,7 @@ func GetExpectedVMIFrom(clItem imgregv1a1.ContentLibraryItem,
 	}
 
 	if providerFunc != nil {
-		_ = providerFunc(nil, "", vmi)
+		_ = providerFunc(nil, nil, vmi)
 	}
 
 	return vmi

--- a/pkg/util/cache.go
+++ b/pkg/util/cache.go
@@ -1,0 +1,183 @@
+// Copyright (c) 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"sync"
+	"time"
+)
+
+// CacheItem wraps T so it has a LastUpdated field and can be used with Cache.
+type CacheItem[T any] struct {
+	// Item is the cached item.
+	Item T
+
+	// LastUpdated is the last time the item was updated.
+	LastUpdated time.Time
+}
+
+// Cache is a generic implementation of a cache that can be configured with a
+// maximum number of items and can evict items after a certain amount of time.
+type Cache[T any] struct {
+	mu       sync.Mutex
+	items    map[string]CacheItem[T]
+	maxItems int
+	done     chan struct{}
+	donce    sync.Once
+
+	// expiredChan returns a channel on which the IDs of items that are expired
+	// are sent. This channel is closed when the cache is closed, but only after
+	// all, pending eviction notices are received.
+	expiredChan chan string
+	expiringNum sync.WaitGroup
+}
+
+// NewCache initializes a new cache with the provided expiration options.
+func NewCache[T any](
+	expireAfter, checkExpireInterval time.Duration,
+	maxItems int) *Cache[T] {
+
+	c := &Cache[T]{
+		expiredChan: make(chan string),
+		done:        make(chan struct{}),
+		items:       map[string]CacheItem[T]{},
+		maxItems:    maxItems,
+	}
+
+	// Start a goroutine to expire items from the cache.
+	go func() {
+		ticker := time.NewTicker(checkExpireInterval)
+
+		// evictFn iterates over the cached items and evicts expired items
+		evictFn := func() {
+			c.mu.Lock()
+			defer c.mu.Unlock()
+			for k, v := range c.items {
+				if time.Since(v.LastUpdated) > expireAfter {
+					// Delete the item from the cache.
+					delete(c.items, k)
+
+					// Notify subscribers that the item with the ID of k has
+					// been evicted if the cache is not closed. Otherwise we
+					// add one to the number of items being expired. This
+					// ensures the channel cannot be closed until all, pending
+					// notifications are sent.
+					select {
+					case <-c.done:
+					default:
+						c.expiringNum.Add(1)
+						go func(k string) {
+							c.expiredChan <- k
+							c.expiringNum.Done()
+						}(k)
+					}
+				}
+			}
+		}
+		for {
+			select {
+			case <-c.done:
+				ticker.Stop()
+				return
+			case <-ticker.C:
+				evictFn()
+			}
+		}
+	}()
+
+	return c
+}
+
+// ExpiredChan returns a channel on which the IDs of items that are expired are
+// sent. This channel is closed when the cache is closed, but only after all,
+// pending eviction notices are received.
+func (c *Cache[T]) ExpiredChan() <-chan string {
+	return c.expiredChan
+}
+
+// Close shuts down the cache. It is safe to call this function more than once.
+func (c *Cache[T]) Close() {
+	c.donce.Do(func() {
+		close(c.done)
+
+		// Wait until all pending, expiry notifications are received until the
+		// expired channel is closed.
+		go func() {
+			c.expiringNum.Wait()
+			close(c.expiredChan)
+		}()
+	})
+}
+
+// Delete removes the specified item from the cache.
+func (c *Cache[T]) Delete(id string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.items, id)
+}
+
+// Get returns the cached item with the provided ID. The function isHit may be
+// optionally provided to further determine whether a cached item should hit
+// or miss.
+func (c *Cache[T]) Get(id string, isHit func(t T) bool) (T, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var emptyT T
+
+	v, ok := c.items[id]
+	if !ok {
+		return emptyT, false
+	}
+
+	if isHit != nil && !isHit(v.Item) {
+		return emptyT, false
+	}
+
+	return v.Item, true
+}
+
+// CachePutResult describes the result of putting an item into the cache.
+type CachePutResult uint
+
+const (
+	// CachePutResultCreate indicates the item was created in the cache.
+	CachePutResultCreate CachePutResult = iota + 1
+
+	// CachePutResultUpdate indicates an existing, cached item was updated.
+	CachePutResultUpdate
+
+	// CachePutResultMaxItemsExceeded indicates the item was not stored because
+	// the cache's maximum number of items would have been exceeded.
+	CachePutResultMaxItemsExceeded
+)
+
+// Put stores the provided item in the cache, updating existing items.
+func (c *Cache[T]) Put(id string, t T) CachePutResult {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	v, ok := c.items[id]
+
+	if ok {
+		// Update existing item.
+		v.Item = t
+		v.LastUpdated = time.Now()
+		c.items[id] = v
+		return CachePutResultUpdate
+	}
+
+	// Store the new item in the cache as long as the maximum number of items
+	// was note exceeded.
+	if len(c.items) < c.maxItems {
+		// Store new item in the cache.
+		c.items[id] = CacheItem[T]{
+			Item:        t,
+			LastUpdated: time.Now(),
+		}
+		return CachePutResultCreate
+	}
+
+	return CachePutResultMaxItemsExceeded
+}

--- a/pkg/util/cache_test.go
+++ b/pkg/util/cache_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package util_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/vmware-tanzu/vm-operator/pkg/util"
+)
+
+var _ = Describe("CacheTest", func() {
+	type person struct {
+		Name string
+		Age  int
+	}
+
+	var (
+		c                   *util.Cache[person]
+		expireAfter         time.Duration
+		checkExpireInterval time.Duration
+		maxItems            int
+	)
+
+	BeforeEach(func() {
+		expireAfter = 3 * time.Second
+		checkExpireInterval = 1 * time.Second
+		maxItems = 3
+	})
+
+	AfterEach(func() {
+		c.Close()
+	})
+
+	JustBeforeEach(func() {
+		c = util.NewCache[person](expireAfter, checkExpireInterval, maxItems)
+	})
+
+	It("item should be created and expire after three seconds", func() {
+		Expect(c.Put("1", person{Name: "name"})).To(Equal(util.CachePutResultCreate))
+		p, ok := c.Get("1", nil)
+		Expect(ok).To(BeTrue())
+		Expect(p).To(Equal(person{Name: "name"}))
+		Eventually(func() string {
+			if p, ok := c.Get("1", nil); ok {
+				return p.Name
+			}
+			return ""
+		}, 5*time.Second, 1*time.Second).Should(BeEmpty())
+	})
+
+	It("item should be updated and expire after three seconds", func() {
+		Expect(c.Put("1", person{Name: "name"})).To(Equal(util.CachePutResultCreate))
+		p, ok := c.Get("1", nil)
+		Expect(ok).To(BeTrue())
+		Expect(p).To(Equal(person{Name: "name"}))
+
+		Expect(c.Put("1", person{Name: "new-name"})).To(Equal(util.CachePutResultUpdate))
+		p, ok = c.Get("1", nil)
+		Expect(ok).To(BeTrue())
+		Expect(p).To(Equal(person{Name: "new-name"}))
+
+		Eventually(func() string {
+			if p, ok := c.Get("1", nil); ok {
+				return p.Name
+			}
+			return ""
+		}, 5*time.Second, 1*time.Second).Should(BeEmpty())
+	})
+
+	It("should receive eviction notice even if cache is closed", func() {
+		Expect(c.Put("1", person{Name: "name"})).To(Equal(util.CachePutResultCreate))
+		p, ok := c.Get("1", nil)
+		Expect(ok).To(BeTrue())
+		Expect(p).To(Equal(person{Name: "name"}))
+
+		Eventually(func() string {
+			if p, ok := c.Get("1", nil); ok {
+				return p.Name
+			}
+			return ""
+		}, 5*time.Second, 1*time.Second).Should(BeEmpty())
+
+		c.Close()
+
+		Expect(<-c.ExpiredChan()).To(Equal("1"))
+		Eventually(c.ExpiredChan()).Should(BeClosed())
+	})
+
+	It("should prevent more than max items from being added", func() {
+		Expect(c.Put("1", person{Name: "name"})).To(Equal(util.CachePutResultCreate))
+		p, ok := c.Get("1", nil)
+		Expect(ok).To(BeTrue())
+		Expect(p).To(Equal(person{Name: "name"}))
+
+		Expect(c.Put("2", person{Name: "name"})).To(Equal(util.CachePutResultCreate))
+		p, ok = c.Get("2", nil)
+		Expect(ok).To(BeTrue())
+		Expect(p).To(Equal(person{Name: "name"}))
+
+		Expect(c.Put("3", person{Name: "name"})).To(Equal(util.CachePutResultCreate))
+		p, ok = c.Get("3", nil)
+		Expect(ok).To(BeTrue())
+		Expect(p).To(Equal(person{Name: "name"}))
+
+		Expect(c.Put("4", person{Name: "name"})).To(Equal(util.CachePutResultMaxItemsExceeded))
+		p, ok = c.Get("4", nil)
+		Expect(ok).To(BeFalse())
+		Expect(p).To(Equal(person{}))
+	})
+
+	It("should match only if isHit", func() {
+		Expect(c.Put("1", person{Name: "name", Age: 99})).To(Equal(util.CachePutResultCreate))
+		Expect(c.Put("2", person{Name: "name", Age: 150})).To(Equal(util.CachePutResultCreate))
+
+		eqGt100 := func(p person) bool {
+			return p.Age >= 100
+		}
+
+		p, ok := c.Get("1", eqGt100)
+		Expect(ok).To(BeFalse())
+		Expect(p).To(Equal(person{}))
+
+		p, ok = c.Get("2", eqGt100)
+		Expect(ok).To(BeTrue())
+		Expect(p).To(Equal(person{Name: "name", Age: 150}))
+	})
+})

--- a/pkg/util/lock_pool.go
+++ b/pkg/util/lock_pool.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"reflect"
+	"sync"
+)
+
+// LockPool is a synchronized set of maps that can be obtained with a provided
+// ID.
+type LockPool[K any, V sync.Locker] struct {
+	ool sync.Map
+}
+
+// Get returns the lock for the provided ID.
+func (p *LockPool[K, V]) Get(id K) sync.Locker {
+	if obj, ok := p.ool.Load(id); ok {
+		return obj.(V)
+	}
+
+	var (
+		v          V
+		objToStore any
+	)
+
+	tv := reflect.TypeOf(v)
+	if tv.Kind() == reflect.Pointer {
+		// Instantiate the type to which V points, ex. if V is a *sync.Mutex
+		// then we want to instantiate a sync.Mutex and use its address.
+		objToStore = reflect.New(tv.Elem()).Interface()
+	}
+
+	// If objToStore does not implement V then &objToStore will.
+	if _, ok := objToStore.(V); !ok {
+		objToStore = &objToStore
+	}
+
+	obj, _ := p.ool.LoadOrStore(id, objToStore)
+	return obj.(V)
+}
+
+// Delete removes the specified lock from the pool.
+func (p *LockPool[K, V]) Delete(id K) {
+	p.ool.Delete(id)
+}

--- a/pkg/util/lock_pool_test.go
+++ b/pkg/util/lock_pool_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package util_test
+
+import (
+	"sync"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/vmware-tanzu/vm-operator/pkg/util"
+)
+
+var _ = Describe("LockPoolTest", func() {
+	It("should obtain a lock", func() {
+		var lp util.LockPool[string, *sync.RWMutex]
+		l := lp.Get("hello")
+		Expect(l).ToNot(BeNil())
+	})
+	It("should return the same lock", func() {
+		var lp util.LockPool[string, *sync.RWMutex]
+		l1 := lp.Get("hello")
+		l2 := lp.Get("hello")
+		Expect(l1).To(BeIdenticalTo(l2))
+	})
+	It("should return different locks", func() {
+		var lp util.LockPool[string, *sync.RWMutex]
+		l1 := lp.Get("hello")
+		l2 := lp.Get("world")
+		Expect(l1).ToNot(BeIdenticalTo(l2))
+	})
+	It("should delete a lock then return a different lock for the same ID", func() {
+		var lp util.LockPool[string, *sync.RWMutex]
+		l1 := lp.Get("hello")
+		l2 := lp.Get("hello")
+		Expect(l1).To(BeIdenticalTo(l2))
+		lp.Delete("hello")
+		l2 = lp.Get("hello")
+		Expect(l1).ToNot(BeIdenticalTo(l2))
+	})
+})

--- a/pkg/vmprovider/fake/fake_vm_provider.go
+++ b/pkg/vmprovider/fake/fake_vm_provider.go
@@ -38,9 +38,9 @@ type funcs struct {
 	ListItemsFromContentLibraryFn              func(ctx context.Context, contentLibrary *v1alpha1.ContentLibraryProvider) ([]string, error)
 	GetVirtualMachineImageFromContentLibraryFn func(ctx context.Context, contentLibrary *v1alpha1.ContentLibraryProvider, itemID string,
 		currentCLImages map[string]v1alpha1.VirtualMachineImage) (*v1alpha1.VirtualMachineImage, error)
-	SyncVirtualMachineImageFn  func(ctx context.Context, itemID string, vmi client.Object) error
 	GetItemFromLibraryByNameFn func(ctx context.Context, contentLibrary, itemName string) (*library.Item, error)
 	UpdateContentLibraryItemFn func(ctx context.Context, itemID, newName string, newDescription *string) error
+	SyncVirtualMachineImageFn  func(ctx context.Context, cli, vmi client.Object) error
 
 	UpdateVcPNIDFn  func(ctx context.Context, vcPNID, vcPort string) error
 	ResetVcClientFn func(ctx context.Context)
@@ -223,12 +223,12 @@ func (s *VMProvider) GetVirtualMachineImageFromContentLibrary(ctx context.Contex
 	return nil, nil
 }
 
-func (s *VMProvider) SyncVirtualMachineImage(ctx context.Context, itemID string, vmi client.Object) error {
+func (s *VMProvider) SyncVirtualMachineImage(ctx context.Context, cli, vmi client.Object) error {
 	s.Lock()
 	defer s.Unlock()
 
 	if s.SyncVirtualMachineImageFn != nil {
-		return s.SyncVirtualMachineImageFn(ctx, itemID, vmi)
+		return s.SyncVirtualMachineImageFn(ctx, cli, vmi)
 	}
 
 	return nil

--- a/pkg/vmprovider/interface.go
+++ b/pkg/vmprovider/interface.go
@@ -37,9 +37,9 @@ type VirtualMachineProviderInterface interface {
 	ListItemsFromContentLibrary(ctx context.Context, contentLibrary *v1alpha1.ContentLibraryProvider) ([]string, error)
 	GetVirtualMachineImageFromContentLibrary(ctx context.Context, contentLibrary *v1alpha1.ContentLibraryProvider, itemID string,
 		currentCLImages map[string]v1alpha1.VirtualMachineImage) (*v1alpha1.VirtualMachineImage, error)
-	SyncVirtualMachineImage(ctx context.Context, itemID string, vmi client.Object) error
 	GetItemFromLibraryByName(ctx context.Context, contentLibrary, itemName string) (*library.Item, error)
 	UpdateContentLibraryItem(ctx context.Context, itemID, newName string, newDescription *string) error
+	SyncVirtualMachineImage(ctx context.Context, cli, vmi client.Object) error
 
 	GetTasksByActID(ctx context.Context, actID string) (tasksInfo []vimTypes.TaskInfo, retErr error)
 }

--- a/pkg/vmprovider/providers/vsphere/vmprovider_test.go
+++ b/pkg/vmprovider/providers/vsphere/vmprovider_test.go
@@ -4,9 +4,13 @@
 package vsphere_test
 
 import (
+	"sync"
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/vmware-tanzu/vm-operator/pkg/util"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
@@ -38,6 +42,47 @@ func cpuFreqTests() {
 	Context("ComputeCPUMinFrequency", func() {
 		It("returns success", func() {
 			Expect(vmProvider.ComputeCPUMinFrequency(ctx)).To(Succeed())
+		})
+	})
+}
+
+func initOvfCacheAndLockPoolTests() {
+
+	var (
+		expireAfter         = 3 * time.Second
+		checkExpireInterval = 1 * time.Second
+		maxItems            = 3
+
+		ovfCache    *util.Cache[vsphere.VersionedOVFEnvelope]
+		ovfLockPool *util.LockPool[string, *sync.RWMutex]
+	)
+
+	BeforeEach(func() {
+		ovfCache, ovfLockPool = vsphere.InitOvfCacheAndLockPool(
+			expireAfter, checkExpireInterval, maxItems)
+	})
+
+	AfterEach(func() {
+		ovfCache = nil
+		ovfLockPool = nil
+	})
+
+	Context("InitOvfCacheAndLockPool", func() {
+		It("should clean up lock pool when the item is expired in cache", func() {
+			Expect(ovfCache).ToNot(BeNil())
+			Expect(ovfLockPool).ToNot(BeNil())
+
+			itemID := "test-item-id"
+			res := ovfCache.Put(itemID, vsphere.VersionedOVFEnvelope{})
+			Expect(res).To(Equal(util.CachePutResultCreate))
+			curItemLock := ovfLockPool.Get(itemID)
+			Expect(curItemLock).ToNot(BeNil())
+
+			Eventually(func() bool {
+				// ovfLockPool.Get() returns a new lock if the item key is not found.
+				// So the lock should be different when the item is expired and deleted from pool.
+				return ovfLockPool.Get(itemID) != curItemLock
+			}, 5*time.Second, 1*time.Second).Should(BeTrue())
 		})
 	})
 }

--- a/pkg/vmprovider/providers/vsphere/vsphere_suite_test.go
+++ b/pkg/vmprovider/providers/vsphere/vsphere_suite_test.go
@@ -15,6 +15,7 @@ var suite = builder.NewTestSuite()
 
 func vcSimTests() {
 	Describe("CPUFreq", cpuFreqTests)
+	Describe("InitOvfCacheAndLockPool", initOvfCacheAndLockPoolTests)
 	Describe("ResourcePolicyTests", resourcePolicyTests)
 	Describe("VirtualMachine", vmTests)
 	Describe("VirtualMachineUtilsTest", vmUtilTests)


### PR DESCRIPTION
This patch introduces an in-memory cache to store and manage downloaded OVF for virtual machine images. It also cleans up stale cached items after a specified time (currently set to 30 minutes). This avoids unnecessary requests to vCenter when the same content library is associated with multiple namespaces within a cluster and speeds up vm image reconciliation time.

Testing Done:
- Internal kind-based e2e tests (both fast and full) passed
- Manually deployed this patch in a WCP testbed (with Image-Registry FSS enabled) and verified the expected workflow by associating a content library to multiple namespaces simultaneously. Logs from VM-Operator (in verbose mode):
```bash
I0207 09:15:21.266601       1 vmprovider.go:248] vsphere "msg"="Cache item miss, downloading OVF from vCenter" "contentVersion"="2" "itemID"="732f3e46-4699-4b66-aa6c-2740b0bfe6ed"
...
I0207 09:15:29.134953       1 vmprovider.go:264] vsphere "msg"="Cache item put" "contentVersion"="2" "itemID"="732f3e46-4699-4b66-aa6c-2740b0bfe6ed" "putResult"=1
I0207 09:15:29.135280       1 vmprovider.go:246] vsphere "msg"="Cache item hit, using cached OVF" "contentVersion"="2" "itemID"="732f3e46-4699-4b66-aa6c-2740b0bfe6ed"
I0207 09:15:29.136055       1 vmprovider.go:246] vsphere "msg"="Cache item hit, using cached OVF" "contentVersion"="2" "itemID"="732f3e46-4699-4b66-aa6c-2740b0bfe6ed"
```