### PR TITLE
🌱 Adds VMI/CVMI test for annotation-status property conversion

### DIFF
--- a/api/v1alpha1/virtualmachineimage_conversion.go
+++ b/api/v1alpha1/virtualmachineimage_conversion.go
@@ -351,11 +351,10 @@ func convert_v1alpha1_VirtualMachineImageAnnotations_To_v1alpha2_VirtualMachineI
 	// copy v1a1 system annotations to v1a2 system properties status field
 	for k, v := range *in {
 		if strings.HasPrefix(k, "vmware-system") {
-			pair := common.KeyValuePair{
+			*dstSystemProperties = append(*dstSystemProperties, common.KeyValuePair{
 				Key:   k,
 				Value: v,
-			}
-			*dstSystemProperties = append(*dstSystemProperties, pair)
+			})
 		}
 	}
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This patch adds tests to up-down and down-up conversion between system annotations and status system properties.

**Which issue(s) is/are addressed by this PR?**:
n/a


**Are there any special notes for your reviewer**:
n/a


**Please add a release note if necessary**:
```release-note
NONE
```