### PR TITLE
🌱 Sanitize named network names

### DIFF
--- a/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator.go
@@ -448,6 +448,11 @@ func (v validator) validateNetworkInterfaceSpec(
 		networkIfCRName = fmt.Sprintf("%s-%s", vmName, interfaceSpec.Name)
 	}
 
+	// Sanitize named network names so it is possible to use network names like vcsim's default 'VM Network'.
+	// IMPORTANT! this is only for testing purposes; in a real environment network names are derived from K8s resources,
+	// so they are valid DNS subdomain by default.
+	networkIfCRName = strings.ToLower(strings.ReplaceAll(networkIfCRName, " ", "-"))
+
 	for _, msg := range validation.NameIsDNSSubdomain(networkIfCRName, false) {
 		allErrs = append(allErrs, field.Invalid(interfacePath.Child("name"), networkIfCRName, "is the resulting network interface name: "+msg))
 	}

--- a/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/v1alpha2/validation/virtualmachine_validator_unit_test.go
@@ -1296,7 +1296,25 @@ func unitTestsValidateCreate() {
 				},
 			),
 
-			Entry("disallow creating VM with network interfaces resulting in a non-DNS1123 combined network interface CR name/label (`vmName-networkName-interfaceName`)",
+			Entry("sanitize network names for test purposes (e.g. vcsim's default 'VM Network')",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						ctx.vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{
+							Interfaces: []vmopv1.VirtualMachineNetworkInterfaceSpec{
+								{
+									Name: "eth0",
+									Network: common.PartialObjectRef{
+										Name: "VM Network",
+									},
+								},
+							},
+						}
+					},
+					expectAllowed: true,
+				},
+			),
+
+			Entry("disallow creating VM with network interfaces resulting in a non-DNS1123 combined network interface CR name/label (`vmName-networkName$-interfaceName`)",
 				testParams{
 					setup: func(ctx *unitValidatingWebhookContext) {
 						ctx.vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{
@@ -1318,7 +1336,7 @@ func unitTestsValidateCreate() {
 					},
 					validate: doValidateWithMsg(
 						fmt.Sprintf(`spec.network.interfaces[0].name: Invalid value: "dummy-vm-for-webhook-validation-dummy-nw-%x": is the resulting network interface name: must be no more than 253 characters`, make([]byte, validation.DNS1123SubdomainMaxLength)),
-						`spec.network.interfaces[1].name: Invalid value: "dummy-vm-for-webhook-validation-dummy-nw-dummy_If": is the resulting network interface name: a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters`,
+						`spec.network.interfaces[1].name: Invalid value: "dummy-vm-for-webhook-validation-dummy-nw-dummy_if": is the resulting network interface name: a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters`,
 						`'-' or '.'`,
 						`and must start and end with an alphanumeric character (e.g. 'example.com'`,
 						"regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')"),


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This PR allows to use network names like "VM operator" **only for testing**
In a production environment network names are derived from K8s resources, so they are correct by definition

cc @akutz @bryanv 