### PR TITLE
⚠️ Mark the v1a1 VirtualMachineImage ContentLibraryRef field as deprecated

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -68,6 +68,9 @@ issues:
   # List of regexps of issue texts to exclude, empty list by default.
   exclude-rules:
   - linters:
+    - staticcheck
+    text: "^SA1019: [^.]+.Status.ContentLibraryRef is deprecated"
+  - linters:
     - revive
     text: ".*should have (a package )?comment.*"
   - linters:

--- a/api/v1alpha1/virtualmachineimage_types.go
+++ b/api/v1alpha1/virtualmachineimage_types.go
@@ -130,6 +130,11 @@ type VirtualMachineImageStatus struct {
 	Conditions []Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 
 	// ContentLibraryRef is a reference to the source ContentLibrary/ClusterContentLibrary resource.
+	//
+	// Deprecated: This field is provider specific but the VirtualMachineImage types are intended to be provider generic.
+	// This field does not exist in later API versions. Instead, the Spec.ProviderRef field should be used to look up the
+	// provider. For images provided by a Content Library, the ProviderRef will point to either a ContentLibraryItem or
+	// ClusterContentLibraryItem that contains a reference to the Content Library.
 	// +optional
 	ContentLibraryRef *corev1.TypedLocalObjectReference `json:"contentLibraryRef,omitempty"`
 

--- a/config/crd/bases/vmoperator.vmware.com_clustervirtualmachineimages.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_clustervirtualmachineimages.yaml
@@ -220,8 +220,14 @@ spec:
                   type: object
                 type: array
               contentLibraryRef:
-                description: ContentLibraryRef is a reference to the source ContentLibrary/ClusterContentLibrary
-                  resource.
+                description: "ContentLibraryRef is a reference to the source ContentLibrary/ClusterContentLibrary
+                  resource. \n Deprecated: This field is provider specific but the
+                  VirtualMachineImage types are intended to be provider generic. This
+                  field does not exist in later API versions. Instead, the Spec.ProviderRef
+                  field should be used to look up the provider. For images provided
+                  by a Content Library, the ProviderRef will point to either a ContentLibraryItem
+                  or ClusterContentLibraryItem that contains a reference to the Content
+                  Library."
                 properties:
                   apiGroup:
                     description: APIGroup is the group for the resource being referenced.

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachineimages.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachineimages.yaml
@@ -220,8 +220,14 @@ spec:
                   type: object
                 type: array
               contentLibraryRef:
-                description: ContentLibraryRef is a reference to the source ContentLibrary/ClusterContentLibrary
-                  resource.
+                description: "ContentLibraryRef is a reference to the source ContentLibrary/ClusterContentLibrary
+                  resource. \n Deprecated: This field is provider specific but the
+                  VirtualMachineImage types are intended to be provider generic. This
+                  field does not exist in later API versions. Instead, the Spec.ProviderRef
+                  field should be used to look up the provider. For images provided
+                  by a Content Library, the ProviderRef will point to either a ContentLibraryItem
+                  or ClusterContentLibraryItem that contains a reference to the Content
+                  Library."
                 properties:
                   apiGroup:
                     description: APIGroup is the group for the resource being referenced.


### PR DESCRIPTION
We do not have a corresponding field in v1a2, and this specific provider field ideally should not be apart of our generic image type. If needed, this can be looked up via the Spec.ProviderRef.

```release-note
The v1alpha1 ClusterVirtualMachineImage and VirtualMachineImage Status.ContentLibraryRef field is deprecated. Instead for images provided by a Content Library, the Spec.ProviderRef will point to either a ContentLibraryItem ClusterContentLibraryItem that contains a reference to the Content Library.
```