### PR TITLE
 🐛 Disallow empty sysPrep bootstrap

### DIFF
--- a/pkg/vmprovider/providers/vsphere2/vmlifecycle/bootstrap_sysprep.go
+++ b/pkg/vmprovider/providers/vsphere2/vmlifecycle/bootstrap_sysprep.go
@@ -55,6 +55,8 @@ func BootstrapSysPrep(
 		}
 	} else if sysPrep := sysPrepSpec.Sysprep; sysPrep != nil {
 		identity = convertTo(sysPrep, bsArgs)
+	} else {
+		return nil, nil, fmt.Errorf("no Sysprep data")
 	}
 
 	nicSettingMap, err := network.GuestOSCustomization(bsArgs.NetworkResults)

--- a/pkg/vmprovider/providers/vsphere2/vmlifecycle/bootstrap_sysprep_test.go
+++ b/pkg/vmprovider/providers/vsphere2/vmlifecycle/bootstrap_sysprep_test.go
@@ -8,6 +8,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"github.com/vmware/govmomi/vim25/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
@@ -95,6 +96,12 @@ var _ = Describe("SysPrep Bootstrap", func() {
 				vAppConfigSpec,
 				&bsArgs,
 			)
+		})
+
+		Context("No data", func() {
+			It("returns error", func() {
+				Expect(err).To(MatchError("no Sysprep data"))
+			})
 		})
 
 		Context("Inlined Sysprep", func() {
@@ -216,44 +223,44 @@ var _ = Describe("SysPrep Bootstrap", func() {
 				Expect(custSpec.NicSettingMap).To(HaveLen(len(bsArgs.NetworkResults.Results)))
 				Expect(custSpec.NicSettingMap[0].MacAddress).To(Equal(macAddr))
 			})
-		})
 
-		Context("when has vAppConfig", func() {
-			const key, value = "fooKey", "fooValue"
+			Context("when has vAppConfig", func() {
+				const key, value = "fooKey", "fooValue"
 
-			BeforeEach(func() {
-				configInfo.VAppConfig = &types.VmConfigInfo{
-					Property: []types.VAppPropertyInfo{
-						{
-							Id:               key,
-							Value:            "should-change",
-							UserConfigurable: pointer.Bool(true),
+				BeforeEach(func() {
+					configInfo.VAppConfig = &types.VmConfigInfo{
+						Property: []types.VAppPropertyInfo{
+							{
+								Id:               key,
+								Value:            "should-change",
+								UserConfigurable: pointer.Bool(true),
+							},
 						},
-					},
-				}
+					}
 
-				vAppConfigSpec = &vmopv1.VirtualMachineBootstrapVAppConfigSpec{
-					Properties: []common.KeyValueOrSecretKeySelectorPair{
-						{
-							Key:   key,
-							Value: common.ValueOrSecretKeySelector{Value: pointer.String(value)},
+					vAppConfigSpec = &vmopv1.VirtualMachineBootstrapVAppConfigSpec{
+						Properties: []common.KeyValueOrSecretKeySelectorPair{
+							{
+								Key:   key,
+								Value: common.ValueOrSecretKeySelector{Value: pointer.String(value)},
+							},
 						},
-					},
-				}
-			})
+					}
+				})
 
-			It("should return expected customization spec", func() {
-				Expect(err).ToNot(HaveOccurred())
-				Expect(custSpec).ToNot(BeNil())
+				It("should return expected customization spec", func() {
+					Expect(err).ToNot(HaveOccurred())
+					Expect(custSpec).ToNot(BeNil())
 
-				Expect(configSpec).ToNot(BeNil())
-				Expect(configSpec.VAppConfig).ToNot(BeNil())
-				vmCs := configSpec.VAppConfig.GetVmConfigSpec()
-				Expect(vmCs).ToNot(BeNil())
-				Expect(vmCs.Property).To(HaveLen(1))
-				Expect(vmCs.Property[0].Info).ToNot(BeNil())
-				Expect(vmCs.Property[0].Info.Id).To(Equal(key))
-				Expect(vmCs.Property[0].Info.Value).To(Equal(value))
+					Expect(configSpec).ToNot(BeNil())
+					Expect(configSpec.VAppConfig).ToNot(BeNil())
+					vmCs := configSpec.VAppConfig.GetVmConfigSpec()
+					Expect(vmCs).ToNot(BeNil())
+					Expect(vmCs.Property).To(HaveLen(1))
+					Expect(vmCs.Property[0].Info).ToNot(BeNil())
+					Expect(vmCs.Property[0].Info.Id).To(Equal(key))
+					Expect(vmCs.Property[0].Info.Value).To(Equal(value))
+				})
 			})
 		})
 	})

--- a/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator.go
@@ -247,6 +247,9 @@ func (v validator) validateBootstrap(
 			if sysPrep.Sysprep != nil && sysPrep.RawSysprep != nil {
 				allErrs = append(allErrs, field.Invalid(p, "sysPrep",
 					"sysprep and rawSysprep are mutually exclusive"))
+			} else if sysPrep.Sysprep == nil && sysPrep.RawSysprep == nil {
+				allErrs = append(allErrs, field.Invalid(p, "sysPrep",
+					"either sysprep or rawSysprep must be provided"))
 			}
 
 			if sysPrep.Sysprep != nil {

--- a/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator_unit_test.go
@@ -422,7 +422,9 @@ func unitTestsValidateCreate() {
 							config.Features.WindowsSysprep = true
 						})
 						ctx.vm.Spec.Bootstrap = &vmopv1.VirtualMachineBootstrapSpec{
-							Sysprep: &vmopv1.VirtualMachineBootstrapSysprepSpec{},
+							Sysprep: &vmopv1.VirtualMachineBootstrapSysprepSpec{
+								RawSysprep: &common.SecretKeySelector{},
+							},
 						}
 					},
 					expectAllowed: true,
@@ -440,6 +442,21 @@ func unitTestsValidateCreate() {
 					},
 					validate: doValidateWithMsg(
 						`spec.bootstrap.sysprep: Invalid value: "Sysprep": the Sysprep feature is not enabled`,
+					),
+				},
+			),
+			Entry("disallow empty Sysprep bootstrap when WCP_Windows_Sysprep FSS is enabled",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						pkgconfig.SetContext(ctx, func(config *pkgconfig.Config) {
+							config.Features.WindowsSysprep = true
+						})
+						ctx.vm.Spec.Bootstrap = &vmopv1.VirtualMachineBootstrapSpec{
+							Sysprep: &vmopv1.VirtualMachineBootstrapSysprepSpec{},
+						}
+					},
+					validate: doValidateWithMsg(
+						`spec.bootstrap.sysprep: Invalid value: "sysPrep": either sysprep or rawSysprep must be provided`,
 					),
 				},
 			),
