### PR TITLE
✨ Support VM deployment from image status (friendly) name

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -217,8 +217,10 @@ rules:
   - clustervirtualmachineimages/status
   verbs:
   - get
+  - list
   - patch
   - update
+  - watch
 - apiGroups:
   - vmoperator.vmware.com
   resources:
@@ -326,8 +328,10 @@ rules:
   - virtualmachineimages/status
   verbs:
   - get
+  - list
   - patch
   - update
+  - watch
 - apiGroups:
   - vmoperator.vmware.com
   resources:

--- a/controllers/contentlibrary/v1alpha1/utils/utils.go
+++ b/controllers/contentlibrary/v1alpha1/utils/utils.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package utils
@@ -17,22 +17,24 @@ import (
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 )
 
-// GetImageFieldNameFromItem returns the Image field name in format of "vmi-<uuid>"
-// by using the same identifier from the given Item name in "clitem-<uuid>".
+// GetImageFieldNameFromItem returns the image field name in the format of
+// "vmi-<uuid>" by using the identifier from the given item name "clitem-<uuid>".
 func GetImageFieldNameFromItem(itemName string) (string, error) {
 	if !strings.HasPrefix(itemName, ItemFieldNamePrefix) {
-		return "", fmt.Errorf("item name doesn't start with %q", ItemFieldNamePrefix)
+		return "", fmt.Errorf("item name %q doesn't start with %q",
+			itemName, ItemFieldNamePrefix)
 	}
+
 	itemNameSplit := strings.Split(itemName, "-")
 	if len(itemNameSplit) < 2 {
-		return "", fmt.Errorf("item name doesn't have an identifier after %s-", ItemFieldNamePrefix)
+		return "", fmt.Errorf("item name %q doesn't contain a uuid", itemName)
 	}
 
 	uuid := strings.Join(itemNameSplit[1:], "-")
 	return fmt.Sprintf("%s-%s", ImageFieldNamePrefix, uuid), nil
 }
 
