### PR TITLE
:sparkles: Ensure lossless conversion of VirtualMachineClass new fields

### DIFF
--- a/api/utilconversion/conversion.go
+++ b/api/utilconversion/conversion.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// NOTE: These functions are borrowed from upstream cluster-api repo.
+
+package utilconversion
+
+import (
+	"encoding/json"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// AnnotationKey is the annotation key to ensure lossless
+// conversion of objects between API versions.
+const AnnotationKey = "vmoperator.vmware.com/conversion"
+
+// MarshalData stores the source object as json data in the destination object annotations map.
+// It ignores the metadata of the source object.
+func MarshalData(src metav1.Object, dst metav1.Object) error {
+	u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(src)
+	if err != nil {
+		return err
+	}
+	delete(u, "metadata")
+
+	data, err := json.Marshal(u)
+	if err != nil {
+		return err
+	}
+	annotations := dst.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[AnnotationKey] = string(data)
+	dst.SetAnnotations(annotations)
+	return nil
+}
+
+// UnmarshalData tries to retrieve the data from the annotation and
+// unmarshals it into the object passed as input.
+func UnmarshalData(from metav1.Object, to interface{}) (bool, error) {
+	annotations := from.GetAnnotations()
+	data, ok := annotations[AnnotationKey]
+	if !ok {
+		return false, nil
+	}
+	if err := json.Unmarshal([]byte(data), to); err != nil {
+		return false, err
+	}
+	delete(annotations, AnnotationKey)
+	from.SetAnnotations(annotations)
+	return true, nil
+}

--- a/api/utilconversion/conversion_fuzz.go
+++ b/api/utilconversion/conversion_fuzz.go
@@ -102,12 +102,10 @@ func FuzzTestFunc(input FuzzTestFuncInput) func(*testing.T) {
 
 				// Remove data annotation eventually added by ConvertFrom for avoiding data loss in hub-spoke-hub round trips
 				// NOTE: There are use case when we want to skip this operation, e.g. if the spoke object does not have ObjectMeta (e.g. kubeadm types).
-				/* TODO: BMV Not yet for us
 				if !input.SkipSpokeAnnotationCleanup {
 					metaAfter := spokeAfter.(metav1.Object)
-					delete(metaAfter.GetAnnotations(), DataAnnotation)
+					delete(metaAfter.GetAnnotations(), AnnotationKey)
 				}
-				*/
 
 				if input.SpokeAfterMutation != nil {
 					input.SpokeAfterMutation(spokeAfter)

--- a/api/v1alpha1/conversion_test.go
+++ b/api/v1alpha1/conversion_test.go
@@ -15,6 +15,7 @@ import (
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 
 	"github.com/vmware-tanzu/vm-operator/api/utilconversion"
+
 	"github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	nextver "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 )
@@ -139,13 +140,19 @@ func overrideVirtualMachineFieldsFuncs(codecs runtimeserializer.CodecFactory) []
 
 func overrideVirtualMachineClassFieldsFuncs(codecs runtimeserializer.CodecFactory) []interface{} {
 	return []interface{}{
-		func(classStatus *nextver.VirtualMachineClassStatus, c fuzz.Continue) {
-			c.Fuzz(classStatus)
+		func(classSpec *nextver.VirtualMachineClassSpec, c fuzz.Continue) {
+			c.Fuzz(classSpec)
 
-			// TODO: Need to save serialized object to support lossless conversions.
-			classStatus.Capabilities = nil
-			classStatus.Conditions = nil
-			classStatus.Ready = false
+			// Since all random byte arrays are not valid JSON
+			// Passing an empty string as a valid input
+			classSpec.ConfigSpec = []byte("")
+		},
+		func(classSpec *v1alpha1.VirtualMachineClassSpec, c fuzz.Continue) {
+			c.Fuzz(classSpec)
+
+			// Since all random byte arrays are not valid JSON
+			// Passing an empty string as a valid input
+			classSpec.ConfigSpec = []byte("")
 		},
 	}
 }


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This patch extends the conversion function for the VirtualMachineClass API type to ensure lossless conversion of the new fields in the Status of the v1alpha2 version of the CR.
When down-converting to v1alpha1 version, the extra fields get added to the CR's annotation and this data can be read during up-conversion to v1alpha2 version.

**Are there any special notes for your reviewer**:
The v1alpha2 version of the `VirtualMachineClass` CR has new fields introduced in the `VirtualMachineClassStatus` type, namely `Ready`, `Conditions` and `Capabilities` which are not present in the v1alpha1 version. When down-converting a v1alpha2 API version, say, via the v1alpha1 versioned client, a straight up conversion will cause these new fields to be lost.

Instead, we store the fields and their JSON marshaled values as an annotation under a special key `vmoperator.vmware.com/conversion` to ensure lossless conversion.  

**Please add a release note if necessary**:
```release-note
:sparkles: Ensure lossless conversion of VirtualMachineClass new fields
```