### PR TITLE
Account for GPU devices when the DaynDate FSS is disabled

### DIFF
--- a/pkg/vmprovider/providers/vsphere/session/session_vm_update.go
+++ b/pkg/vmprovider/providers/vsphere/session/session_vm_update.go
@@ -512,13 +512,13 @@ func (s *Session) prePowerOnVMConfigSpec(
 	configSpec.DeviceChange = append(configSpec.DeviceChange, ethCardDeviceChanges...)
 
 	var expectedPCIDevices []vimTypes.BaseVirtualDevice
-	if configSpecDevs := util.DevicesFromConfigSpec(updateArgs.ConfigSpec); len(configSpecDevs) > 0 {
-		if lib.IsVMClassAsConfigFSSDaynDateEnabled() {
+	if lib.IsVMClassAsConfigFSSDaynDateEnabled() {
+		if configSpecDevs := util.DevicesFromConfigSpec(updateArgs.ConfigSpec); len(configSpecDevs) > 0 {
 			pciPassthruFromConfigSpec := util.SelectVirtualPCIPassthrough(configSpecDevs)
 			expectedPCIDevices = virtualmachine.CreatePCIDevicesFromConfigSpec(pciPassthruFromConfigSpec)
-		} else {
-			expectedPCIDevices = virtualmachine.CreatePCIDevicesFromVMClass(updateArgs.VMClass.Spec.Hardware.Devices)
 		}
+	} else {
+		expectedPCIDevices = virtualmachine.CreatePCIDevicesFromVMClass(updateArgs.VMClass.Spec.Hardware.Devices)
 	}
 
 	pciDeviceChanges, err := UpdatePCIDeviceChanges(expectedPCIDevices, currentPciDevices)

--- a/pkg/vmprovider/providers/vsphere/virtualmachine/configspec.go
+++ b/pkg/vmprovider/providers/vsphere/virtualmachine/configspec.go
@@ -130,11 +130,15 @@ func CreateConfigSpecForPlacement(
 		},
 	})
 
-	for _, dev := range CreatePCIDevicesFromVMClass(vmClassSpec.Hardware.Devices) {
-		configSpec.DeviceChange = append(configSpec.DeviceChange, &vimtypes.VirtualDeviceConfigSpec{
-			Operation: vimtypes.VirtualDeviceConfigSpecOperationAdd,
-			Device:    dev,
-		})
+	// With DaynDate FSS, PCI devices are specified via ConfigSpec.  Ignore such devices from the
+	// VM Class Hardware to avoid duplicate devices being added to the placement spec.
+	if !lib.IsVMClassAsConfigFSSDaynDateEnabled() {
+		for _, dev := range CreatePCIDevicesFromVMClass(vmClassSpec.Hardware.Devices) {
+			configSpec.DeviceChange = append(configSpec.DeviceChange, &vimtypes.VirtualDeviceConfigSpec{
+				Operation: vimtypes.VirtualDeviceConfigSpecOperationAdd,
+				Device:    dev,
+			})
+		}
 	}
 
 	if lib.IsInstanceStorageFSSEnabled() {


### PR DESCRIPTION
Due to a bug introduced by 44cd693, we are not dropping the PCI passthrough devices when the DaynDate FSS is disabled.  This change fixes that.

# Testing Done:
- [x] Added a UT for this
- [x] Exiting Unit and Integration tests

Closes #62 