### PR TITLE
✨ Set more useful interface name in v1a2 VM Status

### DIFF
--- a/pkg/vmprovider/providers/vsphere2/vmlifecycle/update_status_test.go
+++ b/pkg/vmprovider/providers/vsphere2/vmlifecycle/update_status_test.go
@@ -73,6 +73,12 @@ var _ = Describe("UpdateStatus", func() {
 						},
 					},
 				}
+
+				vmCtx.VM.Spec.Network.Interfaces = []vmopv1.VirtualMachineNetworkInterfaceSpec{
+					{
+						Name: "eth42",
+					},
+				}
 			})
 
 			It("Skips pseudo devices", func() {
@@ -80,6 +86,7 @@ var _ = Describe("UpdateStatus", func() {
 
 				Expect(network.Interfaces).To(HaveLen(1))
 				Expect(network.Interfaces[0].IP.MACAddr).To(Equal("mac-4000"))
+				Expect(network.Interfaces[0].Name).To(Equal("eth42"))
 			})
 		})
 


### PR DESCRIPTION
We have a long ways to go before we actually support multiple interfaces, both in bootstrap and in reconcile. The exceedingly common case is just one interface so special case that to provide the interface name in the Status.

```release-note
NONE
```