### PR TITLE
🐛  [codegen]: Uses npm ci command to generate schema types

### DIFF
--- a/pkg/util/cloudinit/schema/Dockerfile.quicktype
+++ b/pkg/util/cloudinit/schema/Dockerfile.quicktype
@@ -1,7 +1,8 @@
 FROM node:20 AS build
 WORKDIR /quicktype
 
-RUN npm install --prefix /quicktype quicktype
+COPY package.json package-lock.json* ./
+RUN npm ci --prefix /quicktype quicktype
 
 FROM gcr.io/distroless/nodejs20-debian12
 COPY --from=build /quicktype /quicktype
@@ -9,7 +10,7 @@ COPY --from=build /quicktype /quicktype
 WORKDIR /output
 CMD [ \
     "/quicktype/node_modules/quicktype/dist/index.js", \
-    "--src", "/schema.json", \
+    "--src", "/schema-cloud-config-v1.json", \
     "--src-lang", "schema", \
     "--out", "/output/cloudconfig.go", \
     "--lang", "go", \

--- a/pkg/util/cloudinit/schema/Makefile
+++ b/pkg/util/cloudinit/schema/Makefile
@@ -85,7 +85,7 @@ build-images: ## Build the docker images
 
 quicktype: $(QUICKTYPE) ## Install quicktype
 $(QUICKTYPE): package.json
-	npm install --user quicktype
+	npm ci --user quicktype
 
 
 ## --------------------------------------


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This patch updates the npm command used to generate the typws for cloud init. Instead of using npm install which will install packages from the node_modules cache, `npm ci` will always use the packages defined in `package-lock.json` to ensure a reproducible build on every run.

**Which issue(s) is/are addressed by this PR?**
Fixes [failed](https://github.com/vmware-tanzu/vm-operator/actions/runs/7451363966/job/20272336654?pr=339) `verify-codegen` GH actions
```
make cloudconfig.go
make[4]: Entering directory '/home/runner/work/vm-operator/vm-operator/pkg/util/cloudinit/schema'
npm install --user quicktype
.....
diff --git a/pkg/util/cloudinit/schema/package-lock.json b/pkg/util/cloudinit/schema/package-lock.json
index 5093659..bd1b[67](https://github.com/vmware-tanzu/vm-operator/actions/runs/7451363966/job/20272336654?pr=339#step:5:68)1 100644
--- a/pkg/util/cloudinit/schema/package-lock.json
+++ b/pkg/util/cloudinit/schema/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "quicktype": "^23.0.80"
+        "quicktype": "^23.0.81"
       }
     },
     "node_modules/@75lb/deep-merge": {
@@ -122,9 +122,9 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
     },
     "node_modules/@types/node": {
-      "version": "16.18.[68](https://github.com/vmware-tanzu/vm-operator/actions/runs/7451363966/job/20272336654?pr=339#step:5:69)",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.68.tgz",
-      "integrity": "sha512-sG3hPIQwJLoewrN7cr0dwEy+yF5nD4D/4FxtQpFciRD/xwUzgD+G05uxZHv5mhfXo4F9Jkp13jjn0CC2q325sg=="
+      "version": "16.18.[70](https://github.com/vmware-tanzu/vm-operator/actions/runs/7451363966/job/20272336654?pr=339#step:5:71)",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.70.tgz",
+      "integrity": "sha512-8eIk20G5VVVQNZNouHjLA2b8utE2NvGybLjMaF4lyhA9uhGwnmXF8o+icdXKGSQSNANJewXva/sFUoZLwAaYAg=="
     },
     "node_modules/@types/urijs": {
       "version": "1.19.25",
...
```


**Are there any special notes for your reviewer**:
n/a


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```