### PR TITLE
Import v1a2 pkg changes

### DIFF
--- a/api/v1alpha2/condition_consts.go
+++ b/api/v1alpha2/condition_consts.go
@@ -1,0 +1,9 @@
+// Copyright (c) 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha2
+
+const (
+	// ReadyConditionType is the Ready condition type that summarizes the operational state of a VM Operator API object.
+	ReadyConditionType = "Ready"
+)

--- a/pkg/conditions2/conditions_suite_test.go
+++ b/pkg/conditions2/conditions_suite_test.go
@@ -1,0 +1,10 @@
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package conditions2
+
+import (
+	_ "github.com/onsi/ginkgo"
+)
+
+// This is required so the Gingko flags are added (specifically gingko.noColor)

--- a/pkg/conditions2/getter.go
+++ b/pkg/conditions2/getter.go
@@ -1,0 +1,257 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conditions2
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+)
+
+const (
+	ReadyConditionType = "Ready"
+)
+
+// Getter interface defines methods that an object should implement in order to
+// use the conditions package for getting conditions.
+type Getter interface {
+	client.Object
+
+	// GetConditions returns the list of conditions for a cluster API object.
+	GetConditions() []metav1.Condition
+}
+
+// Get returns the condition with the given type, if the condition does not exists,
+// it returns nil.
+func Get(from Getter, t string) *metav1.Condition {
+	for _, condition := range from.GetConditions() {
+		if condition.Type == t {
+			return &condition
+		}
+	}
+	return nil
+}
+
+// Has returns true if a condition with the given type exists.
+func Has(from Getter, t string) bool {
+	return Get(from, t) != nil
+}
+
+// IsTrueFromConditions returns true if the condition with the given type is True.
+// This is helpful to check the condition without passing a specific resource object.
+func IsTrueFromConditions(conditions []metav1.Condition, t string) bool {
+	for _, c := range conditions {
+		if c.Type == t {
+			return c.Status == metav1.ConditionTrue
+		}
+	}
+	return false
+}
+
+// IsTrue is true if the condition with the given type is True, otherwise it return false
+// if the condition is not True or if the condition does not exist (is nil).
+func IsTrue(from Getter, t string) bool {
+	if c := Get(from, t); c != nil {
+		return c.Status == metav1.ConditionTrue
+	}
+	return false
+}
+
+// IsFalse is true if the condition with the given type is False, otherwise it return false
+// if the condition is not False or if the condition does not exist (is nil).
+func IsFalse(from Getter, t string) bool {
+	if c := Get(from, t); c != nil {
+		return c.Status == metav1.ConditionFalse
+	}
+	return false
+}
+
+// IsUnknown is true if the condition with the given type is Unknown or if the condition
+// does not exist (is nil).
+func IsUnknown(from Getter, t string) bool {
+	if c := Get(from, t); c != nil {
+		return c.Status == metav1.ConditionUnknown
+	}
+	return true
+}
+
+// GetReason returns a nil safe string of Reason for the condition with the given type.
+func GetReason(from Getter, t string) string {
+	if c := Get(from, t); c != nil {
+		return c.Reason
+	}
+	return ""
+}
+
+// GetMessage returns a nil safe string of Message.
+func GetMessage(from Getter, t string) string {
+	if c := Get(from, t); c != nil {
+		return c.Message
+	}
+	return ""
+}
+
+// GetLastTransitionTime returns the condition Severity or nil if the condition
+// does not exist (is nil).
+func GetLastTransitionTime(from Getter, t string) *metav1.Time {
+	if c := Get(from, t); c != nil {
+		return &c.LastTransitionTime
+	}
+	return nil
+}
+
+// summary returns a Ready condition with the summary of all the conditions existing
+// on an object. If the object does not have other conditions, no summary condition is generated.
+func summary(from Getter, options ...MergeOption) *metav1.Condition {
+	conditions := from.GetConditions()
+
+	mergeOpt := &mergeOptions{}
+	for _, o := range options {
+		o(mergeOpt)
+	}
+
+	// Identifies the conditions in scope for the Summary by taking all the existing conditions except Ready,
+	// or, if a list of conditions types is specified, only the conditions the condition in that list.
+	conditionsInScope := make([]localizedCondition, 0, len(conditions))
+	for i := range conditions {
+		c := conditions[i]
+		if c.Type == vmopv1.ReadyConditionType {
+			continue
+		}
+
+		if mergeOpt.conditionTypes != nil {
+			found := false
+			for _, t := range mergeOpt.conditionTypes {
+				if c.Type == t {
+					found = true
+					break
+				}
+			}
+			if !found {
+				continue
+			}
+		}
+
+		conditionsInScope = append(conditionsInScope, localizedCondition{
+			Condition: &c,
+			Getter:    from,
+		})
+	}
+
+	// If it is required to add a step counter only if a subset of condition exists, check if the conditions
+	// in scope are included in this subset or not.
+	if mergeOpt.addStepCounterIfOnlyConditionTypes != nil {
+		for _, c := range conditionsInScope {
+			found := false
+			for _, t := range mergeOpt.addStepCounterIfOnlyConditionTypes {
+				if c.Type == t {
+					found = true
+					break
+				}
+			}
+			if !found {
+				mergeOpt.addStepCounter = false
+				break
+			}
+		}
+	}
+
+	// If it is required to add a step counter, determine the total number of conditions defaulting
+	// to the selected conditions or, if defined, to the total number of conditions type to be considered.
+	if mergeOpt.addStepCounter {
+		mergeOpt.stepCounter = len(conditionsInScope)
+		if mergeOpt.conditionTypes != nil {
+			mergeOpt.stepCounter = len(mergeOpt.conditionTypes)
+		}
+		if mergeOpt.addStepCounterIfOnlyConditionTypes != nil {
+			mergeOpt.stepCounter = len(mergeOpt.addStepCounterIfOnlyConditionTypes)
+		}
+	}
+
+	return merge(conditionsInScope, vmopv1.ReadyConditionType, mergeOpt)
+}
+
+// mirrorOptions allows to set options for the mirror operation.
+type mirrorOptions struct {
+	fallbackTo      *bool
+	fallbackReason  string
+	fallbackMessage string
+}
+
+// MirrorOptions defines an option for mirroring conditions.
+type MirrorOptions func(*mirrorOptions)
+
+// WithFallbackValue specify a fallback value to use in case the mirrored condition does not exists;
+// in case the fallbackValue is false, given values for reason, severity and message will be used.
+func WithFallbackValue(fallbackValue bool, reason string, message string) MirrorOptions {
+	return func(c *mirrorOptions) {
+		c.fallbackTo = &fallbackValue
+		c.fallbackReason = reason
+		c.fallbackMessage = message
+	}
+}
+
+// mirror mirrors the Ready condition from a dependent object into the target condition;
+// if the Ready condition does not exists in the source object, no target conditions is generated.
+func mirror(from Getter, targetCondition string, options ...MirrorOptions) *metav1.Condition {
+	mirrorOpt := &mirrorOptions{}
+	for _, o := range options {
+		o(mirrorOpt)
+	}
+
+	condition := Get(from, vmopv1.ReadyConditionType)
+
+	if mirrorOpt.fallbackTo != nil && condition == nil {
+		switch *mirrorOpt.fallbackTo {
+		case true:
+			condition = TrueCondition(targetCondition)
+		case false:
+			condition = FalseCondition(targetCondition, mirrorOpt.fallbackReason, mirrorOpt.fallbackMessage)
+		}
+	}
+
+	if condition != nil {
+		condition.Type = targetCondition
+	}
+
+	return condition
+}
+
+// Aggregates all the Ready condition from a list of dependent objects into the target object;
+// if the Ready condition does not exists in one of the source object, the object is excluded from
+// the aggregation; if none of the source object have ready condition, no target conditions is generated.
+func aggregate(from []Getter, targetCondition string, options ...MergeOption) *metav1.Condition {
+	conditionsInScope := make([]localizedCondition, 0, len(from))
+	for i := range from {
+		condition := Get(from[i], vmopv1.ReadyConditionType)
+
+		conditionsInScope = append(conditionsInScope, localizedCondition{
+			Condition: condition,
+			Getter:    from[i],
+		})
+	}
+
+	mergeOpt := &mergeOptions{
+		addStepCounter: true,
+		stepCounter:    len(from),
+	}
+	for _, o := range options {
+		o(mergeOpt)
+	}
+	return merge(conditionsInScope, targetCondition, mergeOpt)
+}

--- a/pkg/conditions2/getter_test.go
+++ b/pkg/conditions2/getter_test.go
@@ -1,0 +1,323 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//nolint:scopelint
+package conditions2
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
+	"github.com/onsi/gomega/types"
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+)
+
+var (
+	nil1          *metav1.Condition
+	true1         = TrueCondition("true1")
+	unknown1      = UnknownCondition("unknown1", "reason unknown1", "message unknown1")
+	falseInfo1    = FalseCondition("falseInfo1", "reason falseInfo1", "message falseInfo1")
+	falseWarning1 = FalseCondition("falseWarning1", "reason falseWarning1", "message falseWarning1")
+	falseError1   = FalseCondition("falseError1", "reason falseError1", "message falseError1")
+)
+
+func TestGetAndHas(t *testing.T) {
+	g := NewWithT(t)
+
+	vm := &vmopv1.VirtualMachine{}
+
+	g.Expect(Has(vm, "conditionBaz")).To(BeFalse())
+	g.Expect(Get(vm, "conditionBaz")).To(BeNil())
+
+	vm.SetConditions(conditionList(TrueCondition("conditionBaz")))
+
+	g.Expect(Has(vm, "conditionBaz")).To(BeTrue())
+	g.Expect(Get(vm, "conditionBaz")).To(haveSameStateOf(TrueCondition("conditionBaz")))
+}
+
+func TestIsMethods(t *testing.T) {
+	g := NewWithT(t)
+
+	obj := getterWithConditions(nil1, true1, unknown1, falseInfo1, falseWarning1, falseError1)
+
+	// test isTrue
+	g.Expect(IsTrue(obj, "nil1")).To(BeFalse())
+	g.Expect(IsTrue(obj, "true1")).To(BeTrue())
+	g.Expect(IsTrue(obj, "falseInfo1")).To(BeFalse())
+	g.Expect(IsTrue(obj, "unknown1")).To(BeFalse())
+
+	// test isFalse
+	g.Expect(IsFalse(obj, "nil1")).To(BeFalse())
+	g.Expect(IsFalse(obj, "true1")).To(BeFalse())
+	g.Expect(IsFalse(obj, "falseInfo1")).To(BeTrue())
+	g.Expect(IsFalse(obj, "unknown1")).To(BeFalse())
+
+	// test isUnknown
+	g.Expect(IsUnknown(obj, "nil1")).To(BeTrue())
+	g.Expect(IsUnknown(obj, "true1")).To(BeFalse())
+	g.Expect(IsUnknown(obj, "falseInfo1")).To(BeFalse())
+	g.Expect(IsUnknown(obj, "unknown1")).To(BeTrue())
+
+	// test GetReason
+	g.Expect(GetReason(obj, "nil1")).To(Equal(""))
+	g.Expect(GetReason(obj, "falseInfo1")).To(Equal("reason falseInfo1"))
+
+	// test GetMessage
+	g.Expect(GetMessage(obj, "nil1")).To(Equal(""))
+	g.Expect(GetMessage(obj, "falseInfo1")).To(Equal("message falseInfo1"))
+
+	// test GetMessage
+	g.Expect(GetLastTransitionTime(obj, "nil1")).To(BeNil())
+	g.Expect(GetLastTransitionTime(obj, "falseInfo1")).ToNot(BeNil())
+}
+
+func TestMirror(t *testing.T) {
+	foo := FalseCondition("foo", "reason foo", "message foo")
+	ready := TrueCondition(vmopv1.ReadyConditionType)
+	readyBar := ready.DeepCopy()
+	readyBar.Type = "bar"
+
+	tests := []struct {
+		name string
+		from Getter
+		t    string
+		want *metav1.Condition
+	}{
+		{
+			name: "Returns nil when the ready condition does not exists",
+			from: getterWithConditions(foo),
+			want: nil,
+		},
+		{
+			name: "Returns ready condition from source",
+			from: getterWithConditions(ready, foo),
+			t:    "bar",
+			want: readyBar,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			got := mirror(tt.from, tt.t)
+			if tt.want == nil {
+				g.Expect(got).To(BeNil())
+				return
+			}
+			g.Expect(got).To(haveSameStateOf(tt.want))
+		})
+	}
+}
+
+func TestSummary(t *testing.T) {
+	foo := TrueCondition("foo")
+	bar := FalseCondition("bar", "reason falseInfo1", "message falseInfo1")
+	baz := FalseCondition("baz", "reason falseInfo2", "message falseInfo2")
+	existingReady := FalseCondition(vmopv1.ReadyConditionType, "reason falseError1", "message falseError1") // NB. existing ready has higher priority than other conditions
+
+	tests := []struct {
+		name    string
+		from    Getter
+		options []MergeOption
+		want    *metav1.Condition
+	}{
+		{
+			name: "Returns nil when there are no conditions to summarize",
+			from: getterWithConditions(),
+			want: nil,
+		},
+		{
+			name: "Returns ready condition with the summary of existing conditions (with default options)",
+			from: getterWithConditions(foo, bar),
+			want: FalseCondition(vmopv1.ReadyConditionType, "reason falseInfo1", "message falseInfo1"),
+		},
+		{
+			name:    "Returns ready condition with the summary of existing conditions (using WithStepCounter options)",
+			from:    getterWithConditions(foo, bar),
+			options: []MergeOption{WithStepCounter()},
+			want:    FalseCondition(vmopv1.ReadyConditionType, "reason falseInfo1", "1 of 2 completed"),
+		},
+		{
+			name:    "Returns ready condition with the summary of existing conditions (using WithStepCounterIf options)",
+			from:    getterWithConditions(foo, bar),
+			options: []MergeOption{WithStepCounterIf(false)},
+			want:    FalseCondition(vmopv1.ReadyConditionType, "reason falseInfo1", "message falseInfo1"),
+		},
+		{
+			name:    "Returns ready condition with the summary of existing conditions (using WithStepCounterIf options)",
+			from:    getterWithConditions(foo, bar),
+			options: []MergeOption{WithStepCounterIf(true)},
+			want:    FalseCondition(vmopv1.ReadyConditionType, "reason falseInfo1", "1 of 2 completed"),
+		},
+		{
+			name:    "Returns ready condition with the summary of existing conditions (using WithStepCounterIf and WithStepCounterIfOnly options)",
+			from:    getterWithConditions(bar),
+			options: []MergeOption{WithStepCounter(), WithStepCounterIfOnly("bar")},
+			want:    FalseCondition(vmopv1.ReadyConditionType, "reason falseInfo1", "0 of 1 completed"),
+		},
+		{
+			name:    "Returns ready condition with the summary of existing conditions (using WithStepCounterIf and WithStepCounterIfOnly options)",
+			from:    getterWithConditions(foo, bar),
+			options: []MergeOption{WithStepCounter(), WithStepCounterIfOnly("foo")},
+			want:    FalseCondition(vmopv1.ReadyConditionType, "reason falseInfo1", "message falseInfo1"),
+		},
+		{
+			name:    "Returns ready condition with the summary of selected conditions (using WithConditions options)",
+			from:    getterWithConditions(foo, bar),
+			options: []MergeOption{WithConditions("foo")}, // bar should be ignored
+			want:    TrueCondition(vmopv1.ReadyConditionType),
+		},
+		{
+			name:    "Returns ready condition with the summary of selected conditions (using WithConditions and WithStepCounter options)",
+			from:    getterWithConditions(foo, bar, baz),
+			options: []MergeOption{WithConditions("foo", "bar"), WithStepCounter()}, // baz should be ignored, total steps should be 2
+			want:    FalseCondition(vmopv1.ReadyConditionType, "reason falseInfo1", "1 of 2 completed"),
+		},
+		{
+			name:    "Returns ready condition with the summary of selected conditions (using WithConditions and WithStepCounterIfOnly options)",
+			from:    getterWithConditions(bar),
+			options: []MergeOption{WithConditions("bar", "baz"), WithStepCounter(), WithStepCounterIfOnly("bar")}, // there is only bar, the step counter should be set and counts only a subset of conditions
+			want:    FalseCondition(vmopv1.ReadyConditionType, "reason falseInfo1", "0 of 1 completed"),
+		},
+		{
+			name:    "Returns ready condition with the summary of selected conditions (using WithConditions and WithStepCounterIfOnly options - with inconsistent order between the two)",
+			from:    getterWithConditions(bar),
+			options: []MergeOption{WithConditions("baz", "bar"), WithStepCounter(), WithStepCounterIfOnly("bar", "baz")}, // conditions in WithStepCounterIfOnly could be in different order than in WithConditions
+			want:    FalseCondition(vmopv1.ReadyConditionType, "reason falseInfo1", "0 of 2 completed"),
+		},
+		{
+			name:    "Returns ready condition with the summary of selected conditions (using WithConditions and WithStepCounterIfOnly options)",
+			from:    getterWithConditions(bar, baz),
+			options: []MergeOption{WithConditions("bar", "baz"), WithStepCounter(), WithStepCounterIfOnly("bar")}, // there is also baz, so the step counter should not be set
+			want:    FalseCondition(vmopv1.ReadyConditionType, "reason falseInfo1", "message falseInfo1"),
+		},
+		{
+			name:    "Ready condition respects merge order",
+			from:    getterWithConditions(bar, baz),
+			options: []MergeOption{WithConditions("baz", "bar")}, // baz should take precedence on bar
+			want:    FalseCondition(vmopv1.ReadyConditionType, "reason falseInfo2", "message falseInfo2"),
+		},
+		{
+			name: "Ignores existing Ready condition when computing the summary",
+			from: getterWithConditions(existingReady, foo, bar),
+			want: FalseCondition(vmopv1.ReadyConditionType, "reason falseInfo1", "message falseInfo1"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			got := summary(tt.from, tt.options...)
+			if tt.want == nil {
+				g.Expect(got).To(BeNil())
+				return
+			}
+			g.Expect(got).To(haveSameStateOf(tt.want))
+		})
+	}
+}
+
+func TestAggregate(t *testing.T) {
+	ready1 := TrueCondition(vmopv1.ReadyConditionType)
+	ready2 := FalseCondition(vmopv1.ReadyConditionType, "reason falseInfo1", "message falseInfo1")
+	bar := FalseCondition("bar", "reason falseError1", "message falseError1") // NB. bar has higher priority than other conditions
+
+	tests := []struct {
+		name string
+		from []Getter
+		t    string
+		want *metav1.Condition
+	}{
+		{
+			name: "Returns nil when there are no conditions to aggregate",
+			from: []Getter{},
+			want: nil,
+		},
+		{
+			name: "Returns foo condition with the aggregation of object's ready conditions",
+			from: []Getter{
+				getterWithConditions(ready1),
+				getterWithConditions(ready1),
+				getterWithConditions(ready2, bar),
+				getterWithConditions(),
+				getterWithConditions(bar),
+			},
+			t:    "foo",
+			want: FalseCondition("foo", "reason falseInfo1", "2 of 5 completed"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			got := aggregate(tt.from, tt.t)
+			if tt.want == nil {
+				g.Expect(got).To(BeNil())
+				return
+			}
+			g.Expect(got).To(haveSameStateOf(tt.want))
+		})
+	}
+}
+
+func getterWithConditions(conditions ...*metav1.Condition) Getter {
+	obj := &vmopv1.VirtualMachine{}
+	obj.SetConditions(conditionList(conditions...))
+	return obj
+}
+
+func conditionList(conditions ...*metav1.Condition) []metav1.Condition {
+	var cs []metav1.Condition
+	for _, x := range conditions {
+		if x != nil {
+			cs = append(cs, *x)
+		}
+	}
+	return cs
+}
+
+func haveSameStateOf(expected *metav1.Condition) types.GomegaMatcher {
+	return &ConditionMatcher{
+		Expected: expected,
+	}
+}
+
+type ConditionMatcher struct {
+	Expected *metav1.Condition
+}
+
+func (matcher *ConditionMatcher) Match(actual interface{}) (success bool, err error) {
+	actualCondition, ok := actual.(*metav1.Condition)
+	if !ok {
+		return false, errors.New("Value should be a condition")
+	}
+
+	return hasSameState(actualCondition, matcher.Expected), nil
+}
+
+func (matcher *ConditionMatcher) FailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, "to have the same state of", matcher.Expected)
+}
+func (matcher *ConditionMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, "not to have the same state of", matcher.Expected)
+}

--- a/pkg/conditions2/matcher.go
+++ b/pkg/conditions2/matcher.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conditions2
+
+import (
+	"fmt"
+
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// MatchConditions returns a custom matcher to check equality of metav1.Conditions.
+func MatchConditions(expected []metav1.Condition) types.GomegaMatcher {
+	return &matchConditions{
+		expected: expected,
+	}
+}
+
+type matchConditions struct {
+	expected []metav1.Condition
+}
+
+func (m matchConditions) Match(actual interface{}) (success bool, err error) {
+	elems := make([]interface{}, 0, len(m.expected))
+	for _, condition := range m.expected {
+		elems = append(elems, MatchCondition(condition))
+	}
+
+	return gomega.ConsistOf(elems).Match(actual)
+}
+
+func (m matchConditions) FailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("expected\n\t%#v\nto match\n\t%#v\n", actual, m.expected)
+}
+
+func (m matchConditions) NegatedFailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("expected\n\t%#v\nto not match\n\t%#v\n", actual, m.expected)
+}
+
+// MatchCondition returns a custom matcher to check equality of metav1.Condition.
+func MatchCondition(expected metav1.Condition) types.GomegaMatcher {
+	return &matchCondition{
+		expected: expected,
+	}
+}
+
+type matchCondition struct {
+	expected metav1.Condition
+}
+
+func (m matchCondition) Match(actual interface{}) (success bool, err error) {
+	actualCondition, ok := actual.(metav1.Condition)
+	if !ok {
+		return false, fmt.Errorf("actual should be of type Condition")
+	}
+
+	ok, err = gomega.Equal(m.expected.Type).Match(actualCondition.Type)
+	if !ok {
+		return ok, err
+	}
+	ok, err = gomega.Equal(m.expected.Status).Match(actualCondition.Status)
+	if !ok {
+		return ok, err
+	}
+	ok, err = gomega.Equal(m.expected.Reason).Match(actualCondition.Reason)
+	if !ok {
+		return ok, err
+	}
+	ok, err = gomega.Equal(m.expected.Message).Match(actualCondition.Message)
+	if !ok {
+		return ok, err
+	}
+
+	return ok, err
+}
+
+func (m matchCondition) FailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("expected\n\t%#v\nto match\n\t%#v\n", actual, m.expected)
+}
+
+func (m matchCondition) NegatedFailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("expected\n\t%#v\nto not match\n\t%#v\n", actual, m.expected)
+}

