### PR TITLE
🐛 Update interface Nameservers and SearchDomains supported bootstrap

### DIFF
--- a/api/v1alpha2/virtualmachine_network_types.go
+++ b/api/v1alpha2/virtualmachine_network_types.go
@@ -132,7 +132,7 @@ type VirtualMachineNetworkInterfaceSpec struct {
 	// nameservers.
 	//
 	// Please note this feature is available only with the following bootstrap
-	// providers: CloudInit, LinuxPrep, and Sysprep (except for RawSysprep).
+	// providers: CloudInit, LinuxPrep, and Sysprep.
 	//
 	// Please note that Linux allows only three nameservers
 	// (https://linux.die.net/man/5/resolv.conf).
@@ -152,7 +152,7 @@ type VirtualMachineNetworkInterfaceSpec struct {
 	// addresses with DNS.
 	//
 	// Please note this feature is available only with the following bootstrap
-	// providers: CloudInit, LinuxPrep, and Sysprep (except for RawSysprep).
+	// providers: CloudInit.
 	//
 	// +optional
 	SearchDomains []string `json:"searchDomains,omitempty"`

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -1455,9 +1455,8 @@ spec:
                           description: "Nameservers is a list of IP4 and/or IP6 addresses
                             used as DNS nameservers. \n Please note this feature is
                             available only with the following bootstrap providers:
-                            CloudInit, LinuxPrep, and Sysprep (except for RawSysprep).
-                            \n Please note that Linux allows only three nameservers
-                            (https://linux.die.net/man/5/resolv.conf)."
+                            CloudInit, LinuxPrep, and Sysprep. \n Please note that
+                            Linux allows only three nameservers (https://linux.die.net/man/5/resolv.conf)."
                           items:
                             type: string
                           type: array
@@ -1516,8 +1515,7 @@ spec:
                           description: "SearchDomains is a list of search domains
                             used when resolving IP addresses with DNS. \n Please note
                             this feature is available only with the following bootstrap
-                            providers: CloudInit, LinuxPrep, and Sysprep (except for
-                            RawSysprep)."
+                            providers: CloudInit."
                           items:
                             type: string
                           type: array

--- a/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator_unit_test.go
@@ -904,7 +904,7 @@ func unitTestsValidateCreate() {
 			),
 
 			// Please note nameservers is available only with the following bootstrap
-			// providers: CloudInit, LinuxPrep, and Sysprep (except for RawSysprep).
+			// providers: CloudInit, LinuxPrep, and Sysprep.
 			Entry("validate nameservers when bootstrap doesn't support nameservers",
 				testParams{
 					setup: func(ctx *unitValidatingWebhookContext) {
@@ -912,9 +912,7 @@ func unitTestsValidateCreate() {
 							config.Features.WindowsSysprep = true
 						})
 						ctx.vm.Spec.Bootstrap = &vmopv1.VirtualMachineBootstrapSpec{
-							Sysprep: &vmopv1.VirtualMachineBootstrapSysprepSpec{
-								RawSysprep: &common.SecretKeySelector{},
-							},
+							VAppConfig: &vmopv1.VirtualMachineBootstrapVAppConfigSpec{},
 						}
 						ctx.vm.Spec.Network.Interfaces[0].Nameservers = []string{
 							"not-an-ip",
@@ -924,7 +922,7 @@ func unitTestsValidateCreate() {
 					validate: doValidateWithMsg(
 						`spec.network.interfaces[0].nameservers[0]: Invalid value: "not-an-ip": must be an IPv4 or IPv6 address`,
 						`spec.network.interfaces[0].nameservers[1]: Invalid value: "192.168.1.1/24": must be an IPv4 or IPv6 address`,
-						`spec.network.interfaces[0].nameservers: Invalid value: "not-an-ip,192.168.1.1/24": nameservers is available only with the following bootstrap providers: CloudInit LinuxPrep and Sysprep (except for RawSysprep)`,
+						`spec.network.interfaces[0].nameservers: Invalid value: "not-an-ip,192.168.1.1/24": nameservers is available only with the following bootstrap providers: CloudInit LinuxPrep and Sysprep`,
 					),
 				},
 			),
@@ -937,7 +935,7 @@ func unitTestsValidateCreate() {
 						})
 						ctx.vm.Spec.Bootstrap = &vmopv1.VirtualMachineBootstrapSpec{
 							Sysprep: &vmopv1.VirtualMachineBootstrapSysprepSpec{
-								Sysprep: &sysprep.Sysprep{},
+								RawSysprep: &common.SecretKeySelector{},
 							},
 						}
 						ctx.vm.Spec.Network.Interfaces[0].Nameservers = []string{
@@ -1008,8 +1006,7 @@ func unitTestsValidateCreate() {
 				},
 			),
 
-			// Please note this feature is available only with the following bootstrap
-			// providers: CloudInit, LinuxPrep, and Sysprep (except for RawSysprep).
+			// Please note this feature is available only with the following bootstrap providers: CloudInit
 			Entry("validate searchDomains when bootstrap doesn't support searchDomains",
 				testParams{
 					setup: func(ctx *unitValidatingWebhookContext) {
@@ -1019,7 +1016,7 @@ func unitTestsValidateCreate() {
 						ctx.vm.Spec.Network.Interfaces[0].SearchDomains = []string{"dev.local"}
 					},
 					validate: doValidateWithMsg(
-						`spec.network.interfaces[0].searchDomains: Invalid value: "dev.local": searchDomains is available only with the following bootstrap providers: CloudInit LinuxPrep and Sysprep (except for RawSysprep)`,
+						`spec.network.interfaces[0].searchDomains: Invalid value: "dev.local": searchDomains is available only with the following bootstrap providers: CloudInit`,
 					),
 				},
 			),
@@ -1028,7 +1025,7 @@ func unitTestsValidateCreate() {
 				testParams{
 					setup: func(ctx *unitValidatingWebhookContext) {
 						ctx.vm.Spec.Bootstrap = &vmopv1.VirtualMachineBootstrapSpec{
-							LinuxPrep: &vmopv1.VirtualMachineBootstrapLinuxPrepSpec{},
+							CloudInit: &vmopv1.VirtualMachineBootstrapCloudInitSpec{},
 						}
 						ctx.vm.Spec.Network.Interfaces[0].SearchDomains = []string{"dev.local"}
 					},


### PR DESCRIPTION
Both raw and inlined Sysprep supports interface nameservers (Sysprep uses the same GOSC fields as LinuxPrep).

As of now, only CloudInit supports per interface search domains. LinuxPrep and Sysprep (because of GOSC) do support global search domains (and name servers) but after ee025083 those top-level fields were removed. We need to think about adding that support back in.

Remove an erroneous InstanceStorage TODO. That is validated in another function (this is the same as the v1a1 validation wehbook).

```release-note
NONE
```
(since this is not released yet)