### PR TITLE
🌱 Adds api unit tests to Makefile

### DIFF
--- a/api/v1alpha1/virtualmachineimage_conversion.go
+++ b/api/v1alpha1/virtualmachineimage_conversion.go
@@ -154,6 +154,10 @@ func convert_v1alpha2_VirtualMachineImageStatusConditions_To_v1alpha1_VirtualMac
 
 func convert_v1alpha1_VirtualMachineImageStatusConditions_To_v1alpha2_VirtualMachineImageStatusConditions(
 	conditions []Condition) []metav1.Condition {
+	if conditions == nil || len(conditions) == 0 {
+		return []metav1.Condition{}
+	}
+
 	var readyCondition *metav1.Condition
 
 	// Condition types which are folded into the Ready condition in v1alpha2


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This patch adds the github.com/vmware-tanzu/vm-operator/api module to be run when running the test Makefile target. Since ./api directory is a separate go module, we run the tests via a separate go command.

This also fixes a minor VMI/CVMI conversion issue wherein an empty condition set should always return an empty condition set on up/down conversion.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
n/a


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:
```release-note
NONE
```