### PR TITLE
Add proxy address in web console request

### DIFF
--- a/api/v1alpha1/webconsolerequest_types.go
+++ b/api/v1alpha1/webconsolerequest_types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2021-2023 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package v1alpha1
@@ -21,6 +21,30 @@ type WebConsoleRequestStatus struct {
 	Response string `json:"response,omitempty"`
 	// ExpiryTime is when the ticket referenced in Response will expire.
 	ExpiryTime metav1.Time `json:"expiryTime,omitempty"`
+	// ProxyAddr describes the host address and optional port used to access
+	// the VM's web console.
+	// The value could be a DNS entry, IPv4, or IPv6 address, followed by an
+	// optional port. For example, valid values include:
+	//
+	//     DNS
+	//         * host.com
+	//         * host.com:6443
+	//
+	//     IPv4
+	//         * 1.2.3.4
+	//         * 1.2.3.4:6443
+	//
+	//     IPv6
+	//         * 1234:1234:1234:1234:1234:1234:1234:1234
+	//         * [1234:1234:1234:1234:1234:1234:1234:1234]:6443
+	//         * 1234:1234:1234:0000:0000:0000:1234:1234
+	//         * 1234:1234:1234::::1234:1234
+	//         * [1234:1234:1234::::1234:1234]:6443
+	//
+	// In other words, the field may be set to any value that is parsable
+	// by Go's https://pkg.go.dev/net#ResolveIPAddr and
+	// https://pkg.go.dev/net#ParseIP functions.
+	ProxyAddr string `json:"proxyAddr,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/vmoperator.vmware.com_webconsolerequests.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_webconsolerequests.yaml
@@ -58,6 +58,18 @@ spec:
                   will expire.
                 format: date-time
                 type: string
+              proxyAddr:
+                description: "ProxyAddr describes the host address and optional port
+                  used to access the VM's web console. The value could be a DNS entry,
+                  IPv4, or IPv6 address, followed by an optional port. For example,
+                  valid values include: \n DNS * host.com * host.com:6443 \n IPv4
+                  * 1.2.3.4 * 1.2.3.4:6443 \n IPv6 * 1234:1234:1234:1234:1234:1234:1234:1234
+                  * [1234:1234:1234:1234:1234:1234:1234:1234]:6443 * 1234:1234:1234:0000:0000:0000:1234:1234
+                  * 1234:1234:1234::::1234:1234 * [1234:1234:1234::::1234:1234]:6443
+                  \n In other words, the field may be set to any value that is parsable
+                  by Go's https://pkg.go.dev/net#ResolveIPAddr and https://pkg.go.dev/net#ParseIP
+                  functions."
+                type: string
               response:
                 description: Response will be the authenticated ticket corresponding
                   to this web console request.

--- a/controllers/webconsolerequest/webconsolerequest_intg_test.go
+++ b/controllers/webconsolerequest/webconsolerequest_intg_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -26,9 +27,10 @@ func intgTests() {
 
 func webConsoleRequestReconcile() {
 	var (
-		ctx *builder.IntegrationTestContext
-		wcr *v1alpha1.WebConsoleRequest
-		vm  *v1alpha1.VirtualMachine
+		ctx      *builder.IntegrationTestContext
+		wcr      *v1alpha1.WebConsoleRequest
+		vm       *v1alpha1.VirtualMachine
+		proxySvc *corev1.Service
 	)
 
 	getWebConsoleRequest := func(ctx *builder.IntegrationTestContext, objKey types.NamespacedName) *v1alpha1.WebConsoleRequest {
@@ -66,6 +68,21 @@ func webConsoleRequestReconcile() {
 			},
 		}
 
+		proxySvc = &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      webconsolerequest.ProxyAddrServiceName,
+				Namespace: webconsolerequest.ProxyAddrServiceNamespace,
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Name: "dummy-proxy-port",
+						Port: 443,
+					},
+				},
+			},
+		}
+
 		fakeVMProvider.Lock()
 		defer fakeVMProvider.Unlock()
 		fakeVMProvider.GetVirtualMachineWebMKSTicketFn = func(ctx context.Context, vm *v1alpha1.VirtualMachine, pubKey string) (string, error) {
@@ -83,6 +100,17 @@ func webConsoleRequestReconcile() {
 		BeforeEach(func() {
 			Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
 			Expect(ctx.Client.Create(ctx, wcr)).To(Succeed())
+			Expect(ctx.Client.Create(ctx, proxySvc)).To(Succeed())
+			proxySvc.Status = corev1.ServiceStatus{
+				LoadBalancer: corev1.LoadBalancerStatus{
+					Ingress: []corev1.LoadBalancerIngress{
+						{
+							IP: "192.168.0.1",
+						},
+					},
+				},
+			}
+			Expect(ctx.Client.Status().Update(ctx, proxySvc)).To(Succeed())
 		})
 
 		AfterEach(func() {
@@ -100,6 +128,7 @@ func webConsoleRequestReconcile() {
 				}
 				return false
 			}).Should(BeTrue(), "waiting for webconsolerequest to be")
+			Expect(wcr.Status.ProxyAddr).To(Equal("192.168.0.1"))
 			Expect(wcr.Status.Response).ToNot(BeEmpty())
 			Expect(wcr.Status.ExpiryTime.Time).To(BeTemporally("~", time.Now(), webconsolerequest.DefaultExpiryTime))
 			Expect(wcr.Labels).To(HaveKeyWithValue(webconsolerequest.UUIDLabelKey, string(wcr.UID)))

--- a/docs/apis/v1alpha1.md
+++ b/docs/apis/v1alpha1.md
@@ -1140,3 +1140,8 @@ _Appears in:_
 | --- | --- |
 | `response` _string_ | Response will be the authenticated ticket corresponding to this web console request. |
 | `expiryTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ | ExpiryTime is when the ticket referenced in Response will expire. |
+| `proxyAddr` _string_ | ProxyAddr describes the host address and optional port used to access the VM's web console. The value could be a DNS entry, IPv4, or IPv6 address, followed by an optional port. For example, valid values include: 
+ DNS * host.com * host.com:6443 
+ IPv4 * 1.2.3.4 * 1.2.3.4:6443 
+ IPv6 * 1234:1234:1234:1234:1234:1234:1234:1234 * [1234:1234:1234:1234:1234:1234:1234:1234]:6443 * 1234:1234:1234:0000:0000:0000:1234:1234 * 1234:1234:1234::::1234:1234 * [1234:1234:1234::::1234:1234]:6443 
+ In other words, the field may be set to any value that is parsable by Go's https://pkg.go.dev/net#ResolveIPAddr and https://pkg.go.dev/net#ParseIP functions. |


### PR DESCRIPTION
This patch adds a new field to the WebConsoleRequest CR to store the proxy address that can be used to access the VM's web-console. It updates the `webconsolerequest_controller` to retrieve the proxy address info from the defined proxy service object (`kube-system/kube-apiserver-lb-svc`).

Testing Done:
- Updated unit & integration tests to cover the newly added field in the CR
- Internal gce2e test succeeded to ensure not to introduce any regressions
- Manually applied the change to an internal testbed and verified the updated reconciliation result:
```
$ kubectl get svc -n kube-system kube-apiserver-lb-svc -o jsonpath='{.status.loadBalancer.ingress[*].ip}'
192.168.0.2%
$ kubectl get webconsolerequest -n sdiliyaer-test  -o jsonpath='{.items[*].status.proxyAddr}'
192.168.0.2%
``` 