### PR TITLE
Add finalizer for vmi and cvmi resources

### DIFF
--- a/api/v1alpha1/condition_consts.go
+++ b/api/v1alpha1/condition_consts.go
@@ -104,6 +104,9 @@ const (
 
 	// VirtualMachineImageProviderReadyCondition denotes readiness of the VirtualMachineImage provider.
 	VirtualMachineImageProviderReadyCondition ConditionType = "VirtualMachineImageProviderReady"
+
+	// VirtualMachineImageProviderSecurityComplianceCondition denotes security compliance of the library item provider.
+	VirtualMachineImageProviderSecurityComplianceCondition ConditionType = "VirtualMachineImageProviderSecurityCompliance"
 )
 
 // Condition.Reason for Conditions related to VirtualMachineImages.
@@ -124,4 +127,8 @@ const (
 	// VirtualMachineImageProviderNotReadyReason (Severity=Error) documents that the VirtualMachineImage provider
 	// is not in ready state.
 	VirtualMachineImageProviderNotReadyReason = "VirtualMachineImageProviderNotReady"
+
+	// VirtualMachineImageProviderSecurityNotCompliantReason (Severity=Error) documents that the
+	// VirtualMachineImage provider doesn't meet security compliance requirements.
+	VirtualMachineImageProviderSecurityNotCompliantReason = "VirtualMachineImageProviderSecurityNotCompliant"
 )

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -119,8 +119,11 @@ rules:
   resources:
   - clustercontentlibraryitems
   verbs:
+  - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - imageregistry.vmware.com
@@ -147,8 +150,11 @@ rules:
   resources:
   - contentlibraryitems
   verbs:
+  - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - imageregistry.vmware.com

--- a/controllers/contentlibrary/utils/constants.go
+++ b/controllers/contentlibrary/utils/constants.go
@@ -10,4 +10,7 @@ const (
 	ClusterContentLibraryItemKind = "ClusterContentLibraryItem"
 	ContentLibraryKind            = "ContentLibrary"
 	ContentLibraryItemKind        = "ContentLibraryItem"
+
+	ContentLibraryItemVmopFinalizer        = "contentlibraryitem.vmoperator.vmware.com"
+	ClusterContentLibraryItemVmopFinalizer = "clustercontentlibraryitem.vmoperator.vmware.com"
 )

--- a/controllers/contentlibrary/utils/test_utils.go
+++ b/controllers/contentlibrary/utils/test_utils.go
@@ -143,6 +143,10 @@ func GetExpectedCVMIFrom(cclItem imgregv1a1.ClusterContentLibraryItem,
 					Status: corev1.ConditionTrue,
 				},
 				{
+					Type:   vmopv1.VirtualMachineImageProviderSecurityComplianceCondition,
+					Status: corev1.ConditionTrue,
+				},
+				{
 					Type:   vmopv1.VirtualMachineImageSyncedCondition,
 					Status: corev1.ConditionTrue,
 				},
