### PR TITLE
📖 Note that HostName is used as Windows Computer Name

### DIFF
--- a/api/v1alpha2/virtualmachine_network_types.go
+++ b/api/v1alpha2/virtualmachine_network_types.go
@@ -166,6 +166,9 @@ type VirtualMachineNetworkSpec struct {
 	// Please note this feature is available only with the following bootstrap
 	// providers: CloudInit, LinuxPrep, and Sysprep (except for RawSysprep).
 	//
+	// When the bootstrap provider is Sysprep (except for RawSysprep) this is
+	// used as the Computer Name.
+	//
 	// +optional
 	HostName string `json:"hostName,omitempty"`
 

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -1371,7 +1371,9 @@ spec:
                     description: "HostName is the value the guest uses as its host
                       name. If omitted then the name of the VM will be used. \n Please
                       note this feature is available only with the following bootstrap
-                      providers: CloudInit, LinuxPrep, and Sysprep (except for RawSysprep)."
+                      providers: CloudInit, LinuxPrep, and Sysprep (except for RawSysprep).
+                      \n When the bootstrap provider is Sysprep (except for RawSysprep)
+                      this is used as the Computer Name."
                     type: string
                   interfaces:
                     description: "Interfaces is the list of network interfaces used


### PR DESCRIPTION
When we're doing inlined Sysprep, if set, the HostName field is what we set as the Computer Name. For ease, just pass this value as-is since internally GOSC does the same. If it becomes pressing later, we can try to do some up front validation.

**Are there any special notes for your reviewer**:

Since GOSC passes this value as-is through w/o validation have us just do the same. Which multibyte characters are allowed or not makes that slightly annoying and I just don't think worth it.

```release-note
NONE
```