### PR TITLE
🌱 Move VM backup/restore related constants to API module

### DIFF
--- a/api/v1alpha1/virtualmachine_types.go
+++ b/api/v1alpha1/virtualmachine_types.go
@@ -112,6 +112,28 @@ const (
 	FirstBootDoneAnnotation = "virtualmachine." + GroupName + "/first-boot-done"
 )
 
+// VirtualMachine backup/restore related constants.
+const (
+	// ManagedByExtensionKey and ManagedByExtensionType represent the ManagedBy
+	// field on the VM. They are used to differentiate VM Service managed VMs
+	// from traditional vSphere VMs.
+	ManagedByExtensionKey  = "com.vmware.vcenter.wcp"
+	ManagedByExtensionType = "VirtualMachine"
+
+	// VMBackupKubeDataExtraConfigKey is the ExtraConfig key to persist the VM's
+	// Kubernetes resource spec data, compressed using gzip and base64-encoded.
+	VMBackupKubeDataExtraConfigKey = "vmservice.virtualmachine.kubedata"
+	// VMBackupBootstrapDataExtraConfigKey is the ExtraConfig key to persist the
+	// VM's bootstrap data object, compressed using gzip and base64-encoded.
+	VMBackupBootstrapDataExtraConfigKey = "vmservice.virtualmachine.bootstrapdata"
+	// VMBackupDiskDataExtraConfigKey is the ExtraConfig key to persist the VM's
+	// attached disk info in JSON, compressed using gzip and base64-encoded.
+	VMBackupDiskDataExtraConfigKey = "vmservice.virtualmachine.diskdata"
+	// VMBackupCloudInitInstanceIDExtraConfigKey is the ExtraConfig key to persist
+	// the VM's Cloud-Init instance ID, compressed using gzip and base64-encoded.
+	VMBackupCloudInitInstanceIDExtraConfigKey = "vmservice.virtualmachine.cloudinit.instanceid"
+)
+
 // VirtualMachinePort is unused and can be considered deprecated.
 type VirtualMachinePort struct {
 	Port     int             `json:"port"`

--- a/api/v1alpha2/virtualmachine_types.go
+++ b/api/v1alpha2/virtualmachine_types.go
@@ -109,6 +109,28 @@ const (
 	FirstBootDoneAnnotation = "virtualmachine." + GroupName + "/first-boot-done"
 )
 
+// VirtualMachine backup/restore related constants.
+const (
+	// ManagedByExtensionKey and ManagedByExtensionType represent the ManagedBy
+	// field on the VM. They are used to differentiate VM Service managed VMs
+	// from traditional vSphere VMs.
+	ManagedByExtensionKey  = "com.vmware.vcenter.wcp"
+	ManagedByExtensionType = "VirtualMachine"
+
+	// VMBackupKubeDataExtraConfigKey is the ExtraConfig key to persist the VM's
+	// Kubernetes resource spec data, compressed using gzip and base64-encoded.
+	VMBackupKubeDataExtraConfigKey = "vmservice.virtualmachine.kubedata"
+	// VMBackupBootstrapDataExtraConfigKey is the ExtraConfig key to persist the
+	// VM's bootstrap data object, compressed using gzip and base64-encoded.
+	VMBackupBootstrapDataExtraConfigKey = "vmservice.virtualmachine.bootstrapdata"
+	// VMBackupDiskDataExtraConfigKey is the ExtraConfig key to persist the VM's
+	// attached disk info in JSON, compressed using gzip and base64-encoded.
+	VMBackupDiskDataExtraConfigKey = "vmservice.virtualmachine.diskdata"
+	// VMBackupCloudInitInstanceIDExtraConfigKey is the ExtraConfig key to persist
+	// the VM's Cloud-Init instance ID, compressed using gzip and base64-encoded.
+	VMBackupCloudInitInstanceIDExtraConfigKey = "vmservice.virtualmachine.cloudinit.instanceid"
+)
+
 // VirtualMachinePowerState defines a VM's desired and observed power states.
 // +kubebuilder:validation:Enum=PoweredOff;PoweredOn;Suspended
 type VirtualMachinePowerState string

--- a/pkg/vmprovider/providers/vsphere/constants/constants.go
+++ b/pkg/vmprovider/providers/vsphere/constants/constants.go
@@ -16,11 +16,6 @@ const (
 	// VCVMAnnotation Annotation placed on the VM.
 	VCVMAnnotation = "Virtual Machine managed by the vSphere Virtual Machine service"
 
-	// ManagedByExtensionKey and ManagedByExtensionType represent the ManagedBy field on the VM.
-	// Historically, this field was used to differentiate VM Service managed VMs from traditional ones.
-	ManagedByExtensionKey  = "com.vmware.vcenter.wcp"
-	ManagedByExtensionType = "VirtualMachine"
-
 	// VSphereCustomizationBypassKey Annotation to skip applying VMware Tools Guest Customization.
 	VSphereCustomizationBypassKey     = pkg.VMOperatorKey + "/vsphere-customization"
 	VSphereCustomizationBypassDisable = "disable"
@@ -118,17 +113,4 @@ const (
 	V1alpha1SubnetMask = "V1alpha1_SubnetMask"
 	// V1alpha1FormatNameservers is an alias for versioned templating function V1alpha1_FormatNameservers.
 	V1alpha1FormatNameservers = "V1alpha1_FormatNameservers"
-
-	// BackupVMKubeDataExtraConfigKey is the ExtraConfig key to the VirtualMachine
-	// resource's Kubernetes spec data, compressed using gzip and base64-encoded.
-	BackupVMKubeDataExtraConfigKey = "vmservice.virtualmachine.kubedata"
-	// BackupVMBootstrapDataExtraConfigKey is the ExtraConfig key to the VM's
-	// bootstrap data object, compressed using gzip and base64-encoded.
-	BackupVMBootstrapDataExtraConfigKey = "vmservice.virtualmachine.bootstrapdata"
-	// BackupVMDiskDataExtraConfigKey is the ExtraConfig key to the VM's disk info
-	// data in JSON, compressed using gzip and base64-encoded.
-	BackupVMDiskDataExtraConfigKey = "vmservice.virtualmachine.diskdata"
-	// BackupVMCloudInitInstanceIDExtraConfigKey is the ExtraConfig key to the VM's
-	// Cloud-Init instance ID, compressed using gzip and base64-encoded.
-	BackupVMCloudInitInstanceIDExtraConfigKey = "vmservice.virtualmachine.cloudinit.instanceid"
 )

--- a/pkg/vmprovider/providers/vsphere/session/session_vm_update.go
+++ b/pkg/vmprovider/providers/vsphere/session/session_vm_update.go
@@ -422,8 +422,8 @@ func UpdateConfigSpecManagedBy(
 	configSpec *vimTypes.VirtualMachineConfigSpec) {
 	if config.ManagedBy == nil {
 		configSpec.ManagedBy = &vimTypes.ManagedByInfo{
-			ExtensionKey: constants.ManagedByExtensionKey,
-			Type:         constants.ManagedByExtensionType,
+			ExtensionKey: vmopv1.ManagedByExtensionKey,
+			Type:         vmopv1.ManagedByExtensionType,
 		}
 	}
 }

--- a/pkg/vmprovider/providers/vsphere/virtualmachine/backup.go
+++ b/pkg/vmprovider/providers/vsphere/virtualmachine/backup.go
@@ -15,7 +15,6 @@ import (
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/util"
-	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/constants"
 )
 
 type VMDiskData struct {
@@ -53,7 +52,7 @@ func BackupVirtualMachine(ctx context.BackupVirtualMachineContext) error {
 		ctx.VMCtx.Logger.V(4).Info("Skipping VM kube data backup as unchanged")
 	} else {
 		ecToUpdate = append(ecToUpdate, &types.OptionValue{
-			Key:   constants.BackupVMKubeDataExtraConfigKey,
+			Key:   vmopv1.VMBackupKubeDataExtraConfigKey,
 			Value: vmKubeDataBackup,
 		})
 	}
@@ -68,7 +67,7 @@ func BackupVirtualMachine(ctx context.BackupVirtualMachineContext) error {
 		ctx.VMCtx.Logger.V(4).Info("Skipping cloud-init instance ID as already stored")
 	} else {
 		ecToUpdate = append(ecToUpdate, &types.OptionValue{
-			Key:   constants.BackupVMCloudInitInstanceIDExtraConfigKey,
+			Key:   vmopv1.VMBackupCloudInitInstanceIDExtraConfigKey,
 			Value: instanceIDBackup,
 		})
 	}
@@ -83,7 +82,7 @@ func BackupVirtualMachine(ctx context.BackupVirtualMachineContext) error {
 		ctx.VMCtx.Logger.V(4).Info("Skipping VM bootstrap data backup as unchanged")
 	} else {
 		ecToUpdate = append(ecToUpdate, &types.OptionValue{
-			Key:   constants.BackupVMBootstrapDataExtraConfigKey,
+			Key:   vmopv1.VMBackupBootstrapDataExtraConfigKey,
 			Value: bootstrapDataBackup,
 		})
 	}
@@ -98,7 +97,7 @@ func BackupVirtualMachine(ctx context.BackupVirtualMachineContext) error {
 		ctx.VMCtx.Logger.V(4).Info("Skipping VM disk data backup as unchanged")
 	} else {
 		ecToUpdate = append(ecToUpdate, &types.OptionValue{
-			Key:   constants.BackupVMDiskDataExtraConfigKey,
+			Key:   vmopv1.VMBackupDiskDataExtraConfigKey,
 			Value: diskDataBackup,
 		})
 	}
@@ -122,7 +121,7 @@ func getDesiredVMKubeDataForBackup(
 	ecMap map[string]string) (string, error) {
 	// If the ExtraConfig already contains the latest VM spec, determined by
 	// 'metadata.generation', return an empty string to skip the backup.
-	if ecKubeData, ok := ecMap[constants.BackupVMKubeDataExtraConfigKey]; ok {
+	if ecKubeData, ok := ecMap[vmopv1.VMBackupKubeDataExtraConfigKey]; ok {
 		vmFromBackup, err := constructVMObj(ecKubeData)
 		if err != nil {
 			return "", err
@@ -158,7 +157,7 @@ func getDesiredCloudInitInstanceIDForBackup(
 	ecMap map[string]string) (string, error) {
 	// Cloud-Init instance ID should not be changed once persisted in VM's
 	// ExtraConfig. Return an empty string to skip the backup if it exists.
-	if _, ok := ecMap[constants.BackupVMCloudInitInstanceIDExtraConfigKey]; ok {
+	if _, ok := ecMap[vmopv1.VMBackupCloudInitInstanceIDExtraConfigKey]; ok {
 		return "", nil
 	}
 
@@ -188,7 +187,7 @@ func getDesiredBootstrapDataForBackup(
 	}
 
 	// Return an empty string to skip the backup if the data is unchanged.
-	if bootstrapDataBackup == ecMap[constants.BackupVMBootstrapDataExtraConfigKey] {
+	if bootstrapDataBackup == ecMap[vmopv1.VMBackupBootstrapDataExtraConfigKey] {
 		return "", nil
 	}
 
@@ -233,7 +232,7 @@ func getDesiredDiskDataForBackup(
 	}
 
 	// Return an empty string to skip the backup if the data is unchanged.
-	if diskDataBackup == ecMap[constants.BackupVMDiskDataExtraConfigKey] {
+	if diskDataBackup == ecMap[vmopv1.VMBackupDiskDataExtraConfigKey] {
 		return "", nil
 	}
 

--- a/pkg/vmprovider/providers/vsphere/virtualmachine/backup_test.go
+++ b/pkg/vmprovider/providers/vsphere/virtualmachine/backup_test.go
@@ -18,7 +18,6 @@ import (
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/util"
-	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/constants"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/virtualmachine"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
@@ -75,7 +74,7 @@ func backupTests() {
 				_, err = vcVM.Reconfigure(vmCtx, types.VirtualMachineConfigSpec{
 					ExtraConfig: []types.BaseOptionValue{
 						&types.OptionValue{
-							Key:   constants.BackupVMKubeDataExtraConfigKey,
+							Key:   vmopv1.VMBackupKubeDataExtraConfigKey,
 							Value: backupVMYamlEncoded,
 						},
 					},
@@ -97,7 +96,7 @@ func backupTests() {
 				vmCopy.Status = vmopv1.VirtualMachineStatus{}
 				vmCopyYaml, err := yaml.Marshal(vmCopy)
 				Expect(err).NotTo(HaveOccurred())
-				verifyBackupDataInExtraConfig(ctx, vcVM, constants.BackupVMKubeDataExtraConfigKey, string(vmCopyYaml))
+				verifyBackupDataInExtraConfig(ctx, vcVM, vmopv1.VMBackupKubeDataExtraConfigKey, string(vmCopyYaml))
 			})
 		})
 
@@ -116,7 +115,7 @@ func backupTests() {
 				_, err = vcVM.Reconfigure(vmCtx, types.VirtualMachineConfigSpec{
 					ExtraConfig: []types.BaseOptionValue{
 						&types.OptionValue{
-							Key:   constants.BackupVMKubeDataExtraConfigKey,
+							Key:   vmopv1.VMBackupKubeDataExtraConfigKey,
 							Value: encodedKubeDataBackup,
 						},
 					},
@@ -134,7 +133,7 @@ func backupTests() {
 					DiskUUIDToPVC: nil,
 				}
 				Expect(virtualmachine.BackupVirtualMachine(backupVMCtx)).To(Succeed())
-				verifyBackupDataInExtraConfig(ctx, vcVM, constants.BackupVMKubeDataExtraConfigKey, kubeDataBackup)
+				verifyBackupDataInExtraConfig(ctx, vcVM, vmopv1.VMBackupKubeDataExtraConfigKey, kubeDataBackup)
 			})
 		})
 	})
@@ -153,7 +152,7 @@ func backupTests() {
 
 			bootstrapDataJSON, err := json.Marshal(bootstrapDataRaw)
 			Expect(err).NotTo(HaveOccurred())
-			verifyBackupDataInExtraConfig(ctx, vcVM, constants.BackupVMBootstrapDataExtraConfigKey, string(bootstrapDataJSON))
+			verifyBackupDataInExtraConfig(ctx, vcVM, vmopv1.VMBackupBootstrapDataExtraConfigKey, string(bootstrapDataJSON))
 		})
 	})
 
@@ -169,7 +168,7 @@ func backupTests() {
 					DiskUUIDToPVC: nil,
 				}
 				Expect(virtualmachine.BackupVirtualMachine(backupVMCtx)).To(Succeed())
-				verifyBackupDataInExtraConfig(ctx, vcVM, constants.BackupVMDiskDataExtraConfigKey, "")
+				verifyBackupDataInExtraConfig(ctx, vcVM, vmopv1.VMBackupDiskDataExtraConfigKey, "")
 			})
 		})
 
@@ -198,7 +197,7 @@ func backupTests() {
 				}
 				diskDataJSON, err := json.Marshal(diskData)
 				Expect(err).NotTo(HaveOccurred())
-				verifyBackupDataInExtraConfig(ctx, vcVM, constants.BackupVMDiskDataExtraConfigKey, string(diskDataJSON))
+				verifyBackupDataInExtraConfig(ctx, vcVM, vmopv1.VMBackupDiskDataExtraConfigKey, string(diskDataJSON))
 			})
 		})
 	})
