### PR TITLE
Update template to support Sysprep guest customization

### DIFF
--- a/api/v1alpha1/virtualmachine_types.go
+++ b/api/v1alpha1/virtualmachine_types.go
@@ -113,8 +113,8 @@ type VirtualMachineNetworkInterface struct {
 }
 
 // VirtualMachineMetadataTransport is used to indicate the transport used by VirtualMachineMetadata
-// Valid values are "ExtraConfig", "OvfEnv", "vAppConfig" and "CloudInit".
-// +kubebuilder:validation:Enum=ExtraConfig;OvfEnv;vAppConfig;CloudInit
+// Valid values are "ExtraConfig", "OvfEnv", "vAppConfig", "CloudInit", and "Sysprep".
+// +kubebuilder:validation:Enum=ExtraConfig;OvfEnv;vAppConfig;CloudInit;Sysprep
 type VirtualMachineMetadataTransport string
 
 const (

--- a/api/v1alpha1/virtualmachinetempl_types.go
+++ b/api/v1alpha1/virtualmachinetempl_types.go
@@ -10,6 +10,10 @@ type NetworkDeviceStatus struct {
 	// +optional
 	Gateway4 string
 
+	// MacAddress is the MAC address of the network device.
+	// +optional
+	MacAddress string
+
 	// IpAddresses represents one or more IP addresses assigned to the network
 	// device in CIDR notation, ex. "192.0.2.1/16".
 	// +optional

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -288,6 +288,7 @@ spec:
                     - OvfEnv
                     - vAppConfig
                     - CloudInit
+                    - Sysprep
                     type: string
                 type: object
               volumes:

--- a/docs/concepts/workloads/vm.md
+++ b/docs/concepts/workloads/vm.md
@@ -25,7 +25,7 @@ The following is an example of a `VirtualMachine` resource that bootstraps a Pho
 To create the VM shown above, run the following command (replacing `<NAMESPACE>` with the name of the [`Namespace`](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) in which to create the VM):
 
 ```shell
-kubectl apply -n <NAMESPACE> -f {{ config.repo_url_raw }}/main/docs/concepts/workloads/vm-example.yaml
+kubectl apply -n <NAMESPACE> -f ${{ config.repo_url_raw }}/main/docs/concepts/workloads/vm-example.yaml
 ```
 
 ## Working with VMs

--- a/docs/ref/proj/docs.md
+++ b/docs/ref/proj/docs.md
@@ -8,7 +8,7 @@ This page outlines how to write documentation for VM Operator.
 
 ## Project Docs
 
-The project documentation lives in the [./docs]({{ config.repo_url}}/tree/main/docs) directory and is written in Markdown. This section reviews the project documentation structure and examples for writing high-quality documentation.
+The project documentation lives in the [./docs](${{ config.repo_url }}/tree/main/docs) directory and is written in Markdown. This section reviews the project documentation structure and examples for writing high-quality documentation.
 
 ### Structure
 
@@ -39,7 +39,7 @@ docs
 
 * Every section should have a `README.md` that summarizes the contents of the section. It does not matter if the section has a single topic in it, if there's a section, then it must have a `README.md`. Besides good organization, there is another reason this is important that will be reviewed later.
 
-* The documentation will not appear unless added to the `nav` section in the project's [`mkdocs.yml`]({{ config.repo_url}}/tree/main/mkdocs.yml) file, ex.:
+* The documentation will not appear unless added to the `nav` section in the project's [`mkdocs.yml`](${{ config.repo_url }}/tree/main/mkdocs.yml) file, ex.:
 
     ```yaml title="mkdocs.yml"
     nav:

--- a/docs/start/quick.md
+++ b/docs/start/quick.md
@@ -28,7 +28,7 @@ Once you are logged into the Supervisor with, a new VM may be realized using the
 Create the new VM with the following command:
 
 ```shell
-kubectl apply -n my-namespace -f {{ config.repo_url_raw }}/main/docs/concepts/workloads/vm-example.yaml
+kubectl apply -n my-namespace -f ${{ config.repo_url_raw }}/main/docs/concepts/workloads/vm-example.yaml
 ```
 
 And that's it! Use `kubectl` to watch the VM until it is powered on with an IP address, at which point you have successfully deployed a workload on Kubernetes with VM Operator.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,7 +56,10 @@ extra_css:
 plugins:
 - search:
     separator: '[\s\u200b\-,:!=\[\]()"`/]+|\.(?!\d)|&[lg]t;|(?!\b)(?=[A-Z][a-z])'
-- markdownextradata
+- markdownextradata:
+    jinja_options:
+      variable_start_string: "${{"
+      variable_end_string: "}}"
 # - git-committers:
 #     enabled: !ENV [CI, false]
 #     repository: vmware-tanzu/vm-operator

--- a/pkg/vmprovider/providers/vsphere/constants/constants.go
+++ b/pkg/vmprovider/providers/vsphere/constants/constants.go
@@ -102,6 +102,8 @@ const (
 
 	// V1alpha1FirstIP is an alias for versioned templating function V1alpha1_FirstIP.
 	V1alpha1FirstIP = "V1alpha1_FirstIP"
+	// V1alpha1FirstNicMacAddr is an alias for versioned templating function V1alpha1_FirstNicMacAddr.
+	V1alpha1FirstNicMacAddr = "V1alpha1_FirstNicMacAddr"
 	// V1alpha1FirstIPFromNIC is an alias for versioned templating function V1alpha1_FirstIPFromNIC.
 	V1alpha1FirstIPFromNIC = "V1alpha1_FirstIPFromNIC"
 	// V1alpha1IPsFromNIC is an alias for versioned templating function V1alpha1_IPsFromNIC.

--- a/pkg/vmprovider/providers/vsphere/network/network_provider.go
+++ b/pkg/vmprovider/providers/vsphere/network/network_provider.go
@@ -108,7 +108,7 @@ type NetplanEthernetNameserver struct {
 }
 
 func (l InterfaceInfoList) GetNetplan(
-	currentEthCards object.VirtualDeviceList,
+	firstNicMacAddr string,
 	dnsServers, searchSuffixes []string) Netplan {
 
 	ethernets := make(map[string]NetplanEthernet)
@@ -116,15 +116,14 @@ func (l InterfaceInfoList) GetNetplan(
 	for index, info := range l {
 		netplanEthernet := info.NetplanEthernet
 
-		if netplanEthernet.Match.MacAddress == "" && len(currentEthCards) == 1 {
-			curNic := currentEthCards[0].(vimtypes.BaseVirtualEthernetCard).GetVirtualEthernetCard()
+		if netplanEthernet.Match.MacAddress == "" {
 			// This assumes we don't have multiple NICs in the same backing network. This is kind of, sort
 			// of enforced by the webhook, but we lack a guaranteed way to match up the NICs.
 
 			// NetOp (VDS) never assigns MacAddress to the NetworkInterface status, therefore
 			// netplanEthernet.Match.MacAddress will be empty.
 			// At this point, it is assumed that VirtualMachine.Config.Hardware.Device has MacAddress generated.
-			netplanEthernet.Match.MacAddress = NormalizeNetplanMac(curNic.GetVirtualEthernetCard().MacAddress)
+			netplanEthernet.Match.MacAddress = NormalizeNetplanMac(firstNicMacAddr)
 		}
 
 		// Inject nameserver settings for each ethernet.

--- a/pkg/vmprovider/providers/vsphere/session/session_suite_test.go
+++ b/pkg/vmprovider/providers/vsphere/session/session_suite_test.go
@@ -1,42 +1,20 @@
-// Copyright (c) 2019-2021 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2019-2023 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package session_test
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/vmware/govmomi/simulator"
 
-	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/test"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
-var (
-	model             *simulator.Model
-	server            *simulator.Server
-	ctx               context.Context
-	tlsTestModel      *simulator.Model
-	tlsServer         *simulator.Server
-	tlsServerCertPath string
-	tlsServerKeyPath  string
-)
-
-var _ = BeforeSuite(func() {
-	ctx, model, server,
-		tlsServerKeyPath, tlsServerCertPath,
-		tlsTestModel, tlsServer = test.BeforeSuite()
-})
-
-var _ = AfterSuite(func() {
-	test.AfterSuite(
-		ctx,
-		model, server,
-		tlsServerKeyPath, tlsServerCertPath,
-		tlsTestModel, tlsServer)
-})
+var suite = builder.NewTestSuite()
+var _ = BeforeSuite(suite.BeforeSuite)
+var _ = AfterSuite(suite.AfterSuite)
 
 func TestSession(t *testing.T) {
 	RegisterFailHandler(Fail)


### PR DESCRIPTION
This PR adds a new `V1alpha1_FirstNicMacAddr` template query required for Sysprep network customization.
It also updates the Guest Customization doc with more examples provided for Sysprep and vAppCofnig (closes #107). A new `jinja_options` is added to indicate variables, allowing the presentation of the template strings in markdown.

Testing:
- [x] Update test code to address the template change
- [x] Successfully deployed and customized the following VMs in both VDS and NSXT testbeds
    - Windows 11
    - Windows Server 2022
    - Ubuntu & CentOS (with CloudInit) 

Sysprep unattend data used for Windows VM:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<unattend xmlns="urn:schemas-microsoft-com:unattend">
  <settings pass="specialize">
    <component name="Microsoft-Windows-TCPIP" processorArchitecture="amd64"
      publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS"
      xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
      <Interfaces>
        <Interface wcm:action="add">
          <Ipv4Settings>
            <DhcpEnabled>false</DhcpEnabled>
          </Ipv4Settings>
          <Ipv6Settings>
            <DhcpEnabled>false</DhcpEnabled>
          </Ipv6Settings>
          <Identifier>{{ V1alpha1_FirstNicMacAddr }}</Identifier>
          <UnicastIpAddresses>
            <IpAddress wcm:action="add" wcm:keyValue="1">{{ V1alpha1_FirstIP }}</IpAddress>
          </UnicastIpAddresses>
          <Routes>
            <Route wcm:action="add">
              <Identifier>0</Identifier>
              <Metric>10</Metric>
              <NextHopAddress>{{ (index .V1alpha1.Net.Devices 0).Gateway4 }}</NextHopAddress>
              <Prefix>{{ V1alpha1_SubnetMask V1alpha1_FirstIP }}</Prefix>
            </Route>
          </Routes>
        </Interface>
      </Interfaces>
    </component>
    <component name="Microsoft-Windows-DNS-Client" processorArchitecture="amd64"
      publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS"
      xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
      <Interfaces>
        <Interface wcm:action="add">
          <Identifier>{{ V1alpha1_FirstNicMacAddr }}</Identifier>
          <DNSServerSearchOrder> {{ range .V1alpha1.Net.Nameservers }} <IpAddress
              wcm:action="add"
              wcm:keyValue="{{.}}"></IpAddress> {{ end }} </DNSServerSearchOrder>
        </Interface>
      </Interfaces>
    </component>
    </component>
  </settings>
</unattend>
``` 

```console
# VDS
$ kubectl get vm -n sdiliyaer-test -o wide
NAME                              POWER-STATE   CLASS               IMAGE                   PRIMARY-IP       AGE
packer-vsphere-supervisor-dfgnb   poweredOn     best-effort-small   vmi-f6340ce6306d86dfb   192.168.128.39   107m
windows-server                    poweredOn     best-effort-large   vmi-633171aab9df9e4f0   192.168.128.40   18m
windows11                         poweredOn     best-effort-large   vmi-1c0d32d81b349c189   192.168.128.36   166m

# NSXT
$ kubectl get vm -n sdiliyaer-test -o wide
NAME                              POWER-STATE   CLASS               IMAGE                   PRIMARY-IP    AGE
packer-vsphere-supervisor-pd89t   poweredOn     best-effort-small   vmi-bed57d9981cdad1c8   172.26.0.52   79m
windows-server                    poweredOn     best-effort-large   vmi-1eb8074794c204b67   172.26.0.51   165m
windows11                         poweredOn     best-effort-large   vmi-40d7dff94ead93f4c   172.26.0.50   46h
```

<!-- readthedocs-preview vm-operator start -->
----
:books: Documentation preview :books:: https://vm-operator--136.org.readthedocs.build/en/136/

<!-- readthedocs-preview vm-operator end -->