### PR TITLE
🌱 Update v1a2 VM printer columns

### DIFF
--- a/api/v1alpha2/virtualmachine_types.go
+++ b/api/v1alpha2/virtualmachine_types.go
@@ -518,10 +518,11 @@ type VirtualMachineStatus struct {
 // +kubebuilder:resource:scope=Namespaced,shortName=vm
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Class",type="string",priority=1,JSONPath=".status.class.name"
-// +kubebuilder:printcolumn:name="Image",type="string",priority=1,JSONPath=".status.image.name"
-// +kubebuilder:printcolumn:name="PowerState",type="string",JSONPath=".status.powerState"
+// +kubebuilder:printcolumn:name="Power-State",type="string",JSONPath=".status.powerState"
+// +kubebuilder:printcolumn:name="Class",type="string",priority=1,JSONPath=".spec.className"
+// +kubebuilder:printcolumn:name="Image",type="string",priority=1,JSONPath=".spec.imageName"
 // +kubebuilder:printcolumn:name="Primary-IP4",type="string",priority=1,JSONPath=".status.network.primaryIP4"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // VirtualMachine is the schema for the virtualmachines API and represents the
 // desired state and observed status of a virtualmachines resource.

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -632,21 +632,24 @@ spec:
     subresources:
       status: {}
   - additionalPrinterColumns:
-    - jsonPath: .status.class.name
+    - jsonPath: .status.powerState
+      name: Power-State
+      type: string
+    - jsonPath: .spec.className
       name: Class
       priority: 1
       type: string
-    - jsonPath: .status.image.name
+    - jsonPath: .spec.imageName
       name: Image
       priority: 1
-      type: string
-    - jsonPath: .status.powerState
-      name: PowerState
       type: string
     - jsonPath: .status.network.primaryIP4
       name: Primary-IP4
       priority: 1
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha2
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
Sync power state and age from v1a1

Use the Spec for the image and class names: for the time being, the corresponding status fields are updated until after the VM has been created on VC.

```release-note
NONE
```