### PR TITLE
🌱 Simplify check if a device is a VirtualEthernetCard

### DIFF
--- a/pkg/util/devices.go
+++ b/pkg/util/devices.go
@@ -188,12 +188,8 @@ func SelectDynamicDirectPathIO(
 }
 
 func IsEthernetCard(dev vimTypes.BaseVirtualDevice) bool {
-	switch dev.(type) {
-	case *vimTypes.VirtualE1000, *vimTypes.VirtualE1000e, *vimTypes.VirtualPCNet32, *vimTypes.VirtualVmxnet2, *vimTypes.VirtualVmxnet3, *vimTypes.VirtualVmxnet3Vrdma, *vimTypes.VirtualSriovEthernetCard:
-		return true
-	default:
-		return false
-	}
+	_, ok := dev.(vimTypes.BaseVirtualEthernetCard)
+	return ok
 }
 
 func isDiskOrDiskController(dev vimTypes.BaseVirtualDevice) bool {

--- a/pkg/vmprovider/providers/vsphere2/session/session_vm_update.go
+++ b/pkg/vmprovider/providers/vsphere2/session/session_vm_update.go
@@ -557,15 +557,9 @@ func (s *Session) ensureNetworkInterfaces(
 
 	var networkDevices []vimTypes.BaseVirtualDevice
 	if pkgconfig.FromContext(vmCtx).Features.VMClassAsConfigDayNDate && configSpec != nil {
-		networkDevices = util.SelectDevicesByTypes(
+		networkDevices = util.SelectDevices[vimTypes.BaseVirtualDevice](
 			util.DevicesFromConfigSpec(configSpec),
-			&vimTypes.VirtualE1000{},
-			&vimTypes.VirtualE1000e{},
-			&vimTypes.VirtualPCNet32{},
-			&vimTypes.VirtualVmxnet2{},
-			&vimTypes.VirtualVmxnet3{},
-			&vimTypes.VirtualVmxnet3Vrdma{},
-			&vimTypes.VirtualSriovEthernetCard{},
+			util.IsEthernetCard,
 		)
 	}
 


### PR DESCRIPTION
Use a type check instead of enumerating possible devices to determine if a device is a VirtualEthernetCard.  This also includes the OG vmxnet device that wasn't in the prior list.

```release-note
NONE
```