### PR TITLE
✨Enable v1a2 controller and webhook integration tests

### DIFF
--- a/controllers/contentlibrary/v1alpha2/clustercontentlibraryitem/clustercontentlibraryitem_controller_suite_test.go
+++ b/controllers/contentlibrary/v1alpha2/clustercontentlibraryitem/clustercontentlibraryitem_controller_suite_test.go
@@ -12,23 +12,23 @@ import (
 
 	"github.com/vmware-tanzu/vm-operator/controllers/contentlibrary/v1alpha2/clustercontentlibraryitem"
 	ctrlContext "github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 	providerfake "github.com/vmware-tanzu/vm-operator/pkg/vmprovider/fake"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 var intgFakeVMProvider = providerfake.NewVMProviderA2()
 
-var suite = builder.NewTestSuiteForController(
+var suite = builder.NewTestSuiteForControllerWithFSS(
 	clustercontentlibraryitem.AddToManager,
 	func(ctx *ctrlContext.ControllerManagerContext, _ ctrlmgr.Manager) error {
 		ctx.VMProviderA2 = intgFakeVMProvider
 		return nil
 	},
-)
+	map[string]bool{lib.VMServiceV1Alpha2FSS: true})
 
 func TestClusterContentLibraryItem(t *testing.T) {
-	_ = intgTests
-	suite.Register(t, "ClusterContentLibraryItem controller suite", nil /*intgTests*/, unitTests)
+	suite.Register(t, "ClusterContentLibraryItem controller suite", intgTests, unitTests)
 }
 
 var _ = BeforeSuite(suite.BeforeSuite)

--- a/controllers/contentlibrary/v1alpha2/contentlibraryitem/contentlibraryitem_controller_intg_test.go
+++ b/controllers/contentlibrary/v1alpha2/contentlibraryitem/contentlibraryitem_controller_intg_test.go
@@ -90,7 +90,7 @@ func clItemReconcile() {
 
 			imageName, err := utils.GetImageFieldNameFromItem(clItemKey.Name)
 			Expect(err).ToNot(HaveOccurred())
-			vmiKey := client.ObjectKey{Name: imageName}
+			vmiKey := client.ObjectKey{Name: imageName, Namespace: ctx.Namespace}
 
 			By("Finalizer should be added to ContentLibraryItem", func() {
 				waitForContentLibraryItemFinalizer(clItemKey)

--- a/controllers/contentlibrary/v1alpha2/contentlibraryitem/contentlibraryitem_controller_suite_test.go
+++ b/controllers/contentlibrary/v1alpha2/contentlibraryitem/contentlibraryitem_controller_suite_test.go
@@ -24,12 +24,12 @@ var suite = builder.NewTestSuiteForControllerWithFSS(
 		ctx.VMProviderA2 = intgFakeVMProvider
 		return nil
 	},
-	map[string]bool{lib.VMImageRegistryFSS: true},
-)
+	map[string]bool{
+		lib.VMImageRegistryFSS:   true,
+		lib.VMServiceV1Alpha2FSS: true})
 
 func TestContentLibraryItem(t *testing.T) {
-	_ = intgTests
-	suite.Register(t, "ContentLibraryItem controller suite", nil /*intgTests*/, unitTests)
+	suite.Register(t, "ContentLibraryItem controller suite", intgTests, unitTests)
 }
 
 var _ = BeforeSuite(suite.BeforeSuite)

--- a/controllers/virtualmachine/v1alpha2/virtualmachine_controller_suite_test.go
+++ b/controllers/virtualmachine/v1alpha2/virtualmachine_controller_suite_test.go
@@ -12,23 +12,23 @@ import (
 
 	virtualmachine "github.com/vmware-tanzu/vm-operator/controllers/virtualmachine/v1alpha2"
 	ctrlContext "github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 	providerfake "github.com/vmware-tanzu/vm-operator/pkg/vmprovider/fake"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 var intgFakeVMProvider = providerfake.NewVMProviderA2()
 
-var suite = builder.NewTestSuiteForController(
+var suite = builder.NewTestSuiteForControllerWithFSS(
 	virtualmachine.AddToManager,
 	func(ctx *ctrlContext.ControllerManagerContext, _ ctrlmgr.Manager) error {
 		ctx.VMProviderA2 = intgFakeVMProvider
 		return nil
 	},
-)
+	map[string]bool{lib.VMServiceV1Alpha2FSS: true})
 
 func TestVirtualMachine(t *testing.T) {
-	_ = intgTests
-	suite.Register(t, "VirtualMachine controller suite", nil /*intgTests*/, unitTests)
+	suite.Register(t, "VirtualMachine controller suite", intgTests, unitTests)
 }
 
 var _ = BeforeSuite(suite.BeforeSuite)

--- a/controllers/virtualmachineclass/v1alpha2/virtualmachineclass_controller_suite_test.go
+++ b/controllers/virtualmachineclass/v1alpha2/virtualmachineclass_controller_suite_test.go
@@ -9,18 +9,18 @@ import (
 	. "github.com/onsi/ginkgo"
 
 	virtualmachineclass "github.com/vmware-tanzu/vm-operator/controllers/virtualmachineclass/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 	"github.com/vmware-tanzu/vm-operator/pkg/manager"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
-var suite = builder.NewTestSuiteForController(
+var suite = builder.NewTestSuiteForControllerWithFSS(
 	virtualmachineclass.AddToManager,
 	manager.InitializeProvidersNoopFn,
-)
+	map[string]bool{lib.VMServiceV1Alpha2FSS: true})
 
 func TestVirtualMachineClass(t *testing.T) {
-	_ = intgTests
-	suite.Register(t, "VirtualMachineClass controller suite", nil /*intgTests*/, unitTests)
+	suite.Register(t, "VirtualMachineClass controller suite", intgTests, unitTests)
 }
 
 var _ = BeforeSuite(suite.BeforeSuite)

--- a/controllers/virtualmachinepublishrequest/v1alpha2/virtualmachinepublishrequest_controller_suite_test.go
+++ b/controllers/virtualmachinepublishrequest/v1alpha2/virtualmachinepublishrequest_controller_suite_test.go
@@ -25,12 +25,12 @@ var suite = builder.NewTestSuiteForControllerWithFSS(
 		ctx.VMProviderA2 = intgFakeVMProvider
 		return nil
 	},
-	map[string]bool{lib.VMImageRegistryFSS: true},
-)
+	map[string]bool{
+		lib.VMImageRegistryFSS:   true,
+		lib.VMServiceV1Alpha2FSS: true})
 
 func TestVirtualMachinePublishRequest(t *testing.T) {
-	_ = intgTests
-	suite.Register(t, "VirtualMachinePublishRequest controller suite", nil /*intgTests*/, unitTests)
+	suite.Register(t, "VirtualMachinePublishRequest controller suite", intgTests, unitTests)
 }
 
 var _ = BeforeSuite(suite.BeforeSuite)

--- a/controllers/virtualmachineservice/v1alpha2/virtualmachineservice_controller_suite_test.go
+++ b/controllers/virtualmachineservice/v1alpha2/virtualmachineservice_controller_suite_test.go
@@ -9,18 +9,19 @@ import (
 	. "github.com/onsi/ginkgo"
 
 	virtualmachineservice "github.com/vmware-tanzu/vm-operator/controllers/virtualmachineservice/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 	"github.com/vmware-tanzu/vm-operator/pkg/manager"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
-var suite = builder.NewTestSuiteForController(
+var suite = builder.NewTestSuiteForControllerWithFSS(
 	virtualmachineservice.AddToManager,
 	manager.InitializeProvidersNoopFn,
-)
+	map[string]bool{lib.VMServiceV1Alpha2FSS: true})
 
 func TestVirtualMachineService(t *testing.T) {
-	_ = intgTests
-	suite.Register(t, "VirtualMachineService controller suite", nil /*intgTests*/, unitTests)
+
+	suite.Register(t, "VirtualMachineService controller suite", intgTests, unitTests)
 }
 
 var _ = BeforeSuite(suite.BeforeSuite)

--- a/controllers/virtualmachinesetresourcepolicy/v1alpha2/virtualmachinesetresourcepolicy_controller_suite_test.go
+++ b/controllers/virtualmachinesetresourcepolicy/v1alpha2/virtualmachinesetresourcepolicy_controller_suite_test.go
@@ -12,23 +12,24 @@ import (
 
 	virtualmachinesetresourcepolicy "github.com/vmware-tanzu/vm-operator/controllers/virtualmachinesetresourcepolicy/v1alpha2"
 	ctrlContext "github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 	providerfake "github.com/vmware-tanzu/vm-operator/pkg/vmprovider/fake"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 var intgFakeVMProvider = providerfake.NewVMProviderA2()
 
-var suite = builder.NewTestSuiteForController(
+var suite = builder.NewTestSuiteForControllerWithFSS(
 	virtualmachinesetresourcepolicy.AddToManager,
 	func(ctx *ctrlContext.ControllerManagerContext, _ ctrlmgr.Manager) error {
 		ctx.VMProviderA2 = intgFakeVMProvider
 		return nil
 	},
-)
+	map[string]bool{lib.VMServiceV1Alpha2FSS: true})
 
 func TestVirtualMachineSetResourcePolicy(t *testing.T) {
-	_ = intgTests
-	suite.Register(t, "VirtualMachineSetResourcePolicy controller suite", nil /*intgTests*/, unitTests)
+
+	suite.Register(t, "VirtualMachineSetResourcePolicy controller suite", intgTests, unitTests)
 }
 
 var _ = BeforeSuite(suite.BeforeSuite)

--- a/controllers/volume/v1alpha2/volume_controller_suite_test.go
+++ b/controllers/volume/v1alpha2/volume_controller_suite_test.go
@@ -12,23 +12,24 @@ import (
 
 	volume "github.com/vmware-tanzu/vm-operator/controllers/volume/v1alpha2"
 	ctrlContext "github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 	providerfake "github.com/vmware-tanzu/vm-operator/pkg/vmprovider/fake"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 var intgFakeVMProvider = providerfake.NewVMProviderA2()
 
-var suite = builder.NewTestSuiteForController(
+var suite = builder.NewTestSuiteForControllerWithFSS(
 	volume.AddToManager,
 	func(ctx *ctrlContext.ControllerManagerContext, _ ctrlmgr.Manager) error {
 		ctx.VMProviderA2 = intgFakeVMProvider
 		return nil
 	},
-)
+	map[string]bool{lib.VMServiceV1Alpha2FSS: true})
 
 func TestVolume(t *testing.T) {
-	_ = intgTests
-	suite.Register(t, "Volume controller suite", nil /*intgTests*/, unitTests)
+
+	suite.Register(t, "Volume controller suite", intgTests, unitTests)
 }
 
 var _ = BeforeSuite(suite.BeforeSuite)

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -24,7 +24,9 @@ import (
 	cnsv1alpha1 "github.com/vmware-tanzu/vm-operator/external/vsphere-csi-driver/pkg/syncer/cnsoperator/apis/cnsnodevmattachment/v1alpha1"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1alpha2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 	"github.com/vmware-tanzu/vm-operator/pkg/record"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere"
 )
@@ -49,6 +51,10 @@ func New(opts Options) (Manager, error) {
 	_ = netopv1alpha1.AddToScheme(opts.Scheme)
 	_ = topologyv1.AddToScheme(opts.Scheme)
 	_ = imgregv1a1.AddToScheme(opts.Scheme)
+
+	if lib.IsVMServiceV1Alpha2FSSEnabled() {
+		_ = vmopv1alpha2.AddToScheme(opts.Scheme)
+	}
 	// +kubebuilder:scaffold:scheme
 
 	// controller-runtime Client creates an Informer for each resource that we watch.

--- a/webhooks/virtualmachine/v1alpha2/mutation/virtualmachine_mutator_suite_test.go
+++ b/webhooks/virtualmachine/v1alpha2/mutation/virtualmachine_mutator_suite_test.go
@@ -9,19 +9,20 @@ import (
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 
+	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachine/v1alpha2/mutation"
 )
 
 // suite is used for unit and integration testing this webhook.
-var suite = builder.NewTestSuiteForMutatingWebhook(
+var suite = builder.NewTestSuiteForMutatingWebhookwithFSS(
 	mutation.AddToManager,
 	mutation.NewMutator,
-	"default.mutating.virtualmachine.v1alpha2.vmoperator.vmware.com")
+	"default.mutating.virtualmachine.v1alpha2.vmoperator.vmware.com",
+	map[string]bool{lib.VMServiceV1Alpha2FSS: true})
 
 func TestWebhook(t *testing.T) {
-	_ = intgTests
-	suite.Register(t, "Mutating webhook suite", nil /*intgTests*/, uniTests)
+	suite.Register(t, "Mutating webhook suite", intgTests, uniTests)
 }
 
 var _ = BeforeSuite(suite.BeforeSuite)

--- a/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator_suite_test.go
+++ b/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator_suite_test.go
@@ -8,19 +8,20 @@ import (
 
 	. "github.com/onsi/ginkgo"
 
+	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachine/v1alpha2/validation"
 )
 
 // suite is used for unit and integration testing this webhook.
-var suite = builder.NewTestSuiteForValidatingWebhook(
+var suite = builder.NewTestSuiteForValidatingWebhookwithFSS(
 	validation.AddToManager,
 	validation.NewValidator,
-	"default.validating.virtualmachine.v1alpha2.vmoperator.vmware.com")
+	"default.validating.virtualmachine.v1alpha2.vmoperator.vmware.com",
+	map[string]bool{lib.VMServiceV1Alpha2FSS: true})
 
 func TestWebhook(t *testing.T) {
-	_ = intgTests
-	suite.Register(t, "Validation webhook suite", nil /*intgTests*/, unitTests)
+	suite.Register(t, "Validation webhook suite", intgTests, unitTests)
 }
 
 var _ = BeforeSuite(suite.BeforeSuite)

--- a/webhooks/virtualmachineclass/v1alpha2/mutation/virtualmachineclass_mutator_suite_test.go
+++ b/webhooks/virtualmachineclass/v1alpha2/mutation/virtualmachineclass_mutator_suite_test.go
@@ -8,19 +8,20 @@ import (
 
 	. "github.com/onsi/ginkgo"
 
+	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachineclass/v1alpha2/mutation"
 )
 
 // suite is used for unit and integration testing this webhook.
-var suite = builder.NewTestSuiteForMutatingWebhook(
+var suite = builder.NewTestSuiteForMutatingWebhookwithFSS(
 	mutation.AddToManager,
 	mutation.NewMutator,
-	"default.mutating.virtualmachineclass.v1alpha2.vmoperator.vmware.com")
+	"default.mutating.virtualmachineclass.v1alpha2.vmoperator.vmware.com",
+	map[string]bool{lib.VMServiceV1Alpha2FSS: true})
 
 func TestWebhook(t *testing.T) {
-	_ = intgTests
-	suite.Register(t, "Mutating webhook suite", nil /*intgTests*/, uniTests)
+	suite.Register(t, "Mutating webhook suite", intgTests, uniTests)
 }
 
 var _ = BeforeSuite(suite.BeforeSuite)

--- a/webhooks/virtualmachineclass/v1alpha2/validation/virtualmachineclass_validator_suite_test.go
+++ b/webhooks/virtualmachineclass/v1alpha2/validation/virtualmachineclass_validator_suite_test.go
@@ -8,19 +8,20 @@ import (
 
 	. "github.com/onsi/ginkgo"
 
+	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachineclass/v1alpha2/validation"
 )
 
 // suite is used for unit and integration testing this webhook.
-var suite = builder.NewTestSuiteForValidatingWebhook(
+var suite = builder.NewTestSuiteForValidatingWebhookwithFSS(
 	validation.AddToManager,
 	validation.NewValidator,
-	"default.validating.virtualmachineclass.v1alpha2.vmoperator.vmware.com")
+	"default.validating.virtualmachineclass.v1alpha2.vmoperator.vmware.com",
+	map[string]bool{lib.VMServiceV1Alpha2FSS: true})
 
 func TestWebhook(t *testing.T) {
-	_ = intgTests
-	suite.Register(t, "Validation webhook suite", nil /*intgTests*/, unitTests)
+	suite.Register(t, "Validation webhook suite", intgTests, unitTests)
 }
 
 var _ = BeforeSuite(suite.BeforeSuite)

--- a/webhooks/virtualmachinepublishrequest/v1alpha2/validation/virtualmachinepublishrequest_validator_suite_test.go
+++ b/webhooks/virtualmachinepublishrequest/v1alpha2/validation/virtualmachinepublishrequest_validator_suite_test.go
@@ -8,19 +8,20 @@ import (
 
 	. "github.com/onsi/ginkgo"
 
+	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachinepublishrequest/v1alpha2/validation"
 )
 
 // suite is used for unit and integration testing this webhook.
-var suite = builder.NewTestSuiteForValidatingWebhook(
+var suite = builder.NewTestSuiteForValidatingWebhookwithFSS(
 	validation.AddToManager,
 	validation.NewValidator,
-	"default.validating.virtualmachinepublishrequest.v1alpha2.vmoperator.vmware.com")
+	"default.validating.virtualmachinepublishrequest.v1alpha2.vmoperator.vmware.com",
+	map[string]bool{lib.VMServiceV1Alpha2FSS: true})
 
 func TestWebhook(t *testing.T) {
-	_ = intgTests
-	suite.Register(t, "Validation webhook suite", nil /*intgTests*/, unitTests)
+	suite.Register(t, "Validation webhook suite", intgTests, unitTests)
 }
 
 var _ = BeforeSuite(suite.BeforeSuite)

--- a/webhooks/virtualmachineservice/v1alpha2/mutation/virtualmachineservice_mutator_suite_test.go
+++ b/webhooks/virtualmachineservice/v1alpha2/mutation/virtualmachineservice_mutator_suite_test.go
@@ -8,18 +8,19 @@ import (
 
 	. "github.com/onsi/ginkgo"
 
+	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachineservice/v1alpha2/mutation"
 )
 
 // suite is used for unit and integration testing this webhook.
-var suite = builder.NewTestSuiteForMutatingWebhook(
+var suite = builder.NewTestSuiteForMutatingWebhookwithFSS(
 	mutation.AddToManager,
 	mutation.NewMutator,
-	"default.mutating.virtualmachineservice.v1alpha2.vmoperator.vmware.com")
+	"default.mutating.virtualmachineservice.v1alpha2.vmoperator.vmware.com",
+	map[string]bool{lib.VMServiceV1Alpha2FSS: true})
 
 func TestWebhook(t *testing.T) {
-	_ = intgTests
 	suite.Register(t, "Mutating webhook suite", intgTests, uniTests)
 }
 

--- a/webhooks/virtualmachineservice/v1alpha2/validation/virtualmachineservice_validator_suite_test.go
+++ b/webhooks/virtualmachineservice/v1alpha2/validation/virtualmachineservice_validator_suite_test.go
@@ -8,19 +8,20 @@ import (
 
 	. "github.com/onsi/ginkgo"
 
+	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachineservice/v1alpha2/validation"
 )
 
 // suite is used for unit and integration testing this webhook.
-var suite = builder.NewTestSuiteForValidatingWebhook(
+var suite = builder.NewTestSuiteForValidatingWebhookwithFSS(
 	validation.AddToManager,
 	validation.NewValidator,
-	"default.validating.virtualmachineservice.v1alpha2.vmoperator.vmware.com")
+	"default.validating.virtualmachineservice.v1alpha2.vmoperator.vmware.com",
+	map[string]bool{lib.VMServiceV1Alpha2FSS: true})
 
 func TestWebhook(t *testing.T) {
-	_ = intgTests
-	suite.Register(t, "Validation webhook suite", nil /*intgTests*/, unitTests)
+	suite.Register(t, "Validation webhook suite", intgTests, unitTests)
 }
 
 var _ = BeforeSuite(suite.BeforeSuite)

--- a/webhooks/virtualmachinesetresourcepolicy/v1alpha2/validation/virtualmachinesetresourcepolicy_validator_suite_test.go
+++ b/webhooks/virtualmachinesetresourcepolicy/v1alpha2/validation/virtualmachinesetresourcepolicy_validator_suite_test.go
@@ -8,19 +8,20 @@ import (
 
 	. "github.com/onsi/ginkgo"
 
+	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachinesetresourcepolicy/v1alpha2/validation"
 )
 
 // suite is used for unit and integration testing this webhook.
-var suite = builder.NewTestSuiteForValidatingWebhook(
+var suite = builder.NewTestSuiteForValidatingWebhookwithFSS(
 	validation.AddToManager,
 	validation.NewValidator,
-	"default.validating.virtualmachinesetresourcepolicy.v1alpha2.vmoperator.vmware.com")
+	"default.validating.virtualmachinesetresourcepolicy.v1alpha2.vmoperator.vmware.com",
+	map[string]bool{lib.VMServiceV1Alpha2FSS: true})
 
 func TestWebhook(t *testing.T) {
-	_ = intgTests
-	suite.Register(t, "Validation webhook suite", nil /*intgTests*/, unitTests)
+	suite.Register(t, "Validation webhook suite", intgTests, unitTests)
 }
 
 var _ = BeforeSuite(suite.BeforeSuite)


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

- This change enables controller and webhook integration tests for v1alpha2.
- The testsuite works with the v1A2 FSS to create the right CRD storage versions prior to the integration tests. This way, the right v1a1 and v1a2 CRDs are installed with the right storage versions when v1a1/v1a2 controller/webhook integration tests are run.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # 
N/A


**Are there any special notes for your reviewer**:
N/A


**Please add a release note if necessary**:
N/A