### PR TITLE
🌱 Make manager the default container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -493,7 +493,7 @@ deploy-local-kind: docker-build load-kind ## Deploy controller in the kind clust
 
 .PHONY: load-kind
 load-kind: ## Load the image into the kind cluster
-	kind load docker-image $(IMG) --name $(KIND_CLUSTER_NAME) --loglevel debug
+	kind load docker-image $(IMG) --name $(KIND_CLUSTER_NAME) -v 10
 
 ## --------------------------------------
 ## Development - run

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
 - ../crd/external-crds/topology.tanzu.vmware.com_vspherezones.yaml
 
 patchesStrategicMerge:
+- manager_default_container_patch.yaml
 - manager_auth_proxy_patch.yaml
 - manager_webhook_patch.yaml
 - manager_replicas_patch.yaml

--- a/config/default/manager_default_container_patch.yaml
+++ b/config/default/manager_default_container_patch.yaml
@@ -1,0 +1,10 @@
+# This patch marks "manager" as the default container.  This means `kubectl logs` and
+# `kubectl exec` will pick the "manager" container unless a different container is
+# specified using the --container flag.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+  annotations:
+    kubectl.kubernetes.io/default-container: manager

--- a/hack/deploy-local-certmanager.sh
+++ b/hack/deploy-local-certmanager.sh
@@ -12,7 +12,9 @@ CERT_MANAGER_URL="${CERT_MANAGER_URL:?}"
 
 mkdir -p artifacts
 
-./hack/tools/bin/kustomize build \
+# Since we modify the PATH var at the beginning of Makefile, kustomize
+# should always be available.
+kustomize build \
   --load-restrictor LoadRestrictionsNone \
   "${CERT_MANAGER_URL}" \
   >artifacts/cert-manager.yaml


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This change makes `manager` the default container so that commands like `kubectl exec` and `kubectl logs` pick that container by default.

Also handle a few trivial things like:
- Changing the now unsupported `verbosity` with `-v` flag in kind load
- Removing the incorrect kustomize path since we now add HOSTOSARCH in the binary path

# Testing Done:
- Generated the manifests and verified that the annotation is present: 
```
$ grep -r 'kubectl.kubernetes.io/default-container: manager' artifacts/local-deployment.yaml artifacts/local-deployment.yaml:
kubectl.kubernetes.io/default-container: manager
```

- Verified that kubectl logs pick up the default container
```
$ k logs -n vmware-system-vmop vmware-system-vmop-controller-manager-6f8d6f8c78-wh5z8 | head Defaulted container "manager" out of: manager, kube-rbac-proxy
I0206 20:42:47.145487       1 main.go:53] entrypoint "msg"="Starting VM Operator controller" "buildnumber"="00000000" "buildtype"="dev" "commit"="42c578ddf9bd43d579475ddf23948f6a3fa7fc53" "version"="1.8.0-479-g42c578dd"
```

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

N/A


**Are there any special notes for your reviewer**:

N/A

**Please add a release note if necessary**:
```release-note
Make "manager" the default container for kubectl log and exec
```