### PR TITLE
✨ Set enabled FSSs to true by default

### DIFF
--- a/config/local/vmoperator/local_env_var_patch.yaml
+++ b/config/local/vmoperator/local_env_var_patch.yaml
@@ -10,7 +10,7 @@ spec:
       - name: manager
         env:
         - name: FSS_WCP_Unified_TKG
-          value: "false"
+          value: "true"
         - name: FSS_WCP_VMSERVICE_V1ALPHA2
           value: "false"
         - name: VSPHERE_NETWORKING
@@ -18,19 +18,19 @@ spec:
         - name: FSS_WCP_FAULTDOMAINS
           value: "true"
         - name: FSS_WCP_INSTANCE_STORAGE
-          value: "false"
+          value: "true"
         - name: FSS_WCP_VM_CLASS_AS_CONFIG
-          value: "false"
+          value: "true"
         - name: FSS_WCP_VM_CLASS_AS_CONFIG_DAYNDATE
-          value: "false"
+          value: "true"
         - name: FSS_WCP_VM_IMAGE_REGISTRY
-          value: "false"
+          value: "true"
         - name: NETWORK_PROVIDER
           value: "NAMED"
         - name: FSS_WCP_NAMESPACED_VM_CLASS
-          value: "false"
+          value: "true"
         - name: FSS_WCP_WINDOWS_SYSPREP
-          value: "false"
+          value: "true"
         - name: FSS_WCP_VMSERVICE_BACKUPRESTORE
           value: "false"
         - name: FSS_PODVMONSTRETCHEDSUPERVISOR


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch updates the local env var patch applied to local Kind instances so that enabled FSSs are set to true by default. This patch touches the following features: Unified TKG, Instance Storage, VM Class as Config, VM Class as Config DnD, Image Registry, Namespaced VM Class, and Sysprep.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```