### PR TITLE
docs: Build RTFD preview for PRs

### DIFF
--- a/.github/workflows/pr-rtfd.yml
+++ b/.github/workflows/pr-rtfd.yml
@@ -1,0 +1,20 @@
+name: pr-rtfd
+on:
+  pull_request_target:
+    types:
+    - opened
+    - reopened
+    - synchronize
+    paths:
+    - docs/**
+
+permissions:
+  pull-requests: write
+
+jobs:
+  pull-request-links:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: readthedocs/actions/preview@v1
+      with:
+        project-slug: vm-operator


### PR DESCRIPTION
This patch adds support for building preview-ReadTheDoc sites on pull requests.

Validated with https://github.com/akutz/vm-operator/pull/7.