-// IsItemReady returns if the given item conditions contain a Ready condition with status True.
+// IsItemReady checks if an item is ready by iterating through its conditions.
 func IsItemReady(itemConditions imgregv1a1.Conditions) bool {
 	var isReady bool
 	for _, condition := range itemConditions {
@@ -45,23 +47,42 @@ func IsItemReady(itemConditions imgregv1a1.Conditions) bool {
 	return isReady
 }
 
-// GetVMImageSpecStatus returns the VirtualMachineImage Spec and Status fields in an image-registry service enabled cluster.
-// It first tries to get the namespace scope VM Image; if not found, it looks up the cluster scope VM Image.
-func GetVMImageSpecStatus(ctx context.Context, ctrlClient client.Client, imageName, namespace string) (
-	spec *vmopv1.VirtualMachineImageSpec, status *vmopv1.VirtualMachineImageStatus, err error) {
-
+// GetVMImageSpecStatus retrieves the VirtualMachineImageSpec and
+// VirtualMachineImageStatus for a given image name and namespace.
+// It first checks if a namespace scope image exists by the resource name,
+// and if not, checks if a cluster scope image exists by the resource name.
+func GetVMImageSpecStatus(
+	ctx context.Context,
+	ctrlClient client.Client,
+	imageName, namespace string) (
+	*vmopv1.VirtualMachineImageSpec,
+	*vmopv1.VirtualMachineImageStatus,
+	error) {
+	// Check if a namespace scope image exists by the resource name.
 	vmi := vmopv1.VirtualMachineImage{}
-	if err = ctrlClient.Get(ctx, client.ObjectKey{Name: imageName, Namespace: namespace}, &vmi); err == nil {
-		spec = &vmi.Spec
-		status = &vmi.Status
-	} else if apierrors.IsNotFound(err) {
-		// Namespace scope image is not found. Check if a cluster scope image with this name exists.
-		cvmi := vmopv1.ClusterVirtualMachineImage{}
-		if err = ctrlClient.Get(ctx, client.ObjectKey{Name: imageName}, &cvmi); err == nil {
-			spec = &cvmi.Spec
-			status = &cvmi.Status
-		}
+	key := client.ObjectKey{Name: imageName, Namespace: namespace}
+	err := ctrlClient.Get(ctx, key, &vmi)
+	if err == nil {
+		return &vmi.Spec, &vmi.Status, nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return nil, nil, err
 	}
 
-	return spec, status, err
+	// Check if a cluster scope image exists by the resource name.
+	cvmi := vmopv1.ClusterVirtualMachineImage{}
+	key = client.ObjectKey{Name: imageName}
+	err = ctrlClient.Get(ctx, key, &cvmi)
+	if err == nil {
+		return &cvmi.Spec, &cvmi.Status, nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return nil, nil, err
+	}
+
+	err = fmt.Errorf(
+		"cannot find a namespace or cluster scope VM image for resource name %q",
+		imageName,
+	)
+	return nil, nil, err
 }

--- a/pkg/lib/env.go
+++ b/pkg/lib/env.go
@@ -14,6 +14,7 @@ import (
 
 const (
 	TrueString                    = "true"
+	FalseString                   = "false"
 	VmopNamespaceEnv              = "POD_NAMESPACE"
 	WcpFaultDomainsFSS            = "FSS_WCP_FAULTDOMAINS"
 	VMServiceV1Alpha2FSS          = "FSS_WCP_VMSERVICE_V1ALPHA2"

--- a/pkg/vmprovider/providers/vsphere/vmprovider_vm_utils.go
+++ b/pkg/vmprovider/providers/vsphere/vmprovider_vm_utils.go
@@ -349,14 +349,13 @@ func resolveVMImage(
 
 	imageSpec, imageStatus, err := clutils.GetVMImageSpecStatus(vmCtx, k8sClient, imageName, vmCtx.VM.Namespace)
 	if err != nil {
-		imageNotFoundMsg := fmt.Sprintf("Failed to get the VM's image: %s", imageName)
 		conditions.MarkFalse(vmCtx.VM,
 			vmopv1.VirtualMachinePrereqReadyCondition,
 			vmopv1.VirtualMachineImageNotFoundReason,
 			vmopv1.ConditionSeverityError,
-			imageNotFoundMsg,
+			fmt.Sprintf("Failed to get the VM's image: %s", imageName),
 		)
-		return nil, nil, errors.Wrap(err, imageNotFoundMsg)
+		return nil, nil, err
 	}
 
 	// Do not return the VM image status if the current image condition is not satisfied.

--- a/webhooks/virtualmachine/v1alpha1/mutation/virtualmachine_mutator_intg_test.go
+++ b/webhooks/virtualmachine/v1alpha1/mutation/virtualmachine_mutator_intg_test.go
@@ -170,6 +170,34 @@ func intgTestsMutating() {
 
 		})
 
+		Context("ResolveImageName", func() {
+
+			BeforeEach(func() {
+				Expect(os.Setenv(lib.VMImageRegistryFSS, lib.TrueString)).To(Succeed())
+			})
+
+			AfterEach(func() {
+				Expect(os.Unsetenv(lib.VMImageRegistryFSS)).To(Succeed())
+			})
+
+			When("Creating VirtualMachine", func() {
+
+				When("When VM ImageName is already a vmi resource name", func() {
+
+					BeforeEach(func() {
+						vm.Spec.ImageName = "vmi-123"
+					})
+
+					It("Should not mutate ImageName", func() {
+						Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
+						modified := &vmopv1.VirtualMachine{}
+						Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(vm), modified)).Should(Succeed())
+						Expect(modified.Spec.ImageName).Should(Equal("vmi-123"))
+					})
+				})
+			})
+		})
+
 		Context("SetNextRestartTime", func() {
 			When("create a VM", func() {
 				When("spec.nextRestartTime is empty", func() {
@@ -268,6 +296,5 @@ func intgTestsMutating() {
 				})
 			})
 		})
-
 	})
 }


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This PR updates the VirtualMachine mutation webhook to replace the `vm.spec.imageName` if it's a friendly image name that matches a **single** namespace or cluster scope image. If multiple images are found, the mutator denies the VM creation request. The mutator also indexes the VirtualMachineImage and ClusterVirtualMachineImage objects by their `.status.imageName` fields to enable efficient querying.

**Which issue(s) is/are addressed by this PR?**
Fixes #214

**Are there any special notes for your reviewer**:
This patch formats the `controllers/contentlibrary/v1alpha1/utils/utils.go` file to not exceed 80 characters. It also replaces the FSS mock calls with `os.Setenv/Unsetenv` in the test code.

**Please add a release note if necessary**:
```release-note
Support VM deployment from image status (friendly) name by mutating `vm.spec.ImageName`.
```

**Testing Done**:
- Added test code to cover VM deployment with image status name.
- Got a successful end-to-end run internally with this change deployed.
- Manually deployed this patch to a WCP testbed and verified VM deployment with all supported `vm.spec.imageName`:

```console
$ kubectl get vmi -n sdiliyaer-test vmi-67264b93813ffcbb4
NAME                    PROVIDER-NAME              CONTENT-LIBRARY-NAME   IMAGE-NAME                      VERSION   OS-TYPE         FORMAT   AGE
vmi-67264b93813ffcbb4   clitem-67264b93813ffcbb4   cl-6e9719d7e81f4b756   centos-stream8-cloudinit-22.1             centos64Guest   OVF      10m

$ kubectl get cvmi -n sdiliyaer-test vmi-b5eef5a79bbee1451
NAME                    PROVIDER-NAME              CONTENT-LIBRARY-NAME   IMAGE-NAME                     VERSION   OS-TYPE         FORMAT   AGE
vmi-b5eef5a79bbee1451   clitem-b5eef5a79bbee1451   cl-6e9719d7e81f4b756   ubuntu-impish-21.10-cloudimg             ubuntu64Guest   OVF      13h

$ kubectl get vm -n sdiliyaer-test -o wide
NAME                                            POWER-STATE   CLASS               IMAGE                   PRIMARY-IP       AGE
vm-from-vmi-b5eef5a79bbee1451                   poweredOn     best-effort-small   vmi-b5eef5a79bbee1451   192.168.128.36   6m23s
vm-from-ubuntu-impish-21.10-cloudimg            poweredOn     best-effort-small   vmi-b5eef5a79bbee1451   192.168.128.37   5m48s
vm-from-cluster-vmi-67264b93813ffcbb4           poweredOn     best-effort-small   vmi-67264b93813ffcbb4   192.168.128.38   4m12s
vm-from-cluster-centos-stream8-cloudinit-22.1   poweredOn     best-effort-small   vmi-67264b93813ffcbb4   192.168.128.39   3m50s
``` 
- The webhook denies the request when multiple images are found with the friendly image name:

```console
$ kubectl get vmi -n sdiliyaer-test | {head -1; grep test-image}
NAME                    PROVIDER-NAME              CONTENT-LIBRARY-NAME   IMAGE-NAME                                              VERSION         OS-TYPE                 FORMAT   AGE
vmi-c23e87019ed276a63   clitem-c23e87019ed276a63   cl-00939f93d26f0624b   test-image                                                              centos8_64Guest         OVF      12m
vmi-c3b4c562afe996007   clitem-c3b4c562afe996007   cl-4def6cd2666ec1b87   test-image                                                              centos8_64Guest         OVF      13m

$ kubectl apply -f /tmp/vm-dup-image-name.yaml
Error from server (no single VM image exists for "test-image"): error when creating "/tmp/vm-dup-image-name.yaml": admission webhook "default.mutating.virtualmachine.vmoperator.vmware.com" denied the request: no single VM image exists for "test-image"
```