### PR TITLE
🐛 Update bootstrap_cloudinit to use MergeExtraConfig

### DIFF
--- a/pkg/vmprovider/providers/vsphere2/vmlifecycle/bootstrap_cloudinit.go
+++ b/pkg/vmprovider/providers/vsphere2/vmlifecycle/bootstrap_cloudinit.go
@@ -190,7 +190,7 @@ func GetCloudInitGuestInfoCustSpec(
 	// always setting VAppConfigRemoved isn't correct: should only set it if the VM has vApp data.
 	// As-is we will always Reconfigure the VM.
 	configSpec := &types.VirtualMachineConfigSpec{}
-	configSpec.ExtraConfig = util.AppendNewExtraConfigValues(config.ExtraConfig, extraConfig)
+	configSpec.ExtraConfig = util.MergeExtraConfig(config.ExtraConfig, extraConfig)
 	// Remove the VAppConfig to ensure Cloud-Init inside the guest does not
 	// activate and prefer the OVF datasource over the VMware datasource.
 	configSpec.VAppConfigRemoved = types.NewBool(true) // FIXME


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This PR updates the `bootstrap_cloudinit.go` file to use the `MergeExtraConfig` function so that the existing EC also gets updated. This ensures that the VM is reconfigured with accurate data when updated (e.g. cloud-init `guestinfo.metadata` with a different instance ID).

**Please add a release note if necessary**:
```release-note
Update existing ExtraConfig keys if the values are changed.
```