### PR TITLE
Do not consider hardware spec and RLS settings in Update path

### DIFF
--- a/pkg/vmprovider/providers/vsphere/constants/constants.go
+++ b/pkg/vmprovider/providers/vsphere/constants/constants.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2021-2023 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package constants
@@ -15,6 +15,11 @@ const (
 
 	// VCVMAnnotation Annotation placed on the VM.
 	VCVMAnnotation = "Virtual Machine managed by the vSphere Virtual Machine service"
+
+	// ManagedByExtensionKey and ManagedByExtensionType represent the ManagedBy field on the VM.
+	// Historically, this field was used to differentiate VM Service managed VMs from traditional ones.
+	ManagedByExtensionKey  = "com.vmware.vcenter.wcp"
+	ManagedByExtensionType = "VirtualMachine"
 
 	// VMOperatorImageSupportedCheckKey Annotation key to skip validation checks of GuestOS Type
 	// TODO: Rename and move to vmoperator-api.

--- a/pkg/vmprovider/providers/vsphere/session/session_vm_update_test.go
+++ b/pkg/vmprovider/providers/vsphere/session/session_vm_update_test.go
@@ -200,11 +200,6 @@ var _ = Describe("Update ConfigSpec", func() {
 			session.UpdateHardwareConfigSpec(config, configSpec, vmClassSpec)
 		})
 
-		It("config spec is empty", func() {
-			Expect(configSpec.Annotation).ToNot(BeEmpty())
-			Expect(configSpec.ManagedBy).ToNot(BeNil())
-		})
-
 		Context("Updates Hardware", func() {
 			BeforeEach(func() {
 				vmClassSpec.Hardware.Cpus = 42

--- a/pkg/vmprovider/providers/vsphere/virtualmachine/configspec_test.go
+++ b/pkg/vmprovider/providers/vsphere/virtualmachine/configspec_test.go
@@ -91,7 +91,7 @@ var _ = Describe("CreateConfigSpec", func() {
 		It("Returns expected config spec", func() {
 			Expect(configSpec.Name).To(Equal(vmName))
 			Expect(configSpec.Annotation).ToNot(BeEmpty())
-			Expect(configSpec.Annotation).ToNot(Equal("test-annotation"))
+			Expect(configSpec.Annotation).To(Equal("test-annotation"))
 			Expect(configSpec.NumCPUs).To(BeEquivalentTo(vmClassSpec.Hardware.Cpus))
 			Expect(configSpec.MemoryMB).To(BeEquivalentTo(4 * 1024))
 			Expect(configSpec.CpuAllocation).ToNot(BeNil())
@@ -190,7 +190,7 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 
 		It("Placement ConfigSpec contains expected field set sans ethernet device from class config spec", func() {
 			Expect(configSpec.Annotation).ToNot(BeEmpty())
-			Expect(configSpec.Annotation).ToNot(Equal("test-annotation"))
+			Expect(configSpec.Annotation).To(Equal(classConfigSpec.Annotation))
 			Expect(configSpec.NumCPUs).To(BeEquivalentTo(vmClassSpec.Hardware.Cpus))
 			Expect(configSpec.MemoryMB).To(BeEquivalentTo(4 * 1024))
 			Expect(configSpec.CpuAllocation).ToNot(BeNil())

--- a/pkg/vmprovider/providers/vsphere/vmprovider_vm_test.go
+++ b/pkg/vmprovider/providers/vsphere/vmprovider_vm_test.go
@@ -73,20 +73,22 @@ func vmTests() {
 
 	Context("Create/Update/Delete VirtualMachine", func() {
 		var (
-			vm *vmopv1alpha1.VirtualMachine
+			vm      *vmopv1alpha1.VirtualMachine
+			vmClass *vmopv1alpha1.VirtualMachineClass
 		)
 
 		BeforeEach(func() {
 			testConfig.WithContentLibrary = true
+			vmClass = builder.DummyVirtualMachineClass()
 			vm = builder.DummyBasicVirtualMachine("test-vm", "")
 		})
 
 		AfterEach(func() {
+			vmClass = nil
 			vm = nil
 		})
 
 		JustBeforeEach(func() {
-			vmClass := builder.DummyVirtualMachineClass()
 			Expect(ctx.Client.Create(ctx, vmClass)).To(Succeed())
 
 			vmClassBinding := builder.DummyVirtualMachineClassBinding(vmClass.Name, nsInfo.Namespace)
@@ -209,6 +211,97 @@ func vmTests() {
 					Expect(vcVM.Properties(ctx, vcVM.Reference(), nil, &o)).To(Succeed())
 					Expect(o.Summary.Config.NumCpu).To(BeEquivalentTo(vmClass.Spec.Hardware.Cpus))
 					Expect(o.Summary.Config.MemorySizeMB).To(BeEquivalentTo(vmClass.Spec.Hardware.Memory.Value() / 1024 / 1024))
+				})
+			})
+
+			Context("ConfigSpec specifies hardware spec", func() {
+				BeforeEach(func() {
+					configSpec = &types.VirtualMachineConfigSpec{
+						Name:     "dummy-VM",
+						NumCPUs:  7,
+						MemoryMB: 5102,
+					}
+				})
+
+				It("CPU and memory from ConfigSpec are ignored", func() {
+					Expect(vm.Status.Phase).To(Equal(vmopv1alpha1.Created))
+
+					vmClass := &vmopv1alpha1.VirtualMachineClass{}
+					Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: vm.Spec.ClassName}, vmClass)).To(Succeed())
+
+					var o mo.VirtualMachine
+					Expect(vcVM.Properties(ctx, vcVM.Reference(), nil, &o)).To(Succeed())
+					Expect(o.Summary.Config.NumCpu).To(BeEquivalentTo(vmClass.Spec.Hardware.Cpus))
+					Expect(o.Summary.Config.NumCpu).To(Not(BeEquivalentTo(configSpec.NumCPUs)))
+					Expect(o.Summary.Config.MemorySizeMB).To(BeEquivalentTo(vmClass.Spec.Hardware.Memory.Value() / 1024 / 1024))
+					Expect(o.Summary.Config.MemorySizeMB).To(Not(BeEquivalentTo(configSpec.MemoryMB)))
+				})
+			})
+
+			Context("VM Class spec CPU reservations are zero and ConfigSpec specifies CPU reservation", func() {
+				BeforeEach(func() {
+					vmClass.Spec.Policies.Resources.Requests.Cpu = resource.MustParse("0")
+					vmClass.Spec.Policies.Resources.Limits.Cpu = resource.MustParse("0")
+
+					// Specify a CPU reservation via ConfigSpec
+					rsv := int64(6)
+					configSpec = &types.VirtualMachineConfigSpec{
+						Name: "dummy-VM",
+						CpuAllocation: &types.ResourceAllocationInfo{
+							Reservation: &rsv,
+						},
+					}
+				})
+
+				It("VM gets CPU reservation from ConfigSpec", func() {
+					Expect(vm.Status.Phase).To(Equal(vmopv1alpha1.Created))
+
+					vmClass := &vmopv1alpha1.VirtualMachineClass{}
+					Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: vm.Spec.ClassName}, vmClass)).To(Succeed())
+
+					var o mo.VirtualMachine
+					Expect(vcVM.Properties(ctx, vcVM.Reference(), nil, &o)).To(Succeed())
+
+					// Freq used by vcsim
+					const freq = 2294
+
+					reservation := o.Config.CpuAllocation.Reservation
+					vmClassCPURes := virtualmachine.CPUQuantityToMhz(vmClass.Spec.Policies.Resources.Requests.Memory, freq)
+					Expect(reservation).ToNot(BeNil())
+					Expect(reservation).To(Not(BeEquivalentTo(vmClassCPURes)))
+					Expect(reservation).To(Equal(configSpec.CpuAllocation.Reservation))
+				})
+			})
+
+			Context("VM Class spec Memory reservations are zero and ConfigSpec specifies memory reservation", func() {
+				BeforeEach(func() {
+					vmClass.Spec.Policies.Resources.Requests.Memory = resource.MustParse("0Mi")
+					vmClass.Spec.Policies.Resources.Limits.Memory = resource.MustParse("0Mi")
+
+					// Specify a Memory reservation via ConfigSpec
+					rsv := int64(5120)
+					configSpec = &types.VirtualMachineConfigSpec{
+						Name: "dummy-VM",
+						MemoryAllocation: &types.ResourceAllocationInfo{
+							Reservation: &rsv,
+						},
+					}
+				})
+
+				It("VM gets memory reservation from ConfigSpec", func() {
+					Expect(vm.Status.Phase).To(Equal(vmopv1alpha1.Created))
+
+					vmClass := &vmopv1alpha1.VirtualMachineClass{}
+					Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: vm.Spec.ClassName}, vmClass)).To(Succeed())
+
+					var o mo.VirtualMachine
+					Expect(vcVM.Properties(ctx, vcVM.Reference(), nil, &o)).To(Succeed())
+
+					reservation := o.Config.MemoryAllocation.Reservation
+					vmClassMemoryRes := virtualmachine.MemoryQuantityToMb(vmClass.Spec.Policies.Resources.Requests.Memory)
+					Expect(reservation).ToNot(BeNil())
+					Expect(*reservation).To(Not(Equal(vmClassMemoryRes)))
+					Expect(reservation).To(Equal(configSpec.MemoryAllocation.Reservation))
 				})
 			})
 


### PR DESCRIPTION
In update path of a VM reconcile, we reconfigure the VM to match the desired config specified in the VM Class.  This means that if a VM class is edited _after_ a VM has already been created from it, we will end up Reconfiguring the VM during next power cycle.  This was never a supported workflow and was just a by product of the original implementation.

With VM Class as Config, we are creating the VM with hardware spec and RLS settings specified form the VM class.  So, we don't need to update these during update.  This change preserves the behavior for clusters that do not have the feature enabled.

Testing Done:
- [x] Existing unit and integration tests
- [x] New tests added
- [x] end to end tests