### PR TITLE
🐛 Bump manager container memory limit

### DIFF
--- a/config/wcp/vmoperator/cpu_resources_patch.yaml
+++ b/config/wcp/vmoperator/cpu_resources_patch.yaml
@@ -13,7 +13,7 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 500Mi
+            memory: 550Mi
           requests:
             cpu: 100m
             memory: 75Mi


### PR DESCRIPTION
The is the quickest change to alleviate the OOM we're seeing in large scale test envs.

Longer term work of setting GOMEMLIMIT, using more metadata only watches, disabling the ctrl-runtime Client for more types, and reworking some types to not store large dumps of data in the annotations so MD-only watches are more effective is needed.

```release-note
NONE
```