### PR TITLE
🐛 Fix a few typos in the v1a2 bootstrap types

### DIFF
--- a/api/v1alpha2/common/types.go
+++ b/api/v1alpha2/common/types.go
@@ -70,7 +70,7 @@ type KeyValuePair struct {
 }
 
 // KeyValueOrSecretKeySelectorPair is useful when wanting to realize a map as a
-// list of key/value pairs where each value could also referenced data stored in
+// list of key/value pairs where each value could also reference data stored in
 // a Secret resource.
 type KeyValueOrSecretKeySelectorPair struct {
 	// Key is the key part of the key/value pair.

--- a/api/v1alpha2/sysprep/sysprep.go
+++ b/api/v1alpha2/sysprep/sysprep.go
@@ -49,7 +49,7 @@ type GUIRunOnce struct {
 	// customization.
 	//
 	// +optional
-	Commands []string `json:"commmands,omitempty"`
+	Commands []string `json:"commands,omitempty"`
 }
 
 // GUIUnattended maps to the GuiUnattended key in the sysprep.xml answer file.

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -1241,7 +1241,7 @@ spec:
                             description: GUIRunOnce is a representation of the Sysprep
                               GuiRunOnce key.
                             properties:
-                              commmands:
+                              commands:
                                 description: Commands is a list of commands to run
                                   at first user logon, after guest customization.
                                 items:
@@ -1446,8 +1446,8 @@ spec:
                         items:
                           description: KeyValueOrSecretKeySelectorPair is useful when
                             wanting to realize a map as a list of key/value pairs
-                            where each value could also referenced data stored in
-                            a Secret resource.
+                            where each value could also reference data stored in a
+                            Secret resource.
                           properties:
                             key:
                               description: Key is the key part of the key/value pair.


### PR DESCRIPTION

```release-note
NONE
```