### PR TITLE
Fix NSX-T LogicalSwitchUUID to DVPG lookup

### DIFF
--- a/pkg/vmprovider/providers/vsphere/network/network_provider_test.go
+++ b/pkg/vmprovider/providers/vsphere/network/network_provider_test.go
@@ -578,7 +578,7 @@ var _ = Describe("NetworkProvider", func() {
 
 				It("should return an error", func() {
 					_, err := np.EnsureNetworkInterface(vmCtx, &vmCtx.VM.Spec.NetworkInterfaces[0])
-					Expect(err).To(MatchError(fmt.Sprintf("opaque network with ID '%s' not found", doesNotExist)))
+					Expect(err).To(MatchError(fmt.Sprintf("no DVPG with NSX-T network ID %q found", doesNotExist)))
 				})
 			})
 


### PR DESCRIPTION
A supported but very, very rare NSX-T configuration is for the same LogicalSwitchUUID to be shared between multiple DPVGs in a Datacenter. To support this, shortly before WCP 1.0 release, a change was made in WCP and then ported over here that used a "all the hosts in the CCR" check to determine which DVPG is the correct one to use. Ever since, this check in WCP and here have been peculiar and the details as to why mostly lost.

This is all host check strict in the sense that it will fail if a host is in MM or otherwise disconnected. Fortunately, within a CCR, the LogicalSwitchUUID to DVPG mapping is unique, so use that to simplify the lookup logic.

The possibility of multiple DVPGs for each CCR will be a pain when we start to do network placement.

Remove the NSX-T OpaqueNetwork support since that was only used pre-1.0 and never in a shipped release.