### PR TITLE
📖 Remove bootstrap doc about automatic LinuxPrep/Sysprep

### DIFF
--- a/api/v1alpha2/virtualmachine_types.go
+++ b/api/v1alpha2/virtualmachine_types.go
@@ -224,15 +224,6 @@ type VirtualMachineSpec struct {
 	// Bootstrap describes the desired state of the guest's bootstrap
 	// configuration.
 	//
-	// If omitted, then the bootstrap method is determined based on the guest
-	// identifier from the VirtualMachineImage. If the image's guest OS type is
-	// Windows, then the Sysprep bootstrap method is used; if Linux, the
-	// LinuxPrep method is used.
-	//
-	// Please note that defaulting to Sysprep for Windows images only works if
-	// the image uses a volume license key, otherwise the image's product ID is
-	// required.
-	//
 	// +optional
 	Bootstrap *VirtualMachineBootstrapSpec `json:"bootstrap,omitempty"`
 

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -704,14 +704,8 @@ spec:
                     type: string
                 type: object
               bootstrap:
-                description: "Bootstrap describes the desired state of the guest's
-                  bootstrap configuration. \n If omitted, then the bootstrap method
-                  is determined based on the guest identifier from the VirtualMachineImage.
-                  If the image's guest OS type is Windows, then the Sysprep bootstrap
-                  method is used; if Linux, the LinuxPrep method is used. \n Please
-                  note that defaulting to Sysprep for Windows images only works if
-                  the image uses a volume license key, otherwise the image's product
-                  ID is required."
+                description: Bootstrap describes the desired state of the guest's
+                  bootstrap configuration.
                 properties:
                   cloudInit:
                     description: "CloudInit may be used to bootstrap Linux guests


### PR DESCRIPTION
This isn't supported yet so remove it from the docs until we get to implementing it.

```release-note
NONE
```

(because this isn't release yet)