### PR TITLE
🌱 Add label to network interface CR for its VM name

### DIFF
--- a/pkg/vmprovider/providers/vsphere2/network/network_test.go
+++ b/pkg/vmprovider/providers/vsphere2/network/network_test.go
@@ -246,6 +246,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 						},
 					}
 					Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(netInterface), netInterface)).To(Succeed())
+					Expect(netInterface.Labels).To(HaveKeyWithValue(network.VMNameLabel, vm.Name))
 					Expect(netInterface.Spec.NetworkName).To(Equal(networkName))
 
 					netInterface.Status.NetworkID = ctx.NetworkRef.Reference().Value
@@ -335,6 +336,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 							},
 						}
 						Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(netInterface), netInterface)).To(Succeed())
+						Expect(netInterface.Labels).To(HaveKeyWithValue(network.VMNameLabel, vm.Name))
 						Expect(netInterface.Spec.NetworkName).To(Equal(networkName))
 
 						netInterface.Status.NetworkID = ctx.NetworkRef.Reference().Value
@@ -436,6 +438,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 						},
 					}
 					Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(netInterface), netInterface)).To(Succeed())
+					Expect(netInterface.Labels).To(HaveKeyWithValue(network.VMNameLabel, vm.Name))
 					Expect(netInterface.Spec.VirtualNetwork).To(Equal(networkName))
 
 					netInterface.Status.InterfaceID = interfaceID


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Going forward for new VMs, once the network interfaces are mutable and we need to reconcile the network interface CRs we can use this to quickly list all the interfaces for the VM instead of having to list all in the namespace.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:



**Please add a release note if necessary**:



```release-note
NONE
```