### PR TITLE
✨ ConfigSpec by value

### DIFF
--- a/pkg/util/configspec.go
+++ b/pkg/util/configspec.go
@@ -16,7 +16,7 @@ import (
 // MarshalConfigSpecToXML returns a byte slice of the provided ConfigSpec
 // marshalled to an XML string.
 func MarshalConfigSpecToXML(
-	configSpec *vimTypes.VirtualMachineConfigSpec) ([]byte, error) {
+	configSpec vimTypes.VirtualMachineConfigSpec) ([]byte, error) {
 
 	start := xml.StartElement{
 		Name: xml.Name{
@@ -53,9 +53,9 @@ func MarshalConfigSpecToXML(
 // UnmarshalConfigSpecFromXML returns a ConfigSpec object from a byte-slice of
 // the ConfigSpec marshaled as an XML string.
 func UnmarshalConfigSpecFromXML(
-	data []byte) (*vimTypes.VirtualMachineConfigSpec, error) {
+	data []byte) (vimTypes.VirtualMachineConfigSpec, error) {
 
-	configSpec := &vimTypes.VirtualMachineConfigSpec{}
+	var configSpec vimTypes.VirtualMachineConfigSpec
 
 	// Instantiate a new XML decoder in order to specify the lookup table used
 	// by GoVmomi to transform XML types to Golang types.
@@ -63,7 +63,7 @@ func UnmarshalConfigSpecFromXML(
 	dec.TypeFunc = vimTypes.TypeFunc()
 
 	if err := dec.Decode(&configSpec); err != nil {
-		return nil, err
+		return vimTypes.VirtualMachineConfigSpec{}, err
 	}
 
 	return configSpec, nil
@@ -72,11 +72,11 @@ func UnmarshalConfigSpecFromXML(
 // UnmarshalConfigSpecFromBase64XML returns a ConfigSpec object from a
 // byte-slice of the ConfigSpec marshaled as a base64-encoded, XML string.
 func UnmarshalConfigSpecFromBase64XML(
-	src []byte) (*vimTypes.VirtualMachineConfigSpec, error) {
+	src []byte) (vimTypes.VirtualMachineConfigSpec, error) {
 
 	data, err := Base64Decode(src)
 	if err != nil {
-		return nil, err
+		return vimTypes.VirtualMachineConfigSpec{}, err
 	}
 	return UnmarshalConfigSpecFromXML(data)
 }
@@ -84,7 +84,7 @@ func UnmarshalConfigSpecFromBase64XML(
 // MarshalConfigSpecToJSON returns a byte slice of the provided ConfigSpec
 // marshaled to a JSON string.
 func MarshalConfigSpecToJSON(
-	configSpec *vimTypes.VirtualMachineConfigSpec) ([]byte, error) {
+	configSpec vimTypes.VirtualMachineConfigSpec) ([]byte, error) {
 
 	var w bytes.Buffer
 	enc := vimTypes.NewJSONEncoder(&w)
@@ -97,15 +97,15 @@ func MarshalConfigSpecToJSON(
 // UnmarshalConfigSpecFromJSON returns a ConfigSpec object from a byte-slice of
 // the ConfigSpec marshaled as a JSON string.
 func UnmarshalConfigSpecFromJSON(
-	data []byte) (*vimTypes.VirtualMachineConfigSpec, error) {
+	data []byte) (vimTypes.VirtualMachineConfigSpec, error) {
 
 	var configSpec vimTypes.VirtualMachineConfigSpec
 
 	dec := vimTypes.NewJSONDecoder(bytes.NewReader(data))
 	if err := dec.Decode(&configSpec); err != nil {
-		return nil, err
+		return vimTypes.VirtualMachineConfigSpec{}, err
 	}
-	return &configSpec, nil
+	return configSpec, nil
 }
 
 // DevicesFromConfigSpec returns a slice of devices from the ConfigSpec's

--- a/pkg/util/configspec_test.go
+++ b/pkg/util/configspec_test.go
@@ -108,17 +108,17 @@ var _ = Describe("DevicesFromConfigSpec", func() {
 var _ = Describe("ConfigSpec Util", func() {
 	Context("MarshalConfigSpecToXML", func() {
 		It("marshals and unmarshal to the same spec", func() {
-			inputSpec := &vimTypes.VirtualMachineConfigSpec{Name: "dummy-VM"}
+			inputSpec := vimTypes.VirtualMachineConfigSpec{Name: "dummy-VM"}
 			bytes, err := util.MarshalConfigSpecToXML(inputSpec)
 			Expect(err).ShouldNot(HaveOccurred())
 			var outputSpec vimTypes.VirtualMachineConfigSpec
 			err = xml.Unmarshal(bytes, &outputSpec)
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(reflect.DeepEqual(inputSpec, &outputSpec)).To(BeTrue())
+			Expect(reflect.DeepEqual(inputSpec, outputSpec)).To(BeTrue())
 		})
 
 		It("marshals spec correctly to expected base64 encoded XML", func() {
-			inputSpec := &vimTypes.VirtualMachineConfigSpec{Name: "dummy-VM"}
+			inputSpec := vimTypes.VirtualMachineConfigSpec{Name: "dummy-VM"}
 			bytes, err := util.MarshalConfigSpecToXML(inputSpec)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(base64.StdEncoding.EncodeToString(bytes)).To(Equal("PG9iaiB4bWxuczp2aW0yNT0idXJuOnZpbTI1I" +

--- a/pkg/vmprovider/providers/vsphere2/placement/cluster_placement.go
+++ b/pkg/vmprovider/providers/vsphere2/placement/cluster_placement.go
@@ -111,11 +111,11 @@ func CloneVMRelocateSpec(
 func PlaceVMForCreate(
 	ctx goctx.Context,
 	cluster *object.ClusterComputeResource,
-	configSpec *types.VirtualMachineConfigSpec) ([]Recommendation, error) {
+	configSpec types.VirtualMachineConfigSpec) ([]Recommendation, error) {
 
 	placementSpec := types.PlacementSpec{
 		PlacementType: string(types.PlacementSpecPlacementTypeCreate),
-		ConfigSpec:    configSpec,
+		ConfigSpec:    &configSpec,
 	}
 
 	resp, err := cluster.PlaceVm(ctx, placementSpec)
@@ -147,18 +147,17 @@ func ClusterPlaceVMForCreate(
 	vmCtx context.VirtualMachineContextA2,
 	vcClient *vim25.Client,
 	resourcePoolsMoRefs []types.ManagedObjectReference,
-	configSpec *types.VirtualMachineConfigSpec,
+	configSpec types.VirtualMachineConfigSpec,
 	needsHost bool) ([]Recommendation, error) {
 
 	// Work around PlaceVmsXCluster bug that crashes vpxd when ConfigSpec.Files is nil.
-	cs := *configSpec
-	cs.Files = new(types.VirtualMachineFileInfo)
+	configSpec.Files = new(types.VirtualMachineFileInfo)
 
 	placementSpec := types.PlaceVmsXClusterSpec{
 		ResourcePools: resourcePoolsMoRefs,
 		VmPlacementSpecs: []types.PlaceVmsXClusterSpecVmPlacementSpec{
 			{
-				ConfigSpec: cs,
+				ConfigSpec: configSpec,
 			},
 		},
 		HostRecommRequired: &needsHost,

--- a/pkg/vmprovider/providers/vsphere2/placement/zone_placement.go
+++ b/pkg/vmprovider/providers/vsphere2/placement/zone_placement.go
@@ -162,7 +162,7 @@ func getPlacementRecommendations(
 	vmCtx context.VirtualMachineContextA2,
 	vcClient *vim25.Client,
 	candidates map[string][]string,
-	configSpec *types.VirtualMachineConfigSpec) map[string][]Recommendation {
+	configSpec types.VirtualMachineConfigSpec) map[string][]Recommendation {
 
 	recommendations := map[string][]Recommendation{}
 
@@ -211,7 +211,7 @@ func getZonalPlacementRecommendations(
 	vmCtx context.VirtualMachineContextA2,
 	vcClient *vim25.Client,
 	candidates map[string][]string,
-	configSpec *types.VirtualMachineConfigSpec,
+	configSpec types.VirtualMachineConfigSpec,
 	needsHost bool) map[string][]Recommendation {
 
 	rpMOToZone := map[types.ManagedObjectReference]string{}
@@ -286,7 +286,7 @@ func Placement(
 	vmCtx context.VirtualMachineContextA2,
 	client ctrlclient.Client,
 	vcClient *vim25.Client,
-	configSpec *types.VirtualMachineConfigSpec,
+	configSpec types.VirtualMachineConfigSpec,
 	childRPName string) (*Result, error) {
 
 	existingRes, zonePlacement, instanceStoragePlacement := doesVMNeedPlacement(vmCtx)

--- a/pkg/vmprovider/providers/vsphere2/placement/zone_placement_test.go
+++ b/pkg/vmprovider/providers/vsphere2/placement/zone_placement_test.go
@@ -72,7 +72,7 @@ func vcSimPlacement() {
 
 		vm         *vmopv1.VirtualMachine
 		vmCtx      context.VirtualMachineContextA2
-		configSpec *types.VirtualMachineConfigSpec
+		configSpec types.VirtualMachineConfigSpec
 	)
 
 	BeforeEach(func() {
@@ -82,7 +82,7 @@ func vcSimPlacement() {
 		vm.Name = "placement-test"
 
 		// Other than the name ConfigSpec contents don't matter for vcsim.
-		configSpec = &types.VirtualMachineConfigSpec{
+		configSpec = types.VirtualMachineConfigSpec{
 			Name: vm.Name,
 		}
 	})

--- a/pkg/vmprovider/providers/vsphere2/session/session_vm_update.go
+++ b/pkg/vmprovider/providers/vsphere2/session/session_vm_update.go
@@ -40,7 +40,7 @@ type VMUpdateArgs struct {
 
 	BootstrapData vmlifecycle.BootstrapData
 
-	ConfigSpec *vimTypes.VirtualMachineConfigSpec
+	ConfigSpec vimTypes.VirtualMachineConfigSpec
 
 	NetworkResults network2.NetworkInterfaceResults
 }
@@ -513,10 +513,10 @@ func updateConfigSpec(
 	UpdateConfigSpecAnnotation(config, configSpec)
 	UpdateConfigSpecManagedBy(config, configSpec)
 	UpdateConfigSpecExtraConfig(
-		vmCtx, config, configSpec, updateArgs.ConfigSpec,
+		vmCtx, config, configSpec, &updateArgs.ConfigSpec,
 		&vmClassSpec, vmCtx.VM, updateArgs.ExtraConfig)
 	UpdateConfigSpecChangeBlockTracking(
-		vmCtx, config, configSpec, updateArgs.ConfigSpec, vmCtx.VM.Spec)
+		vmCtx, config, configSpec, &updateArgs.ConfigSpec, vmCtx.VM.Spec)
 	UpdateConfigSpecFirmware(config, configSpec, vmCtx.VM)
 
 	return configSpec
@@ -552,7 +552,7 @@ func (s *Session) prePowerOnVMConfigSpec(
 	configSpec.DeviceChange = append(configSpec.DeviceChange, ethCardDeviceChanges...)
 
 	var expectedPCIDevices []vimTypes.BaseVirtualDevice
-	if configSpecDevs := util.DevicesFromConfigSpec(updateArgs.ConfigSpec); len(configSpecDevs) > 0 {
+	if configSpecDevs := util.DevicesFromConfigSpec(&updateArgs.ConfigSpec); len(configSpecDevs) > 0 {
 		pciPassthruFromConfigSpec := util.SelectVirtualPCIPassthrough(configSpecDevs)
 		expectedPCIDevices = virtualmachine.CreatePCIDevicesFromConfigSpec(pciPassthruFromConfigSpec)
 	}
@@ -740,7 +740,7 @@ func (s *Session) prepareVMForPowerOn(
 	cfg *vimTypes.VirtualMachineConfigInfo,
 	updateArgs *VMUpdateArgs) error {
 
-	netIfList, err := s.ensureNetworkInterfaces(vmCtx, updateArgs.ConfigSpec)
+	netIfList, err := s.ensureNetworkInterfaces(vmCtx, &updateArgs.ConfigSpec)
 	if err != nil {
 		return err
 	}

--- a/pkg/vmprovider/providers/vsphere2/virtualmachine/configspec_test.go
+++ b/pkg/vmprovider/providers/vsphere2/virtualmachine/configspec_test.go
@@ -30,8 +30,8 @@ var _ = Describe("CreateConfigSpec", func() {
 		vmClassSpec     *vmopv1.VirtualMachineClassSpec
 		vmImageStatus   *vmopv1.VirtualMachineImageStatus
 		minCPUFreq      uint64
-		configSpec      *vimTypes.VirtualMachineConfigSpec
-		classConfigSpec *vimTypes.VirtualMachineConfigSpec
+		configSpec      vimTypes.VirtualMachineConfigSpec
+		classConfigSpec vimTypes.VirtualMachineConfigSpec
 		pvcVolume       = vmopv1.VirtualMachineVolume{
 			Name: "vmware",
 			VirtualMachineVolumeSource: vmopv1.VirtualMachineVolumeSource{
@@ -75,7 +75,7 @@ var _ = Describe("CreateConfigSpec", func() {
 
 	Context("No VM Class ConfigSpec", func() {
 		BeforeEach(func() {
-			classConfigSpec = nil
+			classConfigSpec = vimTypes.VirtualMachineConfigSpec{}
 		})
 
 		When("Basic ConfigSpec assertions", func() {
@@ -118,7 +118,7 @@ var _ = Describe("CreateConfigSpec", func() {
 
 	Context("VM Class ConfigSpec", func() {
 		BeforeEach(func() {
-			classConfigSpec = &vimTypes.VirtualMachineConfigSpec{
+			classConfigSpec = vimTypes.VirtualMachineConfigSpec{
 				Name:       "dont-use-this-dummy-VM",
 				Annotation: "test-annotation",
 				DeviceChange: []vimTypes.BaseVirtualDeviceConfigSpec{
@@ -319,12 +319,12 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 	var (
 		vmCtx               context.VirtualMachineContextA2
 		storageClassesToIDs map[string]string
-		baseConfigSpec      *vimTypes.VirtualMachineConfigSpec
-		configSpec          *vimTypes.VirtualMachineConfigSpec
+		baseConfigSpec      vimTypes.VirtualMachineConfigSpec
+		configSpec          vimTypes.VirtualMachineConfigSpec
 	)
 
 	BeforeEach(func() {
-		baseConfigSpec = &vimTypes.VirtualMachineConfigSpec{}
+		baseConfigSpec = vimTypes.VirtualMachineConfigSpec{}
 		storageClassesToIDs = map[string]string{}
 
 		vm := builder.DummyVirtualMachineA2()
@@ -345,7 +345,7 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 
 	Context("Returns expected ConfigSpec", func() {
 		BeforeEach(func() {
-			baseConfigSpec = &vimTypes.VirtualMachineConfigSpec{
+			baseConfigSpec = vimTypes.VirtualMachineConfigSpec{
 				Name:       "dummy-VM",
 				Annotation: "test-annotation",
 				NumCPUs:    42,
@@ -422,7 +422,7 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 
 	Context("Removes VirtualEthernetCards without a backing", func() {
 		BeforeEach(func() {
-			baseConfigSpec = &vimTypes.VirtualMachineConfigSpec{
+			baseConfigSpec = vimTypes.VirtualMachineConfigSpec{
 				Name: "dummy-VM",
 				DeviceChange: []vimTypes.BaseVirtualDeviceConfigSpec{
 					&vimTypes.VirtualDeviceConfigSpec{
@@ -447,7 +447,7 @@ var _ = Describe("ConfigSpecFromVMClassDevices", func() {
 
 	var (
 		vmClassSpec *vmopv1.VirtualMachineClassSpec
-		configSpec  *vimTypes.VirtualMachineConfigSpec
+		configSpec  vimTypes.VirtualMachineConfigSpec
 	)
 
 	Context("when Class specifies GPU/DDPIO in Hardware", func() {

--- a/pkg/vmprovider/providers/vsphere2/vmlifecycle/create.go
+++ b/pkg/vmprovider/providers/vsphere2/vmlifecycle/create.go
@@ -17,7 +17,7 @@ type CreateArgs struct {
 	UseContentLibrary bool
 	ProviderItemID    string
 
-	ConfigSpec          *types.VirtualMachineConfigSpec
+	ConfigSpec          types.VirtualMachineConfigSpec
 	StorageProvisioning string
 	FolderMoID          string
 	ResourcePoolMoID    string

--- a/pkg/vmprovider/providers/vsphere2/vmlifecycle/create_clone.go
+++ b/pkg/vmprovider/providers/vsphere2/vmlifecycle/create_clone.go
@@ -59,7 +59,7 @@ func createCloneSpec(
 	srcVM *object.VirtualMachine) (*vimtypes.VirtualMachineCloneSpec, error) {
 
 	cloneSpec := &vimtypes.VirtualMachineCloneSpec{
-		Config: createArgs.ConfigSpec,
+		Config: &createArgs.ConfigSpec,
 		Memory: ptr.To(false), // No full memory clones.
 	}
 

--- a/pkg/vmprovider/providers/vsphere2/vmlifecycle/create_contentlibrary.go
+++ b/pkg/vmprovider/providers/vsphere2/vmlifecycle/create_contentlibrary.go
@@ -37,16 +37,14 @@ func deployOVF(
 		deploymentSpec.DefaultDatastoreID = createArgs.DatastoreMoID
 	}
 
-	if createArgs.ConfigSpec != nil {
-		configSpecXML, err := util.MarshalConfigSpecToXML(createArgs.ConfigSpec)
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal ConfigSpec to XML: %w", err)
-		}
+	configSpecXML, err := util.MarshalConfigSpecToXML(createArgs.ConfigSpec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal ConfigSpec to XML: %w", err)
+	}
 
-		deploymentSpec.VmConfigSpec = &vcenter.VmConfigSpec{
-			Provider: constants.ConfigSpecProviderXML,
-			XML:      base64.StdEncoding.EncodeToString(configSpecXML),
-		}
+	deploymentSpec.VmConfigSpec = &vcenter.VmConfigSpec{
+		Provider: constants.ConfigSpecProviderXML,
+		XML:      base64.StdEncoding.EncodeToString(configSpecXML),
 	}
 
 	deploy := vcenter.Deploy{

--- a/pkg/vmprovider/providers/vsphere2/vmprovider_vm_utils.go
+++ b/pkg/vmprovider/providers/vsphere2/vmprovider_vm_utils.go
@@ -377,14 +377,17 @@ func AddInstanceStorageVolumes(
 	return true
 }
 
-func GetVMClassConfigSpec(ctx goctx.Context, raw json.RawMessage) (*types.VirtualMachineConfigSpec, error) {
-	classConfigSpec, err := util.UnmarshalConfigSpecFromJSON(raw)
-	if err != nil {
-		return nil, err
-	}
-	util.SanitizeVMClassConfigSpec(ctx, classConfigSpec)
+func GetVMClassConfigSpec(
+	ctx goctx.Context,
+	raw json.RawMessage) (types.VirtualMachineConfigSpec, error) {
 
-	return classConfigSpec, nil
+	configSpec, err := util.UnmarshalConfigSpecFromJSON(raw)
+	if err != nil {
+		return types.VirtualMachineConfigSpec{}, err
+	}
+	util.SanitizeVMClassConfigSpec(ctx, &configSpec)
+
+	return configSpec, nil
 }
 
 // GetAttachedDiskUUIDToPVC returns a map of disk UUID to PVC object for all


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch updates the way the VM ConfigSpec is handled by several util functions and the vSphere provider to be copy-by-value instead of as a pointer. This is because Golang is much more efficient at handling memory on the stack versus the heap. However, the primary reason for this patch is to change the perception of the `configSpec` variable throughout the rest of its call stack. The spec is not optional, and moving away from a pointer reinforces that notion.

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```