### PR TITLE
🌱 Commonize setting of optional VM ready conditions

### DIFF
--- a/pkg/vmprovider/providers/vsphere2/vmprovider_vm.go
+++ b/pkg/vmprovider/providers/vsphere2/vmprovider_vm.go
@@ -839,6 +839,7 @@ func (vs *vSphereVMProvider) vmCreateDoNetworking(
 
 	networkSpec := vmCtx.VM.Spec.Network
 	if networkSpec == nil || networkSpec.Disabled {
+		conditions.Delete(vmCtx.VM, vmopv1.VirtualMachineConditionNetworkReady)
 		return nil
 	}
 

--- a/pkg/vmprovider/providers/vsphere2/vmprovider_vm2_test.go
+++ b/pkg/vmprovider/providers/vsphere2/vmprovider_vm2_test.go
@@ -20,6 +20,7 @@ import (
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	"github.com/vmware-tanzu/vm-operator/api/v1alpha2/common"
+	conditions "github.com/vmware-tanzu/vm-operator/pkg/conditions2"
 	pkgconfig "github.com/vmware-tanzu/vm-operator/pkg/config"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider"
 	vsphere "github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere2"
@@ -169,6 +170,7 @@ func vmE2ETests() {
 				err := vmProvider.CreateOrUpdateVirtualMachine(ctx, vm)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
+				Expect(conditions.IsFalse(vm, vmopv1.VirtualMachineConditionNetworkReady)).To(BeTrue())
 
 				By("simulate successful NetOP reconcile", func() {
 					netInterface := &netopv1alpha1.NetworkInterface{
@@ -201,6 +203,16 @@ func vmE2ETests() {
 
 				err = vmProvider.CreateOrUpdateVirtualMachine(ctx, vm)
 				Expect(err).ToNot(HaveOccurred())
+
+				By("has expected conditions", func() {
+					Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionClassReady)).To(BeTrue())
+					Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionImageReady)).To(BeTrue())
+					Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionStorageReady)).To(BeTrue())
+					Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionBootstrapReady)).To(BeTrue())
+					Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionNetworkReady)).To(BeTrue())
+					Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionPlacementReady)).To(BeTrue())
+					Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionCreated)).To(BeTrue())
+				})
 
 				Expect(vm.Status.UniqueID).ToNot(BeEmpty())
 				vcVM := ctx.GetVMFromMoID(vm.Status.UniqueID)
@@ -275,6 +287,7 @@ func vmE2ETests() {
 				err := vmProvider.CreateOrUpdateVirtualMachine(ctx, vm)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
+				Expect(conditions.IsFalse(vm, vmopv1.VirtualMachineConditionNetworkReady)).To(BeTrue())
 
 				By("simulate successful NCP reconcile", func() {
 					netInterface := &ncpv1alpha1.VirtualNetworkInterface{
@@ -308,6 +321,16 @@ func vmE2ETests() {
 
 				err = vmProvider.CreateOrUpdateVirtualMachine(ctx, vm)
 				Expect(err).ToNot(HaveOccurred())
+
+				By("has expected conditions", func() {
+					Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionClassReady)).To(BeTrue())
+					Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionImageReady)).To(BeTrue())
+					Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionStorageReady)).To(BeTrue())
+					Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionBootstrapReady)).To(BeTrue())
+					Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionNetworkReady)).To(BeTrue())
+					Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionPlacementReady)).To(BeTrue())
+					Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionCreated)).To(BeTrue())
+				})
 
 				Expect(vm.Status.UniqueID).ToNot(BeEmpty())
 				vcVM := ctx.GetVMFromMoID(vm.Status.UniqueID)

--- a/pkg/vmprovider/providers/vsphere2/vmprovider_vm_test.go
+++ b/pkg/vmprovider/providers/vsphere2/vmprovider_vm_test.go
@@ -1001,9 +1001,21 @@ func vmTests() {
 
 					Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionClassReady)).To(BeTrue())
 					Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionImageReady)).To(BeTrue())
-					Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionBootstrapReady)).To(BeTrue())
 					Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionStorageReady)).To(BeTrue())
 					Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionCreated)).To(BeTrue())
