### PR TITLE
🌱 Use Network Hostname if set for Sysprep computer name

### DIFF
--- a/pkg/vmprovider/providers/vsphere2/vmlifecycle/bootstrap.go
+++ b/pkg/vmprovider/providers/vsphere2/vmlifecycle/bootstrap.go
@@ -44,7 +44,6 @@ type BootstrapArgs struct {
 
 	TemplateRenderFn TemplateRenderFunc
 	NetworkResults   network.NetworkInterfaceResults
-	ComputerName     string
 	Hostname         string
 	DNSServers       []string
 	SearchSuffixes   []string
@@ -132,7 +131,6 @@ func getBootstrapArgs(
 		BootstrapData:  bootstrapData,
 		NetworkResults: networkResults,
 		Hostname:       vmCtx.VM.Name,
-		ComputerName:   vmCtx.VM.Name,
 	}
 
 	if networkSpec := vmCtx.VM.Spec.Network; networkSpec != nil {

--- a/pkg/vmprovider/providers/vsphere2/vmlifecycle/bootstrap_sysprep.go
+++ b/pkg/vmprovider/providers/vsphere2/vmlifecycle/bootstrap_sysprep.go
@@ -106,7 +106,7 @@ func convertTo(from *vmopv1sysprep.Sysprep, bsArgs *BootstrapArgs) *vimTypes.Cus
 	sysprepCustomization.UserData = vimTypes.CustomizationUserData{
 		// This is a mandatory field
 		ComputerName: &vimTypes.CustomizationFixedName{
-			Name: bsArgs.ComputerName,
+			Name: bsArgs.Hostname,
 		},
 	}
 	if from.UserData != nil {

--- a/pkg/vmprovider/providers/vsphere2/vmlifecycle/bootstrap_sysprep_test.go
+++ b/pkg/vmprovider/providers/vsphere2/vmlifecycle/bootstrap_sysprep_test.go
@@ -100,7 +100,7 @@ var _ = Describe("SysPrep Bootstrap", func() {
 		Context("Inlined Sysprep", func() {
 			autoUsers := int32(5)
 			password, domainPassword, productID := "password_foo", "admin_password_foo", "product_id_foo"
-			computerName := "foo-win-vm"
+			hostName := "foo-win-vm"
 
 			BeforeEach(func() {
 				sysPrepSpec.Sysprep = &vmopv1sysprep.Sysprep{
@@ -140,7 +140,7 @@ var _ = Describe("SysPrep Bootstrap", func() {
 					Password:       password,
 					DomainPassword: domainPassword,
 				}
-				bsArgs.ComputerName = computerName
+				bsArgs.Hostname = hostName
 			})
 
 			It("should return expected customization spec", func() {
@@ -160,7 +160,7 @@ var _ = Describe("SysPrep Bootstrap", func() {
 				Expect(sysPrep.UserData.ProductId).To(Equal(productID))
 				name, ok := sysPrep.UserData.ComputerName.(*types.CustomizationFixedName)
 				Expect(ok).To(BeTrue())
-				Expect(name.Name).To(Equal(computerName))
+				Expect(name.Name).To(Equal(hostName))
 
 				Expect(sysPrep.GuiRunOnce.CommandList).To(HaveLen(2))
 
@@ -190,7 +190,7 @@ var _ = Describe("SysPrep Bootstrap", func() {
 
 					name, ok := sysPrep.UserData.ComputerName.(*types.CustomizationFixedName)
 					Expect(ok).To(BeTrue())
-					Expect(name.Name).To(Equal(computerName))
+					Expect(name.Name).To(Equal(hostName))
 				})
 			})
 		})


### PR DESCRIPTION
The intention with the hostName field is to let the user specify a name that's different than the k8s VM object name.

```release-note
NONE
```