### PR TITLE
🐛 Fix inability to get ConfigMap/Secret objs

### DIFF
--- a/controllers/infra/configmap/infra_configmap.go
+++ b/controllers/infra/configmap/infra_configmap.go
@@ -12,7 +12,8 @@ import (
 )
 
 const (
-	// WcpClusterConfigMapNamespace is the namespace of the wcp-cluster-config ConfigMap.
+	// WcpClusterConfigMapNamespace is the namespace of the wcp-cluster-config
+	// ConfigMap.
 	WcpClusterConfigMapNamespace = "kube-system"
 
 	// WcpClusterConfigMapName is the name of the wcp-cluster-config ConfigMap.

--- a/controllers/infra/configmap/infra_configmap_controller.go
+++ b/controllers/infra/configmap/infra_configmap_controller.go
@@ -11,22 +11,25 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	ctrl "sigs.k8s.io/controller-runtime"
-	ctrlbuilder "sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	pkgconfig "github.com/vmware-tanzu/vm-operator/pkg/config"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
+	pkgmgr "github.com/vmware-tanzu/vm-operator/pkg/manager"
 	"github.com/vmware-tanzu/vm-operator/pkg/record"
 )
 
 // AddToManager adds this package's controller to the provided manager.
 func AddToManager(ctx *context.ControllerManagerContext, mgr manager.Manager) error {
 	var (
+		controlledType      = &corev1.ConfigMap{}
 		controllerName      = "infra-configmap"
 		controllerNameShort = fmt.Sprintf("%s-controller", controllerName)
 		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
@@ -41,29 +44,39 @@ func AddToManager(ctx *context.ControllerManagerContext, mgr manager.Manager) er
 		ctx.VMProviderA2,
 	)
 
-	return ctrl.NewControllerManagedBy(mgr).
-		Named(controllerName).
-		Watches(
-			&corev1.ConfigMap{},
-			&handler.EnqueueRequestForObject{},
-			ctrlbuilder.WithPredicates(
-				predicate.Funcs{
-					CreateFunc: func(e event.CreateEvent) bool {
-						return e.Object.GetName() == WcpClusterConfigMapName
-					},
-					UpdateFunc: func(e event.UpdateEvent) bool {
-						return e.ObjectOld.GetName() == WcpClusterConfigMapName
-					},
-					DeleteFunc: func(e event.DeleteEvent) bool {
-						return false
-					},
-					GenericFunc: func(e event.GenericEvent) bool {
-						return false
-					},
-				},
-				predicate.ResourceVersionChangedPredicate{},
-			)).
-		Complete(r)
+	c, err := controller.New(controllerName, mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	cache, err := pkgmgr.NewNamespacedCacheForObject(
+		mgr,
+		&ctx.SyncPeriod,
+		controlledType,
+		WcpClusterConfigMapNamespace)
+	if err != nil {
+		return err
+	}
+
+	return c.Watch(
+		source.Kind(cache, controlledType),
+		&handler.EnqueueRequestForObject{},
+		predicate.Funcs{
+			CreateFunc: func(e event.CreateEvent) bool {
+				return e.Object.GetName() == WcpClusterConfigMapName
+			},
+			UpdateFunc: func(e event.UpdateEvent) bool {
+				return e.ObjectOld.GetName() == WcpClusterConfigMapName
+			},
+			DeleteFunc: func(e event.DeleteEvent) bool {
+				return false
+			},
+			GenericFunc: func(e event.GenericEvent) bool {
+				return false
+			},
+		},
+		predicate.ResourceVersionChangedPredicate{},
+	)
 }
 
 type provider interface {

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -69,16 +69,17 @@ func New(ctx goctx.Context, opts Options) (Manager, error) {
 		Cache: cache.Options{
 			DefaultNamespaces: GetNamespaceCacheConfigs(opts.WatchNamespace),
 			SyncPeriod:        &opts.SyncPeriod,
-			ByObject: map[client.Object]cache.ByObject{
-				&corev1.ConfigMap{}: {
-					Namespaces: map[string]cache.Config{
-						"kube-system": {}, // WCP config map
-					},
-				},
-				&corev1.Secret{}: {
-					Namespaces: map[string]cache.Config{
-						opts.PodNamespace: {}, // VM Op credentials
-					},
+		},
+		Client: client.Options{
+			Cache: &client.CacheOptions{
+				// An informer is created for each watched resource. Due to the
+				// number of ConfigMap and Secret resources that may exist,
+				// watching each one can result in VM Operator being terminated
+				// due to an out-of-memory error, i.e. OOMKill. To avoid this
+				// outcome, ConfigMap and Secret resources are not cached.
+				DisableFor: []client.Object{
+					&corev1.ConfigMap{},
+					&corev1.Secret{},
 				},
 			},
 		},

--- a/pkg/manager/test/cache_test.go
+++ b/pkg/manager/test/cache_test.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package manager_test
+
+import (
+	"context"
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/rest"
+
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+func cacheTests() {
+	var (
+		ctx    *builder.IntegrationTestContext
+		client ctrlclient.Client
+		cache  *cacheProxy
+	)
+
+	BeforeEach(func() {
+		ctx = suite.NewIntegrationTestContext()
+		client = suite.GetManager().GetClient()
+		Expect(suite.GetManager().GetCache()).To(BeAssignableToTypeOf(&cacheProxy{}))
+		cache = suite.GetManager().GetCache().(*cacheProxy)
+	})
+
+	AfterEach(func() {
+		ctx.AfterEach()
+		ctx = nil
+	})
+
+	Context("Getting objects", func() {
+		var (
+			obj    ctrlclient.Object
+			objKey ctrlclient.ObjectKey
+		)
+		JustBeforeEach(func() {
+			obj.SetGenerateName("my-object-")
+			obj.SetNamespace(ctx.Namespace)
+			Expect(client.Create(ctx, obj)).To(Succeed())
+			objKey = ctrlclient.ObjectKeyFromObject(obj)
+		})
+
+		Context("ConfigMap", func() {
+			BeforeEach(func() {
+				obj = &corev1.ConfigMap{}
+			})
+			It("should return the object with a live read", func() {
+				Expect(client.Get(ctx, objKey, obj)).To(Succeed())
+				Expect(cache.getCallCountFor(obj)).To(Equal(0))
+			})
+		})
+		Context("Node", func() {
+			BeforeEach(func() {
+				obj = &corev1.Node{}
+			})
+			It("should return the object with a live read", func() {
+				Expect(client.Get(ctx, objKey, obj)).To(Succeed())
+				Expect(cache.getCallCountFor(obj)).To(Equal(1))
+			})
+		})
+		Context("Secret", func() {
+			BeforeEach(func() {
+				obj = &corev1.Secret{}
+			})
+			It("should return the object with a live read", func() {
+				Expect(client.Get(ctx, objKey, obj)).To(Succeed())
+				Expect(cache.getCallCountFor(obj)).To(Equal(0))
+			})
+		})
+	})
+}
+
+type cacheProxy struct {
+	sync.Mutex
+	ctrlcache.Cache
+	getCalls map[ctrlclient.Object]int
+}
+
+func newCacheProxy(
+	config *rest.Config,
+	opts ctrlcache.Options) (ctrlcache.Cache, error) {
+
+	cache, err := ctrlcache.New(config, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &cacheProxy{
+		Cache:    cache,
+		getCalls: map[ctrlclient.Object]int{},
+	}, nil
+}
+
+func (c *cacheProxy) getCallCountFor(obj ctrlclient.Object) int {
+	c.Lock()
+	defer c.Unlock()
+	return c.getCalls[obj]
+}
+
+func (c *cacheProxy) Get(
+	ctx context.Context,
+	key ctrlclient.ObjectKey,
+	obj ctrlclient.Object,
+	opts ...ctrlclient.GetOption) error {
+
+	c.Lock()
+	defer c.Unlock()
+
+	if i, ok := c.getCalls[obj]; ok {
+		c.getCalls[obj] = i + 1
+	} else {
+		c.getCalls[obj] = 1
+	}
+
+	return c.Cache.Get(ctx, key, obj, opts...)
+}

--- a/pkg/manager/test/manager_suite_test.go
+++ b/pkg/manager/test/manager_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package manager_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+func integTests() {
+	Describe("Cache", Ordered, Label("envtest"), cacheTests)
+}
+
+var suite = builder.NewTestSuite()
+
+func TestManager(t *testing.T) {
+	suite.SetManagerNewCacheFunc(newCacheProxy)
+	suite.Register(t, "Manager Suite", integTests, nil)
+}
+
+var _ = BeforeSuite(suite.BeforeSuite)
+
+var _ = AfterSuite(suite.AfterSuite)

--- a/test/builder/test_suite.go
+++ b/test/builder/test_suite.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/yaml"
@@ -88,6 +89,7 @@ type TestSuite struct {
 	addToManagerFn      pkgmgr.AddToManagerFunc
 	initProvidersFn     pkgmgr.InitializeProvidersFunc
 	integrationTest     bool
+	newCacheFn          ctrlcache.NewCacheFunc
 	manager             pkgmgr.Manager
 	managerRunning      bool
 	managerRunningMutex sync.Mutex
@@ -103,6 +105,14 @@ type TestSuite struct {
 
 func (s *TestSuite) isWebhookTest() bool {
 	return s.webhookName != ""
+}
+
+func (s *TestSuite) GetManager() pkgmgr.Manager {
+	return s.manager
+}
+
+func (s *TestSuite) SetManagerNewCacheFunc(f ctrlcache.NewCacheFunc) {
+	s.newCacheFn = f
 }
 
 func (s *TestSuite) GetEnvTestConfig() *rest.Config {
@@ -337,6 +347,7 @@ func (s *TestSuite) createManager() {
 		MetricsAddr:         "0",
 		AddToManager:        s.addToManagerFn,
 		InitializeProviders: s.initProvidersFn,
+		NewCache:            s.newCacheFn,
 	}
 
 	if pkgconfig.FromContext(s).Features.VMOpV1Alpha2 {


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch addresses a bug created by https://github.com/vmware-tanzu/vm-operator/pull/414 and the move to the new, built-in cache logic in Controller-Runtime v0.17.x. In adopting this logic a mistake was made regarding how the logic corresponded to bypassing the cache for certain object types. This patch fixes the issue by once again disabling the global cache for ConfigMap and Secret resources, but this time using specific caches for the infra controllers.

A new test package, pkg/manager/test, has also been created to verify that the global cache is in fact bypassed for the disabled objects.



**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Fix error when getting ConfigMap and Secret resources
```