### PR TITLE
Add finalizer to VirtualMachinePublishRequest

### DIFF
--- a/pkg/context/virtualmachinepublishrequest_context.go
+++ b/pkg/context/virtualmachinepublishrequest_context.go
@@ -22,6 +22,9 @@ type VirtualMachinePublishRequestContext struct {
 	VM               *vmopv1.VirtualMachine
 	ContentLibrary   *imgregv1a1.ContentLibrary
 	ItemID           string
+	// SkipPatch indicates whether we should skip patching the object after reconcile
+	// because Status is updated separately in the publishing case due to CL API limitations.
+	SkipPatch bool
 }
 
 func (v *VirtualMachinePublishRequestContext) String() string {

--- a/test/builder/util.go
+++ b/test/builder/util.go
@@ -474,8 +474,9 @@ func DummyPersistentVolumeClaim() *corev1.PersistentVolumeClaim {
 func DummyVirtualMachinePublishRequest(name, namespace, sourceName, itemName, clName string) *vmopv1.VirtualMachinePublishRequest {
 	return &vmopv1.VirtualMachinePublishRequest{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
+			Name:       name,
+			Namespace:  namespace,
+			Finalizers: []string{"virtualmachinepublishrequest.vmoperator.vmware.com"},
 		},
 		Spec: vmopv1.VirtualMachinePublishRequestSpec{
 			Source: vmopv1.VirtualMachinePublishRequestSource{


### PR DESCRIPTION
This change adds finalizer to VirtualMachinePublishRequest, so that the DeleteMetrics is guaranteed to be called.

Test done:
- make test
- make test-integration
- manually deployed to a WCP cluster and verified:
```root@42158b2f7e39152b667d27bcedfd360f [ ~ ]# k describe vmpub vmpub-3 -n yijiang-ns
Name:         vmpub-3
Namespace:    yijiang-ns
Labels:       <none>
Annotations:  <none>
API Version:  vmoperator.vmware.com/v1alpha1
Kind:         VirtualMachinePublishRequest
Metadata:
  Creation Timestamp:  2023-02-27T22:07:19Z
  Finalizers:
    virtualmachinepublishrequest.vmoperator.vmware.com
  Generation:  1
  ...
  Resource Version:  21655992
  UID:               c9f637b0-4f4d-46ca-8d0f-cef4146cc568
Spec:
 ...
  Ttl Seconds After Finished:  60
Status:
  Attempts:  1
  ...
Events:             <none>
```
  - the finalizer is applied to the object.
  - the object can be removed.
 ```After some time
root@42158b2f7e39152b667d27bcedfd360f [ ~ ]# k describe vmpub vmpub-3 -n yijiang-ns
Error from server (NotFound): virtualmachinepublishrequests.vmoperator.vmware.com "vmpub-3" not found
```
- internal gce2e job