### PR TITLE
🌱 Adds a Ready condition to CVMI and VMI resources

### DIFF
--- a/api/v1alpha2/virtualmachineimage_types.go
+++ b/api/v1alpha2/virtualmachineimage_types.go
@@ -31,19 +31,6 @@ const (
 	VirtualMachineImageCapabilityLabel = "capability.image." + GroupName + "/"
 )
 
-// Condition types for VirtualMachineImages.
-const (
-	// VirtualMachineImageSyncedCondition documents that the image is synced with the vSphere content library item
-	// that contains the source of this image's information.
-	VirtualMachineImageSyncedCondition = "VirtualMachineImageSynced"
-
-	// VirtualMachineImageProviderReadyCondition denotes readiness of the VirtualMachineImage provider.
-	VirtualMachineImageProviderReadyCondition = "VirtualMachineImageProviderReady"
-
-	// VirtualMachineImageProviderSecurityComplianceCondition denotes security compliance of the library item provider.
-	VirtualMachineImageProviderSecurityComplianceCondition = "VirtualMachineImageProviderSecurityCompliance"
-)
-
 // Condition reasons for VirtualMachineImages.
 const (
 	// VirtualMachineImageNotSyncedReason documents that the VirtualMachineImage is not synced with

--- a/controllers/contentlibrary/v1alpha2/clustercontentlibraryitem/clustercontentlibraryitem_controller_intg_test.go
+++ b/controllers/contentlibrary/v1alpha2/clustercontentlibraryitem/clustercontentlibraryitem_controller_intg_test.go
@@ -46,7 +46,7 @@ func cclItemReconcile() {
 			image := &vmopv1.ClusterVirtualMachineImage{}
 			g.Expect(ctx.Client.Get(ctx, objKey, image)).To(Succeed())
 
-			readyCond := conditions.Get(image, vmopv1.VirtualMachineImageProviderReadyCondition)
+			readyCond := conditions.Get(image, vmopv1.ReadyConditionType)
 			g.Expect(readyCond).ToNot(BeNil())
 			g.Expect(readyCond.Status).To(Equal(metav1.ConditionFalse))
 		}).Should(Succeed(), "waiting for ClusterVirtualMachineImage to be not ready")
@@ -56,7 +56,7 @@ func cclItemReconcile() {
 		Eventually(func(g Gomega) {
 			image := &vmopv1.ClusterVirtualMachineImage{}
 			g.Expect(ctx.Client.Get(ctx, objKey, image)).To(Succeed())
-			g.Expect(conditions.IsTrue(image, vmopv1.VirtualMachineImageProviderReadyCondition))
+			g.Expect(conditions.IsTrue(image, vmopv1.ReadyConditionType))
 			// Assert that SyncVirtualMachineImage() has been called too.
 			g.Expect(image.Status.Firmware).To(Equal(firmwareValue))
 		}).Should(Succeed(), "waiting for ClusterVirtualMachineImage to be sync'd and ready")

--- a/controllers/contentlibrary/v1alpha2/contentlibraryitem/contentlibraryitem_controller.go
+++ b/controllers/contentlibrary/v1alpha2/contentlibraryitem/contentlibraryitem_controller.go
@@ -157,23 +157,41 @@ func (r *Reconciler) ReconcileNormal(ctx *context.ContentLibraryItemContextA2) e
 			savedStatus = vmi.Status.DeepCopy()
 		}()
 
+		// Resetting the ready condition to recalculate the latest state.
+		conditions.Delete(vmi, vmopv1.ReadyConditionType)
+
 		if err := r.setUpVMIFromCLItem(ctx); err != nil {
 			ctx.Logger.Error(err, "Failed to set up VirtualMachineImage from ContentLibraryItem")
 			return err
+		}
+		// Update image condition based on the security compliance of the provider item.
+		clItemSecurityCompliance := ctx.CLItem.Status.SecurityCompliance
+		if clItemSecurityCompliance == nil || !*clItemSecurityCompliance {
+			conditions.MarkFalse(vmi,
+				vmopv1.ReadyConditionType,
+				vmopv1.VirtualMachineImageProviderSecurityNotCompliantReason,
+				"Provider item is not security compliant",
+			)
+			// Since we want to persist a False condition if the CCL Item is
+			// not security compliant.
+			return nil
 		}
 
 		// Check if the item is ready and skip the image content sync if not.
 		if !utils.IsItemReady(ctx.CLItem.Status.Conditions) {
 			conditions.MarkFalse(vmi,
-				vmopv1.VirtualMachineImageProviderReadyCondition,
+				vmopv1.ReadyConditionType,
 				vmopv1.VirtualMachineImageProviderNotReadyReason,
 				"Provider item is not in ready condition",
 			)
 			ctx.Logger.Info("ContentLibraryItem is not ready yet, skipping image content sync")
 		} else {
-			conditions.MarkTrue(vmi, vmopv1.VirtualMachineImageProviderReadyCondition)
 			syncErr = r.syncImageContent(ctx)
 			didSync = true
+		}
+
+		if !conditions.Has(vmi, vmopv1.ReadyConditionType) {
+			conditions.MarkTrue(vmi, vmopv1.ReadyConditionType)
 		}
 
 		// Do not return syncErr here as we still want to patch the updated fields we get above.
