### PR TITLE
:seedling: Bump up go version from 1.21.3 to 1.21.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: ci
 
 env:
-  GO_VERSION: 1.21.3
+  GO_VERSION: 1.21.4
 
 on:
   pull_request:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Go version used to build the binaries.
-ARG GO_VERSION=1.21.3
+ARG GO_VERSION=1.21.4
 
 ## Docker image used to build the binaries.
 FROM golang:${GO_VERSION} as builder


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
According to govulncheck, Vulnerability `Insecure parsing of Windows paths with a \??\ prefix in path/filepath` is fixed in `go1.21.4`. Bumping up go version.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #N/A


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Bump up go version from 1.21.3 to 1.21.4
```