### PR TITLE
 🐛 Set Hardware versions for VMs created with PVC/PCI devices

### DIFF
--- a/pkg/util/devices.go
+++ b/pkg/util/devices.go
@@ -135,6 +135,17 @@ func IsDeviceDynamicDirectPathIO(dev vimTypes.BaseVirtualDevice) bool {
 	return false
 }
 
+// SelectVGPU returns a slice of vGPU devices.
+func SelectVGPU(
+	devices []vimTypes.BaseVirtualDevice,
+) []*vimTypes.VirtualPCIPassthrough {
+
+	return SelectDevicesByDeviceAndBackingType[
+		*vimTypes.VirtualPCIPassthrough,
+		*vimTypes.VirtualPCIPassthroughVmiopBackingInfo,
+	](devices)
+}
+
 // SelectDynamicDirectPathIO returns a slice of dynamic direct path I/O devices.
 func SelectDynamicDirectPathIO(
 	devices []vimTypes.BaseVirtualDevice,

--- a/pkg/util/devices_test.go
+++ b/pkg/util/devices_test.go
@@ -6,7 +6,6 @@ package util_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	vimTypes "github.com/vmware/govmomi/vim25/types"
 
 	"github.com/vmware-tanzu/vm-operator/pkg/util"
@@ -138,6 +137,29 @@ var _ = Describe("SelectDynamicDirectPathIO", func() {
 			Expect(devOut[0]).To(BeEquivalentTo(newPCIPassthroughDevice("")))
 			Expect(devOut[1].Backing).To(BeAssignableToTypeOf(&vimTypes.VirtualPCIPassthroughDynamicBackingInfo{}))
 			Expect(devOut[1]).To(BeEquivalentTo(newPCIPassthroughDevice("")))
+		})
+	})
+})
+
+var _ = Describe("SelectVGPU", func() {
+	Context("selecting a vGPU device", func() {
+		It("will return only the selected device type", func() {
+			devOut := util.SelectVGPU(
+				[]vimTypes.BaseVirtualDevice{
+					newPCIPassthroughDevice(""),
+					&vimTypes.VirtualVmxnet3{},
+					newPCIPassthroughDevice("profile1"),
+					&vimTypes.VirtualSriovEthernetCard{},
+					newPCIPassthroughDevice(""),
+					newPCIPassthroughDevice("profile2"),
+				},
+			)
+			Expect(devOut).To(BeAssignableToTypeOf([]*vimTypes.VirtualPCIPassthrough{}))
+			Expect(devOut).To(HaveLen(2))
+			Expect(devOut[0].Backing).To(BeAssignableToTypeOf(&vimTypes.VirtualPCIPassthroughVmiopBackingInfo{}))
+			Expect(devOut[0]).To(BeEquivalentTo(newPCIPassthroughDevice("profile1")))
+			Expect(devOut[1].Backing).To(BeAssignableToTypeOf(&vimTypes.VirtualPCIPassthroughVmiopBackingInfo{}))
+			Expect(devOut[1]).To(BeEquivalentTo(newPCIPassthroughDevice("profile2")))
 		})
 	})
 })

