### PR TITLE
Only add PCI passthrough devices from ConfigSpec if FSS is enabled

### DIFF
--- a/pkg/util/devices.go
+++ b/pkg/util/devices.go
@@ -125,17 +125,6 @@ func IsDeviceVGPU(dev vimTypes.BaseVirtualDevice) bool {
 	return false
 }
 
-// SelectVGPUs returns a slice of vGPUs.
-func SelectVGPUs(
-	devices []vimTypes.BaseVirtualDevice,
-) []*vimTypes.VirtualPCIPassthrough {
-
-	return SelectDevicesByDeviceAndBackingType[
-		*vimTypes.VirtualPCIPassthrough,
-		*vimTypes.VirtualPCIPassthroughVmiopBackingInfo,
-	](devices)
-}
-
 // IsDeviceDynamicDirectPathIO returns true if the provided device is a
 // dynamic direct path I/O device..
 func IsDeviceDynamicDirectPathIO(dev vimTypes.BaseVirtualDevice) bool {

--- a/pkg/util/devices_test.go
+++ b/pkg/util/devices_test.go
@@ -101,29 +101,6 @@ var _ = Describe("IsDeviceVGPU", func() {
 	})
 })
 
-var _ = Describe("SelectVGPUs", func() {
-	Context("selecting a vGPU", func() {
-		It("will return only the selected device type", func() {
-			devOut := util.SelectVGPUs(
-				[]vimTypes.BaseVirtualDevice{
-					newPCIPassthroughDevice(""),
-					&vimTypes.VirtualVmxnet3{},
-					newPCIPassthroughDevice("profile1"),
-					&vimTypes.VirtualSriovEthernetCard{},
-					newPCIPassthroughDevice(""),
-					newPCIPassthroughDevice("profile2"),
-				},
-			)
-			Expect(devOut).To(BeAssignableToTypeOf([]*vimTypes.VirtualPCIPassthrough{}))
-			Expect(devOut).To(HaveLen(2))
-			Expect(devOut[0].Backing).To(BeAssignableToTypeOf(&vimTypes.VirtualPCIPassthroughVmiopBackingInfo{}))
-			Expect(devOut[0]).To(BeEquivalentTo(newPCIPassthroughDevice("profile1")))
-			Expect(devOut[1].Backing).To(BeAssignableToTypeOf(&vimTypes.VirtualPCIPassthroughVmiopBackingInfo{}))
-			Expect(devOut[1]).To(BeEquivalentTo(newPCIPassthroughDevice("profile2")))
-		})
-	})
-})
-
 var _ = Describe("IsDeviceDynamicDirectPathIO", func() {
 	Context("a VGPU", func() {
 		It("will return false", func() {

--- a/pkg/vmprovider/providers/vsphere/virtualmachine/configspec.go
+++ b/pkg/vmprovider/providers/vsphere/virtualmachine/configspec.go
@@ -130,7 +130,7 @@ func CreateConfigSpecForPlacement(
 		},
 	})
 
-	for _, dev := range CreatePCIDevices(vmClassSpec.Hardware.Devices, nil) {
+	for _, dev := range CreatePCIDevicesFromVMClass(vmClassSpec.Hardware.Devices) {
 		configSpec.DeviceChange = append(configSpec.DeviceChange, &vimtypes.VirtualDeviceConfigSpec{
 			Operation: vimtypes.VirtualDeviceConfigSpecOperationAdd,
 			Device:    dev,


### PR DESCRIPTION
After VM Class as Config is enabled, a ConfigSpec is always expected to (mostly) accurately represent the desired set of devices.  This is done in part, by duplicating the vGPU and DirectPath devices from VM Class spec into the ConfigSpec.

Currently, we look at ConfigSpec /and/ the VM Class `spec.devices` field to determine what devices do we need to add to the VM.  This leads to the vGPU and DirectPath devices being added twice to the VM (since they are present in VM Class `spec.devices` field and are duplicated in ConfigSpec).

This change fixes this behavior by only looking at the ConfigSpec when the FSS is enabled.

Testing Done:
- [X] Existing Unit and Integration tests
- [X] Added new tests
- [x] e2e tests