### PR TITLE
🌱 Rename SelectVGPU taking BackingType into account

### DIFF
--- a/pkg/util/devices.go
+++ b/pkg/util/devices.go
@@ -116,8 +116,8 @@ func SelectVirtualPCIPassthrough(
 	return SelectDevicesByType[*vimTypes.VirtualPCIPassthrough](devices)
 }
 
-// IsDeviceVGPU returns true if the provided device is a vGPU.
-func IsDeviceVGPU(dev vimTypes.BaseVirtualDevice) bool {
+// IsDeviceNvidiaVgpu returns true if the provided device is an Nvidia vGPU.
+func IsDeviceNvidiaVgpu(dev vimTypes.BaseVirtualDevice) bool {
 	if dev, ok := dev.(*vimTypes.VirtualPCIPassthrough); ok {
 		_, ok := dev.Backing.(*vimTypes.VirtualPCIPassthroughVmiopBackingInfo)
 		return ok
@@ -135,8 +135,15 @@ func IsDeviceDynamicDirectPathIO(dev vimTypes.BaseVirtualDevice) bool {
 	return false
 }
 
-// SelectVGPU returns a slice of vGPU devices.
-func SelectVGPU(
+// SelectNvidiaVgpu return a slice of Nvidia vGPU devices.
+func SelectNvidiaVgpu(
+	devices []vimTypes.BaseVirtualDevice,
+) []*vimTypes.VirtualPCIPassthrough {
+	return selectVirtualPCIPassthroughWithVmiopBacking(devices)
+}
+
+// SelectVirtualPCIPassthroughWithVmiopBacking returns a slice of PCI devices with VmiopBacking.
+func selectVirtualPCIPassthroughWithVmiopBacking(
 	devices []vimTypes.BaseVirtualDevice,
 ) []*vimTypes.VirtualPCIPassthrough {
 

--- a/pkg/util/devices_test.go
+++ b/pkg/util/devices_test.go
@@ -82,20 +82,20 @@ var _ = Describe("SelectDevicesByType", func() {
 	})
 })
 
-var _ = Describe("IsDeviceVGPU", func() {
+var _ = Describe("IsDeviceNvidiaVgpu", func() {
 	Context("a VGPU", func() {
 		It("will return true", func() {
-			Expect(util.IsDeviceVGPU(newPCIPassthroughDevice("profile1"))).To(BeTrue())
+			Expect(util.IsDeviceNvidiaVgpu(newPCIPassthroughDevice("profile1"))).To(BeTrue())
 		})
 	})
 	Context("a dynamic direct path I/O device", func() {
 		It("will return false", func() {
-			Expect(util.IsDeviceVGPU(newPCIPassthroughDevice(""))).To(BeFalse())
+			Expect(util.IsDeviceNvidiaVgpu(newPCIPassthroughDevice(""))).To(BeFalse())
 		})
 	})
 	Context("a virtual CD-ROM", func() {
 		It("will return false", func() {
-			Expect(util.IsDeviceVGPU(&vimTypes.VirtualCdrom{})).To(BeFalse())
+			Expect(util.IsDeviceNvidiaVgpu(&vimTypes.VirtualCdrom{})).To(BeFalse())
 		})
 	})
 })
@@ -141,10 +141,10 @@ var _ = Describe("SelectDynamicDirectPathIO", func() {
 	})
 })
 
-var _ = Describe("SelectVGPU", func() {
-	Context("selecting a vGPU device", func() {
+var _ = Describe("SelectNvidiaVgpu", func() {
+	Context("selecting Nvidia vGPU devices", func() {
 		It("will return only the selected device type", func() {
-			devOut := util.SelectVGPU(
+			devOut := util.SelectNvidiaVgpu(
 				[]vimTypes.BaseVirtualDevice{
 					newPCIPassthroughDevice(""),
 					&vimTypes.VirtualVmxnet3{},

--- a/pkg/vmprovider/providers/vsphere/vmprovider_vm_utils.go
+++ b/pkg/vmprovider/providers/vsphere/vmprovider_vm_utils.go
@@ -460,7 +460,7 @@ func HardwareVersionForPVCandPCIDevices(imageHWVersion int32, configSpec *types.
 	var configSpecHWVersion int32
 	configSpecDevs := util.DevicesFromConfigSpec(configSpec)
 
-	if len(util.SelectVGPU(configSpecDevs)) > 0 || len(util.SelectDynamicDirectPathIO(configSpecDevs)) > 0 {
+	if len(util.SelectNvidiaVgpu(configSpecDevs)) > 0 || len(util.SelectDynamicDirectPathIO(configSpecDevs)) > 0 {
 		configSpecHWVersion = constants.MinSupportedHWVersionForPCIPassthruDevices
 		if imageHWVersion != 0 && imageHWVersion > constants.MinSupportedHWVersionForPCIPassthruDevices {
 			configSpecHWVersion = imageHWVersion


### PR DESCRIPTION
This makes the method SelectVGPU more explicit since vGPUs can have DVX backings as well.

**What does this PR do, and why is it needed?**
This makes the method more explicit since vGPUs can have VMIOP and DVX backing.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #162 