+
+					By("did not have VMSetResourcePool", func() {
+						Expect(vm.Spec.Reserved).To(BeNil())
+						Expect(conditions.Has(vm, vmopv1.VirtualMachineConditionVMSetResourcePolicyReady)).To(BeFalse())
+					})
+					By("did not have Bootstrap", func() {
+						Expect(vm.Spec.Bootstrap).To(BeNil())
+						Expect(conditions.Has(vm, vmopv1.VirtualMachineConditionBootstrapReady)).To(BeFalse())
+					})
+					By("did not have Network", func() {
+						Expect(vm.Spec.Network.Disabled).To(BeTrue())
+						Expect(conditions.Has(vm, vmopv1.VirtualMachineConditionNetworkReady)).To(BeFalse())
+					})
 				})
 
 				By("has expected inventory path", func() {
@@ -1143,10 +1155,21 @@ func vmTests() {
 
 						Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionClassReady)).To(BeTrue())
 						Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionImageReady)).To(BeTrue())
-						Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionBootstrapReady)).To(BeTrue())
 						Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionStorageReady)).To(BeTrue())
-
 						Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionCreated)).To(BeTrue())
+
+						By("did not have VMSetResourcePool", func() {
+							Expect(vm.Spec.Reserved).To(BeNil())
+							Expect(conditions.Has(vm, vmopv1.VirtualMachineConditionVMSetResourcePolicyReady)).To(BeFalse())
+						})
+						By("did not have Bootstrap", func() {
+							Expect(vm.Spec.Bootstrap).To(BeNil())
+							Expect(conditions.Has(vm, vmopv1.VirtualMachineConditionBootstrapReady)).To(BeFalse())
+						})
+						By("did not have Network", func() {
+							Expect(vm.Spec.Network.Disabled).To(BeTrue())
+							Expect(conditions.Has(vm, vmopv1.VirtualMachineConditionNetworkReady)).To(BeFalse())
+						})
 					})
 
 					By("has expected inventory path", func() {
@@ -1441,6 +1464,8 @@ func vmTests() {
 					vcVM, err := createOrUpdateAndGetVcVM(ctx, vm)
 					Expect(err).ToNot(HaveOccurred())
 
+					Expect(conditions.Has(vm, vmopv1.VirtualMachineConditionNetworkReady)).To(BeFalse())
+
 					var o mo.VirtualMachine
 					Expect(vcVM.Properties(ctx, vcVM.Reference(), nil, &o)).To(Succeed())
 
@@ -1469,6 +1494,7 @@ func vmTests() {
 					It("Has expected devices", func() {
 						vcVM, err := createOrUpdateAndGetVcVM(ctx, vm)
 						Expect(err).ToNot(HaveOccurred())
+						Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionNetworkReady)).To(BeTrue())
 
 						var o mo.VirtualMachine
 						Expect(vcVM.Properties(ctx, vcVM.Reference(), nil, &o)).To(Succeed())
@@ -1678,6 +1704,10 @@ func vmTests() {
 			It("VM is created in child Folder and ResourcePool", func() {
 				vcVM, err := createOrUpdateAndGetVcVM(ctx, vm)
 				Expect(err).ToNot(HaveOccurred())
+
+				By("has expected condition", func() {
+					Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionVMSetResourcePolicyReady)).To(BeTrue())
+				})
 
 				By("has expected inventory path", func() {
 					Expect(vcVM.InventoryPath).To(HaveSuffix(

--- a/pkg/vmprovider/providers/vsphere2/vmprovider_vm_utils.go
+++ b/pkg/vmprovider/providers/vsphere2/vmprovider_vm_utils.go
@@ -176,7 +176,7 @@ func GetVirtualMachineBootstrap(
 
 	bootstrapSpec := vmCtx.VM.Spec.Bootstrap
 	if bootstrapSpec == nil {
-		conditions.MarkTrue(vmCtx.VM, vmopv1.VirtualMachineConditionBootstrapReady)
+		conditions.Delete(vmCtx.VM, vmopv1.VirtualMachineConditionBootstrapReady)
 		return vmlifecycle.BootstrapData{}, nil
 	}
 


### PR DESCRIPTION
The VM SetResourcePool, Bootstrap, and Network are optional so only set their corresponding ready conditions when they're specified.  We were setting the Bootstrap ready condition when Bootstrap was nil. We we were not setting the other two when not specified or disabled.  Add some conditions.Delete() calls to make the not setting a condition explicit.

Add a bunch of expected condition assertions

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #

**Are there any special notes for your reviewer**:
I'm cool if we want to set these conditions to true when not specified instead. It's just that they should all behave the same.

```release-note
NONE
```