### PR TITLE
📖 Add encoded ConfigSpec examples

### DIFF
--- a/docs/concepts/workloads/vm-class.md
+++ b/docs/concepts/workloads/vm-class.md
@@ -7,3 +7,178 @@ _VirtualMachineClasses_ (VM Class) represent a collection of virtual hardware th
 ## ControllerName
 
 The field `spec.controllerName` in a VM Class indicates the name of the controller responsible for reconciling `VirtualMachine` resources created from the VM Class. The value `vmoperator.vmware.com/vsphere` indicates the default `VirtualMachine` controller is used. VM Classes that do not have this field set or set to an empty value behave as if the field is set to the value returned from the environment variable `DEFAULT_VM_CLASS_CONTROLLER_NAME`. If this environment variable is empty, it defaults to `vmoperator.vmware.com/vsphere`.
+
+## `spec.configSpec`
+
+The field `spec.configSpec` contains a vSphere [`VirtualMachineConfigSpec`](https://vdc-download.vmware.com/vmwb-repository/dcr-public/184bb3ba-6fa8-4574-a767-d0c96e2a38f4/ba9422ef-405c-47dd-8553-e11b619185b2/SDK/vsphere-ws/docs/ReferenceGuide/vim.vm.ConfigSpec.html), a sparse data type capable of representing all of the hardware and options used to deploy a VM, ex:
+
+```yaml
+apiVersion: vmoperator.vmware.com/v1alpha2
+kind: VirtualMachineClass
+metadata:
+  name: my-vm-class
+  namespace: my-namespace
+spec:
+  configSpec:
+    _typeName: VirtualMachineConfigSpec
+    memoryMB: 2048
+    numCPUs: 2
+```
+
+### `VirtualMachineConfigSpec`
+
+The reason the `VirtualMachineConfigSpec` type was selected is because it is sparse, and any value can be omitted. The type [`VirtualMachineConfigInfo`](https://vdc-download.vmware.com/vmwb-repository/dcr-public/184bb3ba-6fa8-4574-a767-d0c96e2a38f4/ba9422ef-405c-47dd-8553-e11b619185b2/SDK/vsphere-ws/docs/ReferenceGuide/vim.vm.ConfigInfo.html) makes more sense for desired state, but there are multiple properties that are required in that type, and it would not have worked as a sparse data type.
+
+#### Device Changes
+
+The only valid operation for a `VirtualMachineConfigSpec` type in a `VirtualMachineClass` resource is `add`. In the context of a `VirtualMachineClass`, the `VirtualMachineConfigSpec` can be thought of as a sparse `VirtualMachineConfigInfo` data type.
+
+### Encoding
+
+JSON was conceived as an alternative to XML, and as such, was designed to be very light-weight. Originally this also meant there was no schema support in JSON, meaning it was not the _best_ candidate for encoding polymorphic data structures. Given the vSphere API is *quite* object oriented and the fact that Kubernetes uses JSON (even if it is typically presented as YAML), how is the `VirtualMachineConfigSpec` data type encoded into a `VirtualMachineClass` resource's `spec.configSpec` field? The answer is JSON discriminators, a technique for embedding the encoded type name (and possibly value) into the data itself. When it comes to encoding the `VirtualMachineConfigSpec`, there are two special discriminator property names:
+
+| Discriminator Property | Description |
+|---|---|
+| `_typeName` | The name of the vSphere type to which this JSON object maps |
+| `_value` | If a Go `struct` has a field that is a Go interface, the actual value may be wrapped in a JSON object that has two properties, `_typeName` and `_value`, the wrapped value |
+
+The file [`./pkg/docs/concepts/vm-class_test.go`](${{ config.repo_url }}/main/pkg/docs/concepts/vm-class_test.go) has several examples of a `VirtualMachineConfigSpec` encoded to both JSON and YAML. 
+
+#### ExtraConfig
+
+##### JSON
+
+```json
+{
+  "_typeName": "VirtualMachineConfigSpec",
+  "numCPUs": 2,
+  "memoryMB": 2048,
+  "extraConfig": [
+    {
+      "_typeName": "OptionValue",
+      "key": "my-key-1",
+      "value": {
+        "_typeName": "string",
+        "_value": "my-value-1"
+      }
+    },
+    {
+      "_typeName": "OptionValue",
+      "key": "my-key-2",
+      "value": {
+        "_typeName": "string",
+        "_value": "my-value-2"
+      }
+    }
+  ]
+}
+```
+
+##### YAML
+
+```yaml
+_typeName: VirtualMachineConfigSpec
+extraConfig:
+- _typeName: OptionValue
+  key: my-key-1
+  value:
+    _typeName: string
+    _value: my-value-1
+- _typeName: OptionValue
+  key: my-key-2
+  value:
+    _typeName: string
+    _value: my-value-2
+memoryMB: 2048
+numCPUs: 2
+```
+
+#### vGPU
+
+##### JSON
+
+```json
+{
+  "_typeName": "VirtualMachineConfigSpec",
+  "deviceChange": [
+    {
+      "_typeName": "VirtualDeviceConfigSpec",
+      "operation": "add",
+      "device": {
+        "_typeName": "VirtualPCIPassthrough",
+        "key": 0,
+        "backing": {
+          "_typeName": "VirtualPCIPassthroughVmiopBackingInfo",
+          "vgpu": "my-vgpu-profile"
+        }
+      }
+    }
+  ]
+}
+```
+
+##### YAML
+
+```yaml
+_typeName: VirtualMachineConfigSpec
+deviceChange:
+- _typeName: VirtualDeviceConfigSpec
+  device:
+    _typeName: VirtualPCIPassthrough
+    backing:
+      _typeName: VirtualPCIPassthroughVmiopBackingInfo
+      vgpu: my-vgpu-profile
+    key: 0
+  operation: add
+```
+
+#### Dynamic Direct Path I/O
+
+##### JSON
+
+```json
+{
+  "_typeName": "VirtualMachineConfigSpec",
+  "deviceChange": [
+    {
+      "_typeName": "VirtualDeviceConfigSpec",
+      "operation": "add",
+      "device": {
+        "_typeName": "VirtualPCIPassthrough",
+        "key": 0,
+        "backing": {
+          "_typeName": "VirtualPCIPassthroughDynamicBackingInfo",
+          "deviceName": "",
+          "allowedDevice": [
+            {
+              "_typeName": "VirtualPCIPassthroughAllowedDevice",
+              "vendorId": -999,
+              "deviceId": -999
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+##### YAML
+
+```yaml
+_typeName: VirtualMachineConfigSpec
+deviceChange:
+- _typeName: VirtualDeviceConfigSpec
+  device:
+    _typeName: VirtualPCIPassthrough
+    backing:
+      _typeName: VirtualPCIPassthroughDynamicBackingInfo
+      allowedDevice:
+      - _typeName: VirtualPCIPassthroughAllowedDevice
+        deviceId: -999
+        vendorId: -999
+      deviceName: ""
+    key: 0
+  operation: add
+```
+

--- a/pkg/docs/concepts/concepts_suite_test.go
+++ b/pkg/docs/concepts/concepts_suite_test.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package concepts
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConcepts(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Docs Concepts Test Suite")
+}

--- a/pkg/docs/concepts/vm-class_test.go
+++ b/pkg/docs/concepts/vm-class_test.go
@@ -1,0 +1,203 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package concepts
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	vimTypes "github.com/vmware/govmomi/vim25/types"
+	"sigs.k8s.io/yaml"
+)
+
+var _ = Describe("VirtualMachineClass", func() {
+	Context("ConfigSpec", func() {
+		var (
+			obj vimTypes.VirtualMachineConfigSpec
+		)
+		Context("JSON", func() {
+			var (
+				act string
+			)
+			JustBeforeEach(func() {
+				var w bytes.Buffer
+				enc := vimTypes.NewJSONEncoder(&w)
+				ExpectWithOffset(1, enc.Encode(obj)).To(Succeed())
+				act = w.String()
+			})
+			AfterEach(func() {
+				if !CurrentSpecReport().Failed() {
+					rawj := json.RawMessage(act)
+					data, err := json.MarshalIndent(rawj, "", "  ")
+					ExpectWithOffset(1, err).ToNot(HaveOccurred())
+					fmt.Fprintf(GinkgoWriter, "JSON\n----\n%s\n\n", string(data))
+
+					data, err = yaml.Marshal(rawj)
+					ExpectWithOffset(1, err).ToNot(HaveOccurred())
+					fmt.Fprintf(GinkgoWriter, "YAML\n----\n%s\n\n", string(data))
+				}
+			})
+
+			Context("Basic", func() {
+				BeforeEach(func() {
+					obj = vimTypes.VirtualMachineConfigSpec{
+						NumCPUs:  2,
+						MemoryMB: 2048,
+					}
+				})
+				It("should match the expected JSON", func() {
+					Expect(act).To(MatchJSON(
+						`{
+							"_typeName": "VirtualMachineConfigSpec",
+							"numCPUs": 2,
+							"memoryMB": 2048
+						}`,
+					))
+				})
+			})
+
+			Context("ExtraConfig", func() {
+				BeforeEach(func() {
+					obj = vimTypes.VirtualMachineConfigSpec{
+						NumCPUs:  2,
+						MemoryMB: 2048,
+						ExtraConfig: []vimTypes.BaseOptionValue{
+							&vimTypes.OptionValue{
+								Key:   "my-key-1",
+								Value: "my-value-1",
+							},
+							&vimTypes.OptionValue{
+								Key:   "my-key-2",
+								Value: "my-value-2",
+							},
+						},
+					}
+				})
+				It("should match the expected JSON", func() {
+					Expect(act).To(MatchJSON(
+						`{
+							"_typeName": "VirtualMachineConfigSpec",
+							"numCPUs": 2,
+							"memoryMB": 2048,
+							"extraConfig": [
+								{
+									"_typeName": "OptionValue",
+									"key": "my-key-1",
+									"value": {
+										"_typeName": "string",
+										"_value": "my-value-1"
+									}
+								},
+								{
+									"_typeName": "OptionValue",
+									"key": "my-key-2",
+									"value": {
+										"_typeName": "string",
+										"_value": "my-value-2"
+									}
+								}
+							]
+						}`,
+					))
+				})
+			})
+
+			Context("vGPU", func() {
+				BeforeEach(func() {
+					obj = vimTypes.VirtualMachineConfigSpec{
+						DeviceChange: []vimTypes.BaseVirtualDeviceConfigSpec{
+							&vimTypes.VirtualDeviceConfigSpec{
+								Operation: vimTypes.VirtualDeviceConfigSpecOperationAdd,
+								Device: &vimTypes.VirtualPCIPassthrough{
+									VirtualDevice: vimTypes.VirtualDevice{
+										Backing: &vimTypes.VirtualPCIPassthroughVmiopBackingInfo{
+											Vgpu: "my-vgpu-profile",
+										},
+									},
+								},
+							},
+						},
+					}
+				})
+				It("should match the expected JSON", func() {
+					Expect(act).To(MatchJSON(
+						`{
+							"_typeName": "VirtualMachineConfigSpec",
+							"deviceChange": [
+								{
+									"_typeName": "VirtualDeviceConfigSpec",
+									"operation": "add",
+									"device": {
+										"_typeName": "VirtualPCIPassthrough",
+										"key": 0,
+										"backing": {
+											"_typeName": "VirtualPCIPassthroughVmiopBackingInfo",
+											"vgpu": "my-vgpu-profile"
+										}
+									}
+								}
+							]
+						}`,
+					))
+				})
+			})
+
+			Context("Dynamic Direct Path I/O", func() {
+				BeforeEach(func() {
+					obj = vimTypes.VirtualMachineConfigSpec{
+						DeviceChange: []vimTypes.BaseVirtualDeviceConfigSpec{
+							&vimTypes.VirtualDeviceConfigSpec{
+								Operation: vimTypes.VirtualDeviceConfigSpecOperationAdd,
+								Device: &vimTypes.VirtualPCIPassthrough{
+									VirtualDevice: vimTypes.VirtualDevice{
+										Backing: &vimTypes.VirtualPCIPassthroughDynamicBackingInfo{
+											AllowedDevice: []vimTypes.VirtualPCIPassthroughAllowedDevice{
+												{
+													DeviceId: -999,
+													VendorId: -999,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}
+				})
+				It("should match the expected JSON", func() {
+					Expect(act).To(MatchJSON(
+						`{
+							"_typeName": "VirtualMachineConfigSpec",
+							"deviceChange": [
+								{
+									"_typeName": "VirtualDeviceConfigSpec",
+									"operation": "add",
+									"device": {
+										"_typeName": "VirtualPCIPassthrough",
+										"key": 0,
+										"backing": {
+											"_typeName": "VirtualPCIPassthroughDynamicBackingInfo",
+											"deviceName": "",
+											"allowedDevice": [
+												{
+													"_typeName": "VirtualPCIPassthroughAllowedDevice",
+													"vendorId": -999,
+													"deviceId": -999
+												}
+											]
+										}
+									}
+								}
+							]
+						}`,
+					))
+				})
+			})
+		})
+	})
+})


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch adds some additional documentation for VM classes, as well as a new package to supplement docs with Golang code, pkg/docs. This package includes a file for providing examples of encoded ConfigSpec structures, pkg/docs/concepts/vm-class_test.go.



**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
The package pkg/docs supplements documentation with Go examples, beginning with examples of encoded ConfigSpec values.
```

<!-- readthedocs-preview vm-operator start -->
----
📚 Documentation preview 📚: https://vm-operator--438.org.readthedocs.build/en/438/

<!-- readthedocs-preview vm-operator end -->