### PR TITLE
Update v1a2 VirtualMachine types

### DIFF
--- a/api/v1alpha1/conversion_test.go
+++ b/api/v1alpha1/conversion_test.go
@@ -124,7 +124,7 @@ func overrideVirtualMachineFieldsFuncs(codecs runtimeserializer.CodecFactory) []
 			vmStatus.NetworkInterfaces = nil
 
 			// Do not exist in v1a2.
-			vmStatus.Phase = ""
+			vmStatus.Phase = v1alpha1.Unknown
 		},
 		func(vmStatus *nextver.VirtualMachineStatus, c fuzz.Continue) {
 			c.Fuzz(vmStatus)

--- a/api/v1alpha1/virtualmachine_types.go
+++ b/api/v1alpha1/virtualmachine_types.go
@@ -29,7 +29,7 @@ const (
 )
 
 // VirtualMachinePowerOpMode represents the various power operation modes when
-// when powering off or suspending a VM.
+// powering off or suspending a VM.
 // +kubebuilder:validation:Enum=hard;soft;trySoft
 type VirtualMachinePowerOpMode string
 

--- a/api/v1alpha2/virtualmachine_types.go
+++ b/api/v1alpha2/virtualmachine_types.go
@@ -23,11 +23,24 @@ const (
 	// For more information please see VirtualMachineImage.Status.Ready.
 	VirtualMachineConditionImageReady = "VirtualMachineImageReady"
 
-	VirtualMachineConditionNetworkReady = "VirtualMachineNetworkReady"
+	// VirtualMachineConditionVMSetResourcePolicyReady indicates that a referenced
+	// VirtualMachineSetResourcePolicy is Ready.
+	VirtualMachineConditionVMSetResourcePolicyReady = "VirtualMachineConditionVMSetResourcePolicyReady"
 
+	// VirtualMachineConditionStorageReady indicates that the storage prerequisites for the VM are ready.
 	VirtualMachineConditionStorageReady = "VirtualMachineStorageReady"
 
+	// VirtualMachineConditionBootstrapReady indicates that the bootstrap prerequisites for the VM are ready.
 	VirtualMachineConditionBootstrapReady = "VirtualMachineBootstrapReady"
+
+	// VirtualMachineConditionNetworkReady indicates that the network prerequisites for the VM are ready.
+	VirtualMachineConditionNetworkReady = "VirtualMachineNetworkReady"
+
+	// VirtualMachineConditionPlacementReady indicates that the placement decision for the VM is ready.
+	VirtualMachineConditionPlacementReady = "VirtualMachineConditionPlacementReady"
+
+	// VirtualMachineConditionCreated indicates that the VM has been created.
+	VirtualMachineConditionCreated = "VirtualMachineCreated"
 )
 
 const (
@@ -101,7 +114,7 @@ const (
 )
 
 // VirtualMachinePowerOpMode represents the various power operation modes when
-// when powering off or suspending a VM.
+// powering off or suspending a VM.
 // +kubebuilder:validation:Enum=Hard;Soft;TrySoft
 type VirtualMachinePowerOpMode string
 
@@ -449,8 +462,16 @@ type VirtualMachine struct {
 	Status VirtualMachineStatus `json:"status,omitempty"`
 }
 
-func (vm VirtualMachine) NamespacedName() string {
+func (vm *VirtualMachine) NamespacedName() string {
 	return vm.Namespace + "/" + vm.Name
+}
+
+func (vm *VirtualMachine) GetConditions() []metav1.Condition {
+	return vm.Status.Conditions
+}
+
+func (vm *VirtualMachine) SetConditions(conditions []metav1.Condition) {
+	vm.Status.Conditions = conditions
 }
 
 // +kubebuilder:object:root=true


### PR DESCRIPTION
 - Add more creation step Conditions
 - Use Condition to infer "Created" phase for v1a1 down conversion since CAPI uses that value to determine if the VM is ready
 - Implement condition Get/Set methods for later v1a2 conditions support