### PR TITLE
🐛 Add missing omitempty on CloudConfig User Passwd field

### DIFF
--- a/api/v1alpha2/cloudinit/cloudconfig.go
+++ b/api/v1alpha2/cloudinit/cloudconfig.go
@@ -130,7 +130,7 @@ type User struct {
 	// please use HashedPasswd instead.
 	//
 	// +optional
-	Passwd *corev1.SecretKeySelector `json:"passwd"`
+	Passwd *corev1.SecretKeySelector `json:"passwd,omitempty"`
 
 	// PrimaryGroup is the primary group for the user.
 	//


### PR DESCRIPTION
This was just accidentally omitted and required for proper serialization.

```release-note
NONE
```