### PR TITLE
tkg: Propogate Supervisor DNS Search Suffixes for TKGs nodes

### DIFF
--- a/pkg/vmprovider/providers/vsphere/network/network_provider.go
+++ b/pkg/vmprovider/providers/vsphere/network/network_provider.go
@@ -103,9 +103,13 @@ type NetplanEthernetMatch struct {
 }
 type NetplanEthernetNameserver struct {
 	Addresses []string `yaml:"addresses,omitempty"`
+	Search    []string `yaml:"search,omitempty"`
 }
 
-func (l InterfaceInfoList) GetNetplan(currentEthCards object.VirtualDeviceList, dnsServers []string) Netplan {
+func (l InterfaceInfoList) GetNetplan(
+	currentEthCards object.VirtualDeviceList,
+	dnsServers, searchSuffixes []string) Netplan {
+
 	ethernets := make(map[string]NetplanEthernet)
 
 	for index, info := range l {
@@ -124,6 +128,7 @@ func (l InterfaceInfoList) GetNetplan(currentEthCards object.VirtualDeviceList, 
 
 		// Inject nameserver settings for each ethernet.
 		netplanEthernet.Nameservers.Addresses = dnsServers
+		netplanEthernet.Nameservers.Search = searchSuffixes
 		name := fmt.Sprintf("eth%d", index)
 		netplanEthernet.SetName = name
 		ethernets[name] = netplanEthernet

--- a/pkg/vmprovider/providers/vsphere/session/session_vm_customization.go
+++ b/pkg/vmprovider/providers/vsphere/session/session_vm_customization.go
@@ -220,7 +220,8 @@ func customizeCloudInit(
 		return nil, nil, err
 	}
 
-	netplan := updateArgs.NetIfList.GetNetplan(ethCards, updateArgs.DNSServers)
+	netplan := updateArgs.NetIfList.GetNetplan(
+		ethCards, updateArgs.DNSServers, updateArgs.SearchSuffixes)
 
 	cloudInitMetadata, err := GetCloudInitMetadata(vmCtx.VM, netplan, updateArgs.VMMetadata.Data)
 	if err != nil {

--- a/pkg/vmprovider/providers/vsphere/session/session_vm_customization_test.go
+++ b/pkg/vmprovider/providers/vsphere/session/session_vm_customization_test.go
@@ -219,6 +219,7 @@ var _ = Describe("CloudInitmetadata", func() {
 					Gateway4:  "192.168.1.1",
 					Nameservers: network.NetplanEthernetNameserver{
 						Addresses: []string{"8.8.8.8", "1.1.1.1"},
+						Search:    []string{"vmware.com", "example.com"},
 					},
 				},
 			},


### PR DESCRIPTION
This patch enables the automatic propogation of Supervisor DNS search suffixes for VMs created on behalf of Cluster API on Supervisor. If a VM has the label "capw.vmware.com/cluster.role" or "capv.vmware.com/cluster.role", then VM Operator will read the DNS search suffix information from the VM Op ConfigMap on Supervisor and use that information when constructing the netplan payload used to configure the VM's networking with Cloud-Init.

A few notes:

* This only works for TKGs nodes deployed with VM Op that set their bootstrap provider type to CloudInit in the VM Op VM resource.
* This is a band-aid until VM Op API is updated to express the full netplan configuration, at which point CAPV can use that to set DNS search suffixes when deploying VMs with VM Op.