### PR TITLE
🐛 Adds event filter to incoming VirtualMachine objects only

### DIFF
--- a/controllers/virtualmachine/v1alpha1/virtualmachine_controller.go
+++ b/controllers/virtualmachine/v1alpha1/virtualmachine_controller.go
@@ -12,6 +12,7 @@ import (
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlbuilder "sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -79,7 +80,23 @@ func AddToManager(ctx *context.ControllerManagerContext, mgr manager.Manager) er
 	)
 
 	builder := ctrl.NewControllerManagedBy(mgr).
-		For(controlledType).
+		// Filter any VMs that reference a VM Class with a spec.controllerName set
+		// to a non-empty value other than "vmoperator.vmware.com/vsphere". Please
+		// note that a VM will *not* be filtered if the VM Class does not exist. A
+		// VM is also not filtered if the field spec.controllerName is missing or
+		// empty as long as the default VM Class controller is
+		// "vmoperator.vmware.com/vsphere".
+		For(controlledType, ctrlbuilder.WithPredicates(kubeutil.VMForControllerPredicate(
+			r.Client,
+			// These events can be very verbose, so be careful to not log them
+			// at too high of a log level.
+			r.Logger.WithName("VMForControllerPredicate").V(8),
+			vmClassControllerName,
+			kubeutil.VMForControllerPredicateOptions{
+				MatchIfVMClassNotFound:            true,
+				MatchIfControllerNameFieldEmpty:   isDefaultVMClassController,
+				MatchIfControllerNameFieldMissing: isDefaultVMClassController,
+			}))).
 		WithOptions(controller.Options{MaxConcurrentReconciles: ctx.MaxConcurrentReconciles})
 
 	if !lib.IsWCPVMImageRegistryEnabled() {
@@ -94,25 +111,6 @@ func AddToManager(ctx *context.ControllerManagerContext, mgr manager.Manager) er
 		builder = builder.Watches(&source.Kind{Type: &vmopv1.VirtualMachineClass{}},
 			handler.EnqueueRequestsFromMapFunc(classToVMMapperFn(ctx, r.Client)))
 	}
-
-	// Filter any VMs that reference a VM Class with a spec.controllerName set
-	// to a non-empty value other than "vmoperator.vmware.com/vsphere". Please
-	// note that a VM will *not* be filtered if the VM Class does not exist. A
-	// VM is also not filtered if the field spec.controllerName is missing or
-	// empty as long as the default VM Class controller is
-	// "vmoperator.vmware.com/vsphere".
-	builder = builder.WithEventFilter(
-		kubeutil.VMForControllerPredicate(
-			r.Client,
-			// These events can be very verbose, so be careful to not log them
-			// at too high of a log level.
-			r.Logger.WithName("VMForControllerPredicate").V(8),
-			vmClassControllerName,
-			kubeutil.VMForControllerPredicateOptions{
-				MatchIfVMClassNotFound:            true,
-				MatchIfControllerNameFieldEmpty:   isDefaultVMClassController,
-				MatchIfControllerNameFieldMissing: isDefaultVMClassController,
-			}))
 
 	return builder.Complete(r)
 }


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This ensures that the controllerName filter is applied to the incoming VirtualMachine objects only instead of all the watched objects by the controller.

This PR replaces #170 

**Please add a release note if necessary**:

```release-note
🐛 Adds event filter to incoming VirtualMachine objects only
```