### PR TITLE
📖 Add troubleshooting readme and troubleshooting deploy vm

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@ Please add one of the following icons to the title of this PR:
 Some other tips:
 
     1. If this is your first time filing a PR, please read our contributor
-       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/latest/start/contrib/submit-change/.
+       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
     2. If this PR is unfinished, please prefix the subject with "WIP:".
 
 Finally, before filing the PR, please delete all of the HTML comments.

--- a/docs/concepts/workloads/guest.md
+++ b/docs/concepts/workloads/guest.md
@@ -362,7 +362,7 @@ To illustrate, the following YAML can be utilized to deploy a VirtualMachine and
     management_gateway: "{{ (index .V1alpha1.Net.Devices 0).Gateway4 }}"
     ```
 
-For more information on vAppConfig, please refer to [tutorial/deploy-vm/vappconfig](https://vm-operator.readthedocs.io/en/latest/tutorials/deploy-vm/vappconfig/).
+For more information on vAppConfig, please refer to [tutorial/deploy-vm/vappconfig](https://vm-operator.readthedocs.io/en/stable/tutorials/deploy-vm/vappconfig/).
 ## Deprecated
 
 The following bootstrap providers are still available, but they are deprecated and are not recommended.

--- a/docs/tutorials/deploy-vm/README.md
+++ b/docs/tutorials/deploy-vm/README.md
@@ -118,7 +118,7 @@ There are a number of methods that may be used to bootstrap a virtual machine's 
 #### Cloud-Init
 
 Cloud-init is the industry standard multi-distribution method for cross-platform cloud instance initialisation.
-Refer to [Deploy a VM With Cloud-Init](https://vm-operator.readthedocs.io/en/latest/tutorials/deploy-vm/cloudinit/) for instructions to use this bootstrap method.
+Refer to [Deploy a VM With Cloud-Init](https://vm-operator.readthedocs.io/en/stable/tutorials/deploy-vm/cloudinit/) for instructions to use this bootstrap method.
 
 #### Sysprep
 
@@ -233,7 +233,7 @@ For more information on Sysprep, please refer to Microsoft's [official documenta
 #### vAppConfig
 
 The vAppConfig bootstrap method is useful for legacy, VM images that rely on bespoke, boot-time processes that leverage vAppConfig properties for customizing a guest.
-Refer to [Deploy a VM with vAppConfig](https://vm-operator.readthedocs.io/en/latest/tutorials/deploy-vm/vappconfig/) for instructions to use this bootstrap method.
+Refer to [Deploy a VM with vAppConfig](https://vm-operator.readthedocs.io/en/stable/tutorials/deploy-vm/vappconfig/) for instructions to use this bootstrap method.
 
 ### Deprecated
 

--- a/docs/tutorials/troubleshooting/README.md
+++ b/docs/tutorials/troubleshooting/README.md
@@ -1,3 +1,10 @@
 # Troubleshooting
+This page reviews troubleshooting procedures related to VM Operator. This page is designed to assist you in identifying and resolving common issues that you might encounter while using VM Operator. Please follow the sections below for troubleshooting different scenarios.
 
-// TODO ([github.com/vmware-tanzu/vm-operator#124](https://github.com/vmware-tanzu/vm-operator/issues/124))
+## Common issues users may encounter:
+- [VM Deployment](https://vm-operator.readthedocs.io/en/stable/tutorials/troubleshooting/deploy-vm)
+- [IP Assignment](https://vm-operator.readthedocs.io/en/stable/tutorials/troubleshooting/ip-assignment)
+- [VM Publish](https://vm-operator.readthedocs.io/en/stable/tutorials/troubleshooting/publish-vm)
+
+## Web console
+In situations where Virtual Machines become inaccessible through the normal network, a console session via the VM Web Console can be an invaluable tool for diagnosing and resolving issues. Refer to [Get a Console Session](https://vm-operator.readthedocs.io/en/stable/tutorials/troubleshooting/get-console-session)

--- a/docs/tutorials/troubleshooting/deploy-vm.md
+++ b/docs/tutorials/troubleshooting/deploy-vm.md
@@ -1,0 +1,73 @@
+# Deploy VM
+This page is dedicated to diagnose issues that can arise during the deployment of virtual machines. Refer to [Deploy VM tutorial](https://vm-operator.readthedocs.io/en/stable/tutorials/deploy-vm/) on how to deploy a virtual machine.
+
+## Best practice
+- Create a namespace
+- Make sure the VM image is available in the namespace.
+```console
+$ kubectl get virtualmachineimage -n <namespace-name>
+$ kubectl get contentlibrary -n <namespace-name>
+```
+- Make sure storage class is specified in the namespace
+```console
+$ kubectl get storageclass -n <namespace-name>
+```
+- Make sure VM Class is attached to the namespace
+```console
+$ kubectl get vmclass -n <namespace-name>
+```
+- Make sure appropriate transport is chosen
+- Deploy VM
+
+## Troubleshoot step
+
+### 1. Access your namespace in the Kubernetes environment.
+
+```console
+$ kubectl config use-context <context-name>
+```
+
+See [Get and Use the Supervisor Context](https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-with-tanzu-services-workloads/GUID-63A1C273-DC75-420B-B7FD-47CB25A50A2C.html#GUID-63A1C273-DC75-420B-B7FD-47CB25A50A2C) if you need help accessing Supervisor clusters.
+
+### 2. Describe Virtual Machine k8s resource
+Run `kubectl describe vm <vm-name> -n <namespace-name>` command. Check `VM.Status.Conditions` as seen in sample output below.
+
+```console
+$ kubectl describe vm <vm-name> -n <namespace-name>
+
+...
+Status:
+  Conditions:
+    Last Transition Time:  2022-07-06T00:43:47Z
+    Status:                Unknown
+    Type:                  GuestCustomization
+    Last Transition Time:  2022-07-06T00:42:41Z
+    Status:                True
+    Type:                  VirtualMachinePrereqReady
+    Last Transition Time:  2022-07-06T00:43:47Z
+    Message:               VMware Tools is not running
+    Reason:                VirtualMachineToolsNotRunning
+    Severity:              Error
+    Status:                False
+    Type:                  VirtualMachineTools
+...
+```
+
+## Error and fix
+This section focuses on leveraging the information provided by the `VM.Status.Conditions` field to diagnose the root cause of errors and provide solutions. By analyzing which conditions showed `Status` as `False`/`Unknown` and `Reason`, you can troubleshoot issues depending on below scenarios.
+
+### VirtualMachinePrereqReady
+- Reason `VirtualMachineClassBindingNotFound`(*deprecated*)/`VirtualMachineClassNotFound`: this means that the VM class has not been associated to the Supervisor namespace.
+    - **Fix**: Attach VM Class to your namespace. Refer to [VMClass](https://vm-operator.readthedocs.io/en/stable/concepts/workloads/vm-class/) for details.
+- Reason `VirtualMachineImageNotFound`: this means that the VirtualMachine Image doesn't exist in the supervisor cluster, which means that this VM image doesn't exist in the vCenter, or the content library which it belongs to has not been associated to any of the supervisor namespaces. 
+    - **Fix**: Upload mentioned VM Image to content library and associate content library to your namespace. Refer to [VM Image](https://vm-operator.readthedocs.io/en/stable/concepts/images/) for details.
+- Reason `ContentSourceBindingNotFound` (*deprecated*): this means that the content library which contains the specified VM Image has not been associated to the Supervisor namespace. 
+    - **Fix**: Associate content library to your namespace. Refer to [VM Image](https://vm-operator.readthedocs.io/en/stable/concepts/images/) for details.
+
+### GuestCustomization/VirtualMachineTools
+- Reason `VirtualMachineToolsNotRunning`:
+This could be happening when VM tools is not installed on the image at use.
+    - **Fix**: Make sure image has VM tools installed. Then [get a console session](https://vm-operator.readthedocs.io/en/stable/tutorials/troubleshooting/get-console-session/) to debug further.
+- Reason `GuestCustomizationFailed`/`VirtualMachineToolsNotRunning`:
+This could be happening when using transport `OvfEnv/ExtraConfig` to deploy a VM. These two transports use VMTools for network configuration, using incompatible virtual machine images could cause race with cloud-init user-data configuration. 
+    - **Fix**: [Get a console session](https://vm-operator.readthedocs.io/en/stable/tutorials/troubleshooting/get-console-session/) to debug further. And consider using transport `CloudInit` for wider VM Image support. Refer to [Deploy with CloudInit](https://vm-operator.readthedocs.io/en/stable/tutorials/deploy-vm/cloudinit/) for details.

--- a/docs/tutorials/troubleshooting/ip-assignment.md
+++ b/docs/tutorials/troubleshooting/ip-assignment.md
@@ -1,0 +1,2 @@
+# Virtual Machine No valid IP Address
+// TODO (github.com/vmware-tanzu/vm-operator#193)

--- a/docs/tutorials/troubleshooting/publish-vm.md
+++ b/docs/tutorials/troubleshooting/publish-vm.md
@@ -1,0 +1,2 @@
+# Publish Virtual Machine
+// TODO (github.com/vmware-tanzu/vm-operator#200)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -149,6 +149,9 @@ nav:
   - Troubleshooting:
     - tutorials/troubleshooting/README.md
     - Get a Console Session: tutorials/troubleshooting/get-console-session.md
+    - VM Deployment: tutorials/troubleshooting/deploy-vm.md
+    - IP Assignment: tutorials/troubleshooting/ip-assignment.md
+    - VM Publish: tutorials/troubleshooting/publish-vm.md
 - Reference:
   - ref/README.md
   - API:


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
Add readme page for https://vm-operator.readthedocs.io/en/stable/tutorials/troubleshooting/ and how to troubleshoot failure on vm deployment. This change also created place holders for troubleshooting VM failed to get a valid IP Address page and troubleshooting VM publish failure.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #124 


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```

<!-- readthedocs-preview vm-operator start -->
----
:books: Documentation preview :books:: https://vm-operator--201.org.readthedocs.build/en/201/

<!-- readthedocs-preview vm-operator end -->