### PR TITLE
🌱 Remove v1a1 VM mutation webhook when v1a2 FSS is enabled

### DIFF
--- a/webhooks/virtualmachine/webhooks.go
+++ b/webhooks/virtualmachine/webhooks.go
@@ -11,7 +11,6 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/lib"
 	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachine/v1alpha1"
-	v1a1mut "github.com/vmware-tanzu/vm-operator/webhooks/virtualmachine/v1alpha1/mutation"
 	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachine/v1alpha2"
 )
 
@@ -19,10 +18,6 @@ func AddToManager(ctx *context.ControllerManagerContext, mgr ctrlmgr.Manager) er
 	if lib.IsVMServiceV1Alpha2FSSEnabled() {
 		if err := v1alpha2.AddToManager(ctx, mgr); err != nil {
 			return errors.Wrap(err, "failed to initialize v1alpha2 webhooks")
-		}
-		// With v1a2 FSS enabled, the v1a1 VM mutation webhook is added to the manager
-		if err := v1a1mut.AddToManager(ctx, mgr); err != nil {
-			return errors.Wrap(err, "failed to initialize v1alpha1 virtual machine mutation webhooks")
 		}
 	} else {
 		if err := v1alpha1.AddToManager(ctx, mgr); err != nil {


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

The v1a1 VM mutation webhook can be safely removed now because the v1a2 VM mutation webhook does the needful.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # N/A


**Are there any special notes for your reviewer**:

We initially had certain things that only the v1a1 VM mutation webhook did. Currently both the v1a1 and v1a2 VM mutation webhook do the same things. 


**Please add a release note if necessary**:

```
```