### PR TITLE
Do not allocate NodePorts for VirtualMachineService Services

### DIFF
--- a/controllers/virtualmachineservice/virtualmachineservice_controller.go
+++ b/controllers/virtualmachineservice/virtualmachineservice_controller.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -392,6 +393,11 @@ func (r *ReconcileVirtualMachineService) createOrUpdateService(ctx *context.Virt
 		service.Spec.ExternalName = vmService.Spec.ExternalName
 		service.Spec.LoadBalancerIP = vmService.Spec.LoadBalancerIP
 		service.Spec.LoadBalancerSourceRanges = vmService.Spec.LoadBalancerSourceRanges
+		if service.Spec.Type == corev1.ServiceTypeLoadBalancer {
+			service.Spec.AllocateLoadBalancerNodePorts = pointer.Bool(false)
+		} else {
+			service.Spec.AllocateLoadBalancerNodePorts = nil
+		}
 
 		// Parts of the Service.Spec can be updated by k8s after creation, and we need to
 		// preserve those fields.

--- a/controllers/virtualmachineservice/virtualmachineservice_controller_unit_test.go
+++ b/controllers/virtualmachineservice/virtualmachineservice_controller_unit_test.go
@@ -173,6 +173,8 @@ func unitTestsReconcile() {
 				Expect(service.Spec.LoadBalancerIP).To(Equal(loadBalancerIP))
 				Expect(service.Spec.LoadBalancerSourceRanges).To(HaveLen(2))
 				Expect(service.Spec.LoadBalancerSourceRanges).To(ContainElements(lbSourceRanges))
+				Expect(service.Spec.AllocateLoadBalancerNodePorts).ToNot(BeNil())
+				Expect(*service.Spec.AllocateLoadBalancerNodePorts).To(BeFalse())
 			})
 
 			Context("With Expected Spec.Ports", func() {


### PR DESCRIPTION
For VirtualMachineServices we create a selectorless Service and manage
the Endpoints to point to the underlying VirtualMachines so NodePorts are
not required because we don't proxy via the Supervisor CP VMs. Set field
added in k8s 1.24 to disable allocating NodePorts. Make this automatic
for LB-type services. This field is ignored/reset for non-LB type Services.

This addresses a scaling issue where we can exhaust the WCP SV cluster
 out of NodePorts, usually via many TKG Services..
