### PR TITLE
🌱 Rename IMAGE-NAME to HUMAN-READABLE-NAME in VM Image printer column

### DIFF
--- a/api/v1alpha1/virtualmachineimage_types.go
+++ b/api/v1alpha1/virtualmachineimage_types.go
@@ -156,7 +156,7 @@ func (vmImage *VirtualMachineImage) SetConditions(conditions Conditions) {
 // +kubebuilder:resource:scope=Cluster,shortName=vmi;vmimage
 // +kubebuilder:storageversion:false
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Image-Name",type="string",JSONPath=".status.imageName"
+// +kubebuilder:printcolumn:name="Human-Readable-Name",type="string",JSONPath=".status.imageName"
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".spec.productInfo.version"
 // +kubebuilder:printcolumn:name="Os-Type",type="string",JSONPath=".spec.osInfo.type"
 // +kubebuilder:printcolumn:name="Format",type="string",JSONPath=".spec.type"
@@ -196,7 +196,7 @@ func (clusterVirtualMachineImage *ClusterVirtualMachineImage) SetConditions(cond
 // +kubebuilder:resource:scope=Cluster,shortName=cvmi;cvmimage;clustervmi;clustervmimage
 // +kubebuilder:storageversion:false
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Image-Name",type="string",JSONPath=".status.imageName"
+// +kubebuilder:printcolumn:name="Human-Readable-Name",type="string",JSONPath=".status.imageName"
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".spec.productInfo.version"
 // +kubebuilder:printcolumn:name="Os-Type",type="string",JSONPath=".spec.osInfo.type"
 // +kubebuilder:printcolumn:name="Format",type="string",JSONPath=".spec.type"

--- a/api/v1alpha2/virtualmachineimage_types.go
+++ b/api/v1alpha2/virtualmachineimage_types.go
@@ -211,7 +211,7 @@ type VirtualMachineImageStatus struct {
 // +kubebuilder:resource:scope=Cluster,shortName=vmi;vmimage
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Image Name",type="string",JSONPath=".status.name"
+// +kubebuilder:printcolumn:name="Human Readable Name",type="string",JSONPath=".status.name"
 // +kubebuilder:printcolumn:name="Image Version",type="string",JSONPath=".status.productInfo.version"
 // +kubebuilder:printcolumn:name="OS Name",type="string",JSONPath=".status.osInfo.type"
 // +kubebuilder:printcolumn:name="OS Version",type="string",JSONPath=".status.osInfo.version"
@@ -248,7 +248,7 @@ type VirtualMachineImageList struct {
 // +kubebuilder:resource:scope=Cluster,shortName=cvmi;cvmimage;clustervmi;clustervmimage
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Image Name",type="string",JSONPath=".status.name"
+// +kubebuilder:printcolumn:name="Human Readable Name",type="string",JSONPath=".status.name"
 // +kubebuilder:printcolumn:name="Image Version",type="string",JSONPath=".status.productInfo.version"
 // +kubebuilder:printcolumn:name="OS Name",type="string",JSONPath=".status.osInfo.type"
 // +kubebuilder:printcolumn:name="OS Version",type="string",JSONPath=".status.osInfo.version"

--- a/config/crd/bases/vmoperator.vmware.com_clustervirtualmachineimages.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_clustervirtualmachineimages.yaml
@@ -22,7 +22,7 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .status.imageName
-      name: Image-Name
+      name: Human-Readable-Name
       type: string
     - jsonPath: .spec.productInfo.version
       name: Version
@@ -275,7 +275,7 @@ spec:
       status: {}
   - additionalPrinterColumns:
     - jsonPath: .status.name
-      name: Image Name
+      name: Human Readable Name
       type: string
     - jsonPath: .status.productInfo.version
       name: Image Version

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachineimages.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachineimages.yaml
@@ -20,7 +20,7 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .status.imageName
-      name: Image-Name
+      name: Human-Readable-Name
       type: string
     - jsonPath: .spec.productInfo.version
       name: Version
@@ -275,7 +275,7 @@ spec:
       status: {}
   - additionalPrinterColumns:
     - jsonPath: .status.name
-      name: Image Name
+      name: Human Readable Name
       type: string
     - jsonPath: .status.productInfo.version
       name: Image Version


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This PR updates the printer column of VirtualMachine Image (in both v1a1 and v1a2) to rename "Image Name" to "Human Readable Name". The previous "Image Name" can be confusing with the `spec.imageName` in the VirtualMachine type.

**Are there any special notes for your reviewer**:
Manually applied the updated CRD in a testbed and verified the output printer column:

```console
$ kubectl get cvmi
NAME                    HUMAN-READABLE-NAME                                          VERSION                  OS-TYPE               FORMAT   AGE
vmi-9b0796bae7b11ea63   photon-3-amd64-vmi-k8s-v1.23.8---vmware.2-tkg.1-zshippable   v1.23.8+vmware.1-tkg.1   vmwarePhoton64Guest   OVF      151m

$ kubectl get vmi -n sdiliyaer-test
NAME                    HUMAN-READABLE-NAME                                     VERSION         OS-TYPE                 FORMAT   AGE
vmi-4321c937fd22e514a   photon-ova_uefi-4.0                                     4.0             vmwarePhoton64Guest     OVF      150m
```

**Please add a release note if necessary**:

```release-note
Rename IMAGE-NAME to HUMAN-READABLE-NAME in the VM Image printer column.
```