### PR TITLE
🌱 Reverse configSpec.firmware order of precedence to Image then Classes

### DIFF
--- a/pkg/vmprovider/providers/vsphere/virtualmachine/configspec.go
+++ b/pkg/vmprovider/providers/vsphere/virtualmachine/configspec.go
@@ -88,8 +88,12 @@ func CreateConfigSpec(
 		}
 	}
 
-	// Use firmware type from the image if config spec doesn't have it.
-	if configSpec.Firmware == "" && imageFirmware != "" {
+	// Always use the image's firmware type if present.
+	// This is necessary until the vSphere UI can support creating VM Classes with
+	// an empty/nil firmware type. Since VM Classes created via the vSphere UI always have
+	// a default firmware value set (efi), this can cause VM boot failures for unsupported images.
+	if imageFirmware != "" {
+		// TODO: Use image firmware only when the class config spec has an empty firmware type.
 		configSpec.Firmware = imageFirmware
 	}
 

--- a/pkg/vmprovider/providers/vsphere/virtualmachine/configspec_test.go
+++ b/pkg/vmprovider/providers/vsphere/virtualmachine/configspec_test.go
@@ -71,6 +71,7 @@ var _ = Describe("CreateConfigSpec", func() {
 						},
 					},
 				},
+				Firmware: "bios",
 			}
 		})
 
@@ -98,6 +99,17 @@ var _ = Describe("CreateConfigSpec", func() {
 			_, ok := dSpec.Device.(*vimtypes.VirtualE1000)
 			Expect(ok).To(BeTrue())
 
+		})
+
+		When("image firmware is empty", func() {
+			BeforeEach(func() {
+				firmware = ""
+			})
+
+			It("config spec has the firmware from the class", func() {
+				Expect(configSpec.Firmware).ToNot(Equal(firmware))
+				Expect(configSpec.Firmware).To(Equal(classConfigSpec.Firmware))
+			})
 		})
 	})
 })

--- a/pkg/vmprovider/providers/vsphere2/virtualmachine/configspec.go
+++ b/pkg/vmprovider/providers/vsphere2/virtualmachine/configspec.go
@@ -47,10 +47,14 @@ func CreateConfigSpec(
 		Type:         constants.ManagedByExtensionType,
 	}
 
-	if val, ok := vmCtx.VM.Annotations[constants.FirmwareOverrideAnnotation]; ok {
+	if val, ok := vmCtx.VM.Annotations[constants.FirmwareOverrideAnnotation]; ok && (val == "efi" || val == "bios") {
 		configSpec.Firmware = val
-	} else if configSpec.Firmware == "" && vmImageStatus != nil {
-		// Use firmware type from the image if ConfigSpec doesn't have it.
+	} else if vmImageStatus != nil && vmImageStatus.Firmware != "" {
+		// Use the image's firmware type if present.
+		// This is necessary until the vSphere UI can support creating VM Classes with
+		// an empty/nil firmware type. Since VM Classes created via the vSphere UI always has
+		// a non-empty firmware value set, this can cause VM boot failures.
+		// TODO: Use image firmware only when the class config spec has an empty firmware type.
 		configSpec.Firmware = vmImageStatus.Firmware
 	}
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This change reverses of the order of precedence to populate the configSpec from the image first then the class. This is necessary since the vSphere UI is currently unable to create VM Classes with an empty firmware type and always defaults to 'efi', creating scenarios for VM boot failures when the image does not support the firmware. 

This reversal can be changed back once vSphere GUI supports creating VM Classes with an optional/empty firmware type as default for a user.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #
N/A


**Are there any special notes for your reviewer**:
N/A


**Please add a release note if necessary**:

```
VM Image will take precedence over a VM Class to provide the configSpec.firmware type.
```