### PR TITLE
✨ Test Labels

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,5 @@
 run:
+  timeout: 5m
   skip-files:
    - ".*generated.*\\.go"
    - external/

--- a/Makefile
+++ b/Makefile
@@ -144,26 +144,19 @@ help: ## Display this help
 .PHONY: test-nocover
 test-nocover: | $(GINKGO)
 test-nocover: ## Run Tests (without code coverage)
-	ENABLE_UNIT_TESTS=true \
-	ENABLE_INTEGRATION_TESTS=false \
-	hack/test.sh
+	LABEL_FILTER='!envtest' hack/test.sh
 
 .PHONY: test
 test: | $(GINKGO)
 test: ## Run tests
 	@rm -f $(COVERAGE_FILE)
-	ENABLE_UNIT_TESTS=true \
-	ENABLE_INTEGRATION_TESTS=false \
-	hack/test.sh $(COVERAGE_FILE)
+	LABEL_FILTER='!envtest' hack/test.sh $(COVERAGE_FILE)
 
 .PHONY: test-integration
 test-integration: | $(GINKGO) $(ETCD) $(KUBE_APISERVER)
 test-integration: ## Run integration tests
 	@rm -f $(INT_COV_FILE)
-	ENABLE_UNIT_TESTS=false \
-	ENABLE_INTEGRATION_TESTS=true \
-	TEST_PKGS="./controllers ./pkg ./webhooks" \
-	hack/test.sh $(INT_COV_FILE)
+	LABEL_FILTER='envtest' hack/test.sh $(INT_COV_FILE)
 
 .PHONY: coverage
 coverage-merge: $(GOCOVMERGE) $(GOCOV) $(GOCOV_XML)

--- a/api/go.mod
+++ b/api/go.mod
@@ -9,10 +9,10 @@ replace github.com/onsi/ginkgo/v2 => github.com/onsi/ginkgo/v2 v2.15.0
 require (
 	github.com/google/go-cmp v0.6.0
 	github.com/google/gofuzz v1.2.0
+	github.com/onsi/ginkgo/v2 v2.15.0
 	github.com/onsi/gomega v1.31.0
 	k8s.io/api v0.29.0
 	k8s.io/apimachinery v0.29.0
-	k8s.io/client-go v0.29.0
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	sigs.k8s.io/controller-runtime v0.17.2
 )
@@ -27,9 +27,11 @@ require (
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect
+	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
+	github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
@@ -47,10 +49,12 @@ require (
 	golang.org/x/sys v0.16.0 // indirect
 	golang.org/x/term v0.15.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
+	golang.org/x/tools v0.16.1 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 	k8s.io/apiextensions-apiserver v0.29.0 // indirect
+	k8s.io/client-go v0.29.0 // indirect
 	k8s.io/component-base v0.29.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 // indirect
 )

--- a/api/go.sum
+++ b/api/go.sum
@@ -2,6 +2,9 @@ github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
+github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -48,6 +51,7 @@ github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJY
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.6 h1:xTNEAn+kxVO7dTZGu0CegyqKZmoWFI0rF8UxjlB2d28=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
@@ -98,6 +102,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
@@ -132,6 +137,7 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.16.0 h1:xWw16ngr6ZMtmxDyKyIgsE93KNKz5HKmMa3b8ALHidU=
 golang.org/x/sys v0.16.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/api/v1alpha1/conversion_test.go
+++ b/api/v1alpha1/conversion_test.go
@@ -1,13 +1,13 @@
-// Copyright (c) 2023 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2023-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package v1alpha1_test
 
 import (
-	"testing"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	fuzz "github.com/google/gofuzz"
-	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -19,70 +19,177 @@ import (
 	nextver "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 )
 
-//nolint:paralleltest
-func TestFuzzyConversion(t *testing.T) {
-	g := NewWithT(t)
-	scheme := runtime.NewScheme()
-	g.Expect(v1alpha1.AddToScheme(scheme)).To(Succeed())
-	g.Expect(nextver.AddToScheme(scheme)).To(Succeed())
+var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 
-	t.Run("for VirtualMachine", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
-		Scheme: scheme,
-		Hub:    &nextver.VirtualMachine{},
-		Spoke:  &v1alpha1.VirtualMachine{},
-		FuzzerFuncs: []fuzzer.FuzzerFuncs{
-			overrideVirtualMachineFieldsFuncs,
-		},
-	}))
+	var (
+		scheme *runtime.Scheme
+		input  utilconversion.FuzzTestFuncInput
+	)
 
-	t.Run("for VirtualMachineClass", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
-		Scheme: scheme,
-		Hub:    &nextver.VirtualMachineClass{},
-		Spoke:  &v1alpha1.VirtualMachineClass{},
-		FuzzerFuncs: []fuzzer.FuzzerFuncs{
-			overrideVirtualMachineClassFieldsFuncs,
-		},
-	}))
+	BeforeEach(func() {
+		scheme = runtime.NewScheme()
+		Expect(v1alpha1.AddToScheme(scheme)).To(Succeed())
+		Expect(nextver.AddToScheme(scheme)).To(Succeed())
+	})
 
-	t.Run("for VirtualMachineImage", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
-		Scheme: scheme,
-		Hub:    &nextver.VirtualMachineImage{},
-		Spoke:  &v1alpha1.VirtualMachineImage{},
-		FuzzerFuncs: []fuzzer.FuzzerFuncs{
-			overrideVirtualMachineImageFieldsFuncs,
-		},
-	}))
+	AfterEach(func() {
+		input = utilconversion.FuzzTestFuncInput{}
+	})
 
-	t.Run("for ClusterVirtualMachineImage", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
-		Scheme: scheme,
-		Hub:    &nextver.ClusterVirtualMachineImage{},
-		Spoke:  &v1alpha1.ClusterVirtualMachineImage{},
-		FuzzerFuncs: []fuzzer.FuzzerFuncs{
-			overrideVirtualMachineImageFieldsFuncs,
-		},
-	}))
+	Context("VirtualMachine", func() {
+		BeforeEach(func() {
+			input = utilconversion.FuzzTestFuncInput{
+				Scheme: scheme,
+				Hub:    &nextver.VirtualMachine{},
+				Spoke:  &v1alpha1.VirtualMachine{},
+				FuzzerFuncs: []fuzzer.FuzzerFuncs{
+					overrideVirtualMachineFieldsFuncs,
+				},
+			}
+		})
+		Context("Spoke-Hub-Spoke", func() {
+			It("should get fuzzy with it", func() {
+				utilconversion.SpokeHubSpoke(input)
+			})
+		})
+		Context("Hub-Spoke-Hub", func() {
+			It("should get fuzzy with it", func() {
+				utilconversion.HubSpokeHub(input)
+			})
+		})
+	})
 
-	t.Run("for VirtualMachinePublishRequest", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
-		Scheme: scheme,
-		Hub:    &nextver.VirtualMachinePublishRequest{},
-		Spoke:  &v1alpha1.VirtualMachinePublishRequest{},
-		FuzzerFuncs: []fuzzer.FuzzerFuncs{
-			overrideVirtualMachinePublishRequestFieldsFuncs,
-		},
-	}))
+	Context("VirtualMachineClass", func() {
+		BeforeEach(func() {
+			input = utilconversion.FuzzTestFuncInput{
+				Scheme: scheme,
+				Hub:    &nextver.VirtualMachineClass{},
+				Spoke:  &v1alpha1.VirtualMachineClass{},
+				FuzzerFuncs: []fuzzer.FuzzerFuncs{
+					overrideVirtualMachineClassFieldsFuncs,
+				},
+			}
+		})
+		Context("Spoke-Hub-Spoke", func() {
+			It("should get fuzzy with it", func() {
+				utilconversion.SpokeHubSpoke(input)
+			})
+		})
+		Context("Hub-Spoke-Hub", func() {
+			It("should get fuzzy with it", func() {
+				utilconversion.HubSpokeHub(input)
+			})
+		})
+	})
 
