### PR TITLE
🌱 Only default to LinuxPrep GOSC on Linux VMs

### DIFF
--- a/api/v1alpha2/virtualmachine_types.go
+++ b/api/v1alpha2/virtualmachine_types.go
@@ -223,6 +223,9 @@ type VirtualMachineSpec struct {
 	// Bootstrap describes the desired state of the guest's bootstrap
 	// configuration.
 	//
+	// If omitted, a default bootstrap method may be selected based on the
+	// guest OS identifier. If Linux, then the LinuxPrep method is used.
+	//
 	// +optional
 	Bootstrap *VirtualMachineBootstrapSpec `json:"bootstrap,omitempty"`
 

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -705,8 +705,10 @@ spec:
                     type: string
                 type: object
               bootstrap:
-                description: Bootstrap describes the desired state of the guest's
-                  bootstrap configuration.
+                description: "Bootstrap describes the desired state of the guest's
+                  bootstrap configuration. \n If omitted, a default bootstrap method
+                  may be selected based on the guest OS identifier. If Linux, then
+                  the LinuxPrep method is used."
                 properties:
                   cloudInit:
                     description: "CloudInit may be used to bootstrap Linux guests


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

In the old v1a1 code, we'd always fallback to LinuxPrep regardless if the guest was Linux or not, and we have tests that assume that behavior. Improve that here by only doing that on guests that would indicate to be some known Linux distro.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

IDK how intentional the prior behavior was but since we have tests that assume this behavior and it is a LCD way of passing in the network config keep doing so. 

**Please add a release note if necessary**:

```release-note
If Bootstrap is omitted and the guest OS identifier is Linux, then the bootstrap will be defaulted to LinuxPrep.
```