--- a/pkg/conditions2/matcher_test.go
+++ b/pkg/conditions2/matcher_test.go
@@ -1,0 +1,274 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//nolint:scopelint
+package conditions2
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestMatchConditions(t *testing.T) {
+	testCases := []struct {
+		name        string
+		actual      interface{}
+		expected    []metav1.Condition
+		expectMatch bool
+	}{
+		{
+			name:        "with an empty conditions",
+			actual:      []metav1.Condition{},
+			expected:    []metav1.Condition{},
+			expectMatch: true,
+		},
+		{
+			name: "with matching conditions",
+			actual: []metav1.Condition{
+				{
+					Type:               "type",
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Now(),
+					Reason:             "reason",
+					Message:            "message",
+				},
+			},
+			expected: []metav1.Condition{
+				{
+					Type:               "type",
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Now(),
+					Reason:             "reason",
+					Message:            "message",
+				},
+			},
+			expectMatch: true,
+		},
+		{
+			name: "with non-matching conditions",
+			actual: []metav1.Condition{
+				{
+					Type:               "type",
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Now(),
+					Reason:             "reason",
+					Message:            "message",
+				},
+				{
+					Type:               "type",
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Now(),
+					Reason:             "reason",
+					Message:            "message",
+				},
+			},
+			expected: []metav1.Condition{
+				{
+					Type:               "type",
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Now(),
+					Reason:             "reason",
+					Message:            "message",
+				},
+				{
+					Type:               "different",
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Now(),
+					Reason:             "different",
+					Message:            "different",
+				},
+			},
+			expectMatch: false,
+		},
+		{
+			name: "with a different number of conditions",
+			actual: []metav1.Condition{
+				{
+					Type:               "type",
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Now(),
+					Reason:             "reason",
+					Message:            "message",
+				},
+				{
+					Type:               "type",
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Now(),
+					Reason:             "reason",
+					Message:            "message",
+				},
+			},
+			expected: []metav1.Condition{
+				{
+					Type:               "type",
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Now(),
+					Reason:             "reason",
+					Message:            "message",
+				},
+			},
+			expectMatch: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			if tc.expectMatch {
+				g.Expect(tc.actual).To(MatchConditions(tc.expected))
+			} else {
+				g.Expect(tc.actual).ToNot(MatchConditions(tc.expected))
+			}
+		})
+	}
+}
+
+func TestMatchCondition(t *testing.T) {
+	testCases := []struct {
+		name        string
+		actual      interface{}
+		expected    metav1.Condition
+		expectMatch bool
+	}{
+		{
+			name:        "with an empty condition",
+			actual:      metav1.Condition{},
+			expected:    metav1.Condition{},
+			expectMatch: true,
+		},
+		{
+			name: "with a matching condition",
+			actual: metav1.Condition{
+				Type:               "type",
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "reason",
+				Message:            "message",
+			},
+			expected: metav1.Condition{
+				Type:               "type",
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "reason",
+				Message:            "message",
+			},
+			expectMatch: true,
+		},
+		{
+			name: "with a different time",
+			actual: metav1.Condition{
+				Type:               "type",
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "reason",
+				Message:            "message",
+			},
+			expected: metav1.Condition{
+				Type:               "type",
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: metav1.Time{},
+				Reason:             "reason",
+				Message:            "message",
+			},
+			expectMatch: true,
+		},
+		{
+			name: "with a different type",
+			actual: metav1.Condition{
+				Type:               "type",
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "reason",
+				Message:            "message",
+			},
+			expected: metav1.Condition{
+				Type:               "different",
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "reason",
+				Message:            "message",
+			},
+			expectMatch: false,
+		},
+		{
+			name: "with a different status",
+			actual: metav1.Condition{
+				Type:               "type",
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "reason",
+				Message:            "message",
+			},
+			expected: metav1.Condition{
+				Type:               "type",
+				Status:             metav1.ConditionFalse,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "reason",
+				Message:            "message",
+			},
+			expectMatch: false,
+		},
+		{
+			name: "with a different reason",
+			actual: metav1.Condition{
+				Type:               "type",
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "reason",
+				Message:            "message",
+			},
+			expected: metav1.Condition{
+				Type:               "type",
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "different",
+				Message:            "message",
+			},
+			expectMatch: false,
+		},
+		{
+			name: "with a different message",
+			actual: metav1.Condition{
+				Type:               "type",
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "reason",
+				Message:            "message",
+			},
+			expected: metav1.Condition{
+				Type:               "type",
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "reason",
+				Message:            "different",
+			},
+			expectMatch: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			if tc.expectMatch {
+				g.Expect(tc.actual).To(MatchCondition(tc.expected))
+			} else {
+				g.Expect(tc.actual).ToNot(MatchCondition(tc.expected))
+			}
+		})
+	}
+}

--- a/pkg/conditions2/merge.go
+++ b/pkg/conditions2/merge.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conditions2
+
+import (
+	"sort"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// localizedCondition defines a condition with the information of the object the conditions
+// was originated from.
+type localizedCondition struct {
+	*metav1.Condition
+	Getter
+}
+
+// merge a list of condition into a single one.
+// This operation is designed to ensure visibility of the most relevant conditions for defining the
+// operational state of a component. E.g. If there is one error in the condition list, this one takes
+// priority over the other conditions and it is should be reflected in the target condition.
+//
+// More specifically:
+// 1. Conditions are grouped by status, severity
+// 2. The resulting condition groups are sorted according to the following priority:
+//   - P0 - Status=False, Severity=Error
+//   - P1 - Status=False, Severity=Warning
+//   - P2 - Status=False, Severity=Info
+//   - P3 - Status=True
+//   - P4 - Status=Unknown
+//
+// 3. The group with highest priority is used to determine status, severity and other info of the target condition.
+//
+// Please note that the last operation includes also the task of computing the Reason and the Message for the target
+// condition; in order to complete such task some trade-off should be made, because there is no a golden rule
+// for summarizing many Reason/Message into single Reason/Message.
+// mergeOptions allows the user to adapt this process to the specific needs by exposing a set of merge strategies.
+func merge(conditions []localizedCondition, targetCondition string, options *mergeOptions) *metav1.Condition {
+	g := getConditionGroups(conditions)
+	if len(g) == 0 {
+		return nil
+	}
+
+	if g.TopGroup().status == metav1.ConditionTrue {
+		return TrueCondition(targetCondition)
+	}
+
+	targetReason := getReason(g, options)
+	targetMessage := getMessage(g, options)
+	if g.TopGroup().status == metav1.ConditionFalse {
+		return FalseCondition(targetCondition, targetReason, targetMessage)
+	}
+	return UnknownCondition(targetCondition, targetReason, targetMessage)
+}
+
+// getConditionGroups groups a list of conditions according to status, severity values.
+// Additionally, the resulting groups are sorted by mergePriority.
+func getConditionGroups(conditions []localizedCondition) conditionGroups {
+	groups := conditionGroups{}
+
+	for _, condition := range conditions {
+		if condition.Condition == nil {
+			continue
+		}
+
+		added := false
+		for i := range groups {
+			if groups[i].status == condition.Status {
+				groups[i].conditions = append(groups[i].conditions, condition)
+				added = true
+				break
+			}
+		}
+		if !added {
+			groups = append(groups, conditionGroup{
+				conditions: []localizedCondition{condition},
+				status:     condition.Status,
+			})
+		}
+	}
+
+	// sort groups by priority
+	sort.Sort(groups)
+
+	// sorts conditions in the TopGroup so we ensure predictable result for merge strategies.
+	// condition are sorted using the same lexicographic order used by Set; in case two conditions
+	// have the same type, condition are sorted using according to the alphabetical order of the source object name.
+	if len(groups) > 0 {
+		sort.Slice(groups[0].conditions, func(i, j int) bool {
+			a := groups[0].conditions[i]
+			b := groups[0].conditions[j]
+			if a.Type != b.Type {
+				return lexicographicLess(a.Condition, b.Condition)
+			}
+			return a.GetName() < b.GetName()
+		})
+	}
+
+	return groups
+}
+
+// conditionGroups provides supports for grouping a list of conditions to be
+// merged into a single condition. ConditionGroups can be sorted by mergePriority.
+type conditionGroups []conditionGroup
+
+func (g conditionGroups) Len() int {
+	return len(g)
+}
+
+func (g conditionGroups) Less(i, j int) bool {
+	return g[i].mergePriority() < g[j].mergePriority()
+}
+
+func (g conditionGroups) Swap(i, j int) {
+	g[i], g[j] = g[j], g[i]
+}
+
+// TopGroup returns the condition group with the highest mergePriority.
+func (g conditionGroups) TopGroup() *conditionGroup {
+	if len(g) == 0 {
+		return nil
+	}
+	return &g[0]
+}
+
+// TrueGroup returns the condition group with status True, if any.
+func (g conditionGroups) TrueGroup() *conditionGroup {
+	return g.getByStatusAndSeverity(metav1.ConditionTrue)
+}
+
+// FalseGroup returns the condition group with status False, if any.
+func (g conditionGroups) FalseGroup() *conditionGroup {
+	return g.getByStatusAndSeverity(metav1.ConditionFalse)
+}
+
+func (g conditionGroups) getByStatusAndSeverity(status metav1.ConditionStatus) *conditionGroup {
+	if len(g) == 0 {
+		return nil
+	}
+	for _, group := range g {
+		if group.status == status {
+			return &group
+		}
+	}
+	return nil
+}
+
+// conditionGroup define a group of conditions with the same status,
+// and thus with the same priority when merging into a Ready condition.
+type conditionGroup struct {
+	status     metav1.ConditionStatus
+	conditions []localizedCondition
+}
+
+// mergePriority provides a priority value for the status and severity tuple that identifies this
+// condition group. The mergePriority value allows an easier sorting of conditions groups.
+func (g conditionGroup) mergePriority() int {
+	switch g.status {
+	case metav1.ConditionFalse:
+		return 2
+	case metav1.ConditionTrue:
+		return 3
+	case metav1.ConditionUnknown:
+		return 4
+	}
+
+	// this should never happen
+	return 99
+}

--- a/pkg/conditions2/merge_strategies.go
+++ b/pkg/conditions2/merge_strategies.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conditions2
+
+import (
+	"fmt"
+	"strings"
+)
+
+// mergeOptions allows to set strategies for merging a set of conditions into a single condition,
+// and more specifically for computing the target Reason and the target Message.
+type mergeOptions struct {
+	conditionTypes                     []string
+	addSourceRef                       bool
+	addStepCounter                     bool
+	addStepCounterIfOnlyConditionTypes []string
+	stepCounter                        int
+}
+
+// MergeOption defines an option for computing a summary of conditions.
+type MergeOption func(*mergeOptions)
+
+// WithConditions instructs merge about the condition types to consider when doing a merge operation;
+// if this option is not specified, all the conditions (excepts Ready) will be considered. This is required
+// so we can provide some guarantees about the semantic of the target condition without worrying about
+// side effects if someone or something adds custom conditions to the objects.
+//
+// NOTE: The order of conditions types defines the priority for determining the Reason and Message for the
+// target condition.
+// IMPORTANT: This options works only while generating the Summary condition.
+func WithConditions(t ...string) MergeOption {
+	return func(c *mergeOptions) {
+		c.conditionTypes = t
+	}
+}
+
+// WithStepCounter instructs merge to add a "x of y completed" string to the message,
+// where x is the number of conditions with Status=true and y is the number of conditions in scope.
+func WithStepCounter() MergeOption {
+	return func(c *mergeOptions) {
+		c.addStepCounter = true
+	}
+}
+
+// WithStepCounterIf adds a step counter if the value is true.
+// This can be used e.g. to add a step counter only if the object is not being deleted.
+//
+// IMPORTANT: This options works only while generating the Summary condition.
+func WithStepCounterIf(value bool) MergeOption {
+	return func(c *mergeOptions) {
+		c.addStepCounter = value
+	}
+}
+
+// WithStepCounterIfOnly ensure a step counter is show only if a subset of condition exists.
+// This applies for example on Machines, where we want to use
+// the step counter notation while provisioning the machine, but then we want to move away from this notation
+// as soon as the machine is provisioned and e.g. a Machine health check condition is generated
+//
+// IMPORTANT: This options requires WithStepCounter or WithStepCounterIf to be set.
+// IMPORTANT: This options works only while generating the Summary condition.
+func WithStepCounterIfOnly(t ...string) MergeOption {
+	return func(c *mergeOptions) {
+		c.addStepCounterIfOnlyConditionTypes = t
+	}
+}
+
+// AddSourceRef instructs merge to add info about the originating object to the target Reason.
+func AddSourceRef() MergeOption {
+	return func(c *mergeOptions) {
+		c.addSourceRef = true
+	}
+}
+
+// getReason returns the reason to be applied to the condition resulting by merging a set of condition groups.
+// The reason is computed according to the given mergeOptions.
+func getReason(groups conditionGroups, options *mergeOptions) string {
+	return getFirstReason(groups, options.conditionTypes, options.addSourceRef)
+}
+
+// getFirstReason returns the first reason from the ordered list of conditions in the top group.
+// If required, the reason gets localized with the source object reference.
+func getFirstReason(g conditionGroups, order []string, addSourceRef bool) string {
+	if condition := getFirstCondition(g, order); condition != nil {
+		reason := condition.Reason
+		if addSourceRef {
+			return localizeReason(reason, condition.Getter)
+		}
+		return reason
+	}
+	return ""
+}
+
+// localizeReason adds info about the originating object to the target Reason.
+func localizeReason(reason string, from Getter) string {
+	if strings.Contains(reason, "@") {
+		return reason
+	}
+	return fmt.Sprintf("%s @ %s/%s", reason, from.GetObjectKind().GroupVersionKind().Kind, from.GetName())
+}
+
+// getMessage returns the message to be applied to the condition resulting by merging a set of condition groups.
+// The message is computed according to the given mergeOptions, but in case of errors or warning a
+// summary of existing errors is automatically added.
+func getMessage(groups conditionGroups, options *mergeOptions) string {
+	if options.addStepCounter {
+		return getStepCounterMessage(groups, options.stepCounter)
+	}
+
+	return getFirstMessage(groups, options.conditionTypes)
+}
+
+// getStepCounterMessage returns a message "x of y completed", where x is the number of conditions
+// with Status=true and y is the number passed to this method.
+func getStepCounterMessage(groups conditionGroups, to int) string {
+	ct := 0
+	if trueGroup := groups.TrueGroup(); trueGroup != nil {
+		ct = len(trueGroup.conditions)
+	}
+	return fmt.Sprintf("%d of %d completed", ct, to)
+}
+
+// getFirstMessage returns the message from the ordered list of conditions in the top group.
+func getFirstMessage(groups conditionGroups, order []string) string {
+	if condition := getFirstCondition(groups, order); condition != nil {
+		return condition.Message
+	}
+	return ""
+}
+
+// getFirstCondition returns a first condition from the ordered list of conditions in the top group.
+func getFirstCondition(g conditionGroups, priority []string) *localizedCondition {
+	topGroup := g.TopGroup()
+	if topGroup == nil {
+		return nil
+	}
+
+	switch len(topGroup.conditions) {
+	case 0:
+		return nil
+	case 1:
+		return &topGroup.conditions[0]
+	default:
+		for _, p := range priority {
+			for _, c := range topGroup.conditions {
+				if c.Type == p {
+					return &c
+				}
+			}
+		}
+		return &topGroup.conditions[0]
+	}
+}

--- a/pkg/conditions2/merge_strategies_test.go
+++ b/pkg/conditions2/merge_strategies_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conditions2
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+)
+
+func TestGetStepCounterMessage(t *testing.T) {
+	g := NewWithT(t)
+
+	groups := getConditionGroups(conditionsWithSource(&vmopv1.VirtualMachine{},
+		nil1,
+		true1, true1,
+		falseInfo1,
+		falseWarning1, falseWarning1,
+		falseError1,
+		unknown1,
+	))
+
+	got := getStepCounterMessage(groups, 8)
+
+	// step count message should report n° if true conditions over to number
+	g.Expect(got).To(Equal("2 of 8 completed"))
+}
+
+func TestLocalizeReason(t *testing.T) {
+	g := NewWithT(t)
+
+	getter := &vmopv1.VirtualMachine{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "VirtualMachine",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-vm",
+		},
+	}
+
+	// localize should reason location
+	got := localizeReason("foo", getter)
+	g.Expect(got).To(Equal("foo @ VirtualMachine/test-vm"))
+
+	// localize should not alter existing location
+	got = localizeReason("foo @ SomeKind/some-name", getter)
+	g.Expect(got).To(Equal("foo @ SomeKind/some-name"))
+}
+
+func TestGetFirstReasonAndMessage(t *testing.T) {
+	g := NewWithT(t)
+
+	foo := FalseCondition("foo", "falseFoo", "message falseFoo")
+	bar := FalseCondition("bar", "falseBar", "message falseBar")
+
+	getter := &vmopv1.VirtualMachine{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "VirtualMachine",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-vm",
+		},
+	}
+
+	groups := getConditionGroups(conditionsWithSource(getter, foo, bar))
+
+	// getFirst should report first condition in lexicografical order if no order is specified
+	gotReason := getFirstReason(groups, nil, false)
+	g.Expect(gotReason).To(Equal("falseBar"))
+	gotMessage := getFirstMessage(groups, nil)
+	g.Expect(gotMessage).To(Equal("message falseBar"))
+
+	// getFirst should report should respect order
+	gotReason = getFirstReason(groups, []string{"foo", "bar"}, false)
+	g.Expect(gotReason).To(Equal("falseFoo"))
+	gotMessage = getFirstMessage(groups, []string{"foo", "bar"})
+	g.Expect(gotMessage).To(Equal("message falseFoo"))
+
+	// getFirst should report should respect order in case of missing conditions
+	gotReason = getFirstReason(groups, []string{"missingBaz", "foo", "bar"}, false)
+	g.Expect(gotReason).To(Equal("falseFoo"))
+	gotMessage = getFirstMessage(groups, []string{"missingBaz", "foo", "bar"})
+	g.Expect(gotMessage).To(Equal("message falseFoo"))
+
+	// getFirst should fallback to first condition if none of the conditions in the list exists
+	gotReason = getFirstReason(groups, []string{"missingBaz"}, false)
+	g.Expect(gotReason).To(Equal("falseBar"))
+	gotMessage = getFirstMessage(groups, []string{"missingBaz"})
+	g.Expect(gotMessage).To(Equal("message falseBar"))
+
+	// getFirstReason should localize reason if required
+	gotReason = getFirstReason(groups, nil, true)
+	g.Expect(gotReason).To(Equal("falseBar @ VirtualMachine/test-vm"))
+}

--- a/pkg/conditions2/merge_test.go
+++ b/pkg/conditions2/merge_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//nolint:scopelint
+package conditions2
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+)
+
+func TestNewConditionsGroup(t *testing.T) {
+	g := NewWithT(t)
+
+	conditions := []*metav1.Condition{nil1, true1, true1, falseInfo1, falseWarning1, falseWarning1, falseError1, unknown1}
+
+	got := getConditionGroups(conditionsWithSource(&vmopv1.VirtualMachine{}, conditions...))
+
+	g.Expect(got).ToNot(BeNil())
+	g.Expect(got).To(HaveLen(3))
+
+	// The top group should be false and it should have four conditions
+	g.Expect(got.TopGroup().status).To(Equal(metav1.ConditionFalse))
+	g.Expect(got.TopGroup().conditions).To(HaveLen(4))
+
+	// The true group should be true and it should have two conditions
+	g.Expect(got.TrueGroup().status).To(Equal(metav1.ConditionTrue))
+	g.Expect(got.TrueGroup().conditions).To(HaveLen(2))
+
+	// The error group should be false and it should have one condition
+	g.Expect(got.FalseGroup().status).To(Equal(metav1.ConditionFalse))
+	g.Expect(got.FalseGroup().conditions).To(HaveLen(4))
+
+	// got[0] should be False and it should have four conditions
+	g.Expect(got[0].status).To(Equal(metav1.ConditionFalse))
+	g.Expect(got[0].conditions).To(HaveLen(4))
+
+	// got[1] should be True and it should have two conditions
+	g.Expect(got[1].status).To(Equal(metav1.ConditionTrue))
+	g.Expect(got[1].conditions).To(HaveLen(2))
+
+	// got[4] should be Unknown and it should have one condition
+	g.Expect(got[2].status).To(Equal(metav1.ConditionUnknown))
+	g.Expect(got[2].conditions).To(HaveLen(1))
+
+	// nil conditions are ignored
+}
+
+func TestMergeRespectPriority(t *testing.T) {
+	tests := []struct {
+		name       string
+		conditions []*metav1.Condition
+		want       *metav1.Condition
+	}{
+		{
+			name:       "aggregate nil list return nil",
+			conditions: nil,
+			want:       nil,
+		},
+		{
+			name:       "aggregate empty list return nil",
+			conditions: []*metav1.Condition{},
+			want:       nil,
+		},
+		{
+			name:       "When there is false/error it returns false/error",
+			conditions: []*metav1.Condition{falseError1, falseWarning1, falseInfo1, unknown1, true1},
+			want:       FalseCondition("foo", "reason falseError1", "message falseError1"),
+		},
+		{
+			name:       "When there is false/info and no false/error or false/warning, it returns false/info",
+			conditions: []*metav1.Condition{falseInfo1, unknown1, true1},
+			want:       FalseCondition("foo", "reason falseInfo1", "message falseInfo1"),
+		},
+		{
+			name:       "When there is true and no false/*, it returns info",
+			conditions: []*metav1.Condition{unknown1, true1},
+			want:       TrueCondition("foo"),
+		},
+		{
+			name:       "When there is unknown and no true or false/*, it returns unknown",
+			conditions: []*metav1.Condition{unknown1},
+			want:       UnknownCondition("foo", "reason unknown1", "message unknown1"),
+		},
+		{
+			name:       "nil conditions are ignored",
+			conditions: []*metav1.Condition{nil1, nil1, nil1},
+			want:       nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			got := merge(conditionsWithSource(&vmopv1.VirtualMachine{}, tt.conditions...), "foo", &mergeOptions{})
+
+			if tt.want == nil {
+				g.Expect(got).To(BeNil())
+				return
+			}
+			g.Expect(got).To(haveSameStateOf(tt.want))
+		})
+	}
+}
+
+func conditionsWithSource(obj Setter, conditions ...*metav1.Condition) []localizedCondition {
+	obj.SetConditions(conditionList(conditions...))
+
+	ret := make([]localizedCondition, 0, len(conditions))
+	for i := range conditions {
+		ret = append(ret, localizedCondition{
+			Condition: conditions[i],
+			Getter:    obj,
+		})
+	}
+
+	return ret
+}