@@ -215,7 +214,7 @@ func backupTests() {
 				_, err := vcVM.Reconfigure(vmCtx, types.VirtualMachineConfigSpec{
 					ExtraConfig: []types.BaseOptionValue{
 						&types.OptionValue{
-							Key:   constants.BackupVMCloudInitInstanceIDExtraConfigKey,
+							Key:   vmopv1.VMBackupCloudInitInstanceIDExtraConfigKey,
 							Value: "ec-instance-id",
 						},
 					},
@@ -234,7 +233,7 @@ func backupTests() {
 					DiskUUIDToPVC: nil,
 				}
 				Expect(virtualmachine.BackupVirtualMachine(backupVMCtx)).To(Succeed())
-				verifyBackupDataInExtraConfig(ctx, vcVM, constants.BackupVMCloudInitInstanceIDExtraConfigKey, "ec-instance-id")
+				verifyBackupDataInExtraConfig(ctx, vcVM, vmopv1.VMBackupCloudInitInstanceIDExtraConfigKey, "ec-instance-id")
 			})
 		})
 
@@ -255,7 +254,7 @@ func backupTests() {
 					DiskUUIDToPVC: nil,
 				}
 				Expect(virtualmachine.BackupVirtualMachine(backupVMCtx)).To(Succeed())
