### PR TITLE
Update pr-labeler workflow to use a new GITHUB_TOKEN

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -35,4 +35,6 @@ jobs:
       with:
         config_path: .github/configs/labeler.yml
       env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        # A non GITHUB_TOKEN is used to enable triggering the testing-needed
+        # workflow when related labels are added from the current workflow.
+        GITHUB_TOKEN: "${{ secrets.PR_LABELER_TOKEN }}"

--- a/.github/workflows/testing-needed.yml
+++ b/.github/workflows/testing-needed.yml
@@ -3,9 +3,6 @@ name: testing-needed
 on:
   pull_request:
     types:
-    - synchronize
-    - opened
-    - reopened
     - labeled
     - unlabeled
 


### PR DESCRIPTION
**NOTE: This PR should be merged AFTER adding the new GitHub token as a secret to this repo.**

This patch updates the `pr-labeler` workflow to use a new (to-be-added) GitHub token, so that it can trigger the `testing-needed` workflow after setting the corresponding labels  (_testing-needed-e2e-fast/full_).

It also removes the "synchronize", "opened", and "reopened" event types from the `testing-needed` workflow to avoid triggering from a stale pull request change (e.g. when the _testing-needed-e2e-fast/full_ labels were not set).

Testing Done:
- Merged this patch in my fork repo and verified the expected status check from its PR: https://github.com/dilyar85/vm-operator/pull/17

Reference doc: https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow

Closes #73 