### PR TITLE
sec: Disable Named Net Provider in Prod

### DIFF
--- a/pkg/lib/env.go
+++ b/pkg/lib/env.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2019-2023 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package lib
@@ -47,9 +47,13 @@ const (
 	// DefaultInstanceStorageSeedRequeueDuration is the default seed requeue duration for instance storage.
 	DefaultInstanceStorageSeedRequeueDuration = 10 * time.Second
 
-	// NetworkProviderType is the cluster network provider type. It can be VSPHERE_NETWORK, NSX-T or NAMED.
-	// NAMED is only used in a local test environment.
-	NetworkProviderType = "NETWORK_PROVIDER"
+	// NetworkProviderType is the cluster network provider type. Valid values
+	// include: NAMED, NSXT, VSPHERE_NETWORK. Please note that NAMED is only
+	// used for testing and is not supported in production environments.
+	NetworkProviderType      = "NETWORK_PROVIDER"
+	NetworkProviderTypeNamed = "NAMED"
+	NetworkProviderTypeNSXT  = "NSXT"
+	NetworkProviderTypeVDS   = "VSPHERE_NETWORK"
 )
 
 // SetVMOpNamespaceEnv sets the VM Operator pod's namespace in the environment.
@@ -68,6 +72,10 @@ func GetVMOpNamespaceFromEnv() (string, error) {
 		return "", fmt.Errorf("VM Operator namespace envvar %s is not set", VmopNamespaceEnv)
 	}
 	return vmopNamespace, nil
