### PR TITLE
 🐛 Various v1a2 bug fixes

### DIFF
--- a/api/v1alpha1/virtualmachine_conversion.go
+++ b/api/v1alpha1/virtualmachine_conversion.go
@@ -202,10 +202,11 @@ func convert_v1alpha2_BootstrapSpec_To_v1alpha1_VmMetadata(
 		return nil
 	}
 
+	// TODO: v1a2 only has a Secret bootstrap field so that's what we set in v1a1. If this was created
+	// as v1a1, we need to store the serialized object to know to set either the ConfigMap or Secret field.
 	out := &VirtualMachineMetadata{}
 
 	if cloudInit := in.CloudInit; cloudInit != nil {
-		// TODO: Here we don't know if this was originally a Secret or a ConfigMap.
 		out.SecretName = cloudInit.RawCloudConfig.Name
 
 		switch cloudInit.RawCloudConfig.Key {
@@ -214,6 +215,9 @@ func convert_v1alpha2_BootstrapSpec_To_v1alpha1_VmMetadata(
 		case "user-data":
 			out.Transport = VirtualMachineMetadataCloudInitTransport
 		}
+	} else if sysprep := in.Sysprep; sysprep != nil {
+		out.SecretName = sysprep.RawSysprep.Name
+		out.Transport = VirtualMachineMetadataSysprepTransport
 	} else if in.VAppConfig != nil {
 		out.SecretName = in.VAppConfig.RawProperties
 

--- a/api/v1alpha2/virtualmachine_network_types.go
+++ b/api/v1alpha2/virtualmachine_network_types.go
@@ -80,7 +80,7 @@ type VirtualMachineNetworkInterfaceSpec struct {
 	// Please note this field is only supported if the network connection
 	// supports DHCP.
 	//
-	// Please note this field is mutually exclusive with IP4 addresses in the
+	// Please note this field is mutually exclusive with IP6 addresses in the
 	// Addresses field and the Gateway6 field.
 	//
 	// +optional
@@ -109,7 +109,7 @@ type VirtualMachineNetworkInterfaceSpec struct {
 	// supports manual IP allocation.
 	//
 	// If the network connection supports manual IP allocation and the
-	// Addresses field includes at least one IP4 address, then this field
+	// Addresses field includes at least one IP6 address, then this field
 	// is required.
 	//
 	// Please note the IP address must include the network prefix length, ex.
@@ -257,7 +257,7 @@ type VirtualMachineNetworkSpec struct {
 	// Please note this field is only supported if the network connection
 	// supports DHCP.
 	//
-	// Please note this field is mutually exclusive with IP4 addresses in the
+	// Please note this field is mutually exclusive with IP6 addresses in the
 	// Addresses field and the Gateway6 field.
 	//
 	// Please note if the Interfaces field is non-empty then this field is
@@ -289,7 +289,7 @@ type VirtualMachineNetworkSpec struct {
 	// supports manual IP allocation.
 	//
 	// If the network connection supports manual IP allocation and the
-	// Addresses field includes at least one IP4 address, then this field
+	// Addresses field includes at least one IP6 address, then this field
 	// is required.
 	//
 	// Please note this field is mutually exclusive with DHCP6.

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -1564,7 +1564,7 @@ spec:
                     description: "DHCP6 indicates whether or not to use DHCP for IP6
                       networking. \n Please note this field is only supported if the
                       network connection supports DHCP. \n Please note this field
-                      is mutually exclusive with IP4 addresses in the Addresses field
+                      is mutually exclusive with IP6 addresses in the Addresses field
                       and the Gateway6 field. \n Please note if the Interfaces field
                       is non-empty then this field is ignored and should be specified
                       on the elements in the Interfaces list."
@@ -1591,7 +1591,7 @@ spec:
                       \n Please note this field is only supported if the network connection
                       supports manual IP allocation. \n If the network connection
                       supports manual IP allocation and the Addresses field includes
-                      at least one IP4 address, then this field is required. \n Please
+                      at least one IP6 address, then this field is required. \n Please
                       note this field is mutually exclusive with DHCP6. \n Please
                       note if the Interfaces field is non-empty then this field is
                       ignored and should be specified on the elements in the Interfaces
@@ -1638,7 +1638,7 @@ spec:
                           description: "DHCP6 indicates whether or not this interface
                             uses DHCP for IP6 networking. \n Please note this field
                             is only supported if the network connection supports DHCP.
-                            \n Please note this field is mutually exclusive with IP4
+                            \n Please note this field is mutually exclusive with IP6
                             addresses in the Addresses field and the Gateway6 field."
                           type: boolean
                         gateway4:
@@ -1656,7 +1656,7 @@ spec:
                             interface. \n Please note this field is only supported
                             if the network connection supports manual IP allocation.
                             \n If the network connection supports manual IP allocation
-                            and the Addresses field includes at least one IP4 address,
+                            and the Addresses field includes at least one IP6 address,
                             then this field is required. \n Please note the IP address
                             must include the network prefix length, ex. 2001:db8:101::1/64.
                             \n Please note this field is mutually exclusive with DHCP6."

--- a/pkg/vmprovider/providers/vsphere2/network/gosc_test.go
+++ b/pkg/vmprovider/providers/vsphere2/network/gosc_test.go
@@ -16,7 +16,7 @@ import (
 
 var _ = Describe("GOSC", func() {
 	const (
-		macAddr1 = "50-8A-80-9D-28-22"
+		macAddr1 = "50:8A:80:9D:28:22"
 
 		ipv4Gateway = "192.168.1.1"
 		ipv4        = "192.168.1.10"

--- a/pkg/vmprovider/providers/vsphere2/session/session_vm_update.go
+++ b/pkg/vmprovider/providers/vsphere2/session/session_vm_update.go
@@ -699,7 +699,7 @@ func (s *Session) customize(
 		// with the actual devices. Old code also made this best effort so do that here too.
 		// I've got a larger change that removes the old session stuff, and improves on all this behavior
 		// but I didn't have the BW to sort out all the changes.
-		if len(updateArgs.NetworkResults.Results) > 1 {
+		if len(updateArgs.NetworkResults.Results) > 0 {
 			mac := updateArgs.NetworkResults.Results[0].MacAddress
 			if mac == "" {
 				ethCards, _ := resVM.GetNetworkDevices(vmCtx)

--- a/pkg/vmprovider/providers/vsphere2/vmlifecycle/bootstrap.go
+++ b/pkg/vmprovider/providers/vsphere2/vmlifecycle/bootstrap.go
@@ -63,10 +63,7 @@ func DoBootstrap(
 		return err
 	}
 
-	if vAppConfig != nil {
-		// I think the intention was to only apply this to vAppData. Old code would apply it to entire
-		// Data map but for like SysPrep that data may be base64/gzip'd, and we'd do the template stuff
-		// prior to plain texting it.
+	if sysPrep != nil || vAppConfig != nil {
 		bootstrapArgs.TemplateRenderFn = GetTemplateRenderFunc(vmCtx, bootstrapArgs)
 	}
 

--- a/pkg/vmprovider/providers/vsphere2/vmlifecycle/bootstrap_linuxprep_test.go
+++ b/pkg/vmprovider/providers/vsphere2/vmlifecycle/bootstrap_linuxprep_test.go
@@ -22,7 +22,7 @@ import (
 
 var _ = Describe("LinuxPrep Bootstrap", func() {
 	const (
-		macAddr = "43-AB-B4-1B-7E-87"
+		macAddr = "43:AB:B4:1B:7E:87"
 	)
 
 	var (

--- a/pkg/vmprovider/providers/vsphere2/vmlifecycle/bootstrap_sysprep.go
+++ b/pkg/vmprovider/providers/vsphere2/vmlifecycle/bootstrap_sysprep.go
@@ -24,11 +24,11 @@ func BootstrapSysPrep(
 	bsArgs *BootstrapArgs) (*vimTypes.VirtualMachineConfigSpec, *vimTypes.CustomizationSpec, error) {
 
 	var data string
+	key := "unattend"
 
 	if equality.Semantic.DeepEqual(sysPrepSpec.Sysprep, sysprep.Sysprep{}) {
 		var err error
 
-		key := "unattend"
 		if sysPrepSpec.RawSysprep.Key != "" {
 			key = sysPrepSpec.RawSysprep.Key
 		}
@@ -46,6 +46,10 @@ func BootstrapSysPrep(
 
 	} else {
 		return nil, nil, fmt.Errorf("TODO: inlined Sysprep")
+	}
+
+	if bsArgs.TemplateRenderFn != nil {
+		data = bsArgs.TemplateRenderFn(key, data)
 	}
 
 	nicSettingMap, err := network.GuestOSCustomization(bsArgs.NetworkResults)

--- a/pkg/vmprovider/providers/vsphere2/vmlifecycle/bootstrap_sysprep_test.go
+++ b/pkg/vmprovider/providers/vsphere2/vmlifecycle/bootstrap_sysprep_test.go
@@ -22,7 +22,7 @@ import (
 
 var _ = Describe("SysPrep Bootstrap", func() {
 	const (
-		macAddr = "43-AB-B4-1B-7E-87"
+		macAddr = "43:AB:B4:1B:7E:87"
 	)
 
 	var (

--- a/pkg/vmprovider/providers/vsphere2/vmprovider_vm_test.go
+++ b/pkg/vmprovider/providers/vsphere2/vmprovider_vm_test.go
@@ -167,7 +167,7 @@ func vmTests() {
 						},
 						ControllerKey: 100,
 					},
-					AddressType: string(types.VirtualEthernetCardMacTypeGenerated),
+					AddressType: string(types.VirtualEthernetCardMacTypeManual),
 					MacAddress:  "00:0c:29:93:d7:27",
 					ResourceAllocation: &types.VirtualEthernetCardResourceAllocation{
 						Reservation: pointer.Int64(42),
@@ -370,7 +370,6 @@ func vmTests() {
 					}
 				})
 
-				// FIXME: Has extra NIC b/c of vcsim DeployOVF bug
 				It("Reconfigures the VM with the NIC specified in ConfigSpec", func() {
 					Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionCreated)).To(BeTrue())
 
@@ -380,17 +379,14 @@ func vmTests() {
 					devList := object.VirtualDeviceList(o.Config.Hardware.Device)
 					l := devList.SelectByType(&types.VirtualEthernetCard{})
 					Expect(l).To(HaveLen(1))
-					// Expect(l).To(HaveLen(1 + 1))
 
 					dev := l[0].GetVirtualDevice()
-					// dev := l[0+1].GetVirtualDevice()
 					backing, ok := dev.Backing.(*types.VirtualEthernetCardDistributedVirtualPortBackingInfo)
 					Expect(ok).Should(BeTrue())
 					_, dvpg := getDVPG(ctx, dvpgName)
 					Expect(backing.Port.PortgroupKey).To(Equal(dvpg.Reference().Value))
 
 					ethDevice, ok := l[0].(*types.VirtualE1000)
-					// ethDevice, ok := l[0+1].(*types.VirtualE1000)
 					Expect(ok).To(BeTrue())
 					Expect(ethDevice.AddressType).To(Equal(ethCard.AddressType))
 					Expect(ethDevice.MacAddress).To(Equal(ethCard.MacAddress))
@@ -413,7 +409,6 @@ func vmTests() {
 					configSpec = &types.VirtualMachineConfigSpec{}
 				})
 
-				// FIXME: Has extra NIC b/c of vcsim DeployOVF bug
 				It("Reconfigures the VM with the default NIC settings from provider", func() {
 					var o mo.VirtualMachine
 					Expect(vcVM.Properties(ctx, vcVM.Reference(), nil, &o)).To(Succeed())
@@ -421,10 +416,8 @@ func vmTests() {
 					devList := object.VirtualDeviceList(o.Config.Hardware.Device)
 					l := devList.SelectByType(&types.VirtualEthernetCard{})
 					Expect(l).To(HaveLen(1))
-					// Expect(l).To(HaveLen(1 + 1))
 
 					dev := l[0].GetVirtualDevice()
-					// dev := l[0+1].GetVirtualDevice()
 					backing, ok := dev.Backing.(*types.VirtualEthernetCardDistributedVirtualPortBackingInfo)
 					Expect(ok).Should(BeTrue())
 					_, dvpg := getDVPG(ctx, dvpgName)
@@ -547,7 +540,6 @@ func vmTests() {
 					}
 				})
 
-				// FIXME: Has extra NIC b/c of vcsim DeployOVF bug
 				It("Reconfigures the VM with a NIC, GPU and DDPIO device specified in ConfigSpec", func() {
 					var o mo.VirtualMachine
 					Expect(vcVM.Properties(ctx, vcVM.Reference(), nil, &o)).To(Succeed())
@@ -555,17 +547,14 @@ func vmTests() {
 					devList := object.VirtualDeviceList(o.Config.Hardware.Device)
 					l := devList.SelectByType(&types.VirtualEthernetCard{})
 					Expect(l).To(HaveLen(1))
-					// Expect(l).To(HaveLen(1 + 1))
 
 					dev := l[0].GetVirtualDevice()
-					// dev := l[0+1].GetVirtualDevice()
 					backing, ok := dev.Backing.(*types.VirtualEthernetCardDistributedVirtualPortBackingInfo)
 					Expect(ok).Should(BeTrue())
 					_, dvpg := getDVPG(ctx, dvpgName)
 					Expect(backing.Port.PortgroupKey).To(Equal(dvpg.Reference().Value))
 
 					ethDevice, ok := l[0].(*types.VirtualE1000)
-					// ethDevice, ok := l[0+1].(*types.VirtualE1000)
 					Expect(ok).To(BeTrue())
 					Expect(ethDevice.AddressType).To(Equal(ethCard.AddressType))
 					Expect(dev.DeviceInfo).To(Equal(ethCard.VirtualDevice.DeviceInfo))


### PR DESCRIPTION
Accumulated fixes as we've continued to test v1a2

 - Add a basic to v1a1 version conversion for SysPrep
 - Use dashes as MAC address separators for SysPrep GOSC
 - Do templating for SysPrep
 - Fix an off by one preventing from fixing up the MAC address in VDS
 - Correct API doc copy-paste for the DHCP6 and Gateway6 fields


```release-note
NONE
```