### PR TITLE
Add PR labeler based on LoC

### DIFF
--- a/.github/configs/labeler.yml
+++ b/.github/configs/labeler.yml
@@ -1,17 +1,20 @@
 version: 1
 labels:
-  - label: "xsmall-diff"
+  - label: "size/XS"
     size-below: 10
-  - label: "small-diff"
+  - label: "size/S"
     size-above: 9
+    size-below: 30
+  - label: "size/M"
+    size-above: 29
     size-below: 100
-  - label: "medium-diff"
+  - label: "size/L"
     size-above: 99
     size-below: 500
-  - label: "large-diff"
+  - label: "size/XL"
     size-above: 499
     size-below: 1000
-  - label: "xlarge-diff"
+  - label: "size/XXL"
     size-above: 999
-  - label: "testing-required-internal-e2e"
+  - label: "testing-needed-e2e-fast"
     size-above: 99

--- a/.github/configs/labeler.yml
+++ b/.github/configs/labeler.yml
@@ -1,0 +1,17 @@
+version: 1
+labels:
+  - label: "xsmall-diff"
+    size-below: 10
+  - label: "small-diff"
+    size-above: 9
+    size-below: 100
+  - label: "medium-diff"
+    size-above: 99
+    size-below: 500
+  - label: "large-diff"
+    size-above: 499
+    size-below: 1000
+  - label: "xlarge-diff"
+    size-above: 999
+  - label: "testing-required-internal-e2e"
+    size-above: 99

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,3 +225,13 @@ jobs:
         path: |
           code-coverage-results.md
           pull_request_id
+
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      # https://github.com/marketplace/actions/pr-labeler-based-on-multiple-rules
+      - uses: srvaroa/labeler@v0.9
+        with:
+          config_path: .github/configs/labeler.yml
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,13 +225,3 @@ jobs:
         path: |
           code-coverage-results.md
           pull_request_id
-
-  label:
-    runs-on: ubuntu-latest
-    steps:
-      # https://github.com/marketplace/actions/pr-labeler-based-on-multiple-rules
-      - uses: srvaroa/labeler@v0.9
-        with:
-          config_path: .github/configs/labeler.yml
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,20 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    # Source: https://github.com/srvaroa/labeler
+    # Using this instead of the GH labeler action as the former supports labeling based on LoC changed.
+    # However, it doesn't work with regex pattern to ignore generated files (CRDs, docs, etc.) in diff.
+    # An issue has been filed https://github.com/srvaroa/labeler/issues/33 to track this improvement.
+    - uses: srvaroa/labeler@v0.9
+      with:
+        config_path: .github/configs/labeler.yml
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This patch adds a new GitHub action that automatically attaches labels to PRs based on their LoC.
It can also be served as a reminder for developers to conduct necessary testing for PRs with large LoC.

Testing Done:
- Updated my fork `main` branch with this change pushed
- Created a PR against my fork with different LoC changing
- Confirmed the labels are added/removed in the PR accordingly

Screenshot of the [above PR](https://github.com/dilyar85/vm-operator/pull/3) in my fork:
<img width="1240" alt="image" src="https://user-images.githubusercontent.com/10840560/215397478-fcd593c0-d5ef-4430-8989-5045a1eef42f.png">