-				verifyBackupDataInExtraConfig(ctx, vcVM, constants.BackupVMCloudInitInstanceIDExtraConfigKey, "annotation-instance-id")
+				verifyBackupDataInExtraConfig(ctx, vcVM, vmopv1.VMBackupCloudInitInstanceIDExtraConfigKey, "annotation-instance-id")
 			})
 		})
 

--- a/pkg/vmprovider/providers/vsphere/virtualmachine/configspec.go
+++ b/pkg/vmprovider/providers/vsphere/virtualmachine/configspec.go
@@ -41,8 +41,8 @@ func CreateConfigSpec(
 	configSpec.MemoryMB = MemoryQuantityToMb(vmClassSpec.Hardware.Memory)
 
 	configSpec.ManagedBy = &vimtypes.ManagedByInfo{
-		ExtensionKey: constants.ManagedByExtensionKey,
-		Type:         constants.ManagedByExtensionType,
+		ExtensionKey: vmopv1.ManagedByExtensionKey,
+		Type:         vmopv1.ManagedByExtensionType,
 	}
 
 	// Populate the CPU reservation and limits in the ConfigSpec if VAPI fields specify any.

--- a/pkg/vmprovider/providers/vsphere2/constants/constants.go
+++ b/pkg/vmprovider/providers/vsphere2/constants/constants.go
@@ -16,11 +16,6 @@ const (
 	// VCVMAnnotation Annotation placed on the VM.
 	VCVMAnnotation = "Virtual Machine managed by the vSphere Virtual Machine service"
 
-	// ManagedByExtensionKey and ManagedByExtensionType represent the ManagedBy field on the VM.
-	// Historically, this field was used to differentiate VM Service managed VMs from traditional ones.
-	ManagedByExtensionKey  = "com.vmware.vcenter.wcp"
-	ManagedByExtensionType = "VirtualMachine"
-
 	// VSphereCustomizationBypassKey Annotation to skip applying VMware Tools Guest Customization.
 	VSphereCustomizationBypassKey     = pkg.VMOperatorKey + "/vsphere-customization"
 	VSphereCustomizationBypassDisable = "disable"
@@ -134,17 +129,4 @@ const (
 	V1alpha2SubnetMask = "V1alpha2_SubnetMask"
 	// V1alpha2FormatNameservers is an alias for versioned templating function V1alpha2_FormatNameservers.
 	V1alpha2FormatNameservers = "V1alpha2_FormatNameservers"
-
-	// BackupVMKubeDataExtraConfigKey is the ExtraConfig key to the VirtualMachine
-	// resource's Kubernetes spec data, compressed using gzip and base64-encoded.
-	BackupVMKubeDataExtraConfigKey = "vmservice.virtualmachine.kubedata"
-	// BackupVMBootstrapDataExtraConfigKey is the ExtraConfig key to the VM's
-	// bootstrap data object, compressed using gzip and base64-encoded.
-	BackupVMBootstrapDataExtraConfigKey = "vmservice.virtualmachine.bootstrapdata"
-	// BackupVMDiskDataExtraConfigKey is the ExtraConfig key to the VM's disk info
-	// data in JSON, compressed using gzip and base64-encoded.
-	BackupVMDiskDataExtraConfigKey = "vmservice.virtualmachine.diskdata"
-	// BackupVMCloudInitInstanceIDExtraConfigKey is the ExtraConfig key to the VM's
-	// Cloud-Init instance ID, compressed using gzip and base64-encoded.
-	BackupVMCloudInitInstanceIDExtraConfigKey = "vmservice.virtualmachine.cloudinit.instanceid"
 )

--- a/pkg/vmprovider/providers/vsphere2/session/session_vm_update.go
+++ b/pkg/vmprovider/providers/vsphere2/session/session_vm_update.go
@@ -417,8 +417,8 @@ func UpdateConfigSpecManagedBy(
 	configSpec *vimTypes.VirtualMachineConfigSpec) {
 	if config.ManagedBy == nil {
 		configSpec.ManagedBy = &vimTypes.ManagedByInfo{
-			ExtensionKey: constants.ManagedByExtensionKey,
-			Type:         constants.ManagedByExtensionType,
+			ExtensionKey: vmopv1.ManagedByExtensionKey,
+			Type:         vmopv1.ManagedByExtensionType,
 		}
 	}
 }

--- a/pkg/vmprovider/providers/vsphere2/virtualmachine/backup.go
+++ b/pkg/vmprovider/providers/vsphere2/virtualmachine/backup.go
@@ -15,7 +15,6 @@ import (
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/util"
-	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere2/constants"
 )
 
 type VMDiskData struct {
@@ -53,7 +52,7 @@ func BackupVirtualMachine(ctx context.BackupVirtualMachineContextA2) error {
 		ctx.VMCtx.Logger.V(4).Info("Skipping VM kube data backup as unchanged")
 	} else {
 		ecToUpdate = append(ecToUpdate, &types.OptionValue{
-			Key:   constants.BackupVMKubeDataExtraConfigKey,
+			Key:   vmopv1.VMBackupKubeDataExtraConfigKey,
 			Value: vmKubeDataBackup,
 		})
 	}
@@ -68,7 +67,7 @@ func BackupVirtualMachine(ctx context.BackupVirtualMachineContextA2) error {
 		ctx.VMCtx.Logger.V(4).Info("Skipping cloud-init instance ID as already stored")
 	} else {
 		ecToUpdate = append(ecToUpdate, &types.OptionValue{
-			Key:   constants.BackupVMCloudInitInstanceIDExtraConfigKey,
+			Key:   vmopv1.VMBackupCloudInitInstanceIDExtraConfigKey,
 			Value: instanceIDBackup,
 		})
 	}
@@ -83,7 +82,7 @@ func BackupVirtualMachine(ctx context.BackupVirtualMachineContextA2) error {
 		ctx.VMCtx.Logger.V(4).Info("Skipping VM bootstrap data backup as unchanged")
 	} else {
 		ecToUpdate = append(ecToUpdate, &types.OptionValue{
-			Key:   constants.BackupVMBootstrapDataExtraConfigKey,
+			Key:   vmopv1.VMBackupBootstrapDataExtraConfigKey,
 			Value: bootstrapDataBackup,
 		})
 	}
@@ -98,7 +97,7 @@ func BackupVirtualMachine(ctx context.BackupVirtualMachineContextA2) error {
 		ctx.VMCtx.Logger.V(4).Info("Skipping VM disk data backup as unchanged")
 	} else {
 		ecToUpdate = append(ecToUpdate, &types.OptionValue{
-			Key:   constants.BackupVMDiskDataExtraConfigKey,
+			Key:   vmopv1.VMBackupDiskDataExtraConfigKey,
 			Value: diskDataBackup,
 		})
 	}
@@ -122,7 +121,7 @@ func getDesiredVMKubeDataForBackup(
 	ecMap map[string]string) (string, error) {
 	// If the ExtraConfig already contains the latest VM spec, determined by
 	// 'metadata.generation', return an empty string to skip the backup.
-	if ecKubeData, ok := ecMap[constants.BackupVMKubeDataExtraConfigKey]; ok {
+	if ecKubeData, ok := ecMap[vmopv1.VMBackupKubeDataExtraConfigKey]; ok {
 		vmFromBackup, err := constructVMObj(ecKubeData)
 		if err != nil {
 			return "", err
@@ -158,7 +157,7 @@ func getDesiredCloudInitInstanceIDForBackup(
 	ecMap map[string]string) (string, error) {
 	// Cloud-Init instance ID should not be changed once persisted in VM's
 	// ExtraConfig. Return an empty string to skip the backup if it exists.
-	if _, ok := ecMap[constants.BackupVMCloudInitInstanceIDExtraConfigKey]; ok {
+	if _, ok := ecMap[vmopv1.VMBackupCloudInitInstanceIDExtraConfigKey]; ok {
 		return "", nil
 	}
 
@@ -188,7 +187,7 @@ func getDesiredBootstrapDataForBackup(
 	}
 
 	// Return an empty string to skip the backup if the data is unchanged.
-	if bootstrapDataBackup == ecMap[constants.BackupVMBootstrapDataExtraConfigKey] {
+	if bootstrapDataBackup == ecMap[vmopv1.VMBackupBootstrapDataExtraConfigKey] {
 		return "", nil
 	}
 
@@ -233,7 +232,7 @@ func getDesiredDiskDataForBackup(
 	}
 
 	// Return an empty string to skip the backup if the data is unchanged.
-	if diskDataBackup == ecMap[constants.BackupVMDiskDataExtraConfigKey] {
+	if diskDataBackup == ecMap[vmopv1.VMBackupDiskDataExtraConfigKey] {
 		return "", nil
 	}
 

--- a/pkg/vmprovider/providers/vsphere2/virtualmachine/backup_test.go
+++ b/pkg/vmprovider/providers/vsphere2/virtualmachine/backup_test.go
@@ -18,7 +18,6 @@ import (
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/util"
-	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere2/constants"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere2/virtualmachine"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
@@ -75,7 +74,7 @@ func backupTests() {
 				_, err = vcVM.Reconfigure(vmCtx, types.VirtualMachineConfigSpec{
 					ExtraConfig: []types.BaseOptionValue{
 						&types.OptionValue{
-							Key:   constants.BackupVMKubeDataExtraConfigKey,
+							Key:   vmopv1.VMBackupKubeDataExtraConfigKey,
 							Value: backupVMYamlEncoded,
 						},
 					},
@@ -97,7 +96,7 @@ func backupTests() {
 				vmCopy.Status = vmopv1.VirtualMachineStatus{}
 				vmCopyYaml, err := yaml.Marshal(vmCopy)
 				Expect(err).NotTo(HaveOccurred())
-				verifyBackupDataInExtraConfig(ctx, vcVM, constants.BackupVMKubeDataExtraConfigKey, string(vmCopyYaml))
+				verifyBackupDataInExtraConfig(ctx, vcVM, vmopv1.VMBackupKubeDataExtraConfigKey, string(vmCopyYaml))
 			})
 		})
 
@@ -116,7 +115,7 @@ func backupTests() {
 				_, err = vcVM.Reconfigure(vmCtx, types.VirtualMachineConfigSpec{
 					ExtraConfig: []types.BaseOptionValue{
 						&types.OptionValue{
-							Key:   constants.BackupVMKubeDataExtraConfigKey,
+							Key:   vmopv1.VMBackupKubeDataExtraConfigKey,
 							Value: encodedKubeDataBackup,
 						},
 					},
@@ -134,7 +133,7 @@ func backupTests() {
 					DiskUUIDToPVC: nil,
 				}
 				Expect(virtualmachine.BackupVirtualMachine(backupVMCtx)).To(Succeed())
-				verifyBackupDataInExtraConfig(ctx, vcVM, constants.BackupVMKubeDataExtraConfigKey, kubeDataBackup)
+				verifyBackupDataInExtraConfig(ctx, vcVM, vmopv1.VMBackupKubeDataExtraConfigKey, kubeDataBackup)
 			})
 		})
 	})
@@ -153,7 +152,7 @@ func backupTests() {
 
 			bootstrapDataJSON, err := json.Marshal(bootstrapDataRaw)
 			Expect(err).NotTo(HaveOccurred())
-			verifyBackupDataInExtraConfig(ctx, vcVM, constants.BackupVMBootstrapDataExtraConfigKey, string(bootstrapDataJSON))
+			verifyBackupDataInExtraConfig(ctx, vcVM, vmopv1.VMBackupBootstrapDataExtraConfigKey, string(bootstrapDataJSON))
 		})
 	})
 
@@ -169,7 +168,7 @@ func backupTests() {
 					DiskUUIDToPVC: nil,
 				}
 				Expect(virtualmachine.BackupVirtualMachine(backupVMCtx)).To(Succeed())
-				verifyBackupDataInExtraConfig(ctx, vcVM, constants.BackupVMDiskDataExtraConfigKey, "")
+				verifyBackupDataInExtraConfig(ctx, vcVM, vmopv1.VMBackupDiskDataExtraConfigKey, "")
 			})
 		})
 
@@ -198,7 +197,7 @@ func backupTests() {
 				}
 				diskDataJSON, err := json.Marshal(diskData)
 				Expect(err).NotTo(HaveOccurred())
-				verifyBackupDataInExtraConfig(ctx, vcVM, constants.BackupVMDiskDataExtraConfigKey, string(diskDataJSON))
+				verifyBackupDataInExtraConfig(ctx, vcVM, vmopv1.VMBackupDiskDataExtraConfigKey, string(diskDataJSON))
 			})
 		})
 	})
