### PR TITLE
:bug: Return err during unmarshaling ovf file to trigger reconcile

### DIFF
--- a/pkg/vmprovider/providers/vsphere/contentlibrary/content_library_provider.go
+++ b/pkg/vmprovider/providers/vsphere/contentlibrary/content_library_provider.go
@@ -196,10 +196,11 @@ func (cs *provider) RetrieveOvfEnvelopeFromLibraryItem(ctx context.Context, item
 		_ = downloadedFileContent.Close()
 	}()
 
+	// OVF file is validated during upload, err here can be internet error.
 	envelope, err := ovf.Unmarshal(downloadedFileContent)
 	if err != nil {
 		logger.Error(err, "error parsing the OVF envelope")
-		return nil, nil
+		return nil, err
 	}
 
 	return envelope, nil
@@ -318,10 +319,6 @@ func (cs *provider) VirtualMachineImageResourceForLibrary(ctx context.Context,
 		if ovfEnvelope, err = cs.RetrieveOvfEnvelopeFromLibraryItem(ctx, item); err != nil {
 			logger.Error(err, "error extracting the OVF envelope from the library item", "itemName", item.Name)
 			return nil, err
-		}
-		if ovfEnvelope == nil {
-			logger.Error(err, "no valid OVF envelope found, skipping library item", "itemName", item.Name)
-			return nil, nil
 		}
 	case library.ItemTypeVMTX:
 		// Do not try to populate VMTX types, but resVm.GetOvfProperties() should return an

--- a/pkg/vmprovider/providers/vsphere/contentlibrary/content_library_test.go
+++ b/pkg/vmprovider/providers/vsphere/contentlibrary/content_library_test.go
@@ -136,7 +136,7 @@ func clTests() {
 			})
 		})
 
-		Context("called with an OVF that is invalid", func() {
+		Context("called with an OVF that is invalid because of network connectivity issue", func() {
 			var ovfPath string
 
 			AfterEach(func() {
@@ -145,7 +145,7 @@ func clTests() {
 				}
 			})
 
-			It("does not return error", func() {
+			It("returns error", func() {
 				ovf, err := os.CreateTemp("", "fake-*.ovf")
 				Expect(err).NotTo(HaveOccurred())
 				ovfPath = ovf.Name()
@@ -169,7 +169,7 @@ func clTests() {
 				Expect(libItem2.Name).To(Equal(libItem.Name))
 
 				ovfEnvelope, err := clProvider.RetrieveOvfEnvelopeFromLibraryItem(ctx, libItem2)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).To(HaveOccurred())
 				Expect(ovfEnvelope).To(BeNil())
 			})
 		})

--- a/pkg/vmprovider/providers/vsphere2/contentlibrary/content_library_provider.go
+++ b/pkg/vmprovider/providers/vsphere2/contentlibrary/content_library_provider.go
@@ -212,10 +212,11 @@ func (cs *provider) RetrieveOvfEnvelopeFromLibraryItem(ctx context.Context, item
 		_ = downloadedFileContent.Close()
 	}()
 
+	// OVF file is validated during upload, err here can be internet error.
 	envelope, err := ovf.Unmarshal(downloadedFileContent)
 	if err != nil {
 		logger.Error(err, "error parsing the OVF envelope")
-		return nil, nil
+		return nil, err
 	}
 
 	return envelope, nil

--- a/pkg/vmprovider/providers/vsphere2/contentlibrary/content_library_test.go
+++ b/pkg/vmprovider/providers/vsphere2/contentlibrary/content_library_test.go
@@ -98,7 +98,7 @@ func clTests() {
 			})
 		})
 
-		Context("called with an OVF that is invalid", func() {
+		Context("called with an OVF that is invalid because of network connectivity issue", func() {
 			var ovfPath string
 
 			AfterEach(func() {
@@ -107,7 +107,7 @@ func clTests() {
 				}
 			})
 
-			It("does not return error", func() {
+			It("returns error", func() {
 				ovf, err := os.CreateTemp("", "fake-*.ovf")
 				Expect(err).NotTo(HaveOccurred())
 				ovfPath = ovf.Name()
@@ -131,7 +131,7 @@ func clTests() {
 				Expect(libItem2.Name).To(Equal(libItem.Name))
 
 				ovfEnvelope, err := clProvider.RetrieveOvfEnvelopeFromLibraryItem(ctx, libItem2)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).To(HaveOccurred())
 				Expect(ovfEnvelope).To(BeNil())
 			})
 		})


### PR DESCRIPTION

**What does this PR do, and why is it needed?**
With image service enabled, we now reconcile individual Content Library Items. So we don't want to skip error handling anymore. This change will allow retrying when encountered errors during `RetrieveOvfEnvelopeFromLibraryItem`.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes N/A


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Return errors to trigger reconcilation when retrieve Ovf envelope from library item
```