@@ -464,7 +481,9 @@ func unitTestsValidateCreate() {
 						})
 						ctx.vm.Spec.Bootstrap = &vmopv1.VirtualMachineBootstrapSpec{
 							CloudInit: &vmopv1.VirtualMachineBootstrapCloudInitSpec{},
-							Sysprep:   &vmopv1.VirtualMachineBootstrapSysprepSpec{},
+							Sysprep: &vmopv1.VirtualMachineBootstrapSysprepSpec{
+								RawSysprep: &common.SecretKeySelector{},
+							},
 						}
 					},
 					validate: doValidateWithMsg(
@@ -495,7 +514,9 @@ func unitTestsValidateCreate() {
 						})
 						ctx.vm.Spec.Bootstrap = &vmopv1.VirtualMachineBootstrapSpec{
 							LinuxPrep: &vmopv1.VirtualMachineBootstrapLinuxPrepSpec{},
-							Sysprep:   &vmopv1.VirtualMachineBootstrapSysprepSpec{},
+							Sysprep: &vmopv1.VirtualMachineBootstrapSysprepSpec{
+								RawSysprep: &common.SecretKeySelector{},
+							},
 						}
 					},
 					validate: doValidateWithMsg(
@@ -522,7 +543,9 @@ func unitTestsValidateCreate() {
 							config.Features.WindowsSysprep = true
 						})
 						ctx.vm.Spec.Bootstrap = &vmopv1.VirtualMachineBootstrapSpec{
-							Sysprep:    &vmopv1.VirtualMachineBootstrapSysprepSpec{},
+							Sysprep: &vmopv1.VirtualMachineBootstrapSysprepSpec{
+								RawSysprep: &common.SecretKeySelector{},
+							},
 							VAppConfig: &vmopv1.VirtualMachineBootstrapVAppConfigSpec{},
 						}
 					},
@@ -759,7 +782,9 @@ func unitTestsValidateCreate() {
 						})
 
 						ctx.vm.Spec.Bootstrap = &vmopv1.VirtualMachineBootstrapSpec{
-							Sysprep: &vmopv1.VirtualMachineBootstrapSysprepSpec{},
+							Sysprep: &vmopv1.VirtualMachineBootstrapSysprepSpec{
+								RawSysprep: &common.SecretKeySelector{},
+							},
 						}
 						ctx.vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{
 							Nameservers: []string{
@@ -1045,7 +1070,9 @@ func unitTestsValidateCreate() {
 							config.Features.WindowsSysprep = true
 						})
 						ctx.vm.Spec.Bootstrap = &vmopv1.VirtualMachineBootstrapSpec{
-							Sysprep: &vmopv1.VirtualMachineBootstrapSysprepSpec{},
+							Sysprep: &vmopv1.VirtualMachineBootstrapSysprepSpec{
+								RawSysprep: &common.SecretKeySelector{},
+							},
 						}
 						ctx.vm.Spec.Network.Interfaces[0].Nameservers = []string{
 							"8.8.8.8",
@@ -1064,7 +1091,9 @@ func unitTestsValidateCreate() {
 							config.Features.WindowsSysprep = true
 						})
 						ctx.vm.Spec.Bootstrap = &vmopv1.VirtualMachineBootstrapSpec{
-							Sysprep: &vmopv1.VirtualMachineBootstrapSysprepSpec{},
+							Sysprep: &vmopv1.VirtualMachineBootstrapSysprepSpec{
+								RawSysprep: &common.SecretKeySelector{},
+							},
 						}
 						ctx.vm.Spec.Network.Interfaces[0].Routes = []vmopv1.VirtualMachineNetworkRouteSpec{
 							{
@@ -1256,7 +1285,9 @@ func unitTestsValidateUpdate() {
 			if ctx.vm.Spec.Bootstrap == nil {
 				ctx.vm.Spec.Bootstrap = &vmopv1.VirtualMachineBootstrapSpec{}
 			}
-			ctx.vm.Spec.Bootstrap.Sysprep = &vmopv1.VirtualMachineBootstrapSysprepSpec{}
+			ctx.vm.Spec.Bootstrap.Sysprep = &vmopv1.VirtualMachineBootstrapSysprepSpec{
+				RawSysprep: &common.SecretKeySelector{},
+			}
 		}
 
 		if args.oldPowerState != "" {


### PR DESCRIPTION
If neither the raw or cooked sysprep data is provided the Windows GOSC Customize() call will fail, and since an empty text for raw sysprep also fails just disallow that configuration.

**Are there any special notes for your reviewer**:

If wanting to do an empty Sysprep ends up being a common request - so the networking is configured - we can investigate more to see if there is some noop default we can fallback to.

```release-note
NONE
```