### PR TITLE
🐛 Fix bugs in vApp bootstrap docs

### DIFF
--- a/docs/concepts/workloads/guest.md
+++ b/docs/concepts/workloads/guest.md
@@ -346,23 +346,23 @@ To illustrate, the following YAML can be utilized to deploy a VirtualMachine and
       management_gateway: "{{ (index .V1alpha1.Net.Devices 0).Gateway4 }}"
     ```
 
-=== "vAppConfig with supporting template"
+=== "vAppConfig with templated data"
 
     ```yaml
     apiVersion: v1
     kind: Secret
     metadata:
-    name: my-secret
-    namespace: test-ns
+      name: my-secret
+      namespace: test-ns
     stringData:
-    # see more details on below Supporting Template Queries section
-    nameservers: "{{ V1alpha1_FormatNameservers 2 \",\" }}"
-    management_ip: "{{ V1alpha1_FormatIP \"192.168.1.10\" \"255.255.255.0\" }}"
-    hostname: "{{ .V1alpha1.VM.Name }} "  
-    management_gateway: "{{ (index .V1alpha1.Net.Devices 0).Gateway4 }}"
+      nameservers: "{{ V1alpha1_FormatNameservers 2 \",\" }}"
+      management_ip: "{{ V1alpha1_FormatIP \"192.168.1.10\" \"255.255.255.0\" }}"
+      hostname: "{{ .V1alpha1.VM.Name }} "  
+      management_gateway: "{{ (index .V1alpha1.Net.Devices 0).Gateway4 }}"
     ```
 
-For more information on vAppConfig, please refer to [tutorial/deploy-vm/vappconfig](https://vm-operator.readthedocs.io/en/stable/tutorials/deploy-vm/vappconfig/).
+For more information on vAppConfig, please refer to this [tutorial](../../tutorials/deploy-vm/vappconfig.md).
+
 ## Deprecated
 
 The following bootstrap providers are still available, but they are deprecated and are not recommended.

--- a/docs/tutorials/deploy-vm/README.md
+++ b/docs/tutorials/deploy-vm/README.md
@@ -232,8 +232,7 @@ For more information on Sysprep, please refer to Microsoft's [official documenta
 
 #### vAppConfig
 
-The vAppConfig bootstrap method is useful for legacy, VM images that rely on bespoke, boot-time processes that leverage vAppConfig properties for customizing a guest.
-Refer to [Deploy a VM with vAppConfig](https://vm-operator.readthedocs.io/en/stable/tutorials/deploy-vm/vappconfig/) for instructions to use this bootstrap method.
+The vAppConfig bootstrap method is useful for legacy, VM images that rely on bespoke, boot-time processes that leverage vAppConfig properties for customizing a guest. Please refer to this [tutorial](../../tutorials/deploy-vm/vappconfig.md) for more information.
 
 ### Deprecated
 

--- a/docs/tutorials/deploy-vm/cloudinit.md
+++ b/docs/tutorials/deploy-vm/cloudinit.md
@@ -1,20 +1,13 @@
 # Deploy a VM With Cloud-Init
 
-This page reviews deploying a VM with the bootstrap method Cloud-Init.
-
-## Description
-
-[Cloud-Init](https://cloudinit.readthedocs.io/en/latest/) is widely recognized as the de facto method for bootstrapping modern VM instances on hyperscalers, including VM Service on vSphere with Tanzu.
-
-## Purpose
-As a DevOps user leveraging Cloud-Init, you have the capability to bootstrap the guest within a VM, enabling seamless execution of operations during the boot process. Some tasks you can accomplish include:
-
-* Adding a custom user,
-* Executing commands on boot, and
-* Writing files.
+[Cloud-Init](https://cloudinit.readthedocs.io/en/latest/) is widely recognized as the de facto method for bootstrapping modern workloads on hyperscalers, including VM Service on vSphere.
 
 
 ## Example
+
+The example below illustrates a `VirtualMachine` resource that specifies a Cloud-Init Cloud Config via a `Secret` resource (`my-vm-bootstrap-data`). For more information on the Cloud-Init Cloud Config format, please see the [official documentation](https://cloudinit.readthedocs.io/en/latest/reference/examples.html).
+
+
 === "VirtualMachine"
 
     ``` yaml
