### PR TITLE
🌱 Updates the minimum hardware version for persistent volumes

### DIFF
--- a/pkg/vmprovider/fake/fake_vm_provider.go
+++ b/pkg/vmprovider/fake/fake_vm_provider.go
@@ -136,7 +136,7 @@ func (s *VMProvider) GetVirtualMachineHardwareVersion(ctx context.Context, vm *v
 	if s.GetVirtualMachineHardwareVersionFn != nil {
 		return s.GetVirtualMachineHardwareVersionFn(ctx, vm)
 	}
-	return 13, nil
+	return 15, nil
 }
 
 func (s *VMProvider) CreateOrUpdateVirtualMachineSetResourcePolicy(ctx context.Context, resourcePolicy *vmopv1.VirtualMachineSetResourcePolicy) error {

--- a/pkg/vmprovider/providers/vsphere/constants/constants.go
+++ b/pkg/vmprovider/providers/vsphere/constants/constants.go
@@ -56,7 +56,7 @@ const (
 	PCIPassthruMMIOSizeDefault        = "512"
 
 	// MinSupportedHWVersionForPVC is the supported virtual hardware version for persistent volumes.
-	MinSupportedHWVersionForPVC = 13
+	MinSupportedHWVersionForPVC = 15
 
 	// FirmwareOverrideAnnotation is the annotation key used for firmware override.
 	FirmwareOverrideAnnotation = pkg.VMOperatorKey + "/firmware"


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This patch updates the minimum hardware version requirement for persistent volumes

**Which issue(s) is/are addressed by this PR?**:
n/a


**Are there any special notes for your reviewer**:
n/a


**Please add a release note if necessary**:
```release-note
Updates the minimum hardware version for persistent volumes
```