### PR TITLE
🌱 Add validation for autoLogonCount and update description

### DIFF
--- a/api/v1alpha2/sysprep/sysprep.go
+++ b/api/v1alpha2/sysprep/sysprep.go
@@ -67,7 +67,7 @@ type GUIUnattended struct {
 	// you may want to increase it. This number may be determined by the list of
 	// commands executed by the GuiRunOnce command.
 	//
-	// Please note this field only matters if AutoLogon is true.
+	// Please note this field must be specified with a non-zero positive integer if AutoLogon is true.
 	//
 	// +optional
 	AutoLogonCount int32 `json:"autoLogonCount,omitempty"`

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -1090,8 +1090,9 @@ spec:
                                   if your setup requires a number of reboots, you
                                   may want to increase it. This number may be determined
                                   by the list of commands executed by the GuiRunOnce
-                                  command. \n Please note this field only matters
-                                  if AutoLogon is true."
+                                  command. \n Please note this field must be specified
+                                  with a non-zero positive integer if AutoLogon is
+                                  true."
                                 format: int32
                                 type: integer
                               password:

--- a/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator.go
@@ -294,7 +294,12 @@ func (v validator) validateInlineSysprep(p *field.Path, sysprep *sysprep.Sysprep
 
 	s := p.Child("sysprep")
 	if guiUnattended := sysprep.GUIUnattended; guiUnattended != nil {
-		if guiUnattended.AutoLogon && guiUnattended.Password.Name == "" {
+		if guiUnattended.AutoLogon && guiUnattended.AutoLogonCount == 0 {
+			allErrs = append(allErrs, field.Invalid(s, "guiUnattended",
+				"autoLogon requires autoLogonCount to be specified"))
+		}
+
+		if guiUnattended.AutoLogon && (guiUnattended.Password == nil || guiUnattended.Password.Name == "") {
 			allErrs = append(allErrs, field.Invalid(s, "guiUnattended",
 				"autoLogon requires password selector to be set"))
 		}

--- a/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator_unit_test.go
@@ -696,6 +696,29 @@ func unitTestsValidateCreate() {
 					),
 				},
 			),
+
+			Entry("disallow inline sysPrep autoLogon with missing autoLogonCount and password",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						pkgconfig.SetContext(ctx, func(config *pkgconfig.Config) {
+							config.Features.WindowsSysprep = true
+						})
+						ctx.vm.Spec.Bootstrap = &vmopv1.VirtualMachineBootstrapSpec{
+							Sysprep: &vmopv1.VirtualMachineBootstrapSysprepSpec{
+								Sysprep: &sysprep.Sysprep{
+									GUIUnattended: &sysprep.GUIUnattended{
+										AutoLogon: true,
+									},
+								},
+							},
+						}
+					},
+					validate: doValidateWithMsg(
+						`spec.bootstrap.sysprep.sysprep: Invalid value: "guiUnattended": autoLogon requires autoLogonCount to be specified`,
+						`spec.bootstrap.sysprep.sysprep: Invalid value: "guiUnattended": autoLogon requires password selector to be set`,
+					),
+				},
+			),
 		)
 	})
 


### PR DESCRIPTION

**What does this PR do, and why is it needed?**
This change adds validations and updates logonCount description to say must be specified
when AutoLogon is true.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # N/A


**Are there any special notes for your reviewer**:

https://learn.microsoft.com/en-us/windows-hardware/customize/desktop/unattend/microsoft-windows-shell-setup-autologon-logoncount


**Please add a release note if necessary**:


```
Update AutoLogonCount description to say must be specified when AutoLogon is true

```