### PR TITLE
:seedling: Emit a webhook warning when OvfEnv or ExtraConfig transport is specified

### DIFF
--- a/webhooks/common/response.go
+++ b/webhooks/common/response.go
@@ -19,6 +19,7 @@ import (
 // errors returned attempting to validate the ingress data.
 func BuildValidationResponse(
 	ctx *context.WebhookRequestContext,
+	validationWarnings admission.Warnings,
 	validationErrs []string,
 	err error,
 	additionalValidationErrors ...string) (response admission.Response) {
@@ -76,5 +77,5 @@ func BuildValidationResponse(
 		}
 	}
 
-	return admission.Allowed("")
+	return admission.Allowed("").WithWarnings(validationWarnings...)
 }

--- a/webhooks/common/response_test.go
+++ b/webhooks/common/response_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Validation Response", func() {
 
 	When("No errors occur", func() {
 		It("Returns allowed", func() {
-			response := common.BuildValidationResponse(ctx, nil, nil)
+			response := common.BuildValidationResponse(ctx, nil, nil, nil)
 			Expect(response.Allowed).To(BeTrue())
 		})
 	})
@@ -43,7 +43,7 @@ var _ = Describe("Validation Response", func() {
 	When("Validation errors occur", func() {
 		It("Returns denied", func() {
 			validationErrs := []string{"this is required"}
-			response := common.BuildValidationResponse(ctx, validationErrs, nil)
+			response := common.BuildValidationResponse(ctx, nil, validationErrs, nil)
 			Expect(response.Allowed).To(BeFalse())
 			Expect(response.Result).ToNot(BeNil())
 			Expect(response.Result.Code).To(Equal(int32(http.StatusUnprocessableEntity)))
@@ -51,10 +51,20 @@ var _ = Describe("Validation Response", func() {
 		})
 	})
 
-	Context("Returns denied for expected well-known errors", func() {
+	When("Validation has warnings", func() {
+		It("Returns allowed, with warnings", func() {
+			validationWarnings := []string{"this is deprecated"}
+			response := common.BuildValidationResponse(ctx, validationWarnings, nil, nil)
+			Expect(response.Allowed).To(BeTrue())
+			Expect(response.Warnings).To(Equal(validationWarnings))
+			Expect(response.Result).ToNot(BeNil())
+			Expect(response.Result.Code).To(Equal(int32(http.StatusOK)))
+		})
+	})
 
+	Context("Returns denied for expected well-known errors", func() {
 		wellKnownError := func(err error, expectedCode int) {
-			response := common.BuildValidationResponse(ctx, nil, err)
+			response := common.BuildValidationResponse(ctx, nil, nil, err)
 			Expect(response.Allowed).To(BeFalse())
 			Expect(response.Result).ToNot(BeNil())
 			Expect(response.Result.Code).To(Equal(int32(expectedCode)))

--- a/webhooks/persistentvolumeclaim/validation/persistentvolumeclaim_validator.go
+++ b/webhooks/persistentvolumeclaim/validation/persistentvolumeclaim_validator.go
@@ -78,7 +78,7 @@ func (v validator) For() schema.GroupVersionKind {
 
 func (v validator) ValidateCreate(ctx *context.WebhookRequestContext) admission.Response {
 	if isPrivilegedAccountForISPVC(ctx) {
-		return common.BuildValidationResponse(ctx, nil, nil)
+		return common.BuildValidationResponse(ctx, nil, nil, nil)
 	}
 
 	var fieldErrs field.ErrorList
@@ -87,12 +87,12 @@ func (v validator) ValidateCreate(ctx *context.WebhookRequestContext) admission.
 			fmt.Sprintf(operationNotAllowedOnPVC, admissionv1.Create)))
 	}
 
-	return common.BuildValidationResponse(ctx, convertToStringArray(fieldErrs), nil)
+	return common.BuildValidationResponse(ctx, nil, convertToStringArray(fieldErrs), nil)
 }
 
 func (v validator) ValidateDelete(ctx *context.WebhookRequestContext) admission.Response {
 	if isPrivilegedAccountForISPVC(ctx) {
-		return common.BuildValidationResponse(ctx, nil, nil)
+		return common.BuildValidationResponse(ctx, nil, nil, nil)
 	}
 
 	var fieldErrs field.ErrorList
@@ -101,12 +101,12 @@ func (v validator) ValidateDelete(ctx *context.WebhookRequestContext) admission.
 			fmt.Sprintf(operationNotAllowedOnPVC, admissionv1.Delete)))
 	}
 
-	return common.BuildValidationResponse(ctx, convertToStringArray(fieldErrs), nil)
+	return common.BuildValidationResponse(ctx, nil, convertToStringArray(fieldErrs), nil)
 }
 
 func (v validator) ValidateUpdate(ctx *context.WebhookRequestContext) admission.Response {
 	if isPrivilegedAccountForISPVC(ctx) {
-		return common.BuildValidationResponse(ctx, nil, nil)
+		return common.BuildValidationResponse(ctx, nil, nil, nil)
 	}
 	var fieldErrs field.ErrorList
 	// If instance storage labels already exists for resource, do not allow update resource
@@ -117,7 +117,7 @@ func (v validator) ValidateUpdate(ctx *context.WebhookRequestContext) admission.
 		fieldErrs = append(fieldErrs, field.Forbidden(labelPath, addingISLabelNotAllowed))
 	}
 
-	return common.BuildValidationResponse(ctx, convertToStringArray(fieldErrs), nil)
+	return common.BuildValidationResponse(ctx, nil, convertToStringArray(fieldErrs), nil)
 }
 
 // isInstanceStorageLabelPresent - returns true/false depending on presence of instance storage label.

--- a/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator.go
@@ -122,7 +122,7 @@ func (v validator) ValidateCreate(ctx *context.WebhookRequestContext) admission.
 		validationErrs = append(validationErrs, fieldErr.Error())
 	}
 
-	return common.BuildValidationResponse(ctx, validationErrs, nil)
+	return common.BuildValidationResponse(ctx, nil, validationErrs, nil)
 }
 
 func (v validator) ValidateDelete(*context.WebhookRequestContext) admission.Response {
@@ -177,7 +177,7 @@ func (v validator) ValidateUpdate(ctx *context.WebhookRequestContext) admission.
 		validationErrs = append(validationErrs, fieldErr.Error())
 	}
 
-	return common.BuildValidationResponse(ctx, validationErrs, nil)
+	return common.BuildValidationResponse(ctx, nil, validationErrs, nil)
 }
 
 func (v validator) validateBootstrap(

--- a/webhooks/virtualmachineclass/v1alpha1/validation/virtualmachineclass_validator.go
+++ b/webhooks/virtualmachineclass/v1alpha1/validation/virtualmachineclass_validator.go
@@ -78,7 +78,7 @@ func (v validator) ValidateCreate(ctx *context.WebhookRequestContext) admission.
 		validationErrs = append(validationErrs, fieldErr.Error())
 	}
 
