### PR TITLE
✨ Sync VMI status to labels

### DIFF
--- a/controllers/contentlibrary/v1alpha2/clustercontentlibraryitem/clustercontentlibraryitem_controller.go
+++ b/controllers/contentlibrary/v1alpha2/clustercontentlibraryitem/clustercontentlibraryitem_controller.go
@@ -28,6 +28,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/metrics"
 	"github.com/vmware-tanzu/vm-operator/pkg/record"
+	imgutil "github.com/vmware-tanzu/vm-operator/pkg/util/image"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider"
 )
 
@@ -306,6 +307,11 @@ func (r *Reconciler) syncImageContent(ctx *context.ClusterContentLibraryItemCont
 	} else {
 		cvmi.Status.ProviderContentVersion = latestVersion
 	}
+
+	// Sync the image's OS information and capabilities to the resource's labels
+	// to make it easier for clients to search for images based on OS info and
+	// image capabilities.
+	imgutil.SyncStatusToLabels(cvmi, cvmi.Status)
 
 	r.Recorder.EmitEvent(cvmi, "Update", err, false)
 	return err

--- a/controllers/contentlibrary/v1alpha2/contentlibraryitem/contentlibraryitem_controller.go
+++ b/controllers/contentlibrary/v1alpha2/contentlibraryitem/contentlibraryitem_controller.go
@@ -28,6 +28,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/metrics"
 	"github.com/vmware-tanzu/vm-operator/pkg/record"
+	imgutil "github.com/vmware-tanzu/vm-operator/pkg/util/image"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmprovider"
 )
 
@@ -274,6 +275,11 @@ func (r *Reconciler) syncImageContent(ctx *context.ContentLibraryItemContextA2) 
 	} else {
 		vmi.Status.ProviderContentVersion = latestVersion
 	}
+
+	// Sync the image's OS information and capabilities to the resource's labels
+	// to make it easier for clients to search for images based on OS info and
+	// image capabilities.
+	imgutil.SyncStatusToLabels(vmi, vmi.Status)
 
 	r.Recorder.EmitEvent(vmi, "Update", err, false)
 	return err

--- a/pkg/util/image/image_suite_test.go
+++ b/pkg/util/image/image_suite_test.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package image_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestImage(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Image Util Test Suite")
+}

--- a/pkg/util/image/status_to_label.go
+++ b/pkg/util/image/status_to_label.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package image
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+)
+
+// SyncStatusToLabels copies the image's capabilities and OS information from
+// the image status to well-known labels on the image in order to make it
+// easier for clients to search for images based on capabilities or OS details.
+func SyncStatusToLabels(
+	obj metav1.Object,
+	status vmopv1.VirtualMachineImageStatus) {
+
+	var (
+		osID      = status.OSInfo.ID
+		osType    = status.OSInfo.Type
+		osVersion = status.OSInfo.Version
+		caps      = status.Capabilities
+	)
+
+	if osID == "" && osType == "" && osVersion == "" && len(caps) == 0 {
+		return
+	}
+
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+
+	if k, v := vmopv1.VirtualMachineImageOSIDLabel, osID; v != "" {
+		labels[k] = v
+	}
+	if k, v := vmopv1.VirtualMachineImageOSTypeLabel, osType; v != "" {
+		labels[k] = v
+	}
+	if k, v := vmopv1.VirtualMachineImageOSVersionLabel, osVersion; v != "" {
+		labels[k] = v
+	}
+	if kp, v := vmopv1.VirtualMachineImageCapabilityLabel, caps; len(v) > 0 {
+		for i := range v {
+			labels[kp+v[i]] = "true"
+		}
+	}
+
+	obj.SetLabels(labels)
+}

