### PR TITLE
📖 Add callout to address incomplete Sysprep state issue

### DIFF
--- a/docs/concepts/workloads/guest.md
+++ b/docs/concepts/workloads/guest.md
@@ -113,6 +113,10 @@ The data in the above `Secret` is called the Cloud-Init _Cloud Config_. For more
 
 Microsoft originally designed Sysprep as a means to prepare a deployed system for use as a template. It was such a useful tool, that VMware utilized it as the means to customize a VM with a Windows guest.
 
+!!! note "Sysprep State"
+
+    Deploying Windows images that have not completed their previous Sysprep operation could cause the Guest OS customization to fail. Therefore, it is important to ensure that the image is sealed correctly and in a clean state when using Sysprep. For more information on this issue, please refer to [this article](https://kb.vmware.com/s/article/86350).
+
 #### Minimal Config
 
 The following YAML may be used to bootstrap a Windows image with minimal information. For proper network configuration and Guest OS Customization (GOSC) completion, Sysprep unattend data requires a template for providing network info and `RunSynchronousCommand` to record GOSC status. Both components are essential for Windows Vista and later versions.


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This PR adds a callout to the Sysprep section in the [Guest Customization](https://vm-operator.readthedocs.io/en/latest/concepts/workloads/guest/) doc. This is to highlight the guest OS customization failure from deploying Windows images with an incomplete Sysprep state. The issue is described in detail in [KB 86350](https://kb.vmware.com/s/article/86350), which is also linked in the callout section.

**Which issue(s) is/are addressed by this PR?**
Fixes #185 

**Please add a release note if necessary**:
NONE

<!-- readthedocs-preview vm-operator start -->
----
:books: Documentation preview :books:: https://vm-operator--186.org.readthedocs.build/en/186/

<!-- readthedocs-preview vm-operator end -->