### PR TITLE
🐛 Remove updates to DeviceGroups

### DIFF
--- a/pkg/vmprovider/providers/vsphere/session/session_vm_update.go
+++ b/pkg/vmprovider/providers/vsphere/session/session_vm_update.go
@@ -440,19 +440,6 @@ func UpdateConfigSpecFirmware(
 	}
 }
 
-// UpdateConfigSpecDeviceGroups sets the desired config spec device groups to reconcile by differencing the
-// current VM config and the class config spec device groups.
-func UpdateConfigSpecDeviceGroups(
-	config *vimTypes.VirtualMachineConfigInfo,
-	configSpec, classConfigSpec *vimTypes.VirtualMachineConfigSpec) {
-
-	if classConfigSpec.DeviceGroups != nil {
-		if config.DeviceGroups == nil || !reflect.DeepEqual(classConfigSpec.DeviceGroups.DeviceGroup, config.DeviceGroups.DeviceGroup) {
-			configSpec.DeviceGroups = classConfigSpec.DeviceGroups
-		}
-	}
-}
-
 // updateConfigSpec overlays the VM Class spec with the provided ConfigSpec to form a desired
 // ConfigSpec that will be used to reconfigure the VM.
 func updateConfigSpec(
@@ -480,7 +467,6 @@ func updateConfigSpec(
 		vmCtx.VM, updateArgs.ExtraConfig, updateArgs.VirtualMachineImageV1Alpha1Compatible)
 	UpdateConfigSpecChangeBlockTracking(config, configSpec, updateArgs.ConfigSpec, vmCtx.VM.Spec)
 	UpdateConfigSpecFirmware(config, configSpec, vmCtx.VM)
-	UpdateConfigSpecDeviceGroups(config, configSpec, updateArgs.ConfigSpec)
 
 	return configSpec
 }

--- a/pkg/vmprovider/providers/vsphere/session/session_vm_update_test.go
+++ b/pkg/vmprovider/providers/vsphere/session/session_vm_update_test.go
@@ -807,59 +807,6 @@ var _ = Describe("Update ConfigSpec", func() {
 
 	})
 
-	Context("DeviceGroups", func() {
-		var classConfigSpec *vimTypes.VirtualMachineConfigSpec
-
-		BeforeEach(func() {
-			classConfigSpec = &vimTypes.VirtualMachineConfigSpec{}
-		})
-
-		It("No DeviceGroups set in class config spec", func() {
-			session.UpdateConfigSpecDeviceGroups(config, configSpec, classConfigSpec)
-			Expect(configSpec.DeviceGroups).To(BeNil())
-		})
-
-		It("DeviceGroups set in class config spec", func() {
-			classConfigSpec.DeviceGroups = &vimTypes.VirtualMachineVirtualDeviceGroups{
-				DeviceGroup: []vimTypes.BaseVirtualMachineVirtualDeviceGroupsDeviceGroup{
-					&vimTypes.VirtualMachineVirtualDeviceGroupsDeviceGroup{
-						GroupInstanceKey: int32(400),
-					},
-				},
-			}
-
-			session.UpdateConfigSpecDeviceGroups(config, configSpec, classConfigSpec)
-			Expect(configSpec.DeviceGroups).NotTo(BeNil())
-			Expect(configSpec.DeviceGroups.DeviceGroup).To(HaveLen(1))
-			deviceGroup := configSpec.DeviceGroups.DeviceGroup[0].GetVirtualMachineVirtualDeviceGroupsDeviceGroup()
-			Expect(deviceGroup.GroupInstanceKey).To(Equal(int32(400)))
-		})
-
-		It("configInfo DeviceGroups set with vals different than the class config spec", func() {
-			classConfigSpec.DeviceGroups = &vimTypes.VirtualMachineVirtualDeviceGroups{
-				DeviceGroup: []vimTypes.BaseVirtualMachineVirtualDeviceGroupsDeviceGroup{
-					&vimTypes.VirtualMachineVirtualDeviceGroupsDeviceGroup{
-						GroupInstanceKey: int32(400),
-					},
-				},
-			}
-
-			config.DeviceGroups = &vimTypes.VirtualMachineVirtualDeviceGroups{
-				DeviceGroup: []vimTypes.BaseVirtualMachineVirtualDeviceGroupsDeviceGroup{
-					&vimTypes.VirtualMachineVirtualDeviceGroupsDeviceGroup{
-						GroupInstanceKey: int32(500),
-					},
-				},
-			}
-
-			session.UpdateConfigSpecDeviceGroups(config, configSpec, classConfigSpec)
-			Expect(configSpec.DeviceGroups).NotTo(BeNil())
-			Expect(configSpec.DeviceGroups.DeviceGroup).To(HaveLen(1))
-			deviceGroup := configSpec.DeviceGroups.DeviceGroup[0].GetVirtualMachineVirtualDeviceGroupsDeviceGroup()
-			Expect(deviceGroup.GroupInstanceKey).To(Equal(int32(400)))
-		})
-	})
-
 	Context("Ethernet Card Changes", func() {
 		var expectedList object.VirtualDeviceList
 		var currentList object.VirtualDeviceList

--- a/pkg/vmprovider/providers/vsphere2/session/session_vm_update.go
+++ b/pkg/vmprovider/providers/vsphere2/session/session_vm_update.go
@@ -435,19 +435,6 @@ func UpdateConfigSpecFirmware(
 	}
 }
 
-// UpdateConfigSpecDeviceGroups sets the desired config spec device groups to reconcile by differencing the
-// current VM config and the class config spec device groups.
-func UpdateConfigSpecDeviceGroups(
-	config *vimTypes.VirtualMachineConfigInfo,
-	configSpec, classConfigSpec *vimTypes.VirtualMachineConfigSpec) {
-
-	if classConfigSpec.DeviceGroups != nil {
-		if config.DeviceGroups == nil || !reflect.DeepEqual(classConfigSpec.DeviceGroups.DeviceGroup, config.DeviceGroups.DeviceGroup) {
-			configSpec.DeviceGroups = classConfigSpec.DeviceGroups
-		}
-	}
-}
-
 // updateConfigSpec overlays the VM Class spec with the provided ConfigSpec to form a desired
 // ConfigSpec that will be used to reconfigure the VM.
 func updateConfigSpec(
@@ -475,7 +462,6 @@ func updateConfigSpec(
 		vmCtx.VM, updateArgs.ExtraConfig, updateArgs.VirtualMachineImageV1Alpha1Compatible)
 	UpdateConfigSpecChangeBlockTracking(config, configSpec, updateArgs.ConfigSpec, vmCtx.VM.Spec)
 	UpdateConfigSpecFirmware(config, configSpec, vmCtx.VM)
-	UpdateConfigSpecDeviceGroups(config, configSpec, updateArgs.ConfigSpec)
 
 	return configSpec
 }

--- a/pkg/vmprovider/providers/vsphere2/session/session_vm_update_test.go
+++ b/pkg/vmprovider/providers/vsphere2/session/session_vm_update_test.go
@@ -647,59 +647,6 @@ var _ = Describe("Update ConfigSpec", func() {
 		})
 	})
 
