### PR TITLE
🌱 Update mkdocs ver & deps ver & build-docs mk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 .DS_Store
 .cache
 
+# Mkdocs
+/.site/
+
 # Test output
 cover.out
 cover.out.norace

--- a/Makefile
+++ b/Makefile
@@ -530,10 +530,28 @@ deploy-local-vcsim: prereqs kustomize-local-vcsim  ## Deploy controller in the c
 ## Documentation
 ## --------------------------------------
 
+.PHONY: docs-build-python
+docs-build-python: ## Build docs w python
+
+# SKIP_PIP_INSTALL is set to true by the GitHub action that verifies the docs
+# can be built successfully since the GitHub action directly installs the deps.
+ifneq (true,$(SKIP_PIP_INSTALL))
+	pip3 install --user -r ./docs/requirements.txt
+endif
+	$$(python3 -m site --user-base)/bin/mkdocs build --clean --config-file mkdocs.yml
+
+.PHONY: docs-build-docker
+docs-build-docker: ## Build docs w Docker
+	docker build -f Dockerfile.docs -t $(IMAGE)-docs:$(IMAGE_TAG) .
+	docker run -it --rm -v "$$(pwd)":/docs --entrypoint /usr/bin/mkdocs \
+	  $(IMAGE)-docs:$(IMAGE_TAG) build --clean --config-file mkdocs.yml
+
+.PHONY: docs-serve-python
 docs-serve-python: ## Serve docs w python
 	pip3 install --user -r ./docs/requirements.txt
 	$$(python3 -m site --user-base)/bin/mkdocs serve
 
+.PHONY: docs-serve-docker
 docs-serve-docker: ## Serve docs w docker
 	docker build -f Dockerfile.docs -t $(IMAGE)-docs:$(IMAGE_TAG) .
 	docker run -it --rm -p 8000:8000 -v "$$(pwd)":/docs $(IMAGE)-docs:$(IMAGE_TAG)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 mkdocs >= 1.5.3
-mkdocs-material >= 9.4.2
-pymdown-extensions >= 10.3
-pygments >= 2.16.1
-mkdocs-git-committers-plugin-2 >= 1.2.0
-mkdocs-git-revision-date-localized-plugin >= 1.2.0
+mkdocs-material >= 9.5.3
+pymdown-extensions >= 10.5
+pygments >= 2.17.2
+mkdocs-git-committers-plugin-2 >= 2.2.2
+mkdocs-git-revision-date-localized-plugin >= 1.2.2
 mkdocs-markdownextradata-plugin >= 0.2.5

--- a/docs/start/contrib/submit-change.md
+++ b/docs/start/contrib/submit-change.md
@@ -19,6 +19,15 @@ When creating or modifying the project's `README.md` file or any of the document
 
 For example, the below link points to the `Quickstart` page:
 
+<!--
+Please note the following message appears when building the site documentation:
+
+    INFO    -  Doc file 'start/contrib/submit-change.md' contains an absolute link '/start/quick.md', it was left as is. Did you mean '../quick.md'?
+
+The above message may be safely ignored. It is caused by the below, intentional
+error that demonstrates the *incorrect* method for defining links.
+-->
+
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 [/start/quick.md](/start/quick.md)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,8 +87,8 @@ markdown_extensions:
 - pymdownx.snippets:
     check_paths: true
 - pymdownx.emoji:
-    emoji_index: !!python/name:materialx.emoji.twemoji
-    emoji_generator: !!python/name:materialx.emoji.to_svg
+    emoji_index: !!python/name:material.extensions.emoji.twemoji
+    emoji_generator: !!python/name:material.extensions.emoji.to_svg
     options:
       custom_icons:
       - material/.icons


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch updates the version of mkdocs used to build the docs as well as versions of the dependencies required by mkdocs. This patch also introduces two, new Makefile targets, `docs-build-python` and `docs-build-docker` for building the documentation without serving it.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```

<!-- readthedocs-preview vm-operator start -->
----
📚 Documentation preview 📚: https://vm-operator--322.org.readthedocs.build/en/322/

<!-- readthedocs-preview vm-operator end -->