### PR TITLE
🌱 Introduces new constant for PCI passthru vmx version

### DIFF
--- a/pkg/vmprovider/providers/vsphere/constants/constants.go
+++ b/pkg/vmprovider/providers/vsphere/constants/constants.go
@@ -57,6 +57,8 @@ const (
 
 	// MinSupportedHWVersionForPVC is the supported virtual hardware version for persistent volumes.
 	MinSupportedHWVersionForPVC = 15
+	// MinSupportedHWVersionForPCIPassthruDevices is the supported virtual hardware version for NVidia PCI devices.
+	MinSupportedHWVersionForPCIPassthruDevices = 17
 
 	// FirmwareOverrideAnnotation is the annotation key used for firmware override.
 	FirmwareOverrideAnnotation = pkg.VMOperatorKey + "/firmware"


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
Attaching PCI passhtru devices to VMs requires a minimum hardware version of 17.

**Which issue(s) is/are addressed by this PR?**:
Fixes #158 


**Are there any special notes for your reviewer**:
None.


**Please add a release note if necessary**:
```release-note
Introduces new constant for PCI passthru vmx version
```