### PR TITLE
✨ GuestInfo prober fetches required props only

### DIFF
--- a/pkg/prober/probe/guestinfo.go
+++ b/pkg/prober/probe/guestinfo.go
@@ -1,9 +1,10 @@
-// Copyright (c) 2023 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2023-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package probe
 
 import (
+	"fmt"
 	"regexp"
 
 	"github.com/vmware-tanzu/vm-operator/pkg/prober/context"
@@ -20,31 +21,56 @@ func NewGuestInfoProber(prober vmProviderGuestInfoProber) Probe {
 }
 
 func (gip guestInfoProber) Probe(ctx *context.ProbeContext) (Result, error) {
-	vmGuestInfo, err := gip.prober.GetVirtualMachineGuestInfo(ctx, ctx.VM)
+
+	numProbes := len(ctx.VM.Spec.ReadinessProbe.GuestInfo)
+	if numProbes == 0 {
+		return Unknown, nil
+	}
+
+	// Build the list of property paths to retrieve based on the guestinfo keys.
+	var (
+		propertyPaths   = make([]string, numProbes)
+		propertyKeyVals = make(map[string]string, numProbes)
+	)
+	for i := range ctx.VM.Spec.ReadinessProbe.GuestInfo {
+		gi := ctx.VM.Spec.ReadinessProbe.GuestInfo[i]
+		pp := fmt.Sprintf(`config.extraConfig["guestinfo.%s"]`, gi.Key)
+		propertyPaths[i] = pp
+		propertyKeyVals[pp] = gi.Value
+	}
+
+	results, err := gip.prober.GetVirtualMachineProperties(ctx, ctx.VM, propertyPaths)
 	if err != nil {
 		return Unknown, err
 	}
 
-	for _, info := range ctx.VM.Spec.ReadinessProbe.GuestInfo {
-		key := "guestinfo." + info.Key
+	for i := range propertyPaths {
+		key := propertyPaths[i]
 
-		val, ok := vmGuestInfo[key]
+		valObj, ok := results[key]
 		if !ok {
 			return Failure, nil
 		}
 
-		if info.Value == "" {
+		expectedVal := propertyKeyVals[key]
+
+		if expectedVal == "" {
 			// Matches everything.
 			continue
 		}
 
-		ex, err := regexp.Compile(info.Value)
+		expectedValRx, err := regexp.Compile(expectedVal)
 		if err != nil {
 			// Treat an invalid expressions as a wildcard too.
 			continue
 		}
 
-		if !ex.Match([]byte(val)) {
+		val, ok := valObj.(string)
+		if !ok {
+			val = fmt.Sprintf("%s", valObj)
+		}
+
+		if !expectedValRx.MatchString(val) {
 			return Failure, nil
 		}
 	}

--- a/pkg/prober/probe/probe.go
+++ b/pkg/prober/probe/probe.go
@@ -34,7 +34,7 @@ type vmProviderGuestHeartbeatProber interface {
 	GetVirtualMachineGuestHeartbeat(ctx context.Context, vm *vmopv1.VirtualMachine) (vmopv1.GuestHeartbeatStatus, error)
 }
 type vmProviderGuestInfoProber interface {
-	GetVirtualMachineGuestInfo(ctx context.Context, vm *vmopv1.VirtualMachine) (map[string]string, error)
+	GetVirtualMachineProperties(ctx context.Context, vm *vmopv1.VirtualMachine, propertyPaths []string) (map[string]any, error)
 }
 type vmProviderProber interface {
 	vmProviderGuestHeartbeatProber

--- a/pkg/providers/fake/fake_vm_provider.go
+++ b/pkg/providers/fake/fake_vm_provider.go
@@ -32,7 +32,7 @@ type funcs struct {
 	PublishVirtualMachineFn        func(ctx context.Context, vm *vmopv1.VirtualMachine,
 		vmPub *vmopv1.VirtualMachinePublishRequest, cl *imgregv1a1.ContentLibrary, actID string) (string, error)
 	GetVirtualMachineGuestHeartbeatFn  func(ctx context.Context, vm *vmopv1.VirtualMachine) (vmopv1.GuestHeartbeatStatus, error)
-	GetVirtualMachineGuestInfoFn       func(ctx context.Context, vm *vmopv1.VirtualMachine) (map[string]string, error)
+	GetVirtualMachinePropertiesFn      func(ctx context.Context, vm *vmopv1.VirtualMachine, propertyPaths []string) (map[string]any, error)
 	GetVirtualMachineWebMKSTicketFn    func(ctx context.Context, vm *vmopv1.VirtualMachine, pubKey string) (string, error)
 	GetVirtualMachineHardwareVersionFn func(ctx context.Context, vm *vmopv1.VirtualMachine) (vimtypes.HardwareVersion, error)
 
@@ -122,11 +122,15 @@ func (s *VMProvider) GetVirtualMachineGuestHeartbeat(ctx context.Context, vm *vm
 	return "", nil
 }
 
-func (s *VMProvider) GetVirtualMachineGuestInfo(ctx context.Context, vm *vmopv1.VirtualMachine) (map[string]string, error) {
+func (s *VMProvider) GetVirtualMachineProperties(
+	ctx context.Context,
+	vm *vmopv1.VirtualMachine,
+	propertyPaths []string) (map[string]any, error) {
+
 	s.Lock()
 	defer s.Unlock()
-	if s.GetVirtualMachineGuestInfoFn != nil {
-		return s.GetVirtualMachineGuestInfoFn(ctx, vm)
+	if s.GetVirtualMachinePropertiesFn != nil {
+		return s.GetVirtualMachinePropertiesFn(ctx, vm, propertyPaths)
 	}
 	return nil, nil
 }

--- a/pkg/providers/vm_provider_interface.go
+++ b/pkg/providers/vm_provider_interface.go
@@ -22,7 +22,7 @@ type VirtualMachineProviderInterface interface {
 	PublishVirtualMachine(ctx context.Context, vm *vmopv1.VirtualMachine,
 		vmPub *vmopv1.VirtualMachinePublishRequest, cl *imgregv1a1.ContentLibrary, actID string) (string, error)
 	GetVirtualMachineGuestHeartbeat(ctx context.Context, vm *vmopv1.VirtualMachine) (vmopv1.GuestHeartbeatStatus, error)
-	GetVirtualMachineGuestInfo(ctx context.Context, vm *vmopv1.VirtualMachine) (map[string]string, error)
+	GetVirtualMachineProperties(ctx context.Context, vm *vmopv1.VirtualMachine, propertyPaths []string) (map[string]any, error)
 	GetVirtualMachineWebMKSTicket(ctx context.Context, vm *vmopv1.VirtualMachine, pubKey string) (string, error)
 	GetVirtualMachineHardwareVersion(ctx context.Context, vm *vmopv1.VirtualMachine) (vimtypes.HardwareVersion, error)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->

This patch updates the GuestInfo prober to only fetch the properties that are part of the specified probe definition. Previously the VM's entire config.extraConfig property path was retrieved, resulting in a very expensive operation, depending on the size of the data in that property. By focusing on specific properties, the number of bytes transferred is limited to the size of the property values required to evaluate the probe. This change is possible because vSphere supports fetching property paths with indexed values. For example, instead of fetching all of config.extraConfig, an array, just to access the element with the key "hello", it is possible to fetch the property path config.extraConfig["hello"].

Additionally, this patch forgoes the use of the GoVmomi VM helper method "Properties" for retrieving the values. GoVmomi uses Golang reflection to unmarshal the result of a property retrieval, and reflection is quite expensive. Instead, the GuestInfo prober inspects the results of the retrieval directly, without unmarshaling the data into a mo.VirtualMachine.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

Currently GoVmomi's vC Sim does not support indexed property path retrieval (cc @dougm), thus testing was performed internally against a real vSphere testbed using the idgit project. I also copied the container image for this PR to a testbed and deployed the following VM:

```yaml
apiVersion: vmoperator.vmware.com/v1alpha3
kind: VirtualMachine
metadata:
  name: my-vm
  namespace: my-namespace
spec:
  bootstrap:
    cloudInit: {}
  className: best-effort-small
  imageName: jammy-server-cloudimg-amd64
  storageClass: wcpglobal-storage-profile
  readinessProbe:
    periodSeconds: 10
    guestInfo:
    - key: metadata
      value: invalid
```

Once deployed, the VM has a `Ready` condition set to `False` because the probe for `metadata` does not equal the value `invalid`:

```yaml
  conditions:
  - lastTransitionTime: "2024-04-23T14:44:23Z"
    message: ""
    reason: NotReady
    status: "False"
    type: Ready
```

I then updated the VM as such:

```yaml
```yaml
apiVersion: vmoperator.vmware.com/v1alpha3
kind: VirtualMachine
metadata:
  name: my-vm
  namespace: my-namespace
spec:
  bootstrap:
    cloudInit: {}
  className: best-effort-small
  imageName: jammy-server-cloudimg-amd64
  storageClass: wcpglobal-storage-profile
  readinessProbe:
    periodSeconds: 10
    guestInfo:
    - key: metadata
      value: '.*'
```

Then the condition `Ready` transitioned to `True`:

```yaml
  conditions:
  - lastTransitionTime: "2024-04-23T14:47:08Z"
    message: ""
    reason: "True"
    status: "True"
    type: Ready
```

**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
GuestInfo prober performance improvement via direct and indexed property retrieval
```