@@ -228,18 +246,6 @@ func (r *Reconciler) setUpVMIFromCLItem(ctx *context.ContentLibraryItemContextA2
 	vmi.Status.Name = clItem.Status.Name
 	vmi.Status.ProviderItemID = string(clItem.Spec.UUID)
 
-	// Update image condition based on the security compliance of the provider item.
-	clItemSecurityCompliance := ctx.CLItem.Status.SecurityCompliance
-	if clItemSecurityCompliance == nil || !*clItemSecurityCompliance {
-		conditions.MarkFalse(vmi,
-			vmopv1.VirtualMachineImageProviderSecurityComplianceCondition,
-			vmopv1.VirtualMachineImageProviderSecurityNotCompliantReason,
-			"Provider item is not security compliant",
-		)
-	} else {
-		conditions.MarkTrue(vmi, vmopv1.VirtualMachineImageProviderSecurityComplianceCondition)
-	}
-
 	return nil
 }
 
@@ -256,11 +262,10 @@ func (r *Reconciler) syncImageContent(ctx *context.ContentLibraryItemContextA2) 
 	err := r.VMProvider.SyncVirtualMachineImage(ctx, clItem, vmi)
 	if err != nil {
 		conditions.MarkFalse(vmi,
-			vmopv1.VirtualMachineImageSyncedCondition,
+			vmopv1.ReadyConditionType,
 			vmopv1.VirtualMachineImageNotSyncedReason,
 			"Failed to sync to the latest content version from provider")
 	} else {
-		conditions.MarkTrue(vmi, vmopv1.VirtualMachineImageSyncedCondition)
 		vmi.Status.ProviderContentVersion = latestVersion
 	}
 

--- a/controllers/contentlibrary/v1alpha2/contentlibraryitem/contentlibraryitem_controller_intg_test.go
+++ b/controllers/contentlibrary/v1alpha2/contentlibraryitem/contentlibraryitem_controller_intg_test.go
@@ -46,7 +46,7 @@ func clItemReconcile() {
 			image := &vmopv1.VirtualMachineImage{}
 			g.Expect(ctx.Client.Get(ctx, objKey, image)).To(Succeed())
 
-			readyCond := conditions.Get(image, vmopv1.VirtualMachineImageProviderReadyCondition)
+			readyCond := conditions.Get(image, vmopv1.ReadyConditionType)
 			g.Expect(readyCond).ToNot(BeNil())
 			g.Expect(readyCond.Status).To(Equal(metav1.ConditionFalse))
 		}).Should(Succeed(), "waiting for VirtualMachineImage to be not ready")
