### PR TITLE
✨ Persist PVC related info in VM ExtraConfig for backup

### DIFF
--- a/pkg/context/backupvirtualmachine_context.go
+++ b/pkg/context/backupvirtualmachine_context.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package context
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/vmware/govmomi/object"
+)
+
+// BackupVirtualMachineContext is the context used for storing backup data of VM
+// and its related objects.
+type BackupVirtualMachineContext struct {
+	VMCtx         VirtualMachineContext
+	VcVM          *object.VirtualMachine
+	BootstrapData map[string]string
+	DiskUUIDToPVC map[string]corev1.PersistentVolumeClaim
+}
+
+func (c *BackupVirtualMachineContext) String() string {
+	return fmt.Sprintf("Backup %s", c.VMCtx.String())
+}
+
+// BackupVirtualMachineContextA2 is the context used for storing backup data of
+// VM and its related objects.
+type BackupVirtualMachineContextA2 struct {
+	VMCtx         VirtualMachineContextA2
+	VcVM          *object.VirtualMachine
+	BootstrapData map[string]string
+	DiskUUIDToPVC map[string]corev1.PersistentVolumeClaim
+}
+
+func (c *BackupVirtualMachineContextA2) String() string {
+	return fmt.Sprintf("Backup %s", c.VMCtx.String())
+}

--- a/pkg/vmprovider/providers/vsphere/virtualmachine/backup.go
+++ b/pkg/vmprovider/providers/vsphere/virtualmachine/backup.go
@@ -4,9 +4,9 @@
 package virtualmachine
 
 import (
-	goctx "context"
 	"encoding/json"
 
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
 
 	"github.com/vmware/govmomi/object"
@@ -19,39 +19,47 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/constants"
 )
 
+// BackupOptions contains the options for calling BackupVirtualMachine() func.
+type BackupOptions struct {
+	VMCtx         context.VirtualMachineContext
+	VcVM          *object.VirtualMachine
+	BootstrapData map[string]string
+	DiskUUIDToPVC map[string]corev1.PersistentVolumeClaim
+}
+
 type VMDiskData struct {
-	// ID of the virtual disk object (only set for FCDs).
-	VDiskID string
 	// Filename contains the datastore path to the virtual disk.
 	FileName string
+	// PVCName is the name of the PVC backed by the virtual disk.
+	PVCName string
+	// AccessMode is the access modes of the PVC backed by the virtual disk.
+	AccessModes []corev1.PersistentVolumeAccessMode
 }
 
 // BackupVirtualMachine backs up the required data of a VM into its ExtraConfig.
 // Currently, the following data is backed up:
 // - Kubernetes VirtualMachine object in YAML format (without its .status field).
 // - VM bootstrap data in JSON (if provided).
