### PR TITLE
Remove Scheme from ControllerManagerContext and Reconciler

### DIFF
--- a/controllers/providerconfigmap/provider_configmap_controller_unit_test.go
+++ b/controllers/providerconfigmap/provider_configmap_controller_unit_test.go
@@ -46,7 +46,6 @@ func unitTestsCM() {
 			ctx = suite.NewUnitTestContextForController(initObjects...)
 			reconciler = providerconfigmap.NewReconciler(
 				ctx.Client,
-				ctx.Scheme,
 				ctx.Logger,
 				ctx.VMProvider,
 			)

--- a/controllers/virtualmachineservice/virtualmachineservice_controller_unit_test.go
+++ b/controllers/virtualmachineservice/virtualmachineservice_controller_unit_test.go
@@ -105,7 +105,6 @@ func unitTestsReconcile() {
 		reconciler = virtualmachineservice.NewReconciler(
 			ctx.Client,
 			ctx.Logger,
-			ctx.Scheme,
 			ctx.Recorder,
 			providers.NoopLoadbalancerProvider{},
 		)
@@ -754,7 +753,6 @@ func nsxtLBProviderTestsReconcile() {
 		reconciler = virtualmachineservice.NewReconciler(
 			ctx.Client,
 			ctx.Logger,
-			ctx.Scheme,
 			ctx.Recorder,
 			lbProvider,
 		)

--- a/controllers/volume/volume_controller.go
+++ b/controllers/volume/volume_controller.go
@@ -16,7 +16,6 @@ import (
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	k8serrors "k8s.io/apimachinery/pkg/util/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -55,7 +54,6 @@ func AddToManager(ctx *context.ControllerManagerContext, mgr manager.Manager) er
 		mgr.GetClient(),
 		ctrl.Log.WithName("controllers").WithName("volume"),
 		record.New(mgr.GetEventRecorderFor(controllerNameLong)),
-		mgr.GetScheme(),
 		ctx.VMProvider,
 	)
 
@@ -98,13 +96,11 @@ func NewReconciler(
 	client client.Client,
 	logger logr.Logger,
 	recorder record.Recorder,
-	scheme *runtime.Scheme,
 	vmProvider vmprovider.VirtualMachineProviderInterface) *Reconciler {
 	return &Reconciler{
 		Client:     client,
 		logger:     logger,
 		recorder:   recorder,
-		scheme:     scheme,
 		VMProvider: vmProvider,
 	}
 }
@@ -115,7 +111,6 @@ type Reconciler struct {
 	client.Client
 	logger     logr.Logger
 	recorder   record.Recorder
-	scheme     *runtime.Scheme
 	VMProvider vmprovider.VirtualMachineProviderInterface
 }
 
@@ -424,7 +419,7 @@ func (r *Reconciler) createInstanceStoragePVC(
 		},
 	}
 
-	if err := controllerutil.SetControllerReference(ctx.VM, pvc, r.scheme); err != nil {
+	if err := controllerutil.SetControllerReference(ctx.VM, pvc, r.Client.Scheme()); err != nil {
 		// This is an unexpected error.
 		return errors.Wrap(err, "Cannot set controller reference on PersistentVolumeClaim")
 	}
@@ -623,7 +618,7 @@ func (r *Reconciler) createCNSAttachment(
 		},
 	}
 
-	if err := controllerutil.SetControllerReference(ctx.VM, attachment, r.scheme); err != nil {
+	if err := controllerutil.SetControllerReference(ctx.VM, attachment, r.Client.Scheme()); err != nil {
 		// This is an unexpected error.
 		return errors.Wrap(err, "Cannot set controller reference on CnsNodeVmAttachment")
 	}

--- a/controllers/volume/volume_controller_unit_test.go
+++ b/controllers/volume/volume_controller_unit_test.go
@@ -122,7 +122,6 @@ func unitTestsReconcile() {
 			ctx.Client,
 			ctx.Logger,
 			ctx.Recorder,
-			ctx.Scheme,
 			ctx.VMProvider,
 		)
 		fakeVMProvider = ctx.VMProvider.(*providerfake.VMProvider)

--- a/pkg/context/controller_manager_context.go
+++ b/pkg/context/controller_manager_context.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/vmware-tanzu/vm-operator/pkg/record"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider"
@@ -46,9 +45,6 @@ type ControllerManagerContext struct {
 
 	// Recorder is used to record events.
 	Recorder record.Recorder
-
-	// Scheme is the controller manager's API scheme.
-	Scheme *runtime.Scheme
 
 	// MaxConcurrentReconciles is the maximum number of reconcile requests this
 	// controller will receive concurrently.

--- a/pkg/context/fake/fake_controller_manager_context.go
+++ b/pkg/context/fake/fake_controller_manager_context.go
@@ -6,7 +6,6 @@ package fake
 import (
 	goctx "context"
 
-	"k8s.io/apimachinery/pkg/runtime"
 	clientrecord "k8s.io/client-go/tools/record"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -17,11 +16,10 @@ import (
 
 // NewControllerManagerContext returns a fake ControllerManagerContext for unit
 // testing reconcilers and webhooks with a fake client.
-func NewControllerManagerContext(scheme *runtime.Scheme) *context.ControllerManagerContext {
+func NewControllerManagerContext() *context.ControllerManagerContext {
 	return &context.ControllerManagerContext{
 		Context:                 goctx.Background(),
 		Logger:                  ctrllog.Log.WithName(ControllerManagerName),
-		Scheme:                  scheme,
 		Namespace:               ControllerManagerNamespace,
 		Name:                    ControllerManagerName,
 		ServiceAccountName:      ServiceAccountName,

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -87,7 +87,6 @@ func New(opts Options) (Manager, error) {
 		MaxConcurrentReconciles: opts.MaxConcurrentReconciles,
 		Logger:                  opts.Logger.WithName(opts.PodName),
 		Recorder:                record.New(mgr.GetEventRecorderFor(fmt.Sprintf("%s/%s", opts.PodNamespace, opts.PodName))),
-		Scheme:                  opts.Scheme,
 		ContainerNode:           opts.ContainerNode,
 		SyncPeriod:              opts.SyncPeriod,
 	}

--- a/test/builder/unit_test_context.go
+++ b/test/builder/unit_test_context.go
@@ -73,7 +73,7 @@ type UnitTestContextForValidatingWebhook struct {
 // for unit testing controllers.
 func NewUnitTestContextForController(initObjects []client.Object) *UnitTestContextForController {
 	fakeClient := NewFakeClient(initObjects...)
-	fakeControllerManagerContext := fake.NewControllerManagerContext(fakeClient.Scheme())
+	fakeControllerManagerContext := fake.NewControllerManagerContext()
 	recorder, events := NewFakeRecorder()
 	fakeControllerManagerContext.Recorder = recorder
 	ctx := &UnitTestContextForController{
@@ -98,7 +98,7 @@ func NewUnitTestContextForValidatingWebhook(
 	initObjects ...client.Object) *UnitTestContextForValidatingWebhook {
 
 	fakeClient := NewFakeClient(initObjects...)
-	fakeManagerContext := fake.NewControllerManagerContext(fakeClient.Scheme())
+	fakeManagerContext := fake.NewControllerManagerContext()
 	fakeWebhookContext := fake.NewWebhookContext(fakeManagerContext)
 
 	ctx := &UnitTestContextForValidatingWebhook{
@@ -133,7 +133,7 @@ func NewUnitTestContextForMutatingWebhook(
 	obj *unstructured.Unstructured) *UnitTestContextForMutatingWebhook {
 
 	fakeClient := NewFakeClient(DummyAvailabilityZone())
-	fakeManagerContext := fake.NewControllerManagerContext(fakeClient.Scheme())
+	fakeManagerContext := fake.NewControllerManagerContext()
 	fakeWebhookContext := fake.NewWebhookContext(fakeManagerContext)
 
 	ctx := &UnitTestContextForMutatingWebhook{


### PR DESCRIPTION
The controller-runtime Client added a Scheme() getter a while back so consistently use that for the Scheme so we don't have multiple ways to get the same thing.