### PR TITLE
✨  Mark v1a2 VirtualMachineClass as namespace scoped

### DIFF
--- a/api/v1alpha2/virtualmachineclass_types.go
+++ b/api/v1alpha2/virtualmachineclass_types.go
@@ -244,7 +244,7 @@ type VirtualMachineClassStatus struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster,shortName=vmclass
+// +kubebuilder:resource:scope=Namespaced,shortName=vmclass
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="CPU",type="string",JSONPath=".spec.hardware.cpus"


### PR DESCRIPTION
The v1a2 class is implicitly scoped because we don't have the bindings. Note this still requires the WCP_Namespaced_VM_Class FFS, and the generated manifest is unchanged because v1a1 is still marked as Cluster scoped.

```release-note
NONE
```