### PR TITLE
Update uses of WCP_VM_Class_as_Config to DND

### DIFF
--- a/pkg/vmprovider/providers/vsphere/session/session_vm_create.go
+++ b/pkg/vmprovider/providers/vsphere/session/session_vm_create.go
@@ -69,7 +69,7 @@ func (s *Session) deployVMFromCL(
 		deploymentSpec.DefaultDatastoreID = createArgs.DatastoreMoID
 	}
 
-	if lib.IsVMClassAsConfigFSSEnabled() && createArgs.ConfigSpec != nil {
+	if lib.IsVMClassAsConfigFSSDaynDateEnabled() && createArgs.ConfigSpec != nil {
 		configSpecXML, err := util.MarshalConfigSpecToXML(createArgs.ConfigSpec)
 		if err != nil {
 			return nil, err

--- a/pkg/vmprovider/providers/vsphere/session/session_vm_update.go
+++ b/pkg/vmprovider/providers/vsphere/session/session_vm_update.go
@@ -56,7 +56,7 @@ type VMUpdateArgs struct {
 }
 
 func ethCardMatch(newBaseEthCard, curBaseEthCard vimTypes.BaseVirtualEthernetCard) bool {
-	if lib.IsVMClassAsConfigFSSEnabled() {
+	if lib.IsVMClassAsConfigFSSDaynDateEnabled() {
 		if reflect.TypeOf(curBaseEthCard) != reflect.TypeOf(newBaseEthCard) {
 			return false
 		}
@@ -542,7 +542,7 @@ func (s *Session) ensureNetworkInterfaces(
 	deviceKey := int32(-100)
 
 	var networkDevices []vimTypes.BaseVirtualDevice
-	if lib.IsVMClassAsConfigFSSEnabled() && configSpec != nil {
+	if lib.IsVMClassAsConfigFSSDaynDateEnabled() && configSpec != nil {
 		networkDevices = util.SelectDevicesByTypes(
 			util.DevicesFromConfigSpec(configSpec),
 			&vimTypes.VirtualE1000{},
@@ -568,7 +568,7 @@ func (s *Session) ensureNetworkInterfaces(
 			return nil, err
 		}
 
-		if lib.IsVMClassAsConfigFSSEnabled() {
+		if lib.IsVMClassAsConfigFSSDaynDateEnabled() {
 			// If VM Class-as-a-Config is supported, we use the network device from the Class.
 			// If the VM class doesn't specify enough number of network devices, we fall back to default behavior.
 			if i < len(networkDevices) {

--- a/pkg/vmprovider/providers/vsphere/session/session_vm_update_test.go
+++ b/pkg/vmprovider/providers/vsphere/session/session_vm_update_test.go
@@ -869,8 +869,8 @@ var _ = Describe("Update ConfigSpec", func() {
 			var oldVMClassAsConfigFunc func() bool
 
 			BeforeEach(func() {
-				oldVMClassAsConfigFunc = lib.IsVMClassAsConfigFSSEnabled
-				lib.IsVMClassAsConfigFSSEnabled = func() bool {
+				oldVMClassAsConfigFunc = lib.IsVMClassAsConfigFSSDaynDateEnabled
+				lib.IsVMClassAsConfigFSSDaynDateEnabled = func() bool {
 					return true
 				}
 				card1, err = object.EthernetCardTypes().CreateEthernetCard("vmxnet3", dvpg1)
@@ -885,7 +885,7 @@ var _ = Describe("Update ConfigSpec", func() {
 			})
 
 			AfterEach(func() {
-				lib.IsVMClassAsConfigFSSEnabled = oldVMClassAsConfigFunc
+				lib.IsVMClassAsConfigFSSDaynDateEnabled = oldVMClassAsConfigFunc
 			})
 
 			It("returns remove and add device changes", func() {

--- a/pkg/vmprovider/providers/vsphere/vmprovider_vm.go
+++ b/pkg/vmprovider/providers/vsphere/vmprovider_vm.go
@@ -542,7 +542,7 @@ func (vs *vSphereVMProvider) vmCreateGetPrereqs(
 		}
 	}
 
-	if lib.IsVMClassAsConfigFSSEnabled() {
+	if lib.IsVMClassAsConfigFSSDaynDateEnabled() {
 		if cs := createArgs.VMClass.Spec.ConfigSpec; cs != nil {
 			classConfigSpec, err := GetVMClassConfigSpec(cs)
 			if err != nil {
@@ -685,7 +685,7 @@ func (vs *vSphereVMProvider) vmUpdateGetArgs(
 		updateArgs.MinCPUFreq = freq
 	}
 
-	if lib.IsVMClassAsConfigFSSEnabled() {
+	if lib.IsVMClassAsConfigFSSDaynDateEnabled() {
 		if cs := updateArgs.VMClass.Spec.ConfigSpec; cs != nil {
 			classConfigSpec, err := GetVMClassConfigSpec(cs)
 			if err != nil {


### PR DESCRIPTION
This patch updates instances of the feature state switch from `WCP_VM_Class_as_Config` to the DaynDate variation. The original feature state switch is not removed entirely as it will be reused for a follow-up release.