### PR TITLE
Convert network provider tests to vcsim test context

### DIFF
--- a/pkg/vmprovider/providers/vsphere/network/network_provider.go
+++ b/pkg/vmprovider/providers/vsphere/network/network_provider.go
@@ -122,7 +122,7 @@ func (l InterfaceInfoList) GetNetplan(
 
 			// NetOp (VDS) never assigns MacAddress to the NetworkInterface status, therefore
 			// netplanEthernet.Match.MacAddress will be empty.
-			// At this point, it is assumed that VirtuaLMachine.Config.Hardware.Device has MacAddress generated.
+			// At this point, it is assumed that VirtualMachine.Config.Hardware.Device has MacAddress generated.
 			netplanEthernet.Match.MacAddress = NormalizeNetplanMac(curNic.GetVirtualEthernetCard().MacAddress)
 		}
 

--- a/pkg/vmprovider/providers/vsphere/network/network_provider_test.go
+++ b/pkg/vmprovider/providers/vsphere/network/network_provider_test.go
@@ -4,24 +4,16 @@
 package network_test
 
 import (
-	goctx "context"
 	"fmt"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	ctrlruntime "sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/vmware/govmomi"
-	"github.com/vmware/govmomi/find"
-	"github.com/vmware/govmomi/object"
-	"github.com/vmware/govmomi/simulator"
-	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/types"
 
 	"github.com/vmware-tanzu/vm-operator/api/v1alpha1"
@@ -37,49 +29,24 @@ import (
 var _ = Describe("NetworkProvider", func() {
 
 	const (
-		dummyObjectName     = "dummy-object"
-		dummyNamespace      = "dummy-ns"
-		dummyNsxSwitchID    = "dummy-opaque-network-id"
-		macAddress          = "01-23-45-67-89-AB-CD-EF"
-		interfaceID         = "interface-id"
-		dummyVirtualNetwork = "dummy-virtual-net"
-		vcsimPortGroup      = "dvportgroup-11"
-		vcsimNetworkName    = "DC0_DVPG0"
-		dummyNetIfName      = "dummy-netIf-name"
-		doesNotExist        = "does-not-exist"
+		macAddress     = "01-23-45-67-89-AB-CD-EF"
+		interfaceID    = "interface-id"
+		vcsimPortGroup = "dvportgroup-11"
+		dummyNetIfName = "dummy-netIf-name"
+		doesNotExist   = "does-not-exist"
 	)
 
 	var (
-		ctx       goctx.Context
-		name      string
-		namespace string
+		testConfig builder.VCSimTestConfig
+		ctx        *builder.TestContextForVCSim
 
-		c          *govmomi.Client
-		finder     *find.Finder
-		cluster    *object.ClusterComputeResource
-		networkObj object.NetworkReference
-
-		vmNif *v1alpha1.VirtualMachineNetworkInterface
 		vm    *v1alpha1.VirtualMachine
 		vmCtx context.VirtualMachineContext
-
-		np network.Provider
+		np    network.Provider
 	)
 
-	createInterface := func(ctx goctx.Context, c *vim25.Client, k8sClient ctrlruntime.Client, _ *runtime.Scheme) {
-		finder := find.NewFinder(c)
-		cluster, err := finder.DefaultClusterComputeResource(ctx)
-		Expect(err).ToNot(HaveOccurred())
-
-		net, err := finder.Network(ctx, "DC0_DVPG0")
-		Expect(err).ToNot(HaveOccurred())
-		dvpg := simulator.Map.Get(net.Reference()).(*simulator.DistributedVirtualPortgroup)
-		dvpg.Config.LogicalSwitchUuid = dummyNsxSwitchID // Convert to an NSX backed PG
-		dvpg.Config.BackingType = "nsx"
-
-		np = network.NewProvider(k8sClient, c, finder, cluster)
-
-		info, err := np.EnsureNetworkInterface(vmCtx, vmNif)
+	createInterface := func(_ *builder.TestContextForVCSim) {
+		info, err := np.EnsureNetworkInterface(vmCtx, &vmCtx.VM.Spec.NetworkInterfaces[0])
 		Expect(err).ToNot(HaveOccurred())
 		Expect(info).NotTo(BeNil())
 
@@ -91,39 +58,23 @@ var _ = Describe("NetworkProvider", func() {
 	}
 
 	BeforeEach(func() {
-		var err error
-		ctx = goctx.TODO()
-		name = dummyObjectName
-		namespace = dummyNamespace
-
-		c, err = govmomi.NewClient(ctx, server.URL, true)
-		Expect(err).ToNot(HaveOccurred())
-		finder = find.NewFinder(c.Client)
-		dc, err := finder.DefaultDatacenter(ctx)
-		Expect(err).ToNot(HaveOccurred())
-		finder.SetDatacenter(dc)
-
-		cluster, err = finder.DefaultClusterComputeResource(ctx)
-		Expect(err).ToNot(HaveOccurred())
-
-		networkObj, err = finder.Network(ctx, vcsimNetworkName)
-		Expect(err).ToNot(HaveOccurred())
-
-		vmNif = &v1alpha1.VirtualMachineNetworkInterface{
-			NetworkName: vcsimNetworkName,
-		}
+		testConfig = builder.VCSimTestConfig{}
 
 		vm = &v1alpha1.VirtualMachine{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: namespace,
+				Name:      "network-provider-test-vm",
+				Namespace: "network-provider-test-ns",
 			},
 			Spec: v1alpha1.VirtualMachineSpec{
 				NetworkInterfaces: []v1alpha1.VirtualMachineNetworkInterface{
-					*vmNif,
+					{},
 				},
 			},
 		}
+	})
+
+	JustBeforeEach(func() {
+		ctx = suite.NewTestContextForVCSim(testConfig)
 
 		vmCtx = context.VirtualMachineContext{
 			Context: ctx,
@@ -132,16 +83,25 @@ var _ = Describe("NetworkProvider", func() {
 		}
 	})
 
+	AfterEach(func() {
+		ctx.AfterEach()
+		ctx = nil
+		np = nil
+	})
+
 	Context("Named Network Provider", func() {
 		BeforeEach(func() {
-			k8sClient := builder.NewFakeClient()
-			np = network.NewProvider(k8sClient, nil, finder, nil)
+			vm.Spec.NetworkInterfaces[0].NetworkName = "DC0_DVPG0"
+		})
+
+		JustBeforeEach(func() {
+			np = network.NewProvider(ctx.Client, ctx.VCClient.Client, ctx.Finder, nil)
 		})
 
 		Context("ensure interface", func() {
 
 			It("create expected virtual device", func() {
-				info, err := np.EnsureNetworkInterface(vmCtx, vmNif)
+				info, err := np.EnsureNetworkInterface(vmCtx, &vmCtx.VM.Spec.NetworkInterfaces[0])
 				Expect(err).ToNot(HaveOccurred())
 				Expect(info).NotTo(BeNil())
 
@@ -150,20 +110,19 @@ var _ = Describe("NetworkProvider", func() {
 				Expect(backing).NotTo(BeNil())
 				backingInfo, ok := backing.(*types.VirtualEthernetCardDistributedVirtualPortBackingInfo)
 				Expect(ok).To(BeTrue())
-				Expect(backingInfo.Port.PortgroupKey).To(Equal(networkObj.Reference().Value))
+				Expect(backingInfo.Port.PortgroupKey).To(Equal(ctx.NetworkRef.Reference().Value))
 			})
 
 			It("create expected interface customization", func() {
-				info, err := np.EnsureNetworkInterface(vmCtx, vmNif)
+				info, err := np.EnsureNetworkInterface(vmCtx, &vmCtx.VM.Spec.NetworkInterfaces[0])
 				Expect(err).ToNot(HaveOccurred())
 				Expect(info.Customization).ToNot(BeNil())
 				Expect(info.Customization.Adapter.Ip).To(BeAssignableToTypeOf(&types.CustomizationDhcpIpGenerator{}))
 			})
 
 			It("should return an error if network does not exist", func() {
-				_, err := np.EnsureNetworkInterface(vmCtx, &v1alpha1.VirtualMachineNetworkInterface{
-					NetworkName: doesNotExist,
-				})
+				vmCtx.VM.Spec.NetworkInterfaces[0].NetworkName = doesNotExist
+				_, err := np.EnsureNetworkInterface(vmCtx, &vmCtx.VM.Spec.NetworkInterfaces[0])
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(MatchError(fmt.Sprintf("unable to find network \"%s\": network '%s' not found", doesNotExist, doesNotExist)))
 			})
@@ -171,24 +130,28 @@ var _ = Describe("NetworkProvider", func() {
 	})
 
 	Context("NetOP Network Provider", func() {
+		const (
+			networkName = "netop-network"
+		)
+
 		var (
-			k8sClient ctrlruntime.Client
-			scheme    *runtime.Scheme
-			netIf     *netopv1alpha1.NetworkInterface
-			dummyIP   = "192.168.100.20"
+			netIf   *netopv1alpha1.NetworkInterface
+			dummyIP = "192.168.100.20"
 		)
 
 		BeforeEach(func() {
-			vmNif.NetworkType = network.VdsNetworkType
+			testConfig.WithNetworkEnv = builder.NetworkEnvVDS
+
 			vm.Spec.NetworkInterfaces[0].NetworkType = network.VdsNetworkType
+			vm.Spec.NetworkInterfaces[0].NetworkName = networkName
 
 			netIf = &netopv1alpha1.NetworkInterface{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("%s-%s", vmNif.NetworkName, vm.Name),
-					Namespace: dummyNamespace,
+					Name:      fmt.Sprintf("%s-%s", vm.Spec.NetworkInterfaces[0].NetworkName, vm.Name),
+					Namespace: vm.Namespace,
 				},
 				Spec: netopv1alpha1.NetworkInterfaceSpec{
-					NetworkName: dummyVirtualNetwork,
+					NetworkName: networkName,
 					Type:        netopv1alpha1.NetworkInterfaceTypeVMXNet3,
 				},
 				Status: netopv1alpha1.NetworkInterfaceStatus{
@@ -212,24 +175,24 @@ var _ = Describe("NetworkProvider", func() {
 		})
 
 		JustBeforeEach(func() {
-			k8sClient = builder.NewFakeClient(netIf)
-			np = network.NewProvider(k8sClient, c.Client, finder, cluster)
+			Expect(ctx.Client.Create(ctx, netIf)).To(Succeed())
+			np = network.NewProvider(ctx.Client, ctx.VCClient.Client, ctx.Finder, ctx.GetSingleClusterCompute())
 		})
 
 		Context("ensure interface", func() {
 
 			// Long test due to poll timeout.
 			It("create netop network interface object", func() {
-				Expect(k8sClient.Delete(ctx, netIf)).To(Succeed())
+				Expect(ctx.Client.Delete(ctx, netIf)).To(Succeed())
 
-				_, err := np.EnsureNetworkInterface(vmCtx, vmNif)
+				_, err := np.EnsureNetworkInterface(vmCtx, &vmCtx.VM.Spec.NetworkInterfaces[0])
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(MatchError(wait.ErrWaitTimeout))
 
 				instance := &netopv1alpha1.NetworkInterface{}
-				err = k8sClient.Get(ctx, ctrlruntime.ObjectKey{Name: netIf.Name, Namespace: netIf.Namespace}, instance)
+				err = ctx.Client.Get(ctx, ctrlruntime.ObjectKeyFromObject(netIf), instance)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(instance.Spec.NetworkName).To(Equal(vcsimNetworkName))
+				Expect(instance.Spec.NetworkName).To(Equal(networkName))
 
 				Expect(instance.OwnerReferences).To(HaveLen(1))
 				Expect(instance.OwnerReferences[0].Name).To(Equal(vm.Name))
@@ -241,7 +204,7 @@ var _ = Describe("NetworkProvider", func() {
 				})
 
 				It("should return an error", func() {
-					_, err := np.EnsureNetworkInterface(vmCtx, vmNif)
+					_, err := np.EnsureNetworkInterface(vmCtx, &vmCtx.VM.Spec.NetworkInterfaces[0])
 					Expect(err).NotTo(BeNil())
 					Expect(err.Error()).To(ContainSubstring("unable to get ethernet card backing info for network DistributedVirtualPortgroup::"))
 				})
@@ -253,7 +216,7 @@ var _ = Describe("NetworkProvider", func() {
 				})
 
 				It("should return an error", func() {
-					_, err := np.EnsureNetworkInterface(vmCtx, vmNif)
+					_, err := np.EnsureNetworkInterface(vmCtx, &vmCtx.VM.Spec.NetworkInterfaces[0])
 					Expect(err).To(MatchError("timed out waiting for the condition"))
 				})
 			})
@@ -264,7 +227,7 @@ var _ = Describe("NetworkProvider", func() {
 				})
 
 				It("should return an error", func() {
-					_, err := np.EnsureNetworkInterface(vmCtx, vmNif)
+					_, err := np.EnsureNetworkInterface(vmCtx, &vmCtx.VM.Spec.NetworkInterfaces[0])
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("unable to get ethernet card backing info for network DistributedVirtualPortgroup:" + doesNotExist))
 				})
@@ -272,24 +235,24 @@ var _ = Describe("NetworkProvider", func() {
 
 			Context("when the network name is not specified", func() {
 				BeforeEach(func() {
-					vmNif.NetworkName = ""
 					netIf.Name = vm.Name
+					vm.Spec.NetworkInterfaces[0].NetworkName = ""
 				})
 
 				It("should succeed", func() {
-					info, err := np.EnsureNetworkInterface(vmCtx, vmNif)
+					info, err := np.EnsureNetworkInterface(vmCtx, &vmCtx.VM.Spec.NetworkInterfaces[0])
 					Expect(err).ToNot(HaveOccurred())
 					Expect(info).NotTo(BeNil())
 
 					instance := &netopv1alpha1.NetworkInterface{}
-					err = k8sClient.Get(ctx, ctrlruntime.ObjectKeyFromObject(netIf), instance)
+					err = ctx.Client.Get(ctx, ctrlruntime.ObjectKeyFromObject(netIf), instance)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(instance.Spec.NetworkName).To(Equal(""))
 				})
 			})
 
 			It("should succeed", func() {
-				info, err := np.EnsureNetworkInterface(vmCtx, vmNif)
+				info, err := np.EnsureNetworkInterface(vmCtx, &vmCtx.VM.Spec.NetworkInterfaces[0])
 				Expect(err).ToNot(HaveOccurred())
 				Expect(info).NotTo(BeNil())
 
@@ -312,7 +275,7 @@ var _ = Describe("NetworkProvider", func() {
 				})
 
 				It("should succeed with generated mac", func() {
-					info, err := np.EnsureNetworkInterface(vmCtx, vmNif)
+					info, err := np.EnsureNetworkInterface(vmCtx, &vmCtx.VM.Spec.NetworkInterfaces[0])
 					Expect(err).ToNot(HaveOccurred())
 					Expect(info).NotTo(BeNil())
 
@@ -328,17 +291,16 @@ var _ = Describe("NetworkProvider", func() {
 			Context("with NetworkInterfaceProvider Referenced in vmNif", func() {
 				BeforeEach(func() {
 					netIf.Name = dummyNetIfName
-					vmNif.ProviderRef = &v1alpha1.NetworkInterfaceProviderReference{
+					vm.Spec.NetworkInterfaces[0].ProviderRef = &v1alpha1.NetworkInterfaceProviderReference{
 						APIGroup:   "netoperator.vmware.com",
 						APIVersion: "v1alpha1",
 						Kind:       "NetworkInterface",
 						Name:       dummyNetIfName,
 					}
-					vm.Spec.NetworkInterfaces[0] = *vmNif
 				})
 
 				It("should succeed", func() {
-					info, err := np.EnsureNetworkInterface(vmCtx, vmNif)
+					info, err := np.EnsureNetworkInterface(vmCtx, &vmCtx.VM.Spec.NetworkInterfaces[0])
 					Expect(err).ToNot(HaveOccurred())
 					Expect(info).NotTo(BeNil())
 
@@ -357,12 +319,11 @@ var _ = Describe("NetworkProvider", func() {
 
 				Context("referencing wrong netIf name", func() {
 					BeforeEach(func() {
-						vmNif.ProviderRef.Name = doesNotExist
-						vm.Spec.NetworkInterfaces[0] = *vmNif
+						vm.Spec.NetworkInterfaces[0].ProviderRef.Name = doesNotExist
 					})
 
 					It("should return an error", func() {
-						_, err := np.EnsureNetworkInterface(vmCtx, vmNif)
+						_, err := np.EnsureNetworkInterface(vmCtx, &vmCtx.VM.Spec.NetworkInterfaces[0])
 						Expect(err).To(HaveOccurred())
 						Expect(err.Error()).To(ContainSubstring("timed out waiting for the condition"))
 					})
@@ -370,14 +331,16 @@ var _ = Describe("NetworkProvider", func() {
 
 				Context("referencing unsupported GVK", func() {
 					BeforeEach(func() {
-						vmNif.ProviderRef.APIVersion = "unsupported-version"
-						vmNif.ProviderRef.APIGroup = "unsupported-group"
-						vmNif.ProviderRef.Kind = "unsupported-kind"
-						vm.Spec.NetworkInterfaces[0] = *vmNif
+						vm.Spec.NetworkInterfaces[0].ProviderRef = &v1alpha1.NetworkInterfaceProviderReference{
+							APIGroup:   "unsupported-group",
+							APIVersion: "unsupported-version",
+							Kind:       "unsupported-kind",
+							Name:       dummyNetIfName,
+						}
 					})
 
 					It("should return an error", func() {
-						_, err := np.EnsureNetworkInterface(vmCtx, vmNif)
+						_, err := np.EnsureNetworkInterface(vmCtx, &vmCtx.VM.Spec.NetworkInterfaces[0])
 						Expect(err).To(HaveOccurred())
 						Expect(err.Error()).To(ContainSubstring("unsupported NetworkInterface ProviderRef"))
 					})
@@ -386,33 +349,29 @@ var _ = Describe("NetworkProvider", func() {
 
 			Context("with NSX-T NetworkType in ProviderRef", func() {
 				BeforeEach(func() {
-					vmNif.NetworkType = network.NsxtNetworkType
+					testConfig.WithNetworkEnv = builder.NetworkEnvNSXT
+
 					netIf.Name = dummyNetIfName
-					netIf.Status.NetworkID = dummyNsxSwitchID
+					netIf.Status.NetworkID = builder.NsxTLogicalSwitchUUID
 					netIf.Status.IPConfigs = nil
 
-					vmNif.ProviderRef = &v1alpha1.NetworkInterfaceProviderReference{
+					vm.Spec.NetworkInterfaces[0].NetworkType = network.NsxtNetworkType
+					vm.Spec.NetworkInterfaces[0].ProviderRef = &v1alpha1.NetworkInterfaceProviderReference{
 						APIGroup:   "netoperator.vmware.com",
 						APIVersion: "v1alpha1",
 						Kind:       "NetworkInterface",
 						Name:       dummyNetIfName,
 					}
-					vm.Spec.NetworkInterfaces[0] = *vmNif
 				})
 
 				Context("should succeed", func() {
 
 					It("with no provider IP configuration", func() {
-						res := simulator.VPX().Run(func(ctx goctx.Context, c *vim25.Client) error {
-							createInterface(ctx, c, k8sClient, scheme)
+						createInterface(ctx)
 
-							info, err := np.EnsureNetworkInterface(vmCtx, vmNif)
-							Expect(err).ToNot(HaveOccurred())
-							Expect(info.Customization.Adapter.Ip).To(BeAssignableToTypeOf(&types.CustomizationDhcpIpGenerator{}))
-
-							return nil
-						})
-						Expect(res).To(BeNil())
+						info, err := np.EnsureNetworkInterface(vmCtx, &vmCtx.VM.Spec.NetworkInterfaces[0])
+						Expect(err).ToNot(HaveOccurred())
+						Expect(info.Customization.Adapter.Ip).To(BeAssignableToTypeOf(&types.CustomizationDhcpIpGenerator{}))
 					})
 				})
 			})
@@ -423,7 +382,7 @@ var _ = Describe("NetworkProvider", func() {
 					BeforeEach(func() { netIf.Status.IPConfigs = nil })
 
 					It("dhcp customization", func() {
-						info, err := np.EnsureNetworkInterface(vmCtx, vmNif)
+						info, err := np.EnsureNetworkInterface(vmCtx, &vmCtx.VM.Spec.NetworkInterfaces[0])
 						Expect(err).ToNot(HaveOccurred())
 						Expect(info.Customization.Adapter.Ip).To(BeAssignableToTypeOf(&types.CustomizationDhcpIpGenerator{}))
 					})
@@ -442,7 +401,7 @@ var _ = Describe("NetworkProvider", func() {
 					})
 
 					It("fixed ipv4 customization", func() {
-						info, err := np.EnsureNetworkInterface(vmCtx, vmNif)
+						info, err := np.EnsureNetworkInterface(vmCtx, &vmCtx.VM.Spec.NetworkInterfaces[0])
 						Expect(err).ToNot(HaveOccurred())
 						Expect(info.Customization.Adapter.Ip).To(BeAssignableToTypeOf(&types.CustomizationFixedIp{}))
 						fixedIP := info.Customization.Adapter.Ip.(*types.CustomizationFixedIp)
@@ -463,7 +422,7 @@ var _ = Describe("NetworkProvider", func() {
 					})
 
 					It("fixed ipv6 customization", func() {
-						info, err := np.EnsureNetworkInterface(vmCtx, vmNif)
+						info, err := np.EnsureNetworkInterface(vmCtx, &vmCtx.VM.Spec.NetworkInterfaces[0])
 						Expect(err).ToNot(HaveOccurred())
 						Expect(info.Customization.Adapter.IpV6Spec).To(BeAssignableToTypeOf(&types.CustomizationIPSettingsIpV6AddressSpec{}))
 						Expect(info.Customization.Adapter.IpV6Spec.Ip).To(HaveLen(1))
@@ -479,7 +438,7 @@ var _ = Describe("NetworkProvider", func() {
 					BeforeEach(func() { netIf.Status.IPConfigs = nil })
 
 					It("dhcp should be True", func() {
-						info, err := np.EnsureNetworkInterface(vmCtx, vmNif)
+						info, err := np.EnsureNetworkInterface(vmCtx, &vmCtx.VM.Spec.NetworkInterfaces[0])
 						Expect(err).ToNot(HaveOccurred())
 						Expect(info.NetplanEthernet.Dhcp4).To(BeTrue())
 					})
@@ -503,12 +462,13 @@ var _ = Describe("NetworkProvider", func() {
 					})
 
 					It("NetplanEthernet with ipv4 customization", func() {
-						info, err := np.EnsureNetworkInterface(vmCtx, vmNif)
+						info, err := np.EnsureNetworkInterface(vmCtx, &vmCtx.VM.Spec.NetworkInterfaces[0])
 						Expect(err).ToNot(HaveOccurred())
 						Expect(info.NetplanEthernet.Dhcp4).To(BeFalse())
 						Expect(info.NetplanEthernet.Match.MacAddress).To(Equal(network.NormalizeNetplanMac(netIf.Status.MacAddress)))
 						Expect(info.NetplanEthernet.Gateway4).ToNot(BeEmpty())
 						Expect(info.NetplanEthernet.Gateway4).To(Equal(netIf.Status.IPConfigs[0].Gateway))
+						Expect(info.NetplanEthernet.Addresses).To(HaveLen(1))
 						Expect(info.NetplanEthernet.Addresses[0]).To(Equal(expectedCidrNotation))
 					})
 				})
@@ -517,54 +477,58 @@ var _ = Describe("NetworkProvider", func() {
 	})
 
 	Context("NSX-T Network Provider", func() {
+		const (
+			networkName = "ncp-network"
+		)
+
 		var (
-			k8sClient ctrlruntime.Client
-			ncpVif    *ncpv1alpha1.VirtualNetworkInterface
-			scheme    *runtime.Scheme
+			ncpVif *ncpv1alpha1.VirtualNetworkInterface
 		)
 
 		BeforeEach(func() {
-			vmNif.NetworkType = network.NsxtNetworkType
+			testConfig.WithNetworkEnv = builder.NetworkEnvNSXT
+
 			vm.Spec.NetworkInterfaces[0].NetworkType = network.NsxtNetworkType
+			vm.Spec.NetworkInterfaces[0].NetworkName = networkName
 
 			ncpVif = &ncpv1alpha1.VirtualNetworkInterface{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("%s-%s-lsp", vmNif.NetworkName, vm.Name),
-					Namespace: dummyNamespace,
+					Name:      fmt.Sprintf("%s-%s-lsp", vm.Spec.NetworkInterfaces[0].NetworkName, vm.Name),
+					Namespace: vm.Namespace,
 				},
 				Spec: ncpv1alpha1.VirtualNetworkInterfaceSpec{
-					VirtualNetwork: dummyVirtualNetwork,
+					VirtualNetwork: networkName,
 				},
 				Status: ncpv1alpha1.VirtualNetworkInterfaceStatus{
 					MacAddress:  macAddress,
 					InterfaceID: interfaceID,
 					Conditions:  []ncpv1alpha1.VirtualNetworkCondition{{Type: "Ready", Status: "True"}},
 					ProviderStatus: &ncpv1alpha1.VirtualNetworkInterfaceProviderStatus{
-						NsxLogicalSwitchID: dummyNsxSwitchID,
+						NsxLogicalSwitchID: builder.NsxTLogicalSwitchUUID,
 					},
 				},
 			}
 		})
 
 		JustBeforeEach(func() {
-			k8sClient = builder.NewFakeClient(ncpVif)
-			np = network.NewProvider(k8sClient, c.Client, finder, cluster)
+			Expect(ctx.Client.Create(ctx, ncpVif)).To(Succeed())
+			np = network.NewProvider(ctx.Client, ctx.VCClient.Client, ctx.Finder, ctx.GetSingleClusterCompute())
 		})
 
 		Context("ensure interface", func() {
 
 			// Long test due to poll timeout.
 			It("create ncp virtual network interface object", func() {
-				Expect(k8sClient.Delete(ctx, ncpVif)).To(Succeed())
+				Expect(ctx.Client.Delete(ctx, ncpVif)).To(Succeed())
 
-				_, err := np.EnsureNetworkInterface(vmCtx, vmNif)
+				_, err := np.EnsureNetworkInterface(vmCtx, &vmCtx.VM.Spec.NetworkInterfaces[0])
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(MatchError(wait.ErrWaitTimeout))
 
 				instance := &ncpv1alpha1.VirtualNetworkInterface{}
-				err = k8sClient.Get(ctx, ctrlruntime.ObjectKey{Name: ncpVif.Name, Namespace: ncpVif.Namespace}, instance)
+				err = ctx.Client.Get(ctx, ctrlruntime.ObjectKeyFromObject(ncpVif), instance)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(instance.Spec.VirtualNetwork).To(Equal(vcsimNetworkName))
+				Expect(instance.Spec.VirtualNetwork).To(Equal(networkName))
 
 				Expect(instance.OwnerReferences).To(HaveLen(1))
 				Expect(instance.OwnerReferences[0].Name).To(Equal(vm.Name))
@@ -578,7 +542,7 @@ var _ = Describe("NetworkProvider", func() {
 				})
 
 				It("should return an error", func() {
-					_, err := np.EnsureNetworkInterface(vmCtx, vmNif)
+					_, err := np.EnsureNetworkInterface(vmCtx, &vmCtx.VM.Spec.NetworkInterfaces[0])
 					Expect(err).NotTo(BeNil())
 					Expect(err.Error()).To(ContainSubstring("failed to get for nsx-t opaque network ID for vnetIf '"))
 				})
@@ -590,7 +554,7 @@ var _ = Describe("NetworkProvider", func() {
 				})
 
 				It("should return an error", func() {
-					_, err := np.EnsureNetworkInterface(vmCtx, vmNif)
+					_, err := np.EnsureNetworkInterface(vmCtx, &vmCtx.VM.Spec.NetworkInterfaces[0])
 					Expect(err).NotTo(BeNil())
 					Expect(err.Error()).To(ContainSubstring("failed to get for nsx-t opaque network ID for vnetIf '"))
 				})
@@ -602,7 +566,7 @@ var _ = Describe("NetworkProvider", func() {
 				})
 
 				It("should return an error", func() {
-					_, err := np.EnsureNetworkInterface(vmCtx, vmNif)
+					_, err := np.EnsureNetworkInterface(vmCtx, &vmCtx.VM.Spec.NetworkInterfaces[0])
 					Expect(err).To(MatchError("timed out waiting for the condition"))
 				})
 			})
@@ -613,7 +577,7 @@ var _ = Describe("NetworkProvider", func() {
 				})
 
 				It("should return an error", func() {
-					_, err := np.EnsureNetworkInterface(vmCtx, vmNif)
+					_, err := np.EnsureNetworkInterface(vmCtx, &vmCtx.VM.Spec.NetworkInterfaces[0])
 					Expect(err).To(MatchError(fmt.Sprintf("opaque network with ID '%s' not found", doesNotExist)))
 				})
 			})
@@ -621,17 +585,12 @@ var _ = Describe("NetworkProvider", func() {
 			Context("should succeed", func() {
 
 				It("with no provider IP configuration", func() {
-					res := simulator.VPX().Run(func(ctx goctx.Context, c *vim25.Client) error {
-						createInterface(ctx, c, k8sClient, scheme)
+					createInterface(ctx)
 
-						info, err := np.EnsureNetworkInterface(vmCtx, vmNif)
-						Expect(err).ToNot(HaveOccurred())
-						Expect(info.Customization.Adapter.Ip).To(BeAssignableToTypeOf(&types.CustomizationDhcpIpGenerator{}))
-						Expect(info.NetplanEthernet.Dhcp4).To(BeTrue())
-
-						return nil
-					})
-					Expect(res).To(BeNil())
+					info, err := np.EnsureNetworkInterface(vmCtx, &vmCtx.VM.Spec.NetworkInterfaces[0])
+					Expect(err).ToNot(HaveOccurred())
+					Expect(info.Customization.Adapter.Ip).To(BeAssignableToTypeOf(&types.CustomizationDhcpIpGenerator{}))
+					Expect(info.NetplanEthernet.Dhcp4).To(BeTrue())
 				})
 
 				Context("with empty IP configuration and gatewayIP supports DHCP", func() {
@@ -645,17 +604,12 @@ var _ = Describe("NetworkProvider", func() {
 						}
 					})
 					It("should work", func() {
-						res := simulator.VPX().Run(func(ctx goctx.Context, c *vim25.Client) error {
-							createInterface(ctx, c, k8sClient, scheme)
+						createInterface(ctx)
 
-							info, err := np.EnsureNetworkInterface(vmCtx, vmNif)
-							Expect(err).ToNot(HaveOccurred())
-							Expect(info.Customization.Adapter.Ip).To(BeAssignableToTypeOf(&types.CustomizationDhcpIpGenerator{}))
-							Expect(info.NetplanEthernet.Dhcp4).To(BeTrue())
-
-							return nil
-						})
-						Expect(res).To(BeNil())
+						info, err := np.EnsureNetworkInterface(vmCtx, &vmCtx.VM.Spec.NetworkInterfaces[0])
+						Expect(err).ToNot(HaveOccurred())
+						Expect(info.Customization.Adapter.Ip).To(BeAssignableToTypeOf(&types.CustomizationDhcpIpGenerator{}))
+						Expect(info.NetplanEthernet.Dhcp4).To(BeTrue())
 					})
 				})
 
@@ -676,21 +630,17 @@ var _ = Describe("NetworkProvider", func() {
 					})
 
 					It("should work", func() {
-						res := simulator.VPX().Run(func(ctx goctx.Context, c *vim25.Client) error {
-							createInterface(ctx, c, k8sClient, scheme)
+						createInterface(ctx)
 
-							info, err := np.EnsureNetworkInterface(vmCtx, vmNif)
-							Expect(err).ToNot(HaveOccurred())
-							fixedIP := info.Customization.Adapter.Ip.(*types.CustomizationFixedIp)
-							Expect(fixedIP.IpAddress).To(Equal(ip))
-							Expect(info.NetplanEthernet.Dhcp4).To(BeFalse())
-							Expect(info.NetplanEthernet.Match.MacAddress).To(Equal(network.NormalizeNetplanMac(ncpVif.Status.MacAddress)))
-							Expect(info.NetplanEthernet.Gateway4).ToNot(BeEmpty())
-							Expect(info.NetplanEthernet.Gateway4).To(Equal(ncpVif.Status.IPAddresses[0].Gateway))
-							Expect(info.NetplanEthernet.Addresses[0]).To(Equal(expectedCidrNotation))
-							return nil
-						})
-						Expect(res).To(BeNil())
+						info, err := np.EnsureNetworkInterface(vmCtx, &vmCtx.VM.Spec.NetworkInterfaces[0])
+						Expect(err).ToNot(HaveOccurred())
+						fixedIP := info.Customization.Adapter.Ip.(*types.CustomizationFixedIp)
+						Expect(fixedIP.IpAddress).To(Equal(ip))
+						Expect(info.NetplanEthernet.Dhcp4).To(BeFalse())
+						Expect(info.NetplanEthernet.Match.MacAddress).To(Equal(network.NormalizeNetplanMac(ncpVif.Status.MacAddress)))
+						Expect(info.NetplanEthernet.Gateway4).ToNot(BeEmpty())
+						Expect(info.NetplanEthernet.Gateway4).To(Equal(ncpVif.Status.IPAddresses[0].Gateway))
+						Expect(info.NetplanEthernet.Addresses[0]).To(Equal(expectedCidrNotation))
 					})
 				})
 			})

--- a/pkg/vmprovider/providers/vsphere/network/network_suite_test.go
+++ b/pkg/vmprovider/providers/vsphere/network/network_suite_test.go
@@ -4,41 +4,19 @@
 package network_test
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"github.com/vmware/govmomi/simulator"
 
-	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/test"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
-var (
-	model             *simulator.Model
-	server            *simulator.Server
-	ctx               context.Context
-	tlsTestModel      *simulator.Model
-	tlsServer         *simulator.Server
-	tlsServerCertPath string
-	tlsServerKeyPath  string
-)
+var suite = builder.NewTestSuite()
 
-var _ = BeforeSuite(func() {
-	ctx, model, server,
-		tlsServerKeyPath, tlsServerCertPath,
-		tlsTestModel, tlsServer = test.BeforeSuite()
-})
-
-var _ = AfterSuite(func() {
-	test.AfterSuite(
-		ctx,
-		model, server,
-		tlsServerKeyPath, tlsServerCertPath,
-		tlsTestModel, tlsServer)
-})
-
-func TestNetwork(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "vSphere Provider Network Suite")
+func TestNetworkProvider(t *testing.T) {
+	suite.Register(t, "vSphere Provider Network Suite", nil, nil)
 }
+
+var _ = BeforeSuite(suite.BeforeSuite)
+
+var _ = AfterSuite(suite.AfterSuite)


### PR DESCRIPTION
We'll eventually need the vcsim test context to be aware of networking in order to create VMs with the correct NICs in the ConfigSpec. Do the conversion now in preparation of fixing an immediate bug in the provider.