### PR TITLE
Remove unused var from VM validation webhook

### DIFF
--- a/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
@@ -152,7 +152,6 @@ func unitTestsValidateCreate() {
 		isNonRestrictedNetworkEnv         bool
 		isNoAvailabilityZones             bool
 		isWCPFaultDomainsFSSEnabled       bool
-		isUnifiedTKGFSSEnabled            bool
 		isInvalidAvailabilityZone         bool
 		isEmptyAvailabilityZone           bool
 		isServiceUser                     bool


### PR DESCRIPTION
0e8d6c7 went through the pipelines prior to now stricter golangci-lint checks from ea31066.