### PR TITLE
✨ Guest bootstrap status as condition

### DIFF
--- a/api/v1alpha1/condition_consts.go
+++ b/api/v1alpha1/condition_consts.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2021-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package v1alpha1
@@ -39,6 +39,12 @@ const (
 	// VirtualMachineImageNotReadyReason (Severity=Error) documents that the VirtualMachineImage specified in the VirtualMachineSpec
 	// is not ready.
 	VirtualMachineImageNotReadyReason = "VirtualMachineImageNotReady"
+)
+
+const (
+	// GuestBootstrapCondition exposes the status of guest bootstrap from within
+	// the guest OS, when available.
+	GuestBootstrapCondition ConditionType = "GuestBootstrap"
 )
 
 const (

--- a/api/v1alpha2/virtualmachine_types.go
+++ b/api/v1alpha2/virtualmachine_types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2023-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package v1alpha2
@@ -41,6 +41,12 @@ const (
 
 	// VirtualMachineConditionCreated indicates that the VM has been created.
 	VirtualMachineConditionCreated = "VirtualMachineCreated"
+)
+
+const (
+	// GuestBootstrapCondition exposes the status of guest bootstrap from within
+	// the guest OS, when available.
+	GuestBootstrapCondition = "GuestBootstrap"
 )
 
 const (

--- a/pkg/util/bootstrap_condition.go
+++ b/pkg/util/bootstrap_condition.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"strconv"
+	"strings"
+
+	vimTypes "github.com/vmware/govmomi/vim25/types"
+)
+
+// GuestInfoBootstrapCondition is the ExtraConfig key at which possible info
+// about the bootstrap status may be stored.
+const GuestInfoBootstrapCondition = "guestinfo.vmservice.bootstrap.condition"
+
+// GetBootstrapConditionValues returns the bootstrap condition values from a
+// VM if the data is present.
+func GetBootstrapConditionValues(
+	configInfo *vimTypes.VirtualMachineConfigInfo) (bool, string, string, bool) {
+
+	if configInfo == nil {
+		return false, "", "", false
+	}
+
+	if len(configInfo.ExtraConfig) == 0 {
+		return false, "", "", false
+	}
+
+	for i := range configInfo.ExtraConfig {
+		if ec := configInfo.ExtraConfig[i]; ec != nil {
+			if ov := ec.GetOptionValue(); ov != nil {
+				if ov.Key == GuestInfoBootstrapCondition {
+					if s, ok := ov.Value.(string); ok {
+						v := strings.SplitN(s, ",", 3)
+						status, _ := strconv.ParseBool(strings.TrimSpace(v[0]))
+						switch len(v) {
+						case 1:
+							return status, "", "", true
+						case 2:
+							return status, strings.TrimSpace(v[1]), "", true
+						case 3:
+							return status,
+								strings.TrimSpace(v[1]),
+								strings.TrimSpace(v[2]),
+								true
+						default:
+							return false, "", "", false
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return false, "", "", false
+}

--- a/pkg/util/bootstrap_condition_test.go
+++ b/pkg/util/bootstrap_condition_test.go
@@ -1,0 +1,311 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package util_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	vimTypes "github.com/vmware/govmomi/vim25/types"
+
+	"github.com/vmware-tanzu/vm-operator/pkg/util"
+)
+
+var _ = Describe("GetBootstrapConditionValuesTest", func() {
+	var (
+		configInfo *vimTypes.VirtualMachineConfigInfo
+		status     bool
+		reason     string
+		msg        string
+		ok         bool
+	)
+	JustBeforeEach(func() {
+		status, reason, msg, ok = util.GetBootstrapConditionValues(configInfo)
+	})
+	AfterEach(func() {
+		configInfo = nil
+		status = false
+		reason = ""
+		msg = ""
+		ok = false
+	})
+	assertResult := func(s bool, r, m string, o bool) {
+		ExpectWithOffset(1, status).To(Equal(s))
+		ExpectWithOffset(1, reason).To(Equal(r))
+		ExpectWithOffset(1, msg).To(Equal(m))
+		ExpectWithOffset(1, ok).To(Equal(o))
+	}
+	When("configInfo is nil", func() {
+		It("should return status=false, reason=\"\", msg=\"\", ok=false", func() {
+			assertResult(false, "", "", false)
+		})
+	})
+	When("extraConfig is zero-length", func() {
+		BeforeEach(func() {
+			configInfo = &vimTypes.VirtualMachineConfigInfo{}
+		})
+		It("should return status=false, reason=\"\", msg=\"\", ok=false", func() {
+			assertResult(false, "", "", false)
+		})
+	})
+	When("extraConfig is missing guestinfo key", func() {
+		BeforeEach(func() {
+			configInfo = &vimTypes.VirtualMachineConfigInfo{
+				ExtraConfig: []vimTypes.BaseOptionValue{
+					&vimTypes.OptionValue{
+						Key:   "key1",
+						Value: "val1",
+					},
+				},
+			}
+		})
+		It("should return status=false, reason=\"\", msg=\"\", ok=false", func() {
+			assertResult(false, "", "", false)
+		})
+	})
+	When("guestinfo val is empty", func() {
+		BeforeEach(func() {
+			configInfo = &vimTypes.VirtualMachineConfigInfo{
+				ExtraConfig: []vimTypes.BaseOptionValue{
+					&vimTypes.OptionValue{
+						Key:   "key1",
+						Value: "val1",
+					},
+					&vimTypes.OptionValue{
+						Key:   util.GuestInfoBootstrapCondition,
+						Value: "",
+					},
+				},
+			}
+		})
+		It("should return status=false, reason=\"\", msg=\"\", ok=true", func() {
+			assertResult(false, "", "", true)
+		})
+	})
+	When("status is 1", func() {
+		BeforeEach(func() {
+			configInfo = &vimTypes.VirtualMachineConfigInfo{
+				ExtraConfig: []vimTypes.BaseOptionValue{
+					&vimTypes.OptionValue{
+						Key:   util.GuestInfoBootstrapCondition,
+						Value: "1",
+					},
+				},
+			}
+		})
+		It("should return status=true, reason=\"\", msg=\"\", ok=true", func() {
+			assertResult(true, "", "", true)
+		})
+	})
+	When("status is TRUE", func() {
+		BeforeEach(func() {
+			configInfo = &vimTypes.VirtualMachineConfigInfo{
+				ExtraConfig: []vimTypes.BaseOptionValue{
+					&vimTypes.OptionValue{
+						Key:   util.GuestInfoBootstrapCondition,
+						Value: "TRUE",
+					},
+				},
+			}
+		})
+		It("should return status=true, reason=\"\", msg=\"\", ok=true", func() {
+			assertResult(true, "", "", true)
+		})
+	})
+	When("status is true", func() {
+		BeforeEach(func() {
+			configInfo = &vimTypes.VirtualMachineConfigInfo{
+				ExtraConfig: []vimTypes.BaseOptionValue{
+					&vimTypes.OptionValue{
+						Key:   util.GuestInfoBootstrapCondition,
+						Value: "true",
+					},
+				},
+			}
+		})
+		It("should return status=true, reason=\"\", msg=\"\", ok=true", func() {
+			assertResult(true, "", "", true)
+		})
+	})
+	When("status is true with a reason", func() {
+		BeforeEach(func() {
+			configInfo = &vimTypes.VirtualMachineConfigInfo{
+				ExtraConfig: []vimTypes.BaseOptionValue{
+					&vimTypes.OptionValue{
+						Key:   util.GuestInfoBootstrapCondition,
+						Value: "true,my-reason",
+					},
+				},
+			}
+		})
+		It("should return status=true, reason=\"my-reason\", msg=\"\", ok=true", func() {
+			assertResult(true, "my-reason", "", true)
+		})
+	})
+	When("status is true with a reason and message", func() {
+		BeforeEach(func() {
+			configInfo = &vimTypes.VirtualMachineConfigInfo{
+				ExtraConfig: []vimTypes.BaseOptionValue{
+					&vimTypes.OptionValue{
+						Key:   util.GuestInfoBootstrapCondition,
+						Value: "true,my-reason,my,comma,delimited,message",
+					},
+				},
+			}
+		})
+		It("should return status=true, reason=\"my-reason\", msg=\"my,comma,delimited,message\", ok=true", func() {
+			assertResult(true, "my-reason", "my,comma,delimited,message", true)
+		})
+	})
+	When("status is true with a reason and message with leading or trailing whitespace", func() {
+		BeforeEach(func() {
+			configInfo = &vimTypes.VirtualMachineConfigInfo{
+				ExtraConfig: []vimTypes.BaseOptionValue{
+					&vimTypes.OptionValue{
+						Key:   util.GuestInfoBootstrapCondition,
+						Value: "  true ,  my-reason ,   my,comma,delimited,message ",
+					},
+				},
+			}
+		})
+		It("should return status=true, reason=\"my-reason\", msg=\"my,comma,delimited,message\", ok=true", func() {
+			assertResult(true, "my-reason", "my,comma,delimited,message", true)
+		})
+	})
+	When("status is empty with empty reason and message", func() {
+		BeforeEach(func() {
+			configInfo = &vimTypes.VirtualMachineConfigInfo{
+				ExtraConfig: []vimTypes.BaseOptionValue{
+					&vimTypes.OptionValue{
+						Key:   util.GuestInfoBootstrapCondition,
+						Value: "  ,,  ",
+					},
+				},
+			}
+		})
+		It("should return status=false, reason=\"\", msg=\"\", ok=true", func() {
+			assertResult(false, "", "", true)
+		})
+	})
+	When("status is 0", func() {
+		BeforeEach(func() {
+			configInfo = &vimTypes.VirtualMachineConfigInfo{
+				ExtraConfig: []vimTypes.BaseOptionValue{
+					&vimTypes.OptionValue{
+						Key:   util.GuestInfoBootstrapCondition,
+						Value: "0",
+					},
+				},
+			}
+		})
+		It("should return status=false, reason=\"\", msg=\"\", ok=true", func() {
+			assertResult(false, "", "", true)
+		})
+	})
+	When("status is FALSE", func() {
+		BeforeEach(func() {
+			configInfo = &vimTypes.VirtualMachineConfigInfo{
+				ExtraConfig: []vimTypes.BaseOptionValue{
+					&vimTypes.OptionValue{
+						Key:   util.GuestInfoBootstrapCondition,
+						Value: "FALSE",
+					},
+				},
+			}
+		})
+		It("should return status=false, reason=\"\", msg=\"\", ok=true", func() {
+			assertResult(false, "", "", true)
+		})
+	})
+	When("status is false", func() {
+		BeforeEach(func() {
+			configInfo = &vimTypes.VirtualMachineConfigInfo{
+				ExtraConfig: []vimTypes.BaseOptionValue{
+					&vimTypes.OptionValue{
+						Key:   util.GuestInfoBootstrapCondition,
+						Value: "false",
+					},
+				},
+			}
+		})
+		It("should return status=false, reason=\"\", msg=\"\", ok=true", func() {
+			assertResult(false, "", "", true)
+		})
+	})
+	When("status is false with a reason", func() {
+		BeforeEach(func() {
+			configInfo = &vimTypes.VirtualMachineConfigInfo{
+				ExtraConfig: []vimTypes.BaseOptionValue{
+					&vimTypes.OptionValue{
+						Key:   util.GuestInfoBootstrapCondition,
+						Value: "false,my-reason",
+					},
+				},
+			}
+		})
+		It("should return status=false, reason=\"my-reason\", msg=\"\", ok=true", func() {
+			assertResult(false, "my-reason", "", true)
+		})
+	})
+	When("status is empty with a reason", func() {
+		BeforeEach(func() {
+			configInfo = &vimTypes.VirtualMachineConfigInfo{
+				ExtraConfig: []vimTypes.BaseOptionValue{
+					&vimTypes.OptionValue{
+						Key:   util.GuestInfoBootstrapCondition,
+						Value: "  ,my-reason",
+					},
+				},
+			}
+		})
+		It("should return status=false, reason=\"my-reason\", msg=\"\", ok=true", func() {
+			assertResult(false, "my-reason", "", true)
+		})
+	})
+	When("status is false with a reason and message", func() {
+		BeforeEach(func() {
+			configInfo = &vimTypes.VirtualMachineConfigInfo{
+				ExtraConfig: []vimTypes.BaseOptionValue{
+					&vimTypes.OptionValue{
+						Key:   util.GuestInfoBootstrapCondition,
+						Value: "false,my-reason,my,comma,delimited,message",
+					},
+				},
+			}
+		})
+		It("should return status=false, reason=\"my-reason\", msg=\"my,comma,delimited,message\", ok=true", func() {
+			assertResult(false, "my-reason", "my,comma,delimited,message", true)
+		})
+	})
+	When("status is false with a reason and message with leading or trailing whitespace", func() {
+		BeforeEach(func() {
+			configInfo = &vimTypes.VirtualMachineConfigInfo{
+				ExtraConfig: []vimTypes.BaseOptionValue{
+					&vimTypes.OptionValue{
+						Key:   util.GuestInfoBootstrapCondition,
+						Value: "  false ,  my-reason ,   my,comma,delimited,message ",
+					},
+				},
+			}
+		})
+		It("should return status=false, reason=\"my-reason\", msg=\"my,comma,delimited,message\", ok=true", func() {
+			assertResult(false, "my-reason", "my,comma,delimited,message", true)
+		})
+	})
+	When("status is empty with a reason and message with leading or trailing whitespace", func() {
+		BeforeEach(func() {
+			configInfo = &vimTypes.VirtualMachineConfigInfo{
+				ExtraConfig: []vimTypes.BaseOptionValue{
+					&vimTypes.OptionValue{
+						Key:   util.GuestInfoBootstrapCondition,
+						Value: "   ,  my-reason ,   my,comma,delimited,message ",
+					},
+				},
+			}
+		})
+		It("should return status=false, reason=\"my-reason\", msg=\"my,comma,delimited,message\", ok=true", func() {
+			assertResult(false, "my-reason", "my,comma,delimited,message", true)
+		})
+	})
+})

--- a/pkg/vmprovider/providers/vsphere2/vmlifecycle/update_status_test.go
+++ b/pkg/vmprovider/providers/vsphere2/vmlifecycle/update_status_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2023-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package vmlifecycle_test
@@ -15,6 +15,7 @@ import (
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	conditions "github.com/vmware-tanzu/vm-operator/pkg/conditions2"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/util"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere2/vmlifecycle"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
@@ -346,6 +347,300 @@ var _ = Describe("VSphere Customization Status to VM Status Condition", func() {
 					*conditions.FalseCondition(vmopv1.GuestCustomizationCondition, "Unknown", guestInfo.CustomizationInfo.ErrorMsg),
 				}
 				Expect(vm.Status.Conditions).To(conditions.MatchConditions(expectedConditions))
+			})
+		})
+	})
+})
+
+var _ = Describe("VSphere Bootstrap Status to VM Status Condition", func() {
+	Context("MarkBootstrapCondition", func() {
+		var (
+			vm         *vmopv1.VirtualMachine
+			configInfo *types.VirtualMachineConfigInfo
+		)
+
+		BeforeEach(func() {
+			vm = &vmopv1.VirtualMachine{}
+			configInfo = &types.VirtualMachineConfigInfo{}
+		})
+
+		JustBeforeEach(func() {
+			vmlifecycle.MarkBootstrapCondition(vm, configInfo)
+		})
+
+		Context("unknown condition", func() {
+			When("configInfo unset", func() {
+				BeforeEach(func() {
+					configInfo = nil
+				})
+				It("sets condition unknown", func() {
+					expectedConditions := []metav1.Condition{
+						*conditions.UnknownCondition(vmopv1.GuestBootstrapCondition, "NoConfigInfo", ""),
+					}
+					Expect(vm.Status.Conditions).To(conditions.MatchConditions(expectedConditions))
+				})
+			})
+			When("extraConfig unset", func() {
+				BeforeEach(func() {
+					configInfo.ExtraConfig = nil
+				})
+				It("sets condition unknown", func() {
+					expectedConditions := []metav1.Condition{
+						*conditions.UnknownCondition(vmopv1.GuestBootstrapCondition, "NoExtraConfig", ""),
+					}
+					Expect(vm.Status.Conditions).To(conditions.MatchConditions(expectedConditions))
+				})
+			})
+			When("no bootstrap status", func() {
+				BeforeEach(func() {
+					configInfo.ExtraConfig = []types.BaseOptionValue{
+						&types.OptionValue{
+							Key:   "key1",
+							Value: "val1",
+						},
+					}
+				})
+				It("sets condition unknown", func() {
+					expectedConditions := []metav1.Condition{
+						*conditions.UnknownCondition(vmopv1.GuestBootstrapCondition, "NoBootstrapStatus", ""),
+					}
+					Expect(vm.Status.Conditions).To(conditions.MatchConditions(expectedConditions))
+				})
+			})
+		})
+		Context("successful condition", func() {
+			When("status is 1", func() {
+				BeforeEach(func() {
+					configInfo.ExtraConfig = []types.BaseOptionValue{
+						&types.OptionValue{
+							Key:   "key1",
+							Value: "val1",
+						},
+						&types.OptionValue{
+							Key:   util.GuestInfoBootstrapCondition,
+							Value: "1",
+						},
+					}
+				})
+				It("sets condition true", func() {
+					expectedConditions := []metav1.Condition{
+						*conditions.TrueCondition(vmopv1.GuestBootstrapCondition),
+					}
+					Expect(vm.Status.Conditions).To(conditions.MatchConditions(expectedConditions))
+				})
+			})
+			When("status is TRUE", func() {
+				BeforeEach(func() {
+					configInfo.ExtraConfig = []types.BaseOptionValue{
+						&types.OptionValue{
+							Key:   "key1",
+							Value: "val1",
+						},
+						&types.OptionValue{
+							Key:   util.GuestInfoBootstrapCondition,
+							Value: "TRUE",
+						},
+					}
+				})
+				It("sets condition true", func() {
+					expectedConditions := []metav1.Condition{
+						*conditions.TrueCondition(vmopv1.GuestBootstrapCondition),
+					}
+					Expect(vm.Status.Conditions).To(conditions.MatchConditions(expectedConditions))
+				})
+			})
+			When("status is true", func() {
+				BeforeEach(func() {
+					configInfo.ExtraConfig = []types.BaseOptionValue{
+						&types.OptionValue{
+							Key:   "key1",
+							Value: "val1",
+						},
+						&types.OptionValue{
+							Key:   util.GuestInfoBootstrapCondition,
+							Value: "true",
+						},
+					}
+				})
+				It("sets condition true", func() {
+					expectedConditions := []metav1.Condition{
+						*conditions.TrueCondition(vmopv1.GuestBootstrapCondition),
+					}
+					Expect(vm.Status.Conditions).To(conditions.MatchConditions(expectedConditions))
+				})
+			})
+			When("status is true and there is a reason", func() {
+				BeforeEach(func() {
+					configInfo.ExtraConfig = []types.BaseOptionValue{
+						&types.OptionValue{
+							Key:   "key1",
+							Value: "val1",
+						},
+						&types.OptionValue{
+							Key:   util.GuestInfoBootstrapCondition,
+							Value: "true,my-reason",
+						},
+					}
+				})
+				It("sets condition true", func() {
+					expectedConditions := []metav1.Condition{
+						*conditions.TrueCondition(vmopv1.GuestBootstrapCondition),
+					}
+					expectedConditions[0].Reason = "my-reason"
+					Expect(vm.Status.Conditions).To(conditions.MatchConditions(expectedConditions))
+				})
+			})
+			When("status is true and there is a reason and message", func() {
+				BeforeEach(func() {
+					configInfo.ExtraConfig = []types.BaseOptionValue{
+						&types.OptionValue{
+							Key:   "key1",
+							Value: "val1",
+						},
+						&types.OptionValue{
+							Key:   util.GuestInfoBootstrapCondition,
+							Value: "true,my-reason,my,comma,delimited,message",
+						},
+					}
+				})
+				It("sets condition true", func() {
+					expectedConditions := []metav1.Condition{
+						*conditions.TrueCondition(vmopv1.GuestBootstrapCondition),
+					}
+					expectedConditions[0].Reason = "my-reason"
+					expectedConditions[0].Message = "my,comma,delimited,message"
+					Expect(vm.Status.Conditions).To(conditions.MatchConditions(expectedConditions))
+				})
+			})
+		})
+		Context("failed condition", func() {
+			When("status is 0", func() {
+				BeforeEach(func() {
+					configInfo.ExtraConfig = []types.BaseOptionValue{
+						&types.OptionValue{
+							Key:   "key1",
+							Value: "val1",
+						},
+						&types.OptionValue{
+							Key:   util.GuestInfoBootstrapCondition,
+							Value: "0",
+						},
+					}
+				})
+				It("sets condition false", func() {
+					expectedConditions := []metav1.Condition{
+						*conditions.FalseCondition(
+							vmopv1.GuestBootstrapCondition, "", ""),
+					}
+					Expect(vm.Status.Conditions).To(conditions.MatchConditions(expectedConditions))
+				})
+			})
+			When("status is FALSE", func() {
+				BeforeEach(func() {
+					configInfo.ExtraConfig = []types.BaseOptionValue{
+						&types.OptionValue{
+							Key:   "key1",
+							Value: "val1",
+						},
+						&types.OptionValue{
+							Key:   util.GuestInfoBootstrapCondition,
+							Value: "FALSE",
+						},
+					}
+				})
+				It("sets condition false", func() {
+					expectedConditions := []metav1.Condition{
+						*conditions.FalseCondition(
+							vmopv1.GuestBootstrapCondition, "", ""),
+					}
+					Expect(vm.Status.Conditions).To(conditions.MatchConditions(expectedConditions))
+				})
+			})
+			When("status is false", func() {
+				BeforeEach(func() {
+					configInfo.ExtraConfig = []types.BaseOptionValue{
+						&types.OptionValue{
+							Key:   "key1",
+							Value: "val1",
+						},
+						&types.OptionValue{
+							Key:   util.GuestInfoBootstrapCondition,
+							Value: "false",
+						},
+					}
+				})
+				It("sets condition false", func() {
+					expectedConditions := []metav1.Condition{
+						*conditions.FalseCondition(
+							vmopv1.GuestBootstrapCondition, "", ""),
+					}
+					Expect(vm.Status.Conditions).To(conditions.MatchConditions(expectedConditions))
+				})
+			})
+			When("status is non-truthy", func() {
+				BeforeEach(func() {
+					configInfo.ExtraConfig = []types.BaseOptionValue{
+						&types.OptionValue{
+							Key:   "key1",
+							Value: "val1",
+						},
+						&types.OptionValue{
+							Key:   util.GuestInfoBootstrapCondition,
+							Value: "not a boolean value",
+						},
+					}
+				})
+				It("sets condition false", func() {
+					expectedConditions := []metav1.Condition{
+						*conditions.FalseCondition(
+							vmopv1.GuestBootstrapCondition, "", ""),
+					}
+					Expect(vm.Status.Conditions).To(conditions.MatchConditions(expectedConditions))
+				})
+			})
+			When("status is false and there is a reason", func() {
+				BeforeEach(func() {
+					configInfo.ExtraConfig = []types.BaseOptionValue{
+						&types.OptionValue{
+							Key:   "key1",
+							Value: "val1",
+						},
+						&types.OptionValue{
+							Key:   util.GuestInfoBootstrapCondition,
+							Value: "false,my-reason",
+						},
+					}
+				})
+				It("sets condition false", func() {
+					expectedConditions := []metav1.Condition{
+						*conditions.FalseCondition(
+							vmopv1.GuestBootstrapCondition, "my-reason", ""),
+					}
+					Expect(vm.Status.Conditions).To(conditions.MatchConditions(expectedConditions))
+				})
+			})
+			When("status is false and there is a reason and message", func() {
+				BeforeEach(func() {
+					configInfo.ExtraConfig = []types.BaseOptionValue{
+						&types.OptionValue{
+							Key:   "key1",
+							Value: "val1",
+						},
+						&types.OptionValue{
+							Key:   util.GuestInfoBootstrapCondition,
+							Value: "false,my-reason,my,comma,delimited,message",
+						},
+					}
+				})
+				It("sets condition false", func() {
+					expectedConditions := []metav1.Condition{
+						*conditions.FalseCondition(
+							vmopv1.GuestBootstrapCondition,
+							"my-reason",
+							"my,comma,delimited,message"),
+					}
+					Expect(vm.Status.Conditions).To(conditions.MatchConditions(expectedConditions))
+				})
 			})
 		})
 	})


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch introduces the condition `GuestBootstrap` such that its status, reason, and message are all surfaced from reading the ExtraConfig key `guestinfo.vmservice.bootstrap.condition`. The key's value is comma-delimited, split at most three times:

| Index | Description |
|---|---|
| `0` | The condition's status |
| `1` | The condition's reason |
| `2` | The condition's message |

The following values for `guestinfo.vmservice.bootstrap.condition` would be parsed accordingly:

| Value | Status | Reason | Message |
|---|---|---|---|
| ` ` | `false` | | |
| `, ,` | `false` | | |
| `  , my-reason` | `false` | `my-reason` | |
| `,my-reason,my-message` | `false` | `my-reason` | `my-message` |
| `a non-truthy value` | `false` | | |
| `a non-truthy value,my-reason` | `false` | `my-reason` | |
| `a non-truthy value,my-reason,my,comma-delimited,message` | `false` | `my-reason` | `my,comma-delimited,message` |
| `0` | `false` | | |
| `FALSE` | `false` | | |
| `false` | `false` | | |
| `false,my-reason` | `false` | `my-reason` | |
| `false,my-reason,my,comma-delimited,message` | `false` | `my-reason` | `my,comma-delimited,message` |
| `1` | `true` | | |
| `TRUE` | `true` | | |
| `true` | `true` | | |
| `true,my-reason` | `true` | `my-reason` | |
| `true,my-reason,my,comma-delimited,message` | `true` | `my-reason` | `my,comma-delimited,message` |

This condition allows users specifying run commands using either the CloudInit or Sysprep bootstrap providers to leverage the `vmware-rpctool` or `vmtoolsd` commands to update the aforementioned guestinfo key with a value that is ultimately realized in the Kubernetes VM's status as a condition.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
The VM status condition GuestBootstrap reflects the information from the ExtraConfig key "guestinfo.vmservice.bootstrap.condition".
```