### PR TITLE
🌱 Removing duplicate  error logger in VM controller

### DIFF
--- a/controllers/virtualmachine/v1alpha1/virtualmachine_controller.go
+++ b/controllers/virtualmachine/v1alpha1/virtualmachine_controller.go
@@ -462,7 +462,6 @@ func (r *Reconciler) ReconcileNormal(ctx *context.VirtualMachineContext) (reterr
 	}()
 
 	if err := r.VMProvider.CreateOrUpdateVirtualMachine(ctx, ctx.VM); err != nil {
-		ctx.Logger.Error(err, "Failed to reconcile VirtualMachine")
 		r.Recorder.EmitEvent(ctx.VM, "CreateOrUpdate", err, false)
 		return err
 	}

--- a/controllers/virtualmachine/v1alpha2/virtualmachine_controller.go
+++ b/controllers/virtualmachine/v1alpha2/virtualmachine_controller.go
@@ -328,7 +328,6 @@ func (r *Reconciler) ReconcileNormal(ctx *context.VirtualMachineContextA2) (rete
 	}()
 
 	if err := r.VMProvider.CreateOrUpdateVirtualMachine(ctx, ctx.VM); err != nil {
-		ctx.Logger.Error(err, "Failed to reconcile VirtualMachine")
 		r.Recorder.EmitEvent(ctx.VM, "CreateOrUpdate", err, false)
 		return err
 	}


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
The same error during MV reconcile normal loop gets logged twice which clutters the log files with duplicates. Removing one of the loggers from VM reconcile loop.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
n/a


**Are there any special notes for your reviewer**:
n/a

**Please add a release note if necessary**:
```release-note
🌱 Removing duplicate error logger in VM controller
```