### PR TITLE
✨ Populate more of the v1a2 Image & Class Status fields

### DIFF
--- a/pkg/vmprovider/providers/vsphere2/vmlifecycle/update_status.go
+++ b/pkg/vmprovider/providers/vsphere2/vmlifecycle/update_status.go
@@ -44,14 +44,21 @@ func UpdateStatus(
 	// TODO: Might set other "prereq" conditions too for version conversion but we'd have to fib a little.
 
 	if vm.Status.Image == nil {
-		// If unset, we don't know if this was a cluster or namespace scoped image at the time.
-		vm.Status.Image = &common.LocalObjectRef{Name: vm.Spec.ImageName}
+		// If unset, we don't know if this was a cluster or namespace scoped image at create time.
+		vm.Status.Image = &common.LocalObjectRef{
+			Name:       vm.Spec.ImageName,
+			APIVersion: vmopv1.SchemeGroupVersion.String(),
+		}
 	}
 	if vm.Status.Class == nil {
-		// We can most likely just assume the other fields of the LocalObjectRef but only fill
-		// in the Name for now. Our handling of this field will be more complicated once we really
-		// support class changes and reconfiguring the VM the fly in response.
-		vm.Status.Class = &common.LocalObjectRef{Name: vm.Spec.ClassName}
+		// In v1a2 we know this will always be the namespace scoped class since v1a2 doesn't have
+		// the bindings. Our handling of this field will be more complicated once we really
+		// support class changes and resizing/reconfiguring the VM the fly in response.
+		vm.Status.Class = &common.LocalObjectRef{
+			Kind:       "VirtualMachineClass",
+			APIVersion: vmopv1.SchemeGroupVersion.String(),
+			Name:       vm.Spec.ClassName,
+		}
 	}
 
 	if vmMO == nil {

--- a/pkg/vmprovider/providers/vsphere2/vmprovider_vm.go
+++ b/pkg/vmprovider/providers/vsphere2/vmprovider_vm.go
@@ -306,6 +306,16 @@ func (vs *vSphereVMProvider) createVirtualMachine(
 	}
 
 	vmCtx.VM.Status.UniqueID = moRef.Reference().Value
+	vmCtx.VM.Status.Image = &common.LocalObjectRef{
+		APIVersion: vmopv1.SchemeGroupVersion.String(),
+		Kind:       createArgs.ImageObj.GetObjectKind().GroupVersionKind().Kind,
+		Name:       createArgs.ImageObj.GetName(),
+	}
+	vmCtx.VM.Status.Class = &common.LocalObjectRef{
+		APIVersion: vmopv1.SchemeGroupVersion.String(),
+		Kind:       createArgs.VMClass.Kind,
+		Name:       createArgs.VMClass.Name,
+	}
 	conditions.MarkTrue(vmCtx.VM, vmopv1.VirtualMachineConditionCreated)
 
 	return object.NewVirtualMachine(vcClient.VimClient(), *moRef), createArgs, nil

--- a/pkg/vmprovider/providers/vsphere2/vmprovider_vm_test.go
+++ b/pkg/vmprovider/providers/vsphere2/vmprovider_vm_test.go
@@ -989,6 +989,14 @@ func vmTests() {
 					Expect(vm.Status.InstanceUUID).To(And(Not(BeEmpty()), Equal(o.Config.InstanceUuid)))
 					Expect(vm.Status.BiosUUID).To(And(Not(BeEmpty()), Equal(o.Config.Uuid)))
 
+					Expect(vm.Status.Image).ToNot(BeNil())
+					Expect(vm.Status.Image.Name).To(Equal(vm.Spec.ImageName))
+					Expect(vm.Status.Image.Kind).To(Equal("ClusterVirtualMachineImage"))
+					Expect(vm.Status.Image.APIVersion).To(Equal(vmopv1.SchemeGroupVersion.String()))
+					Expect(vm.Status.Class).ToNot(BeNil())
+					Expect(vm.Status.Class.Name).To(Equal(vm.Spec.ClassName))
+					Expect(vm.Status.Class.APIVersion).To(Equal(vmopv1.SchemeGroupVersion.String()))
+
 					Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionClassReady)).To(BeTrue())
 					Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionImageReady)).To(BeTrue())
 					Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionBootstrapReady)).To(BeTrue())


### PR DESCRIPTION
After the VM is created on VC, populate those Status fields because for the image we cannot later be absolutely sure what image was used.


```release-note
NONE
```