### PR TITLE
🌱 Preserve class ConfigSpec Annotation if set

### DIFF
--- a/pkg/vmprovider/providers/vsphere2/session/session_vm_update.go
+++ b/pkg/vmprovider/providers/vsphere2/session/session_vm_update.go
@@ -413,7 +413,7 @@ func UpdateHardwareConfigSpec(
 func UpdateConfigSpecAnnotation(
 	config *vimTypes.VirtualMachineConfigInfo,
 	configSpec *vimTypes.VirtualMachineConfigSpec) {
-	if config.Annotation != constants.VCVMAnnotation {
+	if config.Annotation == "" {
 		configSpec.Annotation = constants.VCVMAnnotation
 	}
 }

--- a/pkg/vmprovider/providers/vsphere2/vmprovider_vm_test.go
+++ b/pkg/vmprovider/providers/vsphere2/vmprovider_vm_test.go
@@ -221,8 +221,25 @@ func vmTests() {
 
 					var o mo.VirtualMachine
 					Expect(vcVM.Properties(ctx, vcVM.Reference(), nil, &o)).To(Succeed())
+					Expect(o.Config.Annotation).To(Equal(constants.VCVMAnnotation))
 					Expect(o.Summary.Config.NumCpu).To(BeEquivalentTo(vmClass.Spec.Hardware.Cpus))
 					Expect(o.Summary.Config.MemorySizeMB).To(BeEquivalentTo(vmClass.Spec.Hardware.Memory.Value() / 1024 / 1024))
+				})
+			})
+
+			Context("ConfigSpec specifies annotation", func() {
+				BeforeEach(func() {
+					configSpec = &types.VirtualMachineConfigSpec{
+						Annotation: "my-annotation",
+					}
+				})
+
+				It("VM has class annotation", func() {
+					Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionCreated)).To(BeTrue())
+
+					var o mo.VirtualMachine
+					Expect(vcVM.Properties(ctx, vcVM.Reference(), nil, &o)).To(Succeed())
+					Expect(o.Config.Annotation).To(Equal("my-annotation"))
 				})
 			})
 


### PR DESCRIPTION
If the VC VM already has an Annotation then leave it as-is instead of always reverting back to our default.

```release-note
If the VirtualMachineClass ConfigSpec has the Annotation field set, then a VM created from the class will have that Annotation.
```