### PR TITLE
✨ Persist VM disk path and type info in ExtraConfig

### DIFF
--- a/pkg/vmprovider/providers/vsphere/constants/constants.go
+++ b/pkg/vmprovider/providers/vsphere/constants/constants.go
@@ -125,4 +125,7 @@ const (
 	// BackupVMBootstrapDataExtraConfigKey is the ExtraConfig key to the VM's
 	// bootstrap data object, compressed using gzip and base64-encoded.
 	BackupVMBootstrapDataExtraConfigKey = "vmservice.virtualmachine.bootstrapdata"
+	// BackupVMDiskDataExtraConfigKey is the ExtraConfig key to the VM's disk info
+	// data in JSON, compressed using gzip and base64-encoded.
+	BackupVMDiskDataExtraConfigKey = "vmservice.virtualmachine.diskdata"
 )

--- a/pkg/vmprovider/providers/vsphere/virtualmachine/backup_test.go
+++ b/pkg/vmprovider/providers/vsphere/virtualmachine/backup_test.go
@@ -4,6 +4,8 @@
 package virtualmachine_test
 
 import (
+	"encoding/json"
+
 	"sigs.k8s.io/yaml"
 
 	. "github.com/onsi/ginkgo"
@@ -15,16 +17,16 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/util"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/constants"
+	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/session"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/virtualmachine"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func backupTests() {
 	var (
-		ctx           *builder.TestContextForVCSim
-		vcVM          *object.VirtualMachine
-		vmCtx         context.VirtualMachineContext
-		bootstrapData map[string]string
+		ctx   *builder.TestContextForVCSim
+		vcVM  *object.VirtualMachine
+		vmCtx context.VirtualMachineContext
 	)
 
 	BeforeEach(func() {
@@ -32,12 +34,12 @@ func backupTests() {
 
 		var err error
 		vcVM, err = ctx.Finder.VirtualMachine(ctx, "DC0_C0_RP0_VM0")
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 
 		vmCtx = context.VirtualMachineContext{
 			Context: ctx,
 			Logger:  suite.GetLogger().WithValues("vmName", vcVM.Name()),
-			VM:      builder.DummyVirtualMachine(),
+			VM:      &vmopv1.VirtualMachine{},
 		}
 	})
 
@@ -46,78 +48,71 @@ func backupTests() {
 		ctx = nil
 	})
 
-	Context("VM bootstrap data is NOT provided", func() {
+	Context("VM Kube data", func() {
 
-		It("Should back up only VM kube data in ExtraConfig", func() {
+		BeforeEach(func() {
+			vmCtx.VM = builder.DummyVirtualMachine()
+		})
+
+		It("Should backup VM kube data YAML without status field in ExtraConfig", func() {
 			Expect(virtualmachine.BackupVirtualMachine(vmCtx, vcVM, nil)).To(Succeed())
-			verifyBackupDataInExtraConfig(ctx, vcVM, vmCtx, nil)
+
+			vmCopy := vmCtx.VM.DeepCopy()
+			vmCopy.Status = vmopv1.VirtualMachineStatus{}
+			vmCopyYaml, err := yaml.Marshal(vmCopy)
+			Expect(err).NotTo(HaveOccurred())
+			verifyBackupDataInExtraConfig(ctx, vcVM, constants.BackupVMKubeDataExtraConfigKey, string(vmCopyYaml))
 		})
 	})
 
-	Context("VM bootstrap data is provided", func() {
+	Context("VM bootstrap data", func() {
 
-		BeforeEach(func() {
-			bootstrapData = map[string]string{"foo": "bar"}
-		})
-
-		AfterEach(func() {
-			bootstrapData = nil
-		})
-
-		It("Should back up both VM kube data and bootstrap data in ExtraConfig", func() {
+		It("Should back up bootstrap data as JSON in ExtraConfig", func() {
+			bootstrapData := map[string]string{"foo": "bar"}
 			Expect(virtualmachine.BackupVirtualMachine(vmCtx, vcVM, bootstrapData)).To(Succeed())
-			verifyBackupDataInExtraConfig(ctx, vcVM, vmCtx, bootstrapData)
+
+			bootstrapDataJSON, err := json.Marshal(bootstrapData)
+			Expect(err).NotTo(HaveOccurred())
+			verifyBackupDataInExtraConfig(ctx, vcVM, constants.BackupVMBootstrapDataExtraConfigKey, string(bootstrapDataJSON))
+		})
+	})
+
+	Context("VM Disk data", func() {
+
+		It("Should backup VM disk data as JSON in ExtraConfig", func() {
+			Expect(virtualmachine.BackupVirtualMachine(vmCtx, vcVM, nil)).To(Succeed())
+
+			// Use the default disk info from the vcSim VM for testing.
+			diskData := []virtualmachine.VMDiskData{
+				{
+					VDiskID:  "",
+					FileName: "[LocalDS_0] DC0_C0_RP0_VM0/disk1.vmdk",
+				},
+			}
+			diskDataJSON, err := json.Marshal(diskData)
+			Expect(err).NotTo(HaveOccurred())
+			verifyBackupDataInExtraConfig(ctx, vcVM, constants.BackupVMDiskDataExtraConfigKey, string(diskDataJSON))
 		})
 	})
 }
 
-// verifyBackupDataInExtraConfig verifies that the backup data is stored in VM's ExtraConfig.
-// It gets the expected data and compares it with the actual data in ExtraConfig.
 func verifyBackupDataInExtraConfig(
 	ctx *builder.TestContextForVCSim,
 	vcVM *object.VirtualMachine,
-	vmCtx context.VirtualMachineContext,
-	bootstrapData map[string]string) {
-	// Get expected backup VM's kube data from the VM CR.
-	vmCopy := vmCtx.VM.DeepCopy()
-	vmCopy.Status = vmopv1.VirtualMachineStatus{}
-	vmCopyYaml, err := yaml.Marshal(vmCopy)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(vmCopyYaml).NotTo(BeEmpty())
-	expectedKubeData, err := util.EncodeGzipBase64(string(vmCopyYaml))
-	Expect(err).NotTo(HaveOccurred())
+	expectedKey, expectedValDecoded string) {
 
-	var expectedBootstrapData string
-	if bootstrapData != nil {
-		bootstrapDataYaml, err := yaml.Marshal(bootstrapData)
-		Expect(err).NotTo(HaveOccurred())
-		expectedBootstrapData, err = util.EncodeGzipBase64(string(bootstrapDataYaml))
-		Expect(err).NotTo(HaveOccurred())
-	}
-
-	// Get actual backup data from VM's ExtraConfig.
+	// Get the VM's ExtraConfig and convert it to map.
 	moID := vcVM.Reference().Value
 	objVM := ctx.GetVMFromMoID(moID)
-	Expect(objVM).ToNot(BeNil())
+	Expect(objVM).NotTo(BeNil())
 	var moVM mo.VirtualMachine
 	Expect(objVM.Properties(ctx, objVM.Reference(), []string{"config.extraConfig"}, &moVM)).To(Succeed())
+	ecMap := session.ExtraConfigToMap(moVM.Config.ExtraConfig)
 
-	// Compare the backup data in ExtraConfig with the expected data.
-	var kubeDataMatched, bootstrapDataMatched bool
-	for _, ec := range moVM.Config.ExtraConfig {
-		if ec.GetOptionValue().Key == constants.BackupVMKubeDataExtraConfigKey {
-			Expect(ec.GetOptionValue().Value.(string)).To(Equal(expectedKubeData))
-			kubeDataMatched = true
-		} else if ec.GetOptionValue().Key == constants.BackupVMBootstrapDataExtraConfigKey {
-			Expect(ec.GetOptionValue().Value.(string)).To(Equal(expectedBootstrapData))
-			bootstrapDataMatched = true
-		}
-
-		if kubeDataMatched && bootstrapDataMatched {
-			return
-		}
-	}
-
-	Expect(kubeDataMatched).To(BeTrue(), "Encoded VM kube data is not found in VM's ExtraConfig")
-	Expect(bootstrapDataMatched).To(BeTrue(), "Encoded VM bootstrap data is not found in VM's ExtraConfig")
+	// Verify the expected key exists in ExtraConfig and the decoded values match.
+	Expect(ecMap).To(HaveKey(expectedKey))
+	ecValRaw := ecMap[expectedKey]
+	ecValDecoded, err := util.TryToDecodeBase64Gzip([]byte(ecValRaw))
+	Expect(err).NotTo(HaveOccurred())
+	Expect(ecValDecoded).To(Equal(expectedValDecoded))
 }


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This PR persists a VM's disk path and type (determined by the existence of `VDiskID`) in ExtraConfig. This is required to register any disks as FCDs and expose them as PVCs during a restore operation.

**Which issue(s) is/are addressed by this PR?**:
N/A

**Are there any special notes for your reviewer**:
Currently, the `vm.Reconfigure()` task will not be called because the corresponding FSS is not enabled. A follow-up patch will be submitted to optimize that VC call during VM reconciliation.

**Please add a release note if necessary**:
```release-note
Persist VM disk path and type info in ExtraConfig.
```

**Testing Done**:
- Added unit tests to cover the disk info check in vcSim VM's ExtraConfig
- Manually deployed this change to a WCP testbed and verified the expected backup data

```console
$ govc vm.info -e "test-vm" | grep vmservice.virtualmachine.diskdata
    vmservice.virtualmachine.diskdata:       H4sIAAAAAAAA/4quVgpzySzO9nRRslJS0lFyy8xJ9UvMTVWyUoouzkgsSk0Jy00r1jWIVShJLS7RLcvVh9J6Zbkp2Uq1sQAAAAD//wEAAP//LVdiuEEAAAA=

# VM without any FCD attached
$ echo "H4sIAAAAAAAA/4quVgpzySzO9nRRslJS0lFyy8xJ9UvMTVWyUoouzkgsSk0Jy00r1jWIVShJLS7RLcvVh9J6Zbkp2Uq1sQAAAAD//wEAAP//LVdiuEEAAAA=" \ 
| base64 -d | gunzip | jq .
[
  {
    "VDiskID": "",
    "FileName": "[sharedVmfs-0] test-vm/test-vm.vmdk"
  }
]

# VM with an FCD attached
$ echo "H4sIAAAAAAAA/3zNsQrCMBCA4VeRmxvbq8kl7VwEF8cupcjlkmCpAbGQRXx3Bx2c3P7l55ueMA7Ltp4G6AEqOC63eOYcoYdpu/IjhjGnTTXzrmR1L3LB+hP7ksMKr+r3R8/JU9cplCYo7cgottIqa8m1pDGRM3+NJKEmQSSvGyspajHMNqB3Wh/YSWDDX3h+AwAA//8BAAD//z6Cb9q6AAAA" \
| base64 -d | gunzip | jq .
[
  {
    "VDiskID": "",
    "FileName": "[sharedVmfs-0] vm-pvc_1/vm-pvc.vmdk"
  },
  {
    "VDiskID": "1bafb699-1c0d-4865-a7c2-77682641f685",
    "FileName": "[sharedVmfs-0] fcd/6c116b407cfe4c5aa7d1b8443a8cda5a.vmdk"
  }
]
```