### PR TITLE
🌱 Include required storage class in StorageReady condition

### DIFF
--- a/api/v1alpha2/virtualmachine_types.go
+++ b/api/v1alpha2/virtualmachine_types.go
@@ -220,10 +220,6 @@ type VirtualMachineSpec struct {
 	// Please see https://kubernetes.io/docs/concepts/storage/storage-classes/
 	// for more information on Kubernetes storage classes.
 	//
-	// This field is optional in the cases where there exists a sensible
-	// default value, such as when there is a single StorageClass
-	// resource available in the same Namespace as the VM being deployed.
-	//
 	// +optional
 	StorageClass string `json:"storageClass,omitempty"`
 

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -1707,10 +1707,7 @@ spec:
                 description: "StorageClass describes the name of a Kubernetes StorageClass
                   resource used to configure this VM's storage-related attributes.
                   \n Please see https://kubernetes.io/docs/concepts/storage/storage-classes/
-                  for more information on Kubernetes storage classes. \n This field
-                  is optional in the cases where there exists a sensible default value,
-                  such as when there is a single StorageClass resource available in
-                  the same Namespace as the VM being deployed."
+                  for more information on Kubernetes storage classes."
                 type: string
               suspendMode:
                 default: TrySoft

--- a/pkg/vmprovider/providers/vsphere2/storage/storageclass.go
+++ b/pkg/vmprovider/providers/vsphere2/storage/storageclass.go
@@ -9,57 +9,27 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	topologyv1 "github.com/vmware-tanzu/vm-operator/external/tanzu-topology/api/v1alpha1"
-	cnsstoragev1 "github.com/vmware-tanzu/vm-operator/external/vsphere-csi-driver/pkg/syncer/cnsoperator/apis/storagepolicy/v1alpha1"
-
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
-	pkgconfig "github.com/vmware-tanzu/vm-operator/pkg/config"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
-	"github.com/vmware-tanzu/vm-operator/pkg/topology"
-	"github.com/vmware-tanzu/vm-operator/pkg/util"
 )
 
-// GetStoragePolicyID returns Storage Policy ID from Storage Class Name.
-func GetStoragePolicyID(
+// getStoragePolicyID returns Storage Policy ID from Storage Class Name.
+func getStoragePolicyID(
 	vmCtx context.VirtualMachineContextA2,
 	client ctrlclient.Client,
 	storageClassName string) (string, error) {
 
-	var (
-		policyID string
-		zones    []topologyv1.AvailabilityZone
-	)
-
-	if pkgconfig.FromContext(vmCtx).Features.PodVMOnStretchedSupervisor {
-		azs, err := topology.GetAvailabilityZones(vmCtx, client)
-		if err != nil {
-			return "", err
-		}
-		zones = azs
+	sc := &storagev1.StorageClass{}
+	if err := client.Get(vmCtx, ctrlclient.ObjectKey{Name: storageClassName}, sc); err != nil {
+		vmCtx.Logger.Error(err, "Failed to get StorageClass", "storageClass", storageClassName)
+		return "", err
 	}
 
-	if pkgconfig.FromContext(vmCtx).Features.PodVMOnStretchedSupervisor && len(zones) > 1 {
-		storagePolicyQuota := &cnsstoragev1.StoragePolicyQuota{}
-		if err := client.Get(vmCtx, ctrlclient.ObjectKey{
-			Namespace: vmCtx.VM.Namespace,
-			Name:      util.CNSStoragePolicyQuotaName(storageClassName),
-		}, storagePolicyQuota); err != nil {
-			return "", err
-		}
-
-		policyID = storagePolicyQuota.Spec.StoragePolicyId
-	} else {
-		sc := &storagev1.StorageClass{}
-		if err := client.Get(vmCtx, ctrlclient.ObjectKey{Name: storageClassName}, sc); err != nil {
-			return "", err
-		}
-
-		var ok bool
-		policyID, ok = sc.Parameters["storagePolicyID"]
-		if !ok {
-			return "", fmt.Errorf("StorageClass %s does not have 'storagePolicyID' parameter", storageClassName)
-		}
+	policyID, ok := sc.Parameters["storagePolicyID"]
+	if !ok {
+		return "", fmt.Errorf("StorageClass %s does not have 'storagePolicyID' parameter", storageClassName)
 	}
+
 	return policyID, nil
 }
 
@@ -73,7 +43,7 @@ func GetVMStoragePoliciesIDs(
 
 	for _, name := range storageClassNames {
 		if _, ok := storageClassesToIDs[name]; !ok {
-			id, err := GetStoragePolicyID(vmCtx, client, name)
+			id, err := getStoragePolicyID(vmCtx, client, name)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/vmprovider/providers/vsphere2/vmprovider_vm_test.go
+++ b/pkg/vmprovider/providers/vsphere2/vmprovider_vm_test.go
@@ -1417,6 +1417,14 @@ func vmTests() {
 				vm.Spec.StorageClass = ""
 				err := vmProvider.CreateOrUpdateVirtualMachine(ctx, vm)
 				Expect(err).To(MatchError("StorageClass is required but not specified"))
+
+				c := conditions.Get(vm, vmopv1.VirtualMachineConditionStorageReady)
+				Expect(c).ToNot(BeNil())
+				expectedCondition := conditions.FalseCondition(
+					vmopv1.VirtualMachineConditionStorageReady,
+					"StorageClassRequired",
+					"StorageClass is required but not specified")
+				Expect(*c).To(conditions.MatchCondition(*expectedCondition))
 			})
 
 			It("Can be called multiple times", func() {


### PR DESCRIPTION
If we require a storage class - which as of today will always be the case in WCP, include that as a part of the StorageReady condition check. There is little point in letting the VM creation flow get past this point since we will be able to create the VM.

There is some future that will make this optional for certain VMs so we're not going to enforce this in the webhook at the moment. There is also future UX improvement here: we don't allow the storage class to change - this will also be relaxed in the future - so the only way out of this is to delete the k8s VM resource and recreate it with the intended storage class. We could use the presence of this condition to allow it to be changed.

Remove API doc mentioning this field being defaulted when there is a sensible default, pushing this to v1a3+. The uncertainty about how and when the storage class will be optional for some VMs make me worried about trying to determine a default this moment, so keep the existing v1a1 behavior for v1a2.

Also apply #375 that was inadvertently done to the old v1a1 provider to the new v1a2 provider.

**Are there any special notes for your reviewer**:

This is just an incremental minor improvement change - as noted above this requirement and flow will be changing with future work.

```release-note
NONE
```