@@ -56,7 +56,7 @@ func clItemReconcile() {
 		Eventually(func(g Gomega) {
 			image := &vmopv1.VirtualMachineImage{}
 			g.Expect(ctx.Client.Get(ctx, objKey, image)).To(Succeed())
-			g.Expect(conditions.IsTrue(image, vmopv1.VirtualMachineImageProviderReadyCondition))
+			g.Expect(conditions.IsTrue(image, vmopv1.ReadyConditionType))
 			// Assert that SyncVirtualMachineImage() has been called too.
 			g.Expect(image.Status.Firmware).To(Equal(firmwareValue))
 		}).Should(Succeed(), "waiting for VirtualMachineImage to be sync'd and ready")

--- a/controllers/contentlibrary/v1alpha2/contentlibraryitem/contentlibraryitem_controller_unit_test.go
+++ b/controllers/contentlibrary/v1alpha2/contentlibraryitem/contentlibraryitem_controller_unit_test.go
@@ -118,7 +118,7 @@ func unitTestsReconcile() {
 				Expect(reconciler.ReconcileNormal(clItemCtx)).To(Succeed())
 
 				vmi := getVMI(ctx, clItemCtx)
-				condition := conditions.Get(vmi, vmopv1.VirtualMachineImageProviderReadyCondition)
+				condition := conditions.Get(vmi, vmopv1.ReadyConditionType)
 				Expect(condition).ToNot(BeNil())
 				Expect(condition.Status).To(Equal(metav1.ConditionFalse))
 				Expect(condition.Reason).To(Equal(vmopv1.VirtualMachineImageProviderNotReadyReason))
@@ -135,7 +135,7 @@ func unitTestsReconcile() {
 				Expect(reconciler.ReconcileNormal(clItemCtx)).To(Succeed())
 
 				vmi := getVMI(ctx, clItemCtx)
-				condition := conditions.Get(vmi, vmopv1.VirtualMachineImageProviderSecurityComplianceCondition)
+				condition := conditions.Get(vmi, vmopv1.ReadyConditionType)
 				Expect(condition).ToNot(BeNil())
 				Expect(condition.Status).To(Equal(metav1.ConditionFalse))
 				Expect(condition.Reason).To(Equal(vmopv1.VirtualMachineImageProviderSecurityNotCompliantReason))
@@ -155,7 +155,7 @@ func unitTestsReconcile() {
 				Expect(err).To(MatchError("sync-error"))
 
 				vmi := getVMI(ctx, clItemCtx)
-				condition := conditions.Get(vmi, vmopv1.VirtualMachineImageSyncedCondition)
+				condition := conditions.Get(vmi, vmopv1.ReadyConditionType)
 				Expect(condition).ToNot(BeNil())
 				Expect(condition.Status).To(Equal(metav1.ConditionFalse))
 				Expect(condition.Reason).To(Equal(vmopv1.VirtualMachineImageNotSyncedReason))
@@ -176,9 +176,6 @@ func unitTestsReconcile() {
 				}
 				Expect(readyCond).ToNot(BeNil())
 				Expect(readyCond.Status).To(Equal(corev1.ConditionTrue))
-
-				// BMV: We don't use this field - only the Condition.
-				// Expect(clItemCtx.CLItem.Status.Ready).To(BeTrue())
 
 				Expect(clItemCtx.CLItem.Status.SecurityCompliance).To(Equal(pointer.Bool(true)))
 			})
@@ -293,8 +290,6 @@ func assertVMImageFromCLItem(
 		Expect(vmi.Status.ProviderItemID).To(BeEquivalentTo(clItem.Spec.UUID))
 		Expect(vmi.Status.ProviderContentVersion).To(Equal(clItem.Status.ContentVersion))
 
-		Expect(conditions.IsTrue(vmi, vmopv1.VirtualMachineImageProviderReadyCondition)).To(BeTrue())
-		Expect(conditions.IsTrue(vmi, vmopv1.VirtualMachineImageProviderSecurityComplianceCondition)).To(BeTrue())
-		Expect(conditions.IsTrue(vmi, vmopv1.VirtualMachineImageSyncedCondition)).To(BeTrue())
+		Expect(conditions.IsTrue(vmi, vmopv1.ReadyConditionType)).To(BeTrue())
 	})
 }

