### PR TITLE
🌱 Fix v1a2 cloud-init example

### DIFF
--- a/api/v1alpha2/testdata/vm-with-cloudinit.yaml
+++ b/api/v1alpha2/testdata/vm-with-cloudinit.yaml
@@ -7,12 +7,14 @@ spec:
   className: medium
   imageName: ubuntu-jammy
   network:
-    nameservers:
-    - 1.1.1.1
-    - 8.8.8.8
-    searchDomains:
-    - my.domain.local
-    - my-other.domain.local
+    interfaces:
+    - name: eth0
+      nameservers:
+      - 1.1.1.1
+      - 8.8.8.8
+      searchDomains:
+      - my.domain.local
+      - my-other.domain.local
   bootstrap:
     cloudInit: 
       cloudConfig:


### PR DESCRIPTION
ee0250839 remove these top-level fields in favor of always be apart of the interfaces.

```release-note
NONE
```