### PR TITLE
✨ Add v1a2 controllers

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@ run:
    - ".*generated.*\\.go"
    - external/
    - controllers/virtualmachineservice/v1alpha1/utils/
+   - controllers/virtualmachineservice/v1alpha2/utils/
 
 # override defaults
 linters-settings:

--- a/api/v1alpha1/conversion_test.go
+++ b/api/v1alpha1/conversion_test.go
@@ -54,6 +54,15 @@ func TestFuzzyConversion(t *testing.T) {
 		},
 	}))
 
+	t.Run("for ClusterVirtualMachineImage", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
+		Scheme: scheme,
+		Hub:    &nextver.ClusterVirtualMachineImage{},
+		Spoke:  &v1alpha1.ClusterVirtualMachineImage{},
+		FuzzerFuncs: []fuzzer.FuzzerFuncs{
+			overrideVirtualMachineImageFieldsFuncs,
+		},
+	}))
+
 	t.Run("for VirtualMachinePublishRequest", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
 		Scheme: scheme,
 		Hub:    &nextver.VirtualMachinePublishRequest{},
@@ -179,7 +188,6 @@ func overrideVirtualMachineImageFieldsFuncs(codecs runtimeserializer.CodecFactor
 			// Do not exist in v1a2.
 			imageSpec.Type = ""
 			imageSpec.ImageSourceType = ""
-			imageSpec.ImageID = ""
 			imageSpec.ProviderRef.Namespace = ""
 		},
 		func(imageStatus *v1alpha1.VirtualMachineImageStatus, c fuzz.Continue) {

--- a/api/v1alpha1/virtualmachineimage_conversion.go
+++ b/api/v1alpha1/virtualmachineimage_conversion.go
@@ -50,7 +50,7 @@ func convert_v1alpha1_VirtualMachineImageOSInfo_To_v1alpha2_VirtualMachineImageO
 	return nil
 }
 
-func convert_v1alpah2_VirtualMachineImage_OVFProperties_To_v1alpha1_VirtualMachineImage_OVFEnv(
+func convert_v1alpha2_VirtualMachineImage_OVFProperties_To_v1alpha1_VirtualMachineImage_OVFEnv(
 	in []v1alpha2.OVFProperty, out *map[string]OvfProperty, s apiconversion.Scope) error {
 
 	if in != nil {
@@ -139,6 +139,7 @@ func convert_v1alpha1_VirtualMachineImageSpec_To_v1alpha2_VirtualMachineImageSta
 	// Some fields of the v1a1 ImageSpec moved into the v1a2 ImageStatus.
 	// conversion-gen doesn't handle that so do those here.
 
+	out.ProviderItemID = in.ImageID
 	if in.HardwareVersion != 0 {
 		out.HardwareVersion = &in.HardwareVersion
 	}
@@ -164,6 +165,7 @@ func convert_v1alpha2_VirtualMachineImageStatus_To_v1alpha1_VirtualMachineImageS
 	// Some fields of the v1a1 ImageSpec moved into the v1a2 ImageStatus.
 	// conversion-gen doesn't handle that so do those here.
 
+	out.ImageID = in.ProviderItemID
 	if in.HardwareVersion != nil {
 		out.HardwareVersion = *in.HardwareVersion
 	}
@@ -172,7 +174,7 @@ func convert_v1alpha2_VirtualMachineImageStatus_To_v1alpha1_VirtualMachineImageS
 		return err
 	}
 
-	if err := convert_v1alpah2_VirtualMachineImage_OVFProperties_To_v1alpha1_VirtualMachineImage_OVFEnv(in.OVFProperties, &out.OVFEnv, s); err != nil {
+	if err := convert_v1alpha2_VirtualMachineImage_OVFProperties_To_v1alpha1_VirtualMachineImage_OVFEnv(in.OVFProperties, &out.OVFEnv, s); err != nil {
 		return err
 	}
 
@@ -226,13 +228,29 @@ func (dst *VirtualMachineImageList) ConvertFrom(srcRaw conversion.Hub) error {
 // ConvertTo converts this ClusterVirtualMachineImage to the Hub version.
 func (src *ClusterVirtualMachineImage) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*v1alpha2.ClusterVirtualMachineImage)
-	return Convert_v1alpha1_ClusterVirtualMachineImage_To_v1alpha2_ClusterVirtualMachineImage(src, dst, nil)
+	if err := Convert_v1alpha1_ClusterVirtualMachineImage_To_v1alpha2_ClusterVirtualMachineImage(src, dst, nil); err != nil {
+		return err
+	}
+
+	if err := convert_v1alpha1_VirtualMachineImageSpec_To_v1alpha2_VirtualMachineImageStatus(&src.Spec, &dst.Status, nil); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // ConvertFrom converts the hub version to this ClusterVirtualMachineImage.
 func (dst *ClusterVirtualMachineImage) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*v1alpha2.ClusterVirtualMachineImage)
-	return Convert_v1alpha2_ClusterVirtualMachineImage_To_v1alpha1_ClusterVirtualMachineImage(src, dst, nil)
+	if err := Convert_v1alpha2_ClusterVirtualMachineImage_To_v1alpha1_ClusterVirtualMachineImage(src, dst, nil); err != nil {
+		return err
+	}
+
+	if err := convert_v1alpha2_VirtualMachineImageStatus_To_v1alpha1_VirtualMachineImageSpec(&src.Status, &dst.Spec, nil); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // ConvertTo converts this ClusterVirtualMachineImageList to the Hub version.

--- a/api/v1alpha1/zz_generated.conversion.go
+++ b/api/v1alpha1/zz_generated.conversion.go
@@ -1440,6 +1440,7 @@ func autoConvert_v1alpha2_VirtualMachineImageStatus_To_v1alpha1_VirtualMachineIm
 	// WARNING: in.OVFProperties requires manual conversion: does not exist in peer-type
 	// WARNING: in.ProductInfo requires manual conversion: does not exist in peer-type
 	// WARNING: in.ProviderContentVersion requires manual conversion: does not exist in peer-type
+	// WARNING: in.ProviderItemID requires manual conversion: does not exist in peer-type
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make([]Condition, len(*in))

--- a/api/v1alpha2/virtualmachineimage_types.go
+++ b/api/v1alpha2/virtualmachineimage_types.go
@@ -193,6 +193,12 @@ type VirtualMachineImageStatus struct {
 	// +optional
 	ProviderContentVersion string `json:"providerContentVersion,omitempty"`
 
+	// ProviderItemID describes the ID of the provider item that this image corresponds to.
+	// If the provider of this image is a Content Library, this ID will be that of the
+	// corresponding Content Library item.
+	// +optional
+	ProviderItemID string `json:"providerItemID,omitempty"`
+
 	// Conditions describes the observed conditions for this image.
 	//
 	// +optional
@@ -219,6 +225,14 @@ type VirtualMachineImage struct {
 
 	Spec   VirtualMachineImageSpec   `json:"spec,omitempty"`
 	Status VirtualMachineImageStatus `json:"status,omitempty"`
+}
+
+func (i *VirtualMachineImage) GetConditions() []metav1.Condition {
+	return i.Status.Conditions
+}
+
+func (i *VirtualMachineImage) SetConditions(conditions []metav1.Condition) {
+	i.Status.Conditions = conditions
 }
 
 // +kubebuilder:object:root=true
@@ -248,6 +262,14 @@ type ClusterVirtualMachineImage struct {
 
 	Spec   VirtualMachineImageSpec   `json:"spec,omitempty"`
 	Status VirtualMachineImageStatus `json:"status,omitempty"`
+}
+
+func (i *ClusterVirtualMachineImage) GetConditions() []metav1.Condition {
+	return i.Status.Conditions
+}
+
+func (i *ClusterVirtualMachineImage) SetConditions(conditions []metav1.Condition) {
+	i.Status.Conditions = conditions
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha2/virtualmachinepublishrequest_types.go
+++ b/api/v1alpha2/virtualmachinepublishrequest_types.go
@@ -347,6 +347,14 @@ type VirtualMachinePublishRequest struct {
 	Status VirtualMachinePublishRequestStatus `json:"status,omitempty"`
 }
 
+func (vmpub *VirtualMachinePublishRequest) GetConditions() []metav1.Condition {
+	return vmpub.Status.Conditions
+}
+
+func (vmpub *VirtualMachinePublishRequest) SetConditions(conditions []metav1.Condition) {
+	vmpub.Status.Conditions = conditions
+}
+
 // +kubebuilder:object:root=true
 
 // VirtualMachinePublishRequestList contains a list of

--- a/api/v1alpha2/virtualmachinesetresourcepolicy_types.go
+++ b/api/v1alpha2/virtualmachinesetresourcepolicy_types.go
@@ -59,6 +59,10 @@ type VirtualMachineSetResourcePolicy struct {
 	Status VirtualMachineSetResourcePolicyStatus `json:"status,omitempty"`
 }
 
+func (p *VirtualMachineSetResourcePolicy) NamespacedName() string {
+	return p.Namespace + "/" + p.Name
+}
+
 // +kubebuilder:object:root=true
 
 // VirtualMachineSetResourcePolicyList contains a list of VirtualMachineSetResourcePolicy.

--- a/controllers/contentlibrary/controllers.go
+++ b/controllers/contentlibrary/controllers.go
@@ -7,10 +7,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/vmware-tanzu/vm-operator/controllers/contentlibrary/v1alpha1"
+	"github.com/vmware-tanzu/vm-operator/controllers/contentlibrary/v1alpha2"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 )
 
 // AddToManager adds the controller to the provided manager.
 func AddToManager(ctx *context.ControllerManagerContext, mgr manager.Manager) error {
+	if lib.IsVMServiceV1Alpha2FSSEnabled() {
+		return v1alpha2.AddToManager(ctx, mgr)
+	}
 	return v1alpha1.AddToManager(ctx, mgr)
 }

--- a/controllers/contentlibrary/v1alpha2/clustercontentlibraryitem/clustercontentlibraryitem_controller.go
+++ b/controllers/contentlibrary/v1alpha2/clustercontentlibraryitem/clustercontentlibraryitem_controller.go
@@ -1,0 +1,282 @@
+// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package clustercontentlibraryitem
+
+import (
+	goctx "context"
+	"fmt"
+	"reflect"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/go-logr/logr"
+
+	imgregv1a1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha1"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/api/v1alpha2/common"
+	"github.com/vmware-tanzu/vm-operator/controllers/contentlibrary/v1alpha2/utils"
+	conditions "github.com/vmware-tanzu/vm-operator/pkg/conditions2"
+	"github.com/vmware-tanzu/vm-operator/pkg/context"
+	metrics "github.com/vmware-tanzu/vm-operator/pkg/metrics2"
+	"github.com/vmware-tanzu/vm-operator/pkg/record"
+	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider"
+)
+
+// AddToManager adds this package's controller to the provided manager.
+func AddToManager(ctx *context.ControllerManagerContext, mgr manager.Manager) error {
+	var (
+		cclItemType     = &imgregv1a1.ClusterContentLibraryItem{}
+		cclItemTypeName = reflect.TypeOf(cclItemType).Elem().Name()
+
+		controllerNameShort = fmt.Sprintf("%s-controller", strings.ToLower(cclItemTypeName))
+		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
+	)
+
+	r := NewReconciler(
+		mgr.GetClient(),
+		ctrl.Log.WithName("controllers").WithName(cclItemTypeName),
+		record.New(mgr.GetEventRecorderFor(controllerNameLong)),
+		ctx.VMProviderA2,
+	)
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(cclItemType).
+		// We do not set Owns(ClusterVirtualMachineImage) here as we call SetControllerReference()
+		// when creating such resources in the reconciling process below.
+		WithOptions(controller.Options{MaxConcurrentReconciles: ctx.MaxConcurrentReconciles}).
+		Complete(r)
+}
+
+func NewReconciler(
+	client client.Client,
+	logger logr.Logger,
+	recorder record.Recorder,
+	vmProvider vmprovider.VirtualMachineProviderInterfaceA2) *Reconciler {
+
+	return &Reconciler{
+		Client:     client,
+		Logger:     logger,
+		Recorder:   recorder,
+		VMProvider: vmProvider,
+		Metrics:    metrics.NewContentLibraryItemMetrics(),
+	}
+}
+
+// Reconciler reconciles an IaaS Image Registry Service's ClusterContentLibraryItem object
+// by creating/updating the corresponding VM-Service's ClusterVirtualMachineImage resource.
+type Reconciler struct {
+	client.Client
+	Logger     logr.Logger
+	Recorder   record.Recorder
+	VMProvider vmprovider.VirtualMachineProviderInterfaceA2
+	Metrics    *metrics.ContentLibraryItemMetrics
+}
+
+// +kubebuilder:rbac:groups=imageregistry.vmware.com,resources=clustercontentlibraryitems,verbs=get;list;watch;update;patch;delete
+// +kubebuilder:rbac:groups=imageregistry.vmware.com,resources=clustercontentlibraryitems/status,verbs=get
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=clustervirtualmachineimages,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=clustervirtualmachineimages/status,verbs=get;update;patch
+
+func (r *Reconciler) Reconcile(ctx goctx.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
+	logger := r.Logger.WithValues("cclItemName", req.Name)
+	logger.Info("Reconciling ClusterContentLibraryItem")
+
+	cclItem := &imgregv1a1.ClusterContentLibraryItem{}
+	if err := r.Get(ctx, req.NamespacedName, cclItem); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	cvmiName, nameErr := utils.GetImageFieldNameFromItem(cclItem.Name)
+	if nameErr != nil {
+		logger.Error(nameErr, "Unsupported ClusterContentLibraryItem name, skip reconciling")
+		return ctrl.Result{}, nil
+	}
+	logger = logger.WithValues("cvmiName", cvmiName)
+
+	cclItemCtx := &context.ClusterContentLibraryItemContextA2{
+		Context:      ctx,
+		Logger:       logger,
+		CCLItem:      cclItem,
+		ImageObjName: cvmiName,
+	}
+
+	if !cclItem.DeletionTimestamp.IsZero() {
+		err := r.ReconcileDelete(cclItemCtx)
+		return ctrl.Result{}, err
+	}
+
+	// Create or update the ClusterVirtualMachineImage resource accordingly.
+	err := r.ReconcileNormal(cclItemCtx)
+	return ctrl.Result{}, err
+}
+
+// ReconcileDelete reconciles a deletion for a ClusterContentLibraryItem resource.
+func (r *Reconciler) ReconcileDelete(ctx *context.ClusterContentLibraryItemContextA2) error {
+	if controllerutil.ContainsFinalizer(ctx.CCLItem, utils.ClusterContentLibraryItemVmopFinalizer) {
+		r.Metrics.DeleteMetrics(ctx.Logger, ctx.ImageObjName, "")
+		controllerutil.RemoveFinalizer(ctx.CCLItem, utils.ClusterContentLibraryItemVmopFinalizer)
+		return r.Update(ctx, ctx.CCLItem)
+	}
+
+	return nil
+}
+
+// ReconcileNormal reconciles a ClusterContentLibraryItem resource by creating or
+// updating the corresponding ClusterVirtualMachineImage resource.
+func (r *Reconciler) ReconcileNormal(ctx *context.ClusterContentLibraryItemContextA2) error {
+	if !controllerutil.ContainsFinalizer(ctx.CCLItem, utils.ClusterContentLibraryItemVmopFinalizer) {
+		// The finalizer must be present before proceeding in order to ensure ReconcileDelete() will be called.
+		// Return immediately after here to update the object and then we'll proceed on the next reconciliation.
+		controllerutil.AddFinalizer(ctx.CCLItem, utils.ClusterContentLibraryItemVmopFinalizer)
+		return r.Update(ctx, ctx.CCLItem)
+	}
+
+	// Do not set additional fields here as they will be overwritten in CreateOrPatch below.
+	cvmi := &vmopv1.ClusterVirtualMachineImage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: ctx.ImageObjName,
+		},
+	}
+	ctx.CVMI = cvmi
+
+	var didSync bool
+	var syncErr error
+	var savedStatus *vmopv1.VirtualMachineImageStatus
+
+	opRes, createOrPatchErr := controllerutil.CreateOrPatch(ctx, r.Client, cvmi, func() error {
+		defer func() {
+			savedStatus = cvmi.Status.DeepCopy()
+		}()
+
+		if err := r.setUpCVMIFromCCLItem(ctx); err != nil {
+			ctx.Logger.Error(err, "Failed to set up ClusterVirtualMachineImage from ClusterContentLibraryItem")
+			return err
+		}
+
+		// Check if the item is ready and skip the image content sync if not.
+		if !utils.IsItemReady(ctx.CCLItem.Status.Conditions) {
+			conditions.MarkFalse(cvmi,
+				vmopv1.VirtualMachineImageProviderReadyCondition,
+				vmopv1.VirtualMachineImageProviderNotReadyReason,
+				"Provider item is not in ready condition",
+			)
+			ctx.Logger.Info("ClusterContentLibraryItem is not ready yet, skipping image content sync")
+		} else {
+			conditions.MarkTrue(cvmi, vmopv1.VirtualMachineImageProviderReadyCondition)
+			syncErr = r.syncImageContent(ctx)
+			didSync = true
+		}
+
+		// Do not return syncErr here as we still want to patch the updated fields we get above.
+		return nil
+	})
+
+	ctx.Logger = ctx.Logger.WithValues("operationResult", opRes)
+
+	// Registry metrics based on the corresponding error captured.
+	defer func() {
+		r.Metrics.RegisterVMIResourceResolve(ctx.Logger, cvmi.Name, "", createOrPatchErr == nil)
+		r.Metrics.RegisterVMIContentSync(ctx.Logger, cvmi.Name, "", didSync && syncErr == nil)
+	}()
+
+	if createOrPatchErr != nil {
+		ctx.Logger.Error(createOrPatchErr, "Failed to create or patch ClusterVirtualMachineImage resource")
+		return createOrPatchErr
+	}
+
+	// CreateOrPatch/CreateOrUpdate doesn't patch sub-resource for creation.
+	if opRes == controllerutil.OperationResultCreated {
+		cvmi.Status = *savedStatus
+		if createOrPatchErr = r.Status().Update(ctx, cvmi); createOrPatchErr != nil {
+			ctx.Logger.Error(createOrPatchErr, "Failed to update ClusterVirtualMachineImage status")
+			return createOrPatchErr
+		}
+	}
+
+	if syncErr != nil {
+		ctx.Logger.Error(syncErr, "Failed to sync ClusterVirtualMachineImage to the latest content version")
+		return syncErr
+	}
+
+	ctx.Logger.Info("Successfully reconciled ClusterVirtualMachineImage",
+		"contentVersion", savedStatus.ProviderContentVersion)
+	return nil
+}
+
+// setUpCVMIFromCCLItem sets up the ClusterVirtualMachineImage fields that
+// are retrievable from the given ClusterContentLibraryItem resource.
+func (r *Reconciler) setUpCVMIFromCCLItem(ctx *context.ClusterContentLibraryItemContextA2) error {
+	cclItem := ctx.CCLItem
+	cvmi := ctx.CVMI
+
+	if err := controllerutil.SetControllerReference(cclItem, cvmi, r.Scheme()); err != nil {
+		return err
+	}
+
+	if cvmi.Labels == nil {
+		cvmi.Labels = make(map[string]string)
+	}
+
+	// Only watch for service type labels from ClusterContentLibraryItem
+	for label := range cclItem.Labels {
+		if strings.HasPrefix(label, "type.services.vmware.com/") {
+			cvmi.Labels[label] = ""
+		}
+	}
+
+	cvmi.Spec.ProviderRef = common.LocalObjectRef{
+		APIVersion: cclItem.APIVersion,
+		Kind:       cclItem.Kind,
+		Name:       cclItem.Name,
+	}
+
+	cvmi.Status.Name = cclItem.Status.Name
+	cvmi.Status.ProviderItemID = string(cclItem.Spec.UUID)
+
+	// Update image condition based on the security compliance of the provider item.
+	cclItemSecurityCompliance := ctx.CCLItem.Status.SecurityCompliance
+	if cclItemSecurityCompliance == nil || !*cclItemSecurityCompliance {
+		conditions.MarkFalse(cvmi,
+			vmopv1.VirtualMachineImageProviderSecurityComplianceCondition,
+			vmopv1.VirtualMachineImageProviderSecurityNotCompliantReason,
+			"Provider item is not security compliant",
+		)
+	} else {
+		conditions.MarkTrue(cvmi, vmopv1.VirtualMachineImageProviderSecurityComplianceCondition)
+	}
+
+	return nil
+}
+
+// syncImageContent syncs the ClusterVirtualMachineImage content from the provider.
+// It skips syncing if the image content is already up-to-date.
+func (r *Reconciler) syncImageContent(ctx *context.ClusterContentLibraryItemContextA2) error {
+	cclItem := ctx.CCLItem
+	cvmi := ctx.CVMI
+	latestVersion := cclItem.Status.ContentVersion
+	if cvmi.Status.ProviderContentVersion == latestVersion {
+		return nil
+	}
+
+	err := r.VMProvider.SyncVirtualMachineImage(ctx, cclItem, cvmi)
+	if err != nil {
+		conditions.MarkFalse(cvmi,
+			vmopv1.VirtualMachineImageSyncedCondition,
+			vmopv1.VirtualMachineImageNotSyncedReason,
+			"Failed to sync to the latest content version from provider")
+	} else {
+		conditions.MarkTrue(cvmi, vmopv1.VirtualMachineImageSyncedCondition)
+		cvmi.Status.ProviderContentVersion = latestVersion
+	}
+
+	r.Recorder.EmitEvent(cvmi, "Update", err, false)
+	return err
+}

--- a/controllers/contentlibrary/v1alpha2/clustercontentlibraryitem/clustercontentlibraryitem_controller_intg_test.go
+++ b/controllers/contentlibrary/v1alpha2/clustercontentlibraryitem/clustercontentlibraryitem_controller_intg_test.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package clustercontentlibraryitem_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/google/uuid"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+
+	imgregv1a1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha1"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/controllers/contentlibrary/v1alpha2/utils"
+	conditions "github.com/vmware-tanzu/vm-operator/pkg/conditions2"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+func intgTests() {
+	Describe("Invoking ClusterContentLibraryItem controller integration tests", cclItemReconcile)
+}
+
+func cclItemReconcile() {
+	const firmwareValue = "my-firmware"
+
+	var (
+		ctx *builder.IntegrationTestContext
+	)
+
+	waitForClusterContentLibraryItemFinalizer := func(objKey client.ObjectKey) {
+		Eventually(func(g Gomega) {
+			item := &imgregv1a1.ClusterContentLibraryItem{}
+			g.Expect(ctx.Client.Get(ctx, objKey, item)).To(Succeed())
+			g.Expect(item.Finalizers).To(ContainElement(utils.ClusterContentLibraryItemVmopFinalizer))
+		}).Should(Succeed(), "waiting for ClusterContentLibraryItem finalizer")
+	}
+
+	waitForClusterVirtualMachineImageNotReady := func(objKey client.ObjectKey) {
+		Eventually(func(g Gomega) {
+			image := &vmopv1.ClusterVirtualMachineImage{}
+			g.Expect(ctx.Client.Get(ctx, objKey, image)).To(Succeed())
+
+			readyCond := conditions.Get(image, vmopv1.VirtualMachineImageProviderReadyCondition)
+			g.Expect(readyCond).ToNot(BeNil())
+			g.Expect(readyCond.Status).To(Equal(metav1.ConditionFalse))
+		}).Should(Succeed(), "waiting for ClusterVirtualMachineImage to be not ready")
+	}
+
+	waitForClusterVirtualMachineImageReady := func(objKey client.ObjectKey) {
+		Eventually(func(g Gomega) {
+			image := &vmopv1.ClusterVirtualMachineImage{}
+			g.Expect(ctx.Client.Get(ctx, objKey, image)).To(Succeed())
+			g.Expect(conditions.IsTrue(image, vmopv1.VirtualMachineImageProviderReadyCondition))
+			// Assert that SyncVirtualMachineImage() has been called too.
+			g.Expect(image.Status.Firmware).To(Equal(firmwareValue))
+		}).Should(Succeed(), "waiting for ClusterVirtualMachineImage to be sync'd and ready")
+	}
+
+	BeforeEach(func() {
+		ctx = suite.NewIntegrationTestContext()
+
+		intgFakeVMProvider.Lock()
+		intgFakeVMProvider.SyncVirtualMachineImageFn = func(_ context.Context, _, cvmiObj client.Object) error {
+			cvmi := cvmiObj.(*vmopv1.ClusterVirtualMachineImage)
+			// Use Firmware field to verify the provider function is called.
+			cvmi.Status.Firmware = firmwareValue
+			return nil
+		}
+		intgFakeVMProvider.Unlock()
+	})
+
+	AfterEach(func() {
+		ctx.AfterEach()
+		ctx = nil
+		intgFakeVMProvider.Reset()
+	})
+
+	Context("Reconcile ClusterContentLibraryItem", func() {
+
+		It("Workflow", func() {
+			origCCLItem := utils.DummyClusterContentLibraryItem(utils.ItemFieldNamePrefix + "-" + uuid.NewString())
+			cclItemKey := client.ObjectKeyFromObject(origCCLItem)
+			Expect(ctx.Client.Create(ctx, origCCLItem.DeepCopy())).To(Succeed())
+
+			imageName, err := utils.GetImageFieldNameFromItem(cclItemKey.Name)
+			Expect(err).ToNot(HaveOccurred())
+			cvmiKey := client.ObjectKey{Name: imageName}
+
+			By("Finalizer should be added to ClusterContentLibraryItem", func() {
+				waitForClusterContentLibraryItemFinalizer(cclItemKey)
+			})
+
+			By("ClusterVirtualMachineImage is created but not ready", func() {
+				waitForClusterVirtualMachineImageNotReady(cvmiKey)
+			})
+
+			cclItem := &imgregv1a1.ClusterContentLibraryItem{}
+			By("Update ClusterContentLibraryItem to populate Status and be Ready", func() {
+				Expect(ctx.Client.Get(ctx, cclItemKey, cclItem)).To(Succeed())
+				cclItem.Status = origCCLItem.Status
+				Expect(ctx.Client.Status().Update(ctx, cclItem)).To(Succeed())
+			})
+
+			By("ClusterVirtualMachineImage becomes ready", func() {
+				waitForClusterVirtualMachineImageReady(cvmiKey)
+			})
+
+			/* The non-caching ctx.Client.Get() won't populate these fields. */
+			gvk, err := apiutil.GVKForObject(cclItem, ctx.Client.Scheme())
+			Expect(err).ToNot(HaveOccurred())
+			cclItem.APIVersion, cclItem.Kind = gvk.ToAPIVersionAndKind()
+
+			image := &vmopv1.ClusterVirtualMachineImage{}
+			Expect(ctx.Client.Get(ctx, cvmiKey, image)).To(Succeed())
+			assertCVMImageFromCCLItem(image, cclItem)
+
+			By("ClusterContentLibraryItem has new content version", func() {
+				Expect(ctx.Client.Get(ctx, cclItemKey, cclItem)).To(Succeed())
+				cclItem.Status.ContentVersion += "-new-version"
+				Expect(ctx.Client.Status().Update(ctx, cclItem)).To(Succeed())
+			})
+
+			By("ClusterVirtualMachineImage should be updated with new content version", func() {
+				Eventually(func(g Gomega) {
+					g.Expect(ctx.Client.Get(ctx, cvmiKey, image)).To(Succeed())
+					g.Expect(image.Status.ProviderContentVersion).To(Equal(cclItem.Status.ContentVersion))
+				}).Should(Succeed())
+
+				cclItem.APIVersion, cclItem.Kind = gvk.ToAPIVersionAndKind()
+				assertCVMImageFromCCLItem(image, cclItem)
+			})
+		})
+	})
+}

--- a/controllers/contentlibrary/v1alpha2/clustercontentlibraryitem/clustercontentlibraryitem_controller_suite_test.go
+++ b/controllers/contentlibrary/v1alpha2/clustercontentlibraryitem/clustercontentlibraryitem_controller_suite_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package clustercontentlibraryitem_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+
+	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/vmware-tanzu/vm-operator/controllers/contentlibrary/v1alpha2/clustercontentlibraryitem"
+	ctrlContext "github.com/vmware-tanzu/vm-operator/pkg/context"
+	providerfake "github.com/vmware-tanzu/vm-operator/pkg/vmprovider/fake"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+var intgFakeVMProvider = providerfake.NewVMProviderA2()
+
+var suite = builder.NewTestSuiteForController(
+	clustercontentlibraryitem.AddToManager,
+	func(ctx *ctrlContext.ControllerManagerContext, _ ctrlmgr.Manager) error {
+		ctx.VMProviderA2 = intgFakeVMProvider
+		return nil
+	},
+)
+
+func TestClusterContentLibraryItem(t *testing.T) {
+	_ = intgTests
+	suite.Register(t, "ClusterContentLibraryItem controller suite", nil /*intgTests*/, unitTests)
+}
+
+var _ = BeforeSuite(suite.BeforeSuite)
+
+var _ = AfterSuite(suite.AfterSuite)

--- a/controllers/contentlibrary/v1alpha2/clustercontentlibraryitem/clustercontentlibraryitem_controller_unit_test.go
+++ b/controllers/contentlibrary/v1alpha2/clustercontentlibraryitem/clustercontentlibraryitem_controller_unit_test.go
@@ -1,0 +1,299 @@
+// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package clustercontentlibraryitem_test
+
+import (
+	goctx "context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	imgregv1a1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha1"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/api/v1alpha2/common"
+	"github.com/vmware-tanzu/vm-operator/controllers/contentlibrary/v1alpha2/clustercontentlibraryitem"
+	"github.com/vmware-tanzu/vm-operator/controllers/contentlibrary/v1alpha2/utils"
+	conditions "github.com/vmware-tanzu/vm-operator/pkg/conditions2"
+	"github.com/vmware-tanzu/vm-operator/pkg/context"
+	providerfake "github.com/vmware-tanzu/vm-operator/pkg/vmprovider/fake"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+func unitTests() {
+	Describe("Invoking ClusterContentLibraryItem controller unit tests", unitTestsReconcile)
+}
+
+func unitTestsReconcile() {
+	const firmwareValue = "my-firmware"
+
+	var (
+		ctx *builder.UnitTestContextForController
+
+		reconciler     *clustercontentlibraryitem.Reconciler
+		fakeVMProvider *providerfake.VMProviderA2
+
+		cclItem    *imgregv1a1.ClusterContentLibraryItem
+		cclItemCtx *context.ClusterContentLibraryItemContextA2
+	)
+
+	BeforeEach(func() {
+		ctx = suite.NewUnitTestContextForController()
+
+		reconciler = clustercontentlibraryitem.NewReconciler(
+			ctx.Client,
+			ctx.Logger,
+			ctx.Recorder,
+			ctx.VMProviderA2,
+		)
+
+		fakeVMProvider = ctx.VMProviderA2.(*providerfake.VMProviderA2)
+		fakeVMProvider.SyncVirtualMachineImageFn = func(_ goctx.Context, _, cvmiObj client.Object) error {
+			cvmi := cvmiObj.(*vmopv1.ClusterVirtualMachineImage)
+			// Use Firmware field to verify the provider function is called.
+			cvmi.Status.Firmware = firmwareValue
+			return nil
+		}
+
+		cclItem = utils.DummyClusterContentLibraryItem(utils.ItemFieldNamePrefix + "-dummy")
+		// Add our finalizer so ReconcileNormal() does not return early.
+		cclItem.Finalizers = []string{utils.ClusterContentLibraryItemVmopFinalizer}
+	})
+
+	JustBeforeEach(func() {
+		Expect(ctx.Client.Create(ctx, cclItem)).To(Succeed())
+
+		imageName, err := utils.GetImageFieldNameFromItem(cclItem.Name)
+		Expect(err).ToNot(HaveOccurred())
+
+		cclItemCtx = &context.ClusterContentLibraryItemContextA2{
+			Context:      ctx,
+			Logger:       ctx.Logger,
+			CCLItem:      cclItem,
+			ImageObjName: imageName,
+		}
+	})
+
+	AfterEach(func() {
+		ctx.AfterEach()
+		ctx = nil
+		cclItem = nil
+		reconciler = nil
+		fakeVMProvider.Reset()
+	})
+
+	Context("ReconcileNormal", func() {
+
+		When("ClusterContentLibraryItem doesn't have the VMOP finalizer", func() {
+
+			BeforeEach(func() {
+				cclItem.Finalizers = nil
+			})
+
+			It("should add the finalizer", func() {
+				Expect(reconciler.ReconcileNormal(cclItemCtx)).To(Succeed())
+
+				Expect(cclItem.Finalizers).To(ContainElement(utils.ClusterContentLibraryItemVmopFinalizer))
+			})
+		})
+
+		When("ClusterContentLibraryItem is Not Ready", func() {
+
+			BeforeEach(func() {
+				cclItem.Status.Conditions = []imgregv1a1.Condition{
+					{
+						Type:   imgregv1a1.ReadyCondition,
+						Status: corev1.ConditionFalse,
+					},
+				}
+			})
+
+			It("should mark ClusterVirtualMachineImage condition as provider not ready", func() {
+				Expect(reconciler.ReconcileNormal(cclItemCtx)).To(Succeed())
+
+				cvmi := getClusterVMI(ctx, cclItemCtx.ImageObjName)
+				condition := conditions.Get(cvmi, vmopv1.VirtualMachineImageProviderReadyCondition)
+				Expect(condition).ToNot(BeNil())
+				Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+				Expect(condition.Reason).To(Equal(vmopv1.VirtualMachineImageProviderNotReadyReason))
+			})
+		})
+
+		When("ClusterContentLibraryItem is not security compliant", func() {
+
+			BeforeEach(func() {
+				cclItem.Status.SecurityCompliance = pointer.Bool(false)
+			})
+
+			It("should mark ClusterVirtualMachineImage condition as provider security not compliant", func() {
+				Expect(reconciler.ReconcileNormal(cclItemCtx)).To(Succeed())
+
+				cvmi := getClusterVMI(ctx, cclItemCtx.ImageObjName)
+				condition := conditions.Get(cvmi, vmopv1.VirtualMachineImageProviderSecurityComplianceCondition)
+				Expect(condition).ToNot(BeNil())
+				Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+				Expect(condition.Reason).To(Equal(vmopv1.VirtualMachineImageProviderSecurityNotCompliantReason))
+			})
+		})
+
+		When("SyncVirtualMachineImage returns an error", func() {
+
+			BeforeEach(func() {
+				fakeVMProvider.SyncVirtualMachineImageFn = func(_ goctx.Context, _, _ client.Object) error {
+					return fmt.Errorf("sync-error")
+				}
+			})
+
+			It("should mark ClusterVirtualMachineImage condition synced failed", func() {
+				err := reconciler.ReconcileNormal(cclItemCtx)
+				Expect(err).To(MatchError("sync-error"))
+
+				cvmi := getClusterVMI(ctx, cclItemCtx.ImageObjName)
+				condition := conditions.Get(cvmi, vmopv1.VirtualMachineImageSyncedCondition)
+				Expect(condition).ToNot(BeNil())
+				Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+				Expect(condition.Reason).To(Equal(vmopv1.VirtualMachineImageNotSyncedReason))
+			})
+		})
+
+		When("ClusterContentLibraryItem is ready and security complaint", func() {
+
+			JustBeforeEach(func() {
+				// The DummyClusterContentLibraryItem() should meet these requirements.
+				var readyCond *imgregv1a1.Condition
+				for _, c := range cclItemCtx.CCLItem.Status.Conditions {
+					if c.Type == imgregv1a1.ReadyCondition {
+						c := c
+						readyCond = &c
+						break
+					}
+				}
+				Expect(readyCond).ToNot(BeNil())
+				Expect(readyCond.Status).To(Equal(corev1.ConditionTrue))
+
+				// BMV: We don't use this field - only the Condition.
+				// Expect(cclItemCtx.CCLItem.Status.Ready).To(BeTrue())
+
+				Expect(cclItemCtx.CCLItem.Status.SecurityCompliance).To(Equal(pointer.Bool(true)))
+			})
+
+			When("ClusterVirtualMachineImage resource has not been created yet", func() {
+
+				It("should create a new ClusterVirtualMachineImage syncing up with ClusterContentLibraryItem", func() {
+					Expect(reconciler.ReconcileNormal(cclItemCtx)).To(Succeed())
+
+					cvmi := getClusterVMI(ctx, cclItemCtx.ImageObjName)
+					assertCVMImageFromCCLItem(cvmi, cclItemCtx.CCLItem)
+					Expect(cvmi.Status.Firmware).To(Equal(firmwareValue))
+				})
+			})
+
+			When("ClusterVirtualMachineImage resource is exists but not up-to-date", func() {
+
+				JustBeforeEach(func() {
+					cvmi := &vmopv1.ClusterVirtualMachineImage{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: cclItemCtx.ImageObjName,
+						},
+						Spec: vmopv1.VirtualMachineImageSpec{
+							ProviderRef: common.LocalObjectRef{
+								Name: "bogus",
+							},
+						},
+						Status: vmopv1.VirtualMachineImageStatus{
+							ProviderContentVersion: "stale",
+							Firmware:               "should-be-updated",
+						},
+					}
+					Expect(ctx.Client.Create(ctx, cvmi)).To(Succeed())
+				})
+
+				It("should update the existing ClusterVirtualMachineImage with ClusterContentLibraryItem", func() {
+					cclItemCtx.CCLItem.Status.ContentVersion += "-updated"
+					Expect(reconciler.ReconcileNormal(cclItemCtx)).To(Succeed())
+
+					cvmi := getClusterVMI(ctx, cclItemCtx.ImageObjName)
+					assertCVMImageFromCCLItem(cvmi, cclItemCtx.CCLItem)
+					Expect(cvmi.Status.Firmware).To(Equal(firmwareValue))
+				})
+			})
+
+			When("ClusterVirtualMachineImage resource is created and already up-to-date", func() {
+
+				JustBeforeEach(func() {
+					cvmi := &vmopv1.ClusterVirtualMachineImage{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: cclItemCtx.ImageObjName,
+						},
+						Status: vmopv1.VirtualMachineImageStatus{
+							ProviderContentVersion: cclItemCtx.CCLItem.Status.ContentVersion,
+							Firmware:               "should-not-be-updated",
+						},
+					}
+					Expect(ctx.Client.Create(ctx, cvmi)).To(Succeed())
+				})
+
+				It("should skip updating the ClusterVirtualMachineImage with library item", func() {
+					fakeVMProvider.SyncVirtualMachineImageFn = func(_ goctx.Context, _, _ client.Object) error {
+						// Should not be called since the content versions match.
+						return fmt.Errorf("sync-error")
+					}
+
+					Expect(reconciler.ReconcileNormal(cclItemCtx)).To(Succeed())
+
+					cvmi := getClusterVMI(ctx, cclItemCtx.ImageObjName)
+					Expect(cvmi.Status.Firmware).To(Equal("should-not-be-updated"))
+				})
+			})
+		})
+	})
+
+	Context("ReconcileDelete", func() {
+
+		It("should remove the finalizer from ClusterContentLibraryItem resource", func() {
+			Expect(cclItem.Finalizers).To(ContainElement(utils.ClusterContentLibraryItemVmopFinalizer))
+
+			Expect(reconciler.ReconcileDelete(cclItemCtx)).To(Succeed())
+			Expect(cclItem.Finalizers).ToNot(ContainElement(utils.ClusterContentLibraryItemVmopFinalizer))
+		})
+	})
+}
+
+func getClusterVMI(ctx *builder.UnitTestContextForController, name string) *vmopv1.ClusterVirtualMachineImage {
+	cvmi := &vmopv1.ClusterVirtualMachineImage{}
+	Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: name}, cvmi)).To(Succeed())
+	return cvmi
+}
+
+func assertCVMImageFromCCLItem(
+	cvmi *vmopv1.ClusterVirtualMachineImage,
+	cclItem *imgregv1a1.ClusterContentLibraryItem) {
+
+	Expect(metav1.IsControlledBy(cvmi, cclItem)).To(BeTrue())
+	for k := range utils.FilterServicesTypeLabels(cclItem.Labels) {
+		Expect(cvmi.Labels).To(HaveKey(k))
+	}
+
+	By("Expected ClusterVMImage Spec", func() {
+		Expect(cvmi.Spec.ProviderRef.Name).To(Equal(cclItem.Name))
+		Expect(cvmi.Spec.ProviderRef.APIVersion).To(Equal(cclItem.APIVersion))
+		Expect(cvmi.Spec.ProviderRef.Kind).To(Equal(cclItem.Kind))
+	})
+
+	By("Expected ClusterVMImage Status", func() {
+		Expect(cvmi.Status.Name).To(Equal(cclItem.Status.Name))
+		Expect(cvmi.Status.ProviderItemID).To(BeEquivalentTo(cclItem.Spec.UUID))
+		Expect(cvmi.Status.ProviderContentVersion).To(Equal(cclItem.Status.ContentVersion))
+
+		Expect(conditions.IsTrue(cvmi, vmopv1.VirtualMachineImageProviderReadyCondition)).To(BeTrue())
+		Expect(conditions.IsTrue(cvmi, vmopv1.VirtualMachineImageProviderSecurityComplianceCondition)).To(BeTrue())
+		Expect(conditions.IsTrue(cvmi, vmopv1.VirtualMachineImageSyncedCondition)).To(BeTrue())
+	})
+}

--- a/controllers/contentlibrary/v1alpha2/contentlibraryitem/contentlibraryitem_controller.go
+++ b/controllers/contentlibrary/v1alpha2/contentlibraryitem/contentlibraryitem_controller.go
@@ -1,0 +1,269 @@
+// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package contentlibraryitem
+
+import (
+	goctx "context"
+	"fmt"
+	"reflect"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/go-logr/logr"
+
+	imgregv1a1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha1"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/api/v1alpha2/common"
+	"github.com/vmware-tanzu/vm-operator/controllers/contentlibrary/v1alpha2/utils"
+	conditions "github.com/vmware-tanzu/vm-operator/pkg/conditions2"
+	"github.com/vmware-tanzu/vm-operator/pkg/context"
+	metrics "github.com/vmware-tanzu/vm-operator/pkg/metrics2"
+	"github.com/vmware-tanzu/vm-operator/pkg/record"
+	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider"
+)
+
+// AddToManager adds this package's controller to the provided manager.
+func AddToManager(ctx *context.ControllerManagerContext, mgr manager.Manager) error {
+	var (
+		clItemType     = &imgregv1a1.ContentLibraryItem{}
+		clItemTypeName = reflect.TypeOf(clItemType).Elem().Name()
+
+		controllerNameShort = fmt.Sprintf("%s-controller", strings.ToLower(clItemTypeName))
+		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
+	)
+
+	r := NewReconciler(
+		mgr.GetClient(),
+		ctrl.Log.WithName("controllers").WithName(clItemTypeName),
+		record.New(mgr.GetEventRecorderFor(controllerNameLong)),
+		ctx.VMProviderA2,
+	)
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(clItemType).
+		// We do not set Owns(VirtualMachineImage) here as we call SetControllerReference()
+		// when creating such resources in the reconciling process below.
+		WithOptions(controller.Options{MaxConcurrentReconciles: ctx.MaxConcurrentReconciles}).
+		Complete(r)
+}
+
+func NewReconciler(
+	client client.Client,
+	logger logr.Logger,
+	recorder record.Recorder,
+	vmProvider vmprovider.VirtualMachineProviderInterfaceA2) *Reconciler {
+
+	return &Reconciler{
+		Client:     client,
+		Logger:     logger,
+		Recorder:   recorder,
+		VMProvider: vmProvider,
+		Metrics:    metrics.NewContentLibraryItemMetrics(),
+	}
+}
+
+// Reconciler reconciles an IaaS Image Registry Service's ContentLibraryItem object
+// by creating/updating the corresponding VM-Service's VirtualMachineImage resource.
+type Reconciler struct {
+	client.Client
+	Logger     logr.Logger
+	Recorder   record.Recorder
+	VMProvider vmprovider.VirtualMachineProviderInterfaceA2
+	Metrics    *metrics.ContentLibraryItemMetrics
+}
+
+// +kubebuilder:rbac:groups=imageregistry.vmware.com,resources=contentlibraryitems,verbs=get;list;watch;update;patch;delete
+// +kubebuilder:rbac:groups=imageregistry.vmware.com,resources=contentlibraryitems/status,verbs=get
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachineimages,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachineimages/status,verbs=get;update;patch
+
+func (r *Reconciler) Reconcile(ctx goctx.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
+	logger := r.Logger.WithValues("clItemName", req.Name, "namespace", req.Namespace)
+	logger.Info("Reconciling ContentLibraryItem")
+
+	clItem := &imgregv1a1.ContentLibraryItem{}
+	if err := r.Get(ctx, req.NamespacedName, clItem); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	vmiName, nameErr := utils.GetImageFieldNameFromItem(clItem.Name)
+	if nameErr != nil {
+		logger.Error(nameErr, "Unsupported ContentLibraryItem name, skip reconciling")
+		return ctrl.Result{}, nil
+	}
+	logger = logger.WithValues("vmiName", vmiName)
+
+	clItemCtx := &context.ContentLibraryItemContextA2{
+		Context:      ctx,
+		Logger:       logger,
+		CLItem:       clItem,
+		ImageObjName: vmiName,
+	}
+
+	if !clItem.DeletionTimestamp.IsZero() {
+		err := r.ReconcileDelete(clItemCtx)
+		return ctrl.Result{}, err
+	}
+
+	// Create or update the VirtualMachineImage resource accordingly.
+	err := r.ReconcileNormal(clItemCtx)
+	return ctrl.Result{}, err
+}
+
+// ReconcileDelete reconciles a deletion for a ContentLibraryItem resource.
+func (r *Reconciler) ReconcileDelete(ctx *context.ContentLibraryItemContextA2) error {
+	if controllerutil.ContainsFinalizer(ctx.CLItem, utils.ContentLibraryItemVmopFinalizer) {
+		r.Metrics.DeleteMetrics(ctx.Logger, ctx.ImageObjName, ctx.CLItem.Namespace)
+		controllerutil.RemoveFinalizer(ctx.CLItem, utils.ContentLibraryItemVmopFinalizer)
+		return r.Update(ctx, ctx.CLItem)
+	}
+
+	return nil
+}
+
+// ReconcileNormal reconciles a ContentLibraryItem resource by creating or
+// updating the corresponding VirtualMachineImage resource.
+func (r *Reconciler) ReconcileNormal(ctx *context.ContentLibraryItemContextA2) error {
+	if !controllerutil.ContainsFinalizer(ctx.CLItem, utils.ContentLibraryItemVmopFinalizer) {
+		// The finalizer must be present before proceeding in order to ensure ReconcileDelete() will be called.
+		// Return immediately after here to update the object and then we'll proceed on the next reconciliation.
+		controllerutil.AddFinalizer(ctx.CLItem, utils.ContentLibraryItemVmopFinalizer)
+		return r.Update(ctx, ctx.CLItem)
+	}
+
+	// Do not set additional fields here as they will be overwritten in CreateOrPatch below.
+	vmi := &vmopv1.VirtualMachineImage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ctx.ImageObjName,
+			Namespace: ctx.CLItem.Namespace,
+		},
+	}
+	ctx.VMI = vmi
+
+	var didSync bool
+	var syncErr error
+	var savedStatus *vmopv1.VirtualMachineImageStatus
+
+	opRes, createOrPatchErr := controllerutil.CreateOrPatch(ctx, r.Client, vmi, func() error {
+		defer func() {
+			savedStatus = vmi.Status.DeepCopy()
+		}()
+
+		if err := r.setUpVMIFromCLItem(ctx); err != nil {
+			ctx.Logger.Error(err, "Failed to set up VirtualMachineImage from ContentLibraryItem")
+			return err
+		}
+
+		// Check if the item is ready and skip the image content sync if not.
+		if !utils.IsItemReady(ctx.CLItem.Status.Conditions) {
+			conditions.MarkFalse(vmi,
+				vmopv1.VirtualMachineImageProviderReadyCondition,
+				vmopv1.VirtualMachineImageProviderNotReadyReason,
+				"Provider item is not in ready condition",
+			)
+			ctx.Logger.Info("ContentLibraryItem is not ready yet, skipping image content sync")
+		} else {
+			conditions.MarkTrue(vmi, vmopv1.VirtualMachineImageProviderReadyCondition)
+			syncErr = r.syncImageContent(ctx)
+			didSync = true
+		}
+
+		// Do not return syncErr here as we still want to patch the updated fields we get above.
+		return nil
+	})
+
+	ctx.Logger = ctx.Logger.WithValues("operationResult", opRes)
+
+	// Registry metrics based on the corresponding error captured.
+	defer func() {
+		r.Metrics.RegisterVMIResourceResolve(ctx.Logger, vmi.Name, vmi.Namespace, createOrPatchErr == nil)
+		r.Metrics.RegisterVMIContentSync(ctx.Logger, vmi.Name, vmi.Namespace, didSync && syncErr == nil)
+	}()
+
+	if createOrPatchErr != nil {
+		ctx.Logger.Error(createOrPatchErr, "failed to create or patch VirtualMachineImage resource")
+		return createOrPatchErr
+	}
+
+	// CreateOrPatch/CreateOrUpdate doesn't patch sub-resource for creation.
+	if opRes == controllerutil.OperationResultCreated {
+		vmi.Status = *savedStatus
+		if createOrPatchErr = r.Status().Update(ctx, vmi); createOrPatchErr != nil {
+			ctx.Logger.Error(createOrPatchErr, "Failed to update VirtualMachineImage status")
+			return createOrPatchErr
+		}
+	}
+
+	if syncErr != nil {
+		ctx.Logger.Error(syncErr, "Failed to sync VirtualMachineImage to the latest content version")
+		return syncErr
+	}
+
+	ctx.Logger.Info("Successfully reconciled VirtualMachineImage", "contentVersion", savedStatus.ProviderContentVersion)
+	return nil
+}
+
+// setUpVMIFromCLItem sets up the VirtualMachineImage fields that
+// are retrievable from the given ContentLibraryItem resource.
+func (r *Reconciler) setUpVMIFromCLItem(ctx *context.ContentLibraryItemContextA2) error {
+	clItem := ctx.CLItem
+	vmi := ctx.VMI
+	if err := controllerutil.SetControllerReference(clItem, vmi, r.Scheme()); err != nil {
+		return err
+	}
+
+	vmi.Spec.ProviderRef = common.LocalObjectRef{
+		APIVersion: clItem.APIVersion,
+		Kind:       clItem.Kind,
+		Name:       clItem.Name,
+	}
+	vmi.Status.Name = clItem.Status.Name
+	vmi.Status.ProviderItemID = string(clItem.Spec.UUID)
+
+	// Update image condition based on the security compliance of the provider item.
+	clItemSecurityCompliance := ctx.CLItem.Status.SecurityCompliance
+	if clItemSecurityCompliance == nil || !*clItemSecurityCompliance {
+		conditions.MarkFalse(vmi,
+			vmopv1.VirtualMachineImageProviderSecurityComplianceCondition,
+			vmopv1.VirtualMachineImageProviderSecurityNotCompliantReason,
+			"Provider item is not security compliant",
+		)
+	} else {
+		conditions.MarkTrue(vmi, vmopv1.VirtualMachineImageProviderSecurityComplianceCondition)
+	}
+
+	return nil
+}
+
+// syncImageContent syncs the VirtualMachineImage content from the provider.
+// It skips syncing if the image content is already up-to-date.
+func (r *Reconciler) syncImageContent(ctx *context.ContentLibraryItemContextA2) error {
+	clItem := ctx.CLItem
+	vmi := ctx.VMI
+	latestVersion := clItem.Status.ContentVersion
+	if vmi.Status.ProviderContentVersion == latestVersion {
+		return nil
+	}
+
+	err := r.VMProvider.SyncVirtualMachineImage(ctx, clItem, vmi)
+	if err != nil {
+		conditions.MarkFalse(vmi,
+			vmopv1.VirtualMachineImageSyncedCondition,
+			vmopv1.VirtualMachineImageNotSyncedReason,
+			"Failed to sync to the latest content version from provider")
+	} else {
+		conditions.MarkTrue(vmi, vmopv1.VirtualMachineImageSyncedCondition)
+		vmi.Status.ProviderContentVersion = latestVersion
+	}
+
+	r.Recorder.EmitEvent(vmi, "Update", err, false)
+	return err
+}

--- a/controllers/contentlibrary/v1alpha2/contentlibraryitem/contentlibraryitem_controller_intg_test.go
+++ b/controllers/contentlibrary/v1alpha2/contentlibraryitem/contentlibraryitem_controller_intg_test.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package contentlibraryitem_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/google/uuid"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+
+	imgregv1a1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha1"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/controllers/contentlibrary/v1alpha2/utils"
+	conditions "github.com/vmware-tanzu/vm-operator/pkg/conditions2"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+func intgTests() {
+	Describe("Invoking ContentLibraryItem controller integration tests", clItemReconcile)
+}
+
+func clItemReconcile() {
+	const firmwareValue = "my-firmware"
+
+	var (
+		ctx *builder.IntegrationTestContext
+	)
+
+	waitForContentLibraryItemFinalizer := func(objKey client.ObjectKey) {
+		Eventually(func(g Gomega) {
+			item := &imgregv1a1.ContentLibraryItem{}
+			g.Expect(ctx.Client.Get(ctx, objKey, item)).To(Succeed())
+			g.Expect(item.Finalizers).To(ContainElement(utils.ContentLibraryItemVmopFinalizer))
+		}).Should(Succeed(), "waiting for ContentLibraryItem finalizer")
+	}
+
+	waitForVirtualMachineImageNotReady := func(objKey client.ObjectKey) {
+		Eventually(func(g Gomega) {
+			image := &vmopv1.VirtualMachineImage{}
+			g.Expect(ctx.Client.Get(ctx, objKey, image)).To(Succeed())
+
+			readyCond := conditions.Get(image, vmopv1.VirtualMachineImageProviderReadyCondition)
+			g.Expect(readyCond).ToNot(BeNil())
+			g.Expect(readyCond.Status).To(Equal(metav1.ConditionFalse))
+		}).Should(Succeed(), "waiting for VirtualMachineImage to be not ready")
+	}
+
+	waitForVirtualMachineImageReady := func(objKey client.ObjectKey) {
+		Eventually(func(g Gomega) {
+			image := &vmopv1.VirtualMachineImage{}
+			g.Expect(ctx.Client.Get(ctx, objKey, image)).To(Succeed())
+			g.Expect(conditions.IsTrue(image, vmopv1.VirtualMachineImageProviderReadyCondition))
+			// Assert that SyncVirtualMachineImage() has been called too.
+			g.Expect(image.Status.Firmware).To(Equal(firmwareValue))
+		}).Should(Succeed(), "waiting for VirtualMachineImage to be sync'd and ready")
+	}
+
+	BeforeEach(func() {
+		ctx = suite.NewIntegrationTestContext()
+
+		intgFakeVMProvider.Lock()
+		intgFakeVMProvider.SyncVirtualMachineImageFn = func(_ context.Context, _, vmiObj client.Object) error {
+			vmi := vmiObj.(*vmopv1.VirtualMachineImage)
+			// Use Firmware field to verify the provider function is called.
+			vmi.Status.Firmware = firmwareValue
+			return nil
+		}
+		intgFakeVMProvider.Unlock()
+	})
+
+	AfterEach(func() {
+		ctx.AfterEach()
+		ctx = nil
+		intgFakeVMProvider.Reset()
+	})
+
+	Context("Reconcile ContentLibraryItem", func() {
+
+		It("Workflow", func() {
+			origCLItem := utils.DummyContentLibraryItem(utils.ItemFieldNamePrefix+"-"+uuid.NewString(), ctx.Namespace)
+			clItemKey := client.ObjectKeyFromObject(origCLItem)
+			Expect(ctx.Client.Create(ctx, origCLItem.DeepCopy())).To(Succeed())
+
+			imageName, err := utils.GetImageFieldNameFromItem(clItemKey.Name)
+			Expect(err).ToNot(HaveOccurred())
+			vmiKey := client.ObjectKey{Name: imageName}
+
+			By("Finalizer should be added to ContentLibraryItem", func() {
+				waitForContentLibraryItemFinalizer(clItemKey)
+			})
+
+			By("VirtualMachineImage is created but not ready", func() {
+				waitForVirtualMachineImageNotReady(vmiKey)
+			})
+
+			clItem := &imgregv1a1.ContentLibraryItem{}
+			By("Update ContentLibraryItem to populate Status and be Ready", func() {
+				Expect(ctx.Client.Get(ctx, clItemKey, clItem)).To(Succeed())
+				clItem.Status = origCLItem.Status
+				Expect(ctx.Client.Status().Update(ctx, clItem)).To(Succeed())
+			})
+
+			By("VirtualMachineImage becomes ready", func() {
+				waitForVirtualMachineImageReady(vmiKey)
+			})
+
+			/* The non-caching ctx.Client.Get() won't populate these fields. */
+			gvk, err := apiutil.GVKForObject(clItem, ctx.Client.Scheme())
+			Expect(err).ToNot(HaveOccurred())
+			clItem.APIVersion, clItem.Kind = gvk.ToAPIVersionAndKind()
+
+			image := &vmopv1.VirtualMachineImage{}
+			Expect(ctx.Client.Get(ctx, vmiKey, image)).To(Succeed())
+			assertVMImageFromCLItem(image, clItem)
+
+			By("ContentLibraryItem has new content version", func() {
+				Expect(ctx.Client.Get(ctx, clItemKey, clItem)).To(Succeed())
+				clItem.Status.ContentVersion += "-new-version"
+				Expect(ctx.Client.Status().Update(ctx, clItem)).To(Succeed())
+			})
+
+			By("VirtualMachineImage should be updated with new content version", func() {
+				Eventually(func(g Gomega) {
+					g.Expect(ctx.Client.Get(ctx, vmiKey, image)).To(Succeed())
+					g.Expect(image.Status.ProviderContentVersion).To(Equal(clItem.Status.ContentVersion))
+				}).Should(Succeed())
+
+				clItem.APIVersion, clItem.Kind = gvk.ToAPIVersionAndKind()
+				assertVMImageFromCLItem(image, clItem)
+			})
+		})
+	})
+}

--- a/controllers/contentlibrary/v1alpha2/contentlibraryitem/contentlibraryitem_controller_suite_test.go
+++ b/controllers/contentlibrary/v1alpha2/contentlibraryitem/contentlibraryitem_controller_suite_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package contentlibraryitem_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/vmware-tanzu/vm-operator/controllers/contentlibrary/v1alpha2/contentlibraryitem"
+	ctrlContext "github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/lib"
+	providerfake "github.com/vmware-tanzu/vm-operator/pkg/vmprovider/fake"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+var intgFakeVMProvider = providerfake.NewVMProviderA2()
+
+var suite = builder.NewTestSuiteForControllerWithFSS(
+	contentlibraryitem.AddToManager,
+	func(ctx *ctrlContext.ControllerManagerContext, _ ctrlmgr.Manager) error {
+		ctx.VMProviderA2 = intgFakeVMProvider
+		return nil
+	},
+	map[string]bool{lib.VMImageRegistryFSS: true},
+)
+
+func TestContentLibraryItem(t *testing.T) {
+	_ = intgTests
+	suite.Register(t, "ContentLibraryItem controller suite", nil /*intgTests*/, unitTests)
+}
+
+var _ = BeforeSuite(suite.BeforeSuite)
+
+var _ = AfterSuite(suite.AfterSuite)

--- a/controllers/contentlibrary/v1alpha2/contentlibraryitem/contentlibraryitem_controller_unit_test.go
+++ b/controllers/contentlibrary/v1alpha2/contentlibraryitem/contentlibraryitem_controller_unit_test.go
@@ -1,0 +1,300 @@
+// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package contentlibraryitem_test
+
+import (
+	goctx "context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	imgregv1a1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha1"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/api/v1alpha2/common"
+	"github.com/vmware-tanzu/vm-operator/controllers/contentlibrary/v1alpha2/contentlibraryitem"
+	"github.com/vmware-tanzu/vm-operator/controllers/contentlibrary/v1alpha2/utils"
+	conditions "github.com/vmware-tanzu/vm-operator/pkg/conditions2"
+	"github.com/vmware-tanzu/vm-operator/pkg/context"
+	providerfake "github.com/vmware-tanzu/vm-operator/pkg/vmprovider/fake"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+func unitTests() {
+	Describe("Invoking ContentLibraryItem controller unit tests", unitTestsReconcile)
+}
+
+func unitTestsReconcile() {
+	const firmwareValue = "my-firmware"
+
+	var (
+		ctx *builder.UnitTestContextForController
+
+		reconciler     *contentlibraryitem.Reconciler
+		fakeVMProvider *providerfake.VMProviderA2
+
+		clItem    *imgregv1a1.ContentLibraryItem
+		clItemCtx *context.ContentLibraryItemContextA2
+	)
+
+	BeforeEach(func() {
+		ctx = suite.NewUnitTestContextForController()
+
+		reconciler = contentlibraryitem.NewReconciler(
+			ctx.Client,
+			ctx.Logger,
+			ctx.Recorder,
+			ctx.VMProviderA2,
+		)
+
+		fakeVMProvider = ctx.VMProviderA2.(*providerfake.VMProviderA2)
+
+		fakeVMProvider.SyncVirtualMachineImageFn = func(_ goctx.Context, _, vmiObj client.Object) error {
+			vmi := vmiObj.(*vmopv1.VirtualMachineImage)
+
+			// Use Firmware field to verify the provider function is called.
+			vmi.Status.Firmware = firmwareValue
+			return nil
+		}
+
+		clItem = utils.DummyContentLibraryItem(utils.ItemFieldNamePrefix+"-dummy", "dummy-ns")
+		clItem.Finalizers = []string{utils.ContentLibraryItemVmopFinalizer}
+	})
+
+	JustBeforeEach(func() {
+		Expect(ctx.Client.Create(ctx, clItem)).To(Succeed())
+
+		imageName, err := utils.GetImageFieldNameFromItem(clItem.Name)
+		Expect(err).ToNot(HaveOccurred())
+
+		clItemCtx = &context.ContentLibraryItemContextA2{
+			Context:      ctx,
+			Logger:       ctx.Logger,
+			CLItem:       clItem,
+			ImageObjName: imageName,
+		}
+	})
+
+	AfterEach(func() {
+		ctx.AfterEach()
+		ctx = nil
+		clItem = nil
+		reconciler = nil
+		fakeVMProvider.Reset()
+	})
+
+	Context("ReconcileNormal", func() {
+
+		When("ContentLibraryItem doesn't have the VMOP finalizer", func() {
+			BeforeEach(func() {
+				clItem.Finalizers = nil
+			})
+
+			It("should add the finalizer", func() {
+				Expect(reconciler.ReconcileNormal(clItemCtx)).To(Succeed())
+
+				Expect(clItem.Finalizers).To(ContainElement(utils.ContentLibraryItemVmopFinalizer))
+			})
+		})
+
+		When("ContentLibraryItem is Not Ready", func() {
+			BeforeEach(func() {
+				clItem.Status.Conditions = []imgregv1a1.Condition{
+					{
+						Type:   imgregv1a1.ReadyCondition,
+						Status: corev1.ConditionFalse,
+					},
+				}
+			})
+
+			It("should mark VirtualMachineImage condition as provider not ready", func() {
+				Expect(reconciler.ReconcileNormal(clItemCtx)).To(Succeed())
+
+				vmi := getVMI(ctx, clItemCtx)
+				condition := conditions.Get(vmi, vmopv1.VirtualMachineImageProviderReadyCondition)
+				Expect(condition).ToNot(BeNil())
+				Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+				Expect(condition.Reason).To(Equal(vmopv1.VirtualMachineImageProviderNotReadyReason))
+			})
+		})
+
+		When("ContentLibraryItem is not security compliant", func() {
+
+			BeforeEach(func() {
+				clItem.Status.SecurityCompliance = pointer.Bool(false)
+			})
+
+			It("should mark VirtualMachineImage condition as provider security not compliant", func() {
+				Expect(reconciler.ReconcileNormal(clItemCtx)).To(Succeed())
+
+				vmi := getVMI(ctx, clItemCtx)
+				condition := conditions.Get(vmi, vmopv1.VirtualMachineImageProviderSecurityComplianceCondition)
+				Expect(condition).ToNot(BeNil())
+				Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+				Expect(condition.Reason).To(Equal(vmopv1.VirtualMachineImageProviderSecurityNotCompliantReason))
+			})
+		})
+
+		When("SyncVirtualMachineImage returns an error", func() {
+
+			BeforeEach(func() {
+				fakeVMProvider.SyncVirtualMachineImageFn = func(_ goctx.Context, _, _ client.Object) error {
+					return fmt.Errorf("sync-error")
+				}
+			})
+
+			It("should mark VirtualMachineImage condition synced failed", func() {
+				err := reconciler.ReconcileNormal(clItemCtx)
+				Expect(err).To(MatchError("sync-error"))
+
+				vmi := getVMI(ctx, clItemCtx)
+				condition := conditions.Get(vmi, vmopv1.VirtualMachineImageSyncedCondition)
+				Expect(condition).ToNot(BeNil())
+				Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+				Expect(condition.Reason).To(Equal(vmopv1.VirtualMachineImageNotSyncedReason))
+			})
+		})
+
+		When("ContentLibraryItem is ready and security complaint", func() {
+
+			JustBeforeEach(func() {
+				// The DummyContentLibraryItem() should meet these requirements.
+				var readyCond *imgregv1a1.Condition
+				for _, c := range clItemCtx.CLItem.Status.Conditions {
+					if c.Type == imgregv1a1.ReadyCondition {
+						c := c
+						readyCond = &c
+						break
+					}
+				}
+				Expect(readyCond).ToNot(BeNil())
+				Expect(readyCond.Status).To(Equal(corev1.ConditionTrue))
+
+				// BMV: We don't use this field - only the Condition.
+				// Expect(clItemCtx.CLItem.Status.Ready).To(BeTrue())
+
+				Expect(clItemCtx.CLItem.Status.SecurityCompliance).To(Equal(pointer.Bool(true)))
+			})
+
+			When("VirtualMachineImage resource has not been created yet", func() {
+
+				It("should create a new VirtualMachineImage syncing up with ContentLibraryItem", func() {
+					Expect(reconciler.ReconcileNormal(clItemCtx)).To(Succeed())
+
+					vmi := getVMI(ctx, clItemCtx)
+					assertVMImageFromCLItem(vmi, clItemCtx.CLItem)
+					Expect(vmi.Status.Firmware).To(Equal(firmwareValue))
+				})
+			})
+
+			When("VirtualMachineImage resource is exists but not up-to-date", func() {
+
+				JustBeforeEach(func() {
+					vmi := &vmopv1.VirtualMachineImage{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      clItemCtx.ImageObjName,
+							Namespace: clItem.Namespace,
+						},
+						Spec: vmopv1.VirtualMachineImageSpec{
+							ProviderRef: common.LocalObjectRef{
+								Name: "bogus",
+							},
+						},
+						Status: vmopv1.VirtualMachineImageStatus{
+							ProviderContentVersion: "stale",
+							Firmware:               "should-be-updated",
+						},
+					}
+					Expect(ctx.Client.Create(ctx, vmi)).To(Succeed())
+				})
+
+				It("should update the existing VirtualMachineImage with ContentLibraryItem", func() {
+					clItemCtx.CLItem.Status.ContentVersion += "-updated"
+					Expect(reconciler.ReconcileNormal(clItemCtx)).To(Succeed())
+
+					vmi := getVMI(ctx, clItemCtx)
+					assertVMImageFromCLItem(vmi, clItemCtx.CLItem)
+					Expect(vmi.Status.Firmware).To(Equal(firmwareValue))
+				})
+			})
+
+			When("VirtualMachineImage resource is created and already up-to-date", func() {
+
+				JustBeforeEach(func() {
+					vmi := &vmopv1.VirtualMachineImage{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      clItemCtx.ImageObjName,
+							Namespace: clItemCtx.CLItem.Namespace,
+						},
+						Status: vmopv1.VirtualMachineImageStatus{
+							ProviderContentVersion: clItemCtx.CLItem.Status.ContentVersion,
+							Firmware:               "should-not-be-updated",
+						},
+					}
+					Expect(ctx.Client.Create(ctx, vmi)).To(Succeed())
+				})
+
+				It("should skip updating the VirtualMachineImage with library item", func() {
+					fakeVMProvider.SyncVirtualMachineImageFn = func(_ goctx.Context, _, _ client.Object) error {
+						// Should not be called since the content versions match.
+						return fmt.Errorf("sync-error")
+					}
+
+					Expect(reconciler.ReconcileNormal(clItemCtx)).To(Succeed())
+
+					vmi := getVMI(ctx, clItemCtx)
+					Expect(vmi.Status.Firmware).To(Equal("should-not-be-updated"))
+				})
+			})
+		})
+	})
+
+	Context("ReconcileDelete", func() {
+
+		It("should remove the finalizer from ContentLibraryItem resource", func() {
+			Expect(clItem.Finalizers).To(ContainElement(utils.ContentLibraryItemVmopFinalizer))
+
+			Expect(reconciler.ReconcileDelete(clItemCtx)).To(Succeed())
+			Expect(clItem.Finalizers).ToNot(ContainElement(utils.ContentLibraryItemVmopFinalizer))
+		})
+	})
+}
+
+func getVMI(
+	ctx *builder.UnitTestContextForController,
+	clItemCtx *context.ContentLibraryItemContextA2) *vmopv1.VirtualMachineImage {
+
+	vmi := &vmopv1.VirtualMachineImage{}
+	Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: clItemCtx.ImageObjName, Namespace: clItemCtx.CLItem.Namespace}, vmi)).To(Succeed())
+	return vmi
+}
+
+func assertVMImageFromCLItem(
+	vmi *vmopv1.VirtualMachineImage,
+	clItem *imgregv1a1.ContentLibraryItem) {
+
+	Expect(metav1.IsControlledBy(vmi, clItem)).To(BeTrue())
+
+	By("Expected VMImage Spec", func() {
+		Expect(vmi.Spec.ProviderRef.Name).To(Equal(clItem.Name))
+		Expect(vmi.Spec.ProviderRef.APIVersion).To(Equal(clItem.APIVersion))
+		Expect(vmi.Spec.ProviderRef.Kind).To(Equal(clItem.Kind))
+	})
+
+	By("Expected VMImage Status", func() {
+		Expect(vmi.Status.Name).To(Equal(clItem.Status.Name))
+		Expect(vmi.Status.ProviderItemID).To(BeEquivalentTo(clItem.Spec.UUID))
+		Expect(vmi.Status.ProviderContentVersion).To(Equal(clItem.Status.ContentVersion))
+
+		Expect(conditions.IsTrue(vmi, vmopv1.VirtualMachineImageProviderReadyCondition)).To(BeTrue())
+		Expect(conditions.IsTrue(vmi, vmopv1.VirtualMachineImageProviderSecurityComplianceCondition)).To(BeTrue())
+		Expect(conditions.IsTrue(vmi, vmopv1.VirtualMachineImageSyncedCondition)).To(BeTrue())
+	})
+}

--- a/controllers/contentlibrary/v1alpha2/controllers.go
+++ b/controllers/contentlibrary/v1alpha2/controllers.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha2
+
+import (
+	"github.com/pkg/errors"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/vmware-tanzu/vm-operator/controllers/contentlibrary/v1alpha2/clustercontentlibraryitem"
+	"github.com/vmware-tanzu/vm-operator/controllers/contentlibrary/v1alpha2/contentlibraryitem"
+	"github.com/vmware-tanzu/vm-operator/pkg/context"
+)
+
+// AddToManager adds the controllers to the provided manager.
+func AddToManager(ctx *context.ControllerManagerContext, mgr manager.Manager) error {
+	if err := clustercontentlibraryitem.AddToManager(ctx, mgr); err != nil {
+		return errors.Wrap(err, "failed to initialize ClusterContentLibraryItem controller")
+	}
+	if err := contentlibraryitem.AddToManager(ctx, mgr); err != nil {
+		return errors.Wrap(err, "failed to initialize ContentLibraryItem controller")
+	}
+
+	return nil
+}

--- a/controllers/contentlibrary/v1alpha2/utils/constants.go
+++ b/controllers/contentlibrary/v1alpha2/utils/constants.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+const (
+	ItemFieldNamePrefix           = "clitem"
+	ImageFieldNamePrefix          = "vmi"
+	ClusterContentLibraryKind     = "ClusterContentLibrary"
+	ClusterContentLibraryItemKind = "ClusterContentLibraryItem"
+	ContentLibraryKind            = "ContentLibrary"
+	ContentLibraryItemKind        = "ContentLibraryItem"
+
+	ContentLibraryItemVmopFinalizer        = "contentlibraryitem.vmoperator.vmware.com"
+	ClusterContentLibraryItemVmopFinalizer = "clustercontentlibraryitem.vmoperator.vmware.com"
+)

--- a/controllers/contentlibrary/v1alpha2/utils/test_utils.go
+++ b/controllers/contentlibrary/v1alpha2/utils/test_utils.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	imgregv1a1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha1"
+)
+
+// ContentLibraryServiceTypeLabelKey is used to differentiate a TKG resource from a VM service resource.
+const ContentLibraryServiceTypeLabelKey = "type.services.vmware.com/tkg"
+
+func DummyClusterContentLibraryItem(name string) *imgregv1a1.ClusterContentLibraryItem {
+	cclItem := &imgregv1a1.ClusterContentLibraryItem{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       ClusterContentLibraryItemKind,
+			APIVersion: imgregv1a1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				ContentLibraryServiceTypeLabelKey: "",
+				"dummy-not-service-label":         "",
+			},
+		},
+		Spec: imgregv1a1.ContentLibraryItemSpec{
+			UUID: "dummy-ccl-item-uuid",
+		},
+		Status: imgregv1a1.ContentLibraryItemStatus{
+			Type:           imgregv1a1.ContentLibraryItemTypeOvf,
+			Name:           "dummy-image-name",
+			ContentVersion: "dummy-content-version",
+			ContentLibraryRef: &imgregv1a1.NameAndKindRef{
+				Kind: ClusterContentLibraryKind,
+				Name: "dummy-ccl-name",
+			},
+			Conditions: []imgregv1a1.Condition{
+				{
+					Type:   imgregv1a1.ReadyCondition,
+					Status: corev1.ConditionTrue,
+				},
+			},
+			SecurityCompliance: &[]bool{true}[0],
+		},
+	}
+
+	return cclItem
+}
+
+func DummyContentLibraryItem(name, namespace string) *imgregv1a1.ContentLibraryItem {
+	clItem := &imgregv1a1.ContentLibraryItem{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       ContentLibraryItemKind,
+			APIVersion: imgregv1a1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: imgregv1a1.ContentLibraryItemSpec{
+			UUID: "dummy-cl-item-uuid",
+		},
+		Status: imgregv1a1.ContentLibraryItemStatus{
+			Type:           imgregv1a1.ContentLibraryItemTypeOvf,
+			Name:           "dummy-image-name",
+			ContentVersion: "dummy-content-version",
+			ContentLibraryRef: &imgregv1a1.NameAndKindRef{
+				Kind: ContentLibraryKind,
+				Name: "cl-dummy",
+			},
+			Conditions: []imgregv1a1.Condition{
+				{
+					Type:   imgregv1a1.ReadyCondition,
+					Status: corev1.ConditionTrue,
+				},
+			},
+			SecurityCompliance: &[]bool{true}[0],
+		},
+	}
+
+	return clItem
+}
+
+func FilterServicesTypeLabels(labels map[string]string) map[string]string {
+	filtered := make(map[string]string)
+
+	// Only watch for service type labels
+	for label := range labels {
+		if strings.HasPrefix(label, "type.services.vmware.com/") {
+			filtered[label] = ""
+		}
+	}
+	return filtered
+}

--- a/controllers/contentlibrary/v1alpha2/utils/utils.go
+++ b/controllers/contentlibrary/v1alpha2/utils/utils.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+
+	imgregv1a1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha1"
+)
+
+// GetImageFieldNameFromItem returns the Image field name in format of "vmi-<uuid>"
+// by using the same identifier from the given Item name in "clitem-<uuid>".
+func GetImageFieldNameFromItem(itemName string) (string, error) {
+	if !strings.HasPrefix(itemName, ItemFieldNamePrefix) {
+		return "", fmt.Errorf("item name doesn't start with %q", ItemFieldNamePrefix)
+	}
+	itemNameSplit := strings.Split(itemName, "-")
+	if len(itemNameSplit) < 2 {
+		return "", fmt.Errorf("item name doesn't have an identifier after %s-", ItemFieldNamePrefix)
+	}
+
+	uuid := strings.Join(itemNameSplit[1:], "-")
+	return fmt.Sprintf("%s-%s", ImageFieldNamePrefix, uuid), nil
+}
+
+// IsItemReady returns if the given item conditions contain a Ready condition with status True.
+func IsItemReady(itemConditions imgregv1a1.Conditions) bool {
+	var isReady bool
+	for _, condition := range itemConditions {
+		if condition.Type == imgregv1a1.ReadyCondition {
+			isReady = condition.Status == corev1.ConditionTrue
+			break
+		}
+	}
+
+	return isReady
+}

--- a/controllers/virtualmachine/controllers.go
+++ b/controllers/virtualmachine/controllers.go
@@ -7,10 +7,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachine/v1alpha1"
+	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachine/v1alpha2"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 )
 
 // AddToManager adds the controller to the provided manager.
 func AddToManager(ctx *context.ControllerManagerContext, mgr manager.Manager) error {
+	if lib.IsVMServiceV1Alpha2FSSEnabled() {
+		return v1alpha2.AddToManager(ctx, mgr)
+	}
 	return v1alpha1.AddToManager(ctx, mgr)
 }

--- a/controllers/virtualmachine/v1alpha2/virtualmachine_controller.go
+++ b/controllers/virtualmachine/v1alpha2/virtualmachine_controller.go
@@ -1,0 +1,344 @@
+// Copyright (c) 2019-2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha2
+
+import (
+	goctx "context"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+
+	conditions "github.com/vmware-tanzu/vm-operator/pkg/conditions2"
+	"github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/lib"
+	metrics "github.com/vmware-tanzu/vm-operator/pkg/metrics2"
+	patch "github.com/vmware-tanzu/vm-operator/pkg/patch2"
+	prober "github.com/vmware-tanzu/vm-operator/pkg/prober2"
+	"github.com/vmware-tanzu/vm-operator/pkg/record"
+	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
+	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider"
+)
+
+const (
+	finalizerName = "virtualmachine.vmoperator.vmware.com"
+
+	// vmClassControllerName is the name of the controller specified in a
+	// VirtualMachineClass resource's field spec.controllerName field that
+	// indicates a VM pointing to that VM Class should be reconciled by this
+	// controller.
+	vmClassControllerName = "vmoperator.vmware.com/vsphere"
+)
+
+var (
+	// isDefaultVMClassController is used to configure watches and predicates
+	// for the controller. If a VirtualMachineClass resource's
+	// spec.controllerName field is missing or empty, this controller will
+	// consider that VM Class as long as isDefaultVMClassController is true.
+	isDefaultVMClassController = vmClassControllerName ==
+		lib.GetDefaultVirtualMachineClassControllerName()
+)
+
+// AddToManager adds this package's controller to the provided manager.
+func AddToManager(ctx *context.ControllerManagerContext, mgr manager.Manager) error {
+	var (
+		controlledType     = &vmopv1.VirtualMachine{}
+		controlledTypeName = reflect.TypeOf(controlledType).Elem().Name()
+
+		controllerNameShort = fmt.Sprintf("%s-controller", strings.ToLower(controlledTypeName))
+		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
+	)
+
+	proberManager, err := prober.AddToManager(mgr, ctx.VMProviderA2)
+	if err != nil {
+		return err
+	}
+
+	r := NewReconciler(
+		mgr.GetClient(),
+		ctrl.Log.WithName("controllers").WithName(controlledTypeName),
+		record.New(mgr.GetEventRecorderFor(controllerNameLong)),
+		ctx.VMProviderA2,
+		proberManager,
+		ctx.MaxConcurrentReconciles/(100/lib.MaxConcurrentCreateVMsOnProvider()),
+	)
+
+	builder := ctrl.NewControllerManagedBy(mgr).
+		For(controlledType).
+		WithOptions(controller.Options{MaxConcurrentReconciles: ctx.MaxConcurrentReconciles})
+
+	builder = builder.Watches(&source.Kind{Type: &vmopv1.VirtualMachineClass{}},
+		handler.EnqueueRequestsFromMapFunc(classToVMMapperFn(ctx, r.Client)))
+
+	// Filter any VMs that reference a VM Class with a spec.controllerName set
+	// to a non-empty value other than "vmoperator.vmware.com/vsphere". Please
+	// note that a VM will *not* be filtered if the VM Class does not exist. A
+	// VM is also not filtered if the field spec.controllerName is missing or
+	// empty as long as the default VM Class controller is
+	// "vmoperator.vmware.com/vsphere".
+	builder = builder.WithEventFilter(
+		kubeutil.VMForControllerPredicate(
+			r.Client,
+			// These events can be very verbose, so be careful to not log them
+			// at too high of a log level.
+			r.Logger.WithName("VMForControllerPredicate").V(8),
+			vmClassControllerName,
+			kubeutil.VMForControllerPredicateOptions{
+				MatchIfVMClassNotFound:            true,
+				MatchIfControllerNameFieldEmpty:   isDefaultVMClassController,
+				MatchIfControllerNameFieldMissing: isDefaultVMClassController,
+			}))
+
+	return builder.Complete(r)
+}
+
+// classToVMMapperFn returns a mapper function that can be used to queue reconcile request
+// for the VirtualMachines in response to an event on the VirtualMachineClass resource when
+// WCP_Namespaced_VM_Class FSS is enabled.
+func classToVMMapperFn(ctx *context.ControllerManagerContext, c client.Client) func(o client.Object) []reconcile.Request {
+	// For a given VirtualMachineClass, return reconcile requests
+	// for those VirtualMachines with corresponding VirtualMachinesClasses referenced
+	return func(o client.Object) []reconcile.Request {
+		class := o.(*vmopv1.VirtualMachineClass)
+		logger := ctx.Logger.WithValues("name", class.Name, "namespace", class.Namespace)
+
+		// Only watch resources that reference a VirtualMachineClass with its
+		// field spec.controllerName equal to controllerName or if the field is
+		// empty and isDefaultVMClassController is true.
+		controllerName := class.Spec.ControllerName
+		if controllerName == "" && !isDefaultVMClassController {
+			// Log at a high-level so the logs are not over-run.
+			logger.V(8).Info(
+				"Skipping class with empty controller name & not default VM Class controller",
+				"defaultVMClassController", lib.GetDefaultVirtualMachineClassControllerName(),
+				"expectedControllerName", vmClassControllerName)
+			return nil
+		}
+		if controllerName != vmClassControllerName {
+			// Log at a high-level so the logs are not over-run.
+			logger.V(8).Info(
+				"Skipping class with mismatched controller name",
+				"actualControllerName", controllerName,
+				"expectedControllerName", vmClassControllerName)
+			return nil
+		}
+
+		logger.V(4).Info("Reconciling all VMs referencing a VM class because of a VirtualMachineClass watch")
+
+		// Find all VM resources that reference this VM Class.
+		vmList := &vmopv1.VirtualMachineList{}
+		if err := c.List(ctx, vmList, client.InNamespace(class.Namespace)); err != nil {
+			logger.Error(err, "Failed to list VirtualMachines for reconciliation due to VirtualMachineClass watch")
+			return nil
+		}
+
+		// Populate reconcile requests for VMs that reference this VM Class.
+		var reconcileRequests []reconcile.Request
+		for _, vm := range vmList.Items {
+			if vm.Spec.ClassName == class.Name {
+				key := client.ObjectKey{Namespace: vm.Namespace, Name: vm.Name}
+				reconcileRequests = append(reconcileRequests, reconcile.Request{NamespacedName: key})
+			}
+		}
+
+		logger.Info("Returning VM reconcile requests due to VirtualMachineClass watch", "requests", reconcileRequests)
+		return reconcileRequests
+	}
+}
+
+func NewReconciler(
+	client client.Client,
+	logger logr.Logger,
+	recorder record.Recorder,
+	vmProvider vmprovider.VirtualMachineProviderInterfaceA2,
+	prober prober.Manager,
+	maxDeployThreads int) *Reconciler {
+
+	return &Reconciler{
+		Client:           client,
+		Logger:           logger,
+		Recorder:         recorder,
+		VMProvider:       vmProvider,
+		Prober:           prober,
+		vmMetrics:        metrics.NewVMMetrics(),
+		maxDeployThreads: maxDeployThreads,
+	}
+}
+
+// Reconciler reconciles a VirtualMachine object.
+type Reconciler struct {
+	client.Client
+	Logger           logr.Logger
+	Recorder         record.Recorder
+	VMProvider       vmprovider.VirtualMachineProviderInterfaceA2
+	Prober           prober.Manager
+	vmMetrics        *metrics.VMMetrics
+	maxDeployThreads int
+}
+
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachines,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachines/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachineclasses,verbs=get;list
+// +kubebuilder:rbac:groups=vmware.com,resources=virtualnetworkinterfaces;virtualnetworkinterfaces/status,verbs=create;get;list;patch;delete;watch;update
+// +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=events;configmaps,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=resourcequotas;namespaces,verbs=get;list;watch
+
+func (r *Reconciler) Reconcile(ctx goctx.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
+	vm := &vmopv1.VirtualMachine{}
+	if err := r.Get(ctx, req.NamespacedName, vm); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	vmCtx := &context.VirtualMachineContextA2{
+		Context: goctx.WithValue(ctx, context.MaxDeployThreadsContextKey, r.maxDeployThreads),
+		Logger:  ctrl.Log.WithName("VirtualMachine").WithValues("name", vm.NamespacedName()),
+		VM:      vm,
+	}
+
+	// If the VM has a pause reconcile annotation, it is being restored on vCenter. Return here so our reconcile
+	// does not replace the VM being restored on the vCenter inventory.
+	//
+	// Do not requeue the reconcile here since removing the pause annotation will trigger a reconcile anyway.
+	if _, ok := vm.Annotations[vmopv1.PauseAnnotation]; ok {
+		vmCtx.Logger.Info("Skipping reconcile since Pause annotation is set on the VM")
+		return ctrl.Result{}, nil
+	}
+
+	patchHelper, err := patch.NewHelper(vm, r.Client)
+	if err != nil {
+		return ctrl.Result{}, errors.Wrapf(err, "failed to init patch helper for %s", vmCtx.String())
+	}
+
+	defer func() {
+		if err := patchHelper.Patch(ctx, vm); err != nil {
+			if reterr == nil {
+				reterr = err
+			}
+			vmCtx.Logger.Error(err, "patch failed")
+		}
+	}()
+
+	if !vm.DeletionTimestamp.IsZero() {
+		err = r.ReconcileDelete(vmCtx)
+		return ctrl.Result{}, err
+	}
+
+	if err := r.ReconcileNormal(vmCtx); err != nil {
+		vmCtx.Logger.Error(err, "Failed to reconcile VirtualMachine")
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{RequeueAfter: requeueDelay(vmCtx)}, nil
+}
+
+// Determine if we should request a non-zero requeue delay in order to trigger a non-rate limited reconcile
+// at some point in the future.  Use this delay-based reconcile to trigger a specific reconcile to discovery the VM IP
+// address rather than relying on the resync period to do.
+//
+// TODO: It would be much preferable to determine that a non-error resync is required at the source of the determination that
+// TODO: the VM IP isn't available rather than up here in the reconcile loop.  However, in the interest of time, we are making
+// TODO: this determination here and will have to refactor at some later date.
+func requeueDelay(ctx *context.VirtualMachineContextA2) time.Duration {
+	// If the VM is in Creating phase, the reconciler has run out of threads to Create VMs on the provider. Do not queue
+	// immediately to avoid exponential backoff.
+	if conditions.IsFalse(ctx.VM, vmopv1.VirtualMachineConditionCreated) {
+		return 10 * time.Second
+	}
+
+	if ctx.VM.Status.PowerState == vmopv1.VirtualMachinePowerStateOn {
+		network := ctx.VM.Status.Network
+		if network == nil || (network.PrimaryIP4 == "" && network.PrimaryIP6 == "") {
+			return 10 * time.Second
+		}
+	}
+
+	return 0
+}
+
+func (r *Reconciler) ReconcileDelete(ctx *context.VirtualMachineContextA2) (reterr error) {
+	ctx.Logger.Info("Reconciling VirtualMachine Deletion")
+
+	if controllerutil.ContainsFinalizer(ctx.VM, finalizerName) {
+		defer func() {
+			r.Recorder.EmitEvent(ctx.VM, "Delete", reterr, false)
+		}()
+
+		if err := r.VMProvider.DeleteVirtualMachine(ctx, ctx.VM); err != nil {
+			ctx.Logger.Error(err, "Failed to delete VirtualMachine")
+			return err
+		}
+
+		controllerutil.RemoveFinalizer(ctx.VM, finalizerName)
+		ctx.Logger.Info("Provider Completed deleting Virtual Machine", "time", time.Now().Format(time.RFC3339))
+	}
+
+	// BMV: Shouldn't these be in the ContainsFinalizer block?
+	r.vmMetrics.DeleteMetrics(ctx)
+	r.Prober.RemoveFromProberManager(ctx.VM)
+
+	ctx.Logger.Info("Finished Reconciling VirtualMachine Deletion")
+	return nil
+}
+
+// ReconcileNormal processes a level trigger for this VM: create if it doesn't exist otherwise update the existing VM.
+func (r *Reconciler) ReconcileNormal(ctx *context.VirtualMachineContextA2) (reterr error) {
+	if !controllerutil.ContainsFinalizer(ctx.VM, finalizerName) {
+		// The finalizer must be present before proceeding in order to ensure that the VM will
+		// be cleaned up. Return immediately after here to let the patcher helper update the
+		// object, and then we'll proceed on the next reconciliation.
+		controllerutil.AddFinalizer(ctx.VM, finalizerName)
+		return nil
+	}
+
+	ctx.Logger.Info("Reconciling VirtualMachine")
+
+	defer func(beforeVMStatus *vmopv1.VirtualMachineStatus) {
+		// Log the reconcile time using the CR creation time and the time the VM reached the desired state
+		if reterr == nil && !apiequality.Semantic.DeepEqual(beforeVMStatus, &ctx.VM.Status) {
+			ctx.Logger.Info("Finished Reconciling VirtualMachine with updates to the CR",
+				"createdTime", ctx.VM.CreationTimestamp, "currentTime", time.Now().Format(time.RFC3339),
+				"spec.PowerState", ctx.VM.Spec.PowerState, "status.PowerState", ctx.VM.Status.PowerState)
+		} else {
+			ctx.Logger.Info("Finished Reconciling VirtualMachine")
+		}
+
+		beforeNoIP := beforeVMStatus.Network == nil || (beforeVMStatus.Network.PrimaryIP4 == "" && beforeVMStatus.Network.PrimaryIP6 == "")
+		nowWithIP := ctx.VM.Status.Network != nil && (ctx.VM.Status.Network.PrimaryIP4 != "" || ctx.VM.Status.Network.PrimaryIP6 != "")
+		if beforeNoIP && nowWithIP {
+			ctx.Logger.Info("VM successfully got assigned with an IP address", "time", time.Now().Format(time.RFC3339))
+		}
+	}(ctx.VM.Status.DeepCopy())
+
+	defer func() {
+		r.vmMetrics.RegisterVMCreateOrUpdateMetrics(ctx)
+	}()
+
+	if err := r.VMProvider.CreateOrUpdateVirtualMachine(ctx, ctx.VM); err != nil {
+		ctx.Logger.Error(err, "Failed to reconcile VirtualMachine")
+		r.Recorder.EmitEvent(ctx.VM, "CreateOrUpdate", err, false)
+		return err
+	}
+
+	// Add this VM to prober manager if ReconcileNormal succeeds.
+	r.Prober.AddToProberManager(ctx.VM)
+
+	ctx.Logger.Info("Finished Reconciling VirtualMachine")
+	return nil
+}

--- a/controllers/virtualmachine/v1alpha2/virtualmachine_controller_intg_test.go
+++ b/controllers/virtualmachine/v1alpha2/virtualmachine_controller_intg_test.go
@@ -1,0 +1,215 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha2_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+func intgTests() {
+
+	var (
+		ctx *builder.IntegrationTestContext
+
+		vm    *vmopv1.VirtualMachine
+		vmKey types.NamespacedName
+	)
+
+	BeforeEach(func() {
+		ctx = suite.NewIntegrationTestContext()
+
+		vm = &vmopv1.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ctx.Namespace,
+				Name:      "dummy-vm",
+			},
+			Spec: vmopv1.VirtualMachineSpec{
+				ImageName:  "dummy-image",
+				ClassName:  "dummy-class",
+				PowerState: vmopv1.VirtualMachinePowerStateOn,
+			},
+		}
+		vmKey = types.NamespacedName{Name: vm.Name, Namespace: vm.Namespace}
+	})
+
+	AfterEach(func() {
+		ctx.AfterEach()
+		ctx = nil
+		intgFakeVMProvider.Reset()
+	})
+
+	getVirtualMachine := func(ctx *builder.IntegrationTestContext, objKey types.NamespacedName) *vmopv1.VirtualMachine {
+		vm := &vmopv1.VirtualMachine{}
+		if err := ctx.Client.Get(ctx, objKey, vm); err != nil {
+			return nil
+		}
+		return vm
+	}
+
+	waitForVirtualMachineFinalizer := func(ctx *builder.IntegrationTestContext, objKey types.NamespacedName) {
+		Eventually(func() []string {
+			if vm := getVirtualMachine(ctx, objKey); vm != nil {
+				return vm.GetFinalizers()
+			}
+			return nil
+		}).Should(ContainElement(finalizer), "waiting for VirtualMachine finalizer")
+	}
+
+	Context("Reconcile", func() {
+		dummyInstanceUUID := "instanceUUID1234"
+
+		BeforeEach(func() {
+			intgFakeVMProvider.Lock()
+			intgFakeVMProvider.CreateOrUpdateVirtualMachineFn = func(ctx context.Context, vm *vmopv1.VirtualMachine) error {
+				// Used below just to check for something in the Status is updated.
+				vm.Status.InstanceUUID = dummyInstanceUUID
+				return nil
+			}
+			intgFakeVMProvider.Unlock()
+		})
+
+		AfterEach(func() {
+			By("Delete VirtualMachine", func() {
+				if err := ctx.Client.Delete(ctx, vm); err == nil {
+					vm := &vmopv1.VirtualMachine{}
+					// If VM is still around because of finalizer, try to cleanup for next test.
+					if err := ctx.Client.Get(ctx, vmKey, vm); err == nil && len(vm.Finalizers) > 0 {
+						vm.Finalizers = nil
+						_ = ctx.Client.Update(ctx, vm)
+					}
+				} else {
+					Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+				}
+			})
+		})
+
+		When("the pause annotation is set", func() {
+			It("Reconcile returns early and the finalizer never gets added", func() {
+				// Set the Pause annotation on the VM
+				vm.Annotations = map[string]string{
+					vmopv1.PauseAnnotation: "",
+				}
+
+				Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
+
+				Consistently(func() []string {
+					if vm := getVirtualMachine(ctx, vmKey); vm != nil {
+						return vm.GetFinalizers()
+					}
+					return nil
+				}).ShouldNot(ContainElement(finalizer), "waiting for VirtualMachine finalizer")
+			})
+		})
+
+		It("Reconciles after VirtualMachine creation", func() {
+			Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
+
+			By("VirtualMachine should have finalizer added", func() {
+				waitForVirtualMachineFinalizer(ctx, vmKey)
+			})
+
+			By("VirtualMachine should reflect VMProvider updates", func() {
+				Eventually(func() string {
+					if vm := getVirtualMachine(ctx, vmKey); vm != nil {
+						return vm.Status.InstanceUUID
+					}
+					return ""
+				}).Should(Equal(dummyInstanceUUID), "waiting for expected InstanceUUID")
+			})
+
+			By("VirtualMachine should not be updated in steady-state", func() {
+				vm := getVirtualMachine(ctx, vmKey)
+				Expect(vm).ToNot(BeNil())
+				rv := vm.GetResourceVersion()
+				Expect(rv).ToNot(BeEmpty())
+				expected := fmt.Sprintf("%s :: %d", rv, vm.GetGeneration())
+				// The resync period is 1 second, so balance between giving enough time vs a slow test.
+				// Note: the kube-apiserver we test against (obtained from kubebuilder) is old and
+				// appears to behavior differently than newer versions (like used in the SV) in that noop
+				// Status subresource updates don't increment the ResourceVersion.
+				Consistently(func() string {
+					if vm := getVirtualMachine(ctx, vmKey); vm != nil {
+						return fmt.Sprintf("%s :: %d", vm.GetResourceVersion(), vm.GetGeneration())
+					}
+					return ""
+				}, 4*time.Second).Should(Equal(expected))
+			})
+		})
+
+		When("CreateOrUpdateVirtualMachine returns an error", func() {
+			errMsg := "create error"
+
+			BeforeEach(func() {
+				intgFakeVMProvider.Lock()
+				intgFakeVMProvider.CreateOrUpdateVirtualMachineFn = func(ctx context.Context, vm *vmopv1.VirtualMachine) error {
+					vm.Status.BiosUUID = "dummy-bios-uuid"
+					return errors.New(errMsg)
+				}
+				intgFakeVMProvider.Unlock()
+			})
+
+			It("VirtualMachine is in Creating Phase", func() {
+				Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
+				// Wait for initial reconcile.
+				waitForVirtualMachineFinalizer(ctx, vmKey)
+			})
+		})
+
+		It("Reconciles after VirtualMachine deletion", func() {
+			Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
+			// Wait for initial reconcile.
+			waitForVirtualMachineFinalizer(ctx, vmKey)
+
+			Expect(ctx.Client.Delete(ctx, vm)).To(Succeed())
+			By("Finalizer should be removed after deletion", func() {
+				Eventually(func() []string {
+					if vm := getVirtualMachine(ctx, vmKey); vm != nil {
+						return vm.GetFinalizers()
+					}
+					return nil
+				}).ShouldNot(ContainElement(finalizer))
+			})
+		})
+
+		When("Provider DeleteVM returns an error", func() {
+			errMsg := "delete error"
+
+			BeforeEach(func() {
+				intgFakeVMProvider.Lock()
+				intgFakeVMProvider.DeleteVirtualMachineFn = func(ctx context.Context, vm *vmopv1.VirtualMachine) error {
+					return errors.New(errMsg)
+				}
+				intgFakeVMProvider.Unlock()
+			})
+
+			It("VirtualMachine is in Deleting Phase", func() {
+				Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
+				// Wait for initial reconcile.
+				waitForVirtualMachineFinalizer(ctx, vmKey)
+
+				Expect(ctx.Client.Delete(ctx, vm)).To(Succeed())
+
+				By("Finalizer should still be present", func() {
+					vm := getVirtualMachine(ctx, vmKey)
+					Expect(vm).ToNot(BeNil())
+					Expect(vm.GetFinalizers()).To(ContainElement(finalizer))
+				})
+			})
+		})
+	})
+}

--- a/controllers/virtualmachine/v1alpha2/virtualmachine_controller_suite_test.go
+++ b/controllers/virtualmachine/v1alpha2/virtualmachine_controller_suite_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha2_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+
+	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
+
+	virtualmachine "github.com/vmware-tanzu/vm-operator/controllers/virtualmachine/v1alpha2"
+	ctrlContext "github.com/vmware-tanzu/vm-operator/pkg/context"
+	providerfake "github.com/vmware-tanzu/vm-operator/pkg/vmprovider/fake"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+var intgFakeVMProvider = providerfake.NewVMProviderA2()
+
+var suite = builder.NewTestSuiteForController(
+	virtualmachine.AddToManager,
+	func(ctx *ctrlContext.ControllerManagerContext, _ ctrlmgr.Manager) error {
+		ctx.VMProviderA2 = intgFakeVMProvider
+		return nil
+	},
+)
+
+func TestVirtualMachine(t *testing.T) {
+	_ = intgTests
+	suite.Register(t, "VirtualMachine controller suite", nil /*intgTests*/, unitTests)
+}
+
+var _ = BeforeSuite(suite.BeforeSuite)
+
+var _ = AfterSuite(suite.AfterSuite)

--- a/controllers/virtualmachine/v1alpha2/virtualmachine_controller_unit_test.go
+++ b/controllers/virtualmachine/v1alpha2/virtualmachine_controller_unit_test.go
@@ -1,0 +1,215 @@
+// Copyright (c) 2019-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha2_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+
+	virtualmachine "github.com/vmware-tanzu/vm-operator/controllers/virtualmachine/v1alpha2"
+	vmopContext "github.com/vmware-tanzu/vm-operator/pkg/context"
+	proberfake "github.com/vmware-tanzu/vm-operator/pkg/prober2/fake"
+	providerfake "github.com/vmware-tanzu/vm-operator/pkg/vmprovider/fake"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+func unitTests() {
+	Describe("Invoking Reconcile", unitTestsReconcile)
+}
+
+const finalizer = "virtualmachine.vmoperator.vmware.com"
+
+func unitTestsReconcile() {
+	const (
+		providerError = "provider error"
+	)
+
+	var (
+		initObjects      []client.Object
+		ctx              *builder.UnitTestContextForController
+		reconciler       *virtualmachine.Reconciler
+		fakeProbeManager *proberfake.ProberManager
+		fakeVMProvider   *providerfake.VMProviderA2
+
+		vm    *vmopv1.VirtualMachine
+		vmCtx *vmopContext.VirtualMachineContextA2
+	)
+
+	BeforeEach(func() {
+		vm = &vmopv1.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "dummy-vm",
+				Namespace:  "dummy-ns",
+				Labels:     map[string]string{},
+				Finalizers: []string{finalizer},
+			},
+			Spec: vmopv1.VirtualMachineSpec{
+				ClassName: "dummy-class",
+				ImageName: "dummy-image",
+			},
+		}
+	})
+
+	JustBeforeEach(func() {
+		ctx = suite.NewUnitTestContextForController(initObjects...)
+		fakeProbeManagerIf := proberfake.NewFakeProberManager()
+
+		reconciler = virtualmachine.NewReconciler(
+			ctx.Client,
+			ctx.Logger,
+			ctx.Recorder,
+			ctx.VMProviderA2,
+			fakeProbeManagerIf,
+			16,
+		)
+		fakeVMProvider = ctx.VMProviderA2.(*providerfake.VMProviderA2)
+		fakeProbeManager = fakeProbeManagerIf.(*proberfake.ProberManager)
+
+		vmCtx = &vmopContext.VirtualMachineContextA2{
+			Context: ctx,
+			Logger:  ctx.Logger.WithName(vm.Name),
+			VM:      vm,
+		}
+	})
+
+	AfterEach(func() {
+		ctx.AfterEach()
+		ctx = nil
+		initObjects = nil
+		vmCtx = nil
+		reconciler = nil
+		fakeVMProvider = nil
+	})
+
+	Context("ReconcileNormal", func() {
+		BeforeEach(func() {
+			initObjects = append(initObjects, vm)
+		})
+
+		When("object does not have finalizer set", func() {
+			BeforeEach(func() {
+				vm.Finalizers = nil
+			})
+
+			It("will set finalizer", func() {
+				err := reconciler.ReconcileNormal(vmCtx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(vmCtx.VM.GetFinalizers()).To(ContainElement(finalizer))
+			})
+		})
+
+		It("will have finalizer set upon successful reconciliation", func() {
+			err := reconciler.ReconcileNormal(vmCtx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(vmCtx.VM.GetFinalizers()).To(ContainElement(finalizer))
+		})
+
+		It("will return error when provider fails to CreateOrUpdate VM", func() {
+			fakeVMProvider.CreateOrUpdateVirtualMachineFn = func(ctx context.Context, vm *vmopv1.VirtualMachine) error {
+				return errors.New(providerError)
+			}
+
+			err := reconciler.ReconcileNormal(vmCtx)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(providerError))
+			expectEvent(ctx, "CreateOrUpdateFailure")
+		})
+
+		It("can be called multiple times", func() {
+			err := reconciler.ReconcileNormal(vmCtx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vmCtx.VM.GetFinalizers()).To(ContainElement(finalizer))
+
+			err = reconciler.ReconcileNormal(vmCtx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vmCtx.VM.GetFinalizers()).To(ContainElement(finalizer))
+		})
+
+		It("Should not call add to Prober Manager if CreateOrUpdate fails", func() {
+			fakeVMProvider.CreateOrUpdateVirtualMachineFn = func(ctx context.Context, vm *vmopv1.VirtualMachine) error {
+				return errors.New(providerError)
+			}
+
+			err := reconciler.ReconcileNormal(vmCtx)
+			Expect(err).To(HaveOccurred())
+			Expect(fakeProbeManager.IsAddToProberManagerCalled).Should(BeFalse())
+		})
+
+		It("Should call add to Prober Manager if ReconcileNormal succeeds", func() {
+			fakeProbeManager.AddToProberManagerFn = func(vm *vmopv1.VirtualMachine) {
+				fakeProbeManager.IsAddToProberManagerCalled = true
+			}
+
+			Expect(reconciler.ReconcileNormal(vmCtx)).Should(Succeed())
+			Expect(fakeProbeManager.IsAddToProberManagerCalled).Should(BeTrue())
+		})
+	})
+
+	Context("ReconcileDelete", func() {
+		BeforeEach(func() {
+			initObjects = append(initObjects, vm)
+		})
+
+		JustBeforeEach(func() {
+			// Create the VM to be deleted
+			err := reconciler.ReconcileNormal(vmCtx)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("will delete the created VM and emit corresponding event", func() {
+			err := reconciler.ReconcileDelete(vmCtx)
+			Expect(err).NotTo(HaveOccurred())
+
+			expectEvent(ctx, "DeleteSuccess")
+		})
+
+		It("will emit corresponding event during delete failure", func() {
+			// Simulate delete failure
+			fakeVMProvider.DeleteVirtualMachineFn = func(ctx context.Context, vm *vmopv1.VirtualMachine) error {
+				return errors.New(providerError)
+			}
+			err := reconciler.ReconcileDelete(vmCtx)
+			Expect(err).To(HaveOccurred())
+
+			expectEvent(ctx, "DeleteFailure")
+		})
+
+		It("Should not remove from Prober Manager if ReconcileDelete fails", func() {
+			// Simulate delete failure
+			fakeVMProvider.DeleteVirtualMachineFn = func(ctx context.Context, vm *vmopv1.VirtualMachine) error {
+				return errors.New(providerError)
+			}
+
+			err := reconciler.ReconcileDelete(vmCtx)
+			Expect(err).To(HaveOccurred())
+			Expect(fakeProbeManager.IsRemoveFromProberManagerCalled).Should(BeFalse())
+		})
+
+		It("Should remove from Prober Manager if ReconcileDelete succeeds", func() {
+			fakeProbeManager.RemoveFromProberManagerFn = func(vm *vmopv1.VirtualMachine) {
+				fakeProbeManager.IsRemoveFromProberManagerCalled = true
+			}
+
+			Expect(reconciler.ReconcileDelete(vmCtx)).Should(Succeed())
+			Expect(fakeProbeManager.IsRemoveFromProberManagerCalled).Should(BeTrue())
+		})
+	})
+}
+
+func expectEvent(ctx *builder.UnitTestContextForController, eventStr string) {
+	var event string
+	// This does not work if we have more than one event and the first one does not match.
+	EventuallyWithOffset(1, ctx.Events).Should(Receive(&event))
+	eventComponents := strings.Split(event, " ")
+	ExpectWithOffset(1, eventComponents[1]).To(Equal(eventStr))
+}

--- a/controllers/virtualmachineclass/controllers.go
+++ b/controllers/virtualmachineclass/controllers.go
@@ -7,10 +7,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachineclass/v1alpha1"
+	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachineclass/v1alpha2"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 )
 
 // AddToManager adds the controller to the provided manager.
 func AddToManager(ctx *context.ControllerManagerContext, mgr manager.Manager) error {
+	if lib.IsVMServiceV1Alpha2FSSEnabled() {
+		return v1alpha2.AddToManager(ctx, mgr)
+	}
 	return v1alpha1.AddToManager(ctx, mgr)
 }

--- a/controllers/virtualmachineclass/v1alpha2/virtualmachineclass_controller.go
+++ b/controllers/virtualmachineclass/v1alpha2/virtualmachineclass_controller.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha2
+
+import (
+	goctx "context"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/go-logr/logr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/pkg/context"
+	patch "github.com/vmware-tanzu/vm-operator/pkg/patch2"
+	"github.com/vmware-tanzu/vm-operator/pkg/record"
+)
+
+// AddToManager adds this package's controller to the provided manager.
+func AddToManager(ctx *context.ControllerManagerContext, mgr manager.Manager) error {
+	var (
+		controlledType     = &vmopv1.VirtualMachineClass{}
+		controlledTypeName = reflect.TypeOf(controlledType).Elem().Name()
+
+		controllerNameShort = fmt.Sprintf("%s-controller", strings.ToLower(controlledTypeName))
+		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
+	)
+
+	r := NewReconciler(
+		mgr.GetClient(),
+		ctrl.Log.WithName("controllers").WithName(controlledTypeName),
+		record.New(mgr.GetEventRecorderFor(controllerNameLong)),
+	)
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(controlledType).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
+		Complete(r)
+}
+
+func NewReconciler(
+	client client.Client,
+	logger logr.Logger,
+	recorder record.Recorder) *Reconciler {
+	return &Reconciler{
+		Client:   client,
+		Logger:   logger,
+		Recorder: recorder,
+	}
+}
+
+// Reconciler reconciles a VirtualMachineClass object.
+type Reconciler struct {
+	client.Client
+	Logger   logr.Logger
+	Recorder record.Recorder
+}
+
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachineclasses,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachineclasses/status,verbs=get;update;patch
+
+func (r *Reconciler) Reconcile(ctx goctx.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
+	vmClass := &vmopv1.VirtualMachineClass{}
+	if err := r.Get(ctx, req.NamespacedName, vmClass); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	vmClassCtx := &context.VirtualMachineClassContextA2{
+		Context: ctx,
+		Logger:  ctrl.Log.WithName("VirtualMachineClass").WithValues("name", req.Name),
+		VMClass: vmClass,
+	}
+
+	patchHelper, err := patch.NewHelper(vmClass, r.Client)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to init patch helper for %s: %w", vmClassCtx.String(), err)
+	}
+	defer func() {
+		if err := patchHelper.Patch(ctx, vmClass); err != nil {
+			if reterr == nil {
+				reterr = err
+			}
+			vmClassCtx.Logger.Error(err, "patch failed")
+		}
+	}()
+
+	if !vmClass.DeletionTimestamp.IsZero() {
+		// Noop.
+		return ctrl.Result{}, nil
+	}
+
+	if err := r.ReconcileNormal(vmClassCtx); err != nil {
+		vmClassCtx.Logger.Error(err, "Failed to reconcile VirtualMachineClass")
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *Reconciler) ReconcileNormal(vmClassCtx *context.VirtualMachineClassContextA2) error {
+	// Implicitly always ready until we actually check. Don't worry about the conditions for now.
+	vmClassCtx.VMClass.Status.Ready = true
+	return nil
+}

--- a/controllers/virtualmachineclass/v1alpha2/virtualmachineclass_controller_intg_test.go
+++ b/controllers/virtualmachineclass/v1alpha2/virtualmachineclass_controller_intg_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha2_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+func intgTests() {
+	var (
+		ctx     *builder.IntegrationTestContext
+		vmClass *vmopv1.VirtualMachineClass
+	)
+
+	BeforeEach(func() {
+		ctx = suite.NewIntegrationTestContext()
+
+		vmClass = &vmopv1.VirtualMachineClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "small",
+			},
+			Spec: vmopv1.VirtualMachineClassSpec{
+				Hardware: vmopv1.VirtualMachineClassHardware{
+					Cpus:   4,
+					Memory: resource.MustParse("1Mi"),
+				},
+				Policies: vmopv1.VirtualMachineClassPolicies{
+					Resources: vmopv1.VirtualMachineClassResources{
+						Requests: vmopv1.VirtualMachineResourceSpec{
+							Cpu:    resource.MustParse("1000Mi"),
+							Memory: resource.MustParse("100Mi"),
+						},
+						Limits: vmopv1.VirtualMachineResourceSpec{
+							Cpu:    resource.MustParse("2000Mi"),
+							Memory: resource.MustParse("200Mi"),
+						},
+					},
+				},
+			},
+		}
+	})
+
+	AfterEach(func() {
+		ctx.AfterEach()
+	})
+
+	Context("Reconcile", func() {
+		BeforeEach(func() {
+			Expect(ctx.Client.Create(ctx, vmClass)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			err := ctx.Client.Delete(ctx, vmClass)
+			Expect(err == nil || k8serrors.IsNotFound(err)).To(BeTrue())
+		})
+
+		It("Is Ready", func() {
+			Eventually(func(g Gomega) {
+				class := &vmopv1.VirtualMachineClass{}
+				g.Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(vmClass), class)).To(Succeed())
+				g.Expect(class.Status.Ready).To(BeTrue())
+			}).Should(Succeed())
+		})
+	})
+}

--- a/controllers/virtualmachineclass/v1alpha2/virtualmachineclass_controller_suite_test.go
+++ b/controllers/virtualmachineclass/v1alpha2/virtualmachineclass_controller_suite_test.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha2_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+
+	virtualmachineclass "github.com/vmware-tanzu/vm-operator/controllers/virtualmachineclass/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/pkg/manager"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+var suite = builder.NewTestSuiteForController(
+	virtualmachineclass.AddToManager,
+	manager.InitializeProvidersNoopFn,
+)
+
+func TestVirtualMachineClass(t *testing.T) {
+	_ = intgTests
+	suite.Register(t, "VirtualMachineClass controller suite", nil /*intgTests*/, unitTests)
+}
+
+var _ = BeforeSuite(suite.BeforeSuite)
+
+var _ = AfterSuite(suite.AfterSuite)

--- a/controllers/virtualmachineclass/v1alpha2/virtualmachineclass_controller_unit_test.go
+++ b/controllers/virtualmachineclass/v1alpha2/virtualmachineclass_controller_unit_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha2_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+
+	virtualmachineclass "github.com/vmware-tanzu/vm-operator/controllers/virtualmachineclass/v1alpha2"
+	vmopContext "github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+func unitTests() {
+	Describe("Invoking Reconcile", unitTestsReconcile)
+}
+
+func unitTestsReconcile() {
+	var (
+		initObjects []client.Object
+		ctx         *builder.UnitTestContextForController
+
+		reconciler *virtualmachineclass.Reconciler
+		vmClassCtx *vmopContext.VirtualMachineClassContextA2
+		vmClass    *vmopv1.VirtualMachineClass
+	)
+
+	BeforeEach(func() {
+		vmClass = &vmopv1.VirtualMachineClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "dummy-vmclass",
+			},
+		}
+	})
+
+	JustBeforeEach(func() {
+		ctx = suite.NewUnitTestContextForController(initObjects...)
+		reconciler = virtualmachineclass.NewReconciler(
+			ctx.Client,
+			ctx.Logger,
+			ctx.Recorder,
+		)
+
+		vmClassCtx = &vmopContext.VirtualMachineClassContextA2{
+			Context: ctx,
+			Logger:  ctx.Logger.WithName(vmClass.Name),
+			VMClass: vmClass,
+		}
+	})
+
+	Context("ReconcileNormal", func() {
+		BeforeEach(func() {
+			initObjects = append(initObjects, vmClass)
+		})
+
+		It("returns success", func() {
+			err := reconciler.ReconcileNormal(vmClassCtx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vmClassCtx.VMClass.Status.Ready).To(BeTrue())
+		})
+	})
+}

--- a/controllers/virtualmachinepublishrequest/controllers.go
+++ b/controllers/virtualmachinepublishrequest/controllers.go
@@ -7,10 +7,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachinepublishrequest/v1alpha1"
+	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachinepublishrequest/v1alpha2"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 )
 
 // AddToManager adds the controller to the provided manager.
 func AddToManager(ctx *context.ControllerManagerContext, mgr manager.Manager) error {
+	if lib.IsVMServiceV1Alpha2FSSEnabled() {
+		return v1alpha2.AddToManager(ctx, mgr)
+	}
 	return v1alpha1.AddToManager(ctx, mgr)
 }

--- a/controllers/virtualmachinepublishrequest/v1alpha2/virtualmachinepublishrequest_controller.go
+++ b/controllers/virtualmachinepublishrequest/v1alpha2/virtualmachinepublishrequest_controller.go
@@ -1,0 +1,916 @@
+// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha2
+
+import (
+	goctx "context"
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	"github.com/vmware/govmomi/vapi/library"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+
+	imgregv1a1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha1"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	conditions "github.com/vmware-tanzu/vm-operator/pkg/conditions2"
+	"github.com/vmware-tanzu/vm-operator/pkg/context"
+	metrics "github.com/vmware-tanzu/vm-operator/pkg/metrics2"
+	patch "github.com/vmware-tanzu/vm-operator/pkg/patch2"
+	"github.com/vmware-tanzu/vm-operator/pkg/record"
+	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider"
+)
+
+const (
+	finalizerName     = "virtualmachinepublishrequest.vmoperator.vmware.com"
+	TaskDescriptionID = "com.vmware.ovfs.LibraryItem.capture"
+
+	// waitForTaskTimeout represents the timeout to wait for task existence in task manager.
+	// When calling `CreateOVF` API, there is no guarantee that we can get its task info due to
+	// - this request is not made to VC, e.g. VC credentials rotate.
+	// - VC receives this request, but fails to submit this task.
+	// - content library service hasn't processed far enough to submit and register this task. (Most common case)
+	// Wait for 30 seconds to eliminate the last case in a best-effort manner.
+	waitForTaskTimeout = 30 * time.Second
+
+	clItemPrefix          = "clibitem-"
+	ItemParseErrorMessage = "Failed to get the uploaded item ID. This error is unrecoverable." +
+		" Please create a new VirtualMachinePublishRequest to retry VM publishing."
+
+	// ItemDescriptionRegexString is used to filter the VMPub UID from the content library item description.
+	ItemDescriptionRegexString = "virtualmachinepublishrequest\\.vmoperator\\.vmware\\.com: ([a-z0-9-]*)"
+)
+
+var (
+	itemDescriptionReg = regexp.MustCompile(ItemDescriptionRegexString)
+)
+
+// AddToManager adds this package's controller to the provided manager.
+func AddToManager(ctx *context.ControllerManagerContext, mgr manager.Manager) error {
+	var (
+		controlledType     = &vmopv1.VirtualMachinePublishRequest{}
+		controlledTypeName = reflect.TypeOf(controlledType).Elem().Name()
+
+		controllerNameShort = fmt.Sprintf("%s-controller", strings.ToLower(controlledTypeName))
+		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
+	)
+
+	r := NewReconciler(
+		mgr.GetClient(),
+		mgr.GetAPIReader(),
+		ctrl.Log.WithName("controllers").WithName(controlledTypeName),
+		record.New(mgr.GetEventRecorderFor(controllerNameLong)),
+		ctx.VMProviderA2,
+	)
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(controlledType).
+		WithOptions(controller.Options{MaxConcurrentReconciles: ctx.MaxConcurrentReconciles}).
+		Watches(&source.Kind{Type: &vmopv1.VirtualMachineImage{}},
+			handler.EnqueueRequestsFromMapFunc(vmiToVMPubMapperFn(ctx, r.Client))).
+		Complete(r)
+}
+
+// vmiToVMPubMapperFn returns a mapper function that can be used to queue reconcile request
+// for the VirtualMachinePublishRequests in response to an event on the VirtualMachineImage resource.
+// Note: Only when WCP_VM_Image_Registry FSS is enabled, this controller will be added to the controller manager.
+// In this case, the VirtualMachineImage is a namespace scoped resource.
+func vmiToVMPubMapperFn(ctx *context.ControllerManagerContext, c client.Client) func(o client.Object) []reconcile.Request {
+	// For a given VirtualMachineImage, return reconcile requests
+	// for those VirtualMachinePublishRequests with corresponding VirtualMachinesImage as the target item.
+	return func(o client.Object) []reconcile.Request {
+		vmi := o.(*vmopv1.VirtualMachineImage)
+		logger := ctx.Logger.WithValues("name", vmi.Name, "namespace", vmi.Namespace)
+
+		logger.V(4).Info("Reconciling all VirtualMachinePublishRequests referencing a target item name same " +
+			"with this VirtualMachineImage display name")
+
+		vmPubList := &vmopv1.VirtualMachinePublishRequestList{}
+		if err := c.List(ctx, vmPubList, client.InNamespace(vmi.Namespace)); err != nil {
+			logger.Error(err, "Failed to list VirtualMachinePublishRequests for reconciliation due to VirtualMachineImage watch")
+			return nil
+		}
+
+		// Populate reconcile requests for vmpubs
+		var reconcileRequests []reconcile.Request
+		for _, vmPub := range vmPubList.Items {
+			if vmPub.Status.TargetRef == nil {
+				continue
+			}
+
+			if vmPub.Status.TargetRef.Item.Name == vmi.Status.Name {
+				key := client.ObjectKey{Namespace: vmPub.Namespace, Name: vmPub.Name}
+				reconcileRequests = append(reconcileRequests, reconcile.Request{NamespacedName: key})
+			}
+		}
+
+		logger.V(4).Info("Returning VirtualMachinePublishRequest reconcile requests due to VirtualMachineImage watch",
+			"requests", reconcileRequests)
+		return reconcileRequests
+	}
+}
+
+func NewReconciler(
+	client client.Client,
+	apiReader client.Reader,
+	logger logr.Logger,
+	recorder record.Recorder,
+	vmProvider vmprovider.VirtualMachineProviderInterfaceA2) *Reconciler {
+
+	return &Reconciler{
+		Client:     client,
+		apiReader:  apiReader,
+		Logger:     logger,
+		Recorder:   recorder,
+		VMProvider: vmProvider,
+		Metrics:    metrics.NewVMPublishMetrics(),
+	}
+}
+
+// Reconciler reconciles a VirtualMachinePublishRequest object.
+type Reconciler struct {
+	client.Client
+	apiReader  client.Reader
+	Logger     logr.Logger
+	Recorder   record.Recorder
+	VMProvider vmprovider.VirtualMachineProviderInterfaceA2
+	Metrics    *metrics.VMPublishMetrics
+}
+
+func requeueResult(ctx *context.VirtualMachinePublishRequestContextA2) ctrl.Result {
+	vmPubReq := ctx.VMPublishRequest
+
+	// no need to requeue to trigger another reconcile if:
+	// - target item already exists
+	// - failed to parse item ID from a successful task result
+	if conditions.GetReason(vmPubReq, vmopv1.VirtualMachinePublishRequestConditionTargetValid) == vmopv1.TargetItemAlreadyExistsReason {
+		return ctrl.Result{}
+	}
+
+	if conditions.GetReason(vmPubReq, vmopv1.VirtualMachinePublishRequestConditionUploaded) == vmopv1.UploadItemIDInvalidReason {
+		return ctrl.Result{}
+	}
+
+	// In case the item is uploaded but VMI is not available, or,
+	// the export task is not submitted to the vCenter task manager,
+	// requeue after a short wait time since we expect these issues to be resolved quickly.
+	if conditions.GetReason(vmPubReq, vmopv1.VirtualMachinePublishRequestConditionUploaded) == vmopv1.UploadTaskNotStartedReason ||
+		conditions.IsTrue(vmPubReq, vmopv1.VirtualMachinePublishRequestConditionUploaded) {
+		return ctrl.Result{RequeueAfter: 10 * time.Second}
+	}
+
+	// Skip checking ImageAvailable.
+	// If ImageAvailable is true, Uploaded must be true. This also marks Condition Complete to true,
+	// we will never reach this function.
+
+	// For other cases, requeue after 60 seconds,
+	// including VM Publish request is still in progress: queued/running
+	return ctrl.Result{RequeueAfter: 60 * time.Second}
+}
+
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachinepublishrequests,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachinepublishrequests/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachines,verbs=get;list
+// +kubebuilder:rbac:groups=imageregistry.vmware.com,resources=contentlibraries,verbs=get;list;watch
+// +kubebuilder:rbac:groups=imageregistry.vmware.com,resources=contentlibraries/status,verbs=get;
+
+func (r *Reconciler) Reconcile(ctx goctx.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
+	vmPublishReq := &vmopv1.VirtualMachinePublishRequest{}
+
+	// Get the VirtualMachinePublishRequest directly from the API server - bypassing the cache of the
+	// regular client - to avoid potentially stale objects from cache. We rely on the up-to-date Status
+	// when sending publish VM requests during reconciliation.
+	// Update() of stale object will be rejected by API server and result in unnecessary reconciles.
+	err := r.apiReader.Get(ctx, req.NamespacedName, vmPublishReq)
+	if err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	vmPublishCtx := &context.VirtualMachinePublishRequestContextA2{
+		Context:          ctx,
+		Logger:           ctrl.Log.WithName("VirtualMachinePublishRequest").WithValues("name", req.NamespacedName),
+		VMPublishRequest: vmPublishReq,
+	}
+
+	patchHelper, err := patch.NewHelper(vmPublishReq, r.Client)
+	if err != nil {
+		return ctrl.Result{}, errors.Wrapf(err, "failed to init patch helper for %s", fmt.Sprintf("%s/%s", vmPublishReq.Namespace, vmPublishReq.Name))
+	}
+
+	// the patch is skipped when the VirtualMachinePublishRequest.Status().Update
+	// is called during publishVirtualMachine().
+	defer func() {
+		if vmPublishCtx.SkipPatch {
+			return
+		}
+
+		if err := patchHelper.Patch(ctx, vmPublishReq); err != nil {
+			if reterr == nil {
+				reterr = err
+			}
+			vmPublishCtx.Logger.Error(err, "patch failed")
+		}
+	}()
+
+	if !vmPublishReq.DeletionTimestamp.IsZero() {
+		return r.ReconcileDelete(vmPublishCtx)
+	}
+
+	return r.ReconcileNormal(vmPublishCtx)
+}
+
+func (r *Reconciler) updateSourceAndTargetRef(ctx *context.VirtualMachinePublishRequestContextA2) {
+	vmPubReq := ctx.VMPublishRequest
+
+	if vmPubReq.Status.SourceRef == nil {
+		vmName := vmPubReq.Spec.Source.Name
+		if vmName == "" {
+			// set default source VM to this VirtualMachinePublishRequest's name.
+			vmName = vmPubReq.Name
+		}
+		vmPubReq.Status.SourceRef = &vmopv1.VirtualMachinePublishRequestSource{
+			Name: vmName,
+		}
+	}
+
+	if vmPubReq.Status.TargetRef == nil {
+		targetItemName := vmPubReq.Spec.Target.Item.Name
+		if targetItemName == "" {
+			targetItemName = fmt.Sprintf("%s-image", vmPubReq.Status.SourceRef.Name)
+		}
+
+		vmPubReq.Status.TargetRef = &vmopv1.VirtualMachinePublishRequestTarget{
+			Item: vmopv1.VirtualMachinePublishRequestTargetItem{
+				Name:        targetItemName,
+				Description: vmPubReq.Spec.Target.Item.Description,
+			},
+			Location: vmPubReq.Spec.Target.Location,
+		}
+	}
+}
+
+// publishVirtualMachine checks if source VM and target is valid. Publish a VM if all requirements are met.
+func (r *Reconciler) publishVirtualMachine(ctx *context.VirtualMachinePublishRequestContextA2) error {
+	vmPublishReq := ctx.VMPublishRequest
+	// Check if the source and target is valid
+	if err := r.checkIsSourceValid(ctx); err != nil {
+		ctx.Logger.Error(err, "failed to check if source is valid")
+		return err
+	}
+
+	if err := r.checkIsTargetValid(ctx); err != nil {
+		ctx.Logger.Error(err, "failed to check if target is valid")
+		return err
+	}
+
+	// In case we mark Upload condition to true when checking target, return early.
+	if conditions.IsTrue(ctx.VMPublishRequest, vmopv1.VirtualMachinePublishRequestConditionUploaded) {
+		return nil
+	}
+
+	if conditions.IsTrue(ctx.VMPublishRequest, vmopv1.VirtualMachinePublishRequestConditionSourceValid) &&
+		conditions.IsTrue(ctx.VMPublishRequest, vmopv1.VirtualMachinePublishRequestConditionTargetValid) {
+
+		vmPublishReq.Status.Attempts++
+		vmPublishReq.Status.LastAttemptTime = metav1.Now()
+
+		// Update VirtualMachinePublishRequest object to avoid conflict.
+		// API server will reject the Update request if updating to a stale object, so that we can always
+		// set the correct number of attempts in the status to avoid running into a situation where we end
+		// up sending multiple publish requests with the same actID.
+		//
+		// Patch a stale object won't fail even when the resourceVersion doesn't match. In this case, we
+		// may set .status.attempts to a same number multiple times using Patch.
+		// Use Update instead and skip Patch in the ReconcileNormal defer function.
+		ctx.SkipPatch = true
+		if err := r.Client.Status().Update(ctx, vmPublishReq); err != nil {
+			ctx.Logger.Error(err, "update VirtualMachinePublishRequest status failed")
+			return err
+		}
+
+		go func() {
+			actID := getPublishRequestActID(vmPublishReq)
+			itemID, pubErr := r.VMProvider.PublishVirtualMachine(ctx, ctx.VM, vmPublishReq, ctx.ContentLibrary, actID)
+			if pubErr != nil {
+				ctx.Logger.Error(pubErr, "failed to publish VM")
+			} else {
+				ctx.Logger.Info("created an OVF from VM", "itemID", itemID)
+			}
+			r.Recorder.EmitEvent(vmPublishReq, "Publish", pubErr, false)
+		}()
+		return nil
+	}
+
+	return nil
+}
+
+func (r *Reconciler) removeVMPubResourceFromCluster(ctx *context.VirtualMachinePublishRequestContextA2) (requeueAfter time.Duration,
+	deleted bool, err error) {
+
+	vmPublishReq := ctx.VMPublishRequest
+	ttlSecondsAfterFinished := vmPublishReq.Spec.TTLSecondsAfterFinished
+	if ttlSecondsAfterFinished == nil {
+		// Skip auto clean up
+		return
+	}
+
+	if *ttlSecondsAfterFinished > 0 {
+		completeTime := vmPublishReq.Status.CompletionTime.Time
+		if time.Since(completeTime) < time.Duration(*ttlSecondsAfterFinished)*time.Second {
+			targetTime := completeTime.Add(time.Duration(*ttlSecondsAfterFinished) * time.Second)
+			return time.Until(targetTime), false, nil
+		}
+	}
+
+	// TTLSecondsAfterFinished elapsed, delete the resource
+	ctx.Logger.Info("deleting VM Publish Request")
+	deleted = true
+	if err = r.Delete(ctx, vmPublishReq); err != nil {
+		deleted = false
+		ctx.Logger.Error(err, "failed to delete vm publish requests")
+	}
+
+	return
+}
+
+// checkIsSourceValid function checks if the source VM is valid. It is invalid if the VM k8s resource
+// doesn't exist, or is not in Created phase.
+func (r *Reconciler) checkIsSourceValid(ctx *context.VirtualMachinePublishRequestContextA2) error {
+	vmPubReq := ctx.VMPublishRequest
+	vm := &vmopv1.VirtualMachine{}
+	objKey := client.ObjectKey{Name: vmPubReq.Status.SourceRef.Name, Namespace: vmPubReq.Namespace}
+	err := r.Get(ctx, objKey, vm)
+	if err != nil {
+		ctx.Logger.Error(err, "failed to get VirtualMachine", "vm", objKey)
+		if apiErrors.IsNotFound(err) {
+			conditions.MarkFalse(vmPubReq,
+				vmopv1.VirtualMachinePublishRequestConditionSourceValid,
+				vmopv1.SourceVirtualMachineNotExistReason,
+				err.Error())
+		}
+		return err
+	}
+	ctx.VM = vm
+
+	if vm.Status.UniqueID == "" {
+		err = errors.New("VM hasn't been created and has no uniqueID")
+		conditions.MarkFalse(vmPubReq,
+			vmopv1.VirtualMachinePublishRequestConditionSourceValid,
+			vmopv1.SourceVirtualMachineNotCreatedReason,
+			err.Error())
+		return err
+	}
+
+	conditions.MarkTrue(vmPubReq, vmopv1.VirtualMachinePublishRequestConditionSourceValid)
+	return nil
+}
+
+// checkIsTargetValid checks if the target item is valid.
+// It is invalid if the content library doesn't exist, an item with the same name in the CL exists.
+func (r *Reconciler) checkIsTargetValid(ctx *context.VirtualMachinePublishRequestContextA2) error {
+	vmPubReq := ctx.VMPublishRequest
+	contentLibrary := &imgregv1a1.ContentLibrary{}
+	targetLocationName := vmPubReq.Spec.Target.Location.Name
+	targetItemName := vmPubReq.Status.TargetRef.Item.Name
+	objKey := client.ObjectKey{Name: targetLocationName, Namespace: vmPubReq.Namespace}
+	if err := r.Get(ctx, objKey, contentLibrary); err != nil {
+		ctx.Logger.Error(err, "failed to get ContentLibrary", "cl", objKey)
+		if apiErrors.IsNotFound(err) {
+			conditions.MarkFalse(vmPubReq,
+				vmopv1.VirtualMachinePublishRequestConditionTargetValid,
+				vmopv1.TargetContentLibraryNotExistReason,
+				err.Error())
+		}
+		return err
+	}
+
+	if !contentLibrary.Spec.Writable {
+		err := fmt.Errorf("target location %s is not writable", contentLibrary.Status.Name)
+		conditions.MarkFalse(vmPubReq,
+			vmopv1.VirtualMachinePublishRequestConditionTargetValid,
+			vmopv1.TargetContentLibraryNotWritableReason,
+			err.Error())
+		return err
+	}
+
+	// Check if the content library is ready.
+	isReady := false
+	for _, condition := range contentLibrary.Status.Conditions {
+		if condition.Type == imgregv1a1.ReadyCondition {
+			isReady = condition.Status == corev1.ConditionTrue
+			break
+		}
+	}
+
+	if !isReady {
+		err := fmt.Errorf("target location %s is not ready", contentLibrary.Status.Name)
+		conditions.MarkFalse(vmPubReq,
+			vmopv1.VirtualMachinePublishRequestConditionTargetValid,
+			vmopv1.TargetContentLibraryNotReadyReason,
+			err.Error())
+		return err
+	}
+
+	ctx.ContentLibrary = contentLibrary
+	item, err := r.VMProvider.GetItemFromLibraryByName(ctx, string(contentLibrary.Spec.UUID), targetItemName)
+	if err != nil {
+		ctx.Logger.Error(err, "failed to find item", "cl", objKey, "item name", targetItemName)
+		return err
+	}
+
+	if item != nil {
+		ctx.Logger.Info("target item already exists in the content library",
+			"cl", objKey, "item name", targetItemName)
+		// If item already exists in the content library and attempt is not zero,
+		// check if it is created from this VirtualMachinePublishRequest by getting its description.
+		// If VC forgets the task, or the task hadn't proceeded far enough to be submitted to VC
+		// within 30 seconds window, this check can help us find if there is a prior task succeeded.
+		// Ideally we are unlikely to see this.
+		if vmPubReq.Status.Attempts > 0 {
+			if r.isItemCorrelatedWithVMPub(ctx, item) {
+				ctx.Logger.Info("existing target item is published by this VMPubReq")
+				conditions.MarkTrue(vmPubReq, vmopv1.VirtualMachinePublishRequestConditionTargetValid)
+				conditions.MarkTrue(vmPubReq, vmopv1.VirtualMachinePublishRequestConditionUploaded)
+				ctx.ItemID = item.ID
+				return nil
+			}
+		}
+
+		// If duplicate item name exists, give up at this point.
+		// no need to requeue to cause another reconcile. return nil.
+		conditions.MarkFalse(vmPubReq,
+			vmopv1.VirtualMachinePublishRequestConditionTargetValid,
+			vmopv1.TargetItemAlreadyExistsReason,
+			fmt.Sprintf("item with name %s already exists in the content library %s", targetItemName,
+				contentLibrary.Status.Name))
+		return nil
+	}
+
+	conditions.MarkTrue(vmPubReq, vmopv1.VirtualMachinePublishRequestConditionTargetValid)
+	return nil
+}
+
+// checkIsImageAvailable checks if the published VirtualMachineImage resource is available in the cluster.
+func (r *Reconciler) checkIsImageAvailable(ctx *context.VirtualMachinePublishRequestContextA2) error {
+	if !conditions.IsTrue(ctx.VMPublishRequest, vmopv1.VirtualMachinePublishRequestConditionUploaded) {
+		return nil
+	}
+
+	if conditions.IsTrue(ctx.VMPublishRequest, vmopv1.VirtualMachinePublishRequestConditionImageAvailable) {
+		return nil
+	}
+
+	if ctx.ItemID == "" {
+		id, err := r.getUploadedItemID(ctx)
+		if err != nil {
+			ctx.Logger.Error(err, "failed to get uploaded item UUID")
+			return err
+		}
+		ctx.ItemID = id
+	}
+
+	vmiList := &vmopv1.VirtualMachineImageList{}
+	if err := r.List(ctx, vmiList, client.InNamespace(ctx.VMPublishRequest.Namespace)); err != nil {
+		ctx.Logger.Error(err, "failed to list VirtualMachineImage")
+		return err
+	}
+
+	found := false
+	for _, vmi := range vmiList.Items {
+		if vmi.Status.ProviderItemID == ctx.ItemID {
+			found = true
+			ctx.VMPublishRequest.Status.ImageName = vmi.Name
+			conditions.MarkTrue(ctx.VMPublishRequest, vmopv1.VirtualMachinePublishRequestConditionImageAvailable)
+			ctx.Logger.Info("VirtualMachineImage is available", "vmiName", vmi.Name)
+			break
+		}
+	}
+
+	if !found {
+		conditions.MarkFalse(ctx.VMPublishRequest,
+			vmopv1.VirtualMachinePublishRequestConditionImageAvailable,
+			vmopv1.TargetVirtualMachineImageNotFoundReason,
+			"VirtualMachineImage not found")
+	}
+
+	return nil
+}
+
+// checkIsComplete checks if condition Complete can be marked to true.
+// The condition's status is set to true only when all other conditions present on the resource have a truthy status.
+func (r *Reconciler) checkIsComplete(ctx *context.VirtualMachinePublishRequestContextA2) bool {
+	if conditions.IsTrue(ctx.VMPublishRequest, vmopv1.VirtualMachinePublishRequestConditionComplete) {
+		return true
+	}
+
+	if !conditions.IsTrue(ctx.VMPublishRequest, vmopv1.VirtualMachinePublishRequestConditionUploaded) {
+		conditions.MarkFalse(ctx.VMPublishRequest,
+			vmopv1.VirtualMachinePublishRequestConditionComplete,
+			vmopv1.HasNotBeenUploadedReason,
+			"item hasn't been uploaded yet")
+		return false
+	}
+
+	if !conditions.IsTrue(ctx.VMPublishRequest, vmopv1.VirtualMachinePublishRequestConditionImageAvailable) {
+		conditions.MarkFalse(ctx.VMPublishRequest,
+			vmopv1.VirtualMachinePublishRequestConditionComplete,
+			vmopv1.ImageUnavailableReason,
+			"VirtualMachineImage is not available")
+		return false
+	}
+
+	conditions.MarkTrue(ctx.VMPublishRequest, vmopv1.VirtualMachinePublishRequestConditionComplete)
+	ctx.VMPublishRequest.Status.Ready = true
+	ctx.VMPublishRequest.Status.CompletionTime = metav1.Now()
+	ctx.Logger.Info("VM publish request completed", "time", ctx.VMPublishRequest.Status.CompletionTime)
+
+	return true
+}
+
+// getPublishRequestTask gets task with description id com.vmware.ovfs.LibraryItem.capture and specified actid in taskManager.
+func (r *Reconciler) getPublishRequestTask(ctx *context.VirtualMachinePublishRequestContextA2) (*vimtypes.TaskInfo, error) {
+	actID := getPublishRequestActID(ctx.VMPublishRequest)
+	logger := ctx.Logger.WithValues("activationID", actID)
+
+	tasks, err := r.VMProvider.GetTasksByActID(ctx, actID)
+	if err != nil {
+		logger.Error(err, "failed to get task")
+		return nil, err
+	}
+
+	if len(tasks) == 0 {
+		logger.V(5).Info("task doesn't exist", "actID", actID, "descriptionID", TaskDescriptionID)
+		return nil, nil
+	}
+
+	// Return the first task.
+	// We would never send multiple CreateOvf requests with the same actID,
+	// so that we should never get multiple tasks.
+	publishTask := &tasks[0]
+	if publishTask.DescriptionId != TaskDescriptionID {
+		err = fmt.Errorf("failed to find expected task %s, found %s instead", TaskDescriptionID, publishTask.DescriptionId)
+		logger.Error(err, "task doesn't exist")
+		return nil, err
+	}
+
+	return publishTask, nil
+}
+
+// checkPubReqStatusAndShouldRepublish checks the publish request task status, mark Uploaded condition
+// and check if we should re-publish this VM.
+// Returns
+// - if a following publish task is needed (true if a publish request should be sent, otherwise return false.),
+// - error
+// It filters VM Publish task from VC task manager by activation ID and checks its status.
+// - If this task is queued/running, then we should mark Uploaded to false and no need to retry VM publish.
+// - task succeeded, mark Uploaded to true and return the uploaded item ID.
+// - task failed, mark Uploaded to false and retry the operation.
+func (r *Reconciler) checkPubReqStatusAndShouldRepublish(ctx *context.VirtualMachinePublishRequestContextA2) (bool, error) {
+	if ctx.VMPublishRequest.Status.Attempts == 0 {
+		// No VM publish task has been attempted. return immediately.
+		return true, nil
+	}
+
+	if conditions.IsTrue(ctx.VMPublishRequest, vmopv1.VirtualMachinePublishRequestConditionUploaded) {
+		return false, nil
+	}
+
+	actID := getPublishRequestActID(ctx.VMPublishRequest)
+	logger := ctx.Logger.WithValues("actID", actID, "descriptionID", TaskDescriptionID)
+
+	task, err := r.getPublishRequestTask(ctx)
+	if err != nil {
+		// Failed to get task from taskManager, return early and retry in next reconcile loop.
+		return false, err
+	}
+
+	// If we can not find a relevant task, probably due to:
+	// - Reason 1: VM operator fails to send the request this request is not made to VC,
+	// e.g. VC credentials rotate. Error returned.
+	// - Reason 2: VM operator is able to create the client and send the request, VC receives this request,
+	// but fails to submit and register this task in the VC task manager. Error returned.
+	// - Reason 3: content library service hasn't processed far enough to submit and register this task,
+	// but will eventually succeed. (Most common)
+	// - Reason 4: task is removed from VC. The default task retention in vpxd is set to 30 days, we can ignore such case.
+	//
+	// Ideally we should immediately return error for Reason 1 & 2. But we can't tell why we can't find that task for
+	// sure since we don't track the CreateOVF error. Meanwhile, reason 1 & 2 are rare and won't be a big problem
+	// if not schedule reconcile requests immediately.
+	//
+	// Wait for the configured timeout before retrying VM publish.
+	// This is done so that the controller doesn't schedule reconcile requests immediately in case 3,
+	// and we are not submitting requests over and over when this publish task is actually running.
+	if task == nil {
+		if time.Since(ctx.VMPublishRequest.Status.LastAttemptTime.Time) > waitForTaskTimeout {
+			// CreateOvf API failed to submit this task for some reason. In this case, retry VM publish.
+			ctx.Logger.Info("failed to create task, retry publishing this VM",
+				"taskName", TaskDescriptionID,
+				"lastAttemptTime", ctx.VMPublishRequest.Status.LastAttemptTime.String())
+			return true, nil
+		}
+
+		// CreateOvf request has been sent but the task com.vmware.ovfs.LibraryItem.capture hasn't been
+		// submitted to the task manager yet. retry taskManager query at later reconcile.
+		conditions.MarkFalse(ctx.VMPublishRequest,
+			vmopv1.VirtualMachinePublishRequestConditionUploaded,
+			vmopv1.UploadTaskNotStartedReason,
+			"VM Publish task hasn't started.")
+		return false, nil
+	}
+
+	switch task.State {
+	case vimtypes.TaskInfoStateQueued:
+		logger.V(5).Info("VM Publish task is queued but hasn't started")
+		conditions.MarkFalse(ctx.VMPublishRequest,
+			vmopv1.VirtualMachinePublishRequestConditionUploaded,
+			vmopv1.UploadTaskQueuedReason,
+			"VM Publish task is queued.")
+		return false, nil
+	case vimtypes.TaskInfoStateRunning:
+		// CreateOVF is still in progress
+		// TODO: Add task Progress info.
+		logger.V(5).Info("VM Publish is still in progress", "progress", task.Progress)
+		conditions.MarkFalse(ctx.VMPublishRequest,
+			vmopv1.VirtualMachinePublishRequestConditionUploaded,
+			vmopv1.UploadingReason,
+			"Uploading item to content library.")
+		return false, nil
+	case vimtypes.TaskInfoStateSuccess:
+		// Publish request succeeds. Update Uploaded condition.
+		logger.Info("VM Publish succeeded", "result", task.Result)
+		r.processUploadedItem(ctx, task)
+		return false, nil
+	case vimtypes.TaskInfoStateError:
+		errMsg := "failed to publish source VM"
+		if task.Error != nil {
+			errMsg = task.Error.LocalizedMessage
+		}
+
+		logger.Error(err, "VM Publish failed, will retry this operation",
+			"actID", task.ActivationId, "descriptionID", task.DescriptionId)
+		conditions.MarkFalse(ctx.VMPublishRequest,
+			vmopv1.VirtualMachinePublishRequestConditionUploaded,
+			vmopv1.UploadFailureReason,
+			errMsg)
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (r *Reconciler) processUploadedItem(ctx *context.VirtualMachinePublishRequestContextA2, task *vimtypes.TaskInfo) {
+	itemID, err := parseItemIDFromTaskResult(task.Result)
+	if err != nil {
+		// Don't return err here because the task result won't be updated, the error will persist.
+		// Ideally, this should never happen.
+		ctx.Logger.Error(err, "failed to get uploaded item UUID")
+		conditions.MarkFalse(ctx.VMPublishRequest,
+			vmopv1.VirtualMachinePublishRequestConditionUploaded,
+			vmopv1.UploadItemIDInvalidReason,
+			ItemParseErrorMessage)
+		r.Recorder.Warn(ctx.VMPublishRequest, "PublishFailure", ItemParseErrorMessage)
+		return
+	}
+
+	ctx.ItemID = itemID
+	conditions.MarkTrue(ctx.VMPublishRequest, vmopv1.VirtualMachinePublishRequestConditionUploaded)
+}
+
+// getUploadedItemID returns the uploaded content library item ID.
+func (r *Reconciler) getUploadedItemID(ctx *context.VirtualMachinePublishRequestContextA2) (string, error) {
+	task, err := r.getPublishRequestTask(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	if task == nil || task.State != vimtypes.TaskInfoStateSuccess {
+		// It's rare but still likely that the latest publish task failed due to duplication
+		// when any previous task succeeded. (If 30 seconds waitForTaskTimeout is not enough in edge cases).
+		// In this case, we need to check item descriptions to match this vmPub and get item ID.
+		return r.findCorrelatedItemIDByName(ctx)
+	}
+
+	return parseItemIDFromTaskResult(task.Result)
+}
+
+// isItemCorrelatedWithVMPub checks if the item is correlated with this VM Publish request
+// by checking the item description. We add the vmPub uuid to the target item description when publishing.
+//
+// Currently, there is no easy way to link published item to the VM publish request
+// other than activation ID.
+// However, if we lose track of the activation ID (a previous task hasn't started within 30 seconds
+// waiting time window but a new task with a new actID is already triggered),
+// we'll get stuck if any previous task succeeds because all tasks afterwards
+// would fail due to item duplication error.
+func (r *Reconciler) isItemCorrelatedWithVMPub(ctx *context.VirtualMachinePublishRequestContextA2,
+	item *library.Item) bool {
+	if item.Description != nil {
+		descriptions := itemDescriptionReg.FindStringSubmatch(*item.Description)
+		if len(descriptions) > 1 && descriptions[1] == string(ctx.VMPublishRequest.UID) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// findCorrelatedItemIDByName finds the published item ID in the VC by target item name.
+func (r *Reconciler) findCorrelatedItemIDByName(ctx *context.VirtualMachinePublishRequestContextA2) (string, error) {
+	targetItemName := ctx.VMPublishRequest.Status.TargetRef.Item.Name
+	// We only get ContentLibrary when checking TargetValid condition,
+	// so this ctx.ContentLibrary can be nil in other cases.
+	// Usually we won't fall into this corner cases, don't put this ContentLibrary Get in Reconcile
+	// to avoid unnecessary reads.
+	if ctx.ContentLibrary == nil {
+		contentLibrary := &imgregv1a1.ContentLibrary{}
+		targetLocationName := ctx.VMPublishRequest.Spec.Target.Location.Name
+		objKey := client.ObjectKey{Name: targetLocationName, Namespace: ctx.VMPublishRequest.Namespace}
+		if err := r.Get(ctx, objKey, contentLibrary); err != nil {
+			ctx.Logger.Error(err, "failed to get ContentLibrary", "cl", objKey)
+			return "", err
+		}
+		ctx.ContentLibrary = contentLibrary
+	}
+
+	item, err := r.VMProvider.GetItemFromLibraryByName(ctx, string(ctx.ContentLibrary.Spec.UUID), targetItemName)
+	if err != nil {
+		ctx.Logger.Error(err, "failed to find item from VC by its name", "item name", targetItemName)
+		return "", err
+	}
+
+	if item != nil {
+		// Item already exists in the content library, check if it is created from
+		// this VirtualMachinePublishRequest from its description.
+		// If VC forgets the task, or the task hadn't proceeded far enough to be submitted to VC
+		// within 30 seconds window, this check can help us find if there is a prior task succeeded.
+		// Ideally we are unlikely to see this.
+		if r.isItemCorrelatedWithVMPub(ctx, item) {
+			return item.ID, nil
+		}
+	}
+
+	return "", fmt.Errorf("no item with name %s exists in the VC", targetItemName)
+}
+
+// updatePublishedItemDescription updates item description, which removes vmPub UUID from it.
+func (r *Reconciler) updatePublishedItemDescription(ctx *context.VirtualMachinePublishRequestContextA2) error {
+	if !conditions.IsTrue(ctx.VMPublishRequest, vmopv1.VirtualMachinePublishRequestConditionImageAvailable) {
+		return nil
+	}
+
+	if ctx.ItemID == "" {
+		id, err := r.getUploadedItemID(ctx)
+		if err != nil {
+			ctx.Logger.Error(err, "failed to get uploaded item UUID")
+			return err
+		}
+		ctx.ItemID = id
+	}
+
+	if err := r.VMProvider.UpdateContentLibraryItem(ctx, ctx.ItemID,
+		ctx.VMPublishRequest.Status.TargetRef.Item.Name,
+		&ctx.VMPublishRequest.Spec.Target.Item.Description); err != nil {
+		ctx.Logger.Error(err, "failed to update item description", "itemID", ctx.ItemID,
+			"itemName", ctx.VMPublishRequest.Status.TargetRef.Item.Name, "itemDescription",
+			ctx.VMPublishRequest.Spec.Target.Item.Description)
+		return err
+	}
+	return nil
+}
+
+// getPublishRequestActID returns the activation ID we pass down to the content library vAPI.
+// Append .status.attempts to the vmpublishrequest uuid to generate an activation ID.
+// VC doesn't prevent duplicate activation IDs for different requests, but we can have problems
+// when doing the query, i.e. not returned all the tasks.
+// So we need a unique string, which is also under track to be the actID for a later query.
+func getPublishRequestActID(vmPub *vmopv1.VirtualMachinePublishRequest) string {
+	return fmt.Sprintf("%s-%d", string(vmPub.UID), vmPub.Status.Attempts)
+}
+
+// parseItemIDFromTaskResult returns the content library item UUID from the task result.
+func parseItemIDFromTaskResult(result vimtypes.AnyType) (string, error) {
+	clItem, ok := result.(vimtypes.ManagedObjectReference)
+	if !ok {
+		return "", fmt.Errorf("failed to cast task result to ManagedObjectReference")
+	}
+
+	if clItem.Type != "ContentLibraryItem" {
+		return "", fmt.Errorf("expect task result type to be ContentLibraryItem, get %s instead", clItem.Type)
+	}
+
+	if !strings.HasPrefix(clItem.Value, clItemPrefix) {
+		return "", fmt.Errorf("content library item UUID is invalid, value: %s", clItem.Value)
+	}
+	return clItem.Value[len(clItemPrefix):], nil
+}
+
+func (r *Reconciler) ReconcileNormal(ctx *context.VirtualMachinePublishRequestContextA2) (_ ctrl.Result, reterr error) {
+	ctx.Logger.Info("Reconciling VirtualMachinePublishRequest")
+	vmPublishReq := ctx.VMPublishRequest
+
+	if !controllerutil.ContainsFinalizer(vmPublishReq, finalizerName) {
+		// The finalizer must be present before proceeding in order to ensure that the VirtualMachinePublishRequest will
+		// be cleaned up. Return immediately after here to let the patcher helper update the
+		// object, and then we'll proceed on the next reconciliation.
+		controllerutil.AddFinalizer(vmPublishReq, finalizerName)
+		return
+	}
+
+	// Register VM publish request metrics based on the reconcile result.
+	var isComplete, isDeleted bool
+	defer func() {
+		if isDeleted {
+			// If the vmPub is deleted, return immediately.
+			// We don't need to call DeleteMetrics here, we will run this in ReconcileDelete().
+			return
+		}
+
+		var res metrics.PublishResult
+		switch {
+		case isComplete:
+			res = metrics.PublishSucceeded
+		case reterr != nil:
+			res = metrics.PublishFailed
+		default:
+			res = metrics.PublishInProgress
+		}
+
+		r.Metrics.RegisterVMPublishRequest(r.Logger, vmPublishReq.Name, vmPublishReq.Namespace, res)
+	}()
+
+	// In case the .spec.ttlSecondsAfterFinished is not set, we can return early and no need to do any reconcile.
+	isComplete = conditions.IsTrue(vmPublishReq, vmopv1.VirtualMachinePublishRequestConditionComplete)
+	if isComplete {
+		requeueAfter, deleted, err := r.removeVMPubResourceFromCluster(ctx)
+		isDeleted = deleted
+		return ctrl.Result{RequeueAfter: requeueAfter}, err
+	}
+
+	if vmPublishReq.Status.StartTime.IsZero() {
+		vmPublishReq.Status.StartTime = metav1.Now()
+	}
+
+	r.updateSourceAndTargetRef(ctx)
+
+	shouldPublish, err := r.checkPubReqStatusAndShouldRepublish(ctx)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if shouldPublish {
+		err := r.publishVirtualMachine(ctx)
+		if err != nil {
+			ctx.Logger.Error(err, "failed to publish VirtualMachine")
+			return ctrl.Result{}, errors.Wrapf(err, "failed to publish VirtualMachine")
+		}
+		return requeueResult(ctx), nil
+	}
+
+	if err := r.checkIsImageAvailable(ctx); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Update published item description to remove vmPub UUID from it.
+	// Update the description after all conditions except Complete is set,
+	// otherwise we may lose track of the item if this update fails.
+	if err := r.updatePublishedItemDescription(ctx); err != nil {
+		r.Recorder.EmitEvent(vmPublishReq, "Publish", err, true)
+		return ctrl.Result{}, err
+	}
+
+	if isComplete = r.checkIsComplete(ctx); isComplete {
+		// remove VirtualMachinePublishRequest from the cluster if ttlSecondsAfterFinished is set.
+		requeueAfter, deleted, err := r.removeVMPubResourceFromCluster(ctx)
+		isDeleted = deleted
+		return ctrl.Result{RequeueAfter: requeueAfter}, err
+	}
+
+	return requeueResult(ctx), nil
+}
+
+func (r *Reconciler) ReconcileDelete(ctx *context.VirtualMachinePublishRequestContextA2) (ctrl.Result, error) {
+	if controllerutil.ContainsFinalizer(ctx.VMPublishRequest, finalizerName) {
+		r.Metrics.DeleteMetrics(ctx.Logger, ctx.VMPublishRequest.Name, ctx.VMPublishRequest.Namespace)
+		controllerutil.RemoveFinalizer(ctx.VMPublishRequest, finalizerName)
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/controllers/virtualmachinepublishrequest/v1alpha2/virtualmachinepublishrequest_controller_intg_test.go
+++ b/controllers/virtualmachinepublishrequest/v1alpha2/virtualmachinepublishrequest_controller_intg_test.go
@@ -1,0 +1,251 @@
+// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha2_test
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/google/uuid"
+	"github.com/vmware/govmomi/vim25/types"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	imgregv1a1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha1"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/controllers/contentlibrary/v1alpha1/utils"
+	virtualmachinepublishrequest "github.com/vmware-tanzu/vm-operator/controllers/virtualmachinepublishrequest/v1alpha2"
+	conditions "github.com/vmware-tanzu/vm-operator/pkg/conditions2"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+func intgTests() {
+	Describe("Invoking VirtualMachinePublishRequest controller tests", virtualMachinePublishRequestReconcile)
+}
+
+func virtualMachinePublishRequestReconcile() {
+	var (
+		ctx      *builder.IntegrationTestContext
+		vmPubReq *vmopv1.VirtualMachinePublishRequest
+		vm       *vmopv1.VirtualMachine
+		cl       *imgregv1a1.ContentLibrary
+	)
+
+	getVirtualMachinePublishRequest := func(ctx *builder.IntegrationTestContext, objKey client.ObjectKey) *vmopv1.VirtualMachinePublishRequest {
+		req := &vmopv1.VirtualMachinePublishRequest{}
+		if err := ctx.Client.Get(ctx, objKey, req); err != nil {
+			return nil
+		}
+		return req
+	}
+
+	waitForVirtualMachinePublishRequestFinalizer := func(ctx *builder.IntegrationTestContext, objKey client.ObjectKey) {
+		Eventually(func() []string {
+			if req := getVirtualMachinePublishRequest(ctx, objKey); req != nil {
+				return req.GetFinalizers()
+			}
+			return nil
+		}).Should(ContainElement(finalizerName), "waiting for VirtualMachinePublishRequest finalizer")
+	}
+
+	BeforeEach(func() {
+		ctx = suite.NewIntegrationTestContext()
+
+		vm = &vmopv1.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dummy-vm",
+				Namespace: ctx.Namespace,
+			},
+			Spec: vmopv1.VirtualMachineSpec{
+				ImageName:  "dummy-image",
+				ClassName:  "dummy-class",
+				PowerState: vmopv1.VirtualMachinePowerStateOn,
+			},
+		}
+
+		cl = builder.DummyContentLibrary("dummy-cl", ctx.Namespace, "dummy-cl-uuid")
+
+		vmPubReq = builder.DummyVirtualMachinePublishRequestA2(
+			"dummy-vmpub", ctx.Namespace,
+			vm.Name,
+			"dummy-item",
+			cl.Name)
+	})
+
+	AfterEach(func() {
+		ctx.AfterEach()
+		ctx = nil
+	})
+
+	Context("Reconcile", func() {
+
+		Context("Successfully reconcile a VirtualMachinePublishRequest", func() {
+			BeforeEach(func() {
+				Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
+				vm.Status.UniqueID = "dummy-vm-unique-id"
+				Expect(ctx.Client.Status().Update(ctx, vm)).To(Succeed())
+
+				Expect(ctx.Client.Create(ctx, cl)).To(Succeed())
+				cl.Status.Conditions = []imgregv1a1.Condition{
+					{
+						Type:   imgregv1a1.ReadyCondition,
+						Status: corev1.ConditionTrue,
+					},
+				}
+				Expect(ctx.Client.Status().Update(ctx, cl)).To(Succeed())
+
+				Expect(ctx.Client.Create(ctx, vmPubReq)).To(Succeed())
+			})
+
+			AfterEach(func() {
+				err := ctx.Client.Delete(ctx, vmPubReq)
+				Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
+				err = ctx.Client.Delete(ctx, vm)
+				Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
+				err = ctx.Client.Delete(ctx, cl)
+				Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
+
+				intgFakeVMProvider.Reset()
+			})
+
+			It("VirtualMachinePublishRequest completed", func() {
+				// Wait for initial reconcile.
+				waitForVirtualMachinePublishRequestFinalizer(ctx, client.ObjectKeyFromObject(vmPubReq))
+
+				By("PublishVM should be called", func() {
+					Eventually(intgFakeVMProvider.IsPublishVMCalled).Should(BeTrue())
+				})
+
+				By("VM publish task is queued", func() {
+					intgFakeVMProvider.Lock()
+					intgFakeVMProvider.GetTasksByActIDFn = func(_ context.Context, actID string) ([]types.TaskInfo, error) {
+						task := types.TaskInfo{
+							DescriptionId: virtualmachinepublishrequest.TaskDescriptionID,
+							State:         types.TaskInfoStateQueued,
+						}
+						return []types.TaskInfo{task}, nil
+					}
+					intgFakeVMProvider.Unlock()
+
+					// Force trigger a reconcile.
+					_, err := controllerutil.CreateOrPatch(ctx, ctx.Client, vmPubReq, func() error {
+						vmPubReq.Annotations = map[string]string{"dummy": "dummy-1"}
+						return nil
+					})
+					Expect(err).ToNot(HaveOccurred())
+
+					Eventually(func(g Gomega) {
+						req := getVirtualMachinePublishRequest(ctx, client.ObjectKeyFromObject(vmPubReq))
+						g.Expect(req).ToNot(BeNil())
+						g.Expect(req.Status.Attempts).To(BeEquivalentTo(1))
+
+						condition := conditions.Get(req, vmopv1.VirtualMachinePublishRequestConditionUploaded)
+						g.Expect(condition).ToNot(BeNil())
+						g.Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+						g.Expect(condition.Reason).To(Equal(vmopv1.UploadTaskQueuedReason))
+					}).Should(Succeed())
+				})
+
+				By("VM publish task is running", func() {
+					intgFakeVMProvider.Lock()
+					intgFakeVMProvider.GetTasksByActIDFn = func(_ context.Context, actID string) ([]types.TaskInfo, error) {
+						task := types.TaskInfo{
+							DescriptionId: virtualmachinepublishrequest.TaskDescriptionID,
+							State:         types.TaskInfoStateRunning,
+						}
+						return []types.TaskInfo{task}, nil
+					}
+					intgFakeVMProvider.Unlock()
+
+					// Force trigger a reconcile.
+					_, err := controllerutil.CreateOrPatch(ctx, ctx.Client, vmPubReq, func() error {
+						vmPubReq.Annotations = map[string]string{"dummy": "dummy-2"}
+						return nil
+					})
+					Expect(err).ToNot(HaveOccurred())
+
+					Eventually(func(g Gomega) {
+						req := getVirtualMachinePublishRequest(ctx, client.ObjectKeyFromObject(vmPubReq))
+						g.Expect(req).ToNot(BeNil())
+						g.Expect(req.Status.Attempts).To(BeEquivalentTo(1))
+
+						condition := conditions.Get(req, vmopv1.VirtualMachinePublishRequestConditionUploaded)
+						g.Expect(condition).ToNot(BeNil())
+						g.Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+						g.Expect(condition.Reason).To(Equal(vmopv1.UploadingReason))
+					}).Should(Succeed())
+				})
+
+				itemID := uuid.New().String()
+
+				By("VM publish task succeeded", func() {
+					intgFakeVMProvider.Lock()
+					intgFakeVMProvider.GetTasksByActIDFn = func(_ context.Context, actID string) ([]types.TaskInfo, error) {
+						task := types.TaskInfo{
+							DescriptionId: virtualmachinepublishrequest.TaskDescriptionID,
+							State:         types.TaskInfoStateSuccess,
+							Result:        types.ManagedObjectReference{Type: "ContentLibraryItem", Value: fmt.Sprintf("clibitem-%s", itemID)},
+						}
+						return []types.TaskInfo{task}, nil
+					}
+					intgFakeVMProvider.Unlock()
+
+					By("Simulate ContentLibrary and VM Image reconcile", func() {
+						clItem := utils.DummyContentLibraryItem("dummy-clitem", ctx.Namespace)
+						Expect(ctx.Client.Create(ctx, clItem)).To(Succeed())
+
+						vmi := builder.DummyVirtualMachineImageA2("dummy-image")
+						vmi.Namespace = ctx.Namespace
+						Expect(ctx.Client.Create(ctx, vmi)).To(Succeed())
+						targetName := vmPubReq.Spec.Target.Item.Name
+						Expect(targetName).ToNot(BeEmpty())
+						vmi.Status.Name = targetName
+						vmi.Status.ProviderItemID = itemID
+						Expect(ctx.Client.Status().Update(ctx, vmi)).To(Succeed())
+					})
+
+					// Force trigger a reconcile.
+					_, err := controllerutil.CreateOrPatch(ctx, ctx.Client, vmPubReq, func() error {
+						vmPubReq.Annotations = map[string]string{"dummy": "dummy-3"}
+						return nil
+					})
+					Expect(err).ShouldNot(HaveOccurred())
+
+					Eventually(func(g Gomega) {
+						req := getVirtualMachinePublishRequest(ctx, client.ObjectKeyFromObject(vmPubReq))
+						g.Expect(req).ToNot(BeNil())
+
+						g.Expect(conditions.IsTrue(req, vmopv1.VirtualMachinePublishRequestConditionComplete)).To(BeTrue())
+						g.Expect(req.Status.Ready).To(BeTrue())
+						g.Expect(req.Status.ImageName).To(Equal("dummy-image"))
+						g.Expect(req.Status.CompletionTime).NotTo(BeZero())
+					}).Should(Succeed())
+				})
+			})
+		})
+
+		It("Reconciles after VirtualMachinePublishRequest deletion", func() {
+			Expect(ctx.Client.Create(ctx, vmPubReq)).To(Succeed())
+
+			// Wait for initial reconcile.
+			waitForVirtualMachinePublishRequestFinalizer(ctx, client.ObjectKeyFromObject(vmPubReq))
+
+			Expect(ctx.Client.Delete(ctx, vmPubReq)).To(Succeed())
+			By("Finalizer should be removed after deletion", func() {
+				Eventually(func() []string {
+					if req := getVirtualMachinePublishRequest(ctx, client.ObjectKeyFromObject(vmPubReq)); req != nil {
+						return req.GetFinalizers()
+					}
+					return nil
+				}).ShouldNot(ContainElement(finalizerName))
+			})
+		})
+	})
+}

--- a/controllers/virtualmachinepublishrequest/v1alpha2/virtualmachinepublishrequest_controller_suite_test.go
+++ b/controllers/virtualmachinepublishrequest/v1alpha2/virtualmachinepublishrequest_controller_suite_test.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha2_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+
+	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
+
+	virtualmachinepublishrequest "github.com/vmware-tanzu/vm-operator/controllers/virtualmachinepublishrequest/v1alpha2"
+	ctrlContext "github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/lib"
+	providerfake "github.com/vmware-tanzu/vm-operator/pkg/vmprovider/fake"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+var intgFakeVMProvider = providerfake.NewVMProviderA2()
+
+var suite = builder.NewTestSuiteForControllerWithFSS(
+	virtualmachinepublishrequest.AddToManager,
+	func(ctx *ctrlContext.ControllerManagerContext, _ ctrlmgr.Manager) error {
+		ctx.VMProviderA2 = intgFakeVMProvider
+		return nil
+	},
+	map[string]bool{lib.VMImageRegistryFSS: true},
+)
+
+func TestVirtualMachinePublishRequest(t *testing.T) {
+	_ = intgTests
+	suite.Register(t, "VirtualMachinePublishRequest controller suite", nil /*intgTests*/, unitTests)
+}
+
+var _ = BeforeSuite(suite.BeforeSuite)
+
+var _ = AfterSuite(suite.AfterSuite)

--- a/controllers/virtualmachinepublishrequest/v1alpha2/virtualmachinepublishrequest_controller_unit_test.go
+++ b/controllers/virtualmachinepublishrequest/v1alpha2/virtualmachinepublishrequest_controller_unit_test.go
@@ -1,0 +1,668 @@
+// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha2_test
+
+import (
+	goctx "context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/google/uuid"
+	"github.com/vmware/govmomi/vapi/library"
+	"github.com/vmware/govmomi/vim25/types"
+
+	imgregv1a1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha1"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	virtualmachinepublishrequest "github.com/vmware-tanzu/vm-operator/controllers/virtualmachinepublishrequest/v1alpha2"
+	conditions "github.com/vmware-tanzu/vm-operator/pkg/conditions2"
+	vmopContext "github.com/vmware-tanzu/vm-operator/pkg/context"
+	providerfake "github.com/vmware-tanzu/vm-operator/pkg/vmprovider/fake"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+func unitTests() {
+	Describe("Invoking VirtualMachinePublishRequest Reconcile", unitTestsReconcile)
+}
+
+const finalizerName = "virtualmachinepublishrequest.vmoperator.vmware.com"
+
+func unitTestsReconcile() {
+	var (
+		initObjects []client.Object
+		ctx         *builder.UnitTestContextForController
+
+		reconciler     *virtualmachinepublishrequest.Reconciler
+		fakeVMProvider *providerfake.VMProviderA2
+
+		vm       *vmopv1.VirtualMachine
+		vmpub    *vmopv1.VirtualMachinePublishRequest
+		cl       *imgregv1a1.ContentLibrary
+		vmpubCtx *vmopContext.VirtualMachinePublishRequestContextA2
+	)
+
+	BeforeEach(func() {
+		vm = &vmopv1.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dummy-vm",
+				Namespace: "dummy-ns",
+			},
+			Status: vmopv1.VirtualMachineStatus{
+				UniqueID: "dummy-id",
+			},
+		}
+
+		vmpub = builder.DummyVirtualMachinePublishRequestA2("dummy-vmpub", vm.Namespace, vm.Name, "dummy-item", "dummy-cl")
+		cl = builder.DummyContentLibrary("dummy-cl", vm.Namespace, "dummy-id")
+	})
+
+	JustBeforeEach(func() {
+		ctx = suite.NewUnitTestContextForController(initObjects...)
+		reconciler = virtualmachinepublishrequest.NewReconciler(
+			ctx.Client,
+			ctx.Client,
+			ctx.Logger,
+			ctx.Recorder,
+			ctx.VMProviderA2,
+		)
+		fakeVMProvider = ctx.VMProviderA2.(*providerfake.VMProviderA2)
+		fakeVMProvider.Reset()
+
+		vmpubCtx = &vmopContext.VirtualMachinePublishRequestContextA2{
+			Context:          ctx,
+			Logger:           ctx.Logger.WithName(vmpub.Name),
+			VMPublishRequest: vmpub,
+			VM:               vm,
+			ContentLibrary:   cl,
+		}
+	})
+
+	AfterEach(func() {
+		ctx.AfterEach()
+		ctx = nil
+		initObjects = nil
+		reconciler = nil
+	})
+
+	Context("ReconcileNormal", func() {
+		BeforeEach(func() {
+			initObjects = append(initObjects, cl, vm, vmpub)
+		})
+
+		When("object does not have finalizer set", func() {
+			BeforeEach(func() {
+				vmpub.Finalizers = nil
+			})
+
+			It("will set finalizer", func() {
+				_, err := reconciler.ReconcileNormal(vmpubCtx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(vmpubCtx.VMPublishRequest.GetFinalizers()).To(ContainElement(finalizerName))
+			})
+		})
+
+		It("will have finalizer set upon successful reconciliation and can be called multiple times", func() {
+			_, err := reconciler.ReconcileNormal(vmpubCtx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(vmpubCtx.VMPublishRequest.GetFinalizers()).To(ContainElement(finalizerName))
+
+			_, err = reconciler.ReconcileNormal(vmpubCtx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(vmpubCtx.VMPublishRequest.GetFinalizers()).To(ContainElement(finalizerName))
+		})
+
+		When("VMPubRequest update failed", func() {
+			JustBeforeEach(func() {
+				// mock update failure
+				obj := vmpub.DeepCopy()
+				obj.Annotations = map[string]string{"dummy": "dummy"}
+				Expect(ctx.Client.Status().Update(ctx, obj)).To(Succeed())
+			})
+
+			It("Should not publish VM", func() {
+				_, err := reconciler.ReconcileNormal(vmpubCtx)
+				Expect(err).To(HaveOccurred())
+
+				// vmpub result should be empty because it never starts.
+				Consistently(func() types.TaskInfoState {
+					return fakeVMProvider.GetVMPublishRequestResult(vmpub)
+				}).Should(BeEmpty())
+			})
+		})
+
+		When("Source VM isn't valid", func() {
+			BeforeEach(func() {
+				initObjects = []client.Object{cl, vmpub}
+			})
+
+			It("returns error if source VM doesn't exist", func() {
+				_, err := reconciler.ReconcileNormal(vmpubCtx)
+				Expect(err).To(HaveOccurred())
+
+				// Update SourceValid condition.
+				Expect(conditions.IsTrue(vmpub,
+					vmopv1.VirtualMachinePublishRequestConditionSourceValid)).To(BeFalse())
+			})
+
+			When("Source VM has empty uniqueID", func() {
+				BeforeEach(func() {
+					vm.Status.UniqueID = ""
+					initObjects = append(initObjects, vm)
+				})
+
+				It("should return error and retry", func() {
+					_, err := reconciler.ReconcileNormal(vmpubCtx)
+					Expect(err).To(HaveOccurred())
+
+					// Update SourceValid condition.
+					Expect(conditions.IsTrue(vmpub,
+						vmopv1.VirtualMachinePublishRequestConditionSourceValid)).To(BeFalse())
+				})
+			})
+		})
+
+		When("Target isn't valid", func() {
+			BeforeEach(func() {
+				initObjects = []client.Object{vm, vmpub}
+			})
+
+			It("returns error to retry if content library doesn't exist", func() {
+				_, err := reconciler.ReconcileNormal(vmpubCtx)
+				Expect(err).To(HaveOccurred())
+
+				// Update TargetValid condition.
+				Expect(conditions.IsTrue(vmpub,
+					vmopv1.VirtualMachinePublishRequestConditionTargetValid)).To(BeFalse())
+			})
+
+			It("returns error if content library is not writable", func() {
+				cl.Spec.Writable = false
+				Expect(ctx.Client.Create(ctx, cl)).To(Succeed())
+
+				_, err := reconciler.ReconcileNormal(vmpubCtx)
+				Expect(err).To(HaveOccurred())
+
+				// Update TargetValid condition.
+				Expect(conditions.IsTrue(vmpub,
+					vmopv1.VirtualMachinePublishRequestConditionTargetValid)).To(BeFalse())
+			})
+
+			It("returns error if content library is not ready", func() {
+				cl.Status.Conditions = []imgregv1a1.Condition{
+					{
+						Type:   imgregv1a1.ReadyCondition,
+						Status: corev1.ConditionFalse,
+					},
+				}
+				Expect(ctx.Client.Create(ctx, cl)).To(Succeed())
+
+				_, err := reconciler.ReconcileNormal(vmpubCtx)
+				Expect(err).To(HaveOccurred())
+
+				// Update TargetValid condition.
+				Expect(conditions.IsTrue(vmpub,
+					vmopv1.VirtualMachinePublishRequestConditionTargetValid)).To(BeFalse())
+			})
+
+			When("item with same name already exists in the content library", func() {
+				JustBeforeEach(func() {
+					Expect(ctx.Client.Create(ctx, cl)).To(Succeed())
+					fakeVMProvider.GetItemFromLibraryByNameFn = func(ctx goctx.Context,
+						contentLibrary, itemName string) (*library.Item, error) {
+						return &library.Item{ID: "dummy-id"}, nil
+					}
+				})
+
+				It("doesn't return error to skip requeue", func() {
+					_, err := reconciler.ReconcileNormal(vmpubCtx)
+					Expect(err).NotTo(HaveOccurred())
+
+					// Update TargetValid condition.
+					Expect(conditions.IsTrue(vmpub,
+						vmopv1.VirtualMachinePublishRequestConditionTargetValid)).To(BeFalse())
+				})
+			})
+		})
+
+		When("Source and target are both valid", func() {
+			When("Publish VM succeeds", func() {
+				It("requeue and sets VM Publish request status to Success", func() {
+					_, err := reconciler.ReconcileNormal(vmpubCtx)
+					Expect(err).ToNot(HaveOccurred())
+
+					// Eventually vmpub result should be updated to success.
+					Eventually(func() bool {
+						return fakeVMProvider.IsPublishVMCalled()
+					}).Should(BeTrue())
+
+					Eventually(func() types.TaskInfoState {
+						return fakeVMProvider.GetVMPublishRequestResult(vmpub)
+					}).Should(Equal(types.TaskInfoStateSuccess))
+
+					By("Should set sourceRef/targetRef")
+					Expect(vmpub.Status.SourceRef.Name).To(Equal(vm.Name))
+					Expect(vmpub.Status.TargetRef.Item.Name).To(Equal("dummy-item"))
+					Expect(vmpub.Status.TargetRef.Location).To(Equal(vmpub.Spec.Target.Location))
+				})
+
+				When(".spec.source.name is empty", func() {
+					BeforeEach(func() {
+						vm.Name = vmpub.Name
+						vmpub.Spec.Source.Name = ""
+					})
+
+					It("requeue and sets VM Publish request status to Success", func() {
+						_, err := reconciler.ReconcileNormal(vmpubCtx)
+						Expect(err).ToNot(HaveOccurred())
+
+						// Eventually vmpub result should be updated to success.
+						Eventually(func() bool {
+							return fakeVMProvider.IsPublishVMCalled()
+						}).Should(BeTrue())
+
+						By("Should set sourceRef/targetRef")
+						Expect(vmpub.Status.SourceRef.Name).To(Equal(vm.Name))
+						Expect(vmpub.Status.TargetRef.Item.Name).To(Equal("dummy-item"))
+						Expect(vmpub.Status.TargetRef.Location).To(Equal(vmpub.Spec.Target.Location))
+					})
+				})
+
+				When(".spec.target.item.name is empty", func() {
+					BeforeEach(func() {
+						vmpub.Spec.Target.Item.Name = ""
+					})
+
+					It("requeue and sets VM Publish request status to Success", func() {
+						_, err := reconciler.ReconcileNormal(vmpubCtx)
+						Expect(err).ToNot(HaveOccurred())
+
+						// Eventually vmpub result should be updated to success.
+						Eventually(func() bool {
+							return fakeVMProvider.IsPublishVMCalled()
+						}).Should(BeTrue())
+
+						Eventually(func() types.TaskInfoState {
+							return fakeVMProvider.GetVMPublishRequestResult(vmpub)
+						}).Should(Equal(types.TaskInfoStateSuccess))
+
+						By("Should set sourceRef/targetRef")
+						Expect(vmpub.Status.SourceRef.Name).To(Equal(vm.Name))
+						Expect(vmpub.Status.TargetRef.Item.Name).To(Equal("dummy-vm-image"))
+						Expect(vmpub.Status.TargetRef.Location).To(Equal(vmpub.Spec.Target.Location))
+					})
+				})
+			})
+
+			When("Publish VM fails", func() {
+				JustBeforeEach(func() {
+					fakeVMProvider.PublishVirtualMachineFn = func(ctx goctx.Context, vm *vmopv1.VirtualMachine,
+						vmPub *vmopv1.VirtualMachinePublishRequest, cl *imgregv1a1.ContentLibrary, actID string) (string, error) {
+						fakeVMProvider.AddToVMPublishMap(actID, types.TaskInfoStateError)
+						return "", fmt.Errorf("dummy error")
+					}
+				})
+
+				It("returns success but sets VM Publish status to error", func() {
+					_, err := reconciler.ReconcileNormal(vmpubCtx)
+					Expect(err).NotTo(HaveOccurred())
+
+					// Eventually vmpub result should be updated to error.
+					Eventually(func() bool {
+						return fakeVMProvider.IsPublishVMCalled()
+					}).Should(BeTrue())
+
+					Eventually(func() types.TaskInfoState {
+						return fakeVMProvider.GetVMPublishRequestResult(vmpub)
+					}).Should(Equal(types.TaskInfoStateError))
+
+					By("Should set sourceRef/targetRef")
+					Expect(vmpub.Status.SourceRef.Name).To(Equal(vm.Name))
+					Expect(vmpub.Status.TargetRef.Item.Name).To(Equal(vmpub.Spec.Target.Item.Name))
+					Expect(vmpub.Status.TargetRef.Location).To(Equal(vmpub.Spec.Target.Location))
+				})
+			})
+		})
+
+		Context("A previous publish request has been sent", func() {
+			BeforeEach(func() {
+				vmpub.Status.Attempts = 1
+				lastAttemptTime := time.Now().Add(-time.Minute)
+				vmpub.Status.LastAttemptTime = metav1.NewTime(lastAttemptTime)
+			})
+
+			When("Previous task doesn't exist", func() {
+				JustBeforeEach(func() {
+					fakeVMProvider.Lock()
+					fakeVMProvider.GetTasksByActIDFn = func(ctx goctx.Context, actID string) (tasksInfo []types.TaskInfo, retErr error) {
+						return nil, nil
+					}
+					fakeVMProvider.Unlock()
+				})
+
+				It("Should send a second publish VM request", func() {
+					_, err := reconciler.ReconcileNormal(vmpubCtx)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(conditions.IsTrue(vmpub,
+						vmopv1.VirtualMachinePublishRequestConditionUploaded)).To(BeFalse())
+					Expect(conditions.IsTrue(vmpub,
+						vmopv1.VirtualMachinePublishRequestConditionImageAvailable)).To(BeFalse())
+
+					Eventually(func() bool {
+						return fakeVMProvider.IsPublishVMCalled()
+					}).Should(BeTrue())
+
+					// vmpub result should eventually be success.
+					Eventually(func() types.TaskInfoState {
+						return fakeVMProvider.GetVMPublishRequestResult(vmpub)
+					}).Should(Equal(types.TaskInfoStateSuccess))
+				})
+			})
+
+			When("Previous request succeeded", func() {
+				var (
+					itemID = uuid.New().String()
+					task   *types.TaskInfo
+				)
+
+				When("task succeeded but failed to parse item ID", func() {
+					JustBeforeEach(func() {
+						task = &types.TaskInfo{
+							DescriptionId: virtualmachinepublishrequest.TaskDescriptionID,
+							State:         types.TaskInfoStateSuccess,
+							QueueTime:     time.Now().Add(time.Minute),
+						}
+						fakeVMProvider.GetTasksByActIDFn = func(ctx goctx.Context, actID string) (tasksInfo []types.TaskInfo, retErr error) {
+							return []types.TaskInfo{*task}, nil
+						}
+					})
+
+					It("result object invalid, Upload condition is false, not send a second publish VM request and return success", func() {
+						_, err := reconciler.ReconcileNormal(vmpubCtx)
+						Expect(err).NotTo(HaveOccurred())
+
+						Expect(fakeVMProvider.IsPublishVMCalled()).To(BeFalse())
+
+						uploadCondition := conditions.Get(vmpub, vmopv1.VirtualMachinePublishRequestConditionUploaded)
+						Expect(uploadCondition).ToNot(BeNil())
+						Expect(uploadCondition.Status).To(Equal(metav1.ConditionFalse))
+						Expect(uploadCondition.Reason).To(Equal(vmopv1.UploadItemIDInvalidReason))
+					})
+
+					It("result type invalid, Upload condition is false, not send a second publish VM request and return success", func() {
+						task.Result = types.ManagedObjectReference{Type: "ContentLibrary",
+							Value: fmt.Sprintf("clib-%s", itemID)}
+						_, err := reconciler.ReconcileNormal(vmpubCtx)
+						Expect(err).NotTo(HaveOccurred())
+
+						Expect(fakeVMProvider.IsPublishVMCalled()).To(BeFalse())
+
+						uploadCondition := conditions.Get(vmpub, vmopv1.VirtualMachinePublishRequestConditionUploaded)
+						Expect(uploadCondition.Status).To(Equal(metav1.ConditionFalse))
+						Expect(uploadCondition.Reason).To(Equal(vmopv1.UploadItemIDInvalidReason))
+					})
+
+					It("result value invalid, Upload condition is false, not send a second publish VM request and return success", func() {
+						task.Result = types.ManagedObjectReference{Type: "ContentLibraryItem", Value: itemID}
+						_, err := reconciler.ReconcileNormal(vmpubCtx)
+						Expect(err).NotTo(HaveOccurred())
+
+						Expect(fakeVMProvider.IsPublishVMCalled()).To(BeFalse())
+
+						uploadCondition := conditions.Get(vmpub, vmopv1.VirtualMachinePublishRequestConditionUploaded)
+						Expect(uploadCondition).ToNot(BeNil())
+						Expect(uploadCondition.Status).To(Equal(metav1.ConditionFalse))
+						Expect(uploadCondition.Reason).To(Equal(vmopv1.UploadItemIDInvalidReason))
+					})
+				})
+
+				When("Uploaded item id is valid", func() {
+					JustBeforeEach(func() {
+						fakeVMProvider.Lock()
+						fakeVMProvider.GetTasksByActIDFn = func(ctx goctx.Context, actID string) (tasksInfo []types.TaskInfo, retErr error) {
+							task := types.TaskInfo{
+								DescriptionId: virtualmachinepublishrequest.TaskDescriptionID,
+								State:         types.TaskInfoStateSuccess,
+								QueueTime:     time.Now().Add(time.Minute),
+								Result: types.ManagedObjectReference{Type: "ContentLibraryItem",
+									Value: fmt.Sprintf("clibitem-%s", itemID)},
+							}
+							return []types.TaskInfo{task}, nil
+						}
+						fakeVMProvider.Unlock()
+					})
+
+					When("task succeeded but failed to parse item ID", func() {
+						JustBeforeEach(func() {
+							fakeVMProvider.Lock()
+							fakeVMProvider.GetTasksByActIDFn = func(ctx goctx.Context, actID string) (tasksInfo []types.TaskInfo, retErr error) {
+								task := types.TaskInfo{
+									DescriptionId: virtualmachinepublishrequest.TaskDescriptionID,
+									State:         types.TaskInfoStateSuccess,
+									QueueTime:     time.Now().Add(time.Minute),
+									Result: types.ManagedObjectReference{Type: "ContentLibrary",
+										Value: fmt.Sprintf("item-%s", itemID)},
+								}
+								return []types.TaskInfo{task}, nil
+							}
+							fakeVMProvider.Unlock()
+						})
+					})
+
+					When("VirtualMachineImage is available", func() {
+						JustBeforeEach(func() {
+							vmi := builder.DummyVirtualMachineImageA2("dummy-image")
+							vmi.Namespace = vmpub.Namespace
+							Expect(ctx.Client.Create(ctx, vmi)).To(Succeed())
+							vmi.Status.ProviderItemID = itemID
+							Expect(ctx.Client.Status().Update(ctx, vmi)).To(Succeed())
+						})
+
+						It("Complete condition is true, not send a second publish VM request and return success", func() {
+							_, err := reconciler.ReconcileNormal(vmpubCtx)
+							Expect(err).NotTo(HaveOccurred())
+
+							Expect(fakeVMProvider.IsPublishVMCalled()).To(BeFalse())
+
+							Expect(conditions.IsTrue(vmpub,
+								vmopv1.VirtualMachinePublishRequestConditionUploaded)).To(BeTrue())
+							Expect(conditions.IsTrue(vmpub,
+								vmopv1.VirtualMachinePublishRequestConditionImageAvailable)).To(BeTrue())
+							Expect(vmpub.Status.ImageName).To(Equal("dummy-image"))
+							Expect(conditions.IsTrue(vmpub,
+								vmopv1.VirtualMachinePublishRequestConditionComplete)).To(BeTrue())
+							Expect(vmpub.Status.Ready).To(BeTrue())
+						})
+
+						It("Update item description failed once", func() {
+							fakeVMProvider.Lock()
+							fakeVMProvider.UpdateContentLibraryItemFn = func(ctx goctx.Context,
+								itemID, newName string, newDescription *string) error {
+								return fmt.Errorf("dummy error")
+							}
+							fakeVMProvider.Unlock()
+
+							_, err := reconciler.ReconcileNormal(vmpubCtx)
+							Expect(err).To(HaveOccurred())
+
+							By("ImageAvailable is true and Complete is false")
+							Expect(fakeVMProvider.IsPublishVMCalled()).To(BeFalse())
+							Expect(conditions.IsTrue(vmpub,
+								vmopv1.VirtualMachinePublishRequestConditionUploaded)).To(BeTrue())
+							Expect(conditions.IsTrue(vmpub,
+								vmopv1.VirtualMachinePublishRequestConditionImageAvailable)).To(BeTrue())
+							Expect(conditions.IsTrue(vmpub,
+								vmopv1.VirtualMachinePublishRequestConditionComplete)).To(BeFalse())
+							Expect(vmpub.Status.Ready).To(BeFalse())
+
+							// requeue reconcile and update item description succeeded.
+							fakeVMProvider.Lock()
+							fakeVMProvider.UpdateContentLibraryItemFn = nil
+							fakeVMProvider.Unlock()
+
+							_, err = reconciler.ReconcileNormal(vmpubCtx)
+							Expect(err).NotTo(HaveOccurred())
+
+							By("Complete is true")
+							Expect(conditions.IsTrue(vmpub,
+								vmopv1.VirtualMachinePublishRequestConditionComplete)).To(BeTrue())
+							Expect(vmpub.Status.Ready).To(BeTrue())
+						})
+
+						When("TTLSecondsAfterFinished is set", func() {
+							JustBeforeEach(func() {
+								ttl := int64(0)
+								vmpub.Spec.TTLSecondsAfterFinished = &ttl
+							})
+
+							It("Should delete VirtualMachinePublishRequest resource", func() {
+								_, err := reconciler.ReconcileNormal(vmpubCtx)
+								Expect(err).NotTo(HaveOccurred())
+
+								Eventually(func() bool {
+									newVMPub := &vmopv1.VirtualMachinePublishRequest{}
+									err := ctx.Client.Get(ctx, client.ObjectKeyFromObject(vmpub), newVMPub)
+									return apiErrors.IsNotFound(err) || !newVMPub.DeletionTimestamp.IsZero()
+								}).Should(BeTrue())
+							})
+						})
+					})
+
+					When("VirtualMachineImage is unavailable", func() {
+						It("ImageAvailable condition is false, not send a second publish VM request and return success", func() {
+							_, err := reconciler.ReconcileNormal(vmpubCtx)
+							Expect(err).NotTo(HaveOccurred())
+
+							Expect(fakeVMProvider.IsPublishVMCalled()).To(BeFalse())
+							Expect(conditions.IsTrue(vmpub,
+								vmopv1.VirtualMachinePublishRequestConditionUploaded)).To(BeTrue())
+							Expect(conditions.IsTrue(vmpub,
+								vmopv1.VirtualMachinePublishRequestConditionImageAvailable)).To(BeFalse())
+							Expect(conditions.IsTrue(vmpub,
+								vmopv1.VirtualMachinePublishRequestConditionComplete)).To(BeFalse())
+							Expect(vmpub.Status.Ready).To(BeFalse())
+						})
+					})
+				})
+			})
+
+			When("Previous request failed", func() {
+				JustBeforeEach(func() {
+					fakeVMProvider.GetTasksByActIDFn = func(ctx goctx.Context, actID string) (tasksInfo []types.TaskInfo, retErr error) {
+						currentTime := time.Now()
+						task := types.TaskInfo{
+							DescriptionId: virtualmachinepublishrequest.TaskDescriptionID,
+							State:         types.TaskInfoStateError,
+							StartTime:     &currentTime,
+						}
+						return []types.TaskInfo{task}, nil
+					}
+				})
+
+				It("Should send a second publish VM request", func() {
+					_, err := reconciler.ReconcileNormal(vmpubCtx)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(conditions.IsTrue(vmpub,
+						vmopv1.VirtualMachinePublishRequestConditionUploaded)).To(BeFalse())
+
+					Eventually(func() bool {
+						return fakeVMProvider.IsPublishVMCalled()
+					}).Should(BeTrue())
+
+					// vmpub result should eventually be success.
+					Eventually(func() types.TaskInfoState {
+						return fakeVMProvider.GetVMPublishRequestResult(vmpub)
+					}).Should(Equal(types.TaskInfoStateSuccess))
+				})
+			})
+
+			When("Previous request is queued", func() {
+				JustBeforeEach(func() {
+					fakeVMProvider.GetTasksByActIDFn = func(ctx goctx.Context, actID string) (tasksInfo []types.TaskInfo, retErr error) {
+						task := types.TaskInfo{
+							DescriptionId: virtualmachinepublishrequest.TaskDescriptionID,
+							State:         types.TaskInfoStateQueued,
+							QueueTime:     time.Now().Add(time.Minute),
+						}
+						return []types.TaskInfo{task}, nil
+					}
+				})
+
+				It("Should return early and requeue", func() {
+					_, err := reconciler.ReconcileNormal(vmpubCtx)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(conditions.IsTrue(vmpub,
+						vmopv1.VirtualMachinePublishRequestConditionUploaded)).To(BeFalse())
+
+					Consistently(func() bool {
+						return fakeVMProvider.IsPublishVMCalled()
+					}).Should(BeFalse())
+				})
+			})
+
+			When("Previous request is in progress", func() {
+				JustBeforeEach(func() {
+					fakeVMProvider.GetTasksByActIDFn = func(ctx goctx.Context, actID string) (tasksInfo []types.TaskInfo, retErr error) {
+						task := types.TaskInfo{
+							DescriptionId: virtualmachinepublishrequest.TaskDescriptionID,
+							State:         types.TaskInfoStateRunning,
+							QueueTime:     time.Now(),
+						}
+						return []types.TaskInfo{task}, nil
+					}
+				})
+
+				It("Should return early and requeue", func() {
+					_, err := reconciler.ReconcileNormal(vmpubCtx)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(conditions.IsTrue(vmpub,
+						vmopv1.VirtualMachinePublishRequestConditionUploaded)).To(BeFalse())
+
+					Consistently(func() bool {
+						return fakeVMProvider.IsPublishVMCalled()
+					}).Should(BeFalse())
+				})
+			})
+
+			When("Prior task succeeded but lost track of this task", func() {
+				JustBeforeEach(func() {
+					fakeVMProvider.Lock()
+					fakeVMProvider.GetTasksByActIDFn = func(ctx goctx.Context, actID string) (tasksInfo []types.TaskInfo, retErr error) {
+						return nil, nil
+					}
+					vmpub.UID = "123"
+					description := fmt.Sprintf("virtualmachinepublishrequest.vmoperator.vmware.com: %s\n",
+						vmpub.UID)
+					fakeVMProvider.GetItemFromLibraryByNameFn = func(ctx goctx.Context,
+						contentLibrary, itemName string) (*library.Item, error) {
+						return &library.Item{ID: "dummy-id", Description: &description}, nil
+					}
+					fakeVMProvider.Unlock()
+				})
+
+				It("target valid and mark Upload to true", func() {
+					_, err := reconciler.ReconcileNormal(vmpubCtx)
+					Expect(err).NotTo(HaveOccurred())
+
+					// Update TargetValid condition.
+					Expect(conditions.IsTrue(vmpub,
+						vmopv1.VirtualMachinePublishRequestConditionTargetValid)).To(BeTrue())
+					Expect(conditions.IsTrue(vmpub,
+						vmopv1.VirtualMachinePublishRequestConditionUploaded)).To(BeTrue())
+				})
+			})
+		})
+	})
+}

--- a/controllers/virtualmachineservice/controllers.go
+++ b/controllers/virtualmachineservice/controllers.go
@@ -7,10 +7,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachineservice/v1alpha1"
+	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachineservice/v1alpha2"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 )
 
 // AddToManager adds the controller to the provided manager.
 func AddToManager(ctx *context.ControllerManagerContext, mgr manager.Manager) error {
+	if lib.IsVMServiceV1Alpha2FSSEnabled() {
+		return v1alpha2.AddToManager(ctx, mgr)
+	}
 	return v1alpha1.AddToManager(ctx, mgr)
 }

--- a/controllers/virtualmachineservice/v1alpha2/providers/loadbalancer_provider.go
+++ b/controllers/virtualmachineservice/v1alpha2/providers/loadbalancer_provider.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package providers
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+
+	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachineservice/v1alpha2/providers/simplelb"
+	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachineservice/v1alpha2/utils"
+)
+
+const (
+	NSXTLoadBalancer   = "nsx-t-lb"
+	SimpleLoadBalancer = "simple-lb"
+
+	ServiceLoadBalancerHealthCheckNodePortTagKey = "ncp/healthCheckNodePort"
+	NSXTServiceProxy                             = "nsx-t"
+	// LabelServiceProxyName indicates that an alternative service proxy will implement
+	// this Service. Copied from kubernetes pkg/proxy/apis/well_known_labels.go to avoid
+	// k8s dependency.
+	LabelServiceProxyName = "service.kubernetes.io/service-proxy-name"
+)
+
+// LoadbalancerProvider sets up Loadbalancer for different type of Loadbalancer.
+type LoadbalancerProvider interface {
+	EnsureLoadBalancer(ctx context.Context, vmService *vmopv1.VirtualMachineService) error
+
+	// GetServiceLabels returns the labels, if any, to place on a Service.
+	// This is applicable when VirtualMachineService is translated to a
+	// Service and we would like to apply the provider specific labels
+	// on the corresponding Service.
+	GetServiceLabels(ctx context.Context, vmService *vmopv1.VirtualMachineService) (map[string]string, error)
+
+	// GetToBeRemovedServiceLabels returns the labels, if any, to be
+	// removed from a Service.
+	// This is applicable when VirtualMachineService is translated to a
+	// Service and we would like to remove the provider specific labels
+	// from the corresponding Service
+	// This is needed because other operators(net operator) might have added
+	// labels to the Service so to correctly sync the addition/removal of
+	// labels on the Service object without touching the existing ones,
+	// we need to have clearly defined ownership
+	GetToBeRemovedServiceLabels(ctx context.Context, vmService *vmopv1.VirtualMachineService) (map[string]string, error)
+
+	// GetServiceAnnotations returns the annotations, if any, to place on a Service.
+	// This is applicable when VirtualMachineService is translated to a
+	// Service and we would like to apply the provider specific annotations
+	// on the corresponding Service.
+	GetServiceAnnotations(ctx context.Context, vmService *vmopv1.VirtualMachineService) (map[string]string, error)
+
+	// GetToBeRemovedServiceAnnotations returns the annotations, if any, to be
+	// removed from a Service.
+	// This is applicable when VirtualMachineService is translated to a
+	// Service and we would like to remove the provider specific annotations
+	// from the corresponding Service
+	// This is needed because other operators(net operator) might have added
+	// annotations to the Service so to correctly sync the addition/removal of
+	// annotations on the Service object without touching the existing ones,
+	// we need to have clearly defined ownership
+	GetToBeRemovedServiceAnnotations(ctx context.Context, vmService *vmopv1.VirtualMachineService) (map[string]string, error)
+}
+
+func GetLoadbalancerProviderByType(mgr manager.Manager, providerType string) (LoadbalancerProvider, error) {
+	if providerType == NSXTLoadBalancer {
+		return NsxtLoadBalancerProvider(), nil
+	}
+	if providerType == SimpleLoadBalancer {
+		return simplelb.New(mgr), nil
+	}
+	return NoopLoadbalancerProvider{}, nil
+}
+
+type NoopLoadbalancerProvider struct{}
+
+func (NoopLoadbalancerProvider) EnsureLoadBalancer(context.Context, *vmopv1.VirtualMachineService) error {
+	return nil
+}
+
+func (NoopLoadbalancerProvider) GetServiceLabels(ctx context.Context, vmService *vmopv1.VirtualMachineService) (map[string]string, error) {
+	return nil, nil
+}
+
+func (NoopLoadbalancerProvider) GetToBeRemovedServiceLabels(ctx context.Context, vmService *vmopv1.VirtualMachineService) (map[string]string, error) {
+	return nil, nil
+}
+
+func (NoopLoadbalancerProvider) GetServiceAnnotations(ctx context.Context, vmService *vmopv1.VirtualMachineService) (map[string]string, error) {
+	return nil, nil
+}
+
+func (NoopLoadbalancerProvider) GetToBeRemovedServiceAnnotations(ctx context.Context, vmService *vmopv1.VirtualMachineService) (map[string]string, error) {
+	return nil, nil
+}
+
+type NsxtLoadbalancerProvider struct {
+}
+
+// NsxtLoadBalancerProvider returns a nsxLoadbalancerProvider instance.
+func NsxtLoadBalancerProvider() *NsxtLoadbalancerProvider {
+	return &NsxtLoadbalancerProvider{}
+}
+
+func (nl *NsxtLoadbalancerProvider) EnsureLoadBalancer(ctx context.Context, vmService *vmopv1.VirtualMachineService) error {
+	return nil
+}
+
+// GetServiceLabels provides the intended NSX-T specific labels on Service. The
+// responsibility is left to the caller to actually set them.
+func (nl *NsxtLoadbalancerProvider) GetServiceLabels(ctx context.Context, vmService *vmopv1.VirtualMachineService) (map[string]string, error) {
+	res := make(map[string]string)
+
+	// When externalTrafficPolicy is set to Local, skip kube-proxy for the
+	// target Service
+	if etp := vmService.Annotations[utils.AnnotationServiceExternalTrafficPolicyKey]; corev1.ServiceExternalTrafficPolicyType(etp) == corev1.ServiceExternalTrafficPolicyTypeLocal {
+		res[LabelServiceProxyName] = NSXTServiceProxy
+	}
+
+	return res, nil
+}
+
+// GetToBeRemovedServiceLabels provides the to be removed NSX-T specific labels on
+// Service. The responsibility is left to the caller to actually clear them.
+func (nl *NsxtLoadbalancerProvider) GetToBeRemovedServiceLabels(ctx context.Context, vmService *vmopv1.VirtualMachineService) (map[string]string, error) {
+	res := make(map[string]string)
+
+	// When there is no externalTrafficPolicy configured or it's not Local,
+	// remove the service-proxy label
+	if etp := vmService.Annotations[utils.AnnotationServiceExternalTrafficPolicyKey]; corev1.ServiceExternalTrafficPolicyType(etp) != corev1.ServiceExternalTrafficPolicyTypeLocal {
+		res[LabelServiceProxyName] = NSXTServiceProxy
+	}
+
+	return res, nil
+}
+
+// GetServiceAnnotations provides the intended NSX-T specific annotations on
+// Service. The responsibility is left to the caller to actually set them.
+func (nl *NsxtLoadbalancerProvider) GetServiceAnnotations(ctx context.Context, vmService *vmopv1.VirtualMachineService) (map[string]string, error) {
+	res := make(map[string]string)
+
+	if healthCheckNodePortString, ok := vmService.Annotations[utils.AnnotationServiceHealthCheckNodePortKey]; ok {
+		res[ServiceLoadBalancerHealthCheckNodePortTagKey] = healthCheckNodePortString
+	}
+
+	return res, nil
+}
+
+// GetToBeRemovedServiceAnnotations provides the to be removed NSX-T specific annotations on
+// Service. The responsibility is left to the caller to actually clear them.
+func (nl *NsxtLoadbalancerProvider) GetToBeRemovedServiceAnnotations(ctx context.Context, vmService *vmopv1.VirtualMachineService) (map[string]string, error) {
+	res := make(map[string]string)
+
+	// When healthCheckNodePort is NOT present, the corresponding NSX-T
+	// annotation should be cleared as well
+	if _, ok := vmService.Annotations[utils.AnnotationServiceHealthCheckNodePortKey]; !ok {
+		res[ServiceLoadBalancerHealthCheckNodePortTagKey] = ""
+	}
+
+	return res, nil
+}

--- a/controllers/virtualmachineservice/v1alpha2/providers/loadbalancer_provider_suite_test.go
+++ b/controllers/virtualmachineservice/v1alpha2/providers/loadbalancer_provider_suite_test.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2019-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package providers_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestLoadBalancerProvider(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "LoadBalancer Provider Suite")
+}

--- a/controllers/virtualmachineservice/v1alpha2/providers/loadbalancer_provider_test.go
+++ b/controllers/virtualmachineservice/v1alpha2/providers/loadbalancer_provider_test.go
@@ -1,0 +1,234 @@
+// Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package providers
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachineservice/v1alpha2/utils"
+)
+
+const (
+	dummyNamespace = "dummy"
+)
+
+var _ = Describe("Loadbalancer Provider", func() {
+	var (
+		ctx        context.Context
+		vmService  *vmopv1.VirtualMachineService
+		lbProvider LoadbalancerProvider
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	Context("Get load balancer provider by type", func() {
+		It("should successfully get nsx-t load balancer provider", func() {
+			lbProvider, err := GetLoadbalancerProviderByType(nil, NSXTLoadBalancer)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(lbProvider).ToNot(BeNil())
+		})
+
+		It("should successfully get a noop loadbalancer provider", func() {
+			lbProvider, err := GetLoadbalancerProviderByType(nil, "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(lbProvider).To(Equal(NoopLoadbalancerProvider{}))
+		})
+	})
+
+	Context("noop loadbalancer provider", func() {
+		JustBeforeEach(func() {
+			lbProvider = &NoopLoadbalancerProvider{}
+		})
+
+		Context("EnsureLoadBalancer", func() {
+			It("should return success", func() {
+				err := lbProvider.EnsureLoadBalancer(ctx, nil)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("GetServiceLabels", func() {
+			It("should return empty", func() {
+				annotations, err := lbProvider.GetServiceLabels(ctx, nil)
+				Expect(annotations).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("GetServiceAnnotations", func() {
+			It("should return empty", func() {
+				annotations, err := lbProvider.GetServiceAnnotations(ctx, nil)
+				Expect(annotations).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+	})
+
+	Context("GetServiceAnnotations when VMService has healthCheckNodePort defined", func() {
+		BeforeEach(func() {
+			vmService = &vmopv1.VirtualMachineService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "dummy-vmservice",
+					Namespace:   dummyNamespace,
+					Annotations: make(map[string]string),
+				},
+				Spec: vmopv1.VirtualMachineServiceSpec{
+					Type:         vmopv1.VirtualMachineServiceTypeClusterIP,
+					ClusterIP:    "TEST",
+					ExternalName: "TEST",
+				},
+			}
+			vmService.Annotations[utils.AnnotationServiceHealthCheckNodePortKey] = "30012"
+			lbProvider = NsxtLoadBalancerProvider()
+		})
+
+		It("should get health check node port in the annotation", func() {
+			vmServiceAnnotations, err := lbProvider.GetServiceAnnotations(ctx, vmService)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vmServiceAnnotations).ToNot(BeNil())
+			port := vmServiceAnnotations[ServiceLoadBalancerHealthCheckNodePortTagKey]
+			Expect(port).To(Equal("30012"))
+		})
+	})
+
+	Context("GetToBeRemovedServiceAnnotations when VMService does not have healthCheckNodePort defined", func() {
+		BeforeEach(func() {
+			vmService = &vmopv1.VirtualMachineService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "dummy-vmservice",
+					Namespace:   dummyNamespace,
+					Annotations: make(map[string]string),
+				},
+				Spec: vmopv1.VirtualMachineServiceSpec{
+					Type:         vmopv1.VirtualMachineServiceTypeClusterIP,
+					ClusterIP:    "TEST",
+					ExternalName: "TEST",
+				},
+			}
+			lbProvider = NsxtLoadBalancerProvider()
+		})
+
+		It("should get health check node port in the to be removed annotation", func() {
+			vmServiceAnnotations, err := lbProvider.GetToBeRemovedServiceAnnotations(ctx, vmService)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vmServiceAnnotations).ToNot(BeNil())
+			Expect(vmServiceAnnotations).To(HaveKey(ServiceLoadBalancerHealthCheckNodePortTagKey))
+		})
+	})
+
+	Context("GetServiceLabels when VMService have externalTrafficPolicy annotation defined", func() {
+		BeforeEach(func() {
+			vmService = &vmopv1.VirtualMachineService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "dummy-vmservice",
+					Namespace:   dummyNamespace,
+					Annotations: make(map[string]string),
+				},
+				Spec: vmopv1.VirtualMachineServiceSpec{
+					Type:         vmopv1.VirtualMachineServiceTypeClusterIP,
+					ClusterIP:    "TEST",
+					ExternalName: "TEST",
+				},
+			}
+			vmService.Annotations[utils.AnnotationServiceExternalTrafficPolicyKey] = string(corev1.ServiceExternalTrafficPolicyTypeCluster)
+			lbProvider = NsxtLoadBalancerProvider()
+		})
+
+		Context("EnsureLoadBalancer", func() {
+			It("should return success", func() {
+				err := lbProvider.EnsureLoadBalancer(ctx, nil)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("etp is Cluster", func() {
+			It("should not create any label", func() {
+				labels, err := lbProvider.GetServiceLabels(ctx, vmService)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(labels).To(BeEmpty())
+			})
+		})
+
+		Context("etp is Local", func() {
+			BeforeEach(func() {
+				vmService.Annotations[utils.AnnotationServiceExternalTrafficPolicyKey] = string(corev1.ServiceExternalTrafficPolicyTypeLocal)
+			})
+
+			It("should create one label for ServiceProxyName", func() {
+				labels, err := lbProvider.GetServiceLabels(ctx, vmService)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(labels).To(HaveLen(1))
+				Expect(labels[LabelServiceProxyName]).To(Equal(NSXTServiceProxy))
+			})
+		})
+	})
+
+	Context("GetToBeRemovedServiceLabels", func() {
+		var (
+			labels map[string]string
+			err    error
+		)
+
+		BeforeEach(func() {
+			vmService = &vmopv1.VirtualMachineService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "dummy-vmservice",
+					Namespace:   dummyNamespace,
+					Annotations: make(map[string]string),
+				},
+				Spec: vmopv1.VirtualMachineServiceSpec{
+					Type:         vmopv1.VirtualMachineServiceTypeClusterIP,
+					ClusterIP:    "TEST",
+					ExternalName: "TEST",
+				},
+			}
+			lbProvider = NsxtLoadBalancerProvider()
+		})
+
+		JustBeforeEach(func() {
+			labels, err = lbProvider.GetToBeRemovedServiceLabels(ctx, vmService)
+		})
+
+		Context("etp is not present", func() {
+			It("should remove ServiceProxyName label", func() {
+				Expect(err).ToNot(HaveOccurred())
+				_, exists := labels[LabelServiceProxyName]
+				Expect(exists).To(BeTrue())
+			})
+		})
+
+		Context("etp is Local", func() {
+			BeforeEach(func() {
+				vmService.Annotations[utils.AnnotationServiceExternalTrafficPolicyKey] = string(corev1.ServiceExternalTrafficPolicyTypeLocal)
+			})
+
+			It("should not remove ServiceProxyName label", func() {
+				Expect(err).ToNot(HaveOccurred())
+				_, exists := labels[LabelServiceProxyName]
+				Expect(exists).To(BeFalse())
+			})
+		})
+
+		Context("etp is Cluster", func() {
+			BeforeEach(func() {
+				vmService.Annotations[utils.AnnotationServiceExternalTrafficPolicyKey] = string(corev1.ServiceExternalTrafficPolicyTypeCluster)
+			})
+
+			It("should remove ServiceProxyName label", func() {
+				Expect(err).ToNot(HaveOccurred())
+				_, exists := labels[LabelServiceProxyName]
+				Expect(exists).To(BeTrue())
+			})
+		})
+	})
+})

--- a/controllers/virtualmachineservice/v1alpha2/providers/simplelb/lb_cloudconfig.go
+++ b/controllers/virtualmachineservice/v1alpha2/providers/simplelb/lb_cloudconfig.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package simplelb
+
+import (
+	"encoding/base64"
+	"strings"
+	"text/template"
+
+	"sigs.k8s.io/yaml"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+)
+
+const XdsNodePort = 31799
+
+var envoyBootstrapConfigTemplate, _ = template.New("envoyBootstrapConfig").Parse(envoyBootstrapConfig)
+
+type lbConfigParams struct {
+	NodeID      string
+	Ports       []vmopv1.VirtualMachineServicePort
+	CPNodes     []string
+	XdsNodePort int
+}
+
+const envoyBootstrapConfig = `node:
+  id: {{.NodeID}}
+  cluster: vmop-simple-lb
+static_resources:
+  listeners:
+  # {{- range .Ports}}
+  - name: {{.Name}}
+    address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: {{.Port}}
+    filter_chains:
+    - filters:
+      - name: envoy.tcp_proxy
+        config:
+          stat_prefix: ingress_tcp
+          cluster: {{.Name}}
+  # {{- end}}
+
+  clusters:
+  # {{- range .Ports}}
+  - name: {{.Name}}
+    connect_timeout: 0.25s
+    type: EDS
+    lb_policy: ROUND_ROBIN
+    eds_cluster_config:
+      eds_config:
+        api_config_source:
+          api_type: GRPC
+          grpc_services:
+            envoy_grpc:
+              cluster_name: xds_cluster
+  # {{- end}}
+
+  - name: xds_cluster
+    connect_timeout: 0.25s
+    type: STATIC
+    lb_policy: ROUND_ROBIN
+    http2_protocol_options: {}
+    upstream_connection_options:
+      tcp_keepalive: {}
+    load_assignment:
+      cluster_name: xds_cluster
+      endpoints:
+      - lb_endpoints:
+        # {{- $xdsNodePort := .XdsNodePort}}
+        # {{- range .CPNodes}}
+        - endpoint:
+            address:
+              socket_address:
+                address: {{.}}
+                port_value: {{$xdsNodePort}}
+        # {{- end}}
+
+admin:
+  access_log_path: "/dev/null"
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 9901
+`
+
+const cloudConfigPrefix = `#cloud-config
+`
+
+type cloudConfig struct {
+	WriteFiles []writeFile `json:"write_files,omitempty"`
+}
+
+type writeFile struct {
+	Path    string `json:"path"`
+	Content string `json:"content"`
+}
+
+func renderAndBase64EncodeLBCloudConfig(params lbConfigParams) string {
+	envoyConfigStringBuilder := &strings.Builder{}
+	_ = envoyBootstrapConfigTemplate.Execute(envoyConfigStringBuilder, params)
+
+	cc := &cloudConfig{
+		WriteFiles: []writeFile{{
+			Path:    "/etc/envoy/envoy.yaml",
+			Content: envoyConfigStringBuilder.String(),
+		}},
+	}
+	ccYamlBytes, _ := yaml.Marshal(cc)
+
+	b64StringBuilder := &strings.Builder{}
+	b64enc := base64.NewEncoder(base64.StdEncoding, b64StringBuilder)
+
+	_, _ = b64enc.Write([]byte(cloudConfigPrefix))
+	_, _ = b64enc.Write(ccYamlBytes)
+	_ = b64enc.Close()
+
+	return b64StringBuilder.String()
+}

--- a/controllers/virtualmachineservice/v1alpha2/providers/simplelb/lb_cloudconfig_test.go
+++ b/controllers/virtualmachineservice/v1alpha2/providers/simplelb/lb_cloudconfig_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package simplelb
+
+import (
+	"encoding/base64"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+)
+
+var _ = Describe("lbCloudConfig", func() {
+	Context("envoyBootstrapConfigTemplate", func() {
+		It("should be initialized", func() {
+			Expect(envoyBootstrapConfigTemplate).ToNot(BeNil())
+		})
+
+		When("given properly initialized lbConfigParams", func() {
+			vmService := &vmopv1.VirtualMachineService{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "testnamespace",
+					Name:      "testname",
+				},
+				Spec: vmopv1.VirtualMachineServiceSpec{
+					Ports: []vmopv1.VirtualMachineServicePort{{
+						Name:       "apiserver",
+						Protocol:   "TCP",
+						Port:       6443,
+						TargetPort: 6443,
+					}},
+				},
+			}
+
+			params := lbConfigParams{
+				NodeID:      vmService.NamespacedName(),
+				Ports:       vmService.Spec.Ports,
+				CPNodes:     []string{"10.10.00.3"},
+				XdsNodePort: XdsNodePort,
+			}
+			sb := &strings.Builder{}
+			err := envoyBootstrapConfigTemplate.Execute(sb, params)
+			s := sb.String()
+
+			It("should render without an error", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(s).To(ContainSubstring(vmService.NamespacedName()))
+				Expect(s).ToNot(ContainSubstring("\t"))
+			})
+
+			Context("renderAndBase64EncodeLBCloudConfig()", func() {
+				It("should encode into valid base64 cloud-config", func() {
+					b64s := renderAndBase64EncodeLBCloudConfig(params)
+
+					ccBytes, err := base64.StdEncoding.DecodeString(b64s)
+					Expect(err).NotTo(HaveOccurred())
+					ccString := string(ccBytes)
+					Expect(ccString).To(HavePrefix(cloudConfigPrefix))
+
+					cc := cloudConfig{}
+					err = yaml.Unmarshal(ccBytes, &cc)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(cc.WriteFiles).To(HaveLen(1))
+					Expect(cc.WriteFiles[0].Path).To(Equal("/etc/envoy/envoy.yaml"))
+					Expect(cc.WriteFiles[0].Content).To(Equal(s))
+				})
+			})
+		})
+	})
+})

--- a/controllers/virtualmachineservice/v1alpha2/providers/simplelb/simplelb_provider.go
+++ b/controllers/virtualmachineservice/v1alpha2/providers/simplelb/simplelb_provider.go
@@ -1,0 +1,279 @@
+// Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package simplelb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+)
+
+type Provider struct {
+	client       client.Client
+	controlPlane loadbalancerControlPlane
+	log          logr.Logger
+}
+
+type loadbalancerControlPlane interface {
+	UpdateEndpoints(*corev1.Service, *corev1.Endpoints) error
+}
+
+func New(mgr manager.Manager) *Provider {
+	log := ctrl.Log.WithName("controllers").WithName("simple-lb")
+	return &Provider{
+		client:       mgr.GetClient(),
+		controlPlane: NewXdsServer(mgr, log),
+		log:          log,
+	}
+}
+
+func (s *Provider) EnsureLoadBalancer(ctx context.Context, vmService *vmopv1.VirtualMachineService) error {
+	s.log.Info("ensure load balancer", "VMService", vmService.Name)
+	xdsNodes, err := s.getXDSNodes(ctx)
+	if err != nil {
+		return err
+	}
+	vmImageName, err := s.GetVirtualMachineImageName(ctx)
+	if err != nil {
+		return err
+	}
+	vmClassName, err := s.GetVirtualMachineClassName(ctx, vmService.Namespace)
+	if err != nil {
+		return err
+	}
+	lbParams := getLBConfigParams(vmService, xdsNodes)
+	vm := loadbalancerVM(vmService, vmClassName, vmImageName)
+	secret := loadbalancerSecret(vmService, lbParams)
+	if err := s.ensureLBVM(ctx, vm, secret); err != nil {
+		return err
+	}
+	if err := s.ensureLBIP(ctx, vmService, vm); err != nil {
+		return err
+	}
+
+	return s.updateLBConfig(ctx, vmService)
+}
+
+// GetVirtualMachineClassName returns the class name for loadbalancer-vm.
+// We need to choose the VM class name which the namespace has access to instead of hardcode it.
+func (s *Provider) GetVirtualMachineClassName(ctx context.Context, namespace string) (string, error) {
+	classes := &vmopv1.VirtualMachineClassList{}
+	if err := s.client.List(ctx, classes, client.InNamespace(namespace)); err != nil {
+		s.log.Error(err, "failed to list VirtualMachineClasses from control plane")
+		return "", err
+	}
+
+	if len(classes.Items) == 0 {
+		return "", fmt.Errorf("no virtual machine class is available in namespace %s", namespace)
+	}
+
+	return classes.Items[0].Name, nil
+}
+
+// GetVirtualMachineImageName returns the image name for loadbalancer-vm image in the cluster.
+// Since we use generateName for VirtualMachineImage resources, we cannot directly use 'loadbalancer-vm'.
+func (s *Provider) GetVirtualMachineImageName(ctx context.Context) (string, error) {
+	imageList := &vmopv1.VirtualMachineImageList{}
+	if err := s.client.List(ctx, imageList); err != nil {
+		s.log.Error(err, "failed to list VirtualMachineImages from control plane")
+		return "", err
+	}
+
+	for _, img := range imageList.Items {
+		if strings.Contains(img.Name, "loadbalancer-vm") {
+			return img.Name, nil
+		}
+	}
+	return "", errors.New("no virtual machine image for loadbalancer-vm")
+}
+
+func (s *Provider) GetServiceLabels(ctx context.Context, vmService *vmopv1.VirtualMachineService) (map[string]string, error) {
+	return nil, nil
+}
+
+func (s *Provider) GetToBeRemovedServiceLabels(ctx context.Context, vmService *vmopv1.VirtualMachineService) (map[string]string, error) {
+	return nil, nil
+}
+
+func (s *Provider) GetServiceAnnotations(ctx context.Context, vmService *vmopv1.VirtualMachineService) (map[string]string, error) {
+	return nil, nil
+}
+
+func (s *Provider) GetToBeRemovedServiceAnnotations(ctx context.Context, vmService *vmopv1.VirtualMachineService) (map[string]string, error) {
+	return nil, nil
+}
+
+func (s *Provider) ensureLBVM(ctx context.Context, vm *vmopv1.VirtualMachine, secret *corev1.Secret) error {
+	if err := s.client.Get(ctx, types.NamespacedName{Namespace: secret.Namespace, Name: secret.Name}, secret); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+		if err := s.client.Create(ctx, secret); err != nil {
+			return err
+		}
+	}
+	if err := s.client.Get(ctx, types.NamespacedName{Namespace: vm.Namespace, Name: vm.Name}, vm); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+		if err := s.client.Create(ctx, vm); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func makeVMServiceOwnerRef(vmService *vmopv1.VirtualMachineService) metav1.OwnerReference {
+	virtualMachineServiceKind := reflect.TypeOf(vmopv1.VirtualMachineService{}).Name()
+	virtualMachineServiceAPIVersion := vmopv1.SchemeGroupVersion.String()
+
+	return metav1.OwnerReference{
+		UID:                vmService.UID,
+		Name:               vmService.Name,
+		Controller:         pointer.Bool(false),
+		BlockOwnerDeletion: pointer.Bool(true),
+		Kind:               virtualMachineServiceKind,
+		APIVersion:         virtualMachineServiceAPIVersion,
+	}
+}
+
+func loadbalancerVM(vmService *vmopv1.VirtualMachineService, vmClassName, vmImageName string) *vmopv1.VirtualMachine {
+	return &vmopv1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            vmService.Name + "-lb",
+			Namespace:       vmService.Namespace,
+			OwnerReferences: []metav1.OwnerReference{makeVMServiceOwnerRef(vmService)},
+		},
+		Spec: vmopv1.VirtualMachineSpec{
+			ImageName:  vmImageName,
+			ClassName:  vmClassName,
+			PowerState: vmopv1.VirtualMachinePowerStateOn,
+			Bootstrap: vmopv1.VirtualMachineBootstrapSpec{
+				CloudInit: &vmopv1.VirtualMachineBootstrapCloudInitSpec{
+					RawCloudConfig: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: metadataCMName(vmService)},
+						Key:                  "guestinfo.userdata",
+					},
+				},
+			},
+		},
+	}
+}
+
+func loadbalancerSecret(vmService *vmopv1.VirtualMachineService, params lbConfigParams) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            metadataCMName(vmService),
+			Namespace:       vmService.Namespace,
+			OwnerReferences: []metav1.OwnerReference{makeVMServiceOwnerRef(vmService)},
+		},
+		StringData: map[string]string{
+			"guestinfo.userdata":          renderAndBase64EncodeLBCloudConfig(params),
+			"guestinfo.userdata.encoding": "base64",
+		},
+	}
+}
+
+func metadataCMName(vmService *vmopv1.VirtualMachineService) string {
+	return vmService.Name + "-lb" + "-cloud-init"
+}
+
+func (s *Provider) ensureLBIP(ctx context.Context, vmService *vmopv1.VirtualMachineService, vm *vmopv1.VirtualMachine) error {
+	if len(vmService.Status.LoadBalancer.Ingress) == 0 || vmService.Status.LoadBalancer.Ingress[0].IP == "" {
+		if vm.Status.Network == nil || vm.Status.Network.PrimaryIP4 == "" {
+			return errors.New("LB VM IP is not ready yet")
+		}
+
+		service := &corev1.Service{}
+		if err := s.client.Get(ctx, types.NamespacedName{
+			Namespace: vmService.Namespace,
+			Name:      vmService.Name,
+		}, service); err == nil {
+			service.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{{
+				IP: vm.Status.Network.PrimaryIP4,
+			}}
+			err := s.client.Status().Update(ctx, service)
+			if err != nil {
+				s.log.Error(err, "Failed to update Service")
+				// Keep going.
+			}
+		}
+	}
+	return nil
+}
+
+func (s *Provider) updateLBConfig(ctx context.Context, vmService *vmopv1.VirtualMachineService) error {
+	service := &corev1.Service{}
+	endpoints := &corev1.Endpoints{}
+	if err := s.client.Get(ctx, types.NamespacedName{
+		Namespace: vmService.Namespace,
+		Name:      vmService.Name,
+	}, service); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil // service is not ready yet
+		}
+		return err
+	}
+	if err := s.client.Get(ctx, types.NamespacedName{
+		Namespace: vmService.Namespace,
+		Name:      vmService.Name,
+	}, endpoints); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil // endpoints are not ready yet
+		}
+		return err
+	}
+	return s.controlPlane.UpdateEndpoints(service, endpoints)
+}
+
+func (s *Provider) getXDSNodes(ctx context.Context) ([]corev1.Node, error) {
+	nodeList := &corev1.NodeList{}
+	if err := s.client.List(ctx, nodeList); err != nil {
+		return nil, err
+	}
+	return nodeList.Items, nil
+}
+
+func portName(vmSvcPort vmopv1.VirtualMachineServicePort) string {
+	if vmSvcPort.Name == "" {
+		protocol := vmSvcPort.Protocol
+		if protocol == "" {
+			protocol = string(corev1.ProtocolTCP)
+		}
+		return fmt.Sprintf("%s-%v", protocol, vmSvcPort.Port)
+	}
+	return vmSvcPort.Name
+}
+
+func getLBConfigParams(vmService *vmopv1.VirtualMachineService, nodes []corev1.Node) lbConfigParams {
+	var cpNodes = make([]string, len(nodes))
+	for i, node := range nodes {
+		cpNodes[i] = node.Status.Addresses[0].Address
+	}
+	ports := make([]vmopv1.VirtualMachineServicePort, len(vmService.Spec.Ports))
+	for i, port := range vmService.Spec.Ports {
+		port.Name = portName(port)
+		ports[i] = port
+	}
+	return lbConfigParams{
+		NodeID:      vmService.NamespacedName(),
+		Ports:       ports,
+		CPNodes:     cpNodes,
+		XdsNodePort: XdsNodePort,
+	}
+}

--- a/controllers/virtualmachineservice/v1alpha2/providers/simplelb/simplelb_provider_test.go
+++ b/controllers/virtualmachineservice/v1alpha2/providers/simplelb/simplelb_provider_test.go
@@ -1,0 +1,186 @@
+// Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package simplelb
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+type cpArgs struct {
+	service   *corev1.Service
+	endpoints *corev1.Endpoints
+}
+
+type fakeControlPlane struct {
+	calls []cpArgs
+}
+
+func (cp *fakeControlPlane) UpdateEndpoints(service *corev1.Service, endpoints *corev1.Endpoints) error {
+	cp.calls = append(cp.calls, cpArgs{
+		service:   service,
+		endpoints: endpoints,
+	})
+	return nil
+}
+
+var _ = Describe("", func() {
+	const (
+		testNs  = "test-ns"
+		testSvc = "test-svc"
+		lbVMIP  = "11.12.13.14"
+	)
+	vmService := &vmopv1.VirtualMachineService{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNs,
+			Name:      testSvc,
+		},
+		Spec: vmopv1.VirtualMachineServiceSpec{
+			Ports: []vmopv1.VirtualMachineServicePort{{
+				Name:       "apiserver",
+				Port:       6443,
+				Protocol:   "TCP",
+				TargetPort: 6443,
+			}},
+		},
+	}
+	vmKey := types.NamespacedName{Namespace: testNs, Name: testSvc + "-lb"}
+	vm := &vmopv1.VirtualMachine{}
+	client := builder.NewFakeClient(vmService)
+	controlPlane := &fakeControlPlane{}
+	simpleLbProvider := Provider{
+		client:       client,
+		controlPlane: controlPlane,
+		log:          logr.Discard(),
+	}
+	vmImage := &vmopv1.VirtualMachineImage{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "loadbalancer-vm-",
+		},
+	}
+
+	vmClass := &vmopv1.VirtualMachineClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "best-effort-small",
+			Namespace: testNs,
+		},
+	}
+
+	BeforeEach(func() {
+		// ensure vm class and vm class binding exists.
+		classList := &vmopv1.VirtualMachineClassList{}
+		Expect(client.List(context.TODO(), classList)).To(Succeed())
+		if len(classList.Items) == 0 {
+			Expect(client.Create(context.TODO(), vmClass)).To(Succeed())
+		}
+
+		// ensure vm image exists.
+		imageList := &vmopv1.VirtualMachineImageList{}
+		Expect(client.List(context.TODO(), imageList)).To(Succeed())
+		if len(imageList.Items) == 0 {
+			Expect(client.Create(context.TODO(), vmImage)).To(Succeed())
+		}
+	})
+
+	Context("EnsureLoadBalancer()", func() {
+		It("should create the LB VM", func() {
+			err := simpleLbProvider.EnsureLoadBalancer(context.TODO(), vmService)
+			Expect(err).To(HaveOccurred())
+
+			Expect(err.Error()).To(Equal("LB VM IP is not ready yet"))
+			Expect(controlPlane.calls).To(BeEmpty())
+
+			err = client.Get(context.TODO(), vmKey, vm)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		When("the LB VM has an IP address", func() {
+			It("should update the VMService Loadbalancer IP", func() {
+				vm.Status.Network = &vmopv1.VirtualMachineNetworkStatus{PrimaryIP4: lbVMIP}
+				err := client.Status().Update(context.TODO(), vm)
+				Expect(err).ToNot(HaveOccurred())
+
+				service := &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testSvc,
+						Namespace: testNs,
+					},
+				}
+				Expect(client.Create(context.TODO(), service)).To(Succeed())
+
+				err = simpleLbProvider.EnsureLoadBalancer(context.TODO(), vmService)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(controlPlane.calls).To(BeEmpty())
+
+				err = client.Get(context.TODO(), types.NamespacedName{Namespace: testNs, Name: testSvc}, service)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(service.Status.LoadBalancer.Ingress).To(HaveLen(1))
+				Expect(service.Status.LoadBalancer.Ingress[0].IP).To(Equal(lbVMIP))
+			})
+		})
+
+		When("Service and Endpoints have been created for VMService", func() {
+			const (
+				port     = 6443
+				portName = "apiserver"
+				ip1      = "10.11.12.13"
+				ip2      = "21.22.23.24"
+			)
+			svc := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNs,
+					Name:      testSvc,
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{{
+						Name:     portName,
+						Protocol: "TCP",
+						Port:     port,
+						TargetPort: intstr.IntOrString{
+							Type:   intstr.Int,
+							IntVal: port,
+						},
+					}},
+				},
+			}
+			eps := &corev1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNs,
+					Name:      testSvc,
+				},
+				Subsets: []corev1.EndpointSubset{{
+					Addresses: []corev1.EndpointAddress{{IP: ip1}, {IP: ip2}},
+					Ports: []corev1.EndpointPort{{
+						Name: portName,
+						Port: port,
+					}},
+				}},
+			}
+			It("should update the LB control plane", func() {
+				err := client.Create(context.TODO(), eps)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = simpleLbProvider.EnsureLoadBalancer(context.TODO(), vmService)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(controlPlane.calls).To(HaveLen(1))
+				Expect(controlPlane.calls[0].service.Name).To(Equal(svc.Name))
+				Expect(controlPlane.calls[0].endpoints.Name).To(Equal(eps.Name))
+			})
+		})
+	})
+})

--- a/controllers/virtualmachineservice/v1alpha2/providers/simplelb/simplelb_suite_test.go
+++ b/controllers/virtualmachineservice/v1alpha2/providers/simplelb/simplelb_suite_test.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package simplelb
+
+import (
+	"testing"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+)
+
+func TestSimpleLB(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "Simple LB Provider Suite")
+}

--- a/controllers/virtualmachineservice/v1alpha2/providers/simplelb/xds_server.go
+++ b/controllers/virtualmachineservice/v1alpha2/providers/simplelb/xds_server.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2019-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package simplelb
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	envoy_api_v2_endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
+	"github.com/envoyproxy/go-control-plane/pkg/cache"
+	xds "github.com/envoyproxy/go-control-plane/pkg/server"
+	"github.com/go-logr/logr"
+	"google.golang.org/grpc"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+type XdsServer struct {
+	snapshotCache cache.SnapshotCache
+	log           logr.Logger
+}
+
+func NewXdsServer(mgr manager.Manager, logger logr.Logger) *XdsServer {
+	x := &XdsServer{
+		snapshotCache: cache.NewSnapshotCache(false, cache.IDHash{}, nil),
+		log:           logger,
+	}
+	_ = mgr.Add(x) // nothing can go wrong (we don't inject stuff)
+	return x
+}
+
+func (x *XdsServer) Start(ctx context.Context) error {
+	server := xds.NewServer(ctx, x.snapshotCache, nil)
+	grpcServer := grpc.NewServer()
+
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%v", XdsNodePort))
+	if err != nil {
+		return err
+	}
+
+	envoy_api_v2.RegisterEndpointDiscoveryServiceServer(grpcServer, server)
+
+	go func() {
+		<-ctx.Done()
+		grpcServer.Stop()
+	}()
+
+	return grpcServer.Serve(lis)
+}
+
+func (x *XdsServer) UpdateEndpoints(svc *corev1.Service, eps *corev1.Endpoints) error {
+	clusters := make([]cache.Resource, len(svc.Spec.Ports))
+	endpoints := make([]cache.Resource, len(svc.Spec.Ports))
+	for i, svcPort := range svc.Spec.Ports {
+		clusters[i] = cluster(svcPort)
+		endpoints[i] = clusterEndpoints(svcPort, eps.Subsets)
+	}
+
+	nodeID := nodeID(svc)
+	snapshot := cache.NewSnapshot(eps.ResourceVersion, endpoints, clusters, nil, nil, nil)
+
+	x.log.V(5).Info("setting xds snapshot", "nodeID", nodeID, "snapshot", snapshot)
+	return x.snapshotCache.SetSnapshot(nodeID, snapshot)
+}
+
+func nodeID(svc *corev1.Service) string {
+	return types.NamespacedName{Namespace: svc.Namespace, Name: svc.Name}.String()
+}
+
+func clusterName(svcPort corev1.ServicePort) string {
+	if svcPort.Name == "" {
+		protocol := string(svcPort.Protocol)
+		if protocol == "" {
+			protocol = string(corev1.ProtocolTCP)
+		}
+		return fmt.Sprintf("%s-%v", protocol, svcPort.Port)
+	}
+	return svcPort.Name
+}
+
+func clusterEndpoints(svcPort corev1.ServicePort, subsets []corev1.EndpointSubset) *envoy_api_v2.ClusterLoadAssignment {
+	var lbEndpoints []*envoy_api_v2_endpoint.LbEndpoint
+
+	for _, subset := range subsets {
+		for _, endpointPort := range subset.Ports {
+			if endpointPort.Port != svcPort.TargetPort.IntVal {
+				continue
+			}
+			for _, endpointAddress := range subset.Addresses {
+				lbEndpoints = append(lbEndpoints, &envoy_api_v2_endpoint.LbEndpoint{
+					HostIdentifier: &envoy_api_v2_endpoint.LbEndpoint_Endpoint{
+						Endpoint: &envoy_api_v2_endpoint.Endpoint{
+							Address: &envoy_api_v2_core.Address{
+								Address: &envoy_api_v2_core.Address_SocketAddress{
+									SocketAddress: &envoy_api_v2_core.SocketAddress{
+										Protocol: envoy_api_v2_core.SocketAddress_TCP,
+										Address:  endpointAddress.IP,
+										PortSpecifier: &envoy_api_v2_core.SocketAddress_PortValue{
+											PortValue: uint32(endpointPort.Port),
+										},
+									},
+								},
+							},
+						},
+					},
+				})
+			}
+		}
+	}
+
+	return &envoy_api_v2.ClusterLoadAssignment{
+		ClusterName: clusterName(svcPort),
+		Endpoints: []*envoy_api_v2_endpoint.LocalityLbEndpoints{{
+			LbEndpoints: lbEndpoints,
+		}},
+	}
+}
+
+func cluster(svcPort corev1.ServicePort) *envoy_api_v2.Cluster {
+	return &envoy_api_v2.Cluster{
+		Name: clusterName(svcPort),
+		ClusterDiscoveryType: &envoy_api_v2.Cluster_Type{
+			Type: envoy_api_v2.Cluster_EDS,
+		},
+	}
+}

--- a/controllers/virtualmachineservice/v1alpha2/providers/simplelb/xds_server_test.go
+++ b/controllers/virtualmachineservice/v1alpha2/providers/simplelb/xds_server_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package simplelb
+
+import (
+	"github.com/envoyproxy/go-control-plane/pkg/cache"
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+var _ = Describe("xdsServer", func() {
+	const (
+		testNs       = "test-ns"
+		testSvc      = "test-svc"
+		epResVersion = "123"
+		port         = 6443
+		portName     = "apiserver"
+		ip1          = "10.11.12.13"
+		ip2          = "21.22.23.24"
+	)
+
+	x := &XdsServer{
+		snapshotCache: cache.NewSnapshotCache(false, cache.IDHash{}, nil),
+		log:           logr.Discard(),
+	}
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNs,
+			Name:      testSvc,
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{{
+				Name:     portName,
+				Protocol: "TCP",
+				Port:     port,
+				TargetPort: intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: port,
+				},
+			}},
+		},
+	}
+	eps := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       testNs,
+			Name:            testSvc,
+			ResourceVersion: epResVersion,
+		},
+		Subsets: []corev1.EndpointSubset{{
+			Addresses: []corev1.EndpointAddress{{IP: ip1}, {IP: ip2}},
+			Ports: []corev1.EndpointPort{{
+				Name: portName,
+				Port: port,
+			}},
+		}},
+	}
+
+	It("UpdateEndpoints()", func() {
+		err := x.UpdateEndpoints(svc, eps)
+		Expect(err).ToNot(HaveOccurred())
+
+		snapshot, err := x.snapshotCache.GetSnapshot(nodeID(svc))
+		Expect(err).ToNot(HaveOccurred())
+
+		err = snapshot.Consistent()
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(snapshot.GetVersion(cache.EndpointType)).To(Equal(epResVersion))
+		Expect(snapshot.GetVersion(cache.ClusterType)).To(Equal(epResVersion))
+
+		clusters := snapshot.GetResources(cache.ClusterType)
+		endpoints := snapshot.GetResources(cache.EndpointType)
+		Expect(clusters).To(HaveLen(1))
+		Expect(endpoints).To(HaveLen(1))
+		Expect(endpoints[portName]).ToNot(BeNil())
+		Expect(endpoints[portName].String()).To(ContainSubstring(ip1))
+		Expect(endpoints[portName].String()).To(ContainSubstring(ip2))
+	})
+})

--- a/controllers/virtualmachineservice/v1alpha2/utils/constants.go
+++ b/controllers/virtualmachineservice/v1alpha2/utils/constants.go
@@ -1,0 +1,9 @@
+// Copyright (c) 2018-2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+const (
+	AnnotationServiceExternalTrafficPolicyKey = "virtualmachineservice.vmoperator.vmware.com/service.externalTrafficPolicy"
+	AnnotationServiceHealthCheckNodePortKey   = "virtualmachineservice.vmoperator.vmware.com/service.healthCheckNodePort"
+)

--- a/controllers/virtualmachineservice/v1alpha2/utils/endpoints.go
+++ b/controllers/virtualmachineservice/v1alpha2/utils/endpoints.go
@@ -1,0 +1,252 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Imported https://github.com/kubernetes/kubernetes/blob/master/pkg/api/v1/endpoints/util.go
+// to avoid depending on k8s.io/kubernetes
+
+//nolint: gosec
+package utils
+
+import (
+	"bytes"
+	"crypto/md5"
+	"encoding/hex"
+	"hash"
+	"sort"
+
+	"github.com/davecgh/go-spew/spew"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// DeepHashObject writes specified object to hash using the spew library
+// which follows pointers and prints actual values of the nested objects
+// ensuring the hash does not change when a pointer changes.
+func DeepHashObject(hasher hash.Hash, objectToWrite interface{}) {
+	hasher.Reset()
+	printer := spew.ConfigState{
+		Indent:         " ",
+		SortKeys:       true,
+		DisableMethods: true,
+		SpewKeys:       true,
+	}
+	printer.Fprintf(hasher, "%#v", objectToWrite)
+}
+
+// RepackSubsets takes a slice of EndpointSubset objects, expands it to the full
+// representation, and then repacks that into the canonical layout.  This
+// ensures that code which operates on these objects can rely on the common
+// form for things like comparison.  The result is a newly allocated slice.
+func RepackSubsets(subsets []v1.EndpointSubset) []v1.EndpointSubset {
+	// First map each unique port definition to the sets of hosts that
+	// offer it.
+	allAddrs := map[addressKey]*v1.EndpointAddress{}
+	portToAddrReadyMap := map[v1.EndpointPort]addressSet{}
+	for i := range subsets {
+		if len(subsets[i].Ports) == 0 {
+			// Don't discard endpoints with no ports defined, use a sentinel.
+			mapAddressesByPort(&subsets[i], v1.EndpointPort{Port: -1}, allAddrs, portToAddrReadyMap)
+		} else {
+			for _, port := range subsets[i].Ports {
+				mapAddressesByPort(&subsets[i], port, allAddrs, portToAddrReadyMap)
+			}
+		}
+	}
+
+	// Next, map the sets of hosts to the sets of ports they offer.
+	// Go does not allow maps or slices as keys to maps, so we have
+	// to synthesize an artificial key and do a sort of 2-part
+	// associative entity.
+	type keyString string
+	keyToAddrReadyMap := map[keyString]addressSet{}
+	addrReadyMapKeyToPorts := map[keyString][]v1.EndpointPort{}
+	for port, addrs := range portToAddrReadyMap {
+		key := keyString(hashAddresses(addrs))
+		keyToAddrReadyMap[key] = addrs
+		if port.Port > 0 { // avoid sentinels
+			addrReadyMapKeyToPorts[key] = append(addrReadyMapKeyToPorts[key], port)
+		} else if _, found := addrReadyMapKeyToPorts[key]; !found {
+			// Force it to be present in the map
+			addrReadyMapKeyToPorts[key] = nil
+		}
+	}
+
+	// Next, build the N-to-M association the API wants.
+	final := []v1.EndpointSubset{}
+	for key, ports := range addrReadyMapKeyToPorts {
+		var readyAddrs, notReadyAddrs []v1.EndpointAddress
+		for addr, ready := range keyToAddrReadyMap[key] {
+			if ready {
+				readyAddrs = append(readyAddrs, *addr)
+			} else {
+				notReadyAddrs = append(notReadyAddrs, *addr)
+			}
+		}
+		final = append(final, v1.EndpointSubset{Addresses: readyAddrs, NotReadyAddresses: notReadyAddrs, Ports: ports})
+	}
+
+	// Finally, sort it.
+	return SortSubsets(final)
+}
+
+// The sets of hosts must be de-duped, using IP+UID as the key.
+type addressKey struct {
+	ip  string
+	uid types.UID
+}
+
+// mapAddressesByPort adds all ready and not-ready addresses into a map by a single port.
+func mapAddressesByPort(subset *v1.EndpointSubset, port v1.EndpointPort, allAddrs map[addressKey]*v1.EndpointAddress, portToAddrReadyMap map[v1.EndpointPort]addressSet) {
+	for k := range subset.Addresses {
+		mapAddressByPort(&subset.Addresses[k], port, true, allAddrs, portToAddrReadyMap)
+	}
+	for k := range subset.NotReadyAddresses {
+		mapAddressByPort(&subset.NotReadyAddresses[k], port, false, allAddrs, portToAddrReadyMap)
+	}
+}
+
+// mapAddressByPort adds one address into a map by port, registering the address with a unique pointer, and preserving
+// any existing ready state.
+func mapAddressByPort(addr *v1.EndpointAddress, port v1.EndpointPort, ready bool, allAddrs map[addressKey]*v1.EndpointAddress, portToAddrReadyMap map[v1.EndpointPort]addressSet) *v1.EndpointAddress {
+	// use addressKey to distinguish between two endpoints that are identical addresses
+	// but may have come from different hosts, for attribution. For instance, Mesos
+	// assigns pods the node IP, but the pods are distinct.
+	key := addressKey{ip: addr.IP}
+	if addr.TargetRef != nil {
+		key.uid = addr.TargetRef.UID
+	}
+
+	// Accumulate the address. The full EndpointAddress structure is preserved for use when
+	// we rebuild the subsets so that the final TargetRef has all of the necessary data.
+	existingAddress := allAddrs[key]
+	if existingAddress == nil {
+		// Make a copy so we don't write to the
+		// input args of this function.
+		existingAddress = &v1.EndpointAddress{}
+		*existingAddress = *addr
+		allAddrs[key] = existingAddress
+	}
+
+	// Remember that this port maps to this address.
+	if _, found := portToAddrReadyMap[port]; !found {
+		portToAddrReadyMap[port] = addressSet{}
+	}
+	// if we have not yet recorded this port for this address, or if the previous
+	// state was ready, write the current ready state. not ready always trumps
+	// ready.
+	if wasReady, found := portToAddrReadyMap[port][existingAddress]; !found || wasReady {
+		portToAddrReadyMap[port][existingAddress] = ready
+	}
+	return existingAddress
+}
+
+type addressSet map[*v1.EndpointAddress]bool
+
+type addrReady struct {
+	addr  *v1.EndpointAddress
+	ready bool
+}
+
+func hashAddresses(addrs addressSet) string {
+	// Flatten the list of addresses into a string so it can be used as a
+	// map key.  Unfortunately, DeepHashObject is implemented in terms of
+	// spew, and spew does not handle non-primitive map keys well.  So
+	// first we collapse it into a slice, sort the slice, then hash that.
+	slice := make([]addrReady, 0, len(addrs))
+	for k, ready := range addrs {
+		slice = append(slice, addrReady{k, ready})
+	}
+	sort.Sort(addrsReady(slice))
+	hasher := md5.New()
+	DeepHashObject(hasher, slice)
+	return hex.EncodeToString(hasher.Sum(nil)[0:])
+}
+
+func lessAddrReady(a, b addrReady) bool {
+	// ready is not significant to hashing since we can't have duplicate addresses
+	return LessEndpointAddress(a.addr, b.addr)
+}
+
+type addrsReady []addrReady
+
+func (sl addrsReady) Len() int      { return len(sl) }
+func (sl addrsReady) Swap(i, j int) { sl[i], sl[j] = sl[j], sl[i] }
+func (sl addrsReady) Less(i, j int) bool {
+	return lessAddrReady(sl[i], sl[j])
+}
+
+// LessEndpointAddress compares IP addresses lexicographically and returns true if first argument is lesser than second.
+func LessEndpointAddress(a, b *v1.EndpointAddress) bool {
+	ipComparison := bytes.Compare([]byte(a.IP), []byte(b.IP))
+	if ipComparison != 0 {
+		return ipComparison < 0
+	}
+	if b.TargetRef == nil {
+		return false
+	}
+	if a.TargetRef == nil {
+		return true
+	}
+	return a.TargetRef.UID < b.TargetRef.UID
+}
+
+// SortSubsets sorts an array of EndpointSubset objects in place.  For ease of
+// use it returns the input slice.
+func SortSubsets(subsets []v1.EndpointSubset) []v1.EndpointSubset {
+	for i := range subsets {
+		ss := &subsets[i]
+		sort.Sort(addrsByIPAndUID(ss.Addresses))
+		sort.Sort(addrsByIPAndUID(ss.NotReadyAddresses))
+		sort.Sort(portsByHash(ss.Ports))
+	}
+	sort.Sort(subsetsByHash(subsets))
+	return subsets
+}
+
+func hashObject(hasher hash.Hash, obj interface{}) []byte {
+	DeepHashObject(hasher, obj)
+	return hasher.Sum(nil)
+}
+
+type subsetsByHash []v1.EndpointSubset
+
+func (sl subsetsByHash) Len() int      { return len(sl) }
+func (sl subsetsByHash) Swap(i, j int) { sl[i], sl[j] = sl[j], sl[i] }
+func (sl subsetsByHash) Less(i, j int) bool {
+	hasher := md5.New()
+	h1 := hashObject(hasher, sl[i])
+	h2 := hashObject(hasher, sl[j])
+	return bytes.Compare(h1, h2) < 0
+}
+
+type addrsByIPAndUID []v1.EndpointAddress
+
+func (sl addrsByIPAndUID) Len() int      { return len(sl) }
+func (sl addrsByIPAndUID) Swap(i, j int) { sl[i], sl[j] = sl[j], sl[i] }
+func (sl addrsByIPAndUID) Less(i, j int) bool {
+	return LessEndpointAddress(&sl[i], &sl[j])
+}
+
+type portsByHash []v1.EndpointPort
+
+func (sl portsByHash) Len() int      { return len(sl) }
+func (sl portsByHash) Swap(i, j int) { sl[i], sl[j] = sl[j], sl[i] }
+func (sl portsByHash) Less(i, j int) bool {
+	hasher := md5.New()
+	h1 := hashObject(hasher, sl[i])
+	h2 := hashObject(hasher, sl[j])
+	return bytes.Compare(h1, h2) < 0
+}

--- a/controllers/virtualmachineservice/v1alpha2/virtualmachineservice_controller.go
+++ b/controllers/virtualmachineservice/v1alpha2/virtualmachineservice_controller.go
@@ -1,0 +1,715 @@
+// Copyright (c) 2018-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha2
+
+import (
+	goctx "context"
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+
+	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachineservice/v1alpha2/providers"
+	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachineservice/v1alpha2/utils"
+	conditions "github.com/vmware-tanzu/vm-operator/pkg/conditions2"
+	"github.com/vmware-tanzu/vm-operator/pkg/context"
+	patch "github.com/vmware-tanzu/vm-operator/pkg/patch2"
+	"github.com/vmware-tanzu/vm-operator/pkg/record"
+)
+
+const (
+	finalizerName = "virtualmachineservice.vmoperator.vmware.com"
+
+	OpCreate = "CreateK8sService"
+	OpDelete = "DeleteK8sService"
+	OpUpdate = "UpdateK8sService"
+)
+
+func AddToManager(ctx *context.ControllerManagerContext, mgr manager.Manager) error {
+	var (
+		controlledType     = &vmopv1.VirtualMachineService{}
+		controlledTypeName = reflect.TypeOf(controlledType).Elem().Name()
+
+		controllerNameShort = fmt.Sprintf("%s-controller", strings.ToLower(controlledTypeName))
+		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
+	)
+
+	lbProviderType := os.Getenv("LB_PROVIDER")
+	if lbProviderType == "" {
+		vdsNetwork := os.Getenv("VSPHERE_NETWORKING")
+		if vdsNetwork != "true" {
+			lbProviderType = providers.NSXTLoadBalancer
+		}
+	}
+
+	lbProvider, err := providers.GetLoadbalancerProviderByType(mgr, lbProviderType)
+	if err != nil {
+		return err
+	}
+
+	r := NewReconciler(
+		mgr.GetClient(),
+		ctrl.Log.WithName("controllers").WithName(controlledTypeName),
+		record.New(mgr.GetEventRecorderFor(controllerNameLong)),
+		lbProvider,
+	)
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(controlledType).
+		WithOptions(controller.Options{MaxConcurrentReconciles: ctx.MaxConcurrentReconciles}).
+		Watches(&source.Kind{Type: &corev1.Service{}},
+			&handler.EnqueueRequestForOwner{OwnerType: &vmopv1.VirtualMachineService{}}).
+		Watches(&source.Kind{Type: &corev1.Endpoints{}},
+			&handler.EnqueueRequestForOwner{OwnerType: &vmopv1.VirtualMachineService{}}).
+		Watches(&source.Kind{Type: &vmopv1.VirtualMachine{}},
+			handler.EnqueueRequestsFromMapFunc(r.virtualMachineToVirtualMachineServiceMapper())).
+		Complete(r)
+}
+
+func NewReconciler(
+	client client.Client,
+	logger logr.Logger,
+	recorder record.Recorder,
+	lbProvider providers.LoadbalancerProvider,
+) *ReconcileVirtualMachineService {
+	return &ReconcileVirtualMachineService{
+		Client:               client,
+		log:                  logger,
+		recorder:             recorder,
+		loadbalancerProvider: lbProvider,
+	}
+}
+
+var _ reconcile.Reconciler = &ReconcileVirtualMachineService{}
+
+// ReconcileVirtualMachineService reconciles a VirtualMachineService object.
+type ReconcileVirtualMachineService struct {
+	client.Client
+	log                  logr.Logger
+	recorder             record.Recorder
+	loadbalancerProvider providers.LoadbalancerProvider
+}
+
+// Reconcile reads that state of the cluster for a VirtualMachineService object and makes changes based on the state read
+// and what is in the VirtualMachineService.Spec
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachineservices,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachineservices/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=services/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=endpoints,verbs=get;list;watch;create;update;patch;delete
+
+func (r *ReconcileVirtualMachineService) Reconcile(ctx goctx.Context, request reconcile.Request) (_ reconcile.Result, reterr error) {
+	vmService := &vmopv1.VirtualMachineService{}
+	if err := r.Get(ctx, request.NamespacedName, vmService); err != nil {
+		return reconcile.Result{}, client.IgnoreNotFound(err)
+	}
+
+	vmServiceCtx := &context.VirtualMachineServiceContextA2{
+		Context:   ctx,
+		Logger:    ctrl.Log.WithName("VirtualMachineService").WithValues("name", vmService.NamespacedName()),
+		VMService: vmService,
+	}
+
+	patchHelper, err := patch.NewHelper(vmService, r.Client)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to init patch helper for %s: %w", vmServiceCtx, err)
+	}
+	defer func() {
+		if err := patchHelper.Patch(ctx, vmService); err != nil {
+			if reterr == nil {
+				reterr = err
+			}
+			vmServiceCtx.Logger.Error(err, "patch failed")
+		}
+	}()
+
+	if !vmService.DeletionTimestamp.IsZero() {
+		return reconcile.Result{}, r.ReconcileDelete(vmServiceCtx)
+	}
+
+	return reconcile.Result{}, r.ReconcileNormal(vmServiceCtx)
+}
+
+func (r *ReconcileVirtualMachineService) ReconcileDelete(ctx *context.VirtualMachineServiceContextA2) error {
+	if controllerutil.ContainsFinalizer(ctx.VMService, finalizerName) {
+		objectMeta := metav1.ObjectMeta{
+			Name:      ctx.VMService.Name,
+			Namespace: ctx.VMService.Namespace,
+		}
+
+		endpoint := &corev1.Endpoints{ObjectMeta: objectMeta}
+		if err := r.Client.Delete(ctx, endpoint); client.IgnoreNotFound(err) != nil {
+			ctx.Logger.Error(err, "Failed to delete Endpoints")
+			return err
+		}
+
+		service := &corev1.Service{ObjectMeta: objectMeta}
+		if err := r.Client.Delete(ctx, service); client.IgnoreNotFound(err) != nil {
+			ctx.Logger.Error(err, "Failed to delete Service")
+			return err
+		}
+
+		ctx.Logger.Info("Delete VirtualMachineService")
+		r.recorder.EmitEvent(ctx.VMService, OpDelete, nil, false)
+		controllerutil.RemoveFinalizer(ctx.VMService, finalizerName)
+	}
+
+	return nil
+}
+
+func (r *ReconcileVirtualMachineService) ReconcileNormal(ctx *context.VirtualMachineServiceContextA2) error {
+	if !controllerutil.ContainsFinalizer(ctx.VMService, finalizerName) {
+		controllerutil.AddFinalizer(ctx.VMService, finalizerName)
+		// NOTE: The VirtualMachineService is set as the OwnerReference of the Service and Endpoints.
+		// So while ReconcileDelete() does delete them when our finalizer is set, the k8s GC will
+		// delete them if they still exist if the VirtualMachineService is deleted so we do not have
+		// to return here. The explicit delete in ReconcileDelete() just speeds up the ultimate removal
+		// of the service from the LB.
+	}
+
+	if err := r.reconcileVMService(ctx); err != nil {
+		ctx.Logger.Error(err, "Failed to reconcile VirtualMachineService")
+		return err
+	}
+
+	return nil
+}
+
+func (r *ReconcileVirtualMachineService) reconcileVMService(ctx *context.VirtualMachineServiceContextA2) error {
+	ctx.Logger.Info("Reconcile VirtualMachineService")
+	defer ctx.Logger.Info("Finished Reconcile VirtualMachineService")
+
+	vmService := ctx.VMService
+
+	if vmService.Spec.Type == vmopv1.VirtualMachineServiceTypeLoadBalancer {
+		// Get LoadBalancer to attach
+		err := r.loadbalancerProvider.EnsureLoadBalancer(ctx, vmService)
+		if err != nil {
+			ctx.Logger.Error(err, "Failed to create or get load balancer for VM Service")
+			return err
+		}
+
+		// Get the provider specific annotations for service and add them to the VMService as
+		// that's where Service inherits the values.
+		annotations, err := r.loadbalancerProvider.GetServiceAnnotations(ctx, vmService)
+		if err != nil {
+			ctx.Logger.Error(err, "Failed to get loadbalancer annotations for service")
+			return err
+		}
+
+		if vmService.Annotations == nil {
+			vmService.Annotations = make(map[string]string)
+		}
+
+		for k, v := range annotations {
+			if oldValue, ok := vmService.Annotations[k]; ok {
+				ctx.Logger.V(5).Info("Replacing previous annotation value on VM Service",
+					"key", k, "oldValue", oldValue, "newValue", v)
+			}
+			vmService.Annotations[k] = v
+		}
+
+		// Get the provider specific labels for Service and add them to the vm service
+		// as that's where Service inherits the values.
+		labels, err := r.loadbalancerProvider.GetServiceLabels(ctx, vmService)
+		if err != nil {
+			ctx.Logger.Error(err, "Failed to get loadbalancer labels for service")
+			return err
+		}
+
+		if vmService.Labels == nil {
+			vmService.Labels = make(map[string]string)
+		}
+
+		for k, v := range labels {
+			if oldValue, ok := vmService.Labels[k]; ok {
+				ctx.Logger.V(5).Info("Replacing previous label value on VM Service",
+					"key", k, "oldValue", oldValue, "newValue", v)
+			}
+			vmService.Labels[k] = v
+		}
+	}
+
+	service, err := r.createOrUpdateService(ctx)
+	if err != nil {
+		ctx.Logger.Error(err, "Failed to update VirtualMachineService k8s Service")
+		return err
+	}
+
+	err = r.createOrUpdateEndpoints(ctx, service)
+	if err != nil {
+		ctx.Logger.Error(err, "Failed to update VirtualMachineService Endpoints")
+		return err
+	}
+
+	err = r.updateVMService(ctx, service)
+	if err != nil {
+		ctx.Logger.Error(err, "Failed to update VirtualMachineService Status")
+		return err
+	}
+
+	return nil
+}
+
+// virtualMachineToVirtualMachineServiceMapper returns a mapper function that returns reconcile requests for
+// VirtualMachineServices that select a given VM via label selectors.
+// TODO: The VM's labels could have been changed so this should also return VirtualMachineServices that the
+// VM is currently an Endpoint for, because otherwise the VM won't be removed in a timely manner.
+func (r *ReconcileVirtualMachineService) virtualMachineToVirtualMachineServiceMapper() func(o client.Object) []reconcile.Request {
+	return func(o client.Object) []reconcile.Request {
+		vm := o.(*vmopv1.VirtualMachine)
+
+		reconcileRequests, err := r.getVirtualMachineServicesSelectingVirtualMachine(goctx.Background(), vm)
+		if err != nil {
+			return nil
+		}
+
+		if len(reconcileRequests) != 0 && r.log.V(4).Enabled() {
+			logger := r.log.WithValues("VirtualMachine", client.ObjectKey{Namespace: vm.Namespace, Name: vm.Name})
+			for _, r := range reconcileRequests {
+				logger.V(4).Info("Generating reconcile request for VM Service due to event on VM", "VirtualMachineService", r.NamespacedName)
+			}
+		}
+
+		return reconcileRequests
+	}
+}
+
+// Set labels and annotations on the Service from the VirtualMachineService. Some loadbalancer providers (currently
+// only NCP) need to filter or translate labels and annotations too.
+func (r *ReconcileVirtualMachineService) setServiceAnnotationsAndLabels(
+	ctx *context.VirtualMachineServiceContextA2,
+	service *corev1.Service) error {
+	vmService := ctx.VMService
+
+	// TODO: Clean the provider interfaces here. This is way too verbose.
+
+	if service.Annotations == nil {
+		service.Annotations = make(map[string]string, len(vmService.Annotations))
+		for k, v := range vmService.Annotations {
+			service.Annotations[k] = v
+		}
+	} else {
+		for k, v := range vmService.Annotations {
+			if oldValue, ok := service.Annotations[k]; ok {
+				ctx.Logger.V(5).Info("Replacing previous annotation value on Service",
+					"key", k, "oldValue", oldValue, "newValue", v)
+			}
+			service.Annotations[k] = v
+		}
+	}
+
+	// Explicitly remove provider specific annotations
+	annotationsToBeRemoved, err := r.loadbalancerProvider.GetToBeRemovedServiceAnnotations(ctx, ctx.VMService)
+	if err != nil {
+		ctx.Logger.Error(err, "Failed to get loadbalancer specific annotations to remove from Service")
+		return err
+	}
+	for k := range annotationsToBeRemoved {
+		ctx.Logger.V(5).Info("Removing annotation from service", "key", k)
+		delete(service.Annotations, k)
+	}
+
+	if service.Labels == nil {
+		service.Labels = make(map[string]string, len(vmService.Labels))
+		for k, v := range vmService.Labels {
+			service.Labels[k] = v
+		}
+	} else {
+		for k, v := range vmService.Labels {
+			if oldValue, ok := service.Labels[k]; ok {
+				ctx.Logger.V(5).Info("Replacing previous label value on Service",
+					"key", k, "oldValue", oldValue, "newValue", v)
+			}
+			service.Labels[k] = v
+		}
+	}
+
+	// Explicitly remove provider specific labels
+	labelsToBeRemoved, err := r.loadbalancerProvider.GetToBeRemovedServiceLabels(ctx, ctx.VMService)
+	if err != nil {
+		ctx.Logger.Error(err, "Failed to get loadbalancer specific labels to remove from Service")
+		return err
+	}
+	for k := range labelsToBeRemoved {
+		ctx.Logger.V(5).Info("Removing label from Service", "key", k)
+		delete(service.Labels, k)
+	}
+
+	// Explicitly remove vm service managed annotations if needed
+	for _, k := range []string{utils.AnnotationServiceExternalTrafficPolicyKey, utils.AnnotationServiceHealthCheckNodePortKey} {
+		if _, exist := vmService.Annotations[k]; !exist {
+			if v, exist := service.Annotations[k]; exist {
+				ctx.Logger.V(5).Info("Removing annotation from Service", "key", k, "value", v)
+				delete(service.Annotations, k)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (r *ReconcileVirtualMachineService) createOrUpdateService(ctx *context.VirtualMachineServiceContextA2) (*corev1.Service, error) {
+	ctx.Logger.V(5).Info("Reconciling k8s Service")
+	defer ctx.Logger.V(5).Info("Finished reconciling k8s Service")
+
+	vmService := ctx.VMService
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      vmService.Name,
+			Namespace: vmService.Namespace,
+		},
+	}
+
+	result, err := controllerutil.CreateOrUpdate(ctx, r.Client, service, func() error {
+		if err := controllerutil.SetControllerReference(vmService, service, r.Client.Scheme()); err != nil {
+			return err
+		}
+
+		if err := r.setServiceAnnotationsAndLabels(ctx, service); err != nil {
+			return err
+		}
+
+		service.Spec.Type = corev1.ServiceType(vmService.Spec.Type)
+		service.Spec.ExternalName = vmService.Spec.ExternalName
+		service.Spec.LoadBalancerIP = vmService.Spec.LoadBalancerIP
+		service.Spec.LoadBalancerSourceRanges = vmService.Spec.LoadBalancerSourceRanges
+		if service.Spec.Type == corev1.ServiceTypeLoadBalancer {
+			service.Spec.AllocateLoadBalancerNodePorts = pointer.Bool(false)
+		} else {
+			service.Spec.AllocateLoadBalancerNodePorts = nil
+		}
+
+		// Parts of the Service.Spec can be updated by k8s after creation, and we need to
+		// preserve those fields.
+		if service.ResourceVersion == "" {
+			// ClusterIP cannot be changed through update.
+			service.Spec.ClusterIP = vmService.Spec.ClusterIP
+		}
+
+		// Maintain the existing mapping of ServicePort -> NodePort as un-setting it will cause
+		// a new NodePort to be allocated.
+		// BMV: Just the Name might not be a sufficient key here.
+		nodePortMap := make(map[string]int32, len(service.Spec.Ports))
+		for _, port := range service.Spec.Ports {
+			nodePortMap[port.Name] = port.NodePort
+		}
+		servicePorts := make([]corev1.ServicePort, 0, len(vmService.Spec.Ports))
+		for _, vmPort := range vmService.Spec.Ports {
+			servicePort := corev1.ServicePort{
+				Name:       vmPort.Name,
+				Protocol:   corev1.Protocol(vmPort.Protocol),
+				Port:       vmPort.Port,
+				TargetPort: intstr.FromInt(int(vmPort.TargetPort)),
+				NodePort:   nodePortMap[vmPort.Name],
+			}
+			servicePorts = append(servicePorts, servicePort)
+		}
+		service.Spec.Ports = servicePorts
+
+		// This is the default that k8s would otherwise set (note that we don't really support NodePort).
+		// The only real purpose of this is if the AnnotationServiceExternalTrafficPolicyKey annotation
+		// below is removed, so that we switch the Service back to the default.
+		if service.Spec.Type == corev1.ServiceTypeNodePort || service.Spec.Type == corev1.ServiceTypeLoadBalancer {
+			service.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeCluster
+		}
+
+		if externalTrafficPolicy, ok := service.Annotations[utils.AnnotationServiceExternalTrafficPolicyKey]; ok {
+			// Note that this annotation is only set (and makes sense) from the GC cloud provider.
+			trafficPolicy := corev1.ServiceExternalTrafficPolicyType(externalTrafficPolicy)
+			switch trafficPolicy {
+			case corev1.ServiceExternalTrafficPolicyTypeLocal, corev1.ServiceExternalTrafficPolicyTypeCluster:
+				service.Spec.ExternalTrafficPolicy = trafficPolicy
+			default:
+				ctx.Logger.V(5).Info("Unknown externalTrafficPolicy VirtualMachineService annotation",
+					"externalTrafficPolicy", externalTrafficPolicy)
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	switch result {
+	case controllerutil.OperationResultCreated:
+		r.recorder.EmitEvent(ctx.VMService, OpCreate, nil, false)
+	case controllerutil.OperationResultUpdated:
+		r.recorder.EmitEvent(ctx.VMService, OpUpdate, nil, false)
+	}
+
+	return service, nil
+}
+
+func (r *ReconcileVirtualMachineService) getVirtualMachinesSelectedByVMService(
+	ctx *context.VirtualMachineServiceContextA2) (*vmopv1.VirtualMachineList, error) {
+
+	if len(ctx.VMService.Spec.Selector) == 0 {
+		return nil, nil
+	}
+
+	vmList := &vmopv1.VirtualMachineList{}
+	err := r.List(ctx, vmList, client.InNamespace(ctx.VMService.Namespace), client.MatchingLabels(ctx.VMService.Spec.Selector))
+	return vmList, err
+}
+
+// getVMsReferencedByServiceEndpoints gets all VMs that are referenced by service endpoints.
+func (r *ReconcileVirtualMachineService) getVMsReferencedByServiceEndpoints(
+	ctx *context.VirtualMachineServiceContextA2,
+	service *corev1.Service) map[types.UID]struct{} {
+	endpoints := &corev1.Endpoints{}
+	if err := r.Get(ctx, client.ObjectKey{Name: service.Name, Namespace: service.Namespace}, endpoints); err != nil {
+		ctx.Logger.Error(err, "Failed to get Endpoints")
+		return nil
+	}
+
+	vmToSubsetsMap := make(map[types.UID]struct{})
+	for _, subset := range endpoints.Subsets {
+		for _, epa := range subset.Addresses {
+			if epa.TargetRef != nil {
+				vmToSubsetsMap[epa.TargetRef.UID] = struct{}{}
+			}
+		}
+	}
+	return vmToSubsetsMap
+}
+
+func (r *ReconcileVirtualMachineService) getVirtualMachineServicesSelectingVirtualMachine(
+	ctx goctx.Context,
+	lookupVM *vmopv1.VirtualMachine) ([]reconcile.Request, error) {
+
+	if len(lookupVM.Labels) == 0 {
+		return nil, nil
+	}
+
+	vmServiceList := &vmopv1.VirtualMachineServiceList{}
+	err := r.List(ctx, vmServiceList, client.InNamespace(lookupVM.Namespace))
+	if err != nil {
+		return nil, err
+	}
+
+	var matchingVMServices []reconcile.Request
+	vmLabels := labels.Set(lookupVM.Labels)
+
+	for _, vmService := range vmServiceList.Items {
+		if len(vmService.Spec.Selector) != 0 {
+			sel := labels.SelectorFromValidatedSet(vmService.Spec.Selector)
+			if sel.Matches(vmLabels) {
+				matchingVMServices = append(matchingVMServices, reconcile.Request{
+					NamespacedName: client.ObjectKey{Namespace: vmService.Namespace, Name: vmService.Name},
+				})
+			}
+		}
+	}
+
+	return matchingVMServices, nil
+}
+
+// createOrUpdateEndpoints updates the Endpoints for VirtualMachineService.
+func (r *ReconcileVirtualMachineService) createOrUpdateEndpoints(ctx *context.VirtualMachineServiceContextA2, service *corev1.Service) error {
+	ctx.Logger.V(5).Info("Updating VirtualMachineService Endpoints")
+	defer ctx.Logger.V(5).Info("Finished updating VirtualMachineService Endpoints")
+
+	if len(ctx.VMService.Spec.Selector) == 0 {
+		ctx.Logger.V(5).Info("Selectorless VirtualMachineService so skipping Endpoints reconciliation")
+		return nil
+	}
+
+	unpackedSubsets, err := r.generateSubsetsForService(ctx, service)
+	if err != nil {
+		return err
+	}
+	subsets := utils.RepackSubsets(unpackedSubsets)
+
+	endpoints := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      service.Name,
+			Namespace: service.Namespace,
+		},
+	}
+
+	result, err := controllerutil.CreateOrPatch(ctx, r.Client, endpoints, func() error {
+		if err := controllerutil.SetControllerReference(ctx.VMService, endpoints, r.Client.Scheme()); err != nil {
+			return err
+		}
+
+		// NCP apparently needs the same Labels as what is present on the Service, and I'm not aware
+		// of anything else setting Labels, so just sync the Labels (and Annotations) with the Service.
+		endpoints.Labels = service.Labels
+		endpoints.Annotations = service.Annotations
+		endpoints.Subsets = subsets
+		return nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	switch result {
+	case controllerutil.OperationResultCreated:
+		ctx.Logger.Info("Creating Service Endpoints", "endpoints", endpoints)
+	case controllerutil.OperationResultUpdated:
+		ctx.Logger.Info("Updating Service Endpoints", "endpoints", endpoints)
+	}
+
+	return nil
+}
+
+func findVMPortNum(_ *vmopv1.VirtualMachine, port intstr.IntOrString, _ corev1.Protocol) (int, error) {
+	switch port.Type {
+	case intstr.String:
+		// Not supported.
+	case intstr.Int:
+		return port.IntValue(), nil
+	}
+
+	return 0, fmt.Errorf("no matching port on VM")
+}
+
+// generateSubsetsForService generates Endpoints subsets for a given Service.
+func (r *ReconcileVirtualMachineService) generateSubsetsForService(
+	ctx *context.VirtualMachineServiceContextA2,
+	service *corev1.Service) ([]corev1.EndpointSubset, error) {
+
+	vmList, err := r.getVirtualMachinesSelectedByVMService(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var subsets = make([]corev1.EndpointSubset, 0, len(vmList.Items))
+	var vmInSubsetsMap map[types.UID]struct{}
+
+	for i := range vmList.Items {
+		vm := vmList.Items[i]
+		logger := ctx.Logger.WithValues("virtualMachine", vm.NamespacedName())
+
+		if !vm.DeletionTimestamp.IsZero() {
+			logger.Info("Skipping VM marked for deletion")
+			continue
+		}
+
+		var vmIP string
+		if vm.Status.Network != nil {
+			vmIP = vm.Status.Network.PrimaryIP4
+			if vmIP == "" {
+				vmIP = vm.Status.Network.PrimaryIP6
+			}
+		}
+
+		if vmIP == "" {
+			// The EndpointAddress must have a valid IP so we cannot include this VM in the
+			// NotReadyAddresses.
+			// TODO: When we more fully support multiple NICs, we'll need someway to select which IP.
+			logger.Info("Skipping VM without primary IP assigned")
+			continue
+		}
+
+		// If the VM has a ReadinessProbe and Ready condition, ready is a reflection of the condition
+		// status. If the VM has a ReadinessProbe but no condition, we assume that the prober just
+		// hasn't run against the VM yet, so infer the VM's readiness if it was previously in the EP;
+		// this is to handle upgrade scenarios.
+		// Otherwise, a VM that does not have a ReadinessProbe is implicitly ready.
+		ready := true
+
+		if probe := vm.Spec.ReadinessProbe; probe.TCPSocket != nil || probe.GuestHeartbeat != nil || len(probe.GuestInfo) != 0 {
+			if condition := conditions.Get(&vm, vmopv1.ReadyConditionType); condition == nil {
+				if vmInSubsetsMap == nil {
+					vmInSubsetsMap = r.getVMsReferencedByServiceEndpoints(ctx, service)
+				}
+
+				// If this VM was previously in the EP subset, preserve its readiness until prober
+				// updates the condition (the probe used to be done inline here before we had a
+				// Ready condition).
+				_, ready = vmInSubsetsMap[vm.UID]
+			} else {
+				ready = condition.Status == metav1.ConditionTrue
+			}
+		}
+
+		epa := corev1.EndpointAddress{
+			IP: vmIP,
+			TargetRef: &corev1.ObjectReference{
+				APIVersion: vm.APIVersion,
+				Kind:       vm.Kind,
+				Namespace:  vm.Namespace,
+				Name:       vm.Name,
+				UID:        vm.UID,
+				// NOTE: This currently isn't set to limit downstream reconcile churn in things
+				// watching these Endpoints but isn't ideal. We should be smarter and only update
+				// this when something relevant to the service, e.g. the VM's IP, changes.
+				// ResourceVersion: vm.ResourceVersion,
+			},
+		}
+
+		// Populate the EP subset for this VM. We create one subset for each VM, and then our
+		// caller will repack the subsets that have identical ports.
+		subset := corev1.EndpointSubset{}
+		if ready {
+			subset.Addresses = []corev1.EndpointAddress{epa}
+		} else {
+			subset.NotReadyAddresses = []corev1.EndpointAddress{epa}
+		}
+
+		// TODO: Headless support
+		for _, servicePort := range service.Spec.Ports {
+			portName := servicePort.Name
+			portProto := servicePort.Protocol
+
+			logger.V(5).Info("ServicePort for VirtualMachine",
+				"port name", portName, "port proto", portProto)
+
+			portNum, err := findVMPortNum(&vm, servicePort.TargetPort, portProto)
+			if err != nil {
+				logger.Info("Failed to find port for service",
+					"name", portName, "protocol", portProto, "error", err)
+				continue
+			}
+
+			subset.Ports = append(subset.Ports,
+				corev1.EndpointPort{Name: portName, Port: int32(portNum), Protocol: portProto})
+		}
+
+		subsets = append(subsets, subset)
+	}
+
+	return subsets, nil
+}
+
+// updateVMService syncs the VirtualMachineService Status from the Service status.
+func (r *ReconcileVirtualMachineService) updateVMService(ctx *context.VirtualMachineServiceContextA2, service *corev1.Service) error {
+	vmService := ctx.VMService
+
+	if vmService.Spec.Type == vmopv1.VirtualMachineServiceTypeLoadBalancer {
+		vmService.Status.LoadBalancer.Ingress = make([]vmopv1.LoadBalancerIngress, len(service.Status.LoadBalancer.Ingress))
+		for idx, ingress := range service.Status.LoadBalancer.Ingress {
+			vmIngress := vmopv1.LoadBalancerIngress{
+				IP:       ingress.IP,
+				Hostname: ingress.Hostname,
+			}
+			vmService.Status.LoadBalancer.Ingress[idx] = vmIngress
+		}
+	}
+
+	return nil
+}

--- a/controllers/virtualmachineservice/v1alpha2/virtualmachineservice_controller_intg_test.go
+++ b/controllers/virtualmachineservice/v1alpha2/virtualmachineservice_controller_intg_test.go
@@ -1,0 +1,375 @@
+// Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha2_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+
+	conditions "github.com/vmware-tanzu/vm-operator/pkg/conditions2"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+const (
+	finalizerName = "virtualmachineservice.vmoperator.vmware.com"
+)
+
+func intgTests() {
+	var (
+		ctx *builder.IntegrationTestContext
+
+		selector      map[string]string
+		vmLabels      map[string]string
+		vmIP1, vmIP2  string
+		vmServicePort vmopv1.VirtualMachineServicePort
+		vmServiceName string
+	)
+
+	BeforeEach(func() {
+		ctx = suite.NewIntegrationTestContext()
+
+		selector = map[string]string{"vmservice-intg-test": "selector"}
+		vmLabels = map[string]string{"vmservice-intg-test": "selector", "other": "label"}
+		vmIP1, vmIP2 = "10.100.101.1", "10.100.101.2"
+
+		vmServicePort = vmopv1.VirtualMachineServicePort{
+			Name:       "port1",
+			Protocol:   "TCP",
+			Port:       42,
+			TargetPort: 142,
+		}
+	})
+
+	AfterEach(func() {
+		By("Object cleanup", func() {
+			objMeta := metav1.ObjectMeta{Name: vmServiceName, Namespace: ctx.Namespace}
+
+			vmService := &vmopv1.VirtualMachineService{ObjectMeta: objMeta}
+			err := ctx.Client.Delete(ctx, vmService)
+			Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
+
+			service := &corev1.Service{ObjectMeta: objMeta}
+			err = ctx.Client.Delete(ctx, service)
+			Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
+
+			endpoints := &corev1.Endpoints{ObjectMeta: objMeta}
+			err = ctx.Client.Delete(ctx, endpoints)
+			Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
+		})
+
+		ctx.AfterEach()
+		ctx = nil
+	})
+
+	Context("Reconcile", func() {
+		Context("Reconciles after VirtualMachineService creation", func() {
+			BeforeEach(func() {
+				vmServiceName = "test-vm-service"
+			})
+
+			It("Simulate workflow", func() {
+				dummyAnnotationKey, dummyAnnotationVal := "dummy-annotation-key", "dummy-annotation-val"
+				dummyLabelKey, dummyLabelVal := "dummy-label-key", "dummy-label-val"
+
+				notReadyVM := &vmopv1.VirtualMachine{}
+				By("Create not ready VM with selected labels", func() {
+					notReadyVM = &vmopv1.VirtualMachine{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "not-ready-vm",
+							Namespace: ctx.Namespace,
+							Labels:    vmLabels,
+						},
+						Spec: vmopv1.VirtualMachineSpec{
+							PowerState: vmopv1.VirtualMachinePowerStateOn,
+							ReadinessProbe: vmopv1.VirtualMachineReadinessProbeSpec{
+								TCPSocket: &vmopv1.TCPSocketAction{},
+							},
+						},
+					}
+					Expect(ctx.Client.Create(ctx, notReadyVM)).To(Succeed())
+					notReadyVM.Status.Network = &vmopv1.VirtualMachineNetworkStatus{PrimaryIP4: vmIP1}
+					conditions.MarkFalse(notReadyVM, vmopv1.ReadyConditionType, "not_ready", "VM should be skipped")
+					Expect(ctx.Client.Status().Update(ctx, notReadyVM)).To(Succeed())
+				})
+
+				vmService := &vmopv1.VirtualMachineService{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      vmServiceName,
+						Namespace: ctx.Namespace,
+						Annotations: map[string]string{
+							dummyAnnotationKey: dummyAnnotationVal,
+						},
+						Labels: map[string]string{
+							dummyLabelKey: dummyLabelVal,
+						},
+					},
+					Spec: vmopv1.VirtualMachineServiceSpec{
+						Type:     vmopv1.VirtualMachineServiceTypeLoadBalancer,
+						Ports:    []vmopv1.VirtualMachineServicePort{vmServicePort},
+						Selector: selector,
+					},
+				}
+
+				objKey := client.ObjectKey{Namespace: vmService.Namespace, Name: vmService.Name}
+
+				By("Create VirtualMachineService", func() {
+					Expect(ctx.Client.Create(ctx, vmService)).To(Succeed())
+				})
+
+				By("VirtualMachineService finalizer should get set")
+				Eventually(func() []string {
+					vmService := &vmopv1.VirtualMachineService{}
+					if err := ctx.Client.Get(ctx, objKey, vmService); err == nil {
+						return vmService.GetFinalizers()
+					}
+					return nil
+				}).Should(ContainElement(finalizerName))
+
+				By("Service should be created", func() {
+					service := &corev1.Service{}
+					Eventually(func() error {
+						return ctx.Client.Get(ctx, objKey, service)
+					}).Should(Succeed())
+
+					// Service should have label and annotations replicated on vmService create
+					Expect(service.Labels).To(HaveKeyWithValue(dummyLabelKey, dummyLabelVal))
+					Expect(service.Annotations).To(HaveKeyWithValue(dummyAnnotationKey, dummyAnnotationVal))
+
+					Expect(service.Spec.Type).To(Equal(corev1.ServiceTypeLoadBalancer))
+					Expect(service.Spec.Selector).To(BeEmpty())
+					Expect(service.Status.LoadBalancer.Ingress).To(BeEmpty())
+				})
+
+				By("Endpoints should be created", func() {
+					endpoints := &corev1.Endpoints{}
+					Eventually(func() error {
+						return ctx.Client.Get(ctx, objKey, endpoints)
+					}).Should(Succeed())
+
+					Expect(endpoints.Labels).To(HaveKeyWithValue(dummyLabelKey, dummyLabelVal))
+					Expect(endpoints.Annotations).To(HaveKeyWithValue(dummyAnnotationKey, dummyAnnotationVal))
+
+					Expect(endpoints.Subsets).To(HaveLen(1))
+					subset := endpoints.Subsets[0]
+					Expect(subset.Addresses).To(BeEmpty())
+
+					By("Not ready VM should be included to Endpoints", func() {
+						Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(notReadyVM), notReadyVM)).To(Succeed())
+
+						Expect(subset.NotReadyAddresses).To(HaveLen(1))
+						address := subset.NotReadyAddresses[0]
+						Expect(notReadyVM.Status.Network).ToNot(BeNil())
+						Expect(address.IP).To(Equal(notReadyVM.Status.Network.PrimaryIP4))
+						Expect(address.TargetRef).ToNot(BeNil())
+						Expect(address.TargetRef.Name).To(Equal(notReadyVM.Name))
+						Expect(address.TargetRef.Namespace).To(Equal(notReadyVM.Namespace))
+						Expect(address.TargetRef.UID).To(Equal(notReadyVM.UID))
+						Expect(address.TargetRef.Kind).ToNot(BeEmpty())
+						Expect(address.TargetRef.APIVersion).ToNot(BeEmpty())
+					})
+				})
+
+				readyVM := &vmopv1.VirtualMachine{}
+				By("Create ready VM with selected labels,", func() {
+					readyVM = &vmopv1.VirtualMachine{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "ready-vm",
+							Namespace: ctx.Namespace,
+							Labels:    vmLabels,
+						},
+						Spec: vmopv1.VirtualMachineSpec{
+							PowerState: vmopv1.VirtualMachinePowerStateOn,
+							ReadinessProbe: vmopv1.VirtualMachineReadinessProbeSpec{
+								GuestHeartbeat: &vmopv1.GuestHeartbeatAction{},
+							},
+						},
+					}
+					Expect(ctx.Client.Create(ctx, readyVM)).To(Succeed())
+
+					readyVM.Status.Network = &vmopv1.VirtualMachineNetworkStatus{PrimaryIP4: vmIP2}
+					conditions.MarkTrue(readyVM, vmopv1.ReadyConditionType)
+					Expect(ctx.Client.Status().Update(ctx, readyVM)).To(Succeed())
+				})
+
+				By("Ready VM should be added to Endpoints", func() {
+					endpoints := &corev1.Endpoints{}
+					Eventually(func() bool {
+						if err := ctx.Client.Get(ctx, objKey, endpoints); err == nil && len(endpoints.Subsets) == 1 {
+							subset := endpoints.Subsets[0]
+							return len(subset.Addresses) != 0 && len(subset.NotReadyAddresses) != 0
+						}
+						return false
+					}).Should(BeTrue())
+
+					subsets := endpoints.Subsets
+					Expect(subsets).To(HaveLen(1))
+
+					subset := subsets[0]
+					Expect(subset.Addresses).To(HaveLen(1))
+					Expect(subset.NotReadyAddresses).To(HaveLen(1))
+
+					address := subset.Addresses[0]
+					Expect(readyVM.Status.Network).ToNot(BeNil())
+					Expect(address.IP).To(Equal(readyVM.Status.Network.PrimaryIP4))
+					Expect(address.TargetRef).ToNot(BeNil())
+					Expect(address.TargetRef.Name).To(Equal(readyVM.Name))
+					Expect(address.TargetRef.Namespace).To(Equal(readyVM.Namespace))
+					Expect(address.TargetRef.UID).To(Equal(readyVM.UID))
+					Expect(address.TargetRef.Kind).ToNot(BeEmpty())
+					Expect(address.TargetRef.APIVersion).ToNot(BeEmpty())
+
+					Expect(subset.Ports).To(HaveLen(1))
+					port := subset.Ports[0]
+					Expect(port.Name).To(Equal(port.Name))
+					Expect(port.Port).To(BeEquivalentTo(vmServicePort.TargetPort))
+					Expect(port.Protocol).To(BeEquivalentTo(corev1.ProtocolTCP))
+				})
+
+				By("Deleted VM should be removed from Endpoints", func() {
+					// Must add finalizer here so that the VM does not get deleted immediately, as our
+					// VM mapping function assumes that the VM exists. This is a bug, and should have
+					// a similar solution as the XIt() test below. In practice, this should be hard to
+					// hit because of the VirtualMachine controller finalizer.
+					notReadyVM.Finalizers = append(notReadyVM.Finalizers, "dummy.test.finalizer")
+					Expect(ctx.Client.Update(ctx, notReadyVM)).To(Succeed())
+					Expect(ctx.Client.Delete(ctx, notReadyVM)).To(Succeed())
+
+					Eventually(func() bool {
+						endpoints := &corev1.Endpoints{}
+						if err := ctx.Client.Get(ctx, objKey, endpoints); err == nil {
+							return len(endpoints.Subsets) == 1 && len(endpoints.Subsets[0].NotReadyAddresses) == 0
+						}
+						return false
+					}).Should(BeTrue(), "not ready VM should be removed from Endpoints")
+
+					readyVM.Finalizers = append(readyVM.Finalizers, "dummy.test.finalizer")
+					Expect(ctx.Client.Update(ctx, readyVM)).To(Succeed())
+					Expect(ctx.Client.Delete(ctx, readyVM)).To(Succeed())
+
+					Eventually(func() bool {
+						endpoints := &corev1.Endpoints{}
+						if err := ctx.Client.Get(ctx, objKey, endpoints); err == nil {
+							return len(endpoints.Subsets) == 0
+						}
+						return false
+					}).Should(BeTrue())
+
+					Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(notReadyVM), notReadyVM)).To(Succeed())
+					notReadyVM.Finalizers = nil
+					Expect(ctx.Client.Update(ctx, notReadyVM)).To(Succeed())
+
+					Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(readyVM), readyVM)).To(Succeed())
+					readyVM.Finalizers = nil
+					Expect(ctx.Client.Update(ctx, readyVM)).To(Succeed())
+				})
+
+				By("Delete VirtualMachineService and finalizer should be removed", func() {
+					Expect(ctx.Client.Delete(ctx, vmService)).To(Succeed())
+
+					Eventually(func() []string {
+						vmService := &vmopv1.VirtualMachineService{}
+						if err := ctx.Client.Get(ctx, objKey, vmService); err == nil {
+							return vmService.GetFinalizers()
+						}
+						return nil
+					}).ShouldNot(ContainElement(finalizerName))
+				})
+			})
+		})
+
+		Context("Reconciles after VirtualMachineService after VMs labels no longer match", func() {
+			BeforeEach(func() {
+				vmServiceName = "test-vm-service-unmatched-vm"
+			})
+
+			// The VM mapping function needs to be fixed for this to work.
+			XIt("Simulate workflow", func() {
+				readyVM := &vmopv1.VirtualMachine{}
+				By("Create ready VM with selected labels", func() {
+					readyVM = &vmopv1.VirtualMachine{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "ready-vm",
+							Namespace: ctx.Namespace,
+							Labels:    vmLabels,
+						},
+						Spec: vmopv1.VirtualMachineSpec{
+							PowerState: vmopv1.VirtualMachinePowerStateOn,
+							ReadinessProbe: vmopv1.VirtualMachineReadinessProbeSpec{
+								TCPSocket: &vmopv1.TCPSocketAction{},
+							},
+						},
+					}
+					Expect(ctx.Client.Create(ctx, readyVM)).To(Succeed())
+					readyVM.Status.Network = &vmopv1.VirtualMachineNetworkStatus{PrimaryIP4: vmIP1}
+					conditions.MarkTrue(readyVM, vmopv1.ReadyConditionType)
+					Expect(ctx.Client.Status().Update(ctx, readyVM)).To(Succeed())
+				})
+
+				vmService := &vmopv1.VirtualMachineService{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      vmServiceName,
+						Namespace: ctx.Namespace,
+					},
+					Spec: vmopv1.VirtualMachineServiceSpec{
+						Type:     vmopv1.VirtualMachineServiceTypeLoadBalancer,
+						Ports:    []vmopv1.VirtualMachineServicePort{vmServicePort},
+						Selector: selector,
+					},
+				}
+
+				objKey := client.ObjectKey{Namespace: vmService.Namespace, Name: vmService.Name}
+
+				By("Create VirtualMachineService", func() {
+					Expect(ctx.Client.Create(ctx, vmService)).To(Succeed())
+				})
+
+				By("Ready VM should be added to Endpoints", func() {
+					endpoints := &corev1.Endpoints{}
+					Eventually(func() bool {
+						if err := ctx.Client.Get(ctx, objKey, endpoints); err == nil {
+							return len(endpoints.Subsets) != 0
+						}
+						return false
+					}).Should(BeTrue())
+
+					subsets := endpoints.Subsets
+					Expect(subsets).To(HaveLen(1))
+
+					subset := subsets[0]
+					Expect(subset.Addresses).To(HaveLen(1))
+
+					address := subset.Addresses[0]
+					Expect(address.IP).To(Equal(readyVM.Status.Network.PrimaryIP4))
+
+					Expect(subset.Ports).To(HaveLen(1))
+					port := subset.Ports[0]
+					Expect(port.Name).To(Equal(port.Name))
+					Expect(port.Port).To(BeEquivalentTo(vmServicePort.TargetPort))
+					Expect(port.Protocol).To(BeEquivalentTo(corev1.ProtocolTCP))
+				})
+
+				By("Change VM Labels so it no longer matches selector", func() {
+					readyVM.Labels = map[string]string{"some-other": "label"}
+					Expect(ctx.Client.Update(ctx, readyVM)).To(Succeed())
+				})
+
+				By("VM should be removed from Endpoints", func() {
+					Eventually(func() bool {
+						endpoints := &corev1.Endpoints{}
+						if err := ctx.Client.Get(ctx, objKey, endpoints); err == nil {
+							return len(endpoints.Subsets) == 0
+						}
+						return false
+					}).Should(BeTrue())
+				})
+			})
+		})
+	})
+}

--- a/controllers/virtualmachineservice/v1alpha2/virtualmachineservice_controller_suite_test.go
+++ b/controllers/virtualmachineservice/v1alpha2/virtualmachineservice_controller_suite_test.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha2_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+
+	virtualmachineservice "github.com/vmware-tanzu/vm-operator/controllers/virtualmachineservice/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/pkg/manager"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+var suite = builder.NewTestSuiteForController(
+	virtualmachineservice.AddToManager,
+	manager.InitializeProvidersNoopFn,
+)
+
+func TestVirtualMachineService(t *testing.T) {
+	_ = intgTests
+	suite.Register(t, "VirtualMachineService controller suite", nil /*intgTests*/, unitTests)
+}
+
+var _ = BeforeSuite(suite.BeforeSuite)
+
+var _ = AfterSuite(suite.AfterSuite)

--- a/controllers/virtualmachineservice/v1alpha2/virtualmachineservice_controller_unit_test.go
+++ b/controllers/virtualmachineservice/v1alpha2/virtualmachineservice_controller_unit_test.go
@@ -1,0 +1,993 @@
+// Copyright (c) 2019-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha2_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/onsi/gomega/types"
+
+	corev1 "k8s.io/api/core/v1"
+	apiEquality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+
+	virtualmachineservice "github.com/vmware-tanzu/vm-operator/controllers/virtualmachineservice/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachineservice/v1alpha2/providers"
+	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachineservice/v1alpha2/utils"
+	conditions "github.com/vmware-tanzu/vm-operator/pkg/conditions2"
+	vmopContext "github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+func unitTests() {
+	Describe("Invoking Reconcile", unitTestsReconcile)
+	Describe("Invoking NSXT Reconcile", nsxtLBProviderTestsReconcile)
+}
+
+const LabelServiceProxyName = "service.kubernetes.io/service-proxy-name"
+
+func unitTestsReconcile() {
+	var (
+		initObjects []client.Object
+		ctx         *builder.UnitTestContextForController
+
+		reconciler   *virtualmachineservice.ReconcileVirtualMachineService
+		vmServiceCtx *vmopContext.VirtualMachineServiceContextA2
+
+		vmService      *vmopv1.VirtualMachineService
+		vmServicePort1 vmopv1.VirtualMachineServicePort
+		vmServicePort2 vmopv1.VirtualMachineServicePort
+		lbSourceRanges []string
+		objKey         client.ObjectKey
+	)
+
+	const (
+		externalName   = "my-external-name"
+		clusterIP      = "192.168.100.42"
+		loadBalancerIP = "1.1.1.42"
+
+		annotationName1  = "my-annotation-1"
+		annotationValue1 = "bar1"
+		annotationName2  = "my-annotation-2"
+		annotationValue2 = "bar2"
+		labelName1       = "my-label-1"
+		labelValue1      = "bar3"
+		labelName2       = "my-label-2"
+		labelValue2      = "bar4"
+	)
+
+	BeforeEach(func() {
+		vmService = &vmopv1.VirtualMachineService{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "dummy-vm-service",
+				Namespace:   "dummy-ns",
+				Labels:      map[string]string{},
+				Annotations: map[string]string{},
+			},
+			Spec: vmopv1.VirtualMachineServiceSpec{
+				Type:                     vmopv1.VirtualMachineServiceTypeLoadBalancer,
+				Selector:                 map[string]string{},
+				ExternalName:             externalName,
+				ClusterIP:                clusterIP,
+				LoadBalancerIP:           loadBalancerIP,
+				LoadBalancerSourceRanges: lbSourceRanges,
+			},
+		}
+
+		vmServicePort1 = vmopv1.VirtualMachineServicePort{
+			Name:       "port1",
+			Protocol:   "TCP",
+			Port:       42,
+			TargetPort: 142,
+		}
+
+		vmServicePort2 = vmopv1.VirtualMachineServicePort{
+			Name:       "port2",
+			Protocol:   "UDP",
+			Port:       1042,
+			TargetPort: 1142,
+		}
+
+		lbSourceRanges = []string{"1.1.1.0/24", "2.2.0.0/16"}
+
+		objKey = client.ObjectKey{Namespace: vmService.Namespace, Name: vmService.Name}
+	})
+
+	JustBeforeEach(func() {
+		ctx = suite.NewUnitTestContextForController(initObjects...)
+		reconciler = virtualmachineservice.NewReconciler(
+			ctx.Client,
+			ctx.Logger,
+			ctx.Recorder,
+			providers.NoopLoadbalancerProvider{},
+		)
+
+		vmServiceCtx = &vmopContext.VirtualMachineServiceContextA2{
+			Context:   ctx,
+			Logger:    ctx.Logger.WithName(vmService.Name),
+			VMService: vmService,
+		}
+	})
+
+	AfterEach(func() {
+		ctx.AfterEach()
+		ctx = nil
+		initObjects = nil
+		vmServiceCtx = nil
+		reconciler = nil
+	})
+
+	Context("ReconcileNormal", func() {
+		When("object does not have finalizer set", func() {
+			BeforeEach(func() {
+				vmService.Finalizers = nil
+			})
+
+			It("will set finalizer", func() {
+				err := reconciler.ReconcileNormal(vmServiceCtx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(vmServiceCtx.VMService.GetFinalizers()).To(ContainElement(finalizerName))
+			})
+		})
+
+		It("will have finalizer set upon successful reconciliation", func() {
+			err := reconciler.ReconcileNormal(vmServiceCtx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(vmServiceCtx.VMService.GetFinalizers()).To(ContainElement(finalizerName))
+		})
+
+		Context("Creates expected Service", func() {
+			var service *corev1.Service
+
+			BeforeEach(func() {
+				service = &corev1.Service{}
+			})
+
+			JustBeforeEach(func() {
+				err := reconciler.ReconcileNormal(vmServiceCtx)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(ctx.Events).Should(Receive(ContainSubstring(virtualmachineservice.OpCreate)))
+				Expect(ctx.Client.Get(ctx, objKey, service)).To(Succeed())
+			})
+
+			It("With Expected OwnerReference", func() {
+				ownerRefs := service.GetOwnerReferences()
+				Expect(ownerRefs).To(HaveLen(1))
+				ownerRef := ownerRefs[0]
+				Expect(ownerRef.Name).To(Equal(vmService.Name))
+				Expect(ownerRef.Controller).To(Equal(pointer.Bool(true)))
+			})
+
+			It("With Expected Spec", func() {
+				Expect(service.Spec.Type).To(Equal(corev1.ServiceTypeLoadBalancer))
+				Expect(service.Spec.ExternalName).To(Equal(externalName))
+				Expect(service.Spec.ClusterIP).To(Equal(clusterIP))
+				Expect(service.Spec.LoadBalancerIP).To(Equal(loadBalancerIP))
+				Expect(service.Spec.LoadBalancerSourceRanges).To(HaveLen(2))
+				Expect(service.Spec.LoadBalancerSourceRanges).To(ContainElements(lbSourceRanges))
+				Expect(service.Spec.AllocateLoadBalancerNodePorts).ToNot(BeNil())
+				Expect(*service.Spec.AllocateLoadBalancerNodePorts).To(BeFalse())
+			})
+
+			Context("With Expected Spec.Ports", func() {
+				BeforeEach(func() {
+					vmService.Spec.Ports = []vmopv1.VirtualMachineServicePort{
+						vmServicePort1,
+						vmServicePort2,
+					}
+				})
+
+				It("Service ports", func() {
+					ports := service.Spec.Ports
+					Expect(ports).To(HaveLen(2))
+
+					port := ports[0]
+					Expect(port.Name).To(Equal(vmServicePort1.Name))
+					Expect(port.Protocol).To(BeEquivalentTo(vmServicePort1.Protocol))
+					Expect(port.Port).To(Equal(vmServicePort1.Port))
+					Expect(port.TargetPort.IntValue()).To(Equal(int(vmServicePort1.TargetPort)))
+
+					port = ports[1]
+					Expect(port.Name).To(Equal(vmServicePort2.Name))
+					Expect(port.Protocol).To(BeEquivalentTo(vmServicePort2.Protocol))
+					Expect(port.Port).To(Equal(vmServicePort2.Port))
+					Expect(port.TargetPort.IntValue()).To(Equal(int(vmServicePort2.TargetPort)))
+				})
+			})
+
+			Context("Inherits Annotations and Labels", func() {
+				BeforeEach(func() {
+					vmService.Annotations[annotationName1] = annotationValue1
+					vmService.Labels[labelName1] = labelValue1
+				})
+
+				It("Expected Labels and Annotations", func() {
+					Expect(service.Annotations).To(HaveKeyWithValue(annotationName1, annotationValue1))
+					Expect(service.Labels).To(HaveKeyWithValue(labelName1, labelValue1))
+				})
+
+				// TODO: These don't belong here. Sort out when the Provider interface is improved.
+				Context("NCP specific Labels and Annotations", func() {
+					BeforeEach(func() {
+						vmService.Labels[LabelServiceProxyName] = providers.NSXTServiceProxy
+					})
+
+					It("Expected labels", func() {
+						Expect(service.Labels[LabelServiceProxyName]).To(Equal(providers.NSXTServiceProxy))
+					})
+				})
+			})
+
+			// TODO: NCP Specific. Sort out when the Provider interface is improved.
+			Context("ExternalTrafficPolicy Annotations", func() {
+				BeforeEach(func() {
+					vmService.Annotations[utils.AnnotationServiceExternalTrafficPolicyKey] = string(corev1.ServiceExternalTrafficPolicyTypeLocal)
+					vmService.Annotations[utils.AnnotationServiceHealthCheckNodePortKey] = "99"
+				})
+
+				It("Expected values", func() {
+					Expect(service.Spec.ExternalTrafficPolicy).To(Equal(corev1.ServiceExternalTrafficPolicyTypeLocal))
+					Expect(service.Annotations).To(HaveKeyWithValue(utils.AnnotationServiceHealthCheckNodePortKey, "99"))
+				})
+			})
+		})
+
+		Context("Service Exists", func() {
+			var service *corev1.Service
+
+			BeforeEach(func() {
+				service = &corev1.Service{}
+
+				vmService.Annotations[annotationName1] = annotationValue1
+				vmService.Labels[labelName1] = labelValue1
+			})
+
+			JustBeforeEach(func() {
+				err := reconciler.ReconcileNormal(vmServiceCtx)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(ctx.Events).Should(Receive(ContainSubstring(virtualmachineservice.OpCreate)))
+				Expect(ctx.Client.Get(ctx, objKey, service)).To(Succeed())
+			})
+
+			It("No Update if VirtualMachineService didn't change", func() {
+				err := reconciler.ReconcileNormal(vmServiceCtx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ctx.Events).ShouldNot(Receive(ContainSubstring(virtualmachineservice.OpUpdate)))
+
+				service2 := &corev1.Service{}
+				Expect(ctx.Client.Get(ctx, objKey, service2)).To(Succeed())
+				Expect(apiEquality.Semantic.DeepEqual(service, service2)).To(BeTrue())
+			})
+
+			Context("VirtualMachineService Spec is updated", func() {
+				It("Service Spec is updated accordingly", func() {
+					vmService.Spec.ExternalName = "new-external-name"
+					vmService.Spec.LoadBalancerIP = "new-lb-ip"
+					vmService.Spec.LoadBalancerSourceRanges = []string{"range42"}
+
+					err := reconciler.ReconcileNormal(vmServiceCtx)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(ctx.Events).Should(Receive(ContainSubstring(virtualmachineservice.OpUpdate)))
+					Expect(ctx.Client.Get(ctx, objKey, service)).To(Succeed())
+
+					Expect(service.Spec.ExternalName).To(Equal("new-external-name"))
+					Expect(service.Spec.LoadBalancerIP).To(Equal("new-lb-ip"))
+					Expect(service.Spec.LoadBalancerSourceRanges).To(HaveLen(1))
+					Expect(service.Spec.LoadBalancerSourceRanges).To(ContainElements("range42"))
+				})
+
+				It("Spec Annotations and Labels are updated", func() {
+					vmService.Annotations[annotationName1] = "new-bar1"
+					vmService.Annotations[annotationName2] = "new-bar2"
+					vmService.Labels[labelName1] = "new-bar3"
+					vmService.Labels[labelName2] = "new-bar4"
+
+					err := reconciler.ReconcileNormal(vmServiceCtx)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(ctx.Events).Should(Receive(ContainSubstring(virtualmachineservice.OpUpdate)))
+					Expect(ctx.Client.Get(ctx, objKey, service)).To(Succeed())
+
+					Expect(service.Annotations).To(HaveLen(2))
+					Expect(service.Annotations).To(HaveKeyWithValue(annotationName1, "new-bar1"))
+					Expect(service.Annotations).To(HaveKeyWithValue(annotationName2, "new-bar2"))
+					Expect(service.Labels).To(HaveLen(2))
+					Expect(service.Labels).To(HaveKeyWithValue(labelName1, "new-bar3"))
+					Expect(service.Labels).To(HaveKeyWithValue(labelName2, "new-bar4"))
+				})
+
+				It("VirtualMachineService Annotations and Labels takes precedence", func() {
+					Expect(service.Annotations).To(HaveLen(1))
+					service.Annotations[annotationName2] = "should-be-changed"
+					Expect(service.Labels).To(HaveLen(1))
+					service.Labels[labelName2] = "should-be-changed"
+					Expect(ctx.Client.Update(ctx, service)).To(Succeed())
+
+					newValue := "vmsvc-should-win"
+					vmService.Annotations[annotationName2] = newValue
+					vmService.Labels[labelName2] = newValue
+
+					err := reconciler.ReconcileNormal(vmServiceCtx)
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(ctx.Events).Should(Receive(ContainSubstring(virtualmachineservice.OpUpdate)))
+					Expect(ctx.Client.Get(ctx, objKey, service)).To(Succeed())
+
+					Expect(service.Annotations).To(HaveKeyWithValue(annotationName2, newValue))
+					Expect(service.Labels).To(HaveKeyWithValue(labelName2, newValue))
+				})
+			})
+
+			Context("Preserves Service Annotations and Labels set elsewhere", func() {
+				// NetOp can set additional annotations and labels that we shouldn't delete.
+
+				It("Keeps Labels and Annotations", func() {
+					Expect(service.Annotations).To(HaveLen(1))
+					service.Annotations["netop-annotation"] = "bar42"
+					Expect(service.Labels).To(HaveLen(1))
+					service.Labels["netop-label"] = "bar43"
+					Expect(ctx.Client.Update(ctx, service)).To(Succeed())
+
+					err := reconciler.ReconcileNormal(vmServiceCtx)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(ctx.Events).ShouldNot(Receive(ContainSubstring(virtualmachineservice.OpUpdate)))
+
+					Expect(ctx.Client.Get(ctx, objKey, service)).To(Succeed())
+					Expect(service.Annotations).To(HaveLen(2))
+					Expect(service.Annotations).To(HaveKeyWithValue("netop-annotation", "bar42"))
+					Expect(service.Labels).To(HaveLen(2))
+					Expect(service.Labels).To(HaveKeyWithValue("netop-label", "bar43"))
+				})
+			})
+
+			Context("Preserves existing NodePort", func() {
+				BeforeEach(func() {
+					vmService.Spec.Ports = []vmopv1.VirtualMachineServicePort{
+						vmServicePort1,
+					}
+				})
+
+				It("Keeps NodePort", func() {
+					Expect(service.Spec.Ports).To(HaveLen(1))
+					service.Spec.Ports[0].NodePort = 10000
+					Expect(ctx.Client.Update(ctx, service)).To(Succeed())
+
+					err := reconciler.ReconcileNormal(vmServiceCtx)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(ctx.Events).ShouldNot(Receive(ContainSubstring(virtualmachineservice.OpUpdate)))
+
+					Expect(ctx.Client.Get(ctx, objKey, service)).To(Succeed())
+					ports := service.Spec.Ports
+					Expect(ports).To(HaveLen(1))
+
+					port := ports[0]
+					Expect(port.Name).To(Equal(vmServicePort1.Name))
+					Expect(port.Protocol).To(BeEquivalentTo(vmServicePort1.Protocol))
+					Expect(port.Port).To(Equal(vmServicePort1.Port))
+					Expect(port.TargetPort.IntValue()).To(Equal(int(vmServicePort1.TargetPort)))
+					Expect(port.NodePort).To(BeNumerically("==", 10000))
+				})
+			})
+
+			Context("VirtualMachineService Status Ingress", func() {
+				It("Sets empty Ingress", func() {
+					Expect(vmService.Status.LoadBalancer.Ingress).To(BeEmpty())
+				})
+
+				It("Sets Ingress from Service Status", func() {
+					service.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{
+						{
+							IP: "ip1",
+						},
+						{
+							Hostname: "hostname1",
+						},
+					}
+					Expect(ctx.Client.Update(ctx, service)).To(Succeed())
+
+					err := reconciler.ReconcileNormal(vmServiceCtx)
+					Expect(err).ToNot(HaveOccurred())
+
+					ingress := vmService.Status.LoadBalancer.Ingress
+					Expect(ingress).To(HaveLen(2))
+					Expect(ingress[0].IP).To(Equal("ip1"))
+					Expect(ingress[0].Hostname).To(BeEmpty())
+					Expect(ingress[1].IP).To(BeEmpty())
+					Expect(ingress[1].Hostname).To(Equal("hostname1"))
+				})
+			})
+		})
+
+		Context("Creates expected Endpoints", func() {
+			var endpoints *corev1.Endpoints
+			var labelSelector, vmLabels map[string]string
+			var vm1, vm2, vm3 *vmopv1.VirtualMachine
+
+			BeforeEach(func() {
+				endpoints = &corev1.Endpoints{}
+				labelSelector = map[string]string{"my-app": "dummy-label"}
+				vmLabels = map[string]string{"my-app": "dummy-label", "other": "label"}
+
+				vmService.Annotations[annotationName1] = "bar1"
+				vmService.Labels[labelName1] = "bar2"
+				vmService.Spec.Selector = labelSelector
+				vmService.Spec.Ports = []vmopv1.VirtualMachineServicePort{
+					vmServicePort1,
+				}
+
+				vm1 = &vmopv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "dummy-vm1",
+						Namespace: vmService.Namespace,
+						Labels:    vmLabels,
+					},
+					Status: vmopv1.VirtualMachineStatus{
+						Network: &vmopv1.VirtualMachineNetworkStatus{
+							PrimaryIP4: "1.1.1.1",
+						},
+					},
+				}
+
+				vm2 = &vmopv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "dummy-vm2",
+						Namespace: vmService.Namespace,
+						Labels:    vmLabels,
+					},
+					Status: vmopv1.VirtualMachineStatus{
+						Network: &vmopv1.VirtualMachineNetworkStatus{
+							PrimaryIP4: "2.2.2.2",
+						},
+					},
+				}
+
+				vm3 = &vmopv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "dummy-vm3",
+						Namespace: vmService.Namespace,
+						Labels:    map[string]string{},
+					},
+					Status: vmopv1.VirtualMachineStatus{
+						Network: &vmopv1.VirtualMachineNetworkStatus{
+							PrimaryIP4: "3.3.3.3",
+						},
+					},
+				}
+			})
+
+			JustBeforeEach(func() {
+				err := reconciler.ReconcileNormal(vmServiceCtx)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(ctx.Events).Should(Receive(ContainSubstring(virtualmachineservice.OpCreate)))
+				Expect(ctx.Client.Get(ctx, objKey, endpoints)).To(Succeed())
+			})
+
+			It("With Expected OwnerReference", func() {
+				ownerRefs := endpoints.GetOwnerReferences()
+				Expect(ownerRefs).To(HaveLen(1))
+				ownerRef := ownerRefs[0]
+				Expect(ownerRef.Name).To(Equal(vmService.Name))
+				Expect(ownerRef.Controller).To(Equal(pointer.Bool(true)))
+			})
+
+			It("With Expected Annotations and Labels", func() {
+				Expect(endpoints.Annotations).To(HaveKeyWithValue(annotationName1, "bar1"))
+				Expect(endpoints.Labels).To(HaveKeyWithValue(labelName1, "bar2"))
+			})
+
+			It("Empty Subsets when no VM matches", func() {
+				Expect(endpoints.Subsets).To(BeEmpty())
+			})
+
+			Context("When one VM matches label selector", func() {
+				BeforeEach(func() {
+					initObjects = append(initObjects, vm1, vm3)
+				})
+
+				It("With Expected Subsets", func() {
+					Expect(endpoints.Subsets).To(HaveLen(1))
+					subset := endpoints.Subsets[0]
+
+					Expect(subset.Ports).To(HaveLen(1))
+					assertEPPortFromVMServicePort(subset.Ports[0], vmServicePort1)
+
+					Expect(subset.Addresses).To(HaveLen(1))
+					assertEPAddrFromVM(subset.Addresses[0], vm1)
+					Expect(subset.NotReadyAddresses).To(BeEmpty())
+				})
+
+				Context("When VM does not have IP", func() {
+					BeforeEach(func() {
+						vm1.Status.Network.PrimaryIP4 = ""
+					})
+
+					It("Not included in Subsets", func() {
+						Expect(endpoints.Subsets).To(BeEmpty())
+					})
+				})
+			})
+
+			Context("When multiple VMs match label selector", func() {
+				BeforeEach(func() {
+					initObjects = append(initObjects, vm1, vm2, vm3)
+				})
+
+				It("With Expected Subsets", func() {
+					Expect(endpoints.Subsets).To(HaveLen(1))
+					subset := endpoints.Subsets[0]
+
+					Expect(subset.Ports).To(HaveLen(1))
+					assertEPPortFromVMServicePort(subset.Ports[0], vmServicePort1)
+
+					Expect(subset.Addresses).To(HaveLen(2))
+					assertEPAddrFromVM(subset.Addresses[0], vm1)
+					assertEPAddrFromVM(subset.Addresses[1], vm2)
+					Expect(subset.NotReadyAddresses).To(BeEmpty())
+				})
+
+				When("Service has multiple ports", func() {
+					BeforeEach(func() {
+						vmService.Spec.Ports = append(vmService.Spec.Ports, vmServicePort2)
+						Expect(vmService.Spec.Ports).To(HaveLen(2))
+					})
+
+					It("Expected subsets should be packed", func() {
+						Expect(endpoints.Subsets).To(HaveLen(1))
+						subset := endpoints.Subsets[0]
+
+						Expect(subset.Ports).To(HaveLen(2))
+						assertEPPortFromVMServicePort(subset.Ports[0], vmServicePort1)
+						assertEPPortFromVMServicePort(subset.Ports[1], vmServicePort2)
+
+						Expect(subset.Addresses).To(HaveLen(2))
+						assertEPAddrFromVM(subset.Addresses[0], vm1)
+						assertEPAddrFromVM(subset.Addresses[1], vm2)
+						Expect(subset.NotReadyAddresses).To(BeEmpty())
+					})
+				})
+			})
+
+			Context("When VMs have Readiness Probe", func() {
+				BeforeEach(func() {
+					vm1.Spec.ReadinessProbe.TCPSocket = &vmopv1.TCPSocketAction{}
+					vm2.Spec.ReadinessProbe.TCPSocket = &vmopv1.TCPSocketAction{}
+					vm3.Spec.ReadinessProbe.TCPSocket = &vmopv1.TCPSocketAction{}
+
+					initObjects = append(initObjects, vm1, vm2, vm3)
+				})
+
+				It("VMs without Ready Condition are included in NotReadyAddresses", func() {
+					Expect(endpoints.Subsets).To(HaveLen(1))
+					subset := endpoints.Subsets[0]
+
+					Expect(subset.Ports).To(HaveLen(1))
+					assertEPPortFromVMServicePort(subset.Ports[0], vmServicePort1)
+
+					Expect(subset.Addresses).To(BeEmpty())
+					Expect(subset.NotReadyAddresses).To(HaveLen(2))
+					assertEPAddrFromVM(subset.NotReadyAddresses[0], vm1)
+					assertEPAddrFromVM(subset.NotReadyAddresses[1], vm2)
+				})
+
+				Context("Unready VM with false Ready condition", func() {
+					BeforeEach(func() {
+						conditions.MarkFalse(vm1, vmopv1.ReadyConditionType, "reason", "")
+					})
+
+					It("With expected Subsets", func() {
+						Expect(endpoints.Subsets).To(HaveLen(1))
+						subset := endpoints.Subsets[0]
+
+						Expect(subset.Ports).To(HaveLen(1))
+						assertEPPortFromVMServicePort(subset.Ports[0], vmServicePort1)
+
+						Expect(subset.Addresses).To(BeEmpty())
+						Expect(subset.NotReadyAddresses).To(HaveLen(2))
+						assertEPAddrFromVM(subset.NotReadyAddresses[0], vm1)
+						assertEPAddrFromVM(subset.NotReadyAddresses[1], vm2)
+					})
+				})
+
+				Context("Ready VM with true Ready condition", func() {
+					BeforeEach(func() {
+						conditions.MarkTrue(vm1, vmopv1.ReadyConditionType)
+					})
+
+					It("With expected Subsets", func() {
+						Expect(endpoints.Subsets).To(HaveLen(1))
+						subset := endpoints.Subsets[0]
+
+						Expect(subset.Ports).To(HaveLen(1))
+						assertEPPortFromVMServicePort(subset.Ports[0], vmServicePort1)
+
+						Expect(subset.Addresses).To(HaveLen(1))
+						assertEPAddrFromVM(subset.Addresses[0], vm1)
+						Expect(subset.NotReadyAddresses).To(HaveLen(1))
+						assertEPAddrFromVM(subset.NotReadyAddresses[0], vm2)
+					})
+				})
+			})
+
+			Context("Preserve VMs in Endpoints that have Probe but hasn't run yet", func() {
+				BeforeEach(func() {
+					vm1.UID = "abc"
+					vm1.Spec.ReadinessProbe.TCPSocket = &vmopv1.TCPSocketAction{}
+					vm2.UID = "xyz"
+					vm2.Spec.ReadinessProbe.TCPSocket = &vmopv1.TCPSocketAction{}
+					// Initial setup so that the first Reconcile will add the VM.
+					conditions.MarkTrue(vm1, vmopv1.ReadyConditionType)
+					initObjects = append(initObjects, vm1, vm2)
+				})
+
+				It("VM is kept in Endpoints", func() {
+					subsets := endpoints.Subsets
+					Expect(subsets).To(HaveLen(1))
+					subset := subsets[0]
+					Expect(subset.Addresses).To(HaveLen(1))
+					assertEPAddrFromVM(subset.Addresses[0], vm1)
+					Expect(subset.NotReadyAddresses).To(HaveLen(1))
+					assertEPAddrFromVM(subset.NotReadyAddresses[0], vm2)
+
+					// Remove Ready condition but keep the ReadinessProbe. This simulates the probe not
+					// being run yet.
+					vm1.Status.Conditions = nil
+					Expect(ctx.Client.Status().Update(ctx, vm1)).To(Succeed())
+
+					err := reconciler.ReconcileNormal(vmServiceCtx)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(ctx.Client.Get(ctx, objKey, endpoints)).To(Succeed())
+
+					// VM1 should still be present in the Endpoints.
+					subsets = endpoints.Subsets
+					Expect(subsets).To(HaveLen(1))
+					subset = subsets[0]
+					Expect(subset.Addresses).To(HaveLen(1))
+					assertEPAddrFromVM(subset.Addresses[0], vm1)
+					Expect(subset.NotReadyAddresses).To(HaveLen(1))
+					assertEPAddrFromVM(subset.NotReadyAddresses[0], vm2)
+				})
+			})
+		})
+
+		Context("Selectorless VirtualMachineService", func() {
+			var vm1 *vmopv1.VirtualMachine
+			var labelSelector, vmLabels map[string]string
+
+			BeforeEach(func() {
+				labelSelector = map[string]string{"my-app": "dummy-label"}
+				vmLabels = map[string]string{"my-app": "dummy-label", "other": "label"}
+
+				vmService.Annotations[annotationName1] = "bar1"
+				vmService.Labels[labelName1] = "bar2"
+				vmService.Spec.Ports = []vmopv1.VirtualMachineServicePort{
+					vmServicePort1,
+				}
+
+				vm1 = &vmopv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "dummy-vm1",
+						Namespace: vmService.Namespace,
+						Labels:    vmLabels,
+					},
+					Status: vmopv1.VirtualMachineStatus{
+						Network: &vmopv1.VirtualMachineNetworkStatus{
+							PrimaryIP4: "1.1.1.1",
+						},
+					},
+				}
+
+				initObjects = append(initObjects, vm1)
+			})
+
+			JustBeforeEach(func() {
+				err := reconciler.ReconcileNormal(vmServiceCtx)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(ctx.Events).Should(Receive(ContainSubstring(virtualmachineservice.OpCreate)))
+			})
+
+			It("Creates Service but not Endpoints", func() {
+				service := &corev1.Service{}
+				Expect(ctx.Client.Get(ctx, objKey, service)).To(Succeed())
+
+				endpoints := &corev1.Endpoints{}
+				err := ctx.Client.Get(ctx, objKey, endpoints)
+				Expect(err).To(HaveOccurred())
+				Expect(errors.IsNotFound(err)).To(BeTrue())
+			})
+
+			Context("When VirtualMachineService becomes selectorless", func() {
+				BeforeEach(func() {
+					vmService.Spec.Selector = labelSelector
+				})
+
+				/* This is to match the k8s Service behavior when it changes to selectorless. */
+				It("Does not delete existing Endpoints", func() {
+					endpoints := &corev1.Endpoints{}
+					Expect(ctx.Client.Get(ctx, objKey, endpoints)).To(Succeed())
+
+					vmServiceCtx.VMService.Spec.Selector = nil
+					Expect(reconciler.ReconcileNormal(vmServiceCtx)).To(Succeed())
+					Expect(ctx.Client.Get(ctx, objKey, endpoints)).To(Succeed())
+					Expect(endpoints.Subsets).ToNot(BeEmpty())
+				})
+			})
+		})
+	})
+
+	Context("ReconcileDelete", func() {
+		BeforeEach(func() {
+			vmService.Finalizers = []string{finalizerName}
+		})
+
+		It("will clear finalizer", func() {
+			err := reconciler.ReconcileDelete(vmServiceCtx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vmServiceCtx.VMService.GetFinalizers()).ToNot(ContainElement(finalizerName))
+		})
+
+		Context("When Endpoint and Service exists", func() {
+
+			BeforeEach(func() {
+				objectMeta := metav1.ObjectMeta{
+					Name:      vmService.Name,
+					Namespace: vmService.Namespace,
+				}
+				endpoint := &corev1.Endpoints{ObjectMeta: objectMeta}
+				service := &corev1.Service{ObjectMeta: objectMeta}
+				initObjects = append(initObjects, endpoint, service)
+			})
+
+			It("Deletes Endpoint and Service", func() {
+				err := reconciler.ReconcileDelete(vmServiceCtx)
+				Expect(err).ToNot(HaveOccurred())
+
+				endpoint := &corev1.Endpoints{}
+				err = ctx.Client.Get(ctx, objKey, endpoint)
+				Expect(errors.IsNotFound(err)).To(BeTrue())
+
+				service := &corev1.Service{}
+				err = ctx.Client.Get(ctx, objKey, service)
+				Expect(errors.IsNotFound(err)).To(BeTrue())
+			})
+		})
+	})
+}
+
+// This duplicates some of the above tests just to test bits of the NSX-T LB provider.
+// We should really instead refactor the provider interface so we don't have logic for
+// it in multiples places and can test it just in the existing provider tests. These
+// tests as-is need some improvement.
+func nsxtLBProviderTestsReconcile() {
+	var (
+		initObjects []client.Object
+		ctx         *builder.UnitTestContextForController
+
+		lbProvider   providers.LoadbalancerProvider
+		reconciler   *virtualmachineservice.ReconcileVirtualMachineService
+		vmServiceCtx *vmopContext.VirtualMachineServiceContextA2
+
+		vmServicePort1 vmopv1.VirtualMachineServicePort
+		vmService      *vmopv1.VirtualMachineService
+		objKey         client.ObjectKey
+
+		lbSourceRanges = []string{"1.1.1.0/24", "2.2.0.0/16"}
+	)
+
+	const (
+		externalName   = "my-external-name"
+		clusterIP      = "192.168.100.42"
+		loadBalancerIP = "1.1.1.42"
+	)
+
+	BeforeEach(func() {
+		vmServicePort1 = vmopv1.VirtualMachineServicePort{
+			Name:       "port1",
+			Protocol:   "TCP",
+			Port:       42,
+			TargetPort: 142,
+		}
+
+		vmService = &vmopv1.VirtualMachineService{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "dummy-vm-service",
+				Namespace:   "dummy-ns",
+				Labels:      map[string]string{},
+				Annotations: map[string]string{},
+			},
+			Spec: vmopv1.VirtualMachineServiceSpec{
+				Type:                     vmopv1.VirtualMachineServiceTypeLoadBalancer,
+				Selector:                 map[string]string{},
+				ExternalName:             externalName,
+				ClusterIP:                clusterIP,
+				LoadBalancerIP:           loadBalancerIP,
+				LoadBalancerSourceRanges: lbSourceRanges,
+				Ports:                    []vmopv1.VirtualMachineServicePort{vmServicePort1},
+			},
+		}
+
+		objKey = client.ObjectKey{Namespace: vmService.Namespace, Name: vmService.Name}
+	})
+
+	JustBeforeEach(func() {
+		ctx = suite.NewUnitTestContextForController(initObjects...)
+		lbProvider = providers.NsxtLoadBalancerProvider()
+		reconciler = virtualmachineservice.NewReconciler(
+			ctx.Client,
+			ctx.Logger,
+			ctx.Recorder,
+			lbProvider,
+		)
+
+		vmServiceCtx = &vmopContext.VirtualMachineServiceContextA2{
+			Context:   ctx,
+			Logger:    ctx.Logger.WithName(vmService.Name),
+			VMService: vmService,
+		}
+	})
+
+	AfterEach(func() {
+		ctx.AfterEach()
+		ctx = nil
+		initObjects = nil
+		vmServiceCtx = nil
+		reconciler = nil
+	})
+
+	Describe("ReconcileNormal", func() {
+		var service *corev1.Service
+
+		BeforeEach(func() {
+			service = &corev1.Service{}
+		})
+
+		Describe("Create Or Update k8s Service", func() {
+			JustBeforeEach(func() {
+				err := reconciler.ReconcileNormal(vmServiceCtx)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(ctx.Events).Should(Receive(ContainSubstring(virtualmachineservice.OpCreate)))
+				Expect(ctx.Client.Get(ctx, objKey, service)).To(Succeed())
+			})
+
+			It("Should update the k8s Service to match with the VirtualMachineService", func() {
+				// Modify the VirtualMachineService, corresponding Service should also be modified.
+				newExternalName := "someExternalName"
+				newLoadBalancerIP := "1.1.1.1"
+
+				vmService.Spec.ExternalName = newExternalName
+				vmService.Spec.LoadBalancerIP = newLoadBalancerIP
+				vmService.Spec.LoadBalancerSourceRanges = []string{"1.1.1.0/24", "2.2.2.2/28"}
+				vmService.Annotations[utils.AnnotationServiceExternalTrafficPolicyKey] = string(corev1.ServiceExternalTrafficPolicyTypeLocal)
+				vmService.Annotations[utils.AnnotationServiceHealthCheckNodePortKey] = "30012"
+				vmService.Labels[LabelServiceProxyName] = providers.NSXTServiceProxy
+
+				err := reconciler.ReconcileNormal(vmServiceCtx)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				expectEvent(ctx, ContainSubstring(virtualmachineservice.OpUpdate))
+
+				newService := &corev1.Service{}
+				Expect(ctx.Client.Get(ctx, objKey, newService)).To(Succeed())
+
+				Expect(newService.Spec.ExternalName).To(Equal(newExternalName))
+				Expect(newService.Spec.LoadBalancerIP).To(Equal(newLoadBalancerIP))
+				Expect(newService.Spec.ExternalTrafficPolicy).To(Equal(corev1.ServiceExternalTrafficPolicyTypeLocal))
+				Expect(newService.Labels[LabelServiceProxyName]).To(Equal(providers.NSXTServiceProxy))
+				Expect(newService.Spec.LoadBalancerSourceRanges).To(Equal([]string{"1.1.1.0/24", "2.2.2.2/28"}))
+			})
+
+			It("Should update the k8s Service to match with the VirtualMachineService when LoadBalancerSourceRanges is cleared", func() {
+				vmService.Spec.LoadBalancerSourceRanges = []string{}
+
+				err := reconciler.ReconcileNormal(vmServiceCtx)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				expectEvent(ctx, ContainSubstring(virtualmachineservice.OpUpdate))
+
+				newService := &corev1.Service{}
+				Expect(ctx.Client.Get(ctx, objKey, newService)).To(Succeed())
+				Expect(newService.Spec.LoadBalancerSourceRanges).To(BeEmpty())
+			})
+
+			It("Should update the k8s Service to match with the VirtualMachineService when externalTrafficPolicy is cleared", func() {
+				if service.Annotations == nil {
+					service.Annotations = make(map[string]string)
+				}
+				if service.Labels == nil {
+					service.Labels = make(map[string]string)
+				}
+
+				By("applying externalTrafficPolicy and healthCheckNodePort annotations")
+				service.Annotations[utils.AnnotationServiceExternalTrafficPolicyKey] = string(corev1.ServiceExternalTrafficPolicyTypeLocal)
+				service.Annotations[utils.AnnotationServiceHealthCheckNodePortKey] = "30012"
+				By("applying service-proxy label")
+				service.Labels[LabelServiceProxyName] = providers.NSXTServiceProxy
+				service.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeLocal
+				Expect(ctx.Client.Update(ctx, service)).To(Succeed())
+
+				delete(vmService.Annotations, utils.AnnotationServiceExternalTrafficPolicyKey)
+				delete(vmService.Annotations, utils.AnnotationServiceHealthCheckNodePortKey)
+
+				err := reconciler.ReconcileNormal(vmServiceCtx)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				expectEvent(ctx, ContainSubstring(virtualmachineservice.OpUpdate))
+
+				newService := &corev1.Service{}
+				Expect(ctx.Client.Get(ctx, objKey, newService)).To(Succeed())
+				Expect(newService.Spec.ExternalTrafficPolicy).To(Equal(corev1.ServiceExternalTrafficPolicyTypeCluster))
+				Expect(newService.Annotations).ToNot(HaveKey(utils.AnnotationServiceExternalTrafficPolicyKey))
+				Expect(newService.Annotations).ToNot(HaveKey(utils.AnnotationServiceHealthCheckNodePortKey))
+				Expect(newService.Labels).ToNot(HaveKey(LabelServiceProxyName))
+			})
+
+			It("Should update the k8s Service to remove the provider specific annotations regarding healthCheckNodePort", func() {
+				if service.Annotations == nil {
+					service.Annotations = make(map[string]string)
+				}
+
+				vmService.Annotations[utils.AnnotationServiceHealthCheckNodePortKey] = "30012"
+				annotations, err := lbProvider.GetServiceAnnotations(ctx, vmService)
+				Expect(err).ToNot(HaveOccurred())
+				for k, v := range annotations {
+					service.Annotations[k] = v
+				}
+				Expect(ctx.Client.Update(ctx, service)).To(Succeed())
+
+				err = reconciler.ReconcileNormal(vmServiceCtx)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				expectEvent(ctx, ContainSubstring(virtualmachineservice.OpUpdate))
+
+				newService := &corev1.Service{}
+				Expect(ctx.Client.Get(ctx, objKey, newService)).To(Succeed())
+				By("ensuring the provider specific annotations are removed from the new service")
+				annotationsToBeRemoved, err := lbProvider.GetToBeRemovedServiceAnnotations(ctx, vmService)
+				Expect(err).ToNot(HaveOccurred())
+				for k := range annotationsToBeRemoved {
+					_, exist := newService.Annotations[k]
+					Expect(exist).To(BeFalse())
+				}
+			})
+		})
+	})
+}
+
+func expectEvent(ctx *builder.UnitTestContextForController, matcher types.GomegaMatcher) {
+	var event string
+	EventuallyWithOffset(1, ctx.Events).Should(Receive(&event))
+	ExpectWithOffset(1, event).To(matcher)
+}
+
+func assertEPPortFromVMServicePort(
+	port corev1.EndpointPort,
+	vmServicePort vmopv1.VirtualMachineServicePort) {
+
+	ExpectWithOffset(1, port.Name).To(Equal(vmServicePort.Name))
+	ExpectWithOffset(1, port.Protocol).To(BeEquivalentTo(vmServicePort.Protocol))
+	ExpectWithOffset(1, port.Port).To(Equal(vmServicePort.TargetPort))
+}
+
+func assertEPAddrFromVM(
+	addr corev1.EndpointAddress,
+	vm *vmopv1.VirtualMachine) {
+
+	ExpectWithOffset(1, vm.Status.Network).ToNot(BeNil())
+	ExpectWithOffset(1, addr.IP).To(Equal(vm.Status.Network.PrimaryIP4))
+	ExpectWithOffset(1, addr.TargetRef).ToNot(BeNil())
+	ExpectWithOffset(1, addr.TargetRef.Name).To(Equal(vm.Name))
+	ExpectWithOffset(1, addr.TargetRef.Namespace).To(Equal(vm.Namespace))
+}

--- a/controllers/virtualmachinesetresourcepolicy/controllers.go
+++ b/controllers/virtualmachinesetresourcepolicy/controllers.go
@@ -7,10 +7,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachinesetresourcepolicy/v1alpha1"
+	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachinesetresourcepolicy/v1alpha2"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 )
 
 // AddToManager adds the controller to the provided manager.
 func AddToManager(ctx *context.ControllerManagerContext, mgr manager.Manager) error {
+	if lib.IsVMServiceV1Alpha2FSSEnabled() {
+		return v1alpha2.AddToManager(ctx, mgr)
+	}
 	return v1alpha1.AddToManager(ctx, mgr)
 }

--- a/controllers/virtualmachinesetresourcepolicy/v1alpha2/virtualmachinesetresourcepolicy_controller.go
+++ b/controllers/virtualmachinesetresourcepolicy/v1alpha2/virtualmachinesetresourcepolicy_controller.go
@@ -1,0 +1,164 @@
+// Copyright (c) 2019-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha2
+
+import (
+	goctx "context"
+	"fmt"
+	"reflect"
+
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/pkg/context"
+	patch "github.com/vmware-tanzu/vm-operator/pkg/patch2"
+	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider"
+)
+
+const (
+	finalizerName = "virtualmachinesetresourcepolicy.vmoperator.vmware.com"
+)
+
+// AddToManager adds this package's controller to the provided manager.
+func AddToManager(ctx *context.ControllerManagerContext, mgr manager.Manager) error {
+	var (
+		controlledType     = &vmopv1.VirtualMachineSetResourcePolicy{}
+		controlledTypeName = reflect.TypeOf(controlledType).Elem().Name()
+	)
+
+	r := NewReconciler(
+		mgr.GetClient(),
+		ctrl.Log.WithName("controllers").WithName(controlledTypeName),
+		ctx.VMProviderA2,
+	)
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(controlledType).
+		Complete(r)
+}
+
+func NewReconciler(
+	client client.Client,
+	logger logr.Logger,
+	vmProvider vmprovider.VirtualMachineProviderInterfaceA2) *Reconciler {
+	return &Reconciler{
+		Client:     client,
+		Logger:     logger,
+		VMProvider: vmProvider,
+	}
+}
+
+// Reconciler reconciles a VirtualMachineSetResourcePolicy object.
+type Reconciler struct {
+	client.Client
+	Logger     logr.Logger
+	VMProvider vmprovider.VirtualMachineProviderInterfaceA2
+}
+
+// ReconcileNormal reconciles a VirtualMachineSetResourcePolicy.
+func (r *Reconciler) ReconcileNormal(ctx *context.VirtualMachineSetResourcePolicyContextA2) error {
+	if !controllerutil.ContainsFinalizer(ctx.ResourcePolicy, finalizerName) {
+		// Return here so the VirtualMachineSetResourcePolicy can be patched immediately. This ensures that
+		// the resource policies are cleaned up properly when they are deleted.
+		controllerutil.AddFinalizer(ctx.ResourcePolicy, finalizerName)
+		return nil
+	}
+
+	ctx.Logger.Info("Reconciling VirtualMachineSetResourcePolicy")
+	defer func() {
+		ctx.Logger.Info("Finished Reconciling VirtualMachineSetResourcePolicy")
+	}()
+
+	if err := r.VMProvider.CreateOrUpdateVirtualMachineSetResourcePolicy(ctx, ctx.ResourcePolicy); err != nil {
+		ctx.Logger.Error(err, "Provider failed to reconcile VirtualMachineSetResourcePolicy")
+		return err
+	}
+
+	return nil
+}
+
+// deleteResourcePolicy deletes a VirtualMachineSetResourcePolicy resource.
+func (r *Reconciler) deleteResourcePolicy(ctx *context.VirtualMachineSetResourcePolicyContextA2) error {
+	resourcePolicy := ctx.ResourcePolicy
+
+	// Skip deleting a VirtualMachineSetResourcePolicy if it is referenced by a VirtualMachine.
+	vmsInNamespace := &vmopv1.VirtualMachineList{}
+	if err := r.List(ctx, vmsInNamespace, client.InNamespace(resourcePolicy.Namespace)); err != nil {
+		ctx.Logger.Error(err, "Failed to list VMs in namespace", "namespace", resourcePolicy.Namespace)
+		return err
+	}
+
+	for _, vm := range vmsInNamespace.Items {
+		if vm.Spec.Reserved.ResourcePolicyName == resourcePolicy.Name {
+			return fmt.Errorf("failing VirtualMachineSetResourcePolicy deletion since VM: '%s' is referencing it, resourcePolicyName: '%s'",
+				vm.NamespacedName(), resourcePolicy.NamespacedName())
+		}
+	}
+
+	ctx.Logger.V(4).Info("Attempting to delete VirtualMachineSetResourcePolicy")
+	if err := r.VMProvider.DeleteVirtualMachineSetResourcePolicy(ctx, resourcePolicy); err != nil {
+		ctx.Logger.Error(err, "error in deleting VirtualMachineSetResourcePolicy")
+		return err
+	}
+	ctx.Logger.Info("Deleted VirtualMachineSetResourcePolicy successfully")
+
+	return nil
+}
+
+func (r *Reconciler) ReconcileDelete(ctx *context.VirtualMachineSetResourcePolicyContextA2) error {
+	ctx.Logger.Info("Reconciling VirtualMachineSetResourcePolicy Deletion")
+	defer func() {
+		ctx.Logger.Info("Finished Reconciling VirtualMachineSetResourcePolicy Deletion")
+	}()
+
+	if controllerutil.ContainsFinalizer(ctx.ResourcePolicy, finalizerName) {
+		if err := r.deleteResourcePolicy(ctx); err != nil {
+			return err
+		}
+
+		controllerutil.RemoveFinalizer(ctx.ResourcePolicy, finalizerName)
+	}
+
+	return nil
+}
+
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachinesetresourcepolicies,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachinesetresourcepolicies/status,verbs=get;update;patch
+
+func (r *Reconciler) Reconcile(ctx goctx.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
+	rp := &vmopv1.VirtualMachineSetResourcePolicy{}
+	if err := r.Get(ctx, req.NamespacedName, rp); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	rpCtx := &context.VirtualMachineSetResourcePolicyContextA2{
+		Context:        ctx,
+		Logger:         r.Logger.WithName("VirtualMachineSetResourcePolicy").WithValues("name", rp.NamespacedName()),
+		ResourcePolicy: rp,
+	}
+
+	patchHelper, err := patch.NewHelper(rp, r.Client)
+	if err != nil {
+		return ctrl.Result{}, errors.Wrapf(err, "failed to init patch helper for %s", rpCtx.String())
+	}
+	defer func() {
+		if err := patchHelper.Patch(ctx, rp); err != nil {
+			if reterr == nil {
+				reterr = err
+			}
+			rpCtx.Logger.Error(err, "patch failed")
+		}
+	}()
+
+	if !rp.ObjectMeta.DeletionTimestamp.IsZero() {
+		return ctrl.Result{}, r.ReconcileDelete(rpCtx)
+	}
+
+	return ctrl.Result{}, r.ReconcileNormal(rpCtx)
+}

--- a/controllers/virtualmachinesetresourcepolicy/v1alpha2/virtualmachinesetresourcepolicy_controller_intg_test.go
+++ b/controllers/virtualmachinesetresourcepolicy/v1alpha2/virtualmachinesetresourcepolicy_controller_intg_test.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha2_test
+
+import (
+	"context"
+	"sync/atomic"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+func intgTests() {
+	var (
+		ctx *builder.IntegrationTestContext
+
+		resourcePolicy    *vmopv1.VirtualMachineSetResourcePolicy
+		resourcePolicyKey client.ObjectKey
+	)
+
+	BeforeEach(func() {
+		ctx = suite.NewIntegrationTestContext()
+
+		resourcePolicy = &vmopv1.VirtualMachineSetResourcePolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ctx.Namespace,
+				Name:      "dummy-vm-policy",
+			},
+			Spec: vmopv1.VirtualMachineSetResourcePolicySpec{},
+		}
+
+		resourcePolicyKey = client.ObjectKey{Namespace: resourcePolicy.Namespace, Name: resourcePolicy.Name}
+	})
+
+	AfterEach(func() {
+		ctx.AfterEach()
+		ctx = nil
+		intgFakeVMProvider.Reset()
+	})
+
+	getResourcePolicy := func(ctx *builder.IntegrationTestContext, objKey client.ObjectKey) *vmopv1.VirtualMachineSetResourcePolicy {
+		rp := &vmopv1.VirtualMachineSetResourcePolicy{}
+		if err := ctx.Client.Get(ctx, objKey, rp); err != nil {
+			return nil
+		}
+		return rp
+	}
+
+	waitForResourcePolicyFinalizer := func(ctx *builder.IntegrationTestContext, objKey client.ObjectKey) {
+		Eventually(func() []string {
+			if rp := getResourcePolicy(ctx, objKey); rp != nil {
+				return rp.GetFinalizers()
+			}
+			return nil
+		}).Should(ContainElement(finalizer), "waiting for VirtualMachineSetResourcePolicy finalizer")
+	}
+
+	Context("Reconcile", func() {
+		var called atomic.Bool
+
+		BeforeEach(func() {
+			called.Store(false)
+
+			intgFakeVMProvider.Lock()
+			intgFakeVMProvider.CreateOrUpdateVirtualMachineSetResourcePolicyFn = func(_ context.Context, _ *vmopv1.VirtualMachineSetResourcePolicy) error {
+				called.Store(true)
+				return nil
+			}
+			intgFakeVMProvider.Unlock()
+		})
+
+		It("Reconciles after VirtualMachineSetResourcePolicy creation", func() {
+			Expect(ctx.Client.Create(ctx, resourcePolicy)).To(Succeed())
+
+			By("VirtualMachineSetResourcePolicy should have finalizer added", func() {
+				waitForResourcePolicyFinalizer(ctx, resourcePolicyKey)
+			})
+
+			By("Create policy should be called", func() {
+				Eventually(called.Load).Should(BeTrue())
+			})
+
+			By("Deleting the VirtualMachineSetResourcePolicy", func() {
+				err := ctx.Client.Delete(ctx, resourcePolicy)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			By("VirtualMachineSetResourcePolicy should have finalizer removed", func() {
+				Eventually(func() []string {
+					if rp := getResourcePolicy(ctx, resourcePolicyKey); rp != nil {
+						return rp.GetFinalizers()
+					}
+					return nil
+				}).ShouldNot(ContainElement(finalizer))
+			})
+		})
+	})
+}

--- a/controllers/virtualmachinesetresourcepolicy/v1alpha2/virtualmachinesetresourcepolicy_controller_suite_test.go
+++ b/controllers/virtualmachinesetresourcepolicy/v1alpha2/virtualmachinesetresourcepolicy_controller_suite_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha2_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+
+	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
+
+	virtualmachinesetresourcepolicy "github.com/vmware-tanzu/vm-operator/controllers/virtualmachinesetresourcepolicy/v1alpha2"
+	ctrlContext "github.com/vmware-tanzu/vm-operator/pkg/context"
+	providerfake "github.com/vmware-tanzu/vm-operator/pkg/vmprovider/fake"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+var intgFakeVMProvider = providerfake.NewVMProviderA2()
+
+var suite = builder.NewTestSuiteForController(
+	virtualmachinesetresourcepolicy.AddToManager,
+	func(ctx *ctrlContext.ControllerManagerContext, _ ctrlmgr.Manager) error {
+		ctx.VMProviderA2 = intgFakeVMProvider
+		return nil
+	},
+)
+
+func TestVirtualMachineSetResourcePolicy(t *testing.T) {
+	_ = intgTests
+	suite.Register(t, "VirtualMachineSetResourcePolicy controller suite", nil /*intgTests*/, unitTests)
+}
+
+var _ = BeforeSuite(suite.BeforeSuite)
+
+var _ = AfterSuite(suite.AfterSuite)

--- a/controllers/virtualmachinesetresourcepolicy/v1alpha2/virtualmachinesetresourcepolicy_controller_unit_test.go
+++ b/controllers/virtualmachinesetresourcepolicy/v1alpha2/virtualmachinesetresourcepolicy_controller_unit_test.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha2_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+
+	virtualmachinesetresourcepolicy "github.com/vmware-tanzu/vm-operator/controllers/virtualmachinesetresourcepolicy/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+func unitTests() {
+	Describe("Invoking Reconcile", unitTestsReconcile)
+}
+
+const (
+	finalizer = "virtualmachinesetresourcepolicy.vmoperator.vmware.com"
+)
+
+func unitTestsReconcile() {
+	var (
+		initObjects []client.Object
+		ctx         *builder.UnitTestContextForController
+		reconciler  *virtualmachinesetresourcepolicy.Reconciler
+
+		resourcePolicyCtx *context.VirtualMachineSetResourcePolicyContextA2
+		resourcePolicy    *vmopv1.VirtualMachineSetResourcePolicy
+		vm                *vmopv1.VirtualMachine
+	)
+
+	BeforeEach(func() {
+		resourcePolicy = &vmopv1.VirtualMachineSetResourcePolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dummy-rp",
+				Namespace: "dummy-ns",
+			},
+			Spec: vmopv1.VirtualMachineSetResourcePolicySpec{},
+		}
+		vm = &vmopv1.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dummy-vm",
+				Namespace: "dummy-ns",
+			},
+			Spec: vmopv1.VirtualMachineSpec{
+				Reserved: vmopv1.VirtualMachineReservedSpec{
+					ResourcePolicyName: "dummy-rp",
+				},
+			},
+		}
+	})
+
+	JustBeforeEach(func() {
+		ctx = suite.NewUnitTestContextForController(initObjects...)
+
+		reconciler = &virtualmachinesetresourcepolicy.Reconciler{
+			Client:     ctx.Client,
+			Logger:     ctx.Logger,
+			VMProvider: ctx.VMProviderA2,
+		}
+
+		resourcePolicyCtx = &context.VirtualMachineSetResourcePolicyContextA2{
+			Context:        ctx.Context,
+			Logger:         ctx.Logger.WithName(resourcePolicy.Namespace).WithName(resourcePolicy.Name),
+			ResourcePolicy: resourcePolicy,
+		}
+	})
+
+	AfterEach(func() {
+		ctx.AfterEach()
+		ctx = nil
+		initObjects = nil
+		resourcePolicyCtx = nil
+		reconciler = nil
+	})
+
+	Context("ReconcileNormal", func() {
+		BeforeEach(func() {
+			initObjects = append(initObjects, resourcePolicy)
+		})
+
+		It("will have finalizer set after reconciliation", func() {
+			err := reconciler.ReconcileNormal(resourcePolicyCtx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resourcePolicy.GetFinalizers()).To(ContainElement(finalizer))
+		})
+	})
+
+	Context("ReconcileDelete", func() {
+		BeforeEach(func() {
+			initObjects = append(initObjects, resourcePolicy)
+		})
+
+		When("One or more VMs are referencing this policy", func() {
+			BeforeEach(func() {
+				initObjects = append(initObjects, vm)
+			})
+
+			AfterEach(func() {
+				err := ctx.Client.Delete(ctx, vm)
+				Expect(err == nil || apiErrors.IsNotFound(err)).To(BeTrue())
+			})
+
+			It("will fail to delete the ResourcePolicy", func() {
+				err := reconciler.ReconcileNormal(resourcePolicyCtx)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = reconciler.ReconcileDelete(resourcePolicyCtx)
+				expectedError := fmt.Errorf("failing VirtualMachineSetResourcePolicy deletion since VM: '%s' is referencing it, resourcePolicyName: '%s'", vm.NamespacedName(), resourcePolicy.NamespacedName())
+				Expect(err).To(MatchError(expectedError))
+
+				By("will still have finalizer", func() {
+					Expect(resourcePolicyCtx.ResourcePolicy.GetFinalizers()).To(ContainElement(finalizer))
+				})
+			})
+		})
+
+		It("will delete the created ResourcePolicy", func() {
+			err := reconciler.ReconcileNormal(resourcePolicyCtx)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = reconciler.ReconcileDelete(resourcePolicyCtx)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("will not have finalizer", func() {
+				Expect(resourcePolicyCtx.ResourcePolicy.GetFinalizers()).To(BeEmpty())
+			})
+		})
+	})
+}

--- a/controllers/volume/controllers.go
+++ b/controllers/volume/controllers.go
@@ -7,10 +7,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/vmware-tanzu/vm-operator/controllers/volume/v1alpha1"
+	"github.com/vmware-tanzu/vm-operator/controllers/volume/v1alpha2"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 )
 
 // AddToManager adds the controller to the provided manager.
 func AddToManager(ctx *context.ControllerManagerContext, mgr manager.Manager) error {
+	if lib.IsVMServiceV1Alpha2FSSEnabled() {
+		return v1alpha2.AddToManager(ctx, mgr)
+	}
 	return v1alpha1.AddToManager(ctx, mgr)
 }

--- a/controllers/volume/v1alpha2/helpers.go
+++ b/controllers/volume/v1alpha2/helpers.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha2
+
+import "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+
+// This file contains v1a2 related changes in other packages that haven't been
+// committed yet.
+
+func IsConfiguredA2(vm *v1alpha2.VirtualMachine) bool {
+	for _, vol := range vm.Spec.Volumes {
+		if pvc := vol.PersistentVolumeClaim; pvc != nil && pvc.InstanceVolumeClaim != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func FilterVolumesA2(vm *v1alpha2.VirtualMachine) []v1alpha2.VirtualMachineVolume {
+	var volumes []v1alpha2.VirtualMachineVolume
+	for _, vol := range vm.Spec.Volumes {
+		if pvc := vol.PersistentVolumeClaim; pvc != nil && pvc.InstanceVolumeClaim != nil {
+			volumes = append(volumes, vol)
+		}
+	}
+
+	return volumes
+}

--- a/controllers/volume/v1alpha2/volume_controller.go
+++ b/controllers/volume/v1alpha2/volume_controller.go
@@ -1,0 +1,745 @@
+// Copyright (c) 2019-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha2
+
+import (
+	goctx "context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8serrors "k8s.io/apimachinery/pkg/util/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+
+	cnsv1alpha1 "github.com/vmware-tanzu/vm-operator/external/vsphere-csi-driver/pkg/syncer/cnsoperator/apis/cnsnodevmattachment/v1alpha1"
+	"github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/lib"
+	patch "github.com/vmware-tanzu/vm-operator/pkg/patch2"
+	"github.com/vmware-tanzu/vm-operator/pkg/record"
+	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider"
+	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/constants"
+	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/instancestorage"
+)
+
+const (
+	AttributeFirstClassDiskUUID = "diskUUID"
+)
+
+// AddToManager adds this package's controller to the provided manager.
+func AddToManager(ctx *context.ControllerManagerContext, mgr manager.Manager) error {
+	var (
+		controllerName      = "volume"
+		controllerNameShort = fmt.Sprintf("%s-controller", strings.ToLower(controllerName))
+		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
+	)
+
+	r := NewReconciler(
+		mgr.GetClient(),
+		ctrl.Log.WithName("controllers").WithName("volume"),
+		record.New(mgr.GetEventRecorderFor(controllerNameLong)),
+		ctx.VMProviderA2,
+	)
+
+	c, err := controller.New(controllerName, mgr, controller.Options{
+		Reconciler:              r,
+		MaxConcurrentReconciles: ctx.MaxConcurrentReconciles,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to VirtualMachine.
+	err = c.Watch(&source.Kind{Type: &vmopv1.VirtualMachine{}}, &handler.EnqueueRequestForObject{})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes for CnsNodeVmAttachment, and enqueue VirtualMachine which is the owner of CnsNodeVmAttachment.
+	err = c.Watch(&source.Kind{Type: &cnsv1alpha1.CnsNodeVmAttachment{}}, &handler.EnqueueRequestForOwner{
+		OwnerType:    &vmopv1.VirtualMachine{},
+		IsController: true,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes for PersistentVolumeClaim, and enqueue VirtualMachine which is the owner of PersistentVolumeClaim.
+	err = c.Watch(&source.Kind{Type: &corev1.PersistentVolumeClaim{}}, &handler.EnqueueRequestForOwner{
+		OwnerType:    &vmopv1.VirtualMachine{},
+		IsController: true,
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func NewReconciler(
+	client client.Client,
+	logger logr.Logger,
+	recorder record.Recorder,
+	vmProvider vmprovider.VirtualMachineProviderInterfaceA2) *Reconciler {
+	return &Reconciler{
+		Client:     client,
+		logger:     logger,
+		recorder:   recorder,
+		VMProvider: vmProvider,
+	}
+}
+
+var _ reconcile.Reconciler = &Reconciler{}
+
+type Reconciler struct {
+	client.Client
+	logger     logr.Logger
+	recorder   record.Recorder
+	VMProvider vmprovider.VirtualMachineProviderInterfaceA2
+}
+
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachines,verbs=get;list;watch;
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachines/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=cns.vmware.com,resources=cnsnodevmattachments,verbs=create;delete;get;list;watch;patch;update
+// +kubebuilder:rbac:groups=cns.vmware.com,resources=cnsnodevmattachments/status,verbs=get;list
+// +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=create;delete;get;list;watch;patch;update
+
+// Reconcile reconciles a VirtualMachine object and processes the volumes for attach/detach.
+// Longer term, this should be folded back into the VirtualMachine controller, but exists as
+// a separate controller to ensure volume attachments are processed promptly, since the VM
+// controller can block for a long time, consuming all of the workers.
+func (r *Reconciler) Reconcile(ctx goctx.Context, request ctrl.Request) (_ ctrl.Result, reterr error) {
+	vm := &vmopv1.VirtualMachine{}
+	if err := r.Get(ctx, request.NamespacedName, vm); err != nil {
+		if apiErrors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, err
+	}
+
+	volCtx := &context.VolumeContextA2{
+		Context:                   ctx,
+		Logger:                    ctrl.Log.WithName("Volumes").WithValues("name", vm.NamespacedName()),
+		VM:                        vm,
+		InstanceStorageFSSEnabled: lib.IsInstanceStorageFSSEnabled(),
+	}
+
+	// If the VM has a pause reconcile annotation, it is being restored on vCenter. Return here so our reconcile
+	// does not replace the VM being restored on the vCenter inventory.
+	//
+	// Do not requeue the reconcile here since removing the pause annotation will trigger a reconcile anyway.
+	if _, ok := volCtx.VM.Annotations[vmopv1.PauseAnnotation]; ok {
+		volCtx.Logger.Info("Skipping reconcile since Pause annotation is set on the VM")
+		return ctrl.Result{}, nil
+	}
+
+	patchHelper, err := patch.NewHelper(vm, r.Client)
+	if err != nil {
+		return ctrl.Result{}, errors.Wrapf(err, "failed to init patch helper for %s", volCtx.String())
+	}
+	defer func() {
+		if err := patchHelper.Patch(ctx, vm); err != nil {
+			if reterr == nil {
+				reterr = err
+			}
+			volCtx.Logger.Error(err, "patch failed")
+		}
+	}()
+
+	if !vm.DeletionTimestamp.IsZero() {
+		return ctrl.Result{}, r.ReconcileDelete(volCtx)
+	}
+
+	if err := r.ReconcileNormal(volCtx); err != nil {
+		return ctrl.Result{}, err
+	}
+	return r.reconcileResult(volCtx), nil
+}
+
+func (r *Reconciler) reconcileResult(ctx *context.VolumeContextA2) ctrl.Result {
+	if ctx.InstanceStorageFSSEnabled {
+		// Requeue the request if all instance storage PVCs are not bound.
+		_, pvcsBound := ctx.VM.Annotations[constants.InstanceStoragePVCsBoundAnnotationKey]
+		if IsConfiguredA2(ctx.VM) && !pvcsBound {
+			return ctrl.Result{RequeueAfter: lib.GetInstanceStorageRequeueDelay()}
+		}
+	}
+
+	return ctrl.Result{}
+}
+
+func (r *Reconciler) ReconcileDelete(_ *context.VolumeContextA2) error {
+	// Do nothing here since we depend on the Garbage Collector to do the deletion of the
+	// dependent CNSNodeVMAttachment objects when their owning VM is deleted.
+	// We require the Volume provider to handle the situation where the VM is deleted before
+	// the volumes are detached & removed.
+	return nil
+}
+
+func (r *Reconciler) ReconcileNormal(ctx *context.VolumeContextA2) error {
+	ctx.Logger.Info("Reconciling VirtualMachine for processing volumes")
+	defer func() {
+		ctx.Logger.Info("Finished Reconciling VirtualMachine for processing volumes")
+	}()
+
+	if ctx.InstanceStorageFSSEnabled {
+		ready, err := r.reconcileInstanceStoragePVCs(ctx)
+		if err != nil || !ready {
+			return err
+		}
+	}
+
+	if ctx.VM.Status.BiosUUID == "" {
+		// CSI requires the BiosUUID to match up the attachment request with the VM. Defer here
+		// until it is set by the VirtualMachine controller.
+		ctx.Logger.Info("VM Status does not yet have BiosUUID. Deferring volume attachment")
+		return nil
+	}
+
+	attachments, err := r.getAttachmentsForVM(ctx)
+	if err != nil {
+		ctx.Logger.Error(err, "Error getting existing CnsNodeVmAttachments for VM")
+		return err
+	}
+
+	attachmentsToDelete := r.attachmentsToDelete(ctx, attachments)
+
+	// Delete attachments for this VM that exist but are not currently referenced in the Spec.
+	deleteErr := r.deleteOrphanedAttachments(ctx, attachmentsToDelete)
+	if deleteErr != nil {
+		ctx.Logger.Error(deleteErr, "Error deleting orphaned CnsNodeVmAttachments")
+		// Keep going to the create/update processing below.
+	}
+
+	// Process attachments, creating when needed, and updating the VM Status Volumes.
+	processErr := r.processAttachments(ctx, attachments, attachmentsToDelete)
+	if processErr != nil {
+		ctx.Logger.Error(processErr, "Error processing CnsNodeVmAttachments")
+		// Keep going to return aggregated error below.
+	}
+
+	return k8serrors.NewAggregate([]error{deleteErr, processErr})
+}
+
+func (r *Reconciler) reconcileInstanceStoragePVCs(ctx *context.VolumeContextA2) (bool, error) {
+	// NOTE: We could check for InstanceStoragePVCsBoundAnnotationKey here and short circuit
+	// all of this. Might leave stale PVCs though. Need to think more: instance storage is
+	// this odd quasi reconcilable thing.
+
+	// If the VM Spec doesn't have any instance storage volumes, there is nothing for us to do.
+	// We do not support removing - or changing really - this type of volume.
+	isVolumes := FilterVolumesA2(ctx.VM)
+	if len(isVolumes) == 0 {
+		return true, nil
+	}
+
+	pvcList, getErrs := r.getInstanceStoragePVCs(ctx, isVolumes)
+	if getErrs != nil {
+		return false, k8serrors.NewAggregate(getErrs)
+	}
+
+	expectedVolumesMap := map[string]struct{}{}
+	for _, vol := range isVolumes {
+		expectedVolumesMap[vol.Name] = struct{}{}
+	}
+
+	var (
+		stalePVCs  []client.ObjectKey
+		createErrs []error
+	)
+	existingVolumesMap := map[string]struct{}{}
+	failedVolumesMap := map[string]struct{}{}
+	boundCount := 0
+	selectedNode := ctx.VM.Annotations[constants.InstanceStorageSelectedNodeAnnotationKey]
+	createPVCs := len(selectedNode) > 0
+
+	for _, pvc := range pvcList {
+		pvc := pvc
+
+		if !pvc.DeletionTimestamp.IsZero() {
+			// Ignore PVC that is being deleted. Likely this is from a previous failed
+			// placement and CSI hasn't fully cleaned up yet (a finalizer is still present).
+			// NOTE: Don't add this to existingVolumesMap[], so we'll try to create in case
+			// our cache is stale.
+			continue
+		}
+
+		if !metav1.IsControlledBy(&pvc, ctx.VM) {
+			// This PVC's OwnerRef doesn't match with VM resource UUID. This shouldn't happen
+			// since PVCs are always created with OwnerRef as well as Controller watch filters
+			// out non instance storage PVCs. Ignore it.
+			continue
+		}
+
+		existingVolumesMap[pvc.Name] = struct{}{}
+
+		pvcNode, exists := pvc.Annotations[constants.KubernetesSelectedNodeAnnotationKey]
+		if !exists || pvcNode != selectedNode {
+			// This PVC is ours but NOT on our selected node. Likely, placement previously failed
+			// and we're trying again on a different node.
+			// NOTE: This includes even when selectedNode is "". Bias for full cleanup.
+			stalePVCs = append(stalePVCs, client.ObjectKeyFromObject(&pvc))
+			continue
+		}
+
+		if instanceStoragePVCFailed(&pvc) {
+			// This PVC is ours but has failed. This instance storage placement is doomed.
+			failedVolumesMap[pvc.Name] = struct{}{}
+			continue
+		}
+
+		if pvc.Status.Phase != corev1.ClaimBound {
+			// CSI is still processing this PVC.
+			continue
+		}
+
+		// This PVC is successfully bound to our selected host, and is ready for attachment.
+		boundCount++
+	}
+
+	placementFailed := len(failedVolumesMap) > 0
+	if placementFailed {
+		// Need to start placement over. PVCs successfully realized are recreated or
+		// retailed depending on the next host selection.
+		return false, r.instanceStoragePlacementFailed(ctx, failedVolumesMap)
+	}
+
+	deleteErrs := r.deleteInstanceStoragePVCs(ctx, stalePVCs)
+	if createPVCs {
+		createErrs = r.createMissingInstanceStoragePVCs(ctx, isVolumes, existingVolumesMap, selectedNode)
+	}
+
+	fullyBound := boundCount == len(isVolumes)
+	if fullyBound {
+		// All of our instance storage volumes are bound. This is our final state.
+		ctx.VM.Annotations[constants.InstanceStoragePVCsBoundAnnotationKey] = lib.TrueString
+	}
+
+	// There are some implicit relationship between these values. Like there should have been
+	// nothing missing to be created if we were fully bound. There is a case where some or all
+	// PVCs are successfully created but not found.
+	// Returns
+	//   1. (false, nil) if some or all PVCs not bound and all or some PVCs created.
+	//   2. (false, err) if some or all PVCs not bound and error occurs while deleting or creating PVCs.
+	//   3. (true, nil) if all PVCs are bound.
+	return fullyBound, k8serrors.NewAggregate(append(deleteErrs, createErrs...))
+}
+
+func instanceStoragePVCFailed(pvc *corev1.PersistentVolumeClaim) bool {
+	errAnn := pvc.Annotations[constants.InstanceStoragePVPlacementErrorAnnotationKey]
+	if strings.HasPrefix(errAnn, constants.InstanceStoragePVPlacementErrorPrefix) &&
+		time.Since(pvc.CreationTimestamp.Time) >= lib.GetInstanceStoragePVPlacementFailedTTL() {
+		// This triggers delete PVCs operation - Delay it by 5m (default) so that the system is
+		// not over loaded with repeated create/delete PVCs.
+		// NOTE: There is no limitation of CSI on the rate of create/delete PVCs. With this delay,
+		// there is a better chance of successful instance storage VM creation after a delay.
+		// At the moment there is no logic to anti-affinitize the VM to the ESX Host that just failed,
+		// there is a very high chance that the VM will keep landing on the same host. This will lead
+		// to a wasteful tight loop of failed attempts to bring up the instance VM.
+		return true
+	}
+
+	return false
+}
+
+func (r *Reconciler) instanceStoragePlacementFailed(
+	ctx *context.VolumeContextA2,
+	failedVolumesMap map[string]struct{}) error {
+
+	// Tell the VM controller that it needs to compute placement again.
+	delete(ctx.VM.Annotations, constants.InstanceStorageSelectedNodeAnnotationKey)
+	delete(ctx.VM.Annotations, constants.InstanceStorageSelectedNodeMOIDAnnotationKey)
+
+	objKeys := make([]client.ObjectKey, 0, len(failedVolumesMap))
+	for volName := range failedVolumesMap {
+		objKeys = append(objKeys, client.ObjectKey{Name: volName, Namespace: ctx.VM.Namespace})
+	}
+	deleteErrs := r.deleteInstanceStoragePVCs(ctx, objKeys)
+
+	return k8serrors.NewAggregate(deleteErrs)
+}
+
+func (r *Reconciler) createMissingInstanceStoragePVCs(
+	ctx *context.VolumeContextA2,
+	isVolumes []vmopv1.VirtualMachineVolume,
+	existingVolumesMap map[string]struct{},
+	selectedNode string) []error {
+
+	var createErrs []error
+
+	for _, vol := range isVolumes {
+		if _, exists := existingVolumesMap[vol.Name]; !exists {
+			createErrs = append(createErrs, r.createInstanceStoragePVC(ctx, vol, selectedNode))
+		}
+	}
+
+	return createErrs
+}
+
+func (r *Reconciler) createInstanceStoragePVC(
+	ctx *context.VolumeContextA2,
+	volume vmopv1.VirtualMachineVolume,
+	selectedNode string) error {
+
+	claim := volume.PersistentVolumeClaim.InstanceVolumeClaim
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      volume.PersistentVolumeClaim.ClaimName,
+			Namespace: ctx.VM.Namespace,
+			Labels:    map[string]string{constants.InstanceStorageLabelKey: lib.TrueString},
+			Annotations: map[string]string{
+				constants.KubernetesSelectedNodeAnnotationKey: selectedNode,
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &claim.StorageClass,
+			Resources: corev1.ResourceRequirements{
+				Requests: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceStorage: claim.Size,
+				},
+			},
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+		},
+	}
+
+	if err := controllerutil.SetControllerReference(ctx.VM, pvc, r.Client.Scheme()); err != nil {
+		// This is an unexpected error.
+		return errors.Wrap(err, "Cannot set controller reference on PersistentVolumeClaim")
+	}
+
+	// We merely consider creating non-existing PVCs in reconcileInstanceStoragePVCs flow.
+	// We specifically don't need of CreateOrUpdate / CreateOrPatch.
+	if err := r.Create(ctx, pvc); err != nil {
+		if instancestorage.IsInsufficientQuota(err) {
+			r.recorder.EmitEvent(ctx.VM, "Create", err, true)
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (r *Reconciler) getInstanceStoragePVCs(
+	ctx *context.VolumeContextA2,
+	volumes []vmopv1.VirtualMachineVolume) ([]corev1.PersistentVolumeClaim, []error) {
+
+	var errs []error
+	pvcList := make([]corev1.PersistentVolumeClaim, 0)
+
+	for _, vol := range volumes {
+		objKey := client.ObjectKey{
+			Namespace: ctx.VM.Namespace,
+			Name:      vol.PersistentVolumeClaim.ClaimName,
+		}
+		pvc := &corev1.PersistentVolumeClaim{}
+		if err := r.Get(ctx, objKey, pvc); client.IgnoreNotFound(err) != nil {
+			errs = append(errs, err)
+			continue
+		}
+		pvcList = append(pvcList, *pvc)
+	}
+
+	return pvcList, errs
+}
+
+func (r *Reconciler) deleteInstanceStoragePVCs(
+	ctx *context.VolumeContextA2,
+	objKeys []client.ObjectKey) []error {
+
+	var errs []error
+
+	for _, objKey := range objKeys {
+		pvc := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      objKey.Name,
+				Namespace: objKey.Namespace,
+			},
+		}
+
+		if err := r.Delete(ctx, pvc); client.IgnoreNotFound(err) != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return errs
+}
+
+// Return the existing CnsNodeVmAttachments that are for this VM.
+func (r *Reconciler) getAttachmentsForVM(ctx *context.VolumeContextA2) (map[string]cnsv1alpha1.CnsNodeVmAttachment, error) {
+	// We need to filter the attachments for the ones for this VM. There are a few ways we can do this:
+	//  - Look at the OwnerRefs for this VM. Note that we'd need to compare by the UUID, not the name,
+	//    to handle the situation we the VM is deleted and recreated before the GC deletes any prior
+	//    attachments.
+	//  - Match the attachment NodeUUID to the VM BiosUUID.
+	//
+	// We use the NodeUUID option here. Note that we could speed this by adding an indexer on the
+	// NodeUUID field, but expect the number of attachments to be manageable. Note that doing List
+	// is safer here, as it will discover otherwise orphaned attachments (previous code used the
+	// Volumes in the VM Status as the source of truth).
+
+	list := &cnsv1alpha1.CnsNodeVmAttachmentList{}
+	if err := r.Client.List(ctx, list, client.InNamespace(ctx.VM.Namespace)); err != nil {
+		return nil, errors.Wrap(err, "failed to list CnsNodeVmAttachments")
+	}
+
+	attachments := map[string]cnsv1alpha1.CnsNodeVmAttachment{}
+	for _, attachment := range list.Items {
+		if attachment.Spec.NodeUUID == ctx.VM.Status.BiosUUID {
+			attachments[attachment.Name] = attachment
+		}
+	}
+
+	return attachments, nil
+}
+
+func (r *Reconciler) processAttachments(
+	ctx *context.VolumeContextA2,
+	attachments map[string]cnsv1alpha1.CnsNodeVmAttachment,
+	orphanedAttachments []cnsv1alpha1.CnsNodeVmAttachment) error {
+
+	var volumeStatus []vmopv1.VirtualMachineVolumeStatus
+	var createErrs []error
+	var hasPendingAttachment bool
+
+	// When creating a VM, try to attach the volumes in the VM Spec.Volumes order since that is a reasonable
+	// expectation and the customization like cloud-init may assume that order. There isn't quite a good way
+	// to determine from here if the VM is being created so use the power state to infer it. This is mostly
+	// best-effort, and a hack in the current world since the CnsNodeVmAttachment really should not exist in
+	// the first place.
+	onlyAllowOnePendingAttachment := ctx.VM.Status.PowerState == "" || ctx.VM.Status.PowerState == vmopv1.VirtualMachinePowerStateOff
+
+	for _, volume := range ctx.VM.Spec.Volumes {
+		if volume.PersistentVolumeClaim == nil {
+			// Don't process VsphereVolumes here. Note that we don't have Volume status
+			// for Vsphere volumes, so there is nothing to preserve here.
+			continue
+		}
+
+		attachmentName := CNSAttachmentNameForVolume(ctx.VM.Name, volume.Name)
+		if attachment, ok := attachments[attachmentName]; ok {
+			// The attachment for this volume already exists. Note it might make sense to ensure
+			// that the existing attachment matches what we expect (so like do an Update if needed)
+			// but the old code didn't and let's match that behavior until we need to do otherwise.
+			// Also, the CNS attachment controller doesn't reconcile Spec changes once the volume
+			// is attached.
+			volumeStatus = append(volumeStatus, attachmentToVolumeStatus(volume.Name, attachment))
+			hasPendingAttachment = hasPendingAttachment || !attachment.Status.Attached
+			continue
+		}
+
+		// If we're allowing only one pending attachment, we cannot create the next CnsNodeVmAttachment
+		// until the previous ones are attached. This is really only effective when the VM is first being
+		// created, since the volumes could be added anywhere or the same ones reordered in the Spec.Volumes.
+		if onlyAllowOnePendingAttachment && hasPendingAttachment {
+			// Do not create another CnsNodeVmAttachment while one is already pending, but continue
+			// so we build up the Volume Status for any existing volumes.
+			continue
+		}
+
+		// If VM hardware version doesn't meet minimal requirement, don't create CNS attachment.
+		// We only fetch the hardware version when this is the first time to create the CNS attachment.
+		//
+		// This HW version check block is along with removing VMI hardware version check from VM validation webhook.
+		// We used to deny requests if a PVC is specified in the VM spec while VMI hardware version is not supported.
+		// In this case, no attachments can be created if VM hardware version doesn't meet the requirement.
+		// So if a VM has volume attached, we can safely assume that it has passed the hardware version check.
+		if len(volumeStatus) == 0 && len(attachments) == 0 {
+			hardwareVersion, err := r.VMProvider.GetVirtualMachineHardwareVersion(ctx, ctx.VM)
+			if err != nil {
+				return errors.Wrapf(err, "failed to get VM hardware version")
+			}
+
+			// If hardware version is 0, which means we failed to parse the version from VM, then just assume that it
+			// is above minimal requirement.
+			if hardwareVersion != 0 && hardwareVersion < constants.MinSupportedHWVersionForPVC {
+				retErr := fmt.Errorf("VirtualMachine has an unsupported "+
+					"hardware version %d for PersistentVolumes. Minimum supported hardware version %d",
+					hardwareVersion, constants.MinSupportedHWVersionForPVC)
+				r.recorder.EmitEvent(ctx.VM, "VolumeAttachment", retErr, true)
+				return retErr
+			}
+		}
+
+		if err := r.createCNSAttachment(ctx, attachmentName, volume); err != nil {
+			createErrs = append(createErrs, errors.Wrap(err, "Cannot create CnsNodeVmAttachment"))
+		} else {
+			// Add a placeholder Status entry for this volume. We'll populate it fully on a later
+			// reconcile after the CNS attachment controller updates it.
+			volumeStatus = append(volumeStatus, vmopv1.VirtualMachineVolumeStatus{Name: volume.Name})
+		}
+
+		// Always true even if the creation failed above to try to keep volumes attached in order.
+		hasPendingAttachment = true
+	}
+
+	// Fix up the Volume Status so that attachments that are no longer referenced in the Spec but
+	// still exist are included in the Status. This is more than a little odd.
+	volumeStatus = append(volumeStatus, r.preserveOrphanedAttachmentStatus(ctx, orphanedAttachments)...)
+
+	// This is how the previous code sorted, but IMO keeping in Spec order makes more sense.
+	sort.Slice(volumeStatus, func(i, j int) bool {
+		return volumeStatus[i].DiskUUID < volumeStatus[j].DiskUUID
+	})
+	ctx.VM.Status.Volumes = volumeStatus
+
+	return k8serrors.NewAggregate(createErrs)
+}
+
+func (r *Reconciler) createCNSAttachment(
+	ctx *context.VolumeContextA2,
+	attachmentName string,
+	volume vmopv1.VirtualMachineVolume) error {
+
+	attachment := &cnsv1alpha1.CnsNodeVmAttachment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      attachmentName,
+			Namespace: ctx.VM.Namespace,
+		},
+		Spec: cnsv1alpha1.CnsNodeVmAttachmentSpec{
+			NodeUUID:   ctx.VM.Status.BiosUUID,
+			VolumeName: volume.PersistentVolumeClaim.ClaimName,
+		},
+	}
+
+	if err := controllerutil.SetControllerReference(ctx.VM, attachment, r.Client.Scheme()); err != nil {
+		// This is an unexpected error.
+		return errors.Wrap(err, "Cannot set controller reference on CnsNodeVmAttachment")
+	}
+
+	if err := r.Create(ctx, attachment); err != nil {
+		// An IsAlreadyExists error is not really expected because the only way we'll do a Create()
+		// is if the attachment wasn't returned in the List() done at the start of the reconcile.
+		// The Client cache might have been stale, so ignore the error, but like the comment in the
+		// caller, we might want to perform an Update() in this case too.
+		if !apiErrors.IsAlreadyExists(err) {
+			return errors.Wrap(err, "Error creating CnsNodeVmAttachment")
+		}
+	}
+
+	return nil
+}
+
+// This is a hack to preserve the prior behavior of including detach(ing) volumes that were
+// removed from the Spec in the Status until they are actually deleted.
+func (r *Reconciler) preserveOrphanedAttachmentStatus(
+	ctx *context.VolumeContextA2,
+	orphanedAttachments []cnsv1alpha1.CnsNodeVmAttachment) []vmopv1.VirtualMachineVolumeStatus {
+
+	uuidAttachments := make(map[string]cnsv1alpha1.CnsNodeVmAttachment, len(orphanedAttachments))
+	for _, attachment := range orphanedAttachments {
+		if uuid := attachment.Status.AttachmentMetadata[AttributeFirstClassDiskUUID]; uuid != "" {
+			uuidAttachments[uuid] = attachment
+		}
+	}
+
+	// For the current Volumes in the Status, if there is an orphaned volume, add an Status entry
+	// for this volume. This can lead to some odd results and we should rethink if we actually
+	// want this behavior. It can be nice though to show detaching volumes. It would be nice if
+	// the Volume status has a reference to the CnsNodeVmAttachment.
+	var volumeStatus []vmopv1.VirtualMachineVolumeStatus
+	for _, volume := range ctx.VM.Status.Volumes {
+		if attachment, ok := uuidAttachments[volume.DiskUUID]; ok {
+			volumeStatus = append(volumeStatus, attachmentToVolumeStatus(volume.Name, attachment))
+		}
+	}
+
+	return volumeStatus
+}
+
+func (r *Reconciler) attachmentsToDelete(
+	ctx *context.VolumeContextA2,
+	attachments map[string]cnsv1alpha1.CnsNodeVmAttachment) []cnsv1alpha1.CnsNodeVmAttachment {
+
+	expectedAttachments := make(map[string]bool, len(ctx.VM.Spec.Volumes))
+	for _, volume := range ctx.VM.Spec.Volumes {
+		// Only process CNS volumes here.
+		if volume.PersistentVolumeClaim != nil {
+			attachmentName := CNSAttachmentNameForVolume(ctx.VM.Name, volume.Name)
+			expectedAttachments[attachmentName] = true
+		}
+	}
+
+	// From the existing attachment map, determine which ones shouldn't exist anymore from
+	// the volumes Spec.
+	var attachmentsToDelete []cnsv1alpha1.CnsNodeVmAttachment
+	for _, attachment := range attachments {
+		if exists := expectedAttachments[attachment.Name]; !exists {
+			attachmentsToDelete = append(attachmentsToDelete, attachment)
+		}
+	}
+
+	return attachmentsToDelete
+}
+
+func (r *Reconciler) deleteOrphanedAttachments(ctx *context.VolumeContextA2, attachments []cnsv1alpha1.CnsNodeVmAttachment) error {
+	var errs []error
+
+	for i := range attachments {
+		attachment := attachments[i]
+
+		if !attachment.DeletionTimestamp.IsZero() {
+			continue
+		}
+
+		ctx.Logger.V(2).Info("Deleting orphaned CnsNodeVmAttachment", "attachment", attachment.Name)
+		if err := r.Delete(ctx, &attachment); err != nil {
+			if !apiErrors.IsNotFound(err) {
+				errs = append(errs, err)
+			}
+		}
+	}
+
+	return k8serrors.NewAggregate(errs)
+}
+
+// CNSAttachmentNameForVolume returns the name of the CnsNodeVmAttachment based on the VM and Volume name.
+// This matches the naming used in previous code but there are situations where
+// we may get a collision between VMs and Volume names. I'm not sure if there is
+// an absolute way to avoid that: the same situation can happen with the claimName.
+// Ideally, we would use GenerateName, but we lack the back-linkage to match
+// Volumes and CnsNodeVmAttachment up.
+// The VM webhook validate that this result will be a valid k8s name.
+func CNSAttachmentNameForVolume(vmName string, volumeName string) string {
+	return vmName + "-" + volumeName
+}
+
+// The CSI controller sometimes puts the serialized SOAP error into the CnsNodeVmAttachment
+// error field, which contains things like OpIds and pointers that change on every failed
+// reconcile attempt. Using this error as-is causes VM object churn, so try to avoid that
+// here. The full error message is always available in the CnsNodeVmAttachment.
+func sanitizeCNSErrorMessage(msg string) string {
+	if strings.Contains(msg, "opId:") {
+		idx := strings.Index(msg, ":")
+		return msg[:idx]
+	}
+
+	return msg
+}
+
+func attachmentToVolumeStatus(
+	volumeName string,
+	attachment cnsv1alpha1.CnsNodeVmAttachment) vmopv1.VirtualMachineVolumeStatus {
+	return vmopv1.VirtualMachineVolumeStatus{
+		Name:     volumeName, // Name of the volume as in the Spec
+		Attached: attachment.Status.Attached,
+		DiskUUID: attachment.Status.AttachmentMetadata[AttributeFirstClassDiskUUID],
+		Error:    sanitizeCNSErrorMessage(attachment.Status.Error),
+	}
+}

--- a/controllers/volume/v1alpha2/volume_controller_intg_test.go
+++ b/controllers/volume/v1alpha2/volume_controller_intg_test.go
@@ -1,0 +1,529 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha2_test
+
+import (
+	"fmt"
+	"os"
+	"sync/atomic"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/google/uuid"
+
+	cnsv1alpha1 "github.com/vmware-tanzu/vm-operator/external/vsphere-csi-driver/pkg/syncer/cnsoperator/apis/cnsnodevmattachment/v1alpha1"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	volume "github.com/vmware-tanzu/vm-operator/controllers/volume/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/pkg/lib"
+	patch "github.com/vmware-tanzu/vm-operator/pkg/patch2"
+	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/constants"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+func intgTests() {
+	var (
+		ctx *builder.IntegrationTestContext
+
+		vm                    *vmopv1.VirtualMachine
+		vmKey                 types.NamespacedName
+		vmVolume1             vmopv1.VirtualMachineVolume
+		vmVolume2             vmopv1.VirtualMachineVolume
+		dummyBiosUUID         string
+		dummyDiskUUID1        string
+		dummyDiskUUID2        string
+		dummySelectedNode     string
+		dummySelectedNodeMOID string
+
+		// represents the Instance Storage FSS. This should be manipulated atomically to avoid races
+		// where the controller is trying to read this _while_ the tests are updating it.
+		instanceStorageFSS uint32
+	)
+
+	// Modify the helper function to return the custom value of the FSS
+	lib.IsInstanceStorageFSSEnabled = func() bool {
+		return atomic.LoadUint32(&instanceStorageFSS) != 0
+	}
+
+	BeforeEach(func() {
+		ctx = suite.NewIntegrationTestContext()
+
+		dummyBiosUUID = uuid.New().String()
+		dummyDiskUUID1 = uuid.New().String()
+		dummyDiskUUID2 = uuid.New().String()
+
+		vmVolume1 = vmopv1.VirtualMachineVolume{
+			Name: "cns-volume-1",
+			VirtualMachineVolumeSource: vmopv1.VirtualMachineVolumeSource{
+				PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
+					PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: "pvc-volume-1",
+					},
+				},
+			},
+		}
+
+		vmVolume2 = vmopv1.VirtualMachineVolume{
+			Name: "cns-volume-2",
+			VirtualMachineVolumeSource: vmopv1.VirtualMachineVolumeSource{
+				PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
+					PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: "pvc-volume-2",
+					},
+				},
+			},
+		}
+
+		vm = &vmopv1.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ctx.Namespace,
+				Name:      "dummy-vm",
+			},
+			Spec: vmopv1.VirtualMachineSpec{
+				ImageName:  "dummy-image",
+				PowerState: vmopv1.VirtualMachinePowerStateOff,
+			},
+		}
+		vmKey = types.NamespacedName{Name: vm.Name, Namespace: vm.Namespace}
+
+		dummySelectedNode = "selected-node.domain.com"
+		dummySelectedNodeMOID = "host-88"
+	})
+
+	AfterEach(func() {
+		ctx.AfterEach()
+		ctx = nil
+	})
+
+	getVirtualMachine := func(objKey types.NamespacedName) *vmopv1.VirtualMachine {
+		vm := &vmopv1.VirtualMachine{}
+		if err := ctx.Client.Get(ctx, objKey, vm); err != nil {
+			return nil
+		}
+		return vm
+	}
+
+	getCnsNodeVMAttachment := func(vm *vmopv1.VirtualMachine, vmVol vmopv1.VirtualMachineVolume) *cnsv1alpha1.CnsNodeVmAttachment {
+		objectKey := client.ObjectKey{Name: volume.CNSAttachmentNameForVolume(vm.Name, vmVol.Name), Namespace: vm.Namespace}
+		attachment := &cnsv1alpha1.CnsNodeVmAttachment{}
+		if err := ctx.Client.Get(ctx, objectKey, attachment); err == nil {
+			return attachment
+		}
+		return nil
+	}
+
+	waitForVirtualMachineInstanceStorage := func(objKey types.NamespacedName, selectedNodeSet, bound bool) {
+		getAnnotations := func() map[string]string {
+			vm := getVirtualMachine(objKey)
+			if vm != nil {
+				return vm.Annotations
+			}
+			return map[string]string{}
+		}
+
+		desc := fmt.Sprintf("waiting for selected-node annotation set %v", selectedNodeSet)
+		if selectedNodeSet {
+			Eventually(getAnnotations).Should(HaveKey(constants.InstanceStorageSelectedNodeAnnotationKey), desc)
+			Eventually(getAnnotations).Should(HaveKey(constants.InstanceStorageSelectedNodeMOIDAnnotationKey), desc)
+		} else {
+			Eventually(getAnnotations).ShouldNot(HaveKey(constants.InstanceStorageSelectedNodeAnnotationKey), desc)
+			Eventually(getAnnotations).ShouldNot(HaveKey(constants.InstanceStorageSelectedNodeMOIDAnnotationKey), desc)
+		}
+
+		desc = fmt.Sprintf("waiting for VirtualMachine instance storage volumes BOUND status set to %v", bound)
+		if bound {
+			Eventually(getAnnotations).Should(HaveKey(constants.InstanceStoragePVCsBoundAnnotationKey), desc)
+		} else {
+			Eventually(getAnnotations).ShouldNot(HaveKey(constants.InstanceStoragePVCsBoundAnnotationKey), desc)
+		}
+	}
+
+	waitForInstanceStoragePVCs := func(objKey types.NamespacedName) {
+		vm := getVirtualMachine(objKey)
+		Expect(vm).ToNot(BeNil())
+
+		volumes := volume.FilterVolumesA2(vm)
+		Expect(volumes).ToNot(BeEmpty())
+
+		Eventually(func() bool {
+			for _, vol := range volumes {
+				pvcKey := client.ObjectKey{
+					Namespace: vm.Namespace,
+					Name:      vol.PersistentVolumeClaim.ClaimName,
+				}
+
+				pvc := &corev1.PersistentVolumeClaim{}
+				if ctx.Client.Get(ctx, pvcKey, pvc) != nil {
+					return false
+				}
+
+				isClaim := vol.PersistentVolumeClaim.InstanceVolumeClaim
+				Expect(pvc.Labels).To(HaveKey(constants.InstanceStorageLabelKey))
+				Expect(pvc.Annotations).To(HaveKeyWithValue(constants.KubernetesSelectedNodeAnnotationKey, dummySelectedNode))
+				Expect(pvc.Spec.StorageClassName).ToNot(BeNil())
+				Expect(*pvc.Spec.StorageClassName).To(Equal(isClaim.StorageClass))
+				Expect(pvc.Spec.Resources.Requests).To(HaveKeyWithValue(corev1.ResourceStorage, isClaim.Size))
+				Expect(pvc.Spec.AccessModes).To(ConsistOf(corev1.ReadWriteOnce))
+			}
+			return true
+		}).Should(BeTrue(), "waiting for instance storage PVCs to be created")
+	}
+
+	waitForInstanceStoragePVCsToBeDeleted := func(objKey types.NamespacedName) {
+		vm := getVirtualMachine(objKey)
+		Expect(vm).ToNot(BeNil())
+
+		volumes := volume.FilterVolumesA2(vm)
+		Expect(volumes).ToNot(BeEmpty())
+
+		Eventually(func() bool {
+			for _, vol := range volumes {
+				pvcKey := client.ObjectKey{
+					Namespace: vm.Namespace,
+					Name:      vol.PersistentVolumeClaim.ClaimName,
+				}
+
+				// PVCs gets finalizer set on creation so expect the deletion timestamp to be set.
+				pvc := &corev1.PersistentVolumeClaim{}
+				if err := ctx.Client.Get(ctx, pvcKey, pvc); err != nil || pvc.DeletionTimestamp.IsZero() {
+					return false
+				}
+			}
+			return true
+		}).Should(BeTrue(), "waiting for instance storage PVCs to be deleted")
+	}
+
+	patchInstanceStoragePVCs := func(objKey types.NamespacedName, setStatusBound, setErrorAnnotation bool) {
+		vm := getVirtualMachine(objKey)
+		Expect(vm).ToNot(BeNil())
+
+		volumes := volume.FilterVolumesA2(vm)
+		Expect(volumes).ToNot(BeEmpty())
+
+		for _, vol := range volumes {
+			pvcKey := client.ObjectKey{
+				Namespace: vm.Namespace,
+				Name:      vol.PersistentVolumeClaim.ClaimName,
+			}
+
+			pvc := &corev1.PersistentVolumeClaim{}
+			err := ctx.Client.Get(ctx, pvcKey, pvc)
+			Expect(err).ToNot(HaveOccurred())
+
+			patchHelper, err := patch.NewHelper(pvc, ctx.Client)
+			Expect(err).ToNot(HaveOccurred())
+
+			if setStatusBound {
+				pvc.Status.Phase = corev1.ClaimBound
+			}
+			if setErrorAnnotation {
+				if pvc.Annotations == nil {
+					pvc.Annotations = make(map[string]string)
+				}
+				pvc.Annotations[constants.InstanceStoragePVPlacementErrorAnnotationKey] = constants.InstanceStorageNotEnoughResErr
+			}
+			Expect(patchHelper.Patch(ctx, pvc)).To(Succeed())
+		}
+	}
+
+	Context("Reconcile Instance Storage", func() {
+		var (
+			origInstanceStorageFSSState  uint32
+			origInstanceStorageFailedTTL string
+		)
+
+		BeforeEach(func() {
+			origInstanceStorageFSSState = instanceStorageFSS
+			atomic.StoreUint32(&instanceStorageFSS, 1)
+			origInstanceStorageFailedTTL = os.Getenv(lib.InstanceStoragePVPlacementFailedTTLEnv)
+			Expect(os.Setenv(lib.InstanceStoragePVPlacementFailedTTLEnv, "0s")).To(Succeed())
+
+			vm.Spec.Volumes = append(vm.Spec.Volumes, builder.DummyInstanceStorageVirtualMachineVolumesA2()...)
+			vm.Labels = map[string]string{constants.InstanceStorageLabelKey: lib.TrueString}
+			Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
+
+			// This is line is due to a change in controller-runtime's change to
+			// Create/Update calls that nils out empty fields. If this was set
+			// prior to the above Create call, then vm.Metadata.Annotations
+			// would be reset to nil.
+			vm.Annotations = map[string]string{}
+		})
+
+		AfterEach(func() {
+			err := ctx.Client.Delete(ctx, vm)
+			Expect(err == nil || k8serrors.IsNotFound(err)).To(BeTrue())
+			atomic.StoreUint32(&instanceStorageFSS, origInstanceStorageFSSState)
+			Expect(os.Setenv(lib.InstanceStoragePVPlacementFailedTTLEnv, origInstanceStorageFailedTTL)).To(Succeed())
+		})
+
+		It("Reconcile instance storage PVCs - selected-node annotation not set", func() {
+			waitForVirtualMachineInstanceStorage(vmKey, false, false)
+		})
+
+		It("Reconcile instance storage PVCs - PVCs should be created and realized after setting selected-node annotation", func() {
+			By("set selected-node annotation", func() {
+				vm.Annotations[constants.InstanceStorageSelectedNodeAnnotationKey] = dummySelectedNode
+				vm.Annotations[constants.InstanceStorageSelectedNodeMOIDAnnotationKey] = dummySelectedNodeMOID
+				Expect(ctx.Client.Update(ctx, vm)).To(Succeed())
+			})
+			By("PVCs should be created", func() {
+				waitForInstanceStoragePVCs(vmKey)
+			})
+			By("realize PVCs by setting PVC status to BOUND", func() {
+				patchInstanceStoragePVCs(vmKey, true, false)
+			})
+			By("PVCs should be bound", func() {
+				waitForVirtualMachineInstanceStorage(vmKey, true, true)
+			})
+		})
+
+		It("Reconcile instance storage PVCs - PVCs should be deleted after PVCs turned into error", func() {
+			By("set selected-node annotation", func() {
+				vm.Annotations[constants.InstanceStorageSelectedNodeAnnotationKey] = dummySelectedNode
+				vm.Annotations[constants.InstanceStorageSelectedNodeMOIDAnnotationKey] = dummySelectedNodeMOID
+				Expect(ctx.Client.Update(ctx, vm)).To(Succeed())
+			})
+			By("PVCs should be created", func() {
+				waitForInstanceStoragePVCs(vmKey)
+			})
+			By("Set PVCs with errors", func() {
+				patchInstanceStoragePVCs(vmKey, false, true)
+			})
+			By("PVCs should be deleted", func() {
+				waitForInstanceStoragePVCsToBeDeleted(vmKey)
+			})
+			By("selected-node annotations should be removed", func() {
+				waitForVirtualMachineInstanceStorage(vmKey, false, false)
+			})
+		})
+	})
+
+	Context("Reconcile", func() {
+		BeforeEach(func() {
+		})
+
+		AfterEach(func() {
+			err := ctx.Client.Delete(ctx, vm)
+			Expect(err == nil || k8serrors.IsNotFound(err)).To(BeTrue())
+		})
+
+		It("Reconciles VirtualMachine Spec.Volumes", func() {
+			Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
+
+			vm = getVirtualMachine(vmKey)
+			Expect(vm).ToNot(BeNil())
+
+			By("VM has no volumes", func() {
+				Expect(vm.Spec.Volumes).To(BeEmpty())
+				Expect(vm.Status.Volumes).To(BeEmpty())
+			})
+
+			By("Assign VM BiosUUID", func() {
+				vm.Status.BiosUUID = dummyBiosUUID
+				Expect(ctx.Client.Status().Update(ctx, vm)).To(Succeed())
+			})
+
+			By("Add CNS volume to Spec.Volumes", func() {
+				vm.Spec.Volumes = append(vm.Spec.Volumes, vmVolume1)
+				Expect(ctx.Client.Update(ctx, vm)).To(Succeed())
+			})
+
+			By("CnsNodeVmAttachment should be created for volume", func() {
+				var attachment *cnsv1alpha1.CnsNodeVmAttachment
+				Eventually(func() *cnsv1alpha1.CnsNodeVmAttachment {
+					attachment = getCnsNodeVMAttachment(vm, vmVolume1)
+					return attachment
+				}).ShouldNot(BeNil())
+
+				Expect(attachment.Spec.NodeUUID).To(Equal(dummyBiosUUID))
+				Expect(attachment.Spec.VolumeName).To(Equal(vmVolume1.PersistentVolumeClaim.ClaimName))
+			})
+
+			By("VM Status.Volume should have entry for volume", func() {
+				var vm *vmopv1.VirtualMachine
+				Eventually(func() []vmopv1.VirtualMachineVolumeStatus {
+					vm = getVirtualMachine(vmKey)
+					if vm != nil {
+						return vm.Status.Volumes
+					}
+					return nil
+				}).Should(HaveLen(1))
+
+				volStatus := vm.Status.Volumes[0]
+				Expect(volStatus.Name).To(Equal(vmVolume1.Name))
+				Expect(volStatus.Attached).To(BeFalse())
+			})
+
+			errMsg := "dummy error message"
+
+			By("Simulate CNS attachment", func() {
+				attachment := getCnsNodeVMAttachment(vm, vmVolume1)
+				Expect(attachment).ToNot(BeNil())
+				attachment.Status.Attached = true
+				attachment.Status.Error = errMsg
+				attachment.Status.AttachmentMetadata = map[string]string{
+					volume.AttributeFirstClassDiskUUID: dummyDiskUUID1,
+				}
+				Expect(ctx.Client.Update(ctx, attachment)).To(Succeed())
+			})
+
+			By("VM Status.Volume should reflect attached volume", func() {
+				var vm *vmopv1.VirtualMachine
+				Eventually(func() bool {
+					vm = getVirtualMachine(vmKey)
+					if vm == nil || len(vm.Status.Volumes) != 1 {
+						return false
+					}
+					return vm.Status.Volumes[0].Attached
+				}).Should(BeTrue())
+
+				volStatus := vm.Status.Volumes[0]
+				Expect(volStatus.Name).To(Equal(vmVolume1.Name))
+				Expect(volStatus.DiskUUID).To(Equal(dummyDiskUUID1))
+				Expect(volStatus.Error).To(Equal(errMsg))
+			})
+		})
+
+		It("Reconciles VirtualMachine with multiple Spec.Volumes", func() {
+			Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
+
+			By("Assign VM BiosUUID", func() {
+				vm.Status.BiosUUID = dummyBiosUUID
+				Expect(ctx.Client.Status().Update(ctx, vm)).To(Succeed())
+			})
+
+			By("Add CNS volume to Spec.Volumes", func() {
+				vm.Spec.Volumes = append(vm.Spec.Volumes, vmVolume1, vmVolume2)
+				Expect(ctx.Client.Update(ctx, vm)).To(Succeed())
+			})
+
+			By("CnsNodeVmAttachment should be created for volume1", func() {
+				var attachment *cnsv1alpha1.CnsNodeVmAttachment
+				Eventually(func() *cnsv1alpha1.CnsNodeVmAttachment {
+					attachment = getCnsNodeVMAttachment(vm, vmVolume1)
+					return attachment
+				}).ShouldNot(BeNil())
+
+				Expect(attachment.Spec.NodeUUID).To(Equal(dummyBiosUUID))
+				Expect(attachment.Spec.VolumeName).To(Equal(vmVolume1.PersistentVolumeClaim.ClaimName))
+
+				// Add our own finalizer so it hangs around after the delete below.
+				attachment.Finalizers = append(attachment.Finalizers, "test-finalizer")
+				Expect(ctx.Client.Update(ctx, attachment)).To(Succeed())
+			})
+
+			By("CnsNodeVmAttachment should not be created for volume2", func() {
+				Consistently(func() *cnsv1alpha1.CnsNodeVmAttachment {
+					return getCnsNodeVMAttachment(vm, vmVolume2)
+				}, "3s").Should(BeNil())
+
+				Eventually(func() []vmopv1.VirtualMachineVolumeStatus {
+					if vm := getVirtualMachine(vmKey); vm != nil {
+						return vm.Status.Volumes
+					}
+					return nil
+				}).Should(HaveLen(1))
+			})
+
+			By("Simulate VM being powered on", func() {
+				vm := getVirtualMachine(vmKey)
+				Expect(vm).ToNot(BeNil())
+				vm.Status.PowerState = vmopv1.VirtualMachinePowerStateOn
+				Expect(ctx.Client.Status().Update(ctx, vm)).To(Succeed())
+			})
+
+			By("CnsNodeVmAttachment should be created for volume2", func() {
+				var attachment *cnsv1alpha1.CnsNodeVmAttachment
+				Eventually(func() *cnsv1alpha1.CnsNodeVmAttachment {
+					attachment = getCnsNodeVMAttachment(vm, vmVolume2)
+					return attachment
+				}).ShouldNot(BeNil())
+
+				Expect(attachment.Spec.NodeUUID).To(Equal(dummyBiosUUID))
+				Expect(attachment.Spec.VolumeName).To(Equal(vmVolume2.PersistentVolumeClaim.ClaimName))
+			})
+
+			By("VM Status.Volume should have entry for volume1 and volume2", func() {
+				Eventually(func() []vmopv1.VirtualMachineVolumeStatus {
+					vm = getVirtualMachine(vmKey)
+					if vm != nil {
+						return vm.Status.Volumes
+					}
+					return nil
+				}).Should(HaveLen(2))
+
+				volStatus := vm.Status.Volumes[0]
+				Expect(volStatus.Name).To(Equal(vmVolume1.Name))
+				Expect(volStatus.Attached).To(BeFalse())
+
+				volStatus = vm.Status.Volumes[1]
+				Expect(volStatus.Name).To(Equal(vmVolume2.Name))
+				Expect(volStatus.Attached).To(BeFalse())
+			})
+
+			By("Simulate CNS attachment for volume1", func() {
+				attachment := getCnsNodeVMAttachment(vm, vmVolume1)
+				Expect(attachment).ToNot(BeNil())
+				attachment.Status.Attached = true
+				attachment.Status.AttachmentMetadata = map[string]string{
+					volume.AttributeFirstClassDiskUUID: dummyDiskUUID1,
+				}
+				Expect(ctx.Client.Update(ctx, attachment)).To(Succeed())
+			})
+
+			By("Simulate CNS attachment for volume2", func() {
+				attachment := getCnsNodeVMAttachment(vm, vmVolume2)
+				Expect(attachment).ToNot(BeNil())
+				attachment.Status.Attached = true
+				attachment.Status.AttachmentMetadata = map[string]string{
+					volume.AttributeFirstClassDiskUUID: dummyDiskUUID2,
+				}
+				Expect(ctx.Client.Update(ctx, attachment)).To(Succeed())
+			})
+
+			By("VM Status.Volume should reflect attached volumes", func() {
+				Eventually(func() bool {
+					vm = getVirtualMachine(vmKey)
+					if vm == nil || len(vm.Status.Volumes) != 2 {
+						return false
+					}
+					return vm.Status.Volumes[0].Attached && vm.Status.Volumes[1].Attached
+				}).Should(BeTrue(), "Waiting VM Status.Volumes to show attached")
+			})
+
+			By("Remove CNS volume1 from VM Spec.Volumes", func() {
+				vm = getVirtualMachine(vmKey)
+				Expect(vm).ToNot(BeNil())
+				vm.Spec.Volumes = []vmopv1.VirtualMachineVolume{vmVolume2}
+				Expect(ctx.Client.Update(ctx, vm)).To(Succeed())
+			})
+
+			By("CnsNodeVmAttachment for volume1 should marked for deletion", func() {
+				Eventually(func() bool {
+					attachment := getCnsNodeVMAttachment(vm, vmVolume1)
+					if attachment != nil {
+						return !attachment.DeletionTimestamp.IsZero()
+					}
+					return false
+				}).Should(BeTrue())
+			})
+
+			By("VM Status.Volumes should still have entries for volume1 and volume2", func() {
+				// I'm not sure if we have a better way to check for this.
+				Consistently(func() []vmopv1.VirtualMachineVolumeStatus {
+					vm = getVirtualMachine(vmKey)
+					Expect(vm).ToNot(BeNil())
+					return vm.Status.Volumes
+				}, "3s").Should(HaveLen(2))
+			})
+		})
+	})
+}

--- a/controllers/volume/v1alpha2/volume_controller_suite_test.go
+++ b/controllers/volume/v1alpha2/volume_controller_suite_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha2_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+
+	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
+
+	volume "github.com/vmware-tanzu/vm-operator/controllers/volume/v1alpha2"
+	ctrlContext "github.com/vmware-tanzu/vm-operator/pkg/context"
+	providerfake "github.com/vmware-tanzu/vm-operator/pkg/vmprovider/fake"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+var intgFakeVMProvider = providerfake.NewVMProviderA2()
+
+var suite = builder.NewTestSuiteForController(
+	volume.AddToManager,
+	func(ctx *ctrlContext.ControllerManagerContext, _ ctrlmgr.Manager) error {
+		ctx.VMProviderA2 = intgFakeVMProvider
+		return nil
+	},
+)
+
+func TestVolume(t *testing.T) {
+	_ = intgTests
+	suite.Register(t, "Volume controller suite", nil /*intgTests*/, unitTests)
+}
+
+var _ = BeforeSuite(suite.BeforeSuite)
+
+var _ = AfterSuite(suite.AfterSuite)

--- a/controllers/volume/v1alpha2/volume_controller_unit_test.go
+++ b/controllers/volume/v1alpha2/volume_controller_unit_test.go
@@ -1,0 +1,869 @@
+// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha2_test
+
+import (
+	goctx "context"
+	"errors"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	k8sapierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8serrors "k8s.io/apimachinery/pkg/util/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	cnsv1alpha1 "github.com/vmware-tanzu/vm-operator/external/vsphere-csi-driver/pkg/syncer/cnsoperator/apis/cnsnodevmattachment/v1alpha1"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	volume "github.com/vmware-tanzu/vm-operator/controllers/volume/v1alpha2"
+	volContext "github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/lib"
+	providerfake "github.com/vmware-tanzu/vm-operator/pkg/vmprovider/fake"
+	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/constants"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+func unitTests() {
+	Describe("Invoking Reconcile", unitTestsReconcile)
+}
+
+type testFailClient struct {
+	client.Client
+}
+
+// This is used for returning an error while unit testing.
+func (f *testFailClient) Create(ctx goctx.Context, obj client.Object, opts ...client.CreateOption) error {
+	return k8sapierrors.NewForbidden(schema.GroupResource{}, "", errors.New("insufficient quota for creating PVC"))
+}
+
+func unitTestsReconcile() {
+	const (
+		dummyBiosUUID                 = "dummy-bios-uuid"
+		dummyDiskUUID                 = "111-222-333-disk-uuid"
+		dummyInstanceStorageClassName = "dummy-instance-storage-class"
+	)
+
+	var (
+		initObjects []client.Object
+		ctx         *builder.UnitTestContextForController
+
+		reconciler     *volume.Reconciler
+		fakeVMProvider *providerfake.VMProviderA2
+		volCtx         *volContext.VolumeContextA2
+		vm             *vmopv1.VirtualMachine
+
+		vmVol            vmopv1.VirtualMachineVolume
+		vmVolumeWithPVC1 *vmopv1.VirtualMachineVolume
+		vmVolumeWithPVC2 *vmopv1.VirtualMachineVolume
+
+		vmVolForInstPVC1 *vmopv1.VirtualMachineVolume
+	)
+
+	BeforeEach(func() {
+		vmVolumeWithPVC1 = &vmopv1.VirtualMachineVolume{
+			Name: "cns-volume-1",
+			VirtualMachineVolumeSource: vmopv1.VirtualMachineVolumeSource{
+				PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
+					PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: "pvc-volume-1",
+					},
+				},
+			},
+		}
+
+		vmVolumeWithPVC2 = &vmopv1.VirtualMachineVolume{
+			Name: "cns-volume-2",
+			VirtualMachineVolumeSource: vmopv1.VirtualMachineVolumeSource{
+				PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
+					PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: "pvc-volume-2",
+					},
+				},
+			},
+		}
+
+		vm = &vmopv1.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dummy-vm",
+				Namespace: "dummy-ns",
+			},
+			Status: vmopv1.VirtualMachineStatus{
+				BiosUUID: dummyBiosUUID,
+			},
+		}
+
+		vmVolForInstPVC1 = &vmopv1.VirtualMachineVolume{
+			Name: "instance-pvc-1",
+			VirtualMachineVolumeSource: vmopv1.VirtualMachineVolumeSource{
+				PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
+					PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: "instance-pvc-1",
+					},
+					InstanceVolumeClaim: &vmopv1.InstanceVolumeClaimVolumeSource{
+						StorageClass: dummyInstanceStorageClassName,
+						Size:         resource.MustParse("256Gi"),
+					},
+				},
+			},
+		}
+	})
+
+	JustBeforeEach(func() {
+		ctx = suite.NewUnitTestContextForController(initObjects...)
+		reconciler = volume.NewReconciler(
+			ctx.Client,
+			ctx.Logger,
+			ctx.Recorder,
+			ctx.VMProviderA2,
+		)
+		fakeVMProvider = ctx.VMProviderA2.(*providerfake.VMProviderA2)
+
+		volCtx = &volContext.VolumeContextA2{
+			Context: ctx,
+			Logger:  ctx.Logger,
+			VM:      vm,
+		}
+	})
+
+	AfterEach(func() {
+		ctx.AfterEach()
+		ctx = nil
+		initObjects = nil
+		volCtx = nil
+		reconciler = nil
+	})
+
+	getCNSAttachmentForVolumeName := func(vm *vmopv1.VirtualMachine, volumeName string) *cnsv1alpha1.CnsNodeVmAttachment {
+		objectKey := client.ObjectKey{Name: volume.CNSAttachmentNameForVolume(vm.Name, volumeName), Namespace: vm.Namespace}
+		attachment := &cnsv1alpha1.CnsNodeVmAttachment{}
+
+		err := ctx.Client.Get(ctx, objectKey, attachment)
+		if err == nil {
+			return attachment
+		}
+
+		if k8sapierrors.IsNotFound(err) {
+			return nil
+		}
+
+		ExpectWithOffset(1, err).ToNot(HaveOccurred())
+		return nil
+	}
+
+	Context("ReconcileNormal", func() {
+
+		When("Instance storage is configured on VM", func() {
+			BeforeEach(func() {
+				vmVol = *vmVolForInstPVC1
+				vm.Spec.Volumes = append(vm.Spec.Volumes, vmVol)
+				vm.Annotations = make(map[string]string)
+				vm.Annotations[constants.InstanceStorageSelectedNodeAnnotationKey] = "selected-node.domain.com"
+				vm.Annotations[constants.InstanceStorageSelectedNodeMOIDAnnotationKey] = "host-88"
+			})
+
+			JustBeforeEach(func() {
+				volCtx.InstanceStorageFSSEnabled = true
+			})
+
+			It("selected-node annotation not set - no PVCs created", func() {
+				delete(vm.Annotations, constants.InstanceStorageSelectedNodeAnnotationKey)
+				delete(vm.Annotations, constants.InstanceStorageSelectedNodeMOIDAnnotationKey)
+				err := reconciler.ReconcileNormal(volCtx)
+				Expect(err).ToNot(HaveOccurred())
+				expectPVCsStatus(volCtx, ctx, false, false, 0)
+			})
+
+			It("PVCs are created but not bound after selected-node annotation set", func() {
+				err := reconciler.ReconcileNormal(volCtx)
+				Expect(err).ToNot(HaveOccurred())
+				expectPVCsStatus(volCtx, ctx, true, false, len(vm.Spec.Volumes))
+
+				By("Multiple reconciles", func() {
+					err := reconciler.ReconcileNormal(volCtx)
+					Expect(err).ToNot(HaveOccurred())
+					expectPVCsStatus(volCtx, ctx, true, false, len(vm.Spec.Volumes))
+				})
+			})
+
+			It("PVCs are created and placement is failed - remove all error PVCs", func() {
+				By("create PVCs and not realized", func() {
+					Expect(reconciler.ReconcileNormal(volCtx)).To(Succeed())
+					expectPVCsStatus(volCtx, ctx, true, false, len(vm.Spec.Volumes))
+				})
+
+				By("Adjust PVC CreationTimestamp", func() {
+					adjustPVCCreationTimestamp(volCtx, ctx)
+				})
+
+				By("PVCs realization turned into error - remove all PVCs", func() {
+					patchInstanceStoragePVCs(volCtx, ctx, false, true)
+					Expect(reconciler.ReconcileNormal(volCtx)).To(Succeed())
+					expectPVCsStatus(volCtx, ctx, false, false, 0)
+				})
+			})
+
+			It("PVCs are created and realized", func() {
+				By("create PVCs and not realized", func() {
+					Expect(reconciler.ReconcileNormal(volCtx)).To(Succeed())
+					expectPVCsStatus(volCtx, ctx, true, false, len(vm.Spec.Volumes))
+				})
+
+				By("PVCs are bound", func() {
+					patchInstanceStoragePVCs(volCtx, ctx, true, false)
+					Expect(reconciler.ReconcileNormal(volCtx)).To(Succeed())
+					expectPVCsStatus(volCtx, ctx, true, true, len(vm.Spec.Volumes))
+				})
+			})
+
+			It("Storage policy quota is insufficient - PVCs should not create", func() {
+				tfc := testFailClient{reconciler.Client}
+				reconciler.Client = &tfc
+				err := reconciler.ReconcileNormal(volCtx)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("insufficient quota"))
+				expectPVCsStatus(volCtx, ctx, true, false, 0)
+			})
+		})
+
+		When("VM does not have BiosUUID", func() {
+			BeforeEach(func() {
+				vmVol = *vmVolumeWithPVC1
+				vm.Spec.Volumes = append(vm.Spec.Volumes, vmVol)
+				vm.Status.BiosUUID = ""
+			})
+
+			It("returns success", func() {
+				err := reconciler.ReconcileNormal(volCtx)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Did not create CnsNodeVmAttachment", func() {
+					Expect(getCNSAttachmentForVolumeName(vm, vmVol.Name)).To(BeNil())
+					Expect(vm.Status.Volumes).To(BeEmpty())
+				})
+			})
+		})
+
+		When("VM Spec.Volumes is empty", func() {
+			It("returns success", func() {
+				err := reconciler.ReconcileNormal(volCtx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(vm.Spec.Volumes).To(BeEmpty())
+				Expect(vm.Status.Volumes).To(BeEmpty())
+			})
+		})
+
+		When("CnsNodeVmAttachment exists for a different VM", func() {
+			BeforeEach(func() {
+				vmVol = *vmVolumeWithPVC1
+				vm.Spec.Volumes = append(vm.Spec.Volumes, vmVol)
+				attachment := cnsAttachmentForVMVolume(vm, vmVol)
+
+				otherAttachment := cnsAttachmentForVMVolume(vm, *vmVolumeWithPVC2)
+				otherAttachment.Spec.NodeUUID = "some-other-uuid"
+				otherAttachment.Status.Attached = true
+				otherAttachment.Status.AttachmentMetadata = map[string]string{
+					volume.AttributeFirstClassDiskUUID: dummyDiskUUID,
+				}
+				initObjects = append(initObjects, attachment, otherAttachment)
+			})
+
+			It("returns success", func() {
+				err := reconciler.ReconcileNormal(volCtx)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Ignores the CnsNodeVmAttachment for other VM", func() {
+					Expect(vm.Status.Volumes).To(HaveLen(1))
+
+					attachment := getCNSAttachmentForVolumeName(vm, vmVol.Name)
+					Expect(attachment).ToNot(BeNil())
+					assertVMVolStatusFromAttachment(vmVol, attachment, vm.Status.Volumes[0])
+				})
+			})
+		})
+
+		When("VM Spec.Volumes contains CNS volumes and VM isn't powered on", func() {
+			var vmVol1, vmVol2 vmopv1.VirtualMachineVolume
+
+			BeforeEach(func() {
+				vmVol1 = *vmVolumeWithPVC1
+				vmVol2 = *vmVolumeWithPVC2
+				vm.Spec.Volumes = append(vm.Spec.Volumes, vmVol1, vmVol2)
+
+				vm.Status.PowerState = vmopv1.VirtualMachinePowerStateOff
+			})
+
+			It("only allows one pending attachment at a time", func() {
+				Expect(reconciler.ReconcileNormal(volCtx)).To(Succeed())
+
+				By("Created first CnsNodeVmAttachment", func() {
+					attachments := &cnsv1alpha1.CnsNodeVmAttachmentList{}
+					Expect(ctx.Client.List(ctx, attachments, client.InNamespace(vm.Namespace))).To(Succeed())
+					Expect(attachments.Items).To(HaveLen(1))
+
+					attachment := getCNSAttachmentForVolumeName(vm, vmVol1.Name)
+					Expect(attachment).ToNot(BeNil())
+					assertAttachmentSpecFromVMVol(vm, vmVol1, attachment)
+
+					By("Expected VM Status.Volumes", func() {
+						Expect(vm.Status.Volumes).To(HaveLen(1))
+						assertVMVolStatusFromAttachment(vmVol1, attachment, vm.Status.Volumes[0])
+					})
+
+					// Mark as attached to let next volume proceed.
+					attachment.Status.Attached = true
+					Expect(ctx.Client.Status().Update(ctx, attachment)).To(Succeed())
+				})
+
+				Expect(reconciler.ReconcileNormal(volCtx)).To(Succeed())
+
+				By("First Volume is marked as attached", func() {
+					Expect(vm.Status.Volumes).To(HaveLen(2))
+
+					attachment := getCNSAttachmentForVolumeName(vm, vmVol1.Name)
+					Expect(attachment).ToNot(BeNil())
+					Expect(attachment.Status.Attached).To(BeTrue())
+					assertVMVolStatusFromAttachment(vmVol1, attachment, vm.Status.Volumes[0])
+				})
+
+				By("Created second CnsNodeVmAttachment", func() {
+					attachments := &cnsv1alpha1.CnsNodeVmAttachmentList{}
+					Expect(ctx.Client.List(ctx, attachments, client.InNamespace(vm.Namespace))).To(Succeed())
+					Expect(attachments.Items).To(HaveLen(2))
+
+					Expect(getCNSAttachmentForVolumeName(vm, vmVol1.Name)).ToNot(BeNil())
+					attachment := getCNSAttachmentForVolumeName(vm, vmVol2.Name)
+					Expect(attachment).ToNot(BeNil())
+					assertAttachmentSpecFromVMVol(vm, vmVol2, attachment)
+
+					By("Expected VM Status.Volumes", func() {
+						Expect(vm.Status.Volumes).To(HaveLen(2))
+						assertVMVolStatusFromAttachment(vmVol2, attachment, vm.Status.Volumes[1])
+					})
+
+					attachment.Status.Attached = true
+					Expect(ctx.Client.Status().Update(ctx, attachment)).To(Succeed())
+				})
+
+				Expect(reconciler.ReconcileNormal(volCtx)).To(Succeed())
+
+				By("Second Volume is mark as attached", func() {
+					Expect(vm.Status.Volumes).To(HaveLen(2))
+
+					attachment := getCNSAttachmentForVolumeName(vm, vmVol2.Name)
+					Expect(attachment).ToNot(BeNil())
+					Expect(attachment.Status.Attached).To(BeTrue())
+					assertVMVolStatusFromAttachment(vmVol2, attachment, vm.Status.Volumes[1])
+				})
+			})
+
+			It("only allows one pending attachment at a time when attachment has an error", func() {
+				Expect(reconciler.ReconcileNormal(volCtx)).To(Succeed())
+
+				By("Created first CnsNodeVmAttachment", func() {
+					attachments := &cnsv1alpha1.CnsNodeVmAttachmentList{}
+					Expect(ctx.Client.List(ctx, attachments, client.InNamespace(vm.Namespace))).To(Succeed())
+					Expect(attachments.Items).To(HaveLen(1))
+
+					attachment := getCNSAttachmentForVolumeName(vm, vmVol1.Name)
+					Expect(attachment).ToNot(BeNil())
+					assertAttachmentSpecFromVMVol(vm, vmVol1, attachment)
+
+					By("Expected VM Status.Volumes", func() {
+						Expect(vm.Status.Volumes).To(HaveLen(1))
+						assertVMVolStatusFromAttachment(vmVol1, attachment, vm.Status.Volumes[0])
+					})
+
+					// Mark as failure and ensure the second volume isn't created.
+					attachment.Status.Error = "failure"
+					Expect(ctx.Client.Status().Update(ctx, attachment)).To(Succeed())
+				})
+
+				Expect(reconciler.ReconcileNormal(volCtx)).To(Succeed())
+
+				By("First Volume is marked with error", func() {
+					Expect(vm.Status.Volumes).To(HaveLen(1))
+
+					attachment := getCNSAttachmentForVolumeName(vm, vmVol1.Name)
+					Expect(attachment).ToNot(BeNil())
+					assertVMVolStatusFromAttachment(vmVol1, attachment, vm.Status.Volumes[0])
+				})
+
+				By("Does not create second CnsNodeVmAttachment", func() {
+					attachments := &cnsv1alpha1.CnsNodeVmAttachmentList{}
+					Expect(ctx.Client.List(ctx, attachments, client.InNamespace(vm.Namespace))).To(Succeed())
+					Expect(attachments.Items).To(HaveLen(1))
+
+					Expect(getCNSAttachmentForVolumeName(vm, vmVol1.Name)).ToNot(BeNil())
+					Expect(getCNSAttachmentForVolumeName(vm, vmVol2.Name)).To(BeNil())
+				})
+
+				By("Simulate attach of first volume", func() {
+					attachment := getCNSAttachmentForVolumeName(vm, vmVol1.Name)
+					Expect(attachment).ToNot(BeNil())
+					attachment.Status.Attached = true
+					attachment.Status.Error = ""
+					Expect(ctx.Client.Status().Update(ctx, attachment)).To(Succeed())
+				})
+
+				Expect(reconciler.ReconcileNormal(volCtx)).To(Succeed())
+
+				By("First Volume is marked as attached", func() {
+					Expect(vm.Status.Volumes).To(HaveLen(2))
+
+					attachment := getCNSAttachmentForVolumeName(vm, vmVol1.Name)
+					Expect(attachment).ToNot(BeNil())
+					Expect(attachment.Status.Attached).To(BeTrue())
+					assertVMVolStatusFromAttachment(vmVol1, attachment, vm.Status.Volumes[0])
+				})
+
+				By("Created second CnsNodeVmAttachment", func() {
+					attachments := &cnsv1alpha1.CnsNodeVmAttachmentList{}
+					Expect(ctx.Client.List(ctx, attachments, client.InNamespace(vm.Namespace))).To(Succeed())
+					Expect(attachments.Items).To(HaveLen(2))
+
+					attachment := getCNSAttachmentForVolumeName(vm, vmVol2.Name)
+					Expect(attachment).ToNot(BeNil())
+					assertAttachmentSpecFromVMVol(vm, vmVol2, attachment)
+
+					By("Expected VM Status.Volumes", func() {
+						Expect(vm.Status.Volumes).To(HaveLen(2))
+						assertVMVolStatusFromAttachment(vmVol2, attachment, vm.Status.Volumes[1])
+					})
+				})
+
+				Expect(reconciler.ReconcileNormal(volCtx)).To(Succeed())
+
+				By("Expected VM Status.Volumes", func() {
+					Expect(vm.Status.Volumes).To(HaveLen(2))
+
+					attachment := getCNSAttachmentForVolumeName(vm, vmVol1.Name)
+					Expect(attachment).ToNot(BeNil())
+					assertVMVolStatusFromAttachment(vmVol1, attachment, vm.Status.Volumes[0])
+
+					attachment = getCNSAttachmentForVolumeName(vm, vmVol2.Name)
+					Expect(attachment).ToNot(BeNil())
+					assertVMVolStatusFromAttachment(vmVol2, attachment, vm.Status.Volumes[1])
+				})
+			})
+		})
+
+		When("VM Spec.Volumes contains CNS volumes and need to get VM's hardware version", func() {
+			BeforeEach(func() {
+				vmVol = *vmVolumeWithPVC1
+				vm.Spec.Volumes = append(vm.Spec.Volumes, vmVol)
+			})
+
+			It("returns error when failed to get VM hardware version", func() {
+				fakeVMProvider.Lock()
+				fakeVMProvider.GetVirtualMachineHardwareVersionFn = func(_ goctx.Context, _ *vmopv1.VirtualMachine) (int32, error) {
+					return 0, errors.New("dummy-error")
+				}
+				fakeVMProvider.Unlock()
+
+				err := reconciler.ReconcileNormal(volCtx)
+				Expect(err).To(HaveOccurred())
+
+				attachment := getCNSAttachmentForVolumeName(vm, vmVol.Name)
+
+				Expect(attachment).To(BeNil())
+				Expect(vm.Status.Volumes).To(BeEmpty())
+			})
+
+			It("returns error when VM hardware version is smaller than minimal requirement", func() {
+				fakeVMProvider.Lock()
+				fakeVMProvider.GetVirtualMachineHardwareVersionFn = func(_ goctx.Context, _ *vmopv1.VirtualMachine) (int32, error) {
+					return 11, nil
+				}
+				fakeVMProvider.Unlock()
+
+				err := reconciler.ReconcileNormal(volCtx)
+				Expect(err).To(HaveOccurred())
+
+				attachment := getCNSAttachmentForVolumeName(vm, vmVol.Name)
+
+				Expect(attachment).To(BeNil())
+				Expect(vm.Status.Volumes).To(BeEmpty())
+			})
+
+			It("returns success when failed to parse VM hardware version", func() {
+				fakeVMProvider.Lock()
+				fakeVMProvider.GetVirtualMachineHardwareVersionFn = func(_ goctx.Context, _ *vmopv1.VirtualMachine) (int32, error) {
+					return 0, nil
+				}
+				fakeVMProvider.Unlock()
+
+				err := reconciler.ReconcileNormal(volCtx)
+				Expect(err).ToNot(HaveOccurred())
+
+				attachment := getCNSAttachmentForVolumeName(vm, vmVol.Name)
+
+				By("Created expected CnsNodeVmAttachment", func() {
+					Expect(attachment).ToNot(BeNil())
+					assertAttachmentSpecFromVMVol(vm, vmVol, attachment)
+				})
+
+				By("Expected VM Status.Volumes", func() {
+					Expect(vm.Status.Volumes).To(HaveLen(1))
+					assertVMVolStatusFromAttachment(vmVol, attachment, vm.Status.Volumes[0])
+				})
+			})
+		})
+
+		When("VM Spec.Volumes has CNS volume", func() {
+			BeforeEach(func() {
+				vmVol = *vmVolumeWithPVC1
+				vm.Spec.Volumes = append(vm.Spec.Volumes, vmVol)
+			})
+
+			It("returns success", func() {
+				err := reconciler.ReconcileNormal(volCtx)
+				Expect(err).ToNot(HaveOccurred())
+
+				attachment := getCNSAttachmentForVolumeName(vm, vmVol.Name)
+
+				By("Created expected CnsNodeVmAttachment", func() {
+					Expect(attachment).ToNot(BeNil())
+					assertAttachmentSpecFromVMVol(vm, vmVol, attachment)
+				})
+
+				By("Expected VM Status.Volumes", func() {
+					Expect(vm.Status.Volumes).To(HaveLen(1))
+					assertVMVolStatusFromAttachment(vmVol, attachment, vm.Status.Volumes[0])
+				})
+			})
+		})
+
+		When("VM Spec.Volumes has CNS volume with existing CnsNodeVmAttachment", func() {
+			dummyErrMsg := "vmware foobar 42"
+
+			BeforeEach(func() {
+				vmVol = *vmVolumeWithPVC1
+				vm.Spec.Volumes = append(vm.Spec.Volumes, vmVol)
+
+				attachment := cnsAttachmentForVMVolume(vm, vmVol)
+				attachment.Status.Attached = true
+				attachment.Status.AttachmentMetadata = map[string]string{
+					volume.AttributeFirstClassDiskUUID: dummyDiskUUID,
+				}
+				attachment.Status.Error = dummyErrMsg
+				initObjects = append(initObjects, attachment)
+			})
+
+			It("returns success", func() {
+				err := reconciler.ReconcileNormal(volCtx)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Expected VM Status.Volumes", func() {
+					Expect(vm.Status.Volumes).To(HaveLen(1))
+
+					attachment := getCNSAttachmentForVolumeName(vm, vmVol.Name)
+					Expect(attachment).ToNot(BeNil())
+					assertVMVolStatusFromAttachment(vmVol, attachment, vm.Status.Volumes[0])
+				})
+			})
+		})
+
+		When("VM Spec.Volumes has CNS volume with a SOAP error", func() {
+			awfulErrMsg := `failed to attach cns volume: \"88854b48-2b1c-43f8-8889-de4b5ca2cab5\" to node vm: \"VirtualMachine:vm-42
+[VirtualCenterHost: vc.vmware.com, UUID: 42080725-d6b0-c045-b24e-29c4dadca6f2, Datacenter: Datacenter
+[Datacenter: Datacenter:datacenter, VirtualCenterHost: vc.vmware.com]]\".
+fault: \"(*types.LocalizedMethodFault)(0xc003d9b9a0)({\\n DynamicData: (types.DynamicData)
+{\\n },\\n Fault: (*types.ResourceInUse)(0xc002e69080)({\\n VimFault: (types.VimFault)
+{\\n MethodFault: (types.MethodFault) {\\n FaultCause: (*types.LocalizedMethodFault)(\u003cnil\u003e),\\n
+FaultMessage: ([]types.LocalizableMessage) \u003cnil\u003e\\n }\\n },\\n Type: (string) \\\"\\\",\\n Name:
+(string) (len=6) \\\"volume\\\"\\n }),\\n LocalizedMessage: (string) (len=32)
+\\\"The resource 'volume' is in use.\\\"\\n})\\n\". opId: \"67d69c68\""
+`
+
+			BeforeEach(func() {
+				vmVol = *vmVolumeWithPVC1
+				vm.Spec.Volumes = append(vm.Spec.Volumes, vmVol)
+
+				attachment := cnsAttachmentForVMVolume(vm, vmVol)
+				attachment.Status.Attached = true
+				attachment.Status.AttachmentMetadata = map[string]string{
+					volume.AttributeFirstClassDiskUUID: dummyDiskUUID,
+				}
+				attachment.Status.Error = awfulErrMsg
+				initObjects = append(initObjects, attachment)
+			})
+
+			It("returns success", func() {
+				err := reconciler.ReconcileNormal(volCtx)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Expected VM Status.Volumes with sanitized error", func() {
+					Expect(vm.Status.Volumes).To(HaveLen(1))
+
+					attachment := getCNSAttachmentForVolumeName(vm, vmVol.Name)
+					Expect(attachment).ToNot(BeNil())
+					attachment.Status.Error = "failed to attach cns volume"
+					assertVMVolStatusFromAttachment(vmVol, attachment, vm.Status.Volumes[0])
+				})
+			})
+		})
+
+		When("VM has orphaned CNS volume in Status.Volumes", func() {
+			var attachment *cnsv1alpha1.CnsNodeVmAttachment
+
+			BeforeEach(func() {
+				vmVol = *vmVolumeWithPVC1
+				vm.Status.Volumes = append(vm.Status.Volumes, vmopv1.VirtualMachineVolumeStatus{
+					Name:     vmVol.Name,
+					DiskUUID: dummyDiskUUID,
+				})
+
+				attachment = cnsAttachmentForVMVolume(vm, vmVol)
+				attachment.Status.Attached = true
+				attachment.Status.AttachmentMetadata = map[string]string{
+					volume.AttributeFirstClassDiskUUID: dummyDiskUUID,
+				}
+				initObjects = append(initObjects, attachment)
+			})
+
+			It("returns success", func() {
+				err := reconciler.ReconcileNormal(volCtx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(vm.Spec.Volumes).To(BeEmpty())
+
+				By("Orphaned CNS volume preserved in Status.Volumes", func() {
+					Expect(vm.Status.Volumes).To(HaveLen(1))
+					assertVMVolStatusFromAttachment(vmVol, attachment, vm.Status.Volumes[0])
+
+					// Not in VM Spec so should be deleted.
+					Expect(getCNSAttachmentForVolumeName(vm, vmVol.Name)).To(BeNil())
+				})
+			})
+		})
+
+		When("VM Status.Volumes is sorted as expected", func() {
+			var vmVol1 vmopv1.VirtualMachineVolume
+			var vmVol2 vmopv1.VirtualMachineVolume
+
+			BeforeEach(func() {
+				vmVol1 = *vmVolumeWithPVC1
+				vmVol2 = *vmVolumeWithPVC2
+				vm.Spec.Volumes = append(vm.Spec.Volumes, vmVol1, vmVol2)
+				vm.Status.PowerState = vmopv1.VirtualMachinePowerStateOn
+			})
+
+			// We sort by DiskUUID, but the CnsNodeVmAttachment haven't been "attached" yet,
+			// so expect the Spec.Volumes order.
+			When("CnsNodeVmAttachments do not have DiskUUID set", func() {
+				It("returns success", func() {
+					err := reconciler.ReconcileNormal(volCtx)
+					Expect(err).ToNot(HaveOccurred())
+
+					attachment1 := getCNSAttachmentForVolumeName(vm, vmVol1.Name)
+					Expect(attachment1).ToNot(BeNil())
+					assertAttachmentSpecFromVMVol(vm, vmVol1, attachment1)
+
+					attachment2 := getCNSAttachmentForVolumeName(vm, vmVol2.Name)
+					Expect(attachment2).ToNot(BeNil())
+					assertAttachmentSpecFromVMVol(vm, vmVol2, attachment2)
+
+					By("VM Status.Volumes are stable-sorted by Spec.Volumes order", func() {
+						Expect(vm.Status.Volumes).To(HaveLen(2))
+						assertVMVolStatusFromAttachment(vmVol1, attachment1, vm.Status.Volumes[0])
+						assertVMVolStatusFromAttachment(vmVol2, attachment2, vm.Status.Volumes[1])
+					})
+				})
+			})
+
+			When("CnsNodeVmAttachments have DiskUUID set", func() {
+				dummyDiskUUID1 := "z"
+				dummyDiskUUID2 := "a"
+
+				BeforeEach(func() {
+					attachment1 := cnsAttachmentForVMVolume(vm, vmVol1)
+					attachment1.Status.Attached = true
+					attachment1.Status.AttachmentMetadata = map[string]string{
+						volume.AttributeFirstClassDiskUUID: dummyDiskUUID1,
+					}
+
+					attachment2 := cnsAttachmentForVMVolume(vm, vmVol2)
+					attachment2.Status.Attached = true
+					attachment2.Status.AttachmentMetadata = map[string]string{
+						volume.AttributeFirstClassDiskUUID: dummyDiskUUID2,
+					}
+
+					initObjects = append(initObjects, attachment1, attachment2)
+				})
+
+				It("returns success", func() {
+					err := reconciler.ReconcileNormal(volCtx)
+					Expect(err).ToNot(HaveOccurred())
+
+					attachment1 := getCNSAttachmentForVolumeName(vm, vmVol1.Name)
+					Expect(attachment1).ToNot(BeNil())
+					assertAttachmentSpecFromVMVol(vm, vmVol1, attachment1)
+
+					attachment2 := getCNSAttachmentForVolumeName(vm, vmVol2.Name)
+					Expect(attachment2).ToNot(BeNil())
+					assertAttachmentSpecFromVMVol(vm, vmVol2, attachment2)
+
+					By("VM Status.Volumes are sorted by DiskUUID", func() {
+						Expect(vm.Status.Volumes).To(HaveLen(2))
+						assertVMVolStatusFromAttachment(vmVol2, attachment2, vm.Status.Volumes[0])
+						assertVMVolStatusFromAttachment(vmVol1, attachment1, vm.Status.Volumes[1])
+					})
+				})
+			})
+		})
+	})
+
+	Context("ReconcileDelete", func() {
+		When("VM is marked for deletion", func() {
+			BeforeEach(func() {
+				now := metav1.Now()
+				vm.DeletionTimestamp = &now
+			})
+
+			It("returns success", func() {
+				err := reconciler.ReconcileDelete(volCtx)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+	})
+}
+
+func cnsAttachmentForVMVolume(
+	vm *vmopv1.VirtualMachine,
+	vmVol vmopv1.VirtualMachineVolume) *cnsv1alpha1.CnsNodeVmAttachment {
+	t := true
+	return &cnsv1alpha1.CnsNodeVmAttachment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      volume.CNSAttachmentNameForVolume(vm.Name, vmVol.Name),
+			Namespace: vm.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         "vmoperator.vmware.com/v1alpha1",
+					Kind:               "VirtualMachine",
+					Name:               vm.Name,
+					UID:                vm.UID,
+					Controller:         &t,
+					BlockOwnerDeletion: &t,
+				},
+			},
+		},
+		Spec: cnsv1alpha1.CnsNodeVmAttachmentSpec{
+			NodeUUID:   vm.Status.BiosUUID,
+			VolumeName: vmVol.PersistentVolumeClaim.ClaimName,
+		},
+	}
+}
+
+func expectPVCsStatus(ctx *volContext.VolumeContextA2, testCtx *builder.UnitTestContextForController, selectedNodeSet, bound bool, pvcsCount int) {
+	if selectedNodeSet {
+		Expect(ctx.VM.Annotations).To(HaveKey(constants.InstanceStorageSelectedNodeAnnotationKey))
+		Expect(ctx.VM.Annotations).To(HaveKey(constants.InstanceStorageSelectedNodeMOIDAnnotationKey))
+	} else {
+		Expect(ctx.VM.Annotations).ToNot(HaveKey(constants.InstanceStorageSelectedNodeAnnotationKey))
+		Expect(ctx.VM.Annotations).ToNot(HaveKey(constants.InstanceStorageSelectedNodeMOIDAnnotationKey))
+	}
+
+	if bound {
+		Expect(ctx.VM.Annotations).To(HaveKey(constants.InstanceStoragePVCsBoundAnnotationKey))
+	} else {
+		Expect(ctx.VM.Annotations).ToNot(HaveKey(constants.InstanceStoragePVCsBoundAnnotationKey))
+	}
+
+	pvcList, err := getInstanceStoragePVCs(ctx, testCtx)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(pvcList).To(HaveLen(pvcsCount))
+}
+
+func adjustPVCCreationTimestamp(ctx *volContext.VolumeContextA2, testCtx *builder.UnitTestContextForController) {
+	pvcList, err := getInstanceStoragePVCs(ctx, testCtx)
+	Expect(err).ToNot(HaveOccurred())
+
+	for _, pvc := range pvcList {
+		pvc := pvc
+		pvc.CreationTimestamp = metav1.NewTime(time.Now().Add(-2 * lib.GetInstanceStoragePVPlacementFailedTTL()))
+		Expect(testCtx.Client.Update(ctx, &pvc)).To(Succeed())
+	}
+}
+
+func getInstanceStoragePVCs(ctx *volContext.VolumeContextA2, testCtx *builder.UnitTestContextForController) ([]corev1.PersistentVolumeClaim, error) {
+	var errs []error
+	pvcList := make([]corev1.PersistentVolumeClaim, 0)
+
+	volumes := volume.FilterVolumesA2(ctx.VM)
+	for _, vol := range volumes {
+		objKey := client.ObjectKey{
+			Namespace: ctx.VM.Namespace,
+			Name:      vol.PersistentVolumeClaim.ClaimName,
+		}
+		pvc := &corev1.PersistentVolumeClaim{}
+		if err := testCtx.Client.Get(ctx, objKey, pvc); client.IgnoreNotFound(err) != nil {
+			errs = append(errs, err)
+			continue
+		}
+		// The system returns empty object when no PVC resources exists in the system.
+		// This check filters out unwanted objects that causes assertions fail.
+		if !metav1.IsControlledBy(pvc, ctx.VM) {
+			continue
+		}
+		pvcList = append(pvcList, *pvc)
+	}
+
+	return pvcList, k8serrors.NewAggregate(errs)
+}
+
+func patchInstanceStoragePVCs(ctx *volContext.VolumeContextA2, testCtx *builder.UnitTestContextForController, setStatusBound, setErrorAnnotation bool) {
+	pvcList, err := getInstanceStoragePVCs(ctx, testCtx)
+	Expect(err).ToNot(HaveOccurred())
+
+	for _, pvc := range pvcList {
+		pvc := pvc
+		if setStatusBound {
+			pvc.Status.Phase = corev1.ClaimBound
+		}
+		if setErrorAnnotation {
+			if pvc.Annotations == nil {
+				pvc.Annotations = make(map[string]string)
+			}
+			pvc.Annotations[constants.InstanceStoragePVPlacementErrorAnnotationKey] = constants.InstanceStorageNotEnoughResErr
+		} else {
+			delete(pvc.Annotations, constants.InstanceStoragePVPlacementErrorAnnotationKey)
+		}
+
+		Expect(testCtx.Client.Update(ctx, &pvc)).To(Succeed())
+		Expect(testCtx.Client.Status().Update(ctx, &pvc)).To(Succeed())
+	}
+}
+
+func assertAttachmentSpecFromVMVol(
+	vm *vmopv1.VirtualMachine,
+	vmVol vmopv1.VirtualMachineVolume,
+	attachment *cnsv1alpha1.CnsNodeVmAttachment) {
+
+	ExpectWithOffset(1, attachment.Spec.NodeUUID).To(Equal(vm.Status.BiosUUID))
+	ExpectWithOffset(1, attachment.Spec.VolumeName).To(Equal(vmVol.PersistentVolumeClaim.ClaimName))
+
+	ownerRefs := attachment.GetOwnerReferences()
+	ExpectWithOffset(1, ownerRefs).To(HaveLen(1))
+	ownerRef := ownerRefs[0]
+	ExpectWithOffset(1, ownerRef.Name).To(Equal(vm.Name))
+	ExpectWithOffset(1, ownerRef.Controller).ToNot(BeNil())
+	ExpectWithOffset(1, *ownerRef.Controller).To(BeTrue())
+}
+
+func assertVMVolStatusFromAttachment(
+	vmVol vmopv1.VirtualMachineVolume,
+	attachment *cnsv1alpha1.CnsNodeVmAttachment,
+	vmVolStatus vmopv1.VirtualMachineVolumeStatus) {
+	diskUUID := attachment.Status.AttachmentMetadata[volume.AttributeFirstClassDiskUUID]
+
+	ExpectWithOffset(1, vmVolStatus.Name).To(Equal(vmVol.Name))
+	ExpectWithOffset(1, vmVolStatus.Attached).To(Equal(attachment.Status.Attached))
+	ExpectWithOffset(1, vmVolStatus.DiskUUID).To(Equal(diskUUID))
+	ExpectWithOffset(1, vmVolStatus.Error).To(Equal(attachment.Status.Error))
+}

--- a/pkg/context/clustercontentlibraryitem_context.go
+++ b/pkg/context/clustercontentlibraryitem_context.go
@@ -10,7 +10,8 @@ import (
 	"github.com/go-logr/logr"
 
 	imgregv1a1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha1"
-	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	"github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 )
 
 // ClusterContentLibraryItemContext is the context used for ClusterContentLibraryItem controller.
@@ -18,10 +19,23 @@ type ClusterContentLibraryItemContext struct {
 	context.Context
 	Logger       logr.Logger
 	CCLItem      *imgregv1a1.ClusterContentLibraryItem
-	CVMI         *vmopv1.ClusterVirtualMachineImage
+	CVMI         *v1alpha1.ClusterVirtualMachineImage
 	ImageObjName string
 }
 
 func (c *ClusterContentLibraryItemContext) String() string {
+	return fmt.Sprintf("%s %s", c.CCLItem.GroupVersionKind(), c.CCLItem.Name)
+}
+
+// ClusterContentLibraryItemContextA2 is the context used for ClusterContentLibraryItem controller.
+type ClusterContentLibraryItemContextA2 struct {
+	context.Context
+	Logger       logr.Logger
+	CCLItem      *imgregv1a1.ClusterContentLibraryItem
+	CVMI         *vmopv1.ClusterVirtualMachineImage
+	ImageObjName string
+}
+
+func (c *ClusterContentLibraryItemContextA2) String() string {
 	return fmt.Sprintf("%s %s", c.CCLItem.GroupVersionKind(), c.CCLItem.Name)
 }

--- a/pkg/context/contentlibraryitem_context.go
+++ b/pkg/context/contentlibraryitem_context.go
@@ -11,7 +11,8 @@ import (
 
 	imgregv1a1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha1"
 
-	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	"github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 )
 
 // ContentLibraryItemContext is the context used for ContentLibraryItem controller.
@@ -19,10 +20,23 @@ type ContentLibraryItemContext struct {
 	context.Context
 	Logger       logr.Logger
 	CLItem       *imgregv1a1.ContentLibraryItem
-	VMI          *vmopv1.VirtualMachineImage
+	VMI          *v1alpha1.VirtualMachineImage
 	ImageObjName string
 }
 
 func (c *ContentLibraryItemContext) String() string {
+	return fmt.Sprintf("%s %s/%s", c.CLItem.GroupVersionKind(), c.CLItem.Namespace, c.CLItem.Name)
+}
+
+// ContentLibraryItemContextA2 is the context used for ContentLibraryItem controller.
+type ContentLibraryItemContextA2 struct {
+	context.Context
+	Logger       logr.Logger
+	CLItem       *imgregv1a1.ContentLibraryItem
+	VMI          *vmopv1.VirtualMachineImage
+	ImageObjName string
+}
+
+func (c *ContentLibraryItemContextA2) String() string {
 	return fmt.Sprintf("%s %s/%s", c.CLItem.GroupVersionKind(), c.CLItem.Namespace, c.CLItem.Name)
 }

--- a/pkg/context/fake/fake_controller_manager_context.go
+++ b/pkg/context/fake/fake_controller_manager_context.go
@@ -27,5 +27,6 @@ func NewControllerManagerContext() *context.ControllerManagerContext {
 		LeaderElectionID:        LeaderElectionID,
 		Recorder:                record.New(clientrecord.NewFakeRecorder(1024)),
 		VMProvider:              providerfake.NewVMProvider(),
+		VMProviderA2:            providerfake.NewVMProviderA2(),
 	}
 }

--- a/pkg/context/virtualmachine_context.go
+++ b/pkg/context/virtualmachine_context.go
@@ -9,16 +9,28 @@ import (
 
 	"github.com/go-logr/logr"
 
-	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	"github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 )
 
 // VirtualMachineContext is the context used for VirtualMachineControllers.
 type VirtualMachineContext struct {
 	context.Context
 	Logger logr.Logger
-	VM     *vmopv1.VirtualMachine
+	VM     *v1alpha1.VirtualMachine
 }
 
 func (v *VirtualMachineContext) String() string {
+	return fmt.Sprintf("%s %s/%s", v.VM.GroupVersionKind(), v.VM.Namespace, v.VM.Name)
+}
+
+// VirtualMachineContextA2 is the context used for VirtualMachineControllers.
+type VirtualMachineContextA2 struct {
+	context.Context
+	Logger logr.Logger
+	VM     *vmopv1.VirtualMachine
+}
+
+func (v *VirtualMachineContextA2) String() string {
 	return fmt.Sprintf("%s %s/%s", v.VM.GroupVersionKind(), v.VM.Namespace, v.VM.Name)
 }

--- a/pkg/context/virtualmachineclass_context.go
+++ b/pkg/context/virtualmachineclass_context.go
@@ -9,16 +9,28 @@ import (
 
 	"github.com/go-logr/logr"
 
-	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	"github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 )
 
 // VirtualMachineClassContext is the context used for VirtualMachineClassControllers.
 type VirtualMachineClassContext struct {
 	context.Context
 	Logger  logr.Logger
-	VMClass *vmopv1.VirtualMachineClass
+	VMClass *v1alpha1.VirtualMachineClass
 }
 
 func (v *VirtualMachineClassContext) String() string {
+	return fmt.Sprintf("%s %s/%s", v.VMClass.GroupVersionKind(), v.VMClass.Namespace, v.VMClass.Name)
+}
+
+// VirtualMachineClassContextA2 is the context used for VirtualMachineClassControllers.
+type VirtualMachineClassContextA2 struct {
+	context.Context
+	Logger  logr.Logger
+	VMClass *vmopv1.VirtualMachineClass
+}
+
+func (v *VirtualMachineClassContextA2) String() string {
 	return fmt.Sprintf("%s %s/%s", v.VMClass.GroupVersionKind(), v.VMClass.Namespace, v.VMClass.Name)
 }

--- a/pkg/context/virtualmachinepublishrequest_context.go
+++ b/pkg/context/virtualmachinepublishrequest_context.go
@@ -9,13 +9,31 @@ import (
 
 	"github.com/go-logr/logr"
 
-	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
-
 	imgregv1a1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha1"
+
+	"github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 )
 
 // VirtualMachinePublishRequestContext is the context used for VirtualMachinePublishRequestControllers.
 type VirtualMachinePublishRequestContext struct {
+	context.Context
+	Logger           logr.Logger
+	VMPublishRequest *v1alpha1.VirtualMachinePublishRequest
+	VM               *v1alpha1.VirtualMachine
+	ContentLibrary   *imgregv1a1.ContentLibrary
+	ItemID           string
+	// SkipPatch indicates whether we should skip patching the object after reconcile
+	// because Status is updated separately in the publishing case due to CL API limitations.
+	SkipPatch bool
+}
+
+func (v *VirtualMachinePublishRequestContext) String() string {
+	return fmt.Sprintf("%s %s/%s", v.VMPublishRequest.GroupVersionKind(), v.VMPublishRequest.Namespace, v.VMPublishRequest.Name)
+}
+
+// VirtualMachinePublishRequestContextA2 is the context used for VirtualMachinePublishRequestControllers.
+type VirtualMachinePublishRequestContextA2 struct {
 	context.Context
 	Logger           logr.Logger
 	VMPublishRequest *vmopv1.VirtualMachinePublishRequest
@@ -27,6 +45,6 @@ type VirtualMachinePublishRequestContext struct {
 	SkipPatch bool
 }
 
-func (v *VirtualMachinePublishRequestContext) String() string {
+func (v *VirtualMachinePublishRequestContextA2) String() string {
 	return fmt.Sprintf("%s %s/%s", v.VMPublishRequest.GroupVersionKind(), v.VMPublishRequest.Namespace, v.VMPublishRequest.Name)
 }

--- a/pkg/context/virtualmachineservice_context.go
+++ b/pkg/context/virtualmachineservice_context.go
@@ -9,16 +9,28 @@ import (
 
 	"github.com/go-logr/logr"
 
-	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	"github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 )
 
 // VirtualMachineServiceContext is the context used for VirtualMachineServiceController.
 type VirtualMachineServiceContext struct {
 	context.Context
 	Logger    logr.Logger
-	VMService *vmopv1.VirtualMachineService
+	VMService *v1alpha1.VirtualMachineService
 }
 
 func (v *VirtualMachineServiceContext) String() string {
+	return fmt.Sprintf("%s %s/%s", v.VMService.GroupVersionKind(), v.VMService.Namespace, v.VMService.Name)
+}
+
+// VirtualMachineServiceContextA2 is the context used for VirtualMachineServiceController.
+type VirtualMachineServiceContextA2 struct {
+	context.Context
+	Logger    logr.Logger
+	VMService *vmopv1.VirtualMachineService
+}
+
+func (v *VirtualMachineServiceContextA2) String() string {
 	return fmt.Sprintf("%s %s/%s", v.VMService.GroupVersionKind(), v.VMService.Namespace, v.VMService.Name)
 }

--- a/pkg/context/virtualmachinesetresourcepolicy_context.go
+++ b/pkg/context/virtualmachinesetresourcepolicy_context.go
@@ -9,16 +9,28 @@ import (
 
 	"github.com/go-logr/logr"
 
-	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	"github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 )
 
 // VirtualMachineSetResourcePolicyContext is the context used for VirtualMachineControllers.
 type VirtualMachineSetResourcePolicyContext struct {
 	context.Context
 	Logger         logr.Logger
-	ResourcePolicy *vmopv1.VirtualMachineSetResourcePolicy
+	ResourcePolicy *v1alpha1.VirtualMachineSetResourcePolicy
 }
 
 func (v *VirtualMachineSetResourcePolicyContext) String() string {
+	return fmt.Sprintf("%s %s/%s", v.ResourcePolicy.GroupVersionKind(), v.ResourcePolicy.Namespace, v.ResourcePolicy.Name)
+}
+
+// VirtualMachineSetResourcePolicyContextA2 is the context used for VirtualMachineControllers.
+type VirtualMachineSetResourcePolicyContextA2 struct {
+	context.Context
+	Logger         logr.Logger
+	ResourcePolicy *vmopv1.VirtualMachineSetResourcePolicy
+}
+
+func (v *VirtualMachineSetResourcePolicyContextA2) String() string {
 	return fmt.Sprintf("%s %s/%s", v.ResourcePolicy.GroupVersionKind(), v.ResourcePolicy.Namespace, v.ResourcePolicy.Name)
 }

--- a/pkg/context/volume_context.go
+++ b/pkg/context/volume_context.go
@@ -9,17 +9,30 @@ import (
 
 	"github.com/go-logr/logr"
 
-	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	"github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 )
 
 // VolumeContext is the context used for VolumeController.
 type VolumeContext struct {
 	context.Context
 	Logger                    logr.Logger
-	VM                        *vmopv1.VirtualMachine
+	VM                        *v1alpha1.VirtualMachine
 	InstanceStorageFSSEnabled bool
 }
 
 func (v *VolumeContext) String() string {
+	return fmt.Sprintf("%s %s/%s", v.VM.GroupVersionKind(), v.VM.Namespace, v.VM.Name)
+}
+
+// VolumeContextA2 is the context used for VolumeController.
+type VolumeContextA2 struct {
+	context.Context
+	Logger                    logr.Logger
+	VM                        *vmopv1.VirtualMachine
+	InstanceStorageFSSEnabled bool
+}
+
+func (v *VolumeContextA2) String() string {
 	return fmt.Sprintf("%s %s/%s", v.VM.GroupVersionKind(), v.VM.Namespace, v.VM.Name)
 }

--- a/pkg/lib/env.go
+++ b/pkg/lib/env.go
@@ -91,7 +91,7 @@ var IsWcpFaultDomainsFSSEnabled = func() bool {
 	return os.Getenv(WcpFaultDomainsFSS) == trueString
 }
 
-var IsVMServiceV1Alpha2FSSEnabled = func() bool {
+func IsVMServiceV1Alpha2FSSEnabled() bool {
 	return os.Getenv(VMServiceV1Alpha2FSS) == trueString
 }
 

--- a/pkg/metrics2/clitem_metrics.go
+++ b/pkg/metrics2/clitem_metrics.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics2
+
+import (
+	"sync"
+
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	clItemMetricsOnce sync.Once
+	clItemMetrics     *ContentLibraryItemMetrics
+)
+
+type ContentLibraryItemMetrics struct {
+	vmiResourceResolve *prometheus.GaugeVec
+	vmiContentSync     *prometheus.GaugeVec
+}
+
+// NewContentLibraryItemMetrics initializes a singleton and registers all the defined metrics.
+func NewContentLibraryItemMetrics() *ContentLibraryItemMetrics {
+	clItemMetricsOnce.Do(func() {
+		clItemMetrics = &ContentLibraryItemMetrics{
+			vmiResourceResolve: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+				Namespace: metricsNamespace,
+				Subsystem: "vmi",
+				Name:      "resource_resolve",
+				Help:      "VMImage CR resolve status reconciled by the content library item controller",
+			}, []string{
+				vmiNameLabel,
+				vmiNamespaceLabel,
+			}),
+			vmiContentSync: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+				Namespace: metricsNamespace,
+				Subsystem: "vmi",
+				Name:      "content_sync",
+				Help:      "VMImage content sync status from fetching the library item in vSphere",
+			}, []string{
+				vmiNameLabel,
+				vmiNamespaceLabel,
+			}),
+		}
+
+		metrics.Registry.MustRegister(
+			clItemMetrics.vmiResourceResolve,
+			clItemMetrics.vmiContentSync,
+		)
+	})
+
+	return clItemMetrics
+}
+
+// RegisterVMIResourceResolve registers vmi resource resolve status metrics.
+// If success is true, it sets the value to 1 else to 0.
+func (m *ContentLibraryItemMetrics) RegisterVMIResourceResolve(logger logr.Logger, vmiName, ns string, success bool) {
+	labels := getVMIMetricsLabels(vmiName, ns)
+	m.vmiResourceResolve.With(labels).Set(func() float64 {
+		if success {
+			return 1
+		}
+		return 0
+	}())
+
+	logger.V(5).WithValues("labels", labels).Info("Set metrics for VMImage CR resolve status")
+}
+
+// RegisterVMIContentSync registers vmi content sync status metrics.
+// If success is true, it sets the value to 1 else to 0.
+func (m *ContentLibraryItemMetrics) RegisterVMIContentSync(logger logr.Logger, vmiName, ns string, success bool) {
+	labels := getVMIMetricsLabels(vmiName, ns)
+	m.vmiContentSync.With(labels).Set(func() float64 {
+		if success {
+			return 1
+		}
+		return 0
+	}())
+
+	logger.V(5).WithValues("labels", labels).Info("Set metrics for VMImage content sync status")
+}
+
+// DeleteMetrics deletes all the related ContentLibraryItem metrics from the given name and namespace.
+func (m *ContentLibraryItemMetrics) DeleteMetrics(logger logr.Logger, vmiName, ns string) {
+	labels := getVMIMetricsLabels(vmiName, ns)
+	m.vmiResourceResolve.Delete(labels)
+	m.vmiContentSync.Delete(labels)
+
+	logger.V(5).WithValues("labels", labels).Info("Deleted all VMImage related Metrics")
+}
+
+func getVMIMetricsLabels(name, ns string) prometheus.Labels {
+	return prometheus.Labels{
+		vmiNameLabel:      name,
+		vmiNamespaceLabel: ns,
+	}
+}

--- a/pkg/metrics2/constants.go
+++ b/pkg/metrics2/constants.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics2
+
+const (
+	// If this changes, the metrics collection configs (e.g. telegraf) will need to be updated as well.
+	metricsNamespace = "vmservice"
+
+	// VM related metrics labels.
+	vmNameLabel          = "vm_name"
+	vmNamespaceLabel     = "vm_namespace"
+	conditionTypeLabel   = "condition_type"
+	conditionReasonLabel = "condition_reason"
+	specLabel            = "spec"
+	statusLabel          = "status"
+
+	// VMImage related metrics labels (from image registry service).
+	vmiNameLabel      = "vmi_name"
+	vmiNamespaceLabel = "vmi_namespace"
+)

--- a/pkg/metrics2/vmpub_metrics.go
+++ b/pkg/metrics2/vmpub_metrics.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics2
+
+import (
+	"sync"
+
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type PublishResult int
+
+const (
+	PublishFailed     PublishResult = -1
+	PublishInProgress PublishResult = 0
+	PublishSucceeded  PublishResult = 1
+)
+
+var (
+	vmPubMetricsOnce sync.Once
+	vmPubMetrics     *VMPublishMetrics
+)
+
+type VMPublishMetrics struct {
+	vmPubRequest *prometheus.GaugeVec
+}
+
+// NewVMPublishMetrics initializes a singleton and registers all the defined metrics.
+func NewVMPublishMetrics() *VMPublishMetrics {
+	vmPubMetricsOnce.Do(func() {
+		vmPubMetrics = &VMPublishMetrics{
+			vmPubRequest: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+				Namespace: metricsNamespace,
+				Subsystem: "vm",
+				Name:      "publish_request",
+				Help:      "VirtualMachine publish request result",
+			}, []string{
+				"name",
+				"namespace",
+			}),
+		}
+
+		metrics.Registry.MustRegister(
+			vmPubMetrics.vmPubRequest,
+		)
+	})
+
+	return vmPubMetrics
+}
+
+// RegisterVMPublishRequest registers VM publish request metrics with the given value.
+func (m *VMPublishMetrics) RegisterVMPublishRequest(logger logr.Logger, reqName, ns string, val PublishResult) {
+	labels := getVMPubRequestLabels(reqName, ns)
+	m.vmPubRequest.With(labels).Set(float64(val))
+
+	logger.V(5).WithValues("labels", labels, "result", val).Info("Set metrics for VM publish request")
+}
+
+// DeleteMetrics deletes all the related VM publish request metrics from the given name and namespace.
+func (m *VMPublishMetrics) DeleteMetrics(logger logr.Logger, reqName, ns string) {
+	labels := getVMPubRequestLabels(reqName, ns)
+	deleted := m.vmPubRequest.Delete(labels)
+
+	logger.V(5).WithValues("labels", labels, "deleted", deleted).Info("Delete VM publish request metrics")
+}
+
+func getVMPubRequestLabels(name, ns string) prometheus.Labels {
+	return prometheus.Labels{
+		"name":      name,
+		"namespace": ns,
+	}
+}

--- a/pkg/metrics2/vmservice_metrics.go
+++ b/pkg/metrics2/vmservice_metrics.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics2
+
+import (
+	"sync"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/vmware-tanzu/vm-operator/pkg/context"
+)
+
+var (
+	vmMetricsOnce sync.Once
+	vmMetrics     *VMMetrics
+)
+
+type VMMetrics struct {
+	statusConditionStatus *prometheus.GaugeVec
+	powerState            *prometheus.GaugeVec
+	statusIP              *prometheus.GaugeVec
+}
+
+func NewVMMetrics() *VMMetrics {
+	vmMetricsOnce.Do(func() {
+		vmMetrics = &VMMetrics{
+			statusConditionStatus: prometheus.NewGaugeVec(
+				prometheus.GaugeOpts{
+					Namespace: metricsNamespace,
+					Name:      "vm_status_condition_status",
+					Help:      "True/False/Unknown status of a specific condition on a VM resource"},
+				[]string{vmNameLabel, vmNamespaceLabel, conditionTypeLabel, conditionReasonLabel},
+			),
+			powerState: prometheus.NewGaugeVec(
+				prometheus.GaugeOpts{
+					Namespace: metricsNamespace,
+					Name:      "vm_powerstate",
+					Help:      "Desired and current power state on a VM resource"},
+				[]string{vmNameLabel, vmNamespaceLabel, specLabel, statusLabel},
+			),
+
+			statusIP: prometheus.NewGaugeVec(
+				prometheus.GaugeOpts{
+					Namespace: metricsNamespace,
+					Name:      "vm_status_ip",
+					Help:      "IP address assignment status of a VM resource"},
+				[]string{vmNameLabel, vmNamespaceLabel},
+			),
+		}
+
+		metrics.Registry.MustRegister(
+			vmMetrics.statusConditionStatus,
+			vmMetrics.powerState,
+			vmMetrics.statusIP,
+		)
+	})
+
+	return vmMetrics
+}
+
+func (vmm *VMMetrics) RegisterVMCreateOrUpdateMetrics(vmCtx *context.VirtualMachineContextA2) {
+	vmm.registerVMStatusConditions(vmCtx)
+	vmm.registerVMPowerState(vmCtx)
+	vmm.registerVMStatusIP(vmCtx)
+}
+
+// DeleteMetrics deletes metrics for a specific VM post deletion reconcile.
+// It is critical to stop reporting metrics for a deleted VM resource.
+func (vmm *VMMetrics) DeleteMetrics(vmCtx *context.VirtualMachineContextA2) {
+	vm := vmCtx.VM
+	vmCtx.Logger.V(5).Info("Deleting metrics for VM")
+
+	labels := prometheus.Labels{
+		vmNameLabel:      vm.Name,
+		vmNamespaceLabel: vm.Namespace,
+	}
+
+	// Delete the 'vm.status.condition' metrics.
+	vmm.statusConditionStatus.DeletePartialMatch(labels)
+
+	// Delete the 'vm.spec.powerState' metrics.
+	vmm.powerState.DeletePartialMatch(labels)
+
+	// Delete the 'vm.status.ip' metrics.
+	vmm.statusIP.DeletePartialMatch(labels)
+}
+
+func (vmm *VMMetrics) registerVMStatusConditions(vmCtx *context.VirtualMachineContextA2) {
+	vm := vmCtx.VM
+	vmCtx.Logger.V(5).Info("Adding metrics for VM condition")
+
+	// Delete the previous metrics to address any VM condition reason update.
+	labels := prometheus.Labels{
+		vmNameLabel:      vm.Name,
+		vmNamespaceLabel: vm.Namespace,
+	}
+	vmm.statusConditionStatus.DeletePartialMatch(labels)
+
+	for _, condition := range vm.Status.Conditions {
+		labels := prometheus.Labels{
+			vmNameLabel:          vm.Name,
+			vmNamespaceLabel:     vm.Namespace,
+			conditionTypeLabel:   condition.Type,
+			conditionReasonLabel: condition.Reason,
+		}
+		vmm.statusConditionStatus.With(labels).Set(func() float64 {
+			switch condition.Status {
+			case metav1.ConditionTrue:
+				return 1
+			case metav1.ConditionFalse:
+				return 0
+			case metav1.ConditionUnknown:
+				return -1
+			}
+			return -1
+		}())
+	}
+}
+
+func (vmm *VMMetrics) registerVMPowerState(vmCtx *context.VirtualMachineContextA2) {
+	vm := vmCtx.VM
+	vmCtx.Logger.V(5).Info("Adding metrics for VM power state")
+
+	// Delete the existing power state metrics to address any VM's power state change.
+	labels := prometheus.Labels{
+		vmNameLabel:      vm.Name,
+		vmNamespaceLabel: vm.Namespace,
+	}
+	vmm.powerState.DeletePartialMatch(labels)
+
+	newLabels := prometheus.Labels{
+		vmNameLabel:      vm.Name,
+		vmNamespaceLabel: vm.Namespace,
+		specLabel:        string(vm.Spec.PowerState),
+		statusLabel:      string(vm.Status.PowerState),
+	}
+	vmm.powerState.With(newLabels).Set(1)
+}
+
+func (vmm *VMMetrics) registerVMStatusIP(vmCtx *context.VirtualMachineContextA2) {
+	vm := vmCtx.VM
+	vmCtx.Logger.V(5).Info("Adding metrics for VM IP address assignment status")
+
+	labels := prometheus.Labels{
+		vmNameLabel:      vm.Name,
+		vmNamespaceLabel: vm.Namespace,
+	}
+	vmm.statusIP.With(labels).Set(func() float64 {
+		var ip string
+		if vm.Status.Network != nil {
+			if ip = vm.Status.Network.PrimaryIP4; ip == "" {
+				ip = vm.Status.Network.PrimaryIP6
+			}
+		}
+		if ip == "" {
+			return 0
+		}
+		return 1
+	}())
+}

--- a/pkg/vmprovider/fake/fake_vm_provider_a2.go
+++ b/pkg/vmprovider/fake/fake_vm_provider_a2.go
@@ -136,7 +136,7 @@ func (s *VMProviderA2) GetVirtualMachineHardwareVersion(ctx context.Context, vm 
 	if s.GetVirtualMachineHardwareVersionFn != nil {
 		return s.GetVirtualMachineHardwareVersionFn(ctx, vm)
 	}
-	return 13, nil
+	return 15, nil
 }
 
 func (s *VMProviderA2) CreateOrUpdateVirtualMachineSetResourcePolicy(ctx context.Context, resourcePolicy *vmopv1.VirtualMachineSetResourcePolicy) error {

--- a/test/builder/utila2.go
+++ b/test/builder/utila2.go
@@ -172,3 +172,37 @@ func DummyInstanceStorageVirtualMachineVolumesA2() []vmopv1.VirtualMachineVolume
 		},
 	}
 }
+
+func DummyVirtualMachineImageA2(imageName string) *vmopv1.VirtualMachineImage {
+	return &vmopv1.VirtualMachineImage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: imageName,
+		},
+		Status: vmopv1.VirtualMachineImageStatus{
+			Name: imageName,
+			ProductInfo: vmopv1.VirtualMachineImageProductInfo{
+				FullVersion: DummyDistroVersion,
+			},
+			OSInfo: vmopv1.VirtualMachineImageOSInfo{
+				Type: DummyOSType,
+			},
+		},
+	}
+}
+
+func DummyClusterVirtualMachineImageA2(imageName string) *vmopv1.ClusterVirtualMachineImage {
+	return &vmopv1.ClusterVirtualMachineImage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: imageName,
+		},
+		Status: vmopv1.VirtualMachineImageStatus{
+			Name: imageName,
+			ProductInfo: vmopv1.VirtualMachineImageProductInfo{
+				FullVersion: DummyDistroVersion,
+			},
+			OSInfo: vmopv1.VirtualMachineImageOSInfo{
+				Type: DummyOSType,
+			},
+		},
+	}
+}

--- a/webhooks/virtualmachine/v1alpha2/validation/helpers.go
+++ b/webhooks/virtualmachine/v1alpha2/validation/helpers.go
@@ -8,10 +8,6 @@ import "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 // This file contains v1a2 related changes in other packages that haven't been
 // committed yet.
 
-func cNSAttachmentNameForVolume(vmName string, volumeName string) string {
-	return vmName + "-" + volumeName
-}
-
 func filterVolumesA2(vm *v1alpha2.VirtualMachine) []v1alpha2.VirtualMachineVolume {
 	var volumes []v1alpha2.VirtualMachineVolume
 	for _, vol := range vm.Spec.Volumes {

--- a/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator.go
@@ -31,6 +31,7 @@ import (
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	"github.com/vmware-tanzu/vm-operator/api/v1alpha2/cloudinit"
 	"github.com/vmware-tanzu/vm-operator/api/v1alpha2/sysprep"
+	volume "github.com/vmware-tanzu/vm-operator/controllers/volume/v1alpha2"
 	"github.com/vmware-tanzu/vm-operator/pkg/builder"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/lib"
@@ -373,7 +374,7 @@ func (v validator) validateVolumes(ctx *context.WebhookRequestContext, vm *vmopv
 		}
 
 		if vol.Name != "" {
-			errs := validation.NameIsDNSSubdomain(cNSAttachmentNameForVolume(vm.Name, vol.Name), false)
+			errs := validation.NameIsDNSSubdomain(volume.CNSAttachmentNameForVolume(vm.Name, vol.Name), false)
 			for _, msg := range errs {
 				allErrs = append(allErrs, field.Invalid(volPath.Child("name"), vol.Name, msg))
 			}


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This imports the v1a2 controllers and other requisite changes. Like as was done with the v1a2 webhooks in 9869e81, the integrations tests disabled until we can sort out the mess of dealing with multiple manifest generations on a single branch. Generally, when possible this is mostly a mechanical change, and the diff between v1a1 and v1a2 controllers is relatively small.

This is primarily diff reduction with the v1a2 branch, and allows changes to be made to both versions together since we're still some time from flipping the switch. This is unfortunately a painful and disruptive change.

```release-note
NONE
```