--- a/pkg/vmprovider/providers/vsphere/session/session_vm_create.go
+++ b/pkg/vmprovider/providers/vsphere/session/session_vm_create.go
@@ -29,6 +29,7 @@ import (
 type VMCreateArgs struct {
 	VMClass             *vmopv1.VirtualMachineClass
 	VMImageStatus       *vmopv1.VirtualMachineImageStatus
+	VMImageSpec         *vmopv1.VirtualMachineImageSpec
 	ResourcePolicy      *vmopv1.VirtualMachineSetResourcePolicy
 	VMMetadata          VMMetadata
 	ContentLibraryUUID  string

--- a/pkg/vmprovider/providers/vsphere/vmprovider_vm_utils_test.go
+++ b/pkg/vmprovider/providers/vsphere/vmprovider_vm_utils_test.go
@@ -14,6 +14,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/vmware/govmomi/vim25/types"
+
 	imgregv1a1 "github.com/vmware-tanzu/vm-operator/external/image-registry/api/v1alpha1"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
@@ -207,7 +209,7 @@ func vmUtilTests() {
 
 	})
 
-	Context("GetVMImageStatusAndContentLibraryUUID", func() {
+	Context("GetVMImageAndContentLibraryUUID", func() {
 
 		When("WCPVMImageRegistry FSS is disabled", func() {
 
@@ -241,7 +243,7 @@ func vmUtilTests() {
 				It("returns error and sets condition", func() {
 					expectedErrMsg := fmt.Sprintf("Failed to get VirtualMachineImage: %s", vmCtx.VM.Spec.ImageName)
 
-					_, _, err := vsphere.GetVMImageStatusAndContentLibraryUUID(vmCtx, k8sClient)
+					_, _, _, err := vsphere.GetVMImageAndContentLibraryUUID(vmCtx, k8sClient)
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring(expectedErrMsg))
 
@@ -264,7 +266,7 @@ func vmUtilTests() {
 				It("returns error and sets condition", func() {
 					expectedErrMsg := fmt.Sprintf("Failed to get ContentLibraryProvider: %s", clProvider.Name)
 
-					_, _, err := vsphere.GetVMImageStatusAndContentLibraryUUID(vmCtx, k8sClient)
+					_, _, _, err := vsphere.GetVMImageAndContentLibraryUUID(vmCtx, k8sClient)
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring(expectedErrMsg))
 
@@ -304,7 +306,7 @@ func vmUtilTests() {
 						expectedErrMsg := fmt.Sprintf("Namespace %s does not have access to ContentSource %s for VirtualMachineImage %s",
 							vmCtx.VM.Namespace, clProvider.Spec.UUID, vmCtx.VM.Spec.ImageName)
 
-						_, _, err := vsphere.GetVMImageStatusAndContentLibraryUUID(vmCtx, k8sClient)
+						_, _, _, err := vsphere.GetVMImageAndContentLibraryUUID(vmCtx, k8sClient)
 						Expect(err).To(HaveOccurred())
 						Expect(err.Error()).To(ContainSubstring(expectedErrMsg))
 
@@ -322,7 +324,7 @@ func vmUtilTests() {
 						expectedErrMsg := fmt.Sprintf("Namespace %s does not have access to ContentSource %s for VirtualMachineImage %s",
 							vmCtx.VM.Namespace, clProvider.Spec.UUID, vmCtx.VM.Spec.ImageName)
 
-						_, _, err := vsphere.GetVMImageStatusAndContentLibraryUUID(vmCtx, k8sClient)
+						_, _, _, err := vsphere.GetVMImageAndContentLibraryUUID(vmCtx, k8sClient)
 						Expect(err).To(HaveOccurred())
 						Expect(err.Error()).To(ContainSubstring(expectedErrMsg))
 
@@ -336,7 +338,7 @@ func vmUtilTests() {
 					})
 
 					It("returns success", func() {
-						image, uuid, err := vsphere.GetVMImageStatusAndContentLibraryUUID(vmCtx, k8sClient)
+						_, image, uuid, err := vsphere.GetVMImageAndContentLibraryUUID(vmCtx, k8sClient)
 						Expect(err).ToNot(HaveOccurred())
 						Expect(image).ToNot(BeNil())
 						Expect(uuid).ToNot(BeEmpty())
@@ -378,7 +380,7 @@ func vmUtilTests() {
 			When("Neither cluster or namespace scoped VM image exists", func() {
 
 				It("returns error and sets condition", func() {
-					_, _, err := vsphere.GetVMImageStatusAndContentLibraryUUID(vmCtx, k8sClient)
+					_, _, _, err := vsphere.GetVMImageAndContentLibraryUUID(vmCtx, k8sClient)
 					Expect(err).To(HaveOccurred())
 					expectedErrMsg := fmt.Sprintf("Failed to get the VM's image: %s", vmCtx.VM.Spec.ImageName)
 					Expect(err.Error()).To(ContainSubstring(expectedErrMsg))
@@ -406,7 +408,7 @@ func vmUtilTests() {
 				})
 
 				It("returns error and sets VM condition", func() {
-					_, _, err := vsphere.GetVMImageStatusAndContentLibraryUUID(vmCtx, k8sClient)
+					_, _, _, err := vsphere.GetVMImageAndContentLibraryUUID(vmCtx, k8sClient)
 					Expect(err).To(HaveOccurred())
 					expectedErrMsg := fmt.Sprintf("VM's image provider is not ready: %s", vmCtx.VM.Spec.ImageName)
 					Expect(err.Error()).To(ContainSubstring(expectedErrMsg))
@@ -434,7 +436,7 @@ func vmUtilTests() {
 				})
 
 				It("returns error and sets VM condition", func() {
-					_, _, err := vsphere.GetVMImageStatusAndContentLibraryUUID(vmCtx, k8sClient)
+					_, _, _, err := vsphere.GetVMImageAndContentLibraryUUID(vmCtx, k8sClient)
 					Expect(err).To(HaveOccurred())
 					expectedErrMsg := fmt.Sprintf("VM's image provider is not security compliant: %s", vmCtx.VM.Spec.ImageName)
 					Expect(err.Error()).To(ContainSubstring(expectedErrMsg))
@@ -464,7 +466,7 @@ func vmUtilTests() {
 				})
 
 				It("returns error and sets VM condition", func() {
-					_, _, err := vsphere.GetVMImageStatusAndContentLibraryUUID(vmCtx, k8sClient)
+					_, _, _, err := vsphere.GetVMImageAndContentLibraryUUID(vmCtx, k8sClient)
 					Expect(err).To(HaveOccurred())
 					expectedErrMsg := fmt.Sprintf("VM's image content version is not synced: %s", vmCtx.VM.Spec.ImageName)
 					Expect(err.Error()).To(ContainSubstring(expectedErrMsg))
@@ -490,7 +492,7 @@ func vmUtilTests() {
 				})
 
 				It("returns success", func() {
-					imageStatus, uuid, err := vsphere.GetVMImageStatusAndContentLibraryUUID(vmCtx, k8sClient)
+					_, imageStatus, uuid, err := vsphere.GetVMImageAndContentLibraryUUID(vmCtx, k8sClient)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(imageStatus).ToNot(BeNil())
 					Expect(uuid).To(Equal(string(cl.Spec.UUID)))
@@ -507,7 +509,7 @@ func vmUtilTests() {
 				})
 
 				It("returns success", func() {
-					imageStatus, uuid, err := vsphere.GetVMImageStatusAndContentLibraryUUID(vmCtx, k8sClient)
+					_, imageStatus, uuid, err := vsphere.GetVMImageAndContentLibraryUUID(vmCtx, k8sClient)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(imageStatus).ToNot(BeNil())
 					Expect(uuid).To(Equal(string(clusterCL.Spec.UUID)))
@@ -750,6 +752,99 @@ func vmUtilTests() {
 					Expect(isVolumesAfter).To(Equal(isVolumesBefore))
 				})
 			})
+		})
+	})
+
+	Context("hasPVC", func() {
+		var spec vmopv1.VirtualMachineSpec
+		Context("Spec has no PVC", func() {
+			It("will return false", func() {
+				spec = vmopv1.VirtualMachineSpec{}
+				Expect(vsphere.HasPVC(spec)).To(BeFalse())
+			})
+		})
+		Context("Spec has PVCs", func() {
+			It("will return true", func() {
+				spec = vmopv1.VirtualMachineSpec{
+					Volumes: []vmopv1.VirtualMachineVolume{
+						{
+							Name: "dummy-vol",
+							PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
+								PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: "pvc-claim-1",
+								},
+							},
+						},
+					},
+				}
+				Expect(vsphere.HasPVC(spec)).To(BeTrue())
+			})
+		})
+	})
+
+	Context("HardwareVersionForPVCandPCIDevices", func() {
+		var (
+			configSpec     *types.VirtualMachineConfigSpec
+			imageHWVersion int32
+		)
+
+		BeforeEach(func() {
+			imageHWVersion = 14
+			configSpec = &types.VirtualMachineConfigSpec{
+				Name: "dummy-VM",
+				DeviceChange: []types.BaseVirtualDeviceConfigSpec{
+					&types.VirtualDeviceConfigSpec{
+						Operation: types.VirtualDeviceConfigSpecOperationAdd,
+						Device: &types.VirtualPCIPassthrough{
+							VirtualDevice: types.VirtualDevice{
+								Backing: &types.VirtualPCIPassthroughVmiopBackingInfo{
+									Vgpu: "profile-from-configspec",
+								},
+							},
+						},
+					},
+					&types.VirtualDeviceConfigSpec{
+						Operation: types.VirtualDeviceConfigSpecOperationAdd,
+						Device: &types.VirtualPCIPassthrough{
+							VirtualDevice: types.VirtualDevice{
+								Backing: &types.VirtualPCIPassthroughDynamicBackingInfo{
+									AllowedDevice: []types.VirtualPCIPassthroughAllowedDevice{
+										{
+											VendorId: 52,
+											DeviceId: 53,
+										},
+									},
+									CustomLabel: "label-from-configspec",
+								},
+							},
+						},
+					},
+				},
+			}
+		})
+
+		It("ConfigSpec has PCI devices and VM spec has PVCs", func() {
+			Expect(vsphere.HardwareVersionForPVCandPCIDevices(imageHWVersion, configSpec, true)).To(Equal(int32(17)))
+		})
+
+		It("ConfigSpec has PCI devices and VM spec has no PVCs", func() {
+			Expect(vsphere.HardwareVersionForPVCandPCIDevices(imageHWVersion, configSpec, false)).To(Equal(int32(17)))
+		})
+
+		It("ConfigSpec has PCI devices, VM spec has PVCs image hardware version is higher than min supported HW version for PCI devices", func() {
+			imageHWVersion = 18
+			Expect(vsphere.HardwareVersionForPVCandPCIDevices(imageHWVersion, configSpec, true)).To(Equal(int32(18)))
+		})
+
+		It("VM spec has PVCs and config spec has no devices", func() {
+			configSpec = &types.VirtualMachineConfigSpec{}
+			Expect(vsphere.HardwareVersionForPVCandPCIDevices(imageHWVersion, configSpec, true)).To(Equal(int32(15)))
+		})
+
+		It("VM spec has PVCs, config spec has no devices and image hardware version is higher than min supported PVC HW version", func() {
+			configSpec = &types.VirtualMachineConfigSpec{}
+			imageHWVersion = 16
+			Expect(vsphere.HardwareVersionForPVCandPCIDevices(imageHWVersion, configSpec, true)).To(Equal(int32(16)))
 		})
 	})
 }


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
Set a minimum hardware version for VMs created with PVC/PCI devices when no hardware version is specified in the VM Class
- PVCs == vmx-15
- PVCs and/or PCI (vGPU/DDPIO) devices == vmx-17
- If the VM Image has a higher version than the minimum mentioned above, the image version takes precedence

This makes sure that going forward brownfield VMs/workloads with PVCs/PCI devices still have a supported hardware version specified when the VM Class doesn't mention one.

Fixes #
NA

**Are there any special notes for your reviewer**:

None


**Please add a release note if necessary**:

```
Set minimum hardware version for VMs created with Persistent Volume Claims or PCI devices (eg Nvidia GPUs) when
the VM Class doesn't mention a hardware version
```

**Testing**:
VM with PCI device (vGPU) gets vmx-17
<img width="500" alt="Screenshot 2023-06-08 at 6 24 11 PM" src="https://github.com/vmware-tanzu/vm-operator/assets/53065832/8f108253-2bff-48ba-a7e9-de9a8573b6a7">

VM with PVC gets vmx-15
<img width="500" alt="Screenshot 2023-06-08 at 6 25 53 PM" src="https://github.com/vmware-tanzu/vm-operator/assets/53065832/bedff9ed-c13b-499a-9cfd-ac63ce1954e5">
