### PR TITLE
🌱 Prevent non-admin users from setting first-boot-done annotation

### DIFF
--- a/api/v1alpha1/virtualmachine_types.go
+++ b/api/v1alpha1/virtualmachine_types.go
@@ -105,6 +105,11 @@ const (
 	// the same with the first boot Instance ID to prevent Cloud-Init from treating this VM as first boot
 	// due to different Instance ID. This annotation is used in upgrade script.
 	InstanceIDAnnotation = GroupName + "/cloud-init-instance-id"
+
+	// FirstBootDoneAnnotation is an annotation that indicates the VM has been
+	// booted at least once. This annotation cannot be set by users and will not
+	// be removed once set until the VM is deleted.
+	FirstBootDoneAnnotation = "virtualmachine." + GroupName + "/first-boot-done"
 )
 
 // VirtualMachinePort is unused and can be considered deprecated.

--- a/api/v1alpha2/virtualmachine_types.go
+++ b/api/v1alpha2/virtualmachine_types.go
@@ -102,6 +102,11 @@ const (
 	// the same with the first boot Instance ID to prevent Cloud-Init from treating this VM as first boot
 	// due to different Instance ID. This annotation is used in upgrade script.
 	InstanceIDAnnotation = GroupName + "/cloud-init-instance-id"
+
+	// FirstBootDoneAnnotation is an annotation that indicates the VM has been
+	// booted at least once. This annotation cannot be set by users and will not
+	// be removed once set until the VM is deleted.
+	FirstBootDoneAnnotation = "virtualmachine." + GroupName + "/first-boot-done"
 )
 
 // VirtualMachinePowerState defines a VM's desired and observed power states.

--- a/pkg/vmprovider/providers/vsphere/session/session_vm_update.go
+++ b/pkg/vmprovider/providers/vsphere/session/session_vm_update.go
@@ -32,10 +32,6 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/virtualmachine"
 )
 
-const (
-	FirstBootDoneAnnotation = "virtualmachine.vmoperator.vmware.com/first-boot-done"
-)
-
 type VMMetadata struct {
 	Data      map[string]string
 	Transport vmopv1.VirtualMachineMetadataTransport
@@ -930,7 +926,7 @@ func (s *Session) UpdateVirtualMachine(
 		if vmCtx.VM.Annotations == nil {
 			vmCtx.VM.Annotations = map[string]string{}
 		}
-		vmCtx.VM.Annotations[FirstBootDoneAnnotation] = "true"
+		vmCtx.VM.Annotations[vmopv1.FirstBootDoneAnnotation] = "true"
 	}
 	return nil
 }

--- a/pkg/vmprovider/providers/vsphere/vmprovider_vm.go
+++ b/pkg/vmprovider/providers/vsphere/vmprovider_vm.go
@@ -41,10 +41,6 @@ type vmCreateArgs = session.VMCreateArgs
 type vmUpdateArgs = session.VMUpdateArgs
 type vmMetadata = session.VMMetadata
 
