### PR TITLE
✨Generate v1a2 CRD and webhooks manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -271,7 +271,7 @@ generate-go: ## Generate deepcopy
 generate-manifests: | $(CONTROLLER_GEN)
 generate-manifests: ## Generate manifests e.g. CRD, RBAC etc.
 	$(CONTROLLER_GEN) \
-		paths=github.com/vmware-tanzu/vm-operator/api/v1alpha1/... \
+		paths=github.com/vmware-tanzu/vm-operator/api/... \
 		crd:crdVersions=v1 \
 		output:crd:dir=$(CRD_ROOT) \
 		output:none

--- a/config/crd/bases/vmoperator.vmware.com_clustervirtualmachineimages.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_clustervirtualmachineimages.yaml
@@ -279,3 +279,246 @@ spec:
     storage: true
     subresources:
       status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.name
+      name: Image Name
+      type: string
+    - jsonPath: .status.productInfo.version
+      name: Image Version
+      type: string
+    - jsonPath: .status.osInfo.type
+      name: OS Name
+      type: string
+    - jsonPath: .status.osInfo.version
+      name: OS Version
+      type: string
+    - jsonPath: .status.hardwareVersion
+      name: Hardware Version
+      type: string
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: ClusterVirtualMachineImage is the schema for the clustervirtualmachineimages
+          API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualMachineImageSpec defines the desired state of VirtualMachineImage.
+            properties:
+              providerRef:
+                description: ProviderRef is a reference to the resource that contains
+                  the source of this image's information.
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this
+                      representation of an object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  kind:
+                    description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name refers to a unique resource in the current
+                      namespace. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+            type: object
+          status:
+            description: VirtualMachineImageStatus defines the observed state of VirtualMachineImage.
+            properties:
+              capabilities:
+                description: "Capabilities describes the image's observed capabilities.
+                  \n The capabilities are discerned when VM Operator reconciles an
+                  image. If the source of an image is an OVF in Content Library, then
+                  the capabilities are parsed from the OVF property capabilities.image.vmoperator.vmware.com
+                  as a comma-separated list of values. Well-known capabilities include:
+                  \n * cloud-init * nvidia-gpu * sriov-net \n Every capability is
+                  also added to the resource's labels as VirtualMachineImageCapabilityLabel
+                  + Value. For example, if the capability is \"cloud-init\" then the
+                  following label will be added to the resource: capability.image.vmoperator.vmware.com/cloud-init."
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              conditions:
+                description: Conditions describes the observed conditions for this
+                  image.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              firmware:
+                description: Firmware describe the firmware type used by this image,
+                  ex. BIOS, EFI.
+                type: string
+              hardwareVersion:
+                description: HardwareVersion describes the observed hardware version
+                  of this image.
+                format: int32
+                type: integer
+              name:
+                description: Name describes the observed, "friendly" name for this
+                  image.
+                type: string
+              osInfo:
+                description: "OSInfo describes the observed operating system information
+                  for this image. \n The OS information is also added to the image
+                  resource's labels. Please refer to VirtualMachineImageOSInfo for
+                  more information."
+                properties:
+                  id:
+                    description: "ID describes the operating system ID. \n This value
+                      is also added to the image resource's labels as VirtualMachineImageOSIDLabel."
+                    type: string
+                  type:
+                    description: "Type describes the operating system type. \n This
+                      value is also added to the image resource's labels as VirtualMachineImageOSTypeLabel."
+                    type: string
+                  version:
+                    description: "Version describes the operating system version.
+                      \n This value is also added to the image resource's labels as
+                      VirtualMachineImageOSVersionLabel."
+                    type: string
+                type: object
+              ovfProperties:
+                description: OVFProperties describes the observed OVF properties defined
+                  for this image.
+                items:
+                  description: OVFProperty describes an OVF property associated with
+                    an image. OVF properties may be used in conjunction with the vAppConfig
+                    bootstrap provider to customize a VM during its creation.
+                  properties:
+                    default:
+                      description: Default describes the OVF property's default value.
+                      type: string
+                    key:
+                      description: Key describes the OVF property's key.
+                      type: string
+                    type:
+                      description: Type describes the OVF property's type.
+                      type: string
+                  required:
+                  - key
+                  - type
+                  type: object
+                type: array
+              productInfo:
+                description: ProductInfo describes the observed product information
+                  for this image.
+                properties:
+                  fullVersion:
+                    description: FullVersion describes the long-form version of the
+                      image.
+                    type: string
+                  product:
+                    description: Product is a general descriptor for the image.
+                    type: string
+                  vendor:
+                    description: Vendor describes the organization/user that produced
+                      the image.
+                    type: string
+                  version:
+                    description: Version describes the short-form version of the image.
+                    type: string
+                type: object
+              providerContentVersion:
+                description: ProviderContentVersion describes the content version
+                  from the provider item that this image corresponds to. If the provider
+                  of this image is a Content Library, this will be the version of
+                  the corresponding Content Library item.
+                type: string
+              providerItemID:
+                description: ProviderItemID describes the ID of the provider item
+                  that this image corresponds to. If the provider of this image is
+                  a Content Library, this ID will be that of the corresponding Content
+                  Library item.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachineclasses.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachineclasses.yaml
@@ -218,3 +218,287 @@ spec:
     storage: true
     subresources:
       status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.hardware.cpus
