### PR TITLE
🌱 Refactor v1a2 backup to store all VM additional resources YAML in ExtraConfig

### DIFF
--- a/api/v1alpha2/virtualmachine_types.go
+++ b/api/v1alpha2/virtualmachine_types.go
@@ -117,15 +117,13 @@ const (
 	ManagedByExtensionKey  = "com.vmware.vcenter.wcp"
 	ManagedByExtensionType = "VirtualMachine"
 
-	// VMBackupKubeDataExtraConfigKey is the ExtraConfig key to persist the VM's
-	// Kubernetes resource spec data, compressed using gzip and base64-encoded.
-	VMBackupKubeDataExtraConfigKey = "vmservice.virtualmachine.kubedata"
-	// VMBackupBootstrapDataExtraConfigKey is the ExtraConfig key to persist the
-	// VM's bootstrap data object, compressed using gzip and base64-encoded.
-	VMBackupBootstrapDataExtraConfigKey = "vmservice.virtualmachine.bootstrapdata"
-	// VMBackupDiskDataExtraConfigKey is the ExtraConfig key to persist the VM's
-	// attached disk info in JSON, compressed using gzip and base64-encoded.
-	VMBackupDiskDataExtraConfigKey = "vmservice.virtualmachine.diskdata"
+	// VMBackupKubeObjectsYAMLExtraConfigKey is the ExtraConfig key to persist VM
+	// and its relevant Kubernetes resource YAML separated by "---", compressed
+	// using gzip and base64-encoded.
+	VMBackupKubeObjectsYAMLExtraConfigKey = "vmservice.virtualmachine.kube.objects.yaml"
+	// VMBackupPVCDiskDataExtraConfigKey is the ExtraConfig key to persist the VM's
+	// PVC disk data in JSON, compressed using gzip and base64-encoded.
+	VMBackupPVCDiskDataExtraConfigKey = "vmservice.virtualmachine.pvc.disk.data"
 	// VMBackupCloudInitInstanceIDExtraConfigKey is the ExtraConfig key to persist
 	// the VM's Cloud-Init instance ID, compressed using gzip and base64-encoded.
 	VMBackupCloudInitInstanceIDExtraConfigKey = "vmservice.virtualmachine.cloudinit.instanceid"

--- a/api/v1alpha2/virtualmachine_types.go
+++ b/api/v1alpha2/virtualmachine_types.go
@@ -109,24 +109,28 @@ const (
 	FirstBootDoneAnnotation = "virtualmachine." + GroupName + "/first-boot-done"
 )
 
-// VirtualMachine backup/restore related constants.
 const (
 	// ManagedByExtensionKey and ManagedByExtensionType represent the ManagedBy
 	// field on the VM. They are used to differentiate VM Service managed VMs
 	// from traditional vSphere VMs.
 	ManagedByExtensionKey  = "com.vmware.vcenter.wcp"
 	ManagedByExtensionType = "VirtualMachine"
+)
 
-	// VMBackupKubeObjectsYAMLExtraConfigKey is the ExtraConfig key to persist VM
-	// and its relevant Kubernetes resource YAML separated by "---", compressed
-	// using gzip and base64-encoded.
-	VMBackupKubeObjectsYAMLExtraConfigKey = "vmservice.virtualmachine.kube.objects.yaml"
-	// VMBackupPVCDiskDataExtraConfigKey is the ExtraConfig key to persist the VM's
+// VirtualMachine backup/restore related constants.
+const (
+	// VMResourceYAMLExtraConfigKey is the ExtraConfig key to persist VM
+	// Kubernetes resource YAML, compressed using gzip and base64-encoded.
+	VMResourceYAMLExtraConfigKey = "vmservice.virtualmachine.resource.yaml"
+	// AdditionalResourcesYAMLExtraConfigKey is the ExtraConfig key to persist
+	// VM-relevant Kubernetes resource YAML, compressed using gzip and base64-encoded.
+	AdditionalResourcesYAMLExtraConfigKey = "vmservice.virtualmachine.additional.resources.yaml"
+	// PVCDiskDataExtraConfigKey is the ExtraConfig key to persist the VM's
 	// PVC disk data in JSON, compressed using gzip and base64-encoded.
-	VMBackupPVCDiskDataExtraConfigKey = "vmservice.virtualmachine.pvc.disk.data"
-	// VMBackupCloudInitInstanceIDExtraConfigKey is the ExtraConfig key to persist
+	PVCDiskDataExtraConfigKey = "vmservice.virtualmachine.pvc.disk.data"
+	// CloudInitInstanceIDExtraConfigKey is the ExtraConfig key to persist
 	// the VM's Cloud-Init instance ID, compressed using gzip and base64-encoded.
-	VMBackupCloudInitInstanceIDExtraConfigKey = "vmservice.virtualmachine.cloudinit.instanceid"
+	CloudInitInstanceIDExtraConfigKey = "vmservice.virtualmachine.cloudinit.instanceid"
 )
 
 // VirtualMachinePowerState defines a VM's desired and observed power states.

--- a/pkg/context/backupvirtualmachine_context.go
+++ b/pkg/context/backupvirtualmachine_context.go
@@ -23,16 +23,3 @@ type BackupVirtualMachineContext struct {
 func (c *BackupVirtualMachineContext) String() string {
 	return fmt.Sprintf("Backup %s", c.VMCtx.String())
 }
-
-// BackupVirtualMachineContextA2 is the context used for storing backup data of
-// VM and its related objects.
-type BackupVirtualMachineContextA2 struct {
-	VMCtx         VirtualMachineContextA2
-	VcVM          *object.VirtualMachine
-	BootstrapData map[string]string
-	DiskUUIDToPVC map[string]corev1.PersistentVolumeClaim
-}
-
-func (c *BackupVirtualMachineContextA2) String() string {
-	return fmt.Sprintf("Backup %s", c.VMCtx.String())
-}

--- a/pkg/vmprovider/providers/vsphere/session/session_vm_customization.go
+++ b/pkg/vmprovider/providers/vsphere/session/session_vm_customization.go
@@ -108,6 +108,7 @@ func GetCloudInitMetadata(vm *vmopv1.VirtualMachine,
 	// This is to address a bug when Cloud-Init sans configMap/secret actually got
 	// customized by LinuxPrep. Use annotation as instanceID to avoid
 	// different instanceID triggers CloudInit in brownfield scenario.
+	// This is also used in B/R to ensure it remains the same after VM restore.
 	if value, ok := vm.Annotations[vmopv1.InstanceIDAnnotation]; ok {
 		metadataObj.InstanceID = value
 	}

--- a/pkg/vmprovider/providers/vsphere2/virtualmachine/backup.go
+++ b/pkg/vmprovider/providers/vsphere2/virtualmachine/backup.go
@@ -149,7 +149,6 @@ func getDesiredResourceYAMLForBackup(
 	var isLatestBackup bool
 	if ecKubeData, ok := ecMap[ecKey]; ok {
 		if resourceToVersion := tryGetResourceVersion(ecKubeData); resourceToVersion != nil {
-			fmt.Println("resourceToVersion", resourceToVersion)
 			isLatestBackup = true
 			for _, curObj := range resources {
 				if curObj.GetResourceVersion() != resourceToVersion[string(curObj.GetUID())] {
@@ -192,13 +191,10 @@ func tryGetResourceVersion(ecResourcesYAML string) map[string]string {
 	decUnstructured := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
 	resourcesYAML := strings.Split(decoded, "---\n")
 	for _, resYAML := range resourcesYAML {
-		fmt.Println("resYAML", resYAML)
 		if resYAML != "" {
 			resYAML = strings.TrimSpace(resYAML)
 			res := &unstructured.Unstructured{}
-			_, _, err := decUnstructured.Decode([]byte(resYAML), nil, res)
-			if err != nil {
-				fmt.Println("err", err)
+			if _, _, err := decUnstructured.Decode([]byte(resYAML), nil, res); err != nil {
 				continue
 			}
 			resourceVersions[string(res.GetUID())] = res.GetResourceVersion()

--- a/pkg/vmprovider/providers/vsphere2/virtualmachine/backup.go
+++ b/pkg/vmprovider/providers/vsphere2/virtualmachine/backup.go
@@ -67,7 +67,7 @@ func BackupVirtualMachine(opts BackupVirtualMachineOptions) error {
 		return err
 	}
 	if vmYAML == "" {
-		opts.VMCtx.Logger.Info("Skipping VM resource yaml backup as unchanged")
+		opts.VMCtx.Logger.V(4).Info("Skipping VM resource yaml backup as unchanged")
 	} else {
 		ecToUpdate = append(ecToUpdate, &types.OptionValue{
 			Key:   vmopv1.VMResourceYAMLExtraConfigKey,
@@ -86,7 +86,7 @@ func BackupVirtualMachine(opts BackupVirtualMachineOptions) error {
 	}
 
 	if additionalYAML == "" {
-		opts.VMCtx.Logger.Info("Skipping additional resources yaml backup as unchanged")
+		opts.VMCtx.Logger.V(4).Info("Skipping additional resources yaml backup as unchanged")
 	} else {
 		ecToUpdate = append(ecToUpdate, &types.OptionValue{
 			Key:   vmopv1.AdditionalResourcesYAMLExtraConfigKey,
@@ -125,8 +125,8 @@ func BackupVirtualMachine(opts BackupVirtualMachineOptions) error {
 	}
 
 	if len(ecToUpdate) != 0 {
-		opts.VMCtx.Logger.Info("Updating VM ExtraConfig with latest backup data")
-		opts.VMCtx.Logger.V(4).Info("", "ExtraConfigToUpdate", ecToUpdate)
+		opts.VMCtx.Logger.Info("Updating VM ExtraConfig with latest backup data",
+			"ExtraConfigToUpdate", ecToUpdate)
 		if _, err := opts.VcVM.Reconfigure(opts.VMCtx, types.VirtualMachineConfigSpec{
 			ExtraConfig: ecToUpdate,
 		}); err != nil {

--- a/pkg/vmprovider/providers/vsphere2/virtualmachine/backup.go
+++ b/pkg/vmprovider/providers/vsphere2/virtualmachine/backup.go
@@ -5,19 +5,31 @@ package virtualmachine
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 
-	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/yaml"
-
+	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/util"
 )
 
-type VMDiskData struct {
+// BackupVirtualMachineOptions contains the options for BackupVirtualMachine.
+type BackupVirtualMachineOptions struct {
+	VMCtx         context.VirtualMachineContextA2
+	VcVM          *object.VirtualMachine
+	KubeObjects   []client.Object
+	DiskUUIDToPVC map[string]corev1.PersistentVolumeClaim
+}
+
+// PVCDiskData contains the data of a disk attached to VM backed by a PVC.
+type PVCDiskData struct {
 	// Filename contains the datastore path to the virtual disk.
 	FileName string
 	// PVCName is the name of the PVC backed by the virtual disk.
@@ -28,87 +40,72 @@ type VMDiskData struct {
 
 // BackupVirtualMachine backs up the required data of a VM into its ExtraConfig.
 // Currently, the following data is backed up:
-// - Kubernetes VirtualMachine object in YAML format (without its .status field).
-// - VM bootstrap data in JSON (if provided).
-// - VM disk data in JSON (if created and attached by PVCs).
-func BackupVirtualMachine(ctx context.BackupVirtualMachineContextA2) error {
+// - VM relevant Kubernetes objects in YAML separated by "---".
+// - Cloud-Init instance ID (if not already stored in ExtraConfig).
+// - PVC disk data in JSON format (if DiskUUIDToPVC is not empty).
+func BackupVirtualMachine(opts BackupVirtualMachineOptions) error {
 	var moVM mo.VirtualMachine
-	if err := ctx.VcVM.Properties(ctx.VMCtx, ctx.VcVM.Reference(),
+	if err := opts.VcVM.Properties(opts.VMCtx, opts.VcVM.Reference(),
 		[]string{"config.extraConfig"}, &moVM); err != nil {
-		ctx.VMCtx.Logger.Error(err, "Failed to get VM properties for backup")
+		opts.VMCtx.Logger.Error(err, "Failed to get VM properties for backup")
 		return err
 	}
+
 	curEcMap := util.ExtraConfigToMap(moVM.Config.ExtraConfig)
+	ecToUpdate := []types.BaseOptionValue{}
 
-	var ecToUpdate []types.BaseOptionValue
-
-	vmKubeDataBackup, err := getDesiredVMKubeDataForBackup(ctx.VMCtx.VM, curEcMap)
+	objectsYAML, err := getDesiredKubeObjectsYAMLForBackup(opts.KubeObjects, curEcMap)
 	if err != nil {
-		ctx.VMCtx.Logger.Error(err, "Failed to get VM kube data for backup")
+		opts.VMCtx.Logger.Error(err, "Failed to get kube objects yaml for backup")
 		return err
 	}
 
-	if vmKubeDataBackup == "" {
-		ctx.VMCtx.Logger.V(4).Info("Skipping VM kube data backup as unchanged")
+	if objectsYAML == "" {
+		opts.VMCtx.Logger.Info("Skipping kube objects yaml backup as unchanged")
 	} else {
 		ecToUpdate = append(ecToUpdate, &types.OptionValue{
-			Key:   vmopv1.VMBackupKubeDataExtraConfigKey,
-			Value: vmKubeDataBackup,
+			Key:   vmopv1.VMBackupKubeObjectsYAMLExtraConfigKey,
+			Value: objectsYAML,
 		})
 	}
 
-	instanceIDBackup, err := getDesiredCloudInitInstanceIDForBackup(ctx.VMCtx.VM, curEcMap)
+	instanceID, err := getDesiredCloudInitInstanceIDForBackup(opts.VMCtx.VM, curEcMap)
 	if err != nil {
-		ctx.VMCtx.Logger.Error(err, "Failed to get cloud-init instance ID for backup")
+		opts.VMCtx.Logger.Error(err, "Failed to get cloud-init instance ID for backup")
 		return err
 	}
 
-	if instanceIDBackup == "" {
-		ctx.VMCtx.Logger.V(4).Info("Skipping cloud-init instance ID as already stored")
+	if instanceID == "" {
+		opts.VMCtx.Logger.V(4).Info("Skipping cloud-init instance ID as already stored")
 	} else {
 		ecToUpdate = append(ecToUpdate, &types.OptionValue{
 			Key:   vmopv1.VMBackupCloudInitInstanceIDExtraConfigKey,
-			Value: instanceIDBackup,
+			Value: instanceID,
 		})
 	}
 
-	bootstrapDataBackup, err := getDesiredBootstrapDataForBackup(ctx.BootstrapData, curEcMap)
+	pvcDiskData, err := getDesiredPVCDiskDataForBackup(opts, curEcMap)
 	if err != nil {
-		ctx.VMCtx.Logger.Error(err, "Failed to get VM bootstrap data for backup")
+		opts.VMCtx.Logger.Error(err, "Failed to get PVC disk data for backup")
 		return err
 	}
 
-	if bootstrapDataBackup == "" {
-		ctx.VMCtx.Logger.V(4).Info("Skipping VM bootstrap data backup as unchanged")
+	if pvcDiskData == "" {
+		opts.VMCtx.Logger.V(4).Info("Skipping PVC disk data backup as unchanged")
 	} else {
 		ecToUpdate = append(ecToUpdate, &types.OptionValue{
-			Key:   vmopv1.VMBackupBootstrapDataExtraConfigKey,
-			Value: bootstrapDataBackup,
-		})
-	}
-
-	diskDataBackup, err := getDesiredDiskDataForBackup(ctx, curEcMap)
-	if err != nil {
-		ctx.VMCtx.Logger.Error(err, "Failed to get VM disk data for backup")
-		return err
-	}
-
-	if diskDataBackup == "" {
-		ctx.VMCtx.Logger.V(4).Info("Skipping VM disk data backup as unchanged")
-	} else {
-		ecToUpdate = append(ecToUpdate, &types.OptionValue{
-			Key:   vmopv1.VMBackupDiskDataExtraConfigKey,
-			Value: diskDataBackup,
+			Key:   vmopv1.VMBackupPVCDiskDataExtraConfigKey,
+			Value: pvcDiskData,
 		})
 	}
 
 	if len(ecToUpdate) != 0 {
-		ctx.VMCtx.Logger.Info("Updating VM ExtraConfig with backup data")
-		ctx.VMCtx.Logger.V(4).Info("", "ExtraConfig", ecToUpdate)
-		if _, err := ctx.VcVM.Reconfigure(ctx.VMCtx, types.VirtualMachineConfigSpec{
+		opts.VMCtx.Logger.Info("Updating VM ExtraConfig with latest backup data")
+		opts.VMCtx.Logger.V(4).Info("", "ExtraConfigToUpdate", ecToUpdate)
+		if _, err := opts.VcVM.Reconfigure(opts.VMCtx, types.VirtualMachineConfigSpec{
 			ExtraConfig: ecToUpdate,
 		}); err != nil {
-			ctx.VMCtx.Logger.Error(err, "Failed to update VM ExtraConfig for backup")
+			opts.VMCtx.Logger.Error(err, "Failed to update VM ExtraConfig with latest backup data")
 			return err
 		}
 	}
@@ -116,40 +113,76 @@ func BackupVirtualMachine(ctx context.BackupVirtualMachineContextA2) error {
 	return nil
 }
 
-func getDesiredVMKubeDataForBackup(
-	vm *vmopv1.VirtualMachine,
+func getDesiredKubeObjectsYAMLForBackup(
+	kubeObjects []client.Object,
 	ecMap map[string]string) (string, error) {
-	// If the ExtraConfig already contains the latest VM spec, determined by
-	// 'metadata.generation', return an empty string to skip the backup.
-	if ecKubeData, ok := ecMap[vmopv1.VMBackupKubeDataExtraConfigKey]; ok {
-		vmFromBackup, err := constructVMObj(ecKubeData)
+	// Check if the VM's ExtraConfig already contains the latest version of all
+	// objects, determined by each resource UID to resource version mapping.
+	var isLatestBackup bool
+	if ecKubeData, ok := ecMap[vmopv1.VMBackupKubeObjectsYAMLExtraConfigKey]; ok {
+		if resourceToVersion := tryGetResourceVersion(ecKubeData); resourceToVersion != nil {
+			isLatestBackup = true
+			for _, curObj := range kubeObjects {
+				if curObj.GetResourceVersion() != resourceToVersion[string(curObj.GetUID())] {
+					isLatestBackup = false
+					break
+				}
+			}
+		}
+	}
+
+	// All objects are up-to-date, return an empty string to skip the backup.
+	if isLatestBackup {
+		return "", nil
+	}
+
+	// Backup the latest version of all objects with encoded and gzipped YAML.
+	// Use "---" as the separator between objects to allow for easy parsing.
+	marshaledStrs := []string{}
+	for _, obj := range kubeObjects {
+		marshaledYaml, err := yaml.Marshal(obj)
 		if err != nil {
-			return "", err
+			return "", fmt.Errorf("failed to marshal object %s: %v", obj.GetName(), err)
 		}
-		if vmFromBackup.ObjectMeta.Generation >= vm.ObjectMeta.Generation {
-			return "", nil
-		}
+		marshaledStrs = append(marshaledStrs, string(marshaledYaml))
 	}
 
-	backupVM := vm.DeepCopy()
-	backupVM.Status = vmopv1.VirtualMachineStatus{}
-	backupVMYaml, err := yaml.Marshal(backupVM)
-	if err != nil {
-		return "", err
-	}
-
-	return util.EncodeGzipBase64(string(backupVMYaml))
+	kubeObjectsYAML := strings.Join(marshaledStrs, "---\n")
+	return util.EncodeGzipBase64(kubeObjectsYAML)
 }
 
-func constructVMObj(ecKubeData string) (vmopv1.VirtualMachine, error) {
-	var vmObj vmopv1.VirtualMachine
-	decodedKubeData, err := util.TryToDecodeBase64Gzip([]byte(ecKubeData))
+func tryGetResourceVersion(ecKubeObjectsYAML string) map[string]string {
+	decoded, err := util.TryToDecodeBase64Gzip([]byte(ecKubeObjectsYAML))
 	if err != nil {
-		return vmObj, err
+		return nil
 	}
 
-	err = yaml.Unmarshal([]byte(decodedKubeData), &vmObj)
-	return vmObj, err
+	resourceVersions := map[string]string{}
+	kubeObjectsYAML := strings.Split(decoded, "---\n")
+	for _, objYAML := range kubeObjectsYAML {
+		if objYAML != "" {
+			objYAML = strings.TrimSpace(objYAML)
+			var obj map[string]interface{}
+			if err := yaml.Unmarshal([]byte(objYAML), &obj); err != nil {
+				continue
+			}
+			metadata, ok := obj["metadata"].(map[string]interface{})
+			if !ok {
+				continue
+			}
+			uid, ok := metadata["uid"].(string)
+			if !ok {
+				continue
+			}
+			resourceVersion, ok := metadata["resourceVersion"].(string)
+			if !ok {
+				continue
+			}
+			resourceVersions[uid] = resourceVersion
+		}
+	}
+
+	return resourceVersions
 }
 
 func getDesiredCloudInitInstanceIDForBackup(
@@ -169,50 +202,25 @@ func getDesiredCloudInitInstanceIDForBackup(
 	return util.EncodeGzipBase64(instanceID)
 }
 
-func getDesiredBootstrapDataForBackup(
-	bootstrapDataRaw map[string]string,
-	ecMap map[string]string) (string, error) {
-	// No bootstrap data is specified, return an empty string to skip the backup.
-	if len(bootstrapDataRaw) == 0 {
-		return "", nil
-	}
-
-	bootstrapDataJSON, err := json.Marshal(bootstrapDataRaw)
-	if err != nil {
-		return "", err
-	}
-	bootstrapDataBackup, err := util.EncodeGzipBase64(string(bootstrapDataJSON))
-	if err != nil {
-		return "", err
-	}
-
-	// Return an empty string to skip the backup if the data is unchanged.
-	if bootstrapDataBackup == ecMap[vmopv1.VMBackupBootstrapDataExtraConfigKey] {
-		return "", nil
-	}
-
-	return bootstrapDataBackup, nil
-}
-
-func getDesiredDiskDataForBackup(
-	ctx context.BackupVirtualMachineContextA2,
+func getDesiredPVCDiskDataForBackup(
+	opts BackupVirtualMachineOptions,
 	ecMap map[string]string) (string, error) {
 	// Return an empty string to skip backup if no disk uuid to PVC is specified.
-	if len(ctx.DiskUUIDToPVC) == 0 {
+	if len(opts.DiskUUIDToPVC) == 0 {
 		return "", nil
 	}
 
-	deviceList, err := ctx.VcVM.Device(ctx.VMCtx)
+	deviceList, err := opts.VcVM.Device(opts.VMCtx)
 	if err != nil {
 		return "", err
 	}
 
-	var diskData []VMDiskData
+	var diskData []PVCDiskData
 	for _, device := range deviceList.SelectByType((*types.VirtualDisk)(nil)) {
 		if disk, ok := device.(*types.VirtualDisk); ok {
 			if b, ok := disk.Backing.(*types.VirtualDiskFlatVer2BackingInfo); ok {
-				if pvc, ok := ctx.DiskUUIDToPVC[b.Uuid]; ok {
-					diskData = append(diskData, VMDiskData{
+				if pvc, ok := opts.DiskUUIDToPVC[b.Uuid]; ok {
+					diskData = append(diskData, PVCDiskData{
 						FileName:    b.FileName,
 						PVCName:     pvc.Name,
 						AccessModes: pvc.Spec.AccessModes,
@@ -232,7 +240,7 @@ func getDesiredDiskDataForBackup(
 	}
 
 	// Return an empty string to skip the backup if the data is unchanged.
-	if diskDataBackup == ecMap[vmopv1.VMBackupDiskDataExtraConfigKey] {
+	if diskDataBackup == ecMap[vmopv1.VMBackupPVCDiskDataExtraConfigKey] {
 		return "", nil
 	}
 

--- a/pkg/vmprovider/providers/vsphere2/vmlifecycle/bootstrap_cloudinit.go
+++ b/pkg/vmprovider/providers/vsphere2/vmlifecycle/bootstrap_cloudinit.go
@@ -48,7 +48,13 @@ func BootStrapCloudInit(
 		sshPublicKeys = strings.Join(cloudInitSpec.SSHAuthorizedKeys, "\n")
 	}
 
-	metadata, err := GetCloudInitMetadata(string(vmCtx.VM.UID), bsArgs.Hostname, netPlan, sshPublicKeys)
+	uid := string(vmCtx.VM.UID)
+	// Use the existing instance ID if it is already set on the VM.
+	// This ensures cloud-init uses the same instance ID across B/R.
+	if value, ok := vmCtx.VM.Annotations[vmopv1.InstanceIDAnnotation]; ok {
+		uid = value
+	}
+	metadata, err := GetCloudInitMetadata(uid, bsArgs.Hostname, netPlan, sshPublicKeys)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/vmprovider/providers/vsphere2/vmprovider_vm.go
+++ b/pkg/vmprovider/providers/vsphere2/vmprovider_vm.go
@@ -400,26 +400,26 @@ func (vs *vSphereVMProvider) updateVirtualMachine(
 	if lib.IsVMServiceBackupRestoreFSSEnabled() {
 		vmCtx.Logger.V(4).Info("Backing up VirtualMachine")
 
-		kubeObjects, err := GetKubeObjectsForBackup(vmCtx, vs.k8sClient)
+		diskUUIDToPVC, err := GetAttachedDiskUUIDToPVC(vmCtx, vs.k8sClient)
 		if err != nil {
-			vmCtx.Logger.Error(err, "Failed to get kube objects for backup")
+			vmCtx.Logger.Error(err, "failed to get disk uuid to PVC mapping for backup")
 			return err
 		}
 
-		diskUUIDToPVC, err := GetAttachedDiskUUIDToPVC(vmCtx, vs.k8sClient)
+		additionalResources, err := GetAdditionalResourcesForBackup(vmCtx, vs.k8sClient)
 		if err != nil {
-			vmCtx.Logger.Error(err, "Failed to get disk uuid to PVC for backup")
+			vmCtx.Logger.Error(err, "failed to get additional resources for backup")
 			return err
 		}
 
 		backupOpts := virtualmachine.BackupVirtualMachineOptions{
-			VMCtx:         vmCtx,
-			VcVM:          vcVM,
-			KubeObjects:   kubeObjects,
-			DiskUUIDToPVC: diskUUIDToPVC,
+			VMCtx:               vmCtx,
+			VcVM:                vcVM,
+			DiskUUIDToPVC:       diskUUIDToPVC,
+			AdditionalResources: additionalResources,
 		}
 		if err := virtualmachine.BackupVirtualMachine(backupOpts); err != nil {
-			vmCtx.Logger.Error(err, "Failed to backup VM")
+			vmCtx.Logger.Error(err, "failed to backup VM")
 			return err
 		}
 	}

--- a/pkg/vmprovider/providers/vsphere2/vmprovider_vm_utils_test.go
+++ b/pkg/vmprovider/providers/vsphere2/vmprovider_vm_utils_test.go
@@ -933,7 +933,7 @@ func vmUtilTests() {
 		})
 	})
 
-	Context("GetKubeObjectsForBackup", func() {
+	Context("GetAdditionalResourcesForBackup", func() {
 
 		When("VM spec has no bootstrap data set", func() {
 
@@ -941,11 +941,10 @@ func vmUtilTests() {
 				vmCtx.VM.Spec.Bootstrap = nil
 			})
 
-			It("Should return VM object only", func() {
-				objects, err := vsphere.GetKubeObjectsForBackup(vmCtx, k8sClient)
+			It("Should not return any additional resources for backup", func() {
+				resources, err := vsphere.GetAdditionalResourcesForBackup(vmCtx, k8sClient)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(objects).To(HaveLen(1))
-				Expect(objects[0].GetName()).To(Equal(vmCtx.VM.Name))
+				Expect(resources).To(BeEmpty())
 			})
 		})
 
@@ -973,12 +972,11 @@ func vmUtilTests() {
 				})
 			})
 
-			It("Should return VM and secret objects", func() {
-				objects, err := vsphere.GetKubeObjectsForBackup(vmCtx, k8sClient)
+			It("Should return the Secret object as additional resource for backup", func() {
+				objects, err := vsphere.GetAdditionalResourcesForBackup(vmCtx, k8sClient)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(objects).To(HaveLen(2))
-				Expect(objects[0].GetName()).To(Equal(vmCtx.VM.Name))
-				Expect(objects[1].GetName()).To(Equal("dummy-cloud-config-secret"))
+				Expect(objects).To(HaveLen(1))
+				Expect(objects[0].GetName()).To(Equal("dummy-cloud-config-secret"))
 			})
 		})
 
@@ -1000,12 +998,11 @@ func vmUtilTests() {
 				})
 			})
 
-			It("Should return VM and Secret objects", func() {
-				objects, err := vsphere.GetKubeObjectsForBackup(vmCtx, k8sClient)
+			It("Should return the Secret object as additional resource for backup", func() {
+				objects, err := vsphere.GetAdditionalResourcesForBackup(vmCtx, k8sClient)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(objects).To(HaveLen(2))
-				Expect(objects[0].GetName()).To(Equal(vmCtx.VM.Name))
-				Expect(objects[1].GetName()).To(Equal("dummy-raw-cloud-secret"))
+				Expect(objects).To(HaveLen(1))
+				Expect(objects[0].GetName()).To(Equal("dummy-raw-cloud-secret"))
 			})
 		})
 
@@ -1027,12 +1024,11 @@ func vmUtilTests() {
 				})
 			})
 
-			It("Should return VM and ConfigMap objects", func() {
-				objects, err := vsphere.GetKubeObjectsForBackup(vmCtx, k8sClient)
+			It("Should return the ConfigMap object as additional resource for backup", func() {
+				objects, err := vsphere.GetAdditionalResourcesForBackup(vmCtx, k8sClient)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(objects).To(HaveLen(2))
-				Expect(objects[0].GetName()).To(Equal(vmCtx.VM.Name))
-				Expect(objects[1].GetName()).To(Equal("dummy-raw-cloud-config-map"))
+				Expect(objects).To(HaveLen(1))
+				Expect(objects[0].GetName()).To(Equal("dummy-raw-cloud-config-map"))
 			})
 		})
 
@@ -1058,12 +1054,11 @@ func vmUtilTests() {
 				})
 			})
 
-			It("Should return VM and Secret objects", func() {
-				objects, err := vsphere.GetKubeObjectsForBackup(vmCtx, k8sClient)
+			It("Should return the Secret object as additional resource for backup", func() {
+				objects, err := vsphere.GetAdditionalResourcesForBackup(vmCtx, k8sClient)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(objects).To(HaveLen(2))
-				Expect(objects[0].GetName()).To(Equal(vmCtx.VM.Name))
-				Expect(objects[1].GetName()).To(Equal("dummy-sysprep-secret"))
+				Expect(objects).To(HaveLen(1))
+				Expect(objects[0].GetName()).To(Equal("dummy-sysprep-secret"))
 			})
 		})
 
@@ -1085,12 +1080,11 @@ func vmUtilTests() {
 				})
 			})
 
-			It("Should return VM and secret objects", func() {
-				objects, err := vsphere.GetKubeObjectsForBackup(vmCtx, k8sClient)
+			It("Should return the Secret object as additional resource for backup", func() {
+				objects, err := vsphere.GetAdditionalResourcesForBackup(vmCtx, k8sClient)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(objects).To(HaveLen(2))
-				Expect(objects[0].GetName()).To(Equal(vmCtx.VM.Name))
-				Expect(objects[1].GetName()).To(Equal("dummy-raw-sysprep-secret"))
+				Expect(objects).To(HaveLen(1))
+				Expect(objects[0].GetName()).To(Equal("dummy-raw-sysprep-secret"))
 			})
 		})
 
@@ -1112,12 +1106,11 @@ func vmUtilTests() {
 				})
 			})
 
-			It("Should return VM and ConfigMap objects", func() {
-				objects, err := vsphere.GetKubeObjectsForBackup(vmCtx, k8sClient)
+			It("Should return the ConfigMap object as additional resource for backup", func() {
+				objects, err := vsphere.GetAdditionalResourcesForBackup(vmCtx, k8sClient)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(objects).To(HaveLen(2))
-				Expect(objects[0].GetName()).To(Equal(vmCtx.VM.Name))
-				Expect(objects[1].GetName()).To(Equal("dummy-raw-sysprep-config-map"))
+				Expect(objects).To(HaveLen(1))
+				Expect(objects[0].GetName()).To(Equal("dummy-raw-sysprep-config-map"))
 			})
 		})
 
@@ -1145,12 +1138,11 @@ func vmUtilTests() {
 				})
 			})
 
-			It("Should return VM and Secret objects", func() {
-				objects, err := vsphere.GetKubeObjectsForBackup(vmCtx, k8sClient)
+			It("Should return the Secret object as additional resource for backup", func() {
+				objects, err := vsphere.GetAdditionalResourcesForBackup(vmCtx, k8sClient)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(objects).To(HaveLen(2))
-				Expect(objects[0].GetName()).To(Equal(vmCtx.VM.Name))
-				Expect(objects[1].GetName()).To(Equal("dummy-vapp-config-property-secret"))
+				Expect(objects).To(HaveLen(1))
+				Expect(objects[0].GetName()).To(Equal("dummy-vapp-config-property-secret"))
 			})
 		})
 
@@ -1170,12 +1162,11 @@ func vmUtilTests() {
 				})
 			})
 
-			It("Should return VM and Secret objects", func() {
-				objects, err := vsphere.GetKubeObjectsForBackup(vmCtx, k8sClient)
+			It("Should return the Secret object as additional resource for backup", func() {
+				objects, err := vsphere.GetAdditionalResourcesForBackup(vmCtx, k8sClient)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(objects).To(HaveLen(2))
-				Expect(objects[0].GetName()).To(Equal(vmCtx.VM.Name))
-				Expect(objects[1].GetName()).To(Equal("dummy-raw-vapp-config-secret"))
+				Expect(objects).To(HaveLen(1))
+				Expect(objects[0].GetName()).To(Equal("dummy-raw-vapp-config-secret"))
 			})
 		})
 
@@ -1195,12 +1186,11 @@ func vmUtilTests() {
 				})
 			})
 
-			It("Should return VM and Secret objects", func() {
-				objects, err := vsphere.GetKubeObjectsForBackup(vmCtx, k8sClient)
+			It("Should return the Secret object as additional resource for backup", func() {
+				objects, err := vsphere.GetAdditionalResourcesForBackup(vmCtx, k8sClient)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(objects).To(HaveLen(2))
-				Expect(objects[0].GetName()).To(Equal(vmCtx.VM.Name))
-				Expect(objects[1].GetName()).To(Equal("dummy-raw-vapp-config-config-map"))
+				Expect(objects).To(HaveLen(1))
+				Expect(objects[0].GetName()).To(Equal("dummy-raw-vapp-config-config-map"))
 			})
 		})
 	})

--- a/pkg/vmprovider/providers/vsphere2/vmprovider_vm_utils_test.go
+++ b/pkg/vmprovider/providers/vsphere2/vmprovider_vm_utils_test.go
@@ -1124,6 +1124,15 @@ func vmUtilTests() {
 								Value: common.ValueOrSecretKeySelector{
 									From: &common.SecretKeySelector{
 										Name: "dummy-vapp-config-property-secret",
+										Key:  "foo",
+									},
+								},
+							},
+							{
+								Value: common.ValueOrSecretKeySelector{
+									From: &common.SecretKeySelector{
+										Name: "dummy-vapp-config-property-secret",
+										Key:  "bar",
 									},
 								},
 							},


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
- Replace `BackupVirtualMachineContextA2` with `BackupVirtualMachineOptions`.
- Store VM resource YAML in the "vmservice.virtualmachine.resource.yaml" ExtraConfig key.
- Store VM bootstrap relevant resources YAML (separated by "---") in the "vmservice.virtualmachine.additional.resources.yaml" ExtraConfig key.

These changes are needed to better support backup/restore for v1a2 VMs.

**Are there any special notes for your reviewer**:
- A separate PR will be pushed to either update or remove the v1a1 backup controller code (as it won't be executed if v1a2 and B/R features are enabled in the same release).

**Please add a release note if necessary**:
```release-note
Refactor v1a2 backup to store all bootstrap referencing objects YAML as additional resources in VM ExtraConfig
```

**Testing Done**:
- Add/Update unit tests
- Deployed the change to a WCP testbed and confirmed the updated ExtraConfig with expected data:

<details>
<summary>Linux VM with Cloud-Init</summary>

```console
$ govc vm.info -e "test-vm-pvc-new" | grep "vmservice.virtualmachine.*" | awk '{print $1}'
vmservice.virtualmachine.additional.resources.yaml:
vmservice.virtualmachine.cloudinit.instanceid:
vmservice.virtualmachine.pvc.disk.data:
vmservice.virtualmachine.resource.yaml:

$ govc vm.info -e "test-vm-pvc-new" | grep "vmservice.virtualmachine.resource.yaml" | awk '{print $2}' | base64 -d | gunzip
apiVersion: vmoperator.vmware.com/v1alpha2
kind: VirtualMachine
metadata:
  name: test-vm-pvc-new
  namespace: sdiliyaer-test
...
$ govc vm.info -e "test-vm-pvc-new" | grep "vmservice.virtualmachine.additional.resources.yaml" | awk '{print $2}' | base64 -d | gunzip
apiVersion: v1
kind: Secret
metadata:
  name: test-bootstrap-data
  namespace: sdiliyaer-test
...
```
</details>

<details>
<summary>Windows VM with Sysprep</summary>

```console
$ govc vm.info -e "test-windows" | grep "vmservice.virtualmachine.*" | awk '{print $1}'
vmservice.virtualmachine.additional.resources.yaml:
vmservice.virtualmachine.cloudinit.instanceid:
vmservice.virtualmachine.resource.yaml:

$ govc vm.info -e "test-windows" | grep "vmservice.virtualmachine.resource.yaml" | awk '{print $2}' | base64 -d | gunzip
apiVersion: vmoperator.vmware.com/v1alpha2
kind: VirtualMachine
metadata:
  ...
  name: test-windows
  namespace: sdiliyaer-test
  resourceVersion: "6529899"
  uid: 3ff61661-893f-413b-8177-467265a6eca2
spec:
  advanced: {}
  bootstrap:
    sysprep:
      rawSysprep:
        key: unattend
        name: windows-unattend
...

$ govc vm.info -e "test-windows" | grep "vmservice.virtualmachine.additional.resources.yaml" | awk '{print $2}' | base64 -d | gunzip
apiVersion: v1
data:
  unattend: ...
kind: Secret
metadata:
  ...
  name: windows-unattend
  namespace: sdiliyaer-test
  resourceVersion: "6520758"
  uid: 12a2a784-051f-41d9-a669-c9f2d23ddc39
type: Opaque
...
```
</details>