### PR TITLE
:sparkles: Markdown updates / VM image documentation

### DIFF
--- a/docs/concepts/images/vm-image.md
+++ b/docs/concepts/images/vm-image.md
@@ -2,6 +2,51 @@
 
 // TODO ([github.com/vmware-tanzu/vm-operator#109](https://github.com/vmware-tanzu/vm-operator/issues/109))
 
+
+## Image Scope
+
+There are two types of VM image resources, the `ClusterVirtualMachineImage` and `VirtualMachineImage`. The former is a cluster-scoped resource, while the latter is a namespace-scoped resource. Other than that, the two resources are exactly the same.
+
+
+## Image Names
+
+Prior to vSphere 8.0U2, the name of a VM image resource was derived from the name of a Content Library item. For example, if a Content Library item was named `photonos-5-x64`, then its corresponding  `VirtualMachineImage` resource would also be named `photonos-5-x64`. This caused a problem if there library items with the same name from different libraries. With the exception of the first library item encountered, all subsequent library items would have randomly generated data appended to their corresponding Kubernetes resource names to ensure they were unique. In vSphere 8.0U2+, with the introduction of the Image Registry API and potential for global image catalogs, image names needed to be both unique _and_ deterministic, hence:
+
+```
+vmi-0123456789ABCDEFG
+```
+
+The above value is referred to as a _VMI ID_, where _VMI_ stands for _Virtual Machine Image_. No matter the source of a VM image, all images have unique, predictable VMI IDs. If the source of a VM image is Content Library, then the VMI ID is constructed using the following steps:
+
+1. Remove any `-` characters from the Content Library item's UUID
+2. Calculate the sha1sum of the value from the previous step
+3. Take the first 17 characters from the value from the previous step
+4. Append the value from the previous step to `vmi-`
+
+For example, if the Content Library item's UUID is `e1968c25-dd84-4506-8dc7-9beacb6b688e`, then the VMI ID is `vmi-0a0044d7c690bcbea`, for example:
+
+1. Remove any `-` characters: `e1968c25dd8445068dc79beacb6b688e`.
+1. Get the sha1sum: `0a0044d7c690bcbea07c9b49efc9f743479490e5`.
+1. First 17 characters: `0a0044d7c690bcbea`.
+1. Create the VMI ID: `vmi-0a0044d7c690bcbea`.
+
+
+## Name Resolution
+
+When a `VirtualMachine` resource's field `spec.imageName` is set to a VMI ID, the value is resolved to the `VirtualMachineImage` or `ClusterVirtualMachineImage` with that name. It is also possible to specify images based on their _friendly_ name.
+
+!!! warning "Friendly name resolution"
+
+    Please note that while resolving VM images based on their friendly name was merged into VM Operator with [github.com/vmware-tanzu/vm-operator#214](https://github.com/vmware-tanzu/vm-operator/issues/214), the feature is not yet part of a shipping vSphere release.
+
+For example, if `vmi-0a0044d7c690bcbea` refers to an image with a friendly name of `photonos-5-x64`, then a user could also specify that value for `spec.imageName` as long as the following is true:
+
+* There is no other `VirtualMachineImage` in the same namespace with that friendly name.
+* There is no other `ClusterVirtualMachineImage` with the same friendly name.
+
+If the friendly name unambiguously resolves to the distinct, VM image `vmi-0a0044d7c690bcbea`, then a mutation webhook replaces `spec.imageName: photonos-5-x64` with `spec.imageName: vmi-0a0044d7c690bcbea`.
+
+
 ## Recommended Images
 
 There are no restrictions on the images that can be deployed by VM Operator. However, for users wanting to try things out for themselves, here are a few images the project's developers use on a daily basis:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
-mkdocs >= 1.4.2
-mkdocs-material >= 9.1.0
-pymdown-extensions >= 9.9.1
-pygments >= 2.14.0
-mkdocs-git-committers-plugin-2 >= 1.1.1
+mkdocs >= 1.5.3
+mkdocs-material >= 9.4.2
+pymdown-extensions >= 10.3
+pygments >= 2.16.1
+mkdocs-git-committers-plugin-2 >= 1.2.0
 mkdocs-git-revision-date-localized-plugin >= 1.2.0
 mkdocs-markdownextradata-plugin >= 0.2.5

--- a/docs/www/themes/material/main.html
+++ b/docs/www/themes/material/main.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% block announce %}
+<!--<div style="background-color: #B5A440";>-->
+<div style="text-align: center;">
+  <!-- Add announcement here, including arbitrary HTML -->
+  ✨ Please check out
+  <em>
+    <a href="./concepts/images/vm-image/#image-names">Image Names</a>
+  </em> and
+  <em>
+    <a href="./concepts/images/vm-image/#name-resolution">Name Resolution</a>
+  </em>
+  to learn about changes to <code>VirtualMachineImage</code> and
+  <code>ClusterVirtualMachineImage</code> resources in vSphere 8.0U2+ ✨
+</div>
+<!--</div>-->
+{% endblock %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,7 @@ theme:
   - navigation.path
   - navigation.indexes
   - toc.follow
+  - announce.dismiss
 
 extra_css:
 - www/css/vm-operator.css


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch updates the version of mkdocs, its theme, and dependencies used to build the documentation. This patch also adds documentation about VM image names/resolution and creates a dismissable banner to ensure users see that image name logic has changed in vSphere 8.0U1+.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->
`NA`

**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Document VM image names and image resolution.
```

<!-- readthedocs-preview vm-operator start -->
----
:books: Documentation preview :books:: https://vm-operator--233.org.readthedocs.build/en/233/

<!-- readthedocs-preview vm-operator end -->