### PR TITLE
✨ Support ControllerName for VM Class

### DIFF
--- a/api/v1alpha1/virtualmachineclass_types.go
+++ b/api/v1alpha1/virtualmachineclass_types.go
@@ -83,6 +83,21 @@ type VirtualMachineClassPolicies struct {
 
 // VirtualMachineClassSpec defines the desired state of VirtualMachineClass.
 type VirtualMachineClassSpec struct {
+	// ControllerName describes the name of the controller responsible for
+	// reconciling VirtualMachine resources that are realized from this
+	// VirtualMachineClass.
+	//
+	// When omitted, controllers reconciling VirtualMachine resources determine
+	// the default controller name from the environment variable
+	// DEFAULT_VM_CLASS_CONTROLLER_NAME. If this environment variable is not
+	// defined or empty, it defaults to vmoperator.vmware.com/vsphere.
+	//
+	// Once a non-empty value is assigned to this field, attempts to set this
+	// field to an empty value will be silently ignored.
+	//
+	// +optional
+	ControllerName string `json:"controllerName,omitempty"`
+
 	// Hardware describes the configuration of the VirtualMachineClass attributes related to virtual hardware.  The
 	// configuration specified in this field is used to customize the virtual hardware characteristics of any VirtualMachine
 	// associated with this VirtualMachineClass.

--- a/api/v1alpha1/zz_generated.conversion.go
+++ b/api/v1alpha1/zz_generated.conversion.go
@@ -1213,6 +1213,7 @@ func Convert_v1alpha2_VirtualMachineClassResources_To_v1alpha1_VirtualMachineCla
 }
 
 func autoConvert_v1alpha1_VirtualMachineClassSpec_To_v1alpha2_VirtualMachineClassSpec(in *VirtualMachineClassSpec, out *v1alpha2.VirtualMachineClassSpec, s conversion.Scope) error {
+	out.ControllerName = in.ControllerName
 	if err := Convert_v1alpha1_VirtualMachineClassHardware_To_v1alpha2_VirtualMachineClassHardware(&in.Hardware, &out.Hardware, s); err != nil {
 		return err
 	}
@@ -1230,6 +1231,7 @@ func Convert_v1alpha1_VirtualMachineClassSpec_To_v1alpha2_VirtualMachineClassSpe
 }
 
 func autoConvert_v1alpha2_VirtualMachineClassSpec_To_v1alpha1_VirtualMachineClassSpec(in *v1alpha2.VirtualMachineClassSpec, out *VirtualMachineClassSpec, s conversion.Scope) error {
+	out.ControllerName = in.ControllerName
 	if err := Convert_v1alpha2_VirtualMachineClassHardware_To_v1alpha1_VirtualMachineClassHardware(&in.Hardware, &out.Hardware, s); err != nil {
 		return err
 	}
@@ -2030,6 +2032,10 @@ func autoConvert_v1alpha1_VirtualMachineSpec_To_v1alpha2_VirtualMachineSpec(in *
 	out.ImageName = in.ImageName
 	out.ClassName = in.ClassName
 	out.PowerState = v1alpha2.VirtualMachinePowerState(in.PowerState)
+	out.PowerOffMode = v1alpha2.VirtualMachinePowerOpMode(in.PowerOffMode)
+	out.SuspendMode = v1alpha2.VirtualMachinePowerOpMode(in.SuspendMode)
+	out.NextRestartTime = in.NextRestartTime
+	out.RestartMode = v1alpha2.VirtualMachinePowerOpMode(in.RestartMode)
 	// WARNING: in.Ports requires manual conversion: does not exist in peer-type
 	// WARNING: in.VmMetadata requires manual conversion: does not exist in peer-type
 	out.StorageClass = in.StorageClass
@@ -2058,6 +2064,10 @@ func autoConvert_v1alpha2_VirtualMachineSpec_To_v1alpha1_VirtualMachineSpec(in *
 	// WARNING: in.Bootstrap requires manual conversion: does not exist in peer-type
 	// WARNING: in.Network requires manual conversion: does not exist in peer-type
 	out.PowerState = VirtualMachinePowerState(in.PowerState)
+	out.PowerOffMode = VirtualMachinePowerOpMode(in.PowerOffMode)
+	out.SuspendMode = VirtualMachinePowerOpMode(in.SuspendMode)
+	out.NextRestartTime = in.NextRestartTime
+	out.RestartMode = VirtualMachinePowerOpMode(in.RestartMode)
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes
 		*out = make([]VirtualMachineVolume, len(*in))
@@ -2109,6 +2119,7 @@ func autoConvert_v1alpha1_VirtualMachineStatus_To_v1alpha2_VirtualMachineStatus(
 	out.ChangeBlockTracking = (*bool)(unsafe.Pointer(in.ChangeBlockTracking))
 	// WARNING: in.NetworkInterfaces requires manual conversion: does not exist in peer-type
 	out.Zone = in.Zone
+	out.LastRestartTime = (*v1.Time)(unsafe.Pointer(in.LastRestartTime))
 	return nil
 }
 
@@ -2145,6 +2156,7 @@ func autoConvert_v1alpha2_VirtualMachineStatus_To_v1alpha1_VirtualMachineStatus(
 	}
 	out.ChangeBlockTracking = (*bool)(unsafe.Pointer(in.ChangeBlockTracking))
 	out.Zone = in.Zone
+	out.LastRestartTime = (*v1.Time)(unsafe.Pointer(in.LastRestartTime))
 	return nil
 }
 

--- a/api/v1alpha2/virtualmachineclass_types.go
+++ b/api/v1alpha2/virtualmachineclass_types.go
@@ -154,6 +154,21 @@ type VirtualMachineClassPolicies struct {
 
 // VirtualMachineClassSpec defines the desired state of VirtualMachineClass.
 type VirtualMachineClassSpec struct {
+	// ControllerName describes the name of the controller responsible for
+	// reconciling VirtualMachine resources that are realized from this
+	// VirtualMachineClass.
+	//
+	// When omitted, controllers reconciling VirtualMachine resources determine
+	// the default controller name from the environment variable
+	// DEFAULT_VM_CLASS_CONTROLLER_NAME. If this environment variable is not
+	// defined or empty, it defaults to vmoperator.vmware.com/vsphere.
+	//
+	// Once a non-empty value is assigned to this field, attempts to set this
+	// field to an empty value will be silently ignored.
+	//
+	// +optional
+	ControllerName string `json:"controllerName,omitempty"`
+
 	// Hardware describes the configuration of the VirtualMachineClass
 	// attributes related to virtual hardware. The configuration specified in
 	// this field is used to customize the virtual hardware characteristics of

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachineclasses.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachineclasses.yaml
@@ -67,6 +67,16 @@ spec:
                   discriminator field "_typeName" to preserve type information.
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
+              controllerName:
+                description: "ControllerName describes the name of the controller
+                  responsible for reconciling VirtualMachine resources that are realized
+                  from this VirtualMachineClass. \n When omitted, controllers reconciling
+                  VirtualMachine resources determine the default controller name from
+                  the environment variable DEFAULT_VM_CLASS_CONTROLLER_NAME. If this
+                  environment variable is not defined or empty, it defaults to vmoperator.vmware.com/vsphere.
+                  \n Once a non-empty value is assigned to this field, attempts to
+                  set this field to an empty value will be silently ignored."
+                type: string
               description:
                 description: Description describes the configuration of the VirtualMachineClass
                   which is not related to virtual hardware or infrastructure policy.

--- a/docs/concepts/workloads/vm-class.md
+++ b/docs/concepts/workloads/vm-class.md
@@ -1,3 +1,9 @@
 # VirtualMachineClass
 
 // TODO ([github.com/vmware-tanzu/vm-operator#95](https://github.com/vmware-tanzu/vm-operator/issues/95))
+
+_VirtualMachineClasses_ (VM Class) represent a collection of virtual hardware that is used to realize a new VirtualMachine (VM).
+
+## ControllerName
+
+The field `spec.controllerName` in a VM Class indicates the name of the controller responsible for reconciling `VirtualMachine` resources created from the VM Class. The value `vmoperator.vmware.com/vsphere` indicates the default `VirtualMachine` controller is used. VM Classes that do not have this field set or set to an empty value behave as if the field is set to the value returned from the environment variable `DEFAULT_VM_CLASS_CONTROLLER_NAME`. If this environment variable is empty, it defaults to `vmoperator.vmware.com/vsphere`.

--- a/pkg/lib/env.go
+++ b/pkg/lib/env.go
@@ -55,6 +55,14 @@ const (
 	NetworkProviderTypeNamed = "NAMED"
 	NetworkProviderTypeNSXT  = "NSXT"
 	NetworkProviderTypeVDS   = "VSPHERE_NETWORK"
+
+	// DefaultVirtualMachineClassControllerNameEnv is the name of the
+	// environment variable that contains the name of the default value for
+	// the VirtualMachineClass field spec.controllerName.
+	//
+	// If the environment variable is not set or empty it will be treated as
+	// if it contains vmoperator.vmware.com/vsphere.
+	DefaultVirtualMachineClassControllerNameEnv = "DEFAULT_VM_CLASS_CONTROLLER_NAME"
 )
 
 // SetVMOpNamespaceEnv sets the VM Operator pod's namespace in the environment.
@@ -161,4 +169,14 @@ func GetInstanceStorageRequeueDelay() time.Duration {
 	}
 
 	return wait.Jitter(seedDuration, maxFactor)
+}
+
+// GetDefaultVirtualMachineClassControllerName returns the value to use if
+// a VirtualMachineClass resource's spec.controllerName field is empty.
+var GetDefaultVirtualMachineClassControllerName = func() string {
+	v := os.Getenv(DefaultVirtualMachineClassControllerNameEnv)
+	if v == "" {
+		return "vmoperator.vmware.com/vsphere"
+	}
+	return v
 }

--- a/pkg/util/kube/kube_suite_test.go
+++ b/pkg/util/kube/kube_suite_test.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package kube_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/go-logr/logr"
+
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/klogr"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func init() {
+	klog.InitFlags(nil)
+	klog.SetOutput(GinkgoWriter)
+	logf.SetLogger(klogr.New())
+}
+
+func getLogger() logr.Logger {
+	return logf.Log
+}
+
+func TestKube(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Kube Util Test Suite")
+}

--- a/pkg/util/kube/predicates.go
+++ b/pkg/util/kube/predicates.go
@@ -1,0 +1,231 @@
+// Copyright (c) 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package kube
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// VMForControllerPredicateOptions is used to configure the behavior of the
+// predicate created with VMForControllerPredicate.
+type VMForControllerPredicateOptions struct {
+	MatchIfVMClassNotFound            bool
+	MatchIfControllerNameFieldEmpty   bool
+	MatchIfControllerNameFieldMissing bool
+}
+
+// VMForControllerPredicate returns a predicate.Predicate that filters
+// VirtualMachine resources and returns only those that map to a
+// VirtualMachineClass resource that uses the provided controller.
+//
+// Please note this predicate is schema agnostic and should work with all
+// VM Operator API schema versions.
+func VMForControllerPredicate(
+	c client.Client,
+	log logr.Logger,
+	controllerName string,
+	opts VMForControllerPredicateOptions) predicate.Predicate {
+
+	return &vmForVMClassPredicate{
+		client:         c,
+		log:            log,
+		controllerName: controllerName,
+		opts:           opts,
+	}
+}
+
+type vmForVMClassPredicate struct {
+	client         client.Client
+	log            logr.Logger
+	controllerName string
+	opts           VMForControllerPredicateOptions
+}
+
+// Create returns true if the Create event should be processed.
+func (r *vmForVMClassPredicate) Create(e event.CreateEvent) bool {
+	if ok, err := r.matches(e.Object); !ok {
+		if err != nil {
+			r.log.Error(
+				err,
+				"Failed to match object for VMForVMClassPredicate.CreateEvent")
+		}
+		return false
+	}
+	return true
+}
+
+// Delete returns true if the Delete event should be processed.
+func (r *vmForVMClassPredicate) Delete(e event.DeleteEvent) bool {
+	if ok, err := r.matches(e.Object); !ok {
+		if err != nil {
+			r.log.Error(
+				err,
+				"Failed to match object for VMForVMClassPredicate.DeleteEvent")
+		}
+		return false
+	}
+	return true
+}
+
+// Update returns true if the Update event should be processed.
+func (r *vmForVMClassPredicate) Update(e event.UpdateEvent) bool {
+	if ok, err := r.matches(e.ObjectNew); !ok {
+		if err != nil {
+			r.log.Error(
+				err,
+				"Failed to match object for VMForVMClassPredicate.UpdateEvent")
+		}
+		return false
+	}
+	return true
+}
+
+// Generic returns true if the Generic event should be processed.
+func (r *vmForVMClassPredicate) Generic(e event.GenericEvent) bool {
+	if ok, err := r.matches(e.Object); !ok {
+		if err != nil {
+			r.log.Error(
+				err,
+				"Failed to match object for VMForVMClassPredicate.GenericEvent")
+		}
+		return false
+	}
+	return true
+}
+
+func (r *vmForVMClassPredicate) matches(obj runtime.Object) (bool, error) {
+	obj = obj.DeepCopyObject() // do not mutate the original
+
+	vm, err := r.getVM(obj)
+	if err != nil {
+		return false, err
+	}
+
+	// Get name of the VM Class used by the VM.
+	className, ok, err := unstructured.NestedString(
+		vm.Object, "spec", "className")
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		return false, fmt.Errorf("spec.className not found for %s", vm)
+	}
+
+	// Get the VM Class referenced by the VM.
+	vmClass, err := r.getVMClass(
+		vm.GroupVersionKind().GroupVersion(),
+		vm.GetNamespace(),
+		className)
+	if err != nil {
+		if apierrors.IsNotFound(err) && r.opts.MatchIfVMClassNotFound {
+			return true, nil
+		}
+		return false, err
+	}
+
+	controllerName, ok, err := unstructured.NestedString(
+		vmClass.Object,
+		"spec",
+		"controllerName")
+	if err != nil { // Will be nil if field is not present
+		return false, err
+	}
+
+	if !ok { // Field was not found.
+		if !r.opts.MatchIfControllerNameFieldMissing {
+			return false, errors.New("spec.controllerName field missing")
+		}
+		return true, nil
+	}
+
+	if controllerName == "" {
+		if !r.opts.MatchIfControllerNameFieldEmpty {
+			return false, errors.New("spec.controllerName field is empty")
+		}
+		return true, nil
+	}
+
+	if controllerName != r.controllerName {
+		return false, fmt.Errorf(
+			"spec.controllerName=%q, expected=%q",
+			controllerName, r.controllerName)
+	}
+
+	return true, nil
+}
+
+func (r *vmForVMClassPredicate) getVM(
+	inObj runtime.Object) (*unstructured.Unstructured, error) {
+
+	// Controller-runtime does not assign an object's TypeMeta prior to sending
+	// the object into a predicate. In order to ascertain the object's group,
+	// version, and kind, we need to use the scheme's object mapper. The code
+	// below gets all of the available group, version, kind combinations for
+	// the provided object.
+	gvks, unversioned, err := r.client.Scheme().ObjectKinds(inObj)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to get group, version, & kinds for object: %w", err)
+	}
+	if unversioned {
+		return nil, errors.New("object is unversioned")
+	}
+
+	// Update the inObj with one of the discovered GVKs. The correct version
+	// is not important as all versions of VirtualMachine have a spec.className
+	// field and all versions of VirtualMachineClass have a spec.controllerName
+	// field.
+	inObj.GetObjectKind().SetGroupVersionKind(gvks[0])
+
+	data, err := runtime.DefaultUnstructuredConverter.ToUnstructured(inObj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert to unstructured: %w", err)
+	}
+	outObj := unstructured.Unstructured{Object: data}
+
+	if kind := outObj.GetKind(); kind != "VirtualMachine" {
+		return nil, fmt.Errorf("kind=%q, expected kind=VirtualMachine", kind)
+	}
+
+	return &outObj, nil
+}
+
+func (r *vmForVMClassPredicate) getVMClass(
+	groupVersion schema.GroupVersion,
+	namespace, name string) (*unstructured.Unstructured, error) {
+
+	obj := unstructured.Unstructured{Object: map[string]interface{}{}}
+	obj.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   groupVersion.Group,
+		Version: groupVersion.Version,
+		Kind:    "VirtualMachineClass",
+	})
+
+	var (
+		ctx = context.Background()
+		key = client.ObjectKey{Name: name}
+	)
+
+	// First attempt to get the VM Class as a cluster-scoped resource and,
+	// if that fails, attempt to get it as a namespaced resource.
+	if err := r.client.Get(ctx, key, &obj); err != nil {
+		key.Namespace = namespace
+		if err := r.client.Get(ctx, key, &obj); err != nil {
+			return nil, fmt.Errorf("failed to get VirtualMachineClass: %w", err)
+		}
+	}
+
+	return &obj, nil
+}

