### PR TITLE
🌱 Remove v1a1 imports from v1a2 code

### DIFF
--- a/pkg/vmprovider/providers/vsphere2/placement/zone_placement_test.go
+++ b/pkg/vmprovider/providers/vsphere2/placement/zone_placement_test.go
@@ -10,12 +10,11 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
-
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/topology"
-	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/constants"
-	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/placement"
+	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere2/constants"
+	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere2/placement"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
@@ -72,14 +71,14 @@ func vcSimPlacement() {
 		testConfig  builder.VCSimTestConfig
 
 		vm         *vmopv1.VirtualMachine
-		vmCtx      context.VirtualMachineContext
+		vmCtx      context.VirtualMachineContextA2
 		configSpec *types.VirtualMachineConfigSpec
 	)
 
 	BeforeEach(func() {
 		testConfig = builder.VCSimTestConfig{WithV1A2: true}
 
-		vm = builder.DummyVirtualMachine()
+		vm = builder.DummyVirtualMachineA2()
 		vm.Name = "placement-test"
 
 		// Other than the name ConfigSpec contents don't matter for vcsim.
@@ -94,7 +93,7 @@ func vcSimPlacement() {
 
 		vm.Namespace = nsInfo.Namespace
 
-		vmCtx = context.VirtualMachineContext{
+		vmCtx = context.VirtualMachineContextA2{
 			Context: ctx,
 			Logger:  suite.GetLogger().WithValues("vmName", vm.Name),
 			VM:      vm,
@@ -183,7 +182,9 @@ func vcSimPlacement() {
 				Expect(resourcePolicy).ToNot(BeNil())
 				childRPName := resourcePolicy.Spec.ResourcePool.Name
 				Expect(childRPName).ToNot(BeEmpty())
-				vmCtx.VM.Spec.ResourcePolicyName = resourcePolicy.Name
+				vmCtx.VM.Spec.Reserved = &vmopv1.VirtualMachineReservedSpec{
+					ResourcePolicyName: resourcePolicy.Name,
+				}
 
 				result, err := placement.Placement(vmCtx, ctx.Client, ctx.VCClient.Client, configSpec, childRPName)
 				Expect(err).ToNot(HaveOccurred())
@@ -202,7 +203,7 @@ func vcSimPlacement() {
 
 		BeforeEach(func() {
 			testConfig.WithInstanceStorage = true
-			builder.AddDummyInstanceStorageVolume(vm)
+			builder.AddDummyInstanceStorageVolumeA2(vm)
 			testConfig.NumFaultDomains = 1 // Only support for non-HA "HA"
 		})
 
@@ -246,7 +247,9 @@ func vcSimPlacement() {
 				Expect(resourcePolicy).ToNot(BeNil())
 				childRPName := resourcePolicy.Spec.ResourcePool.Name
 				Expect(childRPName).ToNot(BeEmpty())
-				vmCtx.VM.Spec.ResourcePolicyName = resourcePolicy.Name
+				vmCtx.VM.Spec.Reserved = &vmopv1.VirtualMachineReservedSpec{
+					ResourcePolicyName: resourcePolicy.Name,
+				}
 
 				result, err := placement.Placement(vmCtx, ctx.Client, ctx.VCClient.Client, configSpec, childRPName)
 				Expect(err).ToNot(HaveOccurred())

--- a/pkg/vmprovider/providers/vsphere2/vmprovider_test.go
+++ b/pkg/vmprovider/providers/vsphere2/vmprovider_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/vmware-tanzu/vm-operator/pkg/util"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider"
-	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere"
+	vsphere "github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere2"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
@@ -21,7 +21,7 @@ func cpuFreqTests() {
 	var (
 		testConfig builder.VCSimTestConfig
 		ctx        *builder.TestContextForVCSim
-		vmProvider vmprovider.VirtualMachineProviderInterface
+		vmProvider vmprovider.VirtualMachineProviderInterfaceA2
 	)
 
 	BeforeEach(func() {

--- a/webhooks/persistentvolumeclaim/validation/persistentvolumeclaim_validator.go
+++ b/webhooks/persistentvolumeclaim/validation/persistentvolumeclaim_validator.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/vmware-tanzu/vm-operator/pkg/builder"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
-	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/constants"
+	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere2/constants"
 	"github.com/vmware-tanzu/vm-operator/webhooks/common"
 )
 

--- a/webhooks/persistentvolumeclaim/validation/persistentvolumeclaim_validator_unit_test.go
+++ b/webhooks/persistentvolumeclaim/validation/persistentvolumeclaim_validator_unit_test.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
-	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere/constants"
+	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere2/constants"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 

--- a/webhooks/virtualmachinepublishrequest/v1alpha2/validation/virtualmachinepublishrequest_validator_intg_test.go
+++ b/webhooks/virtualmachinepublishrequest/v1alpha2/validation/virtualmachinepublishrequest_validator_intg_test.go
@@ -30,10 +30,6 @@ func newIntgValidatingWebhookContext() *intgValidatingWebhookContext {
 
 	ctx.vmPub = builder.DummyVirtualMachinePublishRequestA2("dummy-vmpub", ctx.Namespace, "dummy-vm",
 		"dummy-item", "dummy-cl")
-	vm := builder.DummyVirtualMachine()
-	vm.Name = "dummy-vm"
-	vm.Namespace = ctx.Namespace
-
 	return ctx
 }
 

--- a/webhooks/virtualmachinepublishrequest/v1alpha2/validation/virtualmachinepublishrequest_validator_unit_test.go
+++ b/webhooks/virtualmachinepublishrequest/v1alpha2/validation/virtualmachinepublishrequest_validator_unit_test.go
@@ -77,7 +77,6 @@ func unitTestsValidateCreate() {
 		invalidTargetLocationKind       bool
 		sourceNotFound                  bool
 		defaultSourceNotFound           bool
-		defaultSourceExists             bool
 		targetLocationNotWritable       bool
 		targetLocationNameEmpty         bool
 		targetLocationNotFound          bool
@@ -107,13 +106,6 @@ func unitTestsValidateCreate() {
 
 		if args.defaultSourceNotFound {
 			ctx.vmPub.Spec.Source.Name = ""
-		}
-
-		if args.defaultSourceExists {
-			defaultVM := builder.DummyVirtualMachine()
-			defaultVM.Name = ctx.vmPub.Name
-			defaultVM.Namespace = ctx.vmPub.Namespace
-			Expect(ctx.Client.Create(ctx, defaultVM)).To(Succeed())
 		}
 
 		if args.targetLocationNotWritable {


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

This is just a few cherry-picked commits from #401 that fixes v1a2 code still using v1a1 imports.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

I'll rebase #401 after this goes in - I want to keep that MR just v1a1 code removal. Highlights the need for more refactoring so that v1a3+ isn't so invasive.

**Please add a release note if necessary**:


```release-note
NONE
```