### PR TITLE
✨ Created-at annotations

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,6 +15,11 @@ import (
 // to prevent the possibility of race conditions when reading/writing data to
 // a Config instance stored in a context.
 type Config struct {
+	BuildCommit  string
+	BuildNumber  string
+	BuildVersion string
+	BuildType    string
+
 	ContainerNode bool
 
 	ContentAPIWait  time.Duration

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -3,13 +3,22 @@
 
 package config
 
-import "time"
+import (
+	"time"
+
+	"github.com/vmware-tanzu/vm-operator/pkg"
+)
 
 const defaultPrefix = "vmoperator-"
 
 // Default returns a Config object with default values.
 func Default() Config {
 	return Config{
+		BuildCommit:  pkg.BuildCommit,
+		BuildNumber:  pkg.BuildNumber,
+		BuildVersion: pkg.BuildVersion,
+		BuildType:    pkg.BuildType,
+
 		ContainerNode:                false,
 		ContentAPIWait:               1 * time.Second,
 		DefaultVMClassControllerName: "vmoperator.vmware.com/vsphere",

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package constants
+
+const (
+	createdAtPrefix = "vmoperator.vmware.com/created-at-"
+
+	// CreatedAtBuildVersionAnnotationKey is set on VirtualMachine
+	// objects when an object's metadata.generation value is 1.
+	// The value of this annotation may be empty, indicating the VM was first
+	// created before this annotation was used. This information itself is
+	// in fact useful, as it still indicates something about the build version
+	// at which an object was first created.
+	CreatedAtBuildVersionAnnotationKey = createdAtPrefix + "build-version"
+
+	// CreatedAtSchemaVersionAnnotationKey is set on VirtualMachine
+	// objects when an object's metadata.generation value is 1.
+	// The value of this annotation may be empty, indicating the VM was first
+	// created before this annotation was used. This information itself is
+	// in fact useful, as it still indicates something about the schema version
+	// at which an object was first created.
+	CreatedAtSchemaVersionAnnotationKey = createdAtPrefix + "schema-version"
+)

--- a/webhooks/virtualmachine/v1alpha1/mutation/virtualmachine_mutator.go
+++ b/webhooks/virtualmachine/v1alpha1/mutation/virtualmachine_mutator.go
@@ -4,6 +4,7 @@
 package mutation
 
 import (
+	goctx "context"
 	"encoding/json"
 	"net/http"
 	"reflect"
@@ -24,6 +25,7 @@ import (
 
 	"github.com/vmware-tanzu/vm-operator/pkg/builder"
 	pkgconfig "github.com/vmware-tanzu/vm-operator/pkg/config"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
 	providerConfig "github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/config"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/network"
@@ -105,16 +107,13 @@ func (m mutator) Mutate(ctx *context.WebhookRequestContext) admission.Response {
 
 	switch ctx.Op {
 	case admissionv1.Create:
-		if AddDefaultNetworkInterface(ctx, m.client, modified) {
-			wasMutated = true
-		}
-		if SetDefaultPowerState(ctx, m.client, modified) {
-			wasMutated = true
-		}
-		if mutated, err := ResolveImageName(ctx, m.client, modified); err != nil {
+		// SetCreatedAtAnnotations always mutates the VM on create.
+		wasMutated = true
+		SetCreatedAtAnnotations(ctx, modified)
+		AddDefaultNetworkInterface(ctx, m.client, modified)
+		SetDefaultPowerState(ctx, m.client, modified)
+		if _, err := ResolveImageName(ctx, m.client, modified); err != nil {
 			return admission.Denied(err.Error())
-		} else if mutated {
-			wasMutated = true
 		}
 	case admissionv1.Update:
 		oldVM, err := m.vmFromUnstructured(ctx.OldObj)
@@ -325,4 +324,15 @@ func getProviderConfigMap(
 		return "", err
 	}
 	return obj.Data["Network"], nil
+}
+
+func SetCreatedAtAnnotations(ctx goctx.Context, vm *vmopv1.VirtualMachine) {
+	// If this is the first time the VM has been create, then record the
+	// build version and storage schema version into the VM's annotations.
+	// This enables future work to know at what version a VM was "created."
+	if vm.Annotations == nil {
+		vm.Annotations = map[string]string{}
+	}
+	vm.Annotations[constants.CreatedAtBuildVersionAnnotationKey] = pkgconfig.FromContext(ctx).BuildVersion
+	vm.Annotations[constants.CreatedAtSchemaVersionAnnotationKey] = vmopv1.SchemeGroupVersion.Version
 }

--- a/webhooks/virtualmachine/v1alpha1/mutation/virtualmachine_mutator_suite_test.go
+++ b/webhooks/virtualmachine/v1alpha1/mutation/virtualmachine_mutator_suite_test.go
@@ -8,12 +8,17 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 
+	pkgconfig "github.com/vmware-tanzu/vm-operator/pkg/config"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachine/v1alpha1/mutation"
 )
 
 // suite is used for unit and integration testing this webhook.
-var suite = builder.NewTestSuiteForMutatingWebhook(
+var suite = builder.NewTestSuiteForMutatingWebhookWithContext(
+	pkgconfig.WithConfig(
+		pkgconfig.Config{
+			BuildVersion: "v1",
+		}),
 	mutation.AddToManager,
 	mutation.NewMutator,
 	"default.mutating.virtualmachine.v1alpha1.vmoperator.vmware.com")

--- a/webhooks/virtualmachine/v1alpha1/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/v1alpha1/validation/virtualmachine_validator.go
@@ -34,6 +34,7 @@ import (
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/pkg/builder"
 	pkgconfig "github.com/vmware-tanzu/vm-operator/pkg/config"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/topology"
 	"github.com/vmware-tanzu/vm-operator/pkg/util"
@@ -810,6 +811,14 @@ func (v validator) validateAnnotation(ctx *context.WebhookRequestContext, vm, ol
 
 	if vm.Annotations[vmopv1.FirstBootDoneAnnotation] != oldVM.Annotations[vmopv1.FirstBootDoneAnnotation] {
 		allErrs = append(allErrs, field.Forbidden(annotationPath.Child(vmopv1.FirstBootDoneAnnotation), modifyAnnotationNotAllowedForNonAdmin))
+	}
+
+	if vm.Annotations[constants.CreatedAtBuildVersionAnnotationKey] != oldVM.Annotations[constants.CreatedAtBuildVersionAnnotationKey] {
+		allErrs = append(allErrs, field.Forbidden(annotationPath.Child(constants.CreatedAtBuildVersionAnnotationKey), modifyAnnotationNotAllowedForNonAdmin))
+	}
+
+	if vm.Annotations[constants.CreatedAtSchemaVersionAnnotationKey] != oldVM.Annotations[constants.CreatedAtSchemaVersionAnnotationKey] {
+		allErrs = append(allErrs, field.Forbidden(annotationPath.Child(constants.CreatedAtSchemaVersionAnnotationKey), modifyAnnotationNotAllowedForNonAdmin))
 	}
 
 	return allErrs

--- a/webhooks/virtualmachine/v1alpha1/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/v1alpha1/validation/virtualmachine_validator_unit_test.go
@@ -25,6 +25,7 @@ import (
 
 	pkgbuilder "github.com/vmware-tanzu/vm-operator/pkg/builder"
 	pkgconfig "github.com/vmware-tanzu/vm-operator/pkg/config"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants"
 	"github.com/vmware-tanzu/vm-operator/pkg/topology"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/config"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/network"
@@ -33,11 +34,13 @@ import (
 )
 
 const (
-	updateSuffix            = "-updated"
-	dummyNamespaceImageName = "dummy-namespace-image"
-	dummyClusterImageName   = "dummy-cluster-image"
-	dummyInstanceIDVal      = "dummy-instance-id"
-	dummyFirstBootDoneVal   = "dummy-first-boot-done"
+	updateSuffix                   = "-updated"
+	dummyNamespaceImageName        = "dummy-namespace-image"
+	dummyClusterImageName          = "dummy-cluster-image"
+	dummyInstanceIDVal             = "dummy-instance-id"
+	dummyFirstBootDoneVal          = "dummy-first-boot-done"
+	dummyCreatedAtBuildVersionVal  = "dummy-created-at-build-version"
+	dummyCreatedAtSchemaVersionVal = "dummy-created-at-schema-version"
 )
 
 func unitTests() {
@@ -378,6 +381,8 @@ func unitTestsValidateCreate() {
 		if args.adminOnlyAnnotations {
 			ctx.vm.Annotations[vmopv1.InstanceIDAnnotation] = dummyInstanceIDVal
 			ctx.vm.Annotations[vmopv1.FirstBootDoneAnnotation] = dummyFirstBootDoneVal
+			ctx.vm.Annotations[constants.CreatedAtBuildVersionAnnotationKey] = updateSuffix
+			ctx.vm.Annotations[constants.CreatedAtSchemaVersionAnnotationKey] = updateSuffix
 		}
 
 		if args.isPrivilegedUser {
@@ -532,6 +537,8 @@ func unitTestsValidateCreate() {
 			strings.Join([]string{
 				field.Forbidden(annotationPath.Child(vmopv1.InstanceIDAnnotation), "modifying this annotation is not allowed for non-admin users").Error(),
 				field.Forbidden(annotationPath.Child(vmopv1.FirstBootDoneAnnotation), "modifying this annotation is not allowed for non-admin users").Error(),
+				field.Forbidden(annotationPath.Child(constants.CreatedAtBuildVersionAnnotationKey), "modifying this annotation is not allowed for non-admin users").Error(),
+				field.Forbidden(annotationPath.Child(constants.CreatedAtSchemaVersionAnnotationKey), "modifying this annotation is not allowed for non-admin users").Error(),
 			}, ", "), nil),
 		Entry("should allow creating VM with admin-only annotations set by service user", createArgs{isServiceUser: true, adminOnlyAnnotations: true}, true, nil, nil),
 
@@ -712,16 +719,24 @@ func unitTestsValidateUpdate() {
 		if args.addAdminOnlyAnnotations {
 			ctx.vm.Annotations[vmopv1.InstanceIDAnnotation] = dummyInstanceIDVal
 			ctx.vm.Annotations[vmopv1.FirstBootDoneAnnotation] = dummyFirstBootDoneVal
+			ctx.vm.Annotations[constants.CreatedAtBuildVersionAnnotationKey] = dummyCreatedAtBuildVersionVal
+			ctx.vm.Annotations[constants.CreatedAtSchemaVersionAnnotationKey] = dummyCreatedAtSchemaVersionVal
 		}
 		if args.updateAdminOnlyAnnotations {
 			ctx.oldVM.Annotations[vmopv1.InstanceIDAnnotation] = dummyInstanceIDVal
 			ctx.oldVM.Annotations[vmopv1.FirstBootDoneAnnotation] = dummyFirstBootDoneVal
+			ctx.oldVM.Annotations[constants.CreatedAtBuildVersionAnnotationKey] = dummyCreatedAtBuildVersionVal
+			ctx.oldVM.Annotations[constants.CreatedAtSchemaVersionAnnotationKey] = dummyCreatedAtSchemaVersionVal
 			ctx.vm.Annotations[vmopv1.InstanceIDAnnotation] = dummyInstanceIDVal + updateSuffix
 			ctx.vm.Annotations[vmopv1.FirstBootDoneAnnotation] = dummyFirstBootDoneVal + updateSuffix
+			ctx.vm.Annotations[constants.CreatedAtBuildVersionAnnotationKey] = dummyCreatedAtBuildVersionVal + updateSuffix
+			ctx.vm.Annotations[constants.CreatedAtSchemaVersionAnnotationKey] = dummyCreatedAtSchemaVersionVal + updateSuffix
 		}
 		if args.removeAdminOnlyAnnotations {
 			ctx.oldVM.Annotations[vmopv1.InstanceIDAnnotation] = dummyInstanceIDVal
-			ctx.oldVM.Annotations[vmopv1.FirstBootDoneAnnotation] = updateSuffix
+			ctx.oldVM.Annotations[vmopv1.FirstBootDoneAnnotation] = dummyFirstBootDoneVal
+			ctx.oldVM.Annotations[constants.CreatedAtBuildVersionAnnotationKey] = dummyCreatedAtBuildVersionVal
+			ctx.oldVM.Annotations[constants.CreatedAtSchemaVersionAnnotationKey] = dummyCreatedAtSchemaVersionVal
 		}
 
 		if args.isPrivilegedUser {
@@ -834,16 +849,22 @@ func unitTestsValidateUpdate() {
 			strings.Join([]string{
 				field.Forbidden(annotationPath.Child(vmopv1.InstanceIDAnnotation), "modifying this annotation is not allowed for non-admin users").Error(),
 				field.Forbidden(annotationPath.Child(vmopv1.FirstBootDoneAnnotation), "modifying this annotation is not allowed for non-admin users").Error(),
+				field.Forbidden(annotationPath.Child(constants.CreatedAtBuildVersionAnnotationKey), "modifying this annotation is not allowed for non-admin users").Error(),
+				field.Forbidden(annotationPath.Child(constants.CreatedAtSchemaVersionAnnotationKey), "modifying this annotation is not allowed for non-admin users").Error(),
 			}, ", "), nil),
 		Entry("should disallow updating admin-only annotations by SSO user", updateArgs{updateAdminOnlyAnnotations: true}, false,
 			strings.Join([]string{
 				field.Forbidden(annotationPath.Child(vmopv1.InstanceIDAnnotation), "modifying this annotation is not allowed for non-admin users").Error(),
 				field.Forbidden(annotationPath.Child(vmopv1.FirstBootDoneAnnotation), "modifying this annotation is not allowed for non-admin users").Error(),
+				field.Forbidden(annotationPath.Child(constants.CreatedAtBuildVersionAnnotationKey), "modifying this annotation is not allowed for non-admin users").Error(),
+				field.Forbidden(annotationPath.Child(constants.CreatedAtSchemaVersionAnnotationKey), "modifying this annotation is not allowed for non-admin users").Error(),
 			}, ", "), nil),
 		Entry("should disallow removing admin-only annotations by SSO user", updateArgs{removeAdminOnlyAnnotations: true}, false,
 			strings.Join([]string{
 				field.Forbidden(annotationPath.Child(vmopv1.InstanceIDAnnotation), "modifying this annotation is not allowed for non-admin users").Error(),
 				field.Forbidden(annotationPath.Child(vmopv1.FirstBootDoneAnnotation), "modifying this annotation is not allowed for non-admin users").Error(),
+				field.Forbidden(annotationPath.Child(constants.CreatedAtBuildVersionAnnotationKey), "modifying this annotation is not allowed for non-admin users").Error(),
+				field.Forbidden(annotationPath.Child(constants.CreatedAtSchemaVersionAnnotationKey), "modifying this annotation is not allowed for non-admin users").Error(),
 			}, ", "), nil),
 		Entry("should allow adding admin-only annotations by service user", updateArgs{isServiceUser: true, addAdminOnlyAnnotations: true}, true, nil, nil),
 		Entry("should allow updating admin-only annotations by service user", updateArgs{isServiceUser: true, updateAdminOnlyAnnotations: true}, true, nil, nil),

--- a/webhooks/virtualmachine/v1alpha2/mutation/virtualmachine_mutator_intg_test.go
+++ b/webhooks/virtualmachine/v1alpha2/mutation/virtualmachine_mutator_intg_test.go
@@ -13,7 +13,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/pkg"
 	pkgconfig "github.com/vmware-tanzu/vm-operator/pkg/config"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
@@ -279,6 +281,42 @@ func intgTestsMutating() {
 						}},
 						newInvalidNextRestartTimeTableEntries("should return an invalid field error"))...,
 				)
+			})
+		})
+	})
+
+	Context("SetCreatedAtAnnotations", func() {
+		When("creating a VM", func() {
+			It("should add the created-at annotations", func() {
+				Expect(ctx.Client.Create(ctx, ctx.vm)).To(Succeed())
+				vm := &vmopv1.VirtualMachine{}
+				Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(ctx.vm), vm)).To(Succeed())
+				Expect(vm.Annotations).To(HaveKeyWithValue(constants.CreatedAtBuildVersionAnnotationKey, "v1"))
+				Expect(vm.Annotations).To(HaveKeyWithValue(constants.CreatedAtSchemaVersionAnnotationKey, vmopv1.SchemeGroupVersion.Version))
+			})
+		})
+
+		When("updating a VM", func() {
+			var oldBuildVersion string
+			BeforeEach(func() {
+				oldBuildVersion = pkg.BuildVersion
+			})
+			AfterEach(func() {
+				pkg.BuildVersion = oldBuildVersion
+			})
+			It("should not update the created-at annotations", func() {
+				Expect(ctx.Client.Create(ctx, ctx.vm)).To(Succeed())
+				vm := &vmopv1.VirtualMachine{}
+				Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(ctx.vm), vm)).To(Succeed())
+				Expect(vm.Annotations).To(HaveKeyWithValue(constants.CreatedAtBuildVersionAnnotationKey, "v1"))
+				Expect(vm.Annotations).To(HaveKeyWithValue(constants.CreatedAtSchemaVersionAnnotationKey, vmopv1.SchemeGroupVersion.Version))
+
+				pkg.BuildVersion = "v2"
+
+				Expect(ctx.Client.Update(ctx, vm)).To(Succeed())
+				Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(ctx.vm), vm)).To(Succeed())
+				Expect(vm.Annotations).To(HaveKeyWithValue(constants.CreatedAtBuildVersionAnnotationKey, "v1"))
+				Expect(vm.Annotations).To(HaveKeyWithValue(constants.CreatedAtSchemaVersionAnnotationKey, vmopv1.SchemeGroupVersion.Version))
 			})
 		})
 	})

--- a/webhooks/virtualmachine/v1alpha2/mutation/virtualmachine_mutator_suite_test.go
+++ b/webhooks/virtualmachine/v1alpha2/mutation/virtualmachine_mutator_suite_test.go
@@ -15,7 +15,11 @@ import (
 
 // suite is used for unit and integration testing this webhook.
 var suite = builder.NewTestSuiteForMutatingWebhookWithContext(
-	pkgconfig.WithConfig(pkgconfig.Config{Features: pkgconfig.FeatureStates{VMOpV1Alpha2: true}}),
+	pkgconfig.WithConfig(
+		pkgconfig.Config{
+			BuildVersion: "v1",
+			Features:     pkgconfig.FeatureStates{VMOpV1Alpha2: true},
+		}),
 	mutation.AddToManager,
 	mutation.NewMutator,
 	"default.mutating.virtualmachine.v1alpha2.vmoperator.vmware.com")

--- a/webhooks/virtualmachine/v1alpha2/mutation/virtualmachine_mutator_unit_test.go
+++ b/webhooks/virtualmachine/v1alpha2/mutation/virtualmachine_mutator_unit_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	pkgconfig "github.com/vmware-tanzu/vm-operator/pkg/config"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere2/config"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachine/v1alpha2/mutation"
@@ -501,6 +502,56 @@ func unitTestsMutating() {
 					}},
 					newInvalidNextRestartTimeTableEntries("should return an invalid field error"))...,
 			)
