### PR TITLE
🐛 v1a2 VM mutation webhook updates

### DIFF
--- a/pkg/builder/mutating_webhook.go
+++ b/pkg/builder/mutating_webhook.go
@@ -142,6 +142,7 @@ func (h *mutatingWebhookHandler) Handle(_ goctx.Context, req admission.Request) 
 		WebhookContext:      h.WebhookContext,
 		Op:                  req.Operation,
 		Obj:                 obj,
+		RawObj:              req.Object.Raw,
 		OldObj:              oldObj,
 		UserInfo:            req.UserInfo,
 		IsPrivilegedAccount: IsPrivilegedAccount(h.WebhookContext, req.UserInfo),

--- a/pkg/context/webhook_request_context.go
+++ b/pkg/context/webhook_request_context.go
@@ -21,6 +21,9 @@ type WebhookRequestContext struct {
 	// Obj is the resource associated with the webhook request.
 	Obj *unstructured.Unstructured
 
+	// RawObj is the raw object from the webhook request.
+	RawObj []byte
+
 	// OldObj is set only for Update requests.
 	OldObj *unstructured.Unstructured
 

--- a/webhooks/virtualmachineclass/v1alpha2/mutation/virtualmachineclass_mutator.go
+++ b/webhooks/virtualmachineclass/v1alpha2/mutation/virtualmachineclass_mutator.go
@@ -52,14 +52,12 @@ type mutator struct {
 }
 
 func (m mutator) Mutate(ctx *context.WebhookRequestContext) admission.Response {
-	vmClass, err := m.vmClassFromUnstructured(ctx.Obj)
+	modified, err := m.vmClassFromUnstructured(ctx.Obj)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
 
 	var wasMutated bool
-	original := vmClass
-	modified := original.DeepCopy()
 
 	switch ctx.Op {
 	case admissionv1.Create:
@@ -78,15 +76,11 @@ func (m mutator) Mutate(ctx *context.WebhookRequestContext) admission.Response {
 		return admission.Allowed("")
 	}
 
-	rawOriginal, err := json.Marshal(original)
-	if err != nil {
-		return admission.Errored(http.StatusInternalServerError, err)
-	}
 	rawModified, err := json.Marshal(modified)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
-	return admission.PatchResponseFromRaw(rawOriginal, rawModified)
+	return admission.PatchResponseFromRaw(ctx.RawObj, rawModified)
 }
 
 func (m mutator) For() schema.GroupVersionKind {

--- a/webhooks/virtualmachineservice/v1alpha2/mutation/virtualmachineservice_mutator.go
+++ b/webhooks/virtualmachineservice/v1alpha2/mutation/virtualmachineservice_mutator.go
@@ -51,28 +51,22 @@ type mutator struct {
 }
 
 func (m mutator) Mutate(ctx *context.WebhookRequestContext) admission.Response {
-	vmService, err := m.vmServiceFromUnstructured(ctx.Obj)
+	modified, err := m.vmServiceFromUnstructured(ctx.Obj)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
 
 	var wasMutated bool
-	original := vmService
-	modified := original.DeepCopy()
 
 	if !wasMutated {
 		return admission.Allowed("")
 	}
 
-	rawOriginal, err := json.Marshal(original)
-	if err != nil {
-		return admission.Errored(http.StatusInternalServerError, err)
-	}
 	rawModified, err := json.Marshal(modified)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
-	return admission.PatchResponseFromRaw(rawOriginal, rawModified)
+	return admission.PatchResponseFromRaw(ctx.RawObj, rawModified)
 }
 
 func (m mutator) For() schema.GroupVersionKind {


### PR DESCRIPTION
Use the admission request original raw json byte array as the diff patch source: this is needed to generate the correct json diff patches for nested optional fields. This matches a change made to controller-runtime webhook server that we'll eventually switch to.

Sync over remaining differences in the v1a2 webhook and tests from v1a1

```release-note
NONE
```