### PR TITLE
🌱 Simplify get storage policy ID from storage class name

### DIFF
--- a/pkg/vmprovider/providers/vsphere/storage/storageclass.go
+++ b/pkg/vmprovider/providers/vsphere/storage/storageclass.go
@@ -9,58 +9,27 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	topologyv1 "github.com/vmware-tanzu/vm-operator/external/tanzu-topology/api/v1alpha1"
-	cnsstoragev1 "github.com/vmware-tanzu/vm-operator/external/vsphere-csi-driver/pkg/syncer/cnsoperator/apis/storagepolicy/v1alpha1"
-
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
-	pkgconfig "github.com/vmware-tanzu/vm-operator/pkg/config"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
-	"github.com/vmware-tanzu/vm-operator/pkg/topology"
-	"github.com/vmware-tanzu/vm-operator/pkg/util"
 )
 
-// GetStoragePolicyID returns Storage Policy ID from Storage Class Name.
-func GetStoragePolicyID(
+// getStoragePolicyID returns Storage Policy ID from Storage Class Name.
+func getStoragePolicyID(
 	vmCtx context.VirtualMachineContext,
 	client ctrlclient.Client,
 	storageClassName string) (string, error) {
 
-	var (
-		policyID string
-		zones    []topologyv1.AvailabilityZone
-	)
-
-	if pkgconfig.FromContext(vmCtx).Features.PodVMOnStretchedSupervisor {
-		azs, err := topology.GetAvailabilityZones(vmCtx, client)
-		if err != nil {
-			return "", err
-		}
-		zones = azs
+	sc := &storagev1.StorageClass{}
+	if err := client.Get(vmCtx, ctrlclient.ObjectKey{Name: storageClassName}, sc); err != nil {
+		vmCtx.Logger.Error(err, "Failed to get StorageClass", "storageClass", storageClassName)
+		return "", err
 	}
 
-	if pkgconfig.FromContext(vmCtx).Features.PodVMOnStretchedSupervisor && len(zones) > 1 {
-		storagePolicyQuota := &cnsstoragev1.StoragePolicyQuota{}
-		if err := client.Get(vmCtx, ctrlclient.ObjectKey{
-			Namespace: vmCtx.VM.Namespace,
-			Name:      util.CNSStoragePolicyQuotaName(storageClassName),
-		}, storagePolicyQuota); err != nil {
-			return "", err
-		}
-
-		policyID = storagePolicyQuota.Spec.StoragePolicyId
-	} else {
-		sc := &storagev1.StorageClass{}
-		if err := client.Get(vmCtx, ctrlclient.ObjectKey{Name: storageClassName}, sc); err != nil {
-			vmCtx.Logger.Error(err, "Failed to get StorageClass", "storageClass", storageClassName)
-			return "", err
-		}
-
-		var ok bool
-		policyID, ok = sc.Parameters["storagePolicyID"]
-		if !ok {
-			return "", fmt.Errorf("StorageClass %s does not have 'storagePolicyID' parameter", storageClassName)
-		}
+	policyID, ok := sc.Parameters["storagePolicyID"]
+	if !ok {
+		return "", fmt.Errorf("StorageClass %s does not have 'storagePolicyID' parameter", storageClassName)
 	}
+
 	return policyID, nil
 }
 
@@ -74,7 +43,7 @@ func GetVMStoragePoliciesIDs(
 
 	for _, name := range storageClassNames {
 		if _, ok := storageClassesToIDs[name]; !ok {
-			id, err := GetStoragePolicyID(vmCtx, client, name)
+			id, err := getStoragePolicyID(vmCtx, client, name)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
This is a partial revert of 177578e. Regardless if the PodVMOnStretchedSupervisor FFS is enabled and if this setup is stretched we can always resolve the storage policy ID via the cluster scoped StorageClass. The storage namespace association has already be validated by this point.

While here don't export GetStoragePolicyID().

```release-note
NONE
```