### PR TITLE
🐛 Fix linter config after rm v1a1 bits

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,9 +1,7 @@
 run:
-  deadline: 5m
   skip-files:
    - ".*generated.*\\.go"
    - external/
-   - controllers/virtualmachineservice/v1alpha1/utils/
    - controllers/virtualmachineservice/v1alpha2/utils/
    - pkg/util/cloudinit/schema/
 
@@ -62,17 +60,15 @@ linters:
 issues:
   max-same-issues: 0
   max-issues-per-linter: 0
-  # Disable the default golangci exclusions so no issues are skipped. This will help reviewers to focus on
-  # reviewing the most relevant changes in the PRs and avoid nitpicking.
+  # Disable the default golangci exclusions so no issues are skipped. This helps
+  # reviewers focus on reviewing the most relevant changes in the PRs and avoid
+  # nitpicking.
   exclude-use-default: false
   exclude:
   # TODO: Remove the following exclusions over time once we have fixed those.
   - "ST1000: at least one file in a package should have a package comment"
   # List of regexps of issue texts to exclude, empty list by default.
   exclude-rules:
-  - linters:
-    - staticcheck
-    text: "^SA1019: [^.]+.Status.ContentLibraryRef is deprecated"
   - linters:
     - staticcheck
     text: "^SA1019: [^.]+.Wait is deprecated: Please use WaitEx instead."
@@ -86,20 +82,19 @@ issues:
     - revive
     text: "^exported: comment on exported const"
   - linters:
-    - gosec
-    text: "G114: Use of net/http serve function that has no support for setting timeouts"
-  - linters:
     - staticcheck
     text: "^SA1019: .*TCPSocket is deprecated"
   # Dot imports for gomega or ginkgo are allowed within test files.
-  - path: test/
+  - path: test/builder/intg_test_context.go
     text: should not use dot imports
-  # All of our webhooks follow the pattern of passing the webhook context which contains fields like the Client.
-  # Ignore the linter warnings for now.
+  - path: test/builder/test_suite.go
+    text: should not use dot imports
+  - path: test/builder/vcsim_test_context.go
+    text: should not use dot imports
+  # All of our webhooks follow the pattern of passing the webhook context which
+  # contains fields like the Client. Ignore the linter warnings for now.
   - path: webhooks/
     text: ".* `ctx` is unused"
-  - path: pkg/vmprovider/providers/vsphere/internal/internal.go
-    text: ".*ST1003|don\'t use underscores in Go names.*"
   - path: _test.go
     linters:
     - gosec

--- a/main.go
+++ b/main.go
@@ -348,5 +348,12 @@ func runProfiler(addr string) {
 	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
 	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
-	_ = http.ListenAndServe(addr, mux)
+
+	server := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	_ = server.ListenAndServe()
 }

--- a/pkg/webconsolevalidation/server.go
+++ b/pkg/webconsolevalidation/server.go
@@ -6,6 +6,7 @@ package webconsolevalidation
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
@@ -45,7 +46,13 @@ func RunServer(addr, path string) error {
 	mux := http.NewServeMux()
 	mux.HandleFunc(path, HandleWebConsoleValidation)
 
-	return http.ListenAndServe(addr, mux)
+	server := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	return server.ListenAndServe()
 }
 
 // HandleWebConsoleValidation handles the web-console validation server requests.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->

This patch:

* updates the project's linter config to:
  * remove some vestigial references to v1alpha1 code
  * remove the linter deadline as it is no longer supported by the linter
* updates two places where `ListenAndServe` was used instead of an explicit server with a timeout



**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```