### PR TITLE
:sparkles: Implement admin override to pause VM reconciliation

### DIFF
--- a/api/v1alpha2/virtualmachine_types.go
+++ b/api/v1alpha2/virtualmachine_types.go
@@ -152,6 +152,8 @@ const (
 const (
 	// PauseVMExtraConfigKey is the ExtraConfig key to allow override
 	// operations for admins to pause reconciliation of VM Service VM.
+	//
+	// Please note, the value that takes effect is the string "True"(case-insensitive).
 	PauseVMExtraConfigKey = "vmservice.virtualmachine.pause"
 
 	// PausedVMLabelKey is the label key to identify VMs that reconciliation

--- a/api/v1alpha3/virtualmachine_types.go
+++ b/api/v1alpha3/virtualmachine_types.go
@@ -152,6 +152,8 @@ const (
 const (
 	// PauseVMExtraConfigKey is the ExtraConfig key to allow override
 	// operations for admins to pause reconciliation of VM Service VM.
+	//
+	// Please note, the value that takes effect is the string "True"(case-insensitive).
 	PauseVMExtraConfigKey = "vmservice.virtualmachine.pause"
 
 	// PausedVMLabelKey is the label key to identify VMs that reconciliation

--- a/controllers/virtualmachine/virtualmachine_controller.go
+++ b/controllers/virtualmachine/virtualmachine_controller.go
@@ -211,15 +211,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 		VM:      vm,
 	}
 
-	// If the VM has a pause reconcile annotation, it is being restored on vCenter. Return here so our reconcile
-	// does not replace the VM being restored on the vCenter inventory.
-	//
-	// Do not requeue the reconcile here since removing the pause annotation will trigger a reconcile anyway.
-	if _, ok := vm.Annotations[vmopv1.PauseAnnotation]; ok {
-		vmCtx.Logger.Info("Skipping reconcile since Pause annotation is set on the VM")
-		return ctrl.Result{}, nil
-	}
-
 	patchHelper, err := patch.NewHelper(vm, r.Client)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrapf(err, "failed to init patch helper for %s", vmCtx.String())

--- a/controllers/virtualmachine/virtualmachine_controller.go
+++ b/controllers/virtualmachine/virtualmachine_controller.go
@@ -32,6 +32,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/patch"
 	"github.com/vmware-tanzu/vm-operator/pkg/prober"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
+	vspherevm "github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/virtualmachine"
 	"github.com/vmware-tanzu/vm-operator/pkg/record"
 	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 )
@@ -265,12 +266,24 @@ func requeueDelay(ctx *pkgctx.VirtualMachineContext) time.Duration {
 func (r *Reconciler) ReconcileDelete(ctx *pkgctx.VirtualMachineContext) (reterr error) {
 	ctx.Logger.Info("Reconciling VirtualMachine Deletion")
 
+	// If the VM reconciliation has been paused by the developer,
+	// skip deletion and return.
+	if _, exists := ctx.VM.Annotations[vmopv1.PauseAnnotation]; exists {
+		ctx.Logger.Info("VirtualMachine is not deleted because devops paused this VM")
+		return nil
+	}
+
 	if controllerutil.ContainsFinalizer(ctx.VM, finalizerName) {
 		defer func() {
 			r.Recorder.EmitEvent(ctx.VM, "Delete", reterr, false)
 		}()
 
 		if err := r.VMProvider.DeleteVirtualMachine(ctx, ctx.VM); err != nil {
+			// If VM can not be deleted due to reconciliation being paused, ignore that.
+			if errors.Is(err, vspherevm.ErrorVMPausedByAdmin()) {
+				ctx.Logger.Info("VM could not be deleted since it contains the pause reconcile ExtraConfig key")
+				return nil
+			}
 			ctx.Logger.Error(err, "Failed to delete VirtualMachine")
 			return err
 		}

--- a/controllers/virtualmachine/virtualmachine_controller_intg_test.go
+++ b/controllers/virtualmachine/virtualmachine_controller_intg_test.go
@@ -111,24 +111,6 @@ func intgTestsReconcile() {
 			})
 		})
 
-		When("the pause annotation is set", func() {
-			It("Reconcile returns early and the finalizer never gets added", func() {
-				// Set the Pause annotation on the VM
-				vm.Annotations = map[string]string{
-					vmopv1.PauseAnnotation: "",
-				}
-
-				Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
-
-				Consistently(func() []string {
-					if vm := getVirtualMachine(ctx, vmKey); vm != nil {
-						return vm.GetFinalizers()
-					}
-					return nil
-				}).ShouldNot(ContainElement(finalizer), "waiting for VirtualMachine finalizer")
-			})
-		})
-
 		It("Reconciles after VirtualMachine creation", func() {
 			Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
 

--- a/controllers/virtualmachine/virtualmachine_controller_unit_test.go
+++ b/controllers/virtualmachine/virtualmachine_controller_unit_test.go
@@ -57,10 +57,10 @@ func unitTestsReconcile() {
 	BeforeEach(func() {
 		vm = &vmopv1.VirtualMachine{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:       "dummy-vm",
-				Namespace:  "dummy-ns",
-				Labels:     map[string]string{},
-				Finalizers: []string{finalizer},
+				Name:        "dummy-vm",
+				Namespace:   "dummy-ns",
+				Annotations: map[string]string{},
+				Finalizers:  []string{finalizer},
 			},
 			Spec: vmopv1.VirtualMachineSpec{
 				ClassName: "dummy-class",
@@ -176,6 +176,13 @@ func unitTestsReconcile() {
 			// Create the VM to be deleted
 			err := reconciler.ReconcileNormal(vmCtx)
 			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("will not delete the created VM when VM is paused by devops ", func() {
+			vm.Annotations[vmopv1.PauseAnnotation] = "enabled"
+			err := reconciler.ReconcileDelete(vmCtx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(vm.GetFinalizers()).To(ContainElement(finalizer))
 		})
 
 		It("will delete the created VM and emit corresponding event", func() {

--- a/controllers/volume/volume_controller.go
+++ b/controllers/volume/volume_controller.go
@@ -217,12 +217,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (_ ctr
 		VM:      vm,
 	}
 
-	// If the VM has a pause reconcile annotation, it is being restored on vCenter. Return here so our reconcile
-	// does not replace the VM being restored on the vCenter inventory.
-	//
-	// Do not requeue the reconcile here since removing the pause annotation will trigger a reconcile anyway.
-	if _, ok := volCtx.VM.Annotations[vmopv1.PauseAnnotation]; ok {
-		volCtx.Logger.Info("Skipping reconcile since Pause annotation is set on the VM")
+	// If the VM has a pause reconcile label key, Skip volume reconciliation.
+	// Do not requeue the reconcile here since removing the pause label will trigger a reconcile anyway.
+	if val, ok := vm.Labels[vmopv1.PausedVMLabelKey]; ok {
+		volCtx.Logger.Info("Skipping reconcile since pause operation is made on the VM", "paused by", val)
 		return ctrl.Result{}, nil
 	}
 

--- a/controllers/volume/volume_controller.go
+++ b/controllers/volume/volume_controller.go
@@ -220,7 +220,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (_ ctr
 	// If the VM has a pause reconcile label key, Skip volume reconciliation.
 	// Do not requeue the reconcile here since removing the pause label will trigger a reconcile anyway.
 	if val, ok := vm.Labels[vmopv1.PausedVMLabelKey]; ok {
-		volCtx.Logger.Info("Skipping reconcile since pause operation is made on the VM", "paused by", val)
+		volCtx.Logger.Info("Skipping reconciliation because a pause operation has been initiated on this VirtualMachine.", "paused by", val)
 		return ctrl.Result{}, nil
 	}
 

--- a/pkg/providers/vsphere/constants/constants.go
+++ b/pkg/providers/vsphere/constants/constants.go
@@ -23,6 +23,10 @@ const (
 	VSphereCustomizationBypassKey     = pkg.VMOperatorKey + "/vsphere-customization"
 	VSphereCustomizationBypassDisable = "disable"
 
+	// VMPausedByAdminError is an error thrown during VM deletion. Because admin paused VM,
+	// deletion operation is paused.
+	VMPausedByAdminError = "failed to delete this VM because extraConfig Key 'vmservice.virtualmachine.pause' is set by admin"
+
 	// VMOperatorV1Alpha1ExtraConfigKey Special ExtraConfig key for v1alpha1 images.
 	VMOperatorV1Alpha1ExtraConfigKey = "guestinfo.vmservice.defer-cloud-init"
 	VMOperatorV1Alpha1ConfigReady    = "ready"

--- a/pkg/providers/vsphere/session/session_vm_update.go
+++ b/pkg/providers/vsphere/session/session_vm_update.go
@@ -1046,6 +1046,15 @@ func (s *Session) UpdateVirtualMachine(
 		return err
 	}
 
+	// If VM is being paused, only try to update status once.
+	if paused := updateVMPaused(vmCtx, moVM); paused {
+		vmCtx.Logger.Info("Pausing Updating VirtualMachine")
+		if updateErr := vmlifecycle.UpdateStatus(vmCtx, s.K8sClient, vcVM, moVM); updateErr != nil {
+			vmCtx.Logger.Error(updateErr, "Updating VM status failed when VirtualMachine is paused")
+		}
+		return nil
+	}
+
 	// Translate the VM's current power state into the VM Op power state value.
 	var existingPowerState vmopv1.VirtualMachinePowerState
 	switch moVM.Summary.Runtime.PowerState {
@@ -1098,4 +1107,39 @@ func (s *Session) UpdateVirtualMachine(
 	}
 
 	return err
+}
+
+func updateVMPaused(
+	vmCtx context.VirtualMachineContext,
+	moVM *mo.VirtualMachine) bool {
+
+	vm := vmCtx.VM
+	var adminPaused, devopsPaused bool
+
+	for i := range moVM.Config.ExtraConfig {
+		if o := moVM.Config.ExtraConfig[i].GetOptionValue(); o != nil {
+			if o.Key == vmopv1.PauseVMExtraConfigKey && o.Value == constants.ExtraConfigTrue {
+				adminPaused = true
+				break
+			}
+		}
+	}
+
+	if _, ok := vm.Annotations[vmopv1.PauseAnnotation]; ok {
+		devopsPaused = true
+	}
+
+	// Source of truth is EC and Annotation
+	// No need to check previous label val
+	switch {
+	case adminPaused && devopsPaused:
+		vm.Labels[vmopv1.PausedVMLabelKey] = "both"
+	case adminPaused:
+		vm.Labels[vmopv1.PausedVMLabelKey] = "admin"
+	case devopsPaused:
+		vm.Labels[vmopv1.PausedVMLabelKey] = "devops"
+	default:
+		delete(vm.Labels, vmopv1.PausedVMLabelKey)
+	}
+	return adminPaused || devopsPaused
 }

--- a/pkg/providers/vsphere/vmlifecycle/update_status_test.go
+++ b/pkg/providers/vsphere/vmlifecycle/update_status_test.go
@@ -913,7 +913,7 @@ var _ = Describe("VirtualMachineRecocileReady Status to VM Status Condition", fu
 		})
 
 		Context("PausedVMLabel is non-existent", func() {
-			It("sets condition true", func() {
+			It("sets VirtualMachineReconcileReady condition to true", func() {
 				expectedConditions := []metav1.Condition{
 					*conditions.TrueCondition(vmopv1.VirtualMachineReconcileReady),
 				}
@@ -926,7 +926,7 @@ var _ = Describe("VirtualMachineRecocileReady Status to VM Status Condition", fu
 				BeforeEach(func() {
 					vm.Labels[vmopv1.PausedVMLabelKey] = "devops"
 				})
-				It("sets condition false", func() {
+				It("sets VirtualMachineReconcileReady condition to false", func() {
 					expectedConditions := []metav1.Condition{
 						*conditions.FalseCondition(
 							vmopv1.VirtualMachineReconcileReady, vmopv1.VirtualMachineReconcilePausedReason, "Virtual Machine reconciliation paused by DevOps"),
@@ -938,7 +938,7 @@ var _ = Describe("VirtualMachineRecocileReady Status to VM Status Condition", fu
 				BeforeEach(func() {
 					vm.Labels[vmopv1.PausedVMLabelKey] = "admin"
 				})
-				It("sets condition false", func() {
+				It("sets VirtualMachineReconcileReady condition to false", func() {
 					expectedConditions := []metav1.Condition{
 						*conditions.FalseCondition(
 							vmopv1.VirtualMachineReconcileReady, vmopv1.VirtualMachineReconcilePausedReason, "Virtual Machine reconciliation paused by Admin"),
@@ -950,7 +950,7 @@ var _ = Describe("VirtualMachineRecocileReady Status to VM Status Condition", fu
 				BeforeEach(func() {
 					vm.Labels[vmopv1.PausedVMLabelKey] = "both"
 				})
-				It("sets condition false", func() {
+				It("sets VirtualMachineReconcileReady condition to false", func() {
 					expectedConditions := []metav1.Condition{
 						*conditions.FalseCondition(
 							vmopv1.VirtualMachineReconcileReady, vmopv1.VirtualMachineReconcilePausedReason, "Virtual Machine reconciliation paused by Admin, DevOps"),

--- a/pkg/util/vsphere/vm/vm.go
+++ b/pkg/util/vsphere/vm/vm.go
@@ -4,9 +4,14 @@
 package vm
 
 import (
+	"strings"
+
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/mo"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/constants"
 )
 
 func ManagedObjectFromMoRef(moRef vimtypes.ManagedObjectReference) mo.VirtualMachine {
@@ -21,4 +26,17 @@ func ManagedObjectFromMoRef(moRef vimtypes.ManagedObjectReference) mo.VirtualMac
 
 func ManagedObjectFromObject(obj *object.VirtualMachine) mo.VirtualMachine {
 	return ManagedObjectFromMoRef(obj.Reference())
+}
+
+func IsPausedByAdmin(moVM *mo.VirtualMachine) bool {
+	for i := range moVM.Config.ExtraConfig {
+		if o := moVM.Config.ExtraConfig[i].GetOptionValue(); o != nil {
+			if o.Key == vmopv1.PauseVMExtraConfigKey {
+				if value, ok := o.Value.(string); ok {
+					return strings.ToUpper(value) == constants.ExtraConfigTrue
+				}
+			}
+		}
+	}
+	return false
 }

--- a/pkg/util/vsphere/vm/vm_test.go
+++ b/pkg/util/vsphere/vm/vm_test.go
@@ -8,8 +8,11 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/constants"
 	vmutil "github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/vm"
 )
 
@@ -31,6 +34,68 @@ func managedObjectTests() {
 	Context("ManagedObjectFromObject", func() {
 		It("should return a mo.VirtualMachine from the provided object.VirtualMachine", func() {
 			Expect(vmutil.ManagedObjectFromObject(object.NewVirtualMachine(nil, getVMMoRef())).Reference()).To(Equal(getVMMoRef()))
+		})
+	})
+	Context("IsPausedByAdmin", func() {
+		var (
+			mgdObj mo.VirtualMachine
+		)
+
+		BeforeEach(func() {
+			moRef := getVMMoRef()
+			mgdObj = vmutil.ManagedObjectFromMoRef(moRef)
+			mgdObj.Config = &vimtypes.VirtualMachineConfigInfo{
+				ExtraConfig: []vimtypes.BaseOptionValue{},
+			}
+		})
+
+		It("should return false when PauseVMExtraConfigKey is not set", func() {
+			Expect(vmutil.IsPausedByAdmin(&mgdObj)).To(BeFalse())
+		})
+
+		It("should return false when PauseVMExtraConfigKey is set to False", func() {
+			mgdObj.Config.ExtraConfig = append(mgdObj.Config.ExtraConfig, &vimtypes.OptionValue{
+				Key:   vmopv1.PauseVMExtraConfigKey,
+				Value: constants.ExtraConfigFalse,
+			})
+
+			Expect(vmutil.IsPausedByAdmin(&mgdObj)).To(BeFalse())
+		})
+
+		It("should return false when PauseVMExtraConfigKey is set to 1", func() {
+			mgdObj.Config.ExtraConfig = append(mgdObj.Config.ExtraConfig, &vimtypes.OptionValue{
+				Key:   vmopv1.PauseVMExtraConfigKey,
+				Value: 1,
+			})
+
+			Expect(vmutil.IsPausedByAdmin(&mgdObj)).To(BeFalse())
+		})
+
+		It("should return true when PauseVMExtraConfigKey is set to 'true'", func() {
+			mgdObj.Config.ExtraConfig = append(mgdObj.Config.ExtraConfig, &vimtypes.OptionValue{
+				Key:   vmopv1.PauseVMExtraConfigKey,
+				Value: "true",
+			})
+
+			Expect(vmutil.IsPausedByAdmin(&mgdObj)).To(BeTrue())
+		})
+
+		It("should return true when PauseVMExtraConfigKey is set to 'True'", func() {
+			mgdObj.Config.ExtraConfig = append(mgdObj.Config.ExtraConfig, &vimtypes.OptionValue{
+				Key:   vmopv1.PauseVMExtraConfigKey,
+				Value: "True",
+			})
+
+			Expect(vmutil.IsPausedByAdmin(&mgdObj)).To(BeTrue())
+		})
+
+		It("should return true when PauseVMExtraConfigKey is set to 'TRUE'", func() {
+			mgdObj.Config.ExtraConfig = append(mgdObj.Config.ExtraConfig, &vimtypes.OptionValue{
+				Key:   vmopv1.PauseVMExtraConfigKey,
+				Value: constants.ExtraConfigTrue,
+			})
+
+			Expect(vmutil.IsPausedByAdmin(&mgdObj)).To(BeTrue())
 		})
 	})
 }


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This change will support admins to pause VM Service VM reconciliation by adding ExtraConfig Key [PauseVMExtraConfigKey](https://github.com/vmware-tanzu/vm-operator/blob/main/api/v1alpha3/virtualmachine_types.go#L155). After admin adds EC key, VM will have label [PausedVMLabelKey](https://github.com/vmware-tanzu/vm-operator/blob/main/api/v1alpha3/virtualmachine_types.go#L162) =`admin` and `VirtualMachineReconcileReady` condition set to false, showing reason being `VirtualMachineReconcilePaused`, indicates that VirtualMachine reconciliation is being paused by Admin.

This change also patches devops pause VM workflow. DevOps add [PauseAnnotation](https://github.com/vmware-tanzu/vm-operator/blob/main/api/v1alpha3/virtualmachine_types.go#L114) to VM,  it prevents a VM from being reconciled. To align this workflow with above admin Pause VM Workflow: VM will have label [PausedVMLabelKey](https://github.com/vmware-tanzu/vm-operator/blob/main/api/v1alpha3/virtualmachine_types.go#L162) = `devops` and `VirtualMachineReconcileReady` condition set to false, showing reason being `VirtualMachineReconcilePaused`, indicates that VirtualMachine reconciliation is being paused by DevOps.
**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes N/A


**Are there any special notes for your reviewer**:
This is the implementation after https://github.com/vmware-tanzu/vm-operator/pull/460

**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Implement admin override to pause VM reconciliation
```