### PR TITLE
:seedling: Only watch Create and Delete events for VMClass when reconcile VM

### DIFF
--- a/controllers/virtualmachine/virtualmachine_controller.go
+++ b/controllers/virtualmachine/virtualmachine_controller.go
@@ -15,8 +15,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
@@ -87,12 +89,21 @@ func AddToManager(ctx *context.ControllerManagerContext, mgr manager.Manager) er
 			handler.EnqueueRequestsFromMapFunc(csBindingToVMMapperFn(ctx, r.Client)))
 	}
 
-	if !lib.IsNamespacedVMClassFSSEnabled() {
-		builder = builder.Watches(&source.Kind{Type: &vmopv1.VirtualMachineClassBinding{}},
-			handler.EnqueueRequestsFromMapFunc(classBindingToVMMapperFn(ctx, r.Client)))
+	// Predicate functions to determine when a reconcile should be triggered
+	// Used to not watch for VMClass Update event
+	if lib.IsNamespacedVMClassFSSEnabled() {
+		builder = builder.Watches(
+			&source.Kind{Type: &vmopv1.VirtualMachineClass{}},
+			handler.EnqueueRequestsFromMapFunc(classToVMMapperFn(ctx, r.Client))).
+			WithEventFilter(predicate.Funcs{
+				UpdateFunc: func(e event.UpdateEvent) bool {
+					return false
+				},
+			})
 	} else {
-		builder = builder.Watches(&source.Kind{Type: &vmopv1.VirtualMachineClass{}},
-			handler.EnqueueRequestsFromMapFunc(classToVMMapperFn(ctx, r.Client)))
+		builder = builder.Watches(
+			&source.Kind{Type: &vmopv1.VirtualMachineClassBinding{}},
+			handler.EnqueueRequestsFromMapFunc(classBindingToVMMapperFn(ctx, r.Client)))
 	}
 
 	// Filter any VMs that reference a VM Class with a spec.controllerName set

--- a/controllers/virtualmachine/virtualmachine_controller_unit_test.go
+++ b/controllers/virtualmachine/virtualmachine_controller_unit_test.go
@@ -13,6 +13,8 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
@@ -25,6 +27,7 @@ import (
 
 func unitTests() {
 	Describe("Invoking Reconcile", unitTestsReconcile)
+	Describe("Invoking Predicate", unitTestsPredicate)
 }
 
 const finalizer = "virtualmachine.vmoperator.vmware.com"
@@ -215,4 +218,49 @@ func expectEvent(ctx *builder.UnitTestContextForController, eventStr string) {
 	EventuallyWithOffset(1, ctx.Events).Should(Receive(&event))
 	eventComponents := strings.Split(event, " ")
 	ExpectWithOffset(1, eventComponents[1]).To(Equal(eventStr))
+}
+
+func unitTestsPredicate() {
+	var (
+		pred        predicate.Predicate
+		updateEvent event.UpdateEvent
+	)
+
+	BeforeEach(func() {
+		pred = predicate.Funcs{
+			UpdateFunc: func(e event.UpdateEvent) bool {
+				return false
+			},
+		}
+		updateEvent = event.UpdateEvent{
+			ObjectOld: generateVirtualMachineClass("old-vm-class"),
+			ObjectNew: generateVirtualMachineClass("new-vm-class"),
+		}
+	})
+
+	It("should filter out the update event", func() {
+		Expect(pred.Update(updateEvent)).To(BeFalse())
+	})
+
+	It("should not filter out other events", func() {
+		createEvent := event.CreateEvent{
+			Object: generateVirtualMachineClass("vm-class"),
+		}
+		Expect(pred.Create(createEvent)).To(BeTrue())
+
+		deleteEvent := event.DeleteEvent{
+			Object: generateVirtualMachineClass("vm-class"),
+		}
+		Expect(pred.Delete(deleteEvent)).To(BeTrue())
+	})
+}
+
+// Generate a VirtualMachineClass object for testing.
+func generateVirtualMachineClass(name string) *vmopv1.VirtualMachineClass {
+	return &vmopv1.VirtualMachineClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+	}
 }


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR filters VMClass events when it comes to VM reconciliation with Namespaced VMClass FSS enabled. Now only Create and Delete events on namespaced VMClass will trigger reconcile in VM controller

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes NA


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

```release-note
Only watch Create and Delete events for namespaced VMClass when reconcile VM
```