### PR TITLE
🌱 Skip VM Service B/R workflow for TKG node VMs

### DIFF
--- a/pkg/util/kube/vm.go
+++ b/pkg/util/kube/vm.go
@@ -13,10 +13,11 @@ const (
 	CAPVClusterRoleLabelKey = "capv.vmware.com/cluster.role"
 )
 
-func HasTKGLabels(vmLabels map[string]string) bool {
-	_, ok := vmLabels[CAPWClusterRoleLabelKey]
-	if !ok {
-		_, ok = vmLabels[CAPVClusterRoleLabelKey]
-	}
-	return ok
+// HasCAPILabels returns true if the VM has a label indicating it was created by
+// Cluster API such as CAPW or CAPV.
+func HasCAPILabels(vmLabels map[string]string) bool {
+	_, hasCAPWLabel := vmLabels[CAPWClusterRoleLabelKey]
+	_, hasCAPVLabel := vmLabels[CAPVClusterRoleLabelKey]
+
+	return hasCAPWLabel || hasCAPVLabel
 }

--- a/pkg/util/kube/vm.go
+++ b/pkg/util/kube/vm.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package kube
+
+const (
+	// CAPWClusterRoleLabelKey is the key for the label applied to a VM that was
+	// created by CAPW.
+	CAPWClusterRoleLabelKey = "capw.vmware.com/cluster.role" //nolint:gosec
+
+	// CAPVClusterRoleLabelKey is the key for the label applied to a VM that was
+	// created by CAPV.
+	CAPVClusterRoleLabelKey = "capv.vmware.com/cluster.role"
+)
+
+func HasTKGLabels(vmLabels map[string]string) bool {
+	_, ok := vmLabels[CAPWClusterRoleLabelKey]
+	if !ok {
+		_, ok = vmLabels[CAPVClusterRoleLabelKey]
+	}
+	return ok
+}

--- a/pkg/util/kube/vm_test.go
+++ b/pkg/util/kube/vm_test.go
@@ -12,25 +12,25 @@ import (
 
 var _ = Describe("VM", func() {
 
-	Context("HasTKGLabels", func() {
+	Context("HasCAPILabels", func() {
 
 		It("should return true if the VM has a CAPW label", func() {
 			vmLabels := map[string]string{
 				kubeutil.CAPWClusterRoleLabelKey: "",
 			}
-			Expect(kubeutil.HasTKGLabels(vmLabels)).To(BeTrue())
+			Expect(kubeutil.HasCAPILabels(vmLabels)).To(BeTrue())
 		})
 
 		It("should return true if the VM has a CAPV label", func() {
 			vmLabels := map[string]string{
 				kubeutil.CAPVClusterRoleLabelKey: "",
 			}
-			Expect(kubeutil.HasTKGLabels(vmLabels)).To(BeTrue())
+			Expect(kubeutil.HasCAPILabels(vmLabels)).To(BeTrue())
 		})
 
-		It("should return false if the VM has no TKG related labels", func() {
+		It("should return false if the VM has no Cluster API related labels", func() {
 			vmLabels := map[string]string{}
-			Expect(kubeutil.HasTKGLabels(vmLabels)).To(BeFalse())
+			Expect(kubeutil.HasCAPILabels(vmLabels)).To(BeFalse())
 		})
 	})
 })

--- a/pkg/util/kube/vm_test.go
+++ b/pkg/util/kube/vm_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package kube_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
+)
+
+var _ = Describe("VM", func() {
+
+	Context("HasTKGLabels", func() {
+
+		It("should return true if the VM has a CAPW label", func() {
+			vmLabels := map[string]string{
+				kubeutil.CAPWClusterRoleLabelKey: "",
+			}
+			Expect(kubeutil.HasTKGLabels(vmLabels)).To(BeTrue())
+		})
+
+		It("should return true if the VM has a CAPV label", func() {
+			vmLabels := map[string]string{
+				kubeutil.CAPVClusterRoleLabelKey: "",
+			}
+			Expect(kubeutil.HasTKGLabels(vmLabels)).To(BeTrue())
+		})
+
+		It("should return false if the VM has no TKG related labels", func() {
+			vmLabels := map[string]string{}
+			Expect(kubeutil.HasTKGLabels(vmLabels)).To(BeFalse())
+		})
+	})
+})

--- a/pkg/vmprovider/providers/vsphere/session/session_vm_update.go
+++ b/pkg/vmprovider/providers/vsphere/session/session_vm_update.go
@@ -702,7 +702,7 @@ func MutateUpdateArgsWithDNSInformation(
 	// node. Please note that this will only be used by guests for VMs created
 	// by TKGs that use Cloud-Init. Guest OS Customization (GOSC) has no means
 	// to set the DNS search suffix.
-	if !kubeutil.HasTKGLabels(vmLabels) {
+	if !kubeutil.HasCAPILabels(vmLabels) {
 		return nil
 	}
 

--- a/pkg/vmprovider/providers/vsphere/session/session_vm_update.go
+++ b/pkg/vmprovider/providers/vsphere/session/session_vm_update.go
@@ -23,6 +23,7 @@ import (
 	pkgconfig "github.com/vmware-tanzu/vm-operator/pkg/config"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/util"
+	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 	vmutil "github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/vm"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/clustermodules"
 	providercfg "github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/config"
@@ -684,16 +685,6 @@ func (s *Session) prepareVMForPowerOn(
 	return nil
 }
 
-const (
-	// CAPWClusterRoleLabelKey is the key for the label applied to a VM that was
-	// created by CAPW.
-	CAPWClusterRoleLabelKey = "capw.vmware.com/cluster.role" //nolint:gosec
-
-	// CAPVClusterRoleLabelKey is the key for the label applied to a VM that was
-	// created by CAPV.
-	CAPVClusterRoleLabelKey = "capv.vmware.com/cluster.role"
-)
-
 func MutateUpdateArgsWithDNSInformation(
 	ctx goctx.Context,
 	vmLabels map[string]string,
@@ -711,11 +702,7 @@ func MutateUpdateArgsWithDNSInformation(
 	// node. Please note that this will only be used by guests for VMs created
 	// by TKGs that use Cloud-Init. Guest OS Customization (GOSC) has no means
 	// to set the DNS search suffix.
-	_, ok := vmLabels[CAPWClusterRoleLabelKey]
-	if !ok {
-		_, ok = vmLabels[CAPVClusterRoleLabelKey]
-	}
-	if !ok {
+	if !kubeutil.HasTKGLabels(vmLabels) {
 		return nil
 	}
 

--- a/pkg/vmprovider/providers/vsphere/session/session_vm_update_test.go
+++ b/pkg/vmprovider/providers/vsphere/session/session_vm_update_test.go
@@ -22,6 +22,7 @@ import (
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
 	pkgconfig "github.com/vmware-tanzu/vm-operator/pkg/config"
+	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 	providercfg "github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/config"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/constants"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/session"
@@ -103,7 +104,7 @@ var _ = Describe("Mutate update args with DNS information", func() {
 		Context("the CAPW label is present", func() {
 			BeforeEach(func() {
 				labels = map[string]string{
-					session.CAPWClusterRoleLabelKey: "",
+					kubeutil.CAPWClusterRoleLabelKey: "",
 				}
 			})
 			It("the update args will have the search suffixes", func() {
@@ -118,7 +119,7 @@ var _ = Describe("Mutate update args with DNS information", func() {
 		Context("the CAPW label is present w a non-empty value", func() {
 			BeforeEach(func() {
 				labels = map[string]string{
-					session.CAPWClusterRoleLabelKey: "fake",
+					kubeutil.CAPWClusterRoleLabelKey: "fake",
 				}
 			})
 			It("the update args will have the search suffixes", func() {
@@ -133,7 +134,7 @@ var _ = Describe("Mutate update args with DNS information", func() {
 		Context("the CAPV label is present", func() {
 			BeforeEach(func() {
 				labels = map[string]string{
-					session.CAPVClusterRoleLabelKey: "",
+					kubeutil.CAPVClusterRoleLabelKey: "",
 				}
 			})
 			It("the update args will have the search suffixes", func() {
@@ -148,7 +149,7 @@ var _ = Describe("Mutate update args with DNS information", func() {
 		Context("the CAPV label is present w a non-empty value", func() {
 			BeforeEach(func() {
 				labels = map[string]string{
-					session.CAPVClusterRoleLabelKey: "fake",
+					kubeutil.CAPVClusterRoleLabelKey: "fake",
 				}
 			})
 			It("the update args will have the search suffixes", func() {
@@ -163,8 +164,8 @@ var _ = Describe("Mutate update args with DNS information", func() {
 		Context("the CAPW and CAPW labels are present", func() {
 			BeforeEach(func() {
 				labels = map[string]string{
-					session.CAPWClusterRoleLabelKey: "",
-					session.CAPVClusterRoleLabelKey: "",
+					kubeutil.CAPWClusterRoleLabelKey: "",
+					kubeutil.CAPVClusterRoleLabelKey: "",
 				}
 			})
 			It("the update args will have the search suffixes", func() {

--- a/pkg/vmprovider/providers/vsphere2/vmlifecycle/bootstrap.go
+++ b/pkg/vmprovider/providers/vsphere2/vmlifecycle/bootstrap.go
@@ -147,7 +147,7 @@ func getBootstrapArgs(
 	// interface has DNS info, but we would previously set it for every interface so keep doing that
 	// here. Similarly, we didn't populate SearchDomains for non-TKG VMs so we don't here either. This is
 	// all a little nuts & complicated and probably not correct for every situation.
-	isTKG := kubeutil.HasTKGLabels(vmCtx.VM.Labels)
+	isTKG := kubeutil.HasCAPILabels(vmCtx.VM.Labels)
 	getDNSInformationFromConfigMap := false
 	for _, r := range networkResults.Results {
 		if r.DHCP4 || r.DHCP6 {

--- a/pkg/vmprovider/providers/vsphere2/vmlifecycle/bootstrap.go
+++ b/pkg/vmprovider/providers/vsphere2/vmlifecycle/bootstrap.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2023-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package vmlifecycle
@@ -15,6 +15,7 @@ import (
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/cloudinit"
+	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere2/config"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere2/constants"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere2/network"
@@ -146,7 +147,7 @@ func getBootstrapArgs(
 	// interface has DNS info, but we would previously set it for every interface so keep doing that
 	// here. Similarly, we didn't populate SearchDomains for non-TKG VMs so we don't here either. This is
 	// all a little nuts & complicated and probably not correct for every situation.
-	isTKG := hasTKGLabels(vmCtx.VM.Labels)
+	isTKG := kubeutil.HasTKGLabels(vmCtx.VM.Labels)
 	getDNSInformationFromConfigMap := false
 	for _, r := range networkResults.Results {
 		if r.DHCP4 || r.DHCP6 {
@@ -203,24 +204,6 @@ func getBootstrapArgs(
 	}
 
 	return &bootstrapArgs, nil
-}
-
-func hasTKGLabels(vmLabels map[string]string) bool {
-	const (
-		// CAPWClusterRoleLabelKey is the key for the label applied to a VM that was
-		// created by CAPW.
-		CAPWClusterRoleLabelKey = "capw.vmware.com/cluster.role" //nolint:gosec
-
-		// CAPVClusterRoleLabelKey is the key for the label applied to a VM that was
-		// created by CAPV.
-		CAPVClusterRoleLabelKey = "capv.vmware.com/cluster.role"
-	)
-
-	_, ok := vmLabels[CAPWClusterRoleLabelKey]
-	if !ok {
-		_, ok = vmLabels[CAPVClusterRoleLabelKey]
-	}
-	return ok
 }
 
 func doReconfigure(

--- a/pkg/vmprovider/providers/vsphere2/vmprovider_vm.go
+++ b/pkg/vmprovider/providers/vsphere2/vmprovider_vm.go
@@ -398,7 +398,7 @@ func (vs *vSphereVMProvider) updateVirtualMachine(
 	// Back up the VM at the end after a successful update.
 	// Skip TKG VMs since they are backed up differently than VM Service VMs.
 	if pkgconfig.FromContext(vmCtx).Features.AutoVADPBackupRestore &&
-		!kubeutil.HasTKGLabels(vmCtx.VM.Labels) {
+		!kubeutil.HasCAPILabels(vmCtx.VM.Labels) {
 		vmCtx.Logger.V(4).Info("Backing up VM Service managed VM")
 
 		diskUUIDToPVC, err := GetAttachedDiskUUIDToPVC(vmCtx, vs.k8sClient)

--- a/pkg/vmprovider/providers/vsphere2/vmprovider_vm.go
+++ b/pkg/vmprovider/providers/vsphere2/vmprovider_vm.go
@@ -28,6 +28,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/topology"
 	"github.com/vmware-tanzu/vm-operator/pkg/util"
+	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 	vcclient "github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere2/client"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere2/constants"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere2/contentlibrary"
@@ -395,8 +396,10 @@ func (vs *vSphereVMProvider) updateVirtualMachine(
 	}
 
 	// Back up the VM at the end after a successful update.
-	if pkgconfig.FromContext(vmCtx).Features.AutoVADPBackupRestore {
-		vmCtx.Logger.V(4).Info("Backing up VirtualMachine")
+	// Skip TKG VMs since they are backed up differently than VM Service VMs.
+	if pkgconfig.FromContext(vmCtx).Features.AutoVADPBackupRestore &&
+		!kubeutil.HasTKGLabels(vmCtx.VM.Labels) {
+		vmCtx.Logger.V(4).Info("Backing up VM Service managed VM")
 
 		diskUUIDToPVC, err := GetAttachedDiskUUIDToPVC(vmCtx, vs.k8sClient)
 		if err != nil {

--- a/pkg/vmprovider/providers/vsphere2/vmprovider_vm_test.go
+++ b/pkg/vmprovider/providers/vsphere2/vmprovider_vm_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2022-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package vsphere_test
@@ -29,6 +29,8 @@ import (
 	conditions "github.com/vmware-tanzu/vm-operator/pkg/conditions2"
 	pkgconfig "github.com/vmware-tanzu/vm-operator/pkg/config"
 	"github.com/vmware-tanzu/vm-operator/pkg/topology"
+	"github.com/vmware-tanzu/vm-operator/pkg/util"
+	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider"
 	vsphere "github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere2"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere2/constants"
@@ -56,7 +58,11 @@ func vmTests() {
 	)
 
 	BeforeEach(func() {
-		testConfig = builder.VCSimTestConfig{WithV1A2: true}
+		testConfig = builder.VCSimTestConfig{
+			WithV1A2:                  true,
+			WithContentLibrary:        true,
+			WithAutoVADPBackupRestore: true,
+		}
 	})
 
 	JustBeforeEach(func() {
@@ -83,7 +89,6 @@ func vmTests() {
 		)
 
 		BeforeEach(func() {
-			testConfig.WithContentLibrary = true
 			vmClass = builder.DummyVirtualMachineClassA2()
 			vm = builder.DummyBasicVirtualMachineA2("test-vm", "")
 
@@ -1051,7 +1056,33 @@ func vmTests() {
 					Expect(o.Summary.Config.MemorySizeMB).To(BeEquivalentTo(vmClass.Spec.Hardware.Memory.Value() / 1024 / 1024))
 				})
 
+				By("has expected backup ExtraConfig key", func() {
+					Expect(o.Config.ExtraConfig).ToNot(BeNil())
+					ecMap := util.ExtraConfigToMap(o.Config.ExtraConfig)
+					Expect(ecMap).To(HaveKey(vmopv1.VMResourceYAMLExtraConfigKey))
+				})
+
 				// TODO: More assertions!
+			})
+
+			It("TKG VM", func() {
+				if vm.Labels == nil {
+					vm.Labels = make(map[string]string)
+				}
+				vm.Labels[kubeutil.CAPVClusterRoleLabelKey] = ""
+				vm.Labels[kubeutil.CAPWClusterRoleLabelKey] = ""
+
+				vcVM, err := createOrUpdateAndGetVcVM(ctx, vm)
+				Expect(err).ToNot(HaveOccurred())
+
+				var o mo.VirtualMachine
+				Expect(vcVM.Properties(ctx, vcVM.Reference(), nil, &o)).To(Succeed())
+
+				By("does not have any backup ExtraConfig key", func() {
+					Expect(o.Config.ExtraConfig).ToNot(BeNil())
+					ecMap := util.ExtraConfigToMap(o.Config.ExtraConfig)
+					Expect(ecMap).ToNot(HaveKey(vmopv1.VMResourceYAMLExtraConfigKey))
+				})
 			})
 
 			Context("VM Class with PCI passthrough devices", func() {

--- a/test/builder/vcsim_test_context.go
+++ b/test/builder/vcsim_test_context.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2019-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package builder is a comment just to silence the linter.
@@ -104,6 +104,9 @@ type VCSimTestConfig struct {
 
 	// WithNetworkEnv is the network environment type.
 	WithNetworkEnv NetworkEnv
+
+	// WithAutoVADPBackupRestore enables the WCP_VMSERVICE_BACKUPRESTORE FSS.
+	WithAutoVADPBackupRestore bool
 }
 
 type TestContextForVCSim struct {
@@ -348,6 +351,7 @@ func (c *TestContextForVCSim) setupEnv(config VCSimTestConfig) {
 		cc.Features.InstanceStorage = config.WithInstanceStorage
 		cc.Features.VMClassAsConfig = config.WithVMClassAsConfig
 		cc.Features.VMClassAsConfigDayNDate = config.WithVMClassAsConfigDaynDate
+		cc.Features.AutoVADPBackupRestore = config.WithAutoVADPBackupRestore
 	})
 }
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This PR skips persisting backup ExtraConfig keys in TKG node VMs when the `AutoVADPBackupRestore` feature is enabled.  
TKG node VMs will be backed up and restored differently (outside of VM-Operator reconciliation), hence do not require the backup ExtraConfig keys. These keys are only necessary for VM Service managed VMs.

**Which issue(s) is/are addressed by this PR?**
N/A

**Are there any special notes for your reviewer**:
The `HasTKGLabels` function has been moved to a new util file as it is used in multiple locations.

**Please add a release note if necessary**:

```release-note
Skip persisting backup ExtraConfig keys in TKG VMs when the AutoVADPBackupRestore feature is enabled.
```

**Testing Done**
- Deployed TKG VMs to an internal testbed without this patch (the VMs had backup ExtraConfig keys added):
```
$ govc vm.info -e "tkc-default-h4vct-rnppx" | grep "vmservice.virtualmachine" | awk '{print $1}'
vmservice.virtualmachine.resource.yaml:
vmservice.virtualmachine.additional.resources.yaml:
vmservice.virtualmachine.cloudinit.instanceid:
```
- Updated the internal testbed with this patch and redeployed TKG VMs (no longer had backup ExtraConfig keys):
```
$ govc vm.info -e "tkc-default-scqkx-zhwx9" | grep "vmservice.virtualmachine" | wc -l
0
```
