### PR TITLE
🌱 Add conversion annotation to CVMI/VMI to populate missing field

### DIFF
--- a/api/v1alpha1/conversion_test.go
+++ b/api/v1alpha1/conversion_test.go
@@ -183,7 +183,7 @@ func overrideVirtualMachineImageFieldsFuncs(codecs runtimeserializer.CodecFactor
 			overrideConditionsSeverity(imageStatus.Conditions)
 
 			// Do not exist in v1a2.
-			imageStatus.ContentLibraryRef = nil
+			//imageStatus.ContentLibraryRef = nil
 			imageStatus.ImageSupported = nil
 
 			// These are deprecated.

--- a/api/v1alpha1/virtualmachineimage_conversion_test.go
+++ b/api/v1alpha1/virtualmachineimage_conversion_test.go
@@ -4,9 +4,12 @@
 package v1alpha1_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
+	corev1 "k8s.io/api/core/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -40,5 +43,79 @@ func TestVirtualMachineImageConversion(t *testing.T) {
 		g.Expect(spoke.Spec.ProviderRef.Kind).To(Equal("ImageProvider"))
 		g.Expect(spoke.Spec.ProviderRef.Name).To(Equal("my-image"))
 		g.Expect(spoke.Spec.ProviderRef.Namespace).To(Equal("my-namespace"))
+	})
+}
+
+func Test_Status_ContentLibraryRef(t *testing.T) {
+	apiGroup := "foo.bar.com/v1"
+	refData, err := json.Marshal(corev1.TypedLocalObjectReference{
+		APIGroup: &apiGroup,
+		Kind:     "FooKind",
+		Name:     "foo-ref",
+	})
+	NewWithT(t).Expect(err).ToNot(HaveOccurred())
+	annotations := map[string]string{
+		nextver.VMIContentLibRefAnnotation: string(refData),
+	}
+
+	t.Run("CVMI hub-spoke sets up content library ref in status", func(t *testing.T) {
+		g := NewWithT(t)
+
+		// setting up the annotation is performed by the v1a2 controllers
+		nextVerCVMI := nextver.ClusterVirtualMachineImage{ObjectMeta: metav1.ObjectMeta{
+			Name:        "foo",
+			Annotations: annotations,
+		}}
+
+		cvmiAfter := v1alpha1.ClusterVirtualMachineImage{}
+		g.Expect(cvmiAfter.ConvertFrom(&nextVerCVMI)).To(Succeed())
+		g.Expect(cvmiAfter.Status.ContentLibraryRef).ToNot(BeNil())
+		g.Expect(cvmiAfter.Status.ContentLibraryRef.APIGroup).To(gstruct.PointTo(Equal(apiGroup)))
+		g.Expect(cvmiAfter.Status.ContentLibraryRef.Kind).To(Equal("FooKind"))
+		g.Expect(cvmiAfter.Status.ContentLibraryRef.Name).To(Equal("foo-ref"))
+
+		t.Run("when conversion annotation is unset", func(t *testing.T) {
+			g := NewWithT(t)
+			cvmiWithoutLibraryRef := nextver.ClusterVirtualMachineImage{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec:       nextver.VirtualMachineImageSpec{},
+				Status:     nextver.VirtualMachineImageStatus{},
+			}
+
+			cvmiAfter := v1alpha1.ClusterVirtualMachineImage{}
+			g.Expect(cvmiAfter.ConvertFrom(&cvmiWithoutLibraryRef)).To(Succeed())
+			g.Expect(cvmiAfter.Status.ContentLibraryRef).To(BeNil())
+		})
+	})
+
+	t.Run("VMI hub-spoke sets up content library ref in status", func(t *testing.T) {
+		g := NewWithT(t)
+
+		// setting up the annotation is performed by the v1a2 controllers
+		nextVerVMI := nextver.VirtualMachineImage{ObjectMeta: metav1.ObjectMeta{
+			Name:        "foo",
+			Namespace:   "default",
+			Annotations: annotations,
+		}}
+
+		vmiAfter := v1alpha1.VirtualMachineImage{}
+		g.Expect(vmiAfter.ConvertFrom(&nextVerVMI)).To(Succeed())
+		g.Expect(vmiAfter.Status.ContentLibraryRef).ToNot(BeNil())
+		g.Expect(vmiAfter.Status.ContentLibraryRef.APIGroup).To(gstruct.PointTo(Equal(apiGroup)))
+		g.Expect(vmiAfter.Status.ContentLibraryRef.Kind).To(Equal("FooKind"))
+		g.Expect(vmiAfter.Status.ContentLibraryRef.Name).To(Equal("foo-ref"))
+
+		t.Run("when conversion annotation is unset", func(t *testing.T) {
+			g := NewWithT(t)
+			vmiWithoutLibraryRef := nextver.VirtualMachineImage{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec:       nextver.VirtualMachineImageSpec{},
+				Status:     nextver.VirtualMachineImageStatus{},
+			}
+
+			vmiAfter := v1alpha1.VirtualMachineImage{}
+			g.Expect(vmiAfter.ConvertFrom(&vmiWithoutLibraryRef)).To(Succeed())
+			g.Expect(vmiAfter.Status.ContentLibraryRef).To(BeNil())
+		})
 	})
 }

