### PR TITLE
Set default envtest asset directory when not provided

### DIFF
--- a/test/builder/test_suite.go
+++ b/test/builder/test_suite.go
@@ -29,7 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/rest"
-	klog "k8s.io/klog/v2"
+	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/klogr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -224,7 +224,8 @@ func (s *TestSuite) init(crdPaths []string) {
 
 	if s.flags.IntegrationTestsEnabled {
 		s.envTest = envtest.Environment{
-			CRDDirectoryPaths: crdPaths,
+			CRDDirectoryPaths:     crdPaths,
+			BinaryAssetsDirectory: filepath.Join(testutil.GetRootDirOrDie(), "hack", "tools", "bin"),
 		}
 	}
 }


### PR DESCRIPTION
This saves a step - having to set KUBEBUILDER_ASSETS envar - when running an integration test suite on directly on the CLI or an IDE. Top level Makefile still sets KUBEBUILDER_ASSETS so that behavior is unchanged.