--- a/pkg/conditions2/patch.go
+++ b/pkg/conditions2/patch.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conditions2
+
+import (
+	"reflect"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Patch defines a list of operations to change a list of conditions into another.
+type Patch []PatchOperation
+
+// PatchOperation define an operation that changes a single condition.
+type PatchOperation struct {
+	Before *metav1.Condition
+	After  *metav1.Condition
+	Op     PatchOperationType
+}
+
+// PatchOperationType defines patch operation types.
+type PatchOperationType string
+
+const (
+	// AddConditionPatch defines an add condition patch operation.
+	AddConditionPatch PatchOperationType = "Add"
+
+	// ChangeConditionPatch defines an change condition patch operation.
+	ChangeConditionPatch PatchOperationType = "Change"
+
+	// RemoveConditionPatch defines a remove condition patch operation.
+	RemoveConditionPatch PatchOperationType = "Remove"
+)
+
+// NewPatch returns the list of Patch required to align source conditions to after conditions.
+func NewPatch(before Getter, after Getter) Patch {
+	var patch Patch
+
+	// Identify AddCondition and ModifyCondition changes.
+	targetConditions := after.GetConditions()
+	for i := range targetConditions {
+		targetCondition := targetConditions[i]
+		currentCondition := Get(before, targetCondition.Type)
+		if currentCondition == nil {
+			patch = append(patch, PatchOperation{Op: AddConditionPatch, After: &targetCondition})
+			continue
+		}
+
+		if !reflect.DeepEqual(&targetCondition, currentCondition) {
+			patch = append(patch, PatchOperation{Op: ChangeConditionPatch, After: &targetCondition, Before: currentCondition})
+		}
+	}
+
+	// Identify RemoveCondition changes.
+	baseConditions := before.GetConditions()
+	for i := range baseConditions {
+		baseCondition := baseConditions[i]
+		targetCondition := Get(after, baseCondition.Type)
+		if targetCondition == nil {
+			patch = append(patch, PatchOperation{Op: RemoveConditionPatch, Before: &baseCondition})
+		}
+	}
+	return patch
+}
+
+// applyOptions allows to set strategies for patch apply.
+type applyOptions struct {
+	ownedConditions []string
+	forceOverwrite  bool
+}
+
+func (o *applyOptions) isOwnedCondition(t string) bool {
+	for _, i := range o.ownedConditions {
+		if i == t {
+			return true
+		}
+	}
+	return false
+}
+
+// ApplyOption defines an option for applying a condition patch.
+type ApplyOption func(*applyOptions)
+
+// WithOwnedConditions allows to define condition types owned by the controller.
+// In case of conflicts for the owned conditions, the patch helper will always use the value provided by the controller.
+func WithOwnedConditions(t ...string) ApplyOption {
+	return func(c *applyOptions) {
+		c.ownedConditions = t
+	}
+}
+
+// WithForceOverwrite In case of conflicts for the owned conditions, the patch helper will always use the value provided by the controller.
+func WithForceOverwrite(v bool) ApplyOption {
+	return func(c *applyOptions) {
+		c.forceOverwrite = v
+	}
+}
+
+// Apply executes a three-way merge of a list of Patch.
+// When merge conflicts are detected (latest deviated from before in an incompatible way), an error is returned.
+func (p Patch) Apply(latest Setter, options ...ApplyOption) error {
+	if len(p) == 0 {
+		return nil
+	}
+
+	applyOpt := &applyOptions{}
+	for _, o := range options {
+		o(applyOpt)
+	}
+
+	for _, conditionPatch := range p {
+		switch conditionPatch.Op {
+		case AddConditionPatch:
+			// If the conditions is owned, always keep the after value.
+			if applyOpt.forceOverwrite || applyOpt.isOwnedCondition(conditionPatch.After.Type) {
+				Set(latest, conditionPatch.After)
+				continue
+			}
+
+			// If the condition is already on latest, check if latest and after agree on the change; if not, this is a conflict.
+			if latestCondition := Get(latest, conditionPatch.After.Type); latestCondition != nil {
+				// If latest and after agree on the change, then it is a conflict.
+				if !hasSameState(latestCondition, conditionPatch.After) {
+					return errors.Errorf("error patching conditions: The condition %q was modified by a different process and this caused a merge/AddCondition conflict: %v", conditionPatch.After.Type, cmp.Diff(latestCondition, conditionPatch.After))
+				}
+				// otherwise, the latest is already as intended.
+				// NOTE: We are preserving LastTransitionTime from the latest in order to avoid altering the existing value.
+				continue
+			}
+			// If the condition does not exists on the latest, add the new after condition.
+			Set(latest, conditionPatch.After)
+
+		case ChangeConditionPatch:
+			// If the conditions is owned, always keep the after value.
+			if applyOpt.forceOverwrite || applyOpt.isOwnedCondition(conditionPatch.After.Type) {
+				Set(latest, conditionPatch.After)
+				continue
+			}
+
+			latestCondition := Get(latest, conditionPatch.After.Type)
+
+			// If the condition does not exist anymore on the latest, this is a conflict.
+			if latestCondition == nil {
+				return errors.Errorf("error patching conditions: The condition %q was deleted by a different process and this caused a merge/ChangeCondition conflict", conditionPatch.After.Type)
+			}
+
+			// If the condition on the latest is different from the base condition, check if
+			// the after state corresponds to the desired value. If not this is a conflict (unless we should ignore conflicts for this condition type).
+			if !reflect.DeepEqual(latestCondition, conditionPatch.Before) {
+				if !hasSameState(latestCondition, conditionPatch.After) {
+					return errors.Errorf("error patching conditions: The condition %q was modified by a different process and this caused a merge/ChangeCondition conflict: %v", conditionPatch.After.Type, cmp.Diff(latestCondition, conditionPatch.After))
+				}
+				// Otherwise the latest is already as intended.
+				// NOTE: We are preserving LastTransitionTime from the latest in order to avoid altering the existing value.
+				continue
+			}
+			// Otherwise apply the new after condition.
+			Set(latest, conditionPatch.After)
+
+		case RemoveConditionPatch:
+			// If the conditions is owned, always keep the after value (condition should be deleted).
+			if applyOpt.forceOverwrite || applyOpt.isOwnedCondition(conditionPatch.Before.Type) {
+				Delete(latest, conditionPatch.Before.Type)
+				continue
+			}
+
+			// If the condition is still on the latest, check if it is changed in the meantime;
+			// if so then this is a conflict.
+			if latestCondition := Get(latest, conditionPatch.Before.Type); latestCondition != nil {
+				if !hasSameState(latestCondition, conditionPatch.Before) {
+					return errors.Errorf("error patching conditions: The condition %q was modified by a different process and this caused a merge/RemoveCondition conflict: %v", conditionPatch.Before.Type, cmp.Diff(latestCondition, conditionPatch.Before))
+				}
+			}
+			// Otherwise the latest and after agreed on the delete operation, so there's nothing to change.
+			Delete(latest, conditionPatch.Before.Type)
+		}
+	}
+	return nil
+}
+
+// IsZero returns true if the patch has no changes.
+func (p Patch) IsZero() bool {
+	return len(p) == 0
+}

--- a/pkg/conditions2/patch_test.go
+++ b/pkg/conditions2/patch_test.go
@@ -1,0 +1,286 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//nolint:scopelint
+package conditions2
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+)
+
+func TestNewPatch(t *testing.T) {
+	fooTrue := TrueCondition("foo")
+	fooFalse := FalseCondition("foo", "reason foo", "message foo")
+
+	tests := []struct {
+		name   string
+		before Getter
+		after  Getter
+		want   Patch
+	}{
+		{
+			name:   "No changes return empty patch",
+			before: getterWithConditions(),
+			after:  getterWithConditions(),
+			want:   nil,
+		},
+		{
+			name:   "No changes return empty patch",
+			before: getterWithConditions(fooTrue),
+			after:  getterWithConditions(fooTrue),
+			want:   nil,
+		},
+		{
+			name:   "Detects AddConditionPatch",
+			before: getterWithConditions(),
+			after:  getterWithConditions(fooTrue),
+			want: Patch{
+				{
+					Before: nil,
+					After:  fooTrue,
+					Op:     AddConditionPatch,
+				},
+			},
+		},
+		{
+			name:   "Detects ChangeConditionPatch",
+			before: getterWithConditions(fooTrue),
+			after:  getterWithConditions(fooFalse),
+			want: Patch{
+				{
+					Before: fooTrue,
+					After:  fooFalse,
+					Op:     ChangeConditionPatch,
+				},
+			},
+		},
+		{
+			name:   "Detects RemoveConditionPatch",
+			before: getterWithConditions(fooTrue),
+			after:  getterWithConditions(),
+			want: Patch{
+				{
+					Before: fooTrue,
+					After:  nil,
+					Op:     RemoveConditionPatch,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			got := NewPatch(tt.before, tt.after)
+
+			g.Expect(got).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestApply(t *testing.T) {
+	fooTrue := TrueCondition("foo")
+	fooFalse := FalseCondition("foo", "reason foo", "message foo")
+	fooFalse2 := FalseCondition("foo", "different reason foo", "message foo")
+
+	tests := []struct {
+		name    string
+		before  Getter
+		after   Getter
+		latest  Setter
+		options []ApplyOption
+		want    []metav1.Condition
+		wantErr bool
+	}{
+		{
+			name:    "No patch return same list",
+			before:  getterWithConditions(fooTrue),
+			after:   getterWithConditions(fooTrue),
+			latest:  setterWithConditions(fooTrue),
+			want:    conditionList(fooTrue),
+			wantErr: false,
+		},
+		{
+			name:    "Add: When a condition does not exists, it should add",
+			before:  getterWithConditions(),
+			after:   getterWithConditions(fooTrue),
+			latest:  setterWithConditions(),
+			want:    conditionList(fooTrue),
+			wantErr: false,
+		},
+		{
+			name:    "Add: When a condition already exists but without conflicts, it should add",
+			before:  getterWithConditions(),
+			after:   getterWithConditions(fooTrue),
+			latest:  setterWithConditions(fooTrue),
+			want:    conditionList(fooTrue),
+			wantErr: false,
+		},
+		{
+			name:    "Add: When a condition already exists but with conflicts, it should error",
+			before:  getterWithConditions(),
+			after:   getterWithConditions(fooTrue),
+			latest:  setterWithConditions(fooFalse),
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "Add: When a condition already exists but with conflicts, it should not error if the condition is owned",
+			before:  getterWithConditions(),
+			after:   getterWithConditions(fooTrue),
+			latest:  setterWithConditions(fooFalse),
+			options: []ApplyOption{WithOwnedConditions("foo")},
+			want:    conditionList(fooTrue), // after condition should be kept in case of error
+			wantErr: false,
+		},
+		{
+			name:    "Remove: When a condition was already deleted, it should pass",
+			before:  getterWithConditions(fooTrue),
+			after:   getterWithConditions(),
+			latest:  setterWithConditions(),
+			want:    conditionList(),
+			wantErr: false,
+		},
+		{
+			name:    "Remove: When a condition already exists but without conflicts, it should delete",
+			before:  getterWithConditions(fooTrue),
+			after:   getterWithConditions(),
+			latest:  setterWithConditions(fooTrue),
+			want:    conditionList(),
+			wantErr: false,
+		},
+		{
+			name:    "Remove: When a condition already exists but with conflicts, it should error",
+			before:  getterWithConditions(fooTrue),
+			after:   getterWithConditions(),
+			latest:  setterWithConditions(fooFalse),
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "Remove: When a condition already exists but with conflicts, it should not error if the condition is owned",
+			before:  getterWithConditions(fooTrue),
+			after:   getterWithConditions(),
+			latest:  setterWithConditions(fooFalse),
+			options: []ApplyOption{WithOwnedConditions("foo")},
+			want:    conditionList(), // after condition should be kept in case of error
+			wantErr: false,
+		},
+		{
+			name:    "Change: When a condition exists without conflicts, it should change",
+			before:  getterWithConditions(fooTrue),
+			after:   getterWithConditions(fooFalse),
+			latest:  setterWithConditions(fooTrue),
+			want:    conditionList(fooFalse),
+			wantErr: false,
+		},
+		{
+			name:    "Change: When a condition exists with conflicts but there is agreement on the final state, it should change",
+			before:  getterWithConditions(fooFalse),
+			after:   getterWithConditions(fooTrue),
+			latest:  setterWithConditions(fooTrue),
+			want:    conditionList(fooTrue),
+			wantErr: false,
+		},
+
+		{
+			name:    "Change: When a condition exists with conflicts but there is no agreement on the final state, it should error",
+			before:  getterWithConditions(fooFalse2),
+			after:   getterWithConditions(fooFalse),
+			latest:  setterWithConditions(fooTrue),
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "Change: When a condition exists with conflicts but there is no agreement on the final state, it should not error if the condition is owned",
+			before:  getterWithConditions(fooFalse2),
+			after:   getterWithConditions(fooFalse),
+			latest:  setterWithConditions(fooTrue),
+			options: []ApplyOption{WithOwnedConditions("foo")},
+			want:    conditionList(fooFalse), // after condition should be kept in case of error
+			wantErr: false,
+		},
+
+		{
+			name:    "Change: When a condition was deleted, it should error",
+			before:  getterWithConditions(fooTrue),
+			after:   getterWithConditions(fooFalse),
+			latest:  setterWithConditions(),
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "Change: When a condition was deleted, it should not error if the condition is owned",
+			before:  getterWithConditions(fooTrue),
+			after:   getterWithConditions(fooFalse),
+			latest:  setterWithConditions(),
+			options: []ApplyOption{WithOwnedConditions("foo")},
+			want:    conditionList(fooFalse), // after condition should be kept in case of error
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			patch := NewPatch(tt.before, tt.after)
+
+			err := patch.Apply(tt.latest, tt.options...)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+
+			g.Expect(tt.latest.GetConditions()).To(haveSameConditionsOf(tt.want))
+		})
+	}
+}
+
+func TestApplyDoesNotAlterLastTransitionTime(t *testing.T) {
+	g := NewWithT(t)
+
+	before := &vmopv1.VirtualMachine{}
+	after := &vmopv1.VirtualMachine{
+		Status: vmopv1.VirtualMachineStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:               "foo",
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.NewTime(time.Now().UTC().Truncate(time.Second)),
+				},
+			},
+		},
+	}
+	latest := &vmopv1.VirtualMachine{}
+
+	// latest has no conditions, so we are actually adding the condition but in this case we should not set the LastTransition Time
+	// but we should preserve the LastTransition set in after
+
+	diff := NewPatch(before, after)
+	err := diff.Apply(latest)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(latest.GetConditions()).To(Equal(after.GetConditions()))
+}

--- a/pkg/conditions2/setter.go
+++ b/pkg/conditions2/setter.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conditions2
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Setter interface defines methods that a Cluster API object should implement in order to
+// use the conditions package for setting conditions.
+type Setter interface {
+	Getter
+	SetConditions([]metav1.Condition)
+}
+
+// Set sets the given condition.
+//
+// NOTE: If a condition already exists, the LastTransitionTime is updated only if a change is detected
+// in any of the following fields: Status, Reason, Severity and Message.
+func Set(to Setter, condition *metav1.Condition) {
+	if to == nil || condition == nil {
+		return
+	}
+
+	// Check if the new conditions already exists, and change it only if there is a status
+	// transition (otherwise we should preserve the current last transition time)-
+	conditions := to.GetConditions()
+	exists := false
+	for i := range conditions {
+		existingCondition := conditions[i]
+		if existingCondition.Type == condition.Type {
+			exists = true
+			if !hasSameState(&existingCondition, condition) {
+				condition.LastTransitionTime = metav1.NewTime(time.Now().UTC().Truncate(time.Second))
+				conditions[i] = *condition
+				break
+			}
+			condition.LastTransitionTime = existingCondition.LastTransitionTime
+			break
+		}
+	}
+
+	// If the condition does not exist, add it, setting the transition time only if not already set
+	if !exists {
+		if condition.LastTransitionTime.IsZero() {
+			condition.LastTransitionTime = metav1.NewTime(time.Now().UTC().Truncate(time.Second))
+		}
+		conditions = append(conditions, *condition)
+	}
+
+	// Sorts conditions for convenience of the consumer, i.e. kubectl.
+	sort.Slice(conditions, func(i, j int) bool {
+		return lexicographicLess(&conditions[i], &conditions[j])
+	})
+
+	to.SetConditions(conditions)
+}
+
+// TrueCondition returns a condition with Status=True and the given type.
+func TrueCondition(t string) *metav1.Condition {
+	return &metav1.Condition{
+		Type:   t,
+		Reason: t, // BMV: This is required field in metav1.Conditions. Fixup API later.
+		Status: metav1.ConditionTrue,
+	}
+}
+
+// FalseCondition returns a condition with Status=False and the given type.
+func FalseCondition(t string, reason string, messageFormat string, messageArgs ...interface{}) *metav1.Condition {
+	return &metav1.Condition{
+		Type:    t,
+		Status:  metav1.ConditionFalse,
+		Reason:  reason,
+		Message: fmt.Sprintf(messageFormat, messageArgs...),
+	}
+}
+
+// UnknownCondition returns a condition with Status=Unknown and the given type.
+func UnknownCondition(t string, reason string, messageFormat string, messageArgs ...interface{}) *metav1.Condition {
+	return &metav1.Condition{
+		Type:    t,
+		Status:  metav1.ConditionUnknown,
+		Reason:  reason,
+		Message: fmt.Sprintf(messageFormat, messageArgs...),
+	}
+}
+
+// MarkTrue sets Status=True for the condition with the given type.
+func MarkTrue(to Setter, t string) {
+	Set(to, TrueCondition(t))
+}
+
+// MarkUnknown sets Status=Unknown for the condition with the given type.
+func MarkUnknown(to Setter, t string, reason, messageFormat string, messageArgs ...interface{}) {
+	Set(to, UnknownCondition(t, reason, messageFormat, messageArgs...))
+}
+
+// MarkFalse sets Status=False for the condition with the given type.
+func MarkFalse(to Setter, t string, reason string, messageFormat string, messageArgs ...interface{}) {
+	Set(to, FalseCondition(t, reason, messageFormat, messageArgs...))
+}
+
+// SetSummary sets a Ready condition with the summary of all the conditions existing
+// on an object. If the object does not have other conditions, no summary condition is generated.
+func SetSummary(to Setter, options ...MergeOption) {
+	Set(to, summary(to, options...))
+}
+
+// SetMirror creates a new condition by mirroring the the Ready condition from a dependent object;
+// if the Ready condition does not exists in the source object, no target conditions is generated.
+func SetMirror(to Setter, targetCondition string, from Getter, options ...MirrorOptions) {
+	Set(to, mirror(from, targetCondition, options...))
+}
+
+// SetAggregate creates a new condition with the aggregation of all the the Ready condition
+// from a list of dependent objects; if the Ready condition does not exists in one of the source object,
+// the object is excluded from the aggregation; if none of the source object have ready condition,
+// no target conditions is generated.
+func SetAggregate(to Setter, targetCondition string, from []Getter, options ...MergeOption) {
+	Set(to, aggregate(from, targetCondition, options...))
+}
+
+// Delete deletes the condition with the given type.
+func Delete(to Setter, t string) {
+	if to == nil {
+		return
+	}
+
+	conditions := to.GetConditions()
+	newConditions := make([]metav1.Condition, 0, len(conditions))
+	for _, condition := range conditions {
+		if condition.Type != t {
+			newConditions = append(newConditions, condition)
+		}
+	}
+	to.SetConditions(newConditions)
+}
+
+// lexicographicLess returns true if a condition is less than another with regards to the
+// to order of conditions designed for convenience of the consumer, i.e. kubectl.
+// According to this order the Ready condition always goes first, followed by all the other
+// conditions sorted by Type.
+func lexicographicLess(i, j *metav1.Condition) bool {
+	return (i.Type == ReadyConditionType || i.Type < j.Type) && j.Type != ReadyConditionType
+}
+
+// hasSameState returns true if a condition has the same state of another; state is defined
+// by the union of following fields: Type, Status, Reason, Severity and Message (it excludes LastTransitionTime).
+func hasSameState(i, j *metav1.Condition) bool {
+	return i.Type == j.Type &&
+		i.Status == j.Status &&
+		i.Reason == j.Reason &&
+		i.Message == j.Message
+}

--- a/pkg/conditions2/setter_test.go
+++ b/pkg/conditions2/setter_test.go
@@ -1,0 +1,293 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//nolint:scopelint
+package conditions2
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
+	"github.com/onsi/gomega/types"
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+)
+
+func TestHasSameState(t *testing.T) {
+	g := NewWithT(t)
+
+	// same condition
+	falseInfo2 := falseInfo1.DeepCopy()
+	g.Expect(hasSameState(falseInfo1, falseInfo2)).To(BeTrue())
+
+	// different LastTransitionTime does not impact state
+	falseInfo2 = falseInfo1.DeepCopy()
+	falseInfo2.LastTransitionTime = metav1.NewTime(time.Date(1900, time.November, 10, 23, 0, 0, 0, time.UTC))
+	g.Expect(hasSameState(falseInfo1, falseInfo2)).To(BeTrue())
+
+	// different Type, Status, Reason, Severity and Message determine different state
+	falseInfo2 = falseInfo1.DeepCopy()
+	falseInfo2.Type = "another type"
+	g.Expect(hasSameState(falseInfo1, falseInfo2)).To(BeFalse())
+
+	falseInfo2 = falseInfo1.DeepCopy()
+	falseInfo2.Status = metav1.ConditionTrue
+	g.Expect(hasSameState(falseInfo1, falseInfo2)).To(BeFalse())
+
+	falseInfo2 = falseInfo1.DeepCopy()
+	falseInfo2.Reason = "another severity"
+	g.Expect(hasSameState(falseInfo1, falseInfo2)).To(BeFalse())
+
+	falseInfo2 = falseInfo1.DeepCopy()
+	falseInfo2.Message = "another message"
+	g.Expect(hasSameState(falseInfo1, falseInfo2)).To(BeFalse())
+}
+
+func TestLexicographicLess(t *testing.T) {
+	g := NewWithT(t)
+
+	// alphabetical order of Type is respected
+	a := TrueCondition("A")
+	b := TrueCondition("B")
+	g.Expect(lexicographicLess(a, b)).To(BeTrue())
+
+	a = TrueCondition("B")
+	b = TrueCondition("A")
+	g.Expect(lexicographicLess(a, b)).To(BeFalse())
+
+	// Ready condition is treated as an exception and always goes first
+	a = TrueCondition(vmopv1.ReadyConditionType)
+	b = TrueCondition("A")
+	g.Expect(lexicographicLess(a, b)).To(BeTrue())
+
+	a = TrueCondition("A")
+	b = TrueCondition(vmopv1.ReadyConditionType)
+	g.Expect(lexicographicLess(a, b)).To(BeFalse())
+}
+
+func TestSet(t *testing.T) {
+	a := TrueCondition("a")
+	b := TrueCondition("b")
+	ready := TrueCondition(vmopv1.ReadyConditionType)
+
+	tests := []struct {
+		name      string
+		to        Setter
+		condition *metav1.Condition
+		want      []metav1.Condition
+	}{
+		{
+			name:      "Set adds a condition",
+			to:        setterWithConditions(),
+			condition: a,
+			want:      conditionList(a),
+		},
+		{
+			name:      "Set adds more conditions",
+			to:        setterWithConditions(a),
+			condition: b,
+			want:      conditionList(a, b),
+		},
+		{
+			name:      "Set does not duplicate existing conditions",
+			to:        setterWithConditions(a, b),
+			condition: a,
+			want:      conditionList(a, b),
+		},
+		{
+			name:      "Set sorts conditions in lexicographic order",
+			to:        setterWithConditions(b, a),
+			condition: ready,
+			want:      conditionList(ready, a, b),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			Set(tt.to, tt.condition)
+
+			g.Expect(tt.to.GetConditions()).To(haveSameConditionsOf(tt.want))
+		})
+	}
+}
+
+func TestSetLastTransitionTime(t *testing.T) {
+	x := metav1.Date(2012, time.January, 1, 12, 15, 30, 5e8, time.UTC)
+
+	foo := FalseCondition("foo", "reason foo", "message foo")
+	fooWithLastTransitionTime := FalseCondition("foo", "reason foo", "message foo")
+	fooWithLastTransitionTime.LastTransitionTime = x
+	fooWithAnotherState := TrueCondition("foo")
+
+	tests := []struct {
+		name                    string
+		to                      Setter
+		new                     *metav1.Condition
+		LastTransitionTimeCheck func(*WithT, metav1.Time)
+	}{
+		{
+			name: "Set a condition that does not exists should set the last transition time if not defined",
+			to:   setterWithConditions(),
+			new:  foo,
+			LastTransitionTimeCheck: func(g *WithT, lastTransitionTime metav1.Time) {
+				g.Expect(lastTransitionTime).ToNot(BeZero())
+			},
+		},
+		{
+			name: "Set a condition that does not exists should preserve the last transition time if defined",
+			to:   setterWithConditions(),
+			new:  fooWithLastTransitionTime,
+			LastTransitionTimeCheck: func(g *WithT, lastTransitionTime metav1.Time) {
+				g.Expect(lastTransitionTime).To(Equal(x))
+			},
+		},
+		{
+			name: "Set a condition that already exists with the same state should preserves the last transition time",
+			to:   setterWithConditions(fooWithLastTransitionTime),
+			new:  foo,
+			LastTransitionTimeCheck: func(g *WithT, lastTransitionTime metav1.Time) {
+				g.Expect(lastTransitionTime).To(Equal(x))
+			},
+		},
+		{
+			name: "Set a condition that already exists but with different state should changes the last transition time",
+			to:   setterWithConditions(fooWithLastTransitionTime),
+			new:  fooWithAnotherState,
+			LastTransitionTimeCheck: func(g *WithT, lastTransitionTime metav1.Time) {
+				g.Expect(lastTransitionTime).ToNot(Equal(x))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			Set(tt.to, tt.new)
+
+			tt.LastTransitionTimeCheck(g, Get(tt.to, "foo").LastTransitionTime)
+		})
+	}
+}
+
+func TestMarkMethods(t *testing.T) {
+	g := NewWithT(t)
+
+	vm := &vmopv1.VirtualMachine{}
+
+	// test MarkTrue
+	MarkTrue(vm, "conditionFoo")
+	g.Expect(Get(vm, "conditionFoo")).To(haveSameStateOf(&metav1.Condition{
+		Type:   "conditionFoo",
+		Status: metav1.ConditionTrue,
+		Reason: "conditionFoo",
+	}))
+
+	// test MarkFalse
+	MarkFalse(vm, "conditionBar", "reasonBar", "messageBar")
+	g.Expect(Get(vm, "conditionBar")).To(haveSameStateOf(&metav1.Condition{
+		Type:    "conditionBar",
+		Status:  metav1.ConditionFalse,
+		Reason:  "reasonBar",
+		Message: "messageBar",
+	}))
+
+	// test MarkUnknown
+	MarkUnknown(vm, "conditionBaz", "reasonBaz", "messageBaz")
+	g.Expect(Get(vm, "conditionBaz")).To(haveSameStateOf(&metav1.Condition{
+		Type:    "conditionBaz",
+		Status:  metav1.ConditionUnknown,
+		Reason:  "reasonBaz",
+		Message: "messageBaz",
+	}))
+}
+
+func TestSetSummary(t *testing.T) {
+	g := NewWithT(t)
+	target := setterWithConditions(TrueCondition("foo"))
+
+	SetSummary(target)
+
+	g.Expect(Has(target, vmopv1.ReadyConditionType)).To(BeTrue())
+}
+
+func TestSetMirror(t *testing.T) {
+	g := NewWithT(t)
+	source := getterWithConditions(TrueCondition(vmopv1.ReadyConditionType))
+	target := setterWithConditions()
+
+	SetMirror(target, "foo", source)
+
+	g.Expect(Has(target, "foo")).To(BeTrue())
+}
+
+func TestSetAggregate(t *testing.T) {
+	g := NewWithT(t)
+	source1 := getterWithConditions(TrueCondition(vmopv1.ReadyConditionType))
+	source2 := getterWithConditions(TrueCondition(vmopv1.ReadyConditionType))
+	target := setterWithConditions()
+
+	SetAggregate(target, "foo", []Getter{source1, source2})
+
+	g.Expect(Has(target, "foo")).To(BeTrue())
+}
+
+func setterWithConditions(conditions ...*metav1.Condition) Setter {
+	obj := &vmopv1.VirtualMachine{}
+	obj.SetConditions(conditionList(conditions...))
+	return obj
+}
+
+func haveSameConditionsOf(expected []metav1.Condition) types.GomegaMatcher {
+	return &ConditionsMatcher{
+		Expected: expected,
+	}
+}
+
+type ConditionsMatcher struct {
+	Expected []metav1.Condition
+}
+
+func (matcher *ConditionsMatcher) Match(actual interface{}) (success bool, err error) {
+	actualConditions, ok := actual.([]metav1.Condition)
+	if !ok {
+		return false, errors.New("Value should be a conditions list")
+	}
+
+	if len(actualConditions) != len(matcher.Expected) {
+		return false, nil
+	}
+
+	for i := range actualConditions {
+		if !hasSameState(&actualConditions[i], &matcher.Expected[i]) {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func (matcher *ConditionsMatcher) FailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, "to have the same conditions of", matcher.Expected)
+}
+func (matcher *ConditionsMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, "not to have the same conditions of", matcher.Expected)
+}

