### PR TITLE
✨  Set v1a2 as the storageVersion

### DIFF
--- a/api/v1alpha1/virtualmachine_types.go
+++ b/api/v1alpha1/virtualmachine_types.go
@@ -614,7 +614,7 @@ func (vm *VirtualMachine) SetConditions(conditions Conditions) {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Namespaced,shortName=vm
-// +kubebuilder:storageversion
+// +kubebuilder:storageversion:false
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Power-State",type="string",JSONPath=".status.powerState"
 // +kubebuilder:printcolumn:name="Class",type="string",priority=1,JSONPath=".spec.className"

--- a/api/v1alpha1/virtualmachineclass_types.go
+++ b/api/v1alpha1/virtualmachineclass_types.go
@@ -133,7 +133,7 @@ type VirtualMachineClassStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Cluster,shortName=vmclass
-// +kubebuilder:storageversion
+// +kubebuilder:storageversion:false
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="CPU",type="string",JSONPath=".spec.hardware.cpus"
 // +kubebuilder:printcolumn:name="Memory",type="string",JSONPath=".spec.hardware.memory"

--- a/api/v1alpha1/virtualmachineimage_types.go
+++ b/api/v1alpha1/virtualmachineimage_types.go
@@ -154,7 +154,7 @@ func (vmImage *VirtualMachineImage) SetConditions(conditions Conditions) {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Cluster,shortName=vmi;vmimage
-// +kubebuilder:storageversion
+// +kubebuilder:storageversion:false
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Image-Name",type="string",JSONPath=".status.imageName"
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".spec.productInfo.version"
@@ -194,7 +194,7 @@ func (clusterVirtualMachineImage *ClusterVirtualMachineImage) SetConditions(cond
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Cluster,shortName=cvmi;cvmimage;clustervmi;clustervmimage
-// +kubebuilder:storageversion
+// +kubebuilder:storageversion:false
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Image-Name",type="string",JSONPath=".status.imageName"
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".spec.productInfo.version"

--- a/api/v1alpha1/virtualmachinepublishrequest_types.go
+++ b/api/v1alpha1/virtualmachinepublishrequest_types.go
@@ -342,7 +342,7 @@ func (vmpr *VirtualMachinePublishRequest) SetConditions(conditions Conditions) {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Namespaced,shortName=vmpub
-// +kubebuilder:storageversion
+// +kubebuilder:storageversion:false
 // +kubebuilder:subresource:status
 
 // VirtualMachinePublishRequest defines the information necessary to publish a

--- a/api/v1alpha1/virtualmachineservice_types.go
+++ b/api/v1alpha1/virtualmachineservice_types.go
@@ -132,7 +132,7 @@ type VirtualMachineServiceStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:shortName=vmservice
-// +kubebuilder:storageversion
+// +kubebuilder:storageversion:false
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Type",type="string",JSONPath=".spec.type"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"

--- a/api/v1alpha1/virtualmachinesetresourcepolicy_types.go
+++ b/api/v1alpha1/virtualmachinesetresourcepolicy_types.go
@@ -55,7 +55,7 @@ type ClusterModuleStatus struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:storageversion
+// +kubebuilder:storageversion:false
 // +kubebuilder:subresource:status
 
 // VirtualMachineSetResourcePolicy is the Schema for the virtualmachinesetresourcepolicies API.

--- a/api/v1alpha2/virtualmachine_types.go
+++ b/api/v1alpha2/virtualmachine_types.go
@@ -459,7 +459,7 @@ type VirtualMachineStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Namespaced,shortName=vm
-// +kubebuilder:storageversion:false
+// +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Class",type="string",priority=1,JSONPath=".status.class.name"
 // +kubebuilder:printcolumn:name="Image",type="string",priority=1,JSONPath=".status.image.name"

--- a/api/v1alpha2/virtualmachineclass_types.go
+++ b/api/v1alpha2/virtualmachineclass_types.go
@@ -245,7 +245,7 @@ type VirtualMachineClassStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Cluster,shortName=vmclass
-// +kubebuilder:storageversion:false
+// +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="CPU",type="string",JSONPath=".spec.hardware.cpus"
 // +kubebuilder:printcolumn:name="Memory",type="string",JSONPath=".spec.hardware.memory"

--- a/api/v1alpha2/virtualmachineimage_types.go
+++ b/api/v1alpha2/virtualmachineimage_types.go
@@ -209,7 +209,7 @@ type VirtualMachineImageStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Cluster,shortName=vmi;vmimage
-// +kubebuilder:storageversion:false
+// +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Image Name",type="string",JSONPath=".status.name"
 // +kubebuilder:printcolumn:name="Image Version",type="string",JSONPath=".status.productInfo.version"
@@ -246,7 +246,7 @@ type VirtualMachineImageList struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Cluster,shortName=cvmi;cvmimage;clustervmi;clustervmimage
-// +kubebuilder:storageversion:false
+// +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Image Name",type="string",JSONPath=".status.name"
 // +kubebuilder:printcolumn:name="Image Version",type="string",JSONPath=".status.productInfo.version"

--- a/api/v1alpha2/virtualmachinepublishrequest_types.go
+++ b/api/v1alpha2/virtualmachinepublishrequest_types.go
@@ -334,7 +334,7 @@ type VirtualMachinePublishRequestStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Namespaced,shortName=vmpub
-// +kubebuilder:storageversion:false
+// +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 
 // VirtualMachinePublishRequest defines the information necessary to publish a

--- a/api/v1alpha2/virtualmachineservice_types.go
+++ b/api/v1alpha2/virtualmachineservice_types.go
@@ -139,7 +139,7 @@ type VirtualMachineServiceStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:shortName=vmservice
-// +kubebuilder:storageversion:false
+// +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Type",type="string",JSONPath=".spec.type"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"

--- a/api/v1alpha2/virtualmachinesetresourcepolicy_types.go
+++ b/api/v1alpha2/virtualmachinesetresourcepolicy_types.go
@@ -47,7 +47,7 @@ type VSphereClusterModuleStatus struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:storageversion:false
+// +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 
 // VirtualMachineSetResourcePolicy is the Schema for the virtualmachinesetresourcepolicies API.

--- a/config/crd/bases/vmoperator.vmware.com_clustervirtualmachineimages.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_clustervirtualmachineimages.yaml
@@ -270,7 +270,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -513,6 +513,6 @@ spec:
             type: object
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachineclasses.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachineclasses.yaml
@@ -215,7 +215,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -499,6 +499,6 @@ spec:
             type: object
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachineimages.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachineimages.yaml
@@ -270,7 +270,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -516,6 +516,6 @@ spec:
             type: object
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachinepublishrequests.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachinepublishrequests.yaml
@@ -292,7 +292,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
   - name: v1alpha2
@@ -595,6 +595,6 @@ spec:
             type: object
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -593,7 +593,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -2709,6 +2709,6 @@ spec:
             type: object
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachineservices.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachineservices.yaml
@@ -175,7 +175,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -323,6 +323,6 @@ spec:
             type: object
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachinesetresourcepolicies.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachinesetresourcepolicies.yaml
@@ -124,7 +124,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
   - name: v1alpha2
@@ -222,6 +222,6 @@ spec:
             type: object
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}


### PR DESCRIPTION
This is effectively a noop when the v1a2 FFS is not enabled since our post install configure script already forces the storageVersion back to v1a1 in that case. But when the FFS is enabled this results in the correct storageVersion being set.

```release-note
NONE
```