### PR TITLE
:seedling: Allow privileged users to modify annotations on a VirtualMachine object

### DIFF
--- a/config/wcp/vmoperator/manager_env_var_patch.yaml
+++ b/config/wcp/vmoperator/manager_env_var_patch.yaml
@@ -81,3 +81,9 @@
   value:
     name: FSS_WCP_VMSERVICE_BACKUPRESTORE
     value: "<FSS_WCP_VMSERVICE_BACKUPRESTORE_VALUE>"
+
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: PRIVILEGED_USERS
+    value: "<COMMA_SEPARATED_LIST_OF_USERS>"

--- a/pkg/builder/auth.go
+++ b/pkg/builder/auth.go
@@ -6,13 +6,22 @@ import (
 	authv1 "k8s.io/api/authentication/v1"
 
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 )
 
-func isPrivilegedAccount(ctx *context.WebhookContext, userInfo authv1.UserInfo) bool {
+func IsPrivilegedAccount(ctx *context.WebhookContext, userInfo authv1.UserInfo) bool {
 	username := userInfo.Username
 
 	if strings.EqualFold(username, kubeAdminUser) {
 		return true
+	}
+
+	// Users specified by Pod's environment variable "PRIVILEGED_USERS" are considered privileged.
+	if lib.IsVMServiceBackupRestoreFSSEnabled() {
+		privUsers := lib.GetPrivilegedUsers()
+		if _, ok := privUsers[username]; ok {
+			return true
+		}
 	}
 
 	serviceAccount := strings.Join([]string{"system", "serviceaccount", ctx.Namespace, ctx.ServiceAccountName}, ":")

--- a/pkg/builder/mutating_webhook.go
+++ b/pkg/builder/mutating_webhook.go
@@ -144,7 +144,7 @@ func (h *mutatingWebhookHandler) Handle(_ goctx.Context, req admission.Request) 
 		Obj:                 obj,
 		OldObj:              oldObj,
 		UserInfo:            req.UserInfo,
-		IsPrivilegedAccount: isPrivilegedAccount(h.WebhookContext, req.UserInfo),
+		IsPrivilegedAccount: IsPrivilegedAccount(h.WebhookContext, req.UserInfo),
 		Logger:              h.WebhookContext.Logger.WithName(obj.GetNamespace()).WithName(obj.GetName()),
 	}
 

--- a/pkg/builder/validating_webhook.go
+++ b/pkg/builder/validating_webhook.go
@@ -153,7 +153,7 @@ func (h *validatingWebhookHandler) Handle(_ goctx.Context, req admission.Request
 		Obj:                 obj,
 		OldObj:              oldObj,
 		UserInfo:            req.UserInfo,
-		IsPrivilegedAccount: isPrivilegedAccount(h.WebhookContext, req.UserInfo),
+		IsPrivilegedAccount: IsPrivilegedAccount(h.WebhookContext, req.UserInfo),
 		Logger:              h.WebhookContext.Logger.WithName(obj.GetNamespace()).WithName(obj.GetName()),
 	}
 

--- a/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator_unit_test.go
@@ -24,6 +24,7 @@ import (
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	"github.com/vmware-tanzu/vm-operator/api/v1alpha2/common"
+	pkgbuilder "github.com/vmware-tanzu/vm-operator/pkg/builder"
 	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 	"github.com/vmware-tanzu/vm-operator/pkg/topology"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/config"
@@ -76,7 +77,8 @@ func newUnitTestContextForValidatingWebhook(isUpdate bool) *unitValidatingWebhoo
 //nolint:gocyclo
 func unitTestsValidateCreate() {
 	var (
-		ctx *unitValidatingWebhookContext
+		ctx                           *unitValidatingWebhookContext
+		oldVMServiceBackupRestoreFunc func() bool
 	)
 
 	type createArgs struct {
@@ -111,6 +113,7 @@ func unitTestsValidateCreate() {
 		powerState                        vmopv1.VirtualMachinePowerState
 		nextRestartTime                   string
 		adminOnlyAnnotations              bool
+		isPrivilegedUser                  bool
 	}
 
 	validateCreate := func(args createArgs, expectedAllowed bool, expectedReason string, expectedErr error) {
@@ -259,6 +262,21 @@ func unitTestsValidateCreate() {
 			ctx.vm.Annotations[vmopv1.FirstBootDoneAnnotation] = updateSuffix
 		}
 
+		if args.isPrivilegedUser {
+			lib.IsVMServiceBackupRestoreFSSEnabled = func() bool {
+				return true
+			}
+
+			fakeWCPUser := "sso:wcp-12345-fake-machineid-67890@vsphere.local"
+			Expect(os.Setenv(lib.PrivilegedUsersEnv, fakeWCPUser)).To(Succeed())
+			defer func() {
+				Expect(os.Unsetenv(lib.PrivilegedUsersEnv)).To(Succeed())
+			}()
+
+			ctx.UserInfo.Username = fakeWCPUser
+			ctx.IsPrivilegedAccount = pkgbuilder.IsPrivilegedAccount(ctx.WebhookContext, ctx.UserInfo)
+		}
+
 		ctx.vm.Spec.PowerState = args.powerState
 		ctx.vm.Spec.NextRestartTime = args.nextRestartTime
 
@@ -278,11 +296,13 @@ func unitTestsValidateCreate() {
 
 	BeforeEach(func() {
 		ctx = newUnitTestContextForValidatingWebhook(false)
+		oldVMServiceBackupRestoreFunc = lib.IsVMServiceBackupRestoreFSSEnabled
 	})
 
 	AfterEach(func() {
 		Expect(os.Unsetenv(lib.WcpFaultDomainsFSS)).To(Succeed())
 		Expect(os.Unsetenv(lib.WindowsSysprepFSS)).To(Succeed())
+		lib.IsVMServiceBackupRestoreFSSEnabled = oldVMServiceBackupRestoreFunc
 		ctx = nil
 	})
 
@@ -379,12 +399,15 @@ func unitTestsValidateCreate() {
 				field.Forbidden(annotationPath.Child(vmopv1.FirstBootDoneAnnotation), "modifying this annotation is not allowed for non-admin users").Error(),
 			}, ", "), nil),
 		Entry("should allow creating VM with admin-only annotations set by service user", createArgs{isServiceUser: true, adminOnlyAnnotations: true}, true, nil, nil),
+
+		Entry("should allow creating VM with admin-only annotations set by WCP user when the Backup/Restore FSS is enabled", createArgs{adminOnlyAnnotations: true, isPrivilegedUser: true}, true, nil, nil),
 	)
 }
 
 func unitTestsValidateUpdate() {
 	var (
-		ctx *unitValidatingWebhookContext
+		ctx                           *unitValidatingWebhookContext
+		oldVMServiceBackupRestoreFunc func() bool
 	)
 
 	type updateArgs struct {
@@ -407,6 +430,7 @@ func unitTestsValidateUpdate() {
 		addAdminOnlyAnnotations     bool
 		updateAdminOnlyAnnotations  bool
 		removeAdminOnlyAnnotations  bool
+		isPrivilegedUser            bool
 	}
 
 	validateUpdate := func(args updateArgs, expectedAllowed bool, expectedReason string, expectedErr error) {
@@ -475,6 +499,22 @@ func unitTestsValidateUpdate() {
 			ctx.oldVM.Annotations[vmopv1.FirstBootDoneAnnotation] = dummyFirstBootDoneVal
 		}
 
+		if args.isPrivilegedUser {
+			lib.IsVMServiceBackupRestoreFSSEnabled = func() bool {
+				return true
+			}
+
+			privilegedUsersEnvList := "  , foo ,bar , test,  "
+			privilegedUser := "bar"
+			Expect(os.Setenv(lib.PrivilegedUsersEnv, privilegedUsersEnvList)).To(Succeed())
+			defer func() {
+				Expect(os.Unsetenv(lib.PrivilegedUsersEnv)).To(Succeed())
+			}()
+
+			ctx.UserInfo.Username = privilegedUser
+			ctx.IsPrivilegedAccount = pkgbuilder.IsPrivilegedAccount(ctx.WebhookContext, ctx.UserInfo)
+		}
+
 		ctx.oldVM.Spec.NextRestartTime = args.lastRestartTime
 		ctx.vm.Spec.NextRestartTime = args.nextRestartTime
 
@@ -496,12 +536,14 @@ func unitTestsValidateUpdate() {
 
 	BeforeEach(func() {
 		ctx = newUnitTestContextForValidatingWebhook(true)
+		oldVMServiceBackupRestoreFunc = lib.IsVMServiceBackupRestoreFSSEnabled
 	})
 
 	AfterEach(func() {
 		ctx = nil
 		Expect(os.Unsetenv(lib.WcpFaultDomainsFSS)).To(Succeed())
 		Expect(os.Unsetenv(lib.WindowsSysprepFSS)).To(Succeed())
+		lib.IsVMServiceBackupRestoreFSSEnabled = oldVMServiceBackupRestoreFunc
 	})
 
 	msg := "field is immutable"
@@ -572,6 +614,10 @@ func unitTestsValidateUpdate() {
 		Entry("should allow adding admin-only annotations by service user", updateArgs{isServiceUser: true, addAdminOnlyAnnotations: true}, true, nil, nil),
 		Entry("should allow adding admin-only annotations by service user", updateArgs{isServiceUser: true, updateAdminOnlyAnnotations: true}, true, nil, nil),
 		Entry("should allow adding admin-only annotations by service user", updateArgs{isServiceUser: true, removeAdminOnlyAnnotations: true}, true, nil, nil),
+
+		Entry("should allow adding admin-only annotations by privileged users", updateArgs{isPrivilegedUser: true, addAdminOnlyAnnotations: true}, true, nil, nil),
+		Entry("should allow updating admin-only annotations by privileged users", updateArgs{isPrivilegedUser: true, updateAdminOnlyAnnotations: true}, true, nil, nil),
+		Entry("should allow removing admin-only annotations by privileged users", updateArgs{isPrivilegedUser: true, removeAdminOnlyAnnotations: true}, true, nil, nil),
 	)
 
 	When("the update is performed while object deletion", func() {


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Currently, we have webhooks to prevent users from modifying system used annotations.  This is done by validating if the user making the request is the kube-admin user.  However, other parts of the infrastructure (such as WCP service) are not considered privileged, which is required for backup/restore.

This changes expands the definition of a privileged account by including WCP service solution user.  The code expects this particular environment variable to be present in the pod's environment variable.

Testing Done:

1. Create a ServiceAccount
2. Create a ClusterRoleBinding with a roleRef that gives the ServiceAccount permissions to edit/update/delete VM resources
3. Invoke create VM with a reserved annotation
```
$ k apply -f test-yamls/vm.yaml --as system:serviceaccount:default:test-sa
Error from server (metadata.annotations.virtualmachine.vmoperator.vmware.com/first-boot-done: Forbidden: modifying this annotation is not allowed for non-admin users): error when creating "test-yamls/vm.yaml": admission webhook "default.validating.virtualmachine.v1alpha1.vmoperator.vmware.com" denied the request: metadata.annotations.virtualmachine.vmoperator.vmware.com/first-boot-done: Forbidden: modifying this annotation is not allowed for non-admin users
```
5. Modify the VM operator deployment to add the env var.
6. Try to create the VM with the annotation again and verify that it goes through:
```
$ k apply -f test-yamls/vm.yaml --as system:serviceaccount:default:test-sa
virtualmachine.vmoperator.vmware.com/parunesh-test-4 created
```

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes N/A


**Are there any special notes for your reviewer**:

N/A


**Please add a release note if necessary**:
```release-note
Allow privileged users to modify annotations on a VirtualMachine object
```