### PR TITLE
🐛 Add provider test for nil v1a2 VM Spec nil fields

### DIFF
--- a/pkg/vmprovider/providers/vsphere2/vmlifecycle/bootstrap.go
+++ b/pkg/vmprovider/providers/vsphere2/vmlifecycle/bootstrap.go
@@ -124,15 +124,16 @@ func getBootstrapArgs(
 	networkResults network.NetworkInterfaceResults,
 	bootstrapData BootstrapData) (*BootstrapArgs, error) {
 
+	hostname := vmCtx.VM.Name
+	if networkSpec := vmCtx.VM.Spec.Network; networkSpec != nil && networkSpec.HostName != "" {
+		hostname = networkSpec.HostName
+	}
+
 	bootstrapArgs := BootstrapArgs{
 		BootstrapData:  bootstrapData,
 		NetworkResults: networkResults,
-		Hostname:       vmCtx.VM.Spec.Network.HostName,
+		Hostname:       hostname,
 		ComputerName:   vmCtx.VM.Name,
-	}
-
-	if bootstrapArgs.Hostname == "" {
-		bootstrapArgs.Hostname = vmCtx.VM.Name
 	}
 
 	// If the VM is missing DNS info - that is, it did not specify DNS for the interfaces - populate that

--- a/pkg/vmprovider/providers/vsphere2/vmprovider_vm.go
+++ b/pkg/vmprovider/providers/vsphere2/vmprovider_vm.go
@@ -1000,7 +1000,7 @@ func (vs *vSphereVMProvider) vmCreateGenConfigSpecZipNetworkInterfaces(
 	vmCtx context.VirtualMachineContextA2,
 	createArgs *VMCreateArgs) error {
 
-	if vmCtx.VM.Spec.Network.Disabled {
+	if vmCtx.VM.Spec.Network == nil || vmCtx.VM.Spec.Network.Disabled {
 		util.RemoveDevicesFromConfigSpec(createArgs.ConfigSpec, util.IsEthernetCard)
 		return nil
 	}


### PR DESCRIPTION
Post b54465, several spec fields were changed to pointers so add test to cover if those are nil, and fix a few bugs.

```release-note
NONE
```