### PR TITLE
🐛 Fix PodVMOnStretchedSupervisor with WFFC storage class

### DIFF
--- a/pkg/util/cns.go
+++ b/pkg/util/cns.go
@@ -3,8 +3,6 @@
 
 package util
 
-import "fmt"
-
 // CNSAttachmentNameForVolume returns the name of the CnsNodeVmAttachment based
 // on the VM and Volume name.
 // This matches the naming used in previous code but there are situations where
@@ -16,10 +14,4 @@ import "fmt"
 // The VM webhook validate that this result will be a valid k8s name.
 func CNSAttachmentNameForVolume(vmName, volumeName string) string {
 	return vmName + "-" + volumeName
-}
-
-// CNSStoragePolicyQuotaName returns the name of the StorageQuotaPolicy CR based
-// on the name of the storage class.
-func CNSStoragePolicyQuotaName(storageClassName string) string {
-	return fmt.Sprintf("%s-storagepolicyquota", storageClassName)
 }

--- a/test/builder/util.go
+++ b/test/builder/util.go
@@ -188,6 +188,11 @@ func DummyStoragePolicyQuota(quotaName, quotaNs, className string) *cnsstoragev1
 		},
 		Spec: cnsstoragev1.StoragePolicyQuotaSpec{StoragePolicyId: "uuid-abcd-1234"},
 		Status: cnsstoragev1.StoragePolicyQuotaStatus{
+			SCLevelQuotaStatuses: []cnsstoragev1.SCLevelQuotaStatus{
+				{
+					StorageClassName: className,
+				},
+			},
 			ResourceTypeLevelQuotaStatuses: []cnsstoragev1.ResourceTypeLevelQuotaStatus{
 				{
 					ResourceExtensionName: "volume.cns.vsphere.vmware.com",


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

With a WaitForFirstConsumer storage class, "-wffc" is appended to the storage class name but the StorageQuotaPolicy still has just the base name so we cannot depend on those names always being the same.

Instead list all the StorageQuotaPolicys in the namespace to determine if the storage class is associated with the namespace.

When the PodVMOnStretchedSupervisor FFS is enabled, both the ResourceQuotas and StorageQuotaPolicys on non-stretched SV so drop the AZ > 1 check.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:


```release-note
NONE
```