### PR TITLE
:seedling: Add ExtraConfig Key, Label, Condition and validation for break glass override

### DIFF
--- a/api/v1alpha2/virtualmachine_types.go
+++ b/api/v1alpha2/virtualmachine_types.go
@@ -90,6 +90,20 @@ const (
 )
 
 const (
+	// VirtualMachineReconcileReady exposes the status of VirtualMachine reconciliation.
+	VirtualMachineReconcileReady = "VirtualMachineReconcileReady"
+
+	// VirtualMachineReconcileRunningReason indicates that VirtualMachine
+	// reconciliation is running.
+	VirtualMachineReconcileRunningReason = "VirtualMachineReconcileRunning"
+
+	// VirtualMachineReconcilePausedReason indicates that VirtualMachine
+	// reconciliation is being paused.
+	VirtualMachineReconcilePausedReason = "VirtualMachineReconcilePaused"
+
+)
+
+const (
 	// PauseAnnotation is an annotation that prevents a VM from being
 	// reconciled.
 	//
@@ -134,6 +148,19 @@ const (
 	// PVCDiskDataExtraConfigKey is the ExtraConfig key to persist the VM's
 	// PVC disk data in JSON, compressed using gzip and base64-encoded.
 	PVCDiskDataExtraConfigKey = "vmservice.virtualmachine.pvc.disk.data"
+)
+
+const (
+	// PauseVMExtraConfigKey is the ExtraConfig key to allow override
+	// operations for admins to pause reconciliation of VM Service VM.
+	PauseVMExtraConfigKey = "vmservice.virtualmachine.pause"
+
+	// PausedVMLabelKey is the label key to identify VMs that reconciliation
+	// are paused. Value will specify whose operation is responsible for
+	// the pause. It can be admins or devops or both.
+	//
+	// Only privileged user can edit this label.
+	PausedVMLabelKey = GroupName + "/paused"
 )
 
 // VirtualMachinePowerState defines a VM's desired and observed power states.


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This change adds `PauseVMExtraConfigKey`, `PausedVMLabelKey` and `VirtualMachineReconciliationCondition` for later break glass override consumption. It also adds validation to prevent non-admin user to edit PausedVMLabelKey. This label is set by VMOP to specify what persona paused vm reconciliation.
- PauseVMExtraConfigKey = "vmservice.virtualmachine.pause"
- PausedVMLabelKey = "vmoperator.vmware.com/paused-vm", value being:
  - admin
  - devops
  - both
- VirtualMachineReconciliationCondition = "VirtualMachineReconciliation"
  - when false, reason being "VirtualMachineReconciliationPaused"

This change also fixes validation unit test to use `DescribeTable` func.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # N/A


**Are there any special notes for your reviewer**:
Please review naming. Adding unit test WIP.
<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
N/A
```