### PR TITLE
🐛 Remove dup FSS_WCP_NAMESPACED_VM_CLASS FSS env var from manager patch

### DIFF
--- a/config/wcp/vmoperator/manager_env_var_patch.yaml
+++ b/config/wcp/vmoperator/manager_env_var_patch.yaml
@@ -31,12 +31,6 @@
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
-    name: FSS_WCP_NAMESPACED_VM_CLASS
-    value: "<FSS_WCP_NAMESPACED_VM_CLASS_VALUE>"
-
-- op: add
-  path: /spec/template/spec/containers/0/env/-
-  value:
     name: FSS_WCP_VMSERVICE_BACKUPRESTORE
     value: "<FSS_WCP_VMSERVICE_BACKUPRESTORE_VALUE>"
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This change removes the duplicate FSS_WCP_NAMESPACED_VM_CLASS FSS env var that blocking component upgrades during patch.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # N/A


**Are there any special notes for your reviewer**:

Issue similar to https://github.com/helm/helm/issues/10650#issuecomment-1047660003


**Please add a release note if necessary**:
```NONE
```