+		})
+	})
+
+	Describe("SetCreatedAtAnnotations", func() {
+		var (
+			vm *vmopv1.VirtualMachine
+		)
+
+		BeforeEach(func() {
+			vm = ctx.vm.DeepCopy()
+		})
+
+		When("vm does not have any annotations", func() {
+			It("should add the created-at annotations", func() {
+				Expect(vm.Annotations).ToNot(HaveKey(constants.CreatedAtBuildVersionAnnotationKey))
+				Expect(vm.Annotations).ToNot(HaveKey(constants.CreatedAtSchemaVersionAnnotationKey))
+				mutation.SetCreatedAtAnnotations(
+					pkgconfig.UpdateContext(ctx, func(config *pkgconfig.Config) {
+						config.BuildVersion = "v1"
+					}), vm)
+				Expect(vm.Annotations).To(HaveKeyWithValue(constants.CreatedAtBuildVersionAnnotationKey, "v1"))
+				Expect(vm.Annotations).To(HaveKeyWithValue(constants.CreatedAtSchemaVersionAnnotationKey, vmopv1.SchemeGroupVersion.Version))
+			})
+		})
+
+		When("vm does have some existing annotations", func() {
+			It("should add the created-at annotations", func() {
+				vm.Annotations = map[string]string{"k1": "v1", "k2": "v2"}
+				mutation.SetCreatedAtAnnotations(
+					pkgconfig.UpdateContext(ctx, func(config *pkgconfig.Config) {
+						config.BuildVersion = "v1"
+					}), vm)
+				Expect(vm.Annotations).To(HaveKeyWithValue(constants.CreatedAtBuildVersionAnnotationKey, "v1"))
+				Expect(vm.Annotations).To(HaveKeyWithValue(constants.CreatedAtSchemaVersionAnnotationKey, vmopv1.SchemeGroupVersion.Version))
+			})
+		})
+
+		When("vm has the created-at annotations", func() {
+			It("should overwrite the created-at annotations", func() {
+				vm.Annotations = map[string]string{
+					constants.CreatedAtBuildVersionAnnotationKey:  "fake-build-version",
+					constants.CreatedAtSchemaVersionAnnotationKey: "fake-schema-version",
+				}
+				mutation.SetCreatedAtAnnotations(
+					pkgconfig.UpdateContext(ctx, func(config *pkgconfig.Config) {
+						config.BuildVersion = "v1"
+					}), vm)
+				Expect(vm.Annotations).To(HaveKeyWithValue(constants.CreatedAtBuildVersionAnnotationKey, "v1"))
+				Expect(vm.Annotations).To(HaveKeyWithValue(constants.CreatedAtSchemaVersionAnnotationKey, vmopv1.SchemeGroupVersion.Version))
+			})
 		})
 	})
 }