-	t.Run("for VirtualMachineService", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
-		Scheme: scheme,
-		Hub:    &nextver.VirtualMachineService{},
-		Spoke:  &v1alpha1.VirtualMachineService{},
-	}))
+	Context("VirtualMachineImage", func() {
+		BeforeEach(func() {
+			input = utilconversion.FuzzTestFuncInput{
+				Scheme: scheme,
+				Hub:    &nextver.VirtualMachineImage{},
+				Spoke:  &v1alpha1.VirtualMachineImage{},
+				FuzzerFuncs: []fuzzer.FuzzerFuncs{
+					overrideVirtualMachineImageFieldsFuncs,
+				},
+			}
+		})
+		Context("Spoke-Hub-Spoke", func() {
+			It("should get fuzzy with it", func() {
+				utilconversion.SpokeHubSpoke(input)
+			})
+		})
+		Context("Hub-Spoke-Hub", func() {
+			It("should get fuzzy with it", func() {
+				utilconversion.HubSpokeHub(input)
+			})
+		})
+	})
 
-	t.Run("for VirtualMachineSetResourcePolicy", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
-		Scheme: scheme,
-		Hub:    &nextver.VirtualMachineSetResourcePolicy{},
-		Spoke:  &v1alpha1.VirtualMachineSetResourcePolicy{},
-	}))
-}
+	Context("ClusterVirtualMachineImage", func() {
+		BeforeEach(func() {
+			input = utilconversion.FuzzTestFuncInput{
+				Scheme: scheme,
+				Hub:    &nextver.ClusterVirtualMachineImage{},
+				Spoke:  &v1alpha1.ClusterVirtualMachineImage{},
+				FuzzerFuncs: []fuzzer.FuzzerFuncs{
+					overrideVirtualMachineImageFieldsFuncs,
+				},
+			}
+		})
+		Context("Spoke-Hub-Spoke", func() {
+			It("should get fuzzy with it", func() {
+				utilconversion.SpokeHubSpoke(input)
+			})
+		})
+		Context("Hub-Spoke-Hub", func() {
+			It("should get fuzzy with it", func() {
+				utilconversion.HubSpokeHub(input)
+			})
+		})
+	})
+
+	Context("VirtualMachinePublishRequest", func() {
+		BeforeEach(func() {
+			input = utilconversion.FuzzTestFuncInput{
+				Scheme: scheme,
+				Hub:    &nextver.VirtualMachinePublishRequest{},
+				Spoke:  &v1alpha1.VirtualMachinePublishRequest{},
+				FuzzerFuncs: []fuzzer.FuzzerFuncs{
+					overrideVirtualMachinePublishRequestFieldsFuncs,
+				},
+			}
+		})
+		Context("Spoke-Hub-Spoke", func() {
+			It("should get fuzzy with it", func() {
+				utilconversion.SpokeHubSpoke(input)
+			})
+		})
+		Context("Hub-Spoke-Hub", func() {
+			It("should get fuzzy with it", func() {
+				utilconversion.HubSpokeHub(input)
+			})
+		})
+	})
+
+	Context("VirtualMachineService", func() {
+		BeforeEach(func() {
+			input = utilconversion.FuzzTestFuncInput{
+				Scheme: scheme,
+				Hub:    &nextver.VirtualMachineService{},
+				Spoke:  &v1alpha1.VirtualMachineService{},
+			}
+		})
+		Context("Spoke-Hub-Spoke", func() {
+			It("should get fuzzy with it", func() {
+				utilconversion.SpokeHubSpoke(input)
+			})
+		})
+		Context("Hub-Spoke-Hub", func() {
+			It("should get fuzzy with it", func() {
+				utilconversion.HubSpokeHub(input)
+			})
+		})
+	})
+	Context("VirtualMachineSetResourcePolicy", func() {
+		BeforeEach(func() {
+			input = utilconversion.FuzzTestFuncInput{
+				Scheme: scheme,
+				Hub:    &nextver.VirtualMachineSetResourcePolicy{},
+				Spoke:  &v1alpha1.VirtualMachineSetResourcePolicy{},
+			}
+		})
+		Context("Spoke-Hub-Spoke", func() {
+			It("should get fuzzy with it", func() {
+				utilconversion.SpokeHubSpoke(input)
+			})
+		})
+		Context("Hub-Spoke-Hub", func() {
+			It("should get fuzzy with it", func() {
+				utilconversion.HubSpokeHub(input)
+			})
+		})
+	})
+})
 
 func overrideVirtualMachineFieldsFuncs(codecs runtimeserializer.CodecFactory) []interface{} {
 	return []interface{}{

--- a/api/v1alpha1/v1alpha1_suite_test.go
+++ b/api/v1alpha1/v1alpha1_suite_test.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestV1Alpha1(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "v1alpha1 Suite")
+}

--- a/controllers/contentlibrary/v1alpha2/clustercontentlibraryitem/clustercontentlibraryitem_controller_intg_test.go
+++ b/controllers/contentlibrary/v1alpha2/clustercontentlibraryitem/clustercontentlibraryitem_controller_intg_test.go
@@ -26,10 +26,10 @@ import (
 )
 
 func intgTests() {
-	Describe("Invoking ClusterContentLibraryItem controller integration tests", cclItemReconcile)
+	Describe("Reconcile", Label("controller", "envtest", "v1alpha2", "vcsim"), intgTestsReconcile)
 }
 
-func cclItemReconcile() {
+func intgTestsReconcile() {
 	const firmwareValue = "my-firmware"
 
 	var (

--- a/controllers/contentlibrary/v1alpha2/clustercontentlibraryitem/clustercontentlibraryitem_controller_unit_test.go
+++ b/controllers/contentlibrary/v1alpha2/clustercontentlibraryitem/clustercontentlibraryitem_controller_unit_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func unitTests() {
-	Describe("Invoking ClusterContentLibraryItem controller unit tests", unitTestsReconcile)
+	Describe("Reconcile", Label("controller", "v1alpha2"), unitTestsReconcile)
 }
 
 func unitTestsReconcile() {

--- a/controllers/contentlibrary/v1alpha2/contentlibraryitem/contentlibraryitem_controller_intg_test.go
+++ b/controllers/contentlibrary/v1alpha2/contentlibraryitem/contentlibraryitem_controller_intg_test.go
@@ -23,10 +23,10 @@ import (
 )
 
 func intgTests() {
-	Describe("Invoking ContentLibraryItem controller integration tests", clItemReconcile)
+	Describe("Reconcile", Label("controller", "envtest", "v1alpha2", "vcsim"), intgTestsReconcile)
 }
 
-func clItemReconcile() {
+func intgTestsReconcile() {
 	const firmwareValue = "my-firmware"
 
 	var (

--- a/controllers/contentlibrary/v1alpha2/contentlibraryitem/contentlibraryitem_controller_unit_test.go
+++ b/controllers/contentlibrary/v1alpha2/contentlibraryitem/contentlibraryitem_controller_unit_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func unitTests() {
-	Describe("Invoking ContentLibraryItem controller unit tests", unitTestsReconcile)
+	Describe("Reconcile", Label("controller", "v1alpha2"), unitTestsReconcile)
 }
 
 func unitTestsReconcile() {

--- a/controllers/infra/configmap/infra_configmap_controller_intg_test.go
+++ b/controllers/infra/configmap/infra_configmap_controller_intg_test.go
@@ -18,6 +18,10 @@ import (
 )
 
 func intgTests() {
+	Describe("Reconcile", Label("controller", "envtest", "v1alpha2", "vcsim"), intgTestsReconcile)
+}
+
+func intgTestsReconcile() {
 	var (
 		ctx *builder.IntegrationTestContext
 	)

--- a/controllers/infra/configmap/infra_configmap_suite_test.go
+++ b/controllers/infra/configmap/infra_configmap_suite_test.go
@@ -26,10 +26,6 @@ var suite = builder.NewTestSuiteForController(
 	},
 )
 
-var unitTests = func() {
-	Describe("Infra ConfigMap", unitTestsWcpConfig)
-}
-
 func TestWCPConfigMapController(t *testing.T) {
 	suite.Register(t, "Infra ConfigMap Controller suite", intgTests, unitTests)
 }

--- a/controllers/infra/configmap/infra_configmap_test.go
+++ b/controllers/infra/configmap/infra_configmap_test.go
@@ -10,6 +10,10 @@ import (
 	"github.com/vmware-tanzu/vm-operator/controllers/infra/configmap"
 )
 
+func unitTests() {
+	Describe("WCP Config", Label("v1alpha2"), unitTestsWcpConfig)
+}
+
 func unitTestsWcpConfig() {
 	Describe("ParseWcpClusterConfig", func() {
 		var (

--- a/controllers/infra/node/infra_node_controller_intg_test.go
+++ b/controllers/infra/node/infra_node_controller_intg_test.go
@@ -18,6 +18,10 @@ import (
 )
 
 func intgTests() {
+	Describe("Reconcile", Label("controller", "envtest", "v1alpha2", "vcsim"), intgTestsReconcile)
+}
+
+func intgTestsReconcile() {
 	var (
 		ctx *builder.IntegrationTestContext
 		obj *corev1.Node

--- a/controllers/infra/secret/infra_secret_controller_intg_test.go
+++ b/controllers/infra/secret/infra_secret_controller_intg_test.go
@@ -19,6 +19,10 @@ import (
 )
 
 func intgTests() {
+	Describe("Reconcile", Label("controller", "envtest", "v1alpha2", "vcsim"), intgTestsReconcile)
+}
+
+func intgTestsReconcile() {
 	var (
 		ctx *builder.IntegrationTestContext
 	)

--- a/controllers/virtualmachine/v1alpha2/virtualmachine_controller_intg_test.go
+++ b/controllers/virtualmachine/v1alpha2/virtualmachine_controller_intg_test.go
@@ -22,6 +22,10 @@ import (
 )
 
 func intgTests() {
+	Describe("Reconcile", Label("controller", "envtest", "v1alpha2", "vcsim"), intgTestsReconcile)
+}
+
+func intgTestsReconcile() {
 
 	var (
 		ctx *builder.IntegrationTestContext

--- a/controllers/virtualmachine/v1alpha2/virtualmachine_controller_unit_test.go
+++ b/controllers/virtualmachine/v1alpha2/virtualmachine_controller_unit_test.go
@@ -24,11 +24,11 @@ import (
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
-func unitTests() {
-	Describe("Invoking Reconcile", unitTestsReconcile)
-}
-
 const finalizer = "virtualmachine.vmoperator.vmware.com"
+
+func unitTests() {
+	Describe("Reconcile", Label("controller", "v1alpha2"), unitTestsReconcile)
+}
 
 func unitTestsReconcile() {
 	const (

--- a/controllers/virtualmachineclass/v1alpha2/virtualmachineclass_controller_intg_test.go
+++ b/controllers/virtualmachineclass/v1alpha2/virtualmachineclass_controller_intg_test.go
@@ -16,6 +16,10 @@ import (
 )
 
 func intgTests() {
+	Describe("Reconcile", Label("controller", "envtest", "v1alpha2", "vcsim"), intgTestsReconcile)
+}
+
+func intgTestsReconcile() {
 	var (
 		ctx     *builder.IntegrationTestContext
 		vmClass *vmopv1.VirtualMachineClass

--- a/controllers/virtualmachineclass/v1alpha2/virtualmachineclass_controller_unit_test.go
+++ b/controllers/virtualmachineclass/v1alpha2/virtualmachineclass_controller_unit_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func unitTests() {
-	Describe("Invoking Reconcile", unitTestsReconcile)
+	Describe("Reconcile", Label("controller", "v1alpha2"), unitTestsReconcile)
 }
 
 func unitTestsReconcile() {

--- a/controllers/virtualmachinepublishrequest/v1alpha2/virtualmachinepublishrequest_controller_intg_test.go
+++ b/controllers/virtualmachinepublishrequest/v1alpha2/virtualmachinepublishrequest_controller_intg_test.go
@@ -27,10 +27,10 @@ import (
 )
 
 func intgTests() {
-	Describe("Invoking VirtualMachinePublishRequest controller tests", virtualMachinePublishRequestReconcile)
+	Describe("Reconcile", Label("controller", "envtest", "v1alpha2", "vcsim"), intgTestsReconcile)
 }
 
-func virtualMachinePublishRequestReconcile() {
+func intgTestsReconcile() {
 	var (
 		ctx      *builder.IntegrationTestContext
 		vmPubReq *vmopv1.VirtualMachinePublishRequest

--- a/controllers/virtualmachinepublishrequest/v1alpha2/virtualmachinepublishrequest_controller_unit_test.go
+++ b/controllers/virtualmachinepublishrequest/v1alpha2/virtualmachinepublishrequest_controller_unit_test.go
@@ -30,11 +30,11 @@ import (
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
-func unitTests() {
-	Describe("Invoking VirtualMachinePublishRequest Reconcile", unitTestsReconcile)
-}
-
 const finalizerName = "virtualmachinepublishrequest.vmoperator.vmware.com"
+
+func unitTests() {
+	Describe("Reconcile", Label("controller", "v1alpha2"), unitTestsReconcile)
+}
 
 func unitTestsReconcile() {
 	var (

--- a/controllers/virtualmachineservice/v1alpha2/providers/loadbalancer_provider_test.go
+++ b/controllers/virtualmachineservice/v1alpha2/providers/loadbalancer_provider_test.go
@@ -20,7 +20,7 @@ const (
 	dummyNamespace = "dummy"
 )
 
-var _ = Describe("Loadbalancer Provider", func() {
+var _ = Describe("Loadbalancer Provider", Label("controller", "v1alpha2"), func() {
 	var (
 		ctx        context.Context
 		vmService  *vmopv1.VirtualMachineService

--- a/controllers/virtualmachineservice/v1alpha2/virtualmachineservice_controller_intg_test.go
+++ b/controllers/virtualmachineservice/v1alpha2/virtualmachineservice_controller_intg_test.go
@@ -22,6 +22,10 @@ const (
 )
 
 func intgTests() {
+	Describe("Reconcile", Label("controller", "envtest", "v1alpha2", "vcsim"), intgTestsReconcile)
+}
+
+func intgTestsReconcile() {
 	var (
 		ctx *builder.IntegrationTestContext
 

--- a/controllers/virtualmachineservice/v1alpha2/virtualmachineservice_controller_unit_test.go
+++ b/controllers/virtualmachineservice/v1alpha2/virtualmachineservice_controller_unit_test.go
@@ -27,8 +27,8 @@ import (
 )
 
 func unitTests() {
-	Describe("Invoking Reconcile", unitTestsReconcile)
-	Describe("Invoking NSXT Reconcile", nsxtLBProviderTestsReconcile)
+	Describe("Reconcile", Label("controller", "v1alpha2"), unitTestsReconcile)
+	Describe("Reconcile", Label("controller", "nsxt", "v1alpha2"), nsxtLBProviderTestsReconcile)
 }
 
 const LabelServiceProxyName = "service.kubernetes.io/service-proxy-name"

--- a/controllers/virtualmachinesetresourcepolicy/v1alpha2/virtualmachinesetresourcepolicy_controller_intg_test.go
+++ b/controllers/virtualmachinesetresourcepolicy/v1alpha2/virtualmachinesetresourcepolicy_controller_intg_test.go
@@ -19,6 +19,10 @@ import (
 )
 
 func intgTests() {
+	Describe("Reconcile", Label("controller", "envtest", "v1alpha2", "vcsim"), intgTestsReconcile)
+}
+
+func intgTestsReconcile() {
 	var (
 		ctx *builder.IntegrationTestContext
 

--- a/controllers/virtualmachinesetresourcepolicy/v1alpha2/virtualmachinesetresourcepolicy_controller_unit_test.go
+++ b/controllers/virtualmachinesetresourcepolicy/v1alpha2/virtualmachinesetresourcepolicy_controller_unit_test.go
@@ -20,13 +20,13 @@ import (
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
-func unitTests() {
-	Describe("Invoking Reconcile", unitTestsReconcile)
-}
-
 const (
 	finalizer = "virtualmachinesetresourcepolicy.vmoperator.vmware.com"
 )
+
+func unitTests() {
+	Describe("Reconcile", Label("controller", "v1alpha2"), unitTestsReconcile)
+}
 
 func unitTestsReconcile() {
 	var (

--- a/controllers/virtualmachinewebconsolerequest/v1alpha1/patch/patch_test.go
+++ b/controllers/virtualmachinewebconsolerequest/v1alpha1/patch/patch_test.go
@@ -37,6 +37,10 @@ import (
 )
 
 func intgTests() {
+	Describe("Patch", Label("envtest"), intgTestsPatch)
+}
+
+func intgTestsPatch() {
 	var (
 		ctx *builder.IntegrationTestContext
 	)

--- a/controllers/virtualmachinewebconsolerequest/v1alpha1/webconsolerequest_intg_test.go
+++ b/controllers/virtualmachinewebconsolerequest/v1alpha1/webconsolerequest_intg_test.go
@@ -23,10 +23,10 @@ import (
 )
 
 func intgTests() {
-	Describe("Invoking WebConsoleRequest controller tests", webConsoleRequestReconcile)
+	Describe("Reconcile", Label("controller", "envtest", "v1alpha1", "vcsim"), intgTestsReconcile)
 }
 
-func webConsoleRequestReconcile() {
+func intgTestsReconcile() {
 	const v1a2Ticket = "some-fake-webmksticket-v1a2"
 
 	var (

--- a/controllers/virtualmachinewebconsolerequest/v1alpha1/webconsolerequest_unit_test.go
+++ b/controllers/virtualmachinewebconsolerequest/v1alpha1/webconsolerequest_unit_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func unitTests() {
-	Describe("Invoking WebConsoleRequest Reconcile", unitTestsReconcile)
+	Describe("Reconcile", Label("controller", "v1alpha1"), unitTestsReconcile)
 }
 
 func unitTestsReconcile() {

--- a/controllers/virtualmachinewebconsolerequest/v1alpha2/webconsolerequest_intg_test.go
+++ b/controllers/virtualmachinewebconsolerequest/v1alpha2/webconsolerequest_intg_test.go
@@ -21,10 +21,10 @@ import (
 )
 
 func intgTests() {
-	Describe("Invoking VirtualMachineWebConsoleRequest controller tests", webConsoleRequestReconcile)
+	Describe("Reconcile", Label("controller", "envtest", "v1alpha2", "vcsim"), intgTestsReconcile)
 }
 
-func webConsoleRequestReconcile() {
+func intgTestsReconcile() {
 	const ticket = "some-fake-webmksticket"
 
 	var (

--- a/controllers/virtualmachinewebconsolerequest/v1alpha2/webconsolerequest_unit_test.go
+++ b/controllers/virtualmachinewebconsolerequest/v1alpha2/webconsolerequest_unit_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func unitTests() {
-	Describe("Invoking VirtualMachineWebConsoleRequest Reconcile", unitTestsReconcile)
+	Describe("Reconcile", Label("controller", "v1alpha1"), unitTestsReconcile)
 }
 
 func unitTestsReconcile() {

--- a/controllers/volume/v1alpha2/volume_controller_intg_test.go
+++ b/controllers/volume/v1alpha2/volume_controller_intg_test.go
@@ -30,6 +30,10 @@ import (
 )
 
 func intgTests() {
+	Describe("Reconcile", Label("controller", "envtest", "v1alpha2", "vcsim"), intgTestsReconcile)
+}
+
+func intgTestsReconcile() {
 	var (
 		ctx *builder.IntegrationTestContext
 

--- a/controllers/volume/v1alpha2/volume_controller_unit_test.go
+++ b/controllers/volume/v1alpha2/volume_controller_unit_test.go
@@ -33,10 +33,6 @@ import (
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
-func unitTests() {
-	Describe("Invoking Reconcile", unitTestsReconcile)
-}
-
 type testFailClient struct {
 	client.Client
 }
@@ -44,6 +40,10 @@ type testFailClient struct {
 // This is used for returning an error while unit testing.
 func (f *testFailClient) Create(ctx goctx.Context, obj client.Object, opts ...client.CreateOption) error {
 	return k8sapierrors.NewForbidden(schema.GroupResource{}, "", errors.New("insufficient quota for creating PVC"))
+}
+
+func unitTests() {
+	Describe("Reconcile", Label("controller", "v1alpha2"), unitTestsReconcile)
 }
 
 func unitTestsReconcile() {

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -15,9 +15,11 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 COVERAGE_FILE="${1:-}"
 
-TEST_PKGS="${TEST_PKGS:-./api ./controllers ./pkg ./webhooks}"
-
 GO_TEST_FLAGS=("-v" "-r" "--race" "--keep-going")
+
+if [ -n "${LABEL_FILTER:-}" ]; then
+  GO_TEST_FLAGS+=("--label-filter" "${LABEL_FILTER:-}")
+fi
 
 # The first argument is the name of the coverage file to use.
 if [ -n "${COVERAGE_FILE}" ]; then
@@ -28,9 +30,7 @@ fi
 
 # Run the tests.
 # shellcheck disable=SC2086
-ginkgo "${GO_TEST_FLAGS[@]+"${GO_TEST_FLAGS[@]}"}" \
-  ${TEST_PKGS} || \
-  TEST_CMD_EXIT_CODE="${?}"
+ginkgo "${GO_TEST_FLAGS[@]+"${GO_TEST_FLAGS[@]}"}" || TEST_CMD_EXIT_CODE="${?}"
 
 # TEST_CMD_EXIT_CODE may be set to 2 if there are any tests marked as
 # pending/skipped. This pattern is used by developers to leave test

--- a/pkg/util/vsphere/client/client_test.go
+++ b/pkg/util/vsphere/client/client_test.go
@@ -30,7 +30,7 @@ const (
 	valid   = "valid"
 )
 
-var _ = Describe("Client", Ordered /* Avoided race for pkg symbol simulator.SessionIdleTimeout */, func() {
+var _ = Describe("Client", Label("vcsim"), Ordered /* Avoided race for pkg symbol simulator.SessionIdleTimeout */, func() {
 
 	Describe("NewClient", func() {
 		var (

--- a/pkg/util/vsphere/vm/suite_test.go
+++ b/pkg/util/vsphere/vm/suite_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 func vcSimTests() {
-	Describe("Power State", powerStateTests)
-	Describe("Hardware Version", hardwareVersionTests)
+	Describe("Power State", Label("vcsim"), powerStateTests)
+	Describe("Hardware Version", Label("vcsim"), hardwareVersionTests)
 	Describe("Managed Object", managedObjectTests)
 }
 

--- a/pkg/vmprovider/providers/vsphere2/client/client_test.go
+++ b/pkg/vmprovider/providers/vsphere2/client/client_test.go
@@ -34,7 +34,7 @@ const (
 	valid   = "valid"
 )
 
-var _ = Describe("Client", Ordered /* Avoided race for pkg symbol simulator.SessionIdleTimeout */, func() {
+var _ = Describe("Client", Label("vcsim"), Ordered /* Avoided race for pkg symbol simulator.SessionIdleTimeout */, func() {
 
 	Describe("NewClient", func() {
 		var (

--- a/pkg/vmprovider/providers/vsphere2/clustermodules/cluster_modules_suite_test.go
+++ b/pkg/vmprovider/providers/vsphere2/clustermodules/cluster_modules_suite_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func vcSimTests() {
-	Describe("ClusterModules Provider", cmTests)
+	Describe("ClusterModules Provider", Label("vcsim"), cmTests)
 }
 
 var suite = builder.NewTestSuite()

--- a/pkg/vmprovider/providers/vsphere2/config/config_suite_test.go
+++ b/pkg/vmprovider/providers/vsphere2/config/config_suite_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func vcSimTests() {
-	Describe("Config", configTests)
+	Describe("Config", Label("vcsim"), configTests)
 }
 
 var suite = builder.NewTestSuite()

--- a/pkg/vmprovider/providers/vsphere2/contentlibrary/content_library_suite_test.go
+++ b/pkg/vmprovider/providers/vsphere2/contentlibrary/content_library_suite_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func vcSimTests() {
-	Describe("ContentLibrary Provider", clTests)
+	Describe("ContentLibrary Provider", Label("vcsim"), clTests)
 }
 
 var suite = builder.NewTestSuite()

--- a/pkg/vmprovider/providers/vsphere2/network/network_test.go
+++ b/pkg/vmprovider/providers/vsphere2/network/network_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
-var _ = Describe("CreateAndWaitForNetworkInterfaces", func() {
+var _ = Describe("CreateAndWaitForNetworkInterfaces", Label("vcsim"), func() {
 
 	var (
 		testConfig builder.VCSimTestConfig

--- a/pkg/vmprovider/providers/vsphere2/network/nsxt_test.go
+++ b/pkg/vmprovider/providers/vsphere2/network/nsxt_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
-var _ = Describe("ResolveBackingPostPlacement", func() {
+var _ = Describe("ResolveBackingPostPlacement", Label("nsxt", "vcsim"), func() {
 
 	var (
 		testConfig builder.VCSimTestConfig

--- a/pkg/vmprovider/providers/vsphere2/placement/placement_suite_test.go
+++ b/pkg/vmprovider/providers/vsphere2/placement/placement_suite_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func vcSimTests() {
-	Describe("Placement", vcSimPlacement)
+	Describe("Placement", Label("vcsim"), vcSimPlacement)
 }
 
 var suite = builder.NewTestSuite()

--- a/pkg/vmprovider/providers/vsphere2/vcenter/vcenter_suite_test.go
+++ b/pkg/vmprovider/providers/vsphere2/vcenter/vcenter_suite_test.go
@@ -14,11 +14,11 @@ import (
 var suite = builder.NewTestSuite()
 
 func vcSimTests() {
-	Describe("Cluster", clusterTests)
-	Describe("Folder", folderTests)
-	Describe("GetVM", getVMTests)
-	Describe("Host", hostTests)
-	Describe("ResourcePool", resourcePoolTests)
+	Describe("Cluster", Label("vcsim"), clusterTests)
+	Describe("Folder", Label("vcsim"), folderTests)
+	Describe("GetVM", Label("vcsim"), getVMTests)
+	Describe("Host", Label("vcsim"), hostTests)
+	Describe("ResourcePool", Label("vcsim"), resourcePoolTests)
 }
 
 func TestVCenter(t *testing.T) {

--- a/pkg/vmprovider/providers/vsphere2/virtualmachine/virtualmachine_suite_test.go
+++ b/pkg/vmprovider/providers/vsphere2/virtualmachine/virtualmachine_suite_test.go
@@ -12,11 +12,11 @@ import (
 )
 
 func vcSimTests() {
-	Describe("ClusterComputeResource", ccrTests)
-	Describe("Delete", deleteTests)
-	Describe("Publish", publishTests)
-	Describe("Backup", backupTests)
-	Describe("GuestInfo", guestInfoTests)
+	Describe("ClusterComputeResource", Label("vcsim"), ccrTests)
+	Describe("Delete", Label("vcsim"), deleteTests)
+	Describe("Publish", Label("vcsim"), publishTests)
+	Describe("Backup", Label("vcsim"), backupTests)
+	Describe("GuestInfo", Label("vcsim"), guestInfoTests)
 }
 
 var suite = builder.NewTestSuite()

--- a/test/builder/flags.go
+++ b/test/builder/flags.go
@@ -1,13 +1,10 @@
-// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2020-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package builder
 
 import (
 	"flag"
-	"os"
-	"strconv"
-	"strings"
 )
 
 // testFlags contains the configurations we'd like to get from the command line,
@@ -17,14 +14,6 @@ type testFlags struct {
 	// the -root-dir flag.
 	// Defaults to ../../
 	RootDir string
-
-	// integrationTestsEnabled is set to true with the -enable-integration-tests flag.
-	// Defaults to false.
-	IntegrationTestsEnabled bool
-
-	// unitTestsEnabled is set to true with the -enable-unit-tests flag.
-	// Defaults to true.
-	UnitTestsEnabled bool
 }
 
 var (
@@ -33,53 +22,8 @@ var (
 
 func init() {
 	flags = testFlags{}
-	// Create a special flagset used to parse the -enable-integration-tests
-	// and -enable-unit-tests flags. A special flagset is used so as not to
-	// interfere with whatever Ginkgo or Kubernetes might be doing with the
-	// default flagset.
-	//
-	// Please note that in order for this to work, we must copy the os.Args
-	// slice into a new slice, removing any flags except those about which
-	// we're concerned and possibly values immediately succeeding those flags,
-	// provided the values are not prefixed with a "-" character.
-	cmdLine := flag.NewFlagSet("test", flag.PanicOnError)
-	var args []string
-	for i := 0; i < len(os.Args); i++ {
-		if strings.HasPrefix(os.Args[i], "-enable-integration-tests") || strings.HasPrefix(os.Args[i], "-enable-unit-tests") {
-			args = append(args, os.Args[i])
-		}
-	}
-
-	eitFlagDefaultValue, _ := strconv.ParseBool(os.Getenv("ENABLE_INTEGRATION_TESTS"))
-	var eutFlagDefaultValue bool
-	if v, ok := os.LookupEnv("ENABLE_UNIT_TESTS"); ok {
-		eutFlagDefaultValue, _ = strconv.ParseBool(v)
-	} else {
-		eutFlagDefaultValue = true
-	}
-
-	cmdLine.BoolVar(
-		&flags.IntegrationTestsEnabled,
-		"enable-integration-tests",
-		eitFlagDefaultValue,
-		"Enables integration tests")
-	cmdLine.BoolVar(
-		&flags.UnitTestsEnabled,
-		"enable-unit-tests",
-		eutFlagDefaultValue,
-		"Enables unit tests")
-	_ = cmdLine.Parse(args)
 
 	// We still need to add the flags to the default flagset, because otherwise
 	// Ginkgo will complain that the flags are not recognized.
-	flag.Bool(
-		"enable-integration-tests",
-		eitFlagDefaultValue,
-		"Enables integration tests")
-	flag.Bool(
-		"enable-unit-tests",
-		eutFlagDefaultValue,
-		"Enables unit tests")
-
 	flag.StringVar(&flags.RootDir, "root-dir", "../..", "Root project directory")
 }

--- a/webhooks/common/response_test.go
+++ b/webhooks/common/response_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/webhooks/common"
 )
 
-var _ = Describe("Validation Response", func() {
+var _ = Describe("Validation Response", Label("envtest", "v1alpha2", "vcsim", "webhook"), func() {
 
 	var (
 		gr  = schema.GroupResource{Group: vmopv1.SchemeGroupVersion.Group, Resource: "VirtualMachine"}

--- a/webhooks/persistentvolumeclaim/validation/persistentvolumeclaim_validator_intg_test.go
+++ b/webhooks/persistentvolumeclaim/validation/persistentvolumeclaim_validator_intg_test.go
@@ -13,9 +13,9 @@ import (
 )
 
 func intgTests() {
-	Describe("Invoking Create", intgTestsValidateCreate)
-	Describe("Invoking Update", intgTestsValidateUpdate)
-	Describe("Invoking Delete", intgTestsValidateDelete)
+	Describe("Create", Label("create", "envtest", "v1alpha2", "validation", "vcsim", "webhook"), intgTestsValidateCreate)
+	Describe("Update", Label("update", "envtest", "v1alpha2", "validation", "vcsim", "webhook"), intgTestsValidateUpdate)
+	Describe("Delete", Label("delete", "envtest", "v1alpha2", "validation", "vcsim", "webhook"), intgTestsValidateDelete)
 }
 
 type intgValidatingWebhookContext struct {

--- a/webhooks/persistentvolumeclaim/validation/persistentvolumeclaim_validator_unit_test.go
+++ b/webhooks/persistentvolumeclaim/validation/persistentvolumeclaim_validator_unit_test.go
@@ -24,9 +24,9 @@ const (
 )
 
 func unitTests() {
-	Describe("Invoking ValidateCreate", unitTestsValidatePVCCreate)
-	Describe("Invoking ValidateUpdate", unitTestsValidatePVCUpdate)
-	Describe("Invoking ValidateDelete", unitTestsValidatePVCDelete)
+	Describe("Create", Label("create", "v1alpha2", "validation", "webhook"), unitTestsValidatePVCCreate)
+	Describe("Update", Label("update", "v1alpha2", "validation", "webhook"), unitTestsValidatePVCUpdate)
+	Describe("Delete", Label("delete", "v1alpha2", "validation", "webhook"), unitTestsValidatePVCDelete)
 }
 
 type unitValidatingWebhookContext struct {

--- a/webhooks/virtualmachine/v1alpha2/mutation/virtualmachine_mutator_intg_test.go
+++ b/webhooks/virtualmachine/v1alpha2/mutation/virtualmachine_mutator_intg_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func intgTests() {
-	Describe("Invoking Mutation", intgTestsMutating)
+	Describe("Mutate", Label("create", "update", "delete", "envtest", "v1alpha2", "mutation", "vcsim", "webhook"), intgTestsMutating)
 }
 
 type intgMutatingWebhookContext struct {

--- a/webhooks/virtualmachine/v1alpha2/mutation/virtualmachine_mutator_unit_test.go
+++ b/webhooks/virtualmachine/v1alpha2/mutation/virtualmachine_mutator_unit_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func uniTests() {
-	Describe("Invoking Mutate", unitTestsMutating)
+	Describe("Mutate", Label("create", "update", "delete", "v1alpha2", "mutation", "webhook"), unitTestsMutating)
 }
 
 type unitMutationWebhookContext struct {

--- a/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator_intg_test.go
+++ b/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator_intg_test.go
@@ -16,9 +16,9 @@ import (
 )
 
 func intgTests() {
-	Describe("Invoking Create", intgTestsValidateCreate)
-	Describe("Invoking Update", intgTestsValidateUpdate)
-	Describe("Invoking Delete", intgTestsValidateDelete)
+	Describe("Create", Label("create", "envtest", "v1alpha2", "validation", "vcsim", "webhook"), intgTestsValidateCreate)
+	Describe("Update", Label("update", "envtest", "v1alpha2", "validation", "vcsim", "webhook"), intgTestsValidateUpdate)
+	Describe("Delete", Label("delete", "envtest", "v1alpha2", "validation", "vcsim", "webhook"), intgTestsValidateDelete)
 }
 
 type intgValidatingWebhookContext struct {

--- a/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator_unit_test.go
@@ -59,9 +59,9 @@ func doValidateWithMsg(msgs ...string) func(admission.Response) {
 }
 
 func unitTests() {
-	Describe("Invoking ValidateCreate", unitTestsValidateCreate)
-	Describe("Invoking ValidateUpdate", unitTestsValidateUpdate)
-	Describe("Invoking ValidateDelete", unitTestsValidateDelete)
+	Describe("Create", Label("create", "v1alpha2", "validation", "webhook"), unitTestsValidateCreate)
+	Describe("Update", Label("update", "v1alpha2", "validation", "webhook"), unitTestsValidateUpdate)
+	Describe("Delete", Label("delete", "v1alpha2", "validation", "webhook"), unitTestsValidateDelete)
 }
 
 type unitValidatingWebhookContext struct {

--- a/webhooks/virtualmachineclass/v1alpha2/mutation/virtualmachineclass_mutator_intg_test.go
+++ b/webhooks/virtualmachineclass/v1alpha2/mutation/virtualmachineclass_mutator_intg_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func intgTests() {
-	XDescribe("Invoking Mutation", intgTestsMutating)
+	Describe("Mutate", Label("create", "update", "delete", "envtest", "v1alpha2", "mutation", "vcsim", "webhook"), intgTestsMutating)
 }
 
 type intgMutatingWebhookContext struct {

--- a/webhooks/virtualmachineclass/v1alpha2/mutation/virtualmachineclass_mutator_unit_test.go
+++ b/webhooks/virtualmachineclass/v1alpha2/mutation/virtualmachineclass_mutator_unit_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func uniTests() {
-	Describe("Invoking Mutate", unitTestsMutating)
+	Describe("Mutate", Label("create", "update", "delete", "v1alpha2", "mutation", "webhook"), unitTestsMutating)
 }
 
 type unitMutationWebhookContext struct {

--- a/webhooks/virtualmachineclass/v1alpha2/validation/virtualmachineclass_validator_intg_test.go
+++ b/webhooks/virtualmachineclass/v1alpha2/validation/virtualmachineclass_validator_intg_test.go
@@ -15,8 +15,8 @@ import (
 )
 
 func intgTests() {
-	Describe("Invoking Create", intgTestsValidateCreate)
-	Describe("Invoking Delete", intgTestsValidateDelete)
+	Describe("Create", Label("create", "envtest", "v1alpha2", "validation", "vcsim", "webhook"), intgTestsValidateCreate)
+	Describe("Delete", Label("delete", "envtest", "v1alpha2", "validation", "vcsim", "webhook"), intgTestsValidateDelete)
 }
 
 type intgValidatingWebhookContext struct {

--- a/webhooks/virtualmachineclass/v1alpha2/validation/virtualmachineclass_validator_unit_test.go
+++ b/webhooks/virtualmachineclass/v1alpha2/validation/virtualmachineclass_validator_unit_test.go
@@ -19,9 +19,9 @@ import (
 )
 
 func unitTests() {
-	Describe("Invoking ValidateCreate", unitTestsValidateCreate)
-	Describe("Invoking ValidateUpdate", unitTestsValidateUpdate)
-	Describe("Invoking ValidateDelete", unitTestsValidateDelete)
+	Describe("Create", Label("create", "v1alpha2", "validation", "webhook"), unitTestsValidateCreate)
+	Describe("Update", Label("update", "v1alpha2", "validation", "webhook"), unitTestsValidateUpdate)
+	Describe("Delete", Label("delete", "v1alpha2", "validation", "webhook"), unitTestsValidateDelete)
 }
 
 type unitValidatingWebhookContext struct {

--- a/webhooks/virtualmachinepublishrequest/v1alpha2/validation/virtualmachinepublishrequest_validator_intg_test.go
+++ b/webhooks/virtualmachinepublishrequest/v1alpha2/validation/virtualmachinepublishrequest_validator_intg_test.go
@@ -13,9 +13,9 @@ import (
 )
 
 func intgTests() {
-	Describe("Invoking Create", intgTestsValidateCreate)
-	Describe("Invoking Update", intgTestsValidateUpdate)
-	Describe("Invoking Delete", intgTestsValidateDelete)
+	Describe("Create", Label("create", "envtest", "v1alpha2", "validation", "vcsim", "webhook"), intgTestsValidateCreate)
+	Describe("Update", Label("update", "envtest", "v1alpha2", "validation", "vcsim", "webhook"), intgTestsValidateUpdate)
+	Describe("Delete", Label("delete", "envtest", "v1alpha2", "validation", "vcsim", "webhook"), intgTestsValidateDelete)
 }
 
 type intgValidatingWebhookContext struct {

--- a/webhooks/virtualmachinepublishrequest/v1alpha2/validation/virtualmachinepublishrequest_validator_unit_test.go
+++ b/webhooks/virtualmachinepublishrequest/v1alpha2/validation/virtualmachinepublishrequest_validator_unit_test.go
@@ -20,9 +20,9 @@ import (
 )
 
 func unitTests() {
-	Describe("Invoking ValidateCreate", unitTestsValidateCreate)
-	Describe("Invoking ValidateUpdate", unitTestsValidateUpdate)
-	Describe("Invoking ValidateDelete", unitTestsValidateDelete)
+	Describe("Create", Label("create", "v1alpha2", "validation", "webhook"), unitTestsValidateCreate)
+	Describe("Update", Label("update", "v1alpha2", "validation", "webhook"), unitTestsValidateUpdate)
+	Describe("Delete", Label("delete", "v1alpha2", "validation", "webhook"), unitTestsValidateDelete)
 }
 
 type unitValidatingWebhookContext struct {

--- a/webhooks/virtualmachineservice/v1alpha2/mutation/virtualmachineservice_mutator_intg_test.go
+++ b/webhooks/virtualmachineservice/v1alpha2/mutation/virtualmachineservice_mutator_intg_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func intgTests() {
-	XDescribe("Invoking Mutation", intgTestsMutating)
+	Describe("Mutate", Label("create", "update", "delete", "envtest", "v1alpha2", "mutation", "vcsim", "webhook"), intgTestsMutating)
 }
 
 type intgMutatingWebhookContext struct {

--- a/webhooks/virtualmachineservice/v1alpha2/mutation/virtualmachineservice_mutator_unit_test.go
+++ b/webhooks/virtualmachineservice/v1alpha2/mutation/virtualmachineservice_mutator_unit_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func uniTests() {
-	Describe("Invoking Mutate", unitTestsMutating)
+	Describe("Mutate", Label("create", "update", "delete", "v1alpha2", "mutation", "webhook"), unitTestsMutating)
 }
 
 type unitMutationWebhookContext struct {

--- a/webhooks/virtualmachineservice/v1alpha2/validation/virtualmachineservice_validator_intg_test.go
+++ b/webhooks/virtualmachineservice/v1alpha2/validation/virtualmachineservice_validator_intg_test.go
@@ -12,9 +12,9 @@ import (
 )
 
 func intgTests() {
-	Describe("Invoking Create", intgTestsValidateCreate)
-	Describe("Invoking Update", intgTestsValidateUpdate)
-	Describe("Invoking Delete", intgTestsValidateDelete)
+	Describe("Create", Label("create", "envtest", "v1alpha2", "validation", "vcsim", "webhook"), intgTestsValidateCreate)
+	Describe("Update", Label("update", "envtest", "v1alpha2", "validation", "vcsim", "webhook"), intgTestsValidateUpdate)
+	Describe("Delete", Label("delete", "envtest", "v1alpha2", "validation", "vcsim", "webhook"), intgTestsValidateDelete)
 }
 
 type intgValidatingWebhookContext struct {

--- a/webhooks/virtualmachineservice/v1alpha2/validation/virtualmachineservice_validator_unit_test.go
+++ b/webhooks/virtualmachineservice/v1alpha2/validation/virtualmachineservice_validator_unit_test.go
@@ -16,9 +16,9 @@ import (
 )
 
 func unitTests() {
-	Describe("Invoking ValidateCreate", unitTestsValidateCreate)
-	Describe("Invoking ValidateUpdate", unitTestsValidateUpdate)
-	Describe("Invoking ValidateDelete", unitTestsValidateDelete)
+	Describe("Create", Label("create", "v1alpha2", "validation", "webhook"), unitTestsValidateCreate)
+	Describe("Update", Label("update", "v1alpha2", "validation", "webhook"), unitTestsValidateUpdate)
+	Describe("Delete", Label("delete", "v1alpha2", "validation", "webhook"), unitTestsValidateDelete)
 }
 
 type unitValidatingWebhookContext struct {

--- a/webhooks/virtualmachinesetresourcepolicy/v1alpha2/validation/virtualmachinesetresourcepolicy_validator_intg_test.go
+++ b/webhooks/virtualmachinesetresourcepolicy/v1alpha2/validation/virtualmachinesetresourcepolicy_validator_intg_test.go
@@ -16,9 +16,9 @@ import (
 )
 
 func intgTests() {
-	Describe("Invoking Create", intgTestsValidateCreate)
-	Describe("Invoking Update", intgTestsValidateUpdate)
-	Describe("Invoking Delete", intgTestsValidateDelete)
+	Describe("Create", Label("create", "envtest", "v1alpha2", "validation", "vcsim", "webhook"), intgTestsValidateCreate)
+	Describe("Update", Label("update", "envtest", "v1alpha2", "validation", "vcsim", "webhook"), intgTestsValidateUpdate)
+	Describe("Delete", Label("delete", "envtest", "v1alpha2", "validation", "vcsim", "webhook"), intgTestsValidateDelete)
 }
 
 type intgValidatingWebhookContext struct {

--- a/webhooks/virtualmachinesetresourcepolicy/v1alpha2/validation/virtualmachinesetresourcepolicy_validator_unit_test.go
+++ b/webhooks/virtualmachinesetresourcepolicy/v1alpha2/validation/virtualmachinesetresourcepolicy_validator_unit_test.go
@@ -18,9 +18,9 @@ import (
 )
 
 func unitTests() {
-	Describe("Invoking ValidateCreate", unitTestsValidateCreate)
-	Describe("Invoking ValidateUpdate", unitTestsValidateUpdate)
-	Describe("Invoking ValidateDelete", unitTestsValidateDelete)
+	Describe("Create", Label("create", "v1alpha2", "validation", "webhook"), unitTestsValidateCreate)
+	Describe("Update", Label("update", "v1alpha2", "validation", "webhook"), unitTestsValidateUpdate)
+	Describe("Delete", Label("delete", "v1alpha2", "validation", "webhook"), unitTestsValidateDelete)
 }
 
 type unitValidatingWebhookContext struct {

--- a/webhooks/virtualmachinewebconsolerequest/v1alpha1/validation/webconsolerequest_validator_intg_test.go
+++ b/webhooks/virtualmachinewebconsolerequest/v1alpha1/validation/webconsolerequest_validator_intg_test.go
@@ -14,9 +14,9 @@ import (
 )
 
 func intgTests() {
-	Describe("Invoking Create", intgTestsValidateCreate)
-	Describe("Invoking Update", intgTestsValidateUpdate)
-	Describe("Invoking Delete", intgTestsValidateDelete)
+	Describe("Create", Label("create", "envtest", "v1alpha2", "validation", "vcsim", "webhook"), intgTestsValidateCreate)
+	Describe("Update", Label("update", "envtest", "v1alpha2", "validation", "vcsim", "webhook"), intgTestsValidateUpdate)
+	Describe("Delete", Label("delete", "envtest", "v1alpha2", "validation", "vcsim", "webhook"), intgTestsValidateDelete)
 }
 
 type intgValidatingWebhookContext struct {

--- a/webhooks/virtualmachinewebconsolerequest/v1alpha1/validation/webconsolerequest_validator_unit_test.go
+++ b/webhooks/virtualmachinewebconsolerequest/v1alpha1/validation/webconsolerequest_validator_unit_test.go
@@ -19,9 +19,9 @@ import (
 )
 
 func unitTests() {
-	Describe("Invoking ValidateCreate", unitTestsValidateCreate)
-	Describe("Invoking ValidateUpdate", unitTestsValidateUpdate)
-	Describe("Invoking ValidateDelete", unitTestsValidateDelete)
+	Describe("Create", Label("create", "v1alpha1", "validation", "webhook"), unitTestsValidateCreate)
+	Describe("Update", Label("update", "v1alpha1", "validation", "webhook"), unitTestsValidateUpdate)
+	Describe("Delete", Label("delete", "v1alpha1", "validation", "webhook"), unitTestsValidateDelete)
 }
 
 type unitValidatingWebhookContext struct {

--- a/webhooks/virtualmachinewebconsolerequest/v1alpha2/validation/webconsolerequest_validator_intg_test.go
+++ b/webhooks/virtualmachinewebconsolerequest/v1alpha2/validation/webconsolerequest_validator_intg_test.go
@@ -14,9 +14,9 @@ import (
 )
 
 func intgTests() {
-	Describe("Invoking Create", intgTestsValidateCreate)
-	Describe("Invoking Update", intgTestsValidateUpdate)
-	Describe("Invoking Delete", intgTestsValidateDelete)
+	Describe("Create", Label("create", "envtest", "v1alpha2", "validation", "vcsim", "webhook"), intgTestsValidateCreate)
+	Describe("Update", Label("update", "envtest", "v1alpha2", "validation", "vcsim", "webhook"), intgTestsValidateUpdate)
+	Describe("Delete", Label("delete", "envtest", "v1alpha2", "validation", "vcsim", "webhook"), intgTestsValidateDelete)
 }
 
 type intgValidatingWebhookContext struct {

--- a/webhooks/virtualmachinewebconsolerequest/v1alpha2/validation/webconsolerequest_validator_unit_test.go
+++ b/webhooks/virtualmachinewebconsolerequest/v1alpha2/validation/webconsolerequest_validator_unit_test.go
@@ -19,9 +19,9 @@ import (
 )
 
 func unitTests() {
-	Describe("Invoking ValidateCreate", unitTestsValidateCreate)
-	Describe("Invoking ValidateUpdate", unitTestsValidateUpdate)
-	Describe("Invoking ValidateDelete", unitTestsValidateDelete)
+	Describe("Create", Label("create", "v1alpha2", "validation", "webhook"), unitTestsValidateCreate)
+	Describe("Update", Label("update", "v1alpha2", "validation", "webhook"), unitTestsValidateUpdate)
+	Describe("Delete", Label("delete", "v1alpha2", "validation", "webhook"), unitTestsValidateDelete)
 }
 
 type unitValidatingWebhookContext struct {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->

This patch introduces labels to Ginkgo tests. For example, the following labels now exist:

| Label | Description |
|---|---|
| `api` | related to the APIs |
| `controller` | a controller test |
| `create` | a webhook create test |
| `delete` | a webhook delete test |
| `envtest` | depends on envtest |
| `fuzz` | related to fuzz testing |
| `mutation` | a mutation webhook test |
| `nsxt` | related to NSX-T |
| `update` | a webhook update test |
| `validation` | a validation webhook test |
| `v1alpha1` | related to v1alpha1 |
| `v1alpha2` | related to v1alpha2 |
| `vcsim` | depends on vcsim |
| `webhook` | a webhook test |

The above labels make it trivial to run tests related to specific categories, or excluding others. For example, the following command will run all webhook tests that do not depend on envtest:

```shell
ginkgo -r -v --label-filter '!envtest && webhook'
```

The flags `--enable-integration-tests` and `--enable-unit-tests` have also been removed, including their associated environment variables, `ENABLE_INTEGRATION_TESTS` and `ENABLE_UNIT_TESTS`. There is no longer an equivalent for disabling all "unit" tests. However, there is a direct correlation between what used to be considered integration tests and the `envtest` label. Therefore, to run all the tests that used to be considered integration tests, use the following command:

```shell
ginkgo -r -v --label-filter 'envtest'
```

To run all the tests that used to be considered *not* integration tests, use the following command:

```shell
ginkgo -r -v --label-filter '!envtest'
```

The `--label-filter` flag is documented as follows:

>  If set, ginkgo will only run specs with labels that match the label-filter.  The passed-in expression can include boolean operations (!, &&, ||, ','), groupings via '()', and regular expressions '/regexp/'.  e.g. '(cat || dog) && !fruit'

Additionally, the fuzz tests in `./api/v1alpha1/conversion_test.go` have been updated to use Ginkgo in order to take advantage of the test labels.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->

@bryanv , please note this from the description:

> Additionally, the fuzz tests in `./api/v1alpha1/conversion_test.go` have been updated to use Ginkgo in order to take advantage of the test labels.

**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```