### PR TITLE
Fix up computeCPUMinFrequency for the createVM path and add some CPU/Mem Reservation tests

### DIFF
--- a/pkg/vmprovider/providers/vsphere/vmprovider_vm.go
+++ b/pkg/vmprovider/providers/vsphere/vmprovider_vm.go
@@ -564,13 +564,14 @@ func (vs *vSphereVMProvider) vmCreateGetPrereqs(
 		createArgs.ResourcePolicy = resourcePolicy
 		createArgs.ChildFolderName = resourcePolicy.Spec.Folder.Name
 		createArgs.ChildResourcePoolName = rp.Name
-		if !rp.Reservations.Cpu.IsZero() || !rp.Limits.Cpu.IsZero() {
-			freq, err := vs.getOrComputeCPUMinFrequency(vmCtx)
-			if err != nil {
-				return nil, err
-			}
-			createArgs.MinCPUFreq = freq
+	}
+
+	if res := vmClass.Spec.Policies.Resources; !res.Requests.Cpu.IsZero() || !res.Limits.Cpu.IsZero() {
+		freq, err := vs.getOrComputeCPUMinFrequency(vmCtx)
+		if err != nil {
+			return nil, err
 		}
+		createArgs.MinCPUFreq = freq
 	}
 
 	if lib.IsVMClassAsConfigFSSDaynDateEnabled() {


### PR DESCRIPTION
This change to use VM Class spec for resource reservation and limits before computing min frequency was done earlier for the update path but missed out for create.

Adding some cpu/mem reservation tests to validate the same.