### PR TITLE
:sparkles: Create SubnetPort when realizing VPC networking

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -183,6 +183,26 @@ rules:
   - update
   - watch
 - apiGroups:
+  - nsx.vmware.com
+  resources:
+  - subnetports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - nsx.vmware.com
+  resources:
+  - subnetports/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - storage.k8s.io
   resources:
   - storageclasses

--- a/controllers/virtualmachine/v1alpha2/virtualmachine_controller.go
+++ b/controllers/virtualmachine/v1alpha2/virtualmachine_controller.go
@@ -191,6 +191,8 @@ type Reconciler struct {
 // +kubebuilder:rbac:groups=vmware.com,resources=virtualnetworkinterfaces;virtualnetworkinterfaces/status,verbs=create;get;list;patch;delete;watch;update
 // +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=cns.vmware.com,resources=storagepolicyquotas,verbs=get;list;watch
+// +kubebuilder:rbac:groups=nsx.vmware.com,resources=subnetports,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=nsx.vmware.com,resources=subnetports/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=events;configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=resourcequotas;namespaces,verbs=get;list;watch
 

--- a/pkg/vmprovider/providers/vsphere2/constants/constants.go
+++ b/pkg/vmprovider/providers/vsphere2/constants/constants.go
@@ -96,6 +96,9 @@ const (
 	// InstanceStorageVDiskID vDisk ID for instance storage volume.
 	InstanceStorageVDiskID = "cc737f33-2aa3-4594-aa60-df7d6d4cb984"
 
+	// VPCAttachmentRef annotation key is for VPC SubnetPort to get virtual machine name.
+	VPCAttachmentRef = "nsx.vmware.com/attachment_ref"
+
 	// XsiNamespace indicates the XML scheme instance namespace.
 	XsiNamespace = "http://www.w3.org/2001/XMLSchema-instance"
 	// ConfigSpecProviderXML indicates XML as the config spec transport type for virtual machine deployment.

--- a/pkg/vmprovider/providers/vsphere2/network/network.go
+++ b/pkg/vmprovider/providers/vsphere2/network/network.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2023-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 //nolint:revive
@@ -23,12 +23,14 @@ import (
 	ctrlruntime "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	vpcv1alpha1 "github.com/vmware-tanzu/nsx-operator/pkg/apis/nsx.vmware.com/v1alpha1"
 	ncpv1alpha1 "github.com/vmware-tanzu/vm-operator/external/ncp/api/v1alpha1"
 	netopv1alpha1 "github.com/vmware-tanzu/vm-operator/external/net-operator/api/v1alpha1"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	pkgconfig "github.com/vmware-tanzu/vm-operator/pkg/config"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere2/constants"
 )
 
 type NetworkInterfaceResults struct {
@@ -126,6 +128,8 @@ func CreateAndWaitForNetworkInterfaces(
 			result, err = createNetOPNetworkInterface(vmCtx, client, vimClient, interfaceSpec)
 		case pkgconfig.NetworkProviderTypeNSXT:
 			result, err = createNCPNetworkInterface(vmCtx, client, vimClient, clusterMoRef, interfaceSpec)
+		case pkgconfig.NetworkProviderTypeVPC:
+			result, err = createVPCNetworkInterface(vmCtx, client, vimClient, clusterMoRef, interfaceSpec)
 		case pkgconfig.NetworkProviderTypeNamed:
 			result, err = createNamedNetworkInterface(vmCtx, finder, interfaceSpec)
 		default:
@@ -516,6 +520,157 @@ func ncpNetIfToResult(
 	}
 
 	return result, nil
+}
+
+// VPCCRName returns the name to be used for the VPC SubnetPort CR.
+func VPCCRName(vmName, networkName, interfaceName string) string {
+	var name string
+
+	if networkName != "" {
+		name = fmt.Sprintf("%s-%s-%s", vmName, networkName, interfaceName)
+	} else {
+		name = fmt.Sprintf("%s-%s", vmName, interfaceName)
+	}
+
+	return name
+}
+
+func createVPCNetworkInterface(
+	vmCtx context.VirtualMachineContextA2,
+	client ctrlruntime.Client,
+	vimClient *vim25.Client,
+	clusterMoRef *vimtypes.ManagedObjectReference,
+	interfaceSpec *vmopv1.VirtualMachineNetworkInterfaceSpec) (*NetworkInterfaceResult, error) {
+
+	networkName := interfaceSpec.Network.Name
+	vpcSubnetPort := &vpcv1alpha1.SubnetPort{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      VPCCRName(vmCtx.VM.Name, networkName, interfaceSpec.Name),
+			Namespace: vmCtx.VM.Namespace,
+		},
+	}
+
+	switch interfaceSpec.Network.Kind {
+	case "SubnetSet":
+		vpcSubnetPort.Spec.SubnetSet = networkName
+	case "":
+		vpcSubnetPort.Spec.SubnetSet = networkName
+	case "Subnet":
+		vpcSubnetPort.Spec.Subnet = networkName
+	default:
+		return nil, fmt.Errorf("network kind %q is not supported for VPC", interfaceSpec.Network.Kind)
+	}
+
+	_, err := controllerutil.CreateOrUpdate(vmCtx, client, vpcSubnetPort, func() error {
+		if err := controllerutil.SetOwnerReference(vmCtx.VM, vpcSubnetPort, client.Scheme()); err != nil {
+			return err
+		}
+		if vpcSubnetPort.Annotations == nil {
+			vpcSubnetPort.Annotations = make(map[string]string)
+		}
+		vpcSubnetPort.Annotations[constants.VPCAttachmentRef] = "virtualmachine/" + vmCtx.VM.Name
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	vpcSubnetPort, err = waitForReadyVPCSubnetPort(vmCtx, client, vpcSubnetPort.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	return vpcSubnetPortToResult(vmCtx, vimClient, clusterMoRef, vpcSubnetPort)
+}
+
+func vpcSubnetPortToResult(
+	ctx goctx.Context,
+	vimClient *vim25.Client,
+	clusterMoRef *vimtypes.ManagedObjectReference,
+	subnetPort *vpcv1alpha1.SubnetPort) (*NetworkInterfaceResult, error) {
+
+	var backing object.NetworkReference
+	networkID := subnetPort.Status.LogicalSwitchID
+	if clusterMoRef != nil {
+		ccr := object.NewClusterComputeResource(vimClient, *clusterMoRef)
+		// VPC is an NSX-T construct that is attached to an NSX-T Project.
+		networkRef, err := searchNsxtNetworkReference(ctx, ccr, networkID)
+		if err != nil {
+			return nil, err
+		}
+
+		backing = networkRef
+	}
+
+	ipConfigs := []NetworkInterfaceIPConfig{}
+
+	// No DHCP supported in VPC at the moment.
+	ipAddress := subnetPort.Status.IPAddresses
+	for _, ipAddr := range ipAddress {
+		if ipAddr.IP == "" {
+			continue
+		}
+
+		isIPv4 := net.ParseIP(ipAddr.IP).To4() != nil
+		ipConfig := NetworkInterfaceIPConfig{
+			IPCIDR:  ipCIDRNotation(ipAddr.IP, ipAddr.Netmask, isIPv4),
+			IsIPv4:  isIPv4,
+			Gateway: ipAddr.Gateway,
+		}
+
+		ipConfigs = append(ipConfigs, ipConfig)
+	}
+
+	result := &NetworkInterfaceResult{
+		IPConfigs:  ipConfigs,
+		MacAddress: subnetPort.Status.MACAddress,
+		ExternalID: subnetPort.Status.VIFID,
+		NetworkID:  networkID,
+		Backing:    backing,
+	}
+
+	return result, nil
+}
+
+func waitForReadyVPCSubnetPort(
+	vmCtx context.VirtualMachineContextA2,
+	client ctrlruntime.Client,
+	name string) (*vpcv1alpha1.SubnetPort, error) {
+
+	subnetPort := &vpcv1alpha1.SubnetPort{}
+	subnetPortKey := types.NamespacedName{Namespace: vmCtx.VM.Namespace, Name: name}
+
+	// TODO: Watch() this type instead.
+	err := wait.PollUntilContextTimeout(vmCtx, retryInterval, RetryTimeout, true, func(_ goctx.Context) (bool, error) {
+		if err := client.Get(vmCtx, subnetPortKey, subnetPort); err != nil {
+			return false, ctrlruntime.IgnoreNotFound(err)
+		}
+
+		for _, condition := range subnetPort.Status.Conditions {
+			if condition.Type == vpcv1alpha1.Ready && condition.Status == corev1.ConditionTrue {
+				return true, nil
+			}
+		}
+
+		return false, nil
+	})
+
+	if err != nil {
+		if wait.Interrupted(err) {
+			// Try to return a more meaningful error when timed out.
+			for _, cond := range subnetPort.Status.Conditions {
+				if cond.Type == vpcv1alpha1.Ready && cond.Status != corev1.ConditionTrue {
+					return nil, fmt.Errorf("subnetPort is not ready: %s - %s", cond.Reason, cond.Message)
+				}
+			}
+			return nil, fmt.Errorf("subnetPort is not ready yet")
+		}
+
+		return nil, err
+	}
+
+	return subnetPort, nil
 }
 
 func waitForReadyNCPNetworkInterface(

--- a/pkg/vmprovider/providers/vsphere2/network/nsxt.go
+++ b/pkg/vmprovider/providers/vsphere2/network/nsxt.go
@@ -51,6 +51,12 @@ func ResolveBackingPostPlacement(
 			if err != nil {
 				err = fmt.Errorf("post placement NSX-T backing fixup failed: %w", err)
 			}
+		// VPC is an NSX-T construct that is attached to an NSX-T Project.
+		case pkgconfig.NetworkProviderTypeVPC:
+			backing, err = searchNsxtNetworkReference(ctx, ccr, results.Results[idx].NetworkID)
+			if err != nil {
+				err = fmt.Errorf("post placement NSX-T-VPC backing fixup failed: %w", err)
+			}
 		default:
 			err = fmt.Errorf("only NSX-T networks are expected to need post placement backing fixup")
 		}

--- a/pkg/vmprovider/providers/vsphere2/network/nsxt_test.go
+++ b/pkg/vmprovider/providers/vsphere2/network/nsxt_test.go
@@ -41,7 +41,7 @@ var _ = Describe("ResolveBackingPostPlacement", func() {
 		ctx = nil
 	})
 
-	Context("returns success", func() {
+	Context("NSX-T returns success", func() {
 
 		BeforeEach(func() {
 			testConfig.WithNetworkEnv = builder.NetworkEnvNSXT
@@ -50,6 +50,34 @@ var _ = Describe("ResolveBackingPostPlacement", func() {
 				Results: []network.NetworkInterfaceResult{
 					{
 						NetworkID: builder.NsxTLogicalSwitchUUID,
+						Backing:   nil,
+					},
+				},
+			}
+		})
+
+		It("returns success", func() {
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fixedUp).To(BeTrue())
+
+			Expect(results.Results).To(HaveLen(1))
+			By("should populate the backing", func() {
+				backing := results.Results[0].Backing
+				Expect(backing).ToNot(BeNil())
+				Expect(backing.Reference()).To(Equal(ctx.NetworkRef.Reference()))
+			})
+		})
+	})
+
+	Context("VPC returns success", func() {
+
+		BeforeEach(func() {
+			testConfig.WithNetworkEnv = builder.NetworkEnvVPC
+
+			results = &network.NetworkInterfaceResults{
+				Results: []network.NetworkInterfaceResult{
+					{
+						NetworkID: builder.VPCLogicalSwitchUUID,
 						Backing:   nil,
 					},
 				},

--- a/test/builder/fake.go
+++ b/test/builder/fake.go
@@ -58,6 +58,7 @@ func KnownObjectTypes() []client.Object {
 		&netopv1alpha1.NetworkInterface{},
 		&vpcv1alpha1.Subnet{},
 		&vpcv1alpha1.SubnetSet{},
+		&vpcv1alpha1.SubnetPort{},
 	}
 }
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
In VPC mode, we should create a `SubnetPort` when it is time to do IPAM configuration for a Virtual Machine. This is very similar to the `VirtualNetworkInterface` flow of NSX-T, and similar logic should be applied to find the associated DVPG necessary.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes N/A


**Are there any special notes for your reviewer**:
`Subnet` and `SubnetSet` CRs are both supported as network choices if in VPC mode. But only one is supported at a time. Validation story will be a follow-up to avoid the situation both are specified.

- Testing done: 
  - After deploying a VM under VPC networking without specify a subnet/subnetset
```
VM
Name:         test-vm-photon
Status:
    Interfaces:
      Ip:
        Addresses:
          Address:  172.26.0.68
          State:    preferred
          Address:  fe80::650:56ff:fe00:cc02
          State:    unknown
        Mac Addr:   04:50:56:00:cc:02
      Name:         eth0

SubnetPort
Name:         test-vm-photon-eth0
Namespace:    yiyi-test
Labels:       <none>
Annotations:  nsx.vmware.com/attachment_ref: virtualmachine/test-vm-photon
API Version:  nsx.vmware.com/v1alpha1
Kind:         SubnetPort
Metadata:
  Creation Timestamp:  2024-02-27T22:18:44Z
  Finalizers:
    subnetport.nsx.vmware.com/finalizer
  Generation:  1
  Owner References:
    API Version:     vmoperator.vmware.com/v1alpha2
    Kind:            VirtualMachine
    Name:            test-vm-photon
    UID:             46e57916-c39f-4bef-83f1-91668962528f
  Resource Version:  538601
  UID:               73b8ed0a-6b10-467b-a463-dc5689b3f2b3
Spec:
  Attachment Ref:
Status:
  Conditions:
    Message:  NSX subnet port has been successfully created/updated
    Reason:   NSX API returned 200 response code for PATCH
    Status:   True
    Type:     Ready
  Ip Addresses:
    Gateway:          172.26.0.65
    Ip:               172.26.0.68
    Netmask:          255.255.255.192
  Logical Switch ID:  773d649e-165f-4c4d-a7ce-35ab5c78e827
  Mac Address:        04:50:56:00:cc:02
  Vif ID:             37336238-6564-4061-ad36-6231302d3436
Events:               <none>
```

**Please add a release note if necessary**:

```release-note
Create SubnetPort when realizing VPC networking
```