### PR TITLE
🌱 Defer PVC watch in Volume controller until needed

### DIFF
--- a/pkg/context/volume_context.go
+++ b/pkg/context/volume_context.go
@@ -9,28 +9,14 @@ import (
 
 	"github.com/go-logr/logr"
 
-	"github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 )
-
-// VolumeContext is the context used for VolumeController.
-type VolumeContext struct {
-	context.Context
-	Logger                    logr.Logger
-	VM                        *v1alpha1.VirtualMachine
-	InstanceStorageFSSEnabled bool
-}
-
-func (v *VolumeContext) String() string {
-	return fmt.Sprintf("%s %s/%s", v.VM.GroupVersionKind(), v.VM.Namespace, v.VM.Name)
-}
 
 // VolumeContextA2 is the context used for VolumeController.
 type VolumeContextA2 struct {
 	context.Context
-	Logger                    logr.Logger
-	VM                        *vmopv1.VirtualMachine
-	InstanceStorageFSSEnabled bool
+	Logger logr.Logger
+	VM     *vmopv1.VirtualMachine
 }
 
 func (v *VolumeContextA2) String() string {


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

We only need to be aware of PVCs in the Volume controller because of instance storage. This feature isn't enabled in all envs, and is not that commonly used in general, so defer the costs of the Watch() until we need to do so.

Improve getInstanceStoragePVCs() to not return PVCs that did not exist. Things still worked because these PVCs would fail the IsControlledBy() check but it is clearer to just not return these PVCs in the first place.

One goal is to offset some of the memory used by the CnsNodeVmAttachment field index added in 7a6e39d.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:


```release-note
NONE
```