### PR TITLE
🐛 Fix UpdateConfigSpecExtraConfig() when reconciling VM with vGPU/DDPIO

### DIFF
--- a/pkg/vmprovider/providers/vsphere2/session/session_vm_update.go
+++ b/pkg/vmprovider/providers/vsphere2/session/session_vm_update.go
@@ -286,6 +286,9 @@ func UpdateConfigSpecMemoryAllocation(
 	}
 }
 
+// UpdateConfigSpecExtraConfig updates the ExtraConfig of the given ConfigSpec.
+// At a minimum, config and configSpec must be non-nil, in which case it will
+// just ensure MMPowerOffVMExtraConfigKey is no longer part of ExtraConfig.
 func UpdateConfigSpecExtraConfig(
 	ctx goctx.Context,
 	config *vimTypes.VirtualMachineConfigInfo,
@@ -418,6 +421,9 @@ func hasvGPUOrDDPIODevicesInVMClass(
 // information about these flags.
 func setMemoryMappedIOFlagsInExtraConfig(
 	vm *vmopv1.VirtualMachine, extraConfig map[string]string) {
+	if vm == nil {
+		return
+	}
 
 	mmioSize := vm.Annotations[constants.PCIPassthruMMIOOverrideAnnotation]
 	if mmioSize == "" {

--- a/pkg/vmprovider/providers/vsphere2/session/session_vm_update_test.go
+++ b/pkg/vmprovider/providers/vsphere2/session/session_vm_update_test.go
@@ -403,6 +403,32 @@ var _ = Describe("Update ConfigSpec", func() {
 				})
 			})
 
+			Context("when vGPU and DDPIO devices are present but classConfigSpec, vmClassSpec, and vm params are nil", func() {
+				BeforeEach(func() {
+					config.Hardware.Device = []vimTypes.BaseVirtualDevice{
+						&vimTypes.VirtualPCIPassthrough{
+							VirtualDevice: vimTypes.VirtualDevice{
+								Backing: &vimTypes.VirtualPCIPassthroughVmiopBackingInfo{
+									Vgpu: "SampleProfile",
+								},
+							},
+						},
+						&vimTypes.VirtualPCIPassthrough{
+							VirtualDevice: vimTypes.VirtualDevice{
+								Backing: &vimTypes.VirtualPCIPassthroughDynamicBackingInfo{},
+							},
+						},
+					}
+					classConfigSpec = nil
+					vmClassSpec = nil
+					vm = nil
+				})
+
+				Specify("No Changes", func() {
+					Expect(ecMap).To(BeEmpty())
+				})
+			})
+
 			Context("when vGPU device is available", func() {
 				BeforeEach(func() {
 					vmClassSpec.Hardware.Devices = vmopv1.VirtualDevices{VGPUDevices: []vmopv1.VGPUDevice{


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This PR updates the `setMemoryMappedIOFlagsInExtraConfig()` function to skip if the VM is nil. This could be the case when it's called from `UpdateConfigSpecExtraConfig()` while reconciling a powered-on VM with a vGPU or DDPIO device.

**Which issue(s) is/are addressed by this PR?**
Fixes #447.

**Please add a release note if necessary**:

```release-note
Fix UpdateConfigSpecExtraConfig() when reconciling a powered-on VM with vGPU or DDPIO device.
```
