### PR TITLE
✨ Make v1a1 webconsole controller v1a2 VMProvider aware

### DIFF
--- a/controllers/virtualmachinewebconsolerequest/v1alpha1/webconsolerequest_intg_test.go
+++ b/controllers/virtualmachinewebconsolerequest/v1alpha1/webconsolerequest_intg_test.go
@@ -5,6 +5,7 @@ package v1alpha1_test
 
 import (
 	"context"
+	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -16,7 +17,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1alpha2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	webconsolerequest "github.com/vmware-tanzu/vm-operator/controllers/virtualmachinewebconsolerequest/v1alpha1"
+	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
@@ -26,10 +29,12 @@ func intgTests() {
 
 func webConsoleRequestReconcile() {
 	var (
-		ctx      *builder.IntegrationTestContext
-		wcr      *vmopv1.WebConsoleRequest
-		vm       *vmopv1.VirtualMachine
-		proxySvc *corev1.Service
+		ctx                *builder.IntegrationTestContext
+		wcr                *vmopv1.WebConsoleRequest
+		vm                 *vmopv1.VirtualMachine
+		proxySvc           *corev1.Service
+		v1a1ProviderCalled bool
+		v1a2ProviderCalled bool
 	)
 
 	getWebConsoleRequest := func(ctx *builder.IntegrationTestContext, objKey types.NamespacedName) *vmopv1.WebConsoleRequest {
@@ -84,8 +89,18 @@ func webConsoleRequestReconcile() {
 
 		fakeVMProvider.Lock()
 		defer fakeVMProvider.Unlock()
+
 		fakeVMProvider.GetVirtualMachineWebMKSTicketFn = func(ctx context.Context, vm *vmopv1.VirtualMachine, pubKey string) (string, error) {
+			v1a1ProviderCalled = true
 			return "some-fake-webmksticket", nil
+		}
+
+		fakeVMProviderA2.Lock()
+		defer fakeVMProviderA2.Unlock()
+
+		fakeVMProviderA2.GetVirtualMachineWebMKSTicketFn = func(ctx context.Context, vm *vmopv1alpha2.VirtualMachine, pubKey string) (string, error) {
+			v1a2ProviderCalled = true
+			return "some-fake-webmksticket-1", nil
 		}
 	})
 
@@ -93,12 +108,13 @@ func webConsoleRequestReconcile() {
 		ctx.AfterEach()
 		ctx = nil
 		fakeVMProvider.Reset()
+		fakeVMProviderA2.Reset()
+		v1a1ProviderCalled = false
+		v1a2ProviderCalled = false
 	})
 
 	Context("Reconcile", func() {
-		BeforeEach(func() {
-			Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
-			Expect(ctx.Client.Create(ctx, wcr)).To(Succeed())
+		JustBeforeEach(func() {
 			Expect(ctx.Client.Create(ctx, proxySvc)).To(Succeed())
 			proxySvc.Status = corev1.ServiceStatus{
 				LoadBalancer: corev1.LoadBalancerStatus{
@@ -110,27 +126,57 @@ func webConsoleRequestReconcile() {
 				},
 			}
 			Expect(ctx.Client.Status().Update(ctx, proxySvc)).To(Succeed())
+			Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
+			Expect(ctx.Client.Create(ctx, wcr)).To(Succeed())
 		})
 
-		AfterEach(func() {
+		JustAfterEach(func() {
 			err := ctx.Client.Delete(ctx, wcr)
 			Expect(err == nil || k8serrors.IsNotFound(err)).To(BeTrue())
 			err = ctx.Client.Delete(ctx, vm)
 			Expect(err == nil || k8serrors.IsNotFound(err)).To(BeTrue())
+			err = ctx.Client.Delete(ctx, proxySvc)
+			Expect(err == nil || k8serrors.IsNotFound(err)).To(BeTrue())
 		})
 
-		It("resource successfully created", func() {
-			Eventually(func() bool {
-				wcr = getWebConsoleRequest(ctx, types.NamespacedName{Name: wcr.Name, Namespace: wcr.Namespace})
-				if wcr != nil && wcr.Status.Response != "" {
-					return true
-				}
-				return false
-			}).Should(BeTrue(), "waiting for webconsolerequest to be")
-			Expect(wcr.Status.ProxyAddr).To(Equal("192.168.0.1"))
-			Expect(wcr.Status.Response).ToNot(BeEmpty())
-			Expect(wcr.Status.ExpiryTime.Time).To(BeTemporally("~", time.Now(), webconsolerequest.DefaultExpiryTime))
-			Expect(wcr.Labels).To(HaveKeyWithValue(webconsolerequest.UUIDLabelKey, string(wcr.UID)))
+		When("v1a1 provider", func() {
+			It("resource successfully created", func() {
+				Eventually(func(g Gomega) {
+					wcr = getWebConsoleRequest(ctx, types.NamespacedName{Name: wcr.Name, Namespace: wcr.Namespace})
+					g.Expect(wcr).ToNot(BeNil())
+					g.Expect(wcr.Status.Response).ToNot(BeEmpty())
+				}).Should(Succeed(), "waiting for webconsolerequest to be")
+
+				Expect(v1a1ProviderCalled).Should(BeTrue())
+				Expect(wcr.Status.ProxyAddr).To(Equal("192.168.0.1"))
+				Expect(wcr.Status.Response).ToNot(BeEmpty())
+				Expect(wcr.Status.ExpiryTime.Time).To(BeTemporally("~", time.Now(), webconsolerequest.DefaultExpiryTime))
+				Expect(wcr.Labels).To(HaveKeyWithValue(webconsolerequest.UUIDLabelKey, string(wcr.UID)))
+			})
+		})
+
+		When("VM Service v1a2 FSS enabled", func() {
+			BeforeEach(func() {
+				Expect(os.Setenv(lib.VMServiceV1Alpha2FSS, lib.TrueString)).To(Succeed())
+			})
+
+			AfterEach(func() {
+				Expect(os.Unsetenv(lib.VMServiceV1Alpha2FSS)).To(Succeed())
+			})
+
+			It("resource successfully created", func() {
+				Eventually(func(g Gomega) {
+					wcr = getWebConsoleRequest(ctx, types.NamespacedName{Name: wcr.Name, Namespace: wcr.Namespace})
+					g.Expect(wcr).ToNot(BeNil())
+					g.Expect(wcr.Status.Response).ToNot(BeEmpty())
+				}).Should(Succeed(), "waiting for webconsolerequest to be")
+
+				Expect(v1a2ProviderCalled).Should(BeTrue())
+				Expect(wcr.Status.ProxyAddr).To(Equal("192.168.0.1"))
+				Expect(wcr.Status.Response).ToNot(BeEmpty())
+				Expect(wcr.Status.ExpiryTime.Time).To(BeTemporally("~", time.Now(), webconsolerequest.DefaultExpiryTime))
+				Expect(wcr.Labels).To(HaveKeyWithValue(webconsolerequest.UUIDLabelKey, string(wcr.UID)))
+			})
 		})
 	})
 }

--- a/controllers/virtualmachinewebconsolerequest/v1alpha1/webconsolerequest_suite_test.go
+++ b/controllers/virtualmachinewebconsolerequest/v1alpha1/webconsolerequest_suite_test.go
@@ -16,12 +16,16 @@ import (
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
-var fakeVMProvider = providerfake.NewVMProvider()
+var (
+	fakeVMProvider   = providerfake.NewVMProvider()
+	fakeVMProviderA2 = providerfake.NewVMProviderA2()
+)
 
 var suite = builder.NewTestSuiteForController(
 	v1alpha1.AddToManager,
 	func(ctx *ctrlContext.ControllerManagerContext, _ ctrlmgr.Manager) error {
 		ctx.VMProvider = fakeVMProvider
+		ctx.VMProviderA2 = fakeVMProviderA2
 		return nil
 	},
 )

--- a/controllers/virtualmachinewebconsolerequest/v1alpha1/webconsolerequest_unit_test.go
+++ b/controllers/virtualmachinewebconsolerequest/v1alpha1/webconsolerequest_unit_test.go
@@ -5,6 +5,7 @@ package v1alpha1_test
 
 import (
 	"context"
+	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -15,8 +16,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1alpha2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	webconsolerequest "github.com/vmware-tanzu/vm-operator/controllers/virtualmachinewebconsolerequest/v1alpha1"
 	vmopContext "github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 	providerfake "github.com/vmware-tanzu/vm-operator/pkg/vmprovider/fake"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
@@ -79,8 +82,10 @@ func unitTestsReconcile() {
 			ctx.Logger,
 			ctx.Recorder,
 			ctx.VMProvider,
+			ctx.VMProviderA2,
 		)
 		fakeVMProvider = ctx.VMProvider.(*providerfake.VMProvider)
+		fakeVMProviderA2 = ctx.VMProviderA2.(*providerfake.VMProviderA2)
 
 		wcrCtx = &vmopContext.WebConsoleRequestContext{
 			Context:           ctx,
@@ -95,18 +100,35 @@ func unitTestsReconcile() {
 		ctx = nil
 		initObjects = nil
 		reconciler = nil
-		fakeVMProvider.Reset()
 	})
 
 	Context("ReconcileNormal", func() {
+		var (
+			v1a1ProviderCalled bool
+			v1a2ProviderCalled bool
+		)
+
 		BeforeEach(func() {
 			initObjects = append(initObjects, wcr, vm, proxySvc)
 		})
 
 		JustBeforeEach(func() {
 			fakeVMProvider.GetVirtualMachineWebMKSTicketFn = func(ctx context.Context, vm *vmopv1.VirtualMachine, pubKey string) (string, error) {
+				v1a1ProviderCalled = true
 				return "some-fake-webmksticket", nil
 			}
+
+			fakeVMProviderA2.GetVirtualMachineWebMKSTicketFn = func(ctx context.Context, vm *vmopv1alpha2.VirtualMachine, pubKey string) (string, error) {
+				v1a2ProviderCalled = true
+				return "some-fake-webmksticket-1", nil
+			}
+		})
+
+		AfterEach(func() {
+			fakeVMProvider.Reset()
+			fakeVMProviderA2.Reset()
+			v1a1ProviderCalled = false
+			v1a2ProviderCalled = false
 		})
 
 		When("NoOp", func() {
@@ -114,6 +136,7 @@ func unitTestsReconcile() {
 				err := reconciler.ReconcileNormal(wcrCtx)
 				Expect(err).ToNot(HaveOccurred())
 
+				Expect(v1a1ProviderCalled).Should(BeTrue())
 				Expect(wcrCtx.WebConsoleRequest.Status.ProxyAddr).To(Equal("dummy-proxy-ip"))
 				Expect(wcrCtx.WebConsoleRequest.Status.Response).ToNot(BeEmpty())
 				Expect(wcrCtx.WebConsoleRequest.Status.ExpiryTime.Time).To(BeTemporally("~", time.Now(), webconsolerequest.DefaultExpiryTime))
@@ -121,5 +144,28 @@ func unitTestsReconcile() {
 				Expect(wcrCtx.WebConsoleRequest.Labels).To(HaveKey(webconsolerequest.UUIDLabelKey))
 			})
 		})
+
+		When("VM Service v1alpha2 FSS is enabled", func() {
+			BeforeEach(func() {
+				Expect(os.Setenv(lib.VMServiceV1Alpha2FSS, lib.TrueString)).To(Succeed())
+			})
+
+			AfterEach(func() {
+				Expect(os.Unsetenv(lib.VMServiceV1Alpha2FSS)).To(Succeed())
+			})
+
+			It("returns success", func() {
+				err := reconciler.ReconcileNormal(wcrCtx)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(v1a2ProviderCalled).Should(BeTrue())
+				Expect(wcrCtx.WebConsoleRequest.Status.ProxyAddr).To(Equal("dummy-proxy-ip"))
+				Expect(wcrCtx.WebConsoleRequest.Status.Response).ToNot(BeEmpty())
+				Expect(wcrCtx.WebConsoleRequest.Status.ExpiryTime.Time).To(BeTemporally("~", time.Now(), webconsolerequest.DefaultExpiryTime))
+				// Checking the label key only because UID will not be set to a resource during unit test.
+				Expect(wcrCtx.WebConsoleRequest.Labels).To(HaveKey(webconsolerequest.UUIDLabelKey))
+			})
+		})
+
 	})
 }


### PR DESCRIPTION


**What does this PR do, and why is it needed?**

When v1a2 FSS gets enabled, only the v1a2 VM Provider will be available for use. 
Since v1a1 webconsole CRs are still supported in v1a2 world, the v1a1 VM Provider that it uses will NPE.
This requires the v1a1 controller to be v1a2 Provider aware.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #
N/A

**Are there any special notes for your reviewer**:

N/A


**Please add a release note if necessary**:
```
None
```