### PR TITLE
:seedling: Limit template rendering to only vAppConfig and Sysprep transport

### DIFF
--- a/pkg/vmprovider/providers/vsphere/session/session_vm_customization.go
+++ b/pkg/vmprovider/providers/vsphere/session/session_vm_customization.go
@@ -273,8 +273,6 @@ func (s *Session) customize(
 	config *vimTypes.VirtualMachineConfigInfo,
 	updateArgs VMUpdateArgs) error {
 
-	TemplateVMMetadata(vmCtx, resVM, updateArgs)
-
 	transport := updateArgs.VMMetadata.Transport
 
 	var configSpec *vimTypes.VirtualMachineConfigSpec
@@ -288,6 +286,7 @@ func (s *Session) customize(
 		configSpec = GetOvfEnvCustSpec(config, updateArgs)
 		custSpec = GetLinuxPrepCustSpec(vmCtx.VM.Name, updateArgs)
 	case vmopv1.VirtualMachineMetadataVAppConfigTransport:
+		TemplateVMMetadata(vmCtx, resVM, updateArgs)
 		configSpec = GetOvfEnvCustSpec(config, updateArgs)
 	case vmopv1.VirtualMachineMetadataExtraConfigTransport:
 		configSpec = GetExtraConfigCustSpec(config, updateArgs)
@@ -297,6 +296,7 @@ func (s *Session) customize(
 		// In reality, the webhook will prevent "Sysprep" from being used unless
 		// the FSS is enabled.
 		if lib.IsWindowsSysprepFSSEnabled() {
+			TemplateVMMetadata(vmCtx, resVM, updateArgs)
 			configSpec = GetOvfEnvCustSpec(config, updateArgs)
 			custSpec, err = GetSysprepCustSpec(vmCtx.VM.Name, updateArgs)
 		}


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
VM operator can accept Golang template strings in bootstrap user-data and perform any substitutions before passing it down to the guest. However, as of today, the only bootstrap method that supports templating is vAppConfig and Sysprep. This change enforce template rendering to only  vAppConfig and Sysprep transport.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #146 


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->
Testing done: gce2e vmservice test passed with this change.

**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Limit template rendering to only vAppConfig and Sysprep transport
```