### PR TITLE
Standardized VM Operator API import alias

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,8 @@ linters-settings:
       # Kubernetes
       - pkg: k8s.io/api/core/v1
         alias: corev1
+      - pkg: github.com/vmware-tanzu/vm-operator/api/v1alpha1
+        alias: vmopv1
 
 linters:
   disable-all: true

--- a/controllers/contentlibrary/clustercontentlibraryitem/clustercontentlibraryitem_controller_intg_test.go
+++ b/controllers/contentlibrary/clustercontentlibraryitem/clustercontentlibraryitem_controller_intg_test.go
@@ -13,10 +13,9 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	vmopv1a1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
-
 	imgregv1a1 "github.com/vmware-tanzu/vm-operator/external/image-registry/api/v1alpha1"
 
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/controllers/contentlibrary/utils"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
@@ -32,7 +31,7 @@ func cclItemReconcile() {
 	)
 
 	waitForClusterVirtualMachineImageReady := func(ctx *builder.IntegrationTestContext) {
-		curCVMI := vmopv1a1.ClusterVirtualMachineImage{}
+		curCVMI := vmopv1.ClusterVirtualMachineImage{}
 		expectedCVMI := utils.GetExpectedCVMIFrom(*cclItem, intgFakeVMProvider.SyncVirtualMachineImageFn)
 		Eventually(func() bool {
 			cvmiName := utils.GetTestVMINameFrom(cclItem.Name)
@@ -47,7 +46,7 @@ func cclItemReconcile() {
 	}
 
 	waitForClusterVirtualMachineImageDeleted := func(ctx *builder.IntegrationTestContext) {
-		curCVMI := vmopv1a1.ClusterVirtualMachineImage{}
+		curCVMI := vmopv1.ClusterVirtualMachineImage{}
 		Eventually(func() bool {
 			cvmiName := utils.GetTestVMINameFrom(cclItem.Name)
 			if err := ctx.Client.Get(ctx, client.ObjectKey{Name: cvmiName}, &curCVMI); err != nil {
@@ -68,7 +67,7 @@ func cclItemReconcile() {
 		intgFakeVMProvider.SyncVirtualMachineImageFn = func(
 			_ context.Context, _, cvmiObj client.Object) error {
 			// Change a random spec and status field to verify the provider function is called.
-			cvmi := cvmiObj.(*vmopv1a1.ClusterVirtualMachineImage)
+			cvmi := cvmiObj.(*vmopv1.ClusterVirtualMachineImage)
 			cvmi.Spec.HardwareVersion = 123
 			cvmi.Status.ImageSupported = &[]bool{true}[0]
 			return nil
@@ -106,9 +105,9 @@ func cclItemReconcile() {
 			}).Should(BeTrue())
 
 			// Manually delete CVMI as envTest doesn't delete it even if the OwnerReference is set up.
-			Expect(ctx.Client.DeleteAllOf(ctx, &vmopv1a1.ClusterVirtualMachineImage{})).Should(Succeed())
+			Expect(ctx.Client.DeleteAllOf(ctx, &vmopv1.ClusterVirtualMachineImage{})).Should(Succeed())
 			Eventually(func() bool {
-				cvmiList := &vmopv1a1.ClusterVirtualMachineImageList{}
+				cvmiList := &vmopv1.ClusterVirtualMachineImageList{}
 				if err := ctx.Client.List(ctx, cvmiList); err != nil {
 					return false
 				}

--- a/controllers/contentlibrary/clustercontentlibraryitem/clustercontentlibraryitem_controller_unit_test.go
+++ b/controllers/contentlibrary/clustercontentlibraryitem/clustercontentlibraryitem_controller_unit_test.go
@@ -14,10 +14,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	vmopv1a1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
-
 	imgregv1a1 "github.com/vmware-tanzu/vm-operator/external/image-registry/api/v1alpha1"
 
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/controllers/contentlibrary/clustercontentlibraryitem"
 	"github.com/vmware-tanzu/vm-operator/controllers/contentlibrary/utils"
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
@@ -58,7 +57,7 @@ func unitTestsReconcile() {
 		fakeVMProvider = ctx.VMProvider.(*providerfake.VMProvider)
 		fakeVMProvider.SyncVirtualMachineImageFn = func(
 			_ context.Context, _, cvmiObj client.Object) error {
-			cvmi := cvmiObj.(*vmopv1a1.ClusterVirtualMachineImage)
+			cvmi := cvmiObj.(*vmopv1.ClusterVirtualMachineImage)
 			// Change a random spec and status field to verify the provider function is called.
 			cvmi.Spec.HardwareVersion = 123
 			cvmi.Status.ImageSupported = &[]bool{true}[0]
@@ -89,7 +88,7 @@ func unitTestsReconcile() {
 					err := reconciler.ReconcileNormal(ctx, cclItem)
 					Expect(err).ToNot(HaveOccurred())
 
-					cvmiList := &vmopv1a1.ClusterVirtualMachineImageList{}
+					cvmiList := &vmopv1.ClusterVirtualMachineImageList{}
 					Expect(ctx.Client.List(ctx, cvmiList)).To(Succeed())
 					Expect(cvmiList.Items).To(HaveLen(0))
 				})
@@ -99,11 +98,11 @@ func unitTestsReconcile() {
 
 				BeforeEach(func() {
 					cvmiName := utils.GetTestVMINameFrom(cclItem.Name)
-					existingCVMI := &vmopv1a1.ClusterVirtualMachineImage{
+					existingCVMI := &vmopv1.ClusterVirtualMachineImage{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: cvmiName,
 						},
-						Status: vmopv1a1.VirtualMachineImageStatus{
+						Status: vmopv1.VirtualMachineImageStatus{
 							ContentVersion: "dummy-old",
 						},
 					}
@@ -114,7 +113,7 @@ func unitTestsReconcile() {
 					err := reconciler.ReconcileNormal(ctx, cclItem)
 					Expect(err).ToNot(HaveOccurred())
 
-					cvmiList := &vmopv1a1.ClusterVirtualMachineImageList{}
+					cvmiList := &vmopv1.ClusterVirtualMachineImageList{}
 					Expect(ctx.Client.List(ctx, cvmiList)).To(Succeed())
 					Expect(cvmiList.Items).To(HaveLen(0))
 				})
@@ -136,11 +135,11 @@ func unitTestsReconcile() {
 				err := reconciler.ReconcileNormal(ctx, cclItem)
 				Expect(err).ToNot(HaveOccurred())
 
-				cvmiList := &vmopv1a1.ClusterVirtualMachineImageList{}
+				cvmiList := &vmopv1.ClusterVirtualMachineImageList{}
 				Expect(ctx.Client.List(ctx, cvmiList)).To(Succeed())
 				Expect(cvmiList.Items).To(HaveLen(1))
 				unreadyCVMI := cvmiList.Items[0]
-				providerCondition := conditions.Get(&unreadyCVMI, vmopv1a1.VirtualMachineImageProviderReadyCondition)
+				providerCondition := conditions.Get(&unreadyCVMI, vmopv1.VirtualMachineImageProviderReadyCondition)
 				Expect(providerCondition).ToNot(BeNil())
 				Expect(providerCondition.Status).To(Equal(corev1.ConditionFalse))
 
@@ -162,7 +161,7 @@ func unitTestsReconcile() {
 				It("should create a new ClusterVirtualMachineImage syncing up with ClusterContentLibraryItem", func() {
 					err := reconciler.ReconcileNormal(ctx, cclItem)
 					Expect(err).ToNot(HaveOccurred())
-					cvmiList := &vmopv1a1.ClusterVirtualMachineImageList{}
+					cvmiList := &vmopv1.ClusterVirtualMachineImageList{}
 					Expect(ctx.Client.List(ctx, cvmiList)).To(Succeed())
 					Expect(cvmiList.Items).To(HaveLen(1))
 					createdCVMI := cvmiList.Items[0]
@@ -181,11 +180,11 @@ func unitTestsReconcile() {
 
 				BeforeEach(func() {
 					cvmiName := utils.GetTestVMINameFrom(cclItem.Name)
-					existingCVMI := &vmopv1a1.ClusterVirtualMachineImage{
+					existingCVMI := &vmopv1.ClusterVirtualMachineImage{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: cvmiName,
 						},
-						Status: vmopv1a1.VirtualMachineImageStatus{
+						Status: vmopv1.VirtualMachineImageStatus{
 							ContentVersion: "dummy-old",
 						},
 					}
@@ -196,7 +195,7 @@ func unitTestsReconcile() {
 					err := reconciler.ReconcileNormal(ctx, cclItem)
 					Expect(err).ToNot(HaveOccurred())
 
-					cvmiList := &vmopv1a1.ClusterVirtualMachineImageList{}
+					cvmiList := &vmopv1.ClusterVirtualMachineImageList{}
 					Expect(ctx.Client.List(ctx, cvmiList)).To(Succeed())
 					Expect(cvmiList.Items).To(HaveLen(1))
 					updatedCVMI := cvmiList.Items[0]
@@ -226,7 +225,7 @@ func unitTestsReconcile() {
 					err := reconciler.ReconcileNormal(ctx, cclItem)
 					Expect(err).ToNot(HaveOccurred())
 
-					cvmiList := &vmopv1a1.ClusterVirtualMachineImageList{}
+					cvmiList := &vmopv1.ClusterVirtualMachineImageList{}
 					Expect(ctx.Client.List(ctx, cvmiList)).To(Succeed())
 					Expect(cvmiList.Items).To(HaveLen(1))
 					currentCVMI := cvmiList.Items[0]

--- a/controllers/contentlibrary/contentlibraryitem/contentlibraryitem_controller_intg_test.go
+++ b/controllers/contentlibrary/contentlibraryitem/contentlibraryitem_controller_intg_test.go
@@ -13,9 +13,9 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	vmopv1a1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	imgregv1a1 "github.com/vmware-tanzu/vm-operator/external/image-registry/api/v1alpha1"
 
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/controllers/contentlibrary/utils"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
@@ -31,7 +31,7 @@ func clItemReconcile() {
 	)
 
 	waitForVirtualMachineImageReady := func(ctx *builder.IntegrationTestContext) {
-		curVMI := vmopv1a1.VirtualMachineImage{}
+		curVMI := vmopv1.VirtualMachineImage{}
 		expectedVMI := utils.GetExpectedVMIFrom(*clItem, intgFakeVMProvider.SyncVirtualMachineImageFn)
 		Eventually(func() bool {
 			if err := ctx.Client.Get(ctx, client.ObjectKeyFromObject(expectedVMI), &curVMI); err != nil {
@@ -45,7 +45,7 @@ func clItemReconcile() {
 	}
 
 	waitForVirtualMachineImageDeleted := func(ctx *builder.IntegrationTestContext) {
-		curVMI := vmopv1a1.VirtualMachineImage{}
+		curVMI := vmopv1.VirtualMachineImage{}
 		Eventually(func() bool {
 			vmiName := utils.GetTestVMINameFrom(clItem.Name)
 			if err := ctx.Client.Get(ctx, client.ObjectKey{Name: vmiName}, &curVMI); err != nil {
@@ -62,7 +62,7 @@ func clItemReconcile() {
 		defer intgFakeVMProvider.Unlock()
 		intgFakeVMProvider.SyncVirtualMachineImageFn = func(
 			_ context.Context, _, vmiObj client.Object) error {
-			vmi := vmiObj.(*vmopv1a1.VirtualMachineImage)
+			vmi := vmiObj.(*vmopv1.VirtualMachineImage)
 			// Change a random spec and status field to verify the provider function is called.
 			vmi.Spec.HardwareVersion = 123
 			vmi.Status.ImageSupported = &[]bool{true}[0]
@@ -105,10 +105,10 @@ func clItemReconcile() {
 			}).Should(BeTrue())
 
 			// Manually delete VMI as envTest doesn't delete it even if the OwnerReference is set up.
-			Expect(ctx.Client.DeleteAllOf(ctx, &vmopv1a1.VirtualMachineImage{},
+			Expect(ctx.Client.DeleteAllOf(ctx, &vmopv1.VirtualMachineImage{},
 				client.InNamespace(clItem.Namespace))).Should(Succeed())
 			Eventually(func() bool {
-				vmiList := &vmopv1a1.VirtualMachineImageList{}
+				vmiList := &vmopv1.VirtualMachineImageList{}
 				if err := ctx.Client.List(ctx, vmiList); err != nil {
 					return false
 				}

--- a/controllers/contentlibrary/contentlibraryitem/contentlibraryitem_controller_unit_test.go
+++ b/controllers/contentlibrary/contentlibraryitem/contentlibraryitem_controller_unit_test.go
@@ -14,9 +14,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	vmopv1a1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	imgregv1a1 "github.com/vmware-tanzu/vm-operator/external/image-registry/api/v1alpha1"
 
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/controllers/contentlibrary/contentlibraryitem"
 	"github.com/vmware-tanzu/vm-operator/controllers/contentlibrary/utils"
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
@@ -56,7 +56,7 @@ func unitTestsReconcile() {
 		)
 		fakeVMProvider = ctx.VMProvider.(*providerfake.VMProvider)
 		fakeVMProvider.SyncVirtualMachineImageFn = func(_ context.Context, _, vmi client.Object) error {
-			vmiObj := vmi.(*vmopv1a1.VirtualMachineImage)
+			vmiObj := vmi.(*vmopv1.VirtualMachineImage)
 			// Change a random spec and status field to verify the provider function is called.
 			vmiObj.Spec.HardwareVersion = 123
 			vmiObj.Status.ImageSupported = &[]bool{true}[0]
@@ -86,7 +86,7 @@ func unitTestsReconcile() {
 					err := reconciler.ReconcileNormal(ctx, clItem)
 					Expect(err).ToNot(HaveOccurred())
 
-					vmiList := &vmopv1a1.VirtualMachineImageList{}
+					vmiList := &vmopv1.VirtualMachineImageList{}
 					Expect(ctx.Client.List(ctx, vmiList)).To(Succeed())
 					Expect(vmiList.Items).To(HaveLen(0))
 				})
@@ -96,12 +96,12 @@ func unitTestsReconcile() {
 
 				BeforeEach(func() {
 					vmiName := utils.GetTestVMINameFrom(clItem.Name)
-					existingVMI := &vmopv1a1.VirtualMachineImage{
+					existingVMI := &vmopv1.VirtualMachineImage{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      vmiName,
 							Namespace: clItem.Namespace,
 						},
-						Status: vmopv1a1.VirtualMachineImageStatus{
+						Status: vmopv1.VirtualMachineImageStatus{
 							ContentVersion: "dummy-old",
 						},
 					}
@@ -112,7 +112,7 @@ func unitTestsReconcile() {
 					err := reconciler.ReconcileNormal(ctx, clItem)
 					Expect(err).ToNot(HaveOccurred())
 
-					vmiList := &vmopv1a1.VirtualMachineImageList{}
+					vmiList := &vmopv1.VirtualMachineImageList{}
 					Expect(ctx.Client.List(ctx, vmiList)).To(Succeed())
 					Expect(vmiList.Items).To(HaveLen(0))
 				})
@@ -133,11 +133,11 @@ func unitTestsReconcile() {
 				err := reconciler.ReconcileNormal(ctx, clItem)
 				Expect(err).ToNot(HaveOccurred())
 
-				vmiList := &vmopv1a1.VirtualMachineImageList{}
+				vmiList := &vmopv1.VirtualMachineImageList{}
 				Expect(ctx.Client.List(ctx, vmiList, client.InNamespace(clItem.Namespace))).To(Succeed())
 				Expect(vmiList.Items).To(HaveLen(1))
 				unreadyVMI := vmiList.Items[0]
-				providerCondition := conditions.Get(&unreadyVMI, vmopv1a1.VirtualMachineImageProviderReadyCondition)
+				providerCondition := conditions.Get(&unreadyVMI, vmopv1.VirtualMachineImageProviderReadyCondition)
 				Expect(providerCondition).ToNot(BeNil())
 				Expect(providerCondition.Status).To(Equal(corev1.ConditionFalse))
 			})
@@ -150,7 +150,7 @@ func unitTestsReconcile() {
 					err := reconciler.ReconcileNormal(ctx, clItem)
 					Expect(err).ToNot(HaveOccurred())
 
-					vmiList := &vmopv1a1.VirtualMachineImageList{}
+					vmiList := &vmopv1.VirtualMachineImageList{}
 					Expect(ctx.Client.List(ctx, vmiList, client.InNamespace(clItem.Namespace))).To(Succeed())
 					Expect(vmiList.Items).To(HaveLen(1))
 					createdVMI := vmiList.Items[0]
@@ -167,12 +167,12 @@ func unitTestsReconcile() {
 			When("VirtualMachineImage resource is created but not up-to-date", func() {
 				BeforeEach(func() {
 					vmiName := utils.GetTestVMINameFrom(clItem.Name)
-					existingVMI := &vmopv1a1.VirtualMachineImage{
+					existingVMI := &vmopv1.VirtualMachineImage{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      vmiName,
 							Namespace: clItem.Namespace,
 						},
-						Status: vmopv1a1.VirtualMachineImageStatus{
+						Status: vmopv1.VirtualMachineImageStatus{
 							ContentVersion: "dummy-old",
 						},
 					}
@@ -183,7 +183,7 @@ func unitTestsReconcile() {
 					err := reconciler.ReconcileNormal(ctx, clItem)
 					Expect(err).ToNot(HaveOccurred())
 
-					vmiList := &vmopv1a1.VirtualMachineImageList{}
+					vmiList := &vmopv1.VirtualMachineImageList{}
 					Expect(ctx.Client.List(ctx, vmiList, client.InNamespace(clItem.Namespace))).To(Succeed())
 					Expect(vmiList.Items).To(HaveLen(1))
 					updatedVMI := vmiList.Items[0]
@@ -211,7 +211,7 @@ func unitTestsReconcile() {
 					err := reconciler.ReconcileNormal(ctx, clItem)
 					Expect(err).ToNot(HaveOccurred())
 
-					vmiList := &vmopv1a1.VirtualMachineImageList{}
+					vmiList := &vmopv1.VirtualMachineImageList{}
 					Expect(ctx.Client.List(ctx, vmiList, client.InNamespace(clItem.Namespace))).To(Succeed())
 					Expect(vmiList.Items).To(HaveLen(1))
 					currentVMI := vmiList.Items[0]

--- a/controllers/contentlibrary/contentsource/contentsource_controller_intg_test.go
+++ b/controllers/contentlibrary/contentsource/contentsource_controller_intg_test.go
@@ -14,7 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
@@ -25,30 +25,30 @@ func intgTests() {
 	var (
 		ctx *builder.IntegrationTestContext
 
-		cs     vmopv1alpha1.ContentSource
-		cl     vmopv1alpha1.ContentLibraryProvider
+		cs     vmopv1.ContentSource
+		cl     vmopv1.ContentLibraryProvider
 		csKey  types.NamespacedName
 		clKey  types.NamespacedName
 		imgKey types.NamespacedName
 
-		img       vmopv1alpha1.VirtualMachineImage
+		img       vmopv1.VirtualMachineImage
 		imageName = "dummy-image"
 	)
 
 	BeforeEach(func() {
 		ctx = suite.NewIntegrationTestContext()
 
-		cl = vmopv1alpha1.ContentLibraryProvider{
+		cl = vmopv1.ContentLibraryProvider{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "dummy-cl",
 			},
 		}
-		cs = vmopv1alpha1.ContentSource{
+		cs = vmopv1.ContentSource{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "dummy-cs",
 			},
-			Spec: vmopv1alpha1.ContentSourceSpec{
-				ProviderRef: vmopv1alpha1.ContentProviderReference{
+			Spec: vmopv1.ContentSourceSpec{
+				ProviderRef: vmopv1.ContentProviderReference{
 					APIVersion: "vmoperator.vmware.com/v1alpha1",
 					Name:       cl.ObjectMeta.Name,
 					Kind:       "ContentLibraryProvider",
@@ -56,14 +56,14 @@ func intgTests() {
 			},
 		}
 
-		img = vmopv1alpha1.VirtualMachineImage{
+		img = vmopv1.VirtualMachineImage{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: imageName,
 			},
-			Spec: vmopv1alpha1.VirtualMachineImageSpec{
+			Spec: vmopv1.VirtualMachineImageSpec{
 				ImageID: "dummy-id",
 			},
-			Status: vmopv1alpha1.VirtualMachineImageStatus{
+			Status: vmopv1.VirtualMachineImageStatus{
 				ImageName: imageName,
 			},
 		}
@@ -79,8 +79,8 @@ func intgTests() {
 		intgFakeVMProvider.Reset()
 	})
 
-	getContentSource := func(ctx *builder.IntegrationTestContext, objKey types.NamespacedName) *vmopv1alpha1.ContentSource {
-		cs := &vmopv1alpha1.ContentSource{}
+	getContentSource := func(ctx *builder.IntegrationTestContext, objKey types.NamespacedName) *vmopv1.ContentSource {
+		cs := &vmopv1.ContentSource{}
 		if err := ctx.Client.Get(ctx, objKey, cs); err != nil {
 			return nil
 		}
@@ -100,13 +100,13 @@ func intgTests() {
 		err := ctx.Client.Delete(ctx, &cs)
 		Expect(err == nil || k8serrors.IsNotFound(err)).To(BeTrue())
 
-		Eventually(func() *vmopv1alpha1.ContentSource {
+		Eventually(func() *vmopv1.ContentSource {
 			return getContentSource(ctx, objKey)
 		}).Should(BeNil(), "waiting for ContentSource to be deleted")
 	}
 
-	getContentLibraryProvider := func(ctx *builder.IntegrationTestContext, objKey types.NamespacedName) *vmopv1alpha1.ContentLibraryProvider {
-		cl := &vmopv1alpha1.ContentLibraryProvider{}
+	getContentLibraryProvider := func(ctx *builder.IntegrationTestContext, objKey types.NamespacedName) *vmopv1.ContentLibraryProvider {
+		cl := &vmopv1.ContentLibraryProvider{}
 		if err := ctx.Client.Get(ctx, objKey, cl); err != nil {
 			return nil
 		}
@@ -123,8 +123,8 @@ func intgTests() {
 		}).Should(ContainElement(ownerRef), "waiting for ContentSource OwnerRef on the ContentLibraryProvider resource")
 	}
 
-	getVirtualMachineImage := func(ctx *builder.IntegrationTestContext, objKey types.NamespacedName) *vmopv1alpha1.VirtualMachineImage {
-		img := &vmopv1alpha1.VirtualMachineImage{}
+	getVirtualMachineImage := func(ctx *builder.IntegrationTestContext, objKey types.NamespacedName) *vmopv1.VirtualMachineImage {
+		img := &vmopv1.VirtualMachineImage{}
 		if err := ctx.Client.Get(ctx, objKey, img); err != nil {
 			return nil
 		}
@@ -133,7 +133,7 @@ func intgTests() {
 	}
 
 	waitForVirtualMachineImage := func(ctx *builder.IntegrationTestContext, objKey types.NamespacedName,
-		expectedImg vmopv1alpha1.VirtualMachineImage) {
+		expectedImg vmopv1.VirtualMachineImage) {
 		EventuallyWithOffset(1, func() bool {
 			image := getVirtualMachineImage(ctx, objKey)
 			if image == nil {
@@ -145,8 +145,8 @@ func intgTests() {
 		}).Should(BeTrue())
 	}
 
-	populateExpectedImg := func(image vmopv1alpha1.VirtualMachineImage,
-		cl *vmopv1alpha1.ContentLibraryProvider) vmopv1alpha1.VirtualMachineImage {
+	populateExpectedImg := func(image vmopv1.VirtualMachineImage,
+		cl *vmopv1.ContentLibraryProvider) vmopv1.VirtualMachineImage {
 		expectedImg := image
 		expectedImg.OwnerReferences = []metav1.OwnerReference{{
 			APIVersion: "vmoperator.vmware.com/v1alpha1",
@@ -154,7 +154,7 @@ func intgTests() {
 			Name:       cl.Name,
 			UID:        cl.UID,
 		}}
-		expectedImg.Spec.ProviderRef = vmopv1alpha1.ContentProviderReference{
+		expectedImg.Spec.ProviderRef = vmopv1.ContentProviderReference{
 			APIVersion: "vmoperator.vmware.com/v1alpha1",
 			Kind:       "ContentLibraryProvider",
 			Name:       cl.Name,
@@ -167,13 +167,13 @@ func intgTests() {
 			BeforeEach(func() {
 				intgFakeVMProvider.Lock()
 				intgFakeVMProvider.ListItemsFromContentLibraryFn = func(_ context.Context,
-					_ *vmopv1alpha1.ContentLibraryProvider) ([]string, error) {
+					_ *vmopv1.ContentLibraryProvider) ([]string, error) {
 					// use DeepCopy to avoid race
 					return []string{img.Spec.ImageID}, nil
 				}
 				intgFakeVMProvider.GetVirtualMachineImageFromContentLibraryFn = func(_ context.Context,
-					_ *vmopv1alpha1.ContentLibraryProvider, itemID string,
-					_ map[string]vmopv1alpha1.VirtualMachineImage) (*vmopv1alpha1.VirtualMachineImage, error) {
+					_ *vmopv1.ContentLibraryProvider, itemID string,
+					_ map[string]vmopv1.VirtualMachineImage) (*vmopv1.VirtualMachineImage, error) {
 					return img.DeepCopy(), nil
 				}
 				intgFakeVMProvider.Unlock()
@@ -192,7 +192,7 @@ func intgTests() {
 				// Explicitly delete the VirtualMachineImage objects to avoid race.
 				// VirtualMachineImage objects have a OwnerRef pointing to ContentLibraryProvider,
 				// but they are not immediately deleted and can cause race.
-				Expect(ctx.Client.DeleteAllOf(ctx, &vmopv1alpha1.VirtualMachineImage{})).Should(Succeed())
+				Expect(ctx.Client.DeleteAllOf(ctx, &vmopv1.VirtualMachineImage{})).Should(Succeed())
 			})
 
 			It("Reconciles after ContentSource creation", func() {
@@ -230,26 +230,26 @@ func intgTests() {
 					expectedImg := populateExpectedImg(img, clObj)
 					waitForVirtualMachineImage(ctx, imgKey, expectedImg)
 
-					newImg := vmopv1alpha1.VirtualMachineImage{
+					newImg := vmopv1.VirtualMachineImage{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "new-dummy-name",
 						},
-						Spec: vmopv1alpha1.VirtualMachineImageSpec{
+						Spec: vmopv1.VirtualMachineImageSpec{
 							ImageID: "new-dummy-id",
 						},
-						Status: vmopv1alpha1.VirtualMachineImageStatus{
+						Status: vmopv1.VirtualMachineImageStatus{
 							ImageName: "new-dummy-name",
 						},
 					}
 					intgFakeVMProvider.Lock()
 					intgFakeVMProvider.ListItemsFromContentLibraryFn = func(_ context.Context,
-						_ *vmopv1alpha1.ContentLibraryProvider) ([]string, error) {
+						_ *vmopv1.ContentLibraryProvider) ([]string, error) {
 						// use DeepCopy to avoid race
 						return []string{newImg.Spec.ImageID}, nil
 					}
 					intgFakeVMProvider.GetVirtualMachineImageFromContentLibraryFn = func(_ context.Context,
-						_ *vmopv1alpha1.ContentLibraryProvider, _ string,
-						_ map[string]vmopv1alpha1.VirtualMachineImage) (*vmopv1alpha1.VirtualMachineImage, error) {
+						_ *vmopv1.ContentLibraryProvider, _ string,
+						_ map[string]vmopv1.VirtualMachineImage) (*vmopv1.VirtualMachineImage, error) {
 						return newImg.DeepCopy(), nil
 					}
 					intgFakeVMProvider.Unlock()
@@ -277,17 +277,17 @@ func intgTests() {
 			})
 
 			When("a new ContentSource with duplicate vm images is created", func() {
-				newCL := vmopv1alpha1.ContentLibraryProvider{
+				newCL := vmopv1.ContentLibraryProvider{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "dummy-cl-new",
 					},
 				}
-				newCS := vmopv1alpha1.ContentSource{
+				newCS := vmopv1.ContentSource{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "dummy-cs-new",
 					},
-					Spec: vmopv1alpha1.ContentSourceSpec{
-						ProviderRef: vmopv1alpha1.ContentProviderReference{
+					Spec: vmopv1.ContentSourceSpec{
+						ProviderRef: vmopv1.ContentProviderReference{
 							APIVersion: "vmoperator.vmware.com/v1alpha1",
 							Name:       newCL.ObjectMeta.Name,
 							Kind:       "ContentLibraryProvider",
@@ -317,7 +317,7 @@ func intgTests() {
 				})
 
 				It("should reconcile and generate a new VirtualMachineImage object", func() {
-					images := &vmopv1alpha1.VirtualMachineImageList{}
+					images := &vmopv1.VirtualMachineImageList{}
 					Eventually(func() int {
 						if err := ctx.Client.List(ctx, images); err != nil {
 							return 0

--- a/controllers/contentlibrary/contentsource/contentsource_controller_unit_test.go
+++ b/controllers/contentlibrary/contentsource/contentsource_controller_unit_test.go
@@ -13,7 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/controllers/contentlibrary/contentsource"
 	providerfake "github.com/vmware-tanzu/vm-operator/pkg/vmprovider/fake"
@@ -33,26 +33,26 @@ func reconcileProviderRef() {
 		fakeVMProvider *providerfake.VMProvider
 		initObjects    []client.Object
 
-		cs v1alpha1.ContentSource
-		cl v1alpha1.ContentLibraryProvider
+		cs vmopv1.ContentSource
+		cl vmopv1.ContentLibraryProvider
 	)
 
 	BeforeEach(func() {
-		cl = v1alpha1.ContentLibraryProvider{
+		cl = vmopv1.ContentLibraryProvider{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "dummy-cl",
 			},
-			Spec: v1alpha1.ContentLibraryProviderSpec{
+			Spec: vmopv1.ContentLibraryProviderSpec{
 				UUID: "dummy-cl-uuid",
 			},
 		}
 
-		cs = v1alpha1.ContentSource{
+		cs = vmopv1.ContentSource{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "dummy-cs",
 			},
-			Spec: v1alpha1.ContentSourceSpec{
-				ProviderRef: v1alpha1.ContentProviderReference{
+			Spec: vmopv1.ContentSourceSpec{
+				ProviderRef: vmopv1.ContentProviderReference{
 					Name: cl.Name,
 					Kind: "ContentLibraryProvider",
 				},
@@ -91,7 +91,7 @@ func reconcileProviderRef() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(clProvider).NotTo(BeNil())
 
-				clAfterReconcile := &v1alpha1.ContentLibraryProvider{}
+				clAfterReconcile := &vmopv1.ContentLibraryProvider{}
 				clKey := client.ObjectKey{Name: cl.ObjectMeta.Name}
 				err = ctx.Client.Get(ctx, clKey, clAfterReconcile)
 				Expect(err).NotTo(HaveOccurred())
@@ -113,7 +113,7 @@ func unitTestIsImageOwnedByContentLibrary() {
 			Name: "dummy-name-2",
 		},
 	}
-	img := v1alpha1.VirtualMachineImage{
+	img := vmopv1.VirtualMachineImage{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "dummy-image",
 			OwnerReferences: ownerRefs,
@@ -159,14 +159,14 @@ func unitTestsCRUDImage() {
 		fakeVMProvider *providerfake.VMProvider
 		initObjects    []client.Object
 
-		cs v1alpha1.ContentSource
-		cl v1alpha1.ContentLibraryProvider
+		cs vmopv1.ContentSource
+		cl vmopv1.ContentLibraryProvider
 	)
 
 	BeforeEach(func() {
-		cl = v1alpha1.ContentLibraryProvider{
+		cl = vmopv1.ContentLibraryProvider{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: "vmoperator.vmware.com/v1alpha1",
+				APIVersion: "vmoperator.vmware.com/vmopv1",
 				Kind:       "ContentLibraryProvider",
 			},
 			ObjectMeta: metav1.ObjectMeta{
@@ -174,16 +174,16 @@ func unitTestsCRUDImage() {
 			},
 		}
 
-		cs = v1alpha1.ContentSource{
+		cs = vmopv1.ContentSource{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: "vmoperator.vmware.com/v1alpha1",
+				APIVersion: "vmoperator.vmware.com/vmopv1",
 				Kind:       "ContentSource",
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "dummy-cs",
 			},
-			Spec: v1alpha1.ContentSourceSpec{
-				ProviderRef: v1alpha1.ContentProviderReference{
+			Spec: vmopv1.ContentSourceSpec{
+				ProviderRef: vmopv1.ContentProviderReference{
 					Name:      cl.Name,
 					Namespace: cl.Namespace,
 				},
@@ -213,53 +213,53 @@ func unitTestsCRUDImage() {
 
 	Context("SyncImagesFromContentProvider", func() {
 		Context("VirtualMachineImage already exists", func() {
-			var existingImg, providerImg, providerConvertedImg *v1alpha1.VirtualMachineImage
+			var existingImg, providerImg, providerConvertedImg *vmopv1.VirtualMachineImage
 
 			BeforeEach(func() {
-				existingImg = &v1alpha1.VirtualMachineImage{
+				existingImg = &vmopv1.VirtualMachineImage{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "dummy-image",
 						Annotations: map[string]string{
 							"dummy-key": "dummy-value",
 						},
 					},
-					Spec: v1alpha1.VirtualMachineImageSpec{
+					Spec: vmopv1.VirtualMachineImageSpec{
 						Type: "dummy-type-1",
 					},
 				}
 
-				providerImg = &v1alpha1.VirtualMachineImage{
+				providerImg = &vmopv1.VirtualMachineImage{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "dummy-image",
 					},
-					Spec: v1alpha1.VirtualMachineImageSpec{
+					Spec: vmopv1.VirtualMachineImageSpec{
 						Type:    "dummy-type-2",
 						ImageID: "dummy-id-2",
 					},
-					Status: v1alpha1.VirtualMachineImageStatus{
+					Status: vmopv1.VirtualMachineImageStatus{
 						ImageName: "dummy-image",
 					},
 				}
 
-				providerConvertedImg = &v1alpha1.VirtualMachineImage{
+				providerConvertedImg = &vmopv1.VirtualMachineImage{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "dummy-image",
 						OwnerReferences: []metav1.OwnerReference{{
-							APIVersion: "vmoperator.vmware.com/v1alpha1",
+							APIVersion: "vmoperator.vmware.com/vmopv1",
 							Kind:       "ContentLibraryProvider",
 							Name:       "dummy-cl",
 						}},
 					},
-					Spec: v1alpha1.VirtualMachineImageSpec{
+					Spec: vmopv1.VirtualMachineImageSpec{
 						Type:    "dummy-type-2",
 						ImageID: "dummy-id-2",
-						ProviderRef: v1alpha1.ContentProviderReference{
-							APIVersion: "vmoperator.vmware.com/v1alpha1",
+						ProviderRef: vmopv1.ContentProviderReference{
+							APIVersion: "vmoperator.vmware.com/vmopv1",
 							Kind:       "ContentLibraryProvider",
 							Name:       "dummy-cl",
 						},
 					},
-					Status: v1alpha1.VirtualMachineImageStatus{
+					Status: vmopv1.VirtualMachineImageStatus{
 						ImageName: "dummy-image",
 					},
 				}
@@ -270,24 +270,24 @@ func unitTestsCRUDImage() {
 			Context("When upgrading from not supporting duplicate vm image names", func() {
 				BeforeEach(func() {
 					existingImg.OwnerReferences = []metav1.OwnerReference{{
-						APIVersion: "vmoperator.vmware.com/v1alpha1",
+						APIVersion: "vmoperator.vmware.com/vmopv1",
 						Kind:       "ContentLibraryProvider",
 						Name:       "dummy-cl",
 					}}
-					existingImg.Spec.ProviderRef = v1alpha1.ContentProviderReference{
+					existingImg.Spec.ProviderRef = vmopv1.ContentProviderReference{
 						Name: "dummy-cl",
 					}
 					existingImg.Status.ImageName = "dummy-image"
 				})
 
 				It("Should delete all VirtualMachineImage resources with old versions", func() {
-					fakeVMProvider.ListItemsFromContentLibraryFn = func(_ context.Context, contentLibrary *v1alpha1.ContentLibraryProvider) ([]string, error) {
+					fakeVMProvider.ListItemsFromContentLibraryFn = func(_ context.Context, contentLibrary *vmopv1.ContentLibraryProvider) ([]string, error) {
 						return []string{}, nil
 					}
 
 					err := reconciler.SyncImagesFromContentProvider(ctx.Context, &cl)
 					Expect(err).NotTo(HaveOccurred())
-					imgs := &v1alpha1.VirtualMachineImageList{}
+					imgs := &vmopv1.VirtualMachineImageList{}
 					Expect(ctx.Client.List(ctx, imgs)).To(Succeed())
 					Expect(imgs.Items).To(BeEmpty())
 				})
@@ -296,11 +296,11 @@ func unitTestsCRUDImage() {
 			Context("content library contains a valid VM image", func() {
 				JustBeforeEach(func() {
 					fakeVMProvider.Lock()
-					fakeVMProvider.ListItemsFromContentLibraryFn = func(_ context.Context, contentLibrary *v1alpha1.ContentLibraryProvider) ([]string, error) {
+					fakeVMProvider.ListItemsFromContentLibraryFn = func(_ context.Context, contentLibrary *vmopv1.ContentLibraryProvider) ([]string, error) {
 						return []string{providerImg.Spec.ImageID}, nil
 					}
-					fakeVMProvider.GetVirtualMachineImageFromContentLibraryFn = func(_ context.Context, _ *v1alpha1.ContentLibraryProvider, _ string,
-						_ map[string]v1alpha1.VirtualMachineImage) (*v1alpha1.VirtualMachineImage, error) {
+					fakeVMProvider.GetVirtualMachineImageFromContentLibraryFn = func(_ context.Context, _ *vmopv1.ContentLibraryProvider, _ string,
+						_ map[string]vmopv1.VirtualMachineImage) (*vmopv1.VirtualMachineImage, error) {
 						return providerImg.DeepCopy(), nil
 					}
 					fakeVMProvider.Unlock()
@@ -316,12 +316,12 @@ func unitTestsCRUDImage() {
 				Context("another library with a duplicate image name is added", func() {
 					BeforeEach(func() {
 						existingImg.OwnerReferences = []metav1.OwnerReference{{
-							APIVersion: "vmoperator.vmware.com/v1alpha1",
+							APIVersion: "vmoperator.vmware.com/vmopv1",
 							Kind:       "ContentLibraryProvider",
 							Name:       "dummy-cl-2",
 						}}
 						existingImg.Spec.ImageID = "dummy-id-1"
-						existingImg.Spec.ProviderRef = v1alpha1.ContentProviderReference{
+						existingImg.Spec.ProviderRef = vmopv1.ContentProviderReference{
 							Name: "dummy-cl-2",
 						}
 						existingImg.Status.ImageName = "dummy-image"
@@ -331,7 +331,7 @@ func unitTestsCRUDImage() {
 						err := reconciler.SyncImagesFromContentProvider(ctx.Context, &cl)
 						Expect(err).NotTo(HaveOccurred())
 
-						imgList := &v1alpha1.VirtualMachineImageList{}
+						imgList := &vmopv1.VirtualMachineImageList{}
 						Expect(ctx.Client.List(ctx, imgList)).To(Succeed())
 						Expect(len(imgList.Items)).To(Equal(2))
 						if reflect.DeepEqual(imgList.Items[0].OwnerReferences, existingImg.OwnerReferences) {
@@ -358,7 +358,7 @@ func unitTestsCRUDImage() {
 						err := reconciler.SyncImagesFromContentProvider(ctx.Context, &cl)
 						Expect(err).NotTo(HaveOccurred())
 
-						imgList := &v1alpha1.VirtualMachineImageList{}
+						imgList := &vmopv1.VirtualMachineImageList{}
 						Expect(ctx.Client.List(ctx, imgList)).To(Succeed())
 						Expect(len(imgList.Items)).To(Equal(1))
 
@@ -374,7 +374,7 @@ func unitTestsCRUDImage() {
 				When("the existing image doesn't have Image ID and ProviderRef in Spec", func() {
 					BeforeEach(func() {
 						existingImg.OwnerReferences = []metav1.OwnerReference{{
-							APIVersion: "vmoperator.vmware.com/v1alpha1",
+							APIVersion: "vmoperator.vmware.com/vmopv1",
 							Kind:       "ContentLibraryProvider",
 							Name:       "dummy-cl",
 						}}
@@ -384,7 +384,7 @@ func unitTestsCRUDImage() {
 						err := reconciler.SyncImagesFromContentProvider(ctx.Context, &cl)
 						Expect(err).NotTo(HaveOccurred())
 
-						imgList := &v1alpha1.VirtualMachineImageList{}
+						imgList := &vmopv1.VirtualMachineImageList{}
 						Expect(ctx.Client.List(ctx, imgList)).To(Succeed())
 						Expect(len(imgList.Items)).To(Equal(1))
 
@@ -401,8 +401,8 @@ func unitTestsCRUDImage() {
 					It("calls provider with the current image in map", func() {
 						var called bool
 						fakeVMProvider.Lock()
-						fakeVMProvider.GetVirtualMachineImageFromContentLibraryFn = func(_ context.Context, _ *v1alpha1.ContentLibraryProvider, _ string,
-							_ map[string]v1alpha1.VirtualMachineImage) (*v1alpha1.VirtualMachineImage, error) {
+						fakeVMProvider.GetVirtualMachineImageFromContentLibraryFn = func(_ context.Context, _ *vmopv1.ContentLibraryProvider, _ string,
+							_ map[string]vmopv1.VirtualMachineImage) (*vmopv1.VirtualMachineImage, error) {
 							called = true
 							return providerImg.DeepCopy(), nil
 						}
@@ -418,12 +418,12 @@ func unitTestsCRUDImage() {
 					BeforeEach(func() {
 						existingImg.Name = "dummy-image-existing"
 						existingImg.OwnerReferences = []metav1.OwnerReference{{
-							APIVersion: "vmoperator.vmware.com/v1alpha1",
+							APIVersion: "vmoperator.vmware.com/vmopv1",
 							Kind:       "ContentLibraryProvider",
 							Name:       "dummy-cl",
 						}}
 						existingImg.Spec.ImageID = "dummy-id-1"
-						existingImg.Spec.ProviderRef = v1alpha1.ContentProviderReference{
+						existingImg.Spec.ProviderRef = vmopv1.ContentProviderReference{
 							Name: "dummy-cl",
 						}
 						existingImg.Status.ImageName = "dummy-image-existing"
@@ -433,7 +433,7 @@ func unitTestsCRUDImage() {
 						err := reconciler.SyncImagesFromContentProvider(ctx.Context, &cl)
 						Expect(err).NotTo(HaveOccurred())
 
-						imgList := &v1alpha1.VirtualMachineImageList{}
+						imgList := &vmopv1.VirtualMachineImageList{}
 						Expect(ctx.Client.List(ctx, imgList)).To(Succeed())
 						Expect(len(imgList.Items)).To(Equal(1))
 						Expect(imgList.Items[0].Name).To(Equal(providerConvertedImg.Name))
@@ -449,12 +449,12 @@ func unitTestsCRUDImage() {
 
 	Context("DeleteImage", func() {
 		var (
-			images []v1alpha1.VirtualMachineImage
-			image  v1alpha1.VirtualMachineImage
+			images []vmopv1.VirtualMachineImage
+			image  vmopv1.VirtualMachineImage
 		)
 
 		BeforeEach(func() {
-			image = v1alpha1.VirtualMachineImage{
+			image = vmopv1.VirtualMachineImage{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "dummy-vm-image",
 				},
@@ -476,15 +476,15 @@ func unitTestsCRUDImage() {
 	Context("ProcessItemFromContentLibrary", func() {
 		var (
 			itemID          = "dummy-id"
-			currentCLImages = map[string]v1alpha1.VirtualMachineImage{}
-			vmImage         *v1alpha1.VirtualMachineImage
+			currentCLImages = map[string]vmopv1.VirtualMachineImage{}
+			vmImage         *vmopv1.VirtualMachineImage
 		)
 
 		Context("Failed to get VirtualMachineImage from content library", func() {
 			It("Returns error", func() {
 				fakeVMProvider.GetVirtualMachineImageFromContentLibraryFn = func(_ context.Context,
-					_ *v1alpha1.ContentLibraryProvider, _ string,
-					_ map[string]v1alpha1.VirtualMachineImage) (*v1alpha1.VirtualMachineImage, error) {
+					_ *vmopv1.ContentLibraryProvider, _ string,
+					_ map[string]vmopv1.VirtualMachineImage) (*vmopv1.VirtualMachineImage, error) {
 					return nil, fmt.Errorf("failed to get virtual machine image")
 				}
 				err := reconciler.ProcessItemFromContentLibrary(ctx, ctx.Logger, &cl, itemID, currentCLImages)
@@ -495,21 +495,21 @@ func unitTestsCRUDImage() {
 
 		Context("Get VirtualMachineImage from content library successfully", func() {
 			JustBeforeEach(func() {
-				vmImage = &v1alpha1.VirtualMachineImage{
+				vmImage = &vmopv1.VirtualMachineImage{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "dummy-image",
 					},
-					Spec: v1alpha1.VirtualMachineImageSpec{
+					Spec: vmopv1.VirtualMachineImageSpec{
 						Type: "dummy-type-1",
 					},
-					Status: v1alpha1.VirtualMachineImageStatus{
+					Status: vmopv1.VirtualMachineImageStatus{
 						ImageName: "dummy-image",
 					},
 				}
 
 				fakeVMProvider.GetVirtualMachineImageFromContentLibraryFn = func(_ context.Context,
-					_ *v1alpha1.ContentLibraryProvider, _ string,
-					_ map[string]v1alpha1.VirtualMachineImage) (*v1alpha1.VirtualMachineImage, error) {
+					_ *vmopv1.ContentLibraryProvider, _ string,
+					_ map[string]vmopv1.VirtualMachineImage) (*vmopv1.VirtualMachineImage, error) {
 					vmImage.Annotations = map[string]string{
 						"dummy-key": "dummy-value",
 					}
@@ -524,7 +524,7 @@ func unitTestsCRUDImage() {
 			})
 
 			When("Another image with the same name exists", func() {
-				var existingImg *v1alpha1.VirtualMachineImage
+				var existingImg *vmopv1.VirtualMachineImage
 				JustBeforeEach(func() {
 					existingImg = vmImage.DeepCopy()
 					Expect(ctx.Client.Create(ctx, existingImg)).To(Succeed())
@@ -539,7 +539,7 @@ func unitTestsCRUDImage() {
 						err := reconciler.ProcessItemFromContentLibrary(ctx, ctx.Logger, &cl, itemID, currentCLImages)
 						Expect(err).ShouldNot(HaveOccurred())
 
-						imgs := v1alpha1.VirtualMachineImageList{}
+						imgs := vmopv1.VirtualMachineImageList{}
 						Expect(ctx.Client.List(ctx, &imgs)).To(Succeed())
 						Expect(imgs.Items).Should(HaveLen(2))
 						if imgs.Items[0].Name == vmImage.Name {
@@ -554,14 +554,14 @@ func unitTestsCRUDImage() {
 
 				When("Existing image is from the same CL", func() {
 					It("Update a new VirtualMachineImage if VirtualMachineImage exists", func() {
-						img := &v1alpha1.VirtualMachineImage{}
+						img := &vmopv1.VirtualMachineImage{}
 						Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(vmImage), img)).To(Succeed())
 						currentCLImages[vmImage.Status.ImageName] = *img
 
 						err := reconciler.ProcessItemFromContentLibrary(ctx, ctx.Logger, &cl, itemID, currentCLImages)
 						Expect(err).ShouldNot(HaveOccurred())
 
-						img = &v1alpha1.VirtualMachineImage{}
+						img = &vmopv1.VirtualMachineImage{}
 						Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(vmImage), img)).To(Succeed())
 						Expect(img.Annotations).NotTo(BeEmpty())
 						Expect(img.Status.ImageName).To(Equal(vmImage.Name))
@@ -573,15 +573,15 @@ func unitTestsCRUDImage() {
 
 	Context("Get VM image name", func() {
 		var (
-			img v1alpha1.VirtualMachineImage
+			img vmopv1.VirtualMachineImage
 		)
 
 		BeforeEach(func() {
-			img = v1alpha1.VirtualMachineImage{
+			img = vmopv1.VirtualMachineImage{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "dummy-image",
 				},
-				Status: v1alpha1.VirtualMachineImageStatus{
+				Status: vmopv1.VirtualMachineImageStatus{
 					ImageName: "dummy-image-1",
 				},
 			}

--- a/controllers/contentlibrary/utils/test_utils.go
+++ b/controllers/contentlibrary/utils/test_utils.go
@@ -12,8 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	crtlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	vmopv1a1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
-
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	imgregv1a1 "github.com/vmware-tanzu/vm-operator/external/image-registry/api/v1alpha1"
 )
 
@@ -105,9 +104,9 @@ func GetServiceTypeLabels(labels map[string]string) map[string]string {
 }
 
 func GetExpectedCVMIFrom(cclItem imgregv1a1.ClusterContentLibraryItem,
-	providerFunc func(context.Context, crtlclient.Object, crtlclient.Object) error) *vmopv1a1.ClusterVirtualMachineImage {
+	providerFunc func(context.Context, crtlclient.Object, crtlclient.Object) error) *vmopv1.ClusterVirtualMachineImage {
 
-	cvmi := &vmopv1a1.ClusterVirtualMachineImage{
+	cvmi := &vmopv1.ClusterVirtualMachineImage{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   GetTestVMINameFrom(cclItem.Name),
 			Labels: GetServiceTypeLabels(cclItem.Labels),
@@ -121,16 +120,16 @@ func GetExpectedCVMIFrom(cclItem imgregv1a1.ClusterContentLibraryItem,
 				},
 			},
 		},
-		Spec: vmopv1a1.VirtualMachineImageSpec{
+		Spec: vmopv1.VirtualMachineImageSpec{
 			Type:    string(cclItem.Status.Type),
 			ImageID: cclItem.Spec.UUID,
-			ProviderRef: vmopv1a1.ContentProviderReference{
+			ProviderRef: vmopv1.ContentProviderReference{
 				APIVersion: cclItem.APIVersion,
 				Kind:       cclItem.Kind,
 				Name:       cclItem.Name,
 			},
 		},
-		Status: vmopv1a1.VirtualMachineImageStatus{
+		Status: vmopv1.VirtualMachineImageStatus{
 			ImageName:      cclItem.Status.Name,
 			ContentVersion: cclItem.Status.ContentVersion,
 			ContentLibraryRef: &corev1.TypedLocalObjectReference{
@@ -138,13 +137,13 @@ func GetExpectedCVMIFrom(cclItem imgregv1a1.ClusterContentLibraryItem,
 				Kind:     ClusterContentLibraryKind,
 				Name:     cclItem.Status.ClusterContentLibraryRef,
 			},
-			Conditions: []vmopv1a1.Condition{
+			Conditions: []vmopv1.Condition{
 				{
-					Type:   vmopv1a1.VirtualMachineImageProviderReadyCondition,
+					Type:   vmopv1.VirtualMachineImageProviderReadyCondition,
 					Status: corev1.ConditionTrue,
 				},
 				{
-					Type:   vmopv1a1.VirtualMachineImageSyncedCondition,
+					Type:   vmopv1.VirtualMachineImageSyncedCondition,
 					Status: corev1.ConditionTrue,
 				},
 			},
@@ -159,9 +158,9 @@ func GetExpectedCVMIFrom(cclItem imgregv1a1.ClusterContentLibraryItem,
 }
 
 func GetExpectedVMIFrom(clItem imgregv1a1.ContentLibraryItem,
-	providerFunc func(context.Context, crtlclient.Object, crtlclient.Object) error) *vmopv1a1.VirtualMachineImage {
+	providerFunc func(context.Context, crtlclient.Object, crtlclient.Object) error) *vmopv1.VirtualMachineImage {
 
-	vmi := &vmopv1a1.VirtualMachineImage{
+	vmi := &vmopv1.VirtualMachineImage{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      GetTestVMINameFrom(clItem.Name),
 			Namespace: clItem.Namespace,
@@ -175,16 +174,16 @@ func GetExpectedVMIFrom(clItem imgregv1a1.ContentLibraryItem,
 				},
 			},
 		},
-		Spec: vmopv1a1.VirtualMachineImageSpec{
+		Spec: vmopv1.VirtualMachineImageSpec{
 			Type:    string(clItem.Status.Type),
 			ImageID: clItem.Spec.UUID,
-			ProviderRef: vmopv1a1.ContentProviderReference{
+			ProviderRef: vmopv1.ContentProviderReference{
 				APIVersion: clItem.APIVersion,
 				Kind:       clItem.Kind,
 				Name:       clItem.Name,
 			},
 		},
-		Status: vmopv1a1.VirtualMachineImageStatus{
+		Status: vmopv1.VirtualMachineImageStatus{
 			ImageName:      clItem.Status.Name,
 			ContentVersion: clItem.Status.ContentVersion,
 			ContentLibraryRef: &corev1.TypedLocalObjectReference{
@@ -192,13 +191,13 @@ func GetExpectedVMIFrom(clItem imgregv1a1.ContentLibraryItem,
 				Kind:     ContentLibraryKind,
 				Name:     clItem.Status.ContentLibraryRef.Name,
 			},
-			Conditions: []vmopv1a1.Condition{
+			Conditions: []vmopv1.Condition{
 				{
-					Type:   vmopv1a1.VirtualMachineImageProviderReadyCondition,
+					Type:   vmopv1.VirtualMachineImageProviderReadyCondition,
 					Status: corev1.ConditionTrue,
 				},
 				{
-					Type:   vmopv1a1.VirtualMachineImageSyncedCondition,
+					Type:   vmopv1.VirtualMachineImageSyncedCondition,
 					Status: corev1.ConditionTrue,
 				},
 			},
@@ -213,25 +212,25 @@ func GetExpectedVMIFrom(clItem imgregv1a1.ContentLibraryItem,
 }
 
 func PopulateRuntimeFieldsTo(vmi, appliedVMI crtlclient.Object) {
-	status := &vmopv1a1.VirtualMachineImageStatus{}
-	appliedStatus := &vmopv1a1.VirtualMachineImageStatus{}
+	status := &vmopv1.VirtualMachineImageStatus{}
+	appliedStatus := &vmopv1.VirtualMachineImageStatus{}
 
 	switch vmi := vmi.(type) {
-	case *vmopv1a1.ClusterVirtualMachineImage:
+	case *vmopv1.ClusterVirtualMachineImage:
 		status = &vmi.Status
-		appliedStatus = &appliedVMI.(*vmopv1a1.ClusterVirtualMachineImage).Status
-	case *vmopv1a1.VirtualMachineImage:
+		appliedStatus = &appliedVMI.(*vmopv1.ClusterVirtualMachineImage).Status
+	case *vmopv1.VirtualMachineImage:
 		status = &vmi.Status
-		appliedStatus = &appliedVMI.(*vmopv1a1.VirtualMachineImage).Status
+		appliedStatus = &appliedVMI.(*vmopv1.VirtualMachineImage).Status
 	}
 
 	// Populate condition LastTransitionTime.
 	if appliedStatus.Conditions != nil {
-		transactionTimeMap := map[vmopv1a1.ConditionType]metav1.Time{}
+		transactionTimeMap := map[vmopv1.ConditionType]metav1.Time{}
 		for _, condition := range appliedStatus.Conditions {
 			transactionTimeMap[condition.Type] = condition.LastTransitionTime
 		}
-		updatedConditions := []vmopv1a1.Condition{}
+		updatedConditions := []vmopv1.Condition{}
 		for _, condition := range status.Conditions {
 			if transactionTime, ok := transactionTimeMap[condition.Type]; ok {
 				condition.LastTransitionTime = transactionTime

--- a/controllers/contentlibrary/utils/utils.go
+++ b/controllers/contentlibrary/utils/utils.go
@@ -14,7 +14,7 @@ import (
 
 	imgregv1a1 "github.com/vmware-tanzu/vm-operator/external/image-registry/api/v1alpha1"
 
-	vmopv1a1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 )
 
 // GetImageFieldNameFromItem returns the Image field name in format of "vmi-<uuid>"
@@ -47,15 +47,15 @@ func CheckItemReadyCondition(itemConditions imgregv1a1.Conditions) bool {
 // GetVMImageSpecStatus returns the VirtualMachineImage Spec and Status fields in an image-registry service enabled cluster.
 // It first tries to get the namespace scope VM Image; if not found, it looks up the cluster scope VM Image.
 func GetVMImageSpecStatus(ctx context.Context, ctrlClient client.Client, imageName, namespace string) (
-	spec *vmopv1a1.VirtualMachineImageSpec, status *vmopv1a1.VirtualMachineImageStatus, err error) {
+	spec *vmopv1.VirtualMachineImageSpec, status *vmopv1.VirtualMachineImageStatus, err error) {
 
-	vmi := vmopv1a1.VirtualMachineImage{}
+	vmi := vmopv1.VirtualMachineImage{}
 	if err = ctrlClient.Get(ctx, client.ObjectKey{Name: imageName, Namespace: namespace}, &vmi); err == nil {
 		spec = &vmi.Spec
 		status = &vmi.Status
 	} else if apierrors.IsNotFound(err) {
 		// Namespace scope image is not found. Check if a cluster scope image with this name exists.
-		cvmi := vmopv1a1.ClusterVirtualMachineImage{}
+		cvmi := vmopv1.ClusterVirtualMachineImage{}
 		if err = ctrlClient.Get(ctx, client.ObjectKey{Name: imageName}, &cvmi); err == nil {
 			spec = &cvmi.Spec
 			status = &cvmi.Status

--- a/controllers/providerconfigmap/provider_configmap_controller.go
+++ b/controllers/providerconfigmap/provider_configmap_controller.go
@@ -31,7 +31,7 @@ import (
 
 	"github.com/go-logr/logr"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
 	pkgmgr "github.com/vmware-tanzu/vm-operator/pkg/manager"
@@ -152,14 +152,14 @@ type ConfigMapReconciler struct {
 func (r *ConfigMapReconciler) CreateOrUpdateContentSourceResources(ctx goctx.Context, clUUID string) error {
 	r.Logger.Info("Creating ContentLibraryProvider and ContentSource for TKG content library", "contentLibraryUUID", clUUID)
 
-	clProvider := &vmopv1alpha1.ContentLibraryProvider{
+	clProvider := &vmopv1.ContentLibraryProvider{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: clUUID,
 		},
 	}
 
 	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, clProvider, func() error {
-		clProvider.Spec = vmopv1alpha1.ContentLibraryProviderSpec{
+		clProvider.Spec = vmopv1.ContentLibraryProviderSpec{
 			UUID: clUUID,
 		}
 
@@ -169,7 +169,7 @@ func (r *ConfigMapReconciler) CreateOrUpdateContentSourceResources(ctx goctx.Con
 		return err
 	}
 
-	cs := &vmopv1alpha1.ContentSource{
+	cs := &vmopv1.ContentSource{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: clUUID,
 		},
@@ -186,8 +186,8 @@ func (r *ConfigMapReconciler) CreateOrUpdateContentSourceResources(ctx goctx.Con
 		cs.ObjectMeta.Labels = map[string]string{
 			TKGContentSourceLabelKey: TKGContentSourceLabelValue,
 		}
-		cs.Spec = vmopv1alpha1.ContentSourceSpec{
-			ProviderRef: vmopv1alpha1.ContentProviderReference{
+		cs.Spec = vmopv1.ContentSourceSpec{
+			ProviderRef: vmopv1.ContentProviderReference{
 				APIVersion: gvk.GroupVersion().String(),
 				Kind:       gvk.Kind,
 				Name:       clProvider.Name,
@@ -214,7 +214,7 @@ func (r *ConfigMapReconciler) CreateContentSourceBindings(ctx goctx.Context, clU
 		return err
 	}
 
-	cs := &vmopv1alpha1.ContentSource{}
+	cs := &vmopv1.ContentSource{}
 	if err := r.Get(ctx, client.ObjectKey{Name: clUUID}, cs); err != nil {
 		return err
 	}
@@ -228,7 +228,7 @@ func (r *ConfigMapReconciler) CreateContentSourceBindings(ctx goctx.Context, clU
 	resErr := make([]error, 0)
 	for _, ns := range nsList.Items {
 		r.Logger.Info("Creating ContentSourceBinding for TKG content library in namespace", "contentLibraryUUID", clUUID, "namespace", ns.Name)
-		csBinding := &vmopv1alpha1.ContentSourceBinding{
+		csBinding := &vmopv1.ContentSourceBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      clUUID,
 				Namespace: ns.Name,
@@ -241,7 +241,7 @@ func (r *ConfigMapReconciler) CreateContentSourceBindings(ctx goctx.Context, clU
 				return err
 			}
 
-			csBinding.ContentSourceRef = vmopv1alpha1.ContentSourceReference{
+			csBinding.ContentSourceRef = vmopv1.ContentSourceReference{
 				APIVersion: gvk.GroupVersion().String(),
 				Kind:       gvk.Kind,
 				Name:       clUUID,
@@ -283,7 +283,7 @@ func (r *ConfigMapReconciler) ReconcileNormal(ctx goctx.Context, cm *corev1.Conf
 	r.Logger.Info("Reconciling VM provider ConfigMap", "name", cm.Name, "namespace", cm.Namespace)
 
 	// Filter out the ContentSources that should not exist
-	csList := &vmopv1alpha1.ContentSourceList{}
+	csList := &vmopv1.ContentSourceList{}
 	labels := map[string]string{TKGContentSourceLabelKey: TKGContentSourceLabelValue}
 
 	if err := r.List(ctx, csList, client.MatchingLabels(labels)); err != nil {

--- a/controllers/providerconfigmap/provider_configmap_controller_intg_test.go
+++ b/controllers/providerconfigmap/provider_configmap_controller_intg_test.go
@@ -13,7 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/controllers/providerconfigmap"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/config"
@@ -50,13 +50,13 @@ func intgTestsCM() {
 
 	Context("Reconcile", func() {
 		clExists := func(clName string) bool {
-			clObj := &vmopv1alpha1.ContentLibraryProvider{}
+			clObj := &vmopv1.ContentLibraryProvider{}
 			return ctx.Client.Get(ctx, client.ObjectKey{Name: clName}, clObj) == nil
 		}
 
 		// Verifies that a ContentSource exists, has a matching label and has a ProviderRef set to the content library..
 		csExists := func(csName, clName string) bool {
-			csObj := &vmopv1alpha1.ContentSource{}
+			csObj := &vmopv1.ContentSource{}
 			if err := ctx.Client.Get(ctx, client.ObjectKey{Name: csName}, csObj); err != nil {
 				return false
 			}
@@ -76,7 +76,7 @@ func intgTestsCM() {
 
 		When("ConfigMap is created without ContentSource key", func() {
 			It("no ContentSource is created", func() {
-				csList := &vmopv1alpha1.ContentSourceList{}
+				csList := &vmopv1.ContentSourceList{}
 				err := ctx.Client.List(ctx, csList)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(csList.Items).To(HaveLen(0))
@@ -96,7 +96,7 @@ func intgTestsCM() {
 
 				// Validate that no ContentSources exist in the system namespace.
 				Consistently(func() bool {
-					bindingList := &vmopv1alpha1.ContentSourceBindingList{}
+					bindingList := &vmopv1.ContentSourceBindingList{}
 					Expect(ctx.Client.List(ctx, bindingList, client.InNamespace(ctx.PodNamespace))).To(Succeed())
 					return len(bindingList.Items) == 0
 				}).Should(BeTrue())
@@ -135,7 +135,7 @@ func intgTestsCM() {
 		Context("VMService FSS is enabled", func() {
 			verifyContentSourceBinding := func(namespace string) {
 				Eventually(func() bool {
-					bindingList := &vmopv1alpha1.ContentSourceBindingList{}
+					bindingList := &vmopv1.ContentSourceBindingList{}
 					err := ctx.Client.List(ctx, bindingList, client.InNamespace(namespace))
 					return err == nil && len(bindingList.Items) == 1 && bindingList.Items[0].ContentSourceRef.Kind == contentSourceKind &&
 						bindingList.Items[0].ContentSourceRef.Name == clUUID
@@ -209,7 +209,7 @@ func intgTestsCM() {
 							verifyContentSourceBinding(workloadNs.Name)
 
 							// Delete the contentSourceBinding to mock a failed workflow
-							binding := &vmopv1alpha1.ContentSourceBinding{}
+							binding := &vmopv1.ContentSourceBinding{}
 							Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: clUUID, Namespace: workloadNs.Name}, binding)).To(Succeed())
 							Expect(ctx.Client.Delete(ctx, binding)).To(Succeed())
 

--- a/controllers/providerconfigmap/provider_configmap_controller_unit_test.go
+++ b/controllers/providerconfigmap/provider_configmap_controller_unit_test.go
@@ -11,7 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/controllers/providerconfigmap"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/config"
@@ -72,7 +72,7 @@ func unitTestsCM() {
 					objKey := client.ObjectKey{Name: clUUID}
 
 					By("ContentSource should be created and have a ProviderRef for the CL")
-					cs := &vmopv1alpha1.ContentSource{}
+					cs := &vmopv1.ContentSource{}
 					err = ctx.Client.Get(ctx, objKey, cs)
 					Expect(err).NotTo(HaveOccurred())
 
@@ -80,7 +80,7 @@ func unitTestsCM() {
 					Expect(cs.Labels).To(HaveKeyWithValue(providerconfigmap.TKGContentSourceLabelKey, providerconfigmap.TKGContentSourceLabelValue))
 
 					By("ContentLibraryProvider should be created for the CL")
-					cl := &vmopv1alpha1.ContentLibraryProvider{}
+					cl := &vmopv1.ContentLibraryProvider{}
 					err = ctx.Client.Get(ctx, objKey, cl)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(cl.Spec.UUID).To(Equal(clUUID))
@@ -119,7 +119,7 @@ func unitTestsCM() {
 					err = reconciler.CreateContentSourceBindings(ctx, clUUID)
 					Expect(err).NotTo(HaveOccurred())
 
-					binding := &vmopv1alpha1.ContentSourceBinding{}
+					binding := &vmopv1.ContentSourceBinding{}
 					err = ctx.Client.Get(ctx, client.ObjectKey{Name: clUUID, Namespace: workloadNS.Name}, binding)
 					Expect(err).NotTo(HaveOccurred())
 				})

--- a/controllers/virtualmachine/virtualmachine_controller_unit_test.go
+++ b/controllers/virtualmachine/virtualmachine_controller_unit_test.go
@@ -14,7 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachine"
 	vmopContext "github.com/vmware-tanzu/vm-operator/pkg/context"
@@ -41,19 +41,19 @@ func unitTestsReconcile() {
 		fakeProbeManager *proberfake.ProberManager
 		fakeVMProvider   *providerfake.VMProvider
 
-		vm    *vmopv1alpha1.VirtualMachine
+		vm    *vmopv1.VirtualMachine
 		vmCtx *vmopContext.VirtualMachineContext
 	)
 
 	BeforeEach(func() {
-		vm = &vmopv1alpha1.VirtualMachine{
+		vm = &vmopv1.VirtualMachine{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       "dummy-vm",
 				Namespace:  "dummy-ns",
 				Labels:     map[string]string{},
 				Finalizers: []string{finalizer},
 			},
-			Spec: vmopv1alpha1.VirtualMachineSpec{
+			Spec: vmopv1.VirtualMachineSpec{
 				ClassName: "dummy-class",
 				ImageName: "dummy-image",
 			},
@@ -112,11 +112,11 @@ func unitTestsReconcile() {
 			err := reconciler.ReconcileNormal(vmCtx)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(vmCtx.VM.GetFinalizers()).To(ContainElement(finalizer))
-			Expect(vmCtx.VM.Status.Phase).To(Equal(vmopv1alpha1.Created))
+			Expect(vmCtx.VM.Status.Phase).To(Equal(vmopv1.Created))
 		})
 
 		It("will return error when provider fails to CreateOrUpdate VM", func() {
-			fakeVMProvider.CreateOrUpdateVirtualMachineFn = func(ctx context.Context, vm *vmopv1alpha1.VirtualMachine) error {
+			fakeVMProvider.CreateOrUpdateVirtualMachineFn = func(ctx context.Context, vm *vmopv1.VirtualMachine) error {
 				return errors.New(providerError)
 			}
 
@@ -137,7 +137,7 @@ func unitTestsReconcile() {
 		})
 
 		It("Should not call add to Prober Manager if CreateOrUpdate fails", func() {
-			fakeVMProvider.CreateOrUpdateVirtualMachineFn = func(ctx context.Context, vm *vmopv1alpha1.VirtualMachine) error {
+			fakeVMProvider.CreateOrUpdateVirtualMachineFn = func(ctx context.Context, vm *vmopv1.VirtualMachine) error {
 				return errors.New(providerError)
 			}
 
@@ -147,7 +147,7 @@ func unitTestsReconcile() {
 		})
 
 		It("Should call add to Prober Manager if ReconcileNormal succeeds", func() {
-			fakeProbeManager.AddToProberManagerFn = func(vm *vmopv1alpha1.VirtualMachine) {
+			fakeProbeManager.AddToProberManagerFn = func(vm *vmopv1.VirtualMachine) {
 				fakeProbeManager.IsAddToProberManagerCalled = true
 			}
 
@@ -172,24 +172,24 @@ func unitTestsReconcile() {
 			Expect(err).NotTo(HaveOccurred())
 
 			expectEvent(ctx, "DeleteSuccess")
-			Expect(vmCtx.VM.Status.Phase).To(Equal(vmopv1alpha1.Deleted))
+			Expect(vmCtx.VM.Status.Phase).To(Equal(vmopv1.Deleted))
 		})
 
 		It("will emit corresponding event during delete failure", func() {
 			// Simulate delete failure
-			fakeVMProvider.DeleteVirtualMachineFn = func(ctx context.Context, vm *vmopv1alpha1.VirtualMachine) error {
+			fakeVMProvider.DeleteVirtualMachineFn = func(ctx context.Context, vm *vmopv1.VirtualMachine) error {
 				return errors.New(providerError)
 			}
 			err := reconciler.ReconcileDelete(vmCtx)
 			Expect(err).To(HaveOccurred())
 
 			expectEvent(ctx, "DeleteFailure")
-			Expect(vmCtx.VM.Status.Phase).To(Equal(vmopv1alpha1.Deleting))
+			Expect(vmCtx.VM.Status.Phase).To(Equal(vmopv1.Deleting))
 		})
 
 		It("Should not remove from Prober Manager if ReconcileDelete fails", func() {
 			// Simulate delete failure
-			fakeVMProvider.DeleteVirtualMachineFn = func(ctx context.Context, vm *vmopv1alpha1.VirtualMachine) error {
+			fakeVMProvider.DeleteVirtualMachineFn = func(ctx context.Context, vm *vmopv1.VirtualMachine) error {
 				return errors.New(providerError)
 			}
 
@@ -199,7 +199,7 @@ func unitTestsReconcile() {
 		})
 
 		It("Should remove from Prober Manager if ReconcileDelete succeeds", func() {
-			fakeProbeManager.RemoveFromProberManagerFn = func(vm *vmopv1alpha1.VirtualMachine) {
+			fakeProbeManager.RemoveFromProberManagerFn = func(vm *vmopv1.VirtualMachine) {
 				fakeProbeManager.IsRemoveFromProberManagerCalled = true
 			}
 

--- a/controllers/virtualmachineclass/virtualmachineclass_controller.go
+++ b/controllers/virtualmachineclass/virtualmachineclass_controller.go
@@ -16,7 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/record"
@@ -25,7 +25,7 @@ import (
 // AddToManager adds this package's controller to the provided manager.
 func AddToManager(ctx *context.ControllerManagerContext, mgr manager.Manager) error {
 	var (
-		controlledType     = &vmopv1alpha1.VirtualMachineClass{}
+		controlledType     = &vmopv1.VirtualMachineClass{}
 		controlledTypeName = reflect.TypeOf(controlledType).Elem().Name()
 
 		controllerNameShort = fmt.Sprintf("%s-controller", strings.ToLower(controlledTypeName))
@@ -66,7 +66,7 @@ type Reconciler struct {
 // +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachineclasses/status,verbs=get;update;patch
 
 func (r *Reconciler) Reconcile(ctx goctx.Context, req ctrl.Request) (ctrl.Result, error) {
-	vmClass := &vmopv1alpha1.VirtualMachineClass{}
+	vmClass := &vmopv1.VirtualMachineClass{}
 	err := r.Get(ctx, req.NamespacedName, vmClass)
 	if err != nil {
 		if apiErrors.IsNotFound(err) {

--- a/controllers/virtualmachineclass/virtualmachineclass_controller_intg_test.go
+++ b/controllers/virtualmachineclass/virtualmachineclass_controller_intg_test.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
@@ -19,28 +19,28 @@ import (
 func intgTests() {
 	var (
 		ctx     *builder.IntegrationTestContext
-		vmClass *vmopv1alpha1.VirtualMachineClass
+		vmClass *vmopv1.VirtualMachineClass
 	)
 
 	BeforeEach(func() {
 		ctx = suite.NewIntegrationTestContext()
 
-		vmClass = &vmopv1alpha1.VirtualMachineClass{
+		vmClass = &vmopv1.VirtualMachineClass{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "small",
 			},
-			Spec: vmopv1alpha1.VirtualMachineClassSpec{
-				Hardware: vmopv1alpha1.VirtualMachineClassHardware{
+			Spec: vmopv1.VirtualMachineClassSpec{
+				Hardware: vmopv1.VirtualMachineClassHardware{
 					Cpus:   4,
 					Memory: resource.MustParse("1Mi"),
 				},
-				Policies: vmopv1alpha1.VirtualMachineClassPolicies{
-					Resources: vmopv1alpha1.VirtualMachineClassResources{
-						Requests: vmopv1alpha1.VirtualMachineResourceSpec{
+				Policies: vmopv1.VirtualMachineClassPolicies{
+					Resources: vmopv1.VirtualMachineClassResources{
+						Requests: vmopv1.VirtualMachineResourceSpec{
 							Cpu:    resource.MustParse("1000Mi"),
 							Memory: resource.MustParse("100Mi"),
 						},
-						Limits: vmopv1alpha1.VirtualMachineResourceSpec{
+						Limits: vmopv1.VirtualMachineResourceSpec{
 							Cpu:    resource.MustParse("2000Mi"),
 							Memory: resource.MustParse("200Mi"),
 						},

--- a/controllers/virtualmachineclass/virtualmachineclass_controller_unit_test.go
+++ b/controllers/virtualmachineclass/virtualmachineclass_controller_unit_test.go
@@ -10,7 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachineclass"
 	vmopContext "github.com/vmware-tanzu/vm-operator/pkg/context"
@@ -28,11 +28,11 @@ func unitTestsReconcile() {
 
 		reconciler *virtualmachineclass.Reconciler
 		vmClassCtx *vmopContext.VirtualMachineClassContext
-		vmClass    *vmopv1alpha1.VirtualMachineClass
+		vmClass    *vmopv1.VirtualMachineClass
 	)
 
 	BeforeEach(func() {
-		vmClass = &vmopv1alpha1.VirtualMachineClass{
+		vmClass = &vmopv1.VirtualMachineClass{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "dummy-vmclass",
 			},

--- a/controllers/virtualmachinepublishrequest/virtualmachinepublishrequest_controller_intg_test.go
+++ b/controllers/virtualmachinepublishrequest/virtualmachinepublishrequest_controller_intg_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/vmware/govmomi/vim25/types"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	imgregv1a1 "github.com/vmware-tanzu/vm-operator/external/image-registry/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/controllers/contentlibrary/utils"
@@ -35,13 +35,13 @@ func intgTests() {
 func virtualMachinePublishRequestReconcile() {
 	var (
 		ctx   *builder.IntegrationTestContext
-		vmpub *vmopv1alpha1.VirtualMachinePublishRequest
-		vm    *vmopv1alpha1.VirtualMachine
+		vmpub *vmopv1.VirtualMachinePublishRequest
+		vm    *vmopv1.VirtualMachine
 		cl    *imgregv1a1.ContentLibrary
 	)
 
-	getVirtualMachinePublishRequest := func(ctx *builder.IntegrationTestContext, objKey client.ObjectKey) *vmopv1alpha1.VirtualMachinePublishRequest {
-		vmpubObj := &vmopv1alpha1.VirtualMachinePublishRequest{}
+	getVirtualMachinePublishRequest := func(ctx *builder.IntegrationTestContext, objKey client.ObjectKey) *vmopv1.VirtualMachinePublishRequest {
+		vmpubObj := &vmopv1.VirtualMachinePublishRequest{}
 		if err := ctx.Client.Get(ctx, objKey, vmpubObj); err != nil {
 			return nil
 		}
@@ -60,15 +60,15 @@ func virtualMachinePublishRequestReconcile() {
 	BeforeEach(func() {
 		ctx = suite.NewIntegrationTestContext()
 
-		vm = &vmopv1alpha1.VirtualMachine{
+		vm = &vmopv1.VirtualMachine{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "dummy-vm",
 				Namespace: ctx.Namespace,
 			},
-			Spec: vmopv1alpha1.VirtualMachineSpec{
+			Spec: vmopv1.VirtualMachineSpec{
 				ImageName:  "dummy-image",
 				ClassName:  "dummy-class",
-				PowerState: vmopv1alpha1.VirtualMachinePoweredOn,
+				PowerState: vmopv1.VirtualMachinePoweredOn,
 			},
 		}
 
@@ -90,10 +90,10 @@ func virtualMachinePublishRequestReconcile() {
 		Context("Successfully reconcile a VirtualMachinepublishRequest", func() {
 			BeforeEach(func() {
 				Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
-				vmObj := &vmopv1alpha1.VirtualMachine{}
+				vmObj := &vmopv1.VirtualMachine{}
 				Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(vm), vmObj)).To(Succeed())
-				vmObj.Status = vmopv1alpha1.VirtualMachineStatus{
-					Phase:    vmopv1alpha1.Created,
+				vmObj.Status = vmopv1.VirtualMachineStatus{
+					Phase:    vmopv1.Created,
 					UniqueID: "dummy-unique-id",
 				}
 				Expect(ctx.Client.Status().Update(ctx, vmObj)).To(Succeed())
@@ -170,9 +170,9 @@ func virtualMachinePublishRequestReconcile() {
 					Eventually(func() bool {
 						vmPubObj = getVirtualMachinePublishRequest(ctx, client.ObjectKeyFromObject(vmpub))
 						for _, condition := range vmPubObj.Status.Conditions {
-							if condition.Type == vmopv1alpha1.VirtualMachinePublishRequestConditionUploaded {
+							if condition.Type == vmopv1.VirtualMachinePublishRequestConditionUploaded {
 								return condition.Status == corev1.ConditionFalse &&
-									condition.Reason == vmopv1alpha1.UploadTaskQueuedReason &&
+									condition.Reason == vmopv1.UploadTaskQueuedReason &&
 									vmPubObj.Status.Attempts == 1
 							}
 						}
@@ -199,9 +199,9 @@ func virtualMachinePublishRequestReconcile() {
 					Eventually(func() bool {
 						vmPubObj = getVirtualMachinePublishRequest(ctx, client.ObjectKeyFromObject(vmpub))
 						for _, condition := range vmPubObj.Status.Conditions {
-							if condition.Type == vmopv1alpha1.VirtualMachinePublishRequestConditionUploaded {
+							if condition.Type == vmopv1.VirtualMachinePublishRequestConditionUploaded {
 								return condition.Status == corev1.ConditionFalse &&
-									condition.Reason == vmopv1alpha1.UploadingReason &&
+									condition.Reason == vmopv1.UploadingReason &&
 									vmPubObj.Status.Attempts == 1
 							}
 						}
@@ -229,7 +229,7 @@ func virtualMachinePublishRequestReconcile() {
 					Eventually(func(g Gomega) {
 						obj := getVirtualMachinePublishRequest(ctx, client.ObjectKeyFromObject(vmpub))
 						g.Expect(obj).ToNot(BeNil())
-						g.Expect(conditions.IsTrue(obj, vmopv1alpha1.VirtualMachinePublishRequestConditionComplete)).To(BeTrue())
+						g.Expect(conditions.IsTrue(obj, vmopv1.VirtualMachinePublishRequestConditionComplete)).To(BeTrue())
 						g.Expect(obj.Status.Ready).To(BeTrue())
 						g.Expect(obj.Status.ImageName).To(Equal("dummy-image"))
 						g.Expect(obj.Status.CompletionTime).NotTo(BeZero())

--- a/controllers/virtualmachinepublishrequest/virtualmachinepublishrequest_controller_unit_test.go
+++ b/controllers/virtualmachinepublishrequest/virtualmachinepublishrequest_controller_unit_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/vmware/govmomi/vapi/library"
 	"github.com/vmware/govmomi/vim25/types"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	imgregv1a1 "github.com/vmware-tanzu/vm-operator/external/image-registry/api/v1alpha1"
 
@@ -47,21 +47,21 @@ func unitTestsReconcile() {
 		reconciler     *virtualmachinepublishrequest.Reconciler
 		fakeVMProvider *providerfake.VMProvider
 
-		vm       *vmopv1alpha1.VirtualMachine
-		vmpub    *vmopv1alpha1.VirtualMachinePublishRequest
+		vm       *vmopv1.VirtualMachine
+		vmpub    *vmopv1.VirtualMachinePublishRequest
 		cl       *imgregv1a1.ContentLibrary
 		vmpubCtx *vmopContext.VirtualMachinePublishRequestContext
 	)
 
 	BeforeEach(func() {
-		vm = &vmopv1alpha1.VirtualMachine{
+		vm = &vmopv1.VirtualMachine{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "dummy-vm",
 				Namespace: "dummy-ns",
 			},
-			Status: vmopv1alpha1.VirtualMachineStatus{
+			Status: vmopv1.VirtualMachineStatus{
 				UniqueID: "dummy-id",
-				Phase:    vmopv1alpha1.Created,
+				Phase:    vmopv1.Created,
 			},
 		}
 
@@ -154,7 +154,7 @@ func unitTestsReconcile() {
 
 				// Update SourceValid condition.
 				Expect(conditions.IsTrue(vmpub,
-					vmopv1alpha1.VirtualMachinePublishRequestConditionSourceValid)).To(BeFalse())
+					vmopv1.VirtualMachinePublishRequestConditionSourceValid)).To(BeFalse())
 			})
 
 			When("Source VM has empty uniqueID", func() {
@@ -169,7 +169,7 @@ func unitTestsReconcile() {
 
 					// Update SourceValid condition.
 					Expect(conditions.IsTrue(vmpub,
-						vmopv1alpha1.VirtualMachinePublishRequestConditionSourceValid)).To(BeFalse())
+						vmopv1.VirtualMachinePublishRequestConditionSourceValid)).To(BeFalse())
 				})
 			})
 		})
@@ -185,7 +185,7 @@ func unitTestsReconcile() {
 
 				// Update TargetValid condition.
 				Expect(conditions.IsTrue(vmpub,
-					vmopv1alpha1.VirtualMachinePublishRequestConditionTargetValid)).To(BeFalse())
+					vmopv1.VirtualMachinePublishRequestConditionTargetValid)).To(BeFalse())
 			})
 
 			It("returns error if content library is not writable", func() {
@@ -197,7 +197,7 @@ func unitTestsReconcile() {
 
 				// Update TargetValid condition.
 				Expect(conditions.IsTrue(vmpub,
-					vmopv1alpha1.VirtualMachinePublishRequestConditionTargetValid)).To(BeFalse())
+					vmopv1.VirtualMachinePublishRequestConditionTargetValid)).To(BeFalse())
 			})
 
 			It("returns error if content library is not ready", func() {
@@ -214,7 +214,7 @@ func unitTestsReconcile() {
 
 				// Update TargetValid condition.
 				Expect(conditions.IsTrue(vmpub,
-					vmopv1alpha1.VirtualMachinePublishRequestConditionTargetValid)).To(BeFalse())
+					vmopv1.VirtualMachinePublishRequestConditionTargetValid)).To(BeFalse())
 			})
 
 			When("item with same name already exists in the content library", func() {
@@ -232,7 +232,7 @@ func unitTestsReconcile() {
 
 					// Update TargetValid condition.
 					Expect(conditions.IsTrue(vmpub,
-						vmopv1alpha1.VirtualMachinePublishRequestConditionTargetValid)).To(BeFalse())
+						vmopv1.VirtualMachinePublishRequestConditionTargetValid)).To(BeFalse())
 				})
 			})
 		})
@@ -308,8 +308,8 @@ func unitTestsReconcile() {
 
 			When("Publish VM fails", func() {
 				JustBeforeEach(func() {
-					fakeVMProvider.PublishVirtualMachineFn = func(ctx goctx.Context, vm *vmopv1alpha1.VirtualMachine,
-						vmPub *vmopv1alpha1.VirtualMachinePublishRequest, cl *imgregv1a1.ContentLibrary, actID string) (string, error) {
+					fakeVMProvider.PublishVirtualMachineFn = func(ctx goctx.Context, vm *vmopv1.VirtualMachine,
+						vmPub *vmopv1.VirtualMachinePublishRequest, cl *imgregv1a1.ContentLibrary, actID string) (string, error) {
 						fakeVMProvider.AddToVMPublishMap(actID, types.TaskInfoStateError)
 						return "", fmt.Errorf("dummy error")
 					}
@@ -357,9 +357,9 @@ func unitTestsReconcile() {
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(conditions.IsTrue(vmpub,
-						vmopv1alpha1.VirtualMachinePublishRequestConditionUploaded)).To(BeFalse())
+						vmopv1.VirtualMachinePublishRequestConditionUploaded)).To(BeFalse())
 					Expect(conditions.IsTrue(vmpub,
-						vmopv1alpha1.VirtualMachinePublishRequestConditionImageAvailable)).To(BeFalse())
+						vmopv1.VirtualMachinePublishRequestConditionImageAvailable)).To(BeFalse())
 
 					Eventually(func() bool {
 						return fakeVMProvider.IsPublishVMCalled()
@@ -390,8 +390,8 @@ func unitTestsReconcile() {
 						}
 					})
 
-					getCondition := func(obj *vmopv1alpha1.VirtualMachinePublishRequest,
-						condition vmopv1alpha1.ConditionType) *vmopv1alpha1.Condition {
+					getCondition := func(obj *vmopv1.VirtualMachinePublishRequest,
+						condition vmopv1.ConditionType) *vmopv1.Condition {
 						for _, cond := range obj.Status.Conditions {
 							if cond.Type == condition {
 								return &cond
@@ -406,10 +406,10 @@ func unitTestsReconcile() {
 
 						Expect(fakeVMProvider.IsPublishVMCalled()).To(BeFalse())
 
-						uploadCondition := getCondition(vmpub, vmopv1alpha1.VirtualMachinePublishRequestConditionUploaded)
+						uploadCondition := getCondition(vmpub, vmopv1.VirtualMachinePublishRequestConditionUploaded)
 						Expect(uploadCondition).ToNot(BeNil())
 						Expect(uploadCondition.Status).To(Equal(corev1.ConditionFalse))
-						Expect(uploadCondition.Reason).To(Equal(vmopv1alpha1.UploadItemIDInvalidReason))
+						Expect(uploadCondition.Reason).To(Equal(vmopv1.UploadItemIDInvalidReason))
 					})
 
 					It("result type invalid, Upload condition is false, not send a second publish VM request and return success", func() {
@@ -420,9 +420,9 @@ func unitTestsReconcile() {
 
 						Expect(fakeVMProvider.IsPublishVMCalled()).To(BeFalse())
 
-						uploadCondition := getCondition(vmpub, vmopv1alpha1.VirtualMachinePublishRequestConditionUploaded)
+						uploadCondition := getCondition(vmpub, vmopv1.VirtualMachinePublishRequestConditionUploaded)
 						Expect(uploadCondition.Status).To(Equal(corev1.ConditionFalse))
-						Expect(uploadCondition.Reason).To(Equal(vmopv1alpha1.UploadItemIDInvalidReason))
+						Expect(uploadCondition.Reason).To(Equal(vmopv1.UploadItemIDInvalidReason))
 					})
 
 					It("result value invalid, Upload condition is false, not send a second publish VM request and return success", func() {
@@ -432,10 +432,10 @@ func unitTestsReconcile() {
 
 						Expect(fakeVMProvider.IsPublishVMCalled()).To(BeFalse())
 
-						uploadCondition := getCondition(vmpub, vmopv1alpha1.VirtualMachinePublishRequestConditionUploaded)
+						uploadCondition := getCondition(vmpub, vmopv1.VirtualMachinePublishRequestConditionUploaded)
 						Expect(uploadCondition).ToNot(BeNil())
 						Expect(uploadCondition.Status).To(Equal(corev1.ConditionFalse))
-						Expect(uploadCondition.Reason).To(Equal(vmopv1alpha1.UploadItemIDInvalidReason))
+						Expect(uploadCondition.Reason).To(Equal(vmopv1.UploadItemIDInvalidReason))
 					})
 				})
 
@@ -487,12 +487,12 @@ func unitTestsReconcile() {
 							Expect(fakeVMProvider.IsPublishVMCalled()).To(BeFalse())
 
 							Expect(conditions.IsTrue(vmpub,
-								vmopv1alpha1.VirtualMachinePublishRequestConditionUploaded)).To(BeTrue())
+								vmopv1.VirtualMachinePublishRequestConditionUploaded)).To(BeTrue())
 							Expect(conditions.IsTrue(vmpub,
-								vmopv1alpha1.VirtualMachinePublishRequestConditionImageAvailable)).To(BeTrue())
+								vmopv1.VirtualMachinePublishRequestConditionImageAvailable)).To(BeTrue())
 							Expect(vmpub.Status.ImageName).To(Equal("dummy-image"))
 							Expect(conditions.IsTrue(vmpub,
-								vmopv1alpha1.VirtualMachinePublishRequestConditionComplete)).To(BeTrue())
+								vmopv1.VirtualMachinePublishRequestConditionComplete)).To(BeTrue())
 							Expect(vmpub.Status.Ready).To(BeTrue())
 						})
 
@@ -510,11 +510,11 @@ func unitTestsReconcile() {
 							By("ImageAvailable is true and Complete is false")
 							Expect(fakeVMProvider.IsPublishVMCalled()).To(BeFalse())
 							Expect(conditions.IsTrue(vmpub,
-								vmopv1alpha1.VirtualMachinePublishRequestConditionUploaded)).To(BeTrue())
+								vmopv1.VirtualMachinePublishRequestConditionUploaded)).To(BeTrue())
 							Expect(conditions.IsTrue(vmpub,
-								vmopv1alpha1.VirtualMachinePublishRequestConditionImageAvailable)).To(BeTrue())
+								vmopv1.VirtualMachinePublishRequestConditionImageAvailable)).To(BeTrue())
 							Expect(conditions.IsTrue(vmpub,
-								vmopv1alpha1.VirtualMachinePublishRequestConditionComplete)).To(BeFalse())
+								vmopv1.VirtualMachinePublishRequestConditionComplete)).To(BeFalse())
 							Expect(vmpub.Status.Ready).To(BeFalse())
 
 							// requeue reconcile and update item description succeeded.
@@ -527,7 +527,7 @@ func unitTestsReconcile() {
 
 							By("Complete is true")
 							Expect(conditions.IsTrue(vmpub,
-								vmopv1alpha1.VirtualMachinePublishRequestConditionComplete)).To(BeTrue())
+								vmopv1.VirtualMachinePublishRequestConditionComplete)).To(BeTrue())
 							Expect(vmpub.Status.Ready).To(BeTrue())
 						})
 
@@ -542,7 +542,7 @@ func unitTestsReconcile() {
 								Expect(err).NotTo(HaveOccurred())
 
 								Eventually(func() bool {
-									newVMPub := &vmopv1alpha1.VirtualMachinePublishRequest{}
+									newVMPub := &vmopv1.VirtualMachinePublishRequest{}
 									err := ctx.Client.Get(ctx, client.ObjectKeyFromObject(vmpub), newVMPub)
 									return apiErrors.IsNotFound(err) || !newVMPub.DeletionTimestamp.IsZero()
 								}).Should(BeTrue())
@@ -557,11 +557,11 @@ func unitTestsReconcile() {
 
 							Expect(fakeVMProvider.IsPublishVMCalled()).To(BeFalse())
 							Expect(conditions.IsTrue(vmpub,
-								vmopv1alpha1.VirtualMachinePublishRequestConditionUploaded)).To(BeTrue())
+								vmopv1.VirtualMachinePublishRequestConditionUploaded)).To(BeTrue())
 							Expect(conditions.IsTrue(vmpub,
-								vmopv1alpha1.VirtualMachinePublishRequestConditionImageAvailable)).To(BeFalse())
+								vmopv1.VirtualMachinePublishRequestConditionImageAvailable)).To(BeFalse())
 							Expect(conditions.IsTrue(vmpub,
-								vmopv1alpha1.VirtualMachinePublishRequestConditionComplete)).To(BeFalse())
+								vmopv1.VirtualMachinePublishRequestConditionComplete)).To(BeFalse())
 							Expect(vmpub.Status.Ready).To(BeFalse())
 						})
 					})
@@ -586,7 +586,7 @@ func unitTestsReconcile() {
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(conditions.IsTrue(vmpub,
-						vmopv1alpha1.VirtualMachinePublishRequestConditionUploaded)).To(BeFalse())
+						vmopv1.VirtualMachinePublishRequestConditionUploaded)).To(BeFalse())
 
 					Eventually(func() bool {
 						return fakeVMProvider.IsPublishVMCalled()
@@ -616,7 +616,7 @@ func unitTestsReconcile() {
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(conditions.IsTrue(vmpub,
-						vmopv1alpha1.VirtualMachinePublishRequestConditionUploaded)).To(BeFalse())
+						vmopv1.VirtualMachinePublishRequestConditionUploaded)).To(BeFalse())
 
 					Consistently(func() bool {
 						return fakeVMProvider.IsPublishVMCalled()
@@ -641,7 +641,7 @@ func unitTestsReconcile() {
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(conditions.IsTrue(vmpub,
-						vmopv1alpha1.VirtualMachinePublishRequestConditionUploaded)).To(BeFalse())
+						vmopv1.VirtualMachinePublishRequestConditionUploaded)).To(BeFalse())
 
 					Consistently(func() bool {
 						return fakeVMProvider.IsPublishVMCalled()
@@ -672,9 +672,9 @@ func unitTestsReconcile() {
 
 					// Update TargetValid condition.
 					Expect(conditions.IsTrue(vmpub,
-						vmopv1alpha1.VirtualMachinePublishRequestConditionTargetValid)).To(BeTrue())
+						vmopv1.VirtualMachinePublishRequestConditionTargetValid)).To(BeTrue())
 					Expect(conditions.IsTrue(vmpub,
-						vmopv1alpha1.VirtualMachinePublishRequestConditionUploaded)).To(BeTrue())
+						vmopv1.VirtualMachinePublishRequestConditionUploaded)).To(BeTrue())
 				})
 			})
 		})

--- a/controllers/virtualmachineservice/providers/loadbalancer_provider.go
+++ b/controllers/virtualmachineservice/providers/loadbalancer_provider.go
@@ -9,7 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachineservice/providers/simplelb"
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachineservice/utils"
@@ -29,13 +29,13 @@ const (
 
 // LoadbalancerProvider sets up Loadbalancer for different type of Loadbalancer.
 type LoadbalancerProvider interface {
-	EnsureLoadBalancer(ctx context.Context, vmService *vmopv1alpha1.VirtualMachineService) error
+	EnsureLoadBalancer(ctx context.Context, vmService *vmopv1.VirtualMachineService) error
 
 	// GetServiceLabels returns the labels, if any, to place on a Service.
 	// This is applicable when VirtualMachineService is translated to a
 	// Service and we would like to apply the provider specific labels
 	// on the corresponding Service.
-	GetServiceLabels(ctx context.Context, vmService *vmopv1alpha1.VirtualMachineService) (map[string]string, error)
+	GetServiceLabels(ctx context.Context, vmService *vmopv1.VirtualMachineService) (map[string]string, error)
 
 	// GetToBeRemovedServiceLabels returns the labels, if any, to be
 	// removed from a Service.
@@ -46,13 +46,13 @@ type LoadbalancerProvider interface {
 	// labels to the Service so to correctly sync the addition/removal of
 	// labels on the Service object without touching the existing ones,
 	// we need to have clearly defined ownership
-	GetToBeRemovedServiceLabels(ctx context.Context, vmService *vmopv1alpha1.VirtualMachineService) (map[string]string, error)
+	GetToBeRemovedServiceLabels(ctx context.Context, vmService *vmopv1.VirtualMachineService) (map[string]string, error)
 
 	// GetServiceAnnotations returns the annotations, if any, to place on a Service.
 	// This is applicable when VirtualMachineService is translated to a
 	// Service and we would like to apply the provider specific annotations
 	// on the corresponding Service.
-	GetServiceAnnotations(ctx context.Context, vmService *vmopv1alpha1.VirtualMachineService) (map[string]string, error)
+	GetServiceAnnotations(ctx context.Context, vmService *vmopv1.VirtualMachineService) (map[string]string, error)
 
 	// GetToBeRemovedServiceAnnotations returns the annotations, if any, to be
 	// removed from a Service.
@@ -63,7 +63,7 @@ type LoadbalancerProvider interface {
 	// annotations to the Service so to correctly sync the addition/removal of
 	// annotations on the Service object without touching the existing ones,
 	// we need to have clearly defined ownership
-	GetToBeRemovedServiceAnnotations(ctx context.Context, vmService *vmopv1alpha1.VirtualMachineService) (map[string]string, error)
+	GetToBeRemovedServiceAnnotations(ctx context.Context, vmService *vmopv1.VirtualMachineService) (map[string]string, error)
 }
 
 func GetLoadbalancerProviderByType(mgr manager.Manager, providerType string) (LoadbalancerProvider, error) {
@@ -78,23 +78,23 @@ func GetLoadbalancerProviderByType(mgr manager.Manager, providerType string) (Lo
 
 type NoopLoadbalancerProvider struct{}
 
-func (NoopLoadbalancerProvider) EnsureLoadBalancer(context.Context, *vmopv1alpha1.VirtualMachineService) error {
+func (NoopLoadbalancerProvider) EnsureLoadBalancer(context.Context, *vmopv1.VirtualMachineService) error {
 	return nil
 }
 
-func (NoopLoadbalancerProvider) GetServiceLabels(ctx context.Context, vmService *vmopv1alpha1.VirtualMachineService) (map[string]string, error) {
+func (NoopLoadbalancerProvider) GetServiceLabels(ctx context.Context, vmService *vmopv1.VirtualMachineService) (map[string]string, error) {
 	return nil, nil
 }
 
-func (NoopLoadbalancerProvider) GetToBeRemovedServiceLabels(ctx context.Context, vmService *vmopv1alpha1.VirtualMachineService) (map[string]string, error) {
+func (NoopLoadbalancerProvider) GetToBeRemovedServiceLabels(ctx context.Context, vmService *vmopv1.VirtualMachineService) (map[string]string, error) {
 	return nil, nil
 }
 
-func (NoopLoadbalancerProvider) GetServiceAnnotations(ctx context.Context, vmService *vmopv1alpha1.VirtualMachineService) (map[string]string, error) {
+func (NoopLoadbalancerProvider) GetServiceAnnotations(ctx context.Context, vmService *vmopv1.VirtualMachineService) (map[string]string, error) {
 	return nil, nil
 }
 
-func (NoopLoadbalancerProvider) GetToBeRemovedServiceAnnotations(ctx context.Context, vmService *vmopv1alpha1.VirtualMachineService) (map[string]string, error) {
+func (NoopLoadbalancerProvider) GetToBeRemovedServiceAnnotations(ctx context.Context, vmService *vmopv1.VirtualMachineService) (map[string]string, error) {
 	return nil, nil
 }
 
@@ -106,13 +106,13 @@ func NsxtLoadBalancerProvider() *NsxtLoadbalancerProvider {
 	return &NsxtLoadbalancerProvider{}
 }
 
-func (nl *NsxtLoadbalancerProvider) EnsureLoadBalancer(ctx context.Context, vmService *vmopv1alpha1.VirtualMachineService) error {
+func (nl *NsxtLoadbalancerProvider) EnsureLoadBalancer(ctx context.Context, vmService *vmopv1.VirtualMachineService) error {
 	return nil
 }
 
 // GetServiceLabels provides the intended NSX-T specific labels on Service. The
 // responsibility is left to the caller to actually set them.
-func (nl *NsxtLoadbalancerProvider) GetServiceLabels(ctx context.Context, vmService *vmopv1alpha1.VirtualMachineService) (map[string]string, error) {
+func (nl *NsxtLoadbalancerProvider) GetServiceLabels(ctx context.Context, vmService *vmopv1.VirtualMachineService) (map[string]string, error) {
 	res := make(map[string]string)
 
 	// When externalTrafficPolicy is set to Local, skip kube-proxy for the
@@ -126,7 +126,7 @@ func (nl *NsxtLoadbalancerProvider) GetServiceLabels(ctx context.Context, vmServ
 
 // GetToBeRemovedServiceLabels provides the to be removed NSX-T specific labels on
 // Service. The responsibility is left to the caller to actually clear them.
-func (nl *NsxtLoadbalancerProvider) GetToBeRemovedServiceLabels(ctx context.Context, vmService *vmopv1alpha1.VirtualMachineService) (map[string]string, error) {
+func (nl *NsxtLoadbalancerProvider) GetToBeRemovedServiceLabels(ctx context.Context, vmService *vmopv1.VirtualMachineService) (map[string]string, error) {
 	res := make(map[string]string)
 
 	// When there is no externalTrafficPolicy configured or it's not Local,
@@ -140,7 +140,7 @@ func (nl *NsxtLoadbalancerProvider) GetToBeRemovedServiceLabels(ctx context.Cont
 
 // GetServiceAnnotations provides the intended NSX-T specific annotations on
 // Service. The responsibility is left to the caller to actually set them.
-func (nl *NsxtLoadbalancerProvider) GetServiceAnnotations(ctx context.Context, vmService *vmopv1alpha1.VirtualMachineService) (map[string]string, error) {
+func (nl *NsxtLoadbalancerProvider) GetServiceAnnotations(ctx context.Context, vmService *vmopv1.VirtualMachineService) (map[string]string, error) {
 	res := make(map[string]string)
 
 	if healthCheckNodePortString, ok := vmService.Annotations[utils.AnnotationServiceHealthCheckNodePortKey]; ok {
@@ -152,7 +152,7 @@ func (nl *NsxtLoadbalancerProvider) GetServiceAnnotations(ctx context.Context, v
 
 // GetToBeRemovedServiceAnnotations provides the to be removed NSX-T specific annotations on
 // Service. The responsibility is left to the caller to actually clear them.
-func (nl *NsxtLoadbalancerProvider) GetToBeRemovedServiceAnnotations(ctx context.Context, vmService *vmopv1alpha1.VirtualMachineService) (map[string]string, error) {
+func (nl *NsxtLoadbalancerProvider) GetToBeRemovedServiceAnnotations(ctx context.Context, vmService *vmopv1.VirtualMachineService) (map[string]string, error) {
 	res := make(map[string]string)
 
 	// When healthCheckNodePort is NOT present, the corresponding NSX-T

--- a/controllers/virtualmachineservice/providers/loadbalancer_provider_test.go
+++ b/controllers/virtualmachineservice/providers/loadbalancer_provider_test.go
@@ -12,9 +12,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachineservice/utils"
-
-	vmoperatorv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 )
 
 const (
@@ -24,7 +23,7 @@ const (
 var _ = Describe("Loadbalancer Provider", func() {
 	var (
 		ctx        context.Context
-		vmService  *vmoperatorv1alpha1.VirtualMachineService
+		vmService  *vmopv1.VirtualMachineService
 		lbProvider LoadbalancerProvider
 	)
 
@@ -77,14 +76,14 @@ var _ = Describe("Loadbalancer Provider", func() {
 
 	Context("GetServiceAnnotations when VMService has healthCheckNodePort defined", func() {
 		BeforeEach(func() {
-			vmService = &vmoperatorv1alpha1.VirtualMachineService{
+			vmService = &vmopv1.VirtualMachineService{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "dummy-vmservice",
 					Namespace:   dummyNamespace,
 					Annotations: make(map[string]string),
 				},
-				Spec: vmoperatorv1alpha1.VirtualMachineServiceSpec{
-					Type:         vmoperatorv1alpha1.VirtualMachineServiceTypeClusterIP,
+				Spec: vmopv1.VirtualMachineServiceSpec{
+					Type:         vmopv1.VirtualMachineServiceTypeClusterIP,
 					ClusterIP:    "TEST",
 					ExternalName: "TEST",
 				},
@@ -104,14 +103,14 @@ var _ = Describe("Loadbalancer Provider", func() {
 
 	Context("GetToBeRemovedServiceAnnotations when VMService does not have healthCheckNodePort defined", func() {
 		BeforeEach(func() {
-			vmService = &vmoperatorv1alpha1.VirtualMachineService{
+			vmService = &vmopv1.VirtualMachineService{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "dummy-vmservice",
 					Namespace:   dummyNamespace,
 					Annotations: make(map[string]string),
 				},
-				Spec: vmoperatorv1alpha1.VirtualMachineServiceSpec{
-					Type:         vmoperatorv1alpha1.VirtualMachineServiceTypeClusterIP,
+				Spec: vmopv1.VirtualMachineServiceSpec{
+					Type:         vmopv1.VirtualMachineServiceTypeClusterIP,
 					ClusterIP:    "TEST",
 					ExternalName: "TEST",
 				},
@@ -129,14 +128,14 @@ var _ = Describe("Loadbalancer Provider", func() {
 
 	Context("GetServiceLabels when VMService have externalTrafficPolicy annotation defined", func() {
 		BeforeEach(func() {
-			vmService = &vmoperatorv1alpha1.VirtualMachineService{
+			vmService = &vmopv1.VirtualMachineService{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "dummy-vmservice",
 					Namespace:   dummyNamespace,
 					Annotations: make(map[string]string),
 				},
-				Spec: vmoperatorv1alpha1.VirtualMachineServiceSpec{
-					Type:         vmoperatorv1alpha1.VirtualMachineServiceTypeClusterIP,
+				Spec: vmopv1.VirtualMachineServiceSpec{
+					Type:         vmopv1.VirtualMachineServiceTypeClusterIP,
 					ClusterIP:    "TEST",
 					ExternalName: "TEST",
 				},
@@ -181,14 +180,14 @@ var _ = Describe("Loadbalancer Provider", func() {
 		)
 
 		BeforeEach(func() {
-			vmService = &vmoperatorv1alpha1.VirtualMachineService{
+			vmService = &vmopv1.VirtualMachineService{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "dummy-vmservice",
 					Namespace:   dummyNamespace,
 					Annotations: make(map[string]string),
 				},
-				Spec: vmoperatorv1alpha1.VirtualMachineServiceSpec{
-					Type:         vmoperatorv1alpha1.VirtualMachineServiceTypeClusterIP,
+				Spec: vmopv1.VirtualMachineServiceSpec{
+					Type:         vmopv1.VirtualMachineServiceTypeClusterIP,
 					ClusterIP:    "TEST",
 					ExternalName: "TEST",
 				},

--- a/controllers/virtualmachineservice/providers/simplelb/lb_cloudconfig.go
+++ b/controllers/virtualmachineservice/providers/simplelb/lb_cloudconfig.go
@@ -10,7 +10,7 @@ import (
 
 	"sigs.k8s.io/yaml"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 )
 
 const XdsNodePort = 31799
@@ -19,7 +19,7 @@ var envoyBootstrapConfigTemplate, _ = template.New("envoyBootstrapConfig").Parse
 
 type lbConfigParams struct {
 	NodeID      string
-	Ports       []vmopv1alpha1.VirtualMachineServicePort
+	Ports       []vmopv1.VirtualMachineServicePort
 	CPNodes     []string
 	XdsNodePort int
 }

--- a/controllers/virtualmachineservice/providers/simplelb/lb_cloudconfig_test.go
+++ b/controllers/virtualmachineservice/providers/simplelb/lb_cloudconfig_test.go
@@ -12,7 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
-	vmoperatorv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 )
 
 var _ = Describe("lbCloudConfig", func() {
@@ -22,13 +22,13 @@ var _ = Describe("lbCloudConfig", func() {
 		})
 
 		When("given properly initialized lbConfigParams", func() {
-			vmService := &vmoperatorv1alpha1.VirtualMachineService{
+			vmService := &vmopv1.VirtualMachineService{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "testnamespace",
 					Name:      "testname",
 				},
-				Spec: vmoperatorv1alpha1.VirtualMachineServiceSpec{
-					Ports: []vmoperatorv1alpha1.VirtualMachineServicePort{{
+				Spec: vmopv1.VirtualMachineServiceSpec{
+					Ports: []vmopv1.VirtualMachineServicePort{{
 						Name:       "apiserver",
 						Protocol:   "TCP",
 						Port:       6443,

--- a/controllers/virtualmachineservice/providers/simplelb/simplelb_provider_test.go
+++ b/controllers/virtualmachineservice/providers/simplelb/simplelb_provider_test.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
@@ -43,13 +43,13 @@ var _ = Describe("", func() {
 		testSvc = "test-svc"
 		lbVMIP  = "11.12.13.14"
 	)
-	vmService := &vmopv1alpha1.VirtualMachineService{
+	vmService := &vmopv1.VirtualMachineService{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNs,
 			Name:      testSvc,
 		},
-		Spec: vmopv1alpha1.VirtualMachineServiceSpec{
-			Ports: []vmopv1alpha1.VirtualMachineServicePort{{
+		Spec: vmopv1.VirtualMachineServiceSpec{
+			Ports: []vmopv1.VirtualMachineServicePort{{
 				Name:       "apiserver",
 				Port:       6443,
 				Protocol:   "TCP",
@@ -58,7 +58,7 @@ var _ = Describe("", func() {
 		},
 	}
 	vmKey := types.NamespacedName{Namespace: testNs, Name: testSvc + "-lb"}
-	vm := &vmopv1alpha1.VirtualMachine{}
+	vm := &vmopv1.VirtualMachine{}
 	client := builder.NewFakeClient(vmService)
 	controlPlane := &fakeControlPlane{}
 	simpleLbProvider := Provider{
@@ -66,19 +66,19 @@ var _ = Describe("", func() {
 		controlPlane: controlPlane,
 		log:          logr.Discard(),
 	}
-	vmImage := &vmopv1alpha1.VirtualMachineImage{
+	vmImage := &vmopv1.VirtualMachineImage{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "loadbalancer-vm-",
 		},
 	}
 
-	vmClass := &vmopv1alpha1.VirtualMachineClass{
+	vmClass := &vmopv1.VirtualMachineClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "best-effort-small",
 		},
 	}
 
-	vmClassBinding := &vmopv1alpha1.VirtualMachineClassBinding{
+	vmClassBinding := &vmopv1.VirtualMachineClassBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "best-effort-small",
 			Namespace: testNs,
@@ -87,20 +87,20 @@ var _ = Describe("", func() {
 
 	BeforeEach(func() {
 		// ensure vm class and vm class binding exists.
-		classList := &vmopv1alpha1.VirtualMachineClassList{}
+		classList := &vmopv1.VirtualMachineClassList{}
 		Expect(client.List(context.TODO(), classList)).To(Succeed())
 		if len(classList.Items) == 0 {
 			Expect(client.Create(context.TODO(), vmClass)).To(Succeed())
 		}
 
-		bindingList := &vmopv1alpha1.VirtualMachineClassBindingList{}
+		bindingList := &vmopv1.VirtualMachineClassBindingList{}
 		Expect(client.List(context.TODO(), bindingList)).To(Succeed())
 		if len(bindingList.Items) == 0 {
 			Expect(client.Create(context.TODO(), vmClassBinding)).To(Succeed())
 		}
 
 		// ensure vm image exists.
-		imageList := &vmopv1alpha1.VirtualMachineImageList{}
+		imageList := &vmopv1.VirtualMachineImageList{}
 		Expect(client.List(context.TODO(), imageList)).To(Succeed())
 		if len(imageList.Items) == 0 {
 			Expect(client.Create(context.TODO(), vmImage)).To(Succeed())

--- a/controllers/virtualmachineservice/virtualmachineservice_controller_intg_test.go
+++ b/controllers/virtualmachineservice/virtualmachineservice_controller_intg_test.go
@@ -11,7 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
@@ -27,7 +27,7 @@ func intgTests() {
 
 		selector      map[string]string
 		vmIP1, vmIP2  string
-		vmServicePort vmopv1alpha1.VirtualMachineServicePort
+		vmServicePort vmopv1.VirtualMachineServicePort
 		vmServiceName string
 	)
 
@@ -37,7 +37,7 @@ func intgTests() {
 		selector = map[string]string{"vmservice-intg-test": "selector"}
 		vmIP1, vmIP2 = "10.100.101.1", "10.100.101.2"
 
-		vmServicePort = vmopv1alpha1.VirtualMachineServicePort{
+		vmServicePort = vmopv1.VirtualMachineServicePort{
 			Name:       "port1",
 			Protocol:   "TCP",
 			Port:       42,
@@ -49,7 +49,7 @@ func intgTests() {
 		By("Object cleanup", func() {
 			objMeta := metav1.ObjectMeta{Name: vmServiceName, Namespace: ctx.Namespace}
 
-			vmService := &vmopv1alpha1.VirtualMachineService{ObjectMeta: objMeta}
+			vmService := &vmopv1.VirtualMachineService{ObjectMeta: objMeta}
 			err := ctx.Client.Delete(ctx, vmService)
 			Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
 
@@ -76,27 +76,27 @@ func intgTests() {
 				dummyAnnotationKey, dummyAnnotationVal := "dummy-annotation-key", "dummy-annotation-val"
 				dummyLabelKey, dummyLabelVal := "dummy-label-key", "dummy-label-val"
 
-				notReadyVM := &vmopv1alpha1.VirtualMachine{}
+				notReadyVM := &vmopv1.VirtualMachine{}
 				By("Create not ready VM with selected labels", func() {
-					notReadyVM = &vmopv1alpha1.VirtualMachine{
+					notReadyVM = &vmopv1.VirtualMachine{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "not-ready-vm",
 							Namespace: ctx.Namespace,
 							Labels:    selector,
 						},
-						Spec: vmopv1alpha1.VirtualMachineSpec{
-							PowerState:     vmopv1alpha1.VirtualMachinePoweredOn,
-							ReadinessProbe: &vmopv1alpha1.Probe{},
+						Spec: vmopv1.VirtualMachineSpec{
+							PowerState:     vmopv1.VirtualMachinePoweredOn,
+							ReadinessProbe: &vmopv1.Probe{},
 						},
 					}
 					Expect(ctx.Client.Create(ctx, notReadyVM)).To(Succeed())
 					notReadyVM.Status.VmIp = vmIP1
-					conditions.MarkFalse(notReadyVM, vmopv1alpha1.ReadyCondition, "not ready",
-						vmopv1alpha1.ConditionSeverityError, "VM should be skipped")
+					conditions.MarkFalse(notReadyVM, vmopv1.ReadyCondition, "not ready",
+						vmopv1.ConditionSeverityError, "VM should be skipped")
 					Expect(ctx.Client.Status().Update(ctx, notReadyVM))
 				})
 
-				vmService := &vmopv1alpha1.VirtualMachineService{
+				vmService := &vmopv1.VirtualMachineService{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      vmServiceName,
 						Namespace: ctx.Namespace,
@@ -107,9 +107,9 @@ func intgTests() {
 							dummyLabelKey: dummyLabelVal,
 						},
 					},
-					Spec: vmopv1alpha1.VirtualMachineServiceSpec{
-						Type:     vmopv1alpha1.VirtualMachineServiceTypeLoadBalancer,
-						Ports:    []vmopv1alpha1.VirtualMachineServicePort{vmServicePort},
+					Spec: vmopv1.VirtualMachineServiceSpec{
+						Type:     vmopv1.VirtualMachineServiceTypeLoadBalancer,
+						Ports:    []vmopv1.VirtualMachineServicePort{vmServicePort},
 						Selector: selector,
 					},
 				}
@@ -122,7 +122,7 @@ func intgTests() {
 
 				By("VirtualMachineService finalizer should get set")
 				Eventually(func() []string {
-					vmService := &vmopv1alpha1.VirtualMachineService{}
+					vmService := &vmopv1.VirtualMachineService{}
 					if err := ctx.Client.Get(ctx, objKey, vmService); err == nil {
 						return vmService.GetFinalizers()
 					}
@@ -172,23 +172,23 @@ func intgTests() {
 					})
 				})
 
-				readyVM := &vmopv1alpha1.VirtualMachine{}
+				readyVM := &vmopv1.VirtualMachine{}
 				By("Create ready VM with selected labels,", func() {
-					readyVM = &vmopv1alpha1.VirtualMachine{
+					readyVM = &vmopv1.VirtualMachine{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "ready-vm",
 							Namespace: ctx.Namespace,
 							Labels:    selector,
 						},
-						Spec: vmopv1alpha1.VirtualMachineSpec{
-							PowerState:     vmopv1alpha1.VirtualMachinePoweredOn,
-							ReadinessProbe: &vmopv1alpha1.Probe{},
+						Spec: vmopv1.VirtualMachineSpec{
+							PowerState:     vmopv1.VirtualMachinePoweredOn,
+							ReadinessProbe: &vmopv1.Probe{},
 						},
 					}
 					Expect(ctx.Client.Create(ctx, readyVM)).To(Succeed())
 
 					readyVM.Status.VmIp = vmIP2
-					conditions.MarkTrue(readyVM, vmopv1alpha1.ReadyCondition)
+					conditions.MarkTrue(readyVM, vmopv1.ReadyCondition)
 					Expect(ctx.Client.Status().Update(ctx, readyVM)).To(Succeed())
 				})
 
@@ -267,7 +267,7 @@ func intgTests() {
 					Expect(ctx.Client.Delete(ctx, vmService)).To(Succeed())
 
 					Eventually(func() []string {
-						vmService := &vmopv1alpha1.VirtualMachineService{}
+						vmService := &vmopv1.VirtualMachineService{}
 						if err := ctx.Client.Get(ctx, objKey, vmService); err == nil {
 							return vmService.GetFinalizers()
 						}
@@ -284,33 +284,33 @@ func intgTests() {
 
 			// The VM mapping function needs to be fixed for this to work.
 			XIt("Simulate workflow", func() {
-				readyVM := &vmopv1alpha1.VirtualMachine{}
+				readyVM := &vmopv1.VirtualMachine{}
 				By("Create ready VM with selected labels", func() {
-					readyVM = &vmopv1alpha1.VirtualMachine{
+					readyVM = &vmopv1.VirtualMachine{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "not-ready-vm",
 							Namespace: ctx.Namespace,
 							Labels:    selector,
 						},
-						Spec: vmopv1alpha1.VirtualMachineSpec{
-							PowerState:     vmopv1alpha1.VirtualMachinePoweredOn,
-							ReadinessProbe: &vmopv1alpha1.Probe{},
+						Spec: vmopv1.VirtualMachineSpec{
+							PowerState:     vmopv1.VirtualMachinePoweredOn,
+							ReadinessProbe: &vmopv1.Probe{},
 						},
 					}
 					Expect(ctx.Client.Create(ctx, readyVM)).To(Succeed())
 					readyVM.Status.VmIp = vmIP1
-					conditions.MarkTrue(readyVM, vmopv1alpha1.ReadyCondition)
+					conditions.MarkTrue(readyVM, vmopv1.ReadyCondition)
 					Expect(ctx.Client.Status().Update(ctx, readyVM))
 				})
 
-				vmService := &vmopv1alpha1.VirtualMachineService{
+				vmService := &vmopv1.VirtualMachineService{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      vmServiceName,
 						Namespace: ctx.Namespace,
 					},
-					Spec: vmopv1alpha1.VirtualMachineServiceSpec{
-						Type:     vmopv1alpha1.VirtualMachineServiceTypeLoadBalancer,
-						Ports:    []vmopv1alpha1.VirtualMachineServicePort{vmServicePort},
+					Spec: vmopv1.VirtualMachineServiceSpec{
+						Type:     vmopv1.VirtualMachineServiceTypeLoadBalancer,
+						Ports:    []vmopv1.VirtualMachineServicePort{vmServicePort},
 						Selector: selector,
 					},
 				}

--- a/controllers/virtualmachineservice/virtualmachineservice_controller_unit_test.go
+++ b/controllers/virtualmachineservice/virtualmachineservice_controller_unit_test.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachineservice"
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachineservice/providers"
@@ -41,9 +41,9 @@ func unitTestsReconcile() {
 		reconciler   *virtualmachineservice.ReconcileVirtualMachineService
 		vmServiceCtx *vmopContext.VirtualMachineServiceContext
 
-		vmService      *vmopv1alpha1.VirtualMachineService
-		vmServicePort1 vmopv1alpha1.VirtualMachineServicePort
-		vmServicePort2 vmopv1alpha1.VirtualMachineServicePort
+		vmService      *vmopv1.VirtualMachineService
+		vmServicePort1 vmopv1.VirtualMachineServicePort
+		vmServicePort2 vmopv1.VirtualMachineServicePort
 		lbSourceRanges []string
 		objKey         client.ObjectKey
 	)
@@ -64,15 +64,15 @@ func unitTestsReconcile() {
 	)
 
 	BeforeEach(func() {
-		vmService = &vmopv1alpha1.VirtualMachineService{
+		vmService = &vmopv1.VirtualMachineService{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        "dummy-vm-service",
 				Namespace:   "dummy-ns",
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-			Spec: vmopv1alpha1.VirtualMachineServiceSpec{
-				Type:                     vmopv1alpha1.VirtualMachineServiceTypeLoadBalancer,
+			Spec: vmopv1.VirtualMachineServiceSpec{
+				Type:                     vmopv1.VirtualMachineServiceTypeLoadBalancer,
 				Selector:                 map[string]string{},
 				ExternalName:             externalName,
 				ClusterIP:                clusterIP,
@@ -81,14 +81,14 @@ func unitTestsReconcile() {
 			},
 		}
 
-		vmServicePort1 = vmopv1alpha1.VirtualMachineServicePort{
+		vmServicePort1 = vmopv1.VirtualMachineServicePort{
 			Name:       "port1",
 			Protocol:   "TCP",
 			Port:       42,
 			TargetPort: 142,
 		}
 
-		vmServicePort2 = vmopv1alpha1.VirtualMachineServicePort{
+		vmServicePort2 = vmopv1.VirtualMachineServicePort{
 			Name:       "port2",
 			Protocol:   "UDP",
 			Port:       1042,
@@ -177,7 +177,7 @@ func unitTestsReconcile() {
 
 			Context("With Expected Spec.Ports", func() {
 				BeforeEach(func() {
-					vmService.Spec.Ports = []vmopv1alpha1.VirtualMachineServicePort{
+					vmService.Spec.Ports = []vmopv1.VirtualMachineServicePort{
 						vmServicePort1,
 						vmServicePort2,
 					}
@@ -350,7 +350,7 @@ func unitTestsReconcile() {
 
 			Context("Preserves existing NodePort", func() {
 				BeforeEach(func() {
-					vmService.Spec.Ports = []vmopv1alpha1.VirtualMachineServicePort{
+					vmService.Spec.Ports = []vmopv1.VirtualMachineServicePort{
 						vmServicePort1,
 					}
 				})
@@ -409,7 +409,7 @@ func unitTestsReconcile() {
 		Context("Creates expected Endpoints", func() {
 			var endpoints *corev1.Endpoints
 			var labelSelector map[string]string
-			var vm1, vm2, vm3 *vmopv1alpha1.VirtualMachine
+			var vm1, vm2, vm3 *vmopv1.VirtualMachine
 
 			BeforeEach(func() {
 				endpoints = &corev1.Endpoints{}
@@ -418,39 +418,39 @@ func unitTestsReconcile() {
 				vmService.Annotations[annotationName1] = "bar1"
 				vmService.Labels[labelName1] = "bar2"
 				vmService.Spec.Selector = labelSelector
-				vmService.Spec.Ports = []vmopv1alpha1.VirtualMachineServicePort{
+				vmService.Spec.Ports = []vmopv1.VirtualMachineServicePort{
 					vmServicePort1,
 				}
 
-				vm1 = &vmopv1alpha1.VirtualMachine{
+				vm1 = &vmopv1.VirtualMachine{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "dummy-vm1",
 						Namespace: vmService.Namespace,
 						Labels:    labelSelector,
 					},
-					Status: vmopv1alpha1.VirtualMachineStatus{
+					Status: vmopv1.VirtualMachineStatus{
 						VmIp: "1.1.1.1",
 					},
 				}
 
-				vm2 = &vmopv1alpha1.VirtualMachine{
+				vm2 = &vmopv1.VirtualMachine{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "dummy-vm2",
 						Namespace: vmService.Namespace,
 						Labels:    labelSelector,
 					},
-					Status: vmopv1alpha1.VirtualMachineStatus{
+					Status: vmopv1.VirtualMachineStatus{
 						VmIp: "2.2.2.2",
 					},
 				}
 
-				vm3 = &vmopv1alpha1.VirtualMachine{
+				vm3 = &vmopv1.VirtualMachine{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "dummy-vm3",
 						Namespace: vmService.Namespace,
 						Labels:    map[string]string{},
 					},
-					Status: vmopv1alpha1.VirtualMachineStatus{
+					Status: vmopv1.VirtualMachineStatus{
 						VmIp: "3.3.3.3",
 					},
 				}
@@ -551,9 +551,9 @@ func unitTestsReconcile() {
 
 			Context("When VMs have Readiness Probe", func() {
 				BeforeEach(func() {
-					vm1.Spec.ReadinessProbe = &vmopv1alpha1.Probe{}
-					vm2.Spec.ReadinessProbe = &vmopv1alpha1.Probe{}
-					vm3.Spec.ReadinessProbe = &vmopv1alpha1.Probe{}
+					vm1.Spec.ReadinessProbe = &vmopv1.Probe{}
+					vm2.Spec.ReadinessProbe = &vmopv1.Probe{}
+					vm3.Spec.ReadinessProbe = &vmopv1.Probe{}
 
 					initObjects = append(initObjects, vm1, vm2, vm3)
 				})
@@ -573,7 +573,7 @@ func unitTestsReconcile() {
 
 				Context("Unready VM with false Ready condition", func() {
 					BeforeEach(func() {
-						conditions.MarkFalse(vm1, vmopv1alpha1.ReadyCondition, "reason", vmopv1alpha1.ConditionSeverityError, "")
+						conditions.MarkFalse(vm1, vmopv1.ReadyCondition, "reason", vmopv1.ConditionSeverityError, "")
 					})
 
 					It("With expected Subsets", func() {
@@ -592,7 +592,7 @@ func unitTestsReconcile() {
 
 				Context("Ready VM with true Ready condition", func() {
 					BeforeEach(func() {
-						conditions.MarkTrue(vm1, vmopv1alpha1.ReadyCondition)
+						conditions.MarkTrue(vm1, vmopv1.ReadyCondition)
 					})
 
 					It("With expected Subsets", func() {
@@ -613,11 +613,11 @@ func unitTestsReconcile() {
 			Context("Preserve VMs in Endpoints that have Probe but hasn't run yet", func() {
 				BeforeEach(func() {
 					vm1.UID = "abc"
-					vm1.Spec.ReadinessProbe = &vmopv1alpha1.Probe{}
+					vm1.Spec.ReadinessProbe = &vmopv1.Probe{}
 					vm2.UID = "xyz"
-					vm2.Spec.ReadinessProbe = &vmopv1alpha1.Probe{}
+					vm2.Spec.ReadinessProbe = &vmopv1.Probe{}
 					// Initial setup so that the first Reconcile will add the VM.
-					conditions.MarkTrue(vm1, vmopv1alpha1.ReadyCondition)
+					conditions.MarkTrue(vm1, vmopv1.ReadyCondition)
 					initObjects = append(initObjects, vm1, vm2)
 				})
 
@@ -705,8 +705,8 @@ func nsxtLBProviderTestsReconcile() {
 		reconciler   *virtualmachineservice.ReconcileVirtualMachineService
 		vmServiceCtx *vmopContext.VirtualMachineServiceContext
 
-		vmServicePort1 vmopv1alpha1.VirtualMachineServicePort
-		vmService      *vmopv1alpha1.VirtualMachineService
+		vmServicePort1 vmopv1.VirtualMachineServicePort
+		vmService      *vmopv1.VirtualMachineService
 		objKey         client.ObjectKey
 
 		lbSourceRanges = []string{"1.1.1.0/24", "2.2.0.0/16"}
@@ -719,28 +719,28 @@ func nsxtLBProviderTestsReconcile() {
 	)
 
 	BeforeEach(func() {
-		vmServicePort1 = vmopv1alpha1.VirtualMachineServicePort{
+		vmServicePort1 = vmopv1.VirtualMachineServicePort{
 			Name:       "port1",
 			Protocol:   "TCP",
 			Port:       42,
 			TargetPort: 142,
 		}
 
-		vmService = &vmopv1alpha1.VirtualMachineService{
+		vmService = &vmopv1.VirtualMachineService{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        "dummy-vm-service",
 				Namespace:   "dummy-ns",
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-			Spec: vmopv1alpha1.VirtualMachineServiceSpec{
-				Type:                     vmopv1alpha1.VirtualMachineServiceTypeLoadBalancer,
+			Spec: vmopv1.VirtualMachineServiceSpec{
+				Type:                     vmopv1.VirtualMachineServiceTypeLoadBalancer,
 				Selector:                 map[string]string{},
 				ExternalName:             externalName,
 				ClusterIP:                clusterIP,
 				LoadBalancerIP:           loadBalancerIP,
 				LoadBalancerSourceRanges: lbSourceRanges,
-				Ports:                    []vmopv1alpha1.VirtualMachineServicePort{vmServicePort1},
+				Ports:                    []vmopv1.VirtualMachineServicePort{vmServicePort1},
 			},
 		}
 
@@ -900,7 +900,7 @@ func expectEvent(ctx *builder.UnitTestContextForController, matcher types.Gomega
 
 func assertEPPortFromVMServicePort(
 	port corev1.EndpointPort,
-	vmServicePort vmopv1alpha1.VirtualMachineServicePort) {
+	vmServicePort vmopv1.VirtualMachineServicePort) {
 
 	ExpectWithOffset(1, port.Name).To(Equal(vmServicePort.Name))
 	ExpectWithOffset(1, port.Protocol).To(BeEquivalentTo(vmServicePort.Protocol))
@@ -909,7 +909,7 @@ func assertEPPortFromVMServicePort(
 
 func assertEPAddrFromVM(
 	addr corev1.EndpointAddress,
-	vm *vmopv1alpha1.VirtualMachine) {
+	vm *vmopv1.VirtualMachine) {
 
 	ExpectWithOffset(1, addr.IP).To(Equal(vm.Status.VmIp))
 	ExpectWithOffset(1, addr.TargetRef).ToNot(BeNil())

--- a/controllers/virtualmachinesetresourcepolicy/virtualmachinesetresourcepolicy_controller.go
+++ b/controllers/virtualmachinesetresourcepolicy/virtualmachinesetresourcepolicy_controller.go
@@ -15,7 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/patch"
@@ -29,7 +29,7 @@ const (
 // AddToManager adds this package's controller to the provided manager.
 func AddToManager(ctx *context.ControllerManagerContext, mgr manager.Manager) error {
 	var (
-		controlledType     = &vmopv1alpha1.VirtualMachineSetResourcePolicy{}
+		controlledType     = &vmopv1.VirtualMachineSetResourcePolicy{}
 		controlledTypeName = reflect.TypeOf(controlledType).Elem().Name()
 	)
 
@@ -89,7 +89,7 @@ func (r *Reconciler) deleteResourcePolicy(ctx *context.VirtualMachineSetResource
 	resourcePolicy := ctx.ResourcePolicy
 
 	// Skip deleting a VirtualMachineSetResourcePolicy if it is referenced by a VirtualMachine.
-	vmsInNamespace := &vmopv1alpha1.VirtualMachineList{}
+	vmsInNamespace := &vmopv1.VirtualMachineList{}
 	if err := r.List(ctx, vmsInNamespace, client.InNamespace(resourcePolicy.Namespace)); err != nil {
 		ctx.Logger.Error(err, "Failed to list VMs in namespace", "namespace", resourcePolicy.Namespace)
 		return err
@@ -133,7 +133,7 @@ func (r *Reconciler) ReconcileDelete(ctx *context.VirtualMachineSetResourcePolic
 // +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachinesetresourcepolicies/status,verbs=get;update;patch
 
 func (r *Reconciler) Reconcile(ctx goctx.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
-	rp := &vmopv1alpha1.VirtualMachineSetResourcePolicy{}
+	rp := &vmopv1.VirtualMachineSetResourcePolicy{}
 	if err := r.Get(ctx, req.NamespacedName, rp); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}

--- a/controllers/virtualmachinesetresourcepolicy/virtualmachinesetresourcepolicy_controller_intg_test.go
+++ b/controllers/virtualmachinesetresourcepolicy/virtualmachinesetresourcepolicy_controller_intg_test.go
@@ -13,7 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
@@ -22,19 +22,19 @@ func intgTests() {
 	var (
 		ctx *builder.IntegrationTestContext
 
-		resourcePolicy    *vmopv1alpha1.VirtualMachineSetResourcePolicy
+		resourcePolicy    *vmopv1.VirtualMachineSetResourcePolicy
 		resourcePolicyKey client.ObjectKey
 	)
 
 	BeforeEach(func() {
 		ctx = suite.NewIntegrationTestContext()
 
-		resourcePolicy = &vmopv1alpha1.VirtualMachineSetResourcePolicy{
+		resourcePolicy = &vmopv1.VirtualMachineSetResourcePolicy{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ctx.Namespace,
 				Name:      "dummy-vm-policy",
 			},
-			Spec: vmopv1alpha1.VirtualMachineSetResourcePolicySpec{},
+			Spec: vmopv1.VirtualMachineSetResourcePolicySpec{},
 		}
 
 		resourcePolicyKey = client.ObjectKey{Namespace: resourcePolicy.Namespace, Name: resourcePolicy.Name}
@@ -46,8 +46,8 @@ func intgTests() {
 		intgFakeVMProvider.Reset()
 	})
 
-	getResourcePolicy := func(ctx *builder.IntegrationTestContext, objKey client.ObjectKey) *vmopv1alpha1.VirtualMachineSetResourcePolicy {
-		rp := &vmopv1alpha1.VirtualMachineSetResourcePolicy{}
+	getResourcePolicy := func(ctx *builder.IntegrationTestContext, objKey client.ObjectKey) *vmopv1.VirtualMachineSetResourcePolicy {
+		rp := &vmopv1.VirtualMachineSetResourcePolicy{}
 		if err := ctx.Client.Get(ctx, objKey, rp); err != nil {
 			return nil
 		}
@@ -70,7 +70,7 @@ func intgTests() {
 			called.Store(false)
 
 			intgFakeVMProvider.Lock()
-			intgFakeVMProvider.CreateOrUpdateVirtualMachineSetResourcePolicyFn = func(_ context.Context, _ *vmopv1alpha1.VirtualMachineSetResourcePolicy) error {
+			intgFakeVMProvider.CreateOrUpdateVirtualMachineSetResourcePolicyFn = func(_ context.Context, _ *vmopv1.VirtualMachineSetResourcePolicy) error {
 				called.Store(true)
 				return nil
 			}

--- a/controllers/virtualmachinesetresourcepolicy/virtualmachinesetresourcepolicy_controller_unit_test.go
+++ b/controllers/virtualmachinesetresourcepolicy/virtualmachinesetresourcepolicy_controller_unit_test.go
@@ -13,7 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachinesetresourcepolicy"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
@@ -35,24 +35,24 @@ func unitTestsReconcile() {
 		reconciler  *virtualmachinesetresourcepolicy.Reconciler
 
 		resourcePolicyCtx *context.VirtualMachineSetResourcePolicyContext
-		resourcePolicy    *vmopv1alpha1.VirtualMachineSetResourcePolicy
-		vm                *vmopv1alpha1.VirtualMachine
+		resourcePolicy    *vmopv1.VirtualMachineSetResourcePolicy
+		vm                *vmopv1.VirtualMachine
 	)
 
 	BeforeEach(func() {
-		resourcePolicy = &vmopv1alpha1.VirtualMachineSetResourcePolicy{
+		resourcePolicy = &vmopv1.VirtualMachineSetResourcePolicy{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "dummy-rp",
 				Namespace: "dummy-ns",
 			},
-			Spec: vmopv1alpha1.VirtualMachineSetResourcePolicySpec{},
+			Spec: vmopv1.VirtualMachineSetResourcePolicySpec{},
 		}
-		vm = &vmopv1alpha1.VirtualMachine{
+		vm = &vmopv1.VirtualMachine{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "dummy-vm",
 				Namespace: "dummy-ns",
 			},
-			Spec: vmopv1alpha1.VirtualMachineSpec{
+			Spec: vmopv1.VirtualMachineSpec{
 				ResourcePolicyName: "dummy-rp",
 			},
 		}

--- a/controllers/volume/volume_controller_intg_test.go
+++ b/controllers/volume/volume_controller_intg_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/google/uuid"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/controllers/volume"
 	cnsv1alpha1 "github.com/vmware-tanzu/vm-operator/external/vsphere-csi-driver/pkg/syncer/cnsoperator/apis/cnsnodevmattachment/v1alpha1"
@@ -34,10 +34,10 @@ func intgTests() {
 	var (
 		ctx *builder.IntegrationTestContext
 
-		vm                    *vmopv1alpha1.VirtualMachine
+		vm                    *vmopv1.VirtualMachine
 		vmKey                 types.NamespacedName
-		vmVolume1             vmopv1alpha1.VirtualMachineVolume
-		vmVolume2             vmopv1alpha1.VirtualMachineVolume
+		vmVolume1             vmopv1.VirtualMachineVolume
+		vmVolume2             vmopv1.VirtualMachineVolume
 		dummyBiosUUID         string
 		dummyDiskUUID1        string
 		dummyDiskUUID2        string
@@ -61,32 +61,32 @@ func intgTests() {
 		dummyDiskUUID1 = uuid.New().String()
 		dummyDiskUUID2 = uuid.New().String()
 
-		vmVolume1 = vmopv1alpha1.VirtualMachineVolume{
+		vmVolume1 = vmopv1.VirtualMachineVolume{
 			Name: "cns-volume-1",
-			PersistentVolumeClaim: &vmopv1alpha1.PersistentVolumeClaimVolumeSource{
+			PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
 				PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
 					ClaimName: "pvc-volume-1",
 				},
 			},
 		}
 
-		vmVolume2 = vmopv1alpha1.VirtualMachineVolume{
+		vmVolume2 = vmopv1.VirtualMachineVolume{
 			Name: "cns-volume-2",
-			PersistentVolumeClaim: &vmopv1alpha1.PersistentVolumeClaimVolumeSource{
+			PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
 				PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
 					ClaimName: "pvc-volume-2",
 				},
 			},
 		}
 
-		vm = &vmopv1alpha1.VirtualMachine{
+		vm = &vmopv1.VirtualMachine{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ctx.Namespace,
 				Name:      "dummy-vm",
 			},
-			Spec: vmopv1alpha1.VirtualMachineSpec{
+			Spec: vmopv1.VirtualMachineSpec{
 				ImageName:  "dummy-image",
-				PowerState: vmopv1alpha1.VirtualMachinePoweredOff,
+				PowerState: vmopv1.VirtualMachinePoweredOff,
 			},
 		}
 		vmKey = types.NamespacedName{Name: vm.Name, Namespace: vm.Namespace}
@@ -100,15 +100,15 @@ func intgTests() {
 		ctx = nil
 	})
 
-	getVirtualMachine := func(objKey types.NamespacedName) *vmopv1alpha1.VirtualMachine {
-		vm := &vmopv1alpha1.VirtualMachine{}
+	getVirtualMachine := func(objKey types.NamespacedName) *vmopv1.VirtualMachine {
+		vm := &vmopv1.VirtualMachine{}
 		if err := ctx.Client.Get(ctx, objKey, vm); err != nil {
 			return nil
 		}
 		return vm
 	}
 
-	getCnsNodeVMAttachment := func(vm *vmopv1alpha1.VirtualMachine, vmVol vmopv1alpha1.VirtualMachineVolume) *cnsv1alpha1.CnsNodeVmAttachment {
+	getCnsNodeVMAttachment := func(vm *vmopv1.VirtualMachine, vmVol vmopv1.VirtualMachineVolume) *cnsv1alpha1.CnsNodeVmAttachment {
 		objectKey := client.ObjectKey{Name: volume.CNSAttachmentNameForVolume(vm, vmVol.Name), Namespace: vm.Namespace}
 		attachment := &cnsv1alpha1.CnsNodeVmAttachment{}
 		if err := ctx.Client.Get(ctx, objectKey, attachment); err == nil {
@@ -345,8 +345,8 @@ func intgTests() {
 			})
 
 			By("VM Status.Volume should have entry for volume", func() {
-				var vm *vmopv1alpha1.VirtualMachine
-				Eventually(func() []vmopv1alpha1.VirtualMachineVolumeStatus {
+				var vm *vmopv1.VirtualMachine
+				Eventually(func() []vmopv1.VirtualMachineVolumeStatus {
 					vm = getVirtualMachine(vmKey)
 					if vm != nil {
 						return vm.Status.Volumes
@@ -373,7 +373,7 @@ func intgTests() {
 			})
 
 			By("VM Status.Volume should reflect attached volume", func() {
-				var vm *vmopv1alpha1.VirtualMachine
+				var vm *vmopv1.VirtualMachine
 				Eventually(func() bool {
 					vm = getVirtualMachine(vmKey)
 					if vm == nil || len(vm.Status.Volumes) != 1 {
@@ -422,7 +422,7 @@ func intgTests() {
 					return getCnsNodeVMAttachment(vm, vmVolume2)
 				}, "3s").Should(BeNil())
 
-				Eventually(func() []vmopv1alpha1.VirtualMachineVolumeStatus {
+				Eventually(func() []vmopv1.VirtualMachineVolumeStatus {
 					if vm := getVirtualMachine(vmKey); vm != nil {
 						return vm.Status.Volumes
 					}
@@ -433,7 +433,7 @@ func intgTests() {
 			By("Simulate VM being powered on", func() {
 				vm := getVirtualMachine(vmKey)
 				Expect(vm).ToNot(BeNil())
-				vm.Status.PowerState = vmopv1alpha1.VirtualMachinePoweredOn
+				vm.Status.PowerState = vmopv1.VirtualMachinePoweredOn
 				Expect(ctx.Client.Status().Update(ctx, vm)).To(Succeed())
 			})
 
@@ -449,7 +449,7 @@ func intgTests() {
 			})
 
 			By("VM Status.Volume should have entry for volume1 and volume2", func() {
-				Eventually(func() []vmopv1alpha1.VirtualMachineVolumeStatus {
+				Eventually(func() []vmopv1.VirtualMachineVolumeStatus {
 					vm = getVirtualMachine(vmKey)
 					if vm != nil {
 						return vm.Status.Volumes
@@ -499,7 +499,7 @@ func intgTests() {
 			By("Remove CNS volume1 from VM Spec.Volumes", func() {
 				vm = getVirtualMachine(vmKey)
 				Expect(vm).ToNot(BeNil())
-				vm.Spec.Volumes = []vmopv1alpha1.VirtualMachineVolume{vmVolume2}
+				vm.Spec.Volumes = []vmopv1.VirtualMachineVolume{vmVolume2}
 				Expect(ctx.Client.Update(ctx, vm)).To(Succeed())
 			})
 
@@ -515,7 +515,7 @@ func intgTests() {
 
 			By("VM Status.Volumes should still have entries for volume1 and volume2", func() {
 				// I'm not sure if we have a better way to check for this.
-				Consistently(func() []vmopv1alpha1.VirtualMachineVolumeStatus {
+				Consistently(func() []vmopv1.VirtualMachineVolumeStatus {
 					vm = getVirtualMachine(vmKey)
 					Expect(vm).ToNot(BeNil())
 					return vm.Status.Volumes

--- a/controllers/volume/volume_controller_unit_test.go
+++ b/controllers/volume/volume_controller_unit_test.go
@@ -19,8 +19,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/util/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
-
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/controllers/volume"
 	cnsv1alpha1 "github.com/vmware-tanzu/vm-operator/external/vsphere-csi-driver/pkg/syncer/cnsoperator/apis/cnsnodevmattachment/v1alpha1"
 	volContext "github.com/vmware-tanzu/vm-operator/pkg/context"
@@ -58,57 +57,57 @@ func unitTestsReconcile() {
 		reconciler     *volume.Reconciler
 		fakeVMProvider *providerfake.VMProvider
 		volCtx         *volContext.VolumeContext
-		vm             *vmopv1alpha1.VirtualMachine
+		vm             *vmopv1.VirtualMachine
 
-		vmVol               vmopv1alpha1.VirtualMachineVolume
-		vmVolumeWithVsphere *vmopv1alpha1.VirtualMachineVolume
-		vmVolumeWithPVC1    *vmopv1alpha1.VirtualMachineVolume
-		vmVolumeWithPVC2    *vmopv1alpha1.VirtualMachineVolume
+		vmVol               vmopv1.VirtualMachineVolume
+		vmVolumeWithVsphere *vmopv1.VirtualMachineVolume
+		vmVolumeWithPVC1    *vmopv1.VirtualMachineVolume
+		vmVolumeWithPVC2    *vmopv1.VirtualMachineVolume
 
-		vmVolForInstPVC1 *vmopv1alpha1.VirtualMachineVolume
+		vmVolForInstPVC1 *vmopv1.VirtualMachineVolume
 	)
 
 	BeforeEach(func() {
-		vmVolumeWithVsphere = &vmopv1alpha1.VirtualMachineVolume{
+		vmVolumeWithVsphere = &vmopv1.VirtualMachineVolume{
 			Name:          "vsphere-volume",
-			VsphereVolume: &vmopv1alpha1.VsphereVolumeSource{},
+			VsphereVolume: &vmopv1.VsphereVolumeSource{},
 		}
 
-		vmVolumeWithPVC1 = &vmopv1alpha1.VirtualMachineVolume{
+		vmVolumeWithPVC1 = &vmopv1.VirtualMachineVolume{
 			Name: "cns-volume-1",
-			PersistentVolumeClaim: &vmopv1alpha1.PersistentVolumeClaimVolumeSource{
+			PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
 				PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
 					ClaimName: "pvc-volume-1",
 				},
 			},
 		}
 
-		vmVolumeWithPVC2 = &vmopv1alpha1.VirtualMachineVolume{
+		vmVolumeWithPVC2 = &vmopv1.VirtualMachineVolume{
 			Name: "cns-volume-2",
-			PersistentVolumeClaim: &vmopv1alpha1.PersistentVolumeClaimVolumeSource{
+			PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
 				PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
 					ClaimName: "pvc-volume-2",
 				},
 			},
 		}
 
-		vm = &vmopv1alpha1.VirtualMachine{
+		vm = &vmopv1.VirtualMachine{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "dummy-vm",
 				Namespace: "dummy-ns",
 			},
-			Status: vmopv1alpha1.VirtualMachineStatus{
+			Status: vmopv1.VirtualMachineStatus{
 				BiosUUID: dummyBiosUUID,
 			},
 		}
 
-		vmVolForInstPVC1 = &vmopv1alpha1.VirtualMachineVolume{
+		vmVolForInstPVC1 = &vmopv1.VirtualMachineVolume{
 			Name: "instance-pvc-1",
-			PersistentVolumeClaim: &vmopv1alpha1.PersistentVolumeClaimVolumeSource{
+			PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
 				PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
 					ClaimName: "instance-pvc-1",
 				},
-				InstanceVolumeClaim: &vmopv1alpha1.InstanceVolumeClaimVolumeSource{
+				InstanceVolumeClaim: &vmopv1.InstanceVolumeClaimVolumeSource{
 					StorageClass: dummyInstanceStorageClassName,
 					Size:         resource.MustParse("256Gi"),
 				},
@@ -141,7 +140,7 @@ func unitTestsReconcile() {
 		reconciler = nil
 	})
 
-	getCNSAttachmentForVolumeName := func(vm *vmopv1alpha1.VirtualMachine, volumeName string) *cnsv1alpha1.CnsNodeVmAttachment {
+	getCNSAttachmentForVolumeName := func(vm *vmopv1.VirtualMachine, volumeName string) *cnsv1alpha1.CnsNodeVmAttachment {
 		objectKey := client.ObjectKey{Name: volume.CNSAttachmentNameForVolume(vm, volumeName), Namespace: vm.Namespace}
 		attachment := &cnsv1alpha1.CnsNodeVmAttachment{}
 
@@ -304,14 +303,14 @@ func unitTestsReconcile() {
 		})
 
 		When("VM Spec.Volumes contains CNS volumes and VM isn't powered on", func() {
-			var vmVol1, vmVol2 vmopv1alpha1.VirtualMachineVolume
+			var vmVol1, vmVol2 vmopv1.VirtualMachineVolume
 
 			BeforeEach(func() {
 				vmVol1 = *vmVolumeWithPVC1
 				vmVol2 = *vmVolumeWithPVC2
 				vm.Spec.Volumes = append(vm.Spec.Volumes, vmVol1, vmVol2)
 
-				vm.Status.PowerState = vmopv1alpha1.VirtualMachinePoweredOff
+				vm.Status.PowerState = vmopv1.VirtualMachinePoweredOff
 			})
 
 			It("only allows one pending attachment at a time", func() {
@@ -477,7 +476,7 @@ func unitTestsReconcile() {
 
 			It("returns error when failed to get VM hardware version", func() {
 				fakeVMProvider.Lock()
-				fakeVMProvider.GetVirtualMachineHardwareVersionFn = func(_ goctx.Context, _ *vmopv1alpha1.VirtualMachine) (int32, error) {
+				fakeVMProvider.GetVirtualMachineHardwareVersionFn = func(_ goctx.Context, _ *vmopv1.VirtualMachine) (int32, error) {
 					return 0, errors.New("dummy-error")
 				}
 				fakeVMProvider.Unlock()
@@ -493,7 +492,7 @@ func unitTestsReconcile() {
 
 			It("returns error when VM hardware version is smaller than minimal requirement", func() {
 				fakeVMProvider.Lock()
-				fakeVMProvider.GetVirtualMachineHardwareVersionFn = func(_ goctx.Context, _ *vmopv1alpha1.VirtualMachine) (int32, error) {
+				fakeVMProvider.GetVirtualMachineHardwareVersionFn = func(_ goctx.Context, _ *vmopv1.VirtualMachine) (int32, error) {
 					return 11, nil
 				}
 				fakeVMProvider.Unlock()
@@ -509,7 +508,7 @@ func unitTestsReconcile() {
 
 			It("returns success when failed to parse VM hardware version", func() {
 				fakeVMProvider.Lock()
-				fakeVMProvider.GetVirtualMachineHardwareVersionFn = func(_ goctx.Context, _ *vmopv1alpha1.VirtualMachine) (int32, error) {
+				fakeVMProvider.GetVirtualMachineHardwareVersionFn = func(_ goctx.Context, _ *vmopv1.VirtualMachine) (int32, error) {
 					return 0, nil
 				}
 				fakeVMProvider.Unlock()
@@ -630,7 +629,7 @@ FaultMessage: ([]types.LocalizableMessage) \u003cnil\u003e\\n }\\n },\\n Type: (
 
 			BeforeEach(func() {
 				vmVol = *vmVolumeWithPVC1
-				vm.Status.Volumes = append(vm.Status.Volumes, vmopv1alpha1.VirtualMachineVolumeStatus{
+				vm.Status.Volumes = append(vm.Status.Volumes, vmopv1.VirtualMachineVolumeStatus{
 					Name:     vmVol.Name,
 					DiskUuid: dummyDiskUUID,
 				})
@@ -659,14 +658,14 @@ FaultMessage: ([]types.LocalizableMessage) \u003cnil\u003e\\n }\\n },\\n Type: (
 		})
 
 		When("VM Status.Volumes is sorted as expected", func() {
-			var vmVol1 vmopv1alpha1.VirtualMachineVolume
-			var vmVol2 vmopv1alpha1.VirtualMachineVolume
+			var vmVol1 vmopv1.VirtualMachineVolume
+			var vmVol2 vmopv1.VirtualMachineVolume
 
 			BeforeEach(func() {
 				vmVol1 = *vmVolumeWithPVC1
 				vmVol2 = *vmVolumeWithPVC2
 				vm.Spec.Volumes = append(vm.Spec.Volumes, vmVol1, vmVol2)
-				vm.Status.PowerState = vmopv1alpha1.VirtualMachinePoweredOn
+				vm.Status.PowerState = vmopv1.VirtualMachinePoweredOn
 			})
 
 			// We sort by DiskUUID, but the CnsNodeVmAttachment haven't been "attached" yet,
@@ -750,8 +749,8 @@ FaultMessage: ([]types.LocalizableMessage) \u003cnil\u003e\\n }\\n },\\n Type: (
 }
 
 func cnsAttachmentForVMVolume(
-	vm *vmopv1alpha1.VirtualMachine,
-	vmVol vmopv1alpha1.VirtualMachineVolume) *cnsv1alpha1.CnsNodeVmAttachment {
+	vm *vmopv1.VirtualMachine,
+	vmVol vmopv1.VirtualMachineVolume) *cnsv1alpha1.CnsNodeVmAttachment {
 	t := true
 	return &cnsv1alpha1.CnsNodeVmAttachment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -856,8 +855,8 @@ func patchInstanceStoragePVCs(ctx *volContext.VolumeContext, testCtx *builder.Un
 }
 
 func assertAttachmentSpecFromVMVol(
-	vm *vmopv1alpha1.VirtualMachine,
-	vmVol vmopv1alpha1.VirtualMachineVolume,
+	vm *vmopv1.VirtualMachine,
+	vmVol vmopv1.VirtualMachineVolume,
 	attachment *cnsv1alpha1.CnsNodeVmAttachment) {
 
 	ExpectWithOffset(1, attachment.Spec.NodeUUID).To(Equal(vm.Status.BiosUUID))
@@ -872,9 +871,9 @@ func assertAttachmentSpecFromVMVol(
 }
 
 func assertVMVolStatusFromAttachment(
-	vmVol vmopv1alpha1.VirtualMachineVolume,
+	vmVol vmopv1.VirtualMachineVolume,
 	attachment *cnsv1alpha1.CnsNodeVmAttachment,
-	vmVolStatus vmopv1alpha1.VirtualMachineVolumeStatus) {
+	vmVolStatus vmopv1.VirtualMachineVolumeStatus) {
 	diskUUID := attachment.Status.AttachmentMetadata[volume.AttributeFirstClassDiskUUID]
 
 	ExpectWithOffset(1, vmVolStatus.Name).To(Equal(vmVol.Name))

--- a/controllers/webconsolerequest/webconsolerequest_controller.go
+++ b/controllers/webconsolerequest/webconsolerequest_controller.go
@@ -20,7 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/patch"
@@ -39,7 +39,7 @@ const (
 // AddToManager adds this package's controller to the provided manager.
 func AddToManager(ctx *context.ControllerManagerContext, mgr manager.Manager) error {
 	var (
-		controlledType     = &vmopv1alpha1.WebConsoleRequest{}
+		controlledType     = &vmopv1.WebConsoleRequest{}
 		controlledTypeName = reflect.TypeOf(controlledType).Elem().Name()
 
 		controllerNameShort = fmt.Sprintf("%s-controller", strings.ToLower(controlledTypeName))
@@ -87,7 +87,7 @@ type Reconciler struct {
 // +kubebuilder:rbac:groups="",resources=services/status,verbs=get
 
 func (r *Reconciler) Reconcile(ctx goctx.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
-	webconsolerequest := &vmopv1alpha1.WebConsoleRequest{}
+	webconsolerequest := &vmopv1.WebConsoleRequest{}
 	err := r.Get(ctx, req.NamespacedName, webconsolerequest)
 	if err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
@@ -97,7 +97,7 @@ func (r *Reconciler) Reconcile(ctx goctx.Context, req ctrl.Request) (_ ctrl.Resu
 		Context:           ctx,
 		Logger:            ctrl.Log.WithName("WebConsoleRequest").WithValues("name", req.NamespacedName),
 		WebConsoleRequest: webconsolerequest,
-		VM:                &vmopv1alpha1.VirtualMachine{},
+		VM:                &vmopv1.VirtualMachine{},
 	}
 
 	done, err := r.ReconcileEarlyNormal(webConsoleRequestCtx)

--- a/controllers/webconsolerequest/webconsolerequest_intg_test.go
+++ b/controllers/webconsolerequest/webconsolerequest_intg_test.go
@@ -15,8 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/vmware-tanzu/vm-operator/api/v1alpha1"
-
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/controllers/webconsolerequest"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
@@ -28,13 +27,13 @@ func intgTests() {
 func webConsoleRequestReconcile() {
 	var (
 		ctx      *builder.IntegrationTestContext
-		wcr      *v1alpha1.WebConsoleRequest
-		vm       *v1alpha1.VirtualMachine
+		wcr      *vmopv1.WebConsoleRequest
+		vm       *vmopv1.VirtualMachine
 		proxySvc *corev1.Service
 	)
 
-	getWebConsoleRequest := func(ctx *builder.IntegrationTestContext, objKey types.NamespacedName) *v1alpha1.WebConsoleRequest {
-		wcr := &v1alpha1.WebConsoleRequest{}
+	getWebConsoleRequest := func(ctx *builder.IntegrationTestContext, objKey types.NamespacedName) *vmopv1.WebConsoleRequest {
+		wcr := &vmopv1.WebConsoleRequest{}
 		if err := ctx.Client.Get(ctx, objKey, wcr); err != nil {
 			return nil
 		}
@@ -44,25 +43,25 @@ func webConsoleRequestReconcile() {
 	BeforeEach(func() {
 		ctx = suite.NewIntegrationTestContext()
 
-		vm = &v1alpha1.VirtualMachine{
+		vm = &vmopv1.VirtualMachine{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "dummy-vm",
 				Namespace: ctx.Namespace,
 			},
-			Spec: v1alpha1.VirtualMachineSpec{
+			Spec: vmopv1.VirtualMachineSpec{
 				ImageName:  "dummy-image",
-				PowerState: v1alpha1.VirtualMachinePoweredOn,
+				PowerState: vmopv1.VirtualMachinePoweredOn,
 			},
 		}
 
 		_, publicKeyPem := builder.WebConsoleRequestKeyPair()
 
-		wcr = &v1alpha1.WebConsoleRequest{
+		wcr = &vmopv1.WebConsoleRequest{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "dummy-wcr",
 				Namespace: ctx.Namespace,
 			},
-			Spec: v1alpha1.WebConsoleRequestSpec{
+			Spec: vmopv1.WebConsoleRequestSpec{
 				VirtualMachineName: vm.Name,
 				PublicKey:          publicKeyPem,
 			},
@@ -85,7 +84,7 @@ func webConsoleRequestReconcile() {
 
 		fakeVMProvider.Lock()
 		defer fakeVMProvider.Unlock()
-		fakeVMProvider.GetVirtualMachineWebMKSTicketFn = func(ctx context.Context, vm *v1alpha1.VirtualMachine, pubKey string) (string, error) {
+		fakeVMProvider.GetVirtualMachineWebMKSTicketFn = func(ctx context.Context, vm *vmopv1.VirtualMachine, pubKey string) (string, error) {
 			return "some-fake-webmksticket", nil
 		}
 	})

--- a/controllers/webconsolerequest/webconsolerequest_unit_test.go
+++ b/controllers/webconsolerequest/webconsolerequest_unit_test.go
@@ -14,8 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/vmware-tanzu/vm-operator/api/v1alpha1"
-
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/controllers/webconsolerequest"
 	vmopContext "github.com/vmware-tanzu/vm-operator/pkg/context"
 	providerfake "github.com/vmware-tanzu/vm-operator/pkg/vmprovider/fake"
@@ -34,23 +33,23 @@ func unitTestsReconcile() {
 
 		reconciler *webconsolerequest.Reconciler
 		wcrCtx     *vmopContext.WebConsoleRequestContext
-		wcr        *v1alpha1.WebConsoleRequest
-		vm         *v1alpha1.VirtualMachine
+		wcr        *vmopv1.WebConsoleRequest
+		vm         *vmopv1.VirtualMachine
 		proxySvc   *corev1.Service
 	)
 
 	BeforeEach(func() {
-		vm = &v1alpha1.VirtualMachine{
+		vm = &vmopv1.VirtualMachine{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "dummy-vm",
 			},
 		}
 
-		wcr = &v1alpha1.WebConsoleRequest{
+		wcr = &vmopv1.WebConsoleRequest{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "dummy-wcr",
 			},
-			Spec: v1alpha1.WebConsoleRequestSpec{
+			Spec: vmopv1.WebConsoleRequestSpec{
 				VirtualMachineName: vm.Name,
 				PublicKey:          "",
 			},
@@ -105,7 +104,7 @@ func unitTestsReconcile() {
 		})
 
 		JustBeforeEach(func() {
-			fakeVMProvider.GetVirtualMachineWebMKSTicketFn = func(ctx context.Context, vm *v1alpha1.VirtualMachine, pubKey string) (string, error) {
+			fakeVMProvider.GetVirtualMachineWebMKSTicketFn = func(ctx context.Context, vm *vmopv1.VirtualMachine, pubKey string) (string, error) {
 				return "some-fake-webmksticket", nil
 			}
 		})

--- a/pkg/conditions/getter.go
+++ b/pkg/conditions/getter.go
@@ -21,7 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 )
 
 // Getter interface defines methods that a Cluster API object should implement in order to
@@ -30,12 +30,12 @@ type Getter interface {
 	client.Object
 
 	// GetConditions returns the list of conditions for a cluster API object.
-	GetConditions() vmopv1alpha1.Conditions
+	GetConditions() vmopv1.Conditions
 }
 
 // Get returns the condition with the given type, if the condition does not exists,
 // it returns nil.
-func Get(from Getter, t vmopv1alpha1.ConditionType) *vmopv1alpha1.Condition {
+func Get(from Getter, t vmopv1.ConditionType) *vmopv1.Condition {
 	conditions := from.GetConditions()
 	if conditions == nil {
 		return nil
@@ -50,18 +50,18 @@ func Get(from Getter, t vmopv1alpha1.ConditionType) *vmopv1alpha1.Condition {
 }
 
 // Has returns true if a condition with the given type exists.
-func Has(from Getter, t vmopv1alpha1.ConditionType) bool {
+func Has(from Getter, t vmopv1.ConditionType) bool {
 	return Get(from, t) != nil
 }
 
 // IsTrueFromConditions returns true if the condition with the given type is True.
 // This is helpful to check the condition without passing a specific resource object.
-func IsTrueFromConditions(conditions vmopv1alpha1.Conditions, t vmopv1alpha1.ConditionType) bool {
+func IsTrueFromConditions(conditions vmopv1.Conditions, t vmopv1.ConditionType) bool {
 	if conditions == nil {
 		return false
 	}
 
-	var c vmopv1alpha1.Condition
+	var c vmopv1.Condition
 	for _, condition := range conditions {
 		if condition.Type == t {
 			c = condition
@@ -72,7 +72,7 @@ func IsTrueFromConditions(conditions vmopv1alpha1.Conditions, t vmopv1alpha1.Con
 
 // IsTrue is true if the condition with the given type is True, otherwise it return false
 // if the condition is not True or if the condition does not exist (is nil).
-func IsTrue(from Getter, t vmopv1alpha1.ConditionType) bool {
+func IsTrue(from Getter, t vmopv1.ConditionType) bool {
 	if c := Get(from, t); c != nil {
 		return c.Status == corev1.ConditionTrue
 	}
@@ -81,7 +81,7 @@ func IsTrue(from Getter, t vmopv1alpha1.ConditionType) bool {
 
 // IsFalse is true if the condition with the given type is False, otherwise it return false
 // if the condition is not False or if the condition does not exist (is nil).
-func IsFalse(from Getter, t vmopv1alpha1.ConditionType) bool {
+func IsFalse(from Getter, t vmopv1.ConditionType) bool {
 	if c := Get(from, t); c != nil {
 		return c.Status == corev1.ConditionFalse
 	}
@@ -90,7 +90,7 @@ func IsFalse(from Getter, t vmopv1alpha1.ConditionType) bool {
 
 // IsUnknown is true if the condition with the given type is Unknown or if the condition
 // does not exist (is nil).
-func IsUnknown(from Getter, t vmopv1alpha1.ConditionType) bool {
+func IsUnknown(from Getter, t vmopv1.ConditionType) bool {
 	if c := Get(from, t); c != nil {
 		return c.Status == corev1.ConditionUnknown
 	}
@@ -98,7 +98,7 @@ func IsUnknown(from Getter, t vmopv1alpha1.ConditionType) bool {
 }
 
 // GetReason returns a nil safe string of Reason for the condition with the given type.
-func GetReason(from Getter, t vmopv1alpha1.ConditionType) string {
+func GetReason(from Getter, t vmopv1.ConditionType) string {
 	if c := Get(from, t); c != nil {
 		return c.Reason
 	}
@@ -106,7 +106,7 @@ func GetReason(from Getter, t vmopv1alpha1.ConditionType) string {
 }
 
 // GetMessage returns a nil safe string of Message.
-func GetMessage(from Getter, t vmopv1alpha1.ConditionType) string {
+func GetMessage(from Getter, t vmopv1.ConditionType) string {
 	if c := Get(from, t); c != nil {
 		return c.Message
 	}
@@ -115,7 +115,7 @@ func GetMessage(from Getter, t vmopv1alpha1.ConditionType) string {
 
 // GetSeverity returns the condition Severity or nil if the condition
 // does not exist (is nil).
-func GetSeverity(from Getter, t vmopv1alpha1.ConditionType) *vmopv1alpha1.ConditionSeverity {
+func GetSeverity(from Getter, t vmopv1.ConditionType) *vmopv1.ConditionSeverity {
 	if c := Get(from, t); c != nil {
 		return &c.Severity
 	}
@@ -124,7 +124,7 @@ func GetSeverity(from Getter, t vmopv1alpha1.ConditionType) *vmopv1alpha1.Condit
 
 // GetLastTransitionTime returns the condition Severity or nil if the condition
 // does not exist (is nil).
-func GetLastTransitionTime(from Getter, t vmopv1alpha1.ConditionType) *metav1.Time {
+func GetLastTransitionTime(from Getter, t vmopv1.ConditionType) *metav1.Time {
 	if c := Get(from, t); c != nil {
 		return &c.LastTransitionTime
 	}
@@ -133,7 +133,7 @@ func GetLastTransitionTime(from Getter, t vmopv1alpha1.ConditionType) *metav1.Ti
 
 // summary returns a Ready condition with the summary of all the conditions existing
 // on an object. If the object does not have other conditions, no summary condition is generated.
-func summary(from Getter, options ...MergeOption) *vmopv1alpha1.Condition {
+func summary(from Getter, options ...MergeOption) *vmopv1.Condition {
 	conditions := from.GetConditions()
 
 	mergeOpt := &mergeOptions{}
@@ -146,7 +146,7 @@ func summary(from Getter, options ...MergeOption) *vmopv1alpha1.Condition {
 	conditionsInScope := make([]localizedCondition, 0, len(conditions))
 	for i := range conditions {
 		c := conditions[i]
-		if c.Type == vmopv1alpha1.ReadyCondition {
+		if c.Type == vmopv1.ReadyCondition {
 			continue
 		}
 
@@ -199,14 +199,14 @@ func summary(from Getter, options ...MergeOption) *vmopv1alpha1.Condition {
 		}
 	}
 
-	return merge(conditionsInScope, vmopv1alpha1.ReadyCondition, mergeOpt)
+	return merge(conditionsInScope, vmopv1.ReadyCondition, mergeOpt)
 }
 
 // mirrorOptions allows to set options for the mirror operation.
 type mirrorOptions struct {
 	fallbackTo       *bool
 	fallbackReason   string
-	fallbackSeverity vmopv1alpha1.ConditionSeverity
+	fallbackSeverity vmopv1.ConditionSeverity
 	fallbackMessage  string
 }
 
@@ -215,7 +215,7 @@ type MirrorOptions func(*mirrorOptions)
 
 // WithFallbackValue specify a fallback value to use in case the mirrored condition does not exists;
 // in case the fallbackValue is false, given values for reason, severity and message will be used.
-func WithFallbackValue(fallbackValue bool, reason string, severity vmopv1alpha1.ConditionSeverity, message string) MirrorOptions {
+func WithFallbackValue(fallbackValue bool, reason string, severity vmopv1.ConditionSeverity, message string) MirrorOptions {
 	return func(c *mirrorOptions) {
 		c.fallbackTo = &fallbackValue
 		c.fallbackReason = reason
@@ -226,13 +226,13 @@ func WithFallbackValue(fallbackValue bool, reason string, severity vmopv1alpha1.
 
 // mirror mirrors the Ready condition from a dependent object into the target condition;
 // if the Ready condition does not exists in the source object, no target conditions is generated.
-func mirror(from Getter, targetCondition vmopv1alpha1.ConditionType, options ...MirrorOptions) *vmopv1alpha1.Condition {
+func mirror(from Getter, targetCondition vmopv1.ConditionType, options ...MirrorOptions) *vmopv1.Condition {
 	mirrorOpt := &mirrorOptions{}
 	for _, o := range options {
 		o(mirrorOpt)
 	}
 
-	condition := Get(from, vmopv1alpha1.ReadyCondition)
+	condition := Get(from, vmopv1.ReadyCondition)
 
 	if mirrorOpt.fallbackTo != nil && condition == nil {
 		switch *mirrorOpt.fallbackTo {
@@ -253,10 +253,10 @@ func mirror(from Getter, targetCondition vmopv1alpha1.ConditionType, options ...
 // Aggregates all the the Ready condition from a list of dependent objects into the target object;
 // if the Ready condition does not exists in one of the source object, the object is excluded from
 // the aggregation; if none of the source object have ready condition, no target conditions is generated.
-func aggregate(from []Getter, targetCondition vmopv1alpha1.ConditionType, options ...MergeOption) *vmopv1alpha1.Condition {
+func aggregate(from []Getter, targetCondition vmopv1.ConditionType, options ...MergeOption) *vmopv1.Condition {
 	conditionsInScope := make([]localizedCondition, 0, len(from))
 	for i := range from {
-		condition := Get(from[i], vmopv1alpha1.ReadyCondition)
+		condition := Get(from[i], vmopv1.ReadyCondition)
 
 		conditionsInScope = append(conditionsInScope, localizedCondition{
 			Condition: condition,

--- a/pkg/conditions/getter_test.go
+++ b/pkg/conditions/getter_test.go
@@ -25,22 +25,22 @@ import (
 	"github.com/onsi/gomega/types"
 	"github.com/pkg/errors"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 )
 
 var (
-	nil1          *vmopv1alpha1.Condition
+	nil1          *vmopv1.Condition
 	true1         = TrueCondition("true1")
 	unknown1      = UnknownCondition("unknown1", "reason unknown1", "message unknown1")
-	falseInfo1    = FalseCondition("falseInfo1", "reason falseInfo1", vmopv1alpha1.ConditionSeverityInfo, "message falseInfo1")
-	falseWarning1 = FalseCondition("falseWarning1", "reason falseWarning1", vmopv1alpha1.ConditionSeverityWarning, "message falseWarning1")
-	falseError1   = FalseCondition("falseError1", "reason falseError1", vmopv1alpha1.ConditionSeverityError, "message falseError1")
+	falseInfo1    = FalseCondition("falseInfo1", "reason falseInfo1", vmopv1.ConditionSeverityInfo, "message falseInfo1")
+	falseWarning1 = FalseCondition("falseWarning1", "reason falseWarning1", vmopv1.ConditionSeverityWarning, "message falseWarning1")
+	falseError1   = FalseCondition("falseError1", "reason falseError1", vmopv1.ConditionSeverityError, "message falseError1")
 )
 
 func TestGetAndHas(t *testing.T) {
 	g := NewWithT(t)
 
-	vm := &vmopv1alpha1.VirtualMachine{}
+	vm := &vmopv1.VirtualMachine{}
 
 	g.Expect(Has(vm, "conditionBaz")).To(BeFalse())
 	g.Expect(Get(vm, "conditionBaz")).To(BeNil())
@@ -85,7 +85,7 @@ func TestIsMethods(t *testing.T) {
 	// test GetSeverity
 	g.Expect(GetSeverity(obj, "nil1")).To(BeNil())
 	severity := GetSeverity(obj, "falseInfo1")
-	expectedSeverity := vmopv1alpha1.ConditionSeverityInfo
+	expectedSeverity := vmopv1.ConditionSeverityInfo
 	g.Expect(severity).To(Equal(&expectedSeverity))
 
 	// test GetMessage
@@ -94,16 +94,16 @@ func TestIsMethods(t *testing.T) {
 }
 
 func TestMirror(t *testing.T) {
-	foo := FalseCondition("foo", "reason foo", vmopv1alpha1.ConditionSeverityInfo, "message foo")
-	ready := TrueCondition(vmopv1alpha1.ReadyCondition)
+	foo := FalseCondition("foo", "reason foo", vmopv1.ConditionSeverityInfo, "message foo")
+	ready := TrueCondition(vmopv1.ReadyCondition)
 	readyBar := ready.DeepCopy()
 	readyBar.Type = "bar"
 
 	tests := []struct {
 		name string
 		from Getter
-		t    vmopv1alpha1.ConditionType
-		want *vmopv1alpha1.Condition
+		t    vmopv1.ConditionType
+		want *vmopv1.Condition
 	}{
 		{
 			name: "Returns nil when the ready condition does not exists",
@@ -134,15 +134,15 @@ func TestMirror(t *testing.T) {
 
 func TestSummary(t *testing.T) {
 	foo := TrueCondition("foo")
-	bar := FalseCondition("bar", "reason falseInfo1", vmopv1alpha1.ConditionSeverityInfo, "message falseInfo1")
-	baz := FalseCondition("baz", "reason falseInfo2", vmopv1alpha1.ConditionSeverityInfo, "message falseInfo2")
-	existingReady := FalseCondition(vmopv1alpha1.ReadyCondition, "reason falseError1", vmopv1alpha1.ConditionSeverityError, "message falseError1") // NB. existing ready has higher priority than other conditions
+	bar := FalseCondition("bar", "reason falseInfo1", vmopv1.ConditionSeverityInfo, "message falseInfo1")
+	baz := FalseCondition("baz", "reason falseInfo2", vmopv1.ConditionSeverityInfo, "message falseInfo2")
+	existingReady := FalseCondition(vmopv1.ReadyCondition, "reason falseError1", vmopv1.ConditionSeverityError, "message falseError1") // NB. existing ready has higher priority than other conditions
 
 	tests := []struct {
 		name    string
 		from    Getter
 		options []MergeOption
-		want    *vmopv1alpha1.Condition
+		want    *vmopv1.Condition
 	}{
 		{
 			name: "Returns nil when there are no conditions to summarize",
@@ -152,78 +152,78 @@ func TestSummary(t *testing.T) {
 		{
 			name: "Returns ready condition with the summary of existing conditions (with default options)",
 			from: getterWithConditions(foo, bar),
-			want: FalseCondition(vmopv1alpha1.ReadyCondition, "reason falseInfo1", vmopv1alpha1.ConditionSeverityInfo, "message falseInfo1"),
+			want: FalseCondition(vmopv1.ReadyCondition, "reason falseInfo1", vmopv1.ConditionSeverityInfo, "message falseInfo1"),
 		},
 		{
 			name:    "Returns ready condition with the summary of existing conditions (using WithStepCounter options)",
 			from:    getterWithConditions(foo, bar),
 			options: []MergeOption{WithStepCounter()},
-			want:    FalseCondition(vmopv1alpha1.ReadyCondition, "reason falseInfo1", vmopv1alpha1.ConditionSeverityInfo, "1 of 2 completed"),
+			want:    FalseCondition(vmopv1.ReadyCondition, "reason falseInfo1", vmopv1.ConditionSeverityInfo, "1 of 2 completed"),
 		},
 		{
 			name:    "Returns ready condition with the summary of existing conditions (using WithStepCounterIf options)",
 			from:    getterWithConditions(foo, bar),
 			options: []MergeOption{WithStepCounterIf(false)},
-			want:    FalseCondition(vmopv1alpha1.ReadyCondition, "reason falseInfo1", vmopv1alpha1.ConditionSeverityInfo, "message falseInfo1"),
+			want:    FalseCondition(vmopv1.ReadyCondition, "reason falseInfo1", vmopv1.ConditionSeverityInfo, "message falseInfo1"),
 		},
 		{
 			name:    "Returns ready condition with the summary of existing conditions (using WithStepCounterIf options)",
 			from:    getterWithConditions(foo, bar),
 			options: []MergeOption{WithStepCounterIf(true)},
-			want:    FalseCondition(vmopv1alpha1.ReadyCondition, "reason falseInfo1", vmopv1alpha1.ConditionSeverityInfo, "1 of 2 completed"),
+			want:    FalseCondition(vmopv1.ReadyCondition, "reason falseInfo1", vmopv1.ConditionSeverityInfo, "1 of 2 completed"),
 		},
 		{
 			name:    "Returns ready condition with the summary of existing conditions (using WithStepCounterIf and WithStepCounterIfOnly options)",
 			from:    getterWithConditions(bar),
 			options: []MergeOption{WithStepCounter(), WithStepCounterIfOnly("bar")},
-			want:    FalseCondition(vmopv1alpha1.ReadyCondition, "reason falseInfo1", vmopv1alpha1.ConditionSeverityInfo, "0 of 1 completed"),
+			want:    FalseCondition(vmopv1.ReadyCondition, "reason falseInfo1", vmopv1.ConditionSeverityInfo, "0 of 1 completed"),
 		},
 		{
 			name:    "Returns ready condition with the summary of existing conditions (using WithStepCounterIf and WithStepCounterIfOnly options)",
 			from:    getterWithConditions(foo, bar),
 			options: []MergeOption{WithStepCounter(), WithStepCounterIfOnly("foo")},
-			want:    FalseCondition(vmopv1alpha1.ReadyCondition, "reason falseInfo1", vmopv1alpha1.ConditionSeverityInfo, "message falseInfo1"),
+			want:    FalseCondition(vmopv1.ReadyCondition, "reason falseInfo1", vmopv1.ConditionSeverityInfo, "message falseInfo1"),
 		},
 		{
 			name:    "Returns ready condition with the summary of selected conditions (using WithConditions options)",
 			from:    getterWithConditions(foo, bar),
 			options: []MergeOption{WithConditions("foo")}, // bar should be ignored
-			want:    TrueCondition(vmopv1alpha1.ReadyCondition),
+			want:    TrueCondition(vmopv1.ReadyCondition),
 		},
 		{
 			name:    "Returns ready condition with the summary of selected conditions (using WithConditions and WithStepCounter options)",
 			from:    getterWithConditions(foo, bar, baz),
 			options: []MergeOption{WithConditions("foo", "bar"), WithStepCounter()}, // baz should be ignored, total steps should be 2
-			want:    FalseCondition(vmopv1alpha1.ReadyCondition, "reason falseInfo1", vmopv1alpha1.ConditionSeverityInfo, "1 of 2 completed"),
+			want:    FalseCondition(vmopv1.ReadyCondition, "reason falseInfo1", vmopv1.ConditionSeverityInfo, "1 of 2 completed"),
 		},
 		{
 			name:    "Returns ready condition with the summary of selected conditions (using WithConditions and WithStepCounterIfOnly options)",
 			from:    getterWithConditions(bar),
 			options: []MergeOption{WithConditions("bar", "baz"), WithStepCounter(), WithStepCounterIfOnly("bar")}, // there is only bar, the step counter should be set and counts only a subset of conditions
-			want:    FalseCondition(vmopv1alpha1.ReadyCondition, "reason falseInfo1", vmopv1alpha1.ConditionSeverityInfo, "0 of 1 completed"),
+			want:    FalseCondition(vmopv1.ReadyCondition, "reason falseInfo1", vmopv1.ConditionSeverityInfo, "0 of 1 completed"),
 		},
 		{
 			name:    "Returns ready condition with the summary of selected conditions (using WithConditions and WithStepCounterIfOnly options - with inconsistent order between the two)",
 			from:    getterWithConditions(bar),
 			options: []MergeOption{WithConditions("baz", "bar"), WithStepCounter(), WithStepCounterIfOnly("bar", "baz")}, // conditions in WithStepCounterIfOnly could be in different order than in WithConditions
-			want:    FalseCondition(vmopv1alpha1.ReadyCondition, "reason falseInfo1", vmopv1alpha1.ConditionSeverityInfo, "0 of 2 completed"),
+			want:    FalseCondition(vmopv1.ReadyCondition, "reason falseInfo1", vmopv1.ConditionSeverityInfo, "0 of 2 completed"),
 		},
 		{
 			name:    "Returns ready condition with the summary of selected conditions (using WithConditions and WithStepCounterIfOnly options)",
 			from:    getterWithConditions(bar, baz),
 			options: []MergeOption{WithConditions("bar", "baz"), WithStepCounter(), WithStepCounterIfOnly("bar")}, // there is also baz, so the step counter should not be set
-			want:    FalseCondition(vmopv1alpha1.ReadyCondition, "reason falseInfo1", vmopv1alpha1.ConditionSeverityInfo, "message falseInfo1"),
+			want:    FalseCondition(vmopv1.ReadyCondition, "reason falseInfo1", vmopv1.ConditionSeverityInfo, "message falseInfo1"),
 		},
 		{
 			name:    "Ready condition respects merge order",
 			from:    getterWithConditions(bar, baz),
 			options: []MergeOption{WithConditions("baz", "bar")}, // baz should take precedence on bar
-			want:    FalseCondition(vmopv1alpha1.ReadyCondition, "reason falseInfo2", vmopv1alpha1.ConditionSeverityInfo, "message falseInfo2"),
+			want:    FalseCondition(vmopv1.ReadyCondition, "reason falseInfo2", vmopv1.ConditionSeverityInfo, "message falseInfo2"),
 		},
 		{
 			name: "Ignores existing Ready condition when computing the summary",
 			from: getterWithConditions(existingReady, foo, bar),
-			want: FalseCondition(vmopv1alpha1.ReadyCondition, "reason falseInfo1", vmopv1alpha1.ConditionSeverityInfo, "message falseInfo1"),
+			want: FalseCondition(vmopv1.ReadyCondition, "reason falseInfo1", vmopv1.ConditionSeverityInfo, "message falseInfo1"),
 		},
 	}
 
@@ -242,15 +242,15 @@ func TestSummary(t *testing.T) {
 }
 
 func TestAggregate(t *testing.T) {
-	ready1 := TrueCondition(vmopv1alpha1.ReadyCondition)
-	ready2 := FalseCondition(vmopv1alpha1.ReadyCondition, "reason falseInfo1", vmopv1alpha1.ConditionSeverityInfo, "message falseInfo1")
-	bar := FalseCondition("bar", "reason falseError1", vmopv1alpha1.ConditionSeverityError, "message falseError1") // NB. bar has higher priority than other conditions
+	ready1 := TrueCondition(vmopv1.ReadyCondition)
+	ready2 := FalseCondition(vmopv1.ReadyCondition, "reason falseInfo1", vmopv1.ConditionSeverityInfo, "message falseInfo1")
+	bar := FalseCondition("bar", "reason falseError1", vmopv1.ConditionSeverityError, "message falseError1") // NB. bar has higher priority than other conditions
 
 	tests := []struct {
 		name string
 		from []Getter
-		t    vmopv1alpha1.ConditionType
-		want *vmopv1alpha1.Condition
+		t    vmopv1.ConditionType
+		want *vmopv1.Condition
 	}{
 		{
 			name: "Returns nil when there are no conditions to aggregate",
@@ -267,7 +267,7 @@ func TestAggregate(t *testing.T) {
 				getterWithConditions(bar),
 			},
 			t:    "foo",
-			want: FalseCondition("foo", "reason falseInfo1", vmopv1alpha1.ConditionSeverityInfo, "2 of 5 completed"),
+			want: FalseCondition("foo", "reason falseInfo1", vmopv1.ConditionSeverityInfo, "2 of 5 completed"),
 		},
 	}
 
@@ -285,14 +285,14 @@ func TestAggregate(t *testing.T) {
 	}
 }
 
-func getterWithConditions(conditions ...*vmopv1alpha1.Condition) Getter {
-	obj := &vmopv1alpha1.VirtualMachine{}
+func getterWithConditions(conditions ...*vmopv1.Condition) Getter {
+	obj := &vmopv1.VirtualMachine{}
 	obj.SetConditions(conditionList(conditions...))
 	return obj
 }
 
-func conditionList(conditions ...*vmopv1alpha1.Condition) vmopv1alpha1.Conditions {
-	cs := vmopv1alpha1.Conditions{}
+func conditionList(conditions ...*vmopv1.Condition) vmopv1.Conditions {
+	cs := vmopv1.Conditions{}
 	for _, x := range conditions {
 		if x != nil {
 			cs = append(cs, *x)
@@ -301,18 +301,18 @@ func conditionList(conditions ...*vmopv1alpha1.Condition) vmopv1alpha1.Condition
 	return cs
 }
 
-func haveSameStateOf(expected *vmopv1alpha1.Condition) types.GomegaMatcher {
+func haveSameStateOf(expected *vmopv1.Condition) types.GomegaMatcher {
 	return &ConditionMatcher{
 		Expected: expected,
 	}
 }
 
 type ConditionMatcher struct {
-	Expected *vmopv1alpha1.Condition
+	Expected *vmopv1.Condition
 }
 
 func (matcher *ConditionMatcher) Match(actual interface{}) (success bool, err error) {
-	actualCondition, ok := actual.(*vmopv1alpha1.Condition)
+	actualCondition, ok := actual.(*vmopv1.Condition)
 	if !ok {
 		return false, errors.New("Value should be a condition")
 	}

--- a/pkg/conditions/matcher.go
+++ b/pkg/conditions/matcher.go
@@ -22,18 +22,18 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 )
 
-// MatchConditions returns a custom matcher to check equality of vmopv1alpha1.Conditions.
-func MatchConditions(expected vmopv1alpha1.Conditions) types.GomegaMatcher {
+// MatchConditions returns a custom matcher to check equality of vmopv1.Conditions.
+func MatchConditions(expected vmopv1.Conditions) types.GomegaMatcher {
 	return &matchConditions{
 		expected: expected,
 	}
 }
 
 type matchConditions struct {
-	expected vmopv1alpha1.Conditions
+	expected vmopv1.Conditions
 }
 
 func (m matchConditions) Match(actual interface{}) (success bool, err error) {
@@ -53,19 +53,19 @@ func (m matchConditions) NegatedFailureMessage(actual interface{}) (message stri
 	return fmt.Sprintf("expected\n\t%#v\nto not match\n\t%#v\n", actual, m.expected)
 }
 
-// MatchCondition returns a custom matcher to check equality of vmopv1alpha1.Condition.
-func MatchCondition(expected vmopv1alpha1.Condition) types.GomegaMatcher {
+// MatchCondition returns a custom matcher to check equality of vmopv1.Condition.
+func MatchCondition(expected vmopv1.Condition) types.GomegaMatcher {
 	return &matchCondition{
 		expected: expected,
 	}
 }
 
 type matchCondition struct {
-	expected vmopv1alpha1.Condition
+	expected vmopv1.Condition
 }
 
 func (m matchCondition) Match(actual interface{}) (success bool, err error) {
-	actualCondition, ok := actual.(vmopv1alpha1.Condition)
+	actualCondition, ok := actual.(vmopv1.Condition)
 	if !ok {
 		return false, fmt.Errorf("actual should be of type Condition")
 	}

--- a/pkg/conditions/matcher_test.go
+++ b/pkg/conditions/matcher_test.go
@@ -24,39 +24,39 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 )
 
 func TestMatchConditions(t *testing.T) {
 	testCases := []struct {
 		name        string
 		actual      interface{}
-		expected    vmopv1alpha1.Conditions
+		expected    vmopv1.Conditions
 		expectMatch bool
 	}{
 		{
 			name:        "with an empty conditions",
-			actual:      vmopv1alpha1.Conditions{},
-			expected:    vmopv1alpha1.Conditions{},
+			actual:      vmopv1.Conditions{},
+			expected:    vmopv1.Conditions{},
 			expectMatch: true,
 		},
 		{
 			name: "with matching conditions",
-			actual: vmopv1alpha1.Conditions{
+			actual: vmopv1.Conditions{
 				{
-					Type:               vmopv1alpha1.ConditionType("type"),
+					Type:               vmopv1.ConditionType("type"),
 					Status:             corev1.ConditionTrue,
-					Severity:           vmopv1alpha1.ConditionSeverityNone,
+					Severity:           vmopv1.ConditionSeverityNone,
 					LastTransitionTime: metav1.Now(),
 					Reason:             "reason",
 					Message:            "message",
 				},
 			},
-			expected: vmopv1alpha1.Conditions{
+			expected: vmopv1.Conditions{
 				{
-					Type:               vmopv1alpha1.ConditionType("type"),
+					Type:               vmopv1.ConditionType("type"),
 					Status:             corev1.ConditionTrue,
-					Severity:           vmopv1alpha1.ConditionSeverityNone,
+					Severity:           vmopv1.ConditionSeverityNone,
 					LastTransitionTime: metav1.Now(),
 					Reason:             "reason",
 					Message:            "message",
@@ -66,37 +66,37 @@ func TestMatchConditions(t *testing.T) {
 		},
 		{
 			name: "with non-matching conditions",
-			actual: vmopv1alpha1.Conditions{
+			actual: vmopv1.Conditions{
 				{
-					Type:               vmopv1alpha1.ConditionType("type"),
+					Type:               vmopv1.ConditionType("type"),
 					Status:             corev1.ConditionTrue,
-					Severity:           vmopv1alpha1.ConditionSeverityNone,
+					Severity:           vmopv1.ConditionSeverityNone,
 					LastTransitionTime: metav1.Now(),
 					Reason:             "reason",
 					Message:            "message",
 				},
 				{
-					Type:               vmopv1alpha1.ConditionType("type"),
+					Type:               vmopv1.ConditionType("type"),
 					Status:             corev1.ConditionTrue,
-					Severity:           vmopv1alpha1.ConditionSeverityNone,
+					Severity:           vmopv1.ConditionSeverityNone,
 					LastTransitionTime: metav1.Now(),
 					Reason:             "reason",
 					Message:            "message",
 				},
 			},
-			expected: vmopv1alpha1.Conditions{
+			expected: vmopv1.Conditions{
 				{
-					Type:               vmopv1alpha1.ConditionType("type"),
+					Type:               vmopv1.ConditionType("type"),
 					Status:             corev1.ConditionTrue,
-					Severity:           vmopv1alpha1.ConditionSeverityNone,
+					Severity:           vmopv1.ConditionSeverityNone,
 					LastTransitionTime: metav1.Now(),
 					Reason:             "reason",
 					Message:            "message",
 				},
 				{
-					Type:               vmopv1alpha1.ConditionType("different"),
+					Type:               vmopv1.ConditionType("different"),
 					Status:             corev1.ConditionTrue,
-					Severity:           vmopv1alpha1.ConditionSeverityNone,
+					Severity:           vmopv1.ConditionSeverityNone,
 					LastTransitionTime: metav1.Now(),
 					Reason:             "different",
 					Message:            "different",
@@ -106,29 +106,29 @@ func TestMatchConditions(t *testing.T) {
 		},
 		{
 			name: "with a different number of conditions",
-			actual: vmopv1alpha1.Conditions{
+			actual: vmopv1.Conditions{
 				{
-					Type:               vmopv1alpha1.ConditionType("type"),
+					Type:               vmopv1.ConditionType("type"),
 					Status:             corev1.ConditionTrue,
-					Severity:           vmopv1alpha1.ConditionSeverityNone,
+					Severity:           vmopv1.ConditionSeverityNone,
 					LastTransitionTime: metav1.Now(),
 					Reason:             "reason",
 					Message:            "message",
 				},
 				{
-					Type:               vmopv1alpha1.ConditionType("type"),
+					Type:               vmopv1.ConditionType("type"),
 					Status:             corev1.ConditionTrue,
-					Severity:           vmopv1alpha1.ConditionSeverityNone,
+					Severity:           vmopv1.ConditionSeverityNone,
 					LastTransitionTime: metav1.Now(),
 					Reason:             "reason",
 					Message:            "message",
 				},
 			},
-			expected: vmopv1alpha1.Conditions{
+			expected: vmopv1.Conditions{
 				{
-					Type:               vmopv1alpha1.ConditionType("type"),
+					Type:               vmopv1.ConditionType("type"),
 					Status:             corev1.ConditionTrue,
-					Severity:           vmopv1alpha1.ConditionSeverityNone,
+					Severity:           vmopv1.ConditionSeverityNone,
 					LastTransitionTime: metav1.Now(),
 					Reason:             "reason",
 					Message:            "message",
@@ -154,29 +154,29 @@ func TestMatchCondition(t *testing.T) {
 	testCases := []struct {
 		name        string
 		actual      interface{}
-		expected    vmopv1alpha1.Condition
+		expected    vmopv1.Condition
 		expectMatch bool
 	}{
 		{
 			name:        "with an empty condition",
-			actual:      vmopv1alpha1.Condition{},
-			expected:    vmopv1alpha1.Condition{},
+			actual:      vmopv1.Condition{},
+			expected:    vmopv1.Condition{},
 			expectMatch: true,
 		},
 		{
 			name: "with a matching condition",
-			actual: vmopv1alpha1.Condition{
-				Type:               vmopv1alpha1.ConditionType("type"),
+			actual: vmopv1.Condition{
+				Type:               vmopv1.ConditionType("type"),
 				Status:             corev1.ConditionTrue,
-				Severity:           vmopv1alpha1.ConditionSeverityNone,
+				Severity:           vmopv1.ConditionSeverityNone,
 				LastTransitionTime: metav1.Now(),
 				Reason:             "reason",
 				Message:            "message",
 			},
-			expected: vmopv1alpha1.Condition{
-				Type:               vmopv1alpha1.ConditionType("type"),
+			expected: vmopv1.Condition{
+				Type:               vmopv1.ConditionType("type"),
 				Status:             corev1.ConditionTrue,
-				Severity:           vmopv1alpha1.ConditionSeverityNone,
+				Severity:           vmopv1.ConditionSeverityNone,
 				LastTransitionTime: metav1.Now(),
 				Reason:             "reason",
 				Message:            "message",
@@ -185,18 +185,18 @@ func TestMatchCondition(t *testing.T) {
 		},
 		{
 			name: "with a different time",
-			actual: vmopv1alpha1.Condition{
-				Type:               vmopv1alpha1.ConditionType("type"),
+			actual: vmopv1.Condition{
+				Type:               vmopv1.ConditionType("type"),
 				Status:             corev1.ConditionTrue,
-				Severity:           vmopv1alpha1.ConditionSeverityNone,
+				Severity:           vmopv1.ConditionSeverityNone,
 				LastTransitionTime: metav1.Now(),
 				Reason:             "reason",
 				Message:            "message",
 			},
-			expected: vmopv1alpha1.Condition{
-				Type:               vmopv1alpha1.ConditionType("type"),
+			expected: vmopv1.Condition{
+				Type:               vmopv1.ConditionType("type"),
 				Status:             corev1.ConditionTrue,
-				Severity:           vmopv1alpha1.ConditionSeverityNone,
+				Severity:           vmopv1.ConditionSeverityNone,
 				LastTransitionTime: metav1.Time{},
 				Reason:             "reason",
 				Message:            "message",
@@ -205,18 +205,18 @@ func TestMatchCondition(t *testing.T) {
 		},
 		{
 			name: "with a different type",
-			actual: vmopv1alpha1.Condition{
-				Type:               vmopv1alpha1.ConditionType("type"),
+			actual: vmopv1.Condition{
+				Type:               vmopv1.ConditionType("type"),
 				Status:             corev1.ConditionTrue,
-				Severity:           vmopv1alpha1.ConditionSeverityNone,
+				Severity:           vmopv1.ConditionSeverityNone,
 				LastTransitionTime: metav1.Now(),
 				Reason:             "reason",
 				Message:            "message",
 			},
-			expected: vmopv1alpha1.Condition{
-				Type:               vmopv1alpha1.ConditionType("different"),
+			expected: vmopv1.Condition{
+				Type:               vmopv1.ConditionType("different"),
 				Status:             corev1.ConditionTrue,
-				Severity:           vmopv1alpha1.ConditionSeverityNone,
+				Severity:           vmopv1.ConditionSeverityNone,
 				LastTransitionTime: metav1.Now(),
 				Reason:             "reason",
 				Message:            "message",
@@ -225,18 +225,18 @@ func TestMatchCondition(t *testing.T) {
 		},
 		{
 			name: "with a different status",
-			actual: vmopv1alpha1.Condition{
-				Type:               vmopv1alpha1.ConditionType("type"),
+			actual: vmopv1.Condition{
+				Type:               vmopv1.ConditionType("type"),
 				Status:             corev1.ConditionTrue,
-				Severity:           vmopv1alpha1.ConditionSeverityNone,
+				Severity:           vmopv1.ConditionSeverityNone,
 				LastTransitionTime: metav1.Now(),
 				Reason:             "reason",
 				Message:            "message",
 			},
-			expected: vmopv1alpha1.Condition{
-				Type:               vmopv1alpha1.ConditionType("type"),
+			expected: vmopv1.Condition{
+				Type:               vmopv1.ConditionType("type"),
 				Status:             corev1.ConditionFalse,
-				Severity:           vmopv1alpha1.ConditionSeverityNone,
+				Severity:           vmopv1.ConditionSeverityNone,
 				LastTransitionTime: metav1.Now(),
 				Reason:             "reason",
 				Message:            "message",
@@ -245,18 +245,18 @@ func TestMatchCondition(t *testing.T) {
 		},
 		{
 			name: "with a different severity",
-			actual: vmopv1alpha1.Condition{
-				Type:               vmopv1alpha1.ConditionType("type"),
+			actual: vmopv1.Condition{
+				Type:               vmopv1.ConditionType("type"),
 				Status:             corev1.ConditionTrue,
-				Severity:           vmopv1alpha1.ConditionSeverityNone,
+				Severity:           vmopv1.ConditionSeverityNone,
 				LastTransitionTime: metav1.Now(),
 				Reason:             "reason",
 				Message:            "message",
 			},
-			expected: vmopv1alpha1.Condition{
-				Type:               vmopv1alpha1.ConditionType("type"),
+			expected: vmopv1.Condition{
+				Type:               vmopv1.ConditionType("type"),
 				Status:             corev1.ConditionTrue,
-				Severity:           vmopv1alpha1.ConditionSeverityInfo,
+				Severity:           vmopv1.ConditionSeverityInfo,
 				LastTransitionTime: metav1.Now(),
 				Reason:             "reason",
 				Message:            "message",
@@ -265,18 +265,18 @@ func TestMatchCondition(t *testing.T) {
 		},
 		{
 			name: "with a different reason",
-			actual: vmopv1alpha1.Condition{
-				Type:               vmopv1alpha1.ConditionType("type"),
+			actual: vmopv1.Condition{
+				Type:               vmopv1.ConditionType("type"),
 				Status:             corev1.ConditionTrue,
-				Severity:           vmopv1alpha1.ConditionSeverityNone,
+				Severity:           vmopv1.ConditionSeverityNone,
 				LastTransitionTime: metav1.Now(),
 				Reason:             "reason",
 				Message:            "message",
 			},
-			expected: vmopv1alpha1.Condition{
-				Type:               vmopv1alpha1.ConditionType("type"),
+			expected: vmopv1.Condition{
+				Type:               vmopv1.ConditionType("type"),
 				Status:             corev1.ConditionTrue,
-				Severity:           vmopv1alpha1.ConditionSeverityNone,
+				Severity:           vmopv1.ConditionSeverityNone,
 				LastTransitionTime: metav1.Now(),
 				Reason:             "different",
 				Message:            "message",
@@ -285,18 +285,18 @@ func TestMatchCondition(t *testing.T) {
 		},
 		{
 			name: "with a different message",
-			actual: vmopv1alpha1.Condition{
-				Type:               vmopv1alpha1.ConditionType("type"),
+			actual: vmopv1.Condition{
+				Type:               vmopv1.ConditionType("type"),
 				Status:             corev1.ConditionTrue,
-				Severity:           vmopv1alpha1.ConditionSeverityNone,
+				Severity:           vmopv1.ConditionSeverityNone,
 				LastTransitionTime: metav1.Now(),
 				Reason:             "reason",
 				Message:            "message",
 			},
-			expected: vmopv1alpha1.Condition{
-				Type:               vmopv1alpha1.ConditionType("type"),
+			expected: vmopv1.Condition{
+				Type:               vmopv1.ConditionType("type"),
 				Status:             corev1.ConditionTrue,
-				Severity:           vmopv1alpha1.ConditionSeverityNone,
+				Severity:           vmopv1.ConditionSeverityNone,
 				LastTransitionTime: metav1.Now(),
 				Reason:             "reason",
 				Message:            "different",

--- a/pkg/conditions/merge.go
+++ b/pkg/conditions/merge.go
@@ -21,13 +21,13 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 )
 
 // localizedCondition defines a condition with the information of the object the conditions
 // was originated from.
 type localizedCondition struct {
-	*vmopv1alpha1.Condition
+	*vmopv1.Condition
 	Getter
 }
 
@@ -51,7 +51,7 @@ type localizedCondition struct {
 // condition; in order to complete such task some trade-off should be made, because there is no a golden rule
 // for summarizing many Reason/Message into single Reason/Message.
 // mergeOptions allows the user to adapt this process to the specific needs by exposing a set of merge strategies.
-func merge(conditions []localizedCondition, targetCondition vmopv1alpha1.ConditionType, options *mergeOptions) *vmopv1alpha1.Condition {
+func merge(conditions []localizedCondition, targetCondition vmopv1.ConditionType, options *mergeOptions) *vmopv1.Condition {
 	g := getConditionGroups(conditions)
 	if len(g) == 0 {
 		return nil
@@ -142,20 +142,20 @@ func (g conditionGroups) TopGroup() *conditionGroup {
 
 // TrueGroup returns the the condition group with status True, if any.
 func (g conditionGroups) TrueGroup() *conditionGroup {
-	return g.getByStatusAndSeverity(corev1.ConditionTrue, vmopv1alpha1.ConditionSeverityNone)
+	return g.getByStatusAndSeverity(corev1.ConditionTrue, vmopv1.ConditionSeverityNone)
 }
 
 // ErrorGroup returns the the condition group with status False and severity Error, if any.
 func (g conditionGroups) ErrorGroup() *conditionGroup {
-	return g.getByStatusAndSeverity(corev1.ConditionFalse, vmopv1alpha1.ConditionSeverityError)
+	return g.getByStatusAndSeverity(corev1.ConditionFalse, vmopv1.ConditionSeverityError)
 }
 
 // WarningGroup returns the the condition group with status False and severity Warning, if any.
 func (g conditionGroups) WarningGroup() *conditionGroup {
-	return g.getByStatusAndSeverity(corev1.ConditionFalse, vmopv1alpha1.ConditionSeverityWarning)
+	return g.getByStatusAndSeverity(corev1.ConditionFalse, vmopv1.ConditionSeverityWarning)
 }
 
-func (g conditionGroups) getByStatusAndSeverity(status corev1.ConditionStatus, severity vmopv1alpha1.ConditionSeverity) *conditionGroup {
+func (g conditionGroups) getByStatusAndSeverity(status corev1.ConditionStatus, severity vmopv1.ConditionSeverity) *conditionGroup {
 	if len(g) == 0 {
 		return nil
 	}
@@ -171,7 +171,7 @@ func (g conditionGroups) getByStatusAndSeverity(status corev1.ConditionStatus, s
 // and thus with the same priority when merging into a Ready condition.
 type conditionGroup struct {
 	status     corev1.ConditionStatus
-	severity   vmopv1alpha1.ConditionSeverity
+	severity   vmopv1.ConditionSeverity
 	conditions []localizedCondition
 }
 
@@ -181,11 +181,11 @@ func (g conditionGroup) mergePriority() int {
 	switch g.status {
 	case corev1.ConditionFalse:
 		switch g.severity {
-		case vmopv1alpha1.ConditionSeverityError:
+		case vmopv1.ConditionSeverityError:
 			return 0
-		case vmopv1alpha1.ConditionSeverityWarning:
+		case vmopv1.ConditionSeverityWarning:
 			return 1
-		case vmopv1alpha1.ConditionSeverityInfo:
+		case vmopv1.ConditionSeverityInfo:
 			return 2
 		}
 	case corev1.ConditionTrue:

--- a/pkg/conditions/merge_strategies.go
+++ b/pkg/conditions/merge_strategies.go
@@ -20,16 +20,16 @@ import (
 	"fmt"
 	"strings"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 )
 
 // mergeOptions allows to set strategies for merging a set of conditions into a single condition,
 // and more specifically for computing the target Reason and the target Message.
 type mergeOptions struct {
-	conditionTypes                     []vmopv1alpha1.ConditionType
+	conditionTypes                     []vmopv1.ConditionType
 	addSourceRef                       bool
 	addStepCounter                     bool
-	addStepCounterIfOnlyConditionTypes []vmopv1alpha1.ConditionType
+	addStepCounterIfOnlyConditionTypes []vmopv1.ConditionType
 	stepCounter                        int
 }
 
@@ -44,7 +44,7 @@ type MergeOption func(*mergeOptions)
 // NOTE: The order of conditions types defines the priority for determining the Reason and Message for the
 // target condition.
 // IMPORTANT: This options works only while generating the Summary condition.
-func WithConditions(t ...vmopv1alpha1.ConditionType) MergeOption {
+func WithConditions(t ...vmopv1.ConditionType) MergeOption {
 	return func(c *mergeOptions) {
 		c.conditionTypes = t
 	}
@@ -75,7 +75,7 @@ func WithStepCounterIf(value bool) MergeOption {
 //
 // IMPORTANT: This options requires WithStepCounter or WithStepCounterIf to be set.
 // IMPORTANT: This options works only while generating the Summary condition.
-func WithStepCounterIfOnly(t ...vmopv1alpha1.ConditionType) MergeOption {
+func WithStepCounterIfOnly(t ...vmopv1.ConditionType) MergeOption {
 	return func(c *mergeOptions) {
 		c.addStepCounterIfOnlyConditionTypes = t
 	}
@@ -96,7 +96,7 @@ func getReason(groups conditionGroups, options *mergeOptions) string {
 
 // getFirstReason returns the first reason from the ordered list of conditions in the top group.
 // If required, the reason gets localized with the source object reference.
-func getFirstReason(g conditionGroups, order []vmopv1alpha1.ConditionType, addSourceRef bool) string {
+func getFirstReason(g conditionGroups, order []vmopv1.ConditionType, addSourceRef bool) string {
 	if condition := getFirstCondition(g, order); condition != nil {
 		reason := condition.Reason
 		if addSourceRef {
@@ -137,7 +137,7 @@ func getStepCounterMessage(groups conditionGroups, to int) string {
 }
 
 // getFirstMessage returns the message from the ordered list of conditions in the top group.
-func getFirstMessage(groups conditionGroups, order []vmopv1alpha1.ConditionType) string {
+func getFirstMessage(groups conditionGroups, order []vmopv1.ConditionType) string {
 	if condition := getFirstCondition(groups, order); condition != nil {
 		return condition.Message
 	}
@@ -145,7 +145,7 @@ func getFirstMessage(groups conditionGroups, order []vmopv1alpha1.ConditionType)
 }
 
 // getFirstCondition returns a first condition from the ordered list of conditions in the top group.
-func getFirstCondition(g conditionGroups, priority []vmopv1alpha1.ConditionType) *localizedCondition {
+func getFirstCondition(g conditionGroups, priority []vmopv1.ConditionType) *localizedCondition {
 	topGroup := g.TopGroup()
 	if topGroup == nil {
 		return nil

--- a/pkg/conditions/merge_strategies_test.go
+++ b/pkg/conditions/merge_strategies_test.go
@@ -22,13 +22,13 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 )
 
 func TestGetStepCounterMessage(t *testing.T) {
 	g := NewWithT(t)
 
-	groups := getConditionGroups(conditionsWithSource(&vmopv1alpha1.VirtualMachine{},
+	groups := getConditionGroups(conditionsWithSource(&vmopv1.VirtualMachine{},
 		nil1,
 		true1, true1,
 		falseInfo1,
@@ -46,7 +46,7 @@ func TestGetStepCounterMessage(t *testing.T) {
 func TestLocalizeReason(t *testing.T) {
 	g := NewWithT(t)
 
-	getter := &vmopv1alpha1.VirtualMachine{
+	getter := &vmopv1.VirtualMachine{
 		TypeMeta: metav1.TypeMeta{
 			Kind: "VirtualMachine",
 		},
@@ -67,10 +67,10 @@ func TestLocalizeReason(t *testing.T) {
 func TestGetFirstReasonAndMessage(t *testing.T) {
 	g := NewWithT(t)
 
-	foo := FalseCondition("foo", "falseFoo", vmopv1alpha1.ConditionSeverityInfo, "message falseFoo")
-	bar := FalseCondition("bar", "falseBar", vmopv1alpha1.ConditionSeverityInfo, "message falseBar")
+	foo := FalseCondition("foo", "falseFoo", vmopv1.ConditionSeverityInfo, "message falseFoo")
+	bar := FalseCondition("bar", "falseBar", vmopv1.ConditionSeverityInfo, "message falseBar")
 
-	getter := &vmopv1alpha1.VirtualMachine{
+	getter := &vmopv1.VirtualMachine{
 		TypeMeta: metav1.TypeMeta{
 			Kind: "VirtualMachine",
 		},
@@ -88,21 +88,21 @@ func TestGetFirstReasonAndMessage(t *testing.T) {
 	g.Expect(gotMessage).To(Equal("message falseBar"))
 
 	// getFirst should report should respect order
-	gotReason = getFirstReason(groups, []vmopv1alpha1.ConditionType{"foo", "bar"}, false)
+	gotReason = getFirstReason(groups, []vmopv1.ConditionType{"foo", "bar"}, false)
 	g.Expect(gotReason).To(Equal("falseFoo"))
-	gotMessage = getFirstMessage(groups, []vmopv1alpha1.ConditionType{"foo", "bar"})
+	gotMessage = getFirstMessage(groups, []vmopv1.ConditionType{"foo", "bar"})
 	g.Expect(gotMessage).To(Equal("message falseFoo"))
 
 	// getFirst should report should respect order in case of missing conditions
-	gotReason = getFirstReason(groups, []vmopv1alpha1.ConditionType{"missingBaz", "foo", "bar"}, false)
+	gotReason = getFirstReason(groups, []vmopv1.ConditionType{"missingBaz", "foo", "bar"}, false)
 	g.Expect(gotReason).To(Equal("falseFoo"))
-	gotMessage = getFirstMessage(groups, []vmopv1alpha1.ConditionType{"missingBaz", "foo", "bar"})
+	gotMessage = getFirstMessage(groups, []vmopv1.ConditionType{"missingBaz", "foo", "bar"})
 	g.Expect(gotMessage).To(Equal("message falseFoo"))
 
 	// getFirst should fallback to first condition if none of the conditions in the list exists
-	gotReason = getFirstReason(groups, []vmopv1alpha1.ConditionType{"missingBaz"}, false)
+	gotReason = getFirstReason(groups, []vmopv1.ConditionType{"missingBaz"}, false)
 	g.Expect(gotReason).To(Equal("falseBar"))
-	gotMessage = getFirstMessage(groups, []vmopv1alpha1.ConditionType{"missingBaz"})
+	gotMessage = getFirstMessage(groups, []vmopv1.ConditionType{"missingBaz"})
 	g.Expect(gotMessage).To(Equal("message falseBar"))
 
 	// getFirstReason should localize reason if required

--- a/pkg/conditions/merge_test.go
+++ b/pkg/conditions/merge_test.go
@@ -23,62 +23,62 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 )
 
 func TestNewConditionsGroup(t *testing.T) {
 	g := NewWithT(t)
 
-	conditions := []*vmopv1alpha1.Condition{nil1, true1, true1, falseInfo1, falseWarning1, falseWarning1, falseError1, unknown1}
+	conditions := []*vmopv1.Condition{nil1, true1, true1, falseInfo1, falseWarning1, falseWarning1, falseError1, unknown1}
 
-	got := getConditionGroups(conditionsWithSource(&vmopv1alpha1.VirtualMachine{}, conditions...))
+	got := getConditionGroups(conditionsWithSource(&vmopv1.VirtualMachine{}, conditions...))
 
 	g.Expect(got).ToNot(BeNil())
 	g.Expect(got).To(HaveLen(5))
 
 	// The top group should be False/Error and it should have one condition
 	g.Expect(got.TopGroup().status).To(Equal(corev1.ConditionFalse))
-	g.Expect(got.TopGroup().severity).To(Equal(vmopv1alpha1.ConditionSeverityError))
+	g.Expect(got.TopGroup().severity).To(Equal(vmopv1.ConditionSeverityError))
 	g.Expect(got.TopGroup().conditions).To(HaveLen(1))
 
 	// The true group should be true and it should have two conditions
 	g.Expect(got.TrueGroup().status).To(Equal(corev1.ConditionTrue))
-	g.Expect(got.TrueGroup().severity).To(Equal(vmopv1alpha1.ConditionSeverityNone))
+	g.Expect(got.TrueGroup().severity).To(Equal(vmopv1.ConditionSeverityNone))
 	g.Expect(got.TrueGroup().conditions).To(HaveLen(2))
 
 	// The error group should be False/Error and it should have one condition
 	g.Expect(got.ErrorGroup().status).To(Equal(corev1.ConditionFalse))
-	g.Expect(got.ErrorGroup().severity).To(Equal(vmopv1alpha1.ConditionSeverityError))
+	g.Expect(got.ErrorGroup().severity).To(Equal(vmopv1.ConditionSeverityError))
 	g.Expect(got.ErrorGroup().conditions).To(HaveLen(1))
 
 	// The warning group should be False/Warning and it should have two conditions
 	g.Expect(got.WarningGroup().status).To(Equal(corev1.ConditionFalse))
-	g.Expect(got.WarningGroup().severity).To(Equal(vmopv1alpha1.ConditionSeverityWarning))
+	g.Expect(got.WarningGroup().severity).To(Equal(vmopv1.ConditionSeverityWarning))
 	g.Expect(got.WarningGroup().conditions).To(HaveLen(2))
 
 	// got[0] should be False/Error and it should have one condition
 	g.Expect(got[0].status).To(Equal(corev1.ConditionFalse))
-	g.Expect(got[0].severity).To(Equal(vmopv1alpha1.ConditionSeverityError))
+	g.Expect(got[0].severity).To(Equal(vmopv1.ConditionSeverityError))
 	g.Expect(got[0].conditions).To(HaveLen(1))
 
 	// got[1] should be False/Warning and it should have two conditions
 	g.Expect(got[1].status).To(Equal(corev1.ConditionFalse))
-	g.Expect(got[1].severity).To(Equal(vmopv1alpha1.ConditionSeverityWarning))
+	g.Expect(got[1].severity).To(Equal(vmopv1.ConditionSeverityWarning))
 	g.Expect(got[1].conditions).To(HaveLen(2))
 
 	// got[2] should be False/Info and it should have one condition
 	g.Expect(got[2].status).To(Equal(corev1.ConditionFalse))
-	g.Expect(got[2].severity).To(Equal(vmopv1alpha1.ConditionSeverityInfo))
+	g.Expect(got[2].severity).To(Equal(vmopv1.ConditionSeverityInfo))
 	g.Expect(got[2].conditions).To(HaveLen(1))
 
 	// got[3] should be True and it should have two conditions
 	g.Expect(got[3].status).To(Equal(corev1.ConditionTrue))
-	g.Expect(got[3].severity).To(Equal(vmopv1alpha1.ConditionSeverityNone))
+	g.Expect(got[3].severity).To(Equal(vmopv1.ConditionSeverityNone))
 	g.Expect(got[3].conditions).To(HaveLen(2))
 
 	// got[4] should be Unknown and it should have one condition
 	g.Expect(got[4].status).To(Equal(corev1.ConditionUnknown))
-	g.Expect(got[4].severity).To(Equal(vmopv1alpha1.ConditionSeverityNone))
+	g.Expect(got[4].severity).To(Equal(vmopv1.ConditionSeverityNone))
 	g.Expect(got[4].conditions).To(HaveLen(1))
 
 	// nil conditions are ignored
@@ -87,8 +87,8 @@ func TestNewConditionsGroup(t *testing.T) {
 func TestMergeRespectPriority(t *testing.T) {
 	tests := []struct {
 		name       string
-		conditions []*vmopv1alpha1.Condition
-		want       *vmopv1alpha1.Condition
+		conditions []*vmopv1.Condition
+		want       *vmopv1.Condition
 	}{
 		{
 			name:       "aggregate nil list return nil",
@@ -97,37 +97,37 @@ func TestMergeRespectPriority(t *testing.T) {
 		},
 		{
 			name:       "aggregate empty list return nil",
-			conditions: []*vmopv1alpha1.Condition{},
+			conditions: []*vmopv1.Condition{},
 			want:       nil,
 		},
 		{
 			name:       "When there is false/error it returns false/error",
-			conditions: []*vmopv1alpha1.Condition{falseError1, falseWarning1, falseInfo1, unknown1, true1},
-			want:       FalseCondition("foo", "reason falseError1", vmopv1alpha1.ConditionSeverityError, "message falseError1"),
+			conditions: []*vmopv1.Condition{falseError1, falseWarning1, falseInfo1, unknown1, true1},
+			want:       FalseCondition("foo", "reason falseError1", vmopv1.ConditionSeverityError, "message falseError1"),
 		},
 		{
 			name:       "When there is false/warning and no false/error, it returns false/warning",
-			conditions: []*vmopv1alpha1.Condition{falseWarning1, falseInfo1, unknown1, true1},
-			want:       FalseCondition("foo", "reason falseWarning1", vmopv1alpha1.ConditionSeverityWarning, "message falseWarning1"),
+			conditions: []*vmopv1.Condition{falseWarning1, falseInfo1, unknown1, true1},
+			want:       FalseCondition("foo", "reason falseWarning1", vmopv1.ConditionSeverityWarning, "message falseWarning1"),
 		},
 		{
 			name:       "When there is false/info and no false/error or false/warning, it returns false/info",
-			conditions: []*vmopv1alpha1.Condition{falseInfo1, unknown1, true1},
-			want:       FalseCondition("foo", "reason falseInfo1", vmopv1alpha1.ConditionSeverityInfo, "message falseInfo1"),
+			conditions: []*vmopv1.Condition{falseInfo1, unknown1, true1},
+			want:       FalseCondition("foo", "reason falseInfo1", vmopv1.ConditionSeverityInfo, "message falseInfo1"),
 		},
 		{
 			name:       "When there is true and no false/*, it returns info",
-			conditions: []*vmopv1alpha1.Condition{unknown1, true1},
+			conditions: []*vmopv1.Condition{unknown1, true1},
 			want:       TrueCondition("foo"),
 		},
 		{
 			name:       "When there is unknown and no true or false/*, it returns unknown",
-			conditions: []*vmopv1alpha1.Condition{unknown1},
+			conditions: []*vmopv1.Condition{unknown1},
 			want:       UnknownCondition("foo", "reason unknown1", "message unknown1"),
 		},
 		{
 			name:       "nil conditions are ignored",
-			conditions: []*vmopv1alpha1.Condition{nil1, nil1, nil1},
+			conditions: []*vmopv1.Condition{nil1, nil1, nil1},
 			want:       nil,
 		},
 	}
@@ -136,7 +136,7 @@ func TestMergeRespectPriority(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			got := merge(conditionsWithSource(&vmopv1alpha1.VirtualMachine{}, tt.conditions...), "foo", &mergeOptions{})
+			got := merge(conditionsWithSource(&vmopv1.VirtualMachine{}, tt.conditions...), "foo", &mergeOptions{})
 
 			if tt.want == nil {
 				g.Expect(got).To(BeNil())
@@ -147,7 +147,7 @@ func TestMergeRespectPriority(t *testing.T) {
 	}
 }
 
-func conditionsWithSource(obj Setter, conditions ...*vmopv1alpha1.Condition) []localizedCondition {
+func conditionsWithSource(obj Setter, conditions ...*vmopv1.Condition) []localizedCondition {
 	obj.SetConditions(conditionList(conditions...))
 
 	ret := []localizedCondition{}

--- a/pkg/conditions/patch.go
+++ b/pkg/conditions/patch.go
@@ -22,7 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 )
 
 // Patch defines a list of operations to change a list of conditions into another.
@@ -30,8 +30,8 @@ type Patch []PatchOperation
 
 // PatchOperation define an operation that changes a single condition.
 type PatchOperation struct {
-	Before *vmopv1alpha1.Condition
-	After  *vmopv1alpha1.Condition
+	Before *vmopv1.Condition
+	After  *vmopv1.Condition
 	Op     PatchOperationType
 }
 
@@ -82,11 +82,11 @@ func NewPatch(before Getter, after Getter) Patch {
 
 // applyOptions allows to set strategies for patch apply.
 type applyOptions struct {
-	ownedConditions []vmopv1alpha1.ConditionType
+	ownedConditions []vmopv1.ConditionType
 	forceOverwrite  bool
 }
 
-func (o *applyOptions) isOwnedCondition(t vmopv1alpha1.ConditionType) bool {
+func (o *applyOptions) isOwnedCondition(t vmopv1.ConditionType) bool {
 	for _, i := range o.ownedConditions {
 		if i == t {
 			return true
@@ -100,7 +100,7 @@ type ApplyOption func(*applyOptions)
 
 // WithOwnedConditions allows to define condition types owned by the controller.
 // In case of conflicts for the owned conditions, the patch helper will always use the value provided by the controller.
-func WithOwnedConditions(t ...vmopv1alpha1.ConditionType) ApplyOption {
+func WithOwnedConditions(t ...vmopv1.ConditionType) ApplyOption {
 	return func(c *applyOptions) {
 		c.ownedConditions = t
 	}

--- a/pkg/conditions/patch_test.go
+++ b/pkg/conditions/patch_test.go
@@ -25,12 +25,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 )
 
 func TestNewPatch(t *testing.T) {
 	fooTrue := TrueCondition("foo")
-	fooFalse := FalseCondition("foo", "reason foo", vmopv1alpha1.ConditionSeverityInfo, "message foo")
+	fooFalse := FalseCondition("foo", "reason foo", vmopv1.ConditionSeverityInfo, "message foo")
 
 	tests := []struct {
 		name   string
@@ -101,8 +101,8 @@ func TestNewPatch(t *testing.T) {
 
 func TestApply(t *testing.T) {
 	fooTrue := TrueCondition("foo")
-	fooFalse := FalseCondition("foo", "reason foo", vmopv1alpha1.ConditionSeverityInfo, "message foo")
-	fooWarning := FalseCondition("foo", "reason foo", vmopv1alpha1.ConditionSeverityWarning, "message foo")
+	fooFalse := FalseCondition("foo", "reason foo", vmopv1.ConditionSeverityInfo, "message foo")
+	fooWarning := FalseCondition("foo", "reason foo", vmopv1.ConditionSeverityWarning, "message foo")
 
 	tests := []struct {
 		name    string
@@ -110,7 +110,7 @@ func TestApply(t *testing.T) {
 		after   Getter
 		latest  Setter
 		options []ApplyOption
-		want    vmopv1alpha1.Conditions
+		want    vmopv1.Conditions
 		wantErr bool
 	}{
 		{
@@ -260,11 +260,11 @@ func TestApply(t *testing.T) {
 func TestApplyDoesNotAlterLastTransitionTime(t *testing.T) {
 	g := NewWithT(t)
 
-	before := &vmopv1alpha1.VirtualMachine{}
-	after := &vmopv1alpha1.VirtualMachine{
-		Status: vmopv1alpha1.VirtualMachineStatus{
-			Conditions: vmopv1alpha1.Conditions{
-				vmopv1alpha1.Condition{
+	before := &vmopv1.VirtualMachine{}
+	after := &vmopv1.VirtualMachine{
+		Status: vmopv1.VirtualMachineStatus{
+			Conditions: vmopv1.Conditions{
+				vmopv1.Condition{
 					Type:               "foo",
 					Status:             corev1.ConditionTrue,
 					LastTransitionTime: metav1.NewTime(time.Now().UTC().Truncate(time.Second)),
@@ -272,7 +272,7 @@ func TestApplyDoesNotAlterLastTransitionTime(t *testing.T) {
 			},
 		},
 	}
-	latest := &vmopv1alpha1.VirtualMachine{}
+	latest := &vmopv1.VirtualMachine{}
 
 	// latest has no conditions, so we are actually adding the condition but in this case we should not set the LastTransition Time
 	// but we should preserve the LastTransition set in after

--- a/pkg/conditions/setter.go
+++ b/pkg/conditions/setter.go
@@ -24,21 +24,21 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 )
 
 // Setter interface defines methods that a Cluster API object should implement in order to
 // use the conditions package for setting conditions.
 type Setter interface {
 	Getter
-	SetConditions(vmopv1alpha1.Conditions)
+	SetConditions(vmopv1.Conditions)
 }
 
 // Set sets the given condition.
 //
 // NOTE: If a condition already exists, the LastTransitionTime is updated only if a change is detected
 // in any of the following fields: Status, Reason, Severity and Message.
-func Set(to Setter, condition *vmopv1alpha1.Condition) {
+func Set(to Setter, condition *vmopv1.Condition) {
 	if to == nil || condition == nil {
 		return
 	}
@@ -78,16 +78,16 @@ func Set(to Setter, condition *vmopv1alpha1.Condition) {
 }
 
 // TrueCondition returns a condition with Status=True and the given type.
-func TrueCondition(t vmopv1alpha1.ConditionType) *vmopv1alpha1.Condition {
-	return &vmopv1alpha1.Condition{
+func TrueCondition(t vmopv1.ConditionType) *vmopv1.Condition {
+	return &vmopv1.Condition{
 		Type:   t,
 		Status: corev1.ConditionTrue,
 	}
 }
 
 // FalseCondition returns a condition with Status=False and the given type.
-func FalseCondition(t vmopv1alpha1.ConditionType, reason string, severity vmopv1alpha1.ConditionSeverity, messageFormat string, messageArgs ...interface{}) *vmopv1alpha1.Condition {
-	return &vmopv1alpha1.Condition{
+func FalseCondition(t vmopv1.ConditionType, reason string, severity vmopv1.ConditionSeverity, messageFormat string, messageArgs ...interface{}) *vmopv1.Condition {
+	return &vmopv1.Condition{
 		Type:     t,
 		Status:   corev1.ConditionFalse,
 		Reason:   reason,
@@ -97,8 +97,8 @@ func FalseCondition(t vmopv1alpha1.ConditionType, reason string, severity vmopv1
 }
 
 // UnknownCondition returns a condition with Status=Unknown and the given type.
-func UnknownCondition(t vmopv1alpha1.ConditionType, reason string, messageFormat string, messageArgs ...interface{}) *vmopv1alpha1.Condition {
-	return &vmopv1alpha1.Condition{
+func UnknownCondition(t vmopv1.ConditionType, reason string, messageFormat string, messageArgs ...interface{}) *vmopv1.Condition {
+	return &vmopv1.Condition{
 		Type:    t,
 		Status:  corev1.ConditionUnknown,
 		Reason:  reason,
@@ -107,17 +107,17 @@ func UnknownCondition(t vmopv1alpha1.ConditionType, reason string, messageFormat
 }
 
 // MarkTrue sets Status=True for the condition with the given type.
-func MarkTrue(to Setter, t vmopv1alpha1.ConditionType) {
+func MarkTrue(to Setter, t vmopv1.ConditionType) {
 	Set(to, TrueCondition(t))
 }
 
 // MarkUnknown sets Status=Unknown for the condition with the given type.
-func MarkUnknown(to Setter, t vmopv1alpha1.ConditionType, reason, messageFormat string, messageArgs ...interface{}) {
+func MarkUnknown(to Setter, t vmopv1.ConditionType, reason, messageFormat string, messageArgs ...interface{}) {
 	Set(to, UnknownCondition(t, reason, messageFormat, messageArgs...))
 }
 
 // MarkFalse sets Status=False for the condition with the given type.
-func MarkFalse(to Setter, t vmopv1alpha1.ConditionType, reason string, severity vmopv1alpha1.ConditionSeverity, messageFormat string, messageArgs ...interface{}) {
+func MarkFalse(to Setter, t vmopv1.ConditionType, reason string, severity vmopv1.ConditionSeverity, messageFormat string, messageArgs ...interface{}) {
 	Set(to, FalseCondition(t, reason, severity, messageFormat, messageArgs...))
 }
 
@@ -129,7 +129,7 @@ func SetSummary(to Setter, options ...MergeOption) {
 
 // SetMirror creates a new condition by mirroring the the Ready condition from a dependent object;
 // if the Ready condition does not exists in the source object, no target conditions is generated.
-func SetMirror(to Setter, targetCondition vmopv1alpha1.ConditionType, from Getter, options ...MirrorOptions) {
+func SetMirror(to Setter, targetCondition vmopv1.ConditionType, from Getter, options ...MirrorOptions) {
 	Set(to, mirror(from, targetCondition, options...))
 }
 
@@ -137,18 +137,18 @@ func SetMirror(to Setter, targetCondition vmopv1alpha1.ConditionType, from Gette
 // from a list of dependent objects; if the Ready condition does not exists in one of the source object,
 // the object is excluded from the aggregation; if none of the source object have ready condition,
 // no target conditions is generated.
-func SetAggregate(to Setter, targetCondition vmopv1alpha1.ConditionType, from []Getter, options ...MergeOption) {
+func SetAggregate(to Setter, targetCondition vmopv1.ConditionType, from []Getter, options ...MergeOption) {
 	Set(to, aggregate(from, targetCondition, options...))
 }
 
 // Delete deletes the condition with the given type.
-func Delete(to Setter, t vmopv1alpha1.ConditionType) {
+func Delete(to Setter, t vmopv1.ConditionType) {
 	if to == nil {
 		return
 	}
 
 	conditions := to.GetConditions()
-	newConditions := make(vmopv1alpha1.Conditions, 0, len(conditions))
+	newConditions := make(vmopv1.Conditions, 0, len(conditions))
 	for _, condition := range conditions {
 		if condition.Type != t {
 			newConditions = append(newConditions, condition)
@@ -161,13 +161,13 @@ func Delete(to Setter, t vmopv1alpha1.ConditionType) {
 // to order of conditions designed for convenience of the consumer, i.e. kubectl.
 // According to this order the Ready condition always goes first, followed by all the other
 // conditions sorted by Type.
-func lexicographicLess(i, j *vmopv1alpha1.Condition) bool {
-	return (i.Type == vmopv1alpha1.ReadyCondition || i.Type < j.Type) && j.Type != vmopv1alpha1.ReadyCondition
+func lexicographicLess(i, j *vmopv1.Condition) bool {
+	return (i.Type == vmopv1.ReadyCondition || i.Type < j.Type) && j.Type != vmopv1.ReadyCondition
 }
 
 // hasSameState returns true if a condition has the same state of another; state is defined
 // by the union of following fields: Type, Status, Reason, Severity and Message (it excludes LastTransitionTime).
-func hasSameState(i, j *vmopv1alpha1.Condition) bool {
+func hasSameState(i, j *vmopv1.Condition) bool {
 	return i.Type == j.Type &&
 		i.Status == j.Status &&
 		i.Reason == j.Reason &&

--- a/pkg/conditions/setter_test.go
+++ b/pkg/conditions/setter_test.go
@@ -28,7 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 )
 
 func TestHasSameState(t *testing.T) {
@@ -53,7 +53,7 @@ func TestHasSameState(t *testing.T) {
 	g.Expect(hasSameState(falseInfo1, falseInfo2)).To(BeFalse())
 
 	falseInfo2 = falseInfo1.DeepCopy()
-	falseInfo2.Severity = vmopv1alpha1.ConditionSeverityWarning
+	falseInfo2.Severity = vmopv1.ConditionSeverityWarning
 	g.Expect(hasSameState(falseInfo1, falseInfo2)).To(BeFalse())
 
 	falseInfo2 = falseInfo1.DeepCopy()
@@ -78,25 +78,25 @@ func TestLexicographicLess(t *testing.T) {
 	g.Expect(lexicographicLess(a, b)).To(BeFalse())
 
 	// Ready condition is treated as an exception and always goes first
-	a = TrueCondition(vmopv1alpha1.ReadyCondition)
+	a = TrueCondition(vmopv1.ReadyCondition)
 	b = TrueCondition("A")
 	g.Expect(lexicographicLess(a, b)).To(BeTrue())
 
 	a = TrueCondition("A")
-	b = TrueCondition(vmopv1alpha1.ReadyCondition)
+	b = TrueCondition(vmopv1.ReadyCondition)
 	g.Expect(lexicographicLess(a, b)).To(BeFalse())
 }
 
 func TestSet(t *testing.T) {
 	a := TrueCondition("a")
 	b := TrueCondition("b")
-	ready := TrueCondition(vmopv1alpha1.ReadyCondition)
+	ready := TrueCondition(vmopv1.ReadyCondition)
 
 	tests := []struct {
 		name      string
 		to        Setter
-		condition *vmopv1alpha1.Condition
-		want      vmopv1alpha1.Conditions
+		condition *vmopv1.Condition
+		want      vmopv1.Conditions
 	}{
 		{
 			name:      "Set adds a condition",
@@ -138,15 +138,15 @@ func TestSet(t *testing.T) {
 func TestSetLastTransitionTime(t *testing.T) {
 	x := metav1.Date(2012, time.January, 1, 12, 15, 30, 5e8, time.UTC)
 
-	foo := FalseCondition("foo", "reason foo", vmopv1alpha1.ConditionSeverityInfo, "message foo")
-	fooWithLastTransitionTime := FalseCondition("foo", "reason foo", vmopv1alpha1.ConditionSeverityInfo, "message foo")
+	foo := FalseCondition("foo", "reason foo", vmopv1.ConditionSeverityInfo, "message foo")
+	fooWithLastTransitionTime := FalseCondition("foo", "reason foo", vmopv1.ConditionSeverityInfo, "message foo")
 	fooWithLastTransitionTime.LastTransitionTime = x
 	fooWithAnotherState := TrueCondition("foo")
 
 	tests := []struct {
 		name                    string
 		to                      Setter
-		new                     *vmopv1alpha1.Condition
+		new                     *vmopv1.Condition
 		LastTransitionTimeCheck func(*WithT, metav1.Time)
 	}{
 		{
@@ -197,28 +197,28 @@ func TestSetLastTransitionTime(t *testing.T) {
 func TestMarkMethods(t *testing.T) {
 	g := NewWithT(t)
 
-	vm := &vmopv1alpha1.VirtualMachine{}
+	vm := &vmopv1.VirtualMachine{}
 
 	// test MarkTrue
 	MarkTrue(vm, "conditionFoo")
-	g.Expect(Get(vm, "conditionFoo")).To(haveSameStateOf(&vmopv1alpha1.Condition{
+	g.Expect(Get(vm, "conditionFoo")).To(haveSameStateOf(&vmopv1.Condition{
 		Type:   "conditionFoo",
 		Status: corev1.ConditionTrue,
 	}))
 
 	// test MarkFalse
-	MarkFalse(vm, "conditionBar", "reasonBar", vmopv1alpha1.ConditionSeverityError, "messageBar")
-	g.Expect(Get(vm, "conditionBar")).To(haveSameStateOf(&vmopv1alpha1.Condition{
+	MarkFalse(vm, "conditionBar", "reasonBar", vmopv1.ConditionSeverityError, "messageBar")
+	g.Expect(Get(vm, "conditionBar")).To(haveSameStateOf(&vmopv1.Condition{
 		Type:     "conditionBar",
 		Status:   corev1.ConditionFalse,
-		Severity: vmopv1alpha1.ConditionSeverityError,
+		Severity: vmopv1.ConditionSeverityError,
 		Reason:   "reasonBar",
 		Message:  "messageBar",
 	}))
 
 	// test MarkUnknown
 	MarkUnknown(vm, "conditionBaz", "reasonBaz", "messageBaz")
-	g.Expect(Get(vm, "conditionBaz")).To(haveSameStateOf(&vmopv1alpha1.Condition{
+	g.Expect(Get(vm, "conditionBaz")).To(haveSameStateOf(&vmopv1.Condition{
 		Type:    "conditionBaz",
 		Status:  corev1.ConditionUnknown,
 		Reason:  "reasonBaz",
@@ -232,12 +232,12 @@ func TestSetSummary(t *testing.T) {
 
 	SetSummary(target)
 
-	g.Expect(Has(target, vmopv1alpha1.ReadyCondition)).To(BeTrue())
+	g.Expect(Has(target, vmopv1.ReadyCondition)).To(BeTrue())
 }
 
 func TestSetMirror(t *testing.T) {
 	g := NewWithT(t)
-	source := getterWithConditions(TrueCondition(vmopv1alpha1.ReadyCondition))
+	source := getterWithConditions(TrueCondition(vmopv1.ReadyCondition))
 	target := setterWithConditions()
 
 	SetMirror(target, "foo", source)
@@ -247,8 +247,8 @@ func TestSetMirror(t *testing.T) {
 
 func TestSetAggregate(t *testing.T) {
 	g := NewWithT(t)
-	source1 := getterWithConditions(TrueCondition(vmopv1alpha1.ReadyCondition))
-	source2 := getterWithConditions(TrueCondition(vmopv1alpha1.ReadyCondition))
+	source1 := getterWithConditions(TrueCondition(vmopv1.ReadyCondition))
+	source2 := getterWithConditions(TrueCondition(vmopv1.ReadyCondition))
 	target := setterWithConditions()
 
 	SetAggregate(target, "foo", []Getter{source1, source2})
@@ -256,24 +256,24 @@ func TestSetAggregate(t *testing.T) {
 	g.Expect(Has(target, "foo")).To(BeTrue())
 }
 
-func setterWithConditions(conditions ...*vmopv1alpha1.Condition) Setter {
-	obj := &vmopv1alpha1.VirtualMachine{}
+func setterWithConditions(conditions ...*vmopv1.Condition) Setter {
+	obj := &vmopv1.VirtualMachine{}
 	obj.SetConditions(conditionList(conditions...))
 	return obj
 }
 
-func haveSameConditionsOf(expected vmopv1alpha1.Conditions) types.GomegaMatcher {
+func haveSameConditionsOf(expected vmopv1.Conditions) types.GomegaMatcher {
 	return &ConditionsMatcher{
 		Expected: expected,
 	}
 }
 
 type ConditionsMatcher struct {
-	Expected vmopv1alpha1.Conditions
+	Expected vmopv1.Conditions
 }
 
 func (matcher *ConditionsMatcher) Match(actual interface{}) (success bool, err error) {
-	actualConditions, ok := actual.(vmopv1alpha1.Conditions)
+	actualConditions, ok := actual.(vmopv1.Conditions)
 	if !ok {
 		return false, errors.New("Value should be a conditions list")
 	}

--- a/pkg/conditions/unstructured.go
+++ b/pkg/conditions/unstructured.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 )
 
 // UnstructuredGetter return a Getter object that can read conditions from an Unstructured object.
@@ -49,8 +49,8 @@ type unstructuredWrapper struct {
 //     in both cases the operation returns an empty slice is returned.
 //   - If the object doesn't implement conditions on under status as defined in Cluster API,
 //     JSON-unmarshal matches incoming object keys to the keys; this can lead to to conditions values partially set.
-func (c *unstructuredWrapper) GetConditions() vmopv1alpha1.Conditions {
-	conditions := vmopv1alpha1.Conditions{}
+func (c *unstructuredWrapper) GetConditions() vmopv1.Conditions {
+	conditions := vmopv1.Conditions{}
 	if err := UnstructuredUnmarshalField(c.Unstructured, &conditions, "status", "conditions"); err != nil {
 		return nil
 	}
@@ -64,7 +64,7 @@ func (c *unstructuredWrapper) GetConditions() vmopv1alpha1.Conditions {
 //   - Errors during JSON-unmarshal are ignored and a empty collection list is returned.
 //   - It's not possible to detect if the object has an empty condition list or if it does not implement conditions;
 //     in both cases the operation returns an empty slice is returned.
-func (c *unstructuredWrapper) SetConditions(conditions vmopv1alpha1.Conditions) {
+func (c *unstructuredWrapper) SetConditions(conditions vmopv1.Conditions) {
 	v := make([]interface{}, 0, len(conditions))
 	for i := range conditions {
 		m, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&conditions[i])

--- a/pkg/conditions/unstructured_test.go
+++ b/pkg/conditions/unstructured_test.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 )
 
 func TestUnstructuredGetConditions(t *testing.T) {
@@ -33,10 +33,10 @@ func TestUnstructuredGetConditions(t *testing.T) {
 
 	scheme := runtime.NewScheme()
 	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
-	g.Expect(vmopv1alpha1.AddToScheme(scheme)).To(Succeed())
+	g.Expect(vmopv1.AddToScheme(scheme)).To(Succeed())
 
 	// GetConditions should return conditions from an unstructured object
-	c := &vmopv1alpha1.VirtualMachine{}
+	c := &vmopv1.VirtualMachine{}
 	c.SetConditions(conditionList(true1))
 	u := &unstructured.Unstructured{}
 	g.Expect(scheme.Convert(c, u, nil)).To(Succeed())
@@ -44,7 +44,7 @@ func TestUnstructuredGetConditions(t *testing.T) {
 	g.Expect(UnstructuredGetter(u).GetConditions()).To(haveSameConditionsOf(conditionList(true1)))
 
 	// GetConditions should return nil for an unstructured object with empty conditions
-	c = &vmopv1alpha1.VirtualMachine{}
+	c = &vmopv1.VirtualMachine{}
 	u = &unstructured.Unstructured{}
 	g.Expect(scheme.Convert(c, u, nil)).To(Succeed())
 
@@ -82,9 +82,9 @@ func TestUnstructuredSetConditions(t *testing.T) {
 	// gets an unstructured with empty conditions
 	scheme := runtime.NewScheme()
 	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
-	g.Expect(vmopv1alpha1.AddToScheme(scheme)).To(Succeed())
+	g.Expect(vmopv1.AddToScheme(scheme)).To(Succeed())
 
-	c := &vmopv1alpha1.VirtualMachine{}
+	c := &vmopv1.VirtualMachine{}
 	u := &unstructured.Unstructured{}
 	g.Expect(scheme.Convert(c, u, nil)).To(Succeed())
 

--- a/pkg/context/virtualmachinesetresourcepolicy_context.go
+++ b/pkg/context/virtualmachinesetresourcepolicy_context.go
@@ -9,14 +9,14 @@ import (
 
 	"github.com/go-logr/logr"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 )
 
 // VirtualMachineSetResourcePolicyContext is the context used for VirtualMachineControllers.
 type VirtualMachineSetResourcePolicyContext struct {
 	context.Context
 	Logger         logr.Logger
-	ResourcePolicy *vmopv1alpha1.VirtualMachineSetResourcePolicy
+	ResourcePolicy *vmopv1.VirtualMachineSetResourcePolicy
 }
 
 func (v *VirtualMachineSetResourcePolicyContext) String() string {

--- a/pkg/metrics/contentsource_metrics.go
+++ b/pkg/metrics/contentsource_metrics.go
@@ -11,7 +11,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 )
 
 var (
@@ -50,7 +50,7 @@ func NewContentSourceMetrics() *ContentSourceMetrics {
 
 // RegisterVMImageCreateOrUpdate registers the metrics for the given VMImage.
 // If success is true, it sets the value to 1 else to 0.
-func (csm *ContentSourceMetrics) RegisterVMImageCreateOrUpdate(logger logr.Logger, vmImage vmopv1alpha1.VirtualMachineImage, success bool) {
+func (csm *ContentSourceMetrics) RegisterVMImageCreateOrUpdate(logger logr.Logger, vmImage vmopv1.VirtualMachineImage, success bool) {
 	logger.V(5).Info("Adding metrics for a VMImage CR create or update operation")
 	vmImageLabels := getVMImageLabels(vmImage)
 	csm.vmImage.With(vmImageLabels).Set(func() float64 {
@@ -63,7 +63,7 @@ func (csm *ContentSourceMetrics) RegisterVMImageCreateOrUpdate(logger logr.Logge
 
 // RegisterVMImageDelete registers the metrics for the given VMImage delete operation.
 // If success is true, it deletes the metric; otherwise, it sets the value to -1.
-func (csm *ContentSourceMetrics) RegisterVMImageDelete(logger logr.Logger, vmImage vmopv1alpha1.VirtualMachineImage, success bool) {
+func (csm *ContentSourceMetrics) RegisterVMImageDelete(logger logr.Logger, vmImage vmopv1.VirtualMachineImage, success bool) {
 	logger.V(5).Info("Adding metrics for a VMImage CR delete operation")
 	labels := getVMImageLabels(vmImage)
 	if success {
@@ -75,7 +75,7 @@ func (csm *ContentSourceMetrics) RegisterVMImageDelete(logger logr.Logger, vmIma
 }
 
 // DeleteMetrics deletes the related metrics from the given ContentProviderReference.
-func (csm *ContentSourceMetrics) DeleteMetrics(logger logr.Logger, providerRef vmopv1alpha1.ContentProviderReference) {
+func (csm *ContentSourceMetrics) DeleteMetrics(logger logr.Logger, providerRef vmopv1.ContentProviderReference) {
 	logger.V(5).Info("Deleting all VMImage metrics from the given provider name and kind")
 	labels := prometheus.Labels{
 		providerNameLabel: providerRef.Name,
@@ -85,7 +85,7 @@ func (csm *ContentSourceMetrics) DeleteMetrics(logger logr.Logger, providerRef v
 }
 
 // getVMImageLabels is a helper function to return all the required labels for the given VMImage.
-func getVMImageLabels(vmImage vmopv1alpha1.VirtualMachineImage) prometheus.Labels {
+func getVMImageLabels(vmImage vmopv1.VirtualMachineImage) prometheus.Labels {
 	return prometheus.Labels{
 		// Using .Status.ImageName as .Name could be modified in the duplicate VM image name case.
 		imageNameLabel:    vmImage.Status.ImageName,

--- a/pkg/patch/options.go
+++ b/pkg/patch/options.go
@@ -13,7 +13,7 @@ limitations under the License.
 
 package patch
 
-import vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+import vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 // Option is some configuration that modifies options for a patch request.
 type Option interface {
@@ -33,7 +33,7 @@ type HelperOptions struct {
 
 	// OwnedConditions defines condition types owned by the controller.
 	// In case of conflicts for the owned conditions, the patch helper will always use the value provided by the controller.
-	OwnedConditions []vmopv1alpha1.ConditionType
+	OwnedConditions []vmopv1.ConditionType
 }
 
 // WithForceOverwriteConditions allows the patch helper to overwrite conditions in case of conflicts.
@@ -57,7 +57,7 @@ func (w WithStatusObservedGeneration) ApplyToHelper(in *HelperOptions) {
 // WithOwnedConditions allows to define condition types owned by the controller.
 // In case of conflicts for the owned conditions, the patch helper will always use the value provided by the controller.
 type WithOwnedConditions struct {
-	Conditions []vmopv1alpha1.ConditionType
+	Conditions []vmopv1.ConditionType
 }
 
 // ApplyToHelper applies this configuration to the given HelperOptions.

--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
 )
@@ -175,7 +175,7 @@ func (h *Helper) patchStatus(ctx context.Context, obj client.Object) error {
 //
 // Condition changes are then applied to the latest version of the object, and if there are
 // no unresolvable conflicts, the patch is sent again.
-func (h *Helper) patchStatusConditions(ctx context.Context, obj client.Object, forceOverwrite bool, ownedConditions []vmopv1alpha1.ConditionType) error {
+func (h *Helper) patchStatusConditions(ctx context.Context, obj client.Object, forceOverwrite bool, ownedConditions []vmopv1.ConditionType) error {
 	// Nothing to do if the object isn't a condition patcher.
 	if !h.isConditionsSetter {
 		return nil

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
@@ -156,14 +156,14 @@ func intgTests() {
 				}, timeout).Should(BeTrue())
 			})
 
-			Describe("on a vmopv1alpha1a1.VirtualMachine object", func() {
-				obj := &vmopv1alpha1.VirtualMachine{
+			Describe("on a vmopv1.VirtualMachine object", func() {
+				obj := &vmopv1.VirtualMachine{
 					ObjectMeta: metav1.ObjectMeta{
 						GenerateName: "test-",
 						Namespace:    "default",
 					},
-					Spec: vmopv1alpha1.VirtualMachineSpec{
-						PowerState: vmopv1alpha1.VirtualMachinePoweredOn,
+					Spec: vmopv1.VirtualMachineSpec{
+						PowerState: vmopv1.VirtualMachinePoweredOn,
 					},
 				}
 
@@ -182,7 +182,7 @@ func intgTests() {
 					Expect(err).NotTo(HaveOccurred())
 
 					By("Marking Ready=True")
-					conditions.MarkTrue(obj, vmopv1alpha1.ReadyCondition)
+					conditions.MarkTrue(obj, vmopv1.ReadyCondition)
 
 					By("Patching the object")
 					Expect(patcher.Patch(ctx, obj)).To(Succeed())
@@ -209,7 +209,7 @@ func intgTests() {
 					objCopy := obj.DeepCopy()
 
 					By("Marking a custom condition to be false")
-					conditions.MarkFalse(objCopy, vmopv1alpha1.ConditionType("TestCondition"), "reason", vmopv1alpha1.ConditionSeverityInfo, "message")
+					conditions.MarkFalse(objCopy, vmopv1.ConditionType("TestCondition"), "reason", vmopv1.ConditionSeverityInfo, "message")
 					Expect(ctx.Client.Status().Update(ctx, objCopy)).To(Succeed())
 
 					By("Validating that the local object's resource version is behind")
@@ -220,7 +220,7 @@ func intgTests() {
 					Expect(err).NotTo(HaveOccurred())
 
 					By("Marking Ready=True")
-					conditions.MarkTrue(obj, vmopv1alpha1.ReadyCondition)
+					conditions.MarkTrue(obj, vmopv1.ReadyCondition)
 
 					By("Patching the object")
 					Expect(patcher.Patch(ctx, obj)).To(Succeed())
@@ -235,8 +235,8 @@ func intgTests() {
 						testConditionCopy := conditions.Get(objCopy, "TestCondition")
 						testConditionAfter := conditions.Get(objAfter, "TestCondition")
 
-						readyBefore := conditions.Get(obj, vmopv1alpha1.ReadyCondition)
-						readyAfter := conditions.Get(objAfter, vmopv1alpha1.ReadyCondition)
+						readyBefore := conditions.Get(obj, vmopv1.ReadyCondition)
+						readyAfter := conditions.Get(objAfter, vmopv1.ReadyCondition)
 
 						return cmp.Equal(testConditionCopy, testConditionAfter) && cmp.Equal(readyBefore, readyAfter)
 					}, timeout).Should(BeTrue())
@@ -254,7 +254,7 @@ func intgTests() {
 					objCopy := obj.DeepCopy()
 
 					By("Marking a custom condition to be false")
-					conditions.MarkFalse(objCopy, vmopv1alpha1.ConditionType("TestCondition"), "reason", vmopv1alpha1.ConditionSeverityInfo, "message")
+					conditions.MarkFalse(objCopy, vmopv1.ConditionType("TestCondition"), "reason", vmopv1.ConditionSeverityInfo, "message")
 					Expect(ctx.Client.Status().Update(ctx, objCopy)).To(Succeed())
 
 					By("Validating that the local object's resource version is behind")
@@ -267,7 +267,7 @@ func intgTests() {
 					By("Changing the object spec, status, and adding Ready=True condition")
 					obj.Spec.ImageName = "foo-image"
 					obj.Status.Phase = "custom-phase"
-					conditions.MarkTrue(obj, vmopv1alpha1.ReadyCondition)
+					conditions.MarkTrue(obj, vmopv1.ReadyCondition)
 
 					By("Patching the object")
 					Expect(patcher.Patch(ctx, obj)).To(Succeed())
@@ -282,8 +282,8 @@ func intgTests() {
 						testConditionCopy := conditions.Get(objCopy, "TestCondition")
 						testConditionAfter := conditions.Get(objAfter, "TestCondition")
 
-						readyBefore := conditions.Get(obj, vmopv1alpha1.ReadyCondition)
-						readyAfter := conditions.Get(objAfter, vmopv1alpha1.ReadyCondition)
+						readyBefore := conditions.Get(obj, vmopv1.ReadyCondition)
+						readyAfter := conditions.Get(objAfter, vmopv1.ReadyCondition)
 
 						return cmp.Equal(testConditionCopy, testConditionAfter) && cmp.Equal(readyBefore, readyAfter) &&
 							obj.Spec.ImageName == objAfter.Spec.ImageName &&
@@ -303,7 +303,7 @@ func intgTests() {
 					objCopy := obj.DeepCopy()
 
 					By("Marking a custom condition to be false")
-					conditions.MarkFalse(objCopy, vmopv1alpha1.ReadyCondition, "reason", vmopv1alpha1.ConditionSeverityInfo, "message")
+					conditions.MarkFalse(objCopy, vmopv1.ReadyCondition, "reason", vmopv1.ConditionSeverityInfo, "message")
 					Expect(ctx.Client.Status().Update(ctx, objCopy)).To(Succeed())
 
 					By("Validating that the local object's resource version is behind")
@@ -314,7 +314,7 @@ func intgTests() {
 					Expect(err).NotTo(HaveOccurred())
 
 					By("Marking Ready=True")
-					conditions.MarkTrue(obj, vmopv1alpha1.ReadyCondition)
+					conditions.MarkTrue(obj, vmopv1.ReadyCondition)
 
 					By("Patching the object")
 					Expect(patcher.Patch(ctx, obj)).ToNot(Succeed())
@@ -342,7 +342,7 @@ func intgTests() {
 					objCopy := obj.DeepCopy()
 
 					By("Marking a custom condition to be false")
-					conditions.MarkFalse(objCopy, vmopv1alpha1.ReadyCondition, "reason", vmopv1alpha1.ConditionSeverityInfo, "message")
+					conditions.MarkFalse(objCopy, vmopv1.ReadyCondition, "reason", vmopv1.ConditionSeverityInfo, "message")
 					Expect(ctx.Client.Status().Update(ctx, objCopy)).To(Succeed())
 
 					By("Validating that the local object's resource version is behind")
@@ -353,10 +353,10 @@ func intgTests() {
 					Expect(err).NotTo(HaveOccurred())
 
 					By("Marking Ready=True")
-					conditions.MarkTrue(obj, vmopv1alpha1.ReadyCondition)
+					conditions.MarkTrue(obj, vmopv1.ReadyCondition)
 
 					By("Patching the object")
-					Expect(patcher.Patch(ctx, obj, WithOwnedConditions{Conditions: []vmopv1alpha1.ConditionType{vmopv1alpha1.ReadyCondition}})).To(Succeed())
+					Expect(patcher.Patch(ctx, obj, WithOwnedConditions{Conditions: []vmopv1.ConditionType{vmopv1.ReadyCondition}})).To(Succeed())
 
 					By("Validating the object has been updated")
 					Eventually(func() bool {
@@ -365,8 +365,8 @@ func intgTests() {
 							return false
 						}
 
-						readyBefore := conditions.Get(obj, vmopv1alpha1.ReadyCondition)
-						readyAfter := conditions.Get(objAfter, vmopv1alpha1.ReadyCondition)
+						readyBefore := conditions.Get(obj, vmopv1.ReadyCondition)
+						readyAfter := conditions.Get(objAfter, vmopv1.ReadyCondition)
 
 						return cmp.Equal(readyBefore, readyAfter)
 					}, timeout).Should(BeTrue())
@@ -384,7 +384,7 @@ func intgTests() {
 					objCopy := obj.DeepCopy()
 
 					By("Marking a custom condition to be false")
-					conditions.MarkFalse(objCopy, vmopv1alpha1.ReadyCondition, "reason", vmopv1alpha1.ConditionSeverityInfo, "message")
+					conditions.MarkFalse(objCopy, vmopv1.ReadyCondition, "reason", vmopv1.ConditionSeverityInfo, "message")
 					Expect(ctx.Client.Status().Update(ctx, objCopy)).To(Succeed())
 
 					By("Validating that the local object's resource version is behind")
@@ -395,7 +395,7 @@ func intgTests() {
 					Expect(err).NotTo(HaveOccurred())
 
 					By("Marking Ready=True")
-					conditions.MarkTrue(obj, vmopv1alpha1.ReadyCondition)
+					conditions.MarkTrue(obj, vmopv1.ReadyCondition)
 
 					By("Patching the object")
 					Expect(patcher.Patch(ctx, obj, WithForceOverwriteConditions{})).To(Succeed())
@@ -407,8 +407,8 @@ func intgTests() {
 							return false
 						}
 
-						readyBefore := conditions.Get(obj, vmopv1alpha1.ReadyCondition)
-						readyAfter := conditions.Get(objAfter, vmopv1alpha1.ReadyCondition)
+						readyBefore := conditions.Get(obj, vmopv1.ReadyCondition)
+						readyAfter := conditions.Get(objAfter, vmopv1.ReadyCondition)
 
 						return cmp.Equal(readyBefore, readyAfter)
 					}, timeout).Should(BeTrue())
@@ -416,19 +416,19 @@ func intgTests() {
 			})
 		})
 
-		Describe("Should patch a vmopv1alpha1.VirtualMachine", func() {
-			var obj *vmopv1alpha1.VirtualMachine
+		Describe("Should patch a vmopv1.VirtualMachine", func() {
+			var obj *vmopv1.VirtualMachine
 
 			BeforeEach(func() {
-				obj = &vmopv1alpha1.VirtualMachine{
+				obj = &vmopv1.VirtualMachine{
 					ObjectMeta: metav1.ObjectMeta{
 						GenerateName: "test-",
 						Namespace:    ctx.Namespace,
 					},
-					Spec: vmopv1alpha1.VirtualMachineSpec{
-						PowerState: vmopv1alpha1.VirtualMachinePoweredOn,
+					Spec: vmopv1.VirtualMachineSpec{
+						PowerState: vmopv1.VirtualMachinePoweredOn,
 					},
-					Status: vmopv1alpha1.VirtualMachineStatus{
+					Status: vmopv1.VirtualMachineStatus{
 						BiosUUID:     "bios-uuid-foo",
 						InstanceUUID: "instance-uuid-foo",
 						UniqueID:     "unique-id",
@@ -586,7 +586,7 @@ func intgTests() {
 				obj.Status.Host = "vm-host"
 
 				By("Setting Ready condition")
-				conditions.MarkTrue(obj, vmopv1alpha1.ReadyCondition)
+				conditions.MarkTrue(obj, vmopv1.ReadyCondition)
 
 				By("Patching the object")
 				Expect(patcher.Patch(ctx, obj)).To(Succeed())
@@ -599,7 +599,7 @@ func intgTests() {
 					}
 
 					return obj.Status.Host == objAfter.Status.Host &&
-						conditions.IsTrue(objAfter, vmopv1alpha1.ReadyCondition) &&
+						conditions.IsTrue(objAfter, vmopv1.ReadyCondition) &&
 						reflect.DeepEqual(obj.Spec, objAfter.Spec)
 				}, timeout).Should(BeTrue())
 			})

--- a/pkg/patch/utils_test.go
+++ b/pkg/patch/utils_test.go
@@ -23,19 +23,19 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 )
 
 func TestToUnstructured(t *testing.T) {
 	t.Run("with a typed object", func(t *testing.T) {
 		g := NewWithT(t)
 		// Test with a typed object.
-		obj := &vmopv1alpha1.VirtualMachine{
+		obj := &vmopv1.VirtualMachine{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "cluster-1",
 				Namespace: "namespace-1",
 			},
-			Spec: vmopv1alpha1.VirtualMachineSpec{
+			Spec: vmopv1.VirtualMachineSpec{
 				ImageName: "foo",
 			},
 		}

--- a/pkg/prober/context/probe_context.go
+++ b/pkg/prober/context/probe_context.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/go-logr/logr"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/pkg/patch"
 )
@@ -18,9 +18,9 @@ type ProbeContext struct {
 	context.Context
 	Logger      logr.Logger
 	PatchHelper *patch.Helper
-	VM          *vmopv1alpha1.VirtualMachine
+	VM          *vmopv1.VirtualMachine
 	ProbeType   string
-	ProbeSpec   *vmopv1alpha1.Probe
+	ProbeSpec   *vmopv1.Probe
 }
 
 // String returns probe type.

--- a/pkg/prober/fake/fake_prober_manager.go
+++ b/pkg/prober/fake/fake_prober_manager.go
@@ -7,14 +7,13 @@ import (
 	"context"
 	"sync"
 
-	vmoperatorv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
-
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/pkg/prober"
 )
 
 type funcs struct {
-	AddToProberManagerFn      func(vm *vmoperatorv1alpha1.VirtualMachine)
-	RemoveFromProberManagerFn func(vm *vmoperatorv1alpha1.VirtualMachine)
+	AddToProberManagerFn      func(vm *vmopv1.VirtualMachine)
+	RemoveFromProberManagerFn func(vm *vmopv1.VirtualMachine)
 }
 
 type ProberManager struct {
@@ -34,7 +33,7 @@ func (m *ProberManager) Start(ctx context.Context) error {
 	return nil
 }
 
-func (m *ProberManager) AddToProberManager(vm *vmoperatorv1alpha1.VirtualMachine) {
+func (m *ProberManager) AddToProberManager(vm *vmopv1.VirtualMachine) {
 	m.Lock()
 	defer m.Unlock()
 
@@ -44,7 +43,7 @@ func (m *ProberManager) AddToProberManager(vm *vmoperatorv1alpha1.VirtualMachine
 	}
 }
 
-func (m *ProberManager) RemoveFromProberManager(vm *vmoperatorv1alpha1.VirtualMachine) {
+func (m *ProberManager) RemoveFromProberManager(vm *vmopv1.VirtualMachine) {
 	m.Lock()
 	defer m.Unlock()
 

--- a/pkg/prober/fake/worker/fake_prober_worker.go
+++ b/pkg/prober/fake/worker/fake_prober_worker.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/pkg/prober/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/prober/probe"
@@ -46,7 +46,7 @@ func (w *FakeWorker) GetQueue() workqueue.DelayingInterface {
 	return w.queue
 }
 
-func (w *FakeWorker) CreateProbeContext(vm *vmopv1alpha1.VirtualMachine) (*context.ProbeContext, error) {
+func (w *FakeWorker) CreateProbeContext(vm *vmopv1.VirtualMachine) (*context.ProbeContext, error) {
 	return &context.ProbeContext{
 		Context:   goctx.Background(),
 		Logger:    ctrl.Log.WithName("fake-probe").WithValues("vmName", vm.NamespacedName()),

--- a/pkg/prober/probe/heartbeat.go
+++ b/pkg/prober/probe/heartbeat.go
@@ -6,7 +6,7 @@ package probe
 import (
 	"fmt"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/pkg/prober/context"
 )
@@ -21,13 +21,13 @@ func NewGuestHeartbeatProber(vmProviderProber vmProviderProber) Probe {
 	}
 }
 
-func heartbeatValue(value vmopv1alpha1.GuestHeartbeatStatus) int {
+func heartbeatValue(value vmopv1.GuestHeartbeatStatus) int {
 	switch value {
-	case vmopv1alpha1.GreenHeartbeatStatus:
+	case vmopv1.GreenHeartbeatStatus:
 		return 1
-	case vmopv1alpha1.YellowHeartbeatStatus:
+	case vmopv1.YellowHeartbeatStatus:
 		return 0
-	default: // vmopv1alpha1.RedHeartbeatStatus, vmopv1alpha1.GrayHeartbeatStatus
+	default: // vmopv1.RedHeartbeatStatus, vmopv1.GrayHeartbeatStatus
 		return -1
 	}
 }

--- a/pkg/prober/probe/heartbeat_test.go
+++ b/pkg/prober/probe/heartbeat_test.go
@@ -13,23 +13,23 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/pkg/prober/context"
 )
 
 type fakeVMProviderProber struct {
-	status vmopv1alpha1.GuestHeartbeatStatus
+	status vmopv1.GuestHeartbeatStatus
 	err    error
 }
 
-func (tp fakeVMProviderProber) GetVirtualMachineGuestHeartbeat(_ goctx.Context, _ *vmopv1alpha1.VirtualMachine) (vmopv1alpha1.GuestHeartbeatStatus, error) {
+func (tp fakeVMProviderProber) GetVirtualMachineGuestHeartbeat(_ goctx.Context, _ *vmopv1.VirtualMachine) (vmopv1.GuestHeartbeatStatus, error) {
 	return tp.status, tp.err
 }
 
 var _ = Describe("Guest heartbeat probe", func() {
 	var (
-		vm                   *vmopv1alpha1.VirtualMachine
+		vm                   *vmopv1.VirtualMachine
 		fakeProvider         fakeVMProviderProber
 		testVMwareToolsProbe Probe
 
@@ -38,12 +38,12 @@ var _ = Describe("Guest heartbeat probe", func() {
 	)
 
 	BeforeEach(func() {
-		vm = &vmopv1alpha1.VirtualMachine{
+		vm = &vmopv1.VirtualMachine{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "dummy-vm",
 				Namespace: "dummy-ns",
 			},
-			Spec: vmopv1alpha1.VirtualMachineSpec{
+			Spec: vmopv1.VirtualMachineSpec{
 				ClassName:      "dummy-vmclass",
 				ReadinessProbe: getVirtualMachineReadinessHeartbeatProbe(),
 			},
@@ -106,10 +106,10 @@ var _ = Describe("Guest heartbeat probe", func() {
 		})
 
 		Context("Provider returns yellow status", func() {
-			BeforeEach(func() { fakeProvider.status = vmopv1alpha1.YellowHeartbeatStatus })
+			BeforeEach(func() { fakeProvider.status = vmopv1.YellowHeartbeatStatus })
 
 			Context("Threshold status is yellow", func() {
-				BeforeEach(func() { vm.Spec.ReadinessProbe.GuestHeartbeat.ThresholdStatus = vmopv1alpha1.YellowHeartbeatStatus })
+				BeforeEach(func() { vm.Spec.ReadinessProbe.GuestHeartbeat.ThresholdStatus = vmopv1.YellowHeartbeatStatus })
 
 				It("returns success", func() {
 					Expect(err).ToNot(HaveOccurred())
@@ -118,7 +118,7 @@ var _ = Describe("Guest heartbeat probe", func() {
 			})
 
 			Context("Threshold status is green", func() {
-				BeforeEach(func() { vm.Spec.ReadinessProbe.GuestHeartbeat.ThresholdStatus = vmopv1alpha1.GreenHeartbeatStatus })
+				BeforeEach(func() { vm.Spec.ReadinessProbe.GuestHeartbeat.ThresholdStatus = vmopv1.GreenHeartbeatStatus })
 
 				It("returns failure", func() {
 					Expect(res).To(Equal(Failure))
@@ -130,8 +130,8 @@ var _ = Describe("Guest heartbeat probe", func() {
 
 		Context("Provider returns green status", func() {
 			BeforeEach(func() {
-				fakeProvider.status = vmopv1alpha1.GreenHeartbeatStatus
-				vm.Spec.ReadinessProbe.GuestHeartbeat.ThresholdStatus = vmopv1alpha1.GreenHeartbeatStatus
+				fakeProvider.status = vmopv1.GreenHeartbeatStatus
+				vm.Spec.ReadinessProbe.GuestHeartbeat.ThresholdStatus = vmopv1.GreenHeartbeatStatus
 			})
 
 			It("returns success", func() {
@@ -142,10 +142,10 @@ var _ = Describe("Guest heartbeat probe", func() {
 	})
 })
 
-func getVirtualMachineReadinessHeartbeatProbe() *vmopv1alpha1.Probe {
-	return &vmopv1alpha1.Probe{
-		GuestHeartbeat: &vmopv1alpha1.GuestHeartbeatAction{
-			ThresholdStatus: vmopv1alpha1.GreenHeartbeatStatus, // Default.
+func getVirtualMachineReadinessHeartbeatProbe() *vmopv1.Probe {
+	return &vmopv1.Probe{
+		GuestHeartbeat: &vmopv1.GuestHeartbeatAction{
+			ThresholdStatus: vmopv1.GreenHeartbeatStatus, // Default.
 		},
 		PeriodSeconds: 1,
 	}

--- a/pkg/prober/probe/probe.go
+++ b/pkg/prober/probe/probe.go
@@ -7,7 +7,7 @@ import (
 	goctx "context"
 	"time"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/pkg/prober/context"
 )
@@ -32,7 +32,7 @@ type Probe interface {
 
 // Probing related provider methods.
 type vmProviderProber interface {
-	GetVirtualMachineGuestHeartbeat(ctx goctx.Context, vm *vmopv1alpha1.VirtualMachine) (vmopv1alpha1.GuestHeartbeatStatus, error)
+	GetVirtualMachineGuestHeartbeat(ctx goctx.Context, vm *vmopv1.VirtualMachine) (vmopv1.GuestHeartbeatStatus, error)
 }
 
 // Prober contains the different type of probes.

--- a/pkg/prober/probe/tcp.go
+++ b/pkg/prober/probe/tcp.go
@@ -12,8 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	vmoperatorv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
-
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/pkg/prober/context"
 )
 
@@ -59,7 +58,7 @@ func (pr tcpProber) Probe(ctx *context.ProbeContext) (Result, error) {
 	return Success, nil
 }
 
-func findPort(vm *vmoperatorv1alpha1.VirtualMachine, portName intstr.IntOrString, portProto corev1.Protocol) (int, error) {
+func findPort(vm *vmopv1.VirtualMachine, portName intstr.IntOrString, portProto corev1.Protocol) (int, error) {
 	switch portName.Type {
 	case intstr.String:
 		name := portName.StrVal

--- a/pkg/prober/probe/tcp_test.go
+++ b/pkg/prober/probe/tcp_test.go
@@ -17,14 +17,14 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/pkg/prober/context"
 )
 
 var _ = Describe("TCP probe", func() {
 	var (
-		vm           *vmopv1alpha1.VirtualMachine
+		vm           *vmopv1.VirtualMachine
 		testTCPProbe Probe
 
 		testServer *httptest.Server
@@ -33,12 +33,12 @@ var _ = Describe("TCP probe", func() {
 	)
 
 	BeforeEach(func() {
-		vm = &vmopv1alpha1.VirtualMachine{
+		vm = &vmopv1.VirtualMachine{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "dummy-vm",
 				Namespace: "dummy-ns",
 			},
-			Spec: vmopv1alpha1.VirtualMachineSpec{
+			Spec: vmopv1.VirtualMachineSpec{
 				ClassName: "dummy-vmclass",
 			},
 		}
@@ -107,9 +107,9 @@ func setupTestServer() (*httptest.Server, string, int) {
 	return s, host, portInt
 }
 
-func getVirtualMachineReadinessTCPProbe(host string, port int) *vmopv1alpha1.Probe {
-	return &vmopv1alpha1.Probe{
-		TCPSocket: &vmopv1alpha1.TCPSocketAction{
+func getVirtualMachineReadinessTCPProbe(host string, port int) *vmopv1.Probe {
+	return &vmopv1.Probe{
+		TCPSocket: &vmopv1.TCPSocketAction{
 			Host: host,
 			Port: intstr.FromInt(port),
 		},

--- a/pkg/prober/prober_manager_test.go
+++ b/pkg/prober/prober_manager_test.go
@@ -16,7 +16,7 @@ import (
 	clientgorecord "k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/pkg/prober/context"
 	fakeworker "github.com/vmware-tanzu/vm-operator/pkg/prober/fake/worker"
@@ -33,9 +33,9 @@ var _ = Describe("VirtualMachine probes", func() {
 		ctx         goctx.Context
 
 		testManager   *manager
-		vm            *vmopv1alpha1.VirtualMachine
+		vm            *vmopv1.VirtualMachine
 		vmKey         client.ObjectKey
-		vmProbe       *vmopv1alpha1.Probe
+		vmProbe       *vmopv1.Probe
 		periodSeconds int32
 
 		fakeClient   client.Client
@@ -45,19 +45,19 @@ var _ = Describe("VirtualMachine probes", func() {
 	)
 
 	BeforeEach(func() {
-		vm = &vmopv1alpha1.VirtualMachine{
+		vm = &vmopv1.VirtualMachine{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "dummy-vm",
 				Namespace: "dummy-ns",
 			},
-			Spec: vmopv1alpha1.VirtualMachineSpec{
+			Spec: vmopv1.VirtualMachineSpec{
 				ClassName: "dummy-vmclass",
 			},
 		}
 		vmKey = client.ObjectKey{Name: vm.Name, Namespace: vm.Namespace}
 		periodSeconds = 1
-		vmProbe = &vmopv1alpha1.Probe{
-			TCPSocket: &vmopv1alpha1.TCPSocketAction{
+		vmProbe = &vmopv1.Probe{
+			TCPSocket: &vmopv1.TCPSocketAction{
 				Port: intstr.FromInt(10001),
 			},
 			PeriodSeconds: periodSeconds,
@@ -125,7 +125,7 @@ var _ = Describe("VirtualMachine probes", func() {
 			})
 
 			It("Should set probe result as failed if the VM is powered off", func() {
-				vm.Status.PowerState = vmopv1alpha1.VirtualMachinePoweredOff
+				vm.Status.PowerState = vmopv1.VirtualMachinePoweredOff
 				Expect(fakeClient.Status().Update(ctx, vm)).To(Succeed())
 				fakeWorker.ProcessProbeResultFn = func(ctx *context.ProbeContext, res probe.Result, err error) error {
 					if res != probe.Failure {
@@ -143,7 +143,7 @@ var _ = Describe("VirtualMachine probes", func() {
 
 			When("VM is powered on", func() {
 				JustBeforeEach(func() {
-					vm.Status.PowerState = vmopv1alpha1.VirtualMachinePoweredOn
+					vm.Status.PowerState = vmopv1.VirtualMachinePoweredOn
 					Expect(fakeClient.Status().Update(ctx, vm)).To(Succeed())
 				})
 
@@ -196,7 +196,7 @@ var _ = Describe("VirtualMachine probes", func() {
 		})
 
 		JustBeforeEach(func() {
-			vm.Status.PowerState = vmopv1alpha1.VirtualMachinePoweredOn
+			vm.Status.PowerState = vmopv1.VirtualMachinePoweredOn
 			Expect(fakeClient.Status().Update(ctx, vm)).To(Succeed())
 
 			Expect(fakeClient.Get(ctx, vmKey, vm)).To(Succeed())
@@ -225,7 +225,7 @@ var _ = Describe("VirtualMachine probes", func() {
 		})
 
 		When("VM has already been added to the prober manager", func() {
-			var newVM *vmopv1alpha1.VirtualMachine
+			var newVM *vmopv1.VirtualMachine
 			JustBeforeEach(func() {
 				testManager.AddToProberManager(vm)
 				Expect(testManager.readinessQueue.Len()).To(Equal(1))
@@ -235,7 +235,7 @@ var _ = Describe("VirtualMachine probes", func() {
 				}
 				Expect(testManager.processItemFromQueue(fakeWorker)).To(BeFalse())
 
-				newVM = &vmopv1alpha1.VirtualMachine{}
+				newVM = &vmopv1.VirtualMachine{}
 				Expect(fakeClient.Get(ctx, vmKey, newVM)).To(Succeed())
 			})
 

--- a/pkg/prober/worker/prober_worker.go
+++ b/pkg/prober/worker/prober_worker.go
@@ -6,7 +6,7 @@ package worker
 import (
 	"k8s.io/client-go/util/workqueue"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/pkg/prober/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/prober/probe"
@@ -15,7 +15,7 @@ import (
 // Worker represents a prober worker interface.
 type Worker interface {
 	GetQueue() workqueue.DelayingInterface
-	CreateProbeContext(vm *vmopv1alpha1.VirtualMachine) (*context.ProbeContext, error)
+	CreateProbeContext(vm *vmopv1.VirtualMachine) (*context.ProbeContext, error)
 	DoProbe(ctx *context.ProbeContext) error
 	ProcessProbeResult(ctx *context.ProbeContext, res probe.Result, resErr error) error
 }

--- a/pkg/prober/worker/readiness_worker.go
+++ b/pkg/prober/worker/readiness_worker.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	"github.com/vmware-tanzu/vm-operator/pkg/patch"
@@ -58,7 +58,7 @@ func (w *readinessWorker) GetQueue() workqueue.DelayingInterface {
 }
 
 // CreateProbeContext creates a probe context for readiness probe.
-func (w *readinessWorker) CreateProbeContext(vm *vmopv1alpha1.VirtualMachine) (*context.ProbeContext, error) {
+func (w *readinessWorker) CreateProbeContext(vm *vmopv1.VirtualMachine) (*context.ProbeContext, error) {
 	patchHelper, err := patch.NewHelper(vm, w.client)
 	if err != nil {
 		return nil, err
@@ -97,7 +97,7 @@ func (w *readinessWorker) ProcessProbeResult(ctx *context.ProbeContext, res prob
 	conditions.Set(vm, condition)
 
 	err := ctx.PatchHelper.Patch(ctx, vm, patch.WithOwnedConditions{
-		Conditions: []vmopv1alpha1.ConditionType{vmopv1alpha1.ReadyCondition},
+		Conditions: []vmopv1.ConditionType{vmopv1.ReadyCondition},
 	})
 	if err != nil {
 		return errors.Wrapf(err, "patched failed")
@@ -115,7 +115,7 @@ func (w *readinessWorker) DoProbe(ctx *context.ProbeContext) error {
 }
 
 // getProbe returns a specific type of probe method.
-func (w *readinessWorker) getProbe(probeSpec *vmopv1alpha1.Probe) probe.Probe {
+func (w *readinessWorker) getProbe(probeSpec *vmopv1.Probe) probe.Probe {
 	if probeSpec.TCPSocket != nil {
 		return w.prober.TCPProbe
 	}
@@ -136,7 +136,7 @@ func (w *readinessWorker) runProbe(ctx *context.ProbeContext) (probe.Result, err
 }
 
 // getCondition returns condition based on VM probe results.
-func (w *readinessWorker) getCondition(res probe.Result, err error) *vmopv1alpha1.Condition {
+func (w *readinessWorker) getCondition(res probe.Result, err error) *vmopv1.Condition {
 	msg := ""
 	if err != nil {
 		msg = err.Error()
@@ -144,10 +144,10 @@ func (w *readinessWorker) getCondition(res probe.Result, err error) *vmopv1alpha
 
 	switch res {
 	case probe.Success:
-		return conditions.TrueCondition(vmopv1alpha1.ReadyCondition)
+		return conditions.TrueCondition(vmopv1.ReadyCondition)
 	case probe.Failure:
-		return conditions.FalseCondition(vmopv1alpha1.ReadyCondition, notReadyReason, vmopv1alpha1.ConditionSeverityInfo, msg)
+		return conditions.FalseCondition(vmopv1.ReadyCondition, notReadyReason, vmopv1.ConditionSeverityInfo, msg)
 	default: // probe.Unknown
-		return conditions.UnknownCondition(vmopv1alpha1.ReadyCondition, unknownReason, msg)
+		return conditions.UnknownCondition(vmopv1.ReadyCondition, unknownReason, msg)
 	}
 }

--- a/pkg/prober/worker/readiness_worker_test.go
+++ b/pkg/prober/worker/readiness_worker_test.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	"github.com/vmware-tanzu/vm-operator/pkg/prober/context"
@@ -32,7 +32,7 @@ var _ = Describe("VirtualMachine readiness probes", func() {
 	var (
 		testWorker Worker
 
-		vm    *vmopv1alpha1.VirtualMachine
+		vm    *vmopv1.VirtualMachine
 		vmKey client.ObjectKey
 		ctx   *context.ProbeContext
 
@@ -44,12 +44,12 @@ var _ = Describe("VirtualMachine readiness probes", func() {
 	)
 
 	BeforeEach(func() {
-		vm = &vmopv1alpha1.VirtualMachine{
+		vm = &vmopv1.VirtualMachine{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "dummy-vm",
 				Namespace: "dummy-ns",
 			},
-			Spec: vmopv1alpha1.VirtualMachineSpec{
+			Spec: vmopv1.VirtualMachineSpec{
 				ClassName: "dummy-vmclass",
 			},
 		}
@@ -73,14 +73,14 @@ var _ = Describe("VirtualMachine readiness probes", func() {
 
 	checkReadyCondition := func(c client.Client, objKey client.ObjectKey, expectedCondition corev1.ConditionStatus) {
 		Expect(c.Get(ctx, objKey, vm)).Should(Succeed())
-		condition := conditions.Get(vm, vmopv1alpha1.ReadyCondition)
+		condition := conditions.Get(vm, vmopv1.ReadyCondition)
 		Expect(condition).ToNot(BeNil())
 		Expect(condition.Status).Should(Equal(expectedCondition))
 	}
 
 	Context("VM has TCP readiness probe", func() {
 		var (
-			oldStatus vmopv1alpha1.VirtualMachineStatus
+			oldStatus vmopv1.VirtualMachineStatus
 		)
 
 		BeforeEach(func() {
@@ -136,7 +136,7 @@ var _ = Describe("VirtualMachine readiness probes", func() {
 			When("new ReadyCondition isn't in a transition", func() {
 
 				BeforeEach(func() {
-					vmReadyCondition := conditions.TrueCondition(vmopv1alpha1.ReadyCondition)
+					vmReadyCondition := conditions.TrueCondition(vmopv1.ReadyCondition)
 					vm.Status.Conditions = append(vm.Status.Conditions, *vmReadyCondition)
 					Expect(fakeClient.Status().Update(ctx, vm)).To(Succeed())
 					Expect(fakeClient.Get(ctx, vmKey, vm)).Should(Succeed())
@@ -180,7 +180,7 @@ var _ = Describe("VirtualMachine readiness probes", func() {
 
 			Expect(testWorker.DoProbe(ctx)).Should(Succeed())
 			Expect(fakeClient.Get(ctx, vmKey, vm)).Should(Succeed())
-			condition := conditions.Get(vm, vmopv1alpha1.ReadyCondition)
+			condition := conditions.Get(vm, vmopv1.ReadyCondition)
 			Expect(condition).ToNot(BeNil())
 			Expect(condition.Message).To(ContainSubstring("heartbeat error"))
 		})
@@ -192,18 +192,18 @@ func TestReadinessProbeWorker(t *testing.T) {
 	RunSpecs(t, "VM Readiness Workers")
 }
 
-func getVirtualMachineReadinessTCPProbe(port int) *vmopv1alpha1.Probe {
-	return &vmopv1alpha1.Probe{
-		TCPSocket: &vmopv1alpha1.TCPSocketAction{
+func getVirtualMachineReadinessTCPProbe(port int) *vmopv1.Probe {
+	return &vmopv1.Probe{
+		TCPSocket: &vmopv1.TCPSocketAction{
 			Port: intstr.FromInt(port),
 		},
 		PeriodSeconds: 1,
 	}
 }
 
-func getVirtualMachineHeartbeatProbe() *vmopv1alpha1.Probe {
-	return &vmopv1alpha1.Probe{
-		GuestHeartbeat: &vmopv1alpha1.GuestHeartbeatAction{},
+func getVirtualMachineHeartbeatProbe() *vmopv1.Probe {
+	return &vmopv1.Probe{
+		GuestHeartbeat: &vmopv1.GuestHeartbeatAction{},
 		PeriodSeconds:  1,
 	}
 }

--- a/pkg/vmprovider/interface.go
+++ b/pkg/vmprovider/interface.go
@@ -11,33 +11,33 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	imgregv1a1 "github.com/vmware-tanzu/vm-operator/external/image-registry/api/v1alpha1"
 )
 
 // VirtualMachineProviderInterface is a plugable interface for VM Providers.
 type VirtualMachineProviderInterface interface {
-	CreateOrUpdateVirtualMachine(ctx context.Context, vm *v1alpha1.VirtualMachine) error
-	DeleteVirtualMachine(ctx context.Context, vm *v1alpha1.VirtualMachine) error
-	PublishVirtualMachine(ctx context.Context, vm *v1alpha1.VirtualMachine,
-		vmPub *v1alpha1.VirtualMachinePublishRequest, cl *imgregv1a1.ContentLibrary, actID string) (string, error)
-	GetVirtualMachineGuestHeartbeat(ctx context.Context, vm *v1alpha1.VirtualMachine) (v1alpha1.GuestHeartbeatStatus, error)
-	GetVirtualMachineWebMKSTicket(ctx context.Context, vm *v1alpha1.VirtualMachine, pubKey string) (string, error)
-	GetVirtualMachineHardwareVersion(ctx context.Context, vm *v1alpha1.VirtualMachine) (int32, error)
+	CreateOrUpdateVirtualMachine(ctx context.Context, vm *vmopv1.VirtualMachine) error
+	DeleteVirtualMachine(ctx context.Context, vm *vmopv1.VirtualMachine) error
+	PublishVirtualMachine(ctx context.Context, vm *vmopv1.VirtualMachine,
+		vmPub *vmopv1.VirtualMachinePublishRequest, cl *imgregv1a1.ContentLibrary, actID string) (string, error)
+	GetVirtualMachineGuestHeartbeat(ctx context.Context, vm *vmopv1.VirtualMachine) (vmopv1.GuestHeartbeatStatus, error)
+	GetVirtualMachineWebMKSTicket(ctx context.Context, vm *vmopv1.VirtualMachine, pubKey string) (string, error)
+	GetVirtualMachineHardwareVersion(ctx context.Context, vm *vmopv1.VirtualMachine) (int32, error)
 
-	CreateOrUpdateVirtualMachineSetResourcePolicy(ctx context.Context, resourcePolicy *v1alpha1.VirtualMachineSetResourcePolicy) error
-	IsVirtualMachineSetResourcePolicyReady(ctx context.Context, availabilityZoneName string, resourcePolicy *v1alpha1.VirtualMachineSetResourcePolicy) (bool, error)
-	DeleteVirtualMachineSetResourcePolicy(ctx context.Context, resourcePolicy *v1alpha1.VirtualMachineSetResourcePolicy) error
+	CreateOrUpdateVirtualMachineSetResourcePolicy(ctx context.Context, resourcePolicy *vmopv1.VirtualMachineSetResourcePolicy) error
+	IsVirtualMachineSetResourcePolicyReady(ctx context.Context, availabilityZoneName string, resourcePolicy *vmopv1.VirtualMachineSetResourcePolicy) (bool, error)
+	DeleteVirtualMachineSetResourcePolicy(ctx context.Context, resourcePolicy *vmopv1.VirtualMachineSetResourcePolicy) error
 
 	// "Infra" related
 	UpdateVcPNID(ctx context.Context, vcPNID, vcPort string) error
 	ResetVcClient(ctx context.Context)
 	ComputeCPUMinFrequency(ctx context.Context) error
 
-	ListItemsFromContentLibrary(ctx context.Context, contentLibrary *v1alpha1.ContentLibraryProvider) ([]string, error)
-	GetVirtualMachineImageFromContentLibrary(ctx context.Context, contentLibrary *v1alpha1.ContentLibraryProvider, itemID string,
-		currentCLImages map[string]v1alpha1.VirtualMachineImage) (*v1alpha1.VirtualMachineImage, error)
+	ListItemsFromContentLibrary(ctx context.Context, contentLibrary *vmopv1.ContentLibraryProvider) ([]string, error)
+	GetVirtualMachineImageFromContentLibrary(ctx context.Context, contentLibrary *vmopv1.ContentLibraryProvider, itemID string,
+		currentCLImages map[string]vmopv1.VirtualMachineImage) (*vmopv1.VirtualMachineImage, error)
 	GetItemFromLibraryByName(ctx context.Context, contentLibrary, itemName string) (*library.Item, error)
 	UpdateContentLibraryItem(ctx context.Context, itemID, newName string, newDescription *string) error
 	SyncVirtualMachineImage(ctx context.Context, cli, vmi client.Object) error

--- a/pkg/vmprovider/providers/vsphere/clustermodules/cluster_modules_test.go
+++ b/pkg/vmprovider/providers/vsphere/clustermodules/cluster_modules_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/vmware/govmomi/vim25/types"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/clustermodules"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
@@ -23,8 +23,8 @@ func cmTests() {
 			cmProvider clustermodules.Provider
 
 			moduleGroup  string
-			moduleSpec   *vmopv1alpha1.ClusterModuleSpec
-			moduleStatus *vmopv1alpha1.ClusterModuleStatus
+			moduleSpec   *vmopv1.ClusterModuleSpec
+			moduleStatus *vmopv1.ClusterModuleStatus
 			clusterRef   types.ManagedObjectReference
 			vmRef        types.ManagedObjectReference
 		)
@@ -36,7 +36,7 @@ func cmTests() {
 			clusterRef = ctx.GetSingleClusterCompute().Reference()
 
 			moduleGroup = "controller-group"
-			moduleSpec = &vmopv1alpha1.ClusterModuleSpec{
+			moduleSpec = &vmopv1.ClusterModuleSpec{
 				GroupName: moduleGroup,
 			}
 
@@ -44,7 +44,7 @@ func cmTests() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(moduleID).ToNot(BeEmpty())
 
-			moduleStatus = &vmopv1alpha1.ClusterModuleStatus{
+			moduleStatus = &vmopv1.ClusterModuleStatus{
 				GroupName:  moduleSpec.GroupName,
 				ModuleUuid: moduleID,
 			}

--- a/pkg/vmprovider/providers/vsphere/clustermodules/cluster_modules_utils.go
+++ b/pkg/vmprovider/providers/vsphere/clustermodules/cluster_modules_utils.go
@@ -9,8 +9,7 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 	k8serrors "k8s.io/apimachinery/pkg/util/errors"
 
-	"github.com/vmware-tanzu/vm-operator/api/v1alpha1"
-
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 )
 
@@ -19,7 +18,7 @@ import (
 func FindClusterModuleUUID(
 	groupName string,
 	clusterRef types.ManagedObjectReference,
-	resourcePolicy *v1alpha1.VirtualMachineSetResourcePolicy) (int, string) {
+	resourcePolicy *vmopv1.VirtualMachineSetResourcePolicy) (int, string) {
 
 	// Prior to the stretched cluster work, the status did not contain the VC cluster the module was
 	// created for, but we still need to return existing modules when the FSS is not enabled.
@@ -42,7 +41,7 @@ func ClaimClusterModuleUUID(
 	clusterModProvider Provider,
 	groupName string,
 	clusterRef types.ManagedObjectReference,
-	resourcePolicy *v1alpha1.VirtualMachineSetResourcePolicy) (int, string, error) {
+	resourcePolicy *vmopv1.VirtualMachineSetResourcePolicy) (int, string, error) {
 
 	var errs []error
 

--- a/pkg/vmprovider/providers/vsphere/contentlibrary/content_library_provider.go
+++ b/pkg/vmprovider/providers/vsphere/contentlibrary/content_library_provider.go
@@ -21,8 +21,7 @@ import (
 	"github.com/vmware/govmomi/vapi/rest"
 	"github.com/vmware/govmomi/vim25/soap"
 
-	"github.com/vmware-tanzu/vm-operator/api/v1alpha1"
-
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/constants"
 )
@@ -42,7 +41,7 @@ type Provider interface {
 	VirtualMachineImageResourceForLibrary(ctx context.Context,
 		itemID string,
 		clUUID string,
-		currentCLImages map[string]v1alpha1.VirtualMachineImage) (*v1alpha1.VirtualMachineImage, error)
+		currentCLImages map[string]vmopv1.VirtualMachineImage) (*vmopv1.VirtualMachineImage, error)
 }
 
 type provider struct {
@@ -288,7 +287,7 @@ func (cs *provider) CreateLibraryItem(ctx context.Context, libraryItem library.I
 func (cs *provider) VirtualMachineImageResourceForLibrary(ctx context.Context,
 	itemID string,
 	clUUID string,
-	currentCLImages map[string]v1alpha1.VirtualMachineImage) (*v1alpha1.VirtualMachineImage, error) {
+	currentCLImages map[string]vmopv1.VirtualMachineImage) (*vmopv1.VirtualMachineImage, error) {
 	var ovfEnvelope *ovf.Envelope
 	var err error
 

--- a/pkg/vmprovider/providers/vsphere/contentlibrary/content_library_test.go
+++ b/pkg/vmprovider/providers/vsphere/contentlibrary/content_library_test.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -105,7 +105,7 @@ func clTests() {
 
 					Expect(image.Name).To(Equal(ctx.ContentLibraryImageName))
 					image.Spec.Type = "dummy-type-to-test-cache"
-					currentCLImages := map[string]vmopv1alpha1.VirtualMachineImage{
+					currentCLImages := map[string]vmopv1.VirtualMachineImage{
 						image.Status.ImageName: *image,
 					}
 

--- a/pkg/vmprovider/providers/vsphere/contentlibrary/content_library_utils_test.go
+++ b/pkg/vmprovider/providers/vsphere/contentlibrary/content_library_utils_test.go
@@ -15,7 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	"github.com/vmware-tanzu/vm-operator/pkg/lib"
@@ -70,7 +70,7 @@ var _ = Describe("LibItemToVirtualMachineImage", func() {
 			ts          time.Time
 			item        *library.Item
 			ovfEnvelope *ovf.Envelope
-			image       *vmopv1alpha1.VirtualMachineImage
+			image       *vmopv1.VirtualMachineImage
 		)
 
 		BeforeEach(func() {
@@ -287,8 +287,8 @@ var _ = Describe("LibItemToVirtualMachineImage", func() {
 				Expect(image).ToNot(BeNil())
 
 				Expect(image.Status.ImageSupported).Should(Equal(pointer.Bool(true)))
-				expectedCondition := vmopv1alpha1.Conditions{
-					*conditions.TrueCondition(vmopv1alpha1.VirtualMachineImageV1Alpha1CompatibleCondition),
+				expectedCondition := vmopv1.Conditions{
+					*conditions.TrueCondition(vmopv1.VirtualMachineImageV1Alpha1CompatibleCondition),
 				}
 				Expect(image.Status.Conditions).Should(conditions.MatchConditions(expectedCondition))
 			})
@@ -313,10 +313,10 @@ var _ = Describe("LibItemToVirtualMachineImage", func() {
 				Expect(image).ToNot(BeNil())
 				Expect(image.Status.ImageSupported).Should(Equal(pointer.Bool(false)))
 
-				expectedCondition := vmopv1alpha1.Conditions{
-					*conditions.FalseCondition(vmopv1alpha1.VirtualMachineImageV1Alpha1CompatibleCondition,
-						vmopv1alpha1.VirtualMachineImageV1Alpha1NotCompatibleReason,
-						vmopv1alpha1.ConditionSeverityError,
+				expectedCondition := vmopv1.Conditions{
+					*conditions.FalseCondition(vmopv1.VirtualMachineImageV1Alpha1CompatibleCondition,
+						vmopv1.VirtualMachineImageV1Alpha1NotCompatibleReason,
+						vmopv1.ConditionSeverityError,
 						"VirtualMachineImage is either not a TKG image or is not compatible with VMService v1alpha1"),
 				}
 				Expect(image.Status.Conditions).Should(conditions.MatchConditions(expectedCondition))
@@ -341,8 +341,8 @@ var _ = Describe("LibItemToVirtualMachineImage", func() {
 				image := contentlibrary.LibItemToVirtualMachineImage(item, ovfEnvelope)
 				Expect(image).ToNot(BeNil())
 				Expect(image.Status.ImageSupported).Should(Equal(pointer.Bool(true)))
-				expectedCondition := vmopv1alpha1.Conditions{
-					*conditions.TrueCondition(vmopv1alpha1.VirtualMachineImageV1Alpha1CompatibleCondition),
+				expectedCondition := vmopv1.Conditions{
+					*conditions.TrueCondition(vmopv1.VirtualMachineImageV1Alpha1CompatibleCondition),
 				}
 				Expect(image.Status.Conditions).Should(conditions.MatchConditions(expectedCondition))
 			})

--- a/pkg/vmprovider/providers/vsphere/instancestorage/instance_storage.go
+++ b/pkg/vmprovider/providers/vsphere/instancestorage/instance_storage.go
@@ -8,12 +8,12 @@ import (
 
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 )
 
 // IsConfigured checks if VM spec has instance volumes to identify if VM is configured with instance storage
 // and returns true/false accordingly.
-func IsConfigured(vm *vmopv1alpha1.VirtualMachine) bool {
+func IsConfigured(vm *vmopv1.VirtualMachine) bool {
 	for _, vol := range vm.Spec.Volumes {
 		if pvc := vol.PersistentVolumeClaim; pvc != nil && pvc.InstanceVolumeClaim != nil {
 			return true
@@ -23,8 +23,8 @@ func IsConfigured(vm *vmopv1alpha1.VirtualMachine) bool {
 }
 
 // FilterVolumes returns instance storage volumes present in VM spec.
-func FilterVolumes(vm *vmopv1alpha1.VirtualMachine) []vmopv1alpha1.VirtualMachineVolume {
-	var volumes []vmopv1alpha1.VirtualMachineVolume
+func FilterVolumes(vm *vmopv1.VirtualMachine) []vmopv1.VirtualMachineVolume {
+	var volumes []vmopv1.VirtualMachineVolume
 	for _, vol := range vm.Spec.Volumes {
 		if pvc := vol.PersistentVolumeClaim; pvc != nil && pvc.InstanceVolumeClaim != nil {
 			volumes = append(volumes, vol)

--- a/pkg/vmprovider/providers/vsphere/network/network_provider_test.go
+++ b/pkg/vmprovider/providers/vsphere/network/network_provider_test.go
@@ -20,7 +20,7 @@ import (
 	ncpv1alpha1 "github.com/vmware-tanzu/vm-operator/external/ncp/api/v1alpha1"
 	netopv1alpha1 "github.com/vmware-tanzu/vm-operator/external/net-operator/api/v1alpha1"
 
-	"github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/network"
@@ -41,7 +41,7 @@ var _ = Describe("NetworkProvider", func() {
 		testConfig builder.VCSimTestConfig
 		ctx        *builder.TestContextForVCSim
 
-		vm    *v1alpha1.VirtualMachine
+		vm    *vmopv1.VirtualMachine
 		vmCtx context.VirtualMachineContext
 		np    network.Provider
 	)
@@ -61,13 +61,13 @@ var _ = Describe("NetworkProvider", func() {
 	BeforeEach(func() {
 		testConfig = builder.VCSimTestConfig{}
 
-		vm = &v1alpha1.VirtualMachine{
+		vm = &vmopv1.VirtualMachine{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "network-provider-test-vm",
 				Namespace: "network-provider-test-ns",
 			},
-			Spec: v1alpha1.VirtualMachineSpec{
-				NetworkInterfaces: []v1alpha1.VirtualMachineNetworkInterface{
+			Spec: vmopv1.VirtualMachineSpec{
+				NetworkInterfaces: []vmopv1.VirtualMachineNetworkInterface{
 					{},
 				},
 			},
@@ -318,7 +318,7 @@ var _ = Describe("NetworkProvider", func() {
 			Context("with NetworkInterfaceProvider Referenced in vmNif", func() {
 				BeforeEach(func() {
 					netIf.Name = dummyNetIfName
-					vm.Spec.NetworkInterfaces[0].ProviderRef = &v1alpha1.NetworkInterfaceProviderReference{
+					vm.Spec.NetworkInterfaces[0].ProviderRef = &vmopv1.NetworkInterfaceProviderReference{
 						APIGroup:   "netoperator.vmware.com",
 						APIVersion: "v1alpha1",
 						Kind:       "NetworkInterface",
@@ -358,7 +358,7 @@ var _ = Describe("NetworkProvider", func() {
 
 				Context("referencing unsupported GVK", func() {
 					BeforeEach(func() {
-						vm.Spec.NetworkInterfaces[0].ProviderRef = &v1alpha1.NetworkInterfaceProviderReference{
+						vm.Spec.NetworkInterfaces[0].ProviderRef = &vmopv1.NetworkInterfaceProviderReference{
 							APIGroup:   "unsupported-group",
 							APIVersion: "unsupported-version",
 							Kind:       "unsupported-kind",
@@ -383,7 +383,7 @@ var _ = Describe("NetworkProvider", func() {
 					netIf.Status.IPConfigs = nil
 
 					vm.Spec.NetworkInterfaces[0].NetworkType = network.NsxtNetworkType
-					vm.Spec.NetworkInterfaces[0].ProviderRef = &v1alpha1.NetworkInterfaceProviderReference{
+					vm.Spec.NetworkInterfaces[0].ProviderRef = &vmopv1.NetworkInterfaceProviderReference{
 						APIGroup:   "netoperator.vmware.com",
 						APIVersion: "v1alpha1",
 						Kind:       "NetworkInterface",

--- a/pkg/vmprovider/providers/vsphere/placement/zone_placement_test.go
+++ b/pkg/vmprovider/providers/vsphere/placement/zone_placement_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/topology"
@@ -71,7 +71,7 @@ func vcSimPlacement() {
 		nsInfo      builder.WorkloadNamespaceInfo
 		testConfig  builder.VCSimTestConfig
 
-		vm         *vmopv1alpha1.VirtualMachine
+		vm         *vmopv1.VirtualMachine
 		vmCtx      context.VirtualMachineContext
 		configSpec *types.VirtualMachineConfigSpec
 	)

--- a/pkg/vmprovider/providers/vsphere/resources/vm.go
+++ b/pkg/vmprovider/providers/vsphere/resources/vm.go
@@ -15,7 +15,7 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 )
 
 type VirtualMachine struct {
@@ -138,16 +138,16 @@ func (vm *VirtualMachine) UniqueID(ctx context.Context) (string, error) {
 	return vm.ReferenceValue(), nil
 }
 
-func (vm *VirtualMachine) SetPowerState(ctx context.Context, desiredPowerState v1alpha1.VirtualMachinePowerState) error {
+func (vm *VirtualMachine) SetPowerState(ctx context.Context, desiredPowerState vmopv1.VirtualMachinePowerState) error {
 	vm.logger.V(5).Info("SetPowerState", "desiredState", desiredPowerState)
 
 	var powerTask *object.Task
 	var err error
 
 	switch desiredPowerState {
-	case v1alpha1.VirtualMachinePoweredOn:
+	case vmopv1.VirtualMachinePoweredOn:
 		powerTask, err = vm.vcVirtualMachine.PowerOn(ctx)
-	case v1alpha1.VirtualMachinePoweredOff:
+	case vmopv1.VirtualMachinePoweredOff:
 		powerTask, err = vm.vcVirtualMachine.PowerOff(ctx)
 	default:
 		err = fmt.Errorf("invalid desired power state %s", desiredPowerState)

--- a/pkg/vmprovider/providers/vsphere/session/session_vm_create.go
+++ b/pkg/vmprovider/providers/vsphere/session/session_vm_create.go
@@ -15,7 +15,7 @@ import (
 	"github.com/vmware/govmomi/vapi/vcenter"
 	vimTypes "github.com/vmware/govmomi/vim25/types"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/lib"
@@ -27,9 +27,9 @@ import (
 
 // VMCreateArgs contains the arguments needed to create a VM on VC.
 type VMCreateArgs struct {
-	VMClass             *vmopv1alpha1.VirtualMachineClass
-	VMImageStatus       *vmopv1alpha1.VirtualMachineImageStatus
-	ResourcePolicy      *vmopv1alpha1.VirtualMachineSetResourcePolicy
+	VMClass             *vmopv1.VirtualMachineClass
+	VMImageStatus       *vmopv1.VirtualMachineImageStatus
+	ResourcePolicy      *vmopv1.VirtualMachineSetResourcePolicy
 	VMMetadata          VMMetadata
 	ContentLibraryUUID  string
 	StorageClassesToIDs map[string]string

--- a/pkg/vmprovider/providers/vsphere/session/session_vm_customization_test.go
+++ b/pkg/vmprovider/providers/vsphere/session/session_vm_customization_test.go
@@ -20,7 +20,7 @@ import (
 
 	vimTypes "github.com/vmware/govmomi/vim25/types"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/constants"
@@ -78,7 +78,7 @@ var _ = Describe("Customization via ConfigSpec", func() {
 		BeforeEach(func() {
 			updateArgs.VMMetadata = session.VMMetadata{
 				Data:      make(map[string]string),
-				Transport: vmopv1alpha1.VirtualMachineMetadataOvfEnvTransport,
+				Transport: vmopv1.VirtualMachineMetadataOvfEnvTransport,
 			}
 		})
 		JustBeforeEach(func() {
@@ -118,7 +118,7 @@ var _ = Describe("Customization via ConfigSpec", func() {
 		BeforeEach(func() {
 			updateArgs.VMMetadata = session.VMMetadata{
 				Data:      make(map[string]string),
-				Transport: vmopv1alpha1.VirtualMachineMetadataExtraConfigTransport,
+				Transport: vmopv1.VirtualMachineMetadataExtraConfigTransport,
 			}
 		})
 		JustBeforeEach(func() {
@@ -216,7 +216,7 @@ var _ = Describe("Customization via Cust Spec", func() {
 
 var _ = Describe("CloudInitmetadata", func() {
 	var (
-		vm             *vmopv1alpha1.VirtualMachine
+		vm             *vmopv1.VirtualMachine
 		netplan        network.Netplan
 		metadataString string
 		err            error
@@ -224,7 +224,7 @@ var _ = Describe("CloudInitmetadata", func() {
 		publicKeys     string
 	)
 	BeforeEach(func() {
-		vm = &vmopv1alpha1.VirtualMachine{
+		vm = &vmopv1.VirtualMachine{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "dummy-vm",
 				Namespace: "dummy-ns",
@@ -484,12 +484,12 @@ var _ = Describe("TemplateVMMetadata", func() {
 			gateway2    = "192.168.10.1"
 			nameserver1 = "8.8.8.8"
 			nameserver2 = "1.1.1.1"
-			vm          *vmopv1alpha1.VirtualMachine
+			vm          *vmopv1.VirtualMachine
 			vmCtx       context.VirtualMachineContext
 		)
 
 		BeforeEach(func() {
-			vm = &vmopv1alpha1.VirtualMachine{
+			vm = &vmopv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "dummy-vm",
 					Namespace: "dummy-ns",
@@ -694,7 +694,7 @@ var _ = Describe("TemplateVMMetadata", func() {
 		var (
 			updateArgs session.VMUpdateArgs
 		)
-		vm := &vmopv1alpha1.VirtualMachine{
+		vm := &vmopv1.VirtualMachine{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "dummy-vm",
 				Namespace: "dummy-ns",

--- a/pkg/vmprovider/providers/vsphere/session/session_vm_status_test.go
+++ b/pkg/vmprovider/providers/vsphere/session/session_vm_status_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 	vimTypes "github.com/vmware/govmomi/vim25/types"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/session"
@@ -50,12 +50,12 @@ var _ = Describe("Network Interfaces VM Status", func() {
 var _ = Describe("VirtualMachineTools Status to VM Status Condition", func() {
 	Context("markVMToolsRunningStatusCondition", func() {
 		var (
-			vm        *vmopv1alpha1.VirtualMachine
+			vm        *vmopv1.VirtualMachine
 			guestInfo *vimTypes.GuestInfo
 		)
 
 		BeforeEach(func() {
-			vm = &vmopv1alpha1.VirtualMachine{}
+			vm = &vmopv1.VirtualMachine{}
 			guestInfo = &vimTypes.GuestInfo{
 				ToolsRunningStatus: "",
 			}
@@ -70,16 +70,16 @@ var _ = Describe("VirtualMachineTools Status to VM Status Condition", func() {
 				guestInfo = nil
 			})
 			It("sets condition unknown", func() {
-				expectedConditions := vmopv1alpha1.Conditions{
-					*conditions.UnknownCondition(vmopv1alpha1.VirtualMachineToolsCondition, "", ""),
+				expectedConditions := vmopv1.Conditions{
+					*conditions.UnknownCondition(vmopv1.VirtualMachineToolsCondition, "", ""),
 				}
 				Expect(vm.Status.Conditions).To(conditions.MatchConditions(expectedConditions))
 			})
 		})
 		Context("ToolsRunningStatus is empty", func() {
 			It("sets condition unknown", func() {
-				expectedConditions := vmopv1alpha1.Conditions{
-					*conditions.UnknownCondition(vmopv1alpha1.VirtualMachineToolsCondition, "", ""),
+				expectedConditions := vmopv1.Conditions{
+					*conditions.UnknownCondition(vmopv1.VirtualMachineToolsCondition, "", ""),
 				}
 				Expect(vm.Status.Conditions).To(conditions.MatchConditions(expectedConditions))
 			})
@@ -89,8 +89,8 @@ var _ = Describe("VirtualMachineTools Status to VM Status Condition", func() {
 				guestInfo.ToolsRunningStatus = string(vimTypes.VirtualMachineToolsRunningStatusGuestToolsNotRunning)
 			})
 			It("sets condition to false", func() {
-				expectedConditions := vmopv1alpha1.Conditions{
-					*conditions.FalseCondition(vmopv1alpha1.VirtualMachineToolsCondition, vmopv1alpha1.VirtualMachineToolsNotRunningReason, vmopv1alpha1.ConditionSeverityError, "VMware Tools is not running"),
+				expectedConditions := vmopv1.Conditions{
+					*conditions.FalseCondition(vmopv1.VirtualMachineToolsCondition, vmopv1.VirtualMachineToolsNotRunningReason, vmopv1.ConditionSeverityError, "VMware Tools is not running"),
 				}
 				Expect(vm.Status.Conditions).To(conditions.MatchConditions(expectedConditions))
 			})
@@ -100,8 +100,8 @@ var _ = Describe("VirtualMachineTools Status to VM Status Condition", func() {
 				guestInfo.ToolsRunningStatus = string(vimTypes.VirtualMachineToolsRunningStatusGuestToolsRunning)
 			})
 			It("sets condition true", func() {
-				expectedConditions := vmopv1alpha1.Conditions{
-					*conditions.TrueCondition(vmopv1alpha1.VirtualMachineToolsCondition),
+				expectedConditions := vmopv1.Conditions{
+					*conditions.TrueCondition(vmopv1.VirtualMachineToolsCondition),
 				}
 				Expect(vm.Status.Conditions).To(conditions.MatchConditions(expectedConditions))
 			})
@@ -111,8 +111,8 @@ var _ = Describe("VirtualMachineTools Status to VM Status Condition", func() {
 				guestInfo.ToolsRunningStatus = string(vimTypes.VirtualMachineToolsRunningStatusGuestToolsExecutingScripts)
 			})
 			It("sets condition true", func() {
-				expectedConditions := vmopv1alpha1.Conditions{
-					*conditions.TrueCondition(vmopv1alpha1.VirtualMachineToolsCondition),
+				expectedConditions := vmopv1.Conditions{
+					*conditions.TrueCondition(vmopv1.VirtualMachineToolsCondition),
 				}
 				Expect(vm.Status.Conditions).To(conditions.MatchConditions(expectedConditions))
 			})
@@ -122,8 +122,8 @@ var _ = Describe("VirtualMachineTools Status to VM Status Condition", func() {
 				guestInfo.ToolsRunningStatus = "blah"
 			})
 			It("sets condition unknown", func() {
-				expectedConditions := vmopv1alpha1.Conditions{
-					*conditions.UnknownCondition(vmopv1alpha1.VirtualMachineToolsCondition, "", "Unexpected VMware Tools running status"),
+				expectedConditions := vmopv1.Conditions{
+					*conditions.UnknownCondition(vmopv1.VirtualMachineToolsCondition, "", "Unexpected VMware Tools running status"),
 				}
 				Expect(vm.Status.Conditions).To(conditions.MatchConditions(expectedConditions))
 			})
@@ -134,12 +134,12 @@ var _ = Describe("VirtualMachineTools Status to VM Status Condition", func() {
 var _ = Describe("VSphere Customization Status to VM Status Condition", func() {
 	Context("markCustomizationInfoCondition", func() {
 		var (
-			vm        *vmopv1alpha1.VirtualMachine
+			vm        *vmopv1.VirtualMachine
 			guestInfo *vimTypes.GuestInfo
 		)
 
 		BeforeEach(func() {
-			vm = &vmopv1alpha1.VirtualMachine{}
+			vm = &vmopv1.VirtualMachine{}
 			guestInfo = &vimTypes.GuestInfo{
 				CustomizationInfo: &vimTypes.GuestInfoCustomizationInfo{},
 			}
@@ -154,8 +154,8 @@ var _ = Describe("VSphere Customization Status to VM Status Condition", func() {
 				guestInfo = nil
 			})
 			It("sets condition unknown", func() {
-				expectedConditions := vmopv1alpha1.Conditions{
-					*conditions.UnknownCondition(vmopv1alpha1.GuestCustomizationCondition, "", ""),
+				expectedConditions := vmopv1.Conditions{
+					*conditions.UnknownCondition(vmopv1.GuestCustomizationCondition, "", ""),
 				}
 				Expect(vm.Status.Conditions).To(conditions.MatchConditions(expectedConditions))
 			})
@@ -165,8 +165,8 @@ var _ = Describe("VSphere Customization Status to VM Status Condition", func() {
 				guestInfo.CustomizationInfo = nil
 			})
 			It("sets condition unknown", func() {
-				expectedConditions := vmopv1alpha1.Conditions{
-					*conditions.UnknownCondition(vmopv1alpha1.GuestCustomizationCondition, "", ""),
+				expectedConditions := vmopv1.Conditions{
+					*conditions.UnknownCondition(vmopv1.GuestCustomizationCondition, "", ""),
 				}
 				Expect(vm.Status.Conditions).To(conditions.MatchConditions(expectedConditions))
 			})
@@ -176,8 +176,8 @@ var _ = Describe("VSphere Customization Status to VM Status Condition", func() {
 				guestInfo.CustomizationInfo.CustomizationStatus = string(vimTypes.GuestInfoCustomizationStatusTOOLSDEPLOYPKG_IDLE)
 			})
 			It("sets condition true", func() {
-				expectedConditions := vmopv1alpha1.Conditions{
-					*conditions.TrueCondition(vmopv1alpha1.GuestCustomizationCondition),
+				expectedConditions := vmopv1.Conditions{
+					*conditions.TrueCondition(vmopv1.GuestCustomizationCondition),
 				}
 				Expect(vm.Status.Conditions).To(conditions.MatchConditions(expectedConditions))
 			})
@@ -187,8 +187,8 @@ var _ = Describe("VSphere Customization Status to VM Status Condition", func() {
 				guestInfo.CustomizationInfo.CustomizationStatus = string(vimTypes.GuestInfoCustomizationStatusTOOLSDEPLOYPKG_PENDING)
 			})
 			It("sets condition false", func() {
-				expectedConditions := vmopv1alpha1.Conditions{
-					*conditions.FalseCondition(vmopv1alpha1.GuestCustomizationCondition, vmopv1alpha1.GuestCustomizationPendingReason, vmopv1alpha1.ConditionSeverityInfo, ""),
+				expectedConditions := vmopv1.Conditions{
+					*conditions.FalseCondition(vmopv1.GuestCustomizationCondition, vmopv1.GuestCustomizationPendingReason, vmopv1.ConditionSeverityInfo, ""),
 				}
 				Expect(vm.Status.Conditions).To(conditions.MatchConditions(expectedConditions))
 			})
@@ -198,8 +198,8 @@ var _ = Describe("VSphere Customization Status to VM Status Condition", func() {
 				guestInfo.CustomizationInfo.CustomizationStatus = string(vimTypes.GuestInfoCustomizationStatusTOOLSDEPLOYPKG_RUNNING)
 			})
 			It("sets condition false", func() {
-				expectedConditions := vmopv1alpha1.Conditions{
-					*conditions.FalseCondition(vmopv1alpha1.GuestCustomizationCondition, vmopv1alpha1.GuestCustomizationRunningReason, vmopv1alpha1.ConditionSeverityInfo, ""),
+				expectedConditions := vmopv1.Conditions{
+					*conditions.FalseCondition(vmopv1.GuestCustomizationCondition, vmopv1.GuestCustomizationRunningReason, vmopv1.ConditionSeverityInfo, ""),
 				}
 				Expect(vm.Status.Conditions).To(conditions.MatchConditions(expectedConditions))
 			})
@@ -209,8 +209,8 @@ var _ = Describe("VSphere Customization Status to VM Status Condition", func() {
 				guestInfo.CustomizationInfo.CustomizationStatus = string(vimTypes.GuestInfoCustomizationStatusTOOLSDEPLOYPKG_SUCCEEDED)
 			})
 			It("sets condition true", func() {
-				expectedConditions := vmopv1alpha1.Conditions{
-					*conditions.TrueCondition(vmopv1alpha1.GuestCustomizationCondition),
+				expectedConditions := vmopv1.Conditions{
+					*conditions.TrueCondition(vmopv1.GuestCustomizationCondition),
 				}
 				Expect(vm.Status.Conditions).To(conditions.MatchConditions(expectedConditions))
 			})
@@ -221,8 +221,8 @@ var _ = Describe("VSphere Customization Status to VM Status Condition", func() {
 				guestInfo.CustomizationInfo.ErrorMsg = "some error message"
 			})
 			It("sets condition false", func() {
-				expectedConditions := vmopv1alpha1.Conditions{
-					*conditions.FalseCondition(vmopv1alpha1.GuestCustomizationCondition, vmopv1alpha1.GuestCustomizationFailedReason, vmopv1alpha1.ConditionSeverityError, guestInfo.CustomizationInfo.ErrorMsg),
+				expectedConditions := vmopv1.Conditions{
+					*conditions.FalseCondition(vmopv1.GuestCustomizationCondition, vmopv1.GuestCustomizationFailedReason, vmopv1.ConditionSeverityError, guestInfo.CustomizationInfo.ErrorMsg),
 				}
 				Expect(vm.Status.Conditions).To(conditions.MatchConditions(expectedConditions))
 			})
@@ -233,8 +233,8 @@ var _ = Describe("VSphere Customization Status to VM Status Condition", func() {
 				guestInfo.CustomizationInfo.ErrorMsg = "some error message"
 			})
 			It("sets condition false", func() {
-				expectedConditions := vmopv1alpha1.Conditions{
-					*conditions.FalseCondition(vmopv1alpha1.GuestCustomizationCondition, "", vmopv1alpha1.ConditionSeverityError, guestInfo.CustomizationInfo.ErrorMsg),
+				expectedConditions := vmopv1.Conditions{
+					*conditions.FalseCondition(vmopv1.GuestCustomizationCondition, "", vmopv1.ConditionSeverityError, guestInfo.CustomizationInfo.ErrorMsg),
 				}
 				Expect(vm.Status.Conditions).To(conditions.MatchConditions(expectedConditions))
 			})

--- a/pkg/vmprovider/providers/vsphere/session/session_vm_update_test.go
+++ b/pkg/vmprovider/providers/vsphere/session/session_vm_update_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/vmware/govmomi/object"
 	vimTypes "github.com/vmware/govmomi/vim25/types"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/config"
@@ -192,10 +192,10 @@ var _ = Describe("Update ConfigSpec", func() {
 	// better integration tests.
 
 	Context("Basic Hardware", func() {
-		var vmClassSpec *vmopv1alpha1.VirtualMachineClassSpec
+		var vmClassSpec *vmopv1.VirtualMachineClassSpec
 
 		BeforeEach(func() {
-			vmClassSpec = &vmopv1alpha1.VirtualMachineClassSpec{}
+			vmClassSpec = &vmopv1.VirtualMachineClassSpec{}
 		})
 
 		JustBeforeEach(func() {
@@ -230,11 +230,11 @@ var _ = Describe("Update ConfigSpec", func() {
 	})
 
 	Context("CPU Allocation", func() {
-		var vmClassSpec *vmopv1alpha1.VirtualMachineClassSpec
+		var vmClassSpec *vmopv1.VirtualMachineClassSpec
 		var minCPUFreq uint64 = 1
 
 		BeforeEach(func() {
-			vmClassSpec = &vmopv1alpha1.VirtualMachineClassSpec{}
+			vmClassSpec = &vmopv1.VirtualMachineClassSpec{}
 		})
 
 		JustBeforeEach(func() {
@@ -309,10 +309,10 @@ var _ = Describe("Update ConfigSpec", func() {
 	})
 
 	Context("Memory Allocation", func() {
-		var vmClassSpec *vmopv1alpha1.VirtualMachineClassSpec
+		var vmClassSpec *vmopv1.VirtualMachineClassSpec
 
 		BeforeEach(func() {
-			vmClassSpec = &vmopv1alpha1.VirtualMachineClassSpec{}
+			vmClassSpec = &vmopv1.VirtualMachineClassSpec{}
 		})
 
 		JustBeforeEach(func() {
@@ -387,16 +387,16 @@ var _ = Describe("Update ConfigSpec", func() {
 	})
 
 	Context("ExtraConfig", func() {
-		var vmClassSpec *vmopv1alpha1.VirtualMachineClassSpec
+		var vmClassSpec *vmopv1.VirtualMachineClassSpec
 		var classConfigSpec *vimTypes.VirtualMachineConfigSpec
-		var vm *vmopv1alpha1.VirtualMachine
+		var vm *vmopv1.VirtualMachine
 		var globalExtraConfig map[string]string
 		var ecMap map[string]string
 		var imageV1Alpha1Compatible bool
 
 		BeforeEach(func() {
-			vmClassSpec = &vmopv1alpha1.VirtualMachineClassSpec{}
-			vm = &vmopv1alpha1.VirtualMachine{
+			vmClassSpec = &vmopv1.VirtualMachineClassSpec{}
+			vm = &vmopv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: make(map[string]string),
 				},
@@ -451,8 +451,8 @@ var _ = Describe("Update ConfigSpec", func() {
 
 			Context("When VM uses metadata transport types other than CloudInit", func() {
 				BeforeEach(func() {
-					vm.Spec.VmMetadata = &vmopv1alpha1.VirtualMachineMetadata{
-						Transport:     vmopv1alpha1.VirtualMachineMetadataExtraConfigTransport,
+					vm.Spec.VmMetadata = &vmopv1.VirtualMachineMetadata{
+						Transport:     vmopv1.VirtualMachineMetadataExtraConfigTransport,
 						ConfigMapName: "dummy-config",
 					}
 				})
@@ -463,8 +463,8 @@ var _ = Describe("Update ConfigSpec", func() {
 
 			Context("When VM uses CloudInit metadata transport type", func() {
 				BeforeEach(func() {
-					vm.Spec.VmMetadata = &vmopv1alpha1.VirtualMachineMetadata{
-						Transport:     vmopv1alpha1.VirtualMachineMetadataCloudInitTransport,
+					vm.Spec.VmMetadata = &vmopv1.VirtualMachineMetadata{
+						Transport:     vmopv1.VirtualMachineMetadataCloudInitTransport,
 						ConfigMapName: "dummy-config",
 					}
 				})
@@ -495,13 +495,13 @@ var _ = Describe("Update ConfigSpec", func() {
 
 			Context("When InstanceStorage is configured on VM", func() {
 				BeforeEach(func() {
-					vm.Spec.Volumes = append(vm.Spec.Volumes, vmopv1alpha1.VirtualMachineVolume{
+					vm.Spec.Volumes = append(vm.Spec.Volumes, vmopv1.VirtualMachineVolume{
 						Name: "pvc-volume-1",
-						PersistentVolumeClaim: &vmopv1alpha1.PersistentVolumeClaimVolumeSource{
+						PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
 							PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
 								ClaimName: "pvc-volume-1",
 							},
-							InstanceVolumeClaim: &vmopv1alpha1.InstanceVolumeClaimVolumeSource{
+							InstanceVolumeClaim: &vmopv1.InstanceVolumeClaimVolumeSource{
 								StorageClass: "dummyStorageClass",
 								Size:         resource.MustParse("256Gi"),
 							},
@@ -525,7 +525,7 @@ var _ = Describe("Update ConfigSpec", func() {
 
 			Context("when vGPU device is available", func() {
 				BeforeEach(func() {
-					vmClassSpec.Hardware.Devices = vmopv1alpha1.VirtualDevices{VGPUDevices: []vmopv1alpha1.VGPUDevice{
+					vmClassSpec.Hardware.Devices = vmopv1.VirtualDevices{VGPUDevices: []vmopv1.VGPUDevice{
 						{
 							ProfileName: "test-vgpu-profile",
 						},
@@ -555,7 +555,7 @@ var _ = Describe("Update ConfigSpec", func() {
 
 			Context("when DDPIO device is available", func() {
 				BeforeEach(func() {
-					vmClassSpec.Hardware.Devices = vmopv1alpha1.VirtualDevices{DynamicDirectPathIODevices: []vmopv1alpha1.DynamicDirectPathIODevice{
+					vmClassSpec.Hardware.Devices = vmopv1.VirtualDevices{DynamicDirectPathIODevices: []vmopv1.DynamicDirectPathIODevice{
 						{
 							VendorID:    123,
 							DeviceID:    24,
@@ -676,12 +676,12 @@ var _ = Describe("Update ConfigSpec", func() {
 	})
 
 	Context("ChangeBlockTracking", func() {
-		var vmSpec vmopv1alpha1.VirtualMachineSpec
+		var vmSpec vmopv1.VirtualMachineSpec
 		var classConfigSpec *vimTypes.VirtualMachineConfigSpec
 
 		BeforeEach(func() {
-			vmSpec = vmopv1alpha1.VirtualMachineSpec{
-				AdvancedOptions: &vmopv1alpha1.VirtualMachineAdvancedOptions{},
+			vmSpec = vmopv1.VirtualMachineSpec{
+				AdvancedOptions: &vmopv1.VirtualMachineAdvancedOptions{},
 			}
 			config.ChangeTrackingEnabled = nil
 			classConfigSpec = nil
@@ -771,10 +771,10 @@ var _ = Describe("Update ConfigSpec", func() {
 	})
 
 	Context("Firmware", func() {
-		var vm *vmopv1alpha1.VirtualMachine
+		var vm *vmopv1.VirtualMachine
 
 		BeforeEach(func() {
-			vm = &vmopv1alpha1.VirtualMachine{
+			vm = &vmopv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: make(map[string]string),
 				},
@@ -1110,22 +1110,22 @@ var _ = Describe("Update ConfigSpec", func() {
 	})
 
 	Context("Create vSphere PCI device", func() {
-		var vgpuDevices = []vmopv1alpha1.VGPUDevice{
+		var vgpuDevices = []vmopv1.VGPUDevice{
 			{
 				ProfileName: "SampleProfile",
 			},
 		}
-		var ddpioDevices = []vmopv1alpha1.DynamicDirectPathIODevice{
+		var ddpioDevices = []vmopv1.DynamicDirectPathIODevice{
 			{
 				VendorID:    42,
 				DeviceID:    43,
 				CustomLabel: "SampleLabel",
 			},
 		}
-		var pciDevices vmopv1alpha1.VirtualDevices
+		var pciDevices vmopv1.VirtualDevices
 		Context("For VM Class Spec vGPU device", func() {
 			BeforeEach(func() {
-				pciDevices = vmopv1alpha1.VirtualDevices{
+				pciDevices = vmopv1.VirtualDevices{
 					VGPUDevices: vgpuDevices,
 				}
 			})
@@ -1139,7 +1139,7 @@ var _ = Describe("Update ConfigSpec", func() {
 		})
 		Context("For VM Class Spec Dynamic DirectPath I/O device", func() {
 			BeforeEach(func() {
-				pciDevices = vmopv1alpha1.VirtualDevices{
+				pciDevices = vmopv1.VirtualDevices{
 					DynamicDirectPathIODevices: ddpioDevices,
 				}
 			})

--- a/pkg/vmprovider/providers/vsphere/vcenter/getvm.go
+++ b/pkg/vmprovider/providers/vsphere/vcenter/getvm.go
@@ -12,7 +12,7 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/topology"
 )
@@ -111,7 +111,7 @@ func findVMByInventory(
 
 	// When the VM has a ResourcePolicy, the VM is placed in a child folder under the namespace's folder.
 	if policyName := vmCtx.VM.Spec.ResourcePolicyName; policyName != "" {
-		resourcePolicy := &v1alpha1.VirtualMachineSetResourcePolicy{}
+		resourcePolicy := &vmopv1.VirtualMachineSetResourcePolicy{}
 
 		key := ctrlclient.ObjectKey{Name: policyName, Namespace: vmCtx.VM.Namespace}
 		if err := k8sClient.Get(vmCtx, key, resourcePolicy); err != nil {

--- a/pkg/vmprovider/providers/vsphere/vcenter/resourcepool.go
+++ b/pkg/vmprovider/providers/vsphere/vcenter/resourcepool.go
@@ -12,7 +12,7 @@ import (
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/types"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 )
 
 // GetResourcePoolByMoID returns the ResourcePool for the MoID.
@@ -85,7 +85,7 @@ func CreateOrUpdateChildResourcePool(
 	ctx goctx.Context,
 	vimClient *vim25.Client,
 	parentRPMoID string,
-	rpSpec *vmopv1alpha1.ResourcePoolSpec) (string, error) {
+	rpSpec *vmopv1.ResourcePoolSpec) (string, error) {
 
 	parentRP := object.NewResourcePool(vimClient,
 		types.ManagedObjectReference{Type: "ResourcePool", Value: parentRPMoID})

--- a/pkg/vmprovider/providers/vsphere/vcenter/resourcepool_test.go
+++ b/pkg/vmprovider/providers/vsphere/vcenter/resourcepool_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/vmware/govmomi/object"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/vcenter"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
@@ -103,7 +103,7 @@ func createDeleteExistResourcePoolChild() {
 		nsRP   *object.ResourcePool
 
 		parentRPMoID   string
-		resourcePolicy *vmopv1alpha1.VirtualMachineSetResourcePolicy
+		resourcePolicy *vmopv1.VirtualMachineSetResourcePolicy
 	)
 
 	BeforeEach(func() {

--- a/pkg/vmprovider/providers/vsphere/virtualmachine/configspec.go
+++ b/pkg/vmprovider/providers/vsphere/virtualmachine/configspec.go
@@ -8,8 +8,7 @@ import (
 
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 
-	"github.com/vmware-tanzu/vm-operator/api/v1alpha1"
-
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/constants"
@@ -20,7 +19,7 @@ import (
 // ConfigSpec with VM Class spec and other arguments.
 func CreateConfigSpec(
 	name string,
-	vmClassSpec *v1alpha1.VirtualMachineClassSpec,
+	vmClassSpec *vmopv1.VirtualMachineClassSpec,
 	minFreq uint64,
 	imageFirmware string,
 	baseConfigSpec *vimtypes.VirtualMachineConfigSpec) *vimtypes.VirtualMachineConfigSpec {
@@ -101,7 +100,7 @@ func CreateConfigSpec(
 // a ConfigSpec, this should largely - or ideally entirely - be folded into CreateConfigSpec() above.
 func CreateConfigSpecForPlacement(
 	vmCtx context.VirtualMachineContext,
-	vmClassSpec *v1alpha1.VirtualMachineClassSpec,
+	vmClassSpec *vmopv1.VirtualMachineClassSpec,
 	minFreq uint64,
 	storageClassesToIDs map[string]string,
 	imageFirmware string,

--- a/pkg/vmprovider/providers/vsphere/virtualmachine/devices.go
+++ b/pkg/vmprovider/providers/vsphere/virtualmachine/devices.go
@@ -7,8 +7,7 @@ import (
 	vimTypes "github.com/vmware/govmomi/vim25/types"
 	"k8s.io/utils/pointer"
 
-	"github.com/vmware-tanzu/vm-operator/api/v1alpha1"
-
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/constants"
 )
 
@@ -45,7 +44,7 @@ func CreatePCIDevicesFromConfigSpec(pciDevsFromConfigSpec []*vimTypes.VirtualPCI
 }
 
 // CreatePCIDevicesFromVMClass creates vim25 VirtualDevices from the specified list of PCI devices from VM Class spec.
-func CreatePCIDevicesFromVMClass(pciDevicesFromVMClass v1alpha1.VirtualDevices) []vimTypes.BaseVirtualDevice {
+func CreatePCIDevicesFromVMClass(pciDevicesFromVMClass vmopv1.VirtualDevices) []vimTypes.BaseVirtualDevice {
 	devices := make([]vimTypes.BaseVirtualDevice, 0, len(pciDevicesFromVMClass.VGPUDevices)+len(pciDevicesFromVMClass.DynamicDirectPathIODevices))
 
 	deviceKey := pciDevicesStartDeviceKey
@@ -76,7 +75,7 @@ func CreatePCIDevicesFromVMClass(pciDevicesFromVMClass v1alpha1.VirtualDevices) 
 	return devices
 }
 
-func CreateInstanceStorageDiskDevices(isVolumes []v1alpha1.VirtualMachineVolume) []vimTypes.BaseVirtualDevice {
+func CreateInstanceStorageDiskDevices(isVolumes []vmopv1.VirtualMachineVolume) []vimTypes.BaseVirtualDevice {
 	devices := make([]vimTypes.BaseVirtualDevice, 0, len(isVolumes))
 	deviceKey := instanceStorageStartDeviceKey
 

--- a/pkg/vmprovider/providers/vsphere/virtualmachine/heartbeat.go
+++ b/pkg/vmprovider/providers/vsphere/virtualmachine/heartbeat.go
@@ -7,19 +7,19 @@ import (
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/mo"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
 )
 
 func GetGuestHeartBeatStatus(
 	vmCtx context.VirtualMachineContext,
-	vm *object.VirtualMachine) (vmopv1alpha1.GuestHeartbeatStatus, error) {
+	vm *object.VirtualMachine) (vmopv1.GuestHeartbeatStatus, error) {
 
 	var o mo.VirtualMachine
 	if err := vm.Properties(vmCtx, vm.Reference(), []string{"guestHeartbeatStatus"}, &o); err != nil {
 		return "", err
 	}
 
-	return vmopv1alpha1.GuestHeartbeatStatus(o.GuestHeartbeatStatus), nil
+	return vmopv1.GuestHeartbeatStatus(o.GuestHeartbeatStatus), nil
 }

--- a/pkg/vmprovider/providers/vsphere/virtualmachine/publish.go
+++ b/pkg/vmprovider/providers/vsphere/virtualmachine/publish.go
@@ -10,7 +10,7 @@ import (
 	"github.com/vmware/govmomi/vapi/rest"
 	"github.com/vmware/govmomi/vapi/vcenter"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	imgregv1a1 "github.com/vmware-tanzu/vm-operator/external/image-registry/api/v1alpha1"
 
@@ -27,7 +27,7 @@ const (
 )
 
 func CreateOVF(vmCtx context.VirtualMachineContext, client *rest.Client,
-	vmPubReq *vmopv1alpha1.VirtualMachinePublishRequest, cl *imgregv1a1.ContentLibrary, actID string) (string, error) {
+	vmPubReq *vmopv1.VirtualMachinePublishRequest, cl *imgregv1a1.ContentLibrary, actID string) (string, error) {
 	// Use VM Operator specific description so that we can link published items
 	// to the vmPub if anything unexpected happened.
 	descriptionPrefix := fmt.Sprintf(itemDescriptionFormat, string(vmPubReq.UID))

--- a/pkg/vmprovider/providers/vsphere/virtualmachine/publish_test.go
+++ b/pkg/vmprovider/providers/vsphere/virtualmachine/publish_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	imgregv1a1 "github.com/vmware-tanzu/vm-operator/external/image-registry/api/v1alpha1"
 
@@ -24,9 +24,9 @@ func publishTests() {
 	var (
 		ctx      *builder.TestContextForVCSim
 		vcVM     *object.VirtualMachine
-		vm       *vmopv1alpha1.VirtualMachine
+		vm       *vmopv1.VirtualMachine
 		cl       *imgregv1a1.ContentLibrary
-		vmPub    *vmopv1alpha1.VirtualMachinePublishRequest
+		vmPub    *vmopv1.VirtualMachinePublishRequest
 		vmCtx    context.VirtualMachineContext
 		vmPubCtx context.VirtualMachinePublishRequestContext
 	)

--- a/pkg/vmprovider/providers/vsphere/vmprovider.go
+++ b/pkg/vmprovider/providers/vsphere/vmprovider.go
@@ -26,9 +26,9 @@ import (
 	ctrlruntime "sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	imgregv1a1 "github.com/vmware-tanzu/vm-operator/external/image-registry/api/v1alpha1"
 
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 	"github.com/vmware-tanzu/vm-operator/pkg/record"
@@ -184,7 +184,7 @@ func (vs *vSphereVMProvider) clearAndLogoutVcClient(ctx goctx.Context) {
 // ListItemsFromContentLibrary list items from a content library.
 func (vs *vSphereVMProvider) ListItemsFromContentLibrary(
 	ctx goctx.Context,
-	contentLibrary *v1alpha1.ContentLibraryProvider) ([]string, error) {
+	contentLibrary *vmopv1.ContentLibraryProvider) ([]string, error) {
 
 	log.V(4).Info("Listing VirtualMachineImages from ContentLibrary",
 		"name", contentLibrary.Name,
@@ -201,9 +201,9 @@ func (vs *vSphereVMProvider) ListItemsFromContentLibrary(
 // GetVirtualMachineImageFromContentLibrary gets a VM image from a ContentLibrary.
 func (vs *vSphereVMProvider) GetVirtualMachineImageFromContentLibrary(
 	ctx goctx.Context,
-	contentLibrary *v1alpha1.ContentLibraryProvider,
+	contentLibrary *vmopv1.ContentLibraryProvider,
 	itemID string,
-	currentCLImages map[string]v1alpha1.VirtualMachineImage) (*v1alpha1.VirtualMachineImage, error) {
+	currentCLImages map[string]vmopv1.VirtualMachineImage) (*vmopv1.VirtualMachineImage, error) {
 
 	log.V(4).Info("Getting VirtualMachineImage from ContentLibrary",
 		"name", contentLibrary.Name,
@@ -317,7 +317,7 @@ func (vs *vSphereVMProvider) UpdateContentLibraryItem(ctx goctx.Context, itemID,
 	return client.ContentLibClient().UpdateLibraryItem(ctx, itemID, newName, newDescription)
 }
 
-func (vs *vSphereVMProvider) getOpID(vm *v1alpha1.VirtualMachine, operation string) string {
+func (vs *vSphereVMProvider) getOpID(vm *vmopv1.VirtualMachine, operation string) string {
 	const charset = "0123456789abcdef"
 
 	// TODO: Is this actually useful?
@@ -431,7 +431,7 @@ func (vs *vSphereVMProvider) computeCPUMinFrequency(ctx goctx.Context) (uint64, 
 }
 
 // ResVMToVirtualMachineImage isn't currently used.
-func ResVMToVirtualMachineImage(ctx goctx.Context, vm *object.VirtualMachine) (*v1alpha1.VirtualMachineImage, error) {
+func ResVMToVirtualMachineImage(ctx goctx.Context, vm *object.VirtualMachine) (*vmopv1.VirtualMachineImage, error) {
 	var o mo.VirtualMachine
 	err := vm.Properties(ctx, vm.Reference(), []string{"summary", "config.createDate", "config.vAppConfig"}, &o)
 	if err != nil {
@@ -461,17 +461,17 @@ func ResVMToVirtualMachineImage(ctx goctx.Context, vm *object.VirtualMachine) (*
 		}
 	}
 
-	return &v1alpha1.VirtualMachineImage{
+	return &vmopv1.VirtualMachineImage{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              o.Summary.Config.Name,
 			Annotations:       ovfProps,
 			CreationTimestamp: createTimestamp,
 		},
-		Spec: v1alpha1.VirtualMachineImageSpec{
+		Spec: vmopv1.VirtualMachineImageSpec{
 			Type:            "VM",
 			ImageSourceType: "Inventory",
 		},
-		Status: v1alpha1.VirtualMachineImageStatus{
+		Status: vmopv1.VirtualMachineImageStatus{
 			Uuid:       o.Summary.Config.Uuid,
 			InternalId: vm.Reference().Value,
 			PowerState: string(o.Summary.Runtime.PowerState),

--- a/pkg/vmprovider/providers/vsphere/vmprovider_resourcepolicy.go
+++ b/pkg/vmprovider/providers/vsphere/vmprovider_resourcepolicy.go
@@ -10,8 +10,7 @@ import (
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 	k8serrors "k8s.io/apimachinery/pkg/util/errors"
 
-	"github.com/vmware-tanzu/vm-operator/api/v1alpha1"
-
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/pkg/topology"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/clustermodules"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/vcenter"
@@ -21,7 +20,7 @@ import (
 func (vs *vSphereVMProvider) IsVirtualMachineSetResourcePolicyReady(
 	ctx context.Context,
 	azName string,
-	resourcePolicy *v1alpha1.VirtualMachineSetResourcePolicy) (bool, error) {
+	resourcePolicy *vmopv1.VirtualMachineSetResourcePolicy) (bool, error) {
 
 	client, err := vs.getVcClient(ctx)
 	if err != nil {
@@ -65,7 +64,7 @@ func (vs *vSphereVMProvider) IsVirtualMachineSetResourcePolicyReady(
 // CreateOrUpdateVirtualMachineSetResourcePolicy creates if a VirtualMachineSetResourcePolicy doesn't exist, updates otherwise.
 func (vs *vSphereVMProvider) CreateOrUpdateVirtualMachineSetResourcePolicy(
 	ctx context.Context,
-	resourcePolicy *v1alpha1.VirtualMachineSetResourcePolicy) error {
+	resourcePolicy *vmopv1.VirtualMachineSetResourcePolicy) error {
 
 	folderMoID, rpMoIDs, err := vs.getNamespaceFolderAndRPMoIDs(ctx, resourcePolicy.Namespace)
 	if err != nil {
@@ -106,7 +105,7 @@ func (vs *vSphereVMProvider) CreateOrUpdateVirtualMachineSetResourcePolicy(
 // DeleteVirtualMachineSetResourcePolicy deletes the VirtualMachineSetPolicy.
 func (vs *vSphereVMProvider) DeleteVirtualMachineSetResourcePolicy(
 	ctx context.Context,
-	resourcePolicy *v1alpha1.VirtualMachineSetResourcePolicy) error {
+	resourcePolicy *vmopv1.VirtualMachineSetResourcePolicy) error {
 
 	folderMoID, rpMoIDs, err := vs.getNamespaceFolderAndRPMoIDs(ctx, resourcePolicy.Namespace)
 	if err != nil {
@@ -143,7 +142,7 @@ func (vs *vSphereVMProvider) doClusterModulesExist(
 	ctx context.Context,
 	clusterModProvider clustermodules.Provider,
 	clusterRef vimtypes.ManagedObjectReference,
-	resourcePolicy *v1alpha1.VirtualMachineSetResourcePolicy) (bool, error) {
+	resourcePolicy *vmopv1.VirtualMachineSetResourcePolicy) (bool, error) {
 
 	for _, moduleSpec := range resourcePolicy.Spec.ClusterModules {
 		_, moduleID := clustermodules.FindClusterModuleUUID(moduleSpec.GroupName, clusterRef, resourcePolicy)
@@ -166,7 +165,7 @@ func (vs *vSphereVMProvider) createClusterModules(
 	ctx context.Context,
 	clusterModProvider clustermodules.Provider,
 	clusterRef vimtypes.ManagedObjectReference,
-	resourcePolicy *v1alpha1.VirtualMachineSetResourcePolicy) error {
+	resourcePolicy *vmopv1.VirtualMachineSetResourcePolicy) error {
 
 	var errs []error
 
@@ -212,7 +211,7 @@ func (vs *vSphereVMProvider) createClusterModules(
 			resourcePolicy.Status.ClusterModules[idx].ModuleUuid = moduleID
 			resourcePolicy.Status.ClusterModules[idx].ClusterMoID = clusterRef.Value
 		} else {
-			status := v1alpha1.ClusterModuleStatus{
+			status := vmopv1.ClusterModuleStatus{
 				GroupName:   moduleSpec.GroupName,
 				ModuleUuid:  moduleID,
 				ClusterMoID: clusterRef.Value,
@@ -228,9 +227,9 @@ func (vs *vSphereVMProvider) createClusterModules(
 func (vs *vSphereVMProvider) deleteClusterModules(
 	ctx context.Context,
 	clusterModProvider clustermodules.Provider,
-	resourcePolicy *v1alpha1.VirtualMachineSetResourcePolicy) []error {
+	resourcePolicy *vmopv1.VirtualMachineSetResourcePolicy) []error {
 
-	var errModStatus []v1alpha1.ClusterModuleStatus
+	var errModStatus []vmopv1.ClusterModuleStatus
 	var errs []error
 
 	for _, moduleStatus := range resourcePolicy.Status.ClusterModules {

--- a/pkg/vmprovider/providers/vsphere/vmprovider_resourcepolicy_test.go
+++ b/pkg/vmprovider/providers/vsphere/vmprovider_resourcepolicy_test.go
@@ -14,29 +14,29 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
-func getVirtualMachineSetResourcePolicy(name, namespace string) *vmopv1alpha1.VirtualMachineSetResourcePolicy {
-	return &vmopv1alpha1.VirtualMachineSetResourcePolicy{
+func getVirtualMachineSetResourcePolicy(name, namespace string) *vmopv1.VirtualMachineSetResourcePolicy {
+	return &vmopv1.VirtualMachineSetResourcePolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-resourcepolicy", name),
 			Namespace: namespace,
 		},
-		Spec: vmopv1alpha1.VirtualMachineSetResourcePolicySpec{
-			ResourcePool: vmopv1alpha1.ResourcePoolSpec{
+		Spec: vmopv1.VirtualMachineSetResourcePolicySpec{
+			ResourcePool: vmopv1.ResourcePoolSpec{
 				Name:         fmt.Sprintf("%s-resourcepool", name),
-				Reservations: vmopv1alpha1.VirtualMachineResourceSpec{},
-				Limits:       vmopv1alpha1.VirtualMachineResourceSpec{},
+				Reservations: vmopv1.VirtualMachineResourceSpec{},
+				Limits:       vmopv1.VirtualMachineResourceSpec{},
 			},
-			Folder: vmopv1alpha1.FolderSpec{
+			Folder: vmopv1.FolderSpec{
 				Name: fmt.Sprintf("%s-folder", name),
 			},
-			ClusterModules: []vmopv1alpha1.ClusterModuleSpec{
+			ClusterModules: []vmopv1.ClusterModuleSpec{
 				{
 					GroupName: "ControlPlane",
 				},
@@ -78,7 +78,7 @@ func resourcePolicyTests() {
 
 		Context("VirtualMachineSetResourcePolicy", func() {
 			var (
-				resourcePolicy *vmopv1alpha1.VirtualMachineSetResourcePolicy
+				resourcePolicy *vmopv1.VirtualMachineSetResourcePolicy
 			)
 
 			JustBeforeEach(func() {
@@ -130,7 +130,7 @@ func resourcePolicyTests() {
 
 			Context("for a resource policy with invalid cluster module", func() {
 				It("successfully able to delete the resource policy", func() {
-					resourcePolicy.Status.ClusterModules = append([]vmopv1alpha1.ClusterModuleStatus{
+					resourcePolicy.Status.ClusterModules = append([]vmopv1.ClusterModuleStatus{
 						{
 							GroupName:  "invalid-group",
 							ModuleUuid: "invalid-uuid",

--- a/pkg/vmprovider/providers/vsphere/vmprovider_vm_test.go
+++ b/pkg/vmprovider/providers/vsphere/vmprovider_vm_test.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
@@ -79,8 +79,8 @@ func vmTests() {
 
 	Context("Create/Update/Delete VirtualMachine", func() {
 		var (
-			vm      *vmopv1alpha1.VirtualMachine
-			vmClass *vmopv1alpha1.VirtualMachineClass
+			vm      *vmopv1.VirtualMachine
+			vmClass *vmopv1.VirtualMachineClass
 		)
 
 		BeforeEach(func() {
@@ -100,7 +100,7 @@ func vmTests() {
 			vmClassBinding := builder.DummyVirtualMachineClassBinding(vmClass.Name, nsInfo.Namespace)
 			Expect(ctx.Client.Create(ctx, vmClassBinding)).To(Succeed())
 
-			vmImage := &vmopv1alpha1.VirtualMachineImage{}
+			vmImage := &vmopv1.VirtualMachineImage{}
 			if testConfig.WithContentLibrary {
 				Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: ctx.ContentLibraryImageName}, vmImage)).To(Succeed())
 			} else {
@@ -126,7 +126,7 @@ func vmTests() {
 
 		createOrUpdateAndGetVcVM := func(
 			ctx *builder.TestContextForVCSim,
-			vm *vmopv1alpha1.VirtualMachine) (*object.VirtualMachine, error) {
+			vm *vmopv1.VirtualMachine) (*object.VirtualMachine, error) {
 
 			err := vmProvider.CreateOrUpdateVirtualMachine(ctx, vm)
 			if err != nil {
@@ -180,13 +180,13 @@ func vmTests() {
 					Expect(enc.Encode(configSpec)).To(Succeed())
 
 					// Update the VM Class with the XML.
-					vmClass := &vmopv1alpha1.VirtualMachineClass{}
+					vmClass := &vmopv1.VirtualMachineClass{}
 					Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: vm.Spec.ClassName}, vmClass)).To(Succeed())
 					vmClass.Spec.ConfigSpec = w.Bytes()
 					Expect(ctx.Client.Update(ctx, vmClass)).To(Succeed())
 				}
 
-				vm.Spec.NetworkInterfaces = []vmopv1alpha1.VirtualMachineNetworkInterface{
+				vm.Spec.NetworkInterfaces = []vmopv1.VirtualMachineNetworkInterface{
 					{
 						// Use the DVPG network so the updateEthCardDeviceChanges detects a device change.
 						// If we use the "VM Network", then it won't detect any device changes since we
@@ -211,9 +211,9 @@ func vmTests() {
 				})
 
 				It("still creates VM", func() {
-					Expect(vm.Status.Phase).To(Equal(vmopv1alpha1.Created))
+					Expect(vm.Status.Phase).To(Equal(vmopv1.Created))
 
-					vmClass := &vmopv1alpha1.VirtualMachineClass{}
+					vmClass := &vmopv1.VirtualMachineClass{}
 					Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: vm.Spec.ClassName}, vmClass)).To(Succeed())
 
 					var o mo.VirtualMachine
@@ -233,9 +233,9 @@ func vmTests() {
 				})
 
 				It("CPU and memory from ConfigSpec are ignored", func() {
-					Expect(vm.Status.Phase).To(Equal(vmopv1alpha1.Created))
+					Expect(vm.Status.Phase).To(Equal(vmopv1.Created))
 
-					vmClass := &vmopv1alpha1.VirtualMachineClass{}
+					vmClass := &vmopv1.VirtualMachineClass{}
 					Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: vm.Spec.ClassName}, vmClass)).To(Succeed())
 
 					var o mo.VirtualMachine
@@ -263,9 +263,9 @@ func vmTests() {
 				})
 
 				It("VM gets CPU reservation from ConfigSpec", func() {
-					Expect(vm.Status.Phase).To(Equal(vmopv1alpha1.Created))
+					Expect(vm.Status.Phase).To(Equal(vmopv1.Created))
 
-					vmClass := &vmopv1alpha1.VirtualMachineClass{}
+					vmClass := &vmopv1.VirtualMachineClass{}
 					Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: vm.Spec.ClassName}, vmClass)).To(Succeed())
 
 					var o mo.VirtualMachine
@@ -298,9 +298,9 @@ func vmTests() {
 				})
 
 				It("VM gets memory reservation from ConfigSpec", func() {
-					Expect(vm.Status.Phase).To(Equal(vmopv1alpha1.Created))
+					Expect(vm.Status.Phase).To(Equal(vmopv1.Created))
 
-					vmClass := &vmopv1alpha1.VirtualMachineClass{}
+					vmClass := &vmopv1.VirtualMachineClass{}
 					Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: vm.Spec.ClassName}, vmClass)).To(Succeed())
 
 					var o mo.VirtualMachine
@@ -390,9 +390,9 @@ func vmTests() {
 				})
 
 				It("still creates VM", func() {
-					Expect(vm.Status.Phase).To(Equal(vmopv1alpha1.Created))
+					Expect(vm.Status.Phase).To(Equal(vmopv1.Created))
 
-					vmClass := &vmopv1alpha1.VirtualMachineClass{}
+					vmClass := &vmopv1.VirtualMachineClass{}
 					Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: vm.Spec.ClassName}, vmClass)).To(Succeed())
 
 					var o mo.VirtualMachine
@@ -404,13 +404,13 @@ func vmTests() {
 
 			Context("VM Class Spec and ConfigSpec both contain GPU and DirectPath devices", func() {
 				BeforeEach(func() {
-					vmClass.Spec.Hardware.Devices = vmopv1alpha1.VirtualDevices{
-						VGPUDevices: []vmopv1alpha1.VGPUDevice{
+					vmClass.Spec.Hardware.Devices = vmopv1.VirtualDevices{
+						VGPUDevices: []vmopv1.VGPUDevice{
 							{
 								ProfileName: "profile-from-class",
 							},
 						},
-						DynamicDirectPathIODevices: []vmopv1alpha1.DynamicDirectPathIODevice{
+						DynamicDirectPathIODevices: []vmopv1.DynamicDirectPathIODevice{
 							{
 								VendorID:    50,
 								DeviceID:    51,
@@ -559,7 +559,7 @@ func vmTests() {
 					Expect(pciBacking2.AllowedDevice[0].DeviceId).To(Equal(int32(53)))
 					Expect(pciBacking2.CustomLabel).To(Equal("SampleLabel2"))
 
-					vmClass := &vmopv1alpha1.VirtualMachineClass{}
+					vmClass := &vmopv1.VirtualMachineClass{}
 					Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: vm.Spec.ClassName}, vmClass)).To(Succeed())
 
 					// cpu and memory check from vm class
@@ -706,7 +706,7 @@ func vmTests() {
 				Expect(vcVM.Properties(ctx, vcVM.Reference(), nil, &o)).To(Succeed())
 
 				By("has expected Status values", func() {
-					Expect(vm.Status.Phase).To(Equal(vmopv1alpha1.Created))
+					Expect(vm.Status.Phase).To(Equal(vmopv1.Created))
 					Expect(vm.Status.PowerState).To(Equal(vm.Spec.PowerState))
 					Expect(vm.Status.Host).ToNot(BeEmpty())
 					Expect(vm.Status.InstanceUUID).To(And(Not(BeEmpty()), Equal(o.Config.InstanceUuid)))
@@ -729,7 +729,7 @@ func vmTests() {
 					Expect(o.Summary.Runtime.PowerState).To(Equal(types.VirtualMachinePowerStatePoweredOn))
 				})
 
-				vmClass := &vmopv1alpha1.VirtualMachineClass{}
+				vmClass := &vmopv1.VirtualMachineClass{}
 				Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: vm.Spec.ClassName}, vmClass)).To(Succeed())
 				vmClassRes := vmClass.Spec.Policies.Resources
 
@@ -768,13 +768,13 @@ func vmTests() {
 
 			Context("VM Class with PCI passthrough devices", func() {
 				BeforeEach(func() {
-					vmClass.Spec.Hardware.Devices = vmopv1alpha1.VirtualDevices{
-						VGPUDevices: []vmopv1alpha1.VGPUDevice{
+					vmClass.Spec.Hardware.Devices = vmopv1.VirtualDevices{
+						VGPUDevices: []vmopv1.VGPUDevice{
 							{
 								ProfileName: "profile-from-class-without-class-as-config-fss",
 							},
 						},
-						DynamicDirectPathIODevices: []vmopv1alpha1.DynamicDirectPathIODevice{
+						DynamicDirectPathIODevices: []vmopv1.DynamicDirectPathIODevice{
 							{
 								VendorID:    59,
 								DeviceID:    60,
@@ -809,23 +809,23 @@ func vmTests() {
 			})
 
 			Context("Prereq args and Conditions", func() {
-				readyCondition := *conditions.TrueCondition(vmopv1alpha1.VirtualMachinePrereqReadyCondition)
+				readyCondition := *conditions.TrueCondition(vmopv1.VirtualMachinePrereqReadyCondition)
 
 				Context("VM is poweredOn", func() {
 					It("Returns success even if the prereq args are missing", func() {
 						_, err := createOrUpdateAndGetVcVM(ctx, vm)
 						Expect(err).ToNot(HaveOccurred())
 
-						c := conditions.Get(vm, vmopv1alpha1.VirtualMachinePrereqReadyCondition)
+						c := conditions.Get(vm, vmopv1.VirtualMachinePrereqReadyCondition)
 						Expect(c).ToNot(BeNil())
 						Expect(*c).To(conditions.MatchCondition(readyCondition))
 
-						Expect(ctx.Client.DeleteAllOf(ctx, &vmopv1alpha1.VirtualMachineClassBinding{})).To(Succeed())
+						Expect(ctx.Client.DeleteAllOf(ctx, &vmopv1.VirtualMachineClassBinding{})).To(Succeed())
 
 						_, err = createOrUpdateAndGetVcVM(ctx, vm)
 						Expect(err).NotTo(HaveOccurred())
 
-						c = conditions.Get(vm, vmopv1alpha1.VirtualMachinePrereqReadyCondition)
+						c = conditions.Get(vm, vmopv1.VirtualMachinePrereqReadyCondition)
 						Expect(c).ToNot(BeNil())
 						Expect(*c).To(conditions.MatchCondition(readyCondition))
 					})
@@ -836,33 +836,33 @@ func vmTests() {
 						_, err := createOrUpdateAndGetVcVM(ctx, vm)
 						Expect(err).ToNot(HaveOccurred())
 
-						vm.Spec.PowerState = vmopv1alpha1.VirtualMachinePoweredOff
+						vm.Spec.PowerState = vmopv1.VirtualMachinePoweredOff
 						_, err = createOrUpdateAndGetVcVM(ctx, vm)
 						Expect(err).ToNot(HaveOccurred())
 
-						Expect(ctx.Client.DeleteAllOf(ctx, &vmopv1alpha1.VirtualMachineImage{})).To(Succeed())
+						Expect(ctx.Client.DeleteAllOf(ctx, &vmopv1.VirtualMachineImage{})).To(Succeed())
 
-						vm.Spec.PowerState = vmopv1alpha1.VirtualMachinePoweredOn
+						vm.Spec.PowerState = vmopv1.VirtualMachinePoweredOn
 						_, err = createOrUpdateAndGetVcVM(ctx, vm)
 						Expect(err).NotTo(HaveOccurred())
 
-						c := conditions.Get(vm, vmopv1alpha1.VirtualMachinePrereqReadyCondition)
+						c := conditions.Get(vm, vmopv1.VirtualMachinePrereqReadyCondition)
 						Expect(c).ToNot(BeNil())
 						Expect(*c).To(conditions.MatchCondition(readyCondition))
 					})
 
 					It("Returns error if VM image is missing and this VM is first boot", func() {
-						vm.Spec.PowerState = vmopv1alpha1.VirtualMachinePoweredOff
+						vm.Spec.PowerState = vmopv1.VirtualMachinePoweredOff
 						_, err := createOrUpdateAndGetVcVM(ctx, vm)
 						Expect(err).ToNot(HaveOccurred())
 
-						Expect(ctx.Client.DeleteAllOf(ctx, &vmopv1alpha1.VirtualMachineImage{})).To(Succeed())
+						Expect(ctx.Client.DeleteAllOf(ctx, &vmopv1.VirtualMachineImage{})).To(Succeed())
 
-						vm.Spec.PowerState = vmopv1alpha1.VirtualMachinePoweredOn
+						vm.Spec.PowerState = vmopv1.VirtualMachinePoweredOn
 						_, err = createOrUpdateAndGetVcVM(ctx, vm)
 						Expect(err).To(HaveOccurred())
 
-						c := conditions.Get(vm, vmopv1alpha1.VirtualMachinePrereqReadyCondition)
+						c := conditions.Get(vm, vmopv1.VirtualMachinePrereqReadyCondition)
 						Expect(c).ToNot(BeNil())
 						Expect(c.Status).To(Equal(corev1.ConditionFalse))
 					})
@@ -871,22 +871,22 @@ func vmTests() {
 						_, err := createOrUpdateAndGetVcVM(ctx, vm)
 						Expect(err).ToNot(HaveOccurred())
 
-						vm.Spec.PowerState = vmopv1alpha1.VirtualMachinePoweredOff
+						vm.Spec.PowerState = vmopv1.VirtualMachinePoweredOff
 						_, err = createOrUpdateAndGetVcVM(ctx, vm)
 						Expect(err).ToNot(HaveOccurred())
 
-						c := conditions.Get(vm, vmopv1alpha1.VirtualMachinePrereqReadyCondition)
+						c := conditions.Get(vm, vmopv1.VirtualMachinePrereqReadyCondition)
 						Expect(c).ToNot(BeNil())
 						Expect(*c).To(conditions.MatchCondition(readyCondition))
 
 						// Use the class binding removal to toggle the condition state.
-						Expect(ctx.Client.DeleteAllOf(ctx, &vmopv1alpha1.VirtualMachineClassBinding{})).To(Succeed())
+						Expect(ctx.Client.DeleteAllOf(ctx, &vmopv1.VirtualMachineClassBinding{})).To(Succeed())
 
-						vm.Spec.PowerState = vmopv1alpha1.VirtualMachinePoweredOn
+						vm.Spec.PowerState = vmopv1.VirtualMachinePoweredOn
 						_, err = createOrUpdateAndGetVcVM(ctx, vm)
 						Expect(err).To(HaveOccurred())
 
-						c = conditions.Get(vm, vmopv1alpha1.VirtualMachinePrereqReadyCondition)
+						c = conditions.Get(vm, vmopv1.VirtualMachinePrereqReadyCondition)
 						Expect(c).ToNot(BeNil())
 						Expect(c.Status).To(Equal(corev1.ConditionFalse))
 
@@ -897,7 +897,7 @@ func vmTests() {
 						_, err = createOrUpdateAndGetVcVM(ctx, vm)
 						Expect(err).ToNot(HaveOccurred())
 
-						c = conditions.Get(vm, vmopv1alpha1.VirtualMachinePrereqReadyCondition)
+						c = conditions.Get(vm, vmopv1.VirtualMachinePrereqReadyCondition)
 						Expect(c).ToNot(BeNil())
 						Expect(*c).To(conditions.MatchCondition(readyCondition))
 					})
@@ -942,7 +942,7 @@ func vmTests() {
 					Expect(vcVM.Properties(ctx, vcVM.Reference(), nil, &o)).To(Succeed())
 
 					By("has expected Status values", func() {
-						Expect(vm.Status.Phase).To(Equal(vmopv1alpha1.Created))
+						Expect(vm.Status.Phase).To(Equal(vmopv1.Created))
 						Expect(vm.Status.PowerState).To(Equal(vm.Spec.PowerState))
 						Expect(vm.Status.Host).ToNot(BeEmpty())
 						Expect(vm.Status.InstanceUUID).To(And(Not(BeEmpty()), Equal(o.Config.InstanceUuid)))
@@ -966,7 +966,7 @@ func vmTests() {
 					})
 
 					By("has expected hardware config", func() {
-						vmClass := &vmopv1alpha1.VirtualMachineClass{}
+						vmClass := &vmopv1.VirtualMachineClass{}
 						Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: vm.Spec.ClassName}, vmClass)).To(Succeed())
 						Expect(o.Summary.Config.NumCpu).To(BeEquivalentTo(vmClass.Spec.Hardware.Cpus))
 						Expect(o.Summary.Config.MemorySizeMB).To(BeEquivalentTo(vmClass.Spec.Hardware.Memory.Value() / 1024 / 1024))
@@ -1032,8 +1032,8 @@ func vmTests() {
 				})
 
 				expectInstanceStorageVolumes := func(
-					vm *vmopv1alpha1.VirtualMachine,
-					isStorage vmopv1alpha1.InstanceStorage) {
+					vm *vmopv1.VirtualMachine,
+					isStorage vmopv1.InstanceStorage) {
 
 					ExpectWithOffset(1, isStorage.Volumes).ToNot(BeEmpty())
 					isVolumes := instancestorage.FilterVolumes(vm)
@@ -1063,11 +1063,11 @@ func vmTests() {
 				It("create VM with instance storage", func() {
 					Expect(vm.Spec.Volumes).To(BeEmpty())
 
-					vmClass := &vmopv1alpha1.VirtualMachineClass{}
+					vmClass := &vmopv1.VirtualMachineClass{}
 					Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: vm.Spec.ClassName}, vmClass)).To(Succeed())
-					vmClass.Spec.Hardware.InstanceStorage = vmopv1alpha1.InstanceStorage{
+					vmClass.Spec.Hardware.InstanceStorage = vmopv1.InstanceStorage{
 						StorageClass: vm.Spec.StorageClass,
-						Volumes: []vmopv1alpha1.InstanceStorageVolume{
+						Volumes: []vmopv1.InstanceStorageVolume{
 							{
 								Size: resource.MustParse("256Gi"),
 							},
@@ -1102,7 +1102,7 @@ func vmTests() {
 
 						// Simulate what would be set by the volume controller.
 						for _, vol := range vm.Spec.Volumes {
-							vm.Status.Volumes = append(vm.Status.Volumes, vmopv1alpha1.VirtualMachineVolumeStatus{
+							vm.Status.Volumes = append(vm.Status.Volumes, vmopv1.VirtualMachineVolumeStatus{
 								Name:     vol.Name,
 								Attached: true,
 							})
@@ -1120,11 +1120,11 @@ func vmTests() {
 				vcVM, err := createOrUpdateAndGetVcVM(ctx, vm)
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(vm.Status.PowerState).To(Equal(vmopv1alpha1.VirtualMachinePoweredOn))
-				vm.Spec.PowerState = vmopv1alpha1.VirtualMachinePoweredOff
+				Expect(vm.Status.PowerState).To(Equal(vmopv1.VirtualMachinePoweredOn))
+				vm.Spec.PowerState = vmopv1.VirtualMachinePoweredOff
 				Expect(vmProvider.CreateOrUpdateVirtualMachine(ctx, vm)).To(Succeed())
 
-				Expect(vm.Status.PowerState).To(Equal(vmopv1alpha1.VirtualMachinePoweredOff))
+				Expect(vm.Status.PowerState).To(Equal(vmopv1.VirtualMachinePoweredOff))
 				state, err := vcVM.PowerState(ctx)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(state).To(Equal(types.VirtualMachinePowerStatePoweredOff))
@@ -1170,9 +1170,9 @@ func vmTests() {
 						}
 						Expect(ctx.Client.Create(ctx, configMap)).To(Succeed())
 
-						vm.Spec.VmMetadata = &vmopv1alpha1.VirtualMachineMetadata{
+						vm.Spec.VmMetadata = &vmopv1.VirtualMachineMetadata{
 							ConfigMapName: configMap.Name,
-							Transport:     vmopv1alpha1.VirtualMachineMetadataExtraConfigTransport,
+							Transport:     vmopv1.VirtualMachineMetadataExtraConfigTransport,
 						}
 						vcVM, err := createOrUpdateAndGetVcVM(ctx, vm)
 						Expect(err).ToNot(HaveOccurred())
@@ -1241,7 +1241,7 @@ func vmTests() {
 
 				Context("Multiple NICs are specified", func() {
 					BeforeEach(func() {
-						vm.Spec.NetworkInterfaces = []vmopv1alpha1.VirtualMachineNetworkInterface{
+						vm.Spec.NetworkInterfaces = []vmopv1.VirtualMachineNetworkInterface{
 							{
 								NetworkName:      "VM Network",
 								EthernetCardType: "e1000",
@@ -1281,8 +1281,8 @@ func vmTests() {
 
 				Context("VM has thin provisioning", func() {
 					BeforeEach(func() {
-						vm.Spec.AdvancedOptions = &vmopv1alpha1.VirtualMachineAdvancedOptions{
-							DefaultVolumeProvisioningOptions: &vmopv1alpha1.VirtualMachineVolumeProvisioningOptions{
+						vm.Spec.AdvancedOptions = &vmopv1.VirtualMachineAdvancedOptions{
+							DefaultVolumeProvisioningOptions: &vmopv1.VirtualMachineVolumeProvisioningOptions{
 								ThinProvisioned: pointer.Bool(true),
 							},
 						}
@@ -1302,8 +1302,8 @@ func vmTests() {
 
 				XContext("VM has thick provisioning", func() {
 					BeforeEach(func() {
-						vm.Spec.AdvancedOptions = &vmopv1alpha1.VirtualMachineAdvancedOptions{
-							DefaultVolumeProvisioningOptions: &vmopv1alpha1.VirtualMachineVolumeProvisioningOptions{
+						vm.Spec.AdvancedOptions = &vmopv1.VirtualMachineAdvancedOptions{
+							DefaultVolumeProvisioningOptions: &vmopv1.VirtualMachineVolumeProvisioningOptions{
 								ThinProvisioned: pointer.Bool(false),
 							},
 						}
@@ -1324,8 +1324,8 @@ func vmTests() {
 
 				XContext("VM has eager zero provisioning", func() {
 					BeforeEach(func() {
-						vm.Spec.AdvancedOptions = &vmopv1alpha1.VirtualMachineAdvancedOptions{
-							DefaultVolumeProvisioningOptions: &vmopv1alpha1.VirtualMachineVolumeProvisioningOptions{
+						vm.Spec.AdvancedOptions = &vmopv1.VirtualMachineAdvancedOptions{
+							DefaultVolumeProvisioningOptions: &vmopv1.VirtualMachineVolumeProvisioningOptions{
 								EagerZeroed: pointer.Bool(true),
 							},
 						}
@@ -1348,7 +1348,7 @@ func vmTests() {
 					newSize := resource.MustParse("4242Gi")
 
 					It("Succeeds", func() {
-						vm.Spec.PowerState = vmopv1alpha1.VirtualMachinePoweredOff
+						vm.Spec.PowerState = vmopv1.VirtualMachinePoweredOff
 						vcVM, err := createOrUpdateAndGetVcVM(ctx, vm)
 						Expect(err).ToNot(HaveOccurred())
 
@@ -1359,10 +1359,10 @@ func vmTests() {
 						// This is almost always 203 but sometimes it isn't for some reason, so fetch it.
 						deviceKey := int(disk.Key)
 
-						vm.Spec.Volumes = []vmopv1alpha1.VirtualMachineVolume{
+						vm.Spec.Volumes = []vmopv1.VirtualMachineVolume{
 							{
 								Name: "this-api-stinks",
-								VsphereVolume: &vmopv1alpha1.VsphereVolumeSource{
+								VsphereVolume: &vmopv1.VsphereVolumeSource{
 									Capacity: corev1.ResourceList{
 										corev1.ResourceEphemeralStorage: newSize,
 									},
@@ -1371,7 +1371,7 @@ func vmTests() {
 							},
 						}
 
-						vm.Spec.PowerState = vmopv1alpha1.VirtualMachinePoweredOn
+						vm.Spec.PowerState = vmopv1.VirtualMachinePoweredOn
 						Expect(vmProvider.CreateOrUpdateVirtualMachine(ctx, vm)).To(Succeed())
 
 						Expect(vcVM.Properties(ctx, vcVM.Reference(), nil, &o)).To(Succeed())
@@ -1385,16 +1385,16 @@ func vmTests() {
 				cnsVolumeName := "cns-volume-1"
 
 				It("CSI Volumes workflow", func() {
-					vm.Spec.PowerState = vmopv1alpha1.VirtualMachinePoweredOff
+					vm.Spec.PowerState = vmopv1.VirtualMachinePoweredOff
 					_, err := createOrUpdateAndGetVcVM(ctx, vm)
 					Expect(err).ToNot(HaveOccurred())
 
-					vm.Spec.PowerState = vmopv1alpha1.VirtualMachinePoweredOn
+					vm.Spec.PowerState = vmopv1.VirtualMachinePoweredOn
 					By("Add CNS volume to VM", func() {
-						vm.Spec.Volumes = []vmopv1alpha1.VirtualMachineVolume{
+						vm.Spec.Volumes = []vmopv1.VirtualMachineVolume{
 							{
 								Name: cnsVolumeName,
-								PersistentVolumeClaim: &vmopv1alpha1.PersistentVolumeClaimVolumeSource{
+								PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
 									PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
 										ClaimName: "pvc-volume-1",
 									},
@@ -1405,13 +1405,13 @@ func vmTests() {
 						err := vmProvider.CreateOrUpdateVirtualMachine(ctx, vm)
 						Expect(err).To(HaveOccurred())
 						Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("status update pending for persistent volume: %s on VM", cnsVolumeName)))
-						Expect(vm.Status.PowerState).To(Equal(vmopv1alpha1.VirtualMachinePoweredOff))
+						Expect(vm.Status.PowerState).To(Equal(vmopv1.VirtualMachinePoweredOff))
 					})
 
 					By("CNS volume is not attached", func() {
 						errMsg := "blah blah blah not attached"
 
-						vm.Status.Volumes = []vmopv1alpha1.VirtualMachineVolumeStatus{
+						vm.Status.Volumes = []vmopv1.VirtualMachineVolumeStatus{
 							{
 								Name:     cnsVolumeName,
 								Attached: false,
@@ -1422,18 +1422,18 @@ func vmTests() {
 						err := vmProvider.CreateOrUpdateVirtualMachine(ctx, vm)
 						Expect(err).To(HaveOccurred())
 						Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("persistent volume: %s not attached to VM", cnsVolumeName)))
-						Expect(vm.Status.PowerState).To(Equal(vmopv1alpha1.VirtualMachinePoweredOff))
+						Expect(vm.Status.PowerState).To(Equal(vmopv1.VirtualMachinePoweredOff))
 					})
 
 					By("CNS volume is attached", func() {
-						vm.Status.Volumes = []vmopv1alpha1.VirtualMachineVolumeStatus{
+						vm.Status.Volumes = []vmopv1.VirtualMachineVolumeStatus{
 							{
 								Name:     cnsVolumeName,
 								Attached: true,
 							},
 						}
 						Expect(vmProvider.CreateOrUpdateVirtualMachine(ctx, vm)).To(Succeed())
-						Expect(vm.Status.PowerState).To(Equal(vmopv1alpha1.VirtualMachinePoweredOn))
+						Expect(vm.Status.PowerState).To(Equal(vmopv1.VirtualMachinePoweredOn))
 					})
 				})
 			})
@@ -1463,7 +1463,7 @@ func vmTests() {
 		})
 
 		Context("VM SetResourcePolicy", func() {
-			var resourcePolicy *vmopv1alpha1.VirtualMachineSetResourcePolicy
+			var resourcePolicy *vmopv1.VirtualMachineSetResourcePolicy
 
 			JustBeforeEach(func() {
 				resourcePolicyName := "test-policy"
@@ -1520,11 +1520,11 @@ func vmTests() {
 
 			Context("when the VM is off", func() {
 				BeforeEach(func() {
-					vm.Spec.PowerState = vmopv1alpha1.VirtualMachinePoweredOff
+					vm.Spec.PowerState = vmopv1.VirtualMachinePoweredOff
 				})
 
 				It("deletes the VM", func() {
-					Expect(vm.Status.PowerState).To(Equal(vmopv1alpha1.VirtualMachinePoweredOff))
+					Expect(vm.Status.PowerState).To(Equal(vmopv1.VirtualMachinePoweredOff))
 
 					uniqueID := vm.Status.UniqueID
 					Expect(ctx.GetVMFromMoID(uniqueID)).ToNot(BeNil())
@@ -1535,7 +1535,7 @@ func vmTests() {
 			})
 
 			It("when the VM is on", func() {
-				Expect(vm.Status.PowerState).To(Equal(vmopv1alpha1.VirtualMachinePoweredOn))
+				Expect(vm.Status.PowerState).To(Equal(vmopv1.VirtualMachinePoweredOn))
 
 				uniqueID := vm.Status.UniqueID
 				Expect(ctx.GetVMFromMoID(uniqueID)).ToNot(BeNil())

--- a/pkg/vmprovider/providers/vsphere/vmprovider_vm_utils_test.go
+++ b/pkg/vmprovider/providers/vsphere/vmprovider_vm_utils_test.go
@@ -16,7 +16,7 @@ import (
 
 	imgregv1a1 "github.com/vmware-tanzu/vm-operator/external/image-registry/api/v1alpha1"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/lib"
@@ -57,8 +57,8 @@ func vmUtilTests() {
 	Context("GetVirtualMachineClass", func() {
 
 		var (
-			vmClass        *vmopv1alpha1.VirtualMachineClass
-			vmClassBinding *vmopv1alpha1.VirtualMachineClassBinding
+			vmClass        *vmopv1.VirtualMachineClass
+			vmClassBinding *vmopv1.VirtualMachineClassBinding
 		)
 
 		BeforeEach(func() {
@@ -74,25 +74,25 @@ func vmUtilTests() {
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring(expectedErrMsg))
 
-				expectedCondition := vmopv1alpha1.Conditions{
+				expectedCondition := vmopv1.Conditions{
 					*conditions.FalseCondition(
-						vmopv1alpha1.VirtualMachinePrereqReadyCondition,
-						vmopv1alpha1.VirtualMachineClassNotFoundReason,
-						vmopv1alpha1.ConditionSeverityError,
+						vmopv1.VirtualMachinePrereqReadyCondition,
+						vmopv1.VirtualMachineClassNotFoundReason,
+						vmopv1.ConditionSeverityError,
 						expectedErrMsg),
 				}
 				Expect(vmCtx.VM.Status.Conditions).To(conditions.MatchConditions(expectedCondition))
 			})
 		})
 
-		validateNoVMClassBindingCondition := func(vm *vmopv1alpha1.VirtualMachine) {
+		validateNoVMClassBindingCondition := func(vm *vmopv1.VirtualMachine) {
 			msg := fmt.Sprintf("Namespace %s does not have access to VirtualMachineClass %s", vm.Namespace, vm.Spec.ClassName)
 
-			expectedCondition := vmopv1alpha1.Conditions{
+			expectedCondition := vmopv1.Conditions{
 				*conditions.FalseCondition(
-					vmopv1alpha1.VirtualMachinePrereqReadyCondition,
-					vmopv1alpha1.VirtualMachineClassBindingNotFoundReason,
-					vmopv1alpha1.ConditionSeverityError,
+					vmopv1.VirtualMachinePrereqReadyCondition,
+					vmopv1.VirtualMachineClassBindingNotFoundReason,
+					vmopv1.ConditionSeverityError,
 					msg),
 			}
 			Expect(vmCtx.VM.Status.Conditions).To(conditions.MatchConditions(expectedCondition))
@@ -150,15 +150,15 @@ func vmUtilTests() {
 		When("WCPVMImageRegistry FSS is disabled", func() {
 
 			var (
-				contentSource        *vmopv1alpha1.ContentSource
-				clProvider           *vmopv1alpha1.ContentLibraryProvider
-				contentSourceBinding *vmopv1alpha1.ContentSourceBinding
-				vmImage              *vmopv1alpha1.VirtualMachineImage
+				contentSource        *vmopv1.ContentSource
+				clProvider           *vmopv1.ContentLibraryProvider
+				contentSourceBinding *vmopv1.ContentSourceBinding
+				vmImage              *vmopv1.VirtualMachineImage
 			)
 
 			BeforeEach(func() {
 				contentSource, clProvider, contentSourceBinding = builder.DummyContentSourceProviderAndBinding("dummy-cl-uuid", vmCtx.VM.Namespace)
-				vmImage = &vmopv1alpha1.VirtualMachineImage{
+				vmImage = &vmopv1.VirtualMachineImage{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "dummy-image",
 						OwnerReferences: []metav1.OwnerReference{{
@@ -183,11 +183,11 @@ func vmUtilTests() {
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring(expectedErrMsg))
 
-					expectedCondition := vmopv1alpha1.Conditions{
+					expectedCondition := vmopv1.Conditions{
 						*conditions.FalseCondition(
-							vmopv1alpha1.VirtualMachinePrereqReadyCondition,
-							vmopv1alpha1.VirtualMachineImageNotFoundReason,
-							vmopv1alpha1.ConditionSeverityError,
+							vmopv1.VirtualMachinePrereqReadyCondition,
+							vmopv1.VirtualMachineImageNotFoundReason,
+							vmopv1.ConditionSeverityError,
 							expectedErrMsg),
 					}
 					Expect(vmCtx.VM.Status.Conditions).To(conditions.MatchConditions(expectedCondition))
@@ -206,26 +206,26 @@ func vmUtilTests() {
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring(expectedErrMsg))
 
-					expectedCondition := vmopv1alpha1.Conditions{
+					expectedCondition := vmopv1.Conditions{
 						*conditions.FalseCondition(
-							vmopv1alpha1.VirtualMachinePrereqReadyCondition,
-							vmopv1alpha1.ContentLibraryProviderNotFoundReason,
-							vmopv1alpha1.ConditionSeverityError,
+							vmopv1.VirtualMachinePrereqReadyCondition,
+							vmopv1.ContentLibraryProviderNotFoundReason,
+							vmopv1.ConditionSeverityError,
 							expectedErrMsg),
 					}
 					Expect(vmCtx.VM.Status.Conditions).To(conditions.MatchConditions(expectedCondition))
 				})
 			})
 
-			validateNoContentSourceBindingCondition := func(vm *vmopv1alpha1.VirtualMachine, clUUID string) {
+			validateNoContentSourceBindingCondition := func(vm *vmopv1.VirtualMachine, clUUID string) {
 				msg := fmt.Sprintf("Namespace %s does not have access to ContentSource %s for VirtualMachineImage %s",
 					vm.Namespace, clUUID, vm.Spec.ImageName)
 
-				expectedCondition := vmopv1alpha1.Conditions{
+				expectedCondition := vmopv1.Conditions{
 					*conditions.FalseCondition(
-						vmopv1alpha1.VirtualMachinePrereqReadyCondition,
-						vmopv1alpha1.ContentSourceBindingNotFoundReason,
-						vmopv1alpha1.ConditionSeverityError,
+						vmopv1.VirtualMachinePrereqReadyCondition,
+						vmopv1.ContentSourceBindingNotFoundReason,
+						vmopv1.ConditionSeverityError,
 						msg),
 				}
 
@@ -288,9 +288,9 @@ func vmUtilTests() {
 
 			var (
 				cl             *imgregv1a1.ContentLibrary
-				nsVMImage      *vmopv1alpha1.VirtualMachineImage
+				nsVMImage      *vmopv1.VirtualMachineImage
 				clusterCL      *imgregv1a1.ClusterContentLibrary
-				clusterVMImage *vmopv1alpha1.ClusterVirtualMachineImage
+				clusterVMImage *vmopv1.ClusterVirtualMachineImage
 			)
 
 			BeforeEach(func() {
@@ -322,11 +322,11 @@ func vmUtilTests() {
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring(expectedErrMsg))
 
-					expectedCondition := vmopv1alpha1.Conditions{
+					expectedCondition := vmopv1.Conditions{
 						*conditions.FalseCondition(
-							vmopv1alpha1.VirtualMachinePrereqReadyCondition,
-							vmopv1alpha1.VirtualMachineImageNotFoundReason,
-							vmopv1alpha1.ConditionSeverityError,
+							vmopv1.VirtualMachinePrereqReadyCondition,
+							vmopv1.VirtualMachineImageNotFoundReason,
+							vmopv1.ConditionSeverityError,
 							expectedErrMsg),
 					}
 					Expect(vmCtx.VM.Status.Conditions).To(conditions.MatchConditions(expectedCondition))
@@ -336,8 +336,8 @@ func vmUtilTests() {
 			When("VM image exists but the provider is not ready", func() {
 
 				BeforeEach(func() {
-					conditions.MarkTrue(nsVMImage, vmopv1alpha1.VirtualMachineImageProviderReadyCondition)
-					conditions.MarkFalse(nsVMImage, vmopv1alpha1.VirtualMachineImageProviderReadyCondition, "", "", "")
+					conditions.MarkTrue(nsVMImage, vmopv1.VirtualMachineImageProviderReadyCondition)
+					conditions.MarkFalse(nsVMImage, vmopv1.VirtualMachineImageProviderReadyCondition, "", "", "")
 					initObjects = append(initObjects, cl, nsVMImage)
 					vmCtx.VM.Spec.ImageName = nsVMImage.Name
 				})
@@ -348,11 +348,11 @@ func vmUtilTests() {
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring(expectedErrMsg))
 
-					expectedCondition := vmopv1alpha1.Conditions{
+					expectedCondition := vmopv1.Conditions{
 						*conditions.FalseCondition(
-							vmopv1alpha1.VirtualMachinePrereqReadyCondition,
-							vmopv1alpha1.VirtualMachineImageNotReadyReason,
-							vmopv1alpha1.ConditionSeverityError,
+							vmopv1.VirtualMachinePrereqReadyCondition,
+							vmopv1.VirtualMachineImageNotReadyReason,
+							vmopv1.ConditionSeverityError,
 							expectedErrMsg),
 					}
 					Expect(vmCtx.VM.Status.Conditions).To(conditions.MatchConditions(expectedCondition))
@@ -364,8 +364,8 @@ func vmUtilTests() {
 				BeforeEach(func() {
 					// Switch to cluster scoped VM image as we used namespace scoped VM image in the previous test.
 					// So that we don't have to write additional test cases to cover both namespace and cluster images.
-					conditions.MarkTrue(clusterVMImage, vmopv1alpha1.VirtualMachineImageProviderReadyCondition)
-					conditions.MarkFalse(clusterVMImage, vmopv1alpha1.VirtualMachineImageSyncedCondition, "", "", "")
+					conditions.MarkTrue(clusterVMImage, vmopv1.VirtualMachineImageProviderReadyCondition)
+					conditions.MarkFalse(clusterVMImage, vmopv1.VirtualMachineImageSyncedCondition, "", "", "")
 					initObjects = append(initObjects, clusterCL, clusterVMImage)
 					vmCtx.VM.Spec.ImageName = clusterVMImage.Name
 				})
@@ -376,11 +376,11 @@ func vmUtilTests() {
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring(expectedErrMsg))
 
-					expectedCondition := vmopv1alpha1.Conditions{
+					expectedCondition := vmopv1.Conditions{
 						*conditions.FalseCondition(
-							vmopv1alpha1.VirtualMachinePrereqReadyCondition,
-							vmopv1alpha1.VirtualMachineImageNotReadyReason,
-							vmopv1alpha1.ConditionSeverityError,
+							vmopv1.VirtualMachinePrereqReadyCondition,
+							vmopv1.VirtualMachineImageNotReadyReason,
+							vmopv1.ConditionSeverityError,
 							expectedErrMsg),
 					}
 					Expect(vmCtx.VM.Status.Conditions).To(conditions.MatchConditions(expectedCondition))
@@ -389,8 +389,8 @@ func vmUtilTests() {
 
 			When("Namespace scoped VirtualMachineImage exists and ready", func() {
 				BeforeEach(func() {
-					conditions.MarkTrue(nsVMImage, vmopv1alpha1.VirtualMachineImageProviderReadyCondition)
-					conditions.MarkTrue(nsVMImage, vmopv1alpha1.VirtualMachineImageSyncedCondition)
+					conditions.MarkTrue(nsVMImage, vmopv1.VirtualMachineImageProviderReadyCondition)
+					conditions.MarkTrue(nsVMImage, vmopv1.VirtualMachineImageSyncedCondition)
 					initObjects = append(initObjects, cl, nsVMImage)
 					vmCtx.VM.Spec.ImageName = nsVMImage.Name
 				})
@@ -405,8 +405,8 @@ func vmUtilTests() {
 
 			When("ClusterVirtualMachineImage exists and ready", func() {
 				BeforeEach(func() {
-					conditions.MarkTrue(clusterVMImage, vmopv1alpha1.VirtualMachineImageProviderReadyCondition)
-					conditions.MarkTrue(clusterVMImage, vmopv1alpha1.VirtualMachineImageSyncedCondition)
+					conditions.MarkTrue(clusterVMImage, vmopv1.VirtualMachineImageProviderReadyCondition)
+					conditions.MarkTrue(clusterVMImage, vmopv1.VirtualMachineImageSyncedCondition)
 					initObjects = append(initObjects, clusterCL, clusterVMImage)
 					vmCtx.VM.Spec.ImageName = clusterVMImage.Name
 				})
@@ -452,7 +452,7 @@ func vmUtilTests() {
 
 		When("both ConfigMap and Secret are specified", func() {
 			BeforeEach(func() {
-				vmCtx.VM.Spec.VmMetadata = &vmopv1alpha1.VirtualMachineMetadata{
+				vmCtx.VM.Spec.VmMetadata = &vmopv1.VirtualMachineMetadata{
 					ConfigMapName: vmMetaDataConfigMap.Name,
 					SecretName:    vmMetaDataSecret.Name,
 					Transport:     "transport",
@@ -468,7 +468,7 @@ func vmUtilTests() {
 
 		When("VM Metadata is specified via a ConfigMap", func() {
 			BeforeEach(func() {
-				vmCtx.VM.Spec.VmMetadata = &vmopv1alpha1.VirtualMachineMetadata{
+				vmCtx.VM.Spec.VmMetadata = &vmopv1.VirtualMachineMetadata{
 					ConfigMapName: vmMetaDataConfigMap.Name,
 					Transport:     "transport",
 				}
@@ -495,7 +495,7 @@ func vmUtilTests() {
 
 		When("VM Metadata is specified via a Secret", func() {
 			BeforeEach(func() {
-				vmCtx.VM.Spec.VmMetadata = &vmopv1alpha1.VirtualMachineMetadata{
+				vmCtx.VM.Spec.VmMetadata = &vmopv1.VirtualMachineMetadata{
 					SecretName: vmMetaDataSecret.Name,
 					Transport:  "transport",
 				}
@@ -524,18 +524,18 @@ func vmUtilTests() {
 	Context("GetVMSetResourcePolicy", func() {
 
 		var (
-			vmResourcePolicy *vmopv1alpha1.VirtualMachineSetResourcePolicy
+			vmResourcePolicy *vmopv1.VirtualMachineSetResourcePolicy
 		)
 
 		BeforeEach(func() {
-			vmResourcePolicy = &vmopv1alpha1.VirtualMachineSetResourcePolicy{
+			vmResourcePolicy = &vmopv1.VirtualMachineSetResourcePolicy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "dummy-vm-rp",
 					Namespace: vmCtx.VM.Namespace,
 				},
-				Spec: vmopv1alpha1.VirtualMachineSetResourcePolicySpec{
-					ResourcePool: vmopv1alpha1.ResourcePoolSpec{Name: "fooRP"},
-					Folder:       vmopv1alpha1.FolderSpec{Name: "fooFolder"},
+				Spec: vmopv1.VirtualMachineSetResourcePolicySpec{
+					ResourcePool: vmopv1.ResourcePoolSpec{Name: "fooRP"},
+					Folder:       vmopv1.FolderSpec{Name: "fooFolder"},
 				},
 			}
 		})
@@ -571,13 +571,13 @@ func vmUtilTests() {
 	Context("AddInstanceStorageVolumes", func() {
 
 		var (
-			vmClass            *vmopv1alpha1.VirtualMachineClass
+			vmClass            *vmopv1.VirtualMachineClass
 			instanceStorageFSS uint32
 		)
 
 		expectInstanceStorageVolumes := func(
-			vm *vmopv1alpha1.VirtualMachine,
-			isStorage vmopv1alpha1.InstanceStorage) {
+			vm *vmopv1.VirtualMachine,
+			isStorage vmopv1.InstanceStorage) {
 
 			ExpectWithOffset(1, isStorage.Volumes).ToNot(BeEmpty())
 			isVolumes := instancestorage.FilterVolumes(vm)

--- a/pkg/webconsolevalidation/server.go
+++ b/pkg/webconsolevalidation/server.go
@@ -12,7 +12,7 @@ import (
 	ctrlruntime "sigs.k8s.io/controller-runtime/pkg/client"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/controllers/webconsolerequest"
 )
 
@@ -27,7 +27,7 @@ func InitServer() error {
 	}
 
 	scheme := runtime.NewScheme()
-	if err = vmopv1alpha1.AddToScheme(scheme); err != nil {
+	if err = vmopv1.AddToScheme(scheme); err != nil {
 		return err
 	}
 
@@ -86,7 +86,7 @@ func isResourceFound(goCtx context.Context, uuid, namespace string) (bool, error
 	}
 
 	// TODO: Use an Informer to avoid hitting the API server for every request.
-	wcrObjectList := &vmopv1alpha1.WebConsoleRequestList{}
+	wcrObjectList := &vmopv1.WebConsoleRequestList{}
 	if err := K8sClient.List(goCtx, wcrObjectList, ctrlruntime.InNamespace(namespace), labelSelector); err != nil {
 		return false, err
 	}

--- a/pkg/webconsolevalidation/server_test.go
+++ b/pkg/webconsolevalidation/server_test.go
@@ -12,7 +12,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/controllers/webconsolerequest"
 	"github.com/vmware-tanzu/vm-operator/pkg/webconsolevalidation"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
@@ -55,7 +55,7 @@ func serverUnitTests() {
 		Context("requests with a uuid param set", func() {
 
 			BeforeEach(func() {
-				wcr := &vmopv1alpha1.WebConsoleRequest{}
+				wcr := &vmopv1.WebConsoleRequest{}
 				wcr.Namespace = "dummy-namespace"
 				wcr.Labels = map[string]string{
 					webconsolerequest.UUIDLabelKey: "dummy-uuid-1234",

--- a/test/builder/vcsim_test_context.go
+++ b/test/builder/vcsim_test_context.go
@@ -45,7 +45,7 @@ import (
 	_ "github.com/vmware/govmomi/vapi/cluster/simulator"
 	_ "github.com/vmware/govmomi/vapi/simulator"
 
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	topologyv1 "github.com/vmware-tanzu/vm-operator/external/tanzu-topology/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 	"github.com/vmware-tanzu/vm-operator/pkg/record"
@@ -273,13 +273,13 @@ func (c *TestContextForVCSim) CreateWorkloadNamespace() WorkloadNamespaceInfo {
 	}
 
 	if clID := c.ContentLibraryID; clID != "" {
-		csBinding := &vmopv1alpha1.ContentSourceBinding{
+		csBinding := &vmopv1.ContentSourceBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      clID,
 				Namespace: ns.Name,
 			},
-			ContentSourceRef: vmopv1alpha1.ContentSourceReference{
-				APIVersion: vmopv1alpha1.SchemeGroupVersion.Group,
+			ContentSourceRef: vmopv1.ContentSourceReference{
+				APIVersion: vmopv1.SchemeGroupVersion.Group,
 				Kind:       "ContentSource",
 				Name:       clID,
 			},
@@ -465,22 +465,22 @@ func (c *TestContextForVCSim) setupContentLibrary(config VCSimTestConfig) {
 	Expect(clID).ToNot(BeEmpty())
 	c.ContentLibraryID = clID
 
-	clProvider := &vmopv1alpha1.ContentLibraryProvider{
+	clProvider := &vmopv1.ContentLibraryProvider{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: clID,
 		},
-		Spec: vmopv1alpha1.ContentLibraryProviderSpec{
+		Spec: vmopv1.ContentLibraryProviderSpec{
 			UUID: clID,
 		},
 	}
 	Expect(c.Client.Create(c, clProvider)).To(Succeed())
 
-	cs := &vmopv1alpha1.ContentSource{
+	cs := &vmopv1.ContentSource{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: clID,
 		},
-		Spec: vmopv1alpha1.ContentSourceSpec{
-			ProviderRef: vmopv1alpha1.ContentProviderReference{
+		Spec: vmopv1.ContentSourceSpec{
+			ProviderRef: vmopv1.ContentProviderReference{
 				Name: clProvider.Name,
 				Kind: "ContentLibraryProvider",
 			},
@@ -534,7 +534,7 @@ func (c *TestContextForVCSim) ContentLibraryItemTemplate(srcVMName, templateName
 
 	// Create the expected VirtualMachineImage for the template.
 	vmImage := DummyVirtualMachineImage(templateName)
-	cl := &vmopv1alpha1.ContentLibraryProvider{}
+	cl := &vmopv1.ContentLibraryProvider{}
 	Expect(c.Client.Get(c, client.ObjectKey{Name: clID}, cl)).To(Succeed())
 	Expect(controllerutil.SetOwnerReference(cl, vmImage, c.Client.Scheme())).To(Succeed())
 	Expect(c.Client.Create(c, vmImage)).To(Succeed())
@@ -720,7 +720,7 @@ func (c *TestContextForVCSim) GetAZClusterComputes(azName string) []*object.Clus
 
 func (c *TestContextForVCSim) CreateVirtualMachineSetResourcePolicy(
 	name string,
-	nsInfo WorkloadNamespaceInfo) (*vmopv1alpha1.VirtualMachineSetResourcePolicy, *object.Folder) {
+	nsInfo WorkloadNamespaceInfo) (*vmopv1.VirtualMachineSetResourcePolicy, *object.Folder) {
 
 	resourcePolicy := DummyVirtualMachineSetResourcePolicy2(name, nsInfo.Namespace)
 	Expect(c.Client.Create(c, resourcePolicy)).To(Succeed())


### PR DESCRIPTION
In preparation for v1a2 API work use a common import alias - vmopv1 - for the VM Operator API definitions. This is a large, annoying change but will help reduce the diff and work in keeping v1a2 dev work in sync, and will avoid having to do another mass rename for v1a3 and later versions. In addition, during and after the v1a2 work, we'll try to reduce the proliferation of our API types throughout the code base.

Add linter rule to enforce a common alias but still allow unaliased import.