### PR TITLE
Fix nil map in UpdateVirtualMachine

### DIFF
--- a/pkg/vmprovider/providers/vsphere/session/session_vm_update.go
+++ b/pkg/vmprovider/providers/vsphere/session/session_vm_update.go
@@ -850,6 +850,9 @@ func (s *Session) UpdateVirtualMachine(
 			if err != nil {
 				return err
 			}
+			if vmCtx.VM.Annotations == nil {
+				vmCtx.VM.Annotations = map[string]string{}
+			}
 			vmCtx.VM.Annotations[FirstBootDoneAnnotation] = "true"
 		} else {
 			// don't pass classConfigSpec to poweredOnVMReconfigure when VM is already powered on


### PR DESCRIPTION
If the vm. Annotations is nil, and assign entry to it will cause panic. This PR fix this issue by adding a check before assigning.