### PR TITLE
🐛 Set Namespace in v1a1 VirtualMachineImage ProviderRef

### DIFF
--- a/api/v1alpha1/virtualmachineimage_conversion.go
+++ b/api/v1alpha1/virtualmachineimage_conversion.go
@@ -399,6 +399,12 @@ func (dst *VirtualMachineImage) ConvertFrom(srcRaw conversion.Hub) error {
 		return err
 	}
 
+	if dst.Spec.ProviderRef.Name != "" {
+		// The Namespace isn't a field in the v1a2 LocalObjectRef so backfill the namespace here.
+		// The provider is always in the same namespace.
+		dst.Spec.ProviderRef.Namespace = src.Namespace
+	}
+
 	return nil
 }
 

--- a/api/v1alpha1/virtualmachineimage_conversion_test.go
+++ b/api/v1alpha1/virtualmachineimage_conversion_test.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	nextver "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	nextver_common "github.com/vmware-tanzu/vm-operator/api/v1alpha2/common"
+)
+
+func TestVirtualMachineImageConversion(t *testing.T) {
+	g := NewWithT(t)
+
+	t.Run("VirtualMachineImage hub-spoke-hub", func(t *testing.T) {
+		hub := &nextver.VirtualMachineImage{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-image",
+				Namespace: "my-namespace",
+			},
+			Spec: nextver.VirtualMachineImageSpec{
+				ProviderRef: nextver_common.LocalObjectRef{
+					APIVersion: "vmware.com/v1",
+					Kind:       "ImageProvider",
+					Name:       "my-image",
+				},
+			},
+		}
+
+		spoke := &v1alpha1.VirtualMachineImage{}
+		g.Expect(spoke.ConvertFrom(hub)).To(Succeed())
+
+		g.Expect(spoke.Spec.ProviderRef.APIVersion).To(Equal("vmware.com/v1"))
+		g.Expect(spoke.Spec.ProviderRef.Kind).To(Equal("ImageProvider"))
+		g.Expect(spoke.Spec.ProviderRef.Name).To(Equal("my-image"))
+		g.Expect(spoke.Spec.ProviderRef.Namespace).To(Equal("my-namespace"))
+	})
+}

--- a/controllers/contentlibrary/v1alpha1/contentlibraryitem/contentlibraryitem_controller.go
+++ b/controllers/contentlibrary/v1alpha1/contentlibraryitem/contentlibraryitem_controller.go
@@ -228,6 +228,7 @@ func (r *Reconciler) setUpVMIFromCLItem(ctx *context.ContentLibraryItemContext) 
 		APIVersion: clItem.APIVersion,
 		Kind:       clItem.Kind,
 		Name:       clItem.Name,
+		Namespace:  clItem.Namespace,
 	}
 	vmi.Status.ImageName = clItem.Status.Name
 	if clItem.Status.ContentLibraryRef != nil {

--- a/controllers/contentlibrary/v1alpha1/utils/test_utils.go
+++ b/controllers/contentlibrary/v1alpha1/utils/test_utils.go
@@ -188,6 +188,7 @@ func GetExpectedVMIFrom(clItem imgregv1a1.ContentLibraryItem,
 				APIVersion: clItem.APIVersion,
 				Kind:       clItem.Kind,
 				Name:       clItem.Name,
+				Namespace:  clItem.Namespace,
 			},
 		},
 		Status: vmopv1.VirtualMachineImageStatus{


### PR DESCRIPTION
The VirtualMachineImage provided by the namespace scoped ContentLibraryItem so the Namespace field should have been set in the ProviderRef. Otherwise, the field documentation the referenced kind is cluster scoped.

Populate the namespace field when down converting the image to v1a1.

```release-note
For namespaced scoped VirtualMachineImages the Namespace field in the Spec.ProviderRef is now set.
```