@@ -215,7 +214,7 @@ func backupTests() {
 				_, err := vcVM.Reconfigure(vmCtx, types.VirtualMachineConfigSpec{
 					ExtraConfig: []types.BaseOptionValue{
 						&types.OptionValue{
-							Key:   constants.BackupVMCloudInitInstanceIDExtraConfigKey,
+							Key:   vmopv1.VMBackupCloudInitInstanceIDExtraConfigKey,
 							Value: "ec-instance-id",
 						},
 					},
@@ -234,7 +233,7 @@ func backupTests() {
 					DiskUUIDToPVC: nil,
 				}
 				Expect(virtualmachine.BackupVirtualMachine(backupVMCtx)).To(Succeed())
-				verifyBackupDataInExtraConfig(ctx, vcVM, constants.BackupVMCloudInitInstanceIDExtraConfigKey, "ec-instance-id")
+				verifyBackupDataInExtraConfig(ctx, vcVM, vmopv1.VMBackupCloudInitInstanceIDExtraConfigKey, "ec-instance-id")
 			})
 		})
 
@@ -255,7 +254,7 @@ func backupTests() {
 					DiskUUIDToPVC: nil,
 				}
 				Expect(virtualmachine.BackupVirtualMachine(backupVMCtx)).To(Succeed())
