### PR TITLE
 🌱 Redact sensitive fields in bootstrap config and customization specs

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -82,6 +82,10 @@ type Config struct {
 	WebhookSecretName            string
 	WebhookSecretNamespace       string
 	WebhookSecretVolumeMountPath string
+
+	// LogSensitiveData means that logs will potentially contain sensitive data
+	// such as passwords. Defaults to false.
+	LogSensitiveData bool
 }
 
 // GetMaxDeployThreadsOnProvider returns MaxDeployThreadsOnProvider if it is >0

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -24,6 +24,7 @@ func FromEnv() Config {
 	setString(env.LoadBalancerProvider, &config.LoadBalancerProvider)
 	setBool(env.VSphereNetworking, &config.VSphereNetworking)
 	setStringSlice(env.PrivilegedUsers, &config.PrivilegedUsers)
+	setBool(env.LogSensitiveData, &config.LogSensitiveData)
 
 	setDuration(env.InstanceStoragePVPlacementFailedTTL, &config.InstanceStorage.PVPlacementFailedTTL)
 	setFloat64(env.InstanceStorageJitterMaxFactor, &config.InstanceStorage.JitterMaxFactor)

--- a/pkg/config/env/env.go
+++ b/pkg/config/env/env.go
@@ -21,6 +21,7 @@ const (
 	VSphereNetworking
 	ContentAPIWaitDuration
 	JSONExtraConfig
+	LogSensitiveData
 	InstanceStoragePVPlacementFailedTTL
 	InstanceStorageJitterMaxFactor
 	InstanceStorageSeedRequeueDuration
@@ -88,6 +89,8 @@ func (n VarName) String() string {
 		return "CONTENT_API_WAIT_SECS"
 	case JSONExtraConfig:
 		return "JSON_EXTRA_CONFIG"
+	case LogSensitiveData:
+		return "LOG_SENSITIVE_DATA"
 	case InstanceStoragePVPlacementFailedTTL:
 		return "INSTANCE_STORAGE_PV_PLACEMENT_FAILED_TTL"
 	case InstanceStorageJitterMaxFactor:


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Some fields may contain sensitive info like passwords, so redact or nil out those fields for the specs used for logging. This is enabled by default.

This behavior can be toggled by the LOG_FULL_BOOTSTRAP_SPECS envvar.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

I'm not in love with this opt-in field approach fwiw.

**Please add a release note if necessary**:


```release-note

```