### PR TITLE
Update NetworkInterface Name field pattern validation

### DIFF
--- a/api/v1alpha2/virtualmachine_network_types.go
+++ b/api/v1alpha2/virtualmachine_network_types.go
@@ -32,7 +32,7 @@ type VirtualMachineNetworkInterfaceSpec struct {
 	// ensure the provided device name does not conflict with any other devices
 	// inside the guest, ex. dvd, cdrom, sda, etc.
 	//
-	// +kubebuilder:validation:Pattern=^\w\w+$
+	// +kubebuilder:validation:Pattern="^[a-z0-9]{2,}$"
 	Name string `json:"name"`
 
 	// Network is the name of the network resource to which this interface is

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -1449,7 +1449,7 @@ spec:
                             is CloudInit. Please note it is up to the user to ensure
                             the provided device name does not conflict with any other
                             devices inside the guest, ex. dvd, cdrom, sda, etc."
-                          pattern: ^\w\w+$
+                          pattern: ^[a-z0-9]{2,}$
                           type: string
                         nameservers:
                           description: "Nameservers is a list of IP4 and/or IP6 addresses


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Since the networkInterface name is used in the CRD, we need to make sure it is DNSSubDomain compliant. It cannot include A-Z or underscore.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #
N/A


**Are there any special notes for your reviewer**:

Earlier: 
```
root@422c3dc1f0a803888601c2f7bd08a66a [ ~ ]# kubectl apply -f vm.yaml
Error from server (spec.network.interfaces[0].name: Invalid value: "vm-v1a2-ETH0": is the resulting network interface name: a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')): error when creating "vm.yaml": admission webhook "default.validating.virtualmachine.v1alpha2.vmoperator.vmware.com" denied the request: spec.network.interfaces[0].name: Invalid value: "vm-v1a2-ETH0": is the resulting network interface name: a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
```

After the fix: 

```
 [ ~ ]# kubectl apply -f vm.yaml
The VirtualMachine "vm-v1a2" is invalid: spec.network.interfaces[0].name: Invalid value: "ETH0": spec.network.interfaces[0].name in body should match '^[a-z0-9]{2,}$'

[ ~ ]# kubectl apply -f vm.yaml
The VirtualMachine "vm-v1a2" is invalid: spec.network.interfaces[0].name: Invalid value: "e": spec.network.interfaces[0].name in body should match '^[a-z0-9]{2,}$'

yaml snippet:
  network:
    interfaces:
    - name: e0
    
root@4216498efaf1087de1e59cf3390b1430 [ ~ ]# kubectl apply -f vm.yaml
virtualmachine.vmoperator.vmware.com/vm-v1a2 created
    
```



**Please add a release note if necessary**:

```NONE
```