-	return common.BuildValidationResponse(ctx, validationErrs, nil)
+	return common.BuildValidationResponse(ctx, nil, validationErrs, nil)
 }
 
 func (v validator) ValidateDelete(*context.WebhookRequestContext) admission.Response {
@@ -92,7 +92,7 @@ func (v validator) ValidateUpdate(ctx *context.WebhookRequestContext) admission.
 		validationErrs = append(validationErrs, fieldErr.Error())
 	}
 
-	return common.BuildValidationResponse(ctx, validationErrs, nil)
+	return common.BuildValidationResponse(ctx, nil, validationErrs, nil)
 }
 
 func (v validator) validatePolicies(ctx *context.WebhookRequestContext, vmClass *vmopv1.VirtualMachineClass,

--- a/webhooks/virtualmachineclass/v1alpha2/validation/virtualmachineclass_validator.go
+++ b/webhooks/virtualmachineclass/v1alpha2/validation/virtualmachineclass_validator.go
@@ -78,7 +78,7 @@ func (v validator) ValidateCreate(ctx *context.WebhookRequestContext) admission.
 		validationErrs = append(validationErrs, fieldErr.Error())
 	}
 
-	return common.BuildValidationResponse(ctx, validationErrs, nil)
+	return common.BuildValidationResponse(ctx, nil, validationErrs, nil)
 }
 
 func (v validator) ValidateDelete(*context.WebhookRequestContext) admission.Response {
@@ -92,7 +92,7 @@ func (v validator) ValidateUpdate(ctx *context.WebhookRequestContext) admission.
 		validationErrs = append(validationErrs, fieldErr.Error())
 	}
 
