### PR TITLE
✨ Make infra related controllers v1a2 aware

### DIFF
--- a/pkg/context/controller_manager_context.go
+++ b/pkg/context/controller_manager_context.go
@@ -74,6 +74,9 @@ type ControllerManagerContext struct {
 
 	// VMProvider is the controller manager's VM Provider
 	VMProvider vmprovider.VirtualMachineProviderInterface
+
+	// VMProviderA2 is the controller manager's VM Provider for v1alpha2
+	VMProviderA2 vmprovider.VirtualMachineProviderInterfaceA2
 }
 
 // String returns ControllerManagerName.


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

There is nothing inherently v1a2 about these controllers, but the way we have the fat VMProvider interface makes them so. We've wanted to and should get away from our current not Go'ish interface but that is out of scope for my current work. So just for these controllers, define the interface they need and pick the appropriate provider based on the FSS

```release-note
NONE
```