### PR TITLE
🐛 Do not always initialize v1a2 VM Spec.Advanced field

### DIFF
--- a/pkg/vmprovider/providers/vsphere2/session/session_vm.go
+++ b/pkg/vmprovider/providers/vsphere2/session/session_vm.go
@@ -16,7 +16,12 @@ func updateVirtualDiskDeviceChanges(
 	vmCtx context.VirtualMachineContextA2,
 	virtualDisks object.VirtualDeviceList) ([]vimTypes.BaseVirtualDeviceConfigSpec, error) {
 
-	capacity := vmCtx.VM.Spec.Advanced.BootDiskCapacity
+	advanced := vmCtx.VM.Spec.Advanced
+	if advanced == nil {
+		return nil, nil
+	}
+
+	capacity := advanced.BootDiskCapacity
 	if capacity == nil || capacity.IsZero() {
 		return nil, nil
 	}

--- a/pkg/vmprovider/providers/vsphere2/session/session_vm_update_test.go
+++ b/pkg/vmprovider/providers/vsphere2/session/session_vm_update_test.go
@@ -604,7 +604,9 @@ var _ = Describe("Update ConfigSpec", func() {
 					return true
 				}
 				config.ChangeTrackingEnabled = pointer.Bool(false)
-				vmSpec.Advanced.ChangeBlockTracking = true
+				vmSpec.Advanced = &vmopv1.VirtualMachineAdvancedSpec{
+					ChangeBlockTracking: true,
+				}
 			})
 
 			AfterEach(func() {

--- a/pkg/vmprovider/providers/vsphere2/virtualmachine/configspec.go
+++ b/pkg/vmprovider/providers/vsphere2/virtualmachine/configspec.go
@@ -58,11 +58,7 @@ func CreateConfigSpec(
 		configSpec.Firmware = vmImageStatus.Firmware
 	}
 
-	// TODO: Otherwise leave as-is? Our ChangeBlockTracking could be better as a *bool.
-	if vmCtx.VM.Spec.Advanced == nil {
-		vmCtx.VM.Spec.Advanced = &vmopv1.VirtualMachineAdvancedSpec{}
-	}
-	if vmCtx.VM.Spec.Advanced.ChangeBlockTracking {
+	if advanced := vmCtx.VM.Spec.Advanced; advanced != nil && advanced.ChangeBlockTracking {
 		configSpec.ChangeTrackingEnabled = pointer.Bool(true)
 	}
 

--- a/pkg/vmprovider/providers/vsphere2/vmlifecycle/create_clone.go
+++ b/pkg/vmprovider/providers/vsphere2/vmlifecycle/create_clone.go
@@ -159,7 +159,12 @@ func resizeBootDiskDeviceChange(
 	vmCtx context.VirtualMachineContextA2,
 	virtualDisks object.VirtualDeviceList) []vimtypes.BaseVirtualDeviceConfigSpec {
 
-	capacity := vmCtx.VM.Spec.Advanced.BootDiskCapacity
+	advanced := vmCtx.VM.Spec.Advanced
+	if advanced == nil {
+		return nil
+	}
+
+	capacity := advanced.BootDiskCapacity
 	if capacity == nil || capacity.IsZero() {
 		return nil
 	}

--- a/pkg/vmprovider/providers/vsphere2/vmprovider_vm.go
+++ b/pkg/vmprovider/providers/vsphere2/vmprovider_vm.go
@@ -984,8 +984,8 @@ func (vs *vSphereVMProvider) vmCreateGenConfigSpecChangeBootDiskSize(
 	vmCtx context.VirtualMachineContextA2,
 	_ *VMCreateArgs) error {
 
-	capacity := vmCtx.VM.Spec.Advanced.BootDiskCapacity
-	if capacity == nil || capacity.IsZero() {
+	advanced := vmCtx.VM.Spec.Advanced
+	if advanced == nil || advanced.BootDiskCapacity == nil || advanced.BootDiskCapacity.IsZero() {
 		return nil
 	}
 


### PR DESCRIPTION
During VM creation, if the Spec.Advanced field was nil, we'd always set the field to its empty structure. Later when we would Patch the k8s VM at the end of reconcile, the field would get updated. This meant that every VM would have the Advanced field set even when not using any of the advance features.

Fix several NPE bugs the assignment was masking.

```release-note
NONE
```