### PR TITLE
Remove image supported VM validation check

### DIFF
--- a/pkg/vmprovider/providers/vsphere/constants/constants.go
+++ b/pkg/vmprovider/providers/vsphere/constants/constants.go
@@ -21,11 +21,6 @@ const (
 	ManagedByExtensionKey  = "com.vmware.vcenter.wcp"
 	ManagedByExtensionType = "VirtualMachine"
 
-	// VMOperatorImageSupportedCheckKey Annotation key to skip validation checks of GuestOS Type
-	// TODO: Rename and move to vmoperator-api.
-	VMOperatorImageSupportedCheckKey     = pkg.VMOperatorKey + "/image-supported-check"
-	VMOperatorImageSupportedCheckDisable = "disable"
-
 	// VSphereCustomizationBypassKey Annotation to skip applying VMware Tools Guest Customization.
 	VSphereCustomizationBypassKey     = pkg.VMOperatorKey + "/vsphere-customization"
 	VSphereCustomizationBypassDisable = "disable"


### PR DESCRIPTION
With UnifiedTKG FFS being enabled for some time now, this image check has been a noop but we still had tests for the non-FFS path: I recently hit an integration test race where the just created VM Image hadn't yet made it into the ctrl-runtime client cache. The validation webhooks should really just worry about internal object consistency, so here we only care that the imageName field isn't empty.

There is another problematic VM Image check in here w.r.t. the PVC volumes and OVA HW version that will addressed in a later MR.