-				verifyBackupDataInExtraConfig(ctx, vcVM, constants.BackupVMCloudInitInstanceIDExtraConfigKey, "annotation-instance-id")
+				verifyBackupDataInExtraConfig(ctx, vcVM, vmopv1.VMBackupCloudInitInstanceIDExtraConfigKey, "annotation-instance-id")
 			})
 		})
 

--- a/pkg/vmprovider/providers/vsphere2/virtualmachine/configspec.go
+++ b/pkg/vmprovider/providers/vsphere2/virtualmachine/configspec.go
@@ -43,8 +43,8 @@ func CreateConfigSpec(
 	configSpec.NumCPUs = int32(vmClassSpec.Hardware.Cpus)
 	configSpec.MemoryMB = MemoryQuantityToMb(vmClassSpec.Hardware.Memory)
 	configSpec.ManagedBy = &types.ManagedByInfo{
-		ExtensionKey: constants.ManagedByExtensionKey,
-		Type:         constants.ManagedByExtensionType,
+		ExtensionKey: vmopv1.ManagedByExtensionKey,
+		Type:         vmopv1.ManagedByExtensionType,
 	}
 
 	if val, ok := vmCtx.VM.Annotations[constants.FirmwareOverrideAnnotation]; ok && (val == "efi" || val == "bios") {


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This PR moves the constants used for VM backup/restore into the API module to enforce a contract. These constants are utilized when registering a VM Service VM as part of the VM restore process.

**Are there any special notes for your reviewer**:
The WCP service codebase will be updated to use these constants imported from the vm-operator/api module once this change is applied.

**Please add a release note if necessary**:

```release-note
Move VM backup/restore related constants to the API module to enforce a contract.
```
