### PR TITLE
🌱 Rename inlined CloudInit default user field

### DIFF
--- a/api/v1alpha2/cloudinit/cloudconfig.go
+++ b/api/v1alpha2/cloudinit/cloudconfig.go
@@ -19,13 +19,13 @@ type CloudConfig struct {
 	// +optional
 	Timezone string `json:"timezone,omitempty"`
 
-	// AlwaysDefaultUser may be set to true to ensure even if the Users field
+	// DefaultUserEnabled may be set to true to ensure even if the Users field
 	// is not empty, the default user is still created on systems that have one
 	// defined. By default, Cloud-Init ignores the default user if the
 	// CloudConfig provides one or more non-default users via the Users field.
 	//
 	// +optional
-	AlwaysDefaultUser bool `json:"defaultUser,omitempty"`
+	DefaultUserEnabled bool `json:"defaultUserEnabled,omitempty"`
 
 	// Users allows adding/configuring one or more users on the guest.
 	//

--- a/api/v1alpha2/testdata/vm-with-cloudinit.yaml
+++ b/api/v1alpha2/testdata/vm-with-cloudinit.yaml
@@ -16,11 +16,12 @@ spec:
   bootstrap:
     cloudInit: 
       cloudConfig:
+        defaultUserEnabled: true
         users:
-        - default
         - name: akutz
           primary_group: akutz
-          groups: users
+          groups:
+          - users
           ssh_authorized_keys:
           - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDSL7uWGj...
         runcmd:

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -723,11 +723,11 @@ spec:
                           CloudConfig, used to bootstrap the VM. \n Please note this
                           field and RawCloudConfig are mutually exclusive."
                         properties:
-                          defaultUser:
-                            description: AlwaysDefaultUser may be set to true to ensure
-                              even if the Users field is not empty, the default user
-                              is still created on systems that have one defined. By
-                              default, Cloud-Init ignores the default user if the
+                          defaultUserEnabled:
+                            description: DefaultUserEnabled may be set to true to
+                              ensure even if the Users field is not empty, the default
+                              user is still created on systems that have one defined.
+                              By default, Cloud-Init ignores the default user if the
                               CloudConfig provides one or more non-default users via
                               the Users field.
                             type: boolean

--- a/pkg/util/cloudinit/cloudconfig.go
+++ b/pkg/util/cloudinit/cloudconfig.go
@@ -90,7 +90,7 @@ func MarshalYAML(
 
 	if l := len(in.Users); l > 0 {
 		out.Users = &cloudConfigUsers{
-			defaultUser: in.AlwaysDefaultUser,
+			defaultUser: in.DefaultUserEnabled,
 			users:       make([]user, l),
 		}
 		for i := range in.Users {

--- a/pkg/util/cloudinit/cloudconfig_test.go
+++ b/pkg/util/cloudinit/cloudconfig_test.go
@@ -116,7 +116,7 @@ var _ = Describe("CloudConfig MarshalYAML", func() {
 		})
 		When("There is a default user", func() {
 			BeforeEach(func() {
-				cloudConfig.AlwaysDefaultUser = true
+				cloudConfig.DefaultUserEnabled = true
 			})
 			It("Should return user data", func() {
 				Expect(err).ToNot(HaveOccurred())

--- a/pkg/vmprovider/providers/vsphere2/vmlifecycle/bootstrap_cloudinit_test.go
+++ b/pkg/vmprovider/providers/vsphere2/vmlifecycle/bootstrap_cloudinit_test.go
@@ -154,7 +154,7 @@ var _ = Describe("CloudInit Bootstrap", func() {
 
 			Context("With default user", func() {
 				BeforeEach(func() {
-					cloudInitSpec.CloudConfig.AlwaysDefaultUser = true
+					cloudInitSpec.CloudConfig.DefaultUserEnabled = true
 				})
 				It("Should return valid data", func() {
 					Expect(custSpec).To(BeNil())


### PR DESCRIPTION
Use DefaultUserEnabled as the field name for when the default user should still be created when other users are specified.

Update the VM with CloudInit example yaml

```release-note
NONE
```