### PR TITLE
:sparkles: Add default NetworkInterface when VPC network

### DIFF
--- a/webhooks/virtualmachine/v1alpha2/mutation/virtualmachine_mutator.go
+++ b/webhooks/virtualmachine/v1alpha2/mutation/virtualmachine_mutator.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2019-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package mutation
@@ -21,6 +21,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	vpcv1alpha1 "github.com/vmware-tanzu/nsx-operator/pkg/apis/nsx.vmware.com/v1alpha1"
 
 	ncpv1alpha1 "github.com/vmware-tanzu/vm-operator/external/ncp/api/v1alpha1"
 	netopv1alpha1 "github.com/vmware-tanzu/vm-operator/external/net-operator/api/v1alpha1"
@@ -210,6 +212,9 @@ func AddDefaultNetworkInterface(ctx *context.WebhookRequestContext, client clien
 	case pkgconfig.NetworkProviderTypeVDS:
 		kind = "Network"
 		apiVersion = netopv1alpha1.SchemeGroupVersion.String()
+	case pkgconfig.NetworkProviderTypeVPC:
+		kind = "SubnetSet"
+		apiVersion = vpcv1alpha1.SchemeGroupVersion.String()
 	case pkgconfig.NetworkProviderTypeNamed:
 		netName, _ = getProviderConfigMap(ctx, client)
 		if netName == "" {

--- a/webhooks/virtualmachine/v1alpha2/mutation/virtualmachine_mutator_unit_test.go
+++ b/webhooks/virtualmachine/v1alpha2/mutation/virtualmachine_mutator_unit_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2019-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package mutation_test
@@ -120,6 +120,21 @@ func unitTestsMutating() {
 					Expect(ctx.vm.Spec.Network.Interfaces).Should(HaveLen(1))
 					Expect(ctx.vm.Spec.Network.Interfaces[0].Name).Should(Equal("eth0"))
 					Expect(ctx.vm.Spec.Network.Interfaces[0].Network.Kind).Should(Equal("VirtualNetwork"))
+				})
+			})
+
+			When("VPC network", func() {
+				BeforeEach(func() {
+					pkgconfig.SetContext(ctx, func(config *pkgconfig.Config) {
+						config.NetworkProviderType = pkgconfig.NetworkProviderTypeVPC
+					})
+				})
+
+				It("Should add default network interface with type SubnetSet", func() {
+					Expect(mutation.AddDefaultNetworkInterface(&ctx.WebhookRequestContext, ctx.Client, ctx.vm)).To(BeTrue())
+					Expect(ctx.vm.Spec.Network.Interfaces).Should(HaveLen(1))
+					Expect(ctx.vm.Spec.Network.Interfaces[0].Name).Should(Equal("eth0"))
+					Expect(ctx.vm.Spec.Network.Interfaces[0].Network.Kind).Should(Equal("SubnetSet"))
 				})
 			})
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This change adds default network interface `SubnetSet` when VPC Network in VM mutation webhook. 

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes N/A


**Are there any special notes for your reviewer**:
We don't need to determine the network type/name because VPC will pick a namespace default(SubnetSet with the label `nsxoperator.vmware.com/default-subnetset-for: VirtualMachine`)

Testing done: when deployed a VM under VPC network without specifying network, default network interface is added.
```
  Network:
    Interfaces:
      Name:  eth0
      Network:
        API Version:  nsx.vmware.com/v1alpha1
        Kind:         SubnetSet
        Name:
```

**Please add a release note if necessary**:


```release-note
Add default NetworkInterface when VPC network
```