### PR TITLE
✨ Remove content library fields from VirtualMachineImage printer columns

### DIFF
--- a/api/v1alpha1/virtualmachineimage_types.go
+++ b/api/v1alpha1/virtualmachineimage_types.go
@@ -156,8 +156,6 @@ func (vmImage *VirtualMachineImage) SetConditions(conditions Conditions) {
 // +kubebuilder:resource:scope=Cluster,shortName=vmi;vmimage
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Provider-Name",type="string",JSONPath=".spec.providerRef.name"
-// +kubebuilder:printcolumn:name="Content-Library-Name",type="string",JSONPath=".status.contentLibraryRef.name"
 // +kubebuilder:printcolumn:name="Image-Name",type="string",JSONPath=".status.imageName"
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".spec.productInfo.version"
 // +kubebuilder:printcolumn:name="Os-Type",type="string",JSONPath=".spec.osInfo.type"
@@ -198,8 +196,6 @@ func (clusterVirtualMachineImage *ClusterVirtualMachineImage) SetConditions(cond
 // +kubebuilder:resource:scope=Cluster,shortName=cvmi;cvmimage;clustervmi;clustervmimage
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Provider-Name",type="string",JSONPath=".spec.providerRef.name"
-// +kubebuilder:printcolumn:name="Content-Library-Name",type="string",JSONPath=".status.contentLibraryRef.name"
 // +kubebuilder:printcolumn:name="Image-Name",type="string",JSONPath=".status.imageName"
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".spec.productInfo.version"
 // +kubebuilder:printcolumn:name="Os-Type",type="string",JSONPath=".spec.osInfo.type"

--- a/config/crd/bases/vmoperator.vmware.com_clustervirtualmachineimages.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_clustervirtualmachineimages.yaml
@@ -21,12 +21,6 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .spec.providerRef.name
-      name: Provider-Name
-      type: string
-    - jsonPath: .status.contentLibraryRef.name
-      name: Content-Library-Name
-      type: string
     - jsonPath: .status.imageName
       name: Image-Name
       type: string

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachineimages.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachineimages.yaml
@@ -19,12 +19,6 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .spec.providerRef.name
-      name: Provider-Name
-      type: string
-    - jsonPath: .status.contentLibraryRef.name
-      name: Content-Library-Name
-      type: string
     - jsonPath: .status.imageName
       name: Image-Name
       type: string


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch removes the printer columns related to Content Library from the v1a1 VirtualMachineImage and ClusterVirtualMachineImage resources. This is aligned with v1a2, and frankly, these fields provide no real value when printing VMIs and just clutter the output. A user should not care where the image originates, and if they do, they can look at the image's status for more info.


<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->

`NA`

**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Removes the Content Provider and Library Item Name printer columns from the v1alpha1 VirtualMachineImage and ClusterVirtualMachineImage types.
```