### PR TITLE
✨ Persist VM's kubernetes and bootstrap data in ExtraConfig

### DIFF
--- a/controllers/virtualmachine/v1alpha1/virtualmachine_controller.go
+++ b/controllers/virtualmachine/v1alpha1/virtualmachine_controller.go
@@ -474,8 +474,7 @@ func (r *Reconciler) ReconcileNormal(ctx *context.VirtualMachineContext) (reterr
 
 	// Back up this VM if ReconcileNormal succeeds and the FSS is enabled.
 	if lib.IsVMServiceBackupRestoreFSSEnabled() {
-		err := r.VMProvider.BackupVirtualMachine(ctx, ctx.VM)
-		if err != nil {
+		if err := r.VMProvider.BackupVirtualMachine(ctx, ctx.VM); err != nil {
 			ctx.Logger.Error(err, "Failed to backup VirtualMachine")
 			r.Recorder.EmitEvent(ctx.VM, "Backup", err, false)
 			return err

--- a/controllers/virtualmachine/v1alpha1/virtualmachine_controller.go
+++ b/controllers/virtualmachine/v1alpha1/virtualmachine_controller.go
@@ -472,6 +472,16 @@ func (r *Reconciler) ReconcileNormal(ctx *context.VirtualMachineContext) (reterr
 	// Add this VM to prober manager if ReconcileNormal succeeds.
 	r.Prober.AddToProberManager(ctx.VM)
 
+	// Back up this VM if ReconcileNormal succeeds and the FSS is enabled.
+	if lib.IsVMServiceBackupRestoreFSSEnabled() {
+		err := r.VMProvider.BackupVirtualMachine(ctx, ctx.VM)
+		if err != nil {
+			ctx.Logger.Error(err, "Failed to backup VirtualMachine")
+			r.Recorder.EmitEvent(ctx.VM, "Backup", err, false)
+			return err
+		}
+	}
+
 	ctx.Logger.Info("Finished Reconciling VirtualMachine")
 	return nil
 }

--- a/controllers/virtualmachine/v1alpha1/virtualmachine_controller_unit_test.go
+++ b/controllers/virtualmachine/v1alpha1/virtualmachine_controller_unit_test.go
@@ -158,7 +158,6 @@ func unitTestsReconcile() {
 		})
 
 		When("The VM Service Backup and Restore FSS is enabled", func() {
-
 			BeforeEach(func() {
 				Expect(os.Setenv(lib.VMServiceBackupRestoreFSS, lib.TrueString)).To(Succeed())
 			})

--- a/controllers/virtualmachine/v1alpha1/virtualmachine_controller_unit_test.go
+++ b/controllers/virtualmachine/v1alpha1/virtualmachine_controller_unit_test.go
@@ -6,8 +6,8 @@ package v1alpha1_test
 import (
 	"context"
 	"errors"
+	"os"
 	"strings"
-	"sync/atomic"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -158,25 +158,13 @@ func unitTestsReconcile() {
 		})
 
 		When("The VM Service Backup and Restore FSS is enabled", func() {
-			var (
-				// This is manipulated atomically to avoid races where the controller
-				// is trying to read this _while_ the tests are updating it.
-				vmServiceBackupRestoreFSS     uint32
-				origVMServiceBackupRestoreFSS uint32
-			)
-
-			// Modify the helper function to return the custom value of the FSS.
-			lib.IsVMServiceBackupRestoreFSSEnabled = func() bool {
-				return atomic.LoadUint32(&vmServiceBackupRestoreFSS) != 0
-			}
 
 			BeforeEach(func() {
-				origVMServiceBackupRestoreFSS = vmServiceBackupRestoreFSS
-				atomic.StoreUint32(&vmServiceBackupRestoreFSS, 1)
+				Expect(os.Setenv(lib.VMServiceBackupRestoreFSS, lib.TrueString)).To(Succeed())
 			})
 
 			AfterEach(func() {
-				atomic.StoreUint32(&vmServiceBackupRestoreFSS, origVMServiceBackupRestoreFSS)
+				Expect(os.Unsetenv(lib.VMServiceBackupRestoreFSS)).To(Succeed())
 			})
 
 			It("Should call backup Virtual Machine if ReconcileNormal succeeds", func() {

--- a/controllers/virtualmachine/v1alpha2/virtualmachine_controller.go
+++ b/controllers/virtualmachine/v1alpha2/virtualmachine_controller.go
@@ -337,6 +337,16 @@ func (r *Reconciler) ReconcileNormal(ctx *context.VirtualMachineContextA2) (rete
 	// Add this VM to prober manager if ReconcileNormal succeeds.
 	r.Prober.AddToProberManager(ctx.VM)
 
+	// Back up this VM if ReconcileNormal succeeds and the FSS is enabled.
+	if lib.IsVMServiceBackupRestoreFSSEnabled() {
+		err := r.VMProvider.BackupVirtualMachine(ctx, ctx.VM)
+		if err != nil {
+			ctx.Logger.Error(err, "Failed to backup VirtualMachine")
+			r.Recorder.EmitEvent(ctx.VM, "Backup", err, false)
+			return err
+		}
+	}
+
 	ctx.Logger.Info("Finished Reconciling VirtualMachine")
 	return nil
 }

--- a/controllers/virtualmachine/v1alpha2/virtualmachine_controller.go
+++ b/controllers/virtualmachine/v1alpha2/virtualmachine_controller.go
@@ -339,8 +339,7 @@ func (r *Reconciler) ReconcileNormal(ctx *context.VirtualMachineContextA2) (rete
 
 	// Back up this VM if ReconcileNormal succeeds and the FSS is enabled.
 	if lib.IsVMServiceBackupRestoreFSSEnabled() {
-		err := r.VMProvider.BackupVirtualMachine(ctx, ctx.VM)
-		if err != nil {
+		if err := r.VMProvider.BackupVirtualMachine(ctx, ctx.VM); err != nil {
 			ctx.Logger.Error(err, "Failed to backup VirtualMachine")
 			r.Recorder.EmitEvent(ctx.VM, "Backup", err, false)
 			return err

--- a/controllers/virtualmachine/v1alpha2/virtualmachine_controller_unit_test.go
+++ b/controllers/virtualmachine/v1alpha2/virtualmachine_controller_unit_test.go
@@ -6,6 +6,7 @@ package v1alpha2_test
 import (
 	"context"
 	"errors"
+	"os"
 	"strings"
 
 	. "github.com/onsi/ginkgo"
@@ -18,6 +19,7 @@ import (
 
 	virtualmachine "github.com/vmware-tanzu/vm-operator/controllers/virtualmachine/v1alpha2"
 	vmopContext "github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 	proberfake "github.com/vmware-tanzu/vm-operator/pkg/prober2/fake"
 	providerfake "github.com/vmware-tanzu/vm-operator/pkg/vmprovider/fake"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
@@ -152,6 +154,27 @@ func unitTestsReconcile() {
 
 			Expect(reconciler.ReconcileNormal(vmCtx)).Should(Succeed())
 			Expect(fakeProbeManager.IsAddToProberManagerCalled).Should(BeTrue())
+		})
+
+		When("The VM Service Backup and Restore FSS is enabled", func() {
+			BeforeEach(func() {
+				Expect(os.Setenv(lib.VMServiceBackupRestoreFSS, lib.TrueString)).To(Succeed())
+			})
+
+			AfterEach(func() {
+				Expect(os.Unsetenv(lib.VMServiceBackupRestoreFSS)).To(Succeed())
+			})
+
+			It("Should call backup Virtual Machine if ReconcileNormal succeeds", func() {
+				var isBackupVirtualMachineCalled bool
+				fakeVMProvider.BackupVirtualMachineFn = func(ctx context.Context, vm *vmopv1.VirtualMachine) error {
+					isBackupVirtualMachineCalled = true
+					return nil
+				}
+
+				Expect(reconciler.ReconcileNormal(vmCtx)).Should(Succeed())
+				Expect(isBackupVirtualMachineCalled).Should(BeTrue())
+			})
 		})
 	})
 

--- a/pkg/lib/env.go
+++ b/pkg/lib/env.go
@@ -13,7 +13,6 @@ import (
 )
 
 const (
-	trueString                    = "true"
 	TrueString                    = "true"
 	VmopNamespaceEnv              = "POD_NAMESPACE"
 	WcpFaultDomainsFSS            = "FSS_WCP_FAULTDOMAINS"
@@ -89,43 +88,43 @@ var IsNamedNetworkProviderEnabled = func() bool {
 }
 
 var IsWcpFaultDomainsFSSEnabled = func() bool {
-	return os.Getenv(WcpFaultDomainsFSS) == trueString
+	return os.Getenv(WcpFaultDomainsFSS) == TrueString
 }
 
 func IsVMServiceV1Alpha2FSSEnabled() bool {
-	return os.Getenv(VMServiceV1Alpha2FSS) == trueString
+	return os.Getenv(VMServiceV1Alpha2FSS) == TrueString
 }
 
 var IsInstanceStorageFSSEnabled = func() bool {
-	return os.Getenv(InstanceStorageFSS) == trueString
+	return os.Getenv(InstanceStorageFSS) == TrueString
 }
 
 var IsUnifiedTKGFSSEnabled = func() bool {
-	return os.Getenv(UnifiedTKGFSS) == trueString
+	return os.Getenv(UnifiedTKGFSS) == TrueString
 }
 
 var IsVMClassAsConfigFSSEnabled = func() bool {
-	return os.Getenv(VMClassAsConfigFSS) == trueString
+	return os.Getenv(VMClassAsConfigFSS) == TrueString
 }
 
 var IsVMClassAsConfigFSSDaynDateEnabled = func() bool {
-	return os.Getenv(VMClassAsConfigDaynDateFSS) == trueString
+	return os.Getenv(VMClassAsConfigDaynDateFSS) == TrueString
 }
 
 var IsWCPVMImageRegistryEnabled = func() bool {
-	return os.Getenv(VMImageRegistryFSS) == trueString
+	return os.Getenv(VMImageRegistryFSS) == TrueString
 }
 
 var IsNamespacedVMClassFSSEnabled = func() bool {
-	return os.Getenv(NamespacedVMClassFSS) == trueString
+	return os.Getenv(NamespacedVMClassFSS) == TrueString
 }
 
 var IsWindowsSysprepFSSEnabled = func() bool {
-	return os.Getenv(WindowsSysprepFSS) == trueString
+	return os.Getenv(WindowsSysprepFSS) == TrueString
 }
 
 var IsVMServiceBackupRestoreFSSEnabled = func() bool {
-	return os.Getenv(VMServiceBackupRestoreFSS) == trueString
+	return os.Getenv(VMServiceBackupRestoreFSS) == TrueString
 }
 
 // MaxConcurrentCreateVMsOnProvider returns the percentage of reconciler

--- a/pkg/util/enc.go
+++ b/pkg/util/enc.go
@@ -64,6 +64,7 @@ func EncodeGzipBase64(s string) (string, error) {
 	if _, err := zw.Write([]byte(s)); err != nil {
 		return "", err
 	}
+	// Flush before closing to ensure all data is written.
 	if err := zw.Flush(); err != nil {
 		return "", err
 	}

--- a/pkg/util/enc.go
+++ b/pkg/util/enc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package util
@@ -54,4 +54,23 @@ func TryToDecodeBase64Gzip(data []byte) (string, error) {
 	}
 
 	return string(plainText), nil
+}
+
+// EncodeGzipBase64 compresses the input string using gzip and then encodes it
+// using base64.
+func EncodeGzipBase64(s string) (string, error) {
+	var zbuf bytes.Buffer
+	zw := gzip.NewWriter(&zbuf)
+	if _, err := zw.Write([]byte(s)); err != nil {
+		return "", err
+	}
+	if err := zw.Flush(); err != nil {
+		return "", err
+	}
+	if err := zw.Close(); err != nil {
+		return "", err
+	}
+
+	b64 := base64.StdEncoding.EncodeToString(zbuf.Bytes())
+	return b64, nil
 }

--- a/pkg/util/enc_test.go
+++ b/pkg/util/enc_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/base64"
+	"io/ioutil"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -159,7 +160,18 @@ var _ = Describe("EncodeGzipBase64", func() {
 	It("Encodes a string correctly", func() {
 		input := "HelloWorld"
 		output, err := util.EncodeGzipBase64(input)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(output).To(Equal("H4sIAAAAAAAA//JIzcnJD88vykkBAAAA//8BAAD//3kMd3cKAAAA"))
+		Expect(err).NotTo(HaveOccurred())
+		// Decode the base64 output.
+		decoded, err := base64.StdEncoding.DecodeString(output)
+		Expect(err).NotTo(HaveOccurred())
+		// Ungzip the decoded output.
+		reader := bytes.NewReader(decoded)
+		gzipReader, err := gzip.NewReader(reader)
+		Expect(err).NotTo(HaveOccurred())
+		defer Expect(gzipReader.Close()).To(Succeed())
+
+		ungzipped, err := ioutil.ReadAll(gzipReader)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(input).Should(Equal(string(ungzipped)))
 	})
 })

--- a/pkg/util/enc_test.go
+++ b/pkg/util/enc_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package util_test
@@ -153,5 +153,13 @@ var _ = Describe("TryToDecodeBase64Gzip", func() {
 			})
 		})
 	})
+})
 
+var _ = Describe("EncodeGzipBase64", func() {
+	It("Encodes a string correctly", func() {
+		input := "HelloWorld"
+		output, err := util.EncodeGzipBase64(input)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(output).To(Equal("H4sIAAAAAAAA//JIzcnJD88vykkBAAAA//8BAAD//3kMd3cKAAAA"))
+	})
 })

--- a/pkg/vmprovider/fake/fake_vm_provider.go
+++ b/pkg/vmprovider/fake/fake_vm_provider.go
@@ -31,6 +31,7 @@ type funcs struct {
 	DeleteVirtualMachineFn         func(ctx context.Context, vm *vmopv1.VirtualMachine) error
 	PublishVirtualMachineFn        func(ctx context.Context, vm *vmopv1.VirtualMachine,
 		vmPub *vmopv1.VirtualMachinePublishRequest, cl *imgregv1a1.ContentLibrary, actID string) (string, error)
+	BackupVirtualMachineFn             func(ctx context.Context, vm *vmopv1.VirtualMachine) error
 	GetVirtualMachineGuestHeartbeatFn  func(ctx context.Context, vm *vmopv1.VirtualMachine) (vmopv1.GuestHeartbeatStatus, error)
 	GetVirtualMachineWebMKSTicketFn    func(ctx context.Context, vm *vmopv1.VirtualMachine, pubKey string) (string, error)
 	GetVirtualMachineHardwareVersionFn func(ctx context.Context, vm *vmopv1.VirtualMachine) (int32, error)
@@ -110,6 +111,17 @@ func (s *VMProvider) PublishVirtualMachine(ctx context.Context, vm *vmopv1.Virtu
 
 	s.AddToVMPublishMap(actID, vimTypes.TaskInfoStateSuccess)
 	return "dummy-id", nil
+}
+
+func (s *VMProvider) BackupVirtualMachine(ctx context.Context, vm *vmopv1.VirtualMachine) error {
+	s.Lock()
+	defer s.Unlock()
+
+	if s.BackupVirtualMachineFn != nil {
+		return s.BackupVirtualMachineFn(ctx, vm)
+	}
+
+	return nil
 }
 
 func (s *VMProvider) GetVirtualMachineGuestHeartbeat(ctx context.Context, vm *vmopv1.VirtualMachine) (vmopv1.GuestHeartbeatStatus, error) {

--- a/pkg/vmprovider/fake/fake_vm_provider_a2.go
+++ b/pkg/vmprovider/fake/fake_vm_provider_a2.go
@@ -31,6 +31,7 @@ type funcsA2 struct {
 	DeleteVirtualMachineFn         func(ctx context.Context, vm *vmopv1.VirtualMachine) error
 	PublishVirtualMachineFn        func(ctx context.Context, vm *vmopv1.VirtualMachine,
 		vmPub *vmopv1.VirtualMachinePublishRequest, cl *imgregv1a1.ContentLibrary, actID string) (string, error)
+	BackupVirtualMachineFn             func(ctx context.Context, vm *vmopv1.VirtualMachine) error
 	GetVirtualMachineGuestHeartbeatFn  func(ctx context.Context, vm *vmopv1.VirtualMachine) (vmopv1.GuestHeartbeatStatus, error)
 	GetVirtualMachineWebMKSTicketFn    func(ctx context.Context, vm *vmopv1.VirtualMachine, pubKey string) (string, error)
 	GetVirtualMachineHardwareVersionFn func(ctx context.Context, vm *vmopv1.VirtualMachine) (int32, error)
@@ -110,6 +111,17 @@ func (s *VMProviderA2) PublishVirtualMachine(ctx context.Context, vm *vmopv1.Vir
 
 	s.AddToVMPublishMap(actID, vimTypes.TaskInfoStateSuccess)
 	return "dummy-id", nil
+}
+
+func (s *VMProviderA2) BackupVirtualMachine(ctx context.Context, vm *vmopv1.VirtualMachine) error {
+	s.Lock()
+	defer s.Unlock()
+
+	if s.BackupVirtualMachineFn != nil {
+		return s.BackupVirtualMachineFn(ctx, vm)
+	}
+
+	return nil
 }
 
 func (s *VMProviderA2) GetVirtualMachineGuestHeartbeat(ctx context.Context, vm *vmopv1.VirtualMachine) (vmopv1.GuestHeartbeatStatus, error) {

--- a/pkg/vmprovider/interface.go
+++ b/pkg/vmprovider/interface.go
@@ -22,6 +22,7 @@ type VirtualMachineProviderInterface interface {
 	DeleteVirtualMachine(ctx context.Context, vm *vmopv1.VirtualMachine) error
 	PublishVirtualMachine(ctx context.Context, vm *vmopv1.VirtualMachine,
 		vmPub *vmopv1.VirtualMachinePublishRequest, cl *imgregv1a1.ContentLibrary, actID string) (string, error)
+	BackupVirtualMachine(ctx context.Context, vm *vmopv1.VirtualMachine) error
 	GetVirtualMachineGuestHeartbeat(ctx context.Context, vm *vmopv1.VirtualMachine) (vmopv1.GuestHeartbeatStatus, error)
 	GetVirtualMachineWebMKSTicket(ctx context.Context, vm *vmopv1.VirtualMachine, pubKey string) (string, error)
 	GetVirtualMachineHardwareVersion(ctx context.Context, vm *vmopv1.VirtualMachine) (int32, error)

--- a/pkg/vmprovider/interface_a2.go
+++ b/pkg/vmprovider/interface_a2.go
@@ -21,6 +21,7 @@ type VirtualMachineProviderInterfaceA2 interface {
 	DeleteVirtualMachine(ctx context.Context, vm *v1alpha2.VirtualMachine) error
 	PublishVirtualMachine(ctx context.Context, vm *v1alpha2.VirtualMachine,
 		vmPub *v1alpha2.VirtualMachinePublishRequest, cl *imgregv1a1.ContentLibrary, actID string) (string, error)
+	BackupVirtualMachine(ctx context.Context, vm *v1alpha2.VirtualMachine) error
 	GetVirtualMachineGuestHeartbeat(ctx context.Context, vm *v1alpha2.VirtualMachine) (v1alpha2.GuestHeartbeatStatus, error)
 	GetVirtualMachineWebMKSTicket(ctx context.Context, vm *v1alpha2.VirtualMachine, pubKey string) (string, error)
 	GetVirtualMachineHardwareVersion(ctx context.Context, vm *v1alpha2.VirtualMachine) (int32, error)

--- a/pkg/vmprovider/providers/vsphere/constants/constants.go
+++ b/pkg/vmprovider/providers/vsphere/constants/constants.go
@@ -118,4 +118,11 @@ const (
 	V1alpha1SubnetMask = "V1alpha1_SubnetMask"
 	// V1alpha1FormatNameservers is an alias for versioned templating function V1alpha1_FormatNameservers.
 	V1alpha1FormatNameservers = "V1alpha1_FormatNameservers"
+
+	// BackupVMKubeDataExtraConfigKey is the ExtraConfig key to the VirtualMachine
+	// resource's Kubernetes spec data, compressed using gzip and base64-encoded.
+	BackupVMKubeDataExtraConfigKey = "vmservice.virtualmachine.kubedata"
+	// BackupVMBootstrapDataExtraConfigKey is the ExtraConfig key to the VM's
+	// bootstrap data object, compressed using gzip and base64-encoded.
+	BackupVMBootstrapDataExtraConfigKey = "vmservice.virtualmachine.bootstrapdata"
 )

--- a/pkg/vmprovider/providers/vsphere/session/session_util.go
+++ b/pkg/vmprovider/providers/vsphere/session/session_util.go
@@ -1,13 +1,9 @@
-// Copyright (c) 2018-2022 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2018-2023 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package session
 
 import (
-	"bytes"
-	"compress/gzip"
-	"encoding/base64"
-
 	vimTypes "github.com/vmware/govmomi/vim25/types"
 )
 
@@ -80,21 +76,4 @@ func GetMergedvAppConfigSpec(inProps map[string]string, vmProps []vimTypes.VAppP
 		// a CD-ROM device required to use the ISO transport.
 		OvfEnvironmentTransport: []string{OvfEnvironmentTransportGuestInfo},
 	}
-}
-
-func EncodeGzipBase64(s string) (string, error) {
-	var zbuf bytes.Buffer
-	zw := gzip.NewWriter(&zbuf)
-	if _, err := zw.Write([]byte(s)); err != nil {
-		return "", err
-	}
-	if err := zw.Flush(); err != nil {
-		return "", err
-	}
-	if err := zw.Close(); err != nil {
-		return "", err
-	}
-
-	b64 := base64.StdEncoding.EncodeToString(zbuf.Bytes())
-	return b64, nil
 }

--- a/pkg/vmprovider/providers/vsphere/session/session_util_test.go
+++ b/pkg/vmprovider/providers/vsphere/session/session_util_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2019-2023 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package session_test
@@ -154,15 +154,6 @@ var _ = Describe("Test Session Utils", func() {
 				Expect(mergedMap["newkey1"]).To(Equal("newvalue1"))
 				Expect(mergedMap["newkey2"]).To(Equal("newvalue2"))
 			})
-		})
-	})
-
-	Context("EncodeGzipBase64", func() {
-		It("Encodes a string correctly", func() {
-			input := "HelloWorld"
-			output, err := session.EncodeGzipBase64(input)
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(output).To(Equal("H4sIAAAAAAAA//JIzcnJD88vykkBAAAA//8BAAD//3kMd3cKAAAA"))
 		})
 	})
 })

--- a/pkg/vmprovider/providers/vsphere/session/session_vm_customization.go
+++ b/pkg/vmprovider/providers/vsphere/session/session_vm_customization.go
@@ -151,7 +151,7 @@ func GetCloudInitGuestInfoCustSpec(
 
 	extraConfig := map[string]string{}
 
-	encodedMetadata, err := EncodeGzipBase64(cloudInitMetadata)
+	encodedMetadata, err := util.EncodeGzipBase64(cloudInitMetadata)
 	if err != nil {
 		return nil, fmt.Errorf("encoding cloud-init metadata failed %v", err)
 	}
@@ -176,7 +176,7 @@ func GetCloudInitGuestInfoCustSpec(
 			return nil, fmt.Errorf("decoding cloud-init userdata failed %v", err)
 		}
 
-		encodedUserdata, err := EncodeGzipBase64(plainText)
+		encodedUserdata, err := util.EncodeGzipBase64(plainText)
 		if err != nil {
 			return nil, fmt.Errorf("encoding cloud-init userdata failed %v", err)
 		}

--- a/pkg/vmprovider/providers/vsphere/session/session_vm_customization_test.go
+++ b/pkg/vmprovider/providers/vsphere/session/session_vm_customization_test.go
@@ -24,6 +24,7 @@ import (
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/util"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/constants"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/internal"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/network"
@@ -353,7 +354,7 @@ var _ = Describe("Cloud-Init Customization", func() {
 
 		Context("With gzipped, base64-encoded userdata but no encoding specified", func() {
 			BeforeEach(func() {
-				data, err := session.EncodeGzipBase64(cloudInitUserdata)
+				data, err := util.EncodeGzipBase64(cloudInitUserdata)
 				Expect(err).ToNot(HaveOccurred())
 				updateArgs.VMMetadata.Data["user-data"] = data
 			})
@@ -460,7 +461,7 @@ var _ = Describe("Cloud-Init Customization", func() {
 
 		Context("With gzipped, base64-encoded userdata but no encoding specified", func() {
 			BeforeEach(func() {
-				data, err := session.EncodeGzipBase64(cloudInitUserdata)
+				data, err := util.EncodeGzipBase64(cloudInitUserdata)
 				Expect(err).ToNot(HaveOccurred())
 				updateArgs.VMMetadata.Data["user-data"] = data
 			})

--- a/pkg/vmprovider/providers/vsphere/virtualmachine/backup.go
+++ b/pkg/vmprovider/providers/vsphere/virtualmachine/backup.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package virtualmachine
+
+import (
+	goctx "context"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+	corev1 "k8s.io/api/core/v1"
+	ctrlruntime "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	"github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/util"
+	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/constants"
+)
+
+// BackupVirtualMachine backs up the VM's kube data and bootstrap data into the VM's ExtraConfig.
+func BackupVirtualMachine(
+	vmCtx context.VirtualMachineContext,
+	vcVM *object.VirtualMachine,
+	k8sClient ctrlruntime.Client) error {
+	vmKubeData, err := getEncodedVMKubeData(vmCtx.VM)
+	if err != nil {
+		vmCtx.Logger.Error(err, "Failed to get VM kube data for backup")
+		return err
+	}
+
+	vmBootstrapData, err := getEncodedVMBootstrapData(vmCtx.Context, vmCtx.VM, k8sClient)
+	if err != nil {
+		vmCtx.Logger.Error(err, "Failed to get VM bootstrap data for backup")
+		return err
+	}
+	if vmBootstrapData == "" {
+		vmCtx.Logger.V(4).Info("No bootstrap data is set to the VM for backup")
+	}
+
+	_, err = vcVM.Reconfigure(vmCtx, types.VirtualMachineConfigSpec{
+		ExtraConfig: []types.BaseOptionValue{
+			&types.OptionValue{
+				Key:   constants.BackupVMKubeDataExtraConfigKey,
+				Value: vmKubeData,
+			},
+			&types.OptionValue{
+				Key:   constants.BackupVMBootstrapDataExtraConfigKey,
+				Value: vmBootstrapData,
+			},
+		}})
+	if err != nil {
+		vmCtx.Logger.Error(err, "Failed to reconfigure VM's ExtraConfig with backup data")
+		return err
+	}
+
+	return nil
+}
+
+func getEncodedVMKubeData(vm *vmopv1.VirtualMachine) (string, error) {
+	backupVM := vm.DeepCopy()
+	// No need to back up status fields as we expect the VM to be re-created during restore.
+	backupVM.Status = vmopv1.VirtualMachineStatus{}
+	backupYaml, err := yaml.Marshal(backupVM)
+	if err != nil {
+		return "", err
+	}
+
+	return util.EncodeGzipBase64(string(backupYaml))
+}
+
+func getEncodedVMBootstrapData(
+	ctx goctx.Context,
+	vm *vmopv1.VirtualMachine,
+	k8sClient ctrlruntime.Client) (string, error) {
+	// Return early if the VM bootstrap data is not set.
+	if vm.Spec.VmMetadata == nil {
+		return "", nil
+	}
+
+	var bootstrapObj ctrlruntime.Object
+
+	if cmName := vm.Spec.VmMetadata.ConfigMapName; cmName != "" {
+		cm := &corev1.ConfigMap{}
+		cmKey := ctrlruntime.ObjectKey{Name: cmName, Namespace: vm.Namespace}
+		if err := k8sClient.Get(ctx, cmKey, cm); err != nil {
+			return "", err
+		}
+		cm.APIVersion = "v1"
+		cm.Kind = "ConfigMap"
+		bootstrapObj = cm
+	}
+
+	if secretName := vm.Spec.VmMetadata.SecretName; secretName != "" {
+		secret := &corev1.Secret{}
+		secretKey := ctrlruntime.ObjectKey{Name: secretName, Namespace: vm.Namespace}
+		if err := k8sClient.Get(ctx, secretKey, secret); err != nil {
+			return "", err
+		}
+		secret.APIVersion = "v1"
+		secret.Kind = "Secret"
+		bootstrapObj = secret
+	}
+
+	if bootstrapObj == nil {
+		return "", nil
+	}
+
+	bootstrapYaml, err := yaml.Marshal(bootstrapObj)
+	if err != nil {
+		return "", err
+	}
+
+	return util.EncodeGzipBase64(string(bootstrapYaml))
+}

--- a/pkg/vmprovider/providers/vsphere/virtualmachine/backup_test.go
+++ b/pkg/vmprovider/providers/vsphere/virtualmachine/backup_test.go
@@ -1,0 +1,270 @@
+// Copyright (c) 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package virtualmachine_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlruntime "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	"github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/util"
+	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/constants"
+	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/virtualmachine"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+func backupTests() {
+
+	var (
+		ctx   *builder.TestContextForVCSim
+		vcVM  *object.VirtualMachine
+		vmCtx context.VirtualMachineContext
+	)
+
+	BeforeEach(func() {
+		ctx = suite.NewTestContextForVCSim(builder.VCSimTestConfig{})
+
+		var err error
+		vcVM, err = ctx.Finder.VirtualMachine(ctx, "DC0_C0_RP0_VM0")
+		Expect(err).ToNot(HaveOccurred())
+
+		vmCtx = context.VirtualMachineContext{
+			Context: ctx,
+			Logger:  suite.GetLogger().WithValues("vmName", vcVM.Name()),
+			VM:      builder.DummyVirtualMachine(),
+		}
+	})
+
+	AfterEach(func() {
+		ctx.AfterEach()
+		ctx = nil
+	})
+
+	JustBeforeEach(func() {
+		if vmCtx.VM.Spec.VmMetadata == nil {
+			return
+		}
+
+		dummyData := map[string]string{"foo": "bar"}
+
+		if cmName := vmCtx.VM.Spec.VmMetadata.ConfigMapName; cmName != "" {
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cmName,
+					Namespace: vmCtx.VM.Namespace,
+				},
+				Data: dummyData,
+			}
+			Expect(ctx.Client.Create(ctx, cm)).To(Succeed())
+		}
+
+		if secretName := vmCtx.VM.Spec.VmMetadata.SecretName; secretName != "" {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: vmCtx.VM.Namespace,
+				},
+				StringData: dummyData,
+			}
+			Expect(ctx.Client.Create(ctx, secret)).To(Succeed())
+		}
+	})
+
+	JustAfterEach(func() {
+		if vmCtx.VM.Spec.VmMetadata == nil {
+			return
+		}
+
+		if cmName := vmCtx.VM.Spec.VmMetadata.ConfigMapName; cmName != "" {
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cmName,
+					Namespace: vmCtx.VM.Namespace,
+				},
+			}
+			Expect(ctx.Client.Delete(ctx, cm)).To(Succeed())
+		}
+
+		if secretName := vmCtx.VM.Spec.VmMetadata.SecretName; secretName != "" {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: vmCtx.VM.Namespace,
+				},
+			}
+			Expect(ctx.Client.Delete(ctx, secret)).To(Succeed())
+		}
+	})
+
+	Context("VM has no VM Metadata defined", func() {
+
+		var (
+			originalVMMetadata *vmopv1.VirtualMachineMetadata
+		)
+
+		BeforeEach(func() {
+			originalVMMetadata = vmCtx.VM.Spec.VmMetadata
+			vmCtx.VM.Spec.VmMetadata = nil
+		})
+
+		AfterEach(func() {
+			vmCtx.VM.Spec.VmMetadata = originalVMMetadata
+		})
+
+		It("Should back up only VM kube data in ExtraConfig", func() {
+			Expect(virtualmachine.BackupVirtualMachine(vmCtx, vcVM, ctx.Client)).To(Succeed())
+			verifyBackupDataInExtraConfig(ctx, vcVM, vmCtx)
+		})
+	})
+
+	Context("VM has neither ConfigMap or Secret defined in VM Metadata", func() {
+
+		var (
+			originalVMMetadata *vmopv1.VirtualMachineMetadata
+		)
+
+		BeforeEach(func() {
+			originalVMMetadata = vmCtx.VM.Spec.VmMetadata
+			vmCtx.VM.Spec.VmMetadata = &vmopv1.VirtualMachineMetadata{
+				Transport: "CloudInit",
+			}
+		})
+
+		AfterEach(func() {
+			vmCtx.VM.Spec.VmMetadata = originalVMMetadata
+		})
+
+		It("Should back up only VM kube data in ExtraConfig", func() {
+			Expect(virtualmachine.BackupVirtualMachine(vmCtx, vcVM, ctx.Client)).To(Succeed())
+			verifyBackupDataInExtraConfig(ctx, vcVM, vmCtx)
+
+		})
+	})
+
+	Context("VM has bootstrap data defined in ConfigMap", func() {
+
+		var (
+			originalVMMetadata *vmopv1.VirtualMachineMetadata
+		)
+
+		BeforeEach(func() {
+			originalVMMetadata = vmCtx.VM.Spec.VmMetadata
+			vmCtx.VM.Spec.VmMetadata = &vmopv1.VirtualMachineMetadata{
+				ConfigMapName: "dummy-cm",
+			}
+		})
+
+		AfterEach(func() {
+			vmCtx.VM.Spec.VmMetadata = originalVMMetadata
+		})
+
+		It("Should back up both VM kube data and bootstrap data from ConfigMap in ExtraConfig", func() {
+			Expect(virtualmachine.BackupVirtualMachine(vmCtx, vcVM, ctx.Client)).To(Succeed())
+			verifyBackupDataInExtraConfig(ctx, vcVM, vmCtx)
+		})
+
+	})
+
+	Context("VM has bootstrap data defined in Secret", func() {
+
+		var (
+			originalVMMetadata *vmopv1.VirtualMachineMetadata
+		)
+
+		BeforeEach(func() {
+			originalVMMetadata = vmCtx.VM.Spec.VmMetadata
+			vmCtx.VM.Spec.VmMetadata = &vmopv1.VirtualMachineMetadata{
+				SecretName: "dummy-secret",
+			}
+		})
+
+		AfterEach(func() {
+			vmCtx.VM.Spec.VmMetadata = originalVMMetadata
+		})
+
+		It("Should back up both VM kube data and bootstrap data from Secret in ExtraConfig", func() {
+			Expect(virtualmachine.BackupVirtualMachine(vmCtx, vcVM, ctx.Client)).To(Succeed())
+			verifyBackupDataInExtraConfig(ctx, vcVM, vmCtx)
+		})
+	})
+}
+
+// verifyBackupDataInExtraConfig verifies that the backup data is stored in VM's ExtraConfig.
+// It gets the expected data from the VM CR and compares it with the actual data in ExtraConfig.
+func verifyBackupDataInExtraConfig(
+	ctx *builder.TestContextForVCSim,
+	vcVM *object.VirtualMachine,
+	vmCtx context.VirtualMachineContext) {
+	// Get expected backup VM's kube data from the VM CR.
+	vmCopy := vmCtx.VM.DeepCopy()
+	vmCopy.Status = vmopv1.VirtualMachineStatus{}
+	vmCopyYaml, err := yaml.Marshal(vmCopy)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(vmCopyYaml).NotTo(BeEmpty())
+	expectedKubeData, err := util.EncodeGzipBase64(string(vmCopyYaml))
+	Expect(err).NotTo(HaveOccurred())
+
+	// Get expected backup bootstrap data from VM's ConfigMap/Secret if defined.
+	expectedBootstrapData := ""
+	if vmCtx.VM.Spec.VmMetadata != nil {
+		if cmName := vmCtx.VM.Spec.VmMetadata.ConfigMapName; cmName != "" {
+			cm := &corev1.ConfigMap{}
+			cmKey := ctrlruntime.ObjectKey{Name: cmName, Namespace: vmCtx.VM.Namespace}
+			Expect(ctx.Client.Get(ctx, cmKey, cm)).To(Succeed())
+			cm.APIVersion = "v1"
+			cm.Kind = "ConfigMap"
+			cmYaml, err := yaml.Marshal(cm)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cmYaml).NotTo(BeEmpty())
+			expectedBootstrapData, err = util.EncodeGzipBase64(string(cmYaml))
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		if secretName := vmCtx.VM.Spec.VmMetadata.SecretName; secretName != "" {
+			secret := &corev1.Secret{}
+			secretKey := ctrlruntime.ObjectKey{Name: secretName, Namespace: vmCtx.VM.Namespace}
+			Expect(ctx.Client.Get(ctx, secretKey, secret)).To(Succeed())
+			secret.APIVersion = "v1"
+			secret.Kind = "Secret"
+			secretYaml, err := yaml.Marshal(secret)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(secretYaml).NotTo(BeEmpty())
+			expectedBootstrapData, err = util.EncodeGzipBase64(string(secretYaml))
+			Expect(err).NotTo(HaveOccurred())
+		}
+	}
+
+	// Get actual backup data from VM's ExtraConfig.
+	moID := vcVM.Reference().Value
+	objVM := ctx.GetVMFromMoID(moID)
+	Expect(objVM).ToNot(BeNil())
+	var moVM mo.VirtualMachine
+	Expect(objVM.Properties(ctx, objVM.Reference(), []string{"config.extraConfig"}, &moVM)).To(Succeed())
+
+	// Compare the backup data in ExtraConfig with the expected data.
+	var kubeDataMatched, bootstrapDataMatched bool
+	for _, ec := range moVM.Config.ExtraConfig {
+		if ec.GetOptionValue().Key == constants.BackupVMBootstrapDataExtraConfigKey {
+			Expect(ec.GetOptionValue().Value.(string)).To(Equal(expectedBootstrapData))
+			bootstrapDataMatched = true
+		} else if ec.GetOptionValue().Key == constants.BackupVMKubeDataExtraConfigKey {
+			Expect(ec.GetOptionValue().Value.(string)).To(Equal(expectedKubeData))
+			kubeDataMatched = true
+		}
+
+		if kubeDataMatched && bootstrapDataMatched {
+			return
+		}
+	}
+
+	Expect(kubeDataMatched).To(BeTrue())
+	Expect(bootstrapDataMatched).To(BeTrue())
+}

--- a/pkg/vmprovider/providers/vsphere/virtualmachine/backup_test.go
+++ b/pkg/vmprovider/providers/vsphere/virtualmachine/backup_test.go
@@ -4,14 +4,15 @@
 package virtualmachine_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"github.com/vmware/govmomi/object"
-	"github.com/vmware/govmomi/vim25/mo"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlruntime "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"

--- a/pkg/vmprovider/providers/vsphere/virtualmachine/backup_test.go
+++ b/pkg/vmprovider/providers/vsphere/virtualmachine/backup_test.go
@@ -4,9 +4,6 @@
 package virtualmachine_test
 
 import (
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ctrlruntime "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
 	. "github.com/onsi/ginkgo"
@@ -23,11 +20,11 @@ import (
 )
 
 func backupTests() {
-
 	var (
-		ctx   *builder.TestContextForVCSim
-		vcVM  *object.VirtualMachine
-		vmCtx context.VirtualMachineContext
+		ctx           *builder.TestContextForVCSim
+		vcVM          *object.VirtualMachine
+		vmCtx         context.VirtualMachineContext
+		bootstrapData map[string]string
 	)
 
 	BeforeEach(func() {
@@ -49,161 +46,38 @@ func backupTests() {
 		ctx = nil
 	})
 
-	JustBeforeEach(func() {
-		if vmCtx.VM.Spec.VmMetadata == nil {
-			return
-		}
-
-		dummyData := map[string]string{"foo": "bar"}
-
-		if cmName := vmCtx.VM.Spec.VmMetadata.ConfigMapName; cmName != "" {
-			cm := &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      cmName,
-					Namespace: vmCtx.VM.Namespace,
-				},
-				Data: dummyData,
-			}
-			Expect(ctx.Client.Create(ctx, cm)).To(Succeed())
-		}
-
-		if secretName := vmCtx.VM.Spec.VmMetadata.SecretName; secretName != "" {
-			secret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      secretName,
-					Namespace: vmCtx.VM.Namespace,
-				},
-				StringData: dummyData,
-			}
-			Expect(ctx.Client.Create(ctx, secret)).To(Succeed())
-		}
-	})
-
-	JustAfterEach(func() {
-		if vmCtx.VM.Spec.VmMetadata == nil {
-			return
-		}
-
-		if cmName := vmCtx.VM.Spec.VmMetadata.ConfigMapName; cmName != "" {
-			cm := &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      cmName,
-					Namespace: vmCtx.VM.Namespace,
-				},
-			}
-			Expect(ctx.Client.Delete(ctx, cm)).To(Succeed())
-		}
-
-		if secretName := vmCtx.VM.Spec.VmMetadata.SecretName; secretName != "" {
-			secret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      secretName,
-					Namespace: vmCtx.VM.Namespace,
-				},
-			}
-			Expect(ctx.Client.Delete(ctx, secret)).To(Succeed())
-		}
-	})
-
-	Context("VM has no VM Metadata defined", func() {
-
-		var (
-			originalVMMetadata *vmopv1.VirtualMachineMetadata
-		)
-
-		BeforeEach(func() {
-			originalVMMetadata = vmCtx.VM.Spec.VmMetadata
-			vmCtx.VM.Spec.VmMetadata = nil
-		})
-
-		AfterEach(func() {
-			vmCtx.VM.Spec.VmMetadata = originalVMMetadata
-		})
+	Context("VM bootstrap data is NOT provided", func() {
 
 		It("Should back up only VM kube data in ExtraConfig", func() {
-			Expect(virtualmachine.BackupVirtualMachine(vmCtx, vcVM, ctx.Client)).To(Succeed())
-			verifyBackupDataInExtraConfig(ctx, vcVM, vmCtx)
+			Expect(virtualmachine.BackupVirtualMachine(vmCtx, vcVM, nil)).To(Succeed())
+			verifyBackupDataInExtraConfig(ctx, vcVM, vmCtx, nil)
 		})
 	})
 
-	Context("VM has neither ConfigMap or Secret defined in VM Metadata", func() {
-
-		var (
-			originalVMMetadata *vmopv1.VirtualMachineMetadata
-		)
+	Context("VM bootstrap data is provided", func() {
 
 		BeforeEach(func() {
-			originalVMMetadata = vmCtx.VM.Spec.VmMetadata
-			vmCtx.VM.Spec.VmMetadata = &vmopv1.VirtualMachineMetadata{
-				Transport: "CloudInit",
-			}
+			bootstrapData = map[string]string{"foo": "bar"}
 		})
 
 		AfterEach(func() {
-			vmCtx.VM.Spec.VmMetadata = originalVMMetadata
+			bootstrapData = nil
 		})
 
-		It("Should back up only VM kube data in ExtraConfig", func() {
-			Expect(virtualmachine.BackupVirtualMachine(vmCtx, vcVM, ctx.Client)).To(Succeed())
-			verifyBackupDataInExtraConfig(ctx, vcVM, vmCtx)
-
-		})
-	})
-
-	Context("VM has bootstrap data defined in ConfigMap", func() {
-
-		var (
-			originalVMMetadata *vmopv1.VirtualMachineMetadata
-		)
-
-		BeforeEach(func() {
-			originalVMMetadata = vmCtx.VM.Spec.VmMetadata
-			vmCtx.VM.Spec.VmMetadata = &vmopv1.VirtualMachineMetadata{
-				ConfigMapName: "dummy-cm",
-			}
-		})
-
-		AfterEach(func() {
-			vmCtx.VM.Spec.VmMetadata = originalVMMetadata
-		})
-
-		It("Should back up both VM kube data and bootstrap data from ConfigMap in ExtraConfig", func() {
-			Expect(virtualmachine.BackupVirtualMachine(vmCtx, vcVM, ctx.Client)).To(Succeed())
-			verifyBackupDataInExtraConfig(ctx, vcVM, vmCtx)
-		})
-
-	})
-
-	Context("VM has bootstrap data defined in Secret", func() {
-
-		var (
-			originalVMMetadata *vmopv1.VirtualMachineMetadata
-		)
-
-		BeforeEach(func() {
-			originalVMMetadata = vmCtx.VM.Spec.VmMetadata
-			vmCtx.VM.Spec.VmMetadata = &vmopv1.VirtualMachineMetadata{
-				SecretName: "dummy-secret",
-			}
-		})
-
-		AfterEach(func() {
-			vmCtx.VM.Spec.VmMetadata = originalVMMetadata
-		})
-
-		It("Should back up both VM kube data and bootstrap data from Secret in ExtraConfig", func() {
-			Expect(virtualmachine.BackupVirtualMachine(vmCtx, vcVM, ctx.Client)).To(Succeed())
-			verifyBackupDataInExtraConfig(ctx, vcVM, vmCtx)
+		It("Should back up both VM kube data and bootstrap data in ExtraConfig", func() {
+			Expect(virtualmachine.BackupVirtualMachine(vmCtx, vcVM, bootstrapData)).To(Succeed())
+			verifyBackupDataInExtraConfig(ctx, vcVM, vmCtx, bootstrapData)
 		})
 	})
 }
 
 // verifyBackupDataInExtraConfig verifies that the backup data is stored in VM's ExtraConfig.
-// It gets the expected data from the VM CR and compares it with the actual data in ExtraConfig.
+// It gets the expected data and compares it with the actual data in ExtraConfig.
 func verifyBackupDataInExtraConfig(
 	ctx *builder.TestContextForVCSim,
 	vcVM *object.VirtualMachine,
-	vmCtx context.VirtualMachineContext) {
+	vmCtx context.VirtualMachineContext,
+	bootstrapData map[string]string) {
 	// Get expected backup VM's kube data from the VM CR.
 	vmCopy := vmCtx.VM.DeepCopy()
 	vmCopy.Status = vmopv1.VirtualMachineStatus{}
@@ -213,34 +87,12 @@ func verifyBackupDataInExtraConfig(
 	expectedKubeData, err := util.EncodeGzipBase64(string(vmCopyYaml))
 	Expect(err).NotTo(HaveOccurred())
 
-	// Get expected backup bootstrap data from VM's ConfigMap/Secret if defined.
-	expectedBootstrapData := ""
-	if vmCtx.VM.Spec.VmMetadata != nil {
-		if cmName := vmCtx.VM.Spec.VmMetadata.ConfigMapName; cmName != "" {
-			cm := &corev1.ConfigMap{}
-			cmKey := ctrlruntime.ObjectKey{Name: cmName, Namespace: vmCtx.VM.Namespace}
-			Expect(ctx.Client.Get(ctx, cmKey, cm)).To(Succeed())
-			cm.APIVersion = "v1"
-			cm.Kind = "ConfigMap"
-			cmYaml, err := yaml.Marshal(cm)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(cmYaml).NotTo(BeEmpty())
-			expectedBootstrapData, err = util.EncodeGzipBase64(string(cmYaml))
-			Expect(err).NotTo(HaveOccurred())
-		}
-
-		if secretName := vmCtx.VM.Spec.VmMetadata.SecretName; secretName != "" {
-			secret := &corev1.Secret{}
-			secretKey := ctrlruntime.ObjectKey{Name: secretName, Namespace: vmCtx.VM.Namespace}
-			Expect(ctx.Client.Get(ctx, secretKey, secret)).To(Succeed())
-			secret.APIVersion = "v1"
-			secret.Kind = "Secret"
-			secretYaml, err := yaml.Marshal(secret)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(secretYaml).NotTo(BeEmpty())
-			expectedBootstrapData, err = util.EncodeGzipBase64(string(secretYaml))
-			Expect(err).NotTo(HaveOccurred())
-		}
+	var expectedBootstrapData string
+	if bootstrapData != nil {
+		bootstrapDataYaml, err := yaml.Marshal(bootstrapData)
+		Expect(err).NotTo(HaveOccurred())
+		expectedBootstrapData, err = util.EncodeGzipBase64(string(bootstrapDataYaml))
+		Expect(err).NotTo(HaveOccurred())
 	}
 
 	// Get actual backup data from VM's ExtraConfig.
@@ -253,12 +105,12 @@ func verifyBackupDataInExtraConfig(
 	// Compare the backup data in ExtraConfig with the expected data.
 	var kubeDataMatched, bootstrapDataMatched bool
 	for _, ec := range moVM.Config.ExtraConfig {
-		if ec.GetOptionValue().Key == constants.BackupVMBootstrapDataExtraConfigKey {
-			Expect(ec.GetOptionValue().Value.(string)).To(Equal(expectedBootstrapData))
-			bootstrapDataMatched = true
-		} else if ec.GetOptionValue().Key == constants.BackupVMKubeDataExtraConfigKey {
+		if ec.GetOptionValue().Key == constants.BackupVMKubeDataExtraConfigKey {
 			Expect(ec.GetOptionValue().Value.(string)).To(Equal(expectedKubeData))
 			kubeDataMatched = true
+		} else if ec.GetOptionValue().Key == constants.BackupVMBootstrapDataExtraConfigKey {
+			Expect(ec.GetOptionValue().Value.(string)).To(Equal(expectedBootstrapData))
+			bootstrapDataMatched = true
 		}
 
 		if kubeDataMatched && bootstrapDataMatched {
@@ -266,6 +118,6 @@ func verifyBackupDataInExtraConfig(
 		}
 	}
 
-	Expect(kubeDataMatched).To(BeTrue())
-	Expect(bootstrapDataMatched).To(BeTrue())
+	Expect(kubeDataMatched).To(BeTrue(), "Encoded VM kube data is not found in VM's ExtraConfig")
+	Expect(bootstrapDataMatched).To(BeTrue(), "Encoded VM bootstrap data is not found in VM's ExtraConfig")
 }

--- a/pkg/vmprovider/providers/vsphere/virtualmachine/virtualmachine_suite_test.go
+++ b/pkg/vmprovider/providers/vsphere/virtualmachine/virtualmachine_suite_test.go
@@ -15,6 +15,7 @@ func vcSimTests() {
 	Describe("ClusterComputeResource", ccrTests)
 	Describe("Delete", deleteTests)
 	Describe("Publish", publishTests)
+	Describe("Backup", backupTests)
 }
 
 var suite = builder.NewTestSuite()

--- a/pkg/vmprovider/providers/vsphere/vmprovider_vm.go
+++ b/pkg/vmprovider/providers/vsphere/vmprovider_vm.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package vsphere
@@ -133,6 +133,27 @@ func (vs *vSphereVMProvider) PublishVirtualMachine(ctx goctx.Context, vm *vmopv1
 		return "", err
 	}
 	return itemID, nil
+}
+
+// BackupVirtualMachine backs up the VM data required for restore.
+func (vs *vSphereVMProvider) BackupVirtualMachine(ctx goctx.Context, vm *vmopv1.VirtualMachine) error {
+	vmCtx := context.VirtualMachineContext{
+		Context: goctx.WithValue(ctx, types.ID{}, vs.getOpID(vm, "backupVM")),
+		Logger:  log.WithValues("vmName", vm.NamespacedName()),
+		VM:      vm,
+	}
+
+	client, err := vs.getVcClient(ctx)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get vCenter client for backing up Virtual Machine")
+	}
+
+	vcVM, err := vs.getVM(vmCtx, client, true)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get vSphere Virtual Machine for backing up")
+	}
+
+	return virtualmachine.BackupVirtualMachine(vmCtx, vcVM, vs.k8sClient)
 }
 
 func (vs *vSphereVMProvider) GetVirtualMachineGuestHeartbeat(


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This PR updates the VirtualMachine Controller to store the VM's Kubernetes and bootstrap data YAML (compressed using gzip and base64-encoded) into the VM's ExtraConfig, if the corresponding FSS is enabled. This enables the VM to be restored by recreating the YAML from this backup data.

**Are there any special notes for your reviewer**:
The v1a2 VM Controller code has been updated with the new `BackupVirtualMachine()` function. However, the implementation of that function has not been added because the v1a2 VM provider code does not exist yet.

**Please add a release note if necessary**:

```release-note
Persist VM's Kubernetes and bootstrap data in ExtraConfig
```

**Testing Done**
- Added test code in both VM controller and provider.
- Manually deployed this patch to a WCP testbed (with FSS enabled) and verified the expected backup data in the VM's ExtraConfig:

```console
$ kubectl get vm -n sdiliyaer-test
NAME                          POWER-STATE   AGE
test-vm-no-bootstrap-data     poweredOn     64s
test-vm-with-bootstrap-data   poweredOn     18m

$ govc vm.info -e "test-vm-no-bootstrap-data"  | grep vmservice.virtualmachine
    vmservice.virtualmachine.kubedata: H4sIAAAAAAAA/8xWzW7jNhC+6ykInk2vZccbm8duUSCHdAs0yaG3kTiyCVMkS1IKvKnfvSAlO7JiB8kCBZpLrPnnN98MCVY+ofPSaE7a2lh0EIybtvUzOJyWpv7S5qDsFvJsJ7Xg5Em60IC6h3IrNWY1BhAQgGeEgNYmQJBG+/hJyK4psAxqGv87jQH9VJovCnxgYK2SKFhpdCU3jUtunPyT/Ah5oa+FUU7fr4xOaKyNcnpeHJ3QY3mUv9BBeZS/HCZUQ42U04A+sLZm2rDCmOCDA8uSU2fiLZTRzgup5B7QsehBDxPqLZYxcqnA+9+7aEWMhlVlXGC+BqXohMoaNtjr21qyYolYLeF2XRSI+c0ynsCaZ3R/BgjRKH2g+K7phPpgHGzwW8xBOX0u7UaZAhTrFcw6U0kVT9vW94PzBgfaW+MC5fSbMo240zLQw+GQMG47qOoOqullhCvpfEioMGE0ckKDa5BmhJQOE5QPskYfoLac0PlsvmCzNctvHmYLnq94nv8VbSupQckf6BIt2IdSZ4RsUOORF3lGiIICVc+sYKxRZrMfUetHKlKYGqRm5XKWEVKDhg2K3yQq0ef/BOdjriq5PuwtctKFeRoqnnLek7biw2k4yt5MRfc35eTlMPiu+Oen5RSg4pGKr+HPg1f8RNCR/ETMkTzx73tV3RtxUZV4OlK4yAMXLrgMGTxWNd6iFhecXrn8Pmonlp80XccdP64fViqJOjAvBSYk98ms63vC8dEKCNgRS0YwrlL5f0Keiv/c+J4hfD6W1xBuOf1ILjoKPhzWq617b4jHzex/fLp1a57P//PW+QCh8dfnr5DGPz7e/Toeyy3oDf6iTLl7cFDupN6MLYwWsmv/uWJrfBgPs/YBdIkXEmkMz8bt7nRAV0GJ42h2C/7Dg95o+XeDb3K09Z0diX62k74pHHrTuBI56bC93uH5jOeL1GGdFtnV67y3SNc5J+e3eUbIMeOJIvTranG7uI2RGyk4qW5vFsv5as6KfP2V3dx8FWwlcM7ms2Uu1svbclVW2XEPDzbumxdBRshg8V58EMRa3/QskbgXd7Rsvd2iQyakD04WTUCREXK+vbfgTsK+nafnxeDYfxgly31XEqWd4nWf90HON/nVp0i0HC723nu80ger+/Q+yfpRiqz5FwAA//8BAAD//8zNoh+cCgAA

$ govc vm.info -e "test-vm-with-bootstrap-data"  | grep vmservice.virtualmachine
    vmservice.virtualmachine.bootstrapdata:  H4sIAAAAAAAA/1SOsUoEMRBA+/2K4Wy0WK4fsFiwDCpcYRMIc8mcCRsnIZNw6tdLOC1s33vFG8ptDdQJ4XDncxlh9UUu6d2KanT1SqNHhN4GW5mxohWAFYQ+GKGS37lNAlAzJXGdP7urpHoNuMC/IBe//ym4UFa+cR2hIGzGPN5vxjzA88vrdjq9PeFmzG8ROWeE4znJ8UwarSwAdgqNbh6Wlr45uJ2/bn/z0Mph+QEAAP//AQAA///r//O/3wAAAA==
    vmservice.virtualmachine.kubedata: H4sIAAAAAAAA/7RVTW/jNhC961cQvtMr27HW5rFbFMgh3QJNcuhtRI5kwvwqOVKQLfrfC0pKaiv2IrtAbuLMcGY4b94TBP2IMWnvBOutDxiBfFz29gkiLqW3n/oVmHCAVXHUTgn2qCN1YO5AHrTDwiKBAgJRMAbOeQLS3qV8ZKwfY+0Yu7ycv9ExEa+9J668Q8EWFDtcFIzJiEO2e20xEdgg2GJdrje83PPVzX25EeuV2FR/5dhGOzD6G8ahNH9X6YKxFl02D89fFYwZqNFM3ZMP3vj2eXnsaowOCdNS+0/fhiaVt6Adl9uyYMyCgxbVbxqNmur/wFxzrWa4ev8cULAxzeOp43E1tsRYI1JA+XJibCnYP/++nhohDaT0O1ic2bWFFi/Yg3/C+LVp7ry66PqTgOaOmNGIdOFKIh+hxS+5ibmrSwGdunCpt3cnS3T5YTmOIrgUfKRXzzj3KFhGSJLhw8bg4BtHPsz/IagXK+k8gatb9JG42TePbMQbxlx7+88x6WzM5wy5VqoXi/fUWsySn/LmKn7f49Mc0enjh6Fci/Xuw6FMBNSl6ySstU8PD7e/zrl5ANfiL8bL430EedSunUd4p/S4DueOg080Z7RLBE7ihULhAOndbO6c/rvDNzl+FpbU1RGT76JEwcZBfQeujSj3A1xukCbCRLy33PlhjRNFCDyTZopIAYa0Shv9DBh5vlAw9lLxFe9Ftdtuq33O3GklWCNrWe22n/l61yC/wWrH611V8U1VVeUG1/sSyuJFWU80tM4NYdP4SDxZMKZg7ERKe6t5vUVstvB5X9eIq5ttXhqH9OTj8dYRxgYkTj+FyTzuWJ/CASNypRNFXXeEqmDsXI8PEF+NE3bDN6qv7uTZf3ij5fPY0mIxOv5X6CnJuTY/ydAaX4Phk52H6BttMohnUj3dnov0iRh/Mb5Tt05TMfEib81/AAAA//8BAAD//yWXs8lYCAAA
```

<details>
<summary>Decoding "vmservice.virtualmachine.bootstrapdata"</summary>

```console
$ echo "H4sIAAAAAAAA/1SOsUoEMRBA+/2K4Wy0WK4fsFiwDCpcYRMIc8mcCRsnIZNw6tdLOC1s33vFG8ptDdQJ4XDncxlh9UUu6d2KanT1SqNHhN4GW5mxohWAFYQ+GKGS37lNAlAzJXGdP7urpHoNuMC/IBe//ym4UFa+cR2hIGzGPN5vxjzA88vrdjq9PeFmzG8ROWeE4znJ8UwarSwAdgqNbh6Wlr45uJ2/bn/z0Mph+QEAAP//AQAA///r//O/3wAAAA==" | base64 -d | gunzip
user-data: "#cloud-config\nssh_pwauth: true\nusers:\n  - name: packer\n    plain_text_passwd:
  packer\n    lock_passwd: false\n    sudo: ALL=(ALL) NOPASSWD:ALL\n    shell: /bin/bash\n
  \   ssh_authorized_keys:\n    - \n"
```
</details>

<details>
<summary>Decoding "vmservice.virtualmachine.kubedata"</summary>

```console
$ echo "H4sIAAAAAAAA/7xWz2/rNgy++68QcldefrlpddwbBvTQvQFre9iNlmlHiCxpFO2gb9j/PvhHWsdJu7wCW042SX0U+ZGfA8E8I0XjnRJN5QMSsKd5Ux2AcK599aVZgg07WCZ743Ilng1xDfYB9M44TCpkyIFBJUKAc56BjXexfRWi6WOrPnZ+Gb8wFFlm3rPMvUMlZkw1zhIhNGGH9mgqjAxVUGK2WqzWcnEnl5vHxVotNmq9/qONLYwDa74jdanlVakTIUp0rbkrf5kIYSFDO9w+gN4jySaGHRLKWAekxkRPMqJFzZ6UYIwsm0oeDO+6GiITBNl2pMNgH7z15ct8X2dIDhnj3Pgv37tCc1+BcVKni0SIChyUmP9i0OZDDT/ATZur6I4+vgRUood5Hjuel31ZQhRqzNrRNi69/82V+Ovv0XuhrmnJ65FCxYD6DfAUrlDaQoy/QoUTu6mgxAv24A9I34riwecXXb8z8NRBGH1NGn/z1uiXC6DUThbxBczInqDEr+0tp646BnT5hUNN9XDW2kuNjKgJ+ew+rYsJXAye+NXTjwap40QGW5fGHVnoQvrh6CblKeTAvZVNi//uzvzfE3amD+9153O6cULEqR68l6pRs2tyzSbg56tSqA83fUrk8PDD1KVqvf3PqYsMXMf39zYzPj493f88XecduBJ/sl7vHwn03rhyGuFdbnr6Tx07H3kqAi4yOI0XEjnkg6f9vWOkAjRO0cIO4tUCUTvzZ41nOZrqPkxMn2Uy1tlRhZToe/sBwzdqfdsx7Dpt+Pj70sbEAB1wbqx5ASTZHkmEOOZ8HZLZzTZdr7Ytdm1yJdJVVtzdbVFmer2QG7y9ldlG38obWOXpYrlJV8ssOSr4SKuz9kpYFJ5YxgqsTYQYSXZTGZmliEUK27ssQ1xu0nbSzlnrxngw94N5/K7kJjKZrGbMEyFOdX8H9GocCO2eMf/mRmWPBX826x1vQj+AnEr8QYfS+gysHOwykC+MbWk8Ufzh9FTrx5r+r/8L3kT+q/V1fu8MJ8PitTP2DwAAAP//AQAA///kfBUMlwkAAA==" | base64 -d | gunzip
apiVersion: vmoperator.vmware.com/v1alpha1
kind: VirtualMachine
metadata:
  annotations:
    virtualmachine.vmoperator.vmware.com/first-boot-done: "true"
  creationTimestamp: "2023-09-14T03:04:33Z"
  finalizers:
  - virtualmachine.vmoperator.vmware.com
  generation: 1
  labels:
    packer-vsphere-supervisor-selector: test-vm-with-bootstrap-data
    topology.kubernetes.io/zone: domain-c50
  managedFields:
  - apiVersion: vmoperator.vmware.com/v1alpha1
    fieldsType: FieldsV1
    fieldsV1:
      f:metadata:
        f:labels:
          .: {}
          f:packer-vsphere-supervisor-selector: {}
      f:spec:
        .: {}
        f:className: {}
        f:imageName: {}
        f:powerOffMode: {}
        f:powerState: {}
        f:resourcePolicyName: {}
        f:restartMode: {}
        f:storageClass: {}
        f:suspendMode: {}
        f:vmMetadata:
          .: {}
          f:secretName: {}
          f:transport: {}
    manager: packer-plugin-vsphere
    operation: Update
    time: "2023-09-14T03:04:33Z"
  - apiVersion: vmoperator.vmware.com/v1alpha1
    fieldsType: FieldsV1
    fieldsV1:
      f:metadata:
        f:annotations:
          .: {}
          f:virtualmachine.vmoperator.vmware.com/first-boot-done: {}
        f:finalizers:
          .: {}
          v:"virtualmachine.vmoperator.vmware.com": {}
        f:labels:
          f:topology.kubernetes.io/zone: {}
    manager: manager
    operation: Update
    time: "2023-09-14T03:05:37Z"
  - apiVersion: vmoperator.vmware.com/v1alpha1
    fieldsType: FieldsV1
    fieldsV1:
      f:status:
        .: {}
        f:biosUUID: {}
        f:changeBlockTracking: {}
        f:conditions: {}
        f:host: {}
        f:instanceUUID: {}
        f:networkInterfaces: {}
        f:phase: {}
        f:powerState: {}
        f:uniqueID: {}
        f:vmIp: {}
        f:zone: {}
    manager: manager
    operation: Update
    subresource: status
    time: "2023-09-14T03:06:38Z"
  name: test-vm-with-bootstrap-data
  namespace: sdiliyaer-test
  resourceVersion: "675327"
  uid: 52bf997e-bc30-4e88-b4c8-6a2d5014521b
spec:
  className: best-effort-small
  imageName: vmi-b5eef5a79bbee1451
  networkInterfaces:
  - networkType: vsphere-distributed
  powerOffMode: hard
  powerState: poweredOn
  resourcePolicyName: ""
  restartMode: hard
  storageClass: wcpglobal-storage-profile
  suspendMode: hard
  vmMetadata:
    secretName: test-vm-with-bootstrap-data
    transport: CloudInit
status: {}
```
</details>