-	return common.BuildValidationResponse(ctx, validationErrs, nil)
+	return common.BuildValidationResponse(ctx, nil, validationErrs, nil)
 }
 
 func (v validator) validatePolicies(ctx *context.WebhookRequestContext, vmClass *vmopv1.VirtualMachineClass,

--- a/webhooks/virtualmachinepublishrequest/v1alpha1/validation/virtualmachinepublishrequest_validator.go
+++ b/webhooks/virtualmachinepublishrequest/v1alpha1/validation/virtualmachinepublishrequest_validator.go
@@ -65,7 +65,7 @@ func (v validator) For() schema.GroupVersionKind {
 
 func (v validator) ValidateCreate(ctx *context.WebhookRequestContext) admission.Response {
 	if !lib.IsWCPVMImageRegistryEnabled() {
-		return common.BuildValidationResponse(ctx, []string{"WCP_VM_Image_Registry feature not enabled"}, nil)
+		return common.BuildValidationResponse(ctx, nil, []string{"WCP_VM_Image_Registry feature not enabled"}, nil)
 	}
 
 	vmpub, err := v.vmPublishRequestFromUnstructured(ctx.Obj)
@@ -83,7 +83,7 @@ func (v validator) ValidateCreate(ctx *context.WebhookRequestContext) admission.
 		validationErrs = append(validationErrs, fieldErr.Error())
 	}
 
-	return common.BuildValidationResponse(ctx, validationErrs, nil)
+	return common.BuildValidationResponse(ctx, nil, validationErrs, nil)
 }
 
 func (v validator) ValidateDelete(*context.WebhookRequestContext) admission.Response {
@@ -111,7 +111,7 @@ func (v validator) ValidateUpdate(ctx *context.WebhookRequestContext) admission.
 		validationErrs = append(validationErrs, fieldErr.Error())
 	}
 
-	return common.BuildValidationResponse(ctx, validationErrs, nil)
+	return common.BuildValidationResponse(ctx, nil, validationErrs, nil)
 }
 
 func (v validator) validateSource(ctx *context.WebhookRequestContext, vmpub *vmopv1.VirtualMachinePublishRequest) field.ErrorList {

--- a/webhooks/virtualmachinepublishrequest/v1alpha2/validation/virtualmachinepublishrequest_validator.go
+++ b/webhooks/virtualmachinepublishrequest/v1alpha2/validation/virtualmachinepublishrequest_validator.go
@@ -66,7 +66,7 @@ func (v validator) For() schema.GroupVersionKind {
 
 func (v validator) ValidateCreate(ctx *context.WebhookRequestContext) admission.Response {
 	if !lib.IsWCPVMImageRegistryEnabled() {
-		return common.BuildValidationResponse(ctx, []string{"WCP_VM_Image_Registry feature not enabled"}, nil)
+		return common.BuildValidationResponse(ctx, nil, []string{"WCP_VM_Image_Registry feature not enabled"}, nil)
 	}
 
 	vmpub, err := v.vmPublishRequestFromUnstructured(ctx.Obj)
@@ -84,7 +84,7 @@ func (v validator) ValidateCreate(ctx *context.WebhookRequestContext) admission.
 		validationErrs = append(validationErrs, fieldErr.Error())
 	}
 
-	return common.BuildValidationResponse(ctx, validationErrs, nil)
+	return common.BuildValidationResponse(ctx, nil, validationErrs, nil)
 }
 
 func (v validator) ValidateDelete(*context.WebhookRequestContext) admission.Response {
@@ -112,7 +112,7 @@ func (v validator) ValidateUpdate(ctx *context.WebhookRequestContext) admission.
 		validationErrs = append(validationErrs, fieldErr.Error())
 	}
 
-	return common.BuildValidationResponse(ctx, validationErrs, nil)
+	return common.BuildValidationResponse(ctx, nil, validationErrs, nil)
 }
 
 func (v validator) validateSource(ctx *context.WebhookRequestContext, vmpub *vmopv1.VirtualMachinePublishRequest) field.ErrorList {

--- a/webhooks/virtualmachineservice/v1alpha1/validation/virtualmachineservice_validator.go
+++ b/webhooks/virtualmachineservice/v1alpha1/validation/virtualmachineservice_validator.go
@@ -97,7 +97,7 @@ func (v validator) ValidateCreate(ctx *context.WebhookRequestContext) admission.
 		validationErrs = append(validationErrs, fieldErr.Error())
 	}
 
