### PR TITLE
🌱 Separate WCP_Namespaced_Class_And_Windows_Support into two FSS

### DIFF
--- a/config/local/vmoperator/local_env_var_patch.yaml
+++ b/config/local/vmoperator/local_env_var_patch.yaml
@@ -27,5 +27,7 @@ spec:
           value: "false"
         - name: NETWORK_PROVIDER
           value: "NAMED"
-        - name: FSS_WCP_NAMESPACED_CLASS_AND_WINDOWS_SUPPORT
+        - name: FSS_WCP_NAMESPACED_VM_CLASS
+          value: "false"
+        - name: FSS_WCP_WINDOWS_SYSPREP
           value: "false"

--- a/config/wcp/vmoperator/manager_env_var_patch.yaml
+++ b/config/wcp/vmoperator/manager_env_var_patch.yaml
@@ -67,5 +67,11 @@
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
-    name: FSS_WCP_NAMESPACED_CLASS_AND_WINDOWS_SUPPORT
-    value: "<FSS_WCP_NAMESPACED_CLASS_AND_WINDOWS_SUPPORT_VALUE>"
+    name: FSS_WCP_NAMESPACED_VM_CLASS
+    value: "<FSS_WCP_NAMESPACED_VM_CLASS_VALUE>"
+
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: FSS_WCP_WINDOWS_SYSPREP
+    value: "<FSS_WCP_WINDOWS_SYSPREP_VALUE>"

--- a/controllers/virtualmachine/virtualmachine_controller.go
+++ b/controllers/virtualmachine/virtualmachine_controller.go
@@ -69,7 +69,7 @@ func AddToManager(ctx *context.ControllerManagerContext, mgr manager.Manager) er
 			handler.EnqueueRequestsFromMapFunc(csBindingToVMMapperFn(ctx, r.Client)))
 	}
 
