### PR TITLE
🌱 Add friendly image name support in v1a2 and improve duplicate check

### DIFF
--- a/docs/concepts/images/vm-image.md
+++ b/docs/concepts/images/vm-image.md
@@ -44,7 +44,7 @@ For example, if `vmi-0a0044d7c690bcbea` refers to an image with a friendly name 
 * There is no other `VirtualMachineImage` in the same namespace with that friendly name.
 * There is no other `ClusterVirtualMachineImage` with the same friendly name.
 
-If the friendly name unambiguously resolves to the distinct, VM image `vmi-0a0044d7c690bcbea`, then a mutation webhook replaces `spec.imageName: photonos-5-x64` with `spec.imageName: vmi-0a0044d7c690bcbea`.
+If the friendly name unambiguously resolves to the distinct, VM image `vmi-0a0044d7c690bcbea`, then a mutation webhook replaces `spec.imageName: photonos-5-x64` with `spec.imageName: vmi-0a0044d7c690bcbea`. If the friendly name resolves to multiple or no VM images, then the mutation webhook denies the request and outputs an error message accordingly.
 
 
 ## Recommended Images

--- a/webhooks/virtualmachine/v1alpha1/mutation/virtualmachine_mutator.go
+++ b/webhooks/virtualmachine/v1alpha1/mutation/virtualmachine_mutator.go
@@ -199,6 +199,7 @@ func ResolveImageName(
 		return false, nil
 	}
 
