### PR TITLE
🐛 Always set v1a1 CloudInit transport when v1a2 is using CloudInit

### DIFF
--- a/api/v1alpha1/virtualmachine_conversion.go
+++ b/api/v1alpha1/virtualmachine_conversion.go
@@ -230,7 +230,7 @@ func convert_v1alpha2_BootstrapSpec_To_v1alpha1_VmMetadata(
 				// Best approx we can do.
 				out.Transport = VirtualMachineMetadataCloudInitTransport
 			}
-		} else if cloudInit.CloudConfig != nil {
+		} else {
 			out.Transport = VirtualMachineMetadataCloudInitTransport
 		}
 	} else if sysprep := in.Sysprep; sysprep != nil {

--- a/api/v1alpha1/virtualmachine_conversion_test.go
+++ b/api/v1alpha1/virtualmachine_conversion_test.go
@@ -255,6 +255,22 @@ func TestVirtualMachineConversion(t *testing.T) {
 		hubSpokeHub(g, &hub, &v1alpha1.VirtualMachine{})
 	})
 
+	t.Run("VirtualMachine hub-spoke-hub with CloudInit w/ just SSHAuthorizedKeys", func(t *testing.T) {
+		g := NewWithT(t)
+
+		hub := nextver.VirtualMachine{
+			Spec: nextver.VirtualMachineSpec{
+				Bootstrap: &nextver.VirtualMachineBootstrapSpec{
+					CloudInit: &nextver.VirtualMachineBootstrapCloudInitSpec{
+						SSHAuthorizedKeys: []string{"my-ssh-key"},
+					},
+				},
+			},
+		}
+
+		hubSpokeHub(g, &hub, &v1alpha1.VirtualMachine{})
+	})
+
 	t.Run("VirtualMachine hub-spoke-hub with LinuxPrep", func(t *testing.T) {
 		g := NewWithT(t)
 


### PR DESCRIPTION
This is more correct since Bootstrap.CloudInit was non-nil to start with, and correctly handles the case when just SSHAuthorizedKeys is set.

**What does this PR do, and why is it needed?**

Not a common CloudInit use case but by setting the v1a1 VMMetaData transport on down convert, we'll correctly restore the Bootstrap when up converting to v1a2.

```release-note
NONE
```