--- a/pkg/conditions2/getter.go
+++ b/pkg/conditions2/getter.go
@@ -20,7 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	vmop "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 )
 
 const (
@@ -130,7 +130,7 @@ func summary(from Getter, options ...MergeOption) *metav1.Condition {
 	conditionsInScope := make([]localizedCondition, 0, len(conditions))
 	for i := range conditions {
 		c := conditions[i]
-		if c.Type == vmopv1.ReadyConditionType {
+		if c.Type == vmop.ReadyConditionType {
 			continue
 		}
 
@@ -183,7 +183,7 @@ func summary(from Getter, options ...MergeOption) *metav1.Condition {
 		}
 	}
 
-	return merge(conditionsInScope, vmopv1.ReadyConditionType, mergeOpt)
+	return merge(conditionsInScope, vmop.ReadyConditionType, mergeOpt)
 }
 
 // mirrorOptions allows to set options for the mirror operation.
@@ -214,7 +214,7 @@ func mirror(from Getter, targetCondition string, options ...MirrorOptions) *meta
 		o(mirrorOpt)
 	}
 
-	condition := Get(from, vmopv1.ReadyConditionType)
+	condition := Get(from, vmop.ReadyConditionType)
 
 	if mirrorOpt.fallbackTo != nil && condition == nil {
 		switch *mirrorOpt.fallbackTo {
@@ -238,7 +238,7 @@ func mirror(from Getter, targetCondition string, options ...MirrorOptions) *meta
 func aggregate(from []Getter, targetCondition string, options ...MergeOption) *metav1.Condition {
 	conditionsInScope := make([]localizedCondition, 0, len(from))
 	for i := range from {
-		condition := Get(from[i], vmopv1.ReadyConditionType)
+		condition := Get(from[i], vmop.ReadyConditionType)
 
 		conditionsInScope = append(conditionsInScope, localizedCondition{
 			Condition: condition,

--- a/pkg/vmprovider/providers/vsphere2/vmprovider_vm_test.go
+++ b/pkg/vmprovider/providers/vsphere2/vmprovider_vm_test.go
@@ -113,7 +113,7 @@ func vmTests() {
 				// Use the default VM created by vcsim as the source.
 				clusterVMImage = builder.DummyClusterVirtualMachineImageA2("DC0_C0_RP0_VM0")
 				Expect(ctx.Client.Create(ctx, clusterVMImage)).To(Succeed())
-				conditions.MarkTrue(clusterVMImage, vmopv1.VirtualMachineImageSyncedCondition)
+				conditions.MarkTrue(clusterVMImage, vmopv1.ReadyConditionType)
 				Expect(ctx.Client.Status().Update(ctx, clusterVMImage)).To(Succeed())
 			}
 

--- a/test/builder/vcsim_test_context.go
+++ b/test/builder/vcsim_test_context.go
@@ -510,7 +510,7 @@ func (c *TestContextForVCSim) setupContentLibrary(config VCSimTestConfig) {
 		clusterVMImage.Spec.ProviderRef.Kind = "ClusterContentLibraryItem"
 		Expect(c.Client.Create(c, clusterVMImage)).To(Succeed())
 		clusterVMImage.Status.ProviderItemID = itemID
-		conditions2.MarkTrue(clusterVMImage, v1alpha2.VirtualMachineImageSyncedCondition) // TODO: Until we get rollup Ready condition
+		conditions2.MarkTrue(clusterVMImage, v1alpha2.ReadyConditionType)
 		Expect(c.Client.Status().Update(c, clusterVMImage)).To(Succeed())
 
 	} else {
@@ -578,7 +578,7 @@ func (c *TestContextForVCSim) ContentLibraryItemTemplate(srcVMName, templateName
 		clusterVMImage.Spec.ProviderRef.Kind = "ClusterContentLibraryItem"
 		Expect(c.Client.Create(c, clusterVMImage)).To(Succeed())
 		clusterVMImage.Status.ProviderItemID = itemID
-		conditions2.MarkTrue(clusterVMImage, v1alpha2.VirtualMachineImageSyncedCondition) // TODO: Until we get rollup Ready condition
+		conditions2.MarkTrue(clusterVMImage, v1alpha2.ReadyConditionType)
 		Expect(c.Client.Status().Update(c, clusterVMImage)).To(Succeed())
 	} else {
 		vmImage := DummyVirtualMachineImage(templateName)


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This patch introduces 2 different approaches to add a Ready condition to the ClusterVirtualMachineImage and VirtualMachineImage CRs. 

For ClusterVirtualMachineImage, we have added the Ready condition in addition the existing conditions, and calculated the Ready condition as a summary of the existing conditions on the CVMI.
For VirtualMachineImage, we have removed the existing conditions and used the appropriate reason when setting the Ready condition on the VMI.


**Which issue(s) is/are addressed by this PR?** *(optional)*:
Fixes n/a


**Are there any special notes for your reviewer**:
Following tests have been done:
- Existing CVMI resource's Status with previous condition types are replaced with the `Ready` condition **only**.
- Existing VMI resource's Status with previous condition types are replaced with the `Ready` condition **only**.
- New CVMI resource's Status has the Ready condition **only** with the appropriate reason.
- New VMI resource's Status has the Ready condition **only** with the appropriate reason.

**Please add a release note if necessary**:
```release-note
🌱 Adds a Ready condition to CVMI and VMI resources
```