### PR TITLE
:sparkles: Import VPC API from nsx-operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,10 @@ require (
 	sigs.k8s.io/yaml v1.3.0
 )
 
-require gopkg.in/yaml.v3 v3.0.1
+require (
+	github.com/vmware-tanzu/nsx-operator/pkg/apis v0.1.0
+	gopkg.in/yaml.v3 v3.0.1
+)
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -460,6 +460,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/vmware-tanzu/image-registry-operator-api v0.0.0-20230526154708-f67dac7c805f h1:qpQD1XWbDpti3fBxKfQq5YRPmdQkbNS36RynprKJKoc=
 github.com/vmware-tanzu/image-registry-operator-api v0.0.0-20230526154708-f67dac7c805f/go.mod h1:S0HMBgdo3S/0a5hwq+Ya4XZI2aEDtGkSGeojU1cINOg=
+github.com/vmware-tanzu/nsx-operator/pkg/apis v0.1.0 h1:HdnQb/X9vJ8a5WQ03g/0nDr9igIIK1fF6wO5wOtkJT4=
+github.com/vmware-tanzu/nsx-operator/pkg/apis v0.1.0/go.mod h1:Q4JzNkNMvjo7pXtlB5/R3oME4Nhah7fAObWgghVmtxk=
 github.com/vmware/govmomi v0.31.0 h1:+NC7le8yeXj7f4YUC841jgdWsehN7A3ivqLxm79eKyo=
 github.com/vmware/govmomi v0.31.0/go.mod h1:JA63Pg0SgQcSjk+LuPzjh3rJdcWBo/ZNCIwbb1qf2/0=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2019-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package manager
@@ -17,6 +17,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
 	imgregv1a1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha1"
+	vpcv1alpha1 "github.com/vmware-tanzu/nsx-operator/pkg/apis/nsx.vmware.com/v1alpha1"
 
 	ncpv1alpha1 "github.com/vmware-tanzu/vm-operator/external/ncp/api/v1alpha1"
 	netopv1alpha1 "github.com/vmware-tanzu/vm-operator/external/net-operator/api/v1alpha1"
@@ -53,6 +54,10 @@ func New(ctx goctx.Context, opts Options) (Manager, error) {
 
 	if pkgconfig.FromContext(ctx).Features.VMOpV1Alpha2 {
 		_ = vmopv1alpha2.AddToScheme(opts.Scheme)
+	}
+
+	if networkType := pkgconfig.FromContext(ctx).NetworkProviderType; networkType == pkgconfig.NetworkProviderTypeVPC {
+		_ = vpcv1alpha1.AddToScheme(opts.Scheme)
 	}
 	// +kubebuilder:scaffold:scheme
 

--- a/test/builder/fake.go
+++ b/test/builder/fake.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2021-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package builder
@@ -11,6 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	imgregv1a1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha1"
+	vpcv1alpha1 "github.com/vmware-tanzu/nsx-operator/pkg/apis/nsx.vmware.com/v1alpha1"
 
 	ncpv1alpha1 "github.com/vmware-tanzu/vm-operator/external/ncp/api/v1alpha1"
 	netopv1alpha1 "github.com/vmware-tanzu/vm-operator/external/net-operator/api/v1alpha1"
@@ -55,6 +56,8 @@ func KnownObjectTypes() []client.Object {
 		&cnsstoragev1.StoragePolicyQuota{},
 		&ncpv1alpha1.VirtualNetworkInterface{},
 		&netopv1alpha1.NetworkInterface{},
+		&vpcv1alpha1.Subnet{},
+		&vpcv1alpha1.SubnetSet{},
 	}
 }
 
@@ -74,5 +77,6 @@ func NewScheme() *runtime.Scheme {
 	_ = netopv1alpha1.AddToScheme(scheme)
 	_ = topologyv1.AddToScheme(scheme)
 	_ = imgregv1a1.AddToScheme(scheme)
+	_ = vpcv1alpha1.AddToScheme(scheme)
 	return scheme
 }


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This change imports VPC API from https://github.com/vmware-tanzu/nsx-operator/tree/vpc_dev/pkg/apis/nsx.vmware.com/v1alpha1 and adds types to k8s client scheme.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes N/A


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note
Import VPC API from nsx-operator
```