### PR TITLE
🌱 Only sanitize virtual disks that are non-RDM from class config spec

### DIFF
--- a/pkg/util/devices.go
+++ b/pkg/util/devices.go
@@ -174,3 +174,13 @@ func isDiskOrDiskController(dev vimTypes.BaseVirtualDevice) bool {
 		return false
 	}
 }
+
+// isNonRDMDisk returns true for all virtual disk devices excluding disks with a raw device mapping backing.
+func isNonRDMDisk(dev vimTypes.BaseVirtualDevice) bool {
+	if dev, ok := dev.(*vimTypes.VirtualDisk); ok {
+		_, hasRDMBacking := dev.Backing.(*vimTypes.VirtualDiskRawDiskMappingVer1BackingInfo)
+		return !hasRDMBacking
+	}
+
+	return false
+}

--- a/pkg/vmprovider/providers/vsphere/vmprovider_vm_test.go
+++ b/pkg/vmprovider/providers/vsphere/vmprovider_vm_test.go
@@ -879,6 +879,92 @@ func vmTests() {
 					})
 				})
 			})
+
+			Context("VMClassAsConfig FSS is Enabled", func() {
+
+				BeforeEach(func() {
+					testConfig.WithVMClassAsConfig = true
+				})
+
+				When("configSpec has disk and disk controllers", func() {
+					BeforeEach(func() {
+						configSpec = &types.VirtualMachineConfigSpec{
+							Name: "dummy-VM",
+							DeviceChange: []types.BaseVirtualDeviceConfigSpec{
+								&types.VirtualDeviceConfigSpec{
+									Operation: types.VirtualDeviceConfigSpecOperationAdd,
+									Device: &types.VirtualSATAController{
+										VirtualController: types.VirtualController{
+											VirtualDevice: types.VirtualDevice{
+												Key: 101,
+											},
+										},
+									},
+								},
+								&types.VirtualDeviceConfigSpec{
+									Operation: types.VirtualDeviceConfigSpecOperationAdd,
+									Device: &types.VirtualSCSIController{
+										VirtualController: types.VirtualController{
+											VirtualDevice: types.VirtualDevice{
+												Key: 103,
+											},
+										},
+									},
+								},
+								&types.VirtualDeviceConfigSpec{
+									Operation: types.VirtualDeviceConfigSpecOperationAdd,
+									Device: &types.VirtualNVMEController{
+										VirtualController: types.VirtualController{
+											VirtualDevice: types.VirtualDevice{
+												Key: 104,
+											},
+										},
+									},
+								},
+								&types.VirtualDeviceConfigSpec{
+									Operation: types.VirtualDeviceConfigSpecOperationAdd,
+									Device: &types.VirtualDisk{
+										CapacityInBytes: 1024,
+										VirtualDevice: types.VirtualDevice{
+											Key: -42,
+											Backing: &types.VirtualDiskFlatVer2BackingInfo{
+												ThinProvisioned: pointer.Bool(true),
+											},
+										},
+									},
+								},
+							},
+						}
+					})
+
+					It("creates a VM with disk controllers", func() {
+						var o mo.VirtualMachine
+						Expect(vcVM.Properties(ctx, vcVM.Reference(), nil, &o)).To(Succeed())
+
+						devList := object.VirtualDeviceList(o.Config.Hardware.Device)
+						satacont := devList.SelectByType(&types.VirtualSATAController{})
+						Expect(satacont).To(HaveLen(1))
+						dev := satacont[0].GetVirtualDevice()
+						Expect(dev.Key).To(Equal(int32(101)))
+
+						scsicont := devList.SelectByType(&types.VirtualSCSIController{})
+						Expect(scsicont).To(HaveLen(1))
+						dev = scsicont[0].GetVirtualDevice()
+						Expect(dev.Key).To(Equal(int32(103)))
+
+						nvmecont := devList.SelectByType(&types.VirtualNVMEController{})
+						Expect(nvmecont).To(HaveLen(1))
+						dev = nvmecont[0].GetVirtualDevice()
+						Expect(dev.Key).To(Equal(int32(104)))
+
+						// only preexisting disk should be present on VM -- len: 1
+						disks := devList.SelectByType(&types.VirtualDisk{})
+						Expect(disks).To(HaveLen(1))
+						dev1 := disks[0].GetVirtualDevice()
+						Expect(dev1.Key).ToNot(Equal(int32(-42)))
+					})
+				})
+			})
 		})
 
 		Context("CreateOrUpdate VM", func() {


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
When VMClassAsConfig is enabled, this change removes only disks that are not raw device mapping backed. All disk controllers can be added post this FSS.

Testing:
make test

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

Fixes #
N/A


**Are there any special notes for your reviewer**:
N/A


**Please add a release note if necessary**:

```
Remove only virtual disks without RDM backings from the VM Class when VMClassAsConfig FSS is enabled 
```