### PR TITLE
🐛 Update VM Class scope in test builder for FSS

### DIFF
--- a/test/builder/test_suite.go
+++ b/test/builder/test_suite.go
@@ -50,7 +50,11 @@ import (
 )
 
 const (
-	VMICRDName = "virtualmachineimages.vmoperator.vmware.com"
+	scopeCluster   = "Cluster"
+	scopeNamespace = "Namespaced"
+
+	virtualMachineImageResourceName = "virtualmachineimages.vmoperator.vmware.com"
+	virtualMachineClassResourceName = "virtualmachineclasses.vmoperator.vmware.com"
 )
 
 // Reconciler is a base type for builder's reconcilers.
@@ -476,16 +480,25 @@ func (s *TestSuite) beforeSuiteForIntegrationTesting() {
 
 	By("updating CRD scope", func() {
 		if enabled, ok := s.fssMap[lib.VMImageRegistryFSS]; ok {
-			crd := s.GetInstalledCRD(VMICRDName)
+			crd := s.GetInstalledCRD(virtualMachineImageResourceName)
 			Expect(crd).ToNot(BeNil())
 			scope := string(crd.Spec.Scope)
-			if enabled && scope == "Cluster" {
-				s.UpdateCRDScope(crd, "Namespaced")
-			} else if !enabled && scope == "Namespaced" {
-				s.UpdateCRDScope(crd, "Cluster")
+			if enabled && scope == scopeCluster {
+				s.UpdateCRDScope(crd, scopeNamespace)
+			} else if !enabled && scope == scopeNamespace {
+				s.UpdateCRDScope(crd, scopeCluster)
 			}
 		}
-		// TODO: Include NamespacedVMClass related changes
+		if enabled, ok := s.fssMap[lib.NamespacedVMClassFSS]; ok {
+			crd := s.GetInstalledCRD(virtualMachineClassResourceName)
+			Expect(crd).ToNot(BeNil())
+			scope := string(crd.Spec.Scope)
+			if enabled && scope == scopeCluster {
+				s.UpdateCRDScope(crd, scopeNamespace)
+			} else if !enabled && scope == scopeNamespace {
+				s.UpdateCRDScope(crd, scopeCluster)
+			}
+		}
 	})
 
 	// If one or more webhooks are being tested then go ahead and generate a


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch updates the scope of the VM Class CRD in the test builder based on the presence and value of the VM Class Namespace FSS.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```