### PR TITLE
🐛 Add back the V1Alpha1Compatible image condition to v1a2

### DIFF
--- a/api/v1alpha2/virtualmachineimage_types.go
+++ b/api/v1alpha2/virtualmachineimage_types.go
@@ -37,6 +37,12 @@ const (
 	VMIContentLibRefAnnotation = "vmoperator.vmware.com/conversion-content-lib-ref"
 )
 
+const (
+	// VirtualMachineImageV1Alpha1CompatibleCondition denotes that an image was prepared by
+	// VMware specifically for compatibility with VMService.
+	VirtualMachineImageV1Alpha1CompatibleCondition = "VirtualMachineImageV1Alpha1Compatible"
+)
+
 // Condition reasons for VirtualMachineImages.
 const (
 	// VirtualMachineImageNotSyncedReason documents that the VirtualMachineImage is not synced with


### PR DESCRIPTION
For images that have the special ExtraConfig field, set the V1Alpha1Compatible condition like v1a1 did, and update the EC field when using the v1a1 OvfEnv transport converts to in v1a2.  The very old v1a1 ExtraConfig transport is not really supported anymore since we don't allow CloudInit with vAppConfig.

Note that the V1Alpha1Compatible thing is the only reason we need the image post VM create. We cannot set the EC field to "Enabled" at create time since the OVF ExtraConfig takes precedence over conflicting keys in our ConfigSpec. A future change may remove the need for the image and we'll just set the EC field if it is there and "Ready" to "Enabled" since

Do some clean up in UpdateConfigSpecExtraConfig() by using our various util functions.

Remove an InstanceStorage ExtraConfig test that wasn't really testing anything since it didn't have any assertions, and the ExtraConfig we create doesn't vary depending on InstanceStorage volumes.


```release-note
NONE
```