+}
+
+var IsNamedNetworkProviderEnabled = func() bool {
+	return os.Getenv(NetworkProviderType) == NetworkProviderTypeNamed
 }
 
 var IsWcpFaultDomainsFSSEnabled = func() bool {

--- a/pkg/vmprovider/providers/vsphere/vmprovider_vm_test.go
+++ b/pkg/vmprovider/providers/vsphere/vmprovider_vm_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"os"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -29,6 +30,7 @@ import (
 
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 	"github.com/vmware-tanzu/vm-operator/pkg/topology"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere"
@@ -45,15 +47,18 @@ func vmTests() {
 	)
 
 	var (
-		initObjects []client.Object
-		testConfig  builder.VCSimTestConfig
-		ctx         *builder.TestContextForVCSim
-		vmProvider  vmprovider.VirtualMachineProviderInterface
-		nsInfo      builder.WorkloadNamespaceInfo
+		initObjects            []client.Object
+		testConfig             builder.VCSimTestConfig
+		ctx                    *builder.TestContextForVCSim
+		vmProvider             vmprovider.VirtualMachineProviderInterface
+		nsInfo                 builder.WorkloadNamespaceInfo
+		oldNetworkProviderType string
 	)
 
 	BeforeEach(func() {
 		testConfig = builder.VCSimTestConfig{}
+		oldNetworkProviderType = os.Getenv(lib.NetworkProviderType)
+		Expect(os.Setenv(lib.NetworkProviderType, lib.NetworkProviderTypeNamed)).To(Succeed())
 	})
 
 	JustBeforeEach(func() {
@@ -69,6 +74,7 @@ func vmTests() {
 		initObjects = nil
 		vmProvider = nil
 		nsInfo = builder.WorkloadNamespaceInfo{}
+		Expect(os.Setenv(lib.NetworkProviderType, oldNetworkProviderType)).To(Succeed())
 	})
 
 	Context("Create/Update/Delete VirtualMachine", func() {

--- a/webhooks/virtualmachine/mutation/virtualmachine_mutator_intg_test.go
+++ b/webhooks/virtualmachine/mutation/virtualmachine_mutator_intg_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2019-2023 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package mutation_test
@@ -11,11 +11,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
-
 	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/network"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
-	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachine/mutation"
 )
 
 func intgTests() {
@@ -48,7 +46,7 @@ func intgTestsMutating() {
 		ctx = newIntgMutatingWebhookContext()
 		vm = ctx.vm.DeepCopy()
 		vm.Spec.NetworkInterfaces = []vmopv1.VirtualMachineNetworkInterface{}
-		Expect(os.Setenv(lib.NetworkProviderType, mutation.VDSTYPE)).Should(Succeed())
+		Expect(os.Setenv(lib.NetworkProviderType, lib.NetworkProviderTypeVDS)).Should(Succeed())
 	})
 	AfterEach(func() {
 		ctx = nil

--- a/webhooks/virtualmachine/mutation/virtualmachine_mutator_unit_test.go
+++ b/webhooks/virtualmachine/mutation/virtualmachine_mutator_unit_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2019-2023 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package mutation_test
@@ -17,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
-
 	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/config"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
@@ -133,7 +132,7 @@ func unitTestsMutating() {
 
 	Describe("AddDefaultNetworkInterface", func() {
 		BeforeEach(func() {
-			Expect(os.Setenv(lib.NetworkProviderType, mutation.VDSTYPE)).Should(Succeed())
+			Expect(os.Setenv(lib.NetworkProviderType, lib.NetworkProviderTypeVDS)).Should(Succeed())
 		})
 
 		AfterEach(func() {
@@ -159,7 +158,7 @@ func unitTestsMutating() {
 
 			When("NSX-T network", func() {
 				It("Should add default network interface with type NSX-T", func() {
-					Expect(os.Setenv(lib.NetworkProviderType, mutation.NSXTYPE)).Should(Succeed())
+					Expect(os.Setenv(lib.NetworkProviderType, lib.NetworkProviderTypeNSXT)).Should(Succeed())
 
 					Expect(mutation.AddDefaultNetworkInterface(&ctx.WebhookRequestContext, ctx.Client, ctx.vm)).To(BeTrue())
 					Expect(ctx.vm.Spec.NetworkInterfaces).Should(HaveLen(1))
@@ -172,7 +171,7 @@ func unitTestsMutating() {
 
 				BeforeEach(func() {
 					networkName = "VM Network"
-					Expect(os.Setenv(lib.NetworkProviderType, mutation.NAMEDTYPE)).Should(Succeed())
+					Expect(os.Setenv(lib.NetworkProviderType, lib.NetworkProviderTypeNamed)).Should(Succeed())
 				})
 
 				AfterEach(func() {

--- a/webhooks/virtualmachine/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2019-2023 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package validation
@@ -276,7 +276,19 @@ func (v validator) validateNetwork(ctx *context.WebhookRequestContext, vm *vmopv
 		case network.VdsNetworkType:
 			// Empty NetworkName is allowed to let net-operator pick the namespace default.
 		case "":
-			// Must unfortunately allow for testing.
+			if lib.IsNamedNetworkProviderEnabled() {
+				// Allowed for testing.
+			} else {
+				// Disallowed in production.
+				allErrs = append(
+					allErrs,
+					field.Invalid(
+						curPath.Child("networkType"),
+						"",
+						"not supported in production",
+					),
+				)
+			}
 		default:
 			allErrs = append(allErrs, field.NotSupported(curPath.Child("networkType"), nif.NetworkType,
 				[]string{network.NsxtNetworkType, network.VdsNetworkType}))

--- a/webhooks/virtualmachine/validation/virtualmachine_validator_intg_test.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator_intg_test.go
@@ -4,6 +4,8 @@
 package validation_test
 
 import (
+	"os"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
@@ -12,7 +14,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
-
 	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
@@ -33,6 +34,9 @@ type intgValidatingWebhookContext struct {
 }
 
 func newIntgValidatingWebhookContext() *intgValidatingWebhookContext {
+	// Enable the named network provider by default.
+	Expect(os.Setenv(lib.NetworkProviderType, lib.NetworkProviderTypeNamed)).To(Succeed())
+
 	ctx := &intgValidatingWebhookContext{
 		IntegrationTestContext: *suite.NewIntegrationTestContext(),
 	}


### PR DESCRIPTION
This patch disallows the use of the named network provider in production deployments of VM Operator. While used for testing, the named network provider will be rejected unless the VM Operator ConfigMap is explicitly configured to support the named network provider.

This is an important fix as the current state of things violates the security model of Supervisor and Namespace-isolated resources.