### PR TITLE
:sparkles: Update vcsim test frame for VPC networking

### DIFF
--- a/test/builder/vcsim_test_context.go
+++ b/test/builder/vcsim_test_context.go
@@ -60,9 +60,11 @@ type NetworkEnv string
 const (
 	NetworkEnvVDS   = NetworkEnv("vds")
 	NetworkEnvNSXT  = NetworkEnv("nsx-t")
+	NetworkEnvVPC   = NetworkEnv("nsx-t-vpc")
 	NetworkEnvNamed = NetworkEnv("named")
 
 	NsxTLogicalSwitchUUID = "nsxt-dummy-ls-uuid"
+	VPCLogicalSwitchUUID  = "vpc-dummy-ls-uuid"
 )
 
 // VCSimTestConfig configures the vcsim environment.
@@ -316,6 +318,8 @@ func (c *TestContextForVCSim) setupEnv(config VCSimTestConfig) {
 			cc.NetworkProviderType = pkgconfig.NetworkProviderTypeVDS
 		case NetworkEnvNSXT:
 			cc.NetworkProviderType = pkgconfig.NetworkProviderTypeNSXT
+		case NetworkEnvVPC:
+			cc.NetworkProviderType = pkgconfig.NetworkProviderTypeVPC
 		case NetworkEnvNamed:
 			cc.NetworkProviderType = pkgconfig.NetworkProviderTypeNamed
 		default:
@@ -410,6 +414,11 @@ func (c *TestContextForVCSim) setupVCSim(config VCSimTestConfig) {
 		dvpg, ok := simulator.Map.Get(c.NetworkRef.Reference()).(*simulator.DistributedVirtualPortgroup)
 		Expect(ok).To(BeTrue())
 		dvpg.Config.LogicalSwitchUuid = NsxTLogicalSwitchUUID
+		dvpg.Config.BackingType = "nsx"
+	case NetworkEnvVPC:
+		dvpg, ok := simulator.Map.Get(c.NetworkRef.Reference()).(*simulator.DistributedVirtualPortgroup)
+		Expect(ok).To(BeTrue())
+		dvpg.Config.LogicalSwitchUuid = VPCLogicalSwitchUUID
 		dvpg.Config.BackingType = "nsx"
 	}
 }


### PR DESCRIPTION

**What does this PR do, and why is it needed?**
This change updates vcsim test frame for VPC networking. Specific e2e tests will be added after implementation is done.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes N/A


**Are there any special notes for your reviewer**:



**Please add a release note if necessary**:
NONE
