### PR TITLE
🐛 Remove all EthCards from placement ConfigSpec

### DIFF
--- a/pkg/vmprovider/providers/vsphere2/virtualmachine/configspec.go
+++ b/pkg/vmprovider/providers/vsphere2/virtualmachine/configspec.go
@@ -168,12 +168,9 @@ func CreateConfigSpecForPlacement(
 	deviceChangeCopy := make([]types.BaseVirtualDeviceConfigSpec, 0, len(baseConfigSpec.DeviceChange))
 	for _, devChange := range baseConfigSpec.DeviceChange {
 		if spec := devChange.GetVirtualDeviceConfigSpec(); spec != nil {
-			// VC PlaceVmsXCluster() cannot handle VirtualEthernetCard devices that don't have a backing.
-			// Since backing-less cards cannot influence placement (except for assignable devices which
-			// it also doesn't consider today) remove these devices from the placement ConfigSpec. This
-			// can only happen on stretched NSX-T when the VM Class ConfigSpec has VirtualEthernetCard
-			// device that is matched with a VM Spec.Network.Interfaces entry.
-			if util.IsEthernetCard(spec.Device) && spec.Device.GetVirtualDevice().Backing == nil {
+			// VC PlaceVmsXCluster() has issues when the ConfigSpec has EthCards so return to the
+			// prior status quo until those issues get sorted out.
+			if util.IsEthernetCard(spec.Device) {
 				continue
 			}
 		}

--- a/pkg/vmprovider/providers/vsphere2/virtualmachine/configspec_test.go
+++ b/pkg/vmprovider/providers/vsphere2/virtualmachine/configspec_test.go
@@ -387,14 +387,16 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 			Expect(configSpec.MemoryAllocation).To(Equal(baseConfigSpec.MemoryAllocation))
 			Expect(configSpec.Firmware).To(Equal(baseConfigSpec.Firmware))
 
-			Expect(configSpec.DeviceChange).To(HaveLen(3))
+			Expect(configSpec.DeviceChange).To(HaveLen(2))
 			dSpec0 := configSpec.DeviceChange[0].GetVirtualDeviceConfigSpec()
 			_, ok := dSpec0.Device.(*vimtypes.VirtualPCIPassthrough)
 			Expect(ok).To(BeTrue())
+			/* Removed until PlaceVmsXCluster() bugs get fixed.
 			dSpec1 := configSpec.DeviceChange[1].GetVirtualDeviceConfigSpec()
 			_, ok = dSpec1.Device.(*vimtypes.VirtualVmxnet3)
 			Expect(ok).To(BeTrue())
-			dSpec2 := configSpec.DeviceChange[2].GetVirtualDeviceConfigSpec()
+			*/
+			dSpec2 := configSpec.DeviceChange[1].GetVirtualDeviceConfigSpec()
 			_, ok = dSpec2.Device.(*vimtypes.VirtualDisk)
 			Expect(ok).To(BeTrue())
 		})


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

PlaceVmsXCluster() still has issues even with EthCards that have a backing so just remove all eth devices in the ConfigSpec used for placement. Things brings up back to how things used to be when we didn't have the EthCard info until after VM is created.

**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note
NONE
```