### PR TITLE
✨ UpdateExtraConfig for powered on VMs, iterate list once

### DIFF
--- a/pkg/util/configspec.go
+++ b/pkg/util/configspec.go
@@ -210,6 +210,8 @@ func ExtraConfigToMap(input []vimTypes.BaseOptionValue) (output map[string]strin
 // MergeExtraConfig adds the key/value to the ExtraConfig if the key is not
 // present or the new value is different than the existing value.
 // It returns the newly added ExtraConfig.
+// Please note the result *may* include keys with empty values. This indicates
+// to vSphere to remove the key/value pair.
 func MergeExtraConfig(
 	existingExtraConfig []vimTypes.BaseOptionValue,
 	newKeyValuePairs map[string]string) []vimTypes.BaseOptionValue {

--- a/pkg/vmprovider/providers/vsphere2/session/session_vm_update_test.go
+++ b/pkg/vmprovider/providers/vsphere2/session/session_vm_update_test.go
@@ -289,7 +289,19 @@ var _ = Describe("Update ConfigSpec", func() {
 		})
 
 		Context("Empty input", func() {
-			It("No changes", func() {
+			Specify("no changes", func() {
+				Expect(ecMap).To(BeEmpty())
+			})
+		})
+
+		When("classConfigSpec, vmClassSpec, vm, and globalExtraConfig params are nil", func() {
+			BeforeEach(func() {
+				classConfigSpec = nil
+				vmClassSpec = nil
+				vm = nil
+				globalExtraConfig = nil
+			})
+			Specify("no changes", func() {
 				Expect(ecMap).To(BeEmpty())
 			})
 		})
@@ -303,7 +315,7 @@ var _ = Describe("Update ConfigSpec", func() {
 				imageV1Alpha1Compatible = true
 			})
 
-			Context("When VM uses LinuxPrep with vAppConfig bootstrap", func() {
+			When("VM uses LinuxPrep with vAppConfig bootstrap", func() {
 				BeforeEach(func() {
 					vm.Spec.Bootstrap = &vmopv1.VirtualMachineBootstrapSpec{
 						LinuxPrep:  &vmopv1.VirtualMachineBootstrapLinuxPrepSpec{},
@@ -354,6 +366,24 @@ var _ = Describe("Update ConfigSpec", func() {
 			})
 			It("Should be set to an empty value", func() {
 				Expect(ecMap).To(HaveKeyWithValue(constants.MMPowerOffVMExtraConfigKey, ""))
+			})
+			When("classConfigSpec, vmClassSpec, and vm params are nil", func() {
+				BeforeEach(func() {
+					classConfigSpec = nil
+					vmClassSpec = nil
+					vm = nil
+				})
+				It("Should be set to an empty value", func() {
+					Expect(ecMap).To(HaveKeyWithValue(constants.MMPowerOffVMExtraConfigKey, ""))
+				})
+				When("globalExtraConfig is nil", func() {
+					BeforeEach(func() {
+						globalExtraConfig = nil
+					})
+					It("Should be set to an empty value", func() {
+						Expect(ecMap).To(HaveKeyWithValue(constants.MMPowerOffVMExtraConfigKey, ""))
+					})
+				})
 			})
 		})
 


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->
This patch modifies the logic for updating ExtraConfig to support powered on VMs. This ensures powered on VMs that have vGPUs will have the flag in ExtraConfig removed that DRS queries to determine whether or not to power off the VM during vMotion. This was already handled in #353, but that logic is only executed before a VM is powered on, not for currently powered on VMs.

This patch also optimizes the behavior of the UpdateEC function to only iterate over the existing EC list once.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Update ExtraConfig for powered on VMs.
```