### PR TITLE
✨ Make the VM network interfaces immutable

### DIFF
--- a/api/v1alpha1/virtualmachine_types.go
+++ b/api/v1alpha1/virtualmachine_types.go
@@ -474,7 +474,11 @@ type VirtualMachineSpec struct {
 	// NetworkInterfaces describes a list of VirtualMachineNetworkInterfaces to be configured on the VirtualMachine instance.
 	// Each of these VirtualMachineNetworkInterfaces describes external network integration configurations that are to be
 	// used by the VirtualMachine controller when integrating the VirtualMachine into one or more external networks.
+	//
+	// The maximum number of network interface allowed is 10 because of the limit built into vSphere.
+	//
 	// +optional
+	// +kubebuilder:validation:MaxItems=10
 	NetworkInterfaces []VirtualMachineNetworkInterface `json:"networkInterfaces,omitempty"`
 
 	// ResourcePolicyName describes the name of a VirtualMachineSetResourcePolicy to be used when creating the

--- a/api/v1alpha2/virtualmachine_network_types.go
+++ b/api/v1alpha2/virtualmachine_network_types.go
@@ -218,9 +218,13 @@ type VirtualMachineNetworkSpec struct {
 	// If the Interfaces field is empty and the Disabled field is false, then
 	// a default interface with the name eth0 will be created.
 	//
+	// The maximum number of network interface allowed is 10 because of the limit
+	// built into vSphere.
+	//
 	// +optional
 	// +listType=map
 	// +listMapKey=name
+	// +kubebuilder:validation:MaxItems=10
 	Interfaces []VirtualMachineNetworkInterfaceSpec `json:"interfaces,omitempty"`
 }
 
@@ -414,12 +418,21 @@ type VirtualMachineNetworkInterfaceIPStatus struct {
 // VirtualMachineNetworkInterfaceStatus describes the observed state of a
 // VM's network interface.
 type VirtualMachineNetworkInterfaceStatus struct {
-	// Name describes the unique name of this network interface, used to
-	// distinguish it from other network interfaces attached to this VM.
+	// Name describes the corresponding network interface with the same name
+	// in the VM's desired network interface list. If unset, then there is no
+	// corresponding entry for this interface.
 	//
-	// Please note this name is not related to the name of the device as it is
-	// surfaced inside of the guest.
-	Name string `json:"name"`
+	// Please note this name is not necessarily related to the name of the
+	// device as it is surfaced inside of the guest.
+	//
+	// +optional
+	Name string `json:"name,omitempty"`
+
+	// DeviceKey describes the unique hardware device key of this network
+	// interface.
+	//
+	// +optional
+	DeviceKey int32 `json:"deviceKey,omitempty"`
 
 	// IP describes the observed state of the interface's IP configuration.
 	//
@@ -471,8 +484,6 @@ type VirtualMachineNetworkStatus struct {
 	// Interfaces describes the status of the VM's network interfaces.
 	//
 	// +optional
-	// +listType=map
-	// +listMapKey=name
 	Interfaces []VirtualMachineNetworkInterfaceStatus `json:"interfaces,omitempty"`
 
 	// PrimaryIP4 describes the VM's primary IP4 address.

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -132,11 +132,12 @@ spec:
                 minimum: 13
                 type: integer
               networkInterfaces:
-                description: NetworkInterfaces describes a list of VirtualMachineNetworkInterfaces
+                description: "NetworkInterfaces describes a list of VirtualMachineNetworkInterfaces
                   to be configured on the VirtualMachine instance. Each of these VirtualMachineNetworkInterfaces
                   describes external network integration configurations that are to
                   be used by the VirtualMachine controller when integrating the VirtualMachine
-                  into one or more external networks.
+                  into one or more external networks. \n The maximum number of network
+                  interface allowed is 10 because of the limit built into vSphere."
                 items:
                   description: VirtualMachineNetworkInterface defines the properties
                     of a network interface to attach to a VirtualMachine instance.  A
@@ -190,6 +191,7 @@ spec:
                       - name
                       type: object
                   type: object
+                maxItems: 10
                 type: array
               nextRestartTime:
                 description: "NextRestartTime may be used to restart the VM, in accordance
@@ -1392,7 +1394,8 @@ spec:
                     description: "Interfaces is the list of network interfaces used
                       by this VM. \n If the Interfaces field is empty and the Disabled
                       field is false, then a default interface with the name eth0
-                      will be created."
+                      will be created. \n The maximum number of network interface
+                      allowed is 10 because of the limit built into vSphere."
                     items:
                       description: VirtualMachineNetworkInterfaceSpec describes the
                         desired state of a VM's network interface.
@@ -1542,6 +1545,7 @@ spec:
                       required:
                       - name
                       type: object
+                    maxItems: 10
                     type: array
                     x-kubernetes-list-map-keys:
                     - name
@@ -2082,6 +2086,11 @@ spec:
                       description: VirtualMachineNetworkInterfaceStatus describes
                         the observed state of a VM's network interface.
                       properties:
+                        deviceKey:
+                          description: DeviceKey describes the unique hardware device
+                            key of this network interface.
+                          format: int32
+                          type: integer
                         dns:
                           description: DNS describes the observed state of the interface's
                             DNS configuration.
@@ -2276,19 +2285,15 @@ spec:
                               type: string
                           type: object
                         name:
-                          description: "Name describes the unique name of this network
-                            interface, used to distinguish it from other network interfaces
-                            attached to this VM. \n Please note this name is not related
-                            to the name of the device as it is surfaced inside of
-                            the guest."
+                          description: "Name describes the corresponding network interface
+                            with the same name in the VM's desired network interface
+                            list. If unset, then there is no corresponding entry for
+                            this interface. \n Please note this name is not necessarily
+                            related to the name of the device as it is surfaced inside
+                            of the guest."
                           type: string
-                      required:
-                      - name
                       type: object
                     type: array
-                    x-kubernetes-list-map-keys:
-                    - name
-                    x-kubernetes-list-type: map
                   ipRoutes:
                     description: IPRoutes contain the VM's routing tables for all
                       address families.

--- a/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator_intg_test.go
+++ b/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator_intg_test.go
@@ -190,12 +190,17 @@ func intgTestsValidateUpdate() {
 			BeforeEach(func() {
 				ctx.vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{
 					HostName: "my-new-name",
+					Interfaces: []vmopv1.VirtualMachineNetworkInterfaceSpec{
+						{
+							Name: "eth100",
+						},
+					},
 				}
 			})
 
 			It("rejects the request", func() {
-				expectedReason := field.Forbidden(field.NewPath("spec", "network"),
-					"updates to this field is not allowed when VM power is on").Error()
+				expectedReason := field.Forbidden(field.NewPath("spec", "network", "interfaces").Index(0).Child("name"),
+					"field is immutable").Error()
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring(expectedReason))
 			})


### PR DESCRIPTION
In VDS we have difficulty in matching up the network interfaces in our VM spec with the VM's devices. Unlike NCP/NSX-T, VDS does not generate the MAC address - we defer to VC to generate it - and an overly restrictive limitation that on VDS, the EthCard ExternalID cannot be set on device create (but can later set it via an edit). So for now, try to constrain things a bit by making our network interfaces immutable so we can depend on the device order during create.

Limit network interfaces to 10 since that is the VC limit

**What does this PR do, and why is it needed?**

This is just the first small step to make this better supported. In general, multiple interfaces just wouldn't have worked in either NSX-T or VDS so limit what we can make work for now until we have more time to solve this to support hot adding and removal of interfaces.

**Are there any special notes for your reviewer**:

Much more work in this area is needed. One note is that this starts to relax the "only allow network changes when the VM is 'off'". Since we cannot really know the VM's actual power state at that time so we used the Spec. One could get around this by quickly updating the spec from Off -> On without it impacting the VMs actual power state. 

**Please add a release note if necessary**:

```release-note
The VM Spec Network.Interfaces is immutable in that the Name or Network cannot be changed, and interfaces cannot be added or removed.

There is a maximum of 10 network interfaces to reflect the VC limit.
```