--- a/pkg/util/kube/predicates_test.go
+++ b/pkg/util/kube/predicates_test.go
@@ -1,0 +1,194 @@
+// Copyright (c) 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package kube_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	ctrlpredicate "sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
+)
+
+var _ = Describe("Predicates", func() {
+	Context("VMForControllerPredicate", func() {
+		var (
+			client                  ctrlclient.Client
+			log                     logr.Logger
+			vm                      *unstructured.Unstructured
+			vmClass                 *unstructured.Unstructured
+			vmClassControllerName   string
+			predicateControllerName string
+			opts                    kubeutil.VMForControllerPredicateOptions
+			predicate               ctrlpredicate.Predicate
+		)
+
+		BeforeEach(func() {
+			vm = &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "vmoperator.vmware.com/v1alpha1",
+					"kind":       "VirtualMachine",
+					"metadata": map[string]interface{}{
+						"name":      "my-vm",
+						"namespace": "my-namespace",
+					},
+					"spec": map[string]interface{}{
+						"className": "my-vmclass",
+					},
+				},
+			}
+			vmClass = &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "vmoperator.vmware.com/v1alpha1",
+					"kind":       "VirtualMachineClass",
+					"metadata": map[string]interface{}{
+						"name": "my-vmclass",
+					},
+					"spec": map[string]interface{}{},
+				},
+			}
+			log = getLogger()
+		})
+		JustBeforeEach(func() {
+			if vmClassControllerName != "" {
+				Expect(unstructured.SetNestedField(
+					vmClass.Object,
+					vmClassControllerName,
+					"spec", "controllerName")).To(Succeed())
+			}
+			withObjects := []ctrlclient.Object{}
+			if vm != nil {
+				withObjects = append(withObjects, vm)
+			}
+			if vmClass != nil {
+				withObjects = append(withObjects, vmClass)
+			}
+			client = fake.NewClientBuilder().WithObjects(withObjects...).Build()
+			predicate = kubeutil.VMForControllerPredicate(
+				client, log, predicateControllerName, opts)
+		})
+
+		assertEvents := func(
+			newObj, oldObj ctrlclient.Object,
+			create, update, delete, generic bool) {
+
+			By("CreateEvent")
+			ExpectWithOffset(1, predicate.Create(
+				event.CreateEvent{Object: newObj})).To(Equal(create))
+
+			By("UpdateEvent")
+			ExpectWithOffset(1, predicate.Update(
+				event.UpdateEvent{ObjectNew: newObj, ObjectOld: oldObj})).To(Equal(update))
+
+			By("DeleteEvent")
+			ExpectWithOffset(1, predicate.Delete(
+				event.DeleteEvent{Object: newObj})).To(Equal(delete))
+
+			By("GenericEvent")
+			ExpectWithOffset(1, predicate.Generic(
+				event.GenericEvent{Object: newObj})).To(Equal(generic))
+		}
+
+		When("the vm class does not exist", func() {
+			BeforeEach(func() {
+				vmClass = nil
+			})
+			When("opts.MatchIfVMClassNotFound is false", func() {
+				BeforeEach(func() {
+					opts.MatchIfVMClassNotFound = false
+				})
+				It("should return false", func() {
+					assertEvents(vm, vm, false, false, false, false)
+				})
+			})
+			When("opts.MatchIfVMClassNotFound is true", func() {
+				BeforeEach(func() {
+					opts.MatchIfVMClassNotFound = true
+				})
+				It("should return true", func() {
+					assertEvents(vm, vm, true, true, true, true)
+				})
+			})
+		})
+
+		When("the vm class's spec.controllerName field is undefined", func() {
+			When("opts.MatchIfControllerNameFieldMissing is false", func() {
+				BeforeEach(func() {
+					opts.MatchIfControllerNameFieldMissing = false
+				})
+				It("should return false", func() {
+					assertEvents(vm, vm, false, false, false, false)
+				})
+			})
+			When("opts.MatchIfControllerNameFieldMissing is true", func() {
+				BeforeEach(func() {
+					opts.MatchIfControllerNameFieldMissing = true
+				})
+				It("should return true", func() {
+					assertEvents(vm, vm, true, true, true, true)
+				})
+			})
+		})
+
+		When("the vm class's spec.controllerName field is empty", func() {
+			BeforeEach(func() {
+				Expect(unstructured.SetNestedField(
+					vmClass.Object, "",
+					"spec", "controllerName")).To(Succeed())
+			})
+			When("opts.MatchIfControllerNameFieldEmpty is false", func() {
+				BeforeEach(func() {
+					opts.MatchIfControllerNameFieldEmpty = false
+				})
+				It("should return false", func() {
+					assertEvents(vm, vm, false, false, false, false)
+				})
+			})
+			When("opts.MatchIfControllerNameFieldEmpty is true", func() {
+				BeforeEach(func() {
+					opts.MatchIfControllerNameFieldEmpty = true
+				})
+				It("should return true", func() {
+					assertEvents(vm, vm, true, true, true, true)
+				})
+			})
+		})
+
+		When("the vm class's spec.controllerName field is non-empty", func() {
+			BeforeEach(func() {
+				vmClassControllerName = "my-controller"
+			})
+			When("the predicate's controllerName is empty", func() {
+				BeforeEach(func() {
+					predicateControllerName = ""
+				})
+				It("should return false", func() {
+					assertEvents(vm, vm, false, false, false, false)
+				})
+			})
+			When("the predicate's controllerName matches", func() {
+				BeforeEach(func() {
+					predicateControllerName = vmClassControllerName
+				})
+				It("should return true", func() {
+					assertEvents(vm, vm, true, true, true, true)
+				})
+			})
+			When("the predicate's controllerName does not match", func() {
+				BeforeEach(func() {
+					predicateControllerName = "not-" + vmClassControllerName
+				})
+				It("should return false", func() {
+					assertEvents(vm, vm, false, false, false, false)
+				})
+			})
+		})
+	})
+})


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This patch adds support for specifying the field `spec.controllerName` in a `VirtualMachineClass` resource. If this field is set to `vmoperator.vmware.com/vsphere`, then the VM Operator controller for `VirtualMachine` reconciles all VM resources. If the field is empty, then the environment variable `DEFAULT_VM_CLASS_CONTROLLER_NAME` is used to determine the default controller name. If this environment variable is empty, it defaults to `vmoperator.vmware.com/vsphere`. Otherwise the controller responsible for reconciling VM resources is determined by the field `spec.controllerName` in the VM Class referenced by a VM.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

* @srm09 / @aruneshpa -- Should we also skip webhooks for VM resources based on this logic? I opted for `no`, but I wanted your thoughts.
* @bryanv -- I just cannot get `make generate-go-conversions` to work. The field is added in both v1alpha1 and v1alpha2, and it's a `string`. I'm not sure how it gets any simpler.


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Support spec.controllerName in VirtualMachineClass to enable concurrent controllers for the VM Operator API.
```

<!-- readthedocs-preview vm-operator start -->
----
:books: Documentation preview :books:: https://vm-operator--163.org.readthedocs.build/en/163/

<!-- readthedocs-preview vm-operator end -->