### PR TITLE
✨ Add GuestDeviceName to network interfaces spec

### DIFF
--- a/api/v1alpha1/virtualmachine_conversion_test.go
+++ b/api/v1alpha1/virtualmachine_conversion_test.go
@@ -90,6 +90,7 @@ func TestVirtualMachineConversion(t *testing.T) {
 								},
 								Name: "primary",
 							},
+							GuestDeviceName: "eth10",
 						},
 						{
 							Name: "ncp-interface",
@@ -100,6 +101,7 @@ func TestVirtualMachineConversion(t *testing.T) {
 								},
 								Name: "segment1",
 							},
+							GuestDeviceName: "eth20",
 						},
 						{
 							Name: "nsx-vpc-subnet-interface",
@@ -110,6 +112,7 @@ func TestVirtualMachineConversion(t *testing.T) {
 								},
 								Name: "segment-subnet",
 							},
+							GuestDeviceName: "eth30",
 						},
 						{
 							Name: "nsx-vpc-subnetset-interface",
@@ -130,13 +133,14 @@ func TestVirtualMachineConversion(t *testing.T) {
 								},
 								Name: "secondary",
 							},
-							Addresses:   []string{"1.1.1.11", "2.2.2.22"},
-							DHCP4:       true,
-							DHCP6:       true,
-							Gateway4:    "1.1.1.1",
-							Gateway6:    "2.2.2.2",
-							MTU:         ptrOf[int64](9000),
-							Nameservers: []string{"9.9.9.9"},
+							GuestDeviceName: "eth40",
+							Addresses:       []string{"1.1.1.11", "2.2.2.22"},
+							DHCP4:           true,
+							DHCP6:           true,
+							Gateway4:        "1.1.1.1",
+							Gateway6:        "2.2.2.2",
+							MTU:             ptrOf[int64](9000),
+							Nameservers:     []string{"9.9.9.9"},
 							Routes: []nextver.VirtualMachineNetworkRouteSpec{
 								{
 									To:     "3.3.3.3",

--- a/api/v1alpha2/virtualmachine_network_types.go
+++ b/api/v1alpha2/virtualmachine_network_types.go
@@ -27,10 +27,10 @@ type VirtualMachineNetworkInterfaceSpec struct {
 	// Name describes the unique name of this network interface, used to
 	// distinguish it from other network interfaces attached to this VM.
 	//
-	// This value is also used to rename the device inside the guest when the
-	// bootstrap provider is CloudInit. Please note it is up to the user to
-	// ensure the provided device name does not conflict with any other devices
-	// inside the guest, ex. dvd, cdrom, sda, etc.
+	// When the bootstrap provider is Cloud-Init and GuestDeviceName is not
+	// specified, the device inside the guest will be renamed to this value.
+	// Please note it is up to the user to ensure the provided name does not
+	// conflict with any other devices inside the guest, ex. dvd, cdrom, sda, etc.
 	//
 	// +kubebuilder:validation:Pattern="^[a-z0-9]{2,}$"
 	Name string `json:"name"`
@@ -43,6 +43,15 @@ type VirtualMachineNetworkInterfaceSpec struct {
 	//
 	// +optional
 	Network common.PartialObjectRef `json:"network,omitempty"`
+
+	// GuestDeviceName is used to rename the device inside the guest when the
+	// bootstrap provider is Cloud-Init. Please note it is up to the user to
+	// ensure the provided device name does not conflict with any other devices
+	// inside the guest, ex. dvd, cdrom, sda, etc.
+	//
+	// +optional
+	// +kubebuilder:validation:Pattern=^\w\w+$
+	GuestDeviceName string `json:"guestDeviceName,omitempty"`
 
 	// Addresses is an optional list of IP4 or IP6 addresses to assign to this
 	// interface.

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -1444,6 +1444,14 @@ spec:
                             must include the network prefix length, ex. 2001:db8:101::1/64.
                             \n Please note this field is mutually exclusive with DHCP6."
                           type: string
+                        guestDeviceName:
+                          description: GuestDeviceName is used to rename the device
+                            inside the guest when the bootstrap provider is Cloud-Init.
+                            Please note it is up to the user to ensure the provided
+                            device name does not conflict with any other devices inside
+                            the guest, ex. dvd, cdrom, sda, etc.
+                          pattern: ^\w\w+$
+                          type: string
                         mtu:
                           description: "MTU is the Maximum Transmission Unit size
                             in bytes. \n Please note this feature is available only
@@ -1453,11 +1461,12 @@ spec:
                         name:
                           description: "Name describes the unique name of this network
                             interface, used to distinguish it from other network interfaces
-                            attached to this VM. \n This value is also used to rename
-                            the device inside the guest when the bootstrap provider
-                            is CloudInit. Please note it is up to the user to ensure
-                            the provided device name does not conflict with any other
-                            devices inside the guest, ex. dvd, cdrom, sda, etc."
+                            attached to this VM. \n When the bootstrap provider is
+                            Cloud-Init and GuestDeviceName is not specified, the device
+                            inside the guest will be renamed to this value. Please
+                            note it is up to the user to ensure the provided name
+                            does not conflict with any other devices inside the guest,
+                            ex. dvd, cdrom, sda, etc."
                           pattern: ^[a-z0-9]{2,}$
                           type: string
                         nameservers:

--- a/pkg/vmprovider/providers/vsphere2/network/netplan.go
+++ b/pkg/vmprovider/providers/vsphere2/network/netplan.go
@@ -54,7 +54,7 @@ func NetPlanCustomization(result NetworkInterfaceResults) (*Netplan, error) {
 			Match: NetplanEthernetMatch{
 				MacAddress: NormalizeNetplanMac(r.MacAddress),
 			},
-			SetName: r.Name,
+			SetName: r.GuestDeviceName,
 			MTU:     r.MTU,
 			Nameservers: NetplanEthernetNameserver{
 				Addresses: r.Nameservers,
@@ -90,7 +90,7 @@ func NetPlanCustomization(result NetworkInterfaceResults) (*Netplan, error) {
 			npEth.Routes = append(npEth.Routes, NetplanEthernetRoute(route))
 		}
 
-		netPlan.Ethernets[npEth.SetName] = npEth
+		netPlan.Ethernets[r.Name] = npEth
 	}
 
 	return netPlan, nil

--- a/pkg/vmprovider/providers/vsphere2/network/netplan_test.go
+++ b/pkg/vmprovider/providers/vsphere2/network/netplan_test.go
@@ -15,7 +15,8 @@ import (
 
 var _ = Describe("Netplan", func() {
 	const (
-		ifName        = "eth0"
+		ifName        = "my-interface"
+		guestDevName  = "eth42"
 		macAddr1      = "50-8A-80-9D-28-22"
 		macAddr1Norm  = "50:8a:80:9d:28:22"
 		ipv4Gateway   = "192.168.1.1"
@@ -61,13 +62,14 @@ var _ = Describe("Netplan", func() {
 								Gateway: ipv6Gateway,
 							},
 						},
-						MacAddress:    macAddr1,
-						Name:          ifName,
-						DHCP4:         false,
-						DHCP6:         false,
-						MTU:           1500,
-						Nameservers:   []string{dnsServer1},
-						SearchDomains: []string{searchDomain1},
+						MacAddress:      macAddr1,
+						Name:            ifName,
+						GuestDeviceName: guestDevName,
+						DHCP4:           false,
+						DHCP6:           false,
+						MTU:             1500,
+						Nameservers:     []string{dnsServer1},
+						SearchDomains:   []string{searchDomain1},
 						Routes: []network.NetworkInterfaceRoute{
 							{
 								To:     "185.107.56.59",
@@ -89,7 +91,7 @@ var _ = Describe("Netplan", func() {
 
 				np := netplan.Ethernets[ifName]
 				Expect(np.Match.MacAddress).To(Equal(macAddr1Norm))
-				Expect(np.SetName).To(Equal(ifName))
+				Expect(np.SetName).To(Equal(guestDevName))
 				Expect(np.Dhcp4).To(BeFalse())
 				Expect(np.Dhcp6).To(BeFalse())
 				Expect(np.Addresses).To(HaveLen(2))
@@ -112,13 +114,14 @@ var _ = Describe("Netplan", func() {
 			BeforeEach(func() {
 				results.Results = []network.NetworkInterfaceResult{
 					{
-						MacAddress:    macAddr1,
-						Name:          "eth0",
-						DHCP4:         true,
-						DHCP6:         true,
-						MTU:           9000,
-						Nameservers:   []string{dnsServer1},
-						SearchDomains: []string{searchDomain1},
+						MacAddress:      macAddr1,
+						Name:            ifName,
+						GuestDeviceName: guestDevName,
+						DHCP4:           true,
+						DHCP6:           true,
+						MTU:             9000,
+						Nameservers:     []string{dnsServer1},
+						SearchDomains:   []string{searchDomain1},
 					},
 				}
 			})
@@ -133,7 +136,7 @@ var _ = Describe("Netplan", func() {
 
 				np := netplan.Ethernets[ifName]
 				Expect(np.Match.MacAddress).To(Equal(macAddr1Norm))
-				Expect(np.SetName).To(Equal(ifName))
+				Expect(np.SetName).To(Equal(guestDevName))
 				Expect(np.Dhcp4).To(BeTrue())
 				Expect(np.Dhcp6).To(BeTrue())
 				Expect(np.MTU).To(BeEquivalentTo(9000))

--- a/pkg/vmprovider/providers/vsphere2/network/network.go
+++ b/pkg/vmprovider/providers/vsphere2/network/network.go
@@ -47,13 +47,14 @@ type NetworkInterfaceResult struct {
 	Device vimtypes.BaseVirtualDevice
 
 	// Fields from the InterfaceSpec used later during customization.
-	Name          string
-	DHCP4         bool
-	DHCP6         bool
-	MTU           int64
-	Nameservers   []string
-	SearchDomains []string
-	Routes        []NetworkInterfaceRoute
+	Name            string
+	GuestDeviceName string
+	DHCP4           bool
+	DHCP6           bool
+	MTU             int64
+	Nameservers     []string
+	SearchDomains   []string
+	Routes          []NetworkInterfaceRoute
 }
 
 type NetworkInterfaceIPConfig struct {
@@ -194,6 +195,11 @@ func applyInterfaceSpecToResult(
 	}
 
 	result.Name = interfaceSpec.Name
+	result.GuestDeviceName = interfaceSpec.GuestDeviceName
+	if result.GuestDeviceName == "" {
+		result.GuestDeviceName = result.Name
+	}
+
 	result.DHCP4 = dhcp4
 	result.DHCP6 = dhcp6
 	result.Nameservers = interfaceSpec.Nameservers

--- a/pkg/vmprovider/providers/vsphere2/network/network_test.go
+++ b/pkg/vmprovider/providers/vsphere2/network/network_test.go
@@ -120,8 +120,9 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", func() {
 				BeforeEach(func() {
 					interfaceSpecs = []vmopv1.VirtualMachineNetworkInterfaceSpec{
 						{
-							Name:    "eth0",
-							Network: common.PartialObjectRef{Name: networkName},
+							Name:            "my-network-interface",
+							GuestDeviceName: "eth42",
+							Network:         common.PartialObjectRef{Name: networkName},
 							Addresses: []string{
 								"172.42.1.100/24",
 								"fd1a:6c85:79fe:7c98:0000:0000:0000:000f/56",
@@ -154,6 +155,11 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", func() {
 						backingInfo, ok := backing.(*types.VirtualEthernetCardDistributedVirtualPortBackingInfo)
 						Expect(ok).To(BeTrue())
 						Expect(backingInfo.Port.PortgroupKey).To(Equal(ctx.NetworkRef.Reference().Value))
+					})
+
+					By("has expected names", func() {
+						Expect(result.Name).To(Equal("my-network-interface"))
+						Expect(result.GuestDeviceName).To(Equal("eth42"))
 					})
 
 					Expect(result.DHCP4).To(BeFalse())
@@ -283,6 +289,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", func() {
 				Expect(result.Backing).ToNot(BeNil())
 				Expect(result.Backing.Reference()).To(Equal(ctx.NetworkRef.Reference()))
 				Expect(result.Name).To(Equal(interfaceName))
+				Expect(result.GuestDeviceName).To(Equal(interfaceName))
 
 				Expect(result.IPConfigs).To(HaveLen(2))
 				ipConfig := result.IPConfigs[0]
@@ -371,6 +378,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", func() {
 					Expect(result.Backing).ToNot(BeNil())
 					Expect(result.Backing.Reference()).To(Equal(ctx.NetworkRef.Reference()))
 					Expect(result.Name).To(Equal(interfaceName))
+					Expect(result.GuestDeviceName).To(Equal(interfaceName))
 
 					Expect(result.IPConfigs).To(HaveLen(2))
 					ipConfig := result.IPConfigs[0]

--- a/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator.go
@@ -623,6 +623,16 @@ func (v validator) validateNetworkInterfaceSpecWithBootstrap(
 		sysPrep = vm.Spec.Bootstrap.Sysprep
 	}
 
+	if guestDeviceName := interfaceSpec.GuestDeviceName; guestDeviceName != "" {
+		if cloudInit == nil {
+			allErrs = append(allErrs, field.Invalid(
+				interfacePath.Child("guestDeviceName"),
+				guestDeviceName,
+				"guestDeviceName is available only with the following bootstrap providers: CloudInit",
+			))
+		}
+	}
+
 	if mtu := interfaceSpec.MTU; mtu != nil {
 		if cloudInit == nil {
 			allErrs = append(allErrs, field.Invalid(


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

When using cloud-init this allows the device name in the guest to be set to something different that what the name is in the k8s VM and used for the corresponding network interface CR name.

This can be useful if desired device name in the guest does not conform to what k8s allows since Name field is used for part of the interface CR name.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note
When using CloudInit for the bootstrap, the network device name in the guest can be specified with the GuestDeviceName field in the network interface spec. If omitted, the device will be renamed to the Name field of the network interface spec.
```