### PR TITLE
:seedling: Update VPC networking NSX SubnetPort APIs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 )
 
 require (
-	github.com/vmware-tanzu/nsx-operator/pkg/apis v0.1.0
+	github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20240424021250-778eb97fa048
 	github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels v0.0.0-00010101000000-000000000000
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -454,8 +454,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/vmware-tanzu/image-registry-operator-api v0.0.0-20230526154708-f67dac7c805f h1:qpQD1XWbDpti3fBxKfQq5YRPmdQkbNS36RynprKJKoc=
 github.com/vmware-tanzu/image-registry-operator-api v0.0.0-20230526154708-f67dac7c805f/go.mod h1:S0HMBgdo3S/0a5hwq+Ya4XZI2aEDtGkSGeojU1cINOg=
-github.com/vmware-tanzu/nsx-operator/pkg/apis v0.1.0 h1:HdnQb/X9vJ8a5WQ03g/0nDr9igIIK1fF6wO5wOtkJT4=
-github.com/vmware-tanzu/nsx-operator/pkg/apis v0.1.0/go.mod h1:Q4JzNkNMvjo7pXtlB5/R3oME4Nhah7fAObWgghVmtxk=
+github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20240424021250-778eb97fa048 h1:dNjyb0tpct5XqYEuEGhAQbFCiIxRcXBu7mxopOCHl5g=
+github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20240424021250-778eb97fa048/go.mod h1:Q4JzNkNMvjo7pXtlB5/R3oME4Nhah7fAObWgghVmtxk=
 github.com/vmware/govmomi v0.31.1-0.20240424153851-2892d60c5c31 h1:s3ncy0AgEOt7y4ynrTEjwcVZFmj9B+eozx2oRmlTz7I=
 github.com/vmware/govmomi v0.31.1-0.20240424153851-2892d60c5c31/go.mod h1:mtGWtM+YhTADHlCgJBiskSRPOZRsN9MSjPzaZLte/oQ=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/pkg/providers/vsphere/network/network_test.go
+++ b/pkg/providers/vsphere/network/network_test.go
@@ -664,19 +664,17 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 					Expect(subnetPort.Spec.SubnetSet).To(Equal(networkName))
 					Expect(subnetPort.Annotations).To(HaveKeyWithValue(constants.VPCAttachmentRef, annotationVal))
 
-					subnetPort.Status.VIFID = interfaceID
-					subnetPort.Status.MACAddress = macAddress
-					subnetPort.Status.LogicalSwitchID = builder.VPCLogicalSwitchUUID
-					subnetPort.Status.IPAddresses = []vpcv1alpha1.SubnetPortIPAddress{
+					subnetPort.Status.Attachment.ID = interfaceID
+					subnetPort.Status.NetworkInterfaceConfig.MACAddress = macAddress
+					subnetPort.Status.NetworkInterfaceConfig.LogicalSwitchUUID = builder.VPCLogicalSwitchUUID
+					subnetPort.Status.NetworkInterfaceConfig.IPAddresses = []vpcv1alpha1.NetworkInterfaceIPAddress{
 						{
-							IP:      "192.168.1.110",
-							Gateway: "192.168.1.1",
-							Netmask: "255.255.255.0",
+							IPAddress: "192.168.1.110/24",
+							Gateway:   "192.168.1.1",
 						},
 						{
-							IP:      "fd1a:6c85:79fe:7c98:0000:0000:0000:000f",
-							Gateway: "fd1a:6c85:79fe:7c98:0000:0000:0000:0001",
-							Netmask: "ffff:ffff:ffff:ff00:0000:0000:0000:0000",
+							IPAddress: "fd1a:6c85:79fe:7c98::f/56",
+							Gateway:   "fd1a:6c85:79fe:7c98:0000:0000:0000:0001",
 						},
 					}
 					subnetPort.Status.Conditions = []vpcv1alpha1.Condition{

--- a/pkg/providers/vsphere/vmprovider_vm2_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm2_test.go
@@ -421,13 +421,12 @@ func vmE2ETests() {
 					Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(subnetPort), subnetPort)).To(Succeed())
 					Expect(subnetPort.Spec.Subnet).To(Equal(networkName))
 
-					subnetPort.Status.MACAddress = "01-23-45-67-89-AB-CD-EF"
-					subnetPort.Status.LogicalSwitchID = builder.VPCLogicalSwitchUUID
-					subnetPort.Status.IPAddresses = []vpcv1alpha1.SubnetPortIPAddress{
+					subnetPort.Status.NetworkInterfaceConfig.MACAddress = "01-23-45-67-89-AB-CD-EF"
+					subnetPort.Status.NetworkInterfaceConfig.LogicalSwitchUUID = builder.VPCLogicalSwitchUUID
+					subnetPort.Status.NetworkInterfaceConfig.IPAddresses = []vpcv1alpha1.NetworkInterfaceIPAddress{
 						{
-							IP:      "192.168.1.110",
-							Gateway: "192.168.1.1",
-							Netmask: "255.255.255.0",
+							IPAddress: "192.168.1.110/24",
+							Gateway:   "192.168.1.1",
 						},
 					}
 					subnetPort.Status.Conditions = []vpcv1alpha1.Condition{


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This change addresses changes in https://github.com/vmware-tanzu/nsx-operator/pull/546 on SubnetPort APIs. It includes:
- vifID -> attachment.id
- logicalSwitchID -> networkInterfaceConfig.logicalSwitchUuid
- macAddress and ipAddresses move under networkInterfaceConfig
- ipAddresses.netmask goes away.
- ipAddresses.ip -> networkInterfaceConfig.ipAddresses.ipAddress becomes a CIDR format (implicit netmask)

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes N/A


**Are there any special notes for your reviewer**:

Testing done:
- Built CSP with customized wcp-agent, ako, nsx-ujo and cayman_vmop
- Deployed vpc networking testbed
- Tested workflows on creating VM Service VMs with 
  - default subnetset
  - customized subnet/subnetset
  - customized subnet and subnetset

**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
N/A
```