### PR TITLE
📖 Update v1alpha2 Sysprep API related comments

### DIFF
--- a/api/v1alpha2/sysprep/sysprep.go
+++ b/api/v1alpha2/sysprep/sysprep.go
@@ -55,7 +55,7 @@ type GUIRunOnce struct {
 // GUIUnattended maps to the GuiUnattended key in the sysprep.xml answer file.
 type GUIUnattended struct {
 
-	// AutoLogon  determine whether or not the machine automatically logs on as
+	// AutoLogon determine whether or not the machine automatically logs on as
 	// Administrator.
 	//
 	// Please note if AutoLogin is true, then Password must be set or guest
@@ -106,22 +106,30 @@ type GUIUnattended struct {
 // and provides information needed to join a workgroup or domain.
 type Identification struct {
 
-	//
+	// DomainAdmin is the domain user account used for authentication if the
+	// virtual machine is joining a domain. The user does not need to be a
+	// domain administrator, but the account must have the privileges required
+	// to add computers to the domain.
 	//
 	// +optional
 	DomainAdmin string `json:"domainAdmin,omitempty"`
 
-	//
+	// DomainAdminPassword is the password for the domain user account used for
+	// authentication if the virtual machine is joining a domain.
 	//
 	// +optional
 	DomainAdminPassword corev1.SecretKeySelector `json:"domainAdminPassword,omitempty"`
 
-	//
+	// JoinDomain is the domain that the virtual machine should join. If this
+	// value is supplied, then DomainAdmin and DomainAdminPassword must also be
+	// supplied, and the JoinWorkgroup name must be empty.
 	//
 	// +optional
 	JoinDomain string `json:"joinDomain,omitempty"`
 
-	//
+	// JoinWorkgroup is the workgroup that the virtual machine should join. If
+	// this value is supplied, then the JoinDomain and the authentication fields
+	// (DomainAdmin and DomainAdminPassword) must be empty.
 	//
 	// +optional
 	JoinWorkgroup string `json:"joinWorkgroup,omitempty"`

--- a/api/v1alpha2/virtualmachine_network_types.go
+++ b/api/v1alpha2/virtualmachine_network_types.go
@@ -132,7 +132,7 @@ type VirtualMachineNetworkInterfaceSpec struct {
 	// nameservers.
 	//
 	// Please note this feature is available only with the following bootstrap
-	// providers: CloudInit, LinuxPrep, and Sysprep.
+	// providers: CloudInit, LinuxPrep, and Sysprep (except for RawSysprep).
 	//
 	// Please note that Linux allows only three nameservers
 	// (https://linux.die.net/man/5/resolv.conf).
@@ -152,7 +152,7 @@ type VirtualMachineNetworkInterfaceSpec struct {
 	// addresses with DNS.
 	//
 	// Please note this feature is available only with the following bootstrap
-	// providers: CloudInit, LinuxPrep, and Sysprep.
+	// providers: CloudInit, LinuxPrep, and Sysprep (except for RawSysprep).
 	//
 	// +optional
 	SearchDomains []string `json:"searchDomains,omitempty"`
@@ -186,7 +186,7 @@ type VirtualMachineNetworkSpec struct {
 	// If omitted then the name of the VM will be used.
 	//
 	// Please note this feature is available only with the following bootstrap
-	// providers: CloudInit, LinuxPrep, and Sysprep.
+	// providers: CloudInit, LinuxPrep, and Sysprep (except for RawSysprep).
 	//
 	// +optional
 	HostName string `json:"hostName,omitempty"`
@@ -321,7 +321,7 @@ type VirtualMachineNetworkSpec struct {
 	// nameservers.
 	//
 	// Please note this feature is available only with the following bootstrap
-	// providers: CloudInit, LinuxPrep, and Sysprep.
+	// providers: CloudInit, LinuxPrep, and Sysprep (except for RawSysprep).
 	//
 	// Please note that Linux allows only three nameservers
 	// (https://linux.die.net/man/5/resolv.conf).
@@ -347,7 +347,7 @@ type VirtualMachineNetworkSpec struct {
 	// addresses with DNS.
 	//
 	// Please note this feature is available only with the following bootstrap
-	// providers: CloudInit, LinuxPrep, and Sysprep.
+	// providers: CloudInit, LinuxPrep, and Sysprep (except for RawSysprep).
 	//
 	// Please note if the Interfaces field is non-empty then this field is
 	// ignored and should be specified on the elements in the Interfaces list.


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR addresses the missing comments for v1alpha2 Sysprep fields based on the [CustomizationSysprep](https://vdc-repo.vmware.com/vmwb-repository/dcr-public/da47f910-60ac-438b-8b9b-6122f4d14524/16b7274a-bf8b-4b4c-a05e-746f2aa93c8c/doc/vim.vm.customization.Sysprep.html) API. Additionally, this PR includes a clarification regarding the `sysprep.RawSysprep` field, explicitly stating that it is not applicable to certain `VirtualMachineNetworkInterfaceSpec` (all settings will be applied from the sysprep.xml answer file in that case). 

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

N/A

**Are there any special notes for your reviewer**:
- The code has been formatted to adhere to the 80-column length guideline.
- `make generate` has been executed to ensure all changes are up to date.