### PR TITLE
:sparkles: Add validations for Networkspec with its supported Bootstrap and unit tests

### DIFF
--- a/pkg/vmprovider/providers/vsphere2/vmlifecycle/bootstrap.go
+++ b/pkg/vmprovider/providers/vsphere2/vmlifecycle/bootstrap.go
@@ -55,7 +55,7 @@ func DoBootstrap(
 	bootstrap := &vmCtx.VM.Spec.Bootstrap
 	cloudInit := bootstrap.CloudInit
 	linuxPrep := bootstrap.LinuxPrep
-	sysPrep := bootstrap.Sysprep
+	sysprep := bootstrap.Sysprep
 	vAppConfig := bootstrap.VAppConfig
 
 	bootstrapArgs, err := getBootstrapArgs(vmCtx, k8sClient, cloudInit != nil, networkResults, bootstrapData)
@@ -63,7 +63,7 @@ func DoBootstrap(
 		return err
 	}
 
-	if sysPrep != nil || vAppConfig != nil {
+	if sysprep != nil || vAppConfig != nil {
 		bootstrapArgs.TemplateRenderFn = GetTemplateRenderFunc(vmCtx, bootstrapArgs)
 	}
 
@@ -75,8 +75,8 @@ func DoBootstrap(
 		configSpec, customSpec, err = BootStrapCloudInit(vmCtx, config, cloudInit, bootstrapArgs)
 	case linuxPrep != nil:
 		configSpec, customSpec, err = BootStrapLinuxPrep(vmCtx, config, linuxPrep, vAppConfig, bootstrapArgs)
-	case sysPrep != nil:
-		configSpec, customSpec, err = BootstrapSysPrep(vmCtx, config, sysPrep, vAppConfig, bootstrapArgs)
+	case sysprep != nil:
+		configSpec, customSpec, err = BootstrapSysPrep(vmCtx, config, sysprep, vAppConfig, bootstrapArgs)
 	case vAppConfig != nil:
 		configSpec, customSpec, err = BootstrapVAppConfig(vmCtx, config, vAppConfig, bootstrapArgs)
 	default:

--- a/pkg/vmprovider/providers/vsphere2/vmprovider_vm_utils.go
+++ b/pkg/vmprovider/providers/vsphere2/vmprovider_vm_utils.go
@@ -153,8 +153,8 @@ func GetVirtualMachineBootstrap(
 
 	if cloudInit := bootstrapSpec.CloudInit; cloudInit != nil {
 		secretName = cloudInit.RawCloudConfig.Name
-	} else if sysPrep := bootstrapSpec.Sysprep; sysPrep != nil {
-		secretName = sysPrep.RawSysprep.Name
+	} else if sysprep := bootstrapSpec.Sysprep; sysprep != nil {
+		secretName = sysprep.RawSysprep.Name
 	}
 
 	if secretName != "" {


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This PR adds validation on Network Spec with its supported Bootstrap types (according to eg, https://github.com/vmware-tanzu/vm-operator/blob/main/api/v1alpha2/virtualmachine_network_types.go#L125) and unit tests.
This PR also reformats Bootstrap validation unit tests to be more verbose and easier to understand.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # N/A


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

```release-note
Adds validation on Network Spec with its supported Bootstrap types
```