### PR TITLE
🌱 Set HW Version in CreateConfigSpec()

### DIFF
--- a/pkg/util/devices.go
+++ b/pkg/util/devices.go
@@ -126,13 +126,36 @@ func IsDeviceNvidiaVgpu(dev vimTypes.BaseVirtualDevice) bool {
 }
 
 // IsDeviceDynamicDirectPathIO returns true if the provided device is a
-// dynamic direct path I/O device..
+// dynamic direct path I/O device.
 func IsDeviceDynamicDirectPathIO(dev vimTypes.BaseVirtualDevice) bool {
 	if dev, ok := dev.(*vimTypes.VirtualPCIPassthrough); ok {
 		_, ok := dev.Backing.(*vimTypes.VirtualPCIPassthroughDynamicBackingInfo)
 		return ok
 	}
 	return false
+}
+
+// HasDeviceChangeDeviceByType returns true of one of the device change's dev is that of type T.
+func HasDeviceChangeDeviceByType[T vimTypes.BaseVirtualDevice](
+	deviceChanges []vimTypes.BaseVirtualDeviceConfigSpec,
+) bool {
+	for i := range deviceChanges {
+		if spec := deviceChanges[i].GetVirtualDeviceConfigSpec(); spec != nil {
+			if dev := spec.Device; dev != nil {
+				if _, ok := dev.(T); ok {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// HasVirtualPCIPassthroughDeviceChange returns true if any of the device changes are for a passthrough device.
+func HasVirtualPCIPassthroughDeviceChange(
+	devices []vimTypes.BaseVirtualDeviceConfigSpec,
+) bool {
+	return HasDeviceChangeDeviceByType[*vimTypes.VirtualPCIPassthrough](devices)
 }
 
 // SelectNvidiaVgpu return a slice of Nvidia vGPU devices.
@@ -142,7 +165,7 @@ func SelectNvidiaVgpu(
 	return selectVirtualPCIPassthroughWithVmiopBacking(devices)
 }
 
-// SelectVirtualPCIPassthroughWithVmiopBacking returns a slice of PCI devices with VmiopBacking.
+// selectVirtualPCIPassthroughWithVmiopBacking returns a slice of PCI devices with VmiopBacking.
 func selectVirtualPCIPassthroughWithVmiopBacking(
 	devices []vimTypes.BaseVirtualDevice,
 ) []*vimTypes.VirtualPCIPassthrough {

--- a/pkg/util/devices_test.go
+++ b/pkg/util/devices_test.go
@@ -141,6 +141,75 @@ var _ = Describe("SelectDynamicDirectPathIO", func() {
 	})
 })
 
+var _ = Describe("HasVirtualPCIPassthroughDeviceChange", func() {
+
+	var (
+		devices []vimTypes.BaseVirtualDeviceConfigSpec
+		has     bool
+	)
+
+	JustBeforeEach(func() {
+		has = util.HasVirtualPCIPassthroughDeviceChange(devices)
+	})
+
+	AfterEach(func() {
+		devices = nil
+	})
+
+	Context("empty list", func() {
+		It("return false", func() {
+			Expect(has).To(BeFalse())
+		})
+	})
+
+	Context("non passthrough device", func() {
+		BeforeEach(func() {
+			devices = append(devices, &vimTypes.VirtualDeviceConfigSpec{
+				Device: &vimTypes.VirtualVmxnet3{},
+			})
+		})
+
+		It("returns false", func() {
+			Expect(has).To(BeFalse())
+		})
+	})
+
+	Context("vGPU device", func() {
+		BeforeEach(func() {
+			devices = append(devices,
+				&vimTypes.VirtualDeviceConfigSpec{
+					Device: &vimTypes.VirtualVmxnet3{},
+				},
+				&vimTypes.VirtualDeviceConfigSpec{
+					Device: newPCIPassthroughDevice(""),
+				},
+			)
+		})
+
+		It("returns true", func() {
+			Expect(has).To(BeTrue())
+		})
+	})
+
+	Context("DDPIO device", func() {
+		BeforeEach(func() {
+			devices = append(devices,
+				&vimTypes.VirtualDeviceConfigSpec{
+					Device: &vimTypes.VirtualVmxnet3{},
+				},
+				&vimTypes.VirtualDeviceConfigSpec{
+					Device: newPCIPassthroughDevice("profile1"),
+				},
+			)
+		})
+
+		It("returns true", func() {
+			Expect(has).To(BeTrue())
+		})
+	})
+
+})
+
 var _ = Describe("SelectNvidiaVgpu", func() {
 	Context("selecting Nvidia vGPU devices", func() {
 		It("will return only the selected device type", func() {

--- a/pkg/vmprovider/providers/vsphere2/virtualmachine/virtualmachine_suite_test.go
+++ b/pkg/vmprovider/providers/vsphere2/virtualmachine/virtualmachine_suite_test.go
@@ -21,7 +21,7 @@ func vcSimTests() {
 
 var suite = builder.NewTestSuite()
 
-func TestClusterModules(t *testing.T) {
+func TestVirtualMachine(t *testing.T) {
 	suite.Register(t, "vSphere Provider VirtualMachine Suite", nil, vcSimTests)
 }
 


### PR DESCRIPTION
The logic for determining the ConfigSpec version was spread out in two different functions and done separately after creating the ConfigSpec. The version can come from the class ConfigSpec or the class (passthru) devices, image, VM Spec MinHardwareVersion, or if the VM has PVCs at create time. Now have one function that is responsible for determining the version.

**Are there any special notes for your reviewer**:
Prior logic was a little confusing - hopefully this will make the intention clearer

```release-note
NONE
```