### PR TITLE
 PSP to PSA migration to support Kubernetes 1.25

### DIFF
--- a/config/wcp/vmoperator/namespace_patch.yaml
+++ b/config/wcp/vmoperator/namespace_patch.yaml
@@ -1,3 +1,7 @@
 - op: replace
   path: /metadata/name
   value: vmware-system-vmop
+- op: add
+  path: /metadata/labels
+  value:
+    pod-security.kubernetes.io/enforce: privileged


### PR DESCRIPTION
Starting version 1.25, Kubernetes will drop support for pod security policies.  This change modifies our codebase so we are using pod security admission admission.

# Testing Done:
- End to end tests on a testbed
- Deployed a testbed and verified that the namespace gets the correct labels