--- a/pkg/conditions2/unstructured.go
+++ b/pkg/conditions2/unstructured.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conditions2
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// UnstructuredGetter return a Getter object that can read conditions from an Unstructured object.
+// Important. This method should be used only with types implementing Cluster API conditions.
+func UnstructuredGetter(u *unstructured.Unstructured) Getter {
+	return &unstructuredWrapper{Unstructured: u}
+}
+
+// UnstructuredSetter return a Setter object that can set conditions from an Unstructured object.
+// Important. This method should be used only with types implementing Cluster API conditions.
+func UnstructuredSetter(u *unstructured.Unstructured) Setter {
+	return &unstructuredWrapper{Unstructured: u}
+}
+
+type unstructuredWrapper struct {
+	*unstructured.Unstructured
+}
+
+// GetConditions returns the list of conditions from an Unstructured object.
+//
+// NOTE: Due to the constraints of JSON-unmarshal, this operation is to be considered best effort.
+// In more details:
+//   - Errors during JSON-unmarshal are ignored and a empty collection list is returned.
+//   - It's not possible to detect if the object has an empty condition list or if it does not implement conditions;
+//     in both cases the operation returns an empty slice is returned.
+//   - If the object doesn't implement conditions on under status as defined in Cluster API,
+//     JSON-unmarshal matches incoming object keys to the keys; this can lead to conditions values partially set.
+func (c *unstructuredWrapper) GetConditions() []metav1.Condition {
+	var conditions []metav1.Condition
+	if err := UnstructuredUnmarshalField(c.Unstructured, &conditions, "status", "conditions"); err != nil {
+		return nil
+	}
+	return conditions
+}
+
+// SetConditions set the conditions into an Unstructured object.
+//
+// NOTE: Due to the constraints of JSON-unmarshal, this operation is to be considered best effort.
+// In more details:
+//   - Errors during JSON-unmarshal are ignored and a empty collection list is returned.
+//   - It's not possible to detect if the object has an empty condition list or if it does not implement conditions;
+//     in both cases the operation returns an empty slice is returned.
+func (c *unstructuredWrapper) SetConditions(conditions []metav1.Condition) {
+	v := make([]interface{}, 0, len(conditions))
+	for i := range conditions {
+		m, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&conditions[i])
+		if err != nil {
+			log.Log.Error(err, "Failed to convert Condition to unstructured map. This error shouldn't have occurred, please file an issue.", "groupVersionKind", c.GroupVersionKind(), "name", c.GetName(), "namespace", c.GetNamespace())
+			continue
+		}
+		v = append(v, m)
+	}
+	// unstructured.SetNestedField returns an error only if value cannot be set because one of
+	// the nesting levels is not a map[string]interface{}; this is not the case so the error should never happen here.
+	err := unstructured.SetNestedField(c.Unstructured.Object, v, "status", "conditions")
+	if err != nil {
+		log.Log.Error(err, "Failed to set Conditions on unstructured object. This error shouldn't have occurred, please file an issue.", "groupVersionKind", c.GroupVersionKind(), "name", c.GetName(), "namespace", c.GetNamespace())
+	}
+}

--- a/pkg/conditions2/unstructured_test.go
+++ b/pkg/conditions2/unstructured_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conditions2
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+)
+
+func TestUnstructuredGetConditions(t *testing.T) {
+	g := NewWithT(t)
+
+	scheme := runtime.NewScheme()
+	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
+	g.Expect(vmopv1.AddToScheme(scheme)).To(Succeed())
+
+	// GetConditions should return conditions from an unstructured object
+	c := &vmopv1.VirtualMachine{}
+	c.SetConditions(conditionList(true1))
+	u := &unstructured.Unstructured{}
+	g.Expect(scheme.Convert(c, u, nil)).To(Succeed())
+
+	g.Expect(UnstructuredGetter(u).GetConditions()).To(haveSameConditionsOf(conditionList(true1)))
+
+	// GetConditions should return nil for an unstructured object with empty conditions
+	c = &vmopv1.VirtualMachine{}
+	u = &unstructured.Unstructured{}
+	g.Expect(scheme.Convert(c, u, nil)).To(Succeed())
+
+	g.Expect(UnstructuredGetter(u).GetConditions()).To(BeNil())
+
+	// GetConditions should return nil for an unstructured object without conditions
+	e := &corev1.Endpoints{}
+	u = &unstructured.Unstructured{}
+	g.Expect(scheme.Convert(e, u, nil)).To(Succeed())
+
+	g.Expect(UnstructuredGetter(u).GetConditions()).To(BeNil())
+
+	// GetConditions should return conditions from an unstructured object with a different type of conditions.
+	p := &corev1.Pod{Status: corev1.PodStatus{
+		Conditions: []corev1.PodCondition{
+			{
+				Type:               "foo",
+				Status:             "foo",
+				LastProbeTime:      metav1.Time{},
+				LastTransitionTime: metav1.Time{},
+				Reason:             "foo",
+				Message:            "foo",
+			},
+		},
+	}}
+	u = &unstructured.Unstructured{}
+	g.Expect(scheme.Convert(p, u, nil)).To(Succeed())
+
+	g.Expect(UnstructuredGetter(u).GetConditions()).To(HaveLen(1))
+}
+
+func TestUnstructuredSetConditions(t *testing.T) {
+	g := NewWithT(t)
+
+	// gets an unstructured with empty conditions
+	scheme := runtime.NewScheme()
+	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
+	g.Expect(vmopv1.AddToScheme(scheme)).To(Succeed())
+
+	c := &vmopv1.VirtualMachine{}
+	u := &unstructured.Unstructured{}
+	g.Expect(scheme.Convert(c, u, nil)).To(Succeed())
+
+	// set conditions
+	conditions := conditionList(true1, falseInfo1)
+
+	s := UnstructuredSetter(u)
+	s.SetConditions(conditions)
+	g.Expect(s.GetConditions()).To(Equal(conditions))
+}

--- a/pkg/conditions2/utils.go
+++ b/pkg/conditions2/utils.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conditions2
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// Copied from cluster-api util/util.go
+
+var (
+	ErrUnstructuredFieldNotFound = fmt.Errorf("field not found")
+)
+
+// UnstructuredUnmarshalField is a wrapper around json and unstructured objects to decode and copy a specific field
+// value into an object.
+func UnstructuredUnmarshalField(obj *unstructured.Unstructured, v interface{}, fields ...string) error {
+	value, found, err := unstructured.NestedFieldNoCopy(obj.Object, fields...)
+	if err != nil {
+		return errors.Wrapf(err, "failed to retrieve field %q from %q", strings.Join(fields, "."), obj.GroupVersionKind())
+	}
+	if !found || value == nil {
+		return ErrUnstructuredFieldNotFound
+	}
+	valueBytes, err := json.Marshal(value)
+	if err != nil {
+		return errors.Wrapf(err, "failed to json-encode field %q value from %q", strings.Join(fields, "."), obj.GroupVersionKind())
+	}
+	if err := json.Unmarshal(valueBytes, v); err != nil {
+		return errors.Wrapf(err, "failed to json-decode field %q value from %q", strings.Join(fields, "."), obj.GroupVersionKind())
+	}
+	return nil
+}

--- a/pkg/patch2/options.go
+++ b/pkg/patch2/options.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patch2
+
+// Option is some configuration that modifies options for a patch request.
+type Option interface {
+	// ApplyToHelper applies this configuration to the given Helper options.
+	ApplyToHelper(*HelperOptions)
+}
+
+// HelperOptions contains options for patch options.
+type HelperOptions struct {
+	// IncludeStatusObservedGeneration sets the status.observedGeneration field
+	// on the incoming object to match metadata.generation, only if there is a change.
+	IncludeStatusObservedGeneration bool
+
+	// ForceOverwriteConditions allows the patch helper to overwrite conditions in case of conflicts.
+	// This option should only ever be set in controller managing the object being patched.
+	ForceOverwriteConditions bool
+
+	// OwnedConditions defines condition types owned by the controller.
+	// In case of conflicts for the owned conditions, the patch helper will always use the value provided by the controller.
+	OwnedConditions []string
+}
+
+// WithForceOverwriteConditions allows the patch helper to overwrite conditions in case of conflicts.
+// This option should only ever be set in controller managing the object being patched.
+type WithForceOverwriteConditions struct{}
+
+// ApplyToHelper applies this configuration to the given HelperOptions.
+func (w WithForceOverwriteConditions) ApplyToHelper(in *HelperOptions) {
+	in.ForceOverwriteConditions = true
+}
+
+// WithStatusObservedGeneration sets the status.observedGeneration field
+// on the incoming object to match metadata.generation, only if there is a change.
+type WithStatusObservedGeneration struct{}
+
+// ApplyToHelper applies this configuration to the given HelperOptions.
+func (w WithStatusObservedGeneration) ApplyToHelper(in *HelperOptions) {
+	in.IncludeStatusObservedGeneration = true
+}
+
+// WithOwnedConditions allows to define condition types owned by the controller.
+// In case of conflicts for the owned conditions, the patch helper will always use the value provided by the controller.
+type WithOwnedConditions struct {
+	Conditions []string
+}
+
+// ApplyToHelper applies this configuration to the given HelperOptions.
+func (w WithOwnedConditions) ApplyToHelper(in *HelperOptions) {
+	in.OwnedConditions = w.Conditions
+}

