### PR TITLE
Initial pass at v1a2 VirtualMachine CRD doc updates

### DIFF
--- a/api/v1alpha2/virtualmachine_bootstrap_types.go
+++ b/api/v1alpha2/virtualmachine_bootstrap_types.go
@@ -114,7 +114,8 @@ type VirtualMachineBootstrapCloudInitSpec struct {
 	SSHAuthorizedKeys []string `json:"sshAuthorizedKeys,omitempty"`
 }
 
-// VirtualMachineBootstrapLinuxPrepSpec
+// VirtualMachineBootstrapLinuxPrepSpec describes the LinuxPrep configuration
+// used to bootstrap the VM.
 type VirtualMachineBootstrapLinuxPrepSpec struct {
 	// HardwareClockIsUTC specifies whether the hardware clock is in UTC or
 	// local time.
@@ -163,7 +164,8 @@ type VirtualMachineBootstrapSysprepSpec struct {
 	RawSysprep corev1.SecretKeySelector `json:"rawSysprep,omitempty"`
 }
 
-// VirtualMachineBootstrapVAppConfigSpec
+// VirtualMachineBootstrapVAppConfigSpec describes the vApp configuration
+// used to bootstrap the VM.
 type VirtualMachineBootstrapVAppConfigSpec struct {
 	// Properties is a list of vApp/OVF property key/value pairs.
 	//

--- a/api/v1alpha2/virtualmachine_network_types.go
+++ b/api/v1alpha2/virtualmachine_network_types.go
@@ -565,7 +565,7 @@ type VirtualMachineNetworkInterfaceStatus struct {
 }
 
 // VirtualMachineNetworkIPStackStatus describes the observed state of a
-// a VM's IP stack.
+// VM's IP stack.
 type VirtualMachineNetworkIPStackStatus struct {
 	// DHCP describes the VM's observed, client-side, system-wide DHCP options.
 	//
@@ -611,7 +611,7 @@ type VirtualMachineNetworkStatus struct {
 	//
 	// If the bootstrap provider is CloudInit then this value is set to the
 	// value of the VM's "guestinfo.local-ipv4" property. Please see
-	// https://bit.ly/3A66vZg for more information on how this value is
+	// https://bit.ly/3NJB534 for more information on how this value is
 	// calculated.
 	//
 	// If the bootstrap provider is anything else then this field is set to the
@@ -625,7 +625,7 @@ type VirtualMachineNetworkStatus struct {
 	//
 	// If the bootstrap provider is CloudInit then this value is set to the
 	// value of the VM's "guestinfo.local-ipv6" property. Please see
-	// https://bit.ly/3A66vZg for more information on how this value is
+	// https://bit.ly/3NJB534 for more information on how this value is
 	// calculated.
 	//
 	// If the bootstrap provider is anything else then this field is set to the

--- a/api/v1alpha2/virtualmachine_readiness_types.go
+++ b/api/v1alpha2/virtualmachine_readiness_types.go
@@ -77,13 +77,15 @@ type GuestHeartbeatStatus string
 
 // See govmomi.vim25.types.ManagedEntityStatus
 const (
-	// VMware Tools are not installed or not running.
+	// GrayHeartbeatStatus means VMware Tools are not installed or not running.
 	GrayHeartbeatStatus GuestHeartbeatStatus = "gray"
-	// No heartbeat. Guest operating system may have stopped responding.
+	// RedHeartbeatStatus means no heartbeat.
+	// Guest operating system may have stopped responding.
 	RedHeartbeatStatus GuestHeartbeatStatus = "red"
-	// Intermittent heartbeat. May be due to guest load.
+	// YellowHeartbeatStatus means an intermittent heartbeat.
+	// This may be due to guest load.
 	YellowHeartbeatStatus GuestHeartbeatStatus = "yellow"
-	// Guest operating system is responding normally.
+	// GreenHeartbeatStatus means the guest operating system is responding normally.
 	GreenHeartbeatStatus GuestHeartbeatStatus = "green"
 )
 

--- a/api/v1alpha2/virtualmachine_types.go
+++ b/api/v1alpha2/virtualmachine_types.go
@@ -35,23 +35,23 @@ const (
 	// from within the guest OS, when available.
 	GuestCustomizationCondition = "GuestCustomization"
 
-	// GuestCustomizationIdleReason (Severity=Info) documents that guest
+	// GuestCustomizationIdleReason documents that guest
 	// customizations were not applied for the VirtualMachine.
 	GuestCustomizationIdleReason = "GuestCustomizationIdle"
 
-	// GuestCustomizationPendingReason (Severity=Info) documents that guest
+	// GuestCustomizationPendingReason documents that guest
 	// customization is still pending within the guest OS.
 	GuestCustomizationPendingReason = "GuestCustomizationPending"
 
-	// GuestCustomizationRunningReason (Severity=Info) documents that the guest
+	// GuestCustomizationRunningReason documents that the guest
 	// customization is now running on the guest OS.
 	GuestCustomizationRunningReason = "GuestCustomizationRunning"
 
-	// GuestCustomizationSucceededReason (Severity=Info) documents that the
+	// GuestCustomizationSucceededReason documents that the
 	// guest customization succeeded within the guest OS.
 	GuestCustomizationSucceededReason = "GuestCustomizationSucceeded"
 
-	// GuestCustomizationFailedReason (Severity=Error) documents that the guest
+	// GuestCustomizationFailedReason documents that the guest
 	// customization failed within the guest OS.
 	GuestCustomizationFailedReason = "GuestCustomizationFailed"
 )
@@ -61,11 +61,11 @@ const (
 	// in the guest OS, when available.
 	VirtualMachineToolsCondition = "VirtualMachineTools"
 
-	// VirtualMachineToolsNotRunningReason (Severity=Error) documents that
+	// VirtualMachineToolsNotRunningReason documents that
 	// VMware Tools is not running.
 	VirtualMachineToolsNotRunningReason = "VirtualMachineToolsNotRunning"
 
-	// VirtualMachineToolsRunningReason (Severity=Info) documents that VMware
+	// VirtualMachineToolsRunningReason documents that VMware
 	// Tools is running.
 	VirtualMachineToolsRunningReason = "VirtualMachineToolsRunning"
 )
@@ -337,7 +337,7 @@ type VirtualMachineStatus struct {
 // +kubebuilder:printcolumn:name="Class",type="string",priority=1,JSONPath=".status.class.name"
 // +kubebuilder:printcolumn:name="Image",type="string",priority=1,JSONPath=".status.image.name"
 // +kubebuilder:printcolumn:name="PowerState",type="string",JSONPath=".status.powerState"
-// +kubebuilder:printcolumn:name="Primary-IP",type="string",priority=1,JSONPath=".status.vmIp"
+// +kubebuilder:printcolumn:name="Primary-IP4",type="string",priority=1,JSONPath=".status.network.primaryIP4"
 
 // VirtualMachine is the schema for the virtualmachines API and represents the
 // desired state and observed status of a virtualmachines resource.


### PR DESCRIPTION
Update shorten CloudInit docs link to chase new docs URL

Update VM IP printcolumn path to new IP4 field since we do not have just one "primary" IP field anymore

Remove Severity from Conditions comment since metav1.Conditions do not have that field

Add various description boilerplate