### PR TITLE
✨ Add DeviceName to network interfaces spec

### DIFF
--- a/api/v1alpha1/virtualmachine_conversion_test.go
+++ b/api/v1alpha1/virtualmachine_conversion_test.go
@@ -82,7 +82,8 @@ func TestVirtualMachineConversion(t *testing.T) {
 					SearchDomains: []string{"foo.local", "bar.local"},
 					Interfaces: []nextver.VirtualMachineNetworkInterfaceSpec{
 						{
-							Name: "vds-interface",
+							Name:       "vds-interface",
+							DeviceName: "eth10",
 							Network: nextver_common.PartialObjectRef{
 								TypeMeta: metav1.TypeMeta{
 									Kind:       "Network",
@@ -92,7 +93,8 @@ func TestVirtualMachineConversion(t *testing.T) {
 							},
 						},
 						{
-							Name: "ncp-interface",
+							Name:       "ncp-interface",
+							DeviceName: "eth20",
 							Network: nextver_common.PartialObjectRef{
 								TypeMeta: metav1.TypeMeta{
 									Kind:       "VirtualNetwork",
@@ -102,7 +104,8 @@ func TestVirtualMachineConversion(t *testing.T) {
 							},
 						},
 						{
-							Name: "my-interface",
+							Name:       "my-interface",
+							DeviceName: "eth30",
 							Network: nextver_common.PartialObjectRef{
 								TypeMeta: metav1.TypeMeta{
 									Kind:       "Network",

--- a/api/v1alpha2/virtualmachine_network_types.go
+++ b/api/v1alpha2/virtualmachine_network_types.go
@@ -27,10 +27,10 @@ type VirtualMachineNetworkInterfaceSpec struct {
 	// Name describes the unique name of this network interface, used to
 	// distinguish it from other network interfaces attached to this VM.
 	//
-	// This value is also used to rename the device inside the guest when the
-	// bootstrap provider is CloudInit. Please note it is up to the user to
-	// ensure the provided device name does not conflict with any other devices
-	// inside the guest, ex. dvd, cdrom, sda, etc.
+	// When the bootstrap provider is Cloud-Init and DeviceName is not
+	// specified, the device inside the guest will be renamed to this value.
+	// Please note it is up to the user to ensure the provided name does not
+	// conflict with any other devices inside the guest, ex. dvd, cdrom, sda, etc.
 	//
 	// +kubebuilder:validation:Pattern="^[a-z0-9]{2,}$"
 	Name string `json:"name"`
@@ -43,6 +43,15 @@ type VirtualMachineNetworkInterfaceSpec struct {
 	//
 	// +optional
 	Network common.PartialObjectRef `json:"network,omitempty"`
+
+	// DeviceName is used to rename the device inside the guest when the bootstrap
+	// provider is Cloud-Init. Please note it is up to the user to ensure the
+	// provided device name does not conflict with any other devices inside the
+	// guest, ex. dvd, cdrom, sda, etc.
+	//
+	// +optional
+	// +kubebuilder:validation:Pattern=^\w\w+$
+	DeviceName string `json:"deviceName,omitempty"`
 
 	// Addresses is an optional list of IP4 or IP6 addresses to assign to this
 	// interface.

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -1395,6 +1395,14 @@ spec:
                           items:
                             type: string
                           type: array
+                        deviceName:
+                          description: DeviceName is used to rename the device inside
+                            the guest when the bootstrap provider is Cloud-Init. Please
+                            note it is up to the user to ensure the provided device
+                            name does not conflict with any other devices inside the
+                            guest, ex. dvd, cdrom, sda, etc.
+                          pattern: ^\w\w+$
+                          type: string
                         dhcp4:
                           description: "DHCP4 indicates whether or not this interface
                             uses DHCP for IP4 networking. \n Please note this field
@@ -1438,11 +1446,12 @@ spec:
                         name:
                           description: "Name describes the unique name of this network
                             interface, used to distinguish it from other network interfaces
-                            attached to this VM. \n This value is also used to rename
-                            the device inside the guest when the bootstrap provider
-                            is CloudInit. Please note it is up to the user to ensure
-                            the provided device name does not conflict with any other
-                            devices inside the guest, ex. dvd, cdrom, sda, etc."
+                            attached to this VM. \n When the bootstrap provider is
+                            Cloud-Init and DeviceName is not specified, the device
+                            inside the guest will be renamed to this value. Please
+                            note it is up to the user to ensure the provided name
+                            does not conflict with any other devices inside the guest,
+                            ex. dvd, cdrom, sda, etc."
                           pattern: ^[a-z0-9]{2,}$
                           type: string
                         nameservers:

--- a/pkg/vmprovider/providers/vsphere2/network/netplan.go
+++ b/pkg/vmprovider/providers/vsphere2/network/netplan.go
@@ -54,7 +54,7 @@ func NetPlanCustomization(result NetworkInterfaceResults) (*Netplan, error) {
 			Match: NetplanEthernetMatch{
 				MacAddress: NormalizeNetplanMac(r.MacAddress),
 			},
-			SetName: r.Name,
+			SetName: r.DeviceName,
 			MTU:     r.MTU,
 			Nameservers: NetplanEthernetNameserver{
 				Addresses: r.Nameservers,
@@ -90,7 +90,7 @@ func NetPlanCustomization(result NetworkInterfaceResults) (*Netplan, error) {
 			npEth.Routes = append(npEth.Routes, NetplanEthernetRoute(route))
 		}
 
-		netPlan.Ethernets[npEth.SetName] = npEth
+		netPlan.Ethernets[r.Name] = npEth
 	}
 
 	return netPlan, nil

--- a/pkg/vmprovider/providers/vsphere2/network/netplan_test.go
+++ b/pkg/vmprovider/providers/vsphere2/network/netplan_test.go
@@ -15,7 +15,8 @@ import (
 
 var _ = Describe("Netplan", func() {
 	const (
-		ifName        = "eth0"
+		ifName        = "my-interface"
+		devIfName     = "eth42"
 		macAddr1      = "50-8A-80-9D-28-22"
 		macAddr1Norm  = "50:8a:80:9d:28:22"
 		ipv4Gateway   = "192.168.1.1"
@@ -63,6 +64,7 @@ var _ = Describe("Netplan", func() {
 						},
 						MacAddress:    macAddr1,
 						Name:          ifName,
+						DeviceName:    devIfName,
 						DHCP4:         false,
 						DHCP6:         false,
 						MTU:           1500,
@@ -89,7 +91,7 @@ var _ = Describe("Netplan", func() {
 
 				np := netplan.Ethernets[ifName]
 				Expect(np.Match.MacAddress).To(Equal(macAddr1Norm))
-				Expect(np.SetName).To(Equal(ifName))
+				Expect(np.SetName).To(Equal(devIfName))
 				Expect(np.Dhcp4).To(BeFalse())
 				Expect(np.Dhcp6).To(BeFalse())
 				Expect(np.Addresses).To(HaveLen(2))
@@ -113,7 +115,8 @@ var _ = Describe("Netplan", func() {
 				results.Results = []network.NetworkInterfaceResult{
 					{
 						MacAddress:    macAddr1,
-						Name:          "eth0",
+						Name:          ifName,
+						DeviceName:    devIfName,
 						DHCP4:         true,
 						DHCP6:         true,
 						MTU:           9000,
@@ -133,7 +136,7 @@ var _ = Describe("Netplan", func() {
 
 				np := netplan.Ethernets[ifName]
 				Expect(np.Match.MacAddress).To(Equal(macAddr1Norm))
-				Expect(np.SetName).To(Equal(ifName))
+				Expect(np.SetName).To(Equal(devIfName))
 				Expect(np.Dhcp4).To(BeTrue())
 				Expect(np.Dhcp6).To(BeTrue())
 				Expect(np.MTU).To(BeEquivalentTo(9000))

--- a/pkg/vmprovider/providers/vsphere2/network/network.go
+++ b/pkg/vmprovider/providers/vsphere2/network/network.go
@@ -46,6 +46,7 @@ type NetworkInterfaceResult struct {
 
 	// Fields from the InterfaceSpec used later during customization.
 	Name          string
+	DeviceName    string
 	DHCP4         bool
 	DHCP6         bool
 	MTU           int64
@@ -190,6 +191,11 @@ func applyInterfaceSpecToResult(
 	}
 
 	result.Name = interfaceSpec.Name
+	result.DeviceName = interfaceSpec.DeviceName
+	if result.DeviceName == "" {
+		result.DeviceName = result.Name
+	}
+
 	result.DHCP4 = dhcp4
 	result.DHCP6 = dhcp6
 	result.Nameservers = interfaceSpec.Nameservers

--- a/pkg/vmprovider/providers/vsphere2/network/network_test.go
+++ b/pkg/vmprovider/providers/vsphere2/network/network_test.go
@@ -118,8 +118,9 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", func() {
 				BeforeEach(func() {
 					interfaceSpecs = []vmopv1.VirtualMachineNetworkInterfaceSpec{
 						{
-							Name:    "eth0",
-							Network: common.PartialObjectRef{Name: networkName},
+							Name:       "my-network-interface",
+							DeviceName: "eth42",
+							Network:    common.PartialObjectRef{Name: networkName},
 							Addresses: []string{
 								"172.42.1.100/24",
 								"fd1a:6c85:79fe:7c98:0000:0000:0000:000f/56",
@@ -152,6 +153,11 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", func() {
 						backingInfo, ok := backing.(*types.VirtualEthernetCardDistributedVirtualPortBackingInfo)
 						Expect(ok).To(BeTrue())
 						Expect(backingInfo.Port.PortgroupKey).To(Equal(ctx.NetworkRef.Reference().Value))
+					})
+
+					By("has expected names", func() {
+						Expect(result.Name).To(Equal("my-network-interface"))
+						Expect(result.DeviceName).To(Equal("eth42"))
 					})
 
 					Expect(result.DHCP4).To(BeFalse())
@@ -281,6 +287,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", func() {
 				Expect(result.Backing).ToNot(BeNil())
 				Expect(result.Backing.Reference()).To(Equal(ctx.NetworkRef.Reference()))
 				Expect(result.Name).To(Equal(interfaceName))
+				Expect(result.DeviceName).To(Equal(interfaceName))
 
 				Expect(result.IPConfigs).To(HaveLen(2))
 				ipConfig := result.IPConfigs[0]
@@ -369,6 +376,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", func() {
 					Expect(result.Backing).ToNot(BeNil())
 					Expect(result.Backing.Reference()).To(Equal(ctx.NetworkRef.Reference()))
 					Expect(result.Name).To(Equal(interfaceName))
+					Expect(result.DeviceName).To(Equal(interfaceName))
 
 					Expect(result.IPConfigs).To(HaveLen(2))
 					ipConfig := result.IPConfigs[0]

--- a/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator.go
@@ -612,6 +612,16 @@ func (v validator) validateNetworkInterfaceSpecWithBootstrap(
 		sysPrep = vm.Spec.Bootstrap.Sysprep
 	}
 
+	if deviceName := interfaceSpec.DeviceName; deviceName != "" {
+		if cloudInit == nil {
+			allErrs = append(allErrs, field.Invalid(
+				interfacePath.Child("deviceName"),
+				deviceName,
+				"deviceName is available only with the following bootstrap providers: CloudInit",
+			))
+		}
+	}
+
 	if mtu := interfaceSpec.MTU; mtu != nil {
 		if cloudInit == nil {
 			allErrs = append(allErrs, field.Invalid(

--- a/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator_unit_test.go
@@ -836,7 +836,7 @@ func unitTestsValidateCreate() {
 				},
 			),
 
-			Entry("allow static mtu, nameservers, routes and searchDomains when bootstrap is CloudInit",
+			Entry("allow deviceName, static address, mtu, nameservers, routes and searchDomains when bootstrap is CloudInit",
 				testParams{
 					setup: func(ctx *unitValidatingWebhookContext) {
 						ctx.vm.Spec.Bootstrap = &vmopv1.VirtualMachineBootstrapSpec{
@@ -846,7 +846,8 @@ func unitTestsValidateCreate() {
 							HostName: "my-vm",
 							Interfaces: []vmopv1.VirtualMachineNetworkInterfaceSpec{
 								{
-									Name: "eth0",
+									Name:       "eth0",
+									DeviceName: "mydev42",
 									Addresses: []string{
 										"192.168.1.100/24",
 										"2605:a601:a0ba:720:2ce6:776d:8be4:2496/48",
@@ -877,6 +878,24 @@ func unitTestsValidateCreate() {
 						}
 					},
 					expectAllowed: true,
+				},
+			),
+
+			Entry("disallows deviceName without CloudInit",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						ctx.vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{
+							Interfaces: []vmopv1.VirtualMachineNetworkInterfaceSpec{
+								{
+									Name:       "eth0",
+									DeviceName: "mydev",
+								},
+							},
+						}
+					},
+					validate: doValidateWithMsg(
+						`spec.network.interfaces[0].deviceName: Invalid value: "mydev": deviceName is available only with the following bootstrap providers: CloudInit`,
+					),
 				},
 			),
 


### PR DESCRIPTION
When using cloud-init this allows the device name in the guest to be set to something different that what the name is in the k8s VM and used for the corresponding network interface CR name.

This decouples the two names if the user wants to. Note that since the netplan we create always matches by MAC address, continue to use the interface spec name as the netplan Ethernets key so it is easier to match up the VM Spec with the generated netPlan.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # NA

```release-note
DeviceName field in the interfaces spec can be used to specify the network device name when using cloud-init.
```