-	return common.BuildValidationResponse(ctx, validationErrs, nil)
+	return common.BuildValidationResponse(ctx, nil, validationErrs, nil)
 }
 
 func (v validator) ValidateDelete(*context.WebhookRequestContext) admission.Response {
@@ -124,7 +124,7 @@ func (v validator) ValidateUpdate(ctx *context.WebhookRequestContext) admission.
 		validationErrs = append(validationErrs, fieldErr.Error())
 	}
 
-	return common.BuildValidationResponse(ctx, validationErrs, nil)
+	return common.BuildValidationResponse(ctx, nil, validationErrs, nil)
 }
 
 func (v validator) validateMetadata(ctx *context.WebhookRequestContext, vmService *vmopv1.VirtualMachineService) field.ErrorList {

--- a/webhooks/virtualmachineservice/v1alpha2/validation/virtualmachineservice_validator.go
+++ b/webhooks/virtualmachineservice/v1alpha2/validation/virtualmachineservice_validator.go
@@ -97,7 +97,7 @@ func (v validator) ValidateCreate(ctx *context.WebhookRequestContext) admission.
 		validationErrs = append(validationErrs, fieldErr.Error())
 	}
 
-	return common.BuildValidationResponse(ctx, validationErrs, nil)
+	return common.BuildValidationResponse(ctx, nil, validationErrs, nil)
 }
 
 func (v validator) ValidateDelete(*context.WebhookRequestContext) admission.Response {
@@ -124,7 +124,7 @@ func (v validator) ValidateUpdate(ctx *context.WebhookRequestContext) admission.
 		validationErrs = append(validationErrs, fieldErr.Error())
 	}
 
-	return common.BuildValidationResponse(ctx, validationErrs, nil)
+	return common.BuildValidationResponse(ctx, nil, validationErrs, nil)
 }
 
 func (v validator) validateMetadata(ctx *context.WebhookRequestContext, vmService *vmopv1.VirtualMachineService) field.ErrorList {

--- a/webhooks/virtualmachinesetresourcepolicy/v1alpha1/validation/virtualmachinesetresourcepolicy_validator.go
+++ b/webhooks/virtualmachinesetresourcepolicy/v1alpha1/validation/virtualmachinesetresourcepolicy_validator.go
@@ -75,7 +75,7 @@ func (v validator) ValidateCreate(ctx *context.WebhookRequestContext) admission.
 		validationErrs = append(validationErrs, fieldErr.Error())
 	}
 