--- a/pkg/patch2/patch.go
+++ b/pkg/patch2/patch.go
@@ -1,0 +1,305 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patch2
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"time"
+
+	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+
+	conditions "github.com/vmware-tanzu/vm-operator/pkg/conditions2"
+)
+
+// Helper is a utility for ensuring the proper patching of objects.
+type Helper struct {
+	client       client.Client
+	gvk          schema.GroupVersionKind
+	beforeObject client.Object
+	before       *unstructured.Unstructured
+	after        *unstructured.Unstructured
+	changes      map[string]bool
+
+	isConditionsSetter bool
+}
+
+// NewHelper returns an initialized Helper.
+func NewHelper(obj client.Object, crClient client.Client) (*Helper, error) {
+	// Return early if the object is nil.
+	if err := checkNilObject(obj); err != nil {
+		return nil, err
+	}
+
+	// Get the GroupVersionKind of the object,
+	// used to validate against later on.
+	gvk, err := apiutil.GVKForObject(obj, crClient.Scheme())
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert the object to unstructured to compare against our before copy.
+	unstructuredObj, err := toUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if the object satisfies the Cluster API conditions contract.
+	_, canInterfaceConditions := obj.(conditions.Setter)
+
+	return &Helper{
+		client:             crClient,
+		gvk:                gvk,
+		before:             unstructuredObj,
+		beforeObject:       obj.DeepCopyObject().(client.Object),
+		isConditionsSetter: canInterfaceConditions,
+	}, nil
+}
+
+// Patch will attempt to patch the given object, including its status.
+func (h *Helper) Patch(ctx context.Context, obj client.Object, opts ...Option) error {
+	// Return early if the object is nil.
+	if err := checkNilObject(obj); err != nil {
+		return err
+	}
+
+	// Get the GroupVersionKind of the object that we want to patch.
+	gvk, err := apiutil.GVKForObject(obj, h.client.Scheme())
+	if err != nil {
+		return err
+	}
+	if gvk != h.gvk {
+		return errors.Errorf("unmatched GroupVersionKind, expected %q got %q", h.gvk, gvk)
+	}
+
+	// Calculate the options.
+	options := &HelperOptions{}
+	for _, opt := range opts {
+		opt.ApplyToHelper(options)
+	}
+
+	// Convert the object to unstructured to compare against our before copy.
+	h.after, err = toUnstructured(obj)
+	if err != nil {
+		return err
+	}
+
+	// Determine if the object has status.
+	if unstructuredHasStatus(h.after) {
+		if options.IncludeStatusObservedGeneration {
+			// Set status.observedGeneration if we're asked to do so.
+			if err := unstructured.SetNestedField(h.after.Object, h.after.GetGeneration(), "status", "observedGeneration"); err != nil {
+				return err
+			}
+
+			// Restore the changes back to the original object.
+			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(h.after.Object, obj); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Calculate and store the top-level field changes (e.g. "metadata", "spec", "status") we have before/after.
+	h.changes, err = h.calculateChanges(obj)
+	if err != nil {
+		return err
+	}
+
+	// Issue patches and return errors in an aggregate.
+	return kerrors.NewAggregate([]error{
+		// Patch the conditions first.
+		//
+		// Given that we pass in metadata.resourceVersion to perform a 3-way-merge conflict resolution,
+		// patching conditions first avoids an extra loop if spec or status patch succeeds first
+		// given that causes the resourceVersion to mutate.
+		h.patchStatusConditions(ctx, obj, options.ForceOverwriteConditions, options.OwnedConditions),
+
+		// Then proceed to patch the rest of the object.
+		h.patch(ctx, obj),
+		h.patchStatus(ctx, obj),
+	})
+}
+
+// patch issues a patch for metadata and spec.
+func (h *Helper) patch(ctx context.Context, obj client.Object) error {
+	if !h.shouldPatch("metadata") && !h.shouldPatch("spec") {
+		return nil
+	}
+	beforeObject, afterObject, err := h.calculatePatch(obj, specPatch)
+	if err != nil {
+		return err
+	}
+	return h.client.Patch(ctx, afterObject, client.MergeFrom(beforeObject))
+}
+
+// patchStatus issues a patch if the status has changed.
+func (h *Helper) patchStatus(ctx context.Context, obj client.Object) error {
+	if !h.shouldPatch("status") {
+		return nil
+	}
+	beforeObject, afterObject, err := h.calculatePatch(obj, statusPatch)
+	if err != nil {
+		return err
+	}
+	return h.client.Status().Patch(ctx, afterObject, client.MergeFrom(beforeObject))
+}
+
+// patchStatusConditions issues a patch if there are any changes to the conditions slice under
+// the status subresource. This is a special case and it's handled separately given that
+// we allow different controllers to act on conditions of the same object.
+//
+// This method has an internal backoff loop. When a conflict is detected, the method
+// asks the Client for the a new version of the object we're trying to patch.
+//
+// Condition changes are then applied to the latest version of the object, and if there are
+// no unresolvable conflicts, the patch is sent again.
+func (h *Helper) patchStatusConditions(ctx context.Context, obj client.Object, forceOverwrite bool, ownedConditions []string) error {
+	// Nothing to do if the object isn't a condition patcher.
+	if !h.isConditionsSetter {
+		return nil
+	}
+
+	// Make sure our before/after objects satisfy the proper interface before continuing.
+	//
+	// NOTE: The checks and error below are done so that we don't panic if any of the objects don't satisfy the
+	// interface any longer, although this shouldn't happen because we already check when creating the patcher.
+	before, ok := h.beforeObject.(conditions.Getter)
+	if !ok {
+		return errors.Errorf("object %s doesn't satisfy conditions.Getter, cannot patch", before.GetObjectKind())
+	}
+	after, ok := obj.(conditions.Getter)
+	if !ok {
+		return errors.Errorf("object %s doesn't satisfy conditions.Getter, cannot patch", after.GetObjectKind())
+	}
+
+	// Store the diff from the before/after object, and return early if there are no changes.
+	diff := conditions.NewPatch(
+		before,
+		after,
+	)
+	if diff.IsZero() {
+		return nil
+	}
+
+	// Make a copy of the object and store the key used if we have conflicts.
+	key := client.ObjectKeyFromObject(after)
+
+	// Define and start a backoff loop to handle conflicts
+	// between controllers working on the same object.
+	//
+	// This has been copied from https://github.com/kubernetes/kubernetes/blob/release-1.16/pkg/controller/controller_utils.go#L86-L88.
+	backoff := wait.Backoff{
+		Steps:    5,
+		Duration: 100 * time.Millisecond,
+		Jitter:   1.0,
+	}
+
+	// Start the backoff loop and return errors if any.
+	return wait.ExponentialBackoff(backoff, func() (bool, error) {
+		latest, ok := before.DeepCopyObject().(conditions.Setter)
+		if !ok {
+			return false, errors.Errorf("object %s doesn't satisfy conditions.Setter, cannot patch", latest.GetObjectKind())
+		}
+
+		// Get a new copy of the object.
+		if err := h.client.Get(ctx, key, latest); err != nil {
+			return false, err
+		}
+
+		// Create the condition patch before merging conditions.
+		conditionsPatch := client.MergeFromWithOptions(latest.DeepCopyObject().(conditions.Setter), client.MergeFromWithOptimisticLock{})
+
+		// Set the condition patch previously created on the new object.
+		if err := diff.Apply(latest, conditions.WithForceOverwrite(forceOverwrite), conditions.WithOwnedConditions(ownedConditions...)); err != nil {
+			return false, err
+		}
+
+		// Issue the patch.
+		err := h.client.Status().Patch(ctx, latest, conditionsPatch)
+		switch {
+		case apierrors.IsConflict(err):
+			// Requeue.
+			return false, nil
+		case err != nil:
+			return false, err
+		default:
+			return true, nil
+		}
+	})
+}
+
+// calculatePatch returns the before/after objects to be given in a controller-runtime patch, scoped down to the absolute necessary.
+func (h *Helper) calculatePatch(afterObj client.Object, focus patchType) (client.Object, client.Object, error) {
+	// Get a shallow unsafe copy of the before/after object in unstructured form.
+	before := unsafeUnstructuredCopy(h.before, focus, h.isConditionsSetter)
+	after := unsafeUnstructuredCopy(h.after, focus, h.isConditionsSetter)
+
+	// We've now applied all modifications to local unstructured objects,
+	// make copies of the original objects and convert them back.
+	beforeObj := h.beforeObject.DeepCopyObject().(client.Object)
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(before.Object, beforeObj); err != nil {
+		return nil, nil, err
+	}
+	afterObj = afterObj.DeepCopyObject().(client.Object)
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(after.Object, afterObj); err != nil {
+		return nil, nil, err
+	}
+	return beforeObj, afterObj, nil
+}
+
+func (h *Helper) shouldPatch(in string) bool {
+	return h.changes[in]
+}
+
+// calculate changes tries to build a patch from the before/after objects we have
+// and store in a map which top-level fields (e.g. `metadata`, `spec`, `status`, etc.) have changed.
+func (h *Helper) calculateChanges(after client.Object) (map[string]bool, error) {
+	// Calculate patch data.
+	patch := client.MergeFrom(h.beforeObject)
+	diff, err := patch.Data(after)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to calculate patch data")
+	}
+
+	// Unmarshal patch data into a local map.
+	patchDiff := map[string]interface{}{}
+	if err := json.Unmarshal(diff, &patchDiff); err != nil {
+		return nil, errors.Wrapf(err, "failed to unmarshal patch data into a map")
+	}
+
+	// Return the map.
+	res := make(map[string]bool, len(patchDiff))
+	for key := range patchDiff {
+		res[key] = true
+	}
+	return res, nil
+}
+
+func checkNilObject(obj client.Object) error {
+	// If you're wondering why we need reflection to do this check, see https://golang.org/doc/faq#nil_error.
+	// TODO(vincepri): Remove this check and let it panic if used improperly in a future minor release.
+	if obj == nil || (reflect.ValueOf(obj).IsValid() && reflect.ValueOf(obj).IsNil()) {
+		return errors.Errorf("expected non-nil object")
+	}
+	return nil
+}

--- a/pkg/patch2/patch_test.go
+++ b/pkg/patch2/patch_test.go
@@ -1,0 +1,736 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patch2
+
+import (
+	"reflect"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/google/go-cmp/cmp"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	conditions "github.com/vmware-tanzu/vm-operator/pkg/conditions2"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+func intgTests() {
+	var (
+		ctx *builder.IntegrationTestContext
+	)
+
+	BeforeEach(func() {
+		ctx = suite.NewIntegrationTestContext()
+	})
+
+	AfterEach(func() {
+		ctx.AfterEach()
+		ctx = nil
+	})
+
+	Describe("Patch Helper", func() {
+		It("Should patch an unstructured object", func() {
+			obj := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "VirtualMachine",
+					"apiVersion": "vmoperator.vmware.com/v1alpha1",
+					"metadata": map[string]interface{}{
+						"generateName": "test-bootstrap-",
+						"namespace":    "default",
+					},
+				},
+			}
+
+			Context("adding an owner reference, preserving its status", func() {
+				obj := obj.DeepCopy()
+
+				By("Creating the unstructured object")
+				Expect(ctx.Client.Create(ctx, obj)).ToNot(HaveOccurred())
+				key := client.ObjectKey{Name: obj.GetName(), Namespace: obj.GetNamespace()}
+				defer func() {
+					Expect(ctx.Client.Delete(ctx, obj)).To(Succeed())
+				}()
+				obj.Object["status"] = map[string]interface{}{
+					"ready": true,
+				}
+				Expect(ctx.Client.Status().Update(ctx, obj)).To(Succeed())
+
+				By("Creating a new patch helper")
+				patcher, err := NewHelper(obj, ctx.Client)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Modifying the OwnerReferences")
+				refs := []metav1.OwnerReference{
+					{
+						APIVersion: "cluster.x-k8s.io/v1alpha3",
+						Kind:       "Cluster",
+						Name:       "test",
+						UID:        types.UID("fake-uid"),
+					},
+				}
+				obj.SetOwnerReferences(refs)
+
+				By("Patching the unstructured object")
+				Expect(patcher.Patch(ctx, obj)).To(Succeed())
+
+				By("Validating the object has been updated")
+				Eventually(func() bool {
+					objAfter := obj.DeepCopy()
+					if err := ctx.Client.Get(ctx, key, objAfter); err != nil {
+						return false
+					}
+
+					return reflect.DeepEqual(obj.GetOwnerReferences(), objAfter.GetOwnerReferences())
+				}, timeout).Should(BeTrue())
+			})
+		})
+
+		Describe("Should patch conditions", func() {
+			Specify("on a corev1.Node object", func() {
+				conditionTime := metav1.Date(2015, 1, 1, 12, 0, 0, 0, metav1.Now().Location())
+
+				obj := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "node-patch-test-",
+						Annotations: map[string]string{
+							"test": "1",
+						},
+					},
+				}
+
+				By("Creating a Node object")
+				Expect(ctx.Client.Create(ctx, obj)).ToNot(HaveOccurred())
+				key := client.ObjectKey{Name: obj.GetName()}
+				defer func() {
+					Expect(ctx.Client.Delete(ctx, obj)).To(Succeed())
+				}()
+
+				By("Creating a new patch helper")
+				patcher, err := NewHelper(obj, ctx.Client)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Appending a new condition")
+				condition := corev1.NodeCondition{
+					Type:               "CustomCondition",
+					Status:             corev1.ConditionTrue,
+					LastHeartbeatTime:  conditionTime,
+					LastTransitionTime: conditionTime,
+					Reason:             "reason",
+					Message:            "message",
+				}
+				obj.Status.Conditions = append(obj.Status.Conditions, condition)
+
+				By("Patching the Node")
+				Expect(patcher.Patch(ctx, obj)).To(Succeed())
+
+				By("Validating the object has been updated")
+				Eventually(func() bool {
+					objAfter := obj.DeepCopy()
+					Expect(ctx.Client.Get(ctx, key, objAfter)).To(Succeed())
+
+					ok, _ := ContainElement(condition).Match(objAfter.Status.Conditions)
+					return ok
+				}, timeout).Should(BeTrue())
+			})
+
+			Describe("on a vmopv1.VirtualMachine object", func() {
+				obj := &vmopv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "test-",
+						Namespace:    "default",
+					},
+					Spec: vmopv1.VirtualMachineSpec{
+						PowerState: vmopv1.VirtualMachinePowerStateOn,
+					},
+				}
+
+				Specify("should mark it ready", func() {
+					obj := obj.DeepCopy()
+
+					By("Creating the object")
+					Expect(ctx.Client.Create(ctx, obj)).ToNot(HaveOccurred())
+					key := client.ObjectKey{Name: obj.Name, Namespace: obj.Namespace}
+					defer func() {
+						Expect(ctx.Client.Delete(ctx, obj)).To(Succeed())
+					}()
+
+					By("Creating a new patch helper")
+					patcher, err := NewHelper(obj, ctx.Client)
+					Expect(err).NotTo(HaveOccurred())
+
+					By("Marking Ready=True")
+					conditions.MarkTrue(obj, vmopv1.ReadyConditionType)
+
+					By("Patching the object")
+					Expect(patcher.Patch(ctx, obj)).To(Succeed())
+
+					By("Validating the object has been updated")
+					Eventually(func() bool {
+						objAfter := obj.DeepCopy()
+						if err := ctx.Client.Get(ctx, key, objAfter); err != nil {
+							return false
+						}
+						return cmp.Equal(obj.Status.Conditions, objAfter.Status.Conditions)
+					}, timeout).Should(BeTrue())
+				})
+
+				Specify("should recover if there is a resolvable conflict", func() {
+					obj := obj.DeepCopy()
+
+					By("Creating the object")
+					Expect(ctx.Client.Create(ctx, obj)).ToNot(HaveOccurred())
+					key := client.ObjectKey{Name: obj.Name, Namespace: obj.Namespace}
+					defer func() {
+						Expect(ctx.Client.Delete(ctx, obj)).To(Succeed())
+					}()
+					objCopy := obj.DeepCopy()
+
+					By("Marking a custom condition to be false")
+					conditions.MarkFalse(objCopy, "TestCondition", "reason", "message")
+					Expect(ctx.Client.Status().Update(ctx, objCopy)).To(Succeed())
+
+					By("Validating that the local object's resource version is behind")
+					Expect(obj.ResourceVersion).ToNot(Equal(objCopy.ResourceVersion))
+
+					By("Creating a new patch helper")
+					patcher, err := NewHelper(obj, ctx.Client)
+					Expect(err).NotTo(HaveOccurred())
+
+					By("Marking Ready=True")
+					conditions.MarkTrue(obj, vmopv1.ReadyConditionType)
+
+					By("Patching the object")
+					Expect(patcher.Patch(ctx, obj)).To(Succeed())
+
+					By("Validating the object has been updated")
+					Eventually(func() bool {
+						objAfter := obj.DeepCopy()
+						if err := ctx.Client.Get(ctx, key, objAfter); err != nil {
+							return false
+						}
+
+						testConditionCopy := conditions.Get(objCopy, "TestCondition")
+						testConditionAfter := conditions.Get(objAfter, "TestCondition")
+
+						readyBefore := conditions.Get(obj, vmopv1.ReadyConditionType)
+						readyAfter := conditions.Get(objAfter, vmopv1.ReadyConditionType)
+
+						return cmp.Equal(testConditionCopy, testConditionAfter) && cmp.Equal(readyBefore, readyAfter)
+					}, timeout).Should(BeTrue())
+				})
+
+				Specify("should recover if there is a resolvable conflict, incl. patch spec and status", func() {
+					obj := obj.DeepCopy()
+
+					By("Creating the object")
+					Expect(ctx.Client.Create(ctx, obj)).ToNot(HaveOccurred())
+					key := client.ObjectKey{Name: obj.Name, Namespace: obj.Namespace}
+					defer func() {
+						Expect(ctx.Client.Delete(ctx, obj)).To(Succeed())
+					}()
+					objCopy := obj.DeepCopy()
+
+					By("Marking a custom condition to be false")
+					conditions.MarkFalse(objCopy, "TestCondition", "reason", "message")
+					Expect(ctx.Client.Status().Update(ctx, objCopy)).To(Succeed())
+
+					By("Validating that the local object's resource version is behind")
+					Expect(obj.ResourceVersion).ToNot(Equal(objCopy.ResourceVersion))
+
+					By("Creating a new patch helper")
+					patcher, err := NewHelper(obj, ctx.Client)
+					Expect(err).NotTo(HaveOccurred())
+
+					By("Changing the object spec, status, and adding Ready=True condition")
+					obj.Spec.ImageName = "foo-image"
+					conditions.MarkTrue(obj, vmopv1.ReadyConditionType)
+
+					By("Patching the object")
+					Expect(patcher.Patch(ctx, obj)).To(Succeed())
+
+					By("Validating the object has been updated")
+					objAfter := obj.DeepCopy()
+					Eventually(func() bool {
+						if err := ctx.Client.Get(ctx, key, objAfter); err != nil {
+							return false
+						}
+
+						testConditionCopy := conditions.Get(objCopy, "TestCondition")
+						testConditionAfter := conditions.Get(objAfter, "TestCondition")
+
+						readyBefore := conditions.Get(obj, vmopv1.ReadyConditionType)
+						readyAfter := conditions.Get(objAfter, vmopv1.ReadyConditionType)
+
+						return cmp.Equal(testConditionCopy, testConditionAfter) && cmp.Equal(readyBefore, readyAfter) &&
+							obj.Spec.ImageName == objAfter.Spec.ImageName
+					}, timeout).Should(BeTrue(), cmp.Diff(obj, objAfter))
+				})
+
+				Specify("should return an error if there is an unresolvable conflict", func() {
+					obj := obj.DeepCopy()
+
+					By("Creating the object")
+					Expect(ctx.Client.Create(ctx, obj)).ToNot(HaveOccurred())
+					key := client.ObjectKey{Name: obj.Name, Namespace: obj.Namespace}
+					defer func() {
+						Expect(ctx.Client.Delete(ctx, obj)).To(Succeed())
+					}()
+					objCopy := obj.DeepCopy()
+
+					By("Marking a custom condition to be false")
+					conditions.MarkFalse(objCopy, vmopv1.ReadyConditionType, "reason", "message")
+					Expect(ctx.Client.Status().Update(ctx, objCopy)).To(Succeed())
+
+					By("Validating that the local object's resource version is behind")
+					Expect(obj.ResourceVersion).ToNot(Equal(objCopy.ResourceVersion))
+
+					By("Creating a new patch helper")
+					patcher, err := NewHelper(obj, ctx.Client)
+					Expect(err).NotTo(HaveOccurred())
+
+					By("Marking Ready=True")
+					conditions.MarkTrue(obj, vmopv1.ReadyConditionType)
+
+					By("Patching the object")
+					Expect(patcher.Patch(ctx, obj)).ToNot(Succeed())
+
+					By("Validating the object has not been updated")
+					Eventually(func() bool {
+						objAfter := obj.DeepCopy()
+						if err := ctx.Client.Get(ctx, key, objAfter); err != nil {
+							return false
+						}
+						ok, _ := ContainElement(objCopy.Status.Conditions[0]).Match(objAfter.Status.Conditions)
+						return ok
+					}, timeout).Should(BeTrue())
+				})
+
+				Specify("should not return an error if there is an unresolvable conflict but the conditions is owned by the controller", func() {
+					obj := obj.DeepCopy()
+
+					By("Creating the object")
+					Expect(ctx.Client.Create(ctx, obj)).ToNot(HaveOccurred())
+					key := client.ObjectKey{Name: obj.Name, Namespace: obj.Namespace}
+					defer func() {
+						Expect(ctx.Client.Delete(ctx, obj)).To(Succeed())
+					}()
+					objCopy := obj.DeepCopy()
+
+					By("Marking a custom condition to be false")
+					conditions.MarkFalse(objCopy, vmopv1.ReadyConditionType, "reason", "message")
+					Expect(ctx.Client.Status().Update(ctx, objCopy)).To(Succeed())
+
+					By("Validating that the local object's resource version is behind")
+					Expect(obj.ResourceVersion).ToNot(Equal(objCopy.ResourceVersion))
+
+					By("Creating a new patch helper")
+					patcher, err := NewHelper(obj, ctx.Client)
+					Expect(err).NotTo(HaveOccurred())
+
+					By("Marking Ready=True")
+					conditions.MarkTrue(obj, vmopv1.ReadyConditionType)
+
+					By("Patching the object")
+					Expect(patcher.Patch(ctx, obj, WithOwnedConditions{Conditions: []string{vmopv1.ReadyConditionType}})).To(Succeed())
+
+					By("Validating the object has been updated")
+					Eventually(func() bool {
+						objAfter := obj.DeepCopy()
+						if err := ctx.Client.Get(ctx, key, objAfter); err != nil {
+							return false
+						}
+
+						readyBefore := conditions.Get(obj, vmopv1.ReadyConditionType)
+						readyAfter := conditions.Get(objAfter, vmopv1.ReadyConditionType)
+
+						return cmp.Equal(readyBefore, readyAfter)
+					}, timeout).Should(BeTrue())
+				})
+
+				Specify("should not return an error if there is an unresolvable conflict when force overwrite is enabled", func() {
+					obj := obj.DeepCopy()
+
+					By("Creating the object")
+					Expect(ctx.Client.Create(ctx, obj)).ToNot(HaveOccurred())
+					key := client.ObjectKey{Name: obj.Name, Namespace: obj.Namespace}
+					defer func() {
+						Expect(ctx.Client.Delete(ctx, obj)).To(Succeed())
+					}()
+					objCopy := obj.DeepCopy()
+
+					By("Marking a custom condition to be false")
+					conditions.MarkFalse(objCopy, vmopv1.ReadyConditionType, "reason", "message")
+					Expect(ctx.Client.Status().Update(ctx, objCopy)).To(Succeed())
+
+					By("Validating that the local object's resource version is behind")
+					Expect(obj.ResourceVersion).ToNot(Equal(objCopy.ResourceVersion))
+
+					By("Creating a new patch helper")
+					patcher, err := NewHelper(obj, ctx.Client)
+					Expect(err).NotTo(HaveOccurred())
+
+					By("Marking Ready=True")
+					conditions.MarkTrue(obj, vmopv1.ReadyConditionType)
+
+					By("Patching the object")
+					Expect(patcher.Patch(ctx, obj, WithForceOverwriteConditions{})).To(Succeed())
+
+					By("Validating the object has been updated")
+					Eventually(func() bool {
+						objAfter := obj.DeepCopy()
+						if err := ctx.Client.Get(ctx, key, objAfter); err != nil {
+							return false
+						}
+
+						readyBefore := conditions.Get(obj, vmopv1.ReadyConditionType)
+						readyAfter := conditions.Get(objAfter, vmopv1.ReadyConditionType)
+
+						return cmp.Equal(readyBefore, readyAfter)
+					}, timeout).Should(BeTrue())
+				})
+			})
+		})
+
+		Describe("Should patch a vmopv1.VirtualMachine", func() {
+			var obj *vmopv1.VirtualMachine
+
+			BeforeEach(func() {
+				obj = &vmopv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "test-",
+						Namespace:    ctx.Namespace,
+					},
+					Spec: vmopv1.VirtualMachineSpec{
+						PowerState: vmopv1.VirtualMachinePowerStateOn,
+					},
+					Status: vmopv1.VirtualMachineStatus{
+						BiosUUID:     "bios-uuid-foo",
+						InstanceUUID: "instance-uuid-foo",
+						UniqueID:     "unique-id",
+						PowerState:   vmopv1.VirtualMachinePowerStateOn,
+					},
+				}
+			})
+
+			Specify("add a finalizers", func() {
+				obj := obj.DeepCopy()
+
+				By("Creating the object")
+				Expect(ctx.Client.Create(ctx, obj)).ToNot(HaveOccurred())
+				key := client.ObjectKey{Name: obj.Name, Namespace: obj.Namespace}
+				defer func() {
+					Expect(ctx.Client.Delete(ctx, obj)).To(Succeed())
+				}()
+
+				By("Creating a new patch helper")
+				patcher, err := NewHelper(obj, ctx.Client)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Adding a finalizer")
+				obj.Finalizers = append(obj.Finalizers, "vm-finalizer")
+
+				By("Patching the object")
+				Expect(patcher.Patch(ctx, obj)).To(Succeed())
+
+				By("Validating the object has been updated")
+				Eventually(func() bool {
+					objAfter := obj.DeepCopy()
+					if err := ctx.Client.Get(ctx, key, objAfter); err != nil {
+						return false
+					}
+
+					return reflect.DeepEqual(obj.Finalizers, objAfter.Finalizers)
+				}, timeout).Should(BeTrue())
+			})
+
+			Specify("removing finalizers", func() {
+				obj := obj.DeepCopy()
+				obj.Finalizers = append(obj.Finalizers, "vm-finalizer")
+
+				By("Creating the object")
+				Expect(ctx.Client.Create(ctx, obj)).ToNot(HaveOccurred())
+				key := client.ObjectKey{Name: obj.Name, Namespace: obj.Namespace}
+				defer func() {
+					Expect(ctx.Client.Delete(ctx, obj)).To(Succeed())
+				}()
+
+				By("Creating a new patch helper")
+				patcher, err := NewHelper(obj, ctx.Client)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Removing the finalizers")
+				obj.SetFinalizers(nil)
+
+				By("Patching the object")
+				Expect(patcher.Patch(ctx, obj)).To(Succeed())
+
+				By("Validating the object has been updated")
+				Eventually(func() bool {
+					objAfter := obj.DeepCopy()
+					if err := ctx.Client.Get(ctx, key, objAfter); err != nil {
+						return false
+					}
+
+					return len(objAfter.Finalizers) == 0
+				}, timeout).Should(BeTrue())
+			})
+
+			Specify("updating spec", func() {
+				obj := obj.DeepCopy()
+				obj.ObjectMeta.Namespace = ctx.Namespace
+
+				By("Creating the object")
+				Expect(ctx.Client.Create(ctx, obj)).ToNot(HaveOccurred())
+				key := client.ObjectKey{Name: obj.Name, Namespace: obj.Namespace}
+				defer func() {
+					Expect(ctx.Client.Delete(ctx, obj)).To(Succeed())
+				}()
+
+				By("Creating a new patch helper")
+				patcher, err := NewHelper(obj, ctx.Client)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Updating the object spec")
+				obj.Spec.ImageName = "image-name-42"
+
+				By("Patching the object")
+				Expect(patcher.Patch(ctx, obj)).To(Succeed())
+
+				By("Validating the object has been updated")
+				Eventually(func() bool {
+					objAfter := obj.DeepCopy()
+					if err := ctx.Client.Get(ctx, key, objAfter); err != nil {
+						return false
+					}
+
+					return obj.Spec.ImageName == objAfter.Spec.ImageName
+				}, timeout).Should(BeTrue())
+			})
+
+			Specify("updating status", func() {
+				obj := obj.DeepCopy()
+
+				By("Creating the object")
+				Expect(ctx.Client.Create(ctx, obj)).ToNot(HaveOccurred())
+				key := client.ObjectKey{Name: obj.Name, Namespace: obj.Namespace}
+				defer func() {
+					Expect(ctx.Client.Delete(ctx, obj)).To(Succeed())
+				}()
+
+				By("Creating a new patch helper")
+				patcher, err := NewHelper(obj, ctx.Client)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Updating the object status")
+				obj.Status.Host = "vm-host"
+
+				By("Patching the object")
+				Expect(patcher.Patch(ctx, obj)).To(Succeed())
+
+				By("Validating the object has been updated")
+				Eventually(func() bool {
+					objAfter := obj.DeepCopy()
+					if err := ctx.Client.Get(ctx, key, objAfter); err != nil {
+						return false
+					}
+					return reflect.DeepEqual(objAfter.Status, obj.Status)
+				}, timeout).Should(BeTrue())
+			})
+
+			Specify("updating both spec, status, and adding a condition", func() {
+				obj := obj.DeepCopy()
+				obj.ObjectMeta.Namespace = ctx.Namespace
+
+				By("Creating the object")
+				Expect(ctx.Client.Create(ctx, obj)).ToNot(HaveOccurred())
+				key := client.ObjectKey{Name: obj.Name, Namespace: obj.Namespace}
+				defer func() {
+					Expect(ctx.Client.Delete(ctx, obj)).To(Succeed())
+				}()
+
+				By("Creating a new patch helper")
+				patcher, err := NewHelper(obj, ctx.Client)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Updating the object spec")
+				obj.Spec.ImageName = "image-name"
+
+				By("Updating the object status")
+				obj.Status.Host = "vm-host"
+
+				By("Setting Ready condition")
+				conditions.MarkTrue(obj, vmopv1.ReadyConditionType)
+
+				By("Patching the object")
+				Expect(patcher.Patch(ctx, obj)).To(Succeed())
+
+				By("Validating the object has been updated")
+				Eventually(func() bool {
+					objAfter := obj.DeepCopy()
+					if err := ctx.Client.Get(ctx, key, objAfter); err != nil {
+						return false
+					}
+
+					return obj.Status.Host == objAfter.Status.Host &&
+						conditions.IsTrue(objAfter, vmopv1.ReadyConditionType) &&
+						reflect.DeepEqual(obj.Spec, objAfter.Spec)
+				}, timeout).Should(BeTrue())
+			})
+		})
+
+		/*
+			It("Should update Status.ObservedGeneration when using WithStatusObservedGeneration option", func() {
+				obj := &clusterv1.MachineSet{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "test-ms",
+						Namespace:    "test-namespace",
+					},
+					Spec: clusterv1.MachineSetSpec{
+						ClusterName: "test1",
+						Template: clusterv1.MachineTemplateSpec{
+							Spec: clusterv1.MachineSpec{
+								ClusterName: "test1",
+							},
+						},
+					},
+				}
+
+				Context("when updating spec", func() {
+					obj := obj.DeepCopy()
+
+					By("Creating the MachineSet object")
+					Expect(ctx.Client.Create(ctx, obj)).ToNot(HaveOccurred())
+					key := client.ObjectKey{Name: obj.Name, Namespace: obj.Namespace}
+					defer func() {
+						Expect(testEnv.Delete(ctx, obj)).To(Succeed())
+					}()
+
+					By("Creating a new patch helper")
+					patcher, err := NewHelper(obj, testEnv)
+					Expect(err).NotTo(HaveOccurred())
+
+					By("Updating the object spec")
+					obj.Spec.Replicas = pointer.Int32(10)
+
+					By("Patching the object")
+					Expect(patcher.Patch(ctx, obj, WithStatusObservedGeneration{})).To(Succeed())
+
+					By("Validating the object has been updated")
+					Eventually(func() bool {
+						objAfter := obj.DeepCopy()
+						if err := testEnv.Get(ctx, key, objAfter); err != nil {
+							return false
+						}
+
+						return reflect.DeepEqual(obj.Spec, objAfter.Spec) &&
+							obj.GetGeneration() == objAfter.Status.ObservedGeneration
+					}, timeout).Should(BeTrue())
+				})
+
+				Context("when updating spec, status, and metadata", func() {
+					obj := obj.DeepCopy()
+
+					By("Creating the MachineSet object")
+					Expect(testEnv.Create(ctx, obj)).ToNot(HaveOccurred())
+					key := client.ObjectKey{Name: obj.Name, Namespace: obj.Namespace}
+					defer func() {
+						Expect(testEnv.Delete(ctx, obj)).To(Succeed())
+					}()
+
+					By("Creating a new patch helper")
+					patcher, err := NewHelper(obj, testEnv)
+					Expect(err).NotTo(HaveOccurred())
+
+					By("Updating the object spec")
+					obj.Spec.Replicas = pointer.Int32(10)
+
+					By("Updating the object status")
+					obj.Status.AvailableReplicas = 6
+					obj.Status.ReadyReplicas = 6
+
+					By("Updating the object metadata")
+					obj.ObjectMeta.Annotations = map[string]string{
+						"test1": "annotation",
+					}
+
+					By("Patching the object")
+					Expect(patcher.Patch(ctx, obj, WithStatusObservedGeneration{})).To(Succeed())
+
+					By("Validating the object has been updated")
+					Eventually(func() bool {
+						objAfter := obj.DeepCopy()
+						if err := testEnv.Get(ctx, key, objAfter); err != nil {
+							return false
+						}
+
+						return reflect.DeepEqual(obj.Spec, objAfter.Spec) &&
+							reflect.DeepEqual(obj.Status, objAfter.Status) &&
+							obj.GetGeneration() == objAfter.Status.ObservedGeneration
+					}, timeout).Should(BeTrue())
+				})
+
+				Context("without any changes", func() {
+					obj := obj.DeepCopy()
+
+					By("Creating the MachineSet object")
+					Expect(testEnv.Create(ctx, obj)).ToNot(HaveOccurred())
+					key := client.ObjectKey{Name: obj.Name, Namespace: obj.Namespace}
+					defer func() {
+						Expect(testEnv.Delete(ctx, obj)).To(Succeed())
+					}()
+					obj.Status.ObservedGeneration = obj.GetGeneration()
+					lastGeneration := obj.GetGeneration()
+					Expect(testEnv.Status().Update(ctx, obj))
+
+					By("Creating a new patch helper")
+					patcher, err := NewHelper(obj, testEnv)
+					Expect(err).NotTo(HaveOccurred())
+
+					By("Patching the object")
+					Expect(patcher.Patch(ctx, obj, WithStatusObservedGeneration{})).To(Succeed())
+
+					By("Validating the object has been updated")
+					Eventually(func() bool {
+						objAfter := obj.DeepCopy()
+						if err := testEnv.Get(ctx, key, objAfter); err != nil {
+							return false
+						}
+
+						return lastGeneration == objAfter.Status.ObservedGeneration
+					}, timeout).Should(BeTrue())
+				})
+			})
+		*/
+	})
+}
+
+func TestNewHelperNil(t *testing.T) {
+	var x *appsv1.Deployment
+	g := NewWithT(t)
+	_, err := NewHelper(x, nil)
+	g.Expect(err).ToNot(BeNil())
+	_, err = NewHelper(nil, nil)
+	g.Expect(err).ToNot(BeNil())
+}

--- a/pkg/patch2/suite_test.go
+++ b/pkg/patch2/suite_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patch2
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+const (
+	timeout = time.Second * 10
+)
+
+var suite = builder.NewTestSuite()
+
+func TestPatch(t *testing.T) {
+	_ = intgTests
+	suite.Register(t, "Patch Suite", nil /*intgTests*/, nil)
+}
+
+var _ = BeforeSuite(suite.BeforeSuite)
+
+var _ = AfterSuite(suite.AfterSuite)

--- a/pkg/patch2/utils.go
+++ b/pkg/patch2/utils.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patch2
+
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type patchType string
+
+func (p patchType) Key() string {
+	return strings.Split(string(p), ".")[0]
+}
+
+const (
+	specPatch   patchType = "spec"
+	statusPatch patchType = "status"
+)
+
+var (
+	preserveUnstructuredKeys = map[string]bool{
+		"kind":       true,
+		"apiVersion": true,
+		"metadata":   true,
+	}
+)
+
+func unstructuredHasStatus(u *unstructured.Unstructured) bool {
+	_, ok := u.Object["status"]
+	return ok
+}
+
+func toUnstructured(obj runtime.Object) (*unstructured.Unstructured, error) {
+	// If the incoming object is already unstructured, perform a deep copy first
+	// otherwise DefaultUnstructuredConverter ends up returning the inner map without
+	// making a copy.
+	if _, ok := obj.(runtime.Unstructured); ok {
+		obj = obj.DeepCopyObject()
+	}
+	rawMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+	return &unstructured.Unstructured{Object: rawMap}, nil
+}
+
+// unsafeUnstructuredCopy returns a shallow copy of the unstructured object given as input.
+// It copies the common fields such as `kind`, `apiVersion`, `metadata` and the patchType specified.
+//
+// It's not safe to modify any of the keys in the returned unstructured object, the result should be treated as read-only.
+func unsafeUnstructuredCopy(obj *unstructured.Unstructured, focus patchType, isConditionsSetter bool) *unstructured.Unstructured {
+	// Create the return focused-unstructured object with a preallocated map.
+	res := &unstructured.Unstructured{Object: make(map[string]interface{}, len(obj.Object))}
+
+	// Ranges over the keys of the unstructured object, think of this as the very top level of an object
+	// when submitting a yaml to kubectl or a client.
+	// These would be keys like `apiVersion`, `kind`, `metadata`, `spec`, `status`, etc.
+	for key := range obj.Object {
+		value := obj.Object[key]
+
+		// Perform a shallow copy only for the keys we're interested in, or the ones that should be always preserved.
+		if key == focus.Key() || preserveUnstructuredKeys[key] {
+			res.Object[key] = value
+		}
+
+		// If we've determined that we're able to interface with conditions.Setter interface,
+		// when dealing with the status patch, remove the status.conditions sub-field from the object.
+		if isConditionsSetter && focus == statusPatch {
+			// NOTE: Removing status.conditions changes the incoming object! This is safe because the condition patch
+			// doesn't use the unstructured fields, and it runs before any other patch.
+			//
+			// If we want to be 100% safe, we could make a copy of the incoming object before modifying it, although
+			// copies have a high cpu and high memory usage, therefore we intentionally choose to avoid extra copies
+			// given that the ordering of operations and safety is handled internally by the patch helper.
+			unstructured.RemoveNestedField(res.Object, "status", "conditions")
+		}
+	}
+
+	return res
+}