@@ -61,6 +54,3 @@ As a DevOps user leveraging Cloud-Init, you have the capability to bootstrap the
             Hello, world.
     ```
 
-The above example shows a `VirtualMachine` resource that specifies user-data using a `Secret` resource (`my-vm-bootstrap-data`), which will be used by `CloudInit` to bootstrap and customize the guest.
-
-The data in the above `Secret` has the Cloud-Init _Cloud Config_. For more information on the Cloud-Init Cloud Config format, please see its [official documentation](https://cloudinit.readthedocs.io/en/latest/reference/examples.html).

--- a/docs/tutorials/deploy-vm/vappconfig.md
+++ b/docs/tutorials/deploy-vm/vappconfig.md
@@ -1,115 +1,89 @@
 # Deploy a VM with vAppConfig
 
-This page reviews the bootstrap method vAppConfig.
-
-## Description
-The vAppConfig bootstrap method is useful for legacy VM images that rely on bespoke, boot-time processes that leverage vAppConfig properties for customizing a guest.
-
-## Purpose
-As a DevOps user, you can assign Golang-based template strings to vAppConfig values to send information into the guest that is not known ahead of time, such as the IPAM data settings used to configure the VM's network stack.
+The vAppConfig bootstrap method is useful for legacy VM images that rely on bespoke, boot-time processes that leverage vAppConfig properties for customizing a guest. This method also supports properties specified with Golang-style template strings in order to use information not known ahead of time, such as the networking configuration, into the guest via vApp properties.
 
 ## Example
+
+The following example showcases a `VirtualMachine` resource that specifies one or more vApp properties used to bootstrap a guest.
+
 === "VirtualMachine"
 
     ```yaml
     apiVersion: vmoperator.vmware.com/v1alpha1
     kind: VirtualMachine
     metadata:
-    name: legacy-vm
-    namespace: test-ns
+      name: legacy-vm
+      namespace: test-ns
     spec:
-    className: best-effort-small
-    imageName: haproxy-v0.2.0
-    powerState: poweredOn
-    storageClass: wcpglobal-storage-profile
-    vmMetadata:
+      className: best-effort-small
+      imageName: haproxy-v0.2.0
+      powerState: poweredOn
+      storageClass: wcpglobal-storage-profile
+      vmMetadata:
         secretName: my-secret
         transport: vAppConfig
     ```
 
 === "vAppConfig"
 
-    ```yaml
-    apiVersion: v1
-    kind: Secret
-    metadata:
-    name: my-secret
-    namespace: test-ns
-    stringData:
-    nameservers: "{{ (index .V1alpha1.Net.Nameservers 0) }}"         
-    management_ip: "{{ (index (index .V1alpha1.Net.Devices 0).IPAddresses 0) }}"
-    hostname: "{{ .V1alpha1.VM.Name }} "       
-    management_gateway: "{{ (index .V1alpha1.Net.Devices 0).Gateway4 }}"
-    ```
+    !!! note "The vApp properties below..."
 
-=== "vAppConfig with supporting template"
+        The vApp properties used in this example are not standard. All images may define their own properties for configuring the guest's network, or anything else. Please review the image's OVF to understand what properties are available and should be assigned.
 
     ```yaml
     apiVersion: v1
     kind: Secret
     metadata:
-    name: my-secret
-    namespace: test-ns
+      name: my-secret
+      namespace: test-ns
     stringData:
