### PR TITLE
📖 Update VirtualMachine CRD doc

### DIFF
--- a/api/v1alpha1/virtualmachine_types.go
+++ b/api/v1alpha1/virtualmachine_types.go
@@ -370,9 +370,24 @@ type GuestHeartbeatAction struct {
 
 // VirtualMachineSpec defines the desired state of a VirtualMachine.
 type VirtualMachineSpec struct {
-	// ImageName describes the name of a VirtualMachineImage that is to be used as the base Operating System image of
-	// the desired VirtualMachine instances.  The VirtualMachineImage resources can be introspected to discover identifying
-	// attributes that may help users to identify the desired image to use.
+	// ImageName describes the name of the image resource used to deploy this
+	// VM.
+	//
+	// This field may be used to specify the name of a VirtualMachineImage
+	// or ClusterVirtualMachineImage resource. The resolver first checks to see
+	// if there is a VirtualMachineImage with the specified name. If no
+	// such resource exists, the resolver then checks to see if there is a
+	// ClusterVirtualMachineImage resource with the specified name in the same
+	// Namespace as the VM being deployed.
+	//
+	// This field may also be used to specify the display name (vSphere name) of
+	// a VirtualMachineImage or ClusterVirtualMachineImage resource. If the
+	// display name unambiguously resolves to a distinct VM image (among all
+	// existing VirtualMachineImages in the VM's namespace and all existing
+	// ClusterVirtualMachineImages), then a mutation webhook updates this field
+	// with the VM image resource name. If the display name resolves to multiple
+	// or no VM images, then the mutation webhook denies the request and outputs
+	// an error message accordingly.
 	ImageName string `json:"imageName"`
 
 	// ClassName describes the name of a VirtualMachineClass that is to be used as the overlaid resource configuration

--- a/api/v1alpha2/virtualmachine_types.go
+++ b/api/v1alpha2/virtualmachine_types.go
@@ -189,24 +189,25 @@ type VirtualMachineSpec struct {
 	//
 	// This field may be used to specify the name of a VirtualMachineImage
 	// or ClusterVirtualMachineImage resource. The resolver first checks to see
-	// if there is a ClusterVirtualMachineImage with the specified name. If no
+	// if there is a VirtualMachineImage with the specified name. If no
 	// such resource exists, the resolver then checks to see if there is a
-	// VirtualMachineImage resource with the specified name in the same
+	// ClusterVirtualMachineImage resource with the specified name in the same
 	// Namespace as the VM being deployed.
 	//
-	// This field is optional in the cases where there exists a sensible
-	// default value, such as when there is a single VirtualMachineImage
-	// resource available in the same Namespace as the VM being deployed.
+	// This field may also be used to specify the display name (vSphere name) of
+	// a VirtualMachineImage or ClusterVirtualMachineImage resource. If the
+	// display name unambiguously resolves to a distinct VM image (among all
+	// existing VirtualMachineImages in the VM's namespace and all existing
+	// ClusterVirtualMachineImages), then a mutation webhook updates this field
+	// with the VM image resource name. If the display name resolves to multiple
+	// or no VM images, then the mutation webhook denies the request and outputs
+	// an error message accordingly.
 	//
 	// +optional
 	ImageName string `json:"imageName,omitempty"`
 
 	// ClassName describes the name of the VirtualMachineClass resource used to
 	// deploy this VM.
-	//
-	// This field is optional in the cases where there exists a sensible
-	// default value, such as when there is a single VirtualMachineClass
-	// resource available in the same Namespace as the VM being deployed.
 	//
 	// +optional
 	ClassName string `json:"className,omitempty"`

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -101,9 +101,26 @@ spec:
                 type: string
               imageName:
                 description: |-
-                  ImageName describes the name of a VirtualMachineImage that is to be used as the base Operating System image of
-                  the desired VirtualMachine instances.  The VirtualMachineImage resources can be introspected to discover identifying
-                  attributes that may help users to identify the desired image to use.
+                  ImageName describes the name of the image resource used to deploy this
+                  VM.
+
+
+                  This field may be used to specify the name of a VirtualMachineImage
+                  or ClusterVirtualMachineImage resource. The resolver first checks to see
+                  if there is a VirtualMachineImage with the specified name. If no
+                  such resource exists, the resolver then checks to see if there is a
+                  ClusterVirtualMachineImage resource with the specified name in the same
+                  Namespace as the VM being deployed.
+
+
+                  This field may also be used to specify the display name (vSphere name) of
+                  a VirtualMachineImage or ClusterVirtualMachineImage resource. If the
+                  display name unambiguously resolves to a distinct VM image (among all
+                  existing VirtualMachineImages in the VM's namespace and all existing
+                  ClusterVirtualMachineImages), then a mutation webhook updates this field
+                  with the VM image resource name. If the display name resolves to multiple
+                  or no VM images, then the mutation webhook denies the request and outputs
+                  an error message accordingly.
                 type: string
               minHardwareVersion:
                 description: |-
@@ -1554,11 +1571,6 @@ spec:
                 description: |-
                   ClassName describes the name of the VirtualMachineClass resource used to
                   deploy this VM.
-
-
-                  This field is optional in the cases where there exists a sensible
-                  default value, such as when there is a single VirtualMachineClass
-                  resource available in the same Namespace as the VM being deployed.
                 type: string
               imageName:
                 description: |-
@@ -1568,15 +1580,20 @@ spec:
 
                   This field may be used to specify the name of a VirtualMachineImage
                   or ClusterVirtualMachineImage resource. The resolver first checks to see
-                  if there is a ClusterVirtualMachineImage with the specified name. If no
+                  if there is a VirtualMachineImage with the specified name. If no
                   such resource exists, the resolver then checks to see if there is a
-                  VirtualMachineImage resource with the specified name in the same
+                  ClusterVirtualMachineImage resource with the specified name in the same
                   Namespace as the VM being deployed.
 
 
-                  This field is optional in the cases where there exists a sensible
-                  default value, such as when there is a single VirtualMachineImage
-                  resource available in the same Namespace as the VM being deployed.
+                  This field may also be used to specify the display name (vSphere name) of
+                  a VirtualMachineImage or ClusterVirtualMachineImage resource. If the
+                  display name unambiguously resolves to a distinct VM image (among all
+                  existing VirtualMachineImages in the VM's namespace and all existing
+                  ClusterVirtualMachineImages), then a mutation webhook updates this field
+                  with the VM image resource name. If the display name resolves to multiple
+                  or no VM images, then the mutation webhook denies the request and outputs
+                  an error message accordingly.
                 type: string
               minHardwareVersion:
                 description: |-


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This patch updates the `imageName` field in the VM CRD to reflect the correct resolution order from VMI to CVMI. It also includes the user-friendly image resolution done by the mutation webhook for better clarity.  

**Please add a release note if necessary**:

```release-note
Update VirtualMachine API doc to correct the resolving order of the imageName field.
```