--- a/pkg/util/image/status_to_label_test.go
+++ b/pkg/util/image/status_to_label_test.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package image_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	imgutil "github.com/vmware-tanzu/vm-operator/pkg/util/image"
+)
+
+var _ = Describe("SyncStatusToLabels", func() {
+	var (
+		obj    metav1.Object
+		status vmopv1.VirtualMachineImageStatus
+	)
+
+	BeforeEach(func() {
+		vmi := &vmopv1.VirtualMachineImage{}
+		obj = vmi
+		status = vmi.Status
+	})
+
+	JustBeforeEach(func() {
+		imgutil.SyncStatusToLabels(obj, status)
+	})
+
+	When("the status does not have any info", func() {
+		It("should not set any labels", func() {
+			Expect(obj.GetLabels()).To(BeNil())
+		})
+	})
+
+	When("the status has the OS ID", func() {
+		BeforeEach(func() {
+			status.OSInfo.ID = "photon64"
+		})
+		It("should have the OS ID label", func() {
+			Expect(obj.GetLabels()).To(HaveLen(1))
+			Expect(obj.GetLabels()).To(HaveKeyWithValue(
+				vmopv1.VirtualMachineImageOSIDLabel,
+				status.OSInfo.ID))
+		})
+	})
+
+	When("the status has the OS type", func() {
+		BeforeEach(func() {
+			status.OSInfo.Type = "linux"
+		})
+		It("should have the OS ID label", func() {
+			Expect(obj.GetLabels()).To(HaveLen(1))
+			Expect(obj.GetLabels()).To(HaveKeyWithValue(
+				vmopv1.VirtualMachineImageOSTypeLabel,
+				status.OSInfo.Type))
+		})
+	})
+
+	When("the status has the OS version", func() {
+		BeforeEach(func() {
+			status.OSInfo.Version = "5"
+		})
+		It("should have the OS ID label", func() {
+			Expect(obj.GetLabels()).To(HaveLen(1))
+			Expect(obj.GetLabels()).To(HaveKeyWithValue(
+				vmopv1.VirtualMachineImageOSVersionLabel,
+				status.OSInfo.Version))
+		})
+	})
+
+	When("the status has two capabilities", func() {
+		BeforeEach(func() {
+			status.Capabilities = []string{"cloud-init", "nvidia-vgpu"}
+		})
+		It("should have the capability labels", func() {
+			Expect(obj.GetLabels()).To(HaveLen(2))
+			Expect(obj.GetLabels()).To(HaveKeyWithValue(
+				vmopv1.VirtualMachineImageCapabilityLabel+"cloud-init",
+				"true"))
+			Expect(obj.GetLabels()).To(HaveKeyWithValue(
+				vmopv1.VirtualMachineImageCapabilityLabel+"nvidia-vgpu",
+				"true"))
+		})
+	})
+
+	When("the status has OS info and capabilities", func() {
+		BeforeEach(func() {
+			status.OSInfo.ID = "photon64"
+			status.OSInfo.Type = "linux"
+			status.OSInfo.Version = "5"
+			status.Capabilities = []string{"cloud-init", "nvidia-vgpu"}
+		})
+		It("should have the capability labels", func() {
+			Expect(obj.GetLabels()).To(HaveLen(5))
+			Expect(obj.GetLabels()).To(HaveKeyWithValue(
+				vmopv1.VirtualMachineImageOSIDLabel,
+				status.OSInfo.ID))
+			Expect(obj.GetLabels()).To(HaveKeyWithValue(
+				vmopv1.VirtualMachineImageOSTypeLabel,
+				status.OSInfo.Type))
+			Expect(obj.GetLabels()).To(HaveKeyWithValue(
+				vmopv1.VirtualMachineImageOSVersionLabel,
+				status.OSInfo.Version))
+			Expect(obj.GetLabels()).To(HaveKeyWithValue(
+				vmopv1.VirtualMachineImageCapabilityLabel+"cloud-init",
+				"true"))
+			Expect(obj.GetLabels()).To(HaveKeyWithValue(
+				vmopv1.VirtualMachineImageCapabilityLabel+"nvidia-vgpu",
+				"true"))
+		})
+
+		When("the object already has labels", func() {
+			BeforeEach(func() {
+				obj.SetLabels(map[string]string{"hello": "world", "fu": "bar"})
+			})
+			It("should not remove the existing labels", func() {
+				Expect(obj.GetLabels()).To(HaveLen(7))
+				Expect(obj.GetLabels()).To(HaveKeyWithValue("hello", "world"))
+				Expect(obj.GetLabels()).To(HaveKeyWithValue("fu", "bar"))
+				Expect(obj.GetLabels()).To(HaveKeyWithValue(
+					vmopv1.VirtualMachineImageOSIDLabel,
+					status.OSInfo.ID))
+				Expect(obj.GetLabels()).To(HaveKeyWithValue(
+					vmopv1.VirtualMachineImageOSTypeLabel,
+					status.OSInfo.Type))
+				Expect(obj.GetLabels()).To(HaveKeyWithValue(
+					vmopv1.VirtualMachineImageOSVersionLabel,
+					status.OSInfo.Version))
+				Expect(obj.GetLabels()).To(HaveKeyWithValue(
+					vmopv1.VirtualMachineImageCapabilityLabel+"cloud-init",
+					"true"))
+				Expect(obj.GetLabels()).To(HaveKeyWithValue(
+					vmopv1.VirtualMachineImageCapabilityLabel+"nvidia-vgpu",
+					"true"))
+			})
+		})
+	})
+
+})


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch ensures the VirtualMachineImage and ClusterVMI resources have their status.capabilities and status.osInfo fields set on the resources as labels. This behavior was already documented via the v1alpha2 APIs, but was not implemented. This change allows clients to more efficiently discover images based on labels, indexed by the API server, for information about the images' OS or capabilities.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```