### PR TITLE
🐛 Check for GuestInfo prober exclusivity in validation webhook

### DIFF
--- a/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator.go
@@ -749,7 +749,17 @@ func (v validator) validateReadinessProbe(ctx *context.WebhookRequestContext, vm
 
 	readinessProbePath := field.NewPath("spec", "readinessProbe")
 
-	if probe.TCPSocket != nil && probe.GuestHeartbeat != nil {
+	actionsCnt := 0
+	if probe.TCPSocket != nil {
+		actionsCnt++
+	}
+	if probe.GuestHeartbeat != nil {
+		actionsCnt++
+	}
+	if len(probe.GuestInfo) != 0 {
+		actionsCnt++
+	}
+	if actionsCnt > 1 {
 		allErrs = append(allErrs, field.Forbidden(readinessProbePath, readinessProbeOnlyOneAction))
 	}
 

--- a/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator_unit_test.go
@@ -98,6 +98,7 @@ func unitTestsValidateCreate() {
 		validStorageClass                 bool
 		withInstanceStorageVolumes        bool
 		invalidReadinessProbe             bool
+		invalidReadinessProbe2            bool
 		isRestrictedNetworkEnv            bool
 		isRestrictedNetworkValidProbePort bool
 		isNonRestrictedNetworkEnv         bool
@@ -171,6 +172,16 @@ func unitTestsValidateCreate() {
 		if args.invalidReadinessProbe {
 			ctx.vm.Spec.ReadinessProbe = &vmopv1.VirtualMachineReadinessProbeSpec{
 				TCPSocket:      &vmopv1.TCPSocketAction{},
+				GuestHeartbeat: &vmopv1.GuestHeartbeatAction{},
+			}
+		}
+		if args.invalidReadinessProbe2 {
+			ctx.vm.Spec.ReadinessProbe = &vmopv1.VirtualMachineReadinessProbeSpec{
+				GuestInfo: []vmopv1.GuestInfoAction{
+					{
+						Key: "my-key",
+					},
+				},
 				GuestHeartbeat: &vmopv1.GuestHeartbeatAction{},
 			}
 		}
@@ -286,6 +297,8 @@ func unitTestsValidateCreate() {
 			field.Required(specPath.Child("imageName"), "").Error(), nil),
 
 		Entry("should fail when Readiness probe has multiple actions", createArgs{invalidReadinessProbe: true}, false,
+			field.Forbidden(specPath.Child("readinessProbe"), "only one action can be specified").Error(), nil),
+		Entry("should fail when Readiness probe has multiple actions #2", createArgs{invalidReadinessProbe2: true}, false,
 			field.Forbidden(specPath.Child("readinessProbe"), "only one action can be specified").Error(), nil),
 
 		Entry("should deny invalid volume name", createArgs{invalidVolumeName: true}, false,


### PR DESCRIPTION
Like the existing v1a1 prober methods we only support at most one of the methods being specified but GuestInfo was missing from the validation.

Add a quick test that includes GuestInfo in the old style test until we can convert everything over from the big "args" format.

```release-note
NONE
```