### PR TITLE
🌱 Test Labels Constants

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,17 +247,21 @@ modules: ## Validates the modules
 	go mod tidy
 	cd hack/tools && go mod tidy
 	cd api && go mod tidy
+	cd pkg/constants/testlabels && go mod tidy
 
 .PHONY: modules-vendor
 modules-vendor: ## Vendors the modules
 	go mod vendor
-	cd api && go mod tidy
+	cd hack/tools && go mod vendor
+	cd api && go mod vendor
+	cd pkg/constants/testlabels && go mod vendor
 
 .PHONY: modules-download
 modules-download: ## Downloads and caches the modules
 	go mod download
 	cd hack/tools && go mod download
 	cd api && go mod download
+	cd pkg/constants/testlabels && go mod download
 
 .PHONY: generate
 generate: ## Generate code

--- a/api/go.mod
+++ b/api/go.mod
@@ -4,13 +4,14 @@ go 1.21
 
 toolchain go1.21.5
 
-replace github.com/onsi/ginkgo/v2 => github.com/onsi/ginkgo/v2 v2.15.0
+replace github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels => ../pkg/constants/testlabels
 
 require (
 	github.com/google/go-cmp v0.6.0
 	github.com/google/gofuzz v1.2.0
 	github.com/onsi/ginkgo/v2 v2.15.0
 	github.com/onsi/gomega v1.31.0
+	github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels v0.0.0-00010101000000-000000000000
 	k8s.io/api v0.29.0
 	k8s.io/apimachinery v0.29.0
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b

--- a/api/v1alpha1/conversion_test.go
+++ b/api/v1alpha1/conversion_test.go
@@ -14,12 +14,13 @@ import (
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 
 	"github.com/vmware-tanzu/vm-operator/api/utilconversion"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 
 	"github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	nextver "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 )
 
-var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
+var _ = Describe("FuzzyConversion", Label(testlabels.API, testlabels.Fuzz), func() {
 
 	var (
 		scheme *runtime.Scheme

--- a/controllers/contentlibrary/v1alpha2/clustercontentlibraryitem/clustercontentlibraryitem_controller_intg_test.go
+++ b/controllers/contentlibrary/v1alpha2/clustercontentlibraryitem/clustercontentlibraryitem_controller_intg_test.go
@@ -22,11 +22,20 @@ import (
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	"github.com/vmware-tanzu/vm-operator/controllers/contentlibrary/v1alpha2/utils"
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func intgTests() {
-	Describe("Reconcile", Label("controller", "envtest", "v1alpha2"), intgTestsReconcile)
+	Describe(
+		"Reconcile",
+		Label(
+			testlabels.Controller,
+			testlabels.EnvTest,
+			testlabels.V1Alpha2,
+		),
+		intgTestsReconcile,
+	)
 }
 
 func intgTestsReconcile() {

--- a/controllers/contentlibrary/v1alpha2/clustercontentlibraryitem/clustercontentlibraryitem_controller_unit_test.go
+++ b/controllers/contentlibrary/v1alpha2/clustercontentlibraryitem/clustercontentlibraryitem_controller_unit_test.go
@@ -22,13 +22,21 @@ import (
 	"github.com/vmware-tanzu/vm-operator/controllers/contentlibrary/v1alpha2/clustercontentlibraryitem"
 	"github.com/vmware-tanzu/vm-operator/controllers/contentlibrary/v1alpha2/utils"
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
 	providerfake "github.com/vmware-tanzu/vm-operator/pkg/vmprovider/fake"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func unitTests() {
-	Describe("Reconcile", Label("controller", "v1alpha2"), unitTestsReconcile)
+	Describe(
+		"Reconcile",
+		Label(
+			testlabels.Controller,
+			testlabels.V1Alpha2,
+		),
+		unitTestsReconcile,
+	)
 }
 
 func unitTestsReconcile() {

--- a/controllers/contentlibrary/v1alpha2/contentlibraryitem/contentlibraryitem_controller_intg_test.go
+++ b/controllers/contentlibrary/v1alpha2/contentlibraryitem/contentlibraryitem_controller_intg_test.go
@@ -19,11 +19,20 @@ import (
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	"github.com/vmware-tanzu/vm-operator/controllers/contentlibrary/v1alpha2/utils"
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func intgTests() {
-	Describe("Reconcile", Label("controller", "envtest", "v1alpha2"), intgTestsReconcile)
+	Describe(
+		"Reconcile",
+		Label(
+			testlabels.Controller,
+			testlabels.EnvTest,
+			testlabels.V1Alpha2,
+		),
+		intgTestsReconcile,
+	)
 }
 
 func intgTestsReconcile() {

--- a/controllers/contentlibrary/v1alpha2/contentlibraryitem/contentlibraryitem_controller_unit_test.go
+++ b/controllers/contentlibrary/v1alpha2/contentlibraryitem/contentlibraryitem_controller_unit_test.go
@@ -22,13 +22,21 @@ import (
 	"github.com/vmware-tanzu/vm-operator/controllers/contentlibrary/v1alpha2/contentlibraryitem"
 	"github.com/vmware-tanzu/vm-operator/controllers/contentlibrary/v1alpha2/utils"
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
 	providerfake "github.com/vmware-tanzu/vm-operator/pkg/vmprovider/fake"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func unitTests() {
-	Describe("Reconcile", Label("controller", "v1alpha2"), unitTestsReconcile)
+	Describe(
+		"Reconcile",
+		Label(
+			testlabels.Controller,
+			testlabels.V1Alpha2,
+		),
+		unitTestsReconcile,
+	)
 }
 
 func unitTestsReconcile() {

--- a/controllers/infra/configmap/infra_configmap_controller_intg_test.go
+++ b/controllers/infra/configmap/infra_configmap_controller_intg_test.go
@@ -14,11 +14,20 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/vmware-tanzu/vm-operator/controllers/infra/configmap"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func intgTests() {
-	Describe("Reconcile", Label("controller", "envtest", "v1alpha2"), intgTestsReconcile)
+	Describe(
+		"Reconcile",
+		Label(
+			testlabels.Controller,
+			testlabels.EnvTest,
+			testlabels.V1Alpha2,
+		),
+		intgTestsReconcile,
+	)
 }
 
 func intgTestsReconcile() {

--- a/controllers/infra/configmap/infra_configmap_test.go
+++ b/controllers/infra/configmap/infra_configmap_test.go
@@ -8,10 +8,11 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/vmware-tanzu/vm-operator/controllers/infra/configmap"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 )
 
 func unitTests() {
-	Describe("WCP Config", Label("v1alpha2"), unitTestsWcpConfig)
+	Describe("WCP Config", Label(testlabels.V1Alpha2), unitTestsWcpConfig)
 }
 
 func unitTestsWcpConfig() {

--- a/controllers/infra/node/infra_node_controller_intg_test.go
+++ b/controllers/infra/node/infra_node_controller_intg_test.go
@@ -14,11 +14,20 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func intgTests() {
-	Describe("Reconcile", Label("controller", "envtest", "v1alpha2"), intgTestsReconcile)
+	Describe(
+		"Reconcile",
+		Label(
+			testlabels.Controller,
+			testlabels.EnvTest,
+			testlabels.V1Alpha2,
+		),
+		intgTestsReconcile,
+	)
 }
 
 func intgTestsReconcile() {

--- a/controllers/infra/secret/infra_secret_controller_intg_test.go
+++ b/controllers/infra/secret/infra_secret_controller_intg_test.go
@@ -15,11 +15,20 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/vmware-tanzu/vm-operator/controllers/infra/secret"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func intgTests() {
-	Describe("Reconcile", Label("controller", "envtest", "v1alpha2"), intgTestsReconcile)
+	Describe(
+		"Reconcile",
+		Label(
+			testlabels.Controller,
+			testlabels.EnvTest,
+			testlabels.V1Alpha2,
+		),
+		intgTestsReconcile,
+	)
 }
 
 func intgTestsReconcile() {

--- a/controllers/virtualmachine/v1alpha2/virtualmachine_controller_intg_test.go
+++ b/controllers/virtualmachine/v1alpha2/virtualmachine_controller_intg_test.go
@@ -17,12 +17,21 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func intgTests() {
-	Describe("Reconcile", Label("controller", "envtest", "v1alpha2"), intgTestsReconcile)
+	Describe(
+		"Reconcile",
+		Label(
+			testlabels.Controller,
+			testlabels.EnvTest,
+			testlabels.V1Alpha2,
+		),
+		intgTestsReconcile,
+	)
 }
 
 func intgTestsReconcile() {

--- a/controllers/virtualmachine/v1alpha2/virtualmachine_controller_unit_test.go
+++ b/controllers/virtualmachine/v1alpha2/virtualmachine_controller_unit_test.go
@@ -18,6 +18,7 @@ import (
 
 	virtualmachine "github.com/vmware-tanzu/vm-operator/controllers/virtualmachine/v1alpha2"
 	pkgconfig "github.com/vmware-tanzu/vm-operator/pkg/config"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	vmopContext "github.com/vmware-tanzu/vm-operator/pkg/context"
 	proberfake "github.com/vmware-tanzu/vm-operator/pkg/prober/fake"
 	providerfake "github.com/vmware-tanzu/vm-operator/pkg/vmprovider/fake"
@@ -27,7 +28,14 @@ import (
 const finalizer = "virtualmachine.vmoperator.vmware.com"
 
 func unitTests() {
-	Describe("Reconcile", Label("controller", "v1alpha2"), unitTestsReconcile)
+	Describe(
+		"Reconcile",
+		Label(
+			testlabels.Controller,
+			testlabels.V1Alpha2,
+		),
+		unitTestsReconcile,
+	)
 }
 
 func unitTestsReconcile() {

--- a/controllers/virtualmachineclass/v1alpha2/virtualmachineclass_controller_intg_test.go
+++ b/controllers/virtualmachineclass/v1alpha2/virtualmachineclass_controller_intg_test.go
@@ -12,11 +12,20 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func intgTests() {
-	Describe("Reconcile", Label("controller", "envtest", "v1alpha2"), intgTestsReconcile)
+	Describe(
+		"Reconcile",
+		Label(
+			testlabels.Controller,
+			testlabels.EnvTest,
+			testlabels.V1Alpha2,
+		),
+		intgTestsReconcile,
+	)
 }
 
 func intgTestsReconcile() {

--- a/controllers/virtualmachineclass/v1alpha2/virtualmachineclass_controller_unit_test.go
+++ b/controllers/virtualmachineclass/v1alpha2/virtualmachineclass_controller_unit_test.go
@@ -13,12 +13,20 @@ import (
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 
 	virtualmachineclass "github.com/vmware-tanzu/vm-operator/controllers/virtualmachineclass/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	vmopContext "github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func unitTests() {
-	Describe("Reconcile", Label("controller", "v1alpha2"), unitTestsReconcile)
+	Describe(
+		"Reconcile",
+		Label(
+			testlabels.Controller,
+			testlabels.V1Alpha2,
+		),
+		unitTestsReconcile,
+	)
 }
 
 func unitTestsReconcile() {

--- a/controllers/virtualmachinepublishrequest/v1alpha2/virtualmachinepublishrequest_controller_intg_test.go
+++ b/controllers/virtualmachinepublishrequest/v1alpha2/virtualmachinepublishrequest_controller_intg_test.go
@@ -23,11 +23,20 @@ import (
 	"github.com/vmware-tanzu/vm-operator/controllers/contentlibrary/v1alpha2/utils"
 	virtualmachinepublishrequest "github.com/vmware-tanzu/vm-operator/controllers/virtualmachinepublishrequest/v1alpha2"
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func intgTests() {
-	Describe("Reconcile", Label("controller", "envtest", "v1alpha2"), intgTestsReconcile)
+	Describe(
+		"Reconcile",
+		Label(
+			testlabels.Controller,
+			testlabels.EnvTest,
+			testlabels.V1Alpha2,
+		),
+		intgTestsReconcile,
+	)
 }
 
 func intgTestsReconcile() {

--- a/controllers/virtualmachinepublishrequest/v1alpha2/virtualmachinepublishrequest_controller_unit_test.go
+++ b/controllers/virtualmachinepublishrequest/v1alpha2/virtualmachinepublishrequest_controller_unit_test.go
@@ -25,6 +25,7 @@ import (
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	virtualmachinepublishrequest "github.com/vmware-tanzu/vm-operator/controllers/virtualmachinepublishrequest/v1alpha2"
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	vmopContext "github.com/vmware-tanzu/vm-operator/pkg/context"
 	providerfake "github.com/vmware-tanzu/vm-operator/pkg/vmprovider/fake"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
@@ -33,7 +34,14 @@ import (
 const finalizerName = "virtualmachinepublishrequest.vmoperator.vmware.com"
 
 func unitTests() {
-	Describe("Reconcile", Label("controller", "v1alpha2"), unitTestsReconcile)
+	Describe(
+		"Reconcile",
+		Label(
+			testlabels.Controller,
+			testlabels.V1Alpha2,
+		),
+		unitTestsReconcile,
+	)
 }
 
 func unitTestsReconcile() {

--- a/controllers/virtualmachineservice/v1alpha2/providers/loadbalancer_provider_test.go
+++ b/controllers/virtualmachineservice/v1alpha2/providers/loadbalancer_provider_test.go
@@ -14,221 +14,225 @@ import (
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachineservice/v1alpha2/utils"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 )
 
 const (
 	dummyNamespace = "dummy"
 )
 
-var _ = Describe("Loadbalancer Provider", Label("controller", "v1alpha2"), func() {
-	var (
-		ctx        context.Context
-		vmService  *vmopv1.VirtualMachineService
-		lbProvider LoadbalancerProvider
-	)
-
-	BeforeEach(func() {
-		ctx = context.Background()
-	})
-
-	Context("Get load balancer provider by type", func() {
-		It("should successfully get nsx-t load balancer provider", func() {
-			lbProvider, err := GetLoadbalancerProviderByType(nil, NSXTLoadBalancer)
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(lbProvider).ToNot(BeNil())
-		})
-
-		It("should successfully get a noop loadbalancer provider", func() {
-			lbProvider, err := GetLoadbalancerProviderByType(nil, "")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(lbProvider).To(Equal(NoopLoadbalancerProvider{}))
-		})
-	})
-
-	Context("noop loadbalancer provider", func() {
-		JustBeforeEach(func() {
-			lbProvider = &NoopLoadbalancerProvider{}
-		})
-
-		Context("EnsureLoadBalancer", func() {
-			It("should return success", func() {
-				err := lbProvider.EnsureLoadBalancer(ctx, nil)
-				Expect(err).ToNot(HaveOccurred())
-			})
-		})
-
-		Context("GetServiceLabels", func() {
-			It("should return empty", func() {
-				annotations, err := lbProvider.GetServiceLabels(ctx, nil)
-				Expect(annotations).To(BeNil())
-				Expect(err).ToNot(HaveOccurred())
-			})
-		})
-
-		Context("GetServiceAnnotations", func() {
-			It("should return empty", func() {
-				annotations, err := lbProvider.GetServiceAnnotations(ctx, nil)
-				Expect(annotations).To(BeNil())
-				Expect(err).ToNot(HaveOccurred())
-			})
-		})
-	})
-
-	Context("GetServiceAnnotations when VMService has healthCheckNodePort defined", func() {
-		BeforeEach(func() {
-			vmService = &vmopv1.VirtualMachineService{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "dummy-vmservice",
-					Namespace:   dummyNamespace,
-					Annotations: make(map[string]string),
-				},
-				Spec: vmopv1.VirtualMachineServiceSpec{
-					Type:         vmopv1.VirtualMachineServiceTypeClusterIP,
-					ClusterIP:    "TEST",
-					ExternalName: "TEST",
-				},
-			}
-			vmService.Annotations[utils.AnnotationServiceHealthCheckNodePortKey] = "30012"
-			lbProvider = NsxtLoadBalancerProvider()
-		})
-
-		It("should get health check node port in the annotation", func() {
-			vmServiceAnnotations, err := lbProvider.GetServiceAnnotations(ctx, vmService)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(vmServiceAnnotations).ToNot(BeNil())
-			port := vmServiceAnnotations[ServiceLoadBalancerHealthCheckNodePortTagKey]
-			Expect(port).To(Equal("30012"))
-		})
-	})
-
-	Context("GetToBeRemovedServiceAnnotations when VMService does not have healthCheckNodePort defined", func() {
-		BeforeEach(func() {
-			vmService = &vmopv1.VirtualMachineService{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "dummy-vmservice",
-					Namespace:   dummyNamespace,
-					Annotations: make(map[string]string),
-				},
-				Spec: vmopv1.VirtualMachineServiceSpec{
-					Type:         vmopv1.VirtualMachineServiceTypeClusterIP,
-					ClusterIP:    "TEST",
-					ExternalName: "TEST",
-				},
-			}
-			lbProvider = NsxtLoadBalancerProvider()
-		})
-
-		It("should get health check node port in the to be removed annotation", func() {
-			vmServiceAnnotations, err := lbProvider.GetToBeRemovedServiceAnnotations(ctx, vmService)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(vmServiceAnnotations).ToNot(BeNil())
-			Expect(vmServiceAnnotations).To(HaveKey(ServiceLoadBalancerHealthCheckNodePortTagKey))
-		})
-	})
-
-	Context("GetServiceLabels when VMService have externalTrafficPolicy annotation defined", func() {
-		BeforeEach(func() {
-			vmService = &vmopv1.VirtualMachineService{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "dummy-vmservice",
-					Namespace:   dummyNamespace,
-					Annotations: make(map[string]string),
-				},
-				Spec: vmopv1.VirtualMachineServiceSpec{
-					Type:         vmopv1.VirtualMachineServiceTypeClusterIP,
-					ClusterIP:    "TEST",
-					ExternalName: "TEST",
-				},
-			}
-			vmService.Annotations[utils.AnnotationServiceExternalTrafficPolicyKey] = string(corev1.ServiceExternalTrafficPolicyTypeCluster)
-			lbProvider = NsxtLoadBalancerProvider()
-		})
-
-		Context("EnsureLoadBalancer", func() {
-			It("should return success", func() {
-				err := lbProvider.EnsureLoadBalancer(ctx, nil)
-				Expect(err).ToNot(HaveOccurred())
-			})
-		})
-
-		Context("etp is Cluster", func() {
-			It("should not create any label", func() {
-				labels, err := lbProvider.GetServiceLabels(ctx, vmService)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(labels).To(BeEmpty())
-			})
-		})
-
-		Context("etp is Local", func() {
-			BeforeEach(func() {
-				vmService.Annotations[utils.AnnotationServiceExternalTrafficPolicyKey] = string(corev1.ServiceExternalTrafficPolicyTypeLocal)
-			})
-
-			It("should create one label for ServiceProxyName", func() {
-				labels, err := lbProvider.GetServiceLabels(ctx, vmService)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(labels).To(HaveLen(1))
-				Expect(labels[LabelServiceProxyName]).To(Equal(NSXTServiceProxy))
-			})
-		})
-	})
-
-	Context("GetToBeRemovedServiceLabels", func() {
+var _ = Describe(
+	"Loadbalancer Provider",
+	Label(testlabels.Controller, testlabels.V1Alpha2),
+	func() {
 		var (
-			labels map[string]string
-			err    error
+			ctx        context.Context
+			vmService  *vmopv1.VirtualMachineService
+			lbProvider LoadbalancerProvider
 		)
 
 		BeforeEach(func() {
-			vmService = &vmopv1.VirtualMachineService{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "dummy-vmservice",
-					Namespace:   dummyNamespace,
-					Annotations: make(map[string]string),
-				},
-				Spec: vmopv1.VirtualMachineServiceSpec{
-					Type:         vmopv1.VirtualMachineServiceTypeClusterIP,
-					ClusterIP:    "TEST",
-					ExternalName: "TEST",
-				},
-			}
-			lbProvider = NsxtLoadBalancerProvider()
+			ctx = context.Background()
 		})
 
-		JustBeforeEach(func() {
-			labels, err = lbProvider.GetToBeRemovedServiceLabels(ctx, vmService)
-		})
+		Context("Get load balancer provider by type", func() {
+			It("should successfully get nsx-t load balancer provider", func() {
+				lbProvider, err := GetLoadbalancerProviderByType(nil, NSXTLoadBalancer)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(lbProvider).ToNot(BeNil())
+			})
 
-		Context("etp is not present", func() {
-			It("should remove ServiceProxyName label", func() {
-				Expect(err).ToNot(HaveOccurred())
-				_, exists := labels[LabelServiceProxyName]
-				Expect(exists).To(BeTrue())
+			It("should successfully get a noop loadbalancer provider", func() {
+				lbProvider, err := GetLoadbalancerProviderByType(nil, "")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(lbProvider).To(Equal(NoopLoadbalancerProvider{}))
 			})
 		})
 
-		Context("etp is Local", func() {
+		Context("noop loadbalancer provider", func() {
+			JustBeforeEach(func() {
+				lbProvider = &NoopLoadbalancerProvider{}
+			})
+
+			Context("EnsureLoadBalancer", func() {
+				It("should return success", func() {
+					err := lbProvider.EnsureLoadBalancer(ctx, nil)
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+
+			Context("GetServiceLabels", func() {
+				It("should return empty", func() {
+					annotations, err := lbProvider.GetServiceLabels(ctx, nil)
+					Expect(annotations).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+
+			Context("GetServiceAnnotations", func() {
+				It("should return empty", func() {
+					annotations, err := lbProvider.GetServiceAnnotations(ctx, nil)
+					Expect(annotations).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+
+		Context("GetServiceAnnotations when VMService has healthCheckNodePort defined", func() {
 			BeforeEach(func() {
-				vmService.Annotations[utils.AnnotationServiceExternalTrafficPolicyKey] = string(corev1.ServiceExternalTrafficPolicyTypeLocal)
+				vmService = &vmopv1.VirtualMachineService{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "dummy-vmservice",
+						Namespace:   dummyNamespace,
+						Annotations: make(map[string]string),
+					},
+					Spec: vmopv1.VirtualMachineServiceSpec{
+						Type:         vmopv1.VirtualMachineServiceTypeClusterIP,
+						ClusterIP:    "TEST",
+						ExternalName: "TEST",
+					},
+				}
+				vmService.Annotations[utils.AnnotationServiceHealthCheckNodePortKey] = "30012"
+				lbProvider = NsxtLoadBalancerProvider()
 			})
 
-			It("should not remove ServiceProxyName label", func() {
+			It("should get health check node port in the annotation", func() {
+				vmServiceAnnotations, err := lbProvider.GetServiceAnnotations(ctx, vmService)
 				Expect(err).ToNot(HaveOccurred())
-				_, exists := labels[LabelServiceProxyName]
-				Expect(exists).To(BeFalse())
+				Expect(vmServiceAnnotations).ToNot(BeNil())
+				port := vmServiceAnnotations[ServiceLoadBalancerHealthCheckNodePortTagKey]
+				Expect(port).To(Equal("30012"))
 			})
 		})
 
-		Context("etp is Cluster", func() {
+		Context("GetToBeRemovedServiceAnnotations when VMService does not have healthCheckNodePort defined", func() {
 			BeforeEach(func() {
+				vmService = &vmopv1.VirtualMachineService{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "dummy-vmservice",
+						Namespace:   dummyNamespace,
+						Annotations: make(map[string]string),
+					},
+					Spec: vmopv1.VirtualMachineServiceSpec{
+						Type:         vmopv1.VirtualMachineServiceTypeClusterIP,
+						ClusterIP:    "TEST",
+						ExternalName: "TEST",
+					},
+				}
+				lbProvider = NsxtLoadBalancerProvider()
+			})
+
+			It("should get health check node port in the to be removed annotation", func() {
+				vmServiceAnnotations, err := lbProvider.GetToBeRemovedServiceAnnotations(ctx, vmService)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(vmServiceAnnotations).ToNot(BeNil())
+				Expect(vmServiceAnnotations).To(HaveKey(ServiceLoadBalancerHealthCheckNodePortTagKey))
+			})
+		})
+
+		Context("GetServiceLabels when VMService have externalTrafficPolicy annotation defined", func() {
+			BeforeEach(func() {
+				vmService = &vmopv1.VirtualMachineService{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "dummy-vmservice",
+						Namespace:   dummyNamespace,
+						Annotations: make(map[string]string),
+					},
+					Spec: vmopv1.VirtualMachineServiceSpec{
+						Type:         vmopv1.VirtualMachineServiceTypeClusterIP,
+						ClusterIP:    "TEST",
+						ExternalName: "TEST",
+					},
+				}
 				vmService.Annotations[utils.AnnotationServiceExternalTrafficPolicyKey] = string(corev1.ServiceExternalTrafficPolicyTypeCluster)
+				lbProvider = NsxtLoadBalancerProvider()
 			})
 
-			It("should remove ServiceProxyName label", func() {
-				Expect(err).ToNot(HaveOccurred())
-				_, exists := labels[LabelServiceProxyName]
-				Expect(exists).To(BeTrue())
+			Context("EnsureLoadBalancer", func() {
+				It("should return success", func() {
+					err := lbProvider.EnsureLoadBalancer(ctx, nil)
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+
+			Context("etp is Cluster", func() {
+				It("should not create any label", func() {
+					labels, err := lbProvider.GetServiceLabels(ctx, vmService)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(labels).To(BeEmpty())
+				})
+			})
+
+			Context("etp is Local", func() {
+				BeforeEach(func() {
+					vmService.Annotations[utils.AnnotationServiceExternalTrafficPolicyKey] = string(corev1.ServiceExternalTrafficPolicyTypeLocal)
+				})
+
+				It("should create one label for ServiceProxyName", func() {
+					labels, err := lbProvider.GetServiceLabels(ctx, vmService)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(labels).To(HaveLen(1))
+					Expect(labels[LabelServiceProxyName]).To(Equal(NSXTServiceProxy))
+				})
+			})
+		})
+
+		Context("GetToBeRemovedServiceLabels", func() {
+			var (
+				labels map[string]string
+				err    error
+			)
+
+			BeforeEach(func() {
+				vmService = &vmopv1.VirtualMachineService{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "dummy-vmservice",
+						Namespace:   dummyNamespace,
+						Annotations: make(map[string]string),
+					},
+					Spec: vmopv1.VirtualMachineServiceSpec{
+						Type:         vmopv1.VirtualMachineServiceTypeClusterIP,
+						ClusterIP:    "TEST",
+						ExternalName: "TEST",
+					},
+				}
+				lbProvider = NsxtLoadBalancerProvider()
+			})
+
+			JustBeforeEach(func() {
+				labels, err = lbProvider.GetToBeRemovedServiceLabels(ctx, vmService)
+			})
+
+			Context("etp is not present", func() {
+				It("should remove ServiceProxyName label", func() {
+					Expect(err).ToNot(HaveOccurred())
+					_, exists := labels[LabelServiceProxyName]
+					Expect(exists).To(BeTrue())
+				})
+			})
+
+			Context("etp is Local", func() {
+				BeforeEach(func() {
+					vmService.Annotations[utils.AnnotationServiceExternalTrafficPolicyKey] = string(corev1.ServiceExternalTrafficPolicyTypeLocal)
+				})
+
+				It("should not remove ServiceProxyName label", func() {
+					Expect(err).ToNot(HaveOccurred())
+					_, exists := labels[LabelServiceProxyName]
+					Expect(exists).To(BeFalse())
+				})
+			})
+
+			Context("etp is Cluster", func() {
+				BeforeEach(func() {
+					vmService.Annotations[utils.AnnotationServiceExternalTrafficPolicyKey] = string(corev1.ServiceExternalTrafficPolicyTypeCluster)
+				})
+
+				It("should remove ServiceProxyName label", func() {
+					Expect(err).ToNot(HaveOccurred())
+					_, exists := labels[LabelServiceProxyName]
+					Expect(exists).To(BeTrue())
+				})
 			})
 		})
 	})
-})

--- a/controllers/virtualmachineservice/v1alpha2/virtualmachineservice_controller_intg_test.go
+++ b/controllers/virtualmachineservice/v1alpha2/virtualmachineservice_controller_intg_test.go
@@ -14,6 +14,7 @@ import (
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
@@ -22,7 +23,15 @@ const (
 )
 
 func intgTests() {
-	Describe("Reconcile", Label("controller", "envtest", "v1alpha2"), intgTestsReconcile)
+	Describe(
+		"Reconcile",
+		Label(
+			testlabels.Controller,
+			testlabels.EnvTest,
+			testlabels.V1Alpha2,
+		),
+		intgTestsReconcile,
+	)
 }
 
 func intgTestsReconcile() {

--- a/controllers/virtualmachineservice/v1alpha2/virtualmachineservice_controller_unit_test.go
+++ b/controllers/virtualmachineservice/v1alpha2/virtualmachineservice_controller_unit_test.go
@@ -22,13 +22,29 @@ import (
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachineservice/v1alpha2/providers"
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachineservice/v1alpha2/utils"
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	vmopContext "github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func unitTests() {
-	Describe("Reconcile", Label("controller", "v1alpha2"), unitTestsReconcile)
-	Describe("Reconcile", Label("controller", "nsxt", "v1alpha2"), nsxtLBProviderTestsReconcile)
+	Describe(
+		"Reconcile",
+		Label(
+			testlabels.Controller,
+			testlabels.V1Alpha2,
+		),
+		unitTestsReconcile,
+	)
+	Describe(
+		"Reconcile",
+		Label(
+			testlabels.Controller,
+			testlabels.NSXT,
+			testlabels.V1Alpha2,
+		),
+		nsxtLBProviderTestsReconcile,
+	)
 }
 
 const LabelServiceProxyName = "service.kubernetes.io/service-proxy-name"

--- a/controllers/virtualmachinesetresourcepolicy/v1alpha2/virtualmachinesetresourcepolicy_controller_intg_test.go
+++ b/controllers/virtualmachinesetresourcepolicy/v1alpha2/virtualmachinesetresourcepolicy_controller_intg_test.go
@@ -14,12 +14,21 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func intgTests() {
-	Describe("Reconcile", Label("controller", "envtest", "v1alpha2"), intgTestsReconcile)
+	Describe(
+		"Reconcile",
+		Label(
+			testlabels.Controller,
+			testlabels.EnvTest,
+			testlabels.V1Alpha2,
+		),
+		intgTestsReconcile,
+	)
 }
 
 func intgTestsReconcile() {

--- a/controllers/virtualmachinesetresourcepolicy/v1alpha2/virtualmachinesetresourcepolicy_controller_unit_test.go
+++ b/controllers/virtualmachinesetresourcepolicy/v1alpha2/virtualmachinesetresourcepolicy_controller_unit_test.go
@@ -16,6 +16,7 @@ import (
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 
 	virtualmachinesetresourcepolicy "github.com/vmware-tanzu/vm-operator/controllers/virtualmachinesetresourcepolicy/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
@@ -25,7 +26,14 @@ const (
 )
 
 func unitTests() {
-	Describe("Reconcile", Label("controller", "v1alpha2"), unitTestsReconcile)
+	Describe(
+		"Reconcile",
+		Label(
+			testlabels.Controller,
+			testlabels.V1Alpha2,
+		),
+		unitTestsReconcile,
+	)
 }
 
 func unitTestsReconcile() {

--- a/controllers/virtualmachinewebconsolerequest/v1alpha1/patch/patch_test.go
+++ b/controllers/virtualmachinewebconsolerequest/v1alpha1/patch/patch_test.go
@@ -33,11 +33,12 @@ import (
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachinewebconsolerequest/v1alpha1/conditions"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func intgTests() {
-	Describe("Patch", Label("envtest"), intgTestsPatch)
+	Describe("Patch", Label(testlabels.EnvTest), intgTestsPatch)
 }
 
 func intgTestsPatch() {

--- a/controllers/virtualmachinewebconsolerequest/v1alpha1/webconsolerequest_intg_test.go
+++ b/controllers/virtualmachinewebconsolerequest/v1alpha1/webconsolerequest_intg_test.go
@@ -19,11 +19,20 @@ import (
 	vmopv1alpha2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	webconsolerequest "github.com/vmware-tanzu/vm-operator/controllers/virtualmachinewebconsolerequest/v1alpha1"
 	pkgconfig "github.com/vmware-tanzu/vm-operator/pkg/config"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func intgTests() {
-	Describe("Reconcile", Label("controller", "envtest", "v1alpha1"), intgTestsReconcile)
+	Describe(
+		"Reconcile",
+		Label(
+			testlabels.Controller,
+			testlabels.EnvTest,
+			testlabels.V1Alpha1,
+		),
+		intgTestsReconcile,
+	)
 }
 
 func intgTestsReconcile() {

--- a/controllers/virtualmachinewebconsolerequest/v1alpha1/webconsolerequest_unit_test.go
+++ b/controllers/virtualmachinewebconsolerequest/v1alpha1/webconsolerequest_unit_test.go
@@ -18,13 +18,21 @@ import (
 	vmopv1alpha2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	webconsolerequest "github.com/vmware-tanzu/vm-operator/controllers/virtualmachinewebconsolerequest/v1alpha1"
 	pkgconfig "github.com/vmware-tanzu/vm-operator/pkg/config"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	vmopContext "github.com/vmware-tanzu/vm-operator/pkg/context"
 	providerfake "github.com/vmware-tanzu/vm-operator/pkg/vmprovider/fake"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func unitTests() {
-	Describe("Reconcile", Label("controller", "v1alpha1"), unitTestsReconcile)
+	Describe(
+		"Reconcile",
+		Label(
+			testlabels.Controller,
+			testlabels.V1Alpha1,
+		),
+		unitTestsReconcile,
+	)
 }
 
 func unitTestsReconcile() {

--- a/controllers/virtualmachinewebconsolerequest/v1alpha2/webconsolerequest_intg_test.go
+++ b/controllers/virtualmachinewebconsolerequest/v1alpha2/webconsolerequest_intg_test.go
@@ -17,11 +17,20 @@ import (
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	webconsolerequest "github.com/vmware-tanzu/vm-operator/controllers/virtualmachinewebconsolerequest/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func intgTests() {
-	Describe("Reconcile", Label("controller", "envtest", "v1alpha2"), intgTestsReconcile)
+	Describe(
+		"Reconcile",
+		Label(
+			testlabels.Controller,
+			testlabels.EnvTest,
+			testlabels.V1Alpha2,
+		),
+		intgTestsReconcile,
+	)
 }
 
 func intgTestsReconcile() {

--- a/controllers/virtualmachinewebconsolerequest/v1alpha2/webconsolerequest_unit_test.go
+++ b/controllers/virtualmachinewebconsolerequest/v1alpha2/webconsolerequest_unit_test.go
@@ -16,13 +16,18 @@ import (
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	webconsolerequest "github.com/vmware-tanzu/vm-operator/controllers/virtualmachinewebconsolerequest/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	vmopContext "github.com/vmware-tanzu/vm-operator/pkg/context"
 	providerfake "github.com/vmware-tanzu/vm-operator/pkg/vmprovider/fake"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func unitTests() {
-	Describe("Reconcile", Label("controller", "v1alpha1"), unitTestsReconcile)
+	Describe(
+		"Reconcile",
+		Label(testlabels.Controller, testlabels.V1Alpha1),
+		unitTestsReconcile,
+	)
 }
 
 func unitTestsReconcile() {

--- a/controllers/volume/v1alpha2/volume_controller_intg_test.go
+++ b/controllers/volume/v1alpha2/volume_controller_intg_test.go
@@ -22,6 +22,7 @@ import (
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	volume "github.com/vmware-tanzu/vm-operator/controllers/volume/v1alpha2"
 	pkgconfig "github.com/vmware-tanzu/vm-operator/pkg/config"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/pkg/patch"
 	"github.com/vmware-tanzu/vm-operator/pkg/util"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere2/constants"
@@ -30,7 +31,15 @@ import (
 )
 
 func intgTests() {
-	Describe("Reconcile", Label("controller", "envtest", "v1alpha2"), intgTestsReconcile)
+	Describe(
+		"Reconcile",
+		Label(
+			testlabels.Controller,
+			testlabels.EnvTest,
+			testlabels.V1Alpha2,
+		),
+		intgTestsReconcile,
+	)
 }
 
 func intgTestsReconcile() {

--- a/controllers/volume/v1alpha2/volume_controller_unit_test.go
+++ b/controllers/volume/v1alpha2/volume_controller_unit_test.go
@@ -25,6 +25,7 @@ import (
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	volume "github.com/vmware-tanzu/vm-operator/controllers/volume/v1alpha2"
 	pkgconfig "github.com/vmware-tanzu/vm-operator/pkg/config"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	volContext "github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/util"
 	providerfake "github.com/vmware-tanzu/vm-operator/pkg/vmprovider/fake"
@@ -43,7 +44,14 @@ func (f *testFailClient) Create(ctx goctx.Context, obj client.Object, opts ...cl
 }
 
 func unitTests() {
-	Describe("Reconcile", Label("controller", "v1alpha2"), unitTestsReconcile)
+	Describe(
+		"Reconcile",
+		Label(
+			testlabels.Controller,
+			testlabels.V1Alpha2,
+		),
+		unitTestsReconcile,
+	)
 }
 
 func unitTestsReconcile() {

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ replace (
 	github.com/envoyproxy/go-control-plane => github.com/envoyproxy/go-control-plane v0.9.4
 	github.com/envoyproxy/protoc-gen-validate => github.com/envoyproxy/protoc-gen-validate v0.1.0
 	github.com/vmware-tanzu/vm-operator/api => ./api
+	github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels => ./pkg/constants/testlabels
 )
 
 require (
@@ -42,6 +43,7 @@ require (
 
 require (
 	github.com/vmware-tanzu/nsx-operator/pkg/apis v0.1.0
+	github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels v0.0.0-00010101000000-000000000000
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/pkg/constants/testlabels/go.mod
+++ b/pkg/constants/testlabels/go.mod
@@ -1,0 +1,3 @@
+module github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels
+
+go 1.21

--- a/pkg/constants/testlabels/test_labels.go
+++ b/pkg/constants/testlabels/test_labels.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package testlabels
+
+const (
+	// API describes a test related to the APIs.
+	API = "api"
+
+	// Controller describes a test related to the controllers.
+	Controller = "controller"
+
+	// Create describes a test related to create logic.
+	Create = "create"
+
+	// Delete describes a test related to delete logic.
+	Delete = "delete"
+
+	// EnvTest describes a test that uses the envtest package.
+	EnvTest = "envtest"
+
+	// Fuzz describes a fuzz test.
+	Fuzz = "fuzz"
+
+	// Mutation describes a test related to a mutation webhook.
+	Mutation = "mutation"
+
+	// NSXT describes a test related to NSXT.
+	NSXT = "nsxt"
+
+	// Update describes a test related to update logic.
+	Update = "update"
+
+	// Validation describes a test related to a validation webhook.
+	Validation = "validation"
+
+	// V1Alpha1 describes a test related to the v1alpha1 APIs.
+	V1Alpha1 = "v1alpha1"
+
+	// V1Alpha2 describes a test related to the v1alpha2 APIS.
+	V1Alpha2 = "v1alpha2"
+
+	// VCSim describes a test that uses vC Sim.
+	VCSim = "vcsim"
+
+	// Webhook describes a test related to a webhook.
+	Webhook = "webhook"
+)

--- a/pkg/manager/test/manager_suite_test.go
+++ b/pkg/manager/test/manager_suite_test.go
@@ -8,11 +8,12 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func integTests() {
-	Describe("Cache", Ordered, Label("envtest"), cacheTests)
+	Describe("Cache", Ordered, Label(testlabels.EnvTest), cacheTests)
 }
 
 var suite = builder.NewTestSuite()

--- a/pkg/util/vsphere/client/client_test.go
+++ b/pkg/util/vsphere/client/client_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/soap"
 
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/client"
 )
 
@@ -30,7 +31,7 @@ const (
 	valid   = "valid"
 )
 
-var _ = Describe("Client", Label("vcsim"), Ordered /* Avoided race for pkg symbol simulator.SessionIdleTimeout */, func() {
+var _ = Describe("Client", Label(testlabels.VCSim), Ordered /* Avoided race for pkg symbol simulator.SessionIdleTimeout */, func() {
 
 	Describe("NewClient", func() {
 		var (

--- a/pkg/util/vsphere/vm/suite_test.go
+++ b/pkg/util/vsphere/vm/suite_test.go
@@ -8,12 +8,13 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func vcSimTests() {
-	Describe("Power State", Label("vcsim"), powerStateTests)
-	Describe("Hardware Version", Label("vcsim"), hardwareVersionTests)
+	Describe("Power State", Label(testlabels.VCSim), powerStateTests)
+	Describe("Hardware Version", Label(testlabels.VCSim), hardwareVersionTests)
 	Describe("Managed Object", managedObjectTests)
 }
 

--- a/pkg/vmprovider/providers/vsphere2/client/client_test.go
+++ b/pkg/vmprovider/providers/vsphere2/client/client_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/vmware/govmomi/vim25/soap"
 
 	pkgconfig "github.com/vmware-tanzu/vm-operator/pkg/config"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	vsphereclient "github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/client"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere2/client"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere2/config"
@@ -34,7 +35,7 @@ const (
 	valid   = "valid"
 )
 
-var _ = Describe("Client", Label("vcsim"), Ordered /* Avoided race for pkg symbol simulator.SessionIdleTimeout */, func() {
+var _ = Describe("Client", Label(testlabels.VCSim), Ordered /* Avoided race for pkg symbol simulator.SessionIdleTimeout */, func() {
 
 	Describe("NewClient", func() {
 		var (

--- a/pkg/vmprovider/providers/vsphere2/clustermodules/cluster_modules_suite_test.go
+++ b/pkg/vmprovider/providers/vsphere2/clustermodules/cluster_modules_suite_test.go
@@ -8,11 +8,12 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func vcSimTests() {
-	Describe("ClusterModules Provider", Label("vcsim"), cmTests)
+	Describe("ClusterModules Provider", Label(testlabels.VCSim), cmTests)
 }
 
 var suite = builder.NewTestSuite()

--- a/pkg/vmprovider/providers/vsphere2/config/config_suite_test.go
+++ b/pkg/vmprovider/providers/vsphere2/config/config_suite_test.go
@@ -8,11 +8,12 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func vcSimTests() {
-	Describe("Config", Label("vcsim"), configTests)
+	Describe("Config", Label(testlabels.VCSim), configTests)
 }
 
 var suite = builder.NewTestSuite()

--- a/pkg/vmprovider/providers/vsphere2/contentlibrary/content_library_suite_test.go
+++ b/pkg/vmprovider/providers/vsphere2/contentlibrary/content_library_suite_test.go
@@ -8,11 +8,12 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func vcSimTests() {
-	Describe("ContentLibrary Provider", Label("vcsim"), clTests)
+	Describe("ContentLibrary Provider", Label(testlabels.VCSim), clTests)
 }
 
 var suite = builder.NewTestSuite()

--- a/pkg/vmprovider/providers/vsphere2/network/network_test.go
+++ b/pkg/vmprovider/providers/vsphere2/network/network_test.go
@@ -21,13 +21,14 @@ import (
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	"github.com/vmware-tanzu/vm-operator/api/v1alpha2/common"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere2/constants"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere2/network"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
-var _ = Describe("CreateAndWaitForNetworkInterfaces", Label("vcsim"), func() {
+var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), func() {
 
 	var (
 		testConfig builder.VCSimTestConfig

--- a/pkg/vmprovider/providers/vsphere2/network/nsxt_test.go
+++ b/pkg/vmprovider/providers/vsphere2/network/nsxt_test.go
@@ -7,93 +7,97 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere2/network"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
-var _ = Describe("ResolveBackingPostPlacement", Label("nsxt", "vcsim"), func() {
+var _ = Describe(
+	"ResolveBackingPostPlacement",
+	Label(testlabels.NSXT, testlabels.VCSim),
+	func() {
 
-	var (
-		testConfig builder.VCSimTestConfig
-		ctx        *builder.TestContextForVCSim
+		var (
+			testConfig builder.VCSimTestConfig
+			ctx        *builder.TestContextForVCSim
 
-		results *network.NetworkInterfaceResults
-		fixedUp bool
-		err     error
-	)
-
-	BeforeEach(func() {
-		testConfig = builder.VCSimTestConfig{}
-	})
-
-	JustBeforeEach(func() {
-		ctx = suite.NewTestContextForVCSim(testConfig)
-
-		fixedUp, err = network.ResolveBackingPostPlacement(
-			ctx,
-			ctx.VCClient.Client,
-			ctx.GetFirstClusterFromFirstZone().Reference(),
-			results)
-	})
-
-	AfterEach(func() {
-		ctx.AfterEach()
-		ctx = nil
-	})
-
-	Context("NSX-T returns success", func() {
+			results *network.NetworkInterfaceResults
+			fixedUp bool
+			err     error
+		)
 
 		BeforeEach(func() {
-			testConfig.WithNetworkEnv = builder.NetworkEnvNSXT
-
-			results = &network.NetworkInterfaceResults{
-				Results: []network.NetworkInterfaceResult{
-					{
-						NetworkID: builder.NsxTLogicalSwitchUUID,
-						Backing:   nil,
-					},
-				},
-			}
+			testConfig = builder.VCSimTestConfig{}
 		})
 
-		It("returns success", func() {
-			Expect(err).ToNot(HaveOccurred())
-			Expect(fixedUp).To(BeTrue())
+		JustBeforeEach(func() {
+			ctx = suite.NewTestContextForVCSim(testConfig)
 
-			Expect(results.Results).To(HaveLen(1))
-			By("should populate the backing", func() {
-				backing := results.Results[0].Backing
-				Expect(backing).ToNot(BeNil())
-				Expect(backing.Reference()).To(Equal(ctx.NetworkRef.Reference()))
+			fixedUp, err = network.ResolveBackingPostPlacement(
+				ctx,
+				ctx.VCClient.Client,
+				ctx.GetFirstClusterFromFirstZone().Reference(),
+				results)
+		})
+
+		AfterEach(func() {
+			ctx.AfterEach()
+			ctx = nil
+		})
+
+		Context("NSX-T returns success", func() {
+
+			BeforeEach(func() {
+				testConfig.WithNetworkEnv = builder.NetworkEnvNSXT
+
+				results = &network.NetworkInterfaceResults{
+					Results: []network.NetworkInterfaceResult{
+						{
+							NetworkID: builder.NsxTLogicalSwitchUUID,
+							Backing:   nil,
+						},
+					},
+				}
+			})
+
+			It("returns success", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(fixedUp).To(BeTrue())
+
+				Expect(results.Results).To(HaveLen(1))
+				By("should populate the backing", func() {
+					backing := results.Results[0].Backing
+					Expect(backing).ToNot(BeNil())
+					Expect(backing.Reference()).To(Equal(ctx.NetworkRef.Reference()))
+				})
+			})
+		})
+
+		Context("VPC returns success", func() {
+
+			BeforeEach(func() {
+				testConfig.WithNetworkEnv = builder.NetworkEnvVPC
+
+				results = &network.NetworkInterfaceResults{
+					Results: []network.NetworkInterfaceResult{
+						{
+							NetworkID: builder.VPCLogicalSwitchUUID,
+							Backing:   nil,
+						},
+					},
+				}
+			})
+
+			It("returns success", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(fixedUp).To(BeTrue())
+
+				Expect(results.Results).To(HaveLen(1))
+				By("should populate the backing", func() {
+					backing := results.Results[0].Backing
+					Expect(backing).ToNot(BeNil())
+					Expect(backing.Reference()).To(Equal(ctx.NetworkRef.Reference()))
+				})
 			})
 		})
 	})
-
-	Context("VPC returns success", func() {
-
-		BeforeEach(func() {
-			testConfig.WithNetworkEnv = builder.NetworkEnvVPC
-
-			results = &network.NetworkInterfaceResults{
-				Results: []network.NetworkInterfaceResult{
-					{
-						NetworkID: builder.VPCLogicalSwitchUUID,
-						Backing:   nil,
-					},
-				},
-			}
-		})
-
-		It("returns success", func() {
-			Expect(err).ToNot(HaveOccurred())
-			Expect(fixedUp).To(BeTrue())
-
-			Expect(results.Results).To(HaveLen(1))
-			By("should populate the backing", func() {
-				backing := results.Results[0].Backing
-				Expect(backing).ToNot(BeNil())
-				Expect(backing.Reference()).To(Equal(ctx.NetworkRef.Reference()))
-			})
-		})
-	})
-})

--- a/pkg/vmprovider/providers/vsphere2/placement/placement_suite_test.go
+++ b/pkg/vmprovider/providers/vsphere2/placement/placement_suite_test.go
@@ -8,11 +8,12 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func vcSimTests() {
-	Describe("Placement", Label("vcsim"), vcSimPlacement)
+	Describe("Placement", Label(testlabels.VCSim), vcSimPlacement)
 }
 
 var suite = builder.NewTestSuite()

--- a/pkg/vmprovider/providers/vsphere2/vcenter/vcenter_suite_test.go
+++ b/pkg/vmprovider/providers/vsphere2/vcenter/vcenter_suite_test.go
@@ -8,17 +8,18 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 var suite = builder.NewTestSuite()
 
 func vcSimTests() {
-	Describe("Cluster", Label("vcsim"), clusterTests)
-	Describe("Folder", Label("vcsim"), folderTests)
-	Describe("GetVM", Label("vcsim"), getVMTests)
-	Describe("Host", Label("vcsim"), hostTests)
-	Describe("ResourcePool", Label("vcsim"), resourcePoolTests)
+	Describe("Cluster", Label(testlabels.VCSim), clusterTests)
+	Describe("Folder", Label(testlabels.VCSim), folderTests)
+	Describe("GetVM", Label(testlabels.VCSim), getVMTests)
+	Describe("Host", Label(testlabels.VCSim), hostTests)
+	Describe("ResourcePool", Label(testlabels.VCSim), resourcePoolTests)
 }
 
 func TestVCenter(t *testing.T) {

--- a/pkg/vmprovider/providers/vsphere2/virtualmachine/virtualmachine_suite_test.go
+++ b/pkg/vmprovider/providers/vsphere2/virtualmachine/virtualmachine_suite_test.go
@@ -8,15 +8,16 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func vcSimTests() {
-	Describe("ClusterComputeResource", Label("vcsim"), ccrTests)
-	Describe("Delete", Label("vcsim"), deleteTests)
-	Describe("Publish", Label("vcsim"), publishTests)
-	Describe("Backup", Label("vcsim"), backupTests)
-	Describe("GuestInfo", Label("vcsim"), guestInfoTests)
+	Describe("ClusterComputeResource", Label(testlabels.VCSim), ccrTests)
+	Describe("Delete", Label(testlabels.VCSim), deleteTests)
+	Describe("Publish", Label(testlabels.VCSim), publishTests)
+	Describe("Backup", Label(testlabels.VCSim), backupTests)
+	Describe("GuestInfo", Label(testlabels.VCSim), guestInfoTests)
 }
 
 var suite = builder.NewTestSuite()

--- a/test/builder/test_suite.go
+++ b/test/builder/test_suite.go
@@ -45,6 +45,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/controllers/util/remote"
 	"github.com/vmware-tanzu/vm-operator/pkg/builder"
 	pkgconfig "github.com/vmware-tanzu/vm-operator/pkg/config"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	ctrlCtx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	pkgmgr "github.com/vmware-tanzu/vm-operator/pkg/manager"
 	pkgmgrinit "github.com/vmware-tanzu/vm-operator/pkg/manager/init"
@@ -677,5 +678,5 @@ func updateMutatingWebhookConfig(webhookConfig admissionregv1.MutatingWebhookCon
 }
 
 func envTestsEnabled() bool {
-	return Label("envtest").MatchesLabelFilter(GinkgoLabelFilter())
+	return Label(testlabels.EnvTest).MatchesLabelFilter(GinkgoLabelFilter())
 }

--- a/webhooks/common/response_test.go
+++ b/webhooks/common/response_test.go
@@ -15,69 +15,77 @@ import (
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/webhooks/common"
 )
 
-var _ = Describe("Validation Response", Label("envtest", "v1alpha2", "vcsim", "webhook"), func() {
+var _ = Describe(
+	"Validation Response",
+	Label(
+		testlabels.EnvTest,
+		testlabels.V1Alpha2,
+		testlabels.Webhook,
+	),
+	func() {
 
-	var (
-		gr  = schema.GroupResource{Group: vmopv1.SchemeGroupVersion.Group, Resource: "VirtualMachine"}
-		ctx *context.WebhookRequestContext
-	)
-
-	BeforeEach(func() {
-		ctx = &context.WebhookRequestContext{
-			Logger: ctrllog.Log.WithName("validate-response"),
-		}
-	})
-
-	When("No errors occur", func() {
-		It("Returns allowed", func() {
-			response := common.BuildValidationResponse(ctx, nil, nil, nil)
-			Expect(response.Allowed).To(BeTrue())
-		})
-	})
-
-	When("Validation errors occur", func() {
-		It("Returns denied", func() {
-			validationErrs := []string{"this is required"}
-			response := common.BuildValidationResponse(ctx, nil, validationErrs, nil)
-			Expect(response.Allowed).To(BeFalse())
-			Expect(response.Result).ToNot(BeNil())
-			Expect(response.Result.Code).To(Equal(int32(http.StatusUnprocessableEntity)))
-			Expect(string(response.Result.Reason)).To(ContainSubstring(validationErrs[0]))
-		})
-	})
-
-	When("Validation has warnings", func() {
-		It("Returns allowed, with warnings", func() {
-			validationWarnings := []string{"this is deprecated"}
-			response := common.BuildValidationResponse(ctx, validationWarnings, nil, nil)
-			Expect(response.Allowed).To(BeTrue())
-			Expect(response.Warnings).To(Equal(validationWarnings))
-			Expect(response.Result).ToNot(BeNil())
-			Expect(response.Result.Code).To(Equal(int32(http.StatusOK)))
-		})
-	})
-
-	Context("Returns denied for expected well-known errors", func() {
-		wellKnownError := func(err error, expectedCode int) {
-			response := common.BuildValidationResponse(ctx, nil, nil, err)
-			Expect(response.Allowed).To(BeFalse())
-			Expect(response.Result).ToNot(BeNil())
-			Expect(response.Result.Code).To(Equal(int32(expectedCode)))
-		}
-
-		DescribeTable("", wellKnownError,
-			Entry("NotFound", apierrors.NewNotFound(gr, ""), http.StatusNotFound),
-			Entry("Gone", apierrors.NewGone("gone"), http.StatusGone),
-			Entry("ResourceExpired", apierrors.NewResourceExpired("expired"), http.StatusGone),
-			Entry("ServiceUnavailable", apierrors.NewServiceUnavailable("unavailable"), http.StatusServiceUnavailable),
-			Entry("ServiceUnavailable", apierrors.NewServiceUnavailable("unavailable"), http.StatusServiceUnavailable),
-			Entry("Timeout", apierrors.NewTimeoutError("timeout", 42), http.StatusGatewayTimeout),
-			Entry("Server Timeout", apierrors.NewServerTimeout(gr, "op", 42), http.StatusGatewayTimeout),
-			Entry("Generic", apierrors.NewMethodNotSupported(gr, "op"), http.StatusInternalServerError),
+		var (
+			gr  = schema.GroupResource{Group: vmopv1.SchemeGroupVersion.Group, Resource: "VirtualMachine"}
+			ctx *context.WebhookRequestContext
 		)
+
+		BeforeEach(func() {
+			ctx = &context.WebhookRequestContext{
+				Logger: ctrllog.Log.WithName("validate-response"),
+			}
+		})
+
+		When("No errors occur", func() {
+			It("Returns allowed", func() {
+				response := common.BuildValidationResponse(ctx, nil, nil, nil)
+				Expect(response.Allowed).To(BeTrue())
+			})
+		})
+
+		When("Validation errors occur", func() {
+			It("Returns denied", func() {
+				validationErrs := []string{"this is required"}
+				response := common.BuildValidationResponse(ctx, nil, validationErrs, nil)
+				Expect(response.Allowed).To(BeFalse())
+				Expect(response.Result).ToNot(BeNil())
+				Expect(response.Result.Code).To(Equal(int32(http.StatusUnprocessableEntity)))
+				Expect(string(response.Result.Reason)).To(ContainSubstring(validationErrs[0]))
+			})
+		})
+
+		When("Validation has warnings", func() {
+			It("Returns allowed, with warnings", func() {
+				validationWarnings := []string{"this is deprecated"}
+				response := common.BuildValidationResponse(ctx, validationWarnings, nil, nil)
+				Expect(response.Allowed).To(BeTrue())
+				Expect(response.Warnings).To(Equal(validationWarnings))
+				Expect(response.Result).ToNot(BeNil())
+				Expect(response.Result.Code).To(Equal(int32(http.StatusOK)))
+			})
+		})
+
+		Context("Returns denied for expected well-known errors", func() {
+			wellKnownError := func(err error, expectedCode int) {
+				response := common.BuildValidationResponse(ctx, nil, nil, err)
+				Expect(response.Allowed).To(BeFalse())
+				Expect(response.Result).ToNot(BeNil())
+				Expect(response.Result.Code).To(Equal(int32(expectedCode)))
+			}
+
+			DescribeTable("", wellKnownError,
+				Entry("NotFound", apierrors.NewNotFound(gr, ""), http.StatusNotFound),
+				Entry("Gone", apierrors.NewGone("gone"), http.StatusGone),
+				Entry("ResourceExpired", apierrors.NewResourceExpired("expired"), http.StatusGone),
+				Entry("ServiceUnavailable", apierrors.NewServiceUnavailable("unavailable"), http.StatusServiceUnavailable),
+				Entry("ServiceUnavailable", apierrors.NewServiceUnavailable("unavailable"), http.StatusServiceUnavailable),
+				Entry("Timeout", apierrors.NewTimeoutError("timeout", 42), http.StatusGatewayTimeout),
+				Entry("Server Timeout", apierrors.NewServerTimeout(gr, "op", 42), http.StatusGatewayTimeout),
+				Entry("Generic", apierrors.NewMethodNotSupported(gr, "op"), http.StatusInternalServerError),
+			)
+		})
 	})
-})

--- a/webhooks/persistentvolumeclaim/validation/persistentvolumeclaim_validator_intg_test.go
+++ b/webhooks/persistentvolumeclaim/validation/persistentvolumeclaim_validator_intg_test.go
@@ -9,13 +9,44 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func intgTests() {
-	Describe("Create", Label("create", "envtest", "v1alpha2", "validation", "webhook"), intgTestsValidateCreate)
-	Describe("Update", Label("update", "envtest", "v1alpha2", "validation", "webhook"), intgTestsValidateUpdate)
-	Describe("Delete", Label("delete", "envtest", "v1alpha2", "validation", "webhook"), intgTestsValidateDelete)
+	Describe(
+		"Create",
+		Label(
+			testlabels.Create,
+			testlabels.EnvTest,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		intgTestsValidateCreate,
+	)
+	Describe(
+		"Update",
+		Label(
+			testlabels.Update,
+			testlabels.EnvTest,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		intgTestsValidateUpdate,
+	)
+	Describe(
+		"Delete",
+		Label(
+			testlabels.Delete,
+			testlabels.EnvTest,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		intgTestsValidateDelete,
+	)
 }
 
 type intgValidatingWebhookContext struct {

--- a/webhooks/persistentvolumeclaim/validation/persistentvolumeclaim_validator_unit_test.go
+++ b/webhooks/persistentvolumeclaim/validation/persistentvolumeclaim_validator_unit_test.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere2/constants"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
@@ -24,9 +25,36 @@ const (
 )
 
 func unitTests() {
-	Describe("Create", Label("create", "v1alpha2", "validation", "webhook"), unitTestsValidatePVCCreate)
-	Describe("Update", Label("update", "v1alpha2", "validation", "webhook"), unitTestsValidatePVCUpdate)
-	Describe("Delete", Label("delete", "v1alpha2", "validation", "webhook"), unitTestsValidatePVCDelete)
+	Describe(
+		"Create",
+		Label(
+			testlabels.Create,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		unitTestsValidatePVCCreate,
+	)
+	Describe(
+		"Update",
+		Label(
+			testlabels.Update,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		unitTestsValidatePVCUpdate,
+	)
+	Describe(
+		"Delete",
+		Label(
+			testlabels.Delete,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		unitTestsValidatePVCDelete,
+	)
 }
 
 type unitValidatingWebhookContext struct {

--- a/webhooks/virtualmachine/v1alpha2/mutation/virtualmachine_mutator_intg_test.go
+++ b/webhooks/virtualmachine/v1alpha2/mutation/virtualmachine_mutator_intg_test.go
@@ -16,11 +16,24 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg"
 	pkgconfig "github.com/vmware-tanzu/vm-operator/pkg/config"
 	"github.com/vmware-tanzu/vm-operator/pkg/constants"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func intgTests() {
-	Describe("Mutate", Label("create", "update", "delete", "envtest", "v1alpha2", "mutation", "vcsim", "webhook"), intgTestsMutating)
+	Describe(
+		"Mutate",
+		Label(
+			testlabels.Create,
+			testlabels.Update,
+			testlabels.Delete,
+			testlabels.EnvTest,
+			testlabels.V1Alpha2,
+			testlabels.Mutation,
+			testlabels.Webhook,
+		),
+		intgTestsMutating,
+	)
 }
 
 type intgMutatingWebhookContext struct {

--- a/webhooks/virtualmachine/v1alpha2/mutation/virtualmachine_mutator_unit_test.go
+++ b/webhooks/virtualmachine/v1alpha2/mutation/virtualmachine_mutator_unit_test.go
@@ -20,13 +20,25 @@ import (
 	"github.com/vmware-tanzu/vm-operator/api/v1alpha2/common"
 	pkgconfig "github.com/vmware-tanzu/vm-operator/pkg/config"
 	"github.com/vmware-tanzu/vm-operator/pkg/constants"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere2/config"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachine/v1alpha2/mutation"
 )
 
 func uniTests() {
-	Describe("Mutate", Label("create", "update", "delete", "v1alpha2", "mutation", "webhook"), unitTestsMutating)
+	Describe(
+		"Mutate",
+		Label(
+			testlabels.Create,
+			testlabels.Update,
+			testlabels.Delete,
+			testlabels.V1Alpha2,
+			testlabels.Mutation,
+			testlabels.Webhook,
+		),
+		unitTestsMutating,
+	)
 }
 
 type unitMutationWebhookContext struct {

--- a/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator_intg_test.go
+++ b/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator_intg_test.go
@@ -12,13 +12,44 @@ import (
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	"github.com/vmware-tanzu/vm-operator/api/v1alpha2/common"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func intgTests() {
-	Describe("Create", Label("create", "envtest", "v1alpha2", "validation", "webhook"), intgTestsValidateCreate)
-	Describe("Update", Label("update", "envtest", "v1alpha2", "validation", "webhook"), intgTestsValidateUpdate)
-	Describe("Delete", Label("delete", "envtest", "v1alpha2", "validation", "webhook"), intgTestsValidateDelete)
+	Describe(
+		"Create",
+		Label(
+			testlabels.Create,
+			testlabels.EnvTest,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		intgTestsValidateCreate,
+	)
+	Describe(
+		"Update",
+		Label(
+			testlabels.Update,
+			testlabels.EnvTest,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		intgTestsValidateUpdate,
+	)
+	Describe(
+		"Delete",
+		Label(
+			testlabels.Delete,
+			testlabels.EnvTest,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		intgTestsValidateDelete,
+	)
 }
 
 type intgValidatingWebhookContext struct {

--- a/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator_unit_test.go
@@ -28,6 +28,7 @@ import (
 	pkgbuilder "github.com/vmware-tanzu/vm-operator/pkg/builder"
 	pkgconfig "github.com/vmware-tanzu/vm-operator/pkg/config"
 	"github.com/vmware-tanzu/vm-operator/pkg/constants"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/pkg/topology"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider/providers/vsphere2/config"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
@@ -59,9 +60,36 @@ func doValidateWithMsg(msgs ...string) func(admission.Response) {
 }
 
 func unitTests() {
-	Describe("Create", Label("create", "v1alpha2", "validation", "webhook"), unitTestsValidateCreate)
-	Describe("Update", Label("update", "v1alpha2", "validation", "webhook"), unitTestsValidateUpdate)
-	Describe("Delete", Label("delete", "v1alpha2", "validation", "webhook"), unitTestsValidateDelete)
+	Describe(
+		"Create",
+		Label(
+			testlabels.Create,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		unitTestsValidateCreate,
+	)
+	Describe(
+		"Update",
+		Label(
+			testlabels.Update,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		unitTestsValidateUpdate,
+	)
+	Describe(
+		"Delete",
+		Label(
+			testlabels.Delete,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		unitTestsValidateDelete,
+	)
 }
 
 type unitValidatingWebhookContext struct {

--- a/webhooks/virtualmachineclass/v1alpha2/mutation/virtualmachineclass_mutator_intg_test.go
+++ b/webhooks/virtualmachineclass/v1alpha2/mutation/virtualmachineclass_mutator_intg_test.go
@@ -8,11 +8,24 @@ import (
 	. "github.com/onsi/gomega"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func intgTests() {
-	Describe("Mutate", Label("create", "update", "delete", "envtest", "v1alpha2", "mutation", "vcsim", "webhook"), intgTestsMutating)
+	Describe(
+		"Mutate",
+		Label(
+			testlabels.Create,
+			testlabels.Update,
+			testlabels.Delete,
+			testlabels.EnvTest,
+			testlabels.V1Alpha2,
+			testlabels.Mutation,
+			testlabels.Webhook,
+		),
+		intgTestsMutating,
+	)
 }
 
 type intgMutatingWebhookContext struct {

--- a/webhooks/virtualmachineclass/v1alpha2/mutation/virtualmachineclass_mutator_unit_test.go
+++ b/webhooks/virtualmachineclass/v1alpha2/mutation/virtualmachineclass_mutator_unit_test.go
@@ -10,12 +10,24 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachineclass/v1alpha2/mutation"
 )
 
 func uniTests() {
-	Describe("Mutate", Label("create", "update", "delete", "v1alpha2", "mutation", "webhook"), unitTestsMutating)
+	Describe(
+		"Mutate",
+		Label(
+			testlabels.Create,
+			testlabels.Update,
+			testlabels.Delete,
+			testlabels.V1Alpha2,
+			testlabels.Mutation,
+			testlabels.Webhook,
+		),
+		unitTestsMutating,
+	)
 }
 
 type unitMutationWebhookContext struct {

--- a/webhooks/virtualmachineclass/v1alpha2/validation/virtualmachineclass_validator_intg_test.go
+++ b/webhooks/virtualmachineclass/v1alpha2/validation/virtualmachineclass_validator_intg_test.go
@@ -11,12 +11,33 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func intgTests() {
-	Describe("Create", Label("create", "envtest", "v1alpha2", "validation", "webhook"), intgTestsValidateCreate)
-	Describe("Delete", Label("delete", "envtest", "v1alpha2", "validation", "webhook"), intgTestsValidateDelete)
+	Describe(
+		"Create",
+		Label(
+			testlabels.Create,
+			testlabels.EnvTest,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		intgTestsValidateCreate,
+	)
+	Describe(
+		"Delete",
+		Label(
+			testlabels.Delete,
+			testlabels.EnvTest,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		intgTestsValidateDelete,
+	)
 }
 
 type intgValidatingWebhookContext struct {

--- a/webhooks/virtualmachineclass/v1alpha2/validation/virtualmachineclass_validator_unit_test.go
+++ b/webhooks/virtualmachineclass/v1alpha2/validation/virtualmachineclass_validator_unit_test.go
@@ -14,14 +14,42 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func unitTests() {
-	Describe("Create", Label("create", "v1alpha2", "validation", "webhook"), unitTestsValidateCreate)
-	Describe("Update", Label("update", "v1alpha2", "validation", "webhook"), unitTestsValidateUpdate)
-	Describe("Delete", Label("delete", "v1alpha2", "validation", "webhook"), unitTestsValidateDelete)
+	Describe(
+		"Create",
+		Label(
+			testlabels.Create,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		unitTestsValidateCreate,
+	)
+	Describe(
+		"Update",
+		Label(
+			testlabels.Update,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		unitTestsValidateUpdate,
+	)
+	Describe(
+		"Delete",
+		Label(
+			testlabels.Delete,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		unitTestsValidateDelete,
+	)
 }
 
 type unitValidatingWebhookContext struct {

--- a/webhooks/virtualmachinepublishrequest/v1alpha2/validation/virtualmachinepublishrequest_validator_intg_test.go
+++ b/webhooks/virtualmachinepublishrequest/v1alpha2/validation/virtualmachinepublishrequest_validator_intg_test.go
@@ -9,13 +9,44 @@ import (
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	pkgconfig "github.com/vmware-tanzu/vm-operator/pkg/config"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func intgTests() {
-	Describe("Create", Label("create", "envtest", "v1alpha2", "validation", "webhook"), intgTestsValidateCreate)
-	Describe("Update", Label("update", "envtest", "v1alpha2", "validation", "webhook"), intgTestsValidateUpdate)
-	Describe("Delete", Label("delete", "envtest", "v1alpha2", "validation", "webhook"), intgTestsValidateDelete)
+	Describe(
+		"Create",
+		Label(
+			testlabels.Create,
+			testlabels.EnvTest,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		intgTestsValidateCreate,
+	)
+	Describe(
+		"Update",
+		Label(
+			testlabels.Update,
+			testlabels.EnvTest,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		intgTestsValidateUpdate,
+	)
+	Describe(
+		"Delete",
+		Label(
+			testlabels.Delete,
+			testlabels.EnvTest,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		intgTestsValidateDelete,
+	)
 }
 
 type intgValidatingWebhookContext struct {

--- a/webhooks/virtualmachinepublishrequest/v1alpha2/validation/virtualmachinepublishrequest_validator_unit_test.go
+++ b/webhooks/virtualmachinepublishrequest/v1alpha2/validation/virtualmachinepublishrequest_validator_unit_test.go
@@ -16,13 +16,41 @@ import (
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	"github.com/vmware-tanzu/vm-operator/controllers/contentlibrary/v1alpha2/utils"
 	pkgconfig "github.com/vmware-tanzu/vm-operator/pkg/config"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func unitTests() {
-	Describe("Create", Label("create", "v1alpha2", "validation", "webhook"), unitTestsValidateCreate)
-	Describe("Update", Label("update", "v1alpha2", "validation", "webhook"), unitTestsValidateUpdate)
-	Describe("Delete", Label("delete", "v1alpha2", "validation", "webhook"), unitTestsValidateDelete)
+	Describe(
+		"Create",
+		Label(
+			testlabels.Create,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		unitTestsValidateCreate,
+	)
+	Describe(
+		"Update",
+		Label(
+			testlabels.Update,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		unitTestsValidateUpdate,
+	)
+	Describe(
+		"Delete",
+		Label(
+			testlabels.Delete,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		unitTestsValidateDelete,
+	)
 }
 
 type unitValidatingWebhookContext struct {

--- a/webhooks/virtualmachineservice/v1alpha2/mutation/virtualmachineservice_mutator_intg_test.go
+++ b/webhooks/virtualmachineservice/v1alpha2/mutation/virtualmachineservice_mutator_intg_test.go
@@ -8,12 +8,25 @@ import (
 	. "github.com/onsi/gomega"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func intgTests() {
-	Describe("Mutate", Label("create", "update", "delete", "envtest", "v1alpha2", "mutation", "vcsim", "webhook"), intgTestsMutating)
+	Describe(
+		"Mutate",
+		Label(
+			testlabels.Create,
+			testlabels.Update,
+			testlabels.Delete,
+			testlabels.EnvTest,
+			testlabels.V1Alpha2,
+			testlabels.Mutation,
+			testlabels.Webhook,
+		),
+		intgTestsMutating,
+	)
 }
 
 type intgMutatingWebhookContext struct {

--- a/webhooks/virtualmachineservice/v1alpha2/mutation/virtualmachineservice_mutator_unit_test.go
+++ b/webhooks/virtualmachineservice/v1alpha2/mutation/virtualmachineservice_mutator_unit_test.go
@@ -9,12 +9,24 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func uniTests() {
-	Describe("Mutate", Label("create", "update", "delete", "v1alpha2", "mutation", "webhook"), unitTestsMutating)
+	Describe(
+		"Mutate",
+		Label(
+			testlabels.Create,
+			testlabels.Update,
+			testlabels.Delete,
+			testlabels.V1Alpha2,
+			testlabels.Mutation,
+			testlabels.Webhook,
+		),
+		unitTestsMutating,
+	)
 }
 
 type unitMutationWebhookContext struct {

--- a/webhooks/virtualmachineservice/v1alpha2/validation/virtualmachineservice_validator_intg_test.go
+++ b/webhooks/virtualmachineservice/v1alpha2/validation/virtualmachineservice_validator_intg_test.go
@@ -8,13 +8,44 @@ import (
 	. "github.com/onsi/gomega"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func intgTests() {
-	Describe("Create", Label("create", "envtest", "v1alpha2", "validation", "webhook"), intgTestsValidateCreate)
-	Describe("Update", Label("update", "envtest", "v1alpha2", "validation", "webhook"), intgTestsValidateUpdate)
-	Describe("Delete", Label("delete", "envtest", "v1alpha2", "validation", "webhook"), intgTestsValidateDelete)
+	Describe(
+		"Create",
+		Label(
+			testlabels.Create,
+			testlabels.EnvTest,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		intgTestsValidateCreate,
+	)
+	Describe(
+		"Update",
+		Label(
+			testlabels.Update,
+			testlabels.EnvTest,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		intgTestsValidateUpdate,
+	)
+	Describe(
+		"Delete",
+		Label(
+			testlabels.Delete,
+			testlabels.EnvTest,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		intgTestsValidateDelete,
+	)
 }
 
 type intgValidatingWebhookContext struct {

--- a/webhooks/virtualmachineservice/v1alpha2/validation/virtualmachineservice_validator_unit_test.go
+++ b/webhooks/virtualmachineservice/v1alpha2/validation/virtualmachineservice_validator_unit_test.go
@@ -12,13 +12,41 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func unitTests() {
-	Describe("Create", Label("create", "v1alpha2", "validation", "webhook"), unitTestsValidateCreate)
-	Describe("Update", Label("update", "v1alpha2", "validation", "webhook"), unitTestsValidateUpdate)
-	Describe("Delete", Label("delete", "v1alpha2", "validation", "webhook"), unitTestsValidateDelete)
+	Describe(
+		"Create",
+		Label(
+			testlabels.Create,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		unitTestsValidateCreate,
+	)
+	Describe(
+		"Update",
+		Label(
+			testlabels.Update,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		unitTestsValidateUpdate,
+	)
+	Describe(
+		"Delete",
+		Label(
+			testlabels.Delete,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		unitTestsValidateDelete,
+	)
 }
 
 type unitValidatingWebhookContext struct {

--- a/webhooks/virtualmachinesetresourcepolicy/v1alpha2/validation/virtualmachinesetresourcepolicy_validator_intg_test.go
+++ b/webhooks/virtualmachinesetresourcepolicy/v1alpha2/validation/virtualmachinesetresourcepolicy_validator_intg_test.go
@@ -11,14 +11,45 @@ import (
 	. "github.com/onsi/gomega"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func intgTests() {
-	Describe("Create", Label("create", "envtest", "v1alpha2", "validation", "webhook"), intgTestsValidateCreate)
-	Describe("Update", Label("update", "envtest", "v1alpha2", "validation", "webhook"), intgTestsValidateUpdate)
-	Describe("Delete", Label("delete", "envtest", "v1alpha2", "validation", "webhook"), intgTestsValidateDelete)
+	Describe(
+		"Create",
+		Label(
+			testlabels.Create,
+			testlabels.EnvTest,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		intgTestsValidateCreate,
+	)
+	Describe(
+		"Update",
+		Label(
+			testlabels.Update,
+			testlabels.EnvTest,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		intgTestsValidateUpdate,
+	)
+	Describe(
+		"Delete",
+		Label(
+			testlabels.Delete,
+			testlabels.EnvTest,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		intgTestsValidateDelete,
+	)
 }
 
 type intgValidatingWebhookContext struct {

--- a/webhooks/virtualmachinesetresourcepolicy/v1alpha2/validation/virtualmachinesetresourcepolicy_validator_unit_test.go
+++ b/webhooks/virtualmachinesetresourcepolicy/v1alpha2/validation/virtualmachinesetresourcepolicy_validator_unit_test.go
@@ -14,13 +14,41 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func unitTests() {
-	Describe("Create", Label("create", "v1alpha2", "validation", "webhook"), unitTestsValidateCreate)
-	Describe("Update", Label("update", "v1alpha2", "validation", "webhook"), unitTestsValidateUpdate)
-	Describe("Delete", Label("delete", "v1alpha2", "validation", "webhook"), unitTestsValidateDelete)
+	Describe(
+		"Create",
+		Label(
+			testlabels.Create,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		unitTestsValidateCreate,
+	)
+	Describe(
+		"Update",
+		Label(
+			testlabels.Update,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		unitTestsValidateUpdate,
+	)
+	Describe(
+		"Delete",
+		Label(
+			testlabels.Delete,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		unitTestsValidateDelete,
+	)
 }
 
 type unitValidatingWebhookContext struct {

--- a/webhooks/virtualmachinewebconsolerequest/v1alpha1/validation/webconsolerequest_validator_intg_test.go
+++ b/webhooks/virtualmachinewebconsolerequest/v1alpha1/validation/webconsolerequest_validator_intg_test.go
@@ -10,13 +10,44 @@ import (
 	. "github.com/onsi/gomega"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func intgTests() {
-	Describe("Create", Label("create", "envtest", "v1alpha1", "validation", "webhook"), intgTestsValidateCreate)
-	Describe("Update", Label("update", "envtest", "v1alpha1", "validation", "webhook"), intgTestsValidateUpdate)
-	Describe("Delete", Label("delete", "envtest", "v1alpha1", "validation", "webhook"), intgTestsValidateDelete)
+	Describe(
+		"Create",
+		Label(
+			testlabels.Create,
+			testlabels.EnvTest,
+			testlabels.V1Alpha1,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		intgTestsValidateCreate,
+	)
+	Describe(
+		"Update",
+		Label(
+			testlabels.Update,
+			testlabels.EnvTest,
+			testlabels.V1Alpha1,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		intgTestsValidateUpdate,
+	)
+	Describe(
+		"Delete",
+		Label(
+			testlabels.Delete,
+			testlabels.EnvTest,
+			testlabels.V1Alpha1,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		intgTestsValidateDelete,
+	)
 }
 
 type intgValidatingWebhookContext struct {

--- a/webhooks/virtualmachinewebconsolerequest/v1alpha1/validation/webconsolerequest_validator_unit_test.go
+++ b/webhooks/virtualmachinewebconsolerequest/v1alpha1/validation/webconsolerequest_validator_unit_test.go
@@ -15,13 +15,44 @@ import (
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachinewebconsolerequest/v1alpha1"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func unitTests() {
-	Describe("Create", Label("create", "v1alpha1", "validation", "webhook"), unitTestsValidateCreate)
-	Describe("Update", Label("update", "v1alpha1", "validation", "webhook"), unitTestsValidateUpdate)
-	Describe("Delete", Label("delete", "v1alpha1", "validation", "webhook"), unitTestsValidateDelete)
+	Describe(
+		"Create",
+		Label(
+			testlabels.Create,
+			testlabels.EnvTest,
+			testlabels.V1Alpha1,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		unitTestsValidateCreate,
+	)
+	Describe(
+		"Update",
+		Label(
+			testlabels.Update,
+			testlabels.EnvTest,
+			testlabels.V1Alpha1,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		unitTestsValidateUpdate,
+	)
+	Describe(
+		"Delete",
+		Label(
+			testlabels.Delete,
+			testlabels.EnvTest,
+			testlabels.V1Alpha1,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		unitTestsValidateDelete,
+	)
 }
 
 type unitValidatingWebhookContext struct {

--- a/webhooks/virtualmachinewebconsolerequest/v1alpha2/validation/webconsolerequest_validator_intg_test.go
+++ b/webhooks/virtualmachinewebconsolerequest/v1alpha2/validation/webconsolerequest_validator_intg_test.go
@@ -10,13 +10,44 @@ import (
 	. "github.com/onsi/gomega"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func intgTests() {
-	Describe("Create", Label("create", "envtest", "v1alpha2", "validation", "webhook"), intgTestsValidateCreate)
-	Describe("Update", Label("update", "envtest", "v1alpha2", "validation", "webhook"), intgTestsValidateUpdate)
-	Describe("Delete", Label("delete", "envtest", "v1alpha2", "validation", "webhook"), intgTestsValidateDelete)
+	Describe(
+		"Create",
+		Label(
+			testlabels.Create,
+			testlabels.EnvTest,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		intgTestsValidateCreate,
+	)
+	Describe(
+		"Update",
+		Label(
+			testlabels.Update,
+			testlabels.EnvTest,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		intgTestsValidateUpdate,
+	)
+	Describe(
+		"Delete",
+		Label(
+			testlabels.Delete,
+			testlabels.EnvTest,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		intgTestsValidateDelete,
+	)
 }
 
 type intgValidatingWebhookContext struct {

--- a/webhooks/virtualmachinewebconsolerequest/v1alpha2/validation/webconsolerequest_validator_unit_test.go
+++ b/webhooks/virtualmachinewebconsolerequest/v1alpha2/validation/webconsolerequest_validator_unit_test.go
@@ -15,13 +15,41 @@ import (
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachinewebconsolerequest/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func unitTests() {
-	Describe("Create", Label("create", "v1alpha2", "validation", "webhook"), unitTestsValidateCreate)
-	Describe("Update", Label("update", "v1alpha2", "validation", "webhook"), unitTestsValidateUpdate)
-	Describe("Delete", Label("delete", "v1alpha2", "validation", "webhook"), unitTestsValidateDelete)
+	Describe(
+		"Create",
+		Label(
+			testlabels.Create,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		unitTestsValidateCreate,
+	)
+	Describe(
+		"Update",
+		Label(
+			testlabels.Update,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		unitTestsValidateUpdate,
+	)
+	Describe(
+		"Delete",
+		Label(
+			testlabels.Delete,
+			testlabels.V1Alpha2,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		unitTestsValidateDelete,
+	)
 }
 
 type unitValidatingWebhookContext struct {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch introduces the package `pkg/constants/testlabels` to maintain a central location for all test labels used by this project.

The documentation for submitting a change to the project has also been updated to reflect how to work with test labels.



**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

Please note the package `pkg/constants/testlabels` is a separate Go module so it can be used by the core VM Op module as well as the `./api` module.

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Introduces a package for test labels constants and illustrates how to use them in the documentation for submitting a change
```

<!-- readthedocs-preview vm-operator start -->
----
📚 Documentation preview 📚: https://vm-operator--426.org.readthedocs.build/en/426/

<!-- readthedocs-preview vm-operator end -->