-    # see more details on below Supporting Template Queries section
-    nameservers: "{{ V1alpha1_FormatNameservers 2 \",\" }}"
-    management_ip: "{{ V1alpha1_FormatIP \"192.168.1.10\" \"255.255.255.0\" }}"
-    hostname: "{{ .V1alpha1.VM.Name }} "  
-    management_gateway: "{{ (index .V1alpha1.Net.Devices 0).Gateway4 }}"
+      nameservers: "{{ (index .V1alpha1.Net.Nameservers 0) }}"         
+      management_ip: "{{ (index (index .V1alpha1.Net.Devices 0).IPAddresses 0) }}"
+      hostname: "{{ .V1alpha1.VM.Name }} "       
+      management_gateway: "{{ (index .V1alpha1.Net.Devices 0).Gateway4 }}"
     ```
 
-:wave: The Golang based template string is a representation of [vm-operator virtualmachinetempl_types v1alpha1 api](https://github.com/vmware-tanzu/vm-operator/blob/25fb865e615d377192a870583ab32973e9fbd32a/api/v1alpha1/virtualmachinetempl_types.go#L4)
+=== "vAppConfig with templated properties"
 
-:wave: The fields `nameservers`, `hostname`, `management_ip` and `management_gateway` are derived from image `haproxy-v0.2.0` OVF properties.
-```xml
-<Property ovf:key="nameservers" ovf:type="string" ovf:userConfigurable="true" ovf:value="1.1.1.1, 1.0.0.1">
-      <Label>2.2. DNS</Label>
-      <Description>A comma-separated list of IP addresses for up to three DNS servers</Description>
-</Property>
-<Property ovf:key="hostname" ovf:type="string" ovf:userConfigurable="true" ovf:value="ubuntuguest">
-      <Description>Specifies the hostname for the appliance</Description>
-</Property>
-<Property ovf:key="management_ip" ovf:type="string" ovf:userConfigurable="true">
-      <Label>2.3. Management IP</Label>
-      <Description>The static IP address for the appliance on the Management Port Group in CIDR format (.For eg. ip/subnet mask bits). This cannot be DHCP.</Description>
-</Property>
-```
+    !!! note "The vApp properties below..."
 
-## Supporting Template Queries
-To spare users the effort to construct a correct template string, there are some supporting template queries vm-operator provides.
+        The vApp properties used in this example are not standard. All images may define their own properties for configuring the guest's network, or anything else. Please review the image's OVF to understand what properties are available and should be assigned.
+
+
+    ```yaml
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: my-secret
+      namespace: test-ns
+    stringData:
+      # Please see the following section for more information on these functions.
+      nameservers: "{{ V1alpha1_FormatNameservers 2 \",\" }}"
+      management_ip: "{{ V1alpha1_FormatIP \"192.168.1.10\" \"255.255.255.0\" }}"
+      hostname: "{{ .V1alpha1.VM.Name }} "  
+      management_gateway: "{{ (index .V1alpha1.Net.Devices 0).Gateway4 }}"
+    ```
+
+## Templating
+
+Properties are templated according to the Golang [`text/template`](https://pkg.go.dev/text/template) package. Please refer to Go's documentation for a full understanding of how to construct template queries.
+
+### Input object
+
+The object provided to the template engine is the [`VirtualMachineTemplate`](https://github.com/vmware-tanzu/vm-operator/blob/70d22b93b3c454809145725d418c4f6cfebb124c/api/v1alpha1/virtualmachinetempl_types.go#L37-L50) data structure.
+
+### Pre-defined functions
+
+The following table lists the functions VM Operator defines and passes into the template engine to make it easier to construct the information required for vApp properties:
 
 | Query name | Signature | Description |
 | -------- | -------- | -------- |
-| V1alpha1_FirstIP | `func () string` | Get the first non-loopback IP with CIDR from first NIC. |
-| V1alpha1_FirstIPFromNIC | `func (index int) string` | Get non-loopback IP address with CIDR from the ith NIC. if index out of bound, template string won't be parsed. |
-| V1alpha1_FormatIP | `func (IP string, netmask string) string` | see below for detailed use case.|
-| V1alpha1_FirstNicMacAddr | `func() (string, error)` | Get the first NIC's MAC address. |
-| V1alpha1_FormatNameservers| `func (count int, delimiter string) string` | Format the first occurred count of nameservers with specific delimiter (A n.For egative number for count would mean all nameservers). |
-| V1alpha1_IP | `func(IP string) string` | Format a static IP address with default netmask CIDR. If IP is not valid, template string won't be parsed. |
-| V1alpha1_IPsFromNIC | `func (index int) []string` | List all IPs with CIDR from the ith NIC. if index out of bound, template string won't be parsed. |
-| V1alpha1_SubnetMask | `func(cidr string) (string, error)` | Get subnet mask from a CIDR notation IP address and prefix length. |
-
-### `V1alpha1_FormatIP`
-1. Format an IP address with network length. A netmask can be either the length, ex. /24, or the decimal notation, ex. 255.255.255.0. Return IP sans CIDR when input is valid.
-
-2. Format an IP address with CIDR: 
-    - if input netmask is different with CIDR, replace and return IP with new CIDR. 
-    - if input netmask is empty string, return IP sans CIDR. 
-    - if input netmask is not valid, return empty string. 
-
-**Note** when OVF only takes in IP sans CIDR, use `V1alpha1_FormatIP` and pass empty string as input netmask:
-```yaml
-management_ip: '{{ V1alpha1_FormatIP V1alpha1_FirstIP "" }}' # return first non-loopback IP from first NIC without CIDR. For eg, "192.168.1.10".
-```
-
-### Examples
-```yaml
-  management_ip: "{{ V1alpha1_FirstIP }}" # return first non-loopback IP with CIDR from first NIC.
-  management_ip: "{{ V1alpha1_FirstIPFromNIC 1 }}" # return first non-loopback IP with CIDR from second NIC.
-  management_ip: "{{ V1alpha1_FormatIP \"192.168.1.10\" \"255.255.255.0\" }}" # return IP with CIDR. For eg,"192.168.1.10/24".
-  management_ip: "{{ V1alpha1_IP \"192.168.1.37\" }}" # return IP with default netmask CIDR.
-  nameservers: "{{ V1alpha1_FormatNameservers 2 \",\" }}" # return 2 nameservers with "," as delimiter. For eg,"10.20.145.1, 10.20.145.2".
-  subnet_mask: "{{ V1alpha1_SubnetMask V1alpha1_FirstIP }}" # return the subnet mask of the first non-loopback IP with CIDR from first NIC. For eg, "255.255.255.0".
-  mac_address: "{{ v1alpha1_FirstNicMacAddr }}" # return the first NIC's MAC Address.
-```
+| V1alpha1_FirstIP | `func () string` | Get the first, non-loopback IP address (formatted with network length) from the first NIC. |
+| V1alpha1_FirstIPFromNIC | `func (index int) string` | Get the first, non-loopback IP address (formatted with network length) from the n'th NIC. If the specified index is out-of-bounds, the template string is not parsed. |
+| V1alpha1_FormatIP | `func (IP string, netmask string) string` | This function may be used to format an IP address with or without a network prefix length. If the provided netmask is empty, then the IP address returned does not include a network length. If the provided netmask is non-empty, then it must be either a length, ex. `/24`, or decimal notation, ex. `255.255.255.0`. |
+| V1alpha1_FirstNicMacAddr | `func() (string, error)` | Get the MAC address from the first NIC. |
+| V1alpha1_FormatNameservers| `func (count int, delimiter string) string` | Format the first occurred count of nameservers with the provided delimiter. Specify a negative number to include all nameservers. |
+| V1alpha1_IP | `func(IP string) string` | Format an IP address with the default netmask CIDR. If the specified IP is invalid, the template string is not parsed. |
+| V1alpha1_IPsFromNIC | `func (index int) []string` | List all IPs, formatted with the network length, from the n'th NIC. If the specified index is out-of-bounds, the template string is not parsed. |
+| V1alpha1_SubnetMask | `func(cidr string) (string, error)` | Get a subnet mask from an IP address formatted with a network length. |
 


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch fixes some formatting / wording issues in the vApp bootstrap docs.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NONE`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Fixes some errors in the vApp bootstrap documentation.
```

<!-- readthedocs-preview vm-operator start -->
----
📚 Documentation preview 📚: https://vm-operator--307.org.readthedocs.build/en/307/

<!-- readthedocs-preview vm-operator end -->