### PR TITLE
Add WCP_Namespaced_Class_And_Windows_Support FSS into VMOP

### DIFF
--- a/config/local/vmoperator/local_env_var_patch.yaml
+++ b/config/local/vmoperator/local_env_var_patch.yaml
@@ -27,3 +27,5 @@ spec:
           value: "false"
         - name: NETWORK_PROVIDER
           value: "NAMED"
+        - name: FSS_WCP_NAMESPACED_CLASS_AND_WINDOWS_SUPPORT
+          value: "false"

--- a/config/wcp/vmoperator/manager_env_var_patch.yaml
+++ b/config/wcp/vmoperator/manager_env_var_patch.yaml
@@ -64,3 +64,8 @@
     name: NETWORK_PROVIDER
     value: "<NETWORK_PROVIDER_VALUE>"
 
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: FSS_WCP_NAMESPACED_CLASS_AND_WINDOWS_SUPPORT
+    value: "<FSS_WCP_NAMESPACED_CLASS_AND_WINDOWS_SUPPORT_VALUE>"

--- a/hack/deploy-wcp.sh
+++ b/hack/deploy-wcp.sh
@@ -35,6 +35,9 @@ FSS_WCP_FAULTDOMAINS_VALUE=${FSS_WCP_FAULTDOMAINS_VALUE:-false}
 # Image Registry: we use this FSS for VM publish.
 FSS_WCP_VM_IMAGE_REGISTRY_VALUE=${FSS_WCP_VM_IMAGE_REGISTRY_VALUE:-false}
 
+# VM Class migration to namespace FSS
+FSS_WCP_NAMESPACED_CLASS_AND_WINDOWS_SUPPORT_VALUE=${FSS_WCP_NAMESPACED_CLASS_AND_WINDOWS_SUPPORT_VALUE:-false}
+
 # Change directories to the parent directory of the one in which this
 # script is located.
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
@@ -152,6 +155,11 @@ patchWcpDeploymentYaml() {
     sed -i'' -E "s,\"?<FSS_WCP_VM_IMAGE_REGISTRY_VALUE>\"?,\"$FSS_WCP_VM_IMAGE_REGISTRY_VALUE\",g" "artifacts/wcp-deployment.yaml"
     if grep -q "<FSS_WCP_VM_IMAGE_REGISTRY_VALUE>" artifacts/wcp-deployment.yaml; then
         echo "Failed to subst FSS_WCP_VM_IMAGE_REGISTRY_VALUE in artifacts/wcp-deployment.yaml"
+        exit 1
+    fi
+    sed -i'' -E "s,\"?<FSS_WCP_NAMESPACED_CLASS_AND_WINDOWS_SUPPORT_VALUE>\"?,\"$FSS_WCP_VM_IMAGE_REGISTRY_VALUE\",g" "artifacts/wcp-deployment.yaml"
+    if grep -q "<FSS_WCP_NAMESPACED_CLASS_AND_WINDOWS_SUPPORT_VALUE>" artifacts/wcp-deployment.yaml; then
+        echo "Failed to subst FSS_WCP_NAMESPACED_CLASS_AND_WINDOWS_SUPPORT_VALUE in artifacts/wcp-deployment.yaml"
         exit 1
     fi
     if  [[ -n ${INSECURE_TLS:-} ]]; then

--- a/pkg/lib/env.go
+++ b/pkg/lib/env.go
@@ -23,6 +23,7 @@ const (
 	VMClassAsConfigFSS            = "FSS_WCP_VM_CLASS_AS_CONFIG"
 	VMClassAsConfigDaynDateFSS    = "FSS_WCP_VM_CLASS_AS_CONFIG_DAYNDATE"
 	VMImageRegistryFSS            = "FSS_WCP_VM_IMAGE_REGISTRY"
+	NamespacedClassAndWindowsFSS  = "FSS_WCP_NAMESPACED_CLASS_AND_WINDOWS_SUPPORT"
 	MaxCreateVMsOnProviderEnv     = "MAX_CREATE_VMS_ON_PROVIDER"
 	DefaultMaxCreateVMsOnProvider = 80
 
@@ -95,6 +96,10 @@ var IsVMClassAsConfigFSSDaynDateEnabled = func() bool {
 
 var IsWCPVMImageRegistryEnabled = func() bool {
 	return os.Getenv(VMImageRegistryFSS) == trueString
+}
+
+var IsNamespacedClassAndWindowsFSSEnabled = func() bool {
+	return os.Getenv(NamespacedClassAndWindowsFSS) == trueString
 }
 
 // MaxConcurrentCreateVMsOnProvider returns the percentage of reconciler


### PR DESCRIPTION
This MR adds WCP_Namespaced_Class_And_Windows_Support FSS into VMOP. It will guard both VM Serive migration of VM Class to namespace scope work and Windows support work.

Testing:
- Vmop: https://buildweb.eng.vmware.com/sb/63377089/
- Csp: https://buildweb.eng.vmware.com/sb/63377286/
- dev-integ-vds: https://wcp.svc.eng.vmware.com/job/dev-integ-vds/3070/
```
root@42037808056efc7c1853467a8ae6218b [ ~ ]#  k describe deployment vmware-system-vmop-controller-manager -n vmware-system-vmop | grep "FSS_WCP_NAMESPACED_CLASS_AND_WINDOWS_SUPPORT"
      FSS_WCP_NAMESPACED_CLASS_AND_WINDOWS_SUPPORT:  false
```