-// - List of VM disk data in JSON (including FCDs attached to the VM).
-func BackupVirtualMachine(
-	vmCtx context.VirtualMachineContext,
-	vcVM *object.VirtualMachine,
-	bootstrapData map[string]string) error {
+// - VM disk data in JSON (if created and attached by PVCs).
+func BackupVirtualMachine(opts BackupOptions) error {
 	var moVM mo.VirtualMachine
-	if err := vcVM.Properties(vmCtx, vcVM.Reference(),
+	if err := opts.VcVM.Properties(opts.VMCtx, opts.VcVM.Reference(),
 		[]string{"config.extraConfig"}, &moVM); err != nil {
-		vmCtx.Logger.Error(err, "Failed to get VM properties for backup")
+		opts.VMCtx.Logger.Error(err, "Failed to get VM properties for backup")
 		return err
 	}
 	curEcMap := util.ExtraConfigToMap(moVM.Config.ExtraConfig)
 
 	var ecToUpdate []types.BaseOptionValue
 
-	vmKubeDataBackup, err := getDesiredVMKubeDataForBackup(vmCtx.VM, curEcMap)
+	vmKubeDataBackup, err := getDesiredVMKubeDataForBackup(opts.VMCtx.VM, curEcMap)
 	if err != nil {
-		vmCtx.Logger.Error(err, "Failed to get VM kube data for backup")
+		opts.VMCtx.Logger.Error(err, "Failed to get VM kube data for backup")
 		return err
 	}
+
 	if vmKubeDataBackup == "" {
-		vmCtx.Logger.V(4).Info("Skipping VM kube data backup as unchanged")
+		opts.VMCtx.Logger.V(4).Info("Skipping VM kube data backup as unchanged")
 	} else {
 		ecToUpdate = append(ecToUpdate, &types.OptionValue{
 			Key:   constants.BackupVMKubeDataExtraConfigKey,
@@ -59,13 +67,14 @@ func BackupVirtualMachine(
 		})
 	}
 
-	instanceIDBackup, err := getDesiredCloudInitInstanceIDForBackup(vmCtx.VM, curEcMap)
+	instanceIDBackup, err := getDesiredCloudInitInstanceIDForBackup(opts.VMCtx.VM, curEcMap)
 	if err != nil {
-		vmCtx.Logger.Error(err, "Failed to get cloud-init instance ID for backup")
+		opts.VMCtx.Logger.Error(err, "Failed to get cloud-init instance ID for backup")
 		return err
 	}
+
 	if instanceIDBackup == "" {
-		vmCtx.Logger.V(4).Info("Skipping cloud-init instance ID as already stored")
+		opts.VMCtx.Logger.V(4).Info("Skipping cloud-init instance ID as already stored")
 	} else {
 		ecToUpdate = append(ecToUpdate, &types.OptionValue{
 			Key:   constants.BackupVMCloudInitInstanceIDExtraConfigKey,
@@ -73,13 +82,14 @@ func BackupVirtualMachine(
 		})
 	}
 
-	bootstrapDataBackup, err := getDesiredBootstrapDataForBackup(bootstrapData, curEcMap)
+	bootstrapDataBackup, err := getDesiredBootstrapDataForBackup(opts.BootstrapData, curEcMap)
 	if err != nil {
-		vmCtx.Logger.Error(err, "Failed to get VM bootstrap data for backup")
+		opts.VMCtx.Logger.Error(err, "Failed to get VM bootstrap data for backup")
 		return err
 	}
+
 	if bootstrapDataBackup == "" {
-		vmCtx.Logger.V(4).Info("Skipping VM bootstrap data backup as unchanged")
+		opts.VMCtx.Logger.V(4).Info("Skipping VM bootstrap data backup as unchanged")
 	} else {
 		ecToUpdate = append(ecToUpdate, &types.OptionValue{
 			Key:   constants.BackupVMBootstrapDataExtraConfigKey,
@@ -87,13 +97,14 @@ func BackupVirtualMachine(
 		})
 	}
 
-	diskDataBackup, err := getDesiredDiskDataForBackup(vmCtx, vcVM, curEcMap)
+	diskDataBackup, err := getDesiredDiskDataForBackup(opts, curEcMap)
 	if err != nil {
-		vmCtx.Logger.Error(err, "Failed to get VM disk data for backup")
+		opts.VMCtx.Logger.Error(err, "Failed to get VM disk data for backup")
 		return err
 	}
+
 	if diskDataBackup == "" {
-		vmCtx.Logger.V(4).Info("Skipping VM disk data backup as unchanged")
+		opts.VMCtx.Logger.V(4).Info("Skipping VM disk data backup as unchanged")
 	} else {
 		ecToUpdate = append(ecToUpdate, &types.OptionValue{
 			Key:   constants.BackupVMDiskDataExtraConfigKey,
@@ -102,12 +113,12 @@ func BackupVirtualMachine(
 	}
 
 	if len(ecToUpdate) != 0 {
-		vmCtx.Logger.Info("Updating VM ExtraConfig with backup data")
-		vmCtx.Logger.V(4).Info("", "ExtraConfig", ecToUpdate)
-		if _, err := vcVM.Reconfigure(vmCtx, types.VirtualMachineConfigSpec{
+		opts.VMCtx.Logger.Info("Updating VM ExtraConfig with backup data")
+		opts.VMCtx.Logger.V(4).Info("", "ExtraConfig", ecToUpdate)
+		if _, err := opts.VcVM.Reconfigure(opts.VMCtx, types.VirtualMachineConfigSpec{
 			ExtraConfig: ecToUpdate,
 		}); err != nil {
-			vmCtx.Logger.Error(err, "Failed to update VM ExtraConfig for backup")
+			opts.VMCtx.Logger.Error(err, "Failed to update VM ExtraConfig for backup")
 			return err
 		}
 	}
@@ -194,10 +205,14 @@ func getDesiredBootstrapDataForBackup(
 }
 
 func getDesiredDiskDataForBackup(
-	ctx goctx.Context,
-	vcVM *object.VirtualMachine,
+	opts BackupOptions,
 	ecMap map[string]string) (string, error) {
-	deviceList, err := vcVM.Device(ctx)
+	// Return an empty string to skip backup if no disk uuid to PVC is specified.
+	if len(opts.DiskUUIDToPVC) == 0 {
+		return "", nil
+	}
+
+	deviceList, err := opts.VcVM.Device(opts.VMCtx)
 	if err != nil {
 		return "", err
 	}
@@ -205,16 +220,14 @@ func getDesiredDiskDataForBackup(
 	var diskData []VMDiskData
 	for _, device := range deviceList.SelectByType((*types.VirtualDisk)(nil)) {
 		if disk, ok := device.(*types.VirtualDisk); ok {
-			vmDiskData := VMDiskData{}
-			if disk.VDiskId != nil {
-				vmDiskData.VDiskID = disk.VDiskId.Id
-			}
 			if b, ok := disk.Backing.(*types.VirtualDiskFlatVer2BackingInfo); ok {
-				vmDiskData.FileName = b.FileName
-			}
-			// Only add the disk data if it's not empty.
-			if vmDiskData != (VMDiskData{}) {
-				diskData = append(diskData, vmDiskData)
+				if pvc, ok := opts.DiskUUIDToPVC[b.Uuid]; ok {
+					diskData = append(diskData, VMDiskData{
+						FileName:    b.FileName,
+						PVCName:     pvc.Name,
+						AccessModes: pvc.Spec.AccessModes,
+					})
+				}
 			}
 		}
 	}

--- a/pkg/vmprovider/providers/vsphere/virtualmachine/backup_test.go
+++ b/pkg/vmprovider/providers/vsphere/virtualmachine/backup_test.go
@@ -6,6 +6,7 @@ package virtualmachine_test
 import (
 	"encoding/json"
 
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
 
 	. "github.com/onsi/ginkgo"
@@ -23,6 +24,14 @@ import (
 )
 
 func backupTests() {
+	const (
+		// These are the default values of the vcsim VM that are used to
+		// construct the expected backup data in the following tests.
+		vcSimVMPath       = "DC0_C0_RP0_VM0"
+		vcSimDiskUUID     = "be8d2471-f32e-5c7e-a89b-22cb8e533890"
+		vcSimDiskFileName = "[LocalDS_0] DC0_C0_RP0_VM0/disk1.vmdk"
+	)
+
 	var (
 		ctx   *builder.TestContextForVCSim
 		vcVM  *object.VirtualMachine
@@ -33,7 +42,7 @@ func backupTests() {
 		ctx = suite.NewTestContextForVCSim(builder.VCSimTestConfig{})
 
 		var err error
-		vcVM, err = ctx.Finder.VirtualMachine(ctx, "DC0_C0_RP0_VM0")
+		vcVM, err = ctx.Finder.VirtualMachine(ctx, vcSimVMPath)
 		Expect(err).NotTo(HaveOccurred())
 
 		vmCtx = context.VirtualMachineContext{
@@ -76,7 +85,13 @@ func backupTests() {
 
 			It("Should backup VM kube data YAML with the latest spec", func() {
 				vmCtx.VM.ObjectMeta.Generation = 2
-				Expect(virtualmachine.BackupVirtualMachine(vmCtx, vcVM, nil)).To(Succeed())
+				backupOpts := virtualmachine.BackupOptions{
+					VMCtx:         vmCtx,
+					VcVM:          vcVM,
+					BootstrapData: nil,
+					DiskUUIDToPVC: nil,
+				}
+				Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
 
 				vmCopy := vmCtx.VM.DeepCopy()
 				vmCopy.Status = vmopv1.VirtualMachineStatus{}
@@ -112,7 +127,13 @@ func backupTests() {
 			It("Should skip backing up VM kube data", func() {
 				// Update the VM to verify its kube data is not backed up in ExtraConfig.
 				vmCtx.VM.Labels = map[string]string{"foo": "bar"}
-				Expect(virtualmachine.BackupVirtualMachine(vmCtx, vcVM, nil)).To(Succeed())
+				backupOpts := virtualmachine.BackupOptions{
+					VMCtx:         vmCtx,
+					VcVM:          vcVM,
+					BootstrapData: nil,
+					DiskUUIDToPVC: nil,
+				}
+				Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
 				verifyBackupDataInExtraConfig(ctx, vcVM, constants.BackupVMKubeDataExtraConfigKey, kubeDataBackup)
 			})
 		})
@@ -122,7 +143,13 @@ func backupTests() {
 
 		It("Should back up bootstrap data as JSON in ExtraConfig", func() {
 			bootstrapDataRaw := map[string]string{"foo": "bar"}
-			Expect(virtualmachine.BackupVirtualMachine(vmCtx, vcVM, bootstrapDataRaw)).To(Succeed())
+			backupOpts := virtualmachine.BackupOptions{
+				VMCtx:         vmCtx,
+				VcVM:          vcVM,
+				BootstrapData: bootstrapDataRaw,
+				DiskUUIDToPVC: nil,
+			}
+			Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
 
 			bootstrapDataJSON, err := json.Marshal(bootstrapDataRaw)
 			Expect(err).NotTo(HaveOccurred())
@@ -132,19 +159,47 @@ func backupTests() {
 
 	Context("VM Disk data", func() {
 
-		It("Should backup VM disk data as JSON in ExtraConfig", func() {
-			Expect(virtualmachine.BackupVirtualMachine(vmCtx, vcVM, nil)).To(Succeed())
+		When("VM has no disks that are attached from PVCs", func() {
 
-			// Use the default disk info from the vcSim VM for testing.
-			diskData := []virtualmachine.VMDiskData{
-				{
-					VDiskID:  "",
-					FileName: "[LocalDS_0] DC0_C0_RP0_VM0/disk1.vmdk",
-				},
-			}
-			diskDataJSON, err := json.Marshal(diskData)
-			Expect(err).NotTo(HaveOccurred())
-			verifyBackupDataInExtraConfig(ctx, vcVM, constants.BackupVMDiskDataExtraConfigKey, string(diskDataJSON))
+			It("Should skip backing up VM disk data", func() {
+				backupOpts := virtualmachine.BackupOptions{
+					VMCtx:         vmCtx,
+					VcVM:          vcVM,
+					BootstrapData: nil,
+					DiskUUIDToPVC: nil,
+				}
+				Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
+				verifyBackupDataInExtraConfig(ctx, vcVM, constants.BackupVMDiskDataExtraConfigKey, "")
+			})
+		})
+
+		When("VM has disks that are attached from PVCs", func() {
+
+			It("Should backup VM disk data as JSON in ExtraConfig", func() {
+				dummyPVC := builder.DummyPersistentVolumeClaim()
+				diskUUIDToPVC := map[string]corev1.PersistentVolumeClaim{
+					vcSimDiskUUID: *dummyPVC,
+				}
+
+				backupOpts := virtualmachine.BackupOptions{
+					VMCtx:         vmCtx,
+					VcVM:          vcVM,
+					BootstrapData: nil,
+					DiskUUIDToPVC: diskUUIDToPVC,
+				}
+				Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
+
+				diskData := []virtualmachine.VMDiskData{
+					{
+						FileName:    vcSimDiskFileName,
+						PVCName:     dummyPVC.Name,
+						AccessModes: dummyPVC.Spec.AccessModes,
+					},
+				}
+				diskDataJSON, err := json.Marshal(diskData)
+				Expect(err).NotTo(HaveOccurred())
+				verifyBackupDataInExtraConfig(ctx, vcVM, constants.BackupVMDiskDataExtraConfigKey, string(diskDataJSON))
+			})
 		})
 	})
 
@@ -171,8 +226,14 @@ func backupTests() {
 				}
 			})
 
-			It("Should skip backing up the cloud-init instance ID", func() {
-				Expect(virtualmachine.BackupVirtualMachine(vmCtx, vcVM, nil)).To(Succeed())
+			It("Should not change the cloud-init instance ID in VM's ExtraConfig", func() {
+				backupOpts := virtualmachine.BackupOptions{
+					VMCtx:         vmCtx,
+					VcVM:          vcVM,
+					BootstrapData: nil,
+					DiskUUIDToPVC: nil,
+				}
+				Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
 				verifyBackupDataInExtraConfig(ctx, vcVM, constants.BackupVMCloudInitInstanceIDExtraConfigKey, "ec-instance-id")
 			})
 		})
@@ -187,7 +248,13 @@ func backupTests() {
 			})
 
 			It("Should backup the cloud-init instance ID from annotations", func() {
-				Expect(virtualmachine.BackupVirtualMachine(vmCtx, vcVM, nil)).To(Succeed())
+				backupOpts := virtualmachine.BackupOptions{
+					VMCtx:         vmCtx,
+					VcVM:          vcVM,
+					BootstrapData: nil,
+					DiskUUIDToPVC: nil,
+				}
+				Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
 				verifyBackupDataInExtraConfig(ctx, vcVM, constants.BackupVMCloudInitInstanceIDExtraConfigKey, "annotation-instance-id")
 			})
 		})
@@ -199,9 +266,14 @@ func backupTests() {
 				vmCtx.VM.UID = "vm-uid"
 			})
 
-			It("Should backup the cloud-init instance ID from annotations", func() {
-				Expect(virtualmachine.BackupVirtualMachine(vmCtx, vcVM, nil)).To(Succeed())
-				verifyBackupDataInExtraConfig(ctx, vcVM, constants.BackupVMCloudInitInstanceIDExtraConfigKey, "vm-uid")
+			It("Should backup the cloud-init instance ID from VM K8s resource UID", func() {
+				backupOpts := virtualmachine.BackupOptions{
+					VMCtx:         vmCtx,
+					VcVM:          vcVM,
+					BootstrapData: nil,
+					DiskUUIDToPVC: nil,
+				}
+				Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
 			})
 		})
 	})
@@ -219,6 +291,12 @@ func verifyBackupDataInExtraConfig(
 	var moVM mo.VirtualMachine
 	Expect(objVM.Properties(ctx, objVM.Reference(), []string{"config.extraConfig"}, &moVM)).To(Succeed())
 	ecMap := util.ExtraConfigToMap(moVM.Config.ExtraConfig)
+
+	// Verify the expected key doesn't exist in ExtraConfig if the expected value is empty.
+	if expectedValDecoded == "" {
+		Expect(ecMap).NotTo(HaveKey(expectedKey))
+		return
+	}
 
 	// Verify the expected key exists in ExtraConfig and the decoded values match.
 	Expect(ecMap).To(HaveKey(expectedKey))

--- a/pkg/vmprovider/providers/vsphere/virtualmachine/backup_test.go
+++ b/pkg/vmprovider/providers/vsphere/virtualmachine/backup_test.go
@@ -85,13 +85,13 @@ func backupTests() {
 
 			It("Should backup VM kube data YAML with the latest spec", func() {
 				vmCtx.VM.ObjectMeta.Generation = 2
-				backupOpts := virtualmachine.BackupOptions{
+				backupVMCtx := context.BackupVirtualMachineContext{
 					VMCtx:         vmCtx,
 					VcVM:          vcVM,
 					BootstrapData: nil,
 					DiskUUIDToPVC: nil,
 				}
-				Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
+				Expect(virtualmachine.BackupVirtualMachine(backupVMCtx)).To(Succeed())
 
 				vmCopy := vmCtx.VM.DeepCopy()
 				vmCopy.Status = vmopv1.VirtualMachineStatus{}
@@ -127,13 +127,13 @@ func backupTests() {
 			It("Should skip backing up VM kube data", func() {
 				// Update the VM to verify its kube data is not backed up in ExtraConfig.
 				vmCtx.VM.Labels = map[string]string{"foo": "bar"}
-				backupOpts := virtualmachine.BackupOptions{
+				backupVMCtx := context.BackupVirtualMachineContext{
 					VMCtx:         vmCtx,
 					VcVM:          vcVM,
 					BootstrapData: nil,
 					DiskUUIDToPVC: nil,
 				}
-				Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
+				Expect(virtualmachine.BackupVirtualMachine(backupVMCtx)).To(Succeed())
 				verifyBackupDataInExtraConfig(ctx, vcVM, constants.BackupVMKubeDataExtraConfigKey, kubeDataBackup)
 			})
 		})
@@ -143,13 +143,13 @@ func backupTests() {
 
 		It("Should back up bootstrap data as JSON in ExtraConfig", func() {
 			bootstrapDataRaw := map[string]string{"foo": "bar"}
-			backupOpts := virtualmachine.BackupOptions{
+			backupVMCtx := context.BackupVirtualMachineContext{
 				VMCtx:         vmCtx,
 				VcVM:          vcVM,
 				BootstrapData: bootstrapDataRaw,
 				DiskUUIDToPVC: nil,
 			}
-			Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
+			Expect(virtualmachine.BackupVirtualMachine(backupVMCtx)).To(Succeed())
 
 			bootstrapDataJSON, err := json.Marshal(bootstrapDataRaw)
 			Expect(err).NotTo(HaveOccurred())
@@ -162,13 +162,13 @@ func backupTests() {
 		When("VM has no disks that are attached from PVCs", func() {
 
 			It("Should skip backing up VM disk data", func() {
-				backupOpts := virtualmachine.BackupOptions{
+				backupVMCtx := context.BackupVirtualMachineContext{
 					VMCtx:         vmCtx,
 					VcVM:          vcVM,
 					BootstrapData: nil,
 					DiskUUIDToPVC: nil,
 				}
-				Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
+				Expect(virtualmachine.BackupVirtualMachine(backupVMCtx)).To(Succeed())
 				verifyBackupDataInExtraConfig(ctx, vcVM, constants.BackupVMDiskDataExtraConfigKey, "")
 			})
 		})
@@ -181,13 +181,13 @@ func backupTests() {
 					vcSimDiskUUID: *dummyPVC,
 				}
 
-				backupOpts := virtualmachine.BackupOptions{
+				backupVMCtx := context.BackupVirtualMachineContext{
 					VMCtx:         vmCtx,
 					VcVM:          vcVM,
 					BootstrapData: nil,
 					DiskUUIDToPVC: diskUUIDToPVC,
 				}
-				Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
+				Expect(virtualmachine.BackupVirtualMachine(backupVMCtx)).To(Succeed())
 
 				diskData := []virtualmachine.VMDiskData{
 					{
@@ -227,13 +227,13 @@ func backupTests() {
 			})
 
 			It("Should not change the cloud-init instance ID in VM's ExtraConfig", func() {
-				backupOpts := virtualmachine.BackupOptions{
+				backupVMCtx := context.BackupVirtualMachineContext{
 					VMCtx:         vmCtx,
 					VcVM:          vcVM,
 					BootstrapData: nil,
 					DiskUUIDToPVC: nil,
 				}
-				Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
+				Expect(virtualmachine.BackupVirtualMachine(backupVMCtx)).To(Succeed())
 				verifyBackupDataInExtraConfig(ctx, vcVM, constants.BackupVMCloudInitInstanceIDExtraConfigKey, "ec-instance-id")
 			})
 		})
@@ -248,13 +248,13 @@ func backupTests() {
 			})
 
 			It("Should backup the cloud-init instance ID from annotations", func() {
-				backupOpts := virtualmachine.BackupOptions{
+				backupVMCtx := context.BackupVirtualMachineContext{
 					VMCtx:         vmCtx,
 					VcVM:          vcVM,
 					BootstrapData: nil,
 					DiskUUIDToPVC: nil,
 				}
-				Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
+				Expect(virtualmachine.BackupVirtualMachine(backupVMCtx)).To(Succeed())
 				verifyBackupDataInExtraConfig(ctx, vcVM, constants.BackupVMCloudInitInstanceIDExtraConfigKey, "annotation-instance-id")
 			})
 		})
@@ -267,13 +267,13 @@ func backupTests() {
 			})
 
 			It("Should backup the cloud-init instance ID from VM K8s resource UID", func() {
-				backupOpts := virtualmachine.BackupOptions{
+				backupVMCtx := context.BackupVirtualMachineContext{
 					VMCtx:         vmCtx,
 					VcVM:          vcVM,
 					BootstrapData: nil,
 					DiskUUIDToPVC: nil,
 				}
-				Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
+				Expect(virtualmachine.BackupVirtualMachine(backupVMCtx)).To(Succeed())
 			})
 		})
 	})

--- a/pkg/vmprovider/providers/vsphere/vmprovider_vm.go
+++ b/pkg/vmprovider/providers/vsphere/vmprovider_vm.go
@@ -330,13 +330,13 @@ func (vs *vSphereVMProvider) updateVirtualMachine(
 			return err
 		}
 
-		backupOpts := virtualmachine.BackupOptions{
+		backupVMCtx := context.BackupVirtualMachineContext{
 			VMCtx:         vmCtx,
 			VcVM:          vcVM,
 			BootstrapData: data.Data,
 			DiskUUIDToPVC: diskUUIDToPVC,
 		}
-		if err := virtualmachine.BackupVirtualMachine(backupOpts); err != nil {
+		if err := virtualmachine.BackupVirtualMachine(backupVMCtx); err != nil {
 			vmCtx.Logger.Error(err, "Failed to back up VM")
 			return err
 		}

--- a/pkg/vmprovider/providers/vsphere/vmprovider_vm_utils_test.go
+++ b/pkg/vmprovider/providers/vsphere/vmprovider_vm_utils_test.go
@@ -871,4 +871,69 @@ func vmUtilTests() {
 			Expect(vsphere.HardwareVersionForPVCandPCIDevices(imageHWVersion, configSpec, true)).To(Equal(int32(16)))
 		})
 	})
+
+	Context("GetAttachedDiskUuidToPVC", func() {
+		const (
+			attachedDiskUUID = "dummy-uuid"
+		)
+		var (
+			attachedPVC *corev1.PersistentVolumeClaim
+		)
+
+		BeforeEach(func() {
+			// Create multiple PVCs to verity only the expected one is returned.
+			unusedPVC := builder.DummyPersistentVolumeClaim()
+			unusedPVC.Name = "unused-pvc"
+			unusedPVC.Namespace = vmCtx.VM.Namespace
+			unattachedPVC := builder.DummyPersistentVolumeClaim()
+			unattachedPVC.Name = "unattached-pvc"
+			unattachedPVC.Namespace = vmCtx.VM.Namespace
+			attachedPVC = builder.DummyPersistentVolumeClaim()
+			attachedPVC.Name = "attached-pvc"
+			attachedPVC.Namespace = vmCtx.VM.Namespace
+			initObjects = append(initObjects, unusedPVC, unattachedPVC, attachedPVC)
+
+			vmCtx.VM.Spec.Volumes = []vmopv1.VirtualMachineVolume{
+				{
+					Name: "unattached-vol",
+					PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
+						PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: unattachedPVC.Name,
+						},
+					},
+				},
+				{
+					Name: "attached-vol",
+					PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
+						PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: attachedPVC.Name,
+						},
+					},
+				},
+			}
+
+			vmCtx.VM.Status.Volumes = []vmopv1.VirtualMachineVolumeStatus{
+				{
+					Name:     "unattached-vol",
+					Attached: false,
+					DiskUuid: "unattached-disk-uuid",
+				},
+				{
+					Name:     "attached-vol",
+					Attached: true,
+					DiskUuid: attachedDiskUUID,
+				},
+			}
+		})
+
+		It("Should return a map of disk uuid to PVCs that are attached to the VM", func() {
+			diskUUIDToPVCMap, err := vsphere.GetAttachedDiskUUIDToPVC(vmCtx, k8sClient)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(diskUUIDToPVCMap).To(HaveLen(1))
+			Expect(diskUUIDToPVCMap).To(HaveKey(attachedDiskUUID))
+			pvc := diskUUIDToPVCMap[attachedDiskUUID]
+			Expect(pvc.Name).To(Equal(attachedPVC.Name))
+			Expect(pvc.Namespace).To(Equal(attachedPVC.Namespace))
+		})
+	})
 }

--- a/pkg/vmprovider/providers/vsphere2/virtualmachine/backup.go
+++ b/pkg/vmprovider/providers/vsphere2/virtualmachine/backup.go
@@ -9,7 +9,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
 
-	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 
@@ -18,14 +17,6 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/util"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere2/constants"
 )
-
-// BackupOptions contains the options for calling BackupVirtualMachine() func.
-type BackupOptions struct {
-	VMCtx         context.VirtualMachineContextA2
-	VcVM          *object.VirtualMachine
-	BootstrapData map[string]string
-	DiskUUIDToPVC map[string]corev1.PersistentVolumeClaim
-}
 
 type VMDiskData struct {
 	// Filename contains the datastore path to the virtual disk.
@@ -41,25 +32,25 @@ type VMDiskData struct {
 // - Kubernetes VirtualMachine object in YAML format (without its .status field).
 // - VM bootstrap data in JSON (if provided).
 // - VM disk data in JSON (if created and attached by PVCs).
-func BackupVirtualMachine(opts BackupOptions) error {
+func BackupVirtualMachine(ctx context.BackupVirtualMachineContextA2) error {
 	var moVM mo.VirtualMachine
-	if err := opts.VcVM.Properties(opts.VMCtx, opts.VcVM.Reference(),
+	if err := ctx.VcVM.Properties(ctx.VMCtx, ctx.VcVM.Reference(),
 		[]string{"config.extraConfig"}, &moVM); err != nil {
-		opts.VMCtx.Logger.Error(err, "Failed to get VM properties for backup")
+		ctx.VMCtx.Logger.Error(err, "Failed to get VM properties for backup")
 		return err
 	}
 	curEcMap := util.ExtraConfigToMap(moVM.Config.ExtraConfig)
 
 	var ecToUpdate []types.BaseOptionValue
 
-	vmKubeDataBackup, err := getDesiredVMKubeDataForBackup(opts.VMCtx.VM, curEcMap)
+	vmKubeDataBackup, err := getDesiredVMKubeDataForBackup(ctx.VMCtx.VM, curEcMap)
 	if err != nil {
-		opts.VMCtx.Logger.Error(err, "Failed to get VM kube data for backup")
+		ctx.VMCtx.Logger.Error(err, "Failed to get VM kube data for backup")
 		return err
 	}
 
 	if vmKubeDataBackup == "" {
-		opts.VMCtx.Logger.V(4).Info("Skipping VM kube data backup as unchanged")
+		ctx.VMCtx.Logger.V(4).Info("Skipping VM kube data backup as unchanged")
 	} else {
 		ecToUpdate = append(ecToUpdate, &types.OptionValue{
 			Key:   constants.BackupVMKubeDataExtraConfigKey,
@@ -67,14 +58,14 @@ func BackupVirtualMachine(opts BackupOptions) error {
 		})
 	}
 
-	instanceIDBackup, err := getDesiredCloudInitInstanceIDForBackup(opts.VMCtx.VM, curEcMap)
+	instanceIDBackup, err := getDesiredCloudInitInstanceIDForBackup(ctx.VMCtx.VM, curEcMap)
 	if err != nil {
-		opts.VMCtx.Logger.Error(err, "Failed to get cloud-init instance ID for backup")
+		ctx.VMCtx.Logger.Error(err, "Failed to get cloud-init instance ID for backup")
 		return err
 	}
 
 	if instanceIDBackup == "" {
-		opts.VMCtx.Logger.V(4).Info("Skipping cloud-init instance ID as already stored")
+		ctx.VMCtx.Logger.V(4).Info("Skipping cloud-init instance ID as already stored")
 	} else {
 		ecToUpdate = append(ecToUpdate, &types.OptionValue{
 			Key:   constants.BackupVMCloudInitInstanceIDExtraConfigKey,
@@ -82,14 +73,14 @@ func BackupVirtualMachine(opts BackupOptions) error {
 		})
 	}
 
-	bootstrapDataBackup, err := getDesiredBootstrapDataForBackup(opts.BootstrapData, curEcMap)
+	bootstrapDataBackup, err := getDesiredBootstrapDataForBackup(ctx.BootstrapData, curEcMap)
 	if err != nil {
-		opts.VMCtx.Logger.Error(err, "Failed to get VM bootstrap data for backup")
+		ctx.VMCtx.Logger.Error(err, "Failed to get VM bootstrap data for backup")
 		return err
 	}
 
 	if bootstrapDataBackup == "" {
-		opts.VMCtx.Logger.V(4).Info("Skipping VM bootstrap data backup as unchanged")
+		ctx.VMCtx.Logger.V(4).Info("Skipping VM bootstrap data backup as unchanged")
 	} else {
 		ecToUpdate = append(ecToUpdate, &types.OptionValue{
 			Key:   constants.BackupVMBootstrapDataExtraConfigKey,
@@ -97,14 +88,14 @@ func BackupVirtualMachine(opts BackupOptions) error {
 		})
 	}
 
-	diskDataBackup, err := getDesiredDiskDataForBackup(opts, curEcMap)
+	diskDataBackup, err := getDesiredDiskDataForBackup(ctx, curEcMap)
 	if err != nil {
-		opts.VMCtx.Logger.Error(err, "Failed to get VM disk data for backup")
+		ctx.VMCtx.Logger.Error(err, "Failed to get VM disk data for backup")
 		return err
 	}
 
 	if diskDataBackup == "" {
-		opts.VMCtx.Logger.V(4).Info("Skipping VM disk data backup as unchanged")
+		ctx.VMCtx.Logger.V(4).Info("Skipping VM disk data backup as unchanged")
 	} else {
 		ecToUpdate = append(ecToUpdate, &types.OptionValue{
 			Key:   constants.BackupVMDiskDataExtraConfigKey,
@@ -113,12 +104,12 @@ func BackupVirtualMachine(opts BackupOptions) error {
 	}
 
 	if len(ecToUpdate) != 0 {
-		opts.VMCtx.Logger.Info("Updating VM ExtraConfig with backup data")
-		opts.VMCtx.Logger.V(4).Info("", "ExtraConfig", ecToUpdate)
-		if _, err := opts.VcVM.Reconfigure(opts.VMCtx, types.VirtualMachineConfigSpec{
+		ctx.VMCtx.Logger.Info("Updating VM ExtraConfig with backup data")
+		ctx.VMCtx.Logger.V(4).Info("", "ExtraConfig", ecToUpdate)
+		if _, err := ctx.VcVM.Reconfigure(ctx.VMCtx, types.VirtualMachineConfigSpec{
 			ExtraConfig: ecToUpdate,
 		}); err != nil {
-			opts.VMCtx.Logger.Error(err, "Failed to update VM ExtraConfig for backup")
+			ctx.VMCtx.Logger.Error(err, "Failed to update VM ExtraConfig for backup")
 			return err
 		}
 	}
@@ -205,14 +196,14 @@ func getDesiredBootstrapDataForBackup(
 }
 
 func getDesiredDiskDataForBackup(
-	opts BackupOptions,
+	ctx context.BackupVirtualMachineContextA2,
 	ecMap map[string]string) (string, error) {
 	// Return an empty string to skip backup if no disk uuid to PVC is specified.
-	if len(opts.DiskUUIDToPVC) == 0 {
+	if len(ctx.DiskUUIDToPVC) == 0 {
 		return "", nil
 	}
 
-	deviceList, err := opts.VcVM.Device(opts.VMCtx)
+	deviceList, err := ctx.VcVM.Device(ctx.VMCtx)
 	if err != nil {
 		return "", err
 	}
@@ -221,7 +212,7 @@ func getDesiredDiskDataForBackup(
 	for _, device := range deviceList.SelectByType((*types.VirtualDisk)(nil)) {
 		if disk, ok := device.(*types.VirtualDisk); ok {
 			if b, ok := disk.Backing.(*types.VirtualDiskFlatVer2BackingInfo); ok {
-				if pvc, ok := opts.DiskUUIDToPVC[b.Uuid]; ok {
+				if pvc, ok := ctx.DiskUUIDToPVC[b.Uuid]; ok {
 					diskData = append(diskData, VMDiskData{
 						FileName:    b.FileName,
 						PVCName:     pvc.Name,

--- a/pkg/vmprovider/providers/vsphere2/virtualmachine/backup.go
+++ b/pkg/vmprovider/providers/vsphere2/virtualmachine/backup.go
@@ -4,9 +4,9 @@
 package virtualmachine
 
 import (
-	goctx "context"
 	"encoding/json"
 
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
 
 	"github.com/vmware/govmomi/object"
@@ -19,39 +19,47 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere2/constants"
 )
 
+// BackupOptions contains the options for calling BackupVirtualMachine() func.
+type BackupOptions struct {
+	VMCtx         context.VirtualMachineContextA2
+	VcVM          *object.VirtualMachine
+	BootstrapData map[string]string
+	DiskUUIDToPVC map[string]corev1.PersistentVolumeClaim
+}
+
 type VMDiskData struct {
-	// ID of the virtual disk object (only set for FCDs).
-	VDiskID string
 	// Filename contains the datastore path to the virtual disk.
 	FileName string
+	// PVCName is the name of the PVC backed by the virtual disk.
+	PVCName string
+	// AccessMode is the access modes of the PVC backed by the virtual disk.
+	AccessModes []corev1.PersistentVolumeAccessMode
 }
 
 // BackupVirtualMachine backs up the required data of a VM into its ExtraConfig.
 // Currently, the following data is backed up:
 // - Kubernetes VirtualMachine object in YAML format (without its .status field).
 // - VM bootstrap data in JSON (if provided).
-// - List of VM disk data in JSON (including FCDs attached to the VM).
-func BackupVirtualMachine(
-	vmCtx context.VirtualMachineContextA2,
-	vcVM *object.VirtualMachine,
-	bootstrapData map[string]string) error {
+// - VM disk data in JSON (if created and attached by PVCs).
+func BackupVirtualMachine(opts BackupOptions) error {
 	var moVM mo.VirtualMachine
-	if err := vcVM.Properties(vmCtx, vcVM.Reference(),
+	if err := opts.VcVM.Properties(opts.VMCtx, opts.VcVM.Reference(),
 		[]string{"config.extraConfig"}, &moVM); err != nil {
-		vmCtx.Logger.Error(err, "Failed to get VM properties for backup")
+		opts.VMCtx.Logger.Error(err, "Failed to get VM properties for backup")
 		return err
 	}
 	curEcMap := util.ExtraConfigToMap(moVM.Config.ExtraConfig)
 
 	var ecToUpdate []types.BaseOptionValue
 
-	vmKubeDataBackup, err := getDesiredVMKubeDataForBackup(vmCtx.VM, curEcMap)
+	vmKubeDataBackup, err := getDesiredVMKubeDataForBackup(opts.VMCtx.VM, curEcMap)
 	if err != nil {
-		vmCtx.Logger.Error(err, "Failed to get VM kube data for backup")
+		opts.VMCtx.Logger.Error(err, "Failed to get VM kube data for backup")
 		return err
 	}
+
 	if vmKubeDataBackup == "" {
-		vmCtx.Logger.V(4).Info("Skipping VM kube data backup as unchanged")
+		opts.VMCtx.Logger.V(4).Info("Skipping VM kube data backup as unchanged")
 	} else {
 		ecToUpdate = append(ecToUpdate, &types.OptionValue{
 			Key:   constants.BackupVMKubeDataExtraConfigKey,
@@ -59,13 +67,14 @@ func BackupVirtualMachine(
 		})
 	}
 
-	instanceIDBackup, err := getDesiredCloudInitInstanceIDForBackup(vmCtx.VM, curEcMap)
+	instanceIDBackup, err := getDesiredCloudInitInstanceIDForBackup(opts.VMCtx.VM, curEcMap)
 	if err != nil {
-		vmCtx.Logger.Error(err, "Failed to get cloud-init instance ID for backup")
+		opts.VMCtx.Logger.Error(err, "Failed to get cloud-init instance ID for backup")
 		return err
 	}
+
 	if instanceIDBackup == "" {
-		vmCtx.Logger.V(4).Info("Skipping cloud-init instance ID as already stored")
+		opts.VMCtx.Logger.V(4).Info("Skipping cloud-init instance ID as already stored")
 	} else {
 		ecToUpdate = append(ecToUpdate, &types.OptionValue{
 			Key:   constants.BackupVMCloudInitInstanceIDExtraConfigKey,
@@ -73,13 +82,14 @@ func BackupVirtualMachine(
 		})
 	}
 
-	bootstrapDataBackup, err := getDesiredBootstrapDataForBackup(bootstrapData, curEcMap)
+	bootstrapDataBackup, err := getDesiredBootstrapDataForBackup(opts.BootstrapData, curEcMap)
 	if err != nil {
-		vmCtx.Logger.Error(err, "Failed to get VM bootstrap data for backup")
+		opts.VMCtx.Logger.Error(err, "Failed to get VM bootstrap data for backup")
 		return err
 	}
+
 	if bootstrapDataBackup == "" {
-		vmCtx.Logger.V(4).Info("Skipping VM bootstrap data backup as unchanged")
+		opts.VMCtx.Logger.V(4).Info("Skipping VM bootstrap data backup as unchanged")
 	} else {
 		ecToUpdate = append(ecToUpdate, &types.OptionValue{
 			Key:   constants.BackupVMBootstrapDataExtraConfigKey,
@@ -87,13 +97,14 @@ func BackupVirtualMachine(
 		})
 	}
 
-	diskDataBackup, err := getDesiredDiskDataForBackup(vmCtx, vcVM, curEcMap)
+	diskDataBackup, err := getDesiredDiskDataForBackup(opts, curEcMap)
 	if err != nil {
-		vmCtx.Logger.Error(err, "Failed to get VM disk data for backup")
+		opts.VMCtx.Logger.Error(err, "Failed to get VM disk data for backup")
 		return err
 	}
+
 	if diskDataBackup == "" {
-		vmCtx.Logger.V(4).Info("Skipping VM disk data backup as unchanged")
+		opts.VMCtx.Logger.V(4).Info("Skipping VM disk data backup as unchanged")
 	} else {
 		ecToUpdate = append(ecToUpdate, &types.OptionValue{
 			Key:   constants.BackupVMDiskDataExtraConfigKey,
@@ -102,12 +113,12 @@ func BackupVirtualMachine(
 	}
 
 	if len(ecToUpdate) != 0 {
-		vmCtx.Logger.Info("Updating VM ExtraConfig with backup data")
-		vmCtx.Logger.V(4).Info("", "ExtraConfig", ecToUpdate)
-		if _, err := vcVM.Reconfigure(vmCtx, types.VirtualMachineConfigSpec{
+		opts.VMCtx.Logger.Info("Updating VM ExtraConfig with backup data")
+		opts.VMCtx.Logger.V(4).Info("", "ExtraConfig", ecToUpdate)
+		if _, err := opts.VcVM.Reconfigure(opts.VMCtx, types.VirtualMachineConfigSpec{
 			ExtraConfig: ecToUpdate,
 		}); err != nil {
-			vmCtx.Logger.Error(err, "Failed to update VM ExtraConfig for backup")
+			opts.VMCtx.Logger.Error(err, "Failed to update VM ExtraConfig for backup")
 			return err
 		}
 	}
@@ -194,10 +205,14 @@ func getDesiredBootstrapDataForBackup(
 }
 
 func getDesiredDiskDataForBackup(
-	ctx goctx.Context,
-	vcVM *object.VirtualMachine,
+	opts BackupOptions,
 	ecMap map[string]string) (string, error) {
-	deviceList, err := vcVM.Device(ctx)
+	// Return an empty string to skip backup if no disk uuid to PVC is specified.
+	if len(opts.DiskUUIDToPVC) == 0 {
+		return "", nil
+	}
+
+	deviceList, err := opts.VcVM.Device(opts.VMCtx)
 	if err != nil {
 		return "", err
 	}
@@ -205,16 +220,14 @@ func getDesiredDiskDataForBackup(
 	var diskData []VMDiskData
 	for _, device := range deviceList.SelectByType((*types.VirtualDisk)(nil)) {
 		if disk, ok := device.(*types.VirtualDisk); ok {
-			vmDiskData := VMDiskData{}
-			if disk.VDiskId != nil {
-				vmDiskData.VDiskID = disk.VDiskId.Id
-			}
 			if b, ok := disk.Backing.(*types.VirtualDiskFlatVer2BackingInfo); ok {
-				vmDiskData.FileName = b.FileName
-			}
-			// Only add the disk data if it's not empty.
-			if vmDiskData != (VMDiskData{}) {
-				diskData = append(diskData, vmDiskData)
+				if pvc, ok := opts.DiskUUIDToPVC[b.Uuid]; ok {
+					diskData = append(diskData, VMDiskData{
+						FileName:    b.FileName,
+						PVCName:     pvc.Name,
+						AccessModes: pvc.Spec.AccessModes,
+					})
+				}
 			}
 		}
 	}

--- a/pkg/vmprovider/providers/vsphere2/virtualmachine/backup_test.go
+++ b/pkg/vmprovider/providers/vsphere2/virtualmachine/backup_test.go
@@ -85,13 +85,13 @@ func backupTests() {
 
 			It("Should backup VM kube data YAML with the latest spec", func() {
 				vmCtx.VM.ObjectMeta.Generation = 2
-				backupOpts := virtualmachine.BackupOptions{
+				backupVMCtx := context.BackupVirtualMachineContextA2{
 					VMCtx:         vmCtx,
 					VcVM:          vcVM,
 					BootstrapData: nil,
 					DiskUUIDToPVC: nil,
 				}
-				Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
+				Expect(virtualmachine.BackupVirtualMachine(backupVMCtx)).To(Succeed())
 
 				vmCopy := vmCtx.VM.DeepCopy()
 				vmCopy.Status = vmopv1.VirtualMachineStatus{}
@@ -127,13 +127,13 @@ func backupTests() {
 			It("Should skip backing up VM kube data", func() {
 				// Update the VM to verify its kube data is not backed up in ExtraConfig.
 				vmCtx.VM.Labels = map[string]string{"foo": "bar"}
-				backupOpts := virtualmachine.BackupOptions{
+				backupVMCtx := context.BackupVirtualMachineContextA2{
 					VMCtx:         vmCtx,
 					VcVM:          vcVM,
 					BootstrapData: nil,
 					DiskUUIDToPVC: nil,
 				}
-				Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
+				Expect(virtualmachine.BackupVirtualMachine(backupVMCtx)).To(Succeed())
 				verifyBackupDataInExtraConfig(ctx, vcVM, constants.BackupVMKubeDataExtraConfigKey, kubeDataBackup)
 			})
 		})
@@ -143,13 +143,13 @@ func backupTests() {
 
 		It("Should back up bootstrap data as JSON in ExtraConfig", func() {
 			bootstrapDataRaw := map[string]string{"foo": "bar"}
-			backupOpts := virtualmachine.BackupOptions{
+			backupVMCtx := context.BackupVirtualMachineContextA2{
 				VMCtx:         vmCtx,
 				VcVM:          vcVM,
 				BootstrapData: bootstrapDataRaw,
 				DiskUUIDToPVC: nil,
 			}
-			Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
+			Expect(virtualmachine.BackupVirtualMachine(backupVMCtx)).To(Succeed())
 
 			bootstrapDataJSON, err := json.Marshal(bootstrapDataRaw)
 			Expect(err).NotTo(HaveOccurred())
@@ -162,13 +162,13 @@ func backupTests() {
 		When("VM has no disks that are attached from PVCs", func() {
 
 			It("Should skip backing up VM disk data", func() {
-				backupOpts := virtualmachine.BackupOptions{
+				backupVMCtx := context.BackupVirtualMachineContextA2{
 					VMCtx:         vmCtx,
 					VcVM:          vcVM,
 					BootstrapData: nil,
 					DiskUUIDToPVC: nil,
 				}
-				Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
+				Expect(virtualmachine.BackupVirtualMachine(backupVMCtx)).To(Succeed())
 				verifyBackupDataInExtraConfig(ctx, vcVM, constants.BackupVMDiskDataExtraConfigKey, "")
 			})
 		})
@@ -181,13 +181,13 @@ func backupTests() {
 					vcSimDiskUUID: *dummyPVC,
 				}
 
-				backupOpts := virtualmachine.BackupOptions{
+				backupVMCtx := context.BackupVirtualMachineContextA2{
 					VMCtx:         vmCtx,
 					VcVM:          vcVM,
 					BootstrapData: nil,
 					DiskUUIDToPVC: diskUUIDToPVC,
 				}
-				Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
+				Expect(virtualmachine.BackupVirtualMachine(backupVMCtx)).To(Succeed())
 
 				diskData := []virtualmachine.VMDiskData{
 					{
@@ -227,13 +227,13 @@ func backupTests() {
 			})
 
 			It("Should not change the cloud-init instance ID in VM's ExtraConfig", func() {
-				backupOpts := virtualmachine.BackupOptions{
+				backupVMCtx := context.BackupVirtualMachineContextA2{
 					VMCtx:         vmCtx,
 					VcVM:          vcVM,
 					BootstrapData: nil,
 					DiskUUIDToPVC: nil,
 				}
-				Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
+				Expect(virtualmachine.BackupVirtualMachine(backupVMCtx)).To(Succeed())
 				verifyBackupDataInExtraConfig(ctx, vcVM, constants.BackupVMCloudInitInstanceIDExtraConfigKey, "ec-instance-id")
 			})
 		})
@@ -248,13 +248,13 @@ func backupTests() {
 			})
 
 			It("Should backup the cloud-init instance ID from annotations", func() {
-				backupOpts := virtualmachine.BackupOptions{
+				backupVMCtx := context.BackupVirtualMachineContextA2{
 					VMCtx:         vmCtx,
 					VcVM:          vcVM,
 					BootstrapData: nil,
 					DiskUUIDToPVC: nil,
 				}
-				Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
+				Expect(virtualmachine.BackupVirtualMachine(backupVMCtx)).To(Succeed())
 				verifyBackupDataInExtraConfig(ctx, vcVM, constants.BackupVMCloudInitInstanceIDExtraConfigKey, "annotation-instance-id")
 			})
 		})
@@ -267,13 +267,13 @@ func backupTests() {
 			})
 
 			It("Should backup the cloud-init instance ID from VM K8s resource UID", func() {
-				backupOpts := virtualmachine.BackupOptions{
+				backupVMCtx := context.BackupVirtualMachineContextA2{
 					VMCtx:         vmCtx,
 					VcVM:          vcVM,
 					BootstrapData: nil,
 					DiskUUIDToPVC: nil,
 				}
-				Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
+				Expect(virtualmachine.BackupVirtualMachine(backupVMCtx)).To(Succeed())
 			})
 		})
 	})

--- a/pkg/vmprovider/providers/vsphere2/virtualmachine/backup_test.go
+++ b/pkg/vmprovider/providers/vsphere2/virtualmachine/backup_test.go
@@ -6,6 +6,7 @@ package virtualmachine_test
 import (
 	"encoding/json"
 
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
 
 	. "github.com/onsi/ginkgo"
@@ -23,6 +24,14 @@ import (
 )
 
 func backupTests() {
+	const (
+		// These are the default values of the vcsim VM that are used to
+		// construct the expected backup data in the following tests.
+		vcSimVMPath       = "DC0_C0_RP0_VM0"
+		vcSimDiskUUID     = "be8d2471-f32e-5c7e-a89b-22cb8e533890"
+		vcSimDiskFileName = "[LocalDS_0] DC0_C0_RP0_VM0/disk1.vmdk"
+	)
+
 	var (
 		ctx   *builder.TestContextForVCSim
 		vcVM  *object.VirtualMachine
@@ -76,7 +85,13 @@ func backupTests() {
 
 			It("Should backup VM kube data YAML with the latest spec", func() {
 				vmCtx.VM.ObjectMeta.Generation = 2
-				Expect(virtualmachine.BackupVirtualMachine(vmCtx, vcVM, nil)).To(Succeed())
+				backupOpts := virtualmachine.BackupOptions{
+					VMCtx:         vmCtx,
+					VcVM:          vcVM,
+					BootstrapData: nil,
+					DiskUUIDToPVC: nil,
+				}
+				Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
 
 				vmCopy := vmCtx.VM.DeepCopy()
 				vmCopy.Status = vmopv1.VirtualMachineStatus{}
@@ -112,7 +127,13 @@ func backupTests() {
 			It("Should skip backing up VM kube data", func() {
 				// Update the VM to verify its kube data is not backed up in ExtraConfig.
 				vmCtx.VM.Labels = map[string]string{"foo": "bar"}
-				Expect(virtualmachine.BackupVirtualMachine(vmCtx, vcVM, nil)).To(Succeed())
+				backupOpts := virtualmachine.BackupOptions{
+					VMCtx:         vmCtx,
+					VcVM:          vcVM,
+					BootstrapData: nil,
+					DiskUUIDToPVC: nil,
+				}
+				Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
 				verifyBackupDataInExtraConfig(ctx, vcVM, constants.BackupVMKubeDataExtraConfigKey, kubeDataBackup)
 			})
 		})
@@ -122,7 +143,13 @@ func backupTests() {
 
 		It("Should back up bootstrap data as JSON in ExtraConfig", func() {
 			bootstrapDataRaw := map[string]string{"foo": "bar"}
-			Expect(virtualmachine.BackupVirtualMachine(vmCtx, vcVM, bootstrapDataRaw)).To(Succeed())
+			backupOpts := virtualmachine.BackupOptions{
+				VMCtx:         vmCtx,
+				VcVM:          vcVM,
+				BootstrapData: bootstrapDataRaw,
+				DiskUUIDToPVC: nil,
+			}
+			Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
 
 			bootstrapDataJSON, err := json.Marshal(bootstrapDataRaw)
 			Expect(err).NotTo(HaveOccurred())
@@ -132,19 +159,47 @@ func backupTests() {
 
 	Context("VM Disk data", func() {
 
-		It("Should backup VM disk data as JSON in ExtraConfig", func() {
-			Expect(virtualmachine.BackupVirtualMachine(vmCtx, vcVM, nil)).To(Succeed())
+		When("VM has no disks that are attached from PVCs", func() {
 
-			// Use the default disk info from the vcSim VM for testing.
-			diskData := []virtualmachine.VMDiskData{
-				{
-					VDiskID:  "",
-					FileName: "[LocalDS_0] DC0_C0_RP0_VM0/disk1.vmdk",
-				},
-			}
-			diskDataJSON, err := json.Marshal(diskData)
-			Expect(err).NotTo(HaveOccurred())
-			verifyBackupDataInExtraConfig(ctx, vcVM, constants.BackupVMDiskDataExtraConfigKey, string(diskDataJSON))
+			It("Should skip backing up VM disk data", func() {
+				backupOpts := virtualmachine.BackupOptions{
+					VMCtx:         vmCtx,
+					VcVM:          vcVM,
+					BootstrapData: nil,
+					DiskUUIDToPVC: nil,
+				}
+				Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
+				verifyBackupDataInExtraConfig(ctx, vcVM, constants.BackupVMDiskDataExtraConfigKey, "")
+			})
+		})
+
+		When("VM has disks that are attached from PVCs", func() {
+
+			It("Should backup VM disk data as JSON in ExtraConfig", func() {
+				dummyPVC := builder.DummyPersistentVolumeClaim()
+				diskUUIDToPVC := map[string]corev1.PersistentVolumeClaim{
+					vcSimDiskUUID: *dummyPVC,
+				}
+
+				backupOpts := virtualmachine.BackupOptions{
+					VMCtx:         vmCtx,
+					VcVM:          vcVM,
+					BootstrapData: nil,
+					DiskUUIDToPVC: diskUUIDToPVC,
+				}
+				Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
+
+				diskData := []virtualmachine.VMDiskData{
+					{
+						FileName:    vcSimDiskFileName,
+						PVCName:     dummyPVC.Name,
+						AccessModes: dummyPVC.Spec.AccessModes,
+					},
+				}
+				diskDataJSON, err := json.Marshal(diskData)
+				Expect(err).NotTo(HaveOccurred())
+				verifyBackupDataInExtraConfig(ctx, vcVM, constants.BackupVMDiskDataExtraConfigKey, string(diskDataJSON))
+			})
 		})
 	})
 
@@ -171,8 +226,14 @@ func backupTests() {
 				}
 			})
 
-			It("Should skip backing up the cloud-init instance ID", func() {
-				Expect(virtualmachine.BackupVirtualMachine(vmCtx, vcVM, nil)).To(Succeed())
+			It("Should not change the cloud-init instance ID in VM's ExtraConfig", func() {
+				backupOpts := virtualmachine.BackupOptions{
+					VMCtx:         vmCtx,
+					VcVM:          vcVM,
+					BootstrapData: nil,
+					DiskUUIDToPVC: nil,
+				}
+				Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
 				verifyBackupDataInExtraConfig(ctx, vcVM, constants.BackupVMCloudInitInstanceIDExtraConfigKey, "ec-instance-id")
 			})
 		})
@@ -187,7 +248,13 @@ func backupTests() {
 			})
 
 			It("Should backup the cloud-init instance ID from annotations", func() {
-				Expect(virtualmachine.BackupVirtualMachine(vmCtx, vcVM, nil)).To(Succeed())
+				backupOpts := virtualmachine.BackupOptions{
+					VMCtx:         vmCtx,
+					VcVM:          vcVM,
+					BootstrapData: nil,
+					DiskUUIDToPVC: nil,
+				}
+				Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
 				verifyBackupDataInExtraConfig(ctx, vcVM, constants.BackupVMCloudInitInstanceIDExtraConfigKey, "annotation-instance-id")
 			})
 		})
@@ -199,9 +266,14 @@ func backupTests() {
 				vmCtx.VM.UID = "vm-uid"
 			})
 
-			It("Should backup the cloud-init instance ID from annotations", func() {
-				Expect(virtualmachine.BackupVirtualMachine(vmCtx, vcVM, nil)).To(Succeed())
-				verifyBackupDataInExtraConfig(ctx, vcVM, constants.BackupVMCloudInitInstanceIDExtraConfigKey, "vm-uid")
+			It("Should backup the cloud-init instance ID from VM K8s resource UID", func() {
+				backupOpts := virtualmachine.BackupOptions{
+					VMCtx:         vmCtx,
+					VcVM:          vcVM,
+					BootstrapData: nil,
+					DiskUUIDToPVC: nil,
+				}
+				Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
 			})
 		})
 	})
@@ -219,6 +291,12 @@ func verifyBackupDataInExtraConfig(
 	var moVM mo.VirtualMachine
 	Expect(objVM.Properties(ctx, objVM.Reference(), []string{"config.extraConfig"}, &moVM)).To(Succeed())
 	ecMap := util.ExtraConfigToMap(moVM.Config.ExtraConfig)
+
+	// Verify the expected key doesn't exist in ExtraConfig if the expected value is empty.
+	if expectedValDecoded == "" {
+		Expect(ecMap).NotTo(HaveKey(expectedKey))
+		return
+	}
 
 	// Verify the expected key exists in ExtraConfig and the decoded values match.
 	Expect(ecMap).To(HaveKey(expectedKey))

--- a/pkg/vmprovider/providers/vsphere2/vmprovider_vm.go
+++ b/pkg/vmprovider/providers/vsphere2/vmprovider_vm.go
@@ -373,13 +373,13 @@ func (vs *vSphereVMProvider) updateVirtualMachine(
 			return err
 		}
 
-		backupOpts := virtualmachine.BackupOptions{
+		backupVMCtx := context.BackupVirtualMachineContextA2{
 			VMCtx:         vmCtx,
 			VcVM:          vcVM,
 			BootstrapData: data,
 			DiskUUIDToPVC: diskUUIDToPVC,
 		}
-		if err := virtualmachine.BackupVirtualMachine(backupOpts); err != nil {
+		if err := virtualmachine.BackupVirtualMachine(backupVMCtx); err != nil {
 			vmCtx.Logger.Error(err, "Failed to backup VM")
 			return err
 		}

--- a/pkg/vmprovider/providers/vsphere2/vmprovider_vm_utils.go
+++ b/pkg/vmprovider/providers/vsphere2/vmprovider_vm_utils.go
@@ -333,3 +333,43 @@ func HardwareVersionForPVCandPCIDevices(imageHWVersion int32, configSpec *types.
 
 	return configSpecHWVersion
 }
+
+// GetAttachedDiskUUIDToPVC returns a map of disk UUID to PVC object for all
+// attached disks by checking the VM's spec and status of volumes.
+func GetAttachedDiskUUIDToPVC(
+	vmCtx context.VirtualMachineContextA2,
+	k8sClient ctrlclient.Client) (map[string]corev1.PersistentVolumeClaim, error) {
+	if !HasPVC(vmCtx.VM.Spec) {
+		return nil, nil
+	}
+
+	vmVolNameToPVCName := map[string]string{}
+	for _, vol := range vmCtx.VM.Spec.Volumes {
+		if pvc := vol.PersistentVolumeClaim; pvc != nil {
+			vmVolNameToPVCName[vol.Name] = pvc.ClaimName
+		}
+	}
+
+	diskUUIDToPVC := map[string]corev1.PersistentVolumeClaim{}
+	for _, vol := range vmCtx.VM.Status.Volumes {
+		if !vol.Attached || vol.DiskUUID == "" {
+			continue
+		}
+
+		pvcName := vmVolNameToPVCName[vol.Name]
+		// This could happen if the volume was just removed from VM spec but not reconciled yet.
+		if pvcName == "" {
+			continue
+		}
+
+		pvcObj := corev1.PersistentVolumeClaim{}
+		objKey := ctrlclient.ObjectKey{Name: pvcName, Namespace: vmCtx.VM.Namespace}
+		if err := k8sClient.Get(vmCtx, objKey, &pvcObj); err != nil {
+			return nil, err
+		}
+
+		diskUUIDToPVC[vol.DiskUUID] = pvcObj
+	}
+
+	return diskUUIDToPVC, nil
+}


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This PR stores a VM's disk UUID to PVC mapping info in ExtraConfig during the backup process. This will enable us to register the volumes of the VM with the same PVC name and access modes during the restore. The change has also been added to the v1a2 package.

**Are there any special notes for your reviewer**:
A helper function is added in `vmprovider_vm_utils.go` to retrieve the disk UUID to PVC mapping. This eliminates the need to pass a K8s client in the `backup.go` file. Also, the `BackupVirtualMachine` function is updated to have all the necessary params from the new `BackupOptions` struct.

**Please add a release note if necessary**:

```release-note
Persist VM's disk UUID to PVC mapping info in ExtraConfig during VM reconciliation.
```

**Testing Done**
- Updated test code to verify the new function and the data stored for backup
- Manually deployed this change to a testbed and validated the expected data in the VM's ExtraConfig:

```console
$ govc vm.info -e "vm-pvc" | grep vmservice.virtualmachine.diskdata
    vmservice.virtualmachine.diskdata:              H4sIAAAAAAAA/yzMvQrCMBAH8FeRm1ttTEJrNxHc/MChDiVDuPsXi0alF7qI7+7iC/z6D+3HB44xgVrq9RYnSJcGLauwGFhWbG1TeS/GuNrZNW+Ea2N97Yyr0MAv5yR3Kujc7f5IhubyPTMVtGWG6uElUGp7uiDKdRozTk8GhW/4AQAA//8BAAD//7ET0vd+AAAA

$ echo "H4sIAAAAAAAA/yzMvQrCMBAH8FeRm1ttTEJrNxHc/MChDiVDuPsXi0alF7qI7+7iC/z6D+3HB44xgVrq9RYnSJcGLauwGFhWbG1TeS/GuNrZNW+Ea2N97Yyr0MAv5yR3Kujc7f5IhubyPTMVtGWG6uElUGp7uiDKdRozTk8GhW/4AQAA//8BAAD//7ET0vd+AAAA" | base64 -d | gunzip | jq .
[
  {
    "FileName": "[sharedVmfs-0] fcd/c338055d1147432c9dc713574140e8e5.vmdk",
    "PVCName": "test-pvc",
    "AccessModes": [
      "ReadWriteOnce"
    ]
  }
]
```