@@ -194,6 +198,10 @@ func GetExpectedVMIFrom(clItem imgregv1a1.ContentLibraryItem,
 			Conditions: []vmopv1.Condition{
 				{
 					Type:   vmopv1.VirtualMachineImageProviderReadyCondition,
+					Status: corev1.ConditionTrue,
+				},
+				{
+					Type:   vmopv1.VirtualMachineImageProviderSecurityComplianceCondition,
 					Status: corev1.ConditionTrue,
 				},
 				{

--- a/controllers/contentlibrary/utils/utils.go
+++ b/controllers/contentlibrary/utils/utils.go
@@ -24,15 +24,16 @@ func GetImageFieldNameFromItem(itemName string) (string, error) {
 		return "", fmt.Errorf("item name doesn't start with %q", ItemFieldNamePrefix)
 	}
 	itemNameSplit := strings.Split(itemName, "-")
-	if len(itemNameSplit) != 2 || itemNameSplit[1] == "" {
+	if len(itemNameSplit) < 2 {
 		return "", fmt.Errorf("item name doesn't have an identifier after %s-", ItemFieldNamePrefix)
 	}
 
-	return fmt.Sprintf("%s-%s", ImageFieldNamePrefix, itemNameSplit[1]), nil
+	uuid := strings.Join(itemNameSplit[1:], "-")
+	return fmt.Sprintf("%s-%s", ImageFieldNamePrefix, uuid), nil
 }
 
-// CheckItemReadyCondition checks if the given item conditions contain a Ready condition.
-func CheckItemReadyCondition(itemConditions imgregv1a1.Conditions) bool {
+// IsItemReady returns if the given item conditions contain a Ready condition with status True.
+func IsItemReady(itemConditions imgregv1a1.Conditions) bool {
 	var isReady bool
 	for _, condition := range itemConditions {
 		if condition.Type == imgregv1a1.ReadyCondition {

--- a/pkg/context/clustercontentlibraryitem_context.go
+++ b/pkg/context/clustercontentlibraryitem_context.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package context
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	imgregv1a1 "github.com/vmware-tanzu/vm-operator/external/image-registry/api/v1alpha1"
+)
+
+// ClusterContentLibraryItemContext is the context used for ClusterContentLibraryItem controller.
+type ClusterContentLibraryItemContext struct {
+	context.Context
+	Logger       logr.Logger
+	CCLItem      *imgregv1a1.ClusterContentLibraryItem
+	CVMI         *vmopv1.ClusterVirtualMachineImage
+	ImageObjName string
+}
+
+func (c *ClusterContentLibraryItemContext) String() string {
+	return fmt.Sprintf("%s %s", c.CCLItem.GroupVersionKind(), c.CCLItem.Name)
+}

--- a/pkg/context/contentlibraryitem_context.go
+++ b/pkg/context/contentlibraryitem_context.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package context
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	imgregv1a1 "github.com/vmware-tanzu/vm-operator/external/image-registry/api/v1alpha1"
+)
+
+// ContentLibraryItemContext is the context used for ContentLibraryItem controller.
+type ContentLibraryItemContext struct {
+	context.Context
+	Logger       logr.Logger
+	CLItem       *imgregv1a1.ContentLibraryItem
+	VMI          *vmopv1.VirtualMachineImage
+	ImageObjName string
+}
+
+func (c *ContentLibraryItemContext) String() string {
+	return fmt.Sprintf("%s %s/%s", c.CLItem.GroupVersionKind(), c.CLItem.Namespace, c.CLItem.Name)
+}


### PR DESCRIPTION
This patch updates the cl-item & ccl-item controllers by adding/removing a finalizer during their reconciliation process. This ensures that when these resources are deleted from a K8s cluster, the corresponding image metrics are also deleted by calling our ReconcileDelete function. Two `contentlibraryitem_context` and `clustercontentlibraryitem_context` files are added to streamline the reconciling function params in both controllers.

Additionally, the security compliance check of item resources is also updated to avoid deleting the image resources. Instead, a new condition is introduced and added to images, which is verified during the VM deployment process (in the `vmprovider_vm_utils.go` file).

Testing: 
- [x] Add and pass unit tests
- [x] Add and pass integration tests 
- [x] Internal end-to-end tests
- [x] Manually applied this patch to an internal testbed and verified the expected workflow:
```console
# CCL-Item & CVMI
$ kubectl get cclitem clitem-d71052e4b82561b37 -o jsonpath={.metadata.finalizers}
["clustercontentlibraryitem.vmoperator.vmware.com","clustercontentlibraryitem.imageregistry.vmware.com"]
$ curl -s localhost:8083/metrics | grep vmi-d71052e4b82561b37
vmservice_vmi_content_sync{vmi_name="vmi-d71052e4b82561b37",vmi_namespace=""} 1
vmservice_vmi_resource_resolve{vmi_name="vmi-d71052e4b82561b37",vmi_namespace=""} 1
$ kubectl delete cclitem clitem-d71052e4b82561b37
clustercontentlibraryitem.imageregistry.vmware.com "clitem-d71052e4b82561b37" deleted
$ curl -s localhost:8083/metrics | grep vmi-d71052e4b82561b37
$

# CL-Item & VMI
$ kubectl get clitem -n sdiliyaer-test-2 clitem-018c0d3a6ebdd07ca -o jsonpath={.metadata.finalizers}
["contentlibraryitem.imageregistry.vmware.com","contentlibraryitem.vmoperator.vmware.com"]
$ kubectl get vmi -n sdiliyaer-test-2 vmi-018c0d3a6ebdd07ca -o json | jq .status.conditions
[
  {
    "lastTransitionTime": "2023-03-29T03:16:19Z",
    "status": "True",
    "type": "VirtualMachineImageProviderReady"
  },
  {
    "lastTransitionTime": "2023-03-29T15:56:04Z",
    "status": "True",
    "type": "VirtualMachineImageProviderSecurityCompliance"
  },
  {
    "lastTransitionTime": "2023-03-29T04:05:15Z",
    "status": "True",
    "type": "VirtualMachineImageSynced"
  },
  {
    "lastTransitionTime": "2023-03-29T04:05:15Z",
    "status": "True",
    "type": "VirtualMachineImageV1Alpha1Compatible"
  }
]