+      name: CPU
+      type: string
+    - jsonPath: .spec.hardware.memory
+      name: Memory
+      type: string
+    - jsonPath: .status.capabilities
+      name: Capabilities
+      priority: 1
+      type: string
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: VirtualMachineClass is the schema for the virtualmachineclasses
+          API and represents the desired state and observed status of a virtualmachineclasses
+          resource.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualMachineClassSpec defines the desired state of VirtualMachineClass.
+            properties:
+              configSpec:
+                description: ConfigSpec describes additional configuration information
+                  for a VirtualMachine. The contents of this field are the VirtualMachineConfigSpec
+                  data object (https://bit.ly/3HDtiRu) marshaled to JSON using the
+                  discriminator field "_typeName" to preserve type information.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              controllerName:
+                description: "ControllerName describes the name of the controller
+                  responsible for reconciling VirtualMachine resources that are realized
+                  from this VirtualMachineClass. \n When omitted, controllers reconciling
+                  VirtualMachine resources determine the default controller name from
+                  the environment variable DEFAULT_VM_CLASS_CONTROLLER_NAME. If this
+                  environment variable is not defined or empty, it defaults to vmoperator.vmware.com/vsphere.
+                  \n Once a non-empty value is assigned to this field, attempts to
+                  set this field to an empty value will be silently ignored."
+                type: string
+              description:
+                description: Description describes the configuration of the VirtualMachineClass
+                  which is not related to virtual hardware or infrastructure policy.
+                  This field is used to address remaining specs about this VirtualMachineClass.
+                type: string
+              hardware:
+                description: Hardware describes the configuration of the VirtualMachineClass
+                  attributes related to virtual hardware. The configuration specified
+                  in this field is used to customize the virtual hardware characteristics
+                  of any VirtualMachine associated with this VirtualMachineClass.
+                properties:
+                  cpus:
+                    format: int64
+                    type: integer
+                  devices:
+                    description: VirtualDevices contains information about the virtual
+                      devices associated with a VirtualMachineClass.
+                    properties:
+                      dynamicDirectPathIODevices:
+                        items:
+                          description: DynamicDirectPathIODevice contains the configuration
+                            corresponding to a Dynamic DirectPath I/O device.
+                          properties:
+                            customLabel:
+                              type: string
+                            deviceID:
+                              format: int64
+                              type: integer
+                            vendorID:
+                              format: int64
+                              type: integer
+                          required:
+                          - deviceID
+                          - vendorID
+                          type: object
+                        type: array
+                      vgpuDevices:
+                        items:
+                          description: VGPUDevice contains the configuration corresponding
+                            to a vGPU device.
+                          properties:
+                            profileName:
+                              type: string
+                          required:
+                          - profileName
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - profileName
+                        x-kubernetes-list-type: map
+                    type: object
+                  instanceStorage:
+                    description: InstanceStorage provides information used to configure
+                      instance storage volumes for a VirtualMachine.
+                    properties:
+                      storageClass:
+                        description: StorageClass refers to the name of a StorageClass
+                          resource used to provide the storage for the configured
+                          instance storage volumes. The value of this field has no
+                          relationship to or bearing on the field virtualMachine.spec.storageClass.
+                          Please note the referred StorageClass must be available
+                          in the same namespace as the VirtualMachineClass that uses
+                          it for configuring instance storage.
+                        type: string
+                      volumes:
+                        description: Volumes describes instance storage volumes created
+                          for a VirtualMachine instance that use this VirtualMachineClass.
+                        items:
+                          description: InstanceStorageVolume contains information
+                            required to create an instance storage volume on a VirtualMachine.
+                          properties:
+                            size:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - size
+                          type: object
+                        type: array
+                    type: object
+                  memory:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                type: object
+              policies:
+                description: Policies describes the configuration of the VirtualMachineClass
+                  attributes related to virtual infrastructure policy. The configuration
+                  specified in this field is used to customize various policies related
+                  to infrastructure resource consumption.
+                properties:
+                  resources:
+                    description: VirtualMachineClassResources describes the virtual
+                      hardware resource reservations and limits configuration to be
+                      used by a VirtualMachineClass.
+                    properties:
+                      limits:
+                        description: VirtualMachineResourceSpec describes a virtual
+                          hardware policy specification.
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        description: VirtualMachineResourceSpec describes a virtual
+                          hardware policy specification.
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                type: object
+            type: object
+          status:
+            description: VirtualMachineClassStatus defines the observed state of VirtualMachineClass.
+            properties:
+              capabilities:
+                description: "Capabilities describes the class's observed capabilities.
+                  \n The capabilities are discerned when VM Operator reconciles a
+                  class and inspects its specification. Well-known capabilities include:
+                  \n * instance-storage * nvidia-gpu * sriov-net \n In addition to
+                  \"nvidia-gpu\", a capability is added for every nVidia profile name
+                  associated with the class. \n Every capability is also added to
+                  the resource's labels as VirtualMachineClassCapabilityLabel + Value.
+                  For example, if the capability is \"nvidia-gpu\" then the following
+                  label will be added to the resource: capability.class.vmoperator.vmware.com/nvidia-gpu."
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              conditions:
+                description: Conditions describes the observed conditions of the VirtualMachineClass.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              ready:
+                description: "Ready describes whether the class's hardware can be
+                  realized in the cluster. \n This field is only set to true if all
+                  of the class resource's conditions have Status=True."
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachineimages.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachineimages.yaml
@@ -279,3 +279,249 @@ spec:
     storage: true
     subresources:
       status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.name
+      name: Image Name
+      type: string
+    - jsonPath: .status.productInfo.version
+      name: Image Version
+      type: string
+    - jsonPath: .status.osInfo.type
+      name: OS Name
+      type: string
+    - jsonPath: .status.osInfo.version
+      name: OS Version
+      type: string
+    - jsonPath: .status.hardwareVersion
+      name: Hardware Version
+      type: string
+    - jsonPath: .status.capabilities
+      name: Capabilities
+      type: string
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: VirtualMachineImage is the schema for the virtualmachineimages
+          API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualMachineImageSpec defines the desired state of VirtualMachineImage.
+            properties:
+              providerRef:
+                description: ProviderRef is a reference to the resource that contains
+                  the source of this image's information.
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this
+                      representation of an object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  kind:
+                    description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name refers to a unique resource in the current
+                      namespace. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+            type: object
+          status:
+            description: VirtualMachineImageStatus defines the observed state of VirtualMachineImage.
+            properties:
+              capabilities:
+                description: "Capabilities describes the image's observed capabilities.
+                  \n The capabilities are discerned when VM Operator reconciles an
+                  image. If the source of an image is an OVF in Content Library, then
+                  the capabilities are parsed from the OVF property capabilities.image.vmoperator.vmware.com
+                  as a comma-separated list of values. Well-known capabilities include:
+                  \n * cloud-init * nvidia-gpu * sriov-net \n Every capability is
+                  also added to the resource's labels as VirtualMachineImageCapabilityLabel
+                  + Value. For example, if the capability is \"cloud-init\" then the
+                  following label will be added to the resource: capability.image.vmoperator.vmware.com/cloud-init."
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              conditions:
+                description: Conditions describes the observed conditions for this
+                  image.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              firmware:
+                description: Firmware describe the firmware type used by this image,
+                  ex. BIOS, EFI.
+                type: string
+              hardwareVersion:
+                description: HardwareVersion describes the observed hardware version
+                  of this image.
+                format: int32
+                type: integer
+              name:
+                description: Name describes the observed, "friendly" name for this
+                  image.
+                type: string
+              osInfo:
+                description: "OSInfo describes the observed operating system information
+                  for this image. \n The OS information is also added to the image
+                  resource's labels. Please refer to VirtualMachineImageOSInfo for
+                  more information."
+                properties:
+                  id:
+                    description: "ID describes the operating system ID. \n This value
+                      is also added to the image resource's labels as VirtualMachineImageOSIDLabel."
+                    type: string
+                  type:
+                    description: "Type describes the operating system type. \n This
+                      value is also added to the image resource's labels as VirtualMachineImageOSTypeLabel."
+                    type: string
+                  version:
+                    description: "Version describes the operating system version.
+                      \n This value is also added to the image resource's labels as
+                      VirtualMachineImageOSVersionLabel."
+                    type: string
+                type: object
+              ovfProperties:
+                description: OVFProperties describes the observed OVF properties defined
+                  for this image.
+                items:
+                  description: OVFProperty describes an OVF property associated with
+                    an image. OVF properties may be used in conjunction with the vAppConfig
+                    bootstrap provider to customize a VM during its creation.
+                  properties:
+                    default:
+                      description: Default describes the OVF property's default value.
+                      type: string
+                    key:
+                      description: Key describes the OVF property's key.
+                      type: string
+                    type:
+                      description: Type describes the OVF property's type.
+                      type: string
+                  required:
+                  - key
+                  - type
+                  type: object
+                type: array
+              productInfo:
+                description: ProductInfo describes the observed product information
+                  for this image.
+                properties:
+                  fullVersion:
+                    description: FullVersion describes the long-form version of the
+                      image.
+                    type: string
+                  product:
+                    description: Product is a general descriptor for the image.
+                    type: string
+                  vendor:
+                    description: Vendor describes the organization/user that produced
+                      the image.
+                    type: string
+                  version:
+                    description: Version describes the short-form version of the image.
+                    type: string
+                type: object
+              providerContentVersion:
+                description: ProviderContentVersion describes the content version
+                  from the provider item that this image corresponds to. If the provider
+                  of this image is a Content Library, this will be the version of
+                  the corresponding Content Library item.
+                type: string
+              providerItemID:
+                description: ProviderItemID describes the ID of the provider item
+                  that this image corresponds to. If the provider of this image is
+                  a Content Library, this ID will be that of the corresponding Content
+                  Library item.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachinepublishrequests.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachinepublishrequests.yaml
@@ -295,3 +295,306 @@ spec:
     storage: true
     subresources:
       status: {}
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: VirtualMachinePublishRequest defines the information necessary
+          to publish a VirtualMachine as a VirtualMachineImage to an image registry.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: "VirtualMachinePublishRequestSpec defines the desired state
+              of a VirtualMachinePublishRequest. \n All the fields in this spec are
+              optional. This is especially useful when a DevOps persona wants to publish
+              a VM without doing anything more than applying a VirtualMachinePublishRequest
+              resource that has the same name as said VM in the same namespace as
+              said VM."
+            properties:
+              source:
+                description: "Source is the source of the publication request, ex.
+                  a VirtualMachine resource. \n If this value is omitted then the
+                  publication controller checks to see if there is a resource with
+                  the same name as this VirtualMachinePublishRequest resource, an
+                  API version equal to spec.source.apiVersion, and a kind equal to
+                  spec.source.kind. If such a resource exists, then it is the source
+                  of the publication."
+                properties:
+                  apiVersion:
+                    default: vmoperator.vmware.com/v1alpha1
+                    description: APIVersion is the API version of the referenced object.
+                    type: string
+                  kind:
+                    default: VirtualMachine
+                    description: Kind is the kind of referenced object.
+                    type: string
+                  name:
+                    description: "Name is the name of the referenced object. \n If
+                      omitted this value defaults to the name of the VirtualMachinePublishRequest
+                      resource."
+                    type: string
+                type: object
+              target:
+                description: "Target is the target of the publication request, ex.
+                  item information and a ContentLibrary resource. \n If this value
+                  is omitted, the controller uses spec.source.name + \"-image\" as
+                  the name of the published item. Additionally, when omitted the controller
+                  attempts to identify the target location by matching a resource
+                  with an API version equal to spec.target.location.apiVersion, a
+                  kind equal to spec.target.location.kind, w/ the label \"imageregistry.vmware.com/default\".
+                  \n Please note that while optional, if a VirtualMachinePublishRequest
+                  sans target information is applied to a namespace without a default
+                  publication target, then the VirtualMachinePublishRequest resource
+                  will be marked in error."
+                properties:
+                  item:
+                    description: "Item contains information about the name of the
+                      object to which the VM is published. \n Please note this value
+                      is optional and if omitted, the controller will use spec.source.name
+                      + \"-image\" as the name of the published item."
+                    properties:
+                      description:
+                        description: Description is the description to assign to the
+                          published object.
+                        type: string
+                      name:
+                        description: "Name is the name of the published object. \n
+                          If the spec.target.location.apiVersion equals imageregistry.vmware.com/v1alpha1
+                          and the spec.target.location.kind equals ContentLibrary,
+                          then this should be the name that will show up in vCenter
+                          Content Library, not the custom resource name in the namespace.
+                          \n If omitted then the controller will use spec.source.name
+                          + \"-image\"."
+                        type: string
+                    type: object
+                  location:
+                    description: Location contains information about the location
+                      to which to publish the VM.
+                    properties:
+                      apiVersion:
+                        default: imageregistry.vmware.com/v1alpha1
+                        description: APIVersion is the API version of the referenced
+                          object.
+                        type: string
+                      kind:
+                        default: ContentLibrary
+                        description: Kind is the kind of referenced object.
+                        type: string
+                      name:
+                        description: "Name is the name of the referenced object. \n
+                          Please note an error will be returned if this field is not
+                          set in a namespace that lacks a default publication target.
+                          \n A default publication target is a resource with an API
+                          version equal to spec.target.location.apiVersion, a kind
+                          equal to spec.target.location.kind, and has the label \"imageregistry.vmware.com/default\"."
+                        type: string
+                    type: object
+                type: object
+              ttlSecondsAfterFinished:
+                description: "TTLSecondsAfterFinished is the time-to-live duration
+                  for how long this resource will be allowed to exist once the publication
+                  operation completes. After the TTL expires, the resource will be
+                  automatically deleted without the user having to take any direct
+                  action. \n If this field is unset then the request resource will
+                  not be automatically deleted. If this field is set to zero then
+                  the request resource is eligible for deletion immediately after
+                  it finishes."
+                format: int64
+                minimum: 0
+                type: integer
+            type: object
+          status:
+            description: VirtualMachinePublishRequestStatus defines the observed state
+              of a VirtualMachinePublishRequest.
+            properties:
+              attempts:
+                description: Attempts represents the number of times the request to
+                  publish the VM has been attempted.
+                format: int64
+                type: integer
+              completionTime:
+                description: "CompletionTime represents time when the request was
+                  completed. It is not guaranteed to be set in happens-before order
+                  across separate operations. It is represented in RFC3339 form and
+                  is in UTC. \n The value of this field should be equal to the value
+                  of the LastTransitionTime for the status condition Type=Complete."
+                format: date-time
+                type: string
+              conditions:
+                description: Conditions is a list of the latest, available observations
+                  of the request's current state.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              imageName:
+                description: "ImageName is the name of the VirtualMachineImage resource
+                  that is eventually realized in the same namespace as the VM and
+                  publication request after the publication operation completes. \n
+                  This field will not be set until the VirtualMachineImage resource
+                  is realized."
+                type: string
+              lastAttemptTime:
+                description: LastAttemptTime represents the time when the latest request
+                  was sent.
+                format: date-time
+                type: string
+              ready:
+                description: "Ready is set to true only when the VM has been published
+                  successfully and the new VirtualMachineImage resource is ready.
+                  \n Readiness is determined by waiting until there is status condition
+                  Type=Complete and ensuring it and all other status conditions present
+                  have a Status=True. The conditions present will be: \n * SourceValid
+                  * TargetValid * Uploaded * ImageAvailable * Complete"
+                type: boolean
+              sourceRef:
+                description: SourceRef is the reference to the source of the publication
+                  request, ex. a VirtualMachine resource.
+                properties:
+                  apiVersion:
+                    default: vmoperator.vmware.com/v1alpha1
+                    description: APIVersion is the API version of the referenced object.
+                    type: string
+                  kind:
+                    default: VirtualMachine
+                    description: Kind is the kind of referenced object.
+                    type: string
+                  name:
+                    description: "Name is the name of the referenced object. \n If
+                      omitted this value defaults to the name of the VirtualMachinePublishRequest
+                      resource."
+                    type: string
+                type: object
+              startTime:
+                description: StartTime represents time when the request was acknowledged
+                  by the controller. It is not guaranteed to be set in happens-before
+                  order across separate operations. It is represented in RFC3339 form
+                  and is in UTC.
+                format: date-time
+                type: string
+              targetRef:
+                description: TargetRef is the reference to the target of the publication
+                  request, ex. item information and a ContentLibrary resource.
+                properties:
+                  item:
+                    description: "Item contains information about the name of the
+                      object to which the VM is published. \n Please note this value
+                      is optional and if omitted, the controller will use spec.source.name
+                      + \"-image\" as the name of the published item."
+                    properties:
+                      description:
+                        description: Description is the description to assign to the
+                          published object.
+                        type: string
+                      name:
+                        description: "Name is the name of the published object. \n
+                          If the spec.target.location.apiVersion equals imageregistry.vmware.com/v1alpha1
+                          and the spec.target.location.kind equals ContentLibrary,
+                          then this should be the name that will show up in vCenter
+                          Content Library, not the custom resource name in the namespace.
+                          \n If omitted then the controller will use spec.source.name
+                          + \"-image\"."
+                        type: string
+                    type: object
+                  location:
+                    description: Location contains information about the location
+                      to which to publish the VM.
+                    properties:
+                      apiVersion:
+                        default: imageregistry.vmware.com/v1alpha1
+                        description: APIVersion is the API version of the referenced
+                          object.
+                        type: string
+                      kind:
+                        default: ContentLibrary
+                        description: Kind is the kind of referenced object.
+                        type: string
+                      name:
+                        description: "Name is the name of the referenced object. \n
+                          Please note an error will be returned if this field is not
+                          set in a namespace that lacks a default publication target.
+                          \n A default publication target is a resource with an API
+                          version equal to spec.target.location.apiVersion, a kind
+                          equal to spec.target.location.kind, and has the label \"imageregistry.vmware.com/default\"."
+                        type: string
+                    type: object
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -596,3 +596,2119 @@ spec:
     storage: true
     subresources:
       status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.class.name
+      name: Class
+      priority: 1
+      type: string
+    - jsonPath: .status.image.name
+      name: Image
+      priority: 1
+      type: string
+    - jsonPath: .status.powerState
+      name: PowerState
+      type: string
+    - jsonPath: .status.network.primaryIP4
+      name: Primary-IP4
+      priority: 1
+      type: string
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: VirtualMachine is the schema for the virtualmachines API and
+          represents the desired state and observed status of a virtualmachines resource.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualMachineSpec defines the desired state of a VirtualMachine.
+            properties:
+              advanced:
+                description: Advanced describes a set of optional, advanced VM configuration
+                  options.
+                properties:
+                  bootDiskCapacity:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: "BootDiskCapacity is the capacity of the VM's boot
+                      disk -- the first disk from the VirtualMachineImage from which
+                      the VM was deployed. \n Please note it is not advised to change
+                      this value while the VM is running. Also, resizing the VM's
+                      boot disk may require actions inside of the guest to take advantage
+                      of the additional capacity. Finally, changing the size of the
+                      VM's boot disk, even increasing it, could adversely affect the
+                      VM."
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  changeBlockTracking:
+                    description: ChangeBlockTracking is a flag that enables incremental
+                      backup support for this VM, a feature utilized by external backup
+                      systems such as VMware Data Recovery.
+                    type: boolean
+                  defaultVolumeProvisioningMode:
+                    description: DefaultVolumeProvisioningMode specifies the default
+                      provisioning mode for persistent volumes managed by this VM.
+                    enum:
+                    - Thin
+                    - Thick
+                    - ThickEagerZero
+                    type: string
+                type: object
+              bootstrap:
+                description: "Bootstrap describes the desired state of the guest's
+                  bootstrap configuration. \n If omitted, then the bootstrap method
+                  is determined based on the guest identifier from the VirtualMachineImage.
+                  If the image's guest OS type is Windows, then the Sysprep bootstrap
+                  method is used; if Linux, the LinuxPrep method is used. \n Please
+                  note that defaulting to Sysprep for Windows images only works if
+                  the image uses a volume license key, otherwise the image's product
+                  ID is required."
+                properties:
+                  cloudInit:
+                    description: "CloudInit may be used to bootstrap Linux guests
+                      with Cloud-Init or Windows guests that support Cloudbase-Init.
+                      \n The guest's networking stack is configured by Cloud-Init
+                      on Linux guests and Cloudbase-Init on Windows guests. \n Please
+                      note this bootstrap provider may not be used in conjunction
+                      with the other bootstrap providers."
+                    properties:
+                      cloudConfig:
+                        description: "CloudConfig describes a subset of a Cloud-Init
+                          CloudConfig, used to bootstrap the VM. \n Please note this
+                          field and RawCloudConfig are mutually exclusive."
+                        properties:
+                          timezone:
+                            description: Timezone describes the timezone represented
+                              in /usr/share/zoneinfo.
+                            type: string
+                          user:
+                            description: User enables overriding the "default_user"
+                              configuration from "/etc/cloud/cloud.cfg".
+                            properties:
+                              create_groups:
+                                description: "CreateGroups is a flag that may be set
+                                  to false to disable creation of specified user groups.
+                                  \n Defaults to true when Name is not \"default\"."
+                                type: boolean
+                              expiredate:
+                                description: ExpireData is the date on which the user's
+                                  account will be disabled.
+                                type: string
+                              gecos:
+                                description: Gecos is an optional comment about the
+                                  user, usually a comma-separated string of the user's
+                                  real name and contact information.
+                                type: string
+                              groups:
+                                description: Groups is an optional list of groups
+                                  to add to the user.
+                                items:
+                                  type: string
+                                type: array
+                              hashed_passwd:
+                                description: HashedPasswd is a hash of the user's
+                                  password that will be applied even if the specified
+                                  user already exists.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              homedir:
+                                description: "Homedir is the optional home directory
+                                  for the user. \n Defaults to \"/home/<username>\"
+                                  when Name is not \"default\"."
+                                type: string
+                              inactive:
+                                description: Inactive optionally represents the number
+                                  of days until the user is disabled.
+                                format: int32
+                                type: integer
+                              lock_passwd:
+                                description: "LockPasswd disables password login.
+                                  \n Defaults to true when Name is not \"default\"."
+                                type: boolean
+                              name:
+                                description: "Name is the user's login name. \n Please
+                                  note this field may be set to the special value
+                                  of \"default\" when this User is the first element
+                                  in the Users list from the CloudConfig. When set
+                                  to \"default\", all other fields from this User
+                                  must be nil."
+                                type: string
+                              no_create_home:
+                                description: "NoCreateHome prevents the creation of
+                                  the home directory. \n Defaults to false when Name
+                                  is not \"default\"."
+                                type: boolean
+                              no_log_init:
+                                description: "NoLogInit prevents the initialization
+                                  of lastlog and faillog for the user. \n Defaults
+                                  to false when Name is not \"default\"."
+                                type: boolean
+                              no_user_group:
+                                description: "NoUserGroup prevents the creation of
+                                  the group named after the user. \n Defaults to false
+                                  when Name is not \"default\"."
+                                type: boolean
+                              passwd:
+                                description: Passwd is a hash of the user's password
+                                  that will be applied only to a newly created user.
+                                  To apply a new, hashed password to an existing user
+                                  please use HashedPasswd instead.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              primary_group:
+                                description: "PrimaryGroup is the primary group for
+                                  the user. \n Defaults to the value of the Name field
+                                  when it is not \"default\"."
+                                type: string
+                              selinux_user:
+                                description: SELinuxUser is the SELinux user for the
+                                  user's login.
+                                type: string
+                              shell:
+                                description: "Shell is the path to the user's login
+                                  shell. \n Please note the default is to set no shell,
+                                  which results in a system-specific default being
+                                  used."
+                                type: string
+                              snapuser:
+                                description: "SnapUser specifies an e-mail address
+                                  to create the user as a Snappy user through \"snap
+                                  create-user\". \n If an Ubuntu SSO account is associated
+                                  with the address, the username and SSH keys will
+                                  be requested from there."
+                                type: string
+                              ssh_authorized_keys:
+                                description: "SSHAuthorizedKeys is a list of SSH keys
+                                  to add to the user's authorized keys file. \n Please
+                                  note this field may not be combined with SSHRedirectUser."
+                                items:
+                                  type: string
+                                type: array
+                              ssh_import_id:
+                                description: "SSHImportID is a list of SSH IDs to
+                                  import for the user. \n Please note this field may
+                                  not be combined with SSHRedirectUser."
+                                items:
+                                  type: string
+                                type: array
+                              ssh_redirect_user:
+                                description: "SSHRedirectUser may be set to true to
+                                  disable SSH logins for this user. \n Please note
+                                  that when specified, all SSH keys from cloud meta-data
+                                  will be configured in a disabled state for this
+                                  user. Any SSH login as this user will timeout with
+                                  a message to login instead as the default user.
+                                  \n This field may not be combined with SSHAuthorizedKeys
+                                  or SSHImportID. \n Defaults to false when Name is
+                                  not \"default\"."
+                                type: boolean
+                              sudo:
+                                description: "Sudo is a sudo rule to apply to the
+                                  user. \n When omitted, no sudo rules will be applied
+                                  to the user."
+                                type: string
+                              system:
+                                description: "System is an optional flag that indicates
+                                  the user should be created as a system user with
+                                  no home directory. \n Defaults to false when Name
+                                  is not \"default\"."
+                                type: boolean
+                              uid:
+                                description: "UID is the user's ID. \n When omitted
+                                  the guest will default to the next available number."
+                                format: int64
+                                type: integer
+                            required:
+                            - name
+                            type: object
+                          users:
+                            description: "Users allows adding/configuring one or more
+                              users on the guest. \n Please note if the first element
+                              in this list has a Name field set to \"default\", then
+                              that element will be serialized as \"- default\" when
+                              marshaling this list as part of generating a YAML CloudConfig."
+                            items:
+                              description: User is a CloudConfig user data structure.
+                              properties:
+                                create_groups:
+                                  description: "CreateGroups is a flag that may be
+                                    set to false to disable creation of specified
+                                    user groups. \n Defaults to true when Name is
+                                    not \"default\"."
+                                  type: boolean
+                                expiredate:
+                                  description: ExpireData is the date on which the
+                                    user's account will be disabled.
+                                  type: string
+                                gecos:
+                                  description: Gecos is an optional comment about
+                                    the user, usually a comma-separated string of
+                                    the user's real name and contact information.
+                                  type: string
+                                groups:
+                                  description: Groups is an optional list of groups
+                                    to add to the user.
+                                  items:
+                                    type: string
+                                  type: array
+                                hashed_passwd:
+                                  description: HashedPasswd is a hash of the user's
+                                    password that will be applied even if the specified
+                                    user already exists.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                homedir:
+                                  description: "Homedir is the optional home directory
+                                    for the user. \n Defaults to \"/home/<username>\"
+                                    when Name is not \"default\"."
+                                  type: string
+                                inactive:
+                                  description: Inactive optionally represents the
+                                    number of days until the user is disabled.
+                                  format: int32
+                                  type: integer
+                                lock_passwd:
+                                  description: "LockPasswd disables password login.
+                                    \n Defaults to true when Name is not \"default\"."
+                                  type: boolean
+                                name:
+                                  description: "Name is the user's login name. \n
+                                    Please note this field may be set to the special
+                                    value of \"default\" when this User is the first
+                                    element in the Users list from the CloudConfig.
+                                    When set to \"default\", all other fields from
+                                    this User must be nil."
+                                  type: string
+                                no_create_home:
+                                  description: "NoCreateHome prevents the creation
+                                    of the home directory. \n Defaults to false when
+                                    Name is not \"default\"."
+                                  type: boolean
+                                no_log_init:
+                                  description: "NoLogInit prevents the initialization
+                                    of lastlog and faillog for the user. \n Defaults
+                                    to false when Name is not \"default\"."
+                                  type: boolean
+                                no_user_group:
+                                  description: "NoUserGroup prevents the creation
+                                    of the group named after the user. \n Defaults
+                                    to false when Name is not \"default\"."
+                                  type: boolean
+                                passwd:
+                                  description: Passwd is a hash of the user's password
+                                    that will be applied only to a newly created user.
+                                    To apply a new, hashed password to an existing
+                                    user please use HashedPasswd instead.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                primary_group:
+                                  description: "PrimaryGroup is the primary group
+                                    for the user. \n Defaults to the value of the
+                                    Name field when it is not \"default\"."
+                                  type: string
+                                selinux_user:
+                                  description: SELinuxUser is the SELinux user for
+                                    the user's login.
+                                  type: string
+                                shell:
+                                  description: "Shell is the path to the user's login
+                                    shell. \n Please note the default is to set no
+                                    shell, which results in a system-specific default
+                                    being used."
+                                  type: string
+                                snapuser:
+                                  description: "SnapUser specifies an e-mail address
+                                    to create the user as a Snappy user through \"snap
+                                    create-user\". \n If an Ubuntu SSO account is
+                                    associated with the address, the username and
+                                    SSH keys will be requested from there."
+                                  type: string
+                                ssh_authorized_keys:
+                                  description: "SSHAuthorizedKeys is a list of SSH
+                                    keys to add to the user's authorized keys file.
+                                    \n Please note this field may not be combined
+                                    with SSHRedirectUser."
+                                  items:
+                                    type: string
+                                  type: array
+                                ssh_import_id:
+                                  description: "SSHImportID is a list of SSH IDs to
+                                    import for the user. \n Please note this field
+                                    may not be combined with SSHRedirectUser."
+                                  items:
+                                    type: string
+                                  type: array
+                                ssh_redirect_user:
+                                  description: "SSHRedirectUser may be set to true
+                                    to disable SSH logins for this user. \n Please
+                                    note that when specified, all SSH keys from cloud
+                                    meta-data will be configured in a disabled state
+                                    for this user. Any SSH login as this user will
+                                    timeout with a message to login instead as the
+                                    default user. \n This field may not be combined
+                                    with SSHAuthorizedKeys or SSHImportID. \n Defaults
+                                    to false when Name is not \"default\"."
+                                  type: boolean
+                                sudo:
+                                  description: "Sudo is a sudo rule to apply to the
+                                    user. \n When omitted, no sudo rules will be applied
+                                    to the user."
+                                  type: string
+                                system:
+                                  description: "System is an optional flag that indicates
+                                    the user should be created as a system user with
+                                    no home directory. \n Defaults to false when Name
+                                    is not \"default\"."
+                                  type: boolean
+                                uid:
+                                  description: "UID is the user's ID. \n When omitted
+                                    the guest will default to the next available number."
+                                  format: int64
+                                  type: integer
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          write_files:
+                            description: WriteFiles
+                            items:
+                              description: WriteFile is a CloudConfig write_file data
+                                structure.
+                              properties:
+                                append:
+                                  description: Append specifies whether or not to
+                                    append the content to an existing file if the
+                                    file specified by Path already exists.
+                                  type: boolean
+                                content:
+                                  description: "Content is the optional content to
+                                    write to the provided Path. \n When omitted an
+                                    empty file will be created or existing file will
+                                    be modified."
+                                  properties:
+                                    from:
+                                      description: "From is specified to reference
+                                        a value from a Secret resource. \n Please
+                                        note this field is mutually exclusive with
+                                        the Value field."
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    value:
+                                      description: "Value is used to directly specify
+                                        a value. \n Please note this field is mutually
+                                        exclusive with the From field."
+                                      type: string
+                                  type: object
+                                defer:
+                                  description: Defer indicates to defer writing the
+                                    file until Cloud-Init's "final" stage, after users
+                                    are created and packages are installed.
+                                  type: boolean
+                                encoding:
+                                  default: text/plain
+                                  description: Encoding is an optional encoding type
+                                    of the content.
+                                  enum:
+                                  - b64
+                                  - base64
+                                  - gz
+                                  - gzip
+                                  - gz+b64
+                                  - gz+base64
+                                  - gzip+b64
+                                  - gzip+base64
+                                  - text/plain
+                                  type: string
+                                owner:
+                                  default: root:root
+                                  description: Owner is an optional "owner:group"
+                                    to chown the file.
+                                  type: string
+                                path:
+                                  description: Path is the path of the file to which
+                                    the content is decoded and written.
+                                  type: string
+                                permissions:
+                                  default: "0644"
+                                  description: "Permissions an optional set of file
+                                    permissions to set. \n Please note the permissions
+                                    should be specified as an octal string, ex. \"0###\".
+                                    \n When omitted the guest will default this value
+                                    to \"0644\"."
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - path
+                            x-kubernetes-list-type: map
+                        type: object
+                      rawCloudConfig:
+                        description: "RawCloudConfig describes a key in a Secret resource
+                          that contains the CloudConfig data used to bootstrap the
+                          VM. \n The CloudConfig data specified by the key may be
+                          plain-text, base64-encoded, or gzipped and base64-encoded.
+                          \n Please note this field and CloudConfig are mutually exclusive."
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      sshAuthorizedKeys:
+                        description: SSHAuthorizedKeys is a list of public keys that
+                          CloudInit will apply to the guest's default user.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  linuxPrep:
+                    description: "LinuxPrep may be used to bootstrap Linux guests.
+                      \n The guest's networking stack is configured by Guest OS Customization
+                      (GOSC). \n Please note this bootstrap provider may be used in
+                      conjunction with the VAppConfig bootstrap provider when wanting
+                      to configure the guest's network with GOSC but also send vApp/OVF
+                      properties into the guest. \n This bootstrap provider may not
+                      be used in conjunction with the CloudInit or Sysprep bootstrap
+                      providers."
+                    properties:
+                      hardwareClockIsUTC:
+                        description: HardwareClockIsUTC specifies whether the hardware
+                          clock is in UTC or local time.
+                        type: boolean
+                      timeZone:
+                        description: "TimeZone is a case-sensitive timezone, such
+                          as Europe/Sofia. \n Valid values are based on the tz (timezone)
+                          database used by Linux and other Unix systems. The values
+                          are strings in the form of \"Area/Location,\" in which Area
+                          is a continent or ocean name, and Location is the city,
+                          island, or other regional designation. \n Please see https://kb.vmware.com/s/article/2145518
+                          for a list of valid time zones for Linux systems."
+                        type: string
+                    type: object
+                  sysprep:
+                    description: "Sysprep may be used to bootstrap Windows guests.
+                      \n The guest's networking stack is configured by Guest OS Customization
+                      (GOSC). \n Please note this bootstrap provider may be used in
+                      conjunction with the VAppConfig bootstrap provider when wanting
+                      to configure the guest's network with GOSC but also send vApp/OVF
+                      properties into the guest. \n This bootstrap provider may not
+                      be used in conjunction with the CloudInit or LinuxPrep bootstrap
+                      providers."
+                    properties:
+                      rawSysprep:
+                        description: "RawSysprep describes a key in a Secret resource
+                          that contains an XML string of the Sysprep text used to
+                          bootstrap the VM. \n The data specified by the Secret key
+                          may be plain-text, base64-encoded, or gzipped and base64-encoded.
+                          \n Please note this field and Sysprep are mutually exclusive."
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      sysprep:
+                        description: "Sysprep is an object representation of a Windows
+                          sysprep.xml answer file. \n This field encloses all the
+                          individual keys listed in a sysprep.xml file. \n For more
+                          detailed information please see https://technet.microsoft.com/en-us/library/cc771830(v=ws.10).aspx.
+                          \n Please note this field and RawSysprep are mutually exclusive."
+                        properties:
+                          guiRunOnce:
+                            description: GUIRunOnce is a representation of the Sysprep
+                              GuiRunOnce key.
+                            properties:
+                              commmands:
+                                description: Commands is a list of commands to run
+                                  at first user logon, after guest customization.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          guiUnattended:
+                            description: GUIUnattended is a representation of the
+                              Sysprep GUIUnattended key.
+                            properties:
+                              autoLogon:
+                                description: "AutoLogon determine whether or not the
+                                  machine automatically logs on as Administrator.
+                                  \n Please note if AutoLogin is true, then Password
+                                  must be set or guest customization will fail."
+                                type: boolean
+                              autoLogonCount:
+                                description: "AutoLogonCount specifies the number
+                                  of times the machine should automatically log on
+                                  as Administrator. \n Generally it should be 1, but
+                                  if your setup requires a number of reboots, you
+                                  may want to increase it. This number may be determined
+                                  by the list of commands executed by the GuiRunOnce
+                                  command. \n Please note this field only matters
+                                  if AutoLogin is true."
+                                format: int32
+                                type: integer
+                              password:
+                                description: "Password is the new administrator password
+                                  for the machine. \n To specify that the password
+                                  should be set to blank (that is, no password), set
+                                  the password value to NULL. Because of encryption,
+                                  \"\" is NOT a valid value. \n Please note if the
+                                  password is set to blank and AutoLogon is true,
+                                  the guest customization will fail. \n If the XML
+                                  file is generated by the VirtualCenter Customization
+                                  Wizard, then the password is encrypted. Otherwise,
+                                  the client should set the plainText attribute to
+                                  true, so that the customization process does not
+                                  attempt to decrypt the string."
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              timeZone:
+                                description: "TimeZone is the time zone index for
+                                  the virtual machine. \n Please note that numbers
+                                  correspond to time zones listed at https://bit.ly/3Rzv8oL."
+                                format: int32
+                                type: integer
+                            type: object
+                          identification:
+                            description: Identification is a representation of the
+                              Sysprep Identification key.
+                            properties:
+                              domainAdmin:
+                                description: DomainAdmin is the domain user account
+                                  used for authentication if the virtual machine is
+                                  joining a domain. The user does not need to be a
+                                  domain administrator, but the account must have
+                                  the privileges required to add computers to the
+                                  domain.
+                                type: string
+                              domainAdminPassword:
+                                description: DomainAdminPassword is the password for
+                                  the domain user account used for authentication
+                                  if the virtual machine is joining a domain.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              joinDomain:
+                                description: JoinDomain is the domain that the virtual
+                                  machine should join. If this value is supplied,
+                                  then DomainAdmin and DomainAdminPassword must also
+                                  be supplied, and the JoinWorkgroup name must be
+                                  empty.
+                                type: string
+                              joinWorkgroup:
+                                description: JoinWorkgroup is the workgroup that the
+                                  virtual machine should join. If this value is supplied,
+                                  then the JoinDomain and the authentication fields
+                                  (DomainAdmin and DomainAdminPassword) must be empty.
+                                type: string
+                            type: object
+                          licenseFilePrintData:
+                            description: "LicenseFilePrintData is a representation
+                              of the Sysprep LicenseFilePrintData key. \n Please note
+                              this is required only for Windows 2000 Server and Windows
+                              Server 2003."
+                            properties:
+                              autoMode:
+                                description: AutoMode specifies the server licensing
+                                  mode.
+                                enum:
+                                - perSeat
+                                - perServer
+                                type: string
+                              autoUsers:
+                                description: "AutoUsers indicates the number of client
+                                  licenses purchased for the VirtualCenter server
+                                  being installed. \n Please note this value is ignored
+                                  unless AutoMode is PerServer."
+                                format: int32
+                                type: integer
+                            required:
+                            - autoMode
+                            type: object
+                          userData:
+                            description: UserData is a representation of the Sysprep
+                              UserData key.
+                            properties:
+                              fullName:
+                                description: FullName is the user's full name.
+                                type: string
+                              orgName:
+                                description: OrgName is the name of the user's organization.
+                                type: string
+                              productID:
+                                description: "ProductID is a valid serial number.
+                                  \n Please note unless the VirtualMachineImage was
+                                  installed with a volume license key, ProductID must
+                                  be set or guest customization will fail."
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                        required:
+                        - guiUnattended
+                        - identification
+                        - userData
+                        type: object
+                    type: object
+                  vAppConfig:
+                    description: "VAppConfig may be used to bootstrap guests that
+                      rely on vApp properties (how VMware surfaces OVF properties
+                      on guests) to transport data into the guest. \n The guest's
+                      networking stack may be configured using either vApp properties
+                      or GOSC. \n Many OVFs define one or more properties that are
+                      used by the guest to bootstrap its networking stack. If the
+                      VirtualMachineImage defines one or more properties like this,
+                      then they can be configured to use the network data provided
+                      for this VM at runtime by setting these properties to Go template
+                      strings. \n It is also possible to use GOSC to bootstrap this
+                      VM's network stack by configuring either the LinuxPrep or Sysprep
+                      bootstrap providers. \n Please note the VAppConfig bootstrap
+                      provider in conjunction with the LinuxPrep bootstrap provider
+                      is the equivalent of setting the v1alpha1 VM metadata transport
+                      to \"OvfEnv\". \n This bootstrap provider may not be used in
+                      conjunction with the CloudInit bootstrap provider."
+                    properties:
+                      properties:
+                        description: "Properties is a list of vApp/OVF property key/value
+                          pairs. \n Please note this field and RawProperties are mutually
+                          exclusive."
+                        items:
+                          description: KeyValueOrSecretKeySelectorPair is useful when
+                            wanting to realize a map as a list of key/value pairs
+                            where each value could also referenced data stored in
+                            a Secret resource.
+                          properties:
+                            key:
+                              description: Key is the key part of the key/value pair.
+                              type: string
+                            value:
+                              description: Value is the optional value part of the
+                                key/value pair.
+                              properties:
+                                from:
+                                  description: "From is specified to reference a value
+                                    from a Secret resource. \n Please note this field
+                                    is mutually exclusive with the Value field."
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                value:
+                                  description: "Value is used to directly specify
+                                    a value. \n Please note this field is mutually
+                                    exclusive with the From field."
+                                  type: string
+                              type: object
+                          required:
+                          - key
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
+                      rawProperties:
+                        description: "RawProperties is the name of a Secret resource
+                          in the same Namespace as this VM where each key/value pair
+                          from the Secret is used as a vApp key/value pair. \n Please
+                          note this field and Properties are mutually exclusive."
+                        type: string
+                    type: object
+                type: object
+              className:
+                description: "Class describes the name of the VirtualMachineClass
+                  resource used to deploy this VM. \n This field is optional in the
+                  cases where there exists a sensible default value, such as when
+                  there is a single VirtualMachineClass resource available in the
+                  same Namespace as the VM being deployed."
+                type: string
+              imageName:
+                description: "ImageName describes the name of the image resource used
+                  to deploy this VM. \n This field may be used to specify the name
+                  of a VirtualMachineImage or ClusterVirtualMachineImage resource.
+                  The resolver first checks to see if there is a ClusterVirtualMachineImage
+                  with the specified name. If no such resource exists, the resolver
+                  then checks to see if there is a VirtualMachineImage resource with
+                  the specified name in the same Namespace as the VM being deployed.
+                  \n This field is optional in the cases where there exists a sensible
+                  default value, such as when there is a single VirtualMachineImage
+                  resource available in the same Namespace as the VM being deployed."
+                type: string
+              network:
+                description: "Network describes the desired network configuration
+                  for the VM. \n Please note this value may be omitted entirely and
+                  the VM will be assigned a single, virtual network interface that
+                  is connected to the Namespace's default network."
+                properties:
+                  addresses:
+                    description: "Addresses is an optional list of IP4 or IP6 addresses
+                      to assign to the VM. \n Please note this field is only supported
+                      if the connected network supports manual IP allocation. \n Please
+                      note IP4 and IP6 addresses must include the network prefix length,
+                      ex. 192.168.0.10/24 or 2001:db8:101::a/64. \n Please note this
+                      field may not contain IP4 addresses if DHCP4 is set to true
+                      or IP6 addresses if DHCP6 is set to true. \n Please note if
+                      the Interfaces field is non-empty then this field is ignored
+                      and should be specified on the elements in the Interfaces list."
+                    items:
+                      type: string
+                    type: array
+                  deviceName:
+                    description: "DeviceName describes the unique name of this network
+                      interface, used to distinguish it from other network interfaces
+                      attached to this VM. \n This value is also used to rename the
+                      device inside the guest when the bootstrap provider is CloudInit.
+                      Please note it is up to the user to ensure the provided device
+                      name does not conflict with any other devices inside the guest,
+                      ex. dvd, cdrom, sda, etc. \n Please note if the Interfaces field
+                      is non-empty then this field is ignored and should be specified
+                      on the elements in the Interfaces list. \n If the Interfaces
+                      field is empty and this field is not specified, then the default
+                      interface's name will be eth0."
+                    pattern: ^\w\w+$
+                    type: string
+                  dhcp4:
+                    description: "DHCP4 indicates whether or not to use DHCP for IP4
+                      networking. \n Please note this field is only supported if the
+                      network connection supports DHCP. \n Please note this field
+                      is mutually exclusive with IP4 addresses in the Addresses field
+                      and the Gateway4 field. \n Please note if the Interfaces field
+                      is non-empty then this field is ignored and should be specified
+                      on the elements in the Interfaces list."
+                    type: boolean
+                  dhcp6:
+                    description: "DHCP6 indicates whether or not to use DHCP for IP6
+                      networking. \n Please note this field is only supported if the
+                      network connection supports DHCP. \n Please note this field
+                      is mutually exclusive with IP4 addresses in the Addresses field
+                      and the Gateway6 field. \n Please note if the Interfaces field
+                      is non-empty then this field is ignored and should be specified
+                      on the elements in the Interfaces list."
+                    type: boolean
+                  disabled:
+                    description: "Disabled is a flag that indicates whether or not
+                      to disable networking for this VM. \n When set to true, the
+                      VM is not configured with a default interface nor any specified
+                      from the Interfaces field."
+                    type: boolean
+                  gateway4:
+                    description: "Gateway4 is the default, IP4 gateway for this VM.
+                      \n Please note this field is only supported if the network connection
+                      supports manual IP allocation. \n If the network connection
+                      supports manual IP allocation and the Addresses field includes
+                      at least one IP4 address, then this field is required. \n Please
+                      note the IP address must include the network prefix length,
+                      ex. 192.168.0.1/24. \n Please note this field is mutually exclusive
+                      with DHCP4. \n Please note if the Interfaces field is non-empty
+                      then this field is ignored and should be specified on the elements
+                      in the Interfaces list."
+                    type: string
+                  gateway6:
+                    description: "Gateway6 is the primary IP6 gateway for this VM.
+                      \n Please note this field is only supported if the network connection
+                      supports manual IP allocation. \n If the network connection
+                      supports manual IP allocation and the Addresses field includes
+                      at least one IP4 address, then this field is required. \n Please
+                      note the IP address must include the network prefix length,
+                      ex. 2001:db8:101::1/64. \n Please note this field is mutually
+                      exclusive with DHCP6. \n Please note if the Interfaces field
+                      is non-empty then this field is ignored and should be specified
+                      on the elements in the Interfaces list."
+                    type: string
+                  hostName:
+                    description: "HostName is the value the guest uses as its host
+                      name. If omitted then the name of the VM will be used. \n Please
+                      note this feature is available only with the following bootstrap
+                      providers: CloudInit, LinuxPrep, and Sysprep (except for RawSysprep)."
+                    type: string
+                  interfaces:
+                    description: "Interfaces is the list of network interfaces used
+                      by this VM. \n Please note this field is mutually exclusive
+                      with the following fields: DeviceName, Network, Addresses, DHCP4,
+                      DHCP6, Gateway4, Gateway6, MTU, Nameservers, Routes, and SearchDomains."
+                    items:
+                      description: VirtualMachineNetworkInterfaceSpec describes the
+                        desired state of a VM's network interface.
+                      properties:
+                        addresses:
+                          description: "Addresses is an optional list of IP4 or IP6
+                            addresses to assign to this interface. \n Please note
+                            this field is only supported if the connected network
+                            supports manual IP allocation. \n Please note IP4 and
+                            IP6 addresses must include the network prefix length,
+                            ex. 192.168.0.10/24 or 2001:db8:101::a/64. \n Please note
+                            this field may not contain IP4 addresses if DHCP4 is set
+                            to true or IP6 addresses if DHCP6 is set to true. \n Please
+                            note if the Interfaces field is non-empty then this field
+                            is ignored and should be specified on the elements in
+                            the Interfaces list."
+                          items:
+                            type: string
+                          type: array
+                        dhcp4:
+                          description: "DHCP4 indicates whether or not this interface
+                            uses DHCP for IP4 networking. \n Please note this field
+                            is only supported if the network connection supports DHCP.
+                            \n Please note this field is mutually exclusive with IP4
+                            addresses in the Addresses field and the Gateway4 field."
+                          type: boolean
+                        dhcp6:
+                          description: "DHCP6 indicates whether or not this interface
+                            uses DHCP for IP6 networking. \n Please note this field
+                            is only supported if the network connection supports DHCP.
+                            \n Please note this field is mutually exclusive with IP4
+                            addresses in the Addresses field and the Gateway6 field."
+                          type: boolean
+                        gateway4:
+                          description: "Gateway4 is the default, IP4 gateway for this
+                            interface. \n Please note this field is only supported
+                            if the network connection supports manual IP allocation.
+                            \n If the network connection supports manual IP allocation
+                            and the Addresses field includes at least one IP4 address,
+                            then this field is required. \n Please note the IP address
+                            must include the network prefix length, ex. 192.168.0.1/24.
+                            \n Please note this field is mutually exclusive with DHCP4."
+                          type: string
+                        gateway6:
+                          description: "Gateway6 is the primary IP6 gateway for this
+                            interface. \n Please note this field is only supported
+                            if the network connection supports manual IP allocation.
+                            \n If the network connection supports manual IP allocation
+                            and the Addresses field includes at least one IP4 address,
+                            then this field is required. \n Please note the IP address
+                            must include the network prefix length, ex. 2001:db8:101::1/64.
+                            \n Please note this field is mutually exclusive with DHCP6."
+                          type: string
+                        mtu:
+                          description: "MTU is the Maximum Transmission Unit size
+                            in bytes. \n Please note this feature is available only
+                            with the following bootstrap providers: CloudInit."
+                          format: int64
+                          type: integer
+                        name:
+                          description: "Name describes the unique name of this network
+                            interface, used to distinguish it from other network interfaces
+                            attached to this VM. \n This value is also used to rename
+                            the device inside the guest when the bootstrap provider
+                            is CloudInit. Please note it is up to the user to ensure
+                            the provided device name does not conflict with any other
+                            devices inside the guest, ex. dvd, cdrom, sda, etc."
+                          pattern: ^\w\w+$
+                          type: string
+                        nameservers:
+                          description: "Nameservers is a list of IP4 and/or IP6 addresses
+                            used as DNS nameservers. \n Please note this feature is
+                            available only with the following bootstrap providers:
+                            CloudInit, LinuxPrep, and Sysprep (except for RawSysprep).
+                            \n Please note that Linux allows only three nameservers
+                            (https://linux.die.net/man/5/resolv.conf)."
+                          items:
+                            type: string
+                          type: array
+                        network:
+                          description: "Network is the name of the network resource
+                            to which this interface is connected. \n If no network
+                            is provided, then this interface will be connected to
+                            the Namespace's default network."
+                          properties:
+                            apiVersion:
+                              description: 'APIVersion defines the versioned schema
+                                of this representation of an object. Servers should
+                                convert recognized schemas to the latest internal
+                                value, and may reject unrecognized values. More info:
+                                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                              type: string
+                            kind:
+                              description: 'Kind is a string value representing the
+                                REST resource this object represents. Servers may
+                                infer this from the endpoint the client submits requests
+                                to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name refers to a unique resource in the
+                                current namespace. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        routes:
+                          description: "Routes is a list of optional, static routes.
+                            \n Please note this feature is available only with the
+                            following bootstrap providers: CloudInit."
+                          items:
+                            description: VirtualMachineNetworkRouteSpec defines a
+                              static route for a guest.
+                            properties:
+                              metric:
+                                description: Metric is the weight/priority of the
+                                  route.
+                                format: int32
+                                type: integer
+                              to:
+                                description: To is an IP4 address.
+                                type: string
+                              via:
+                                description: Via is an IP4 address.
+                                type: string
+                            required:
+                            - metric
+                            - to
+                            - via
+                            type: object
+                          type: array
+                        searchDomains:
+                          description: "SearchDomains is a list of search domains
+                            used when resolving IP addresses with DNS. \n Please note
+                            this feature is available only with the following bootstrap
+                            providers: CloudInit, LinuxPrep, and Sysprep (except for
+                            RawSysprep)."
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  mtu:
+                    description: "MTU is the Maximum Transmission Unit size in bytes.
+                      \n Please note this feature is available only with the following
+                      bootstrap providers: CloudInit. \n Please note if the Interfaces
+                      field is non-empty then this field is ignored and should be
+                      specified on the elements in the Interfaces list."
+                    format: int64
+                    type: integer
+                  nameservers:
+                    description: "Nameservers is a list of IP4 and/or IP6 addresses
+                      used as DNS nameservers. \n Please note this feature is available
+                      only with the following bootstrap providers: CloudInit, LinuxPrep,
+                      and Sysprep (except for RawSysprep). \n Please note that Linux
+                      allows only three nameservers (https://linux.die.net/man/5/resolv.conf).
+                      \n Please note if the Interfaces field is non-empty then this
+                      field is ignored and should be specified on the elements in
+                      the Interfaces list."
+                    items:
+                      type: string
+                    type: array
+                  network:
+                    description: "Network is the optional name of the network resource
+                      to which this VM is connected. \n Please note if the Interfaces
+                      field is non-empty then this field is ignored. \n If networking
+                      is not disabled, no interfaces are defined, and this value is
+                      omitted, then the VM will be provided a single virtual network
+                      interface and connected to the Namespace's default network."
+                    properties:
+                      apiVersion:
+                        description: 'APIVersion defines the versioned schema of this
+                          representation of an object. Servers should convert recognized
+                          schemas to the latest internal value, and may reject unrecognized
+                          values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                        type: string
+                      kind:
+                        description: 'Kind is a string value representing the REST
+                          resource this object represents. Servers may infer this
+                          from the endpoint the client submits requests to. Cannot
+                          be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name refers to a unique resource in the current
+                          namespace. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  routes:
+                    description: "Routes is a list of optional, static routes. \n
+                      Please note this feature is available only with the following
+                      bootstrap providers: CloudInit. \n Please note if the Interfaces
+                      field is non-empty then this field is ignored and should be
+                      specified on the elements in the Interfaces list."
+                    items:
+                      description: VirtualMachineNetworkRouteSpec defines a static
+                        route for a guest.
+                      properties:
+                        metric:
+                          description: Metric is the weight/priority of the route.
+                          format: int32
+                          type: integer
+                        to:
+                          description: To is an IP4 address.
+                          type: string
+                        via:
+                          description: Via is an IP4 address.
+                          type: string
+                      required:
+                      - metric
+                      - to
+                      - via
+                      type: object
+                    type: array
+                  searchDomains:
+                    description: "SearchDomains is a list of search domains used when
+                      resolving IP addresses with DNS. \n Please note this feature
+                      is available only with the following bootstrap providers: CloudInit,
+                      LinuxPrep, and Sysprep (except for RawSysprep). \n Please note
+                      if the Interfaces field is non-empty then this field is ignored
+                      and should be specified on the elements in the Interfaces list."
+                    items:
+                      type: string
+                    type: array
+                type: object
+              nextRestartTime:
+                description: "NextRestartTime may be used to restart the VM, in accordance
+                  with RestartMode, by setting the value of this field to \"now\"
+                  (case-insensitive). \n A mutating webhook changes this value to
+                  the current time (UTC), which the VM controller then uses to determine
+                  the VM should be restarted by comparing the value to the timestamp
+                  of the last time the VM was restarted. \n Please note it is not
+                  possible to schedule future restarts using this field. The only
+                  value that users may set is the string \"now\" (case-insensitive)."
+                type: string
+              powerOffMode:
+                default: TrySoft
+                description: "PowerOffMode describes the desired behavior when powering
+                  off a VM. \n There are three, supported power off modes: Hard, Soft,
+                  and TrySoft. The first mode, Hard, is the equivalent of a physical
+                  system's power cord being ripped from the wall. The Soft mode requires
+                  the VM's guest to have VM Tools installed and attempts to gracefully
+                  shutdown the VM. Its variant, TrySoft, first attempts a graceful
+                  shutdown, and if that fails or the VM is not in a powered off state
+                  after five minutes, the VM is halted. \n If omitted, the mode defaults
+                  to TrySoft."
+                enum:
+                - Hard
+                - Soft
+                - TrySoft
+                type: string
+              powerState:
+                description: "PowerState describes the desired power state of a VirtualMachine.
+                  \n Please note this field may be omitted when creating a new VM
+                  and will default to \"PoweredOn.\" However, once the field is set
+                  to a non-empty value, it may no longer be set to an empty value.
+                  \n Additionally, setting this value to \"Suspended\" is not supported
+                  when creating a new VM. The valid values when creating a new VM
+                  are \"PoweredOn\" and \"PoweredOff.\" An empty value is also allowed
+                  on create since this value defaults to \"PoweredOn\" for new VMs."
+                enum:
+                - PoweredOff
+                - PoweredOn
+                - Suspended
+                type: string
+              readinessGates:
+                description: "ReadinessGates, if specified, will be evaluated to determine
+                  the VM's readiness. \n A VM is ready when its readiness probe, if
+                  specified, is true AND all of the conditions specified by the readiness
+                  gates have a status equal to \"True\"."
+                items:
+                  description: VirtualMachineReadinessGate contains the reference
+                    to a VM condition.
+                  properties:
+                    conditionType:
+                      description: ConditionType refers to a condition in the VM's
+                        condition list with matching type.
+                      type: string
+                  required:
+                  - conditionType
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - conditionType
+                x-kubernetes-list-type: map
+              readinessProbe:
+                description: ReadinessProbe describes a probe used to determine the
+                  VM's ready state.
+                properties:
+                  guestHeartbeat:
+                    description: GuestHeartbeat specifies an action involving the
+                      guest heartbeat status.
+                    properties:
+                      thresholdStatus:
+                        default: green
+                        description: ThresholdStatus is the value that the guest heartbeat
+                          status must be at or above to be considered successful.
+                        enum:
+                        - yellow
+                        - green
+                        type: string
+                    type: object
+                  guestInfo:
+                    description: "GuestInfo specifies an action involving key/value
+                      pairs from GuestInfo. \n The elements are evaluated with the
+                      logical AND operator, meaning all expressions must evaluate
+                      as true for the probe to succeed. \n For example, a VM resource's
+                      probe definition could be specified as the following: \n guestInfo:
+                      - key:   ready value: true \n With the above configuration in
+                      place, the VM would not be considered ready until the GuestInfo
+                      key \"ready\" was set to the value \"true\". \n From within
+                      the guest operating system it is possible to set GuestInfo key/value
+                      pairs using the program \"vmware-rpctool,\" which is included
+                      with VM Tools. For example, the following command will set the
+                      key \"guestinfo.ready\" to the value \"true\": \n vmware-rpctool
+                      \"info-set guestinfo.ready true\" \n Once executed, the VM's
+                      readiness probe will be signaled and the VM resource will be
+                      marked as ready."
+                    items:
+                      description: GuestInfoAction describes a key from GuestInfo
+                        that must match the associated value expression.
+                      properties:
+                        key:
+                          description: "Key is the name of the GuestInfo key. \n Values
+                            are automatically prefixed with \"guestinfo.\" before
+                            being evaluated. Thus if the key \"guestinfo.mykey\" is
+                            provided, it will be evaluated as \"guestinfo.guestinfo.mykey\"."
+                          type: string
+                        value:
+                          description: "Value is a regular expression that is matched
+                            against the value of the specified key. \n An empty value
+                            is the equivalent of \"match any\" or \".*\". \n All values
+                            must adhere to the RE2 regular expression syntax as documented
+                            at https://golang.org/s/re2syntax. Invalid values may
+                            be rejected or ignored depending on the implementation
+                            of this API. Either way, invalid values will not be considered
+                            when evaluating the ready state of a VM."
+                          type: string
+                      required:
+                      - key
+                      type: object
+                    type: array
+                  periodSeconds:
+                    description: PeriodSeconds specifics how often (in seconds) to
+                      perform the probe. Defaults to 10 seconds. Minimum value is
+                      1.
+                    format: int32
+                    minimum: 1
+                    type: integer
+                  tcpSocket:
+                    description: TCPSocket specifies an action involving a TCP port.
+                    properties:
+                      host:
+                        description: Host is an optional host name to connect to.
+                          Host defaults to the VM IP.
+                        type: string
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Port specifies a number or name of the port to
+                          access on the VM. If the format of port is a number, it
+                          must be in the range 1 to 65535. If the format of name is
+                          a string, it must be an IANA_SVC_NAME.
+                        x-kubernetes-int-or-string: true
+                    required:
+                    - port
+                    type: object
+                  timeoutSeconds:
+                    description: TimeoutSeconds specifies a number of seconds after
+                      which the probe times out. Defaults to 10 seconds. Minimum value
+                      is 1.
+                    format: int32
+                    maximum: 60
+                    minimum: 1
+                    type: integer
+                type: object
+              reserved:
+                description: "Reserved describes a set of VM configuration options
+                  reserved for system use. \n Please note attempts to modify the value
+                  of this field by a DevOps user will result in a validation error."
+                properties:
+                  resourcePolicyName:
+                    description: ResourcePolicyName describes the name of a VirtualMachineSetResourcePolicy
+                      resource used to configure the VM's resource policy.
+                    type: string
+                type: object
+              restartMode:
+                default: TrySoft
+                description: "RestartMode describes the desired behavior for restarting
+                  a VM when spec.nextRestartTime is set to \"now\" (case-insensitive).
+                  \n There are three, supported suspend modes: Hard, Soft, and TrySoft.
+                  The first mode, Hard, is where vSphere resets the VM without any
+                  interaction inside of the guest. The Soft mode requires the VM's
+                  guest to have VM Tools installed and asks the guest to restart the
+                  VM. Its variant, TrySoft, first attempts a soft restart, and if
+                  that fails or does not complete within five minutes, the VM is hard
+                  reset. \n If omitted, the mode defaults to TrySoft."
+                enum:
+                - Hard
+                - Soft
+                - TrySoft
+                type: string
+              storageClass:
+                description: "StorageClass describes the name of a Kubernetes StorageClass
+                  resource used to configure this VM's storage-related attributes.
+                  \n Please see https://kubernetes.io/docs/concepts/storage/storage-classes/
+                  for more information on Kubernetes storage classes. \n This field
+                  is optional in the cases where there exists a sensible default value,
+                  such as when there is a single StorageClass resource available in
+                  the same Namespace as the VM being deployed."
+                type: string
+              suspendMode:
+                default: TrySoft
+                description: "SuspendMode describes the desired behavior when suspending
+                  a VM. \n There are three, supported suspend modes: Hard, Soft, and
+                  TrySoft. The first mode, Hard, is where vSphere suspends the VM
+                  to disk without any interaction inside of the guest. The Soft mode
+                  requires the VM's guest to have VM Tools installed and attempts
+                  to gracefully suspend the VM. Its variant, TrySoft, first attempts
+                  a graceful suspend, and if that fails or the VM is not in a put
+                  into standby by the guest after five minutes, the VM is suspended.
+                  \n If omitted, the mode defaults to TrySoft."
+                enum:
+                - Hard
+                - Soft
+                - TrySoft
+                type: string
+              volumes:
+                description: Volumes describes a list of volumes that can be mounted
+                  to the VM.
+                items:
+                  description: VirtualMachineVolume represents a named volume in a
+                    VM.
+                  properties:
+                    name:
+                      description: Name represents the volume's name. Must be a DNS_LABEL
+                        and unique within the VM.
+                      type: string
+                    persistentVolumeClaim:
+                      description: "PersistentVolumeClaim represents a reference to
+                        a PersistentVolumeClaim in the same namespace. \n More information
+                        is available at https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims."
+                      properties:
+                        claimName:
+                          description: 'claimName is the name of a PersistentVolumeClaim
+                            in the same namespace as the pod using this volume. More
+                            info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                          type: string
+                        instanceVolumeClaim:
+                          description: InstanceVolumeClaim is set if the PVC is backed
+                            by instance storage.
+                          properties:
+                            size:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Size is the size of the requested instance
+                                storage volume.
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            storageClass:
+                              description: StorageClass is the name of the Kubernetes
+                                StorageClass that provides the backing storage for
+                                this instance storage volume.
+                              type: string
+                          required:
+                          - size
+                          - storageClass
+                          type: object
+                        readOnly:
+                          description: readOnly Will force the ReadOnly setting in
+                            VolumeMounts. Default false.
+                          type: boolean
+                      required:
+                      - claimName
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            type: object
+          status:
+            description: VirtualMachineStatus defines the observed state of a VirtualMachine
+              instance.
+            properties:
+              biosUUID:
+                description: BiosUUID describes a unique identifier provided by the
+                  underlying infrastructure provider that is exposed to the Guest
+                  OS BIOS as a unique hardware identifier.
+                type: string
+              changeBlockTracking:
+                description: ChangeBlockTracking describes the CBT enablement status
+                  on the VM.
+                type: boolean
+              class:
+                description: Class is a reference to the VirtualMachineClass resource
+                  used to deploy this VM.
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this
+                      representation of an object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  kind:
+                    description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name refers to a unique resource in the current
+                      namespace. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+              conditions:
+                description: Conditions describes the observed conditions of the VirtualMachine.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              host:
+                description: Host describes the hostname or IP address of the infrastructure
+                  host where the VM is executed.
+                type: string
+              image:
+                description: Image is a reference to the VirtualMachineImage resource
+                  used to deploy this VM.
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this
+                      representation of an object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  kind:
+                    description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name refers to a unique resource in the current
+                      namespace. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+              instanceUUID:
+                description: InstanceUUID describes the unique instance UUID provided
+                  by the underlying infrastructure provider, such as vSphere.
+                type: string
+              lastRestartTime:
+                description: LastRestartTime describes the last time the VM was restarted.
+                format: date-time
+                type: string
+              network:
+                description: Network describes the observed state of the VM's network
+                  configuration. Please note much of the network status information
+                  is only available if the guest has VM Tools installed.
+                properties:
+                  dhcp:
+                    description: DHCP describes the VM's observed, client-side, system-wide
+                      DHCP options.
+                    properties:
+                      ip4:
+                        description: IP4 describes the observed state of the IP4 DHCP
+                          client settings.
+                        properties:
+                          config:
+                            description: "Config describes platform-dependent settings
+                              for the DHCP client. \n The key part is a unique number
+                              while the value part is the platform specific configuration
+                              command. For example on Linux and BSD systems using
+                              the file dhclient.conf output would be reported at system
+                              scope: key='1', value='timeout 60;' key='2', value='reboot
+                              10;'. The output reported per interface would be: key='1',
+                              value='prepend domain-name-servers 192.0.2.1;' key='2',
+                              value='require subnet-mask, domain-name-servers;'."
+                            items:
+                              description: KeyValuePair is useful when wanting to
+                                realize a map as a list of key/value pairs.
+                              properties:
+                                key:
+                                  description: Key is the key part of the key/value
+                                    pair.
+                                  type: string
+                                value:
+                                  description: Value is the optional value part of
+                                    the key/value pair.
+                                  type: string
+                              required:
+                              - key
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - key
+                            x-kubernetes-list-type: map
+                          enabled:
+                            description: Enabled reports the status of the DHCP client
+                              services.
+                            type: boolean
+                        type: object
+                      ip6:
+                        description: IP6 describes the observed state of the IP6 DHCP
+                          client settings.
+                        properties:
+                          config:
+                            description: "Config describes platform-dependent settings
+                              for the DHCP client. \n The key part is a unique number
+                              while the value part is the platform specific configuration
+                              command. For example on Linux and BSD systems using
+                              the file dhclient.conf output would be reported at system
+                              scope: key='1', value='timeout 60;' key='2', value='reboot
+                              10;'. The output reported per interface would be: key='1',
+                              value='prepend domain-name-servers 192.0.2.1;' key='2',
+                              value='require subnet-mask, domain-name-servers;'."
+                            items:
+                              description: KeyValuePair is useful when wanting to
+                                realize a map as a list of key/value pairs.
+                              properties:
+                                key:
+                                  description: Key is the key part of the key/value
+                                    pair.
+                                  type: string
+                                value:
+                                  description: Value is the optional value part of
+                                    the key/value pair.
+                                  type: string
+                              required:
+                              - key
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - key
+                            x-kubernetes-list-type: map
+                          enabled:
+                            description: Enabled reports the status of the DHCP client
+                              services.
+                            type: boolean
+                        type: object
+                    type: object
+                  dns:
+                    description: DNS describes the VM's observed, client-side DNS
+                      configuration.
+                    properties:
+                      dhcp:
+                        description: DHCP indicates whether or not dynamic host control
+                          protocol (DHCP) was used to configure DNS configuration.
+                        type: boolean
+                      domainName:
+                        description: DomainName is the domain name portion of the
+                          DNS name. For example, the "domain.local" part of "my-vm.domain.local".
+                        type: string
+                      hostName:
+                        description: HostName is the host name portion of the DNS
+                          name. For example, the "my-vm" part of "my-vm.domain.local".
+                        type: string
+                      nameservers:
+                        description: "Nameservers is a list of the IP addresses for
+                          the DNS servers to use. \n IP4 addresses are specified using
+                          dotted decimal notation. For example, \"192.0.2.1\". \n
+                          IP6 addresses are 128-bit addresses represented as eight
+                          fields of up to four hexadecimal digits. A colon separates
+                          each field (:). For example, 2001:DB8:101::230:6eff:fe04:d9ff.
+                          The address can also consist of the symbol '::' to represent
+                          multiple 16-bit groups of contiguous 0's only once in an
+                          address as described in RFC 2373."
+                        items:
+                          type: string
+                        type: array
+                      searchDomains:
+                        description: SearchDomains is a list of domains in which to
+                          search for hosts, in the order of preference.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  interfaces:
+                    description: Interfaces describes the status of the VM's network
+                      interfaces.
+                    items:
+                      description: VirtualMachineNetworkInterfaceStatus describes
+                        the observed state of a VM's network interface.
+                      properties:
+                        dns:
+                          description: DNS describes the observed state of the interface's
+                            DNS configuration.
+                          properties:
+                            dhcp:
+                              description: DHCP indicates whether or not dynamic host
+                                control protocol (DHCP) was used to configure DNS
+                                configuration.
+                              type: boolean
+                            domainName:
+                              description: DomainName is the domain name portion of
+                                the DNS name. For example, the "domain.local" part
+                                of "my-vm.domain.local".
+                              type: string
+                            hostName:
+                              description: HostName is the host name portion of the
+                                DNS name. For example, the "my-vm" part of "my-vm.domain.local".
+                              type: string
+                            nameservers:
+                              description: "Nameservers is a list of the IP addresses
+                                for the DNS servers to use. \n IP4 addresses are specified
+                                using dotted decimal notation. For example, \"192.0.2.1\".
+                                \n IP6 addresses are 128-bit addresses represented
+                                as eight fields of up to four hexadecimal digits.
+                                A colon separates each field (:). For example, 2001:DB8:101::230:6eff:fe04:d9ff.
+                                The address can also consist of the symbol '::' to
+                                represent multiple 16-bit groups of contiguous 0's
+                                only once in an address as described in RFC 2373."
+                              items:
+                                type: string
+                              type: array
+                            searchDomains:
+                              description: SearchDomains is a list of domains in which
+                                to search for hosts, in the order of preference.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        ip:
+                          description: IP describes the observed state of the interface's
+                            IP configuration.
+                          properties:
+                            addresses:
+                              description: Addresses describes observed IP addresses
+                                for this interface.
+                              items:
+                                description: VirtualMachineNetworkInterfaceIPAddrStatus
+                                  describes information about a specific IP address.
+                                properties:
+                                  address:
+                                    description: "Address is an IP4 or IP6 address
+                                      and their network prefix length. \n An IP4 address
+                                      is specified using dotted decimal notation.
+                                      For example, \"192.0.2.1\". \n IP6 addresses
+                                      are 128-bit addresses represented as eight fields
+                                      of up to four hexadecimal digits. A colon separates
+                                      each field (:). For example, 2001:DB8:101::230:6eff:fe04:d9ff.
+                                      The address can also consist of the symbol '::'
+                                      to represent multiple 16-bit groups of contiguous
+                                      0's only once in an address as described in
+                                      RFC 2373."
+                                    type: string
+                                  lifetime:
+                                    description: Lifetime describes when this address
+                                      will expire.
+                                    format: date-time
+                                    type: string
+                                  origin:
+                                    description: Origin describes how this address
+                                      was configured.
+                                    enum:
+                                    - dhcp
+                                    - linklayer
+                                    - manual
+                                    - other
+                                    - random
+                                    type: string
+                                  state:
+                                    description: State describes the state of this
+                                      IP address.
+                                    enum:
+                                    - deprecated
+                                    - duplicate
+                                    - inaccessible
+                                    - invalid
+                                    - preferred
+                                    - tentative
+                                    - unknown
+                                    type: string
+                                required:
+                                - address
+                                type: object
+                              type: array
+                            autoConfigurationEnabled:
+                              description: "AutoConfigurationEnabled describes whether
+                                or not ICMPv6 router solicitation requests are enabled
+                                or disabled from a given interface. \n These requests
+                                acquire an IP6 address and default gateway route from
+                                zero-to-many routers on the connected network. \n
+                                If not set then ICMPv6 is not available on this VM."
+                              type: boolean
+                            dhcp:
+                              description: DHCP describes the VM's observed, client-side,
+                                interface-specific DHCP options.
+                              properties:
+                                ip4:
+                                  description: IP4 describes the observed state of
+                                    the IP4 DHCP client settings.
+                                  properties:
+                                    config:
+                                      description: "Config describes platform-dependent
+                                        settings for the DHCP client. \n The key part
+                                        is a unique number while the value part is
+                                        the platform specific configuration command.
+                                        For example on Linux and BSD systems using
+                                        the file dhclient.conf output would be reported
+                                        at system scope: key='1', value='timeout 60;'
+                                        key='2', value='reboot 10;'. The output reported
+                                        per interface would be: key='1', value='prepend
+                                        domain-name-servers 192.0.2.1;' key='2', value='require
+                                        subnet-mask, domain-name-servers;'."
+                                      items:
+                                        description: KeyValuePair is useful when wanting
+                                          to realize a map as a list of key/value
+                                          pairs.
+                                        properties:
+                                          key:
+                                            description: Key is the key part of the
+                                              key/value pair.
+                                            type: string
+                                          value:
+                                            description: Value is the optional value
+                                              part of the key/value pair.
+                                            type: string
+                                        required:
+                                        - key
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - key
+                                      x-kubernetes-list-type: map
+                                    enabled:
+                                      description: Enabled reports the status of the
+                                        DHCP client services.
+                                      type: boolean
+                                  type: object
+                                ip6:
+                                  description: IP6 describes the observed state of
+                                    the IP6 DHCP client settings.
+                                  properties:
+                                    config:
+                                      description: "Config describes platform-dependent
+                                        settings for the DHCP client. \n The key part
+                                        is a unique number while the value part is
+                                        the platform specific configuration command.
+                                        For example on Linux and BSD systems using
+                                        the file dhclient.conf output would be reported
+                                        at system scope: key='1', value='timeout 60;'
+                                        key='2', value='reboot 10;'. The output reported
+                                        per interface would be: key='1', value='prepend
+                                        domain-name-servers 192.0.2.1;' key='2', value='require
+                                        subnet-mask, domain-name-servers;'."
+                                      items:
+                                        description: KeyValuePair is useful when wanting
+                                          to realize a map as a list of key/value
+                                          pairs.
+                                        properties:
+                                          key:
+                                            description: Key is the key part of the
+                                              key/value pair.
+                                            type: string
+                                          value:
+                                            description: Value is the optional value
+                                              part of the key/value pair.
+                                            type: string
+                                        required:
+                                        - key
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - key
+                                      x-kubernetes-list-type: map
+                                    enabled:
+                                      description: Enabled reports the status of the
+                                        DHCP client services.
+                                      type: boolean
+                                  type: object
+                              type: object
+                            macAddr:
+                              description: MACAddr describes the observed MAC address
+                                for this interface.
+                              type: string
+                          type: object
+                        name:
+                          description: "Name describes the unique name of this network
+                            interface, used to distinguish it from other network interfaces
+                            attached to this VM. \n Please note this name is not related
+                            to the name of the device as it is surfaced inside of
+                            the guest."
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  ipRoutes:
+                    description: IPRoutes contain the VM's routing tables for all
+                      address families.
+                    items:
+                      description: VirtualMachineNetworkIPRouteStatus describes the
+                        observed state of a guest network's IP routes.
+                      properties:
+                        gateway:
+                          description: Gateway describes where to send the packets
+                            to next.
+                          properties:
+                            address:
+                              description: Address is the IP4 or IP6 address of the
+                                gateway.
+                              type: string
+                            device:
+                              description: Device is the name of the device in the
+                                guest for which this gateway applies.
+                              type: string
+                          type: object
+                        networkAddress:
+                          description: "NetworkAddress is the IP4 or IP6 address of
+                            the destination network. \n Addresses include the network's
+                            prefix length, ex. 192.168.0.0/24 or 2001:DB8:101::230:6eff:fe04:d9ff::/64.
+                            \n IP6 addresses are 128-bit addresses represented as
+                            eight fields of up to four hexadecimal digits. A colon
+                            separates each field (:). For example, 2001:DB8:101::230:6eff:fe04:d9ff.
+                            The address can also consist of symbol '::' to represent
+                            multiple 16-bit groups of contiguous 0's only once in
+                            an address as described in RFC 2373."
+                          type: string
+                      required:
+                      - gateway
+                      - networkAddress
+                      type: object
+                    type: array
+                  kernelConfig:
+                    description: "KernelConfig describes the observed state of the
+                      VM's kernel IP configuration settings. \n The key part contains
+                      a unique number while the value part contains the 'key=value'
+                      as provided by the underlying provider. For example, on Linux
+                      and/or BSD, the systcl -a output would be reported as: key='5',
+                      value='net.ipv4.tcp_keepalive_time = 7200'."
+                    items:
+                      description: KeyValuePair is useful when wanting to realize
+                        a map as a list of key/value pairs.
+                      properties:
+                        key:
+                          description: Key is the key part of the key/value pair.
+                          type: string
+                        value:
+                          description: Value is the optional value part of the key/value
+                            pair.
+                          type: string
+                      required:
+                      - key
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - key
+                    x-kubernetes-list-type: map
+                  primaryIP4:
+                    description: "PrimaryIP4 describes the VM's primary IP4 address.
+                      \n If the bootstrap provider is CloudInit then this value is
+                      set to the value of the VM's \"guestinfo.local-ipv4\" property.
+                      Please see https://bit.ly/3NJB534 for more information on how
+                      this value is calculated. \n If the bootstrap provider is anything
+                      else then this field is set to the value of the infrastructure
+                      VM's \"guest.ipAddress\" field. Please see https://bit.ly/3Au0jM4
+                      for more information."
+                    type: string
+                  primaryIP6:
+                    description: "PrimaryIP6 describes the VM's primary IP6 address.
+                      \n If the bootstrap provider is CloudInit then this value is
+                      set to the value of the VM's \"guestinfo.local-ipv6\" property.
+                      Please see https://bit.ly/3NJB534 for more information on how
+                      this value is calculated. \n If the bootstrap provider is anything
+                      else then this field is set to the value of the infrastructure
+                      VM's \"guest.ipAddress\" field. Please see https://bit.ly/3Au0jM4
+                      for more information."
+                    type: string
+                type: object
+              powerState:
+                description: PowerState describes the observed power state of the
+                  VirtualMachine.
+                enum:
+                - PoweredOff
+                - PoweredOn
+                - Suspended
+                type: string
+              uniqueID:
+                description: UniqueID describes a unique identifier that is provided
+                  by the underlying infrastructure provider, such as vSphere.
+                type: string
+              volumes:
+                description: Volumes describes a list of current status information
+                  for each Volume that is desired to be attached to the VM.
+                items:
+                  description: VirtualMachineVolumeStatus defines the observed state
+                    of a VirtualMachineVolume instance.
+                  properties:
+                    attached:
+                      description: Attached represents whether a volume has been successfully
+                        attached to the VirtualMachine or not.
+                      type: boolean
+                    diskUUID:
+                      description: DiskUUID represents the underlying virtual disk
+                        UUID and is present when attachment succeeds.
+                      type: string
+                    error:
+                      description: Error represents the last error seen when attaching
+                        or detaching a volume.  Error will be empty if attachment
+                        succeeds.
+                      type: string
+                    name:
+                      description: Name is the name of the attached volume.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              zone:
+                description: "Zone describes the availability zone where the VirtualMachine
+                  has been scheduled. \n Please note this field may be empty when
+                  the cluster is not zone-aware."
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachineservices.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachineservices.yaml
@@ -178,3 +178,151 @@ spec:
     storage: true
     subresources:
       status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.type
+      name: Type
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: VirtualMachineService is the Schema for the virtualmachineservices
+          API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualMachineServiceSpec defines the desired state of VirtualMachineService.
+            properties:
+              clusterIp:
+                description: 'clusterIP is the IP address of the service and is usually
+                  assigned randomly by the master. If an address is specified manually
+                  and is not in use by others, it will be allocated to the service;
+                  otherwise, creation of the service will fail. This field can not
+                  be changed through updates. Valid values are "None", empty string
+                  (""), or a valid IP address. "None" can be specified for headless
+                  services when proxying is not required. Only applies to types ClusterIP
+                  and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                type: string
+              externalName:
+                description: externalName is the external reference that kubedns or
+                  equivalent will return as a CNAME record for this service. No proxying
+                  will be involved. Must be a valid RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
+                  and requires Type to be ExternalName.
+                type: string
+              loadBalancerIP:
+                description: 'Only applies to VirtualMachineService Type: LoadBalancer
+                  LoadBalancer will get created with the IP specified in this field.
+                  This feature depends on whether the underlying load balancer provider
+                  supports specifying the loadBalancerIP when a load balancer is created.
+                  This field will be ignored if the provider does not support the
+                  feature.'
+                type: string
+              loadBalancerSourceRanges:
+                description: 'LoadBalancerSourceRanges is an array of IP addresses
+                  in the format of CIDRs, for example: 103.21.244.0/22 and 10.0.0.0/24.
+                  If specified and supported by the load balancer provider, this will
+                  restrict ingress traffic to the specified client IPs. This field
+                  will be ignored if the provider does not support the feature.'
+                items:
+                  type: string
+                type: array
+              ports:
+                description: Ports specifies a list of VirtualMachineServicePort to
+                  expose with this VirtualMachineService. Each of these ports will
+                  be an accessible network entry point to access this service by.
+                items:
+                  description: VirtualMachineServicePort describes the specification
+                    of a service port to be exposed by a VirtualMachineService. This
+                    VirtualMachineServicePort specification includes attributes that
+                    define the external and internal representation of the service
+                    port.
+                  properties:
+                    name:
+                      description: Name describes the name to be used to identify
+                        this VirtualMachineServicePort.
+                      type: string
+                    port:
+                      description: Port describes the external port that will be exposed
+                        by the service.
+                      format: int32
+                      type: integer
+                    protocol:
+                      description: Protocol describes the Layer 4 transport protocol
+                        for this port. Supports "TCP", "UDP", and "SCTP".
+                      type: string
+                    targetPort:
+                      description: TargetPort describes the internal port open on
+                        a VirtualMachine that should be mapped to the external Port.
+                      format: int32
+                      type: integer
+                  required:
+                  - name
+                  - port
+                  - protocol
+                  - targetPort
+                  type: object
+                type: array
+              selector:
+                additionalProperties:
+                  type: string
+                description: Selector specifies a map of key-value pairs, also known
+                  as a Label Selector, that is used to match this VirtualMachineService
+                  with the set of VirtualMachines that should back this VirtualMachineService.
+                type: object
+              type:
+                description: Type specifies a desired VirtualMachineServiceType for
+                  this VirtualMachineService. Supported types are ClusterIP, LoadBalancer,
+                  ExternalName.
+                type: string
+            required:
+            - type
+            type: object
+          status:
+            description: VirtualMachineServiceStatus defines the observed state of
+              VirtualMachineService.
+            properties:
+              loadBalancer:
+                description: LoadBalancer contains the current status of the load
+                  balancer, if one is present.
+                properties:
+                  ingress:
+                    description: Ingress is a list containing ingress addresses for
+                      the load balancer. Traffic intended for the service should be
+                      sent to any of these ingress points.
+                    items:
+                      description: 'LoadBalancerIngress represents the status of a
+                        load balancer ingress point: traffic intended for the service
+                        should be sent to an ingress point. IP or Hostname may both
+                        be set in this structure. It is up to the consumer to determine
+                        which field should be used when accessing this LoadBalancer.'
+                      properties:
+                        hostname:
+                          description: Hostname is set for load balancer ingress points
+                            that are specified by a DNS address.
+                          type: string
+                        ip:
+                          description: IP is set for load balancer ingress points
+                            that are specified by an IP address.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachinesetresourcepolicies.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachinesetresourcepolicies.yaml
@@ -127,3 +127,101 @@ spec:
     storage: true
     subresources:
       status: {}
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: VirtualMachineSetResourcePolicy is the Schema for the virtualmachinesetresourcepolicies
+          API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualMachineSetResourcePolicySpec defines the desired state
+              of VirtualMachineSetResourcePolicy.
+            properties:
+              clusterModuleGroups:
+                items:
+                  type: string
+                type: array
+              folder:
+                type: string
+              resourcePool:
+                description: ResourcePoolSpec defines a Logical Grouping of workloads
+                  that share resource policies.
+                properties:
+                  limits:
+                    description: Limits describes the limit to resources available
+                      to the ResourcePool.
+                    properties:
+                      cpu:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      memory:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  name:
+                    description: Name describes the name of the ResourcePool grouping.
+                    type: string
+                  reservations:
+                    description: Reservations describes the guaranteed resources reserved
+                      for the ResourcePool.
+                    properties:
+                      cpu:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      memory:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                    type: object
+                type: object
+            type: object
+          status:
+            description: VirtualMachineSetResourcePolicyStatus defines the observed
+              state of VirtualMachineSetResourcePolicy.
+            properties:
+              clustermodules:
+                items:
+                  description: VSphereClusterModuleStatus describes the observed state
+                    of a vSphere cluster module.
+                  properties:
+                    clusterMoID:
+                      type: string
+                    groupName:
+                      type: string
+                    moduleUUID:
+                      type: string
+                  required:
+                  - clusterMoID
+                  - groupName
+                  - moduleUUID
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -26,6 +26,27 @@ webhooks:
     resources:
     - virtualmachines
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /default-mutate-vmoperator-vmware-com-v1alpha2-virtualmachine
+  failurePolicy: Fail
+  name: default.mutating.virtualmachine.v1alpha2.vmoperator.vmware.com
+  rules:
+  - apiGroups:
+    - vmoperator.vmware.com
+    apiVersions:
+    - v1alpha2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - virtualmachines
+  sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -179,4 +200,109 @@ webhooks:
     - UPDATE
     resources:
     - webconsolerequests
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /default-validate-vmoperator-vmware-com-v1alpha2-virtualmachine
+  failurePolicy: Fail
+  name: default.validating.virtualmachine.v1alpha2.vmoperator.vmware.com
+  rules:
+  - apiGroups:
+    - vmoperator.vmware.com
+    apiVersions:
+    - v1alpha2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - virtualmachines
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /default-validate-vmoperator-vmware-com-v1alpha2-virtualmachineclass
+  failurePolicy: Fail
+  name: default.validating.virtualmachineclass.v1alpha2.vmoperator.vmware.com
+  rules:
+  - apiGroups:
+    - vmoperator.vmware.com
+    apiVersions:
+    - v1alpha2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - virtualmachineclasses
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /default-validate-vmoperator-vmware-com-v1alpha2-virtualmachinepublishrequest
+  failurePolicy: Fail
+  name: default.validating.virtualmachinepublishrequest.v1alpha2.vmoperator.vmware.com
+  rules:
+  - apiGroups:
+    - vmoperator.vmware.com
+    apiVersions:
+    - v1alpha2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - virtualmachinepublishrequests
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /default-validate-vmoperator-vmware-com-v1alpha2-virtualmachineservice
+  failurePolicy: Fail
+  name: default.validating.virtualmachineservice.v1alpha2.vmoperator.vmware.com
+  rules:
+  - apiGroups:
+    - vmoperator.vmware.com
+    apiVersions:
+    - v1alpha2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - virtualmachineservices
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /default-validate-vmoperator-vmware-com-v1alpha2-virtualmachinesetresourcepolicy
+  failurePolicy: Fail
+  name: default.validating.virtualmachinesetresourcepolicy.v1alpha2.vmoperator.vmware.com
+  rules:
+  - apiGroups:
+    - vmoperator.vmware.com
+    apiVersions:
+    - v1alpha2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - virtualmachinesetresourcepolicies
   sideEffects: None

--- a/webhooks/virtualmachine/v1alpha2/mutation/virtualmachine_mutator.go
+++ b/webhooks/virtualmachine/v1alpha2/mutation/virtualmachine_mutator.go
@@ -28,9 +28,9 @@ const (
 	webHookName = "default"
 )
 
-// -kubebuilder:webhook:path=/default-mutate-vmoperator-vmware-com-v1alpha2-virtualmachine,mutating=true,failurePolicy=fail,groups=vmoperator.vmware.com,resources=virtualmachines,verbs=create;update,versions=v1alpha2,name=default.mutating.virtualmachine.v1alpha2.vmoperator.vmware.com,sideEffects=None,admissionReviewVersions=v1;v1beta1
-// -kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachine,verbs=get;list
-// -kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachine/status,verbs=get
+// +kubebuilder:webhook:path=/default-mutate-vmoperator-vmware-com-v1alpha2-virtualmachine,mutating=true,failurePolicy=fail,groups=vmoperator.vmware.com,resources=virtualmachines,verbs=create;update,versions=v1alpha2,name=default.mutating.virtualmachine.v1alpha2.vmoperator.vmware.com,sideEffects=None,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachine,verbs=get;list
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachine/status,verbs=get
 
 // AddToManager adds the webhook to the provided manager.
 func AddToManager(ctx *context.ControllerManagerContext, mgr ctrlmgr.Manager) error {

--- a/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator.go
@@ -61,9 +61,9 @@ const (
 	invalidNextRestartTimeOnUpdateNow        = "mutation webhooks are required to restart VM"
 )
 
-// -kubebuilder:webhook:verbs=create;update,path=/default-validate-vmoperator-vmware-com-v1alpha2-virtualmachine,mutating=false,failurePolicy=fail,groups=vmoperator.vmware.com,resources=virtualmachines,versions=v1alpha2,name=default.validating.virtualmachine.v1alpha2.vmoperator.vmware.com,sideEffects=None,admissionReviewVersions=v1;v1beta1
-// -kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachines,verbs=get;list
-// -kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachines/status,verbs=get
+// +kubebuilder:webhook:verbs=create;update,path=/default-validate-vmoperator-vmware-com-v1alpha2-virtualmachine,mutating=false,failurePolicy=fail,groups=vmoperator.vmware.com,resources=virtualmachines,versions=v1alpha2,name=default.validating.virtualmachine.v1alpha2.vmoperator.vmware.com,sideEffects=None,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachines,verbs=get;list
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachines/status,verbs=get
 
 // AddToManager adds the webhook to the provided manager.
 func AddToManager(ctx *context.ControllerManagerContext, mgr ctrlmgr.Manager) error {

--- a/webhooks/virtualmachineclass/v1alpha2/validation/virtualmachineclass_validator.go
+++ b/webhooks/virtualmachineclass/v1alpha2/validation/virtualmachineclass_validator.go
@@ -33,9 +33,9 @@ const (
 	invalidMemoryReqMsg = "memory request must not be larger than the memory limit"
 )
 
-// -kubebuilder:webhook:verbs=create;update,path=/default-validate-vmoperator-vmware-com-v1alpha2-virtualmachineclass,mutating=false,failurePolicy=fail,groups=vmoperator.vmware.com,resources=virtualmachineclasses,versions=v1alpha2,name=default.validating.virtualmachineclass.v1alpha2.vmoperator.vmware.com,sideEffects=None,admissionReviewVersions=v1;v1beta1
-// -kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachineclasses,verbs=get;list
-// -kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachineclasses/status,verbs=get
+// +kubebuilder:webhook:verbs=create;update,path=/default-validate-vmoperator-vmware-com-v1alpha2-virtualmachineclass,mutating=false,failurePolicy=fail,groups=vmoperator.vmware.com,resources=virtualmachineclasses,versions=v1alpha2,name=default.validating.virtualmachineclass.v1alpha2.vmoperator.vmware.com,sideEffects=None,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachineclasses,verbs=get;list
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachineclasses/status,verbs=get
 
 // AddToManager adds the webhook to the provided manager.
 func AddToManager(ctx *context.ControllerManagerContext, mgr ctrlmgr.Manager) error {

--- a/webhooks/virtualmachinepublishrequest/v1alpha2/validation/virtualmachinepublishrequest_validator.go
+++ b/webhooks/virtualmachinepublishrequest/v1alpha2/validation/virtualmachinepublishrequest_validator.go
@@ -31,10 +31,10 @@ const (
 	webHookName = "default"
 )
 
-// -kubebuilder:webhook:verbs=create;update,path=/default-validate-vmoperator-vmware-com-v1alpha2-virtualmachinepublishrequest,mutating=false,failurePolicy=fail,groups=vmoperator.vmware.com,resources=virtualmachinepublishrequests,versions=v1alpha2,name=default.validating.virtualmachinepublishrequest.v1alpha2.vmoperator.vmware.com,sideEffects=None,admissionReviewVersions=v1;v1beta1
-// -kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachinepublishrequests,verbs=get;list
-// -kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachinepublishrequests/status,verbs=get
-// -kubebuilder:rbac:groups=imageregistry.vmware.com,resources=contentlibraries,verbs=get;list;
+// +kubebuilder:webhook:verbs=create;update,path=/default-validate-vmoperator-vmware-com-v1alpha2-virtualmachinepublishrequest,mutating=false,failurePolicy=fail,groups=vmoperator.vmware.com,resources=virtualmachinepublishrequests,versions=v1alpha2,name=default.validating.virtualmachinepublishrequest.v1alpha2.vmoperator.vmware.com,sideEffects=None,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachinepublishrequests,verbs=get;list
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachinepublishrequests/status,verbs=get
+// +kubebuilder:rbac:groups=imageregistry.vmware.com,resources=contentlibraries,verbs=get;list;
 
 // AddToManager adds the webhook to the provided manager.
 func AddToManager(ctx *context.ControllerManagerContext, mgr ctrlmgr.Manager) error {

--- a/webhooks/virtualmachineservice/v1alpha2/validation/virtualmachineservice_validator.go
+++ b/webhooks/virtualmachineservice/v1alpha2/validation/virtualmachineservice_validator.go
@@ -48,9 +48,9 @@ var (
 	)
 )
 
-// -kubebuilder:webhook:verbs=create;update,path=/default-validate-vmoperator-vmware-com-v1alpha2-virtualmachineservice,mutating=false,failurePolicy=fail,groups=vmoperator.vmware.com,resources=virtualmachineservices,versions=v1alpha2,name=default.validating.virtualmachineservice.v1alpha2.vmoperator.vmware.com,sideEffects=None,admissionReviewVersions=v1;v1beta1
-// -kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachineservices,verbs=get;list
-// -kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachineservices/status,verbs=get
+// +kubebuilder:webhook:verbs=create;update,path=/default-validate-vmoperator-vmware-com-v1alpha2-virtualmachineservice,mutating=false,failurePolicy=fail,groups=vmoperator.vmware.com,resources=virtualmachineservices,versions=v1alpha2,name=default.validating.virtualmachineservice.v1alpha2.vmoperator.vmware.com,sideEffects=None,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachineservices,verbs=get;list
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachineservices/status,verbs=get
 
 // AddToManager adds the webhook to the provided manager.
 func AddToManager(ctx *context.ControllerManagerContext, mgr ctrlmgr.Manager) error {

--- a/webhooks/virtualmachinesetresourcepolicy/v1alpha2/validation/virtualmachinesetresourcepolicy_validator.go
+++ b/webhooks/virtualmachinesetresourcepolicy/v1alpha2/validation/virtualmachinesetresourcepolicy_validator.go
@@ -31,9 +31,9 @@ const (
 	webHookName = "default"
 )
 
-// -kubebuilder:webhook:verbs=create;update,path=/default-validate-vmoperator-vmware-com-v1alpha2-virtualmachinesetresourcepolicy,mutating=false,failurePolicy=fail,groups=vmoperator.vmware.com,resources=virtualmachinesetresourcepolicies,versions=v1alpha2,name=default.validating.virtualmachinesetresourcepolicy.v1alpha2.vmoperator.vmware.com,sideEffects=None,admissionReviewVersions=v1;v1beta1
-// -kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachinesetresourcepolicies,verbs=get;list
-// -kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachinesetresourcepolicies/status,verbs=get
+// +kubebuilder:webhook:verbs=create;update,path=/default-validate-vmoperator-vmware-com-v1alpha2-virtualmachinesetresourcepolicy,mutating=false,failurePolicy=fail,groups=vmoperator.vmware.com,resources=virtualmachinesetresourcepolicies,versions=v1alpha2,name=default.validating.virtualmachinesetresourcepolicy.v1alpha2.vmoperator.vmware.com,sideEffects=None,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachinesetresourcepolicies,verbs=get;list
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachinesetresourcepolicies/status,verbs=get
 
 // AddToManager adds the webhook to the provided manager.
 func AddToManager(ctx *context.ControllerManagerContext, mgr ctrlmgr.Manager) error {


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This change generates the v1alpha2 CRD and webhook manifests.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # N/A


**Are there any special notes for your reviewer**:

CSP (a consumer of the wcp deployment manifests) has code to strip out v1a2 manifests based on the V1A2 FSS value. 

**Please add a release note if necessary**:


```
Generate v1alpha2 custom resource definition and webhook manifests

```