### PR TITLE
:seedling: Bump up min go version to 1.20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: ci
 
 env:
-  GO_VERSION: 1.19.3
+  GO_VERSION: 1.20.0
 
 on:
   pull_request:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Go version used to build the binaries.
-ARG GO_VERSION=1.18.4
+ARG GO_VERSION=1.20
 
 ## Docker image used to build the binaries.
 FROM golang:${GO_VERSION} as builder

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/vm-operator
 
-go 1.18
+go 1.20
 
 replace (
 	github.com/envoyproxy/go-control-plane => github.com/envoyproxy/go-control-plane v0.9.4

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ package main
 import (
 	"crypto/tls"
 	"flag"
-	"math/rand"
 	"net/http"
 	"net/http/pprof"
 	"os"
@@ -118,8 +117,6 @@ func main() {
 
 	setupLog.Info("Starting VM Operator controller", "version", pkg.BuildVersion,
 		"buildnumber", pkg.BuildNumber, "buildtype", pkg.BuildType, "commit", pkg.BuildCommit)
-
-	rand.Seed(time.Now().UnixNano())
 
 	profilerAddress := flag.String(
 		"profiler-address",

--- a/pkg/util/enc_test.go
+++ b/pkg/util/enc_test.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/base64"
-	"io/ioutil"
+	"io"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -170,7 +170,7 @@ var _ = Describe("EncodeGzipBase64", func() {
 		Expect(err).NotTo(HaveOccurred())
 		defer Expect(gzipReader.Close()).To(Succeed())
 
-		ungzipped, err := ioutil.ReadAll(gzipReader)
+		ungzipped, err := io.ReadAll(gzipReader)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(input).Should(Equal(string(ungzipped)))
 	})

--- a/test/builder/util.go
+++ b/test/builder/util.go
@@ -12,7 +12,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/google/uuid"
@@ -604,7 +604,7 @@ func indexOfVersion(
 
 func LoadCRDs(rootFilePath string) ([]*apiextensionsv1.CustomResourceDefinition, error) {
 	// Read the CRD files.
-	files, err := ioutil.ReadDir(rootFilePath)
+	files, err := os.ReadDir(rootFilePath)
 	if err != nil {
 		return nil, err
 	}
@@ -641,7 +641,7 @@ func LoadCRDs(rootFilePath string) ([]*apiextensionsv1.CustomResourceDefinition,
 // copied from https://github.com/kubernetes-sigs/controller-runtime/blob/5bf44d2ffd6201703508e11fbae74fcedc5ce148/pkg/envtest/crd.go#L434-L458
 func readDocuments(fp string) ([][]byte, error) {
 	//nolint:gosec
-	b, err := ioutil.ReadFile(fp)
+	b, err := os.ReadFile(fp)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
`controller-runtime` v15 has a min Golang version requirement that breaks the container builds.  This change bumps up the Go version used to build the container.  Starting 1.21 Golang, go.mod requires the Go version and treats that as min required go version to compile your binary.  So, also bump up the Go version for local builds.

**Which issue(s) is/are addressed by this PR?** 
N/A

**Are there any special notes for your reviewer**:
N/A

**Please add a release note if necessary**:
```release-note
NONE
```