--- a/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator.go
@@ -36,6 +36,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/api/v1alpha2/sysprep"
 	"github.com/vmware-tanzu/vm-operator/pkg/builder"
 	pkgconfig "github.com/vmware-tanzu/vm-operator/pkg/config"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/topology"
 	"github.com/vmware-tanzu/vm-operator/pkg/util"
@@ -1020,6 +1021,14 @@ func (v validator) validateAnnotation(ctx *context.WebhookRequestContext, vm, ol
 
 	if vm.Annotations[vmopv1.FirstBootDoneAnnotation] != oldVM.Annotations[vmopv1.FirstBootDoneAnnotation] {
 		allErrs = append(allErrs, field.Forbidden(annotationPath.Child(vmopv1.FirstBootDoneAnnotation), modifyAnnotationNotAllowedForNonAdmin))
+	}
+
+	if vm.Annotations[constants.CreatedAtBuildVersionAnnotationKey] != oldVM.Annotations[constants.CreatedAtBuildVersionAnnotationKey] {
+		allErrs = append(allErrs, field.Forbidden(annotationPath.Child(constants.CreatedAtBuildVersionAnnotationKey), modifyAnnotationNotAllowedForNonAdmin))
+	}
+
+	if vm.Annotations[constants.CreatedAtSchemaVersionAnnotationKey] != oldVM.Annotations[constants.CreatedAtSchemaVersionAnnotationKey] {
+		allErrs = append(allErrs, field.Forbidden(annotationPath.Child(constants.CreatedAtSchemaVersionAnnotationKey), modifyAnnotationNotAllowedForNonAdmin))
 	}
 
 	return allErrs

--- a/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator_unit_test.go
@@ -27,15 +27,18 @@ import (
 	"github.com/vmware-tanzu/vm-operator/api/v1alpha2/sysprep"
 	pkgbuilder "github.com/vmware-tanzu/vm-operator/pkg/builder"
 	pkgconfig "github.com/vmware-tanzu/vm-operator/pkg/config"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants"
 	"github.com/vmware-tanzu/vm-operator/pkg/topology"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere2/config"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 const (
-	updateSuffix          = "-updated"
-	dummyInstanceIDVal    = "dummy-instance-id"
-	dummyFirstBootDoneVal = "dummy-first-boot-done"
+	updateSuffix                   = "-updated"
+	dummyInstanceIDVal             = "dummy-instance-id"
+	dummyFirstBootDoneVal          = "dummy-first-boot-done"
+	dummyCreatedAtBuildVersionVal  = "dummy-created-at-build-version"
+	dummyCreatedAtSchemaVersionVal = "dummy-created-at-schema-version"
 )
 
 func unitTests() {
@@ -218,6 +221,8 @@ func unitTestsValidateCreate() {
 		if args.adminOnlyAnnotations {
 			ctx.vm.Annotations[vmopv1.InstanceIDAnnotation] = updateSuffix
 			ctx.vm.Annotations[vmopv1.FirstBootDoneAnnotation] = updateSuffix
+			ctx.vm.Annotations[constants.CreatedAtBuildVersionAnnotationKey] = updateSuffix
+			ctx.vm.Annotations[constants.CreatedAtSchemaVersionAnnotationKey] = updateSuffix
 		}
 
 		if args.isPrivilegedUser {
@@ -349,6 +354,8 @@ func unitTestsValidateCreate() {
 			strings.Join([]string{
 				field.Forbidden(annotationPath.Child(vmopv1.InstanceIDAnnotation), "modifying this annotation is not allowed for non-admin users").Error(),
 				field.Forbidden(annotationPath.Child(vmopv1.FirstBootDoneAnnotation), "modifying this annotation is not allowed for non-admin users").Error(),
+				field.Forbidden(annotationPath.Child(constants.CreatedAtBuildVersionAnnotationKey), "modifying this annotation is not allowed for non-admin users").Error(),
+				field.Forbidden(annotationPath.Child(constants.CreatedAtSchemaVersionAnnotationKey), "modifying this annotation is not allowed for non-admin users").Error(),
 			}, ", "), nil),
 		Entry("should allow creating VM with admin-only annotations set by service user", createArgs{isServiceUser: true, adminOnlyAnnotations: true}, true, nil, nil),
 
@@ -1281,16 +1288,24 @@ func unitTestsValidateUpdate() {
 		if args.addAdminOnlyAnnotations {
 			ctx.vm.Annotations[vmopv1.InstanceIDAnnotation] = dummyInstanceIDVal
 			ctx.vm.Annotations[vmopv1.FirstBootDoneAnnotation] = dummyFirstBootDoneVal
+			ctx.vm.Annotations[constants.CreatedAtBuildVersionAnnotationKey] = dummyCreatedAtBuildVersionVal
+			ctx.vm.Annotations[constants.CreatedAtSchemaVersionAnnotationKey] = dummyCreatedAtSchemaVersionVal
 		}
 		if args.updateAdminOnlyAnnotations {
 			ctx.oldVM.Annotations[vmopv1.InstanceIDAnnotation] = dummyInstanceIDVal
 			ctx.oldVM.Annotations[vmopv1.FirstBootDoneAnnotation] = dummyFirstBootDoneVal
+			ctx.oldVM.Annotations[constants.CreatedAtBuildVersionAnnotationKey] = dummyCreatedAtBuildVersionVal
+			ctx.oldVM.Annotations[constants.CreatedAtSchemaVersionAnnotationKey] = dummyCreatedAtSchemaVersionVal
 			ctx.vm.Annotations[vmopv1.InstanceIDAnnotation] = dummyInstanceIDVal + updateSuffix
 			ctx.vm.Annotations[vmopv1.FirstBootDoneAnnotation] = dummyFirstBootDoneVal + updateSuffix
+			ctx.vm.Annotations[constants.CreatedAtBuildVersionAnnotationKey] = dummyCreatedAtBuildVersionVal + updateSuffix
+			ctx.vm.Annotations[constants.CreatedAtSchemaVersionAnnotationKey] = dummyCreatedAtSchemaVersionVal + updateSuffix
 		}
 		if args.removeAdminOnlyAnnotations {
 			ctx.oldVM.Annotations[vmopv1.InstanceIDAnnotation] = dummyInstanceIDVal
 			ctx.oldVM.Annotations[vmopv1.FirstBootDoneAnnotation] = dummyFirstBootDoneVal
+			ctx.oldVM.Annotations[constants.CreatedAtBuildVersionAnnotationKey] = dummyCreatedAtBuildVersionVal
+			ctx.oldVM.Annotations[constants.CreatedAtSchemaVersionAnnotationKey] = dummyCreatedAtSchemaVersionVal
 		}
 
 		if args.isPrivilegedUser {
@@ -1390,16 +1405,22 @@ func unitTestsValidateUpdate() {
 			strings.Join([]string{
 				field.Forbidden(annotationPath.Child(vmopv1.InstanceIDAnnotation), "modifying this annotation is not allowed for non-admin users").Error(),
 				field.Forbidden(annotationPath.Child(vmopv1.FirstBootDoneAnnotation), "modifying this annotation is not allowed for non-admin users").Error(),
+				field.Forbidden(annotationPath.Child(constants.CreatedAtBuildVersionAnnotationKey), "modifying this annotation is not allowed for non-admin users").Error(),
+				field.Forbidden(annotationPath.Child(constants.CreatedAtSchemaVersionAnnotationKey), "modifying this annotation is not allowed for non-admin users").Error(),
 			}, ", "), nil),
 		Entry("should disallow updating admin-only annotations by SSO user", updateArgs{updateAdminOnlyAnnotations: true}, false,
 			strings.Join([]string{
 				field.Forbidden(annotationPath.Child(vmopv1.InstanceIDAnnotation), "modifying this annotation is not allowed for non-admin users").Error(),
 				field.Forbidden(annotationPath.Child(vmopv1.FirstBootDoneAnnotation), "modifying this annotation is not allowed for non-admin users").Error(),
+				field.Forbidden(annotationPath.Child(constants.CreatedAtBuildVersionAnnotationKey), "modifying this annotation is not allowed for non-admin users").Error(),
+				field.Forbidden(annotationPath.Child(constants.CreatedAtSchemaVersionAnnotationKey), "modifying this annotation is not allowed for non-admin users").Error(),
 			}, ", "), nil),
 		Entry("should disallow removing admin-only annotations by SSO user", updateArgs{removeAdminOnlyAnnotations: true}, false,
 			strings.Join([]string{
 				field.Forbidden(annotationPath.Child(vmopv1.InstanceIDAnnotation), "modifying this annotation is not allowed for non-admin users").Error(),
 				field.Forbidden(annotationPath.Child(vmopv1.FirstBootDoneAnnotation), "modifying this annotation is not allowed for non-admin users").Error(),
+				field.Forbidden(annotationPath.Child(constants.CreatedAtBuildVersionAnnotationKey), "modifying this annotation is not allowed for non-admin users").Error(),
+				field.Forbidden(annotationPath.Child(constants.CreatedAtSchemaVersionAnnotationKey), "modifying this annotation is not allowed for non-admin users").Error(),
 			}, ", "), nil),
 		Entry("should allow adding admin-only annotations by service user", updateArgs{isServiceUser: true, addAdminOnlyAnnotations: true}, true, nil, nil),
 		Entry("should allow adding admin-only annotations by service user", updateArgs{isServiceUser: true, updateAdminOnlyAnnotations: true}, true, nil, nil),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch introduces support for the `created-at` annotations for VM resources. A VM's mutation webhook ensures the first time a VM is created the following annotations are patched into the VM:

* `vmoperator.vmware.com/created-at-build-version`
* `vmoperator.vmware.com/created-at-schema-version`

The above information allows future changes to VM Operator know helpful details about the version of VM Operator and schema version that were used to create a VM resource. Even the absence of the information is informative as it indicates the VM was created before the annotations were introduced.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Support for the created-at annotations on VM resources
```