### PR TITLE
🌱 Enabled v1a1 VM mutation webhooks on v1a2 FSS enabled env

### DIFF
--- a/webhooks/virtualmachine/webhooks.go
+++ b/webhooks/virtualmachine/webhooks.go
@@ -11,14 +11,18 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachine/v1alpha1"
+	v1a1mut "github.com/vmware-tanzu/vm-operator/webhooks/virtualmachine/v1alpha1/mutation"
 	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachine/v1alpha2"
 )
 
 func AddToManager(ctx *context.ControllerManagerContext, mgr ctrlmgr.Manager) error {
 	if lib.IsVMServiceV1Alpha2FSSEnabled() {
-		// TODO: We'll likely still need the v1a1 mutation wehbook (at least some limited version of it)
 		if err := v1alpha2.AddToManager(ctx, mgr); err != nil {
 			return errors.Wrap(err, "failed to initialize v1alpha2 webhooks")
+		}
+		// With v1a2 FSS enabled, the v1a1 VM mutation webhook is added to the manager
+		if err := v1a1mut.AddToManager(ctx, mgr); err != nil {
+			return errors.Wrap(err, "failed to initialize v1alpha1 virtual machine mutation webhooks")
 		}
 	} else {
 		if err := v1alpha1.AddToManager(ctx, mgr); err != nil {


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
The v1a1 VM mutating webhooks are still required in a v1a2 environment to preserve fields in v1a1 unknown to v1a2 CR.
The mutation webhooks also run serially, so they don't have the problem of racing that a validation webhook would have.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # N/A


**Are there any special notes for your reviewer**:

N/A


**Please add a release note if necessary**:

```
N/A
```