### PR TITLE
Remove VM image hardware version check in VM validation webhook.

### DIFF
--- a/controllers/volume/volume_controller_suite_test.go
+++ b/controllers/volume/volume_controller_suite_test.go
@@ -8,14 +8,21 @@ import (
 
 	. "github.com/onsi/ginkgo"
 
+	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
+
 	"github.com/vmware-tanzu/vm-operator/controllers/volume"
-	pkgmgr "github.com/vmware-tanzu/vm-operator/pkg/manager"
+	ctrlContext "github.com/vmware-tanzu/vm-operator/pkg/context"
+	providerfake "github.com/vmware-tanzu/vm-operator/pkg/vmprovider/fake"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
+var intgFakeVMProvider = providerfake.NewVMProvider()
 var suite = builder.NewTestSuiteForController(
 	volume.AddToManager,
-	pkgmgr.InitializeProvidersNoopFn,
+	func(ctx *ctrlContext.ControllerManagerContext, _ ctrlmgr.Manager) error {
+		ctx.VMProvider = intgFakeVMProvider
+		return nil
+	},
 )
 
 func TestVolume(t *testing.T) {

--- a/pkg/vmprovider/fake/fake_vm_provider.go
+++ b/pkg/vmprovider/fake/fake_vm_provider.go
@@ -32,8 +32,9 @@ type funcs struct {
 	DeleteVirtualMachineFn         func(ctx context.Context, vm *v1alpha1.VirtualMachine) error
 	PublishVirtualMachineFn        func(ctx context.Context, vm *v1alpha1.VirtualMachine,
 		vmPub *v1alpha1.VirtualMachinePublishRequest, cl *imgregv1a1.ContentLibrary, actID string) (string, error)
-	GetVirtualMachineGuestHeartbeatFn func(ctx context.Context, vm *v1alpha1.VirtualMachine) (v1alpha1.GuestHeartbeatStatus, error)
-	GetVirtualMachineWebMKSTicketFn   func(ctx context.Context, vm *v1alpha1.VirtualMachine, pubKey string) (string, error)
+	GetVirtualMachineGuestHeartbeatFn  func(ctx context.Context, vm *v1alpha1.VirtualMachine) (v1alpha1.GuestHeartbeatStatus, error)
+	GetVirtualMachineWebMKSTicketFn    func(ctx context.Context, vm *v1alpha1.VirtualMachine, pubKey string) (string, error)
+	GetVirtualMachineHardwareVersionFn func(ctx context.Context, vm *v1alpha1.VirtualMachine) (int32, error)
 
 	ListItemsFromContentLibraryFn              func(ctx context.Context, contentLibrary *v1alpha1.ContentLibraryProvider) ([]string, error)
 	GetVirtualMachineImageFromContentLibraryFn func(ctx context.Context, contentLibrary *v1alpha1.ContentLibraryProvider, itemID string,
@@ -128,6 +129,15 @@ func (s *VMProvider) GetVirtualMachineWebMKSTicket(ctx context.Context, vm *v1al
 		return s.GetVirtualMachineWebMKSTicketFn(ctx, vm, pubKey)
 	}
 	return "", nil
+}
+
+func (s *VMProvider) GetVirtualMachineHardwareVersion(ctx context.Context, vm *v1alpha1.VirtualMachine) (int32, error) {
+	s.Lock()
+	defer s.Unlock()
+	if s.GetVirtualMachineHardwareVersionFn != nil {
+		return s.GetVirtualMachineHardwareVersionFn(ctx, vm)
+	}
+	return 13, nil
 }
 
 func (s *VMProvider) CreateOrUpdateVirtualMachineSetResourcePolicy(ctx context.Context, resourcePolicy *v1alpha1.VirtualMachineSetResourcePolicy) error {

--- a/pkg/vmprovider/interface.go
+++ b/pkg/vmprovider/interface.go
@@ -24,6 +24,7 @@ type VirtualMachineProviderInterface interface {
 		vmPub *v1alpha1.VirtualMachinePublishRequest, cl *imgregv1a1.ContentLibrary, actID string) (string, error)
 	GetVirtualMachineGuestHeartbeat(ctx context.Context, vm *v1alpha1.VirtualMachine) (v1alpha1.GuestHeartbeatStatus, error)
 	GetVirtualMachineWebMKSTicket(ctx context.Context, vm *v1alpha1.VirtualMachine, pubKey string) (string, error)
+	GetVirtualMachineHardwareVersion(ctx context.Context, vm *v1alpha1.VirtualMachine) (int32, error)
 
 	CreateOrUpdateVirtualMachineSetResourcePolicy(ctx context.Context, resourcePolicy *v1alpha1.VirtualMachineSetResourcePolicy) error
 	IsVirtualMachineSetResourcePolicyReady(ctx context.Context, availabilityZoneName string, resourcePolicy *v1alpha1.VirtualMachineSetResourcePolicy) (bool, error)

--- a/pkg/vmprovider/providers/vsphere/vmprovider_vm_test.go
+++ b/pkg/vmprovider/providers/vsphere/vmprovider_vm_test.go
@@ -1562,6 +1562,18 @@ func vmTests() {
 			})
 		})
 
+		Context("VM hardware version", func() {
+			JustBeforeEach(func() {
+				Expect(vmProvider.CreateOrUpdateVirtualMachine(ctx, vm)).To(Succeed())
+			})
+
+			It("return version", func() {
+				version, err := vmProvider.GetVirtualMachineHardwareVersion(ctx, vm)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(version).To(Equal(int32(9)))
+			})
+		})
+
 		Context("ResVMToVirtualMachineImage", func() {
 			JustBeforeEach(func() {
 				Expect(vmProvider.CreateOrUpdateVirtualMachine(ctx, vm)).To(Succeed())

--- a/webhooks/virtualmachine/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator.go
@@ -28,7 +28,6 @@ import (
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
-	clutils "github.com/vmware-tanzu/vm-operator/controllers/contentlibrary/utils"
 	"github.com/vmware-tanzu/vm-operator/controllers/volume"
 	netopv1alpha1 "github.com/vmware-tanzu/vm-operator/external/net-operator/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/pkg/builder"
@@ -36,7 +35,6 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 	"github.com/vmware-tanzu/vm-operator/pkg/topology"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/config"
-	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/constants"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/instancestorage"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/network"
 	"github.com/vmware-tanzu/vm-operator/webhooks/common"
@@ -53,7 +51,6 @@ const (
 	updatesNotAllowedWhenPowerOn              = "updates to this field is not allowed when VM power is on"
 	storageClassNotAssignedFmt                = "Storage policy is not associated with the namespace %s"
 	storageClassNotFoundFmt                   = "Storage policy is not associated with the namespace %s"
-	pvcHardwareVersionNotSupportedFmt         = "VirtualMachineImage has an unsupported hardware version %d for PersistentVolumes. Minimum supported hardware version %d"
 	invalidVolumeSpecified                    = "only one of persistentVolumeClaim or vsphereVolume must be specified"
 	vSphereVolumeSizeNotMBMultiple            = "value must be a multiple of MB"
 	eagerZeroedAndThinProvisionedNotSupported = "Volume provisioning cannot have EagerZeroed and ThinProvisioning set. Eager zeroing requires thick provisioning"
@@ -339,7 +336,6 @@ func (v validator) validateVolumes(ctx *context.WebhookRequestContext, vm *vmopv
 
 	volumesPath := field.NewPath("spec", "volumes")
 	volumeNames := map[string]bool{}
-	hasPVC := false
 
 	for i, vol := range vm.Spec.Volumes {
 		curVolPath := volumesPath.Index(i)
@@ -361,44 +357,10 @@ func (v validator) validateVolumes(ctx *context.WebhookRequestContext, vm *vmopv
 		}
 
 		if vol.PersistentVolumeClaim != nil {
-			hasPVC = true
 			allErrs = append(allErrs, v.validateVolumeWithPVC(ctx, vm, vol, curVolPath)...)
 		} else { // vol.VsphereVolume != nil
 			allErrs = append(allErrs, v.validateVsphereVolume(vol.VsphereVolume, curVolPath)...)
 		}
-	}
-
-	if !hasPVC {
-		return allErrs
-	}
-
-	imageNamePath := field.NewPath("spec", "imageName")
-	imageName := vm.Spec.ImageName
-	var imageHardwareVersion int32
-
-	if lib.IsWCPVMImageRegistryEnabled() {
-		imageSpec, _, err := clutils.GetVMImageSpecStatus(ctx, v.client, imageName, vm.Namespace)
-		if err != nil {
-			return append(allErrs, field.Invalid(imageNamePath, imageName,
-				fmt.Sprintf("error validating image hardware version for PVC: %s", err.Error())))
-		}
-
-		imageHardwareVersion = imageSpec.HardwareVersion
-
-	} else {
-		image := vmopv1.VirtualMachineImage{}
-		if err := v.client.Get(ctx, client.ObjectKey{Name: imageName}, &image); err != nil {
-			return append(allErrs, field.Invalid(imageNamePath, imageName,
-				fmt.Sprintf("error validating image hardware version for PVC: %s", err.Error())))
-		}
-
-		imageHardwareVersion = image.Spec.HardwareVersion
-	}
-
-	// Check that the VirtualMachineImage's hardware version is at least the minimum supported virtual hardware version.
-	if imageHardwareVersion != 0 && imageHardwareVersion < constants.MinSupportedHWVersionForPVC {
-		allErrs = append(allErrs, field.Invalid(imageNamePath, imageName,
-			fmt.Sprintf(pvcHardwareVersionNotSupportedFmt, imageHardwareVersion, constants.MinSupportedHWVersionForPVC)))
 	}
 
 	return allErrs


### PR DESCRIPTION
This change removes VM image hardware version check in VM validation webhook. After we enable WCP_VM_Image_Registry FSS, VMI name format has been changed. When PVC is added to an existing VM, which is created from the old format VMI, the validation webhook rejects the request since it fails to find the VMI and check the image hardware version.

To solve this issue, this change introduces a new condition PVCHardwareVersion in VM status. When the volume controller reconciles, it will first check if the HW version is supported when the PVC is sepcified in the VM spec.

Test done:
- [X] make test
- [X] make test-integration
- [X] manually test in WCP cluster:
    ```
    Deployed a VM with PVC:
    root@421eb72411625ac28f829640dd47abe7 [ ~ ]# k describe vm ubuntu-volume -n yijiang-ns
    ...
    Spec:
      Class Name:  best-effort-small
      Image Name:  vmi-8fae851a896a59a92
      Network Interfaces:
        Network Type:  vsphere-distributed
      Power State:     poweredOn
      Storage Class:   wcpglobal-storage-profile
      Volumes:
        Name:  my-pvc
        Persistent Volume Claim:
          Claim Name:  my-pvc
          Read Only:   false
    ...
    Events:
      Type     Reason                   Age                 From

                 Message
      ----     ------                   ----                ----

                 -------
      Warning  VolumeAttachmentFailure  36s (x14 over 77s)  vmware-system-vmop/vmware-system-vmop-controller-manager-7c9d847f57-ckppw/volume-controller          VirtualMachine has an unsupported hardware version 10 for PersistentVolumes. Minimum supported hardware version 13
      Warning  CreateOrUpdateFailure    35s (x14 over 77s)  vmware-system-vmop/vmware-system-vmop-controller-manager-7c9d847f57-ckppw/virtualmachine-controller  status update pending for persistent volume: my-pvc on VM
    ```
- [X] Upgrade test:
    ```
    - Deploy a VM when FSS is disabled.
    - VM is created and powered on.
    - Enable the FSS.
    - Add volume in VM .Spec.
    ...
    Events:
    ...
      Warning  VolumeAttachmentFailure  4s (x27 over 12m)     vmware-system-vmop/vmware-system-vmop-controller-manager-7c69df85b6-fwp8t/volume-controller  VirtualMachine has an unsupported hardware version 10 for PersistentVolumes. Minimum supported hardware version 13
  ```