### PR TITLE
✨Move tkg vmware-system-* annotations to vmi/cvmi status

### DIFF
--- a/api/v1alpha1/zz_generated.conversion.go
+++ b/api/v1alpha1/zz_generated.conversion.go
@@ -1448,6 +1448,7 @@ func autoConvert_v1alpha2_VirtualMachineImageStatus_To_v1alpha1_VirtualMachineIm
 	// WARNING: in.HardwareVersion requires manual conversion: does not exist in peer-type
 	// WARNING: in.OSInfo requires manual conversion: does not exist in peer-type
 	// WARNING: in.OVFProperties requires manual conversion: does not exist in peer-type
+	// WARNING: in.VMwareSystemProperties requires manual conversion: does not exist in peer-type
 	// WARNING: in.ProductInfo requires manual conversion: does not exist in peer-type
 	// WARNING: in.ProviderContentVersion requires manual conversion: does not exist in peer-type
 	// WARNING: in.ProviderItemID requires manual conversion: does not exist in peer-type

--- a/api/v1alpha2/virtualmachineimage_types.go
+++ b/api/v1alpha2/virtualmachineimage_types.go
@@ -164,11 +164,17 @@ type VirtualMachineImageStatus struct {
 	// +optional
 	OSInfo VirtualMachineImageOSInfo `json:"osInfo,omitempty"`
 
-	// OVFProperties describes the observed OVF properties defined for this
+	// OVFProperties describes the observed user configurable OVF properties defined for this
 	// image.
 	//
 	// +optional
 	OVFProperties []OVFProperty `json:"ovfProperties,omitempty"`
+
+	// VMwareSystemProperties describes the observed VMware system properties defined for
+	// this image.
+	//
+	// +optional
+	VMwareSystemProperties []common.KeyValuePair `json:"vmwareSystemProperties,omitempty"`
 
 	// ProductInfo describes the observed product information for this image.
 	// +optional

--- a/api/v1alpha2/zz_generated.deepcopy.go
+++ b/api/v1alpha2/zz_generated.deepcopy.go
@@ -861,6 +861,11 @@ func (in *VirtualMachineImageStatus) DeepCopyInto(out *VirtualMachineImageStatus
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.VMwareSystemProperties != nil {
+		in, out := &in.VMwareSystemProperties, &out.VMwareSystemProperties
+		*out = make([]common.KeyValuePair, len(*in))
+		copy(*out, *in)
+	}
 	out.ProductInfo = in.ProductInfo
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions

--- a/config/crd/bases/vmoperator.vmware.com_clustervirtualmachineimages.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_clustervirtualmachineimages.yaml
@@ -456,8 +456,8 @@ spec:
                     type: string
                 type: object
               ovfProperties:
-                description: OVFProperties describes the observed OVF properties defined
-                  for this image.
+                description: OVFProperties describes the observed user configurable
+                  OVF properties defined for this image.
                 items:
                   description: OVFProperty describes an OVF property associated with
                     an image. OVF properties may be used in conjunction with the vAppConfig
@@ -508,6 +508,24 @@ spec:
                   a Content Library, this ID will be that of the corresponding Content
                   Library item.
                 type: string
+              vmwareSystemProperties:
+                description: VMwareSystemProperties describes the observed VMware
+                  system properties defined for this image.
+                items:
+                  description: KeyValuePair is useful when wanting to realize a map
+                    as a list of key/value pairs.
+                  properties:
+                    key:
+                      description: Key is the key part of the key/value pair.
+                      type: string
+                    value:
+                      description: Value is the optional value part of the key/value
+                        pair.
+                      type: string
+                  required:
+                  - key
+                  type: object
+                type: array
             type: object
         type: object
     served: true

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachineimages.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachineimages.yaml
@@ -459,8 +459,8 @@ spec:
                     type: string
                 type: object
               ovfProperties:
-                description: OVFProperties describes the observed OVF properties defined
-                  for this image.
+                description: OVFProperties describes the observed user configurable
+                  OVF properties defined for this image.
                 items:
                   description: OVFProperty describes an OVF property associated with
                     an image. OVF properties may be used in conjunction with the vAppConfig
@@ -511,6 +511,24 @@ spec:
                   a Content Library, this ID will be that of the corresponding Content
                   Library item.
                 type: string
+              vmwareSystemProperties:
+                description: VMwareSystemProperties describes the observed VMware
+                  system properties defined for this image.
+                items:
+                  description: KeyValuePair is useful when wanting to realize a map
+                    as a list of key/value pairs.
+                  properties:
+                    key:
+                      description: Key is the key part of the key/value pair.
+                      type: string
+                    value:
+                      description: Value is the optional value part of the key/value
+                        pair.
+                      type: string
+                  required:
+                  - key
+                  type: object
+                type: array
             type: object
         type: object
     served: true

--- a/pkg/vmprovider/providers/vsphere2/contentlibrary/content_library_utils.go
+++ b/pkg/vmprovider/providers/vsphere2/contentlibrary/content_library_utils.go
@@ -12,6 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/api/v1alpha2/common"
 )
 
 var vmxRe = regexp.MustCompile(`vmx-(\d+)`)
@@ -48,19 +49,6 @@ func UpdateVmiWithOvfEnvelope(vmi client.Object, ovfEnvelope ovf.Envelope) {
 
 	if ovfEnvelope.VirtualSystem != nil {
 		initImageStatusFromOVFVirtualSystem(status, ovfEnvelope.VirtualSystem)
-
-		ovfSystemProps := getVmwareSystemPropertiesFromOvf(ovfEnvelope.VirtualSystem)
-		if len(ovfSystemProps) > 0 {
-			annotations := vmi.GetAnnotations()
-			if annotations == nil {
-				annotations = make(map[string]string)
-				vmi.SetAnnotations(annotations)
-			}
-
-			for k, v := range ovfSystemProps {
-				annotations[k] = v
-			}
-		}
 	}
 }
 
@@ -116,6 +104,17 @@ func initImageStatusFromOVFVirtualSystem(
 				}
 				imageStatus.OVFProperties = append(imageStatus.OVFProperties, property)
 			}