--- a/pkg/patch2/utils_test.go
+++ b/pkg/patch2/utils_test.go
@@ -1,0 +1,227 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patch2
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+)
+
+func TestToUnstructured(t *testing.T) {
+	t.Run("with a typed object", func(t *testing.T) {
+		g := NewWithT(t)
+		// Test with a typed object.
+		obj := &vmopv1.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster-1",
+				Namespace: "namespace-1",
+			},
+			Spec: vmopv1.VirtualMachineSpec{
+				ImageName: "foo",
+			},
+		}
+		newObj, err := toUnstructured(obj)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(newObj.GetName()).To(Equal(obj.Name))
+		g.Expect(newObj.GetNamespace()).To(Equal(obj.Namespace))
+
+		// Change a spec field and validate that it stays the same in the incoming object.
+		g.Expect(unstructured.SetNestedField(newObj.Object, false, "spec", "paused")).To(Succeed())
+		g.Expect(obj.Spec.ImageName).To(Equal("foo"))
+	})
+
+	t.Run("with an unstructured object", func(t *testing.T) {
+		g := NewWithT(t)
+
+		obj := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "test.x.y.z/v1",
+				"metadata": map[string]interface{}{
+					"name":      "test-1",
+					"namespace": "namespace-1",
+				},
+				"spec": map[string]interface{}{
+					"paused": true,
+				},
+			},
+		}
+
+		newObj, err := toUnstructured(obj)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(newObj.GetName()).To(Equal(obj.GetName()))
+		g.Expect(newObj.GetNamespace()).To(Equal(obj.GetNamespace()))
+
+		// Validate that the maps point to different addresses.
+		g.Expect(obj.Object).ToNot(BeIdenticalTo(newObj.Object))
+
+		// Change a spec field and validate that it stays the same in the incoming object.
+		g.Expect(unstructured.SetNestedField(newObj.Object, false, "spec", "paused")).To(Succeed())
+		pausedValue, _, err := unstructured.NestedBool(obj.Object, "spec", "paused")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(pausedValue).To(BeTrue())
+
+		// Change the name of the new object and make sure it doesn't change it the old one.
+		newObj.SetName("test-2")
+		g.Expect(obj.GetName()).To(Equal("test-1"))
+	})
+}
+
+func TestUnsafeFocusedUnstructured(t *testing.T) {
+	t.Run("focus=spec, should only return spec and common fields", func(t *testing.T) {
+		g := NewWithT(t)
+
+		obj := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "test.x.y.z/v1",
+				"kind":       "TestCluster",
+				"metadata": map[string]interface{}{
+					"name":      "test-1",
+					"namespace": "namespace-1",
+				},
+				"spec": map[string]interface{}{
+					"paused": true,
+				},
+				"status": map[string]interface{}{
+					"infrastructureReady": true,
+					"conditions": []interface{}{
+						map[string]interface{}{
+							"type":   "Ready",
+							"status": "True",
+						},
+					},
+				},
+			},
+		}
+
+		newObj := unsafeUnstructuredCopy(obj, specPatch, true)
+
+		// Validate that common fields are always preserved.
+		g.Expect(newObj.Object["apiVersion"]).To(Equal(obj.Object["apiVersion"]))
+		g.Expect(newObj.Object["kind"]).To(Equal(obj.Object["kind"]))
+		g.Expect(newObj.Object["metadata"]).To(Equal(obj.Object["metadata"]))
+
+		// Validate that the spec has been preserved.
+		g.Expect(newObj.Object["spec"]).To(Equal(obj.Object["spec"]))
+
+		// Validate that the status is nil, but preserved in the original object.
+		g.Expect(newObj.Object["status"]).To(BeNil())
+		g.Expect(obj.Object["status"]).ToNot(BeNil())
+		g.Expect(obj.Object["status"].(map[string]interface{})["conditions"]).ToNot(BeNil())
+	})
+
+	t.Run("focus=status w/ condition-setter object, should only return status (without conditions) and common fields", func(t *testing.T) {
+		g := NewWithT(t)
+
+		obj := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "test.x.y.z/v1",
+				"kind":       "TestCluster",
+				"metadata": map[string]interface{}{
+					"name":      "test-1",
+					"namespace": "namespace-1",
+				},
+				"spec": map[string]interface{}{
+					"paused": true,
+				},
+				"status": map[string]interface{}{
+					"infrastructureReady": true,
+					"conditions": []interface{}{
+						map[string]interface{}{
+							"type":   "Ready",
+							"status": "True",
+						},
+					},
+				},
+			},
+		}
+
+		newObj := unsafeUnstructuredCopy(obj, statusPatch, true)
+
+		// Validate that common fields are always preserved.
+		g.Expect(newObj.Object["apiVersion"]).To(Equal(obj.Object["apiVersion"]))
+		g.Expect(newObj.Object["kind"]).To(Equal(obj.Object["kind"]))
+		g.Expect(newObj.Object["metadata"]).To(Equal(obj.Object["metadata"]))
+
+		// Validate that spec is nil in the new object, but still exists in the old copy.
+		g.Expect(newObj.Object["spec"]).To(BeNil())
+		g.Expect(obj.Object["spec"]).To(Equal(map[string]interface{}{
+			"paused": true,
+		}))
+
+		// Validate that the status has been copied, without conditions.
+		g.Expect(newObj.Object["status"]).To(HaveLen(1))
+		g.Expect(newObj.Object["status"].(map[string]interface{})["infrastructureReady"]).To(Equal(true))
+		g.Expect(newObj.Object["status"].(map[string]interface{})["conditions"]).To(BeNil())
+
+		// When working with conditions, the inner map is going to be removed from the original object.
+		g.Expect(obj.Object["status"].(map[string]interface{})["conditions"]).To(BeNil())
+	})
+
+	t.Run("focus=status w/o condition-setter object, should only return status and common fields", func(t *testing.T) {
+		g := NewWithT(t)
+
+		obj := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "test.x.y.z/v1",
+				"kind":       "TestCluster",
+				"metadata": map[string]interface{}{
+					"name":      "test-1",
+					"namespace": "namespace-1",
+				},
+				"spec": map[string]interface{}{
+					"paused": true,
+					"other":  "field",
+				},
+				"status": map[string]interface{}{
+					"infrastructureReady": true,
+					"conditions": []interface{}{
+						map[string]interface{}{
+							"type":   "Ready",
+							"status": "True",
+						},
+					},
+				},
+			},
+		}
+
+		newObj := unsafeUnstructuredCopy(obj, statusPatch, false)
+
+		// Validate that spec is nil in the new object, but still exists in the old copy.
+		g.Expect(newObj.Object["spec"]).To(BeNil())
+		g.Expect(obj.Object["spec"]).To(Equal(map[string]interface{}{
+			"paused": true,
+			"other":  "field",
+		}))
+
+		// Validate that common fields are always preserved.
+		g.Expect(newObj.Object["apiVersion"]).To(Equal(obj.Object["apiVersion"]))
+		g.Expect(newObj.Object["kind"]).To(Equal(obj.Object["kind"]))
+		g.Expect(newObj.Object["metadata"]).To(Equal(obj.Object["metadata"]))
+
+		// Validate that the status has been copied, without conditions.
+		g.Expect(newObj.Object["status"]).To(HaveLen(2))
+		g.Expect(newObj.Object["status"]).To(Equal(obj.Object["status"]))
+
+		// Make sure that we didn't modify the incoming object if this object isn't a condition setter.
+		g.Expect(obj.Object["status"].(map[string]interface{})["conditions"]).ToNot(BeNil())
+	})
+}

--- a/pkg/prober2/context/probe_context.go
+++ b/pkg/prober2/context/probe_context.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package context
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+
+	patch "github.com/vmware-tanzu/vm-operator/pkg/patch2"
+)
+
+// ProbeContext is the context used for VM Probes.
+type ProbeContext struct {
+	context.Context
+	Logger        logr.Logger
+	PatchHelper   *patch.Helper
+	VM            *vmopv1.VirtualMachine
+	ProbeType     string
+	PeriodSeconds int32
+}
+
+// String returns probe type.
+func (p *ProbeContext) String() string {
+	return p.ProbeType
+}

--- a/pkg/prober2/fake/fake_prober_manager.go
+++ b/pkg/prober2/fake/fake_prober_manager.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package fake
+
+import (
+	"context"
+	"sync"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	prober "github.com/vmware-tanzu/vm-operator/pkg/prober2"
+)
+
+type funcs struct {
+	AddToProberManagerFn      func(vm *vmopv1.VirtualMachine)
+	RemoveFromProberManagerFn func(vm *vmopv1.VirtualMachine)
+}
+
+type ProberManager struct {
+	funcs
+	sync.Mutex
+	IsAddToProberManagerCalled      bool
+	IsRemoveFromProberManagerCalled bool
+}
+
+func NewFakeProberManager() prober.Manager {
+	return &ProberManager{}
+}
+
+func (m *ProberManager) Start(ctx context.Context) error {
+	<-ctx.Done()
+
+	return nil
+}
+
+func (m *ProberManager) AddToProberManager(vm *vmopv1.VirtualMachine) {
+	m.Lock()
+	defer m.Unlock()
+
+	if m.AddToProberManagerFn != nil {
+		m.AddToProberManagerFn(vm)
+		return
+	}
+}
+
+func (m *ProberManager) RemoveFromProberManager(vm *vmopv1.VirtualMachine) {
+	m.Lock()
+	defer m.Unlock()
+
+	if m.RemoveFromProberManagerFn != nil {
+		m.RemoveFromProberManagerFn(vm)
+		return
+	}
+}

--- a/pkg/prober2/fake/probe/fake_probe.go
+++ b/pkg/prober2/fake/probe/fake_probe.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package probe
+
+import (
+	"sync"
+
+	"github.com/vmware-tanzu/vm-operator/pkg/prober2/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/prober2/probe"
+)
+
+type funcs struct {
+	ProbeFn func(ctx *context.ProbeContext) (probe.Result, error)
+}
+
+type FakeProbe struct {
+	sync.Mutex
+	funcs
+}
+
+func NewFakeProbe() probe.Probe {
+	return &FakeProbe{}
+}
+
+func (p *FakeProbe) Probe(ctx *context.ProbeContext) (probe.Result, error) {
+	p.Lock()
+	defer p.Unlock()
+
+	if p.ProbeFn != nil {
+		return p.ProbeFn(ctx)
+	}
+
+	return probe.Unknown, nil
+}

--- a/pkg/prober2/fake/worker/fake_prober_worker.go
+++ b/pkg/prober2/fake/worker/fake_prober_worker.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package worker
+
+import (
+	goctx "context"
+	"fmt"
+	"sync"
+
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+
+	"github.com/vmware-tanzu/vm-operator/pkg/prober2/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/prober2/probe"
+	"github.com/vmware-tanzu/vm-operator/pkg/prober2/worker"
+)
+
+type funcs struct {
+	DoProbeFn            func(ctx *context.ProbeContext) error
+	ProcessProbeResultFn func(ctx *context.ProbeContext, res probe.Result, err error) error
+}
+
+type FakeWorker struct {
+	sync.Mutex
+	funcs
+	queue workqueue.DelayingInterface
+}
+
+func NewFakeWorker(queue workqueue.DelayingInterface) worker.Worker {
+	return &FakeWorker{
+		queue: queue,
+	}
+}
+
+func (w *FakeWorker) Reset() {
+	w.Lock()
+	defer w.Unlock()
+
+	w.funcs = funcs{}
+}
+
+func (w *FakeWorker) GetQueue() workqueue.DelayingInterface {
+	return w.queue
+}
+
+func (w *FakeWorker) CreateProbeContext(vm *vmopv1.VirtualMachine) (*context.ProbeContext, error) {
+	if vm.Spec.ReadinessProbe.TCPSocket == nil {
+		return nil, nil
+	}
+
+	return &context.ProbeContext{
+		Context:       goctx.Background(),
+		Logger:        ctrl.Log.WithName("fake-probe").WithValues("vmName", vm.NamespacedName()),
+		VM:            vm,
+		ProbeType:     "fake-probe",
+		PeriodSeconds: vm.Spec.ReadinessProbe.PeriodSeconds,
+	}, nil
+}
+
+func (w *FakeWorker) DoProbe(ctx *context.ProbeContext) error {
+	w.Lock()
+	defer w.Unlock()
+
+	if w.funcs.DoProbeFn != nil {
+		return w.funcs.DoProbeFn(ctx)
+	}
+	return fmt.Errorf("unexpected method call: DoProbe")
+}
+
+func (w *FakeWorker) ProcessProbeResult(ctx *context.ProbeContext, res probe.Result, err error) error {
+	w.Lock()
+	defer w.Unlock()
+
+	if w.funcs.ProcessProbeResultFn != nil {
+		return w.funcs.ProcessProbeResultFn(ctx, res, err)
+	}
+	return fmt.Errorf("unexpected method call: ProcessProbeResult")
+}

--- a/pkg/prober2/probe/heartbeat.go
+++ b/pkg/prober2/probe/heartbeat.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package probe
+
+import (
+	"fmt"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+
+	"github.com/vmware-tanzu/vm-operator/pkg/prober2/context"
+)
+
+type guestHeartbeatProber struct {
+	prober vmProviderProber
+}
+
+func NewGuestHeartbeatProber(vmProviderProber vmProviderProber) Probe {
+	return &guestHeartbeatProber{
+		prober: vmProviderProber,
+	}
+}
+
+func heartbeatValue(value vmopv1.GuestHeartbeatStatus) int {
+	switch value {
+	case vmopv1.GreenHeartbeatStatus:
+		return 1
+	case vmopv1.YellowHeartbeatStatus:
+		return 0
+	default: // vmopv1.RedHeartbeatStatus, vmopv1.GrayHeartbeatStatus
+		return -1
+	}
+}
+
+func (hbp guestHeartbeatProber) Probe(ctx *context.ProbeContext) (Result, error) {
+	heartbeat, err := hbp.prober.GetVirtualMachineGuestHeartbeat(ctx, ctx.VM)
+	if err != nil {
+		return Unknown, err
+	}
+
+	if heartbeat == "" {
+		return Unknown, fmt.Errorf("no heartbeat value")
+	}
+
+	if heartbeatValue(heartbeat) < heartbeatValue(ctx.VM.Spec.ReadinessProbe.GuestHeartbeat.ThresholdStatus) {
+		return Failure, fmt.Errorf("heartbeat status %q is below threshold", heartbeat)
+	}
+
+	return Success, nil
+}

--- a/pkg/prober2/probe/heartbeat_test.go
+++ b/pkg/prober2/probe/heartbeat_test.go
@@ -1,0 +1,151 @@
+// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package probe
+
+import (
+	goctx "context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+
+	"github.com/vmware-tanzu/vm-operator/pkg/prober2/context"
+)
+
+type fakeVMProviderProber struct {
+	status vmopv1.GuestHeartbeatStatus
+	err    error
+}
+
+func (tp fakeVMProviderProber) GetVirtualMachineGuestHeartbeat(_ goctx.Context, _ *vmopv1.VirtualMachine) (vmopv1.GuestHeartbeatStatus, error) {
+	return tp.status, tp.err
+}
+
+var _ = Describe("Guest heartbeat probe", func() {
+	var (
+		vm                   *vmopv1.VirtualMachine
+		fakeProvider         fakeVMProviderProber
+		testVMwareToolsProbe Probe
+
+		err error
+		res Result
+	)
+
+	BeforeEach(func() {
+		vm = &vmopv1.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dummy-vm",
+				Namespace: "dummy-ns",
+			},
+			Spec: vmopv1.VirtualMachineSpec{
+				ClassName:      "dummy-vmclass",
+				ReadinessProbe: getVirtualMachineReadinessHeartbeatProbe(),
+			},
+		}
+
+		fakeProvider = fakeVMProviderProber{}
+		testVMwareToolsProbe = NewGuestHeartbeatProber(&fakeProvider)
+	})
+
+	JustBeforeEach(func() {
+		probeCtx := &context.ProbeContext{
+			Logger: ctrl.Log.WithName("Probe").WithValues("name", vm.NamespacedName()),
+			VM:     vm,
+		}
+
+		res, err = testVMwareToolsProbe.Probe(probeCtx)
+	})
+
+	Context("Provider returns an error", func() {
+		BeforeEach(func() { fakeProvider.err = fmt.Errorf("fake error") })
+
+		It("returns error", func() {
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(fmt.Errorf("fake error")))
+			Expect(res).To(Equal(Unknown))
+		})
+	})
+
+	Context("Provider does not return an error", func() {
+
+		Context("Provider returns empty status", func() {
+			BeforeEach(func() { fakeProvider.status = "" })
+
+			It("returns unknown", func() {
+				Expect(res).To(Equal(Unknown))
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(fmt.Errorf("no heartbeat value")))
+			})
+		})
+
+		Context("Provider returns gray status", func() {
+			BeforeEach(func() { fakeProvider.status = "gray" })
+
+			It("returns failure", func() {
+				Expect(res).To(Equal(Failure))
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(fmt.Errorf(`heartbeat status "gray" is below threshold`)))
+			})
+		})
+
+		Context("Provider returns red status", func() {
+			BeforeEach(func() { fakeProvider.status = "red" })
+
+			It("returns failure", func() {
+				Expect(res).To(Equal(Failure))
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(fmt.Errorf(`heartbeat status "red" is below threshold`)))
+			})
+		})
+
+		Context("Provider returns yellow status", func() {
+			BeforeEach(func() { fakeProvider.status = vmopv1.YellowHeartbeatStatus })
+
+			Context("Threshold status is yellow", func() {
+				BeforeEach(func() { vm.Spec.ReadinessProbe.GuestHeartbeat.ThresholdStatus = vmopv1.YellowHeartbeatStatus })
+
+				It("returns success", func() {
+					Expect(err).ToNot(HaveOccurred())
+					Expect(res).To(Equal(Success))
+				})
+			})
+
+			Context("Threshold status is green", func() {
+				BeforeEach(func() { vm.Spec.ReadinessProbe.GuestHeartbeat.ThresholdStatus = vmopv1.GreenHeartbeatStatus })
+
+				It("returns failure", func() {
+					Expect(res).To(Equal(Failure))
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(MatchError(fmt.Errorf(`heartbeat status "yellow" is below threshold`)))
+				})
+			})
+		})
+
+		Context("Provider returns green status", func() {
+			BeforeEach(func() {
+				fakeProvider.status = vmopv1.GreenHeartbeatStatus
+				vm.Spec.ReadinessProbe.GuestHeartbeat.ThresholdStatus = vmopv1.GreenHeartbeatStatus
+			})
+
+			It("returns success", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res).To(Equal(Success))
+			})
+		})
+	})
+})
+
+func getVirtualMachineReadinessHeartbeatProbe() vmopv1.VirtualMachineReadinessProbeSpec {
+	return vmopv1.VirtualMachineReadinessProbeSpec{
+		GuestHeartbeat: &vmopv1.GuestHeartbeatAction{
+			ThresholdStatus: vmopv1.GreenHeartbeatStatus, // Default.
+		},
+		PeriodSeconds: 1,
+	}
+}

--- a/pkg/prober2/probe/probe.go
+++ b/pkg/prober2/probe/probe.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package probe
+
+import (
+	goctx "context"
+	"time"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+
+	"github.com/vmware-tanzu/vm-operator/pkg/prober2/context"
+)
+
+type Result int
+
+const (
+	// Failure is encoded as -1 (type Result).
+	Failure Result = iota - 1
+	// Unknown is encoded as 0 (type Result).
+	Unknown
+	// Success is encoded as 1 (type Result).
+	Success
+
+	defaultConnectTimeout = 10 * time.Second
+)
+
+// Probe is the interface to execute VM probes.
+type Probe interface {
+	Probe(ctx *context.ProbeContext) (Result, error)
+}
+
+// Probing related provider methods.
+type vmProviderProber interface {
+	GetVirtualMachineGuestHeartbeat(ctx goctx.Context, vm *vmopv1.VirtualMachine) (vmopv1.GuestHeartbeatStatus, error)
+}
+
+// Prober contains the different type of probes.
+type Prober struct {
+	TCPProbe       Probe
+	GuestHeartbeat Probe
+}
+
+// NewProber creates a new Prober.
+func NewProber(vmProviderProber vmProviderProber) *Prober {
+	return &Prober{
+		TCPProbe:       NewTCPProber(),
+		GuestHeartbeat: NewGuestHeartbeatProber(vmProviderProber),
+	}
+}

--- a/pkg/prober2/probe/tcp.go
+++ b/pkg/prober2/probe/tcp.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package probe
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/pkg/prober2/context"
+)
+
+// tcpProber implements the Probe interface.
+type tcpProber struct{}
+
+// NewTCPProber creates a new tcp prober which implements the Probe interface to execute tcp probes.
+func NewTCPProber() Probe {
+	return &tcpProber{}
+}
+
+func (pr tcpProber) Probe(ctx *context.ProbeContext) (Result, error) {
+	vm := ctx.VM
+	p := &ctx.VM.Spec.ReadinessProbe
+
+	portProto := corev1.ProtocolTCP
+	portNum, err := findPort(vm, p.TCPSocket.Port, portProto)
+	if err != nil {
+		return Failure, err
+	}
+
+	ip := p.TCPSocket.Host
+	if ip == "" {
+		ctx.Logger.V(4).Info("TCPSocket Host not specified, using VM IP", "probe", ctx.String())
+		if vm.Status.Network != nil {
+			ip = vm.Status.Network.PrimaryIP4
+			if ip == "" {
+				ip = vm.Status.Network.PrimaryIP6
+			}
+		}
+		if ip == "" {
+			return Failure, fmt.Errorf("VM %s doesn't have an IP assigned", vm.NamespacedName())
+		}
+	}
+
+	var timeout time.Duration
+	if p.TimeoutSeconds <= 0 {
+		timeout = defaultConnectTimeout
+	} else {
+		timeout = time.Duration(p.TimeoutSeconds) * time.Second
+	}
+
+	if err := checkConnection("tcp", ip, strconv.Itoa(portNum), timeout); err != nil {
+		return Failure, err
+	}
+
+	return Success, nil
+}
+
+func findPort(vm *vmopv1.VirtualMachine, portName intstr.IntOrString, _ corev1.Protocol) (int, error) {
+	switch portName.Type {
+	case intstr.String:
+		// Not supported.
+	case intstr.Int:
+		return portName.IntValue(), nil
+	}
+
+	return 0, fmt.Errorf("no suitable port for manifest: %s", vm.UID)
+}
+
+func checkConnection(proto, host, port string, timeout time.Duration) error {
+	address := net.JoinHostPort(host, port)
+	conn, err := net.DialTimeout(proto, address, timeout)
+	if err != nil {
+		return err
+	}
+
+	return conn.Close()
+}

--- a/pkg/prober2/probe/tcp_test.go
+++ b/pkg/prober2/probe/tcp_test.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package probe
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+
+	"github.com/vmware-tanzu/vm-operator/pkg/prober2/context"
+)
+
+var _ = Describe("TCP probe", func() {
+	var (
+		vm           *vmopv1.VirtualMachine
+		testTCPProbe Probe
+
+		testServer *httptest.Server
+		testHost   string
+		testPort   int
+	)
+
+	BeforeEach(func() {
+		vm = &vmopv1.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dummy-vm",
+				Namespace: "dummy-ns",
+			},
+			Spec: vmopv1.VirtualMachineSpec{
+				ClassName: "dummy-vmclass",
+			},
+			Status: vmopv1.VirtualMachineStatus{
+				Network: &vmopv1.VirtualMachineNetworkStatus{},
+			},
+		}
+
+		testServer, testHost, testPort = setupTestServer()
+		testTCPProbe = NewTCPProber()
+	})
+
+	AfterEach(func() {
+		testServer.Close()
+	})
+
+	It("TCP probe succeeds, with TCP host set in VM spec ", func() {
+		vm.Spec.ReadinessProbe = getVirtualMachineReadinessTCPProbe(testHost, testPort)
+		probeCtx := &context.ProbeContext{
+			VM:     vm,
+			Logger: ctrl.Log.WithName("Probe").WithValues("name", vm.NamespacedName()),
+		}
+
+		res, err := testTCPProbe.Probe(probeCtx)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(res).To(Equal(Success))
+	})
+
+	It("TCP probe succeeds, with empty TCP host", func() {
+		vm.Status.Network.PrimaryIP4 = testHost
+		vm.Spec.ReadinessProbe = getVirtualMachineReadinessTCPProbe("", testPort)
+		probeCtx := &context.ProbeContext{
+			VM:     vm,
+			Logger: ctrl.Log.WithName("Probe").WithValues("name", vm.NamespacedName()),
+		}
+
+		res, err := testTCPProbe.Probe(probeCtx)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(res).To(Equal(Success))
+	})
+
+	It("TCP probe fails", func() {
+		vm.Spec.ReadinessProbe = getVirtualMachineReadinessTCPProbe(testHost, 10001)
+		probeCtx := &context.ProbeContext{
+			VM: vm,
+		}
+
+		res, err := testTCPProbe.Probe(probeCtx)
+		Expect(err).Should(HaveOccurred())
+		Expect(res).To(Equal(Failure))
+	})
+})
+
+func TestTCPProbe(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "TCP probe")
+}
+
+func setupTestServer() (*httptest.Server, string, int) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	host, port, err := net.SplitHostPort(s.Listener.Addr().String())
+	Expect(err).NotTo(HaveOccurred())
+	portInt, err := strconv.Atoi(port)
+	Expect(err).NotTo(HaveOccurred())
+	return s, host, portInt
+}
+
+func getVirtualMachineReadinessTCPProbe(host string, port int) vmopv1.VirtualMachineReadinessProbeSpec {
+	return vmopv1.VirtualMachineReadinessProbeSpec{
+		TCPSocket: &vmopv1.TCPSocketAction{
+			Host: host,
+			Port: intstr.FromInt(port),
+		},
+		PeriodSeconds: 1,
+	}
+}

