### PR TITLE
📖 VM controller docs / workflows

### DIFF
--- a/docs/concepts/workloads/README.md
+++ b/docs/concepts/workloads/README.md
@@ -9,6 +9,7 @@ VM Operator virtual machines (VM) have a defined lifecycle. For example, on vSph
 This section provides information about workload resources, such as:
 
 * [`VirualMachine`](./vm.md)
+* [`VirtualMachine` controller](./vm-controller.md)
 * [`VirualMachineClass`](./vm-class.md)
 * [`WebConsoleRequest`](./vm-web-console.md)
 

--- a/docs/concepts/workloads/vm-controller.md
+++ b/docs/concepts/workloads/vm-controller.md
@@ -1,0 +1,72 @@
+# VirtualMachine Controller
+
+The `VirtualMachine` controller is responsible for reconciling `VirtualMachine` objects.
+
+## Reconcile
+
+```mermaid
+flowchart LR
+    Start(Start) --> GetVM
+
+    GetVM(Get VM) --> GetVMErr{Error?}
+    GetVMErr -->|No| HasPauseAnnotation{Has pause\nannotation?}
+    GetVMErr ---->|Yes| StoreGetErrAndReturnErr
+
+    HasPauseAnnotation --> |No| CreatePatchHelper
+    HasPauseAnnotation ----> |Yes| End
+
+    CreatePatchHelper(Create patch helper) --> HasDeletionTimestamp{Has deletion\ntimestamp?}
+
+    HasDeletionTimestamp --> |Yes| ReconcileDelete
+    HasDeletionTimestamp ----> |No| ReconcileNormal
+
+    ReconcileDelete(Reconcile delete) --> ReconcileDeleteNormalErr
+    ReconcileNormal(Reconcile normal) --> ReconcileDeleteNormalErr
+    ReconcileDeleteNormalErr{Error?}
+    ReconcileDeleteNormalErr --> |No| PatchVM
+    ReconcileDeleteNormalErr ----> |Yes| StoreErrAndPatch
+    StoreErrAndPatch(Store reconcile error\nin <code>result</code>) --> PatchVM
+
+    PatchVM(Patch VM) --> PatchVMErr{Error?}
+    PatchVMErr --> |Yes| IsResultErr{Is error already\nstored in <code>result</code>?}
+    PatchVMErr ----> |No| ReturnResult
+    IsResultErr --> |No| StorePatchErr
+    IsResultErr ----> |Yes| LogPatchErr
+    LogPatchErr(Log patch error) --> ReturnResult
+    StorePatchErr(Store patch error\nin <code>result</code>) --> ReturnResult
+
+    %% This element's position keeps the graph from having to transect points
+    %% between nodes.
+    StoreGetErrAndReturnErr(Store get error\nin <code>result</code>) --> ReturnResult
+
+    ReturnResult(Return <code>result</code>) --> End
+
+    End(End)
+```
+
+### Reconcile Delete
+
+```mermaid
+flowchart LR
+    Start(Start) --> HasFinalizer{Has finalizer?}
+
+    HasFinalizer --> |No| DeleteMetrics(Delete metrics)
+    HasFinalizer ----> |Yes| DeleteVM(Delete vSphere VM)
+
+    DeleteVM --> DeleteVMErr{Error?}
+    DeleteVMErr --> |No| RemoveFinalizer(Remove finalizer)
+    DeleteVMErr ----> |Yes| ReturnErr(Return error)
+
+    RemoveFinalizer --> DeleteMetrics(Delete metrics)
+
+    DeleteMetrics --> RemoveProbe(Remove probe)
+    RemoveProbe --> End
+
+    ReturnErr --> End
+
+    End(End)
+```
+
+### Reconcile Normal
+
+// TODO ([github.com/vmware-tanzu/vm-operator#444](https://github.com/vmware-tanzu/vm-operator/issues/444))

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -133,6 +133,7 @@ nav:
   - Workloads:
     - concepts/workloads/README.md
     - VirtualMachine: concepts/workloads/vm.md
+    - VirtualMachine Controller: concepts/workloads/vm-controller.md
     - VirtualMachineClass: concepts/workloads/vm-class.md
     - WebConsoleRequest: concepts/workloads/vm-web-console.md
     - Guest Customization: concepts/workloads/guest.md


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->
This patch adds a docs page for the VM controller and includes workflow diagrams for the basic VM Reconcile and Delete workflows.

There is a TODO for the ReconcileNormal workflow.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Initial documentation for the VM controller
```

<!-- readthedocs-preview vm-operator start -->
----
📚 Documentation preview 📚: https://vm-operator--445.org.readthedocs.build/en/445/

<!-- readthedocs-preview vm-operator end -->