### PR TITLE
⚠️ Add note that the TCPSocket probe method is deprecated

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -76,6 +76,9 @@ issues:
   - linters:
     - gosec
     text: "G114: Use of net/http serve function that has no support for setting timeouts"
+  - linters:
+    - staticcheck
+    text: "^SA1019: .*TCPSocket is deprecated"
   # Dot imports for gomega or ginkgo are allowed within test files.
   - path: test/
     text: should not use dot imports

--- a/api/v1alpha1/virtualmachine_types.go
+++ b/api/v1alpha1/virtualmachine_types.go
@@ -321,6 +321,9 @@ type VsphereVolumeSource struct {
 // alive or ready to receive traffic. Only one probe action can be specified.
 type Probe struct {
 	// TCPSocket specifies an action involving a TCP port.
+	//
+	// Deprecated: The TCPSocket action requires network connectivity that is not supported in all environments.
+	// This field will be removed in a later API version.
 	// +optional
 	TCPSocket *TCPSocketAction `json:"tcpSocket,omitempty"`
 

--- a/api/v1alpha2/virtualmachine_readiness_types.go
+++ b/api/v1alpha2/virtualmachine_readiness_types.go
@@ -11,6 +11,9 @@ import (
 // is in a ready state. All probe actions are mutually exclusive.
 type VirtualMachineReadinessProbeSpec struct {
 	// TCPSocket specifies an action involving a TCP port.
+	//
+	// Deprecated: The TCPSocket action requires network connectivity that is not supported in all environments.
+	// This field will be removed in a later API version.
 	// +optional
 	TCPSocket *TCPSocketAction `json:"tcpSocket,omitempty"`
 

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -278,7 +278,10 @@ spec:
                     minimum: 1
                     type: integer
                   tcpSocket:
-                    description: TCPSocket specifies an action involving a TCP port.
+                    description: "TCPSocket specifies an action involving a TCP port.
+                      \n Deprecated: The TCPSocket action requires network connectivity
+                      that is not supported in all environments. This field will be
+                      removed in a later API version."
                     properties:
                       host:
                         description: Host is an optional host name to connect to.  Host
@@ -1625,7 +1628,10 @@ spec:
                     minimum: 1
                     type: integer
                   tcpSocket:
-                    description: TCPSocket specifies an action involving a TCP port.
+                    description: "TCPSocket specifies an action involving a TCP port.
+                      \n Deprecated: The TCPSocket action requires network connectivity
+                      that is not supported in all environments. This field will be
+                      removed in a later API version."
                     properties:
                       host:
                         description: Host is an optional host name to connect to.


### PR DESCRIPTION
This probe method was added at the last minute of the first WCP release as a stopgap to address a limitation with the NSX-T LB at the time. Since the probe is done via VM Operator pod on one of the Supervisor CP VMs it requires network connectivity that does not exist in certain environments, and TKGs - the primary user of this probe method - will be switching to different method that's introduced in v1a2.

```release-note
The TCPSocket probe action is deprecated and will be removed in a later API version.
```