--- a/pkg/prober2/prober_manager.go
+++ b/pkg/prober2/prober_manager.go
@@ -1,0 +1,218 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package prober2
+
+import (
+	goctx "context"
+	"fmt"
+	"reflect"
+	"sync"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/go-logr/logr"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/pkg/prober2/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/prober2/probe"
+	"github.com/vmware-tanzu/vm-operator/pkg/prober2/worker"
+	vmoprecord "github.com/vmware-tanzu/vm-operator/pkg/record"
+	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider"
+)
+
+const (
+	proberManagerName       = "virtualmachine-prober-manager"
+	readinessProbeQueueName = "readinessProbeQueue"
+
+	// defaultPeriodSeconds represents the default value for the frequency (in seconds) to perform the probe.
+	// We use the same default value as the kubernetes container probe.
+	defaultPeriodSeconds = 10
+
+	// the number of readiness workers.
+	// TODO: find a way to calibrate it.
+	numberOfReadinessWorkers = 5
+)
+
+// Manager represents a prober manager interface.
+type Manager interface {
+	ctrlmgr.Runnable
+	AddToProberManager(vm *vmopv1.VirtualMachine)
+	RemoveFromProberManager(vm *vmopv1.VirtualMachine)
+}
+
+// manager represents the probe manager, which implements the ManagerInterface.
+type manager struct {
+	client         client.Client
+	readinessQueue workqueue.DelayingInterface
+	prober         *probe.Prober
+	log            logr.Logger
+	recorder       vmoprecord.Recorder
+
+	workersWG sync.WaitGroup
+
+	// We will use AddAfter to add an item to the queue, which will insert the item to a heap first
+	// if the time duration set in the AddAfter is not zero. vmReadinessProbeList can be used to avoid
+	// adding VMs to the readiness queue when this VM is already in the heap but not in the queue.
+	readinessMutex       sync.Mutex
+	vmReadinessProbeList map[string]vmopv1.VirtualMachineReadinessProbeSpec
+}
+
+// NewManger initializes a prober manager.
+func NewManger(client client.Client, record vmoprecord.Recorder, vmProvider vmprovider.VirtualMachineProviderInterfaceA2) Manager {
+	probeManager := &manager{
+		client:               client,
+		readinessQueue:       workqueue.NewNamedDelayingQueue(readinessProbeQueueName),
+		prober:               probe.NewProber(vmProvider),
+		log:                  ctrl.Log.WithName(proberManagerName),
+		recorder:             record,
+		vmReadinessProbeList: make(map[string]vmopv1.VirtualMachineReadinessProbeSpec),
+	}
+	return probeManager
+}
+
+// AddToManager adds the probe manager controller manager.
+func AddToManager(mgr ctrlmgr.Manager, vmProvider vmprovider.VirtualMachineProviderInterfaceA2) (Manager, error) {
+	probeRecorder := vmoprecord.New(mgr.GetEventRecorderFor(proberManagerName))
+
+	// Add the probe manager explicitly as runnable in order to receive a Start() event.
+	m := NewManger(mgr.GetClient(), probeRecorder, vmProvider)
+	if err := mgr.Add(m); err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}
+
+// AddToProberManager adds a VM to the prober manager.
+func (m *manager) AddToProberManager(vm *vmopv1.VirtualMachine) {
+	vmName := vm.NamespacedName()
+	m.log.V(4).Info("Add to prober manager", "vm", vmName)
+
+	m.readinessMutex.Lock()
+	defer m.readinessMutex.Unlock()
+
+	if vm.Spec.ReadinessProbe.TCPSocket != nil || vm.Spec.ReadinessProbe.GuestHeartbeat != nil {
+		// if the VM is not in the list, or its readiness probe spec has been updated, immediately add it to the queue
+		// otherwise, ignore it.
+		if oldProbe, ok := m.vmReadinessProbeList[vmName]; ok && reflect.DeepEqual(oldProbe, vm.Spec.ReadinessProbe) {
+			m.log.V(4).Info("VM is already in the readiness probe list and its probe spec is not updated, skip it", "vm", vmName)
+			return
+		}
+
+		m.readinessQueue.Add(client.ObjectKey{Name: vm.Name, Namespace: vm.Namespace})
+		m.vmReadinessProbeList[vmName] = vm.Spec.ReadinessProbe
+	} else {
+		delete(m.vmReadinessProbeList, vmName)
+	}
+}
+
+// RemoveFromProberManager removes a VM from the prober manager.
+func (m *manager) RemoveFromProberManager(vm *vmopv1.VirtualMachine) {
+	vmName := vm.NamespacedName()
+	m.log.V(4).Info("Remove from prober manager", "vm", vmName)
+
+	m.readinessMutex.Lock()
+	defer m.readinessMutex.Unlock()
+	delete(m.vmReadinessProbeList, vmName)
+}
+
+// Start starts the probe manager.
+func (m *manager) Start(ctx goctx.Context) error {
+	m.log.Info("Start VirtualMachine Probe Manager")
+	defer m.log.Info("Stop VirtualMachine Probe Manager")
+
+	m.log.Info("Starting readiness workers", "count", numberOfReadinessWorkers)
+	m.workersWG.Add(numberOfReadinessWorkers)
+	for i := 0; i < numberOfReadinessWorkers; i++ {
+		readinessWorker := worker.NewReadinessWorker(m.readinessQueue, m.prober, m.client, m.recorder)
+		m.worker(readinessWorker)
+	}
+
+	<-ctx.Done()
+
+	m.readinessQueue.ShutDown()
+	m.workersWG.Wait()
+	return nil
+}
+
+// worker starts the probe manager workers, which are used to process items from queues.
+func (m *manager) worker(in worker.Worker) {
+	go func() {
+		defer m.workersWG.Done()
+
+		for {
+			if quit := m.processItemFromQueue(in); quit {
+				return
+			}
+		}
+	}()
+}
+
+// processItemFromQueue gets a VM from a probe queue and processes the VM.
+func (m *manager) processItemFromQueue(w worker.Worker) bool {
+	queue := w.GetQueue()
+	itemIf, quit := queue.Get()
+	if quit {
+		// stop the probe manager
+		return true
+	}
+	defer queue.Done(itemIf)
+
+	item := itemIf.(client.ObjectKey)
+
+	vm := &vmopv1.VirtualMachine{}
+	if err := m.client.Get(goctx.Background(), item, vm); err != nil {
+		if !apierrors.IsNotFound(err) {
+			// Get VM error, immediately re-queue the VM.
+			queue.Add(item)
+		}
+		return false
+	}
+
+	ctx, err := w.CreateProbeContext(vm)
+	if err != nil || ctx == nil {
+		return false
+	}
+
+	if !vm.ObjectMeta.DeletionTimestamp.IsZero() {
+		ctx.Logger.V(4).Info("the VirtualMachine is marked for deletion, skip running the probe")
+		return false
+	}
+
+	err = m.processVMProbe(w, ctx)
+	// Immediately re-queue the request if error occurs.
+	m.addItemToQueue(queue, ctx, item, err != nil)
+
+	return false
+}
+
+// processVMProbe processes the Probe specified in VM spec.
+func (m *manager) processVMProbe(w worker.Worker, ctx *context.ProbeContext) error {
+	if ctx.VM.Status.PowerState != vmopv1.VirtualMachinePowerStateOn {
+		// If a vm is not powered on, we don't run probes against it and translate probe result to failure.
+		// Populate the Condition and update the VM status.
+		ctx.Logger.V(4).Info("the VirtualMachine is not powered on")
+		return w.ProcessProbeResult(ctx, probe.Failure, fmt.Errorf("virtual machine is not powered on"))
+	}
+	return w.DoProbe(ctx)
+}
+
+// addItemToQueue adds the vm to the queue. If immediate is true, immediately add the item.
+// Otherwise, add to queue after a time period.
+func (m *manager) addItemToQueue(queue workqueue.DelayingInterface, ctx *context.ProbeContext, item client.ObjectKey, immediate bool) {
+	if immediate {
+		queue.Add(item)
+	} else {
+		periodSeconds := ctx.PeriodSeconds
+		if periodSeconds <= 0 {
+			periodSeconds = defaultPeriodSeconds
+		}
+		queue.AddAfter(item, time.Duration(periodSeconds)*time.Second)
+	}
+}

--- a/pkg/prober2/prober_manager_test.go
+++ b/pkg/prober2/prober_manager_test.go
@@ -1,0 +1,268 @@
+// Copyright (c) 2019-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package prober2
+
+import (
+	goctx "context"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	clientgorecord "k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+
+	"github.com/vmware-tanzu/vm-operator/pkg/prober2/context"
+	fakeworker "github.com/vmware-tanzu/vm-operator/pkg/prober2/fake/worker"
+	"github.com/vmware-tanzu/vm-operator/pkg/prober2/probe"
+	"github.com/vmware-tanzu/vm-operator/pkg/prober2/worker"
+	"github.com/vmware-tanzu/vm-operator/pkg/record"
+	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/fake"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+var _ = Describe("VirtualMachine probes", func() {
+	var (
+		initObjects []client.Object
+		ctx         goctx.Context
+
+		testManager   *manager
+		vm            *vmopv1.VirtualMachine
+		vmKey         client.ObjectKey
+		periodSeconds int32
+
+		fakeClient   client.Client
+		fakeRecorder record.Recorder
+		fakeWorkerIf worker.Worker
+		fakeWorker   *fakeworker.FakeWorker
+	)
+
+	BeforeEach(func() {
+		ctx = goctx.Background()
+		periodSeconds = 1
+
+		vm = &vmopv1.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dummy-vm",
+				Namespace: "dummy-ns",
+			},
+			Spec: vmopv1.VirtualMachineSpec{
+				ClassName: "dummy-vmclass",
+				ReadinessProbe: vmopv1.VirtualMachineReadinessProbeSpec{
+					TCPSocket: &vmopv1.TCPSocketAction{
+						Port: intstr.FromInt(10001),
+					},
+					PeriodSeconds: periodSeconds,
+				},
+			},
+		}
+		vmKey = client.ObjectKey{Name: vm.Name, Namespace: vm.Namespace}
+
+		initObjects = append(initObjects, vm)
+	})
+
+	JustBeforeEach(func() {
+		fakeClient = builder.NewFakeClient(initObjects...)
+		eventRecorder := clientgorecord.NewFakeRecorder(1024)
+		fakeRecorder = record.New(eventRecorder)
+		fakeVMProvider := &fake.VMProviderA2{}
+		testManagerIf := NewManger(fakeClient, fakeRecorder, fakeVMProvider)
+		testManager = testManagerIf.(*manager)
+		fakeWorkerIf = fakeworker.NewFakeWorker(testManager.readinessQueue)
+		fakeWorker = fakeWorkerIf.(*fakeworker.FakeWorker)
+	})
+
+	AfterEach(func() {
+		fakeWorker.Reset()
+		fakeWorker = nil
+		fakeClient = nil
+		fakeRecorder = nil
+		testManager = nil
+		initObjects = nil
+	})
+
+	checkProbeQueueLenEventually := func(interval int32, expectedLen int) {
+		Eventually(func() int {
+			return testManager.readinessQueue.Len()
+		}, interval).Should(Equal(expectedLen))
+	}
+
+	checkProbeQueueLenConsistently := func(interval int32, expectedLen int) {
+		Consistently(func() int {
+			return testManager.readinessQueue.Len()
+		}, interval).Should(Equal(expectedLen))
+	}
+
+	Context("Probe manager processes items from the queue", func() {
+		JustBeforeEach(func() {
+			testManager.readinessQueue.Add(vmKey)
+		})
+
+		When("VM doesn't specify a probe", func() {
+			BeforeEach(func() {
+				vm.Spec.ReadinessProbe = vmopv1.VirtualMachineReadinessProbeSpec{}
+			})
+
+			It("Should return immediately", func() {
+				quit := testManager.processItemFromQueue(fakeWorker)
+				Expect(quit).To(BeFalse())
+				checkProbeQueueLenConsistently(2*periodSeconds, 0)
+			})
+		})
+
+		When("VM specifies a probe", func() {
+
+			It("Should not run probes when VM is in deleting phase", func() {
+				Expect(fakeClient.Delete(ctx, vm)).To(Succeed())
+
+				quit := testManager.processItemFromQueue(fakeWorker)
+				Expect(quit).To(BeFalse())
+				checkProbeQueueLenConsistently(2*periodSeconds, 0)
+			})
+
+			It("Should set probe result as failed if the VM is powered off", func() {
+				vm.Status.PowerState = vmopv1.VirtualMachinePowerStateOff
+				Expect(fakeClient.Status().Update(ctx, vm)).To(Succeed())
+				fakeWorker.ProcessProbeResultFn = func(ctx *context.ProbeContext, res probe.Result, err error) error {
+					if res != probe.Failure {
+						return fmt.Errorf("dummy error")
+					}
+					return nil
+				}
+				quit := testManager.processItemFromQueue(fakeWorker)
+				Expect(quit).To(BeFalse())
+
+				By("Should add to queue after a time period", func() {
+					checkProbeQueueLenEventually(2*periodSeconds, 1)
+				})
+			})
+
+			When("VM is powered on", func() {
+				JustBeforeEach(func() {
+					vm.Status.PowerState = vmopv1.VirtualMachinePowerStateOn
+					Expect(fakeClient.Status().Update(ctx, vm)).To(Succeed())
+				})
+
+				It("Should immediately add to the queue if DoProbe returns error", func() {
+					fakeWorker.DoProbeFn = func(ctx *context.ProbeContext) error {
+						return fmt.Errorf("dummy error")
+					}
+					quit := testManager.processItemFromQueue(fakeWorker)
+					Expect(quit).To(BeFalse())
+
+					Expect(testManager.readinessQueue.Len()).To(Equal(1))
+				})
+
+				When("DoProbe succeeds", func() {
+					JustBeforeEach(func() {
+						fakeWorker.DoProbeFn = func(ctx *context.ProbeContext) error {
+							return nil
+						}
+					})
+
+					It("Should add to the queue after default value if periodSeconds is not set in Probe spec", func() {
+						vm.Spec.ReadinessProbe.PeriodSeconds = 0
+						Expect(fakeClient.Update(ctx, vm)).To(Succeed())
+						quit := testManager.processItemFromQueue(fakeWorker)
+						Expect(quit).To(BeFalse())
+
+						By("Should add to queue after a time period", func() {
+							checkProbeQueueLenEventually(2*defaultPeriodSeconds, 1)
+						})
+					})
+
+					It("Should add to queue after specific time period if periodSeconds is set in probe spec", func() {
+						quit := testManager.processItemFromQueue(fakeWorker)
+						Expect(quit).To(BeFalse())
+
+						By("Should add to queue after a time period", func() {
+							checkProbeQueueLenEventually(2*periodSeconds, 1)
+						})
+					})
+				})
+			})
+		})
+	})
+
+	Context("Probe manager manages VMs when they are created, updated or deleted", func() {
+
+		JustBeforeEach(func() {
+			vm.Status.PowerState = vmopv1.VirtualMachinePowerStateOn
+			Expect(fakeClient.Status().Update(ctx, vm)).To(Succeed())
+		})
+
+		It("Should not add to prober manager if Probe spec is not specified", func() {
+			vm.Spec.ReadinessProbe = vmopv1.VirtualMachineReadinessProbeSpec{}
+			testManager.AddToProberManager(vm)
+
+			Expect(testManager.readinessQueue.Len()).To(Equal(0))
+			testManager.readinessMutex.Lock()
+			Expect(testManager.vmReadinessProbeList).ShouldNot(HaveKey(vm.NamespacedName()))
+			testManager.readinessMutex.Unlock()
+		})
+
+		When("VM is first time being added to the prober manager", func() {
+			It("Should add to the queue and list", func() {
+				testManager.AddToProberManager(vm)
+
+				Expect(testManager.readinessQueue.Len()).To(Equal(1))
+				testManager.readinessMutex.Lock()
+				Expect(testManager.vmReadinessProbeList).Should(HaveKey(vm.NamespacedName()))
+				testManager.readinessMutex.Unlock()
+			})
+		})
+
+		When("VM has already been added to the prober manager", func() {
+			var newVM *vmopv1.VirtualMachine
+			JustBeforeEach(func() {
+				testManager.AddToProberManager(vm)
+				Expect(testManager.readinessQueue.Len()).To(Equal(1))
+
+				fakeWorker.DoProbeFn = func(ctx *context.ProbeContext) error {
+					return nil
+				}
+				Expect(testManager.processItemFromQueue(fakeWorker)).To(BeFalse())
+
+				newVM = &vmopv1.VirtualMachine{}
+				Expect(fakeClient.Get(ctx, vmKey, newVM)).To(Succeed())
+			})
+
+			It("Should do nothing if VM probe is not updated", func() {
+				testManager.AddToProberManager(newVM)
+				Expect(testManager.readinessQueue.Len()).To(Equal(0))
+			})
+
+			It("Should add to queue immediately if the VM's probe spec is updated", func() {
+				newVM.Spec.ReadinessProbe.PeriodSeconds = 0
+				Expect(fakeClient.Update(ctx, newVM)).To(Succeed())
+
+				testManager.AddToProberManager(newVM)
+
+				Expect(testManager.readinessQueue.Len()).To(Equal(1))
+			})
+
+			It("Should remove from the manager if the VM's probe spec is changed to nil", func() {
+				newVM.Spec.ReadinessProbe = vmopv1.VirtualMachineReadinessProbeSpec{}
+				Expect(fakeClient.Update(ctx, newVM)).To(Succeed())
+
+				testManager.AddToProberManager(newVM)
+
+				Expect(testManager.readinessQueue.Len()).To(Equal(0))
+				testManager.readinessMutex.Lock()
+				Expect(testManager.vmReadinessProbeList).ShouldNot(HaveKey(vm.NamespacedName()))
+				testManager.readinessMutex.Unlock()
+			})
+		})
+	})
+})
+
+func TestProberManager(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "VM Prober Manager")
+}

--- a/pkg/prober2/worker/prober_worker.go
+++ b/pkg/prober2/worker/prober_worker.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package worker
+
+import (
+	"k8s.io/client-go/util/workqueue"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+
+	"github.com/vmware-tanzu/vm-operator/pkg/prober2/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/prober2/probe"
+)
+
+// Worker represents a prober worker interface.
+type Worker interface {
+	GetQueue() workqueue.DelayingInterface
+	CreateProbeContext(vm *vmopv1.VirtualMachine) (*context.ProbeContext, error)
+	DoProbe(ctx *context.ProbeContext) error
+	ProcessProbeResult(ctx *context.ProbeContext, res probe.Result, resErr error) error
+}

--- a/pkg/prober2/worker/readiness_worker.go
+++ b/pkg/prober2/worker/readiness_worker.go
@@ -1,0 +1,161 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package worker
+
+import (
+	goctx "context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/pkg/errors"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+
+	conditions "github.com/vmware-tanzu/vm-operator/pkg/conditions2"
+	patch "github.com/vmware-tanzu/vm-operator/pkg/patch2"
+	"github.com/vmware-tanzu/vm-operator/pkg/prober2/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/prober2/probe"
+	vmoprecord "github.com/vmware-tanzu/vm-operator/pkg/record"
+)
+
+const (
+	// readyReason, notReadyReason and unknownReason represent reasons for probe events and Condition.
+	readyReason    string = "Ready"
+	notReadyReason string = "NotReady"
+	unknownReason  string = "Unknown"
+)
+
+// readinessWorker implements Worker interface.
+type readinessWorker struct {
+	queue    workqueue.DelayingInterface
+	prober   *probe.Prober
+	client   client.Client
+	recorder vmoprecord.Recorder
+}
+
+// NewReadinessWorker creates a new readiness worker to run readiness probes.
+func NewReadinessWorker(
+	queue workqueue.DelayingInterface,
+	prober *probe.Prober,
+	client client.Client,
+	recorder vmoprecord.Recorder,
+) Worker {
+	return &readinessWorker{
+		queue:    queue,
+		prober:   prober,
+		client:   client,
+		recorder: recorder,
+	}
+}
+
+func (w *readinessWorker) GetQueue() workqueue.DelayingInterface {
+	return w.queue
+}
+
+// CreateProbeContext creates a probe context for readiness probe.
+func (w *readinessWorker) CreateProbeContext(vm *vmopv1.VirtualMachine) (*context.ProbeContext, error) {
+	p := &vm.Spec.ReadinessProbe
+
+	if p.TCPSocket == nil && p.GuestHeartbeat == nil && len(p.GuestInfo) == 0 {
+		return nil, nil
+	}
+
+	patchHelper, err := patch.NewHelper(vm, w.client)
+	if err != nil {
+		return nil, err
+	}
+
+	return &context.ProbeContext{
+		Context:       goctx.Background(),
+		Logger:        ctrl.Log.WithName("readiness-probe").WithValues("vmName", vm.NamespacedName()),
+		PatchHelper:   patchHelper,
+		VM:            vm,
+		ProbeType:     "readiness",
+		PeriodSeconds: p.PeriodSeconds,
+	}, nil
+}
+
+// ProcessProbeResult processes probe results to get ReadyCondition and
+// sets the ReadyCondition in vm status if the new condition status is a transition.
+func (w *readinessWorker) ProcessProbeResult(ctx *context.ProbeContext, res probe.Result, resErr error) error {
+	vm := ctx.VM
+	condition := w.getCondition(res, resErr)
+
+	// We only send event when either the condition type is added or its status changes, not
+	// if either its reason, severity, or message changes.
+	if c := conditions.Get(vm, condition.Type); c == nil || c.Status != condition.Status {
+		if condition.Status == metav1.ConditionTrue {
+			w.recorder.Eventf(vm, readyReason, "")
+		} else {
+			w.recorder.Eventf(vm, condition.Reason, condition.Message)
+		}
+		// Log the time when the VM changes its readiness condition.
+		ctx.Logger.Info("VM resource READINESS probe condition updated",
+			"condition.status", condition.Status, "time", condition.LastTransitionTime,
+			"reason", condition.Reason)
+	}
+
+	conditions.Set(vm, condition)
+
+	err := ctx.PatchHelper.Patch(ctx, vm, patch.WithOwnedConditions{
+		Conditions: []string{vmopv1.ReadyConditionType},
+	})
+	if err != nil {
+		return errors.Wrapf(err, "patched failed")
+	}
+
+	return nil
+}
+
+func (w *readinessWorker) DoProbe(ctx *context.ProbeContext) error {
+	res, err := w.runProbe(ctx)
+	if err != nil {
+		ctx.Logger.Error(err, "readiness probe fails", "result", res)
+	}
+	return w.ProcessProbeResult(ctx, res, err)
+}
+
+// getProbe returns a specific type of probe method.
+func (w *readinessWorker) getProbe(probeSpec *vmopv1.VirtualMachineReadinessProbeSpec) probe.Probe {
+	if probeSpec.TCPSocket != nil {
+		return w.prober.TCPProbe
+	}
+	if probeSpec.GuestHeartbeat != nil {
+		return w.prober.GuestHeartbeat
+	}
+
+	// TODO: probeSpec.GuestInfo
+
+	return nil
+}
+
+// runProbe runs a specific type of probe based on the VM probe spec.
+func (w *readinessWorker) runProbe(ctx *context.ProbeContext) (probe.Result, error) {
+	if p := w.getProbe(&ctx.VM.Spec.ReadinessProbe); p != nil {
+		return p.Probe(ctx)
+	}
+
+	return probe.Unknown, fmt.Errorf("unknown action specified for VM %s readiness probe", ctx.VM.NamespacedName())
+}
+
+// getCondition returns condition based on VM probe results.
+func (w *readinessWorker) getCondition(res probe.Result, err error) *metav1.Condition {
+	msg := ""
+	if err != nil {
+		msg = err.Error()
+	}
+
+	switch res {
+	case probe.Success:
+		return conditions.TrueCondition(vmopv1.ReadyConditionType)
+	case probe.Failure:
+		return conditions.FalseCondition(vmopv1.ReadyConditionType, notReadyReason, msg)
+	default: // probe.Unknown
+		return conditions.UnknownCondition(vmopv1.ReadyConditionType, unknownReason, msg)
+	}
+}

