### PR TITLE
🌱 Combine test and coverage actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,29 +180,6 @@ jobs:
         cache-dependency-path: '**/go.sum'
     - name: Test
       run: make test
-    - name: Store test coverage
-      uses: actions/upload-artifact@v4
-      with:
-        name: test-coverage
-        path: cover.out
-
-  code-coverage:
-    needs:
-    - test
-    runs-on: ubuntu-latest
-    steps:
-    - name: Check out code
-      uses: actions/checkout@v4
-    - name: Install Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: ${{ env.GO_VERSION }}
-        cache: true
-        cache-dependency-path: '**/go.sum'
-    - name: Fetch test coverage
-      uses: actions/download-artifact@v4
-      with:
-        name: test-coverage
     - name: Convert coverage to XML report
       run: make coverage-xml
     - name: Produce code coverage report
@@ -217,20 +194,6 @@ jobs:
         indicators: true
         output: both
         thresholds: '60 80'
-
-    #
-    # Commenting this out for now to ensure it is possible to re-run this job
-    # without having to re-run the test jobs. We should probably think about
-    # re-enabling this step if at some point the size of artifacts we store
-    # per-PR grows too large.
-    #
-    # - name: Delete the stored test coverage
-    #   if: github.event_name != 'pull_request'
-    #   uses: geekyeggo/delete-artifact@v2
-    #   with:
-    #     name: |
-    #       test-coverage
-
     - name: Save pull request ID
       if: github.event_name == 'pull_request'
       env:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch removes the distinct GitHub action for parsing the code coverage produced by the test action. Instead, the coverage logic is now handled at the end of the test action. Previously the coverage logic needed to be a distinct step since there were two, separate test jobs. However, now those are combined into one, meaning we can remove the need to upload the coverage artifact to be processed later.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

Depends on #475 

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```