-	return common.BuildValidationResponse(ctx, validationErrs, nil)
+	return common.BuildValidationResponse(ctx, nil, validationErrs, nil)
 }
 
 func (v validator) ValidateDelete(*context.WebhookRequestContext) admission.Response {
@@ -101,7 +101,7 @@ func (v validator) ValidateUpdate(ctx *context.WebhookRequestContext) admission.
 		validationErrs = append(validationErrs, fieldErr.Error())
 	}
 
-	return common.BuildValidationResponse(ctx, validationErrs, nil)
+	return common.BuildValidationResponse(ctx, nil, validationErrs, nil)
 }
 
 func (v validator) validateSpec(ctx *context.WebhookRequestContext, vmRP *vmopv1.VirtualMachineSetResourcePolicy) field.ErrorList {

--- a/webhooks/virtualmachinesetresourcepolicy/v1alpha2/validation/virtualmachinesetresourcepolicy_validator.go
+++ b/webhooks/virtualmachinesetresourcepolicy/v1alpha2/validation/virtualmachinesetresourcepolicy_validator.go
@@ -75,7 +75,7 @@ func (v validator) ValidateCreate(ctx *context.WebhookRequestContext) admission.
 		validationErrs = append(validationErrs, fieldErr.Error())
 	}
 
-	return common.BuildValidationResponse(ctx, validationErrs, nil)
+	return common.BuildValidationResponse(ctx, nil, validationErrs, nil)
 }
 
 func (v validator) ValidateDelete(*context.WebhookRequestContext) admission.Response {
@@ -101,7 +101,7 @@ func (v validator) ValidateUpdate(ctx *context.WebhookRequestContext) admission.
 		validationErrs = append(validationErrs, fieldErr.Error())
 	}
 
-	return common.BuildValidationResponse(ctx, validationErrs, nil)
+	return common.BuildValidationResponse(ctx, nil, validationErrs, nil)
 }
 
 func (v validator) validateSpec(ctx *context.WebhookRequestContext, vmRP *vmopv1.VirtualMachineSetResourcePolicy) field.ErrorList {

--- a/webhooks/virtualmachinewebconsolerequest/v1alpha1/validation/webconsolerequest_validator.go
+++ b/webhooks/virtualmachinewebconsolerequest/v1alpha1/validation/webconsolerequest_validator.go
@@ -75,7 +75,7 @@ func (v validator) ValidateCreate(ctx *context.WebhookRequestContext) admission.
 		validationErrs = append(validationErrs, fieldErr.Error())
 	}
 
-	return common.BuildValidationResponse(ctx, validationErrs, nil)
+	return common.BuildValidationResponse(ctx, nil, validationErrs, nil)
 }
 
 func (v validator) ValidateDelete(*context.WebhookRequestContext) admission.Response {
@@ -101,7 +101,7 @@ func (v validator) ValidateUpdate(ctx *context.WebhookRequestContext) admission.
 	for _, fieldErr := range fieldErrs {
 		validationErrs = append(validationErrs, fieldErr.Error())
 	}
-	return common.BuildValidationResponse(ctx, validationErrs, nil)
+	return common.BuildValidationResponse(ctx, nil, validationErrs, nil)
 }
 
 func (v validator) validateMetadata(ctx *context.WebhookRequestContext, wcr *vmopv1.WebConsoleRequest) field.ErrorList {


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This change emits a warning when a user specifies OvfEnv transport in a VM's spec.  In order to support warnings, modify the BuildValidationResponse so it can now take warnings from any validations.
At some point, we should move our webhooks to controller-runtime generated webhooks which will remove the need to synthesize the response from errors and warnings ourselves.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
None

**Please add a release note if necessary**:
```release-note
Emit a webhook warning when OvfEnv or ExtraConfig transport is specified
```