### PR TITLE
🐛 Fix generated CloudConfig type via Docker

### DIFF
--- a/pkg/util/cloudinit/schema/Makefile
+++ b/pkg/util/cloudinit/schema/Makefile
@@ -97,7 +97,7 @@ ifeq (docker,$(QUICKTYPE_METHOD))
 $(CLOUD_CONFIG_GO): build-images-quicktype
 	docker run -it --rm \
 	  -v $$(pwd):/output \
-	  -v $$(pwd)/$(SCHEMA_CLOUD_CONFIG):/schema.json \
+	  -v $$(pwd)/$(SCHEMA_CLOUD_CONFIG):/schema-cloud-config-v1.json \
 	  $(QUICKTYPE_IMAGE)
 	$(GOIMPORTS) -w $@
 else


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch fixes a weird issue when generate the Golang type(s) for a Cloud-Init CloudConfig. When generating them via Docker, the program quicktype used the schema's filename as part of the generated types. This caused the file to look different when generated locally versus when generated via a container.



**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Fixes mismatched `cloudconfig.go` when using `quicktype` via Docker versus locally
```