### PR TITLE
Support for Sysprep / Windows images

### DIFF
--- a/api/v1alpha1/virtualmachine_types.go
+++ b/api/v1alpha1/virtualmachine_types.go
@@ -156,6 +156,14 @@ const (
 	//
 	// For more information, please refer to cloud-init's official documentation.
 	VirtualMachineMetadataCloudInitTransport VirtualMachineMetadataTransport = "CloudInit"
+
+	// VirtualMachineMetadataSysprepTransport indicates the data set in
+	// the VirtualMachineMetadata Transport Resource, i.e., a ConfigMap or Secret,
+	// in the "unattend" key is an XML, Sysprep answers file.
+	//
+	// For more information, please refer to Microsoft's documentation on
+	// "Answer files (unattend.xml)" and "Unattended Windows Setup Reference".
+	VirtualMachineMetadataSysprepTransport VirtualMachineMetadataTransport = "Sysprep"
 )
 
 // VirtualMachineMetadata defines any metadata that should be passed to the VirtualMachine instance.  A typical use


### PR DESCRIPTION
This patch introduces support for a Sysprep transport for VMs, enabling the use of Windows images. An example, minimal Sysprep answers file is:

```xml
<?xml version="1.0" encoding="utf-8"?>
<unattend xmlns="urn:schemas-microsoft-com:unattend">
  <settings pass="oobeSystem">
    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
      <OOBE>
        <SkipMachineOOBE>true</SkipMachineOOBE>
        <SkipUserOOBE>true</SkipUserOOBE>
      </OOBE>
    </component>
  </settings>
</unattend>
```

This could be created as a Secret resource with:

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: my-vm-bootstrap-data
  namespace: my-ns
stringData:
  unattend: |
    <?xml version="1.0" encoding="utf-8"?>
    <unattend xmlns="urn:schemas-microsoft-com:unattend">
      <settings pass="oobeSystem">
        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
          <OOBE>
            <SkipMachineOOBE>true</SkipMachineOOBE>
            <SkipUserOOBE>true</SkipUserOOBE>
          </OOBE>
        </component>
      </settings>
    </unattend>
```

<!-- readthedocs-preview vm-operator start -->
----
:books: Documentation preview :books:: https://vm-operator--83.org.readthedocs.build/en/83/

<!-- readthedocs-preview vm-operator end -->