### PR TITLE
:seedling: Introduce FSS for workload management of VMs using Kubernetes patterns

### DIFF
--- a/config/local/vmoperator/local_env_var_patch.yaml
+++ b/config/local/vmoperator/local_env_var_patch.yaml
@@ -42,3 +42,5 @@ spec:
           value: "true"
         - name: FSS_WCP_WINDOWS_SYSPREP
           value: "true"
+        - name: FSS_WCP_VMSERVICE_K8S_WORKLOAD_MGMT_API
+          value: "true"

--- a/config/wcp/vmoperator/manager_env_var_patch.yaml
+++ b/config/wcp/vmoperator/manager_env_var_patch.yaml
@@ -52,6 +52,12 @@
     name: FSS_WCP_TKG_Multiple_CL
     value: "<FSS_WCP_TKG_Multiple_CL_VALUE>"
 
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: FSS_WCP_VMSERVICE_K8S_WORKLOAD_MGMT_API
+    value: "<FSS_WCP_VMSERVICE_K8S_WORKLOAD_MGMT_API_VALUE>"
+
 #
 # Feature state switch flags beneath this line are enabled on main and only
 # retained in this file because it is used by internal testing to determine the

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -105,6 +105,7 @@ type FeatureStates struct {
 	InstanceStorage            bool // FSS_WCP_INSTANCE_STORAGE
 	PodVMOnStretchedSupervisor bool // FSS_PODVMONSTRETCHEDSUPERVISOR
 	TKGMultipleCL              bool // FSS_WCP_TKG_Multiple_CL
+	K8sWorkloadMgmtAPI         bool // FSS_WCP_VMSERVICE_K8S_WORKLOAD_MGMT_API
 }
 
 type InstanceStorage struct {

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -50,6 +50,7 @@ func FromEnv() Config {
 
 	setBool(env.FSSInstanceStorage, &config.Features.InstanceStorage)
 	setBool(env.FSSVMServiceBackupRestore, &config.Features.AutoVADPBackupRestore)
+	setBool(env.FSSK8sWorkloadMgmtAPI, &config.Features.K8sWorkloadMgmtAPI)
 	setBool(env.FSSPodVMOnStretchedSupervisor, &config.Features.PodVMOnStretchedSupervisor)
 	setBool(env.FSSTKGMultipleCL, &config.Features.TKGMultipleCL)
 

--- a/pkg/config/env/env.go
+++ b/pkg/config/env/env.go
@@ -45,6 +45,7 @@ const (
 	FSSVMServiceBackupRestore
 	FSSPodVMOnStretchedSupervisor
 	FSSTKGMultipleCL
+	FSSK8sWorkloadMgmtAPI
 
 	_varNameEnd
 )
@@ -133,6 +134,8 @@ func (n VarName) String() string {
 		return "FSS_WCP_INSTANCE_STORAGE"
 	case FSSVMServiceBackupRestore:
 		return "FSS_WCP_VMSERVICE_BACKUPRESTORE"
+	case FSSK8sWorkloadMgmtAPI:
+		return "FSS_WCP_VMSERVICE_K8S_WORKLOAD_MGMT_API"
 	case FSSPodVMOnStretchedSupervisor:
 		return "FSS_PODVMONSTRETCHEDSUPERVISOR"
 	case FSSTKGMultipleCL:

--- a/pkg/config/env_test.go
+++ b/pkg/config/env_test.go
@@ -89,6 +89,7 @@ var _ = Describe(
 					Expect(os.Setenv("FSS_WCP_INSTANCE_STORAGE", "false")).To(Succeed())
 					Expect(os.Setenv("FSS_WCP_NAMESPACED_VM_CLASS", "false")).To(Succeed())
 					Expect(os.Setenv("FSS_WCP_VMSERVICE_BACKUPRESTORE", "true")).To(Succeed())
+					Expect(os.Setenv("FSS_WCP_VMSERVICE_K8S_WORKLOAD_MGMT_API", "true")).To(Succeed())
 					Expect(os.Setenv("FSS_WCP_TKG_Multiple_CL", "false")).To(Succeed())
 				})
 				It("Should return a default config overridden by the environment", func() {
@@ -126,6 +127,7 @@ var _ = Describe(
 						Features: pkgcfg.FeatureStates{
 							InstanceStorage:       false,
 							AutoVADPBackupRestore: true,
+							K8sWorkloadMgmtAPI:    true,
 						},
 					}))
 				})


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This change introduces the FSS for the initiative that allows workload management of VMs using Kubernetes primitives such as Deployments, ReplicaSets and StatefulSets.

**Please add a release note if necessary**:
```release-note
Feature state switch for k8s primitive workload management APIs
```