### PR TITLE
🐛 Check VM.Spec.Network for nil in v1a2 mutation wehbook

### DIFF
--- a/webhooks/virtualmachine/v1alpha2/mutation/virtualmachine_mutator.go
+++ b/webhooks/virtualmachine/v1alpha2/mutation/virtualmachine_mutator.go
@@ -199,7 +199,7 @@ func AddDefaultNetworkInterface(ctx *context.WebhookRequestContext, client clien
 		return false
 	}
 
-	if vm.Spec.Network.Disabled || len(vm.Spec.Network.Interfaces) != 0 {
+	if vm.Spec.Network != nil && (vm.Spec.Network.Disabled || len(vm.Spec.Network.Interfaces) != 0) {
 		return false
 	}
 
@@ -218,6 +218,10 @@ func AddDefaultNetworkInterface(ctx *context.WebhookRequestContext, client clien
 		}
 	default:
 		return false
+	}
+
+	if vm.Spec.Network == nil {
+		vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
 	}
 
 	vm.Spec.Network.Interfaces = []vmopv1.VirtualMachineNetworkInterfaceSpec{

--- a/webhooks/virtualmachine/v1alpha2/mutation/virtualmachine_mutator_unit_test.go
+++ b/webhooks/virtualmachine/v1alpha2/mutation/virtualmachine_mutator_unit_test.go
@@ -72,6 +72,26 @@ func unitTestsMutating() {
 
 	Describe("AddDefaultNetworkInterface", func() {
 
+		Context("When VM Network is nil", func() {
+			BeforeEach(func() {
+				ctx.vm.Spec.Network = nil
+			})
+
+			// Just any network is OK here - just checking that we don't NPE.
+			When("VDS network", func() {
+				BeforeEach(func() {
+					Expect(os.Setenv(lib.NetworkProviderType, lib.NetworkProviderTypeVDS)).Should(Succeed())
+				})
+
+				It("Should add default network interface with type vsphere-distributed", func() {
+					Expect(mutation.AddDefaultNetworkInterface(&ctx.WebhookRequestContext, ctx.Client, ctx.vm)).To(BeTrue())
+					Expect(ctx.vm.Spec.Network.Interfaces).Should(HaveLen(1))
+					Expect(ctx.vm.Spec.Network.Interfaces[0].Name).Should(Equal("eth0"))
+					Expect(ctx.vm.Spec.Network.Interfaces[0].Network.Kind).Should(Equal("Network"))
+				})
+			})
+		})
+
 		Context("When VM NetworkInterface is empty", func() {
 			BeforeEach(func() {
 				ctx.vm.Spec.Network.Interfaces = []vmopv1.VirtualMachineNetworkInterfaceSpec{}


### PR DESCRIPTION
When the Network stanza is entirely omitted we'd otherwise NPE when adding the default network interface.

Fixes b54465

```release-note
NONE
```