### PR TITLE
:sparkles: Introduce WCP_TKG_Multiple_CL FSS in vm-operator 

### DIFF
--- a/config/local/vmoperator/local_env_var_patch.yaml
+++ b/config/local/vmoperator/local_env_var_patch.yaml
@@ -33,3 +33,5 @@ spec:
           value: "false"
         - name: FSS_PODVMONSTRETCHEDSUPERVISOR
           value: "false"
+        - name: FSS_WCP_TKG_Multiple_CL
+          value: "false"

--- a/config/wcp/vmoperator/manager_env_var_patch.yaml
+++ b/config/wcp/vmoperator/manager_env_var_patch.yaml
@@ -87,3 +87,9 @@
   value:
     name: FSS_PODVMONSTRETCHEDSUPERVISOR
     value: "<FSS_PODVMONSTRETCHEDSUPERVISOR>"
+
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: FSS_WCP_TKG_Multiple_CL
+    value: "<FSS_WCP_TKG_Multiple_CL_VALUE>"

--- a/controllers/contentlibrary/v1alpha2/utils/constants.go
+++ b/controllers/contentlibrary/v1alpha2/utils/constants.go
@@ -13,4 +13,17 @@ const (
 
 	ContentLibraryItemVmopFinalizer        = "contentlibraryitem.vmoperator.vmware.com"
 	ClusterContentLibraryItemVmopFinalizer = "clustercontentlibraryitem.vmoperator.vmware.com"
+
+	// TKGServiceTypeLabelKeyPrefix is a label prefix used to identify
+	// labels that contain information about the type of service provided
+	// by a ClusterContentLibrary.
+	// This label prefix is replaced by MultipleCLServiceTypeLabelKeyPrefix
+	// when Features.TKGMultipleCL is enabled.
+	TKGServiceTypeLabelKeyPrefix = "type.services.vmware.com/"
+	// MultipleCLServiceTypeLabelKeyPrefix is a label prefix used to identify
+	// labels that contain information about the type of service provided
+	// by a ClusterContentLibrary.
+	// This label prefix is used only when Features.TKGMultipleCL is enabled,
+	// otherwise TKGServiceTypeLabelKeyPrefix is used.
+	MultipleCLServiceTypeLabelKeyPrefix = "services.supervisor.vmware.com/"
 )

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -107,6 +107,7 @@ type FeatureStates struct {
 	VMClassAsConfigDayNDate    bool // FSS_WCP_VM_CLASS_AS_CONFIG_DAYNDATE
 	VMOpV1Alpha2               bool // FSS_WCP_VMSERVICE_V1ALPHA2
 	PodVMOnStretchedSupervisor bool // FSS_PODVMONSTRETCHEDSUPERVISOR
+	TKGMultipleCL              bool // FSS_WCP_TKG_Multiple_CL
 }
 
 type InstanceStorage struct {

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -33,6 +33,7 @@ func Default() Config {
 			VMClassAsConfigDayNDate:    true,
 			VMOpV1Alpha2:               true,
 			PodVMOnStretchedSupervisor: false,
+			TKGMultipleCL:              false,
 		},
 		InstanceStorage: InstanceStorage{
 			JitterMaxFactor:      1.0,

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -57,6 +57,7 @@ func FromEnv() Config {
 	setBool(env.FSSWindowsSysprep, &config.Features.WindowsSysprep)
 	setBool(env.FSSVMServiceBackupRestore, &config.Features.AutoVADPBackupRestore)
 	setBool(env.FSSPodVMOnStretchedSupervisor, &config.Features.PodVMOnStretchedSupervisor)
+	setBool(env.FSSTKGMultipleCL, &config.Features.TKGMultipleCL)
 
 	return config
 }

--- a/pkg/config/env/env.go
+++ b/pkg/config/env/env.go
@@ -50,6 +50,7 @@ const (
 	FSSWindowsSysprep
 	FSSVMServiceBackupRestore
 	FSSPodVMOnStretchedSupervisor
+	FSSTKGMultipleCL
 
 	_varNameEnd
 )
@@ -152,6 +153,8 @@ func (n VarName) String() string {
 		return "FSS_WCP_VMSERVICE_BACKUPRESTORE"
 	case FSSPodVMOnStretchedSupervisor:
 		return "FSS_PODVMONSTRETCHEDSUPERVISOR"
+	case FSSTKGMultipleCL:
+		return "FSS_WCP_TKG_Multiple_CL"
 	}
 	panic("unknown environment variable")
 }

--- a/pkg/config/env_test.go
+++ b/pkg/config/env_test.go
@@ -95,6 +95,7 @@ var _ = Describe(
 					Expect(os.Setenv("FSS_WCP_NAMESPACED_VM_CLASS", "false")).To(Succeed())
 					Expect(os.Setenv("FSS_WCP_WINDOWS_SYSPREP", "false")).To(Succeed())
 					Expect(os.Setenv("FSS_WCP_VMSERVICE_BACKUPRESTORE", "true")).To(Succeed())
+					Expect(os.Setenv("FSS_WCP_TKG_Multiple_CL", "false")).To(Succeed())
 				})
 				It("Should return a default config overridden by the environment", func() {
 					Expect(config).To(Equal(pkgconfig.Config{


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR will bring in the following changes:
1.  Adding support for WCP_TKG_Multiple_CL in the following :
    a. YAML Changes
        - config/local/vmoperator/local_env_var_patch.yaml
        - config/wcp/vmoperator/manager_env_var_patch.yaml
    b. Adding a new variable for TKGMultipleCL
        -  pkg/config/config.go
        -  pkg/config/default.go
        -  pkg/config/env.go
        -  pkg/config/env/env.go
    c. Updating the variable `TKGMultipleCL` as env variable in UTs in `pkg/config/env_test.go`

2. Updating the reconcile logic in `setUpCVMIFromCCLItem` to update the labels on if the labels exists in CCLItems.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #427 


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:


```NONE

```