-const (
-	FirstBootDoneAnnotation = "virtualmachine.vmoperator.vmware.com/first-boot-done"
-)
-
 var (
 	createCountLock       sync.Mutex
 	concurrentCreateCount int
@@ -811,7 +807,7 @@ func (vs *vSphereVMProvider) vmUpdateGetArgs(
 }
 
 func isVMFirstBoot(vmCtx context.VirtualMachineContext) bool {
-	if _, ok := vmCtx.VM.Annotations[FirstBootDoneAnnotation]; ok {
+	if _, ok := vmCtx.VM.Annotations[vmopv1.FirstBootDoneAnnotation]; ok {
 		return false
 	}
 

--- a/pkg/vmprovider/providers/vsphere2/session/session_vm_update.go
+++ b/pkg/vmprovider/providers/vsphere2/session/session_vm_update.go
@@ -31,10 +31,6 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere2/vmlifecycle"
 )
 
-const (
-	FirstBootDoneAnnotation = "virtualmachine.vmoperator.vmware.com/first-boot-done"
-)
-
 // VMUpdateArgs contains the arguments needed to update a VM on VC.
 type VMUpdateArgs struct {
 	VMClass        *vmopv1.VirtualMachineClass
@@ -951,7 +947,7 @@ func (s *Session) UpdateVirtualMachine(
 		if vmCtx.VM.Annotations == nil {
 			vmCtx.VM.Annotations = map[string]string{}
 		}
-		vmCtx.VM.Annotations[FirstBootDoneAnnotation] = "true"
+		vmCtx.VM.Annotations[vmopv1.FirstBootDoneAnnotation] = "true"
 	}
 	return nil
 }

--- a/pkg/vmprovider/providers/vsphere2/vmprovider_vm.go
+++ b/pkg/vmprovider/providers/vsphere2/vmprovider_vm.go
@@ -62,10 +62,6 @@ type VMCreateArgs struct {
 // TODO: Until we sort out what the Session becomes.
 type vmUpdateArgs = session.VMUpdateArgs
 
-const (
-	FirstBootDoneAnnotation = "virtualmachine.vmoperator.vmware.com/first-boot-done"
-)
-
 var (
 	createCountLock       sync.Mutex
 	concurrentCreateCount int
@@ -1161,7 +1157,7 @@ func (vs *vSphereVMProvider) vmUpdateGetArgs(
 }
 
 func isVMFirstBoot(vmCtx context.VirtualMachineContextA2) bool {
-	if _, ok := vmCtx.VM.Annotations[FirstBootDoneAnnotation]; ok {
+	if _, ok := vmCtx.VM.Annotations[vmopv1.FirstBootDoneAnnotation]; ok {
 		return false
 	}
 

--- a/webhooks/virtualmachine/v1alpha1/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/v1alpha1/validation/virtualmachine_validator_unit_test.go
@@ -36,6 +36,8 @@ const (
 	updateSuffix            = "-updated"
 	dummyNamespaceImageName = "dummy-namespace-image"
 	dummyClusterImageName   = "dummy-cluster-image"
+	dummyInstanceIDVal      = "dummy-instance-id"
+	dummyFirstBootDoneVal   = "dummy-first-boot-done"
 )
 
 func unitTests() {
@@ -371,8 +373,8 @@ func unitTestsValidateCreate() {
 		}
 
 		if args.adminOnlyAnnotations {
-			ctx.vm.Annotations[vmopv1.InstanceIDAnnotation] = "some-value"
-			ctx.vm.Annotations[vmopv1.FirstBootDoneAnnotation] = "some-value"
+			ctx.vm.Annotations[vmopv1.InstanceIDAnnotation] = dummyInstanceIDVal
+			ctx.vm.Annotations[vmopv1.FirstBootDoneAnnotation] = dummyFirstBootDoneVal
 		}
 
 		ctx.vm.Spec.PowerState = args.powerState
@@ -600,18 +602,18 @@ func unitTestsValidateUpdate() {
 		ctx.vm.Spec.NextRestartTime = args.nextRestartTime
 
 		if args.addAdminOnlyAnnotations {
-			ctx.vm.Annotations[vmopv1.InstanceIDAnnotation] = "some-value"
-			ctx.vm.Annotations[vmopv1.FirstBootDoneAnnotation] = "some-value"
+			ctx.vm.Annotations[vmopv1.InstanceIDAnnotation] = dummyInstanceIDVal
+			ctx.vm.Annotations[vmopv1.FirstBootDoneAnnotation] = dummyFirstBootDoneVal
 		}
 		if args.updateAdminOnlyAnnotations {
-			ctx.oldVM.Annotations[vmopv1.InstanceIDAnnotation] = "some-value"
-			ctx.oldVM.Annotations[vmopv1.FirstBootDoneAnnotation] = "some-value"
-			ctx.vm.Annotations[vmopv1.InstanceIDAnnotation] = "some-other-value"
-			ctx.vm.Annotations[vmopv1.FirstBootDoneAnnotation] = "some-other-value"
+			ctx.oldVM.Annotations[vmopv1.InstanceIDAnnotation] = dummyInstanceIDVal
+			ctx.oldVM.Annotations[vmopv1.FirstBootDoneAnnotation] = dummyFirstBootDoneVal
+			ctx.vm.Annotations[vmopv1.InstanceIDAnnotation] = dummyInstanceIDVal + updateSuffix
+			ctx.vm.Annotations[vmopv1.FirstBootDoneAnnotation] = dummyFirstBootDoneVal + updateSuffix
 		}
 		if args.removeAdminOnlyAnnotations {
-			ctx.oldVM.Annotations[vmopv1.InstanceIDAnnotation] = "some-value"
-			ctx.oldVM.Annotations[vmopv1.FirstBootDoneAnnotation] = "some-value"
+			ctx.oldVM.Annotations[vmopv1.InstanceIDAnnotation] = dummyInstanceIDVal
+			ctx.oldVM.Annotations[vmopv1.FirstBootDoneAnnotation] = updateSuffix
 		}
 
 		// Named network provider

--- a/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator.go
@@ -59,7 +59,7 @@ const (
 	invalidNextRestartTimeOnCreate           = "cannot restart VM on create"
 	invalidNextRestartTimeOnUpdate           = "must be formatted as RFC3339Nano"
 	invalidNextRestartTimeOnUpdateNow        = "mutation webhooks are required to restart VM"
-	settingAnnotationNotAllowed              = "adding this annotation is not allowed"
+	modifyAnnotationNotAllowedForNonAdmin    = "modifying this annotation is not allowed for non-admin users"
 )
 
 // +kubebuilder:webhook:verbs=create;update,path=/default-validate-vmoperator-vmware-com-v1alpha2-virtualmachine,mutating=false,failurePolicy=fail,groups=vmoperator.vmware.com,resources=virtualmachines,versions=v1alpha2,name=default.validating.virtualmachine.v1alpha2.vmoperator.vmware.com,sideEffects=None,admissionReviewVersions=v1;v1beta1
@@ -115,7 +115,7 @@ func (v validator) ValidateCreate(ctx *context.WebhookRequestContext) admission.
 	fieldErrs = append(fieldErrs, v.validateAdvanced(ctx, vm)...)
 	fieldErrs = append(fieldErrs, v.validatePowerStateOnCreate(ctx, vm)...)
 	fieldErrs = append(fieldErrs, v.validateNextRestartTimeOnCreate(ctx, vm)...)
-	fieldErrs = append(fieldErrs, v.validateAnnotation(ctx, vm)...)
+	fieldErrs = append(fieldErrs, v.validateAnnotation(ctx, vm, nil)...)
 
 	validationErrs := make([]string, 0, len(fieldErrs))
 	for _, fieldErr := range fieldErrs {
@@ -170,7 +170,7 @@ func (v validator) ValidateUpdate(ctx *context.WebhookRequestContext) admission.
 	fieldErrs = append(fieldErrs, v.validateAdvanced(ctx, vm)...)
 	fieldErrs = append(fieldErrs, v.validateInstanceStorageVolumes(ctx, vm, oldVM)...)
 	fieldErrs = append(fieldErrs, v.validateNextRestartTimeOnUpdate(ctx, vm, oldVM)...)
-	fieldErrs = append(fieldErrs, v.validateAnnotation(ctx, vm)...)
+	fieldErrs = append(fieldErrs, v.validateAnnotation(ctx, vm, oldVM)...)
 
 	validationErrs := make([]string, 0, len(fieldErrs))
 	for _, fieldErr := range fieldErrs {
@@ -683,17 +683,26 @@ func (v validator) isNetworkRestrictedForReadinessProbe(ctx *context.WebhookRequ
 	return configMap.Data[isRestrictedNetworkKey] == "true", nil
 }
 
-func (v validator) validateAnnotation(ctx *context.WebhookRequestContext, vm *vmopv1.VirtualMachine) field.ErrorList {
+func (v validator) validateAnnotation(ctx *context.WebhookRequestContext, vm, oldVM *vmopv1.VirtualMachine) field.ErrorList {
 	var allErrs field.ErrorList
 
-	if ctx.IsPrivilegedAccount || vm.Annotations == nil {
+	if ctx.IsPrivilegedAccount {
 		return allErrs
+	}
+
+	// Use an empty VM if the oldVM is nil to validate a creation request.
+	if oldVM == nil {
+		oldVM = &vmopv1.VirtualMachine{}
 	}
 
 	annotationPath := field.NewPath("metadata", "annotations")
 
-	if _, exists := vm.Annotations[vmopv1.InstanceIDAnnotation]; exists {
-		allErrs = append(allErrs, field.Forbidden(annotationPath.Child(vmopv1.InstanceIDAnnotation), settingAnnotationNotAllowed))
+	if vm.Annotations[vmopv1.InstanceIDAnnotation] != oldVM.Annotations[vmopv1.InstanceIDAnnotation] {
+		allErrs = append(allErrs, field.Forbidden(annotationPath.Child(vmopv1.InstanceIDAnnotation), modifyAnnotationNotAllowedForNonAdmin))
+	}
+
+	if vm.Annotations[vmopv1.FirstBootDoneAnnotation] != oldVM.Annotations[vmopv1.FirstBootDoneAnnotation] {
+		allErrs = append(allErrs, field.Forbidden(annotationPath.Child(vmopv1.FirstBootDoneAnnotation), modifyAnnotationNotAllowedForNonAdmin))
 	}
 
 	return allErrs

--- a/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator_unit_test.go
@@ -31,7 +31,9 @@ import (
 )
 
 const (
-	updateSuffix = "-updated"
+	updateSuffix          = "-updated"
+	dummyInstanceIDVal    = "dummy-instance-id"
+	dummyFirstBootDoneVal = "dummy-first-boot-done"
 )
 
 func unitTests() {
@@ -253,8 +255,8 @@ func unitTestsValidateCreate() {
 		}
 
 		if args.adminOnlyAnnotations {
-			ctx.vm.Annotations[vmopv1.InstanceIDAnnotation] = "some-value"
-			ctx.vm.Annotations[vmopv1.FirstBootDoneAnnotation] = "some-value"
+			ctx.vm.Annotations[vmopv1.InstanceIDAnnotation] = updateSuffix
+			ctx.vm.Annotations[vmopv1.FirstBootDoneAnnotation] = updateSuffix
 		}
 
 		ctx.vm.Spec.PowerState = args.powerState
@@ -459,18 +461,18 @@ func unitTestsValidateUpdate() {
 		}
 
 		if args.addAdminOnlyAnnotations {
-			ctx.vm.Annotations[vmopv1.InstanceIDAnnotation] = "some-value"
-			ctx.vm.Annotations[vmopv1.FirstBootDoneAnnotation] = "some-value"
+			ctx.vm.Annotations[vmopv1.InstanceIDAnnotation] = dummyInstanceIDVal
+			ctx.vm.Annotations[vmopv1.FirstBootDoneAnnotation] = dummyFirstBootDoneVal
 		}
 		if args.updateAdminOnlyAnnotations {
-			ctx.oldVM.Annotations[vmopv1.InstanceIDAnnotation] = "some-value"
-			ctx.oldVM.Annotations[vmopv1.FirstBootDoneAnnotation] = "some-value"
-			ctx.vm.Annotations[vmopv1.InstanceIDAnnotation] = "some-other-value"
-			ctx.vm.Annotations[vmopv1.FirstBootDoneAnnotation] = "some-other-value"
+			ctx.oldVM.Annotations[vmopv1.InstanceIDAnnotation] = dummyInstanceIDVal
+			ctx.oldVM.Annotations[vmopv1.FirstBootDoneAnnotation] = dummyFirstBootDoneVal
+			ctx.vm.Annotations[vmopv1.InstanceIDAnnotation] = dummyInstanceIDVal + updateSuffix
+			ctx.vm.Annotations[vmopv1.FirstBootDoneAnnotation] = dummyFirstBootDoneVal + updateSuffix
 		}
 		if args.removeAdminOnlyAnnotations {
-			ctx.oldVM.Annotations[vmopv1.InstanceIDAnnotation] = "some-value"
-			ctx.oldVM.Annotations[vmopv1.FirstBootDoneAnnotation] = "some-value"
+			ctx.oldVM.Annotations[vmopv1.InstanceIDAnnotation] = dummyInstanceIDVal
+			ctx.oldVM.Annotations[vmopv1.FirstBootDoneAnnotation] = dummyFirstBootDoneVal
 		}
 
 		ctx.oldVM.Spec.NextRestartTime = args.lastRestartTime


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This patch updates the VM mutation webhook to disallow non-admin users from adding/updating/removing the `first-boot-done` annotation. It is only meant to be modified by the VM-Operator. Also, it fixes the current implementation which could cause all VM updates from non-admin users to fail if the `cloud-init-instance-id` annotations exist.

**Which issue(s) is/are addressed by this PR?**
Fixes #221 

**Are there any special notes for your reviewer**:
This change is a prerequisite for another upcoming change that will rely on the existence of the `first-boot-done` annotation set by the VM-Operator.

**Please add a release note if necessary**:
```release-note
Prevent non-admin users from setting first-boot-done annotation
```