### PR TITLE
🐛 Add GVK in additional resource backup

### DIFF
--- a/pkg/vmprovider/providers/vsphere2/vmprovider_vm_utils_test.go
+++ b/pkg/vmprovider/providers/vsphere2/vmprovider_vm_utils_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2022-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package vsphere_test
@@ -873,6 +873,7 @@ func vmUtilTests() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(objects).To(HaveLen(1))
 				Expect(objects[0].GetName()).To(Equal("dummy-cloud-config-secret"))
+				Expect(objects[0].GetObjectKind().GroupVersionKind()).To(Equal(corev1.SchemeGroupVersion.WithKind("Secret")))
 			})
 		})
 
@@ -899,6 +900,7 @@ func vmUtilTests() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(objects).To(HaveLen(1))
 				Expect(objects[0].GetName()).To(Equal("dummy-raw-cloud-secret"))
+				Expect(objects[0].GetObjectKind().GroupVersionKind()).To(Equal(corev1.SchemeGroupVersion.WithKind("Secret")))
 			})
 		})
 
@@ -925,6 +927,7 @@ func vmUtilTests() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(objects).To(HaveLen(1))
 				Expect(objects[0].GetName()).To(Equal("dummy-raw-cloud-config-map"))
+				Expect(objects[0].GetObjectKind().GroupVersionKind()).To(Equal(corev1.SchemeGroupVersion.WithKind("ConfigMap")))
 			})
 		})
 
@@ -955,6 +958,7 @@ func vmUtilTests() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(objects).To(HaveLen(1))
 				Expect(objects[0].GetName()).To(Equal("dummy-sysprep-secret"))
+				Expect(objects[0].GetObjectKind().GroupVersionKind()).To(Equal(corev1.SchemeGroupVersion.WithKind("Secret")))
 			})
 		})
 
@@ -981,6 +985,7 @@ func vmUtilTests() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(objects).To(HaveLen(1))
 				Expect(objects[0].GetName()).To(Equal("dummy-raw-sysprep-secret"))
+				Expect(objects[0].GetObjectKind().GroupVersionKind()).To(Equal(corev1.SchemeGroupVersion.WithKind("Secret")))
 			})
 		})
 
@@ -1007,6 +1012,7 @@ func vmUtilTests() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(objects).To(HaveLen(1))
 				Expect(objects[0].GetName()).To(Equal("dummy-raw-sysprep-config-map"))
+				Expect(objects[0].GetObjectKind().GroupVersionKind()).To(Equal(corev1.SchemeGroupVersion.WithKind("ConfigMap")))
 			})
 		})
 
@@ -1048,6 +1054,7 @@ func vmUtilTests() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(objects).To(HaveLen(1))
 				Expect(objects[0].GetName()).To(Equal("dummy-vapp-config-property-secret"))
+				Expect(objects[0].GetObjectKind().GroupVersionKind()).To(Equal(corev1.SchemeGroupVersion.WithKind("Secret")))
 			})
 		})
 
@@ -1072,6 +1079,7 @@ func vmUtilTests() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(objects).To(HaveLen(1))
 				Expect(objects[0].GetName()).To(Equal("dummy-raw-vapp-config-secret"))
+				Expect(objects[0].GetObjectKind().GroupVersionKind()).To(Equal(corev1.SchemeGroupVersion.WithKind("Secret")))
 			})
 		})
 
@@ -1096,6 +1104,7 @@ func vmUtilTests() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(objects).To(HaveLen(1))
 				Expect(objects[0].GetName()).To(Equal("dummy-raw-vapp-config-config-map"))
+				Expect(objects[0].GetObjectKind().GroupVersionKind()).To(Equal(corev1.SchemeGroupVersion.WithKind("ConfigMap")))
 			})
 		})
 	})


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This PR adds GVK into the bootstrap secret resources during backup, so that they can be recreated successfully during the restore. 
It appears that the `Decoder` used for getting K8s core resources clears the GVK info (see https://github.com/kubernetes/kubernetes/issues/80609 for more details).

**Which issue(s) is/are addressed by this PR?**
N/A.

**Are there any special notes for your reviewer**:
N/A.

**Please add a release note if necessary**:

```release-note
Add GVK in additional resource backup to ensure a successful restore of VM bootstrap data.
```

**Testing Done**:
- CloudInit with inlined secret data
```
$ govc vm.info -e "test-ubuntu-impish-inlined-cloud-config" | grep "vmservice.virtualmachine.additional.resources.yaml" | awk '{print $2}' | base64 -d | gunzip
apiVersion: v1
kind: Secret
...
```
- Sysprep with inlined secret data 
```
$ govc vm.info -e "test-windows-inlined-sysprep" | grep "vmservice.virtualmachine.additional.resources.yaml" | awk '{print $2}' | base64 -d | gunzip
apiVersion: v1
kind: Secret
...
```