### PR TITLE
🌱 Add FSS for VM Service Backup Restore

### DIFF
--- a/config/local/vmoperator/local_env_var_patch.yaml
+++ b/config/local/vmoperator/local_env_var_patch.yaml
@@ -31,3 +31,5 @@ spec:
           value: "false"
         - name: FSS_WCP_WINDOWS_SYSPREP
           value: "false"
+        - name: FSS_WCP_VMSERVICE_BACKUPRESTORE
+          value: "false"

--- a/config/wcp/vmoperator/manager_env_var_patch.yaml
+++ b/config/wcp/vmoperator/manager_env_var_patch.yaml
@@ -75,3 +75,9 @@
   value:
     name: FSS_WCP_WINDOWS_SYSPREP
     value: "<FSS_WCP_WINDOWS_SYSPREP_VALUE>"
+
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: FSS_WCP_VMSERVICE_BACKUPRESTORE
+    value: "<FSS_WCP_VMSERVICE_BACKUPRESTORE_VALUE>"

--- a/pkg/lib/env.go
+++ b/pkg/lib/env.go
@@ -25,6 +25,7 @@ const (
 	VMImageRegistryFSS            = "FSS_WCP_VM_IMAGE_REGISTRY"
 	NamespacedVMClassFSS          = "FSS_WCP_NAMESPACED_VM_CLASS"
 	WindowsSysprepFSS             = "FSS_WCP_WINDOWS_SYSPREP"
+	VMServiceBackupRestoreFSS     = "FSS_WCP_VMSERVICE_BACKUPRESTORE"
 	MaxCreateVMsOnProviderEnv     = "MAX_CREATE_VMS_ON_PROVIDER"
 	DefaultMaxCreateVMsOnProvider = 80
 
@@ -121,6 +122,10 @@ var IsNamespacedVMClassFSSEnabled = func() bool {
 
 var IsWindowsSysprepFSSEnabled = func() bool {
 	return os.Getenv(WindowsSysprepFSS) == trueString
+}
+
+var IsVMServiceBackupRestoreFSSEnabled = func() bool {
+	return os.Getenv(VMServiceBackupRestoreFSS) == trueString
 }
 
 // MaxConcurrentCreateVMsOnProvider returns the percentage of reconciler


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR adds a new Feature-State-Switch (FSS) that will be used for the upcoming VM Service VM backup and restore-related feature implementation.

**Are there any special notes for your reviewer**:

This FSS already exists in the vCenter and a corresponding change has been created to the internal CSP repo.

**Please add a release note if necessary**:

```release-note
NONE
```