### PR TITLE
⚠️ Remove need for VM Image in Update path

### DIFF
--- a/config/local-vcsim/vcsim-patch.yaml
+++ b/config/local-vcsim/vcsim-patch.yaml
@@ -13,4 +13,4 @@ spec:
         # Add extraConfig to the VirtualMachines to tell vcsim to run a container per VM
         - name: "JSON_EXTRA_CONFIG"
           value: |
-            {"RUN.container":"[\"--privileged\", \"-v=/lib/modules:/lib/modules:ro\", \"{{.ImageName}}\"]"}
+            {"RUN.container":"[\"--privileged\", \"-v=/lib/modules:/lib/modules:ro\", \"{{.Name}}\"]"}

--- a/pkg/vmprovider/providers/vsphere2/constants/constants.go
+++ b/pkg/vmprovider/providers/vsphere2/constants/constants.go
@@ -14,6 +14,7 @@ const (
 	ExtraConfigFalse           = "FALSE"
 	ExtraConfigUnset           = ""
 	ExtraConfigGuestInfoPrefix = "guestinfo."
+	ExtraConfigRunContainerKey = "RUN.container"
 
 	// VCVMAnnotation Annotation placed on the VM.
 	VCVMAnnotation = "Virtual Machine managed by the vSphere Virtual Machine service"

--- a/pkg/vmprovider/providers/vsphere2/session/session_vm_update_test.go
+++ b/pkg/vmprovider/providers/vsphere2/session/session_vm_update_test.go
@@ -261,7 +261,6 @@ var _ = Describe("Update ConfigSpec", func() {
 		var vm *vmopv1.VirtualMachine
 		var globalExtraConfig map[string]string
 		var ecMap map[string]string
-		var imageV1Alpha1Compatible bool
 
 		BeforeEach(func() {
 			vmClassSpec = &vmopv1.VirtualMachineClassSpec{}
@@ -282,8 +281,7 @@ var _ = Describe("Update ConfigSpec", func() {
 				classConfigSpec,
 				vmClassSpec,
 				vm,
-				globalExtraConfig,
-				imageV1Alpha1Compatible)
+				globalExtraConfig)
 
 			ecMap = util.ExtraConfigToMap(configSpec.ExtraConfig)
 		})
@@ -312,7 +310,6 @@ var _ = Describe("Update ConfigSpec", func() {
 					Key: constants.VMOperatorV1Alpha1ExtraConfigKey, Value: constants.VMOperatorV1Alpha1ConfigReady})
 				globalExtraConfig["guestinfo.test"] = "test"
 				globalExtraConfig["global"] = "test"
-				imageV1Alpha1Compatible = true
 			})
 
 			When("VM uses LinuxPrep with vAppConfig bootstrap", func() {


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Post create, I'd like us to never have to depend in the image resource existing since it may get deleted. Fix the two situations where the image was being used.

First the JSON_EXTRA_CONFIG contains RUN.container that uses a template to fill in the image name so vcsim creates a container under the covers. This was used for old local gce2e testing, and isn't used by us but some other teams have a desire to use it so keep it around. Now that is just set on create in the EC and we don't need to re-eval it later on.

Second remove the V1Alpha1Compatible condition check and always check the EC. This does change the behavior that if an image did not have the condition but had guestinfo.vmservice.defer-cloud-init=ready, we'll now always set it to enabled. I don't think this will really matter.

For now continue to set the FirstBootDoneAnnotation.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

Could remove FirstBootDoneAnnotation too if we want to.

**Please add a release note if necessary**:


```release-note
NONE
```