--- a/pkg/prober2/worker/readiness_worker_test.go
+++ b/pkg/prober2/worker/readiness_worker_test.go
@@ -1,0 +1,208 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package worker
+
+import (
+	goctx "context"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	clientgorecord "k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+
+	conditions "github.com/vmware-tanzu/vm-operator/pkg/conditions2"
+	"github.com/vmware-tanzu/vm-operator/pkg/prober2/context"
+	fakeprobe "github.com/vmware-tanzu/vm-operator/pkg/prober2/fake/probe"
+	"github.com/vmware-tanzu/vm-operator/pkg/prober2/probe"
+	"github.com/vmware-tanzu/vm-operator/pkg/record"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+var _ = Describe("VirtualMachine readiness probes", func() {
+	var (
+		testWorker Worker
+
+		vm    *vmopv1.VirtualMachine
+		vmKey client.ObjectKey
+		ctx   *context.ProbeContext
+
+		fakeClient         client.Client
+		fakeRecorder       record.Recorder
+		fakeEvents         chan string
+		fakeTCPProbe       *fakeprobe.FakeProbe
+		fakeHeartbeatProbe *fakeprobe.FakeProbe
+	)
+
+	BeforeEach(func() {
+		vm = &vmopv1.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dummy-vm",
+				Namespace: "dummy-ns",
+			},
+			Spec: vmopv1.VirtualMachineSpec{
+				ClassName: "dummy-vmclass",
+			},
+		}
+
+		vmKey = client.ObjectKey{Name: vm.Name, Namespace: vm.Namespace}
+
+		fakeClient = builder.NewFakeClient()
+		eventRecorder := clientgorecord.NewFakeRecorder(1024)
+		fakeRecorder = record.New(eventRecorder)
+		fakeEvents = eventRecorder.Events
+
+		queue := workqueue.NewNamedDelayingQueue("test")
+		fakeTCPProbe = fakeprobe.NewFakeProbe().(*fakeprobe.FakeProbe)
+		fakeHeartbeatProbe = fakeprobe.NewFakeProbe().(*fakeprobe.FakeProbe)
+		prober := &probe.Prober{
+			TCPProbe:       fakeTCPProbe,
+			GuestHeartbeat: fakeHeartbeatProbe,
+		}
+		testWorker = NewReadinessWorker(queue, prober, fakeClient, fakeRecorder)
+	})
+
+	checkReadyCondition := func(c client.Client, objKey client.ObjectKey, expectedCondition metav1.ConditionStatus) {
+		Expect(c.Get(ctx, objKey, vm)).Should(Succeed())
+		condition := conditions.Get(vm, vmopv1.ReadyConditionType)
+		Expect(condition).ToNot(BeNil())
+		Expect(condition.Status).Should(Equal(expectedCondition))
+	}
+
+	Context("VM has TCP readiness probe", func() {
+		var (
+			oldStatus vmopv1.VirtualMachineStatus
+		)
+
+		BeforeEach(func() {
+			vm.Spec.ReadinessProbe = getVirtualMachineReadinessTCPProbe(10001)
+			Expect(fakeClient.Create(goctx.Background(), vm)).Should(Succeed())
+			Expect(fakeClient.Get(goctx.Background(), vmKey, vm)).Should(Succeed())
+		})
+
+		JustBeforeEach(func() {
+			var err error
+			ctx, err = testWorker.CreateProbeContext(vm)
+			Expect(err).ShouldNot(HaveOccurred())
+			oldStatus = vm.Status
+		})
+
+		When("new ReadyCondition is in a transition", func() {
+			It("Should update ReadyCondition when probe succeeds", func() {
+				fakeTCPProbe.ProbeFn = func(ctx *context.ProbeContext) (probe.Result, error) {
+					return probe.Success, nil
+				}
+
+				Expect(testWorker.DoProbe(ctx)).Should(Succeed())
+
+				By("Should set ReadyCondition status as true", func() {
+					checkReadyCondition(fakeClient, vmKey, metav1.ConditionTrue)
+				})
+
+				By("Conditions in VM status should be updated", func() {
+					Expect(fakeClient.Get(ctx, vmKey, vm)).Should(Succeed())
+					Expect(vm.Status.Conditions).ShouldNot(Equal(oldStatus.Conditions))
+					Expect(fakeEvents).Should(Receive(ContainSubstring(readyReason)))
+				})
+			})
+
+			It("Should update ReadyCondition when probe fails", func() {
+				fakeTCPProbe.ProbeFn = func(ctx *context.ProbeContext) (probe.Result, error) {
+					return probe.Failure, nil
+				}
+
+				Expect(testWorker.DoProbe(ctx)).Should(Succeed())
+
+				By("Should set ReadyCondition value as false", func() {
+					checkReadyCondition(fakeClient, vmKey, metav1.ConditionFalse)
+				})
+
+				By("Conditions in VM status should be updated", func() {
+					Expect(fakeClient.Get(ctx, vmKey, vm)).Should(Succeed())
+					Expect(vm.Status.Conditions).ShouldNot(Equal(oldStatus.Conditions))
+					Expect(fakeEvents).Should(Receive(ContainSubstring(notReadyReason)))
+				})
+			})
+
+			When("new ReadyCondition isn't in a transition", func() {
+
+				BeforeEach(func() {
+					vmReadyCondition := conditions.TrueCondition(vmopv1.ReadyConditionType)
+					vm.Status.Conditions = append(vm.Status.Conditions, *vmReadyCondition)
+					Expect(fakeClient.Status().Update(ctx, vm)).To(Succeed())
+					Expect(fakeClient.Get(ctx, vmKey, vm)).Should(Succeed())
+					oldStatus = vm.Status
+				})
+
+				It("Shouldn't update the Condition in status", func() {
+
+					fakeTCPProbe.ProbeFn = func(ctx *context.ProbeContext) (probe.Result, error) {
+						return probe.Success, nil
+					}
+
+					Expect(testWorker.DoProbe(ctx)).Should(Succeed())
+
+					By("Conditions in VM status should not be updated", func() {
+						Expect(fakeClient.Get(ctx, vmKey, vm)).Should(Succeed())
+						Expect(vm.Status.Conditions).Should(Equal(oldStatus.Conditions))
+						Expect(fakeEvents).ShouldNot(Receive(ContainSubstring(readyReason)))
+					})
+				})
+			})
+		})
+	})
+
+	Context("Guest heartbeat Probe", func() {
+
+		BeforeEach(func() {
+			vm.Spec.ReadinessProbe = getVirtualMachineHeartbeatProbe()
+			Expect(fakeClient.Create(goctx.Background(), vm)).Should(Succeed())
+			Expect(fakeClient.Get(goctx.Background(), vmKey, vm)).Should(Succeed())
+			var err error
+			ctx, err = testWorker.CreateProbeContext(vm)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		// Just need to test for probe selection.
+		It("Should update ReadyCondition when probe fails", func() {
+			fakeHeartbeatProbe.ProbeFn = func(ctx *context.ProbeContext) (probe.Result, error) {
+				return probe.Failure, fmt.Errorf("heartbeat error")
+			}
+
+			Expect(testWorker.DoProbe(ctx)).Should(Succeed())
+			Expect(fakeClient.Get(ctx, vmKey, vm)).Should(Succeed())
+			condition := conditions.Get(vm, vmopv1.ReadyConditionType)
+			Expect(condition).ToNot(BeNil())
+			Expect(condition.Message).To(ContainSubstring("heartbeat error"))
+		})
+	})
+})
+
+func TestReadinessProbeWorker(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "VM Readiness Workers")
+}
+
+func getVirtualMachineReadinessTCPProbe(port int) vmopv1.VirtualMachineReadinessProbeSpec {
+	return vmopv1.VirtualMachineReadinessProbeSpec{
+		TCPSocket: &vmopv1.TCPSocketAction{
+			Port: intstr.FromInt(port),
+		},
+		PeriodSeconds: 1,
+	}
+}
+
+func getVirtualMachineHeartbeatProbe() vmopv1.VirtualMachineReadinessProbeSpec {
+	return vmopv1.VirtualMachineReadinessProbeSpec{
+		GuestHeartbeat: &vmopv1.GuestHeartbeatAction{},
+		PeriodSeconds:  1,
+	}
+}

--- a/pkg/vmprovider/fake/fake_vm_provider_a2.go
+++ b/pkg/vmprovider/fake/fake_vm_provider_a2.go
@@ -1,0 +1,355 @@
+// Copyright (c) 2020-2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package fake
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/vmware/govmomi/vapi/library"
+	vimTypes "github.com/vmware/govmomi/vim25/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	imgregv1a1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha1"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider"
+)
+
+// This Fake Provider is supposed to simulate an actual VM provider.
+// That includes maintaining states for objects created through this
+// provider, and query/get APIs reflecting those states. As a convenience
+// to simulate scenarios, this provider also exposes a few function variables
+// to override certain behaviors. The functionality of this provider is
+// expected to evolve as more tests get added in the future.
+
+type funcsA2 struct {
+	CreateOrUpdateVirtualMachineFn func(ctx context.Context, vm *vmopv1.VirtualMachine) error
+	DeleteVirtualMachineFn         func(ctx context.Context, vm *vmopv1.VirtualMachine) error
+	PublishVirtualMachineFn        func(ctx context.Context, vm *vmopv1.VirtualMachine,
+		vmPub *vmopv1.VirtualMachinePublishRequest, cl *imgregv1a1.ContentLibrary, actID string) (string, error)
+	GetVirtualMachineGuestHeartbeatFn  func(ctx context.Context, vm *vmopv1.VirtualMachine) (vmopv1.GuestHeartbeatStatus, error)
+	GetVirtualMachineWebMKSTicketFn    func(ctx context.Context, vm *vmopv1.VirtualMachine, pubKey string) (string, error)
+	GetVirtualMachineHardwareVersionFn func(ctx context.Context, vm *vmopv1.VirtualMachine) (int32, error)
+
+	// ListItemsFromContentLibraryFn              func(ctx context.Context, contentLibrary *vmopv1.ContentLibraryProvider) ([]string, error)
+	// GetVirtualMachineImageFromContentLibraryFn func(ctx context.Context, contentLibrary *vmopv1.ContentLibraryProvider, itemID string,
+	//	currentCLImages map[string]vmopv1.VirtualMachineImage) (*vmopv1.VirtualMachineImage, error)
+
+	GetItemFromLibraryByNameFn func(ctx context.Context, contentLibrary, itemName string) (*library.Item, error)
+	UpdateContentLibraryItemFn func(ctx context.Context, itemID, newName string, newDescription *string) error
+	SyncVirtualMachineImageFn  func(ctx context.Context, cli, vmi client.Object) error
+
+	UpdateVcPNIDFn  func(ctx context.Context, vcPNID, vcPort string) error
+	ResetVcClientFn func(ctx context.Context)
+
+	CreateOrUpdateVirtualMachineSetResourcePolicyFn func(ctx context.Context, rp *vmopv1.VirtualMachineSetResourcePolicy) error
+	IsVirtualMachineSetResourcePolicyReadyFn        func(ctx context.Context, azName string, rp *vmopv1.VirtualMachineSetResourcePolicy) (bool, error)
+	DeleteVirtualMachineSetResourcePolicyFn         func(ctx context.Context, rp *vmopv1.VirtualMachineSetResourcePolicy) error
+	ComputeCPUMinFrequencyFn                        func(ctx context.Context) error
+
+	GetTasksByActIDFn func(ctx context.Context, actID string) (tasksInfo []vimTypes.TaskInfo, retErr error)
+}
+
+type VMProviderA2 struct {
+	sync.Mutex
+	funcsA2
+	vmMap             map[client.ObjectKey]*vmopv1.VirtualMachine
+	resourcePolicyMap map[client.ObjectKey]*vmopv1.VirtualMachineSetResourcePolicy
+	vmPubMap          map[string]vimTypes.TaskInfoState
+
+	isPublishVMCalled bool
+}
+
+var _ vmprovider.VirtualMachineProviderInterfaceA2 = &VMProviderA2{}
+
+func (s *VMProviderA2) Reset() {
+	s.Lock()
+	defer s.Unlock()
+
+	s.funcsA2 = funcsA2{}
+	s.vmMap = make(map[client.ObjectKey]*vmopv1.VirtualMachine)
+	s.resourcePolicyMap = make(map[client.ObjectKey]*vmopv1.VirtualMachineSetResourcePolicy)
+	s.vmPubMap = make(map[string]vimTypes.TaskInfoState)
+	s.isPublishVMCalled = false
+}
+
+func (s *VMProviderA2) CreateOrUpdateVirtualMachine(ctx context.Context, vm *vmopv1.VirtualMachine) error {
+	s.Lock()
+	defer s.Unlock()
+	if s.CreateOrUpdateVirtualMachineFn != nil {
+		return s.CreateOrUpdateVirtualMachineFn(ctx, vm)
+	}
+	s.addToVMMap(vm)
+	return nil
+}
+
+func (s *VMProviderA2) DeleteVirtualMachine(ctx context.Context, vm *vmopv1.VirtualMachine) error {
+	s.Lock()
+	defer s.Unlock()
+	if s.DeleteVirtualMachineFn != nil {
+		return s.DeleteVirtualMachineFn(ctx, vm)
+	}
+	s.deleteFromVMMap(vm)
+	return nil
+}
+
+func (s *VMProviderA2) PublishVirtualMachine(ctx context.Context, vm *vmopv1.VirtualMachine,
+	vmPub *vmopv1.VirtualMachinePublishRequest, cl *imgregv1a1.ContentLibrary, actID string) (string, error) {
+	s.Lock()
+	defer s.Unlock()
+
+	s.isPublishVMCalled = true
+
+	if s.PublishVirtualMachineFn != nil {
+		return s.PublishVirtualMachineFn(ctx, vm, vmPub, cl, actID)
+	}
+
+	s.AddToVMPublishMap(actID, vimTypes.TaskInfoStateSuccess)
+	return "dummy-id", nil
+}
+
+func (s *VMProviderA2) GetVirtualMachineGuestHeartbeat(ctx context.Context, vm *vmopv1.VirtualMachine) (vmopv1.GuestHeartbeatStatus, error) {
+	s.Lock()
+	defer s.Unlock()
+	if s.GetVirtualMachineGuestHeartbeatFn != nil {
+		return s.GetVirtualMachineGuestHeartbeatFn(ctx, vm)
+	}
+	return "", nil
+}
+
+func (s *VMProviderA2) GetVirtualMachineWebMKSTicket(ctx context.Context, vm *vmopv1.VirtualMachine, pubKey string) (string, error) {
+	s.Lock()
+	defer s.Unlock()
+	if s.GetVirtualMachineWebMKSTicketFn != nil {
+		return s.GetVirtualMachineWebMKSTicketFn(ctx, vm, pubKey)
+	}
+	return "", nil
+}
+
+func (s *VMProviderA2) GetVirtualMachineHardwareVersion(ctx context.Context, vm *vmopv1.VirtualMachine) (int32, error) {
+	s.Lock()
+	defer s.Unlock()
+	if s.GetVirtualMachineHardwareVersionFn != nil {
+		return s.GetVirtualMachineHardwareVersionFn(ctx, vm)
+	}
+	return 13, nil
+}
+
+func (s *VMProviderA2) CreateOrUpdateVirtualMachineSetResourcePolicy(ctx context.Context, resourcePolicy *vmopv1.VirtualMachineSetResourcePolicy) error {
+	s.Lock()
+	defer s.Unlock()
+
+	if s.CreateOrUpdateVirtualMachineSetResourcePolicyFn != nil {
+		return s.CreateOrUpdateVirtualMachineSetResourcePolicyFn(ctx, resourcePolicy)
+	}
+	s.addToResourcePolicyMap(resourcePolicy)
+
+	return nil
+}
+
+func (s *VMProviderA2) IsVirtualMachineSetResourcePolicyReady(ctx context.Context, azName string, resourcePolicy *vmopv1.VirtualMachineSetResourcePolicy) (bool, error) {
+	s.Lock()
+	defer s.Unlock()
+
+	if s.IsVirtualMachineSetResourcePolicyReadyFn != nil {
+		return s.IsVirtualMachineSetResourcePolicyReadyFn(ctx, azName, resourcePolicy)
+	}
+	objectKey := client.ObjectKey{
+		Namespace: resourcePolicy.Namespace,
+		Name:      resourcePolicy.Name,
+	}
+	_, found := s.resourcePolicyMap[objectKey]
+
+	return found, nil
+}
+
+func (s *VMProviderA2) DeleteVirtualMachineSetResourcePolicy(ctx context.Context, resourcePolicy *vmopv1.VirtualMachineSetResourcePolicy) error {
+	s.Lock()
+	defer s.Unlock()
+
+	if s.DeleteVirtualMachineSetResourcePolicyFn != nil {
+		return s.DeleteVirtualMachineSetResourcePolicyFn(ctx, resourcePolicy)
+	}
+	s.deleteFromResourcePolicyMap(resourcePolicy)
+
+	return nil
+}
+
+func (s *VMProviderA2) ComputeCPUMinFrequency(ctx context.Context) error {
+	s.Lock()
+	defer s.Unlock()
+	if s.ComputeCPUMinFrequencyFn != nil {
+		return s.ComputeCPUMinFrequencyFn(ctx)
+	}
+
+	return nil
+}
+
+func (s *VMProviderA2) UpdateVcPNID(ctx context.Context, vcPNID, vcPort string) error {
+	s.Lock()
+	defer s.Unlock()
+	if s.UpdateVcPNIDFn != nil {
+		return s.UpdateVcPNIDFn(ctx, vcPNID, vcPort)
+	}
+	return nil
+}
+
+func (s *VMProviderA2) ResetVcClient(ctx context.Context) {
+	s.Lock()
+	defer s.Unlock()
+
+	if s.ResetVcClientFn != nil {
+		s.ResetVcClientFn(ctx)
+	}
+}
+
+/*
+func (s *VMProviderA2) ListItemsFromContentLibrary(ctx context.Context, contentLibrary *vmopv1.ContentLibraryProvider) ([]string, error) {
+	s.Lock()
+	defer s.Unlock()
+
+	if s.ListItemsFromContentLibraryFn != nil {
+		return s.ListItemsFromContentLibraryFn(ctx, contentLibrary)
+	}
+
+	// No-op for now.
+	return []string{}, nil
+}
+
+func (s *VMProviderA2) GetVirtualMachineImageFromContentLibrary(ctx context.Context, contentLibrary *vmopv1.ContentLibraryProvider, itemID string,
+	currentCLImages map[string]vmopv1.VirtualMachineImage) (*vmopv1.VirtualMachineImage, error) {
+	s.Lock()
+	defer s.Unlock()
+
+	if s.GetVirtualMachineImageFromContentLibraryFn != nil {
+		return s.GetVirtualMachineImageFromContentLibraryFn(ctx, contentLibrary, itemID, currentCLImages)
+	}
+
+	// No-op for now.
+	return nil, nil
+}
+*/
+
+func (s *VMProviderA2) SyncVirtualMachineImage(ctx context.Context, cli, vmi client.Object) error {
+	s.Lock()
+	defer s.Unlock()
+
+	if s.SyncVirtualMachineImageFn != nil {
+		return s.SyncVirtualMachineImageFn(ctx, cli, vmi)
+	}
+
+	return nil
+}
+
+func (s *VMProviderA2) GetItemFromLibraryByName(ctx context.Context,
+	contentLibrary, itemName string) (*library.Item, error) {
+	s.Lock()
+	defer s.Unlock()
+
+	if s.GetItemFromLibraryByNameFn != nil {
+		return s.GetItemFromLibraryByNameFn(ctx, contentLibrary, itemName)
+	}
+
+	return nil, nil
+}
+
+func (s *VMProviderA2) UpdateContentLibraryItem(ctx context.Context, itemID, newName string, newDescription *string) error {
+	s.Lock()
+	defer s.Unlock()
+
+	if s.UpdateContentLibraryItemFn != nil {
+		return s.UpdateContentLibraryItemFn(ctx, itemID, newName, newDescription)
+	}
+	return nil
+}
+
+func (s *VMProviderA2) GetTasksByActID(ctx context.Context, actID string) (tasksInfo []vimTypes.TaskInfo, retErr error) {
+	s.Lock()
+	defer s.Unlock()
+
+	if s.GetTasksByActIDFn != nil {
+		return s.GetTasksByActIDFn(ctx, actID)
+	}
+
+	status := s.vmPubMap[actID]
+	if status == "" {
+		return nil, nil
+	}
+
+	task1 := vimTypes.TaskInfo{
+		DescriptionId: "com.vmware.ovfs.LibraryItem.capture",
+		ActivationId:  actID,
+		State:         status,
+	}
+
+	return []vimTypes.TaskInfo{task1}, nil
+}
+
+func (s *VMProviderA2) addToVMMap(vm *vmopv1.VirtualMachine) {
+	objectKey := client.ObjectKey{
+		Namespace: vm.Namespace,
+		Name:      vm.Name,
+	}
+	s.vmMap[objectKey] = vm
+}
+
+func (s *VMProviderA2) deleteFromVMMap(vm *vmopv1.VirtualMachine) {
+	objectKey := client.ObjectKey{
+		Namespace: vm.Namespace,
+		Name:      vm.Name,
+	}
+	delete(s.vmMap, objectKey)
+}
+
+func (s *VMProviderA2) addToResourcePolicyMap(rp *vmopv1.VirtualMachineSetResourcePolicy) {
+	objectKey := client.ObjectKey{
+		Namespace: rp.Namespace,
+		Name:      rp.Name,
+	}
+
+	s.resourcePolicyMap[objectKey] = rp
+}
+
+func (s *VMProviderA2) deleteFromResourcePolicyMap(rp *vmopv1.VirtualMachineSetResourcePolicy) {
+	objectKey := client.ObjectKey{
+		Namespace: rp.Namespace,
+		Name:      rp.Name,
+	}
+	delete(s.resourcePolicyMap, objectKey)
+}
+
+func (s *VMProviderA2) AddToVMPublishMap(actID string, result vimTypes.TaskInfoState) {
+	s.vmPubMap[actID] = result
+}
+
+func (s *VMProviderA2) GetVMPublishRequestResult(vmPub *vmopv1.VirtualMachinePublishRequest) vimTypes.TaskInfoState {
+	s.Lock()
+	defer s.Unlock()
+
+	actID := fmt.Sprintf("%s-%d", vmPub.UID, vmPub.Status.Attempts)
+	return s.vmPubMap[actID]
+}
+
+func (s *VMProviderA2) GetVMPublishRequestResultWithActIDLocked(actID string) vimTypes.TaskInfoState {
+	return s.vmPubMap[actID]
+}
+
+func (s *VMProviderA2) IsPublishVMCalled() bool {
+	s.Lock()
+	defer s.Unlock()
+
+	return s.isPublishVMCalled
+}
+
+func NewVMProviderA2() *VMProviderA2 {
+	provider := VMProviderA2{
+		vmMap:             map[client.ObjectKey]*vmopv1.VirtualMachine{},
+		resourcePolicyMap: map[client.ObjectKey]*vmopv1.VirtualMachineSetResourcePolicy{},
+		vmPubMap:          map[string]vimTypes.TaskInfoState{},
+	}
+	return &provider
+}

--- a/pkg/vmprovider/interface_a2.go
+++ b/pkg/vmprovider/interface_a2.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package vmprovider
+
+import (
+	"context"
+
+	"github.com/vmware/govmomi/vapi/library"
+	vimTypes "github.com/vmware/govmomi/vim25/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	imgregv1a1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha1"
+	"github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+)
+
+// VirtualMachineProviderInterfaceA2 is a plugable interface for VM Providers.
+type VirtualMachineProviderInterfaceA2 interface {
+	CreateOrUpdateVirtualMachine(ctx context.Context, vm *v1alpha2.VirtualMachine) error
+	DeleteVirtualMachine(ctx context.Context, vm *v1alpha2.VirtualMachine) error
+	PublishVirtualMachine(ctx context.Context, vm *v1alpha2.VirtualMachine,
+		vmPub *v1alpha2.VirtualMachinePublishRequest, cl *imgregv1a1.ContentLibrary, actID string) (string, error)
+	GetVirtualMachineGuestHeartbeat(ctx context.Context, vm *v1alpha2.VirtualMachine) (v1alpha2.GuestHeartbeatStatus, error)
+	GetVirtualMachineWebMKSTicket(ctx context.Context, vm *v1alpha2.VirtualMachine, pubKey string) (string, error)
+	GetVirtualMachineHardwareVersion(ctx context.Context, vm *v1alpha2.VirtualMachine) (int32, error)
+
+	CreateOrUpdateVirtualMachineSetResourcePolicy(ctx context.Context, resourcePolicy *v1alpha2.VirtualMachineSetResourcePolicy) error
+	IsVirtualMachineSetResourcePolicyReady(ctx context.Context, availabilityZoneName string, resourcePolicy *v1alpha2.VirtualMachineSetResourcePolicy) (bool, error)
+	DeleteVirtualMachineSetResourcePolicy(ctx context.Context, resourcePolicy *v1alpha2.VirtualMachineSetResourcePolicy) error
+
+	// "Infra" related
+	UpdateVcPNID(ctx context.Context, vcPNID, vcPort string) error
+	ResetVcClient(ctx context.Context)
+	ComputeCPUMinFrequency(ctx context.Context) error
+
+	GetItemFromLibraryByName(ctx context.Context, contentLibrary, itemName string) (*library.Item, error)
+	UpdateContentLibraryItem(ctx context.Context, itemID, newName string, newDescription *string) error
+	SyncVirtualMachineImage(ctx context.Context, cli, vmi client.Object) error
+
+	GetTasksByActID(ctx context.Context, actID string) (tasksInfo []vimTypes.TaskInfo, retErr error)
+}


### PR DESCRIPTION
This contains the non provider pkg/ changes for v1a2, which is most of the changes required to get the v1a2 controllers working.

With the change to metav1.Condition types, the Reason field is now required which previously we wouldn't provide when setting the condition to true. To keep the later changes smaller we reuse the type field value but will need to refactor our conditions API later to add a reason argument and meaningful reason messages where we want to.

Contains selective changes from #172 and #173 required to compile that will rebase out