### PR TITLE
🌱 Moves common annotation logic to util package

### DIFF
--- a/controllers/contentlibrary/v1alpha2/clustercontentlibraryitem/clustercontentlibraryitem_controller.go
+++ b/controllers/contentlibrary/v1alpha2/clustercontentlibraryitem/clustercontentlibraryitem_controller.go
@@ -5,12 +5,10 @@ package clustercontentlibraryitem
 
 import (
 	goctx "context"
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -260,34 +258,7 @@ func (r *Reconciler) setUpCVMIFromCCLItem(ctx *context.ClusterContentLibraryItem
 	cvmi.Status.Name = cclItem.Status.Name
 	cvmi.Status.ProviderItemID = string(cclItem.Spec.UUID)
 
-	return addContentLibraryRefToAnnotation(ctx)
-}
-
-// addContentLibraryRefToAnnotation adds the conversion annotation with the content
-// library ref value populated.
-func addContentLibraryRefToAnnotation(ctx *context.ClusterContentLibraryItemContextA2) error {
-	if ctx.CCLItem.Status.ContentLibraryRef == nil {
-		return nil
-	}
-
-	contentLibraryRef := corev1.TypedLocalObjectReference{
-		APIGroup: &imgregv1a1.GroupVersion.Group,
-		Kind:     ctx.CCLItem.Status.ContentLibraryRef.Kind,
-		Name:     ctx.CCLItem.Status.ContentLibraryRef.Name,
-	}
-	data, err := json.Marshal(contentLibraryRef)
-	if err != nil {
-		return err
-	}
-
-	annotations := ctx.CVMI.Annotations
-	if annotations == nil {
-		annotations = map[string]string{}
-	}
-	annotations[vmopv1.VMIContentLibRefAnnotation] = string(data)
-	ctx.CVMI.SetAnnotations(annotations)
-
-	return nil
+	return utils.AddContentLibraryRefToAnnotation(cvmi, ctx.CCLItem.Status.ContentLibraryRef)
 }
 
 // syncImageContent syncs the ClusterVirtualMachineImage content from the provider.

--- a/controllers/contentlibrary/v1alpha2/contentlibraryitem/contentlibraryitem_controller.go
+++ b/controllers/contentlibrary/v1alpha2/contentlibraryitem/contentlibraryitem_controller.go
@@ -5,12 +5,10 @@ package contentlibraryitem
 
 import (
 	goctx "context"
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -247,34 +245,7 @@ func (r *Reconciler) setUpVMIFromCLItem(ctx *context.ContentLibraryItemContextA2
 	vmi.Status.Name = clItem.Status.Name
 	vmi.Status.ProviderItemID = string(clItem.Spec.UUID)
 
-	return addContentLibraryRefToAnnotation(ctx)
-}
-
-// addContentLibraryRefToAnnotation adds the conversion annotation with the content
-// library ref value populated.
-func addContentLibraryRefToAnnotation(ctx *context.ContentLibraryItemContextA2) error {
-	if ctx.CLItem.Status.ContentLibraryRef == nil {
-		return nil
-	}
-
-	contentLibraryRef := corev1.TypedLocalObjectReference{
-		APIGroup: &imgregv1a1.GroupVersion.Group,
-		Kind:     ctx.CLItem.Status.ContentLibraryRef.Kind,
-		Name:     ctx.CLItem.Status.ContentLibraryRef.Name,
-	}
-	data, err := json.Marshal(contentLibraryRef)
-	if err != nil {
-		return err
-	}
-
-	annotations := ctx.VMI.Annotations
-	if annotations == nil {
-		annotations = map[string]string{}
-	}
-	annotations[vmopv1.VMIContentLibRefAnnotation] = string(data)
-	ctx.VMI.SetAnnotations(annotations)
-
-	return nil
+	return utils.AddContentLibraryRefToAnnotation(vmi, ctx.CLItem.Status.ContentLibraryRef)
 }
 
 // syncImageContent syncs the VirtualMachineImage content from the provider.

--- a/controllers/contentlibrary/v1alpha2/utils/utils_test.go
+++ b/controllers/contentlibrary/v1alpha2/utils/utils_test.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package utils_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	imgregv1a1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha1"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/controllers/contentlibrary/v1alpha2/utils"
+)
+
+func Test_AddContentLibRefToAnnotation(t *testing.T) {
+	obj := &vmopv1.ClusterVirtualMachineImage{
+		ObjectMeta: metav1.ObjectMeta{},
+	}
+
+	t.Run("when the CL ref is missing", func(t *testing.T) {
+		g := NewWithT(t)
+		g.Expect(utils.AddContentLibraryRefToAnnotation(obj, nil)).To(Succeed())
+	})
+
+	t.Run("with a valid CL ref", func(t *testing.T) {
+		g := NewWithT(t)
+		ref := &imgregv1a1.NameAndKindRef{
+			Kind: "FooKind",
+			Name: "foo",
+		}
+
+		t.Run("annotation gets correctly set", func(t *testing.T) {
+			g.Expect(utils.AddContentLibraryRefToAnnotation(obj, ref)).To(Succeed())
+			g.Expect(obj.Annotations).To(HaveLen(1))
+			assertAnnotation(g, obj)
+		})
+
+		t.Run("the new annotation does not override existing annotations", func(t *testing.T) {
+			obj.Annotations = map[string]string{"bar": "baz"}
+			g.Expect(utils.AddContentLibraryRefToAnnotation(obj, ref)).To(Succeed())
+			g.Expect(len(obj.Annotations)).To(BeNumerically(">=", 1))
+			assertAnnotation(g, obj)
+		})
+
+	})
+}
+
+func assertAnnotation(g *WithT, obj client.Object) {
+	g.Expect(obj.GetAnnotations()).To(HaveKey(vmopv1.VMIContentLibRefAnnotation))
+
+	val := obj.GetAnnotations()[vmopv1.VMIContentLibRefAnnotation]
+	coreRef := corev1.TypedLocalObjectReference{}
+	g.Expect(json.Unmarshal([]byte(val), &coreRef)).To(Succeed())
+
+	g.Expect(coreRef.APIGroup).To(gstruct.PointTo(Equal(imgregv1a1.GroupVersion.Group)))
+	g.Expect(coreRef.Kind).To(Equal("FooKind"))
+	g.Expect(coreRef.Name).To(Equal("foo"))
+}


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This patch moves the common logic of checking for an annotation on the VMI and CVMI v1a2 objects into a common utility function. This is a follow up from the [comment](https://github.com/vmware-tanzu/vm-operator/pull/313#discussion_r1432943964) on #313 

**Which issue(s) is/are addressed by this PR?**:
n/a


**Are there any special notes for your reviewer**:
n/a


**Please add a release note if necessary**:
```release-note
NONE
```