--- a/api/v1alpha2/virtualmachineimage_types.go
+++ b/api/v1alpha2/virtualmachineimage_types.go
@@ -31,6 +31,12 @@ const (
 	VirtualMachineImageCapabilityLabel = "capability.image." + GroupName + "/"
 )
 
+const (
+	// VMIContentLibRefAnnotation is the key for the annotation that stores the content library
+	// reference for VMI and CVMI down conversion.
+	VMIContentLibRefAnnotation = "vmoperator.vmware.com/conversion-content-lib-ref"
+)
+
 // Condition reasons for VirtualMachineImages.
 const (
 	// VirtualMachineImageNotSyncedReason documents that the VirtualMachineImage is not synced with

--- a/controllers/contentlibrary/v1alpha2/clustercontentlibraryitem/clustercontentlibraryitem_controller_intg_test.go
+++ b/controllers/contentlibrary/v1alpha2/clustercontentlibraryitem/clustercontentlibraryitem_controller_intg_test.go
@@ -125,6 +125,15 @@ func cclItemReconcile() {
 					waitForClusterVirtualMachineImageNotReadyWithReason(cvmiKey,
 						vmopv1.VirtualMachineImageProviderSecurityNotCompliantReason)
 				})
+
+				By("ClusterVirtualMachineImage should have conversion annotation set", func() {
+					Eventually(func(g Gomega) {
+						image := &vmopv1.ClusterVirtualMachineImage{}
+						g.Expect(ctx.Client.Get(ctx, cvmiKey, image)).To(Succeed())
+						g.Expect(len(image.Annotations)).To(BeNumerically(">=", 1))
+						g.Expect(image.Annotations).To(HaveKey(vmopv1.VMIContentLibRefAnnotation))
+					}).Should(Succeed())
+				})
 			})
 
 			cclItem := &imgregv1a1.ClusterContentLibraryItem{}

--- a/controllers/contentlibrary/v1alpha2/contentlibraryitem/contentlibraryitem_controller.go
+++ b/controllers/contentlibrary/v1alpha2/contentlibraryitem/contentlibraryitem_controller.go
@@ -5,10 +5,12 @@ package contentlibraryitem
 
 import (
 	goctx "context"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -244,6 +246,33 @@ func (r *Reconciler) setUpVMIFromCLItem(ctx *context.ContentLibraryItemContextA2
 	}
 	vmi.Status.Name = clItem.Status.Name
 	vmi.Status.ProviderItemID = string(clItem.Spec.UUID)
+
+	return addContentLibraryRefToAnnotation(ctx)
+}
+
+// addContentLibraryRefToAnnotation adds the conversion annotation with the content
+// library ref value populated.
+func addContentLibraryRefToAnnotation(ctx *context.ContentLibraryItemContextA2) error {
+	if ctx.CLItem.Status.ContentLibraryRef == nil {
+		return nil
+	}
+
+	contentLibraryRef := corev1.TypedLocalObjectReference{
+		APIGroup: &imgregv1a1.GroupVersion.Group,
+		Kind:     ctx.CLItem.Status.ContentLibraryRef.Kind,
+		Name:     ctx.CLItem.Status.ContentLibraryRef.Name,
+	}
+	data, err := json.Marshal(contentLibraryRef)
+	if err != nil {
+		return err
+	}
+
+	annotations := ctx.VMI.Annotations
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[vmopv1.VMIContentLibRefAnnotation] = string(data)
+	ctx.VMI.SetAnnotations(annotations)
 
 	return nil
 }


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
In the VMI and CVMI v1a2 controllers, we add the conversion annotation by converting the current v1a2 object to a v1a1 object and adding the content library ref info into the v1a1 CVMI status. This v1a1 object is then marshalled and stored as an annotation in the v1a2 object. When a v1a1 object is requested by the client, the conversion function ConvertTo() accesses this stored annotation, unmarshalls it to get the content library data and sets it on the v1a1 object.

**Which issue(s) is/are addressed by this PR?**:
n/a


**Are there any special notes for your reviewer**:
Here is the excerpt of an existing VMI from a v1a2 FSS enabled testbed