-	if !lib.IsNamespacedClassAndWindowsFSSEnabled() {
+	if !lib.IsNamespacedVMClassFSSEnabled() {
 		builder = builder.Watches(&source.Kind{Type: &vmopv1.VirtualMachineClassBinding{}},
 			handler.EnqueueRequestsFromMapFunc(classBindingToVMMapperFn(ctx, r.Client)))
 	} else {
@@ -173,7 +173,7 @@ func classBindingToVMMapperFn(ctx *context.ControllerManagerContext, c client.Cl
 
 // classToVMMapperFn returns a mapper function that can be used to queue reconcile request
 // for the VirtualMachines in response to an event on the VirtualMachineClass resource when
-// WCP_Namespaced_Class_And_Windows_Support is enabled.
+// WCP_Namespaced_VM_Class FSS is enabled.
 func classToVMMapperFn(ctx *context.ControllerManagerContext, c client.Client) func(o client.Object) []reconcile.Request {
 	// For a given VirtualMachineClass, return reconcile requests
 	// for those VirtualMachines with corresponding VirtualMachinesClasses referenced

--- a/pkg/lib/env.go
+++ b/pkg/lib/env.go
@@ -23,7 +23,8 @@ const (
 	VMClassAsConfigFSS            = "FSS_WCP_VM_CLASS_AS_CONFIG"
 	VMClassAsConfigDaynDateFSS    = "FSS_WCP_VM_CLASS_AS_CONFIG_DAYNDATE"
 	VMImageRegistryFSS            = "FSS_WCP_VM_IMAGE_REGISTRY"
-	NamespacedClassAndWindowsFSS  = "FSS_WCP_NAMESPACED_CLASS_AND_WINDOWS_SUPPORT"
+	NamespacedVMClassFSS          = "FSS_WCP_NAMESPACED_VM_CLASS"
+	WindowsSysprepFSS             = "FSS_WCP_WINDOWS_SYSPREP"
 	MaxCreateVMsOnProviderEnv     = "MAX_CREATE_VMS_ON_PROVIDER"
 	DefaultMaxCreateVMsOnProvider = 80
 
@@ -106,8 +107,12 @@ var IsWCPVMImageRegistryEnabled = func() bool {
 	return os.Getenv(VMImageRegistryFSS) == trueString
 }
 
-var IsNamespacedClassAndWindowsFSSEnabled = func() bool {
-	return os.Getenv(NamespacedClassAndWindowsFSS) == trueString
+var IsNamespacedVMClassFSSEnabled = func() bool {
+	return os.Getenv(NamespacedVMClassFSS) == trueString
+}
+
+var IsWindowsSysprepFSSEnabled = func() bool {
+	return os.Getenv(WindowsSysprepFSS) == trueString
 }
 
 // MaxConcurrentCreateVMsOnProvider returns the percentage of reconciler

--- a/pkg/vmprovider/providers/vsphere/session/session_vm_customization.go
+++ b/pkg/vmprovider/providers/vsphere/session/session_vm_customization.go
@@ -296,7 +296,7 @@ func (s *Session) customize(
 		// This is to simply comply with the spirit of the feature switch.
 		// In reality, the webhook will prevent "Sysprep" from being used unless
 		// the FSS is enabled.
-		if lib.IsNamespacedClassAndWindowsFSSEnabled() {
+		if lib.IsWindowsSysprepFSSEnabled() {
 			configSpec = GetOvfEnvCustSpec(config, updateArgs)
 			custSpec, err = GetSysprepCustSpec(vmCtx.VM.Name, updateArgs)
 		}

--- a/pkg/vmprovider/providers/vsphere/vmprovider_vm_utils.go
+++ b/pkg/vmprovider/providers/vsphere/vmprovider_vm_utils.go
@@ -39,7 +39,7 @@ func GetVirtualMachineClass(
 
 	className := vmCtx.VM.Spec.ClassName
 	key := ctrlclient.ObjectKey{Name: className}
-	if lib.IsNamespacedClassAndWindowsFSSEnabled() {
+	if lib.IsNamespacedVMClassFSSEnabled() {
 		// namespace scoped VM classes
 		key.Namespace = vmCtx.VM.Namespace
 	}
@@ -55,8 +55,8 @@ func GetVirtualMachineClass(
 		return nil, errors.Wrap(err, msg)
 	}
 
-	if lib.IsNamespacedClassAndWindowsFSSEnabled() {
-		// After WCP_Namespaced_Class_And_Windows_Support is enabled, VirtualMachineClass is migrated
+	if lib.IsNamespacedVMClassFSSEnabled() {
+		// After WCP_Namespaced_VM_Class FSS is enabled, VirtualMachineClass is migrated
 		// from cluster scoped to namespace scoped. VirtualMachineClassBinding CRD will be removed
 		// and doesn't make any sense anymore.
 		// We can immediately return the VM class here and skip checking VM class bindings.

--- a/pkg/vmprovider/providers/vsphere/vmprovider_vm_utils_test.go
+++ b/pkg/vmprovider/providers/vsphere/vmprovider_vm_utils_test.go
@@ -55,9 +55,9 @@ func vmUtilTests() {
 	})
 
 	Context("GetVirtualMachineClass", func() {
-		oldNamespacedClassAndWindowsEnabledFunc := lib.IsNamespacedClassAndWindowsFSSEnabled
+		oldNamespacedVMClassFSSEnabledFunc := lib.IsNamespacedVMClassFSSEnabled
 
-		When("WCP_Namespaced_Class_And_Windows_Support FSS is disabled", func() {
+		When("WCP_Namespaced_VM_Class FSS is disabled", func() {
 			var (
 				vmClass        *vmopv1.VirtualMachineClass
 				vmClassBinding *vmopv1.VirtualMachineClassBinding
@@ -67,13 +67,13 @@ func vmUtilTests() {
 				vmClass, vmClassBinding = builder.DummyVirtualMachineClassAndBinding("dummy-vm-class", vmCtx.VM.Namespace)
 				vmCtx.VM.Spec.ClassName = vmClass.Name
 
-				lib.IsNamespacedClassAndWindowsFSSEnabled = func() bool {
+				lib.IsNamespacedVMClassFSSEnabled = func() bool {
 					return false
 				}
 			})
 
 			AfterEach(func() {
-				lib.IsNamespacedClassAndWindowsFSSEnabled = oldNamespacedClassAndWindowsEnabledFunc
+				lib.IsNamespacedVMClassFSSEnabled = oldNamespacedVMClassFSSEnabledFunc
 			})
 
 			Context("VirtualMachineClass custom resource doesn't exist", func() {
@@ -154,7 +154,7 @@ func vmUtilTests() {
 			})
 		})
 
-		When("WCP_Namespaced_Class_And_Windows_Support FSS is enabled", func() {
+		When("WCP_Namespaced_VM_Class FSS is enabled", func() {
 			var (
 				vmClass *vmopv1.VirtualMachineClass
 			)
@@ -164,13 +164,13 @@ func vmUtilTests() {
 				vmClass.Namespace = vmCtx.VM.Namespace
 				vmCtx.VM.Spec.ClassName = vmClass.Name
 
-				lib.IsNamespacedClassAndWindowsFSSEnabled = func() bool {
+				lib.IsNamespacedVMClassFSSEnabled = func() bool {
 					return true
 				}
 			})
 
 			AfterEach(func() {
-				lib.IsNamespacedClassAndWindowsFSSEnabled = oldNamespacedClassAndWindowsEnabledFunc
+				lib.IsNamespacedVMClassFSSEnabled = oldNamespacedVMClassFSSEnabledFunc
 			})
 
 			Context("VirtualMachineClass custom resource doesn't exist", func() {

--- a/webhooks/virtualmachine/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator.go
@@ -200,7 +200,7 @@ func (v validator) validateMetadata(ctx *context.WebhookRequestContext, vm *vmop
 	}
 
 	// Do not allow the Sysprep transport unless the FSS is enabled.
-	if !lib.IsNamespacedClassAndWindowsFSSEnabled() {
+	if !lib.IsWindowsSysprepFSSEnabled() {
 		if v := vmopv1.VirtualMachineMetadataSysprepTransport; v == vm.Spec.VmMetadata.Transport {
 			allErrs = append(allErrs,
 				field.Invalid(mdPath.Child("transport"), v,

--- a/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
@@ -143,14 +143,14 @@ func initNamedNetworkProviderConfig(
 }
 
 func initSysprepTestConfig(ctx *unitValidatingWebhookContext, enabled, used bool) func() {
-	oldFSSValue := os.Getenv(lib.NamespacedClassAndWindowsFSS)
+	oldFSSValue := os.Getenv(lib.WindowsSysprepFSS)
 	deferredFn := func() {
-		Expect(os.Setenv(lib.NamespacedClassAndWindowsFSS, oldFSSValue)).To(Succeed())
+		Expect(os.Setenv(lib.WindowsSysprepFSS, oldFSSValue)).To(Succeed())
 	}
 	if enabled {
-		Expect(os.Setenv(lib.NamespacedClassAndWindowsFSS, "true")).To(Succeed())
+		Expect(os.Setenv(lib.WindowsSysprepFSS, "true")).To(Succeed())
 	} else {
-		Expect(os.Setenv(lib.NamespacedClassAndWindowsFSS, "")).To(Succeed())
+		Expect(os.Setenv(lib.WindowsSysprepFSS, "")).To(Succeed())
 	}
 	if used {
 		if ctx.vm.Spec.VmMetadata == nil {


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This PR refactors the WCP_Namespaced_Class_And_Windows_Support into two separate FSS, so that they can be enabled individually.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

N/A

**Are there any special notes for your reviewer**:

Deployed an internal testbed with the corresponding builds and verified that the updated FSS env vars were passed down properly:

```console
$ kubectl get deploy -n vmware-system-vmop -o yaml | grep FSS_WCP -C 2
...
- name: FSS_WCP_NAMESPACED_VM_CLASS
value: "false"
- name: FSS_WCP_WINDOWS_SYSPREP
value: "false"
```
