### PR TITLE
🐛 Fix cloudconfig runcmd / YAML->JSON on parse

### DIFF
--- a/api/v1alpha2/cloudinit/cloudconfig.go
+++ b/api/v1alpha2/cloudinit/cloudconfig.go
@@ -49,7 +49,9 @@ type CloudConfig struct {
 	//       - "Hello, world."
 	//
 	// +optional
-	RunCmd []json.RawMessage `json:"runcmd,omitempty"`
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
+	RunCmd json.RawMessage `json:"runcmd,omitempty"`
 
 	// WriteFiles
 	//
@@ -275,6 +277,8 @@ type WriteFile struct {
 	//       key: my-file-content
 	//
 	// +optional
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
 	Content json.RawMessage `json:"content,omitempty"`
 
 	// Defer indicates to defer writing the file until Cloud-Init's "final"

--- a/api/v1alpha2/cloudinit/zz_generated.deepcopy.go
+++ b/api/v1alpha2/cloudinit/zz_generated.deepcopy.go
@@ -25,14 +25,8 @@ func (in *CloudConfig) DeepCopyInto(out *CloudConfig) {
 	}
 	if in.RunCmd != nil {
 		in, out := &in.RunCmd, &out.RunCmd
-		*out = make([]json.RawMessage, len(*in))
-		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = make(json.RawMessage, len(*in))
-				copy(*out, *in)
-			}
-		}
+		*out = make(json.RawMessage, len(*in))
+		copy(*out, *in)
 	}
 	if in.WriteFiles != nil {
 		in, out := &in.WriteFiles, &out.WriteFiles

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -738,13 +738,7 @@ spec:
                               contains the command and its arguments, ex. \n runcmd:
                               - \"ls -al\" \n Format 2 -- a list of the command and
                               its arguments, ex. \n runcmd: - - echo - \"Hello, world.\""
-                            items:
-                              description: RawMessage is a raw encoded JSON value.
-                                It implements Marshaler and Unmarshaler and can be
-                                used to delay JSON decoding or precompute a JSON encoding.
-                              format: byte
-                              type: string
-                            type: array
+                            x-kubernetes-preserve-unknown-fields: true
                           timezone:
                             description: Timezone describes the timezone represented
                               in /usr/share/zoneinfo.
@@ -941,8 +935,7 @@ spec:
                                     with the name of the key that contains the content
                                     for the file, ex. \n content: name: my-bootstrap-secret
                                     key: my-file-content"
-                                  format: byte
-                                  type: string
+                                  x-kubernetes-preserve-unknown-fields: true
                                 defer:
                                   description: Defer indicates to defer writing the
                                     file until Cloud-Init's "final" stage, after users

--- a/pkg/util/cloudinit/cloudconfig_secret.go
+++ b/pkg/util/cloudinit/cloudconfig_secret.go
@@ -5,9 +5,9 @@ package cloudinit
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
-	"gopkg.in/yaml.v3"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/vmware-tanzu/vm-operator/api/v1alpha2/cloudinit"
@@ -127,7 +127,7 @@ func getSecretDataForWriteFile(
 
 	// First try to unmarshal the value into a string. If that does
 	// not work, try unmarshaling the data into a SecretKeySelector.
-	if err := yaml.Unmarshal(
+	if err := json.Unmarshal(
 		in.Content,
 		out); err == nil {
 
@@ -136,7 +136,7 @@ func getSecretDataForWriteFile(
 
 	*out = ""
 	var sks common.SecretKeySelector
-	if err := yaml.Unmarshal(in.Content, &sks); err != nil {
+	if err := json.Unmarshal(in.Content, &sks); err != nil {
 		return err
 	}
 

--- a/pkg/util/cloudinit/cloudconfig_secret_test.go
+++ b/pkg/util/cloudinit/cloudconfig_secret_test.go
@@ -161,7 +161,7 @@ var _ = Describe("CloudConfig GetCloudConfigSecretData", func() {
 		})
 		When("The string is a single line", func() {
 			BeforeEach(func() {
-				cloudConfig.WriteFiles[0].Content = []byte("world")
+				cloudConfig.WriteFiles[0].Content = []byte(`"world"`)
 			})
 			It("Should return valid data", func() {
 				Expect(err).ToNot(HaveOccurred())
@@ -171,7 +171,7 @@ var _ = Describe("CloudConfig GetCloudConfigSecretData", func() {
 		})
 		When("The string is a multi-line value", func() {
 			BeforeEach(func() {
-				cloudConfig.WriteFiles[0].Content = []byte("|\n  world\n  and the universe!")
+				cloudConfig.WriteFiles[0].Content = []byte(`"world\nand the universe!"`)
 			})
 			It("Should return valid data", func() {
 				Expect(err).ToNot(HaveOccurred())
@@ -183,7 +183,7 @@ var _ = Describe("CloudConfig GetCloudConfigSecretData", func() {
 
 	When("CloudConfig has a file that references data from a secret", func() {
 		BeforeEach(func() {
-			cloudConfig.WriteFiles[0].Content = []byte("name: \"my-bootstrap-data\"\nkey: \"file-hello\"")
+			cloudConfig.WriteFiles[0].Content = []byte(`{"name":"my-bootstrap-data","key":"file-hello"}`)
 		})
 		When("The secret does not exist", func() {
 			It("Should return an error", func() {
@@ -275,7 +275,7 @@ var _ = Describe("CloudConfig GetCloudConfigSecretData", func() {
 				WriteFiles: []vmopv1cloudinit.WriteFile{
 					{
 						Path:    "/hello",
-						Content: []byte("name: \"my-bootstrap-files\"\nkey: \"file-hello\""),
+						Content: []byte(`{"name":"my-bootstrap-files","key":"file-hello"}`),
 					},
 				},
 			}

--- a/pkg/util/cloudinit/cloudconfig_test.go
+++ b/pkg/util/cloudinit/cloudconfig_test.go
@@ -5,7 +5,6 @@ package cloudinit_test
 
 import (
 	"context"
-	"encoding/json"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -137,11 +136,7 @@ var _ = Describe("CloudConfig MarshalYAML", func() {
 						},
 					},
 				},
-				RunCmd: []json.RawMessage{
-					[]byte("ls /"),
-					[]byte(`[ "ls", "-a", "-l", "/" ]`),
-					[]byte("- echo\n- \"hello, world.\""),
-				},
+				RunCmd: []byte(`["ls /",["ls","-a","-l","/"],["echo","hello, world."]]`),
 			}
 			cloudConfigSecretData = cloudinit.CloudConfigSecretData{
 				Users: map[string]cloudinit.CloudConfigUserSecretData{
@@ -214,15 +209,11 @@ var _ = Describe("CloudConfig MarshalYAML", func() {
 						UID:               addrOf(int64(123)),
 					},
 				},
-				RunCmd: []json.RawMessage{
-					[]byte("ls /"),
-					[]byte(`[ "ls", "-a", "-l", "/" ]`),
-					[]byte("- echo\n- \"hello, world.\""),
-				},
+				RunCmd: []byte(`["ls /",["ls","-a","-l","/"],["echo","hello, world."]]`),
 				WriteFiles: []vmopv1cloudinit.WriteFile{
 					{
 						Path:        "/hello",
-						Content:     []byte("world"),
+						Content:     []byte(`"world"`),
 						Append:      true,
 						Defer:       true,
 						Encoding:    vmopv1cloudinit.WriteFileEncodingTextPlain,
@@ -231,7 +222,7 @@ var _ = Describe("CloudConfig MarshalYAML", func() {
 					},
 					{
 						Path:        "/hi",
-						Content:     []byte("name: \"my-bootstrap-data\"\nkey: \"/hi\""),
+						Content:     []byte(`{"name":"my-bootstrap-data","key":"/hi"}`),
 						Append:      false,
 						Defer:       false,
 						Encoding:    vmopv1cloudinit.WriteFileEncodingTextPlain,
@@ -240,7 +231,7 @@ var _ = Describe("CloudConfig MarshalYAML", func() {
 					},
 					{
 						Path:        "/doc",
-						Content:     []byte("|\n  a multi-line\n  document"),
+						Content:     []byte(`"a multi-line\ndocument"`),
 						Append:      true,
 						Defer:       true,
 						Encoding:    vmopv1cloudinit.WriteFileEncodingTextPlain,

--- a/pkg/vmprovider/providers/vsphere2/vmlifecycle/bootstrap_cloudinit_test.go
+++ b/pkg/vmprovider/providers/vsphere2/vmlifecycle/bootstrap_cloudinit_test.go
@@ -6,7 +6,6 @@ package vmlifecycle_test
 import (
 	goctx "context"
 	"encoding/base64"
-	"encoding/json"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -121,11 +120,11 @@ var _ = Describe("CloudInit Bootstrap", func() {
 					WriteFiles: []vmopv1cloudinit.WriteFile{
 						{
 							Path:    "/hello",
-							Content: []byte("world"),
+							Content: []byte(`"world"`),
 						},
 						{
 							Path:    "/hi",
-							Content: []byte("name: \"my-bootstrap-data\"\nkey: \"cloud-init-files-hi\""),
+							Content: []byte(`{"name":"my-bootstrap-data","key":"cloud-init-files-hi"}`),
 						},
 					},
 				}
@@ -178,11 +177,7 @@ var _ = Describe("CloudInit Bootstrap", func() {
 
 			Context("With runcmds", func() {
 				BeforeEach(func() {
-					cloudInitSpec.CloudConfig.RunCmd = []json.RawMessage{
-						[]byte("ls /"),
-						[]byte(`[ "ls", "-a", "-l", "/" ]`),
-						[]byte("- echo\n- \"hello, world.\""),
-					}
+					cloudInitSpec.CloudConfig.RunCmd = []byte(`["ls /",["ls","-a","-l","/"],["echo","hello, world."]]`)
 				})
 				It("Should return valid data", func() {
 					Expect(custSpec).To(BeNil())


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->

This patch updates the inline cloud config's runcmd field to be of type json.RawMessage instead of a slice of them. This is because kubebuilder cannot generate the correct CRD for elements in the slice, and they are expected to be base64-encoded. Instead the entire runcmd is now a json.RawMessage.

Additionally, this patch fixes an issue in the validation logic for the inline cloud config. It was based on YAML in, YAML out, but it should have been JSON in, YAML out.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->

I applied the CRD to a kind cluster and was able to successfully apply:

```yaml
apiVersion: vmoperator.vmware.com/v1alpha2
kind: VirtualMachine
metadata:
  name: vm101
  namespace: default
  annotations:
    vmoperator.vmware.com/pause-reconcile: "yes"
spec:
  className: best-effort-medium
  storageClass: wcpglobal-storage-profile
  imageName: vmi-f961d7d94a24339bf
  powerState: PoweredOn
  bootstrap:
    cloudInit:
      cloudConfig:
        runcmd:
        - "ls /"
        - - ls
          - /
          - "echo hello"
        write_files:
        - path: /
          content: |
            Hello
        - path: /hello
          content:
            name: secret
            key: file
        - path: /hello2
          content: hi
```

Kubectl then returns the same when getting the VM. This should prove this works as expected assuming the validations are correct, for which there are tests.


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```