### PR TITLE
 🌱 Fix deploy-local script for v1a2 disabled scenarios

### DIFF
--- a/hack/deploy-local.sh
+++ b/hack/deploy-local.sh
@@ -53,9 +53,18 @@ fi
 
 FSS_V1A2=$(yq '.spec.template.spec.containers[]| select(.name == "manager") | .env[] | select(.name == "FSS_WCP_VMSERVICE_V1ALPHA2") | .value' "$YAML")
 if [ "${FSS_V1A2}" = "false" ]; then \
-  yq -i 'del(.spec.versions[] | select(.name == "v1alpha2"))' "$YAML"
+  # remove conversion webhooks from CRDs
+  yq -i 'del(select(.kind == "CustomResourceDefinition") | .spec.conversion | select(.strategy == "Webhook"))' "$YAML"
+  # set storage version to v1alpha1
+  yq -i '(select(.kind == "CustomResourceDefinition") | .spec.versions[] | select(.name == "v1alpha1")).storage = true' "$YAML"
+  # remove v1alpha2 versions from CRDs
+  yq -i 'del(select(.kind == "CustomResourceDefinition") | .spec.versions[] | select(.name == "v1alpha2"))' "$YAML"
+  # remove CRDs with empty spec.versions
+  yq -i 'del(select(.kind == "CustomResourceDefinition") | select(.spec.versions | length == 0))' "$YAML"
+  # remove all v1alpha2 webhooks
   yq -i 'del(.webhooks[] | select(.name == "*v1alpha2*"))' "$YAML"
 fi;
+
 
 $KUBECTL apply -f "$YAML"
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This fixes the deploy-local.sh script to work with v1a2 FSS disabled scenarios. 


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # N/A


**Are there any special notes for your reviewer**:

waiting for gce2e-build to pass


**Please add a release note if necessary**:

```N/A

```