+	var determinedImageName string
 	// Check if a single namespace scope image exists by the status name.
 	vmiList := &vmopv1.VirtualMachineImageList{}
 	if err := c.List(ctx, vmiList, client.InNamespace(vm.Namespace),
@@ -208,9 +209,13 @@ func ResolveImageName(
 	); err != nil {
 		return false, err
 	}
-	if len(vmiList.Items) == 1 {
-		vm.Spec.ImageName = vmiList.Items[0].Name
-		return true, nil
+	switch len(vmiList.Items) {
+	case 0:
+		break
+	case 1:
+		determinedImageName = vmiList.Items[0].Name
+	default:
+		return false, errors.Errorf("multiple VM images exist for %q in namespace scope", imageName)
 	}
 
 	// Check if a single cluster scope image exists by the status name.
@@ -220,12 +225,24 @@ func ResolveImageName(
 	}); err != nil {
 		return false, err
 	}
-	if len(cvmiList.Items) == 1 {
-		vm.Spec.ImageName = cvmiList.Items[0].Name
-		return true, nil
+	switch len(cvmiList.Items) {
+	case 0:
+		break
+	case 1:
+		if determinedImageName != "" {
+			return false, errors.Errorf("multiple VM images exist for %q in namespace and cluster scope", imageName)
+		}
+		determinedImageName = cvmiList.Items[0].Name
+	default:
+		return false, errors.Errorf("multiple VM images exist for %q in cluster scope", imageName)
 	}
 
-	return false, errors.Errorf("no single VM image exists for %q", imageName)
+	if determinedImageName == "" {
+		return false, errors.Errorf("no VM image exists for %q in namespace or cluster scope", imageName)
+	}
+
+	vm.Spec.ImageName = determinedImageName
+	return true, nil
 }
 
 // SetNextRestartTime sets spec.nextRestartTime for a VM if the field's

--- a/webhooks/virtualmachine/v1alpha1/mutation/virtualmachine_mutator_intg_test.go
+++ b/webhooks/virtualmachine/v1alpha1/mutation/virtualmachine_mutator_intg_test.go
@@ -182,7 +182,7 @@ func intgTestsMutating() {
 
 			When("Creating VirtualMachine", func() {
 
-				When("When VM ImageName is already a vmi resource name", func() {
+				When("VM ImageName is already a vmi resource name", func() {
 
 					BeforeEach(func() {
 						vm.Spec.ImageName = "vmi-123"

--- a/webhooks/virtualmachine/v1alpha2/mutation/virtualmachine_mutator.go
+++ b/webhooks/virtualmachine/v1alpha2/mutation/virtualmachine_mutator.go
@@ -22,6 +22,7 @@ import (
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	"github.com/vmware-tanzu/vm-operator/pkg/builder"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 )
 
 const (
@@ -31,9 +32,36 @@ const (
 // +kubebuilder:webhook:path=/default-mutate-vmoperator-vmware-com-v1alpha2-virtualmachine,mutating=true,failurePolicy=fail,groups=vmoperator.vmware.com,resources=virtualmachines,verbs=create;update,versions=v1alpha2,name=default.mutating.virtualmachine.v1alpha2.vmoperator.vmware.com,sideEffects=None,admissionReviewVersions=v1;v1beta1
 // +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachine,verbs=get;list
 // +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachine/status,verbs=get
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachineimages,verbs=get;list;watch
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachineimages/status,verbs=get;list;watch
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=clustervirtualmachineimages,verbs=get;list;watch
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=clustervirtualmachineimages/status,verbs=get;list;watch
 
 // AddToManager adds the webhook to the provided manager.
 func AddToManager(ctx *context.ControllerManagerContext, mgr ctrlmgr.Manager) error {
+	// Index the VirtualMachineImage and ClusterVirtualMachineImage objects by
+	// status.name field to allow efficient querying in ResolveImageName().
+	if err := mgr.GetFieldIndexer().IndexField(
+		ctx,
+		&vmopv1.VirtualMachineImage{},
+		"status.name",
+		func(rawObj client.Object) []string {
+			vmi := rawObj.(*vmopv1.VirtualMachineImage)
+			return []string{vmi.Status.Name}
+		}); err != nil {
+		return err
+	}
+	if err := mgr.GetFieldIndexer().IndexField(
+		ctx,
+		&vmopv1.ClusterVirtualMachineImage{},
+		"status.name",
+		func(rawObj client.Object) []string {
+			cvmi := rawObj.(*vmopv1.ClusterVirtualMachineImage)
+			return []string{cvmi.Status.Name}
+		}); err != nil {
+		return err
+	}
+
 	hook, err := builder.NewMutatingWebhook(ctx, mgr, webHookName, NewMutator(mgr.GetClient()))
 	if err != nil {
 		return errors.Wrapf(err, "failed to create mutation webhook")
@@ -70,8 +98,13 @@ func (m mutator) Mutate(ctx *context.WebhookRequestContext) admission.Response {
 	original := vm
 	modified := original.DeepCopy()
 
-	//nolint:gocritic
 	switch ctx.Op {
+	case admissionv1.Create:
+		if mutated, err := ResolveImageName(ctx, m.client, modified); err != nil {
+			return admission.Denied(err.Error())
+		} else if mutated {
+			wasMutated = true
+		}
 	case admissionv1.Update:
 		oldVM, err := m.vmFromUnstructured(ctx.OldObj)
 		if err != nil {
@@ -141,4 +174,63 @@ func SetNextRestartTime(
 		field.NewPath("spec", "nextRestartTime"),
 		newVM.Spec.NextRestartTime,
 		`may only be set to "now"`)
+}
+
+// ResolveImageName mutates the vm.spec.imageName if it's not set to a vmi name
+// and there is a single namespace or cluster scope image with that status name.
+func ResolveImageName(
+	ctx *context.WebhookRequestContext,
+	c client.Client,
+	vm *vmopv1.VirtualMachine) (bool, error) {
+	// Return early if the VM image name is empty or already set to a vmi name.
+	imageName := vm.Spec.ImageName
+	if imageName == "" || !lib.IsWCPVMImageRegistryEnabled() ||
+		strings.HasPrefix(imageName, "vmi-") {
+		return false, nil
+	}
+
+	var determinedImageName string
+	// Check if a single namespace scope image exists by the status name.
+	vmiList := &vmopv1.VirtualMachineImageList{}
+	if err := c.List(ctx, vmiList, client.InNamespace(vm.Namespace),
+		client.MatchingFields{
+			"status.name": imageName,
+		},
+	); err != nil {
+		return false, err
+	}
+	switch len(vmiList.Items) {
+	case 0:
+		break
+	case 1:
+		determinedImageName = vmiList.Items[0].Name
+	default:
+		return false, errors.Errorf("multiple VM images exist for %q in namespace scope", imageName)
+	}
+
+	// Check if a single cluster scope image exists by the status name.
+	cvmiList := &vmopv1.ClusterVirtualMachineImageList{}
+	if err := c.List(ctx, cvmiList, client.MatchingFields{
+		"status.name": imageName,
+	}); err != nil {
+		return false, err
+	}
+	switch len(cvmiList.Items) {
+	case 0:
+		break
+	case 1:
+		if determinedImageName != "" {
+			return false, errors.Errorf("multiple VM images exist for %q in namespace and cluster scope", imageName)
+		}
+		determinedImageName = cvmiList.Items[0].Name
+	default:
+		return false, errors.Errorf("multiple VM images exist for %q in cluster scope", imageName)
+	}
+
+	if determinedImageName == "" {
+		return false, errors.Errorf("no VM image exists for %q in namespace or cluster scope", imageName)
+	}
+
+	vm.Spec.ImageName = determinedImageName
+	return true, nil
 }

--- a/webhooks/virtualmachine/v1alpha2/mutation/virtualmachine_mutator_unit_test.go
+++ b/webhooks/virtualmachine/v1alpha2/mutation/virtualmachine_mutator_unit_test.go
@@ -4,6 +4,7 @@
 package mutation_test
 
 import (
+	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -12,8 +13,11 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachine/v1alpha2/mutation"
 )
@@ -220,6 +224,141 @@ func unitTestsMutating() {
 				},
 				newInvalidNextRestartTimeTableEntries("should return an invalid field error")...,
 			)
+		})
+	})
+
+	Describe(("ResolveImageName"), func() {
+		const (
+			dupImageStatusName    = "dup-status-name"
+			uniqueImageStatusName = "unique-status-name"
+		)
+
+		BeforeEach(func() {
+			// Replace the client with a fake client that has the index of VM images.
+			ctx.Client = fake.NewClientBuilder().WithScheme(builder.NewScheme()).
+				WithIndex(
+					&vmopv1.VirtualMachineImage{},
+					"status.name",
+					func(rawObj client.Object) []string {
+						image := rawObj.(*vmopv1.VirtualMachineImage)
+						return []string{image.Status.Name}
+					}).
+				WithIndex(&vmopv1.ClusterVirtualMachineImage{},
+					"status.name",
+					func(rawObj client.Object) []string {
+						image := rawObj.(*vmopv1.ClusterVirtualMachineImage)
+						return []string{image.Status.Name}
+					}).Build()
+			Expect(os.Setenv(lib.VMImageRegistryFSS, lib.TrueString)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			Expect(os.Unsetenv(lib.VMImageRegistryFSS)).To(Succeed())
+		})
+
+		Context("When VM ImageName is set to vmi resource name", func() {
+
+			BeforeEach(func() {
+				ctx.vm.Spec.ImageName = "vmi-xxx"
+			})
+
+			It("Should not mutate ImageName", func() {
+				mutated, err := mutation.ResolveImageName(&ctx.WebhookRequestContext, ctx.Client, ctx.vm)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(mutated).To(BeFalse())
+				Expect(ctx.vm.Spec.ImageName).Should(Equal("vmi-xxx"))
+			})
+		})
+
+		Context("When VM ImageName is set to a status name matching multiple namespace scope images", func() {
+
+			BeforeEach(func() {
+				vmi1 := builder.DummyVirtualMachineImageA2("vmi-1")
+				vmi1.Status.Name = dupImageStatusName
+				vmi2 := builder.DummyVirtualMachineImageA2("vmi-2")
+				vmi2.Status.Name = dupImageStatusName
+				Expect(ctx.Client.Create(ctx, vmi1)).To(Succeed())
+				Expect(ctx.Client.Create(ctx, vmi2)).To(Succeed())
+				ctx.vm.Spec.ImageName = dupImageStatusName
+			})
+
+			It("Should return an error", func() {
+				_, err := mutation.ResolveImageName(&ctx.WebhookRequestContext, ctx.Client, ctx.vm)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("multiple VM images exist for \"dup-status-name\" in namespace scope"))
+			})
+		})
+
+		Context("When VM ImageName is set to a status name matching multiple cluster scope images", func() {
+
+			BeforeEach(func() {
+				cvmi1 := builder.DummyClusterVirtualMachineImageA2("cvmi-1")
+				cvmi1.Status.Name = dupImageStatusName
+				cvmi2 := builder.DummyClusterVirtualMachineImageA2("cvmi-2")
+				cvmi2.Status.Name = dupImageStatusName
+				Expect(ctx.Client.Create(ctx, cvmi1)).To(Succeed())
+				Expect(ctx.Client.Create(ctx, cvmi2)).To(Succeed())
+				ctx.vm.Spec.ImageName = dupImageStatusName
+			})
+
+			It("Should return an error", func() {
+				_, err := mutation.ResolveImageName(&ctx.WebhookRequestContext, ctx.Client, ctx.vm)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("multiple VM images exist for \"dup-status-name\" in cluster scope"))
+			})
+		})
+
+		Context("When VM ImageName is set to a status name matching one namespace and one cluster scope images", func() {
+
+			BeforeEach(func() {
+				vmi := builder.DummyVirtualMachineImageA2("vmi-123")
+				vmi.Status.Name = dupImageStatusName
+				cvmi := builder.DummyClusterVirtualMachineImageA2("cvmi-123")
+				cvmi.Status.Name = dupImageStatusName
+				Expect(ctx.Client.Create(ctx, vmi)).To(Succeed())
+				Expect(ctx.Client.Create(ctx, cvmi)).To(Succeed())
+				ctx.vm.Spec.ImageName = dupImageStatusName
+			})
+
+			It("Should return an error", func() {
+				_, err := mutation.ResolveImageName(&ctx.WebhookRequestContext, ctx.Client, ctx.vm)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("multiple VM images exist for \"dup-status-name\" in namespace and cluster scope"))
+			})
+		})
+
+		Context("When VM ImageName is set to a status name matching a single namespace scope image", func() {
+
+			BeforeEach(func() {
+				vmi := builder.DummyVirtualMachineImageA2("vmi-123")
+				vmi.Status.Name = uniqueImageStatusName
+				Expect(ctx.Client.Create(ctx, vmi)).To(Succeed())
+				ctx.vm.Spec.ImageName = uniqueImageStatusName
+			})
+
+			It("Should mutate ImageName to the resource name of the namespace scope image", func() {
+				mutated, err := mutation.ResolveImageName(&ctx.WebhookRequestContext, ctx.Client, ctx.vm)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(mutated).To(BeTrue())
+				Expect(ctx.vm.Spec.ImageName).Should(Equal("vmi-123"))
+			})
+		})
+
+		Context("When VM ImageName is set to a status name matching a single cluster scope image", func() {
+
+			BeforeEach(func() {
+				cvmi := builder.DummyClusterVirtualMachineImageA2("vmi-123")
+				cvmi.Status.Name = uniqueImageStatusName
+				Expect(ctx.Client.Create(ctx, cvmi)).To(Succeed())
+				ctx.vm.Spec.ImageName = uniqueImageStatusName
+			})
+
+			It("Should mutate ImageName to the resource name of the cluster scope image", func() {
+				mutated, err := mutation.ResolveImageName(&ctx.WebhookRequestContext, ctx.Client, ctx.vm)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(mutated).To(BeTrue())
+				Expect(ctx.vm.Spec.ImageName).Should(Equal("vmi-123"))
+			})
 		})
 	})
 }


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This patch updates the VM mutation webhook to take both namespace and cluster scope images into consideration when resolving the VM image resource from the specified friendly name. It also adds the corresponding implementation in v1a2.

**Please add a release note if necessary**:

```release-note
Consider both namespace and cluster scope images when mutating VM image names.
Add support for deploying VMs with friendly image status names in v1a2.
```

**Testing Done:**
- Updated test code to reflect this change
- Manually deployed this change to a testbed and verified all different cases:

```console
# Successfully deployed VM with unique friendly names and "vmi-" names in both cluster and namespace scopes
$ kubectl get vm -n sdiliyaer-test -o wide
NAME                                   POWER-STATE   CLASS               IMAGE                   PRIMARY-IP       AGE
vm-from-frinendly-cluster-image-name   poweredOn     best-effort-small   vmi-dfd7b60cfe5e567ec   192.168.128.39   62m
vm-from-frinendly-ns-image-name        poweredOn     best-effort-small   vmi-8785c9f7dc653f8e2   192.168.128.38   63m
vm-from-vmi-cluster-image-name         poweredOn     best-effort-small   vmi-dfd7b60cfe5e567ec   192.168.128.41   57m
vm-from-vmi-ns-image-name              poweredOn     best-effort-small   vmi-8785c9f7dc653f8e2   192.168.128.40   60m

# Expected error from deploying a VM with a duplicate friendly name only in namespace scope
$ kubectl apply -f dup-ns-img-vm.yaml
Error from server (Forbidden): error when creating "dup-ns-img-vm.yaml": admission webhook "default.mutating.virtualmachine.v1alpha1.vmoperator.vmware.com" denied the request: multiple VM images exist for "test-image" in namespace scope

# Expected error from deploying a VM with a duplicate friendly name only in cluster scope
$ kubectl apply -f dup-cluster-img-vm.yaml
Error from server (Forbidden): error when creating "dup-cluster-img-vm.yaml": admission webhook "default.mutating.virtualmachine.v1alpha1.vmoperator.vmware.com" denied the request: multiple VM images exist for "test-image" in cluster scope

# Expected error from deploying a VM with a single friendly name in both namespace and cluster scopes
$ kubectl apply -f dup-ns-and-cluster-img-vm.yaml
Error from server (Forbidden): error when creating "dup-ns-and-cluster-img-vm.yaml": admission webhook "default.mutating.virtualmachine.v1alpha1.vmoperator.vmware.com" denied the request: multiple VM images exist for "test-image" in namespace and cluster scope

# Expected error from deploying a VM with a non-existing friendly image name
$ kubectl apply -f non-img-vm.yaml
Error from server (Forbidden): error when creating "vm.yaml": admission webhook "default.mutating.virtualmachine.v1alpha1.vmoperator.vmware.com" denied the request: no VM image exists for "test-image-non" in namespace or cluster scope
```

<!-- readthedocs-preview vm-operator start -->
----
:books: Documentation preview :books:: https://vm-operator--243.org.readthedocs.build/en/243/

<!-- readthedocs-preview vm-operator end -->