+		}
+	}
+
+	ovfSystemProps := getVmwareSystemPropertiesFromOvf(ovfVirtualSystem)
+	if len(ovfSystemProps) > 0 {
+		for k, v := range ovfSystemProps {
+			prop := common.KeyValuePair{
+				Key:   k,
+				Value: v,
+			}
+			imageStatus.VMwareSystemProperties = append(imageStatus.VMwareSystemProperties, prop)
 		}
 	}
 }

--- a/pkg/vmprovider/providers/vsphere2/contentlibrary/content_library_utils_test.go
+++ b/pkg/vmprovider/providers/vsphere2/contentlibrary/content_library_utils_test.go
@@ -7,7 +7,12 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/vmware/govmomi/ovf"
+	"k8s.io/utils/pointer"
+
+	"github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere2/contentlibrary"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 var _ = Describe("ParseVirtualHardwareVersion", func() {
@@ -24,5 +29,121 @@ var _ = Describe("ParseVirtualHardwareVersion", func() {
 	It("valid hardware version string eg. vmx-15", func() {
 		vmxHwVersionString := "vmx-15"
 		Expect(contentlibrary.ParseVirtualHardwareVersion(vmxHwVersionString)).To(Equal(int32(15)))
+	})
+})
+
+var _ = Describe("UpdateVmiWithOvfEnvelope", func() {
+	const (
+		ovfStringType          = "string"
+		userConfigurableKey    = "dummy-key-configurable"
+		notUserConfigurableKey = "dummy-key-not-configurable"
+		defaultValue           = "dummy-value"
+		versionKey             = "vmware-system.tkr.os-version"
+		versionVal             = "1.15"
+	)
+
+	var (
+		ovfEnvelope ovf.Envelope
+		image       *v1alpha2.VirtualMachineImage
+	)
+
+	BeforeEach(func() {
+		ovfEnvelope = ovf.Envelope{
+			VirtualSystem: &ovf.VirtualSystem{
+				Product: []ovf.ProductSection{
+					{
+						Vendor:      "vendor",
+						Product:     "product",
+						FullVersion: "fullVersion",
+						Version:     "version",
+						Property: []ovf.Property{
+							{
+								Key:     versionKey,
+								Type:    ovfStringType,
+								Default: pointer.String(versionVal),
+							},
+							{
+								Key:              userConfigurableKey,
+								Type:             ovfStringType,
+								Default:          pointer.String(defaultValue),
+								UserConfigurable: pointer.Bool(true),
+							},
+							{
+								Key:              notUserConfigurableKey,
+								Type:             ovfStringType,
+								Default:          pointer.String(defaultValue),
+								UserConfigurable: pointer.Bool(false),
+							},
+							{
+								Key:              notUserConfigurableKey,
+								Type:             ovfStringType,
+								Default:          pointer.String(defaultValue),
+								UserConfigurable: pointer.Bool(false),
+							},
+						},
+					},
+				},
+				OperatingSystem: []ovf.OperatingSystemSection{
+					{
+						OSType:  pointer.String("dummy_os_type"),
+						ID:      int16(100),
+						Version: pointer.String("dummy_version"),
+					},
+				},
+				VirtualHardware: []ovf.VirtualHardwareSection{
+					{
+						Config: []ovf.Config{
+							{
+								Key:   "firmware",
+								Value: "efi",
+							},
+						},
+
+						System: &ovf.VirtualSystemSettingData{
+							CIMVirtualSystemSettingData: ovf.CIMVirtualSystemSettingData{
+								VirtualSystemType: pointer.String("vmx-10"),
+							},
+						},
+					},
+				},
+			},
+		}
+
+		image = builder.DummyVirtualMachineImageA2("dummy-image")
+	})
+
+	AfterEach(func() {
+		ovfEnvelope = ovf.Envelope{}
+		image = nil
+	})
+
+	JustBeforeEach(func() {
+		contentlibrary.UpdateVmiWithOvfEnvelope(image, ovfEnvelope)
+	})
+
+	It("Image status should have expected ProductInfo, OSInfo, Firmware, User configurable and System Properties", func() {
+		Expect(image).ToNot(BeNil())
+		Expect(image.Name).Should(Equal("dummy-image"))
+
+		Expect(image.Status.ProductInfo.Vendor).Should(Equal("vendor"))
+		Expect(image.Status.ProductInfo.Product).Should(Equal("product"))
+		Expect(image.Status.ProductInfo.Version).Should(Equal("version"))
+		Expect(image.Status.ProductInfo.FullVersion).Should(Equal("fullVersion"))
+
+		Expect(image.Status.OSInfo.Type).Should(Equal("dummy_os_type"))
+		Expect(image.Status.OSInfo.Version).Should(Equal("dummy_version"))
+		Expect(image.Status.OSInfo.ID).Should(Equal("100"))
+
+		Expect(image.Status.HardwareVersion).Should(Equal(pointer.Int32(10)))
+		Expect(image.Status.Firmware).Should(Equal("efi"))
+
+		Expect(image.Status.OVFProperties).Should(HaveLen(1))
+		Expect(image.Status.OVFProperties[0].Key).Should(Equal(userConfigurableKey))
+		Expect(image.Status.OVFProperties[0].Type).Should(Equal(ovfStringType))
+		Expect(image.Status.OVFProperties[0].Default).Should(Equal(pointer.String(defaultValue)))
+
+		Expect(image.Status.VMwareSystemProperties).Should(HaveLen(1))
+		Expect(image.Status.VMwareSystemProperties[0].Key).Should(Equal(versionKey))
+		Expect(image.Status.VMwareSystemProperties[0].Value).Should(Equal(versionVal))
 	})
 })


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

One of the goals w/ this is to make Metadata watches more effective in v1a2 by not having big yamls in the ObjectMeta.

This change moves the
- tkg vmware-system-* annotations to a v1a2 status field
- adds conversions for this status field to convert to annotations for v1a1.
- v1a1 annotations when up-converted are copied over to the v1a2 status field and removed from v1a2 annotations if already present

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # N/A


**Are there any special notes for your reviewer**:
Testing TKC deployments and scaled up to check vmware-system annotations are fetched from the v1a1 virtualmachineimage.

**Please add a release note if necessary**:

```
N/A
```