### PR TITLE
✨ Set v1a2 FSS to true by default

### DIFF
--- a/config/local/vmoperator/local_env_var_patch.yaml
+++ b/config/local/vmoperator/local_env_var_patch.yaml
@@ -12,7 +12,7 @@ spec:
         - name: FSS_WCP_Unified_TKG
           value: "false"
         - name: FSS_WCP_VMSERVICE_V1ALPHA2
-          value: "false"
+          value: "true"
         - name: VSPHERE_NETWORKING
           value: "false"
         - name: FSS_WCP_FAULTDOMAINS

--- a/controllers/contentlibrary/v1alpha1/contentlibraryitem/contentlibraryitem_controller_suite_test.go
+++ b/controllers/contentlibrary/v1alpha1/contentlibraryitem/contentlibraryitem_controller_suite_test.go
@@ -23,6 +23,7 @@ var suite = builder.NewTestSuiteForControllerWithContext(
 		pkgconfig.NewContextWithDefaultConfig(),
 		func(config *pkgconfig.Config) {
 			config.Features.ImageRegistry = true
+			config.Features.VMOpV1Alpha2 = false
 		}),
 	contentlibraryitem.AddToManager,
 	func(ctx *ctrlContext.ControllerManagerContext, _ ctrlmgr.Manager) error {

--- a/controllers/virtualmachinepublishrequest/v1alpha1/virtualmachinepublishrequest_controller_suite_test.go
+++ b/controllers/virtualmachinepublishrequest/v1alpha1/virtualmachinepublishrequest_controller_suite_test.go
@@ -24,6 +24,7 @@ var suite = builder.NewTestSuiteForControllerWithContext(
 		pkgconfig.NewContextWithDefaultConfig(),
 		func(config *pkgconfig.Config) {
 			config.Features.ImageRegistry = true
+			config.Features.VMOpV1Alpha2 = false
 		}),
 	virtualmachinepublishrequest.AddToManager,
 	func(ctx *ctrlContext.ControllerManagerContext, _ ctrlmgr.Manager) error {

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -23,7 +23,7 @@ func Default() Config {
 			UnifiedTKG:                 true,
 			VMClassAsConfig:            true,
 			VMClassAsConfigDayNDate:    true,
-			VMOpV1Alpha2:               false,
+			VMOpV1Alpha2:               true,
 			PodVMOnStretchedSupervisor: false,
 		},
 		InstanceStorage: InstanceStorage{

--- a/pkg/config/env_test.go
+++ b/pkg/config/env_test.go
@@ -87,7 +87,7 @@ var _ = Describe(
 					Expect(os.Setenv("WEBHOOK_SECRET_NAME", "123")).To(Succeed())
 					Expect(os.Setenv("WEBHOOK_SECRET_NAMESPACE", "124")).To(Succeed())
 					Expect(os.Setenv("FSS_WCP_FAULTDOMAINS", "false")).To(Succeed())
-					Expect(os.Setenv("FSS_WCP_VMSERVICE_V1ALPHA2", "true")).To(Succeed())
+					Expect(os.Setenv("FSS_WCP_VMSERVICE_V1ALPHA2", "false")).To(Succeed())
 					Expect(os.Setenv("FSS_WCP_INSTANCE_STORAGE", "false")).To(Succeed())
 					Expect(os.Setenv("FSS_WCP_Unified_TKG", "false")).To(Succeed())
 					Expect(os.Setenv("FSS_WCP_VM_CLASS_AS_CONFIG", "false")).To(Succeed())
@@ -131,7 +131,7 @@ var _ = Describe(
 						WebhookSecretVolumeMountPath: pkgconfig.Default().WebhookSecretVolumeMountPath,
 						Features: pkgconfig.FeatureStates{
 							FaultDomains:            false,
-							VMOpV1Alpha2:            true,
+							VMOpV1Alpha2:            false,
 							InstanceStorage:         false,
 							UnifiedTKG:              false,
 							VMClassAsConfig:         false,


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch updates the logic in `pkg/config` to treat the v1a2 FSS as true by default since this feature was enabled on main.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

The two test updates were required due to them being integration tests for v1a1 that do not expect v1a2 to be enabled.


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Enable v1alpha2 by default.
```