### PR TITLE
🐛 Restore previous LinuxPrep default customization behavior

### DIFF
--- a/pkg/vmprovider/providers/vsphere2/vmlifecycle/bootstrap.go
+++ b/pkg/vmprovider/providers/vsphere2/vmlifecycle/bootstrap.go
@@ -57,7 +57,8 @@ func DoBootstrap(
 
 	bootstrap := vmCtx.VM.Spec.Bootstrap
 	if bootstrap == nil {
-		return nil
+		// For backwards compat we have to keep going and default to LinuxPrep.
+		bootstrap = &vmopv1.VirtualMachineBootstrapSpec{}
 	}
 
 	cloudInit := bootstrap.CloudInit


### PR DESCRIPTION
We have E2E tests that assume this behavior so preserve that in v1a2 as well. The pointer API change in b54465 changed the behavior to exit bootstrap early. This is just a quick fix to get pipelines fixed. There is an existing story to both improve this default behavior - like by inspecting the image OS, and to keep addressing the prior lack of tests in this area.
