### PR TITLE
🐛 Revert "Mark v1a2 VirtualMachineClass as namespace scoped"

### DIFF
--- a/api/v1alpha2/virtualmachineclass_types.go
+++ b/api/v1alpha2/virtualmachineclass_types.go
@@ -244,7 +244,7 @@ type VirtualMachineClassStatus struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Namespaced,shortName=vmclass
+// +kubebuilder:resource:scope=Cluster,shortName=vmclass
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="CPU",type="string",JSONPath=".spec.hardware.cpus"


### PR DESCRIPTION
This reverts commit 25b6933d95656b4178f23a5a7c4229c0cf99573b.

While apparently very biased towards v1a1, the controller-gen manifest output is not deterministic. Since this change was just for informational purposes - the Scope field is fixed up later - revert this change.

```release-note
NONE
```