### PR TITLE
Update testing-needed workflow to prevent label race

### DIFF
--- a/.github/configs/labeler.yml
+++ b/.github/configs/labeler.yml
@@ -16,5 +16,3 @@ labels:
     size-below: 1000
   - label: "size/XXL"
     size-above: 999
-  - label: "testing-needed-e2e-fast"
-    size-above: 99

--- a/.github/workflows/testing-needed.yml
+++ b/.github/workflows/testing-needed.yml
@@ -1,15 +1,71 @@
 name: testing-needed
 
 on:
-  pull_request:
+  pull_request_target:
     types:
-    - synchronize
-    - opened
-    - reopened
-    - labeled
-    - unlabeled
+      - synchronize
+      - opened
+      - reopened
+      - labeled
+      - unlabeled
 
 jobs:
+  verify-change:
+    runs-on: ubuntu-latest
+    outputs:
+      label_names: ${{ steps.update-label.outputs.label_names }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          # The pull_request_target event runs in the context of the BASE of the pull request.
+          # We need to checkout the HEAD of the pull request to be able to check the diff.
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - name: Check diff
+        id: check-diff
+        run: |
+          loc=$(git diff --shortstat HEAD ${{ github.sha }} | awk '{print $4+$6}')
+          echo "Lines of change: $loc"
+          echo "lines_of_change=$loc" >> $GITHUB_OUTPUT
+      - name: Update label
+        id: update-label
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # TODO: Add testing-needed-e2e-full label once the pipeline supports running e2e-full tests.
+          script: |
+            if (${{ steps.check-diff.outputs.lines_of_change > 99 }}) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: ['testing-needed-e2e-fast']
+              })
+            } else {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  name: 'testing-needed-e2e-fast'
+                })
+              } catch (e) {
+                if (e.status !== 404) {
+                  throw e
+                }
+              }
+            }
+
+            const labels = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            })
+            const label_names = labels.data.map(label => label.name)
+            core.info('Current label names: ' + label_names)
+            core.setOutput('label_names', label_names)
+
   check-label:
     strategy:
       matrix:
@@ -17,17 +73,20 @@ jobs:
         # type "e2e-fast", the labels would be testing-needed-e2e-fast and
         # testing-done-e2e-fast
         test-type:
-        - e2e-fast
-        - e2e-full
+          - e2e-fast
+          - e2e-full
     runs-on: ubuntu-latest
+    needs: verify-change
     steps:
-    - name: do-not-merge
-      # the step will run if one of the labels is present and the corresponding
-      # label indicating testing is done is not present, ex. the label
-      # testing-needed-e2e-fast is present without also testing-done-e2e-fast
-      if: |
-        contains(github.event.*.labels.*.name, format('testing-needed-{0}', matrix.test-type)) &&
-        !contains(github.event.*.labels.*.name, format('testing-done-{0}', matrix.test-type))
-      run: |
-        echo "Pull request is labeled as 'testing-needed-${{ matrix.test-type }}'"
-        exit 1
+      - name: do-not-merge
+        env:
+          LABEL_NAMES: ${{ needs.verify-change.outputs.label_names }}
+        # the step will run if one of the labels is present and the corresponding
+        # label indicating testing is done is not present, ex. the label
+        # testing-needed-e2e-fast is present without also testing-done-e2e-fast
+        if: |
+          contains(env.LABEL_NAMES, format('testing-needed-{0}', matrix.test-type)) &&
+          !contains(env.LABEL_NAMES, format('testing-done-{0}', matrix.test-type))
+        run: |
+          echo "Pull request is labeled as 'testing-needed-${{ matrix.test-type }}'"
+          exit 1


### PR DESCRIPTION
This patch updates the testing-needed workflow to address a race condition (see #73) by applying and checking related labels in a single workflow, without using an additional GitHub token as previously proposed in PR #75.

Testing Done:
- Pushed this change into a fork's main: https://github.com/dilyar85/vm-operator/
- Created a PR from another fork (https://github.com/test-vmop/vm-operator) to the above repo: https://github.com/dilyar85/vm-operator/pull/23
    - [x] expected workflow to add a "testing-needed-e2e-fast" label and fail the check
- Manually remove the "testing-needed-e2e-fast" label from the PR
    - [x] expected workflow to re-add a "testing-needed-e2e-fast" label and fail the check
- Added a "testing-done-e2e-fast" label to the PR
    - [x] expected the workflow to rerun and succeed
- Updated the PR with a smaller LoC
    - [x] expected the workflow to remove the "testing-needed-e2e-fast" label and succeed

Screenshot:
<img width="400" alt="image" src="https://user-images.githubusercontent.com/10840560/227887049-e338143b-cd87-448c-97ee-d88d09f550ab.png">