```bash
$ k get vmi -n trial vmi-004ebcb5558f33270 -oyaml
apiVersion: vmoperator.vmware.com/v1alpha2
kind: VirtualMachineImage
metadata:
  annotations:
    vmoperator.vmware.com/conversion-content-lib-ref: '{"apiGroup":"imageregistry.vmware.com","kind":"ContentLibrary","name":"cl-309e086fd3e2cff49"}'
  creationTimestamp: "2023-12-18T02:12:45Z"
  generation: 1
  name: vmi-004ebcb5558f33270
  namespace: trial
  ownerReferences:
  - apiVersion: imageregistry.vmware.com/v1alpha1
    blockOwnerDeletion: true
    controller: true
    kind: ContentLibraryItem
    name: clitem-004ebcb5558f33270
    uid: 5b59a8cd-a15c-4ff9-8b50-691caa20c716
  resourceVersion: "2344826"
  uid: 9f49d478-0201-40a5-9e1e-029627eb6c6c
spec:
  providerRef:
    apiVersion: imageregistry.vmware.com/v1alpha1
    kind: ContentLibraryItem
    name: clitem-004ebcb5558f33270
status:
  conditions:
  - lastTransitionTime: "2023-12-18T02:13:02Z"
    message: ""
    reason: "True"
    status: "True"
    type: Ready
  firmware: bios
  hardwareVersion: 10
  name: groovy-20210415.1-with-ovt-11.3
  osInfo:
    id: "94"
    type: ubuntu64Guest
  ovfProperties:
  - default: id-ovf
    key: instance-id
    type: string
  - default: ubuntuguest
    key: hostname
    type: string
  - key: seedfrom
    type: string
  - key: public-keys
    type: string
  - key: user-data
    type: string
  - key: password
    type: string
  productInfo:
    product: Ubuntu 20.10 Server (20210416)
  providerContentVersion: "2"
  providerItemID: 52d59bfd-ee56-4e0c-8a7a-7ee0a2b28451

$ k get virtualmachineimage.v1alpha1.vmoperator.vmware.com -n trial vmi-004ebcb5558f33270 -oyaml
apiVersion: vmoperator.vmware.com/v1alpha1
kind: VirtualMachineImage
metadata:
  annotations:
    vmoperator.vmware.com/conversion-content-lib-ref: '{"apiGroup":"imageregistry.vmware.com","kind":"ContentLibrary","name":"cl-309e086fd3e2cff49"}'
  creationTimestamp: "2023-12-18T02:12:45Z"
  generation: 1
  name: vmi-004ebcb5558f33270
  namespace: trial
  ownerReferences:
  - apiVersion: imageregistry.vmware.com/v1alpha1
    blockOwnerDeletion: true
    controller: true
    kind: ContentLibraryItem
    name: clitem-004ebcb5558f33270
    uid: 5b59a8cd-a15c-4ff9-8b50-691caa20c716
  resourceVersion: "2344826"
  uid: 9f49d478-0201-40a5-9e1e-029627eb6c6c
spec:
  hwVersion: 10
  imageID: 52d59bfd-ee56-4e0c-8a7a-7ee0a2b28451
  osInfo:
    type: ubuntu64Guest
  ovfEnv:
    hostname:
      default: ubuntuguest
      key: hostname
      type: string
    instance-id:
      default: id-ovf
      key: instance-id
      type: string
    password:
      key: password
      type: string
    public-keys:
      key: public-keys
      type: string
    seedfrom:
      key: seedfrom
      type: string
    user-data:
      key: user-data
      type: string
  productInfo:
    product: Ubuntu 20.10 Server (20210416)
  providerRef:
    apiVersion: imageregistry.vmware.com/v1alpha1
    kind: ContentLibraryItem
    name: clitem-004ebcb5558f33270
    namespace: trial
  type: ""
status:
  conditions:
  - lastTransitionTime: "2023-12-18T02:13:02Z"
    status: "True"
    type: VirtualMachineImageProviderSecurityCompliance
  - lastTransitionTime: "2023-12-18T02:13:02Z"
    status: "True"
    type: VirtualMachineImageSynced
  - lastTransitionTime: "2023-12-18T02:13:02Z"
    status: "True"
    type: VirtualMachineImageProviderReady
  contentLibraryRef:                       <============================== missing value from before
    apiGroup: imageregistry.vmware.com
    kind: ContentLibrary
    name: cl-309e086fd3e2cff49
  contentVersion: "2"
  firmware: bios
  imageName: groovy-20210415.1-with-ovt-11.3

```


**Please add a release note if necessary**:
```release-note
🌱 Add conversion annotation to CVMI/VMI to populate missing field
```