-	Context("DeviceGroups", func() {
-		var classConfigSpec *vimTypes.VirtualMachineConfigSpec
-
-		BeforeEach(func() {
-			classConfigSpec = &vimTypes.VirtualMachineConfigSpec{}
-		})
-
-		It("No DeviceGroups set in class config spec", func() {
-			session.UpdateConfigSpecDeviceGroups(config, configSpec, classConfigSpec)
-			Expect(configSpec.DeviceGroups).To(BeNil())
-		})
-
-		It("DeviceGroups set in class config spec", func() {
-			classConfigSpec.DeviceGroups = &vimTypes.VirtualMachineVirtualDeviceGroups{
-				DeviceGroup: []vimTypes.BaseVirtualMachineVirtualDeviceGroupsDeviceGroup{
-					&vimTypes.VirtualMachineVirtualDeviceGroupsDeviceGroup{
-						GroupInstanceKey: int32(400),
-					},
-				},
-			}
-
-			session.UpdateConfigSpecDeviceGroups(config, configSpec, classConfigSpec)
-			Expect(configSpec.DeviceGroups).NotTo(BeNil())
-			Expect(configSpec.DeviceGroups.DeviceGroup).To(HaveLen(1))
-			deviceGroup := configSpec.DeviceGroups.DeviceGroup[0].GetVirtualMachineVirtualDeviceGroupsDeviceGroup()
-			Expect(deviceGroup.GroupInstanceKey).To(Equal(int32(400)))
-		})
-
-		It("configInfo DeviceGroups set with vals different than the class config spec", func() {
-			classConfigSpec.DeviceGroups = &vimTypes.VirtualMachineVirtualDeviceGroups{
-				DeviceGroup: []vimTypes.BaseVirtualMachineVirtualDeviceGroupsDeviceGroup{
-					&vimTypes.VirtualMachineVirtualDeviceGroupsDeviceGroup{
-						GroupInstanceKey: int32(400),
-					},
-				},
-			}
-
-			config.DeviceGroups = &vimTypes.VirtualMachineVirtualDeviceGroups{
-				DeviceGroup: []vimTypes.BaseVirtualMachineVirtualDeviceGroupsDeviceGroup{
-					&vimTypes.VirtualMachineVirtualDeviceGroupsDeviceGroup{
-						GroupInstanceKey: int32(500),
-					},
-				},
-			}
-
-			session.UpdateConfigSpecDeviceGroups(config, configSpec, classConfigSpec)
-			Expect(configSpec.DeviceGroups).NotTo(BeNil())
-			Expect(configSpec.DeviceGroups.DeviceGroup).To(HaveLen(1))
-			deviceGroup := configSpec.DeviceGroups.DeviceGroup[0].GetVirtualMachineVirtualDeviceGroupsDeviceGroup()
-			Expect(deviceGroup.GroupInstanceKey).To(Equal(int32(400)))
-		})
-	})
-
 	Context("Ethernet Card Changes", func() {
 		var expectedList object.VirtualDeviceList
 		var currentList object.VirtualDeviceList


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This change removes the update of deviceGroups in the UpdateVM path. We don't currently support this workflow on Update and DeviceGroups are already covered in the CreatePath. The code for this is currently incomplete to support deviceGroups on update and will be prioritized when we support Resizing VMs in VM operator.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # N/A


**Are there any special notes for your reviewer**:

N/A


**Please add a release note if necessary**:

```
```