### PR TITLE
Sync v1a1 VirtualMachineImage changes to v1a2

### DIFF
--- a/api/v1alpha1/conversion_test.go
+++ b/api/v1alpha1/conversion_test.go
@@ -180,7 +180,6 @@ func overrideVirtualMachineImageFieldsFuncs(codecs runtimeserializer.CodecFactor
 			overrideConditionsSeverity(imageStatus.Conditions)
 
 			// Do not exist in v1a2.
-			imageStatus.ContentVersion = ""
 			imageStatus.ContentLibraryRef = nil
 			imageStatus.ImageSupported = nil
 

--- a/api/v1alpha1/virtualmachineimage_conversion.go
+++ b/api/v1alpha1/virtualmachineimage_conversion.go
@@ -104,9 +104,9 @@ func Convert_v1alpha1_VirtualMachineImageStatus_To_v1alpha2_VirtualMachineImageS
 	in *VirtualMachineImageStatus, out *v1alpha2.VirtualMachineImageStatus, s apiconversion.Scope) error {
 
 	out.Name = in.ImageName
+	out.ProviderContentVersion = in.ContentVersion
 	// in.ImageSupported
 	// in.ContentLibraryRef
-	// in.ContentVersion
 
 	// Deprecated:
 	// in.Uuid
@@ -120,8 +120,8 @@ func Convert_v1alpha2_VirtualMachineImageStatus_To_v1alpha1_VirtualMachineImageS
 	in *v1alpha2.VirtualMachineImageStatus, out *VirtualMachineImageStatus, s apiconversion.Scope) error {
 
 	out.ImageName = in.Name
+	out.ContentVersion = in.ProviderContentVersion
 	// out.ContentLibraryRef =
-	// out.ContentVersion =
 
 	// in.Capabilities
 

--- a/api/v1alpha1/zz_generated.conversion.go
+++ b/api/v1alpha1/zz_generated.conversion.go
@@ -1381,6 +1381,7 @@ func autoConvert_v1alpha2_VirtualMachineImageStatus_To_v1alpha1_VirtualMachineIm
 	// WARNING: in.OSInfo requires manual conversion: does not exist in peer-type
 	// WARNING: in.OVFProperties requires manual conversion: does not exist in peer-type
 	// WARNING: in.ProductInfo requires manual conversion: does not exist in peer-type
+	// WARNING: in.ProviderContentVersion requires manual conversion: does not exist in peer-type
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make([]Condition, len(*in))

--- a/api/v1alpha2/virtualmachineimage_types.go
+++ b/api/v1alpha2/virtualmachineimage_types.go
@@ -31,6 +31,34 @@ const (
 	VirtualMachineImageCapabilityLabel = "capability.image." + GroupName + "/"
 )
 
+// Condition types for VirtualMachineImages.
+const (
+	// VirtualMachineImageSyncedCondition documents that the image is synced with the vSphere content library item
+	// that contains the source of this image's information.
+	VirtualMachineImageSyncedCondition = "VirtualMachineImageSynced"
+
+	// VirtualMachineImageProviderReadyCondition denotes readiness of the VirtualMachineImage provider.
+	VirtualMachineImageProviderReadyCondition = "VirtualMachineImageProviderReady"
+
+	// VirtualMachineImageProviderSecurityComplianceCondition denotes security compliance of the library item provider.
+	VirtualMachineImageProviderSecurityComplianceCondition = "VirtualMachineImageProviderSecurityCompliance"
+)
+
+// Condition reasons for VirtualMachineImages.
+const (
+	// VirtualMachineImageNotSyncedReason documents that the VirtualMachineImage is not synced with
+	// the vSphere content library item that contains the source of this image's information.
+	VirtualMachineImageNotSyncedReason = "VirtualMachineImageNotSynced"
+
+	// VirtualMachineImageProviderNotReadyReason documents that the VirtualMachineImage provider
+	// is not in ready state.
+	VirtualMachineImageProviderNotReadyReason = "VirtualMachineImageProviderNotReady"
+
+	// VirtualMachineImageProviderSecurityNotCompliantReason documents that the
+	// VirtualMachineImage provider doesn't meet security compliance requirements.
+	VirtualMachineImageProviderSecurityNotCompliantReason = "VirtualMachineImageProviderSecurityNotCompliant"
+)
+
 // VirtualMachineImageProductInfo describes product information for an image.
 type VirtualMachineImageProductInfo struct {
 	// Product is a general descriptor for the image.
@@ -158,6 +186,12 @@ type VirtualMachineImageStatus struct {
 	// ProductInfo describes the observed product information for this image.
 	// +optional
 	ProductInfo VirtualMachineImageProductInfo `json:"productInfo,omitempty"`
+
+	// ProviderContentVersion describes the content version from the provider item
+	// that this image corresponds to. If the provider of this image is a Content
+	// Library, this will be the version of the corresponding Content Library item.
+	// +optional
+	ProviderContentVersion string `json:"providerContentVersion,omitempty"`
 
 	// Conditions describes the observed conditions for this image.
 	//


### PR DESCRIPTION
Add ProviderContentVersion to the image Status that's used to track last synced Content Library item version. This is used to avoid repeated CL item fetch tasks.

Add Condition type and reasons