### PR TITLE
:sparkles: Add VM create/update e2e testing for VPC networking

### DIFF
--- a/pkg/vmprovider/providers/vsphere2/vmprovider_vm2_test.go
+++ b/pkg/vmprovider/providers/vsphere2/vmprovider_vm2_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2023-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package vsphere_test
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	vpcv1alpha1 "github.com/vmware-tanzu/nsx-operator/pkg/apis/nsx.vmware.com/v1alpha1"
 	ncpv1alpha1 "github.com/vmware-tanzu/vm-operator/external/ncp/api/v1alpha1"
 	netopv1alpha1 "github.com/vmware-tanzu/vm-operator/external/net-operator/api/v1alpha1"
 
@@ -30,10 +31,10 @@ import (
 
 // vmE2ETests() tries to close the gap in the existing vmTests() have in the sense that we don't do e2e-like
 // tests of the typical VM create/update workflow. This somewhat of a super-set of the vmTests() but those
-// tests are already kind of unwieldy and   in places, and until we switch over to v1a2, I don't
+// tests are already kind of unwieldy and in places, and until we switch over to v1a2, I don't want
 // to disturb that file so keeping things in sync easier.
-// For now, these tests focus on a real - VDS or NSX-T - network env w/ cloud init, and we'll see how these
-// need to evolve.
+// For now, these tests focus on a real - VDS, NSX-T or VPC - network env w/ cloud init or sysprep,
+// and we'll see how these need to evolve.
 func vmE2ETests() {
 
 	var (
@@ -43,8 +44,10 @@ func vmE2ETests() {
 		vmProvider  vmprovider.VirtualMachineProviderInterfaceA2
 		nsInfo      builder.WorkloadNamespaceInfo
 
-		vm      *vmopv1.VirtualMachine
-		vmClass *vmopv1.VirtualMachineClass
+		vm              *vmopv1.VirtualMachine
+		vmClass         *vmopv1.VirtualMachineClass
+		cloudInitSecret *corev1.Secret
+		sysprepSecret   *corev1.Secret
 	)
 
 	BeforeEach(func() {
@@ -81,6 +84,27 @@ func vmE2ETests() {
 			vm.Spec.Network.Interfaces[0].Nameservers = []string{"1.1.1.1", "8.8.8.8"}
 			vm.Spec.Network.Interfaces[0].SearchDomains = []string{"vmware.local"}
 		}
+		// used in VDS and VPC network
+		cloudInitSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-cloud-init-secret",
+				Namespace: nsInfo.Namespace,
+			},
+			Data: map[string][]byte{
+				"user-value": []byte(""),
+			},
+		}
+
+		// used in NSX-T network
+		sysprepSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-sysprep-secret",
+				Namespace: nsInfo.Namespace,
+			},
+			Data: map[string][]byte{
+				"unattend": []byte("foo"),
+			},
+		}
 	})
 
 	AfterEach(func() {
@@ -92,6 +116,8 @@ func vmE2ETests() {
 
 		vm = nil
 		vmClass = nil
+		cloudInitSecret = nil
+		sysprepSecret = nil
 	})
 
 	Context("Nil fields in Spec", func() {
@@ -145,17 +171,7 @@ func vmE2ETests() {
 		Context("CloudInit Bootstrap", func() {
 
 			JustBeforeEach(func() {
-				cloudInitSecret := &corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "my-cloud-init-secret",
-						Namespace: nsInfo.Namespace,
-					},
-					Data: map[string][]byte{
-						"user-value": []byte(""),
-					},
-				}
 				Expect(ctx.Client.Create(ctx, cloudInitSecret)).To(Succeed())
-
 				vm.Spec.Bootstrap = &vmopv1.VirtualMachineBootstrapSpec{
 					CloudInit: &vmopv1.VirtualMachineBootstrapCloudInitSpec{
 						RawCloudConfig: &common.SecretKeySelector{
@@ -262,15 +278,6 @@ func vmE2ETests() {
 		Context("Sysprep Bootstrap", func() {
 
 			JustBeforeEach(func() {
-				sysprepSecret := &corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "my-sysprep-secret",
-						Namespace: nsInfo.Namespace,
-					},
-					Data: map[string][]byte{
-						"unattend": []byte("foo"),
-					},
-				}
 				Expect(ctx.Client.Create(ctx, sysprepSecret)).To(Succeed())
 
 				vm.Spec.Bootstrap = &vmopv1.VirtualMachineBootstrapSpec{
@@ -317,6 +324,115 @@ func vmE2ETests() {
 						},
 					}
 					Expect(ctx.Client.Status().Update(ctx, netInterface)).To(Succeed())
+				})
+
+				err = vmProvider.CreateOrUpdateVirtualMachine(ctx, vm)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("has expected conditions", func() {
+					Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionClassReady)).To(BeTrue())
+					Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionImageReady)).To(BeTrue())
+					Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionStorageReady)).To(BeTrue())
+					Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionBootstrapReady)).To(BeTrue())
+					Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionNetworkReady)).To(BeTrue())
+					Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionPlacementReady)).To(BeTrue())
+					Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionCreated)).To(BeTrue())
+				})
+
+				Expect(vm.Status.UniqueID).ToNot(BeEmpty())
+				vcVM := ctx.GetVMFromMoID(vm.Status.UniqueID)
+				var o mo.VirtualMachine
+				Expect(vcVM.Properties(ctx, vcVM.Reference(), nil, &o)).To(Succeed())
+				devList, err := vcVM.Device(ctx)
+				Expect(err).ToNot(HaveOccurred())
+
+				// For now just check the expected Nic backing.
+				By("Has expected NIC backing", func() {
+					l := devList.SelectByType(&types.VirtualEthernetCard{})
+					Expect(l).To(HaveLen(1))
+
+					dev1 := l[0].GetVirtualDevice()
+					backingInfo, ok := dev1.Backing.(*types.VirtualEthernetCardDistributedVirtualPortBackingInfo)
+					Expect(ok).Should(BeTrue())
+					Expect(backingInfo.Port.PortgroupKey).To(Equal(ctx.NetworkRef.Reference().Value))
+				})
+			})
+		})
+	})
+
+	Context("VPC", func() {
+
+		const (
+			networkName   = "my-vpc-network"
+			interfaceName = "eth0"
+		)
+
+		BeforeEach(func() {
+			testConfig.WithNetworkEnv = builder.NetworkEnvVPC
+		})
+
+		JustBeforeEach(func() {
+			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{
+				Interfaces: []vmopv1.VirtualMachineNetworkInterfaceSpec{
+					{
+						Name: interfaceName,
+						Network: common.PartialObjectRef{
+							Name: networkName,
+							TypeMeta: metav1.TypeMeta{
+								Kind:       "Subnet",
+								APIVersion: "nsx.vmware.com/v1alpha1",
+							},
+						},
+					},
+				},
+			}
+		})
+
+		Context("CloudInit Bootstrap", func() {
+
+			JustBeforeEach(func() {
+				Expect(ctx.Client.Create(ctx, cloudInitSecret)).To(Succeed())
+				vm.Spec.Bootstrap = &vmopv1.VirtualMachineBootstrapSpec{
+					CloudInit: &vmopv1.VirtualMachineBootstrapCloudInitSpec{
+						RawCloudConfig: &common.SecretKeySelector{
+							Name: cloudInitSecret.Name,
+						},
+					},
+				}
+			})
+
+			It("DoIt", func() {
+				err := vmProvider.CreateOrUpdateVirtualMachine(ctx, vm)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("subnetPort is not ready yet"))
+				Expect(conditions.IsFalse(vm, vmopv1.VirtualMachineConditionNetworkReady)).To(BeTrue())
+
+				By("simulate successful NSX Operator reconcile", func() {
+					subnetPort := &vpcv1alpha1.SubnetPort{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      network.VPCCRName(vm.Name, networkName, interfaceName),
+							Namespace: vm.Namespace,
+						},
+					}
+					Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(subnetPort), subnetPort)).To(Succeed())
+					Expect(subnetPort.Spec.Subnet).To(Equal(networkName))
+
+					subnetPort.Status.MACAddress = "01-23-45-67-89-AB-CD-EF"
+					subnetPort.Status.LogicalSwitchID = builder.VPCLogicalSwitchUUID
+					subnetPort.Status.IPAddresses = []vpcv1alpha1.SubnetPortIPAddress{
+						{
+							IP:      "192.168.1.110",
+							Gateway: "192.168.1.1",
+							Netmask: "255.255.255.0",
+						},
+					}
+					subnetPort.Status.Conditions = []vpcv1alpha1.Condition{
+						{
+							Type:   vpcv1alpha1.Ready,
+							Status: corev1.ConditionTrue,
+						},
+					}
+					Expect(ctx.Client.Status().Update(ctx, subnetPort)).To(Succeed())
 				})
 
 				err = vmProvider.CreateOrUpdateVirtualMachine(ctx, vm)


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This change adds a e2e like test in vcsim env for VPC networking to better test the create-update reconcile workflow. It creates a VM with CloudInit Bootstrap and simulates successful NSX Operator reconcile to check VM conditions and NIC Backing.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

FixesN/A


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:



```release-note
Add VM create/update e2e testing for VPC networking
```