### PR TITLE
 🌱 Store resolved Cloud-Init instance ID in spec

### DIFF
--- a/api/v1alpha3/virtualmachine_types.go
+++ b/api/v1alpha3/virtualmachine_types.go
@@ -447,8 +447,8 @@ type VirtualMachineSpec struct {
 
 	// BiosUUID describes the desired BIOS UUID for a VM.
 	// If omitted, this field defaults to a random UUID.
-	// When the bootstrap provider is Cloud-Init, this value is
-	// used as the Cloud-Init instance ID.
+	// When the bootstrap provider is Cloud-Init, this value is used as the
+	// default value for spec.bootstrap.cloudInit.instanceID if it is omitted.
 	BiosUUID string `json:"biosUUID,omitempty"`
 }
 

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -3191,8 +3191,8 @@ spec:
                 description: |-
                   BiosUUID describes the desired BIOS UUID for a VM.
                   If omitted, this field defaults to a random UUID.
-                  When the bootstrap provider is Cloud-Init, this value is
-                  used as the Cloud-Init instance ID.
+                  When the bootstrap provider is Cloud-Init, this value is used as the
+                  default value for spec.bootstrap.cloudInit.instanceID if it is omitted.
                 format: uuid4
                 type: string
               bootstrap:

--- a/docs/ref/api/v1alpha3.md
+++ b/docs/ref/api/v1alpha3.md
@@ -2149,8 +2149,8 @@ behavior. In other words, please be careful when choosing to upgrade a
 VM to a newer hardware version. |
 | `biosUUID` _string_ | BiosUUID describes the desired BIOS UUID for a VM.
 If omitted, this field defaults to a random UUID.
-When the bootstrap provider is Cloud-Init, this value is
-used as the Cloud-Init instance ID. |
+When the bootstrap provider is Cloud-Init, this value is used as the
+default value for spec.bootstrap.cloudInit.instanceID if it is omitted. |
 
 ### VirtualMachineStatus
 

--- a/webhooks/virtualmachine/mutation/virtualmachine_mutator.go
+++ b/webhooks/virtualmachine/mutation/virtualmachine_mutator.go
@@ -325,14 +325,18 @@ func SetDefaultBiosUUID(
 
 	if vm.Spec.BiosUUID == "" {
 		// Default to a Random (Version 4) UUID.
-		// This is the same UUID flavor/version used by Kubernetes and preferred by vSphere.
+		// This is the same UUID flavor/version used by Kubernetes and preferred
+		// by vSphere.
 		vm.Spec.BiosUUID = uuid.New().String()
 		wasMutated = true
 	}
 
-	if vm.Spec.Bootstrap != nil {
-		if ci := vm.Spec.Bootstrap.CloudInit; ci != nil {
+	if bs := vm.Spec.Bootstrap; bs != nil {
+		if ci := bs.CloudInit; ci != nil {
 			if ci.InstanceID == "" {
+				// If the Cloud-Init bootstrap provider was selected and the
+				// value for spec.bootstrap.cloudInit.instanceID was omitted,
+				// then default it to the value of spec.biosUUID.
 				ci.InstanceID = vm.Spec.BiosUUID
 				wasMutated = true
 			}


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch stores the Cloud-Init instance ID derived from either spec, the object UID, or the annotation, back into spec if the derived version is different than what is in spec. Additionally, the annotation that can overrride the instance ID is deleted once its value is stored in the spec.

This patch also updates some documentation to make the logic more clear, as well as provide historical context for why certain logic exists in the first place.


<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Store derived Cloud-Init instance ID back to spec.bootstrap.cloudInit.instanceID.
```

<!-- readthedocs-preview vm-operator start -->
----
📚 Documentation preview 📚: https://vm-operator--495.org.readthedocs.build/en/495/

<!-- readthedocs-preview vm-operator end -->