### PR TITLE
🐛 Fixes unset/empty write file content in cloudinit

### DIFF
--- a/pkg/util/cloudinit/cloudconfig.go
+++ b/pkg/util/cloudinit/cloudconfig.go
@@ -139,9 +139,11 @@ func MarshalYAML(
 			// a string from the Content field.
 			content := secret.WriteFiles[in.WriteFiles[i].Path]
 			if content == "" {
-				if err := json.Unmarshal(
-					in.WriteFiles[i].Content, &content); err != nil {
-
+				inContent := in.WriteFiles[i].Content
+				if len(inContent) == 0 {
+					inContent = []byte(`""`)
+				}
+				if err := json.Unmarshal(inContent, &content); err != nil {
 					return "", err
 				}
 			}

--- a/pkg/util/cloudinit/validate/testdata/valid-cloud-config-1.yaml
+++ b/pkg/util/cloudinit/validate/testdata/valid-cloud-config-1.yaml
@@ -147,3 +147,20 @@ users:
 #     lock_passwd: True
 #     gecos: Ubuntu
 #     groups: [adm, cdrom, dip, lxd, sudo]
+
+write_files:
+  - encoding: b64
+    content: CiMgVGhpcyBmaWxlIGNvbnRyb2xzIHRoZSBzdGF0ZSBvZiBTRUxpbnV4
+    owner: root:root
+    path: /etc/sysconfig/selinux
+    permissions: '0644'
+  - content: |
+      # My new /etc/sysconfig/samba file
+
+      SMBDOPTIONS="-D"
+    path: /etc/sysconfig/samba
+  - path: /tmp/user-content
+    permissions: '0444'
+    content:
+  - path: /bin/arch
+    permissions: '0555'

--- a/pkg/util/cloudinit/validate/validate.go
+++ b/pkg/util/cloudinit/validate/validate.go
@@ -102,23 +102,28 @@ func validateWriteFiles(
 	for i := range in {
 		fieldPath := fieldPath.Key(in[i].Path)
 
+		content := in[i].Content
+		if len(content) == 0 {
+			content = []byte(`""`)
+		}
+
 		// First try to unmarshal the value into a string. If that does
 		// not work, try unmarshaling the data into a SecretKeySelector object.
 		var singleString string
 		if err := json.Unmarshal(
-			in[i].Content,
+			content,
 			&singleString); err != nil {
 
 			var sks common.SecretKeySelector
 			if err := json.Unmarshal(
-				in[i].Content,
+				content,
 				&sks); err != nil {
 
 				allErrs = append(
 					allErrs,
 					field.Invalid(
 						fieldPath,
-						string(in[i].Content),
+						string(content),
 						invalidWriteFileContent))
 			}
 		}

--- a/pkg/util/cloudinit/validate/validate_test.go
+++ b/pkg/util/cloudinit/validate/validate_test.go
@@ -97,6 +97,24 @@ var _ = Describe("Validate CloudConfigJSONRawMessage", func() {
 			})
 		})
 	})
+
+	When("The CloudConfig's first file content is unset", func() {
+		BeforeEach(func() {
+			cloudConfig.WriteFiles[0].Content = nil
+		})
+		It("Should not return any errors", func() {
+			Expect(errs).To(HaveLen(0))
+		})
+	})
+
+	When("The CloudConfig's first file content is empty", func() {
+		BeforeEach(func() {
+			cloudConfig.WriteFiles[0].Content = []byte(``)
+		})
+		It("Should not return any errors", func() {
+			Expect(errs).To(HaveLen(0))
+		})
+	})
 })
 
 var _ = Describe("Validate CloudConfigYAML", func() {


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This patch fixes the validation logic to include the content in the CloudInit WriteFiles section to be empty. Since the API declares it as a required field, we set it to empty during the marshaling process to generate the YAML cloudconfig document.

**Which issue(s) is/are addressed by this PR?**:
n/a


**Are there any special notes for your reviewer**:
n/a

**Please add a release note if necessary**:
```release-note
🐛 Fixes empty or unset write file content in cloudinit
```