### PR TITLE
✨Add PublicKey and Response fields to v1a2 VirtualMachineWebConsoleRequest CRD

### DIFF
--- a/api/v1alpha2/virtualmachinewebconsolerequest_types.go
+++ b/api/v1alpha2/virtualmachinewebconsolerequest_types.go
@@ -13,11 +13,15 @@ type VirtualMachineWebConsoleRequestSpec struct {
 	// Name is the name of a VM in the same Namespace as this web console
 	// request.
 	Name string `json:"name"`
+	// PublicKey is used to encrypt the status.response. This is expected to be a RSA OAEP public key in X.509 PEM format.
+	PublicKey string `json:"publicKey"`
 }
 
 // VirtualMachineWebConsoleRequestStatus describes the observed state of the
 // request.
 type VirtualMachineWebConsoleRequestStatus struct {
+	// Response will be the authenticated ticket corresponding to this web console request.
+	Response string `json:"response,omitempty"`
 	// ExpiryTime is the time at which access via this request will expire.
 	ExpiryTime metav1.Time `json:"expiryTime,omitempty"`
 

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachinewebconsolerequests.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachinewebconsolerequests.yaml
@@ -41,8 +41,13 @@ spec:
                 description: Name is the name of a VM in the same Namespace as this
                   web console request.
                 type: string
+              publicKey:
+                description: PublicKey is used to encrypt the status.response. This
+                  is expected to be a RSA OAEP public key in X.509 PEM format.
+                type: string
             required:
             - name
+            - publicKey
             type: object
           status:
             description: VirtualMachineWebConsoleRequestStatus describes the observed
@@ -64,6 +69,10 @@ spec:
                   \n In other words, the field may be set to any value that is parsable
                   by Go's https://pkg.go.dev/net#ResolveIPAddr and https://pkg.go.dev/net#ParseIP
                   functions."
+                type: string
+              response:
+                description: Response will be the authenticated ticket corresponding
+                  to this web console request.
                 type: string
             type: object
         type: object


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

- This change adds the spec.PublicKey and status.Response fields to the v1a2 VirtualMachineWebConsoleRequest CRD similar the v1a1 CRD. These are still required 


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #
N/A


**Please add a release note if necessary**:
N/A