### PR TITLE
✨ Single test target / workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
     - name: Build Web Console Validator
       run: make web-console-validator-only
 
-  unit-test:
+  test:
     needs:
     - verify-go-modules
     runs-on: ubuntu-latest
@@ -178,39 +178,17 @@ jobs:
         go-version: ${{ env.GO_VERSION }}
         cache: true
         cache-dependency-path: '**/go.sum'
-    - name: Unit Test
+    - name: Test
       run: make test
     - name: Store test coverage
       uses: actions/upload-artifact@v3
       with:
-        name: unit-test-coverage
+        name: test-coverage
         path: cover.out
-
-  integration-test:
-    needs:
-    - verify-go-modules
-    runs-on: ubuntu-latest
-    steps:
-    - name: Check out code
-      uses: actions/checkout@v4
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        go-version: ${{ env.GO_VERSION }}
-        cache: true
-        cache-dependency-path: '**/go.sum'
-    - name: Integration Test
-      run: make test-integration
-    - name: Store test coverage
-      uses: actions/upload-artifact@v3
-      with:
-        name: integration-test-coverage
-        path: integration-cover.out
 
   code-coverage:
     needs:
-    - unit-test
-    - integration-test
+    - test
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
@@ -221,22 +199,18 @@ jobs:
         go-version: ${{ env.GO_VERSION }}
         cache: true
         cache-dependency-path: '**/go.sum'
-    - name: Fetch unit test coverage
+    - name: Fetch test coverage
       uses: actions/download-artifact@v3
       with:
-        name: unit-test-coverage
-    - name: Fetch integration test coverage
-      uses: actions/download-artifact@v3
-      with:
-        name: integration-test-coverage
-    - name: Merge test coverage
-      run: make coverage-merge
+        name: test-coverage
+    - name: Convert coverage to XML report
+      run: make coverage-xml
     - name: Produce code coverage report
       uses: irongut/CodeCoverageSummary@v1.3.0
       with:
-        filename: merged-cover.xml
+        filename: cover.xml
         badge: true
-        fail_below_min: true
+        fail_below_min: false
         format: markdown
         hide_branch_rate: false
         hide_complexity: true
@@ -246,17 +220,16 @@ jobs:
 
     #
     # Commenting this out for now to ensure it is possible to re-run this job
-    # without having to re-run the unit and integration test jobs. We should
-    # probably think about re-enabling this step if at some point the size of
-    # artifacts we store per-PR grows too large.
+    # without having to re-run the test jobs. We should probably think about
+    # re-enabling this step if at some point the size of artifacts we store
+    # per-PR grows too large.
     #
     # - name: Delete the stored test coverage
     #   if: github.event_name != 'pull_request'
     #   uses: geekyeggo/delete-artifact@v2
     #   with:
     #     name: |
-    #       unit-test-coverage
-    #       integration-test-coverage
+    #       test-coverage
 
     - name: Save pull request ID
       if: github.event_name == 'pull_request'

--- a/Makefile
+++ b/Makefile
@@ -143,36 +143,24 @@ help: ## Display this help
 
 .PHONY: test-nocover
 test-nocover: | $(GINKGO)
-test-nocover: ## Run Tests (without code coverage)
-	LABEL_FILTER='!envtest' hack/test.sh
+test-nocover: ## Run tests sans coverage
+	hack/test.sh
 
 .PHONY: test
-test: | $(GINKGO)
+test: | $(GINKGO) $(ETCD) $(KUBE_APISERVER)
 test: ## Run tests
 	@rm -f $(COVERAGE_FILE)
-	LABEL_FILTER='!envtest' hack/test.sh $(COVERAGE_FILE)
+	hack/test.sh $(COVERAGE_FILE)
 
-.PHONY: test-integration
-test-integration: | $(GINKGO) $(ETCD) $(KUBE_APISERVER)
-test-integration: ## Run integration tests
-	@rm -f $(INT_COV_FILE)
-	LABEL_FILTER='envtest' hack/test.sh $(INT_COV_FILE)
-
-.PHONY: coverage
-coverage-merge: $(GOCOVMERGE) $(GOCOV) $(GOCOV_XML)
-coverage-merge: ## Merge the coverage from unit and integration tests
-	$(GOCOVMERGE) $(COVERAGE_FILE) $(INT_COV_FILE) >$(FULL_COV_FILE)
-	gocov convert "$(FULL_COV_FILE)" | gocov-xml >"$(FULL_COV_FILE:.out=.xml)"
+.PHONY: coverage-xml
+coverage-xml: $(GOCOV) $(GOCOV_XML)
+coverage-xml:
+	gocov convert "$(COVERAGE_FILE)" | gocov-xml >"$(COVERAGE_FILE:.out=.xml)"
 
 .PHONY: coverage
-coverage: test ## Show unit test code coverage (opens a browser)
+coverage: ## Show test coverage in browser
 	go tool cover -html=$(COVERAGE_FILE)
 
-.PHONY: coverage-full
-coverage-full: test test-integration
-coverage-full: ## Show combined code coverage for unit and integration tests (opens a browser)
-	$(MAKE) coverage-merge
-	go tool cover -html=$(FULL_COV_FILE)
 
 ## --------------------------------------
 ## Binaries


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch simplifies the Makefile test targets so there is now a single test target named "test". There is also a single test workflow in GitHub, reducing the duplicate tests that would run as part of the old unit/integration test division.

This patch also updates the code coverage workflow to warn if coverage falls below the minimum instead of failing the job.

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Simplify testing with a single Makefile target named "test"
```