### PR TITLE
Mark VirtualMachineService LoadBalancerIP as deprecated

### DIFF
--- a/api/v1alpha1/virtualmachineservice_types.go
+++ b/api/v1alpha1/virtualmachineservice_types.go
@@ -91,6 +91,9 @@ type VirtualMachineServiceSpec struct {
 	// This feature depends on whether the underlying load balancer provider supports specifying
 	// the loadBalancerIP when a load balancer is created.
 	// This field will be ignored if the provider does not support the feature.
+	// Deprecated: This field was under-specified and its meaning varies across implementations.
+	// Using it is non-portable and it may not support dual-stack.
+	// Users are encouraged to use implementation-specific annotations when available.
 	// +optional
 	LoadBalancerIP string `json:"loadBalancerIP,omitempty"`
 

--- a/api/v1alpha2/virtualmachineservice_types.go
+++ b/api/v1alpha2/virtualmachineservice_types.go
@@ -97,6 +97,9 @@ type VirtualMachineServiceSpec struct {
 	// This feature depends on whether the underlying load balancer provider
 	// supports specifying the loadBalancerIP when a load balancer is created.
 	// This field will be ignored if the provider does not support the feature.
+	// Deprecated: This field was under-specified and its meaning varies across implementations.
+	// Using it is non-portable and it may not support dual-stack.
+	// Users are encouraged to use implementation-specific annotations when available.
 	// +optional
 	LoadBalancerIP string `json:"loadBalancerIP,omitempty"`
 

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachineservices.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachineservices.yaml
@@ -84,6 +84,9 @@ spec:
                   This feature depends on whether the underlying load balancer provider supports specifying
                   the loadBalancerIP when a load balancer is created.
                   This field will be ignored if the provider does not support the feature.
+                  Deprecated: This field was under-specified and its meaning varies across implementations.
+                  Using it is non-portable and it may not support dual-stack.
+                  Users are encouraged to use implementation-specific annotations when available.
                 type: string
               loadBalancerSourceRanges:
                 description: |-
@@ -241,6 +244,9 @@ spec:
                   This feature depends on whether the underlying load balancer provider
                   supports specifying the loadBalancerIP when a load balancer is created.
                   This field will be ignored if the provider does not support the feature.
+                  Deprecated: This field was under-specified and its meaning varies across implementations.
+                  Using it is non-portable and it may not support dual-stack.
+                  Users are encouraged to use implementation-specific annotations when available.
                 type: string
               loadBalancerSourceRanges:
                 description: |-


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

The underlying k8s Service field was deprecated in v1.24 and our controller just passes through the from the VirtualMachineService to the Service. Use the same deprecate message as upstream.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

I can tweak the deprecation message to be more specific to our env/wcp instead. We'll have to update this depreciation message once we implement a single annotation that covers all our possible/supported LBs.

See https://github.com/kubernetes/kubernetes/pull/107235 for the upstream deprecation

**Please add a release note if necessary**:

```release-note
The VirtualMachineService.Spec.LoadBalancerIP is deprecated. Users are encouraged to use implementation-specific annotations when available. 
```