### PR TITLE
✨ Disable DRS PowerOff for VMs with vGPU/Dynamic Direct Path IO devices

### DIFF
--- a/pkg/util/configspec.go
+++ b/pkg/util/configspec.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2022-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package util
@@ -208,17 +208,28 @@ func ExtraConfigToMap(input []vimTypes.BaseOptionValue) (output map[string]strin
 	return
 }
 
-// MergeExtraConfig adds the key/value to the ExtraConfig if the key is not present.
+// MergeExtraConfig adds the key/value to the ExtraConfig if the key is not
+// present or the new value is different than the existing value.
 // It returns the newly added ExtraConfig.
-func MergeExtraConfig(extraConfig []vimTypes.BaseOptionValue, newMap map[string]string) []vimTypes.BaseOptionValue {
-	merged := make([]vimTypes.BaseOptionValue, 0)
-	ecMap := ExtraConfigToMap(extraConfig)
-	for k, v := range newMap {
-		if _, exists := ecMap[k]; !exists {
-			merged = append(merged, &vimTypes.OptionValue{Key: k, Value: v})
+func MergeExtraConfig(
+	existingExtraConfig []vimTypes.BaseOptionValue,
+	newKeyValuePairs map[string]string) []vimTypes.BaseOptionValue {
+
+	mergedExtraConfig := make([]vimTypes.BaseOptionValue, 0)
+	existingExtraConfigKeyValuePairs := ExtraConfigToMap(existingExtraConfig)
+
+	for nk, nv := range newKeyValuePairs {
+		if ev, ok := existingExtraConfigKeyValuePairs[nk]; !ok || nv != ev {
+			mergedExtraConfig = append(
+				mergedExtraConfig,
+				&vimTypes.OptionValue{
+					Key:   nk,
+					Value: nv,
+				})
 		}
 	}
-	return merged
+
+	return mergedExtraConfig
 }
 
 // EnsureMinHardwareVersionInConfigSpec ensures that the hardware version in the ConfigSpec

--- a/pkg/util/configspec_test.go
+++ b/pkg/util/configspec_test.go
@@ -474,12 +474,23 @@ var _ = Describe("MergeExtraConfig", func() {
 		})
 	})
 
-	Context("NewMap with existing key", func() {
+	Context("NewMap with existing key and same value", func() {
 		BeforeEach(func() {
-			newMap["existingkey1"] = "existingkey1"
+			newMap["existingkey1"] = "existingvalue1"
 		})
 		It("Return empty merged", func() {
 			Expect(merged).To(BeEmpty())
+		})
+	})
+
+	Context("NewMap with existing key and new value", func() {
+		BeforeEach(func() {
+			newMap["existingkey1"] = "newvalue1"
+		})
+		It("Return merged map", func() {
+			Expect(merged).To(HaveLen(1))
+			mergedMap := util.ExtraConfigToMap(merged)
+			Expect(mergedMap["existingkey1"]).To(Equal("newvalue1"))
 		})
 	})
 

--- a/pkg/vmprovider/providers/vsphere/constants/constants.go
+++ b/pkg/vmprovider/providers/vsphere/constants/constants.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2021-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package constants
@@ -32,8 +32,12 @@ const (
 	// EnableDiskUUIDExtraConfigKey Enable UUID ExtraConfig key.
 	EnableDiskUUIDExtraConfigKey = "disk.enableUUID"
 
-	// MMPowerOffVMExtraConfigKey ExtraConfig key to enable DRS to powerOff VMs when underlying host enters into
-	// maintenance mode. This is to ensure the maintenance mode workflow is consistent for VMs with vGPU/DDPIO devices.
+	// MMPowerOffVMExtraConfigKey ExtraConfig key to enable DRS to powerOff VMs
+	// when the underlying host enters into maintenance mode. This is to ensure
+	// the maintenance mode workflow is consistent for VMs with vGPU/DDPIO
+	// devices.
+	// Deprecated: Admins can power off the VMs as they would VMs that are not
+	//             managed by VM Operator.
 	MMPowerOffVMExtraConfigKey = "maintenance.vm.evacuation.poweroff"
 
 	// NetPlanVersion points to the version used for Network config.

--- a/pkg/vmprovider/providers/vsphere/session/session_vm_update_test.go
+++ b/pkg/vmprovider/providers/vsphere/session/session_vm_update_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2021-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package session_test
@@ -480,6 +480,20 @@ var _ = Describe("Update ConfigSpec", func() {
 			})
 		})
 
+		Context("ExtraConfig has a non-empty MM flag", func() {
+			BeforeEach(func() {
+				config.ExtraConfig = append(
+					config.ExtraConfig,
+					&vimTypes.OptionValue{
+						Key:   constants.MMPowerOffVMExtraConfigKey,
+						Value: "true",
+					})
+			})
+			It("Should be set to an empty value", func() {
+				Expect(ecMap).To(HaveKeyWithValue(constants.MMPowerOffVMExtraConfigKey, ""))
+			})
+		})
+
 		Context("ExtraConfig value already exists", func() {
 			BeforeEach(func() {
 				config.ExtraConfig = append(config.ExtraConfig, &vimTypes.OptionValue{Key: "foo", Value: "bar"})
@@ -492,31 +506,9 @@ var _ = Describe("Update ConfigSpec", func() {
 		})
 
 		Context("InstanceStorage related tests", func() {
-
 			Context("When InstanceStorage is NOT configured on VM", func() {
 				It("No Changes", func() {
 					Expect(ecMap).To(BeEmpty())
-				})
-			})
-
-			Context("When InstanceStorage is configured on VM", func() {
-				BeforeEach(func() {
-					vm.Spec.Volumes = append(vm.Spec.Volumes, vmopv1.VirtualMachineVolume{
-						Name: "pvc-volume-1",
-						PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
-							PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
-								ClaimName: "pvc-volume-1",
-							},
-							InstanceVolumeClaim: &vmopv1.InstanceVolumeClaimVolumeSource{
-								StorageClass: "dummyStorageClass",
-								Size:         resource.MustParse("256Gi"),
-							},
-						},
-					})
-				})
-
-				It("maintenance mode powerOff extraConfig should be added", func() {
-					Expect(ecMap).To(HaveKeyWithValue(constants.MMPowerOffVMExtraConfigKey, constants.ExtraConfigTrue))
 				})
 			})
 		})
@@ -536,10 +528,6 @@ var _ = Describe("Update ConfigSpec", func() {
 							ProfileName: "test-vgpu-profile",
 						},
 					}}
-				})
-
-				It("maintenance mode powerOff extraConfig should be added", func() {
-					Expect(ecMap).To(HaveKeyWithValue(constants.MMPowerOffVMExtraConfigKey, constants.ExtraConfigTrue))
 				})
 
 				It("PCI passthru MMIO extraConfig should be added", func() {
@@ -568,10 +556,6 @@ var _ = Describe("Update ConfigSpec", func() {
 							CustomLabel: "",
 						},
 					}}
-				})
-
-				It("maintenance mode powerOff extraConfig should be added", func() {
-					Expect(ecMap).To(HaveKeyWithValue(constants.MMPowerOffVMExtraConfigKey, constants.ExtraConfigTrue))
 				})
 
 				It("PCI passthru MMIO extraConfig should be added", func() {
@@ -665,8 +649,7 @@ var _ = Describe("Update ConfigSpec", func() {
 
 					})
 
-					It("extraConfig Map has MMIO and MMPowerOff related keys added", func() {
-						Expect(ecMap).To(HaveKeyWithValue(constants.MMPowerOffVMExtraConfigKey, constants.ExtraConfigTrue))
+					It("extraConfig Map has MMIO keys added", func() {
 						Expect(ecMap).To(HaveKeyWithValue(constants.PCIPassthruMMIOExtraConfigKey, constants.ExtraConfigTrue))
 						Expect(ecMap).To(HaveKeyWithValue(constants.PCIPassthruMMIOSizeExtraConfigKey, constants.PCIPassthruMMIOSizeDefault))
 					})

--- a/pkg/vmprovider/providers/vsphere2/constants/constants.go
+++ b/pkg/vmprovider/providers/vsphere2/constants/constants.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2021-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package constants
@@ -32,8 +32,12 @@ const (
 	// EnableDiskUUIDExtraConfigKey Enable UUID ExtraConfig key.
 	EnableDiskUUIDExtraConfigKey = "disk.enableUUID"
 
-	// MMPowerOffVMExtraConfigKey ExtraConfig key to enable DRS to powerOff VMs when underlying host enters into
-	// maintenance mode. This is to ensure the maintenance mode workflow is consistent for VMs with vGPU/DDPIO devices.
+	// MMPowerOffVMExtraConfigKey ExtraConfig key to enable DRS to powerOff VMs
+	// when the underlying host enters into maintenance mode. This is to ensure
+	// the maintenance mode workflow is consistent for VMs with vGPU/DDPIO
+	// devices.
+	// Deprecated: Admins can power off the VMs as they would VMs that are not
+	//             managed by VM Operator.
 	MMPowerOffVMExtraConfigKey = "maintenance.vm.evacuation.poweroff"
 
 	// NetPlanVersion points to the version used for Network config.

--- a/pkg/vmprovider/providers/vsphere2/session/session_vm_update_test.go
+++ b/pkg/vmprovider/providers/vsphere2/session/session_vm_update_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2021-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package session_test
@@ -324,6 +324,20 @@ var _ = Describe("Update ConfigSpec", func() {
 			})
 		})
 
+		Context("ExtraConfig has a non-empty MM flag", func() {
+			BeforeEach(func() {
+				config.ExtraConfig = append(
+					config.ExtraConfig,
+					&vimTypes.OptionValue{
+						Key:   constants.MMPowerOffVMExtraConfigKey,
+						Value: "true",
+					})
+			})
+			It("Should be set to an empty value", func() {
+				Expect(ecMap).To(HaveKeyWithValue(constants.MMPowerOffVMExtraConfigKey, ""))
+			})
+		})
+
 		Context("ExtraConfig value already exists", func() {
 			BeforeEach(func() {
 				config.ExtraConfig = append(config.ExtraConfig, &vimTypes.OptionValue{Key: "foo", Value: "bar"})
@@ -360,10 +374,6 @@ var _ = Describe("Update ConfigSpec", func() {
 						},
 					})
 				})
-
-				It("maintenance mode powerOff extraConfig should be added", func() {
-					Expect(ecMap).To(HaveKeyWithValue(constants.MMPowerOffVMExtraConfigKey, constants.ExtraConfigTrue))
-				})
 			})
 		})
 
@@ -382,10 +392,6 @@ var _ = Describe("Update ConfigSpec", func() {
 							ProfileName: "test-vgpu-profile",
 						},
 					}}
-				})
-
-				It("maintenance mode powerOff extraConfig should be added", func() {
-					Expect(ecMap).To(HaveKeyWithValue(constants.MMPowerOffVMExtraConfigKey, constants.ExtraConfigTrue))
 				})
 
 				It("PCI passthru MMIO extraConfig should be added", func() {
@@ -414,10 +420,6 @@ var _ = Describe("Update ConfigSpec", func() {
 							CustomLabel: "",
 						},
 					}}
-				})
-
-				It("maintenance mode powerOff extraConfig should be added", func() {
-					Expect(ecMap).To(HaveKeyWithValue(constants.MMPowerOffVMExtraConfigKey, constants.ExtraConfigTrue))
 				})
 
 				It("PCI passthru MMIO extraConfig should be added", func() {
@@ -511,8 +513,7 @@ var _ = Describe("Update ConfigSpec", func() {
 
 					})
 
-					It("extraConfig Map has MMIO and MMPowerOff related keys added", func() {
-						Expect(ecMap).To(HaveKeyWithValue(constants.MMPowerOffVMExtraConfigKey, constants.ExtraConfigTrue))
+					It("extraConfig Map has MMIO keys added", func() {
 						Expect(ecMap).To(HaveKeyWithValue(constants.PCIPassthruMMIOExtraConfigKey, constants.ExtraConfigTrue))
 						Expect(ecMap).To(HaveKeyWithValue(constants.PCIPassthruMMIOSizeExtraConfigKey, constants.PCIPassthruMMIOSizeDefault))
 					})

--- a/pkg/vmprovider/providers/vsphere2/vmprovider_vm.go
+++ b/pkg/vmprovider/providers/vsphere2/vmprovider_vm.go
@@ -953,10 +953,6 @@ func (vs *vSphereVMProvider) vmCreateGenConfigSpecExtraConfig(
 
 	hasPassthroughDevices := len(util.SelectVirtualPCIPassthrough(util.DevicesFromConfigSpec(createArgs.ConfigSpec))) > 0
 
-	if hasPassthroughDevices || createArgs.HasInstanceStorage {
-		ecMap[constants.MMPowerOffVMExtraConfigKey] = constants.ExtraConfigTrue
-	}
-
 	if hasPassthroughDevices {
 		mmioSize := vmCtx.VM.Annotations[constants.PCIPassthruMMIOOverrideAnnotation]
 		if mmioSize == "" {


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

It used to be the case that VI Admins could not manage the power state of VM Service managed VMs on vSphere via API or the HTML5 client (H5C). This presented a challenge to maintenance mode. If a VM could not be automatically evacuated from a host entering maintenance mode, the host could not successfully enter maintenance mode. In vSphere 7, VMs with vGPUs were not automatically vMotioned, and in vSphere 8+, VMs with PCI Passthru devices still are not vMotioned. There are also other CPU related settings that might pin a VM to a host, preventing DRS from vMotioning a VM to evacuate it off of a host entering maintenance mode.

Normally a VI Admin would power off a VM that blocks maintenance mode, but since VM Service managed VMs used to disallow VI Admins from doing so, a work-around was needed. VM Operator would apply a special flag in a VM's ExtraConfig to inform DRS to power off this VM if a host is entering maintenance mode. This flag was only applied for VMs with vGPUs or PCI Passthru devices because these were the only configurations allowed by VM Operator that would block evacuation-by-vMotion. And again, at the time this was implemented, VI Admins could not simply choose to power off these VM Service managed VMs as the VI Admins would do for any other VM. Since it is not possible to power on a VM on a host marked for maintenance mode, attempts to power the VM on by VM Operator will force DRS to attempt to find another compatible host for the VM.

Starting in vSphere 8, VMs with vGPUs *can* be automatically vMotioned, but VMs managed by VM Service are still powered off due to the special flag. Also starting in vSphere 8, VM Service managed VMs *can* be powered off by VI Admins in H5C. Beginning with vSphere 8.0U2, it is also possible to realize VM Service managed VMs using the *entire* virtual hardware and configuration surface of a vSphere VM, increasing the number of ways in which a VM Service managed VM might block a VM from being evacuated by vMotion.

Due to these factors, it is no longer desirable for DRS to automatically power off a VM Service managed VM. Instead, if a VM Service VM is blocking a host from entering maintenance mode, the VI Admin may treat it like any other VM and power off the VM using the web client or the vSphere API.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->
`NA`

**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
DRS will no longer evacuate VMs with vGPUs and/or Dynamic Direct Path I/O devices from a host entering maintenance mode by powering off the VMs. Instead, VI Admins may configure a vSphere Cluster to indicate the level of stun time a VM with a vGPU is allowed to tolerate during a vMotion. Additionally, whether the VM cannot be evacuated due to a vGPU or any other reason, VI Admins may now power off the VM via the vSphere web client just like any other VM.
```