### PR TITLE
🐛 Specify BIOS and instance UUIDs when creating VM

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -9,6 +9,7 @@ replace github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels => ../pkg/c
 require (
 	github.com/google/go-cmp v0.6.0
 	github.com/google/gofuzz v1.2.0
+	github.com/google/uuid v1.3.0
 	github.com/onsi/ginkgo/v2 v2.15.0
 	github.com/onsi/gomega v1.31.0
 	github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels v0.0.0-00010101000000-000000000000
@@ -33,7 +34,6 @@ require (
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/api/v1alpha1/virtualmachine_conversion.go
+++ b/api/v1alpha1/virtualmachine_conversion.go
@@ -930,6 +930,12 @@ func restore_v1alpha3_VirtualMachineReadinessProbeSpec(
 	}
 }
 
+func restore_v1alpha3_VirtualMachineBiosUUID(
+	dst, src *vmopv1.VirtualMachine) {
+
+	dst.Spec.BiosUUID = src.Spec.BiosUUID
+}
+
 func convert_v1alpha1_PreReqsReadyCondition_to_v1alpha3_Conditions(
 	dst *vmopv1.VirtualMachine) []metav1.Condition {
 
@@ -1118,6 +1124,7 @@ func (src *VirtualMachine) ConvertTo(dstRaw ctrlconversion.Hub) error {
 	restore_v1alpha3_VirtualMachineBootstrapSpec(dst, restored)
 	restore_v1alpha3_VirtualMachineNetworkSpec(dst, restored)
 	restore_v1alpha3_VirtualMachineReadinessProbeSpec(dst, restored)
+	restore_v1alpha3_VirtualMachineBiosUUID(dst, restored)
 
 	// END RESTORE
 

--- a/api/v1alpha1/virtualmachine_conversion_test.go
+++ b/api/v1alpha1/virtualmachine_conversion_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -212,6 +213,7 @@ func TestVirtualMachineConversion(t *testing.T) {
 					ResourcePolicyName: "my-resource-policy",
 				},
 				MinHardwareVersion: 42,
+				BiosUUID:           uuid.New().String(),
 			},
 		}
 

--- a/api/v1alpha2/virtualmachine_conversion.go
+++ b/api/v1alpha2/virtualmachine_conversion.go
@@ -91,6 +91,12 @@ func Convert_v1alpha2_VirtualMachine_To_v1alpha3_VirtualMachine(in *VirtualMachi
 	return nil
 }
 
+func restore_v1alpha3_VirtualMachineBiosUUID(
+	dst, src *vmopv1.VirtualMachine) {
+
+	dst.Spec.BiosUUID = src.Spec.BiosUUID
+}
+
 // ConvertTo converts this VirtualMachine to the Hub version.
 func (src *VirtualMachine) ConvertTo(dstRaw ctrlconversion.Hub) error {
 	dst := dstRaw.(*vmopv1.VirtualMachine)
@@ -107,6 +113,7 @@ func (src *VirtualMachine) ConvertTo(dstRaw ctrlconversion.Hub) error {
 	// BEGIN RESTORE
 
 	restore_v1alpha3_VirtualMachineImage(dst, restored)
+	restore_v1alpha3_VirtualMachineBiosUUID(dst, restored)
 
 	// END RESTORE
 

--- a/api/v1alpha3/virtualmachine_bootstrap_types.go
+++ b/api/v1alpha3/virtualmachine_bootstrap_types.go
@@ -85,6 +85,12 @@ type VirtualMachineBootstrapSpec struct {
 // VirtualMachineBootstrapCloudInitSpec describes the CloudInit configuration
 // used to bootstrap the VM.
 type VirtualMachineBootstrapCloudInitSpec struct {
+	// InstanceID is the cloud-init metadata instance ID.
+	// If omitted, this field defaults to the VM's BiosUUID.
+	//
+	// +optional
+	InstanceID string `json:"instanceID,omitempty"`
+
 	// CloudConfig describes a subset of a Cloud-Init CloudConfig, used to
 	// bootstrap the VM.
 	//

--- a/api/v1alpha3/virtualmachine_types.go
+++ b/api/v1alpha3/virtualmachine_types.go
@@ -436,6 +436,14 @@ type VirtualMachineSpec struct {
 	// behavior. In other words, please be careful when choosing to upgrade a
 	// VM to a newer hardware version.
 	MinHardwareVersion int32 `json:"minHardwareVersion,omitempty"`
+
+	// BiosUUID describes the desired BIOS UUID for a VM.
+	// If omitted, this field defaults to a random UUID.
+	// When the bootstrap provider is Cloud-Init, this value is
+	// used as the Cloud-Init instance ID.
+	// +optional
+	// +kubebuilder:validation:Format:=uuid4
+	BiosUUID string `json:"biosUUID,omitempty"`
 }
 
 // VirtualMachineReservedSpec describes a set of VM configuration options

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -3187,6 +3187,14 @@ spec:
                     - ThickEagerZero
                     type: string
                 type: object
+              biosUUID:
+                description: |-
+                  BiosUUID describes the desired BIOS UUID for a VM.
+                  If omitted, this field defaults to a random UUID.
+                  When the bootstrap provider is Cloud-Init, this value is
+                  used as the Cloud-Init instance ID.
+                format: uuid4
+                type: string
               bootstrap:
                 description: |-
                   Bootstrap describes the desired state of the guest's bootstrap
@@ -3552,6 +3560,11 @@ spec:
                             - path
                             x-kubernetes-list-type: map
                         type: object
+                      instanceID:
+                        description: |-
+                          InstanceID is the cloud-init metadata instance ID.
+                          If omitted, this field defaults to the VM's BiosUUID.
+                        type: string
                       rawCloudConfig:
                         description: |-
                           RawCloudConfig describes a key in a Secret resource that contains the

--- a/pkg/providers/vsphere/vcenter/getvm.go
+++ b/pkg/providers/vsphere/vcenter/getvm.go
@@ -25,20 +25,17 @@ func GetVirtualMachine(
 	datacenter *object.Datacenter,
 	finder *find.Finder) (*object.VirtualMachine, error) {
 
+	if instanceUUID := vmCtx.VM.UID; instanceUUID != "" {
+		if vm, err := findVMByUUID(vmCtx, vimClient, datacenter, string(instanceUUID), true); err == nil {
+			return vm, nil
+		}
+	}
+
 	if uniqueID := vmCtx.VM.Status.UniqueID; uniqueID != "" {
 		if vm, err := findVMByMoID(vmCtx, finder, uniqueID); err == nil {
 			return vm, nil
 		}
 	}
-
-	// For when we start to use the k8s VM.UID for the VC VM's InstanceUUID or UUID (aka BiosUUID):
-	/*
-		if instanceUUID := vmCtx.VM.UID; instanceUUID != "" {
-			if vm, err := findVMByUUID(vmCtx, vimClient, datacenter, string(instanceUUID), true); err == nil {
-				return vm, nil
-			}
-		}
-	*/
 
 	return findVMByInventory(vmCtx, k8sClient, vimClient, finder)
 }
@@ -62,7 +59,6 @@ func findVMByMoID(
 	return vm, nil
 }
 
-//nolint:unused
 func findVMByUUID(
 	vmCtx pkgctx.VirtualMachineContext,
 	vimClient *vim25.Client,

--- a/pkg/providers/vsphere/vcenter/getvm_test.go
+++ b/pkg/providers/vsphere/vcenter/getvm_test.go
@@ -110,8 +110,7 @@ func getVM() {
 		})
 	})
 
-	// Not until we start setting either the InstanceUUID or BiosUUID
-	XContext("Gets VM by UUID", func() {
+	Context("Gets VM by UUID", func() {
 		BeforeEach(func() {
 			vm, err := ctx.Finder.VirtualMachine(ctx, vcVMName)
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/providers/vsphere/virtualmachine/configspec.go
+++ b/pkg/providers/vsphere/virtualmachine/configspec.go
@@ -41,6 +41,13 @@ func CreateConfigSpec(
 		Type:         vmopv1.ManagedByExtensionType,
 	}
 
+	// spec.biosUUID is only set when creating a VM and is immutable.
+	// These two fields should not be updated for existing VMs.
+	if id := vmCtx.VM.Spec.BiosUUID; id != "" {
+		configSpec.Uuid = id
+		configSpec.InstanceUuid = string(vmCtx.VM.UID)
+	}
+
 	hardwareVersion := determineHardwareVersion(vmCtx.VM, &configSpec, vmImageStatus)
 	if hardwareVersion.IsValid() {
 		configSpec.Version = hardwareVersion.String()

--- a/pkg/providers/vsphere/vmlifecycle/bootstrap_cloudinit.go
+++ b/pkg/providers/vsphere/vmlifecycle/bootstrap_cloudinit.go
@@ -49,9 +49,12 @@ func BootStrapCloudInit(
 		sshPublicKeys = strings.Join(cloudInitSpec.SSHAuthorizedKeys, "\n")
 	}
 
-	uid := string(vmCtx.VM.UID)
-	// Use the existing instance ID if it is already set on the VM.
-	// This ensures cloud-init uses the same instance ID across B/R.
+	uid := cloudInitSpec.InstanceID
+	if uid == "" {
+		// InstanceID will be set to the VM bios uuid when creating new VMs.
+		// Use VM.UID for backward compatibility when InstanceID is not set.
+		uid = string(vmCtx.VM.UID)
+	}
 	if value, ok := vmCtx.VM.Annotations[vmopv1.InstanceIDAnnotation]; ok {
 		uid = value
 	}


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

When creating a new VirtualMachine:
- InstanceUUID is set to VM ObjectMeta.UID
- BiosUUID is included in VirtualMachineSpec
- cloud-init metadata instance ID is set to VM spec.biosUUID

Enable find by UUID preference in vcenter.GetVirtualMachine, as it is more stable than Inventory path.
