### PR TITLE
🐛 Restore v1a2 Sysprep with vAppConfig in hub-spoke-hub

### DIFF
--- a/api/v1alpha1/virtualmachine_conversion.go
+++ b/api/v1alpha1/virtualmachine_conversion.go
@@ -828,6 +828,13 @@ func restore_v1alpha2_VirtualMachineBootstrapSpec(
 		if srcSysPrep := srcBootstrap.Sysprep; srcSysPrep != nil {
 			dstSysPrep.Sysprep = srcSysPrep.Sysprep
 			dstSysPrep.RawSysprep = mergeSecretKeySelector(dstSysPrep.RawSysprep, srcSysPrep.RawSysprep)
+
+			// In v1a1 we don't have way to denote Sysprep with vAppConfig. LinuxPrep with vAppConfig works
+			// because that translates to OvfEnvTransport. If we have saved vAppConfig restore that now if
+			// we wouldn't do it right below.
+			if dstBootstrap.VAppConfig == nil && srcBootstrap.VAppConfig != nil {
+				dstBootstrap.VAppConfig = srcBootstrap.VAppConfig
+			}
 		}
 	}
 

--- a/api/v1alpha1/virtualmachine_conversion_test.go
+++ b/api/v1alpha1/virtualmachine_conversion_test.go
@@ -233,6 +233,51 @@ func TestVirtualMachineConversion(t *testing.T) {
 		hubSpokeHub(g, &hub, &v1alpha1.VirtualMachine{})
 	})
 
+	t.Run("VirtualMachine hub-spoke-hub with LinuxPrep", func(t *testing.T) {
+		g := NewWithT(t)
+
+		hub := nextver.VirtualMachine{
+			Spec: nextver.VirtualMachineSpec{
+				Bootstrap: &nextver.VirtualMachineBootstrapSpec{
+					LinuxPrep: &nextver.VirtualMachineBootstrapLinuxPrepSpec{
+						HardwareClockIsUTC: true,
+						TimeZone:           "my-tz",
+					},
+				},
+			},
+		}
+
+		hubSpokeHub(g, &hub, &v1alpha1.VirtualMachine{})
+	})
+
+	t.Run("VirtualMachine hub-spoke-hub with LinuxPrep and vAppConfig", func(t *testing.T) {
+		g := NewWithT(t)
+
+		hub := nextver.VirtualMachine{
+			Spec: nextver.VirtualMachineSpec{
+				Bootstrap: &nextver.VirtualMachineBootstrapSpec{
+					LinuxPrep: &nextver.VirtualMachineBootstrapLinuxPrepSpec{
+						HardwareClockIsUTC: true,
+						TimeZone:           "my-tz",
+					},
+					VAppConfig: &nextver.VirtualMachineBootstrapVAppConfigSpec{
+						Properties: []nextver_common.KeyValueOrSecretKeySelectorPair{
+							{
+								Key: "my-key",
+								Value: nextver_common.ValueOrSecretKeySelector{
+									Value: ptrOf("my-value"),
+								},
+							},
+						},
+						RawProperties: "my-secret",
+					},
+				},
+			},
+		}
+
+		hubSpokeHub(g, &hub, &v1alpha1.VirtualMachine{})
+	})
+
 	t.Run("VirtualMachine hub-spoke-hub with Sysprep", func(t *testing.T) {
 		g := NewWithT(t)
 
@@ -281,15 +326,17 @@ func TestVirtualMachineConversion(t *testing.T) {
 		hubSpokeHub(g, &hub, &v1alpha1.VirtualMachine{})
 	})
 
-	t.Run("VirtualMachine hub-spoke-hub with LinuxPrep and vAppConfig", func(t *testing.T) {
+	t.Run("VirtualMachine hub-spoke-hub with Sysprep and vAppConfig", func(t *testing.T) {
 		g := NewWithT(t)
 
 		hub := nextver.VirtualMachine{
 			Spec: nextver.VirtualMachineSpec{
 				Bootstrap: &nextver.VirtualMachineBootstrapSpec{
-					LinuxPrep: &nextver.VirtualMachineBootstrapLinuxPrepSpec{
-						HardwareClockIsUTC: true,
-						TimeZone:           "my-tz",
+					Sysprep: &nextver.VirtualMachineBootstrapSysprepSpec{
+						RawSysprep: &nextver_common.SecretKeySelector{
+							Name: "sysprep-secret",
+							Key:  "my-key",
+						},
 					},
 					VAppConfig: &nextver.VirtualMachineBootstrapVAppConfigSpec{
 						Properties: []nextver_common.KeyValueOrSecretKeySelectorPair{
@@ -301,23 +348,6 @@ func TestVirtualMachineConversion(t *testing.T) {
 							},
 						},
 						RawProperties: "my-secret",
-					},
-				},
-			},
-		}
-
-		hubSpokeHub(g, &hub, &v1alpha1.VirtualMachine{})
-	})
-
-	t.Run("VirtualMachine hub-spoke-hub with LinuxPrep", func(t *testing.T) {
-		g := NewWithT(t)
-
-		hub := nextver.VirtualMachine{
-			Spec: nextver.VirtualMachineSpec{
-				Bootstrap: &nextver.VirtualMachineBootstrapSpec{
-					LinuxPrep: &nextver.VirtualMachineBootstrapLinuxPrepSpec{
-						HardwareClockIsUTC: true,
-						TimeZone:           "my-tz",
 					},
 				},
 			},


### PR DESCRIPTION
Resort a few of the bootstrap hubSpokeHub tests to be grouped together.

```release-note
NONE
```