### PR TITLE
🐛 Fix "make generate" due to testlabels mod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,9 +292,7 @@ generate-manifests: ## Generate manifests e.g. CRD, RBAC etc.
 		output:webhook:dir=$(WEBHOOK_ROOT) \
 		webhook
 	$(CONTROLLER_GEN) \
-		paths=./controllers/... \
-		paths=./pkg/... \
-		paths=./webhooks/... \
+		paths=github.com/vmware-tanzu/vm-operator/... \
 		output:rbac:dir=$(RBAC_ROOT) \
 		rbac:roleName=manager-role
 


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->

This patch fixes the "make generate" target, which was failing due to the introduction of the testlabels module. Apparently this was not caught by the PR testing, so we need to look into that. The controller-gen binary was not happy with the ./pkg/... path that included another module, i.e. ./pkg/constants/testlabels. Instead the command has been updated to specify a single path, the recursive pattern for the main module, which results in scanning more paths than before, but importantly excludes the testlabels module.



**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Fix bug in "make generate" target complaining about testlabels module
```