### PR TITLE
🌱 Update GitHub actions to exclude generated files when checking diff

### DIFF
--- a/.github/configs/labeler.yml
+++ b/.github/configs/labeler.yml
@@ -1,24 +1,41 @@
+# Please ensure to update the corresponding command in the testing-needed.yml
+# workflow file when modifying the following exclude-file list.
+defaults: &defaults
+  exclude-files:
+    - ".*_generated.go"
+    - ".*_generated.deepcopy.go"
+    - ".*_generated.conversion.go"
+    - "config\\/crd\\/bases\\/.*"
+    - "docs\\/ref\\/api\\/v.*.md"
+    - "go.sum"
+
 version: 1
 labels:
   - label: "size/XS"
     size:
       below: 10
+      <<: *defaults
   - label: "size/S"
     size:
       above: 9
       below: 30
+      <<: *defaults
   - label: "size/M"
     size:
       above: 29
       below: 100
+      <<: *defaults
   - label: "size/L"
     size:
       above: 99
       below: 500
+      <<: *defaults
   - label: "size/XL"
     size:
       above: 499
       below: 1000
+      <<: *defaults
   - label: "size/XXL"
     size:
       above: 999
+      <<: *defaults

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,26 +12,11 @@ jobs:
     # This action originates from https://github.com/srvaroa/labeler. We are
     # using this action instead of the GitHub labeler action as the former
     # supports adding labels based on the number of changed, lines-of-code.
-    # However, while the GitHub labeler action supports excluding files, the
-    # action we are using does not. It would be nice if the GitHub labeler
-    # action supported LoC labeling or if this action supported exclusions.
-    # There are issues filed for both:
     #
     # * GitHub labeler LoC support:
     #   https://github.com/actions/labeler/issues/486
     #
-    # * srvaroa labeler action exclusion support:
-    #   https://github.com/srvaroa/labeler/issues/33
-    #
-    # For now we will use the srvaroa labeler action to afford ourselves the
-    # support for LoC-based labels. If/when GitHub supports LoC, we will switch
-    # to that and ignore the following, generated content:
-    #
-    # - "*_generated.go"       # generated Go sources
-    # - "config/crd/bases/.*"  # generated CRDs
-    # - "docs/apis/v*.md"      # generated API documentation,
-    #                          # ex. docs/apis/v1alpha1.md
-    - uses: srvaroa/labeler@v1.9.0
+    - uses: srvaroa/labeler@v1.10.1
       with:
         config_path: .github/configs/labeler.yml
       env:

--- a/.github/workflows/testing-needed.yml
+++ b/.github/workflows/testing-needed.yml
@@ -24,8 +24,16 @@ jobs:
           fetch-depth: 0
       - name: Check diff
         id: check-diff
+        # The following exclude files should match the ones in labeler.yml file.
         run: |
-          loc=$(git diff --shortstat HEAD ${{ github.sha }} | awk '{print $4+$6}')
+          loc=$(git diff --shortstat HEAD ${{ github.sha }} -- . \
+              ':(exclude)*_generated.go' \
+              ':(exclude)*_generated.deepcopy.go' \
+              ':(exclude)*_generated.conversion.go' \
+              ':(exclude)config/crd/bases/*' \
+              ':(exclude)docs/ref/api/v.*.md' \
+              ':(exclude)*go.sum' \
+              | awk '{print $4+$6}')
           echo "Lines of change: $loc"
           echo "lines_of_change=$loc" >> $GITHUB_OUTPUT
       - name: Update label


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR updates the **pr-labeler** and **testing-needed** GitHub action workflows to exclude generated files when calculating the changed lines of code (LoC).  This ensures that proper labels (size and testing-needed) are attached to a PR based on the calculated LoC.

Testing Done:
- Submitted this change to main in my fork and verified in a PR changing both generated and non-generated files: https://github.com/dilyar85/vm-operator/pull/26
- Output from the `pr-labeler` job:

```console
2024/05/02 14:27:44 Counting changes in file a/README.md
2024/05/02 14:27:44 Counting changes in file b/README.md
2024/05/02 14:27:44 Count line +
2024/05/02 14:27:44 Count line +
2024/05/02 14:27:44 Ignoring file a/api/v1alpha2/zz_generated.conversion.go
2024/05/02 14:27:44 Ignoring file b/api/v1alpha2/zz_generated.conversion.go
2024/05/02 14:27:44 Ignoring file a/api/v1alpha3/zz_generated.deepcopy.go
2024/05/02 14:27:44 Ignoring file b/api/v1alpha3/zz_generated.deepcopy.go
2024/05/02 14:27:44 Ignoring file a/api/v1alpha3/zz_virtualmachine_guestosid_generated.go
2024/05/02 14:27:44 Ignoring file b/api/v1alpha3/zz_virtualmachine_guestosid_generated.go
2024/05/02 14:27:44 Ignoring file a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
2024/05/02 14:27:44 Ignoring file b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
2024/05/02 14:27:44 Ignoring file a/external/ncp/go.sum
2024/05/02 14:27:44 Ignoring file b/external/ncp/go.sum
2024/05/02 14:27:44 Ignoring file a/go.sum
2024/05/02 14:27:44 Ignoring file b/go.sum
2024/05/02 14:27:44 Total count 2
```

- Output from the `testing-needed` job:

```console
Run loc=$(git diff --shortstat HEAD 78a3b0db249b2781272241fa52771a442379cc17 -- . \
  loc=$(git diff --shortstat HEAD 78a3b0db[2](https://github.com/dilyar85/vm-operator/actions/runs/8925566798/job/24514518107?pr=26#step:3:2)49b2781272241fa52771a442379cc17 -- . \
      ':(exclude)*_generated.go' \
      ':(exclude)*_generated.deepcopy.go' \
      ':(exclude)*_generated.conversion.go' \
      ':(exclude)config/crd/bases/*' \
      ':(exclude)docs/ref/api/v.*.md' \
      ':(exclude)*go.sum' \
      | awk '{print $[4](https://github.com/dilyar85/vm-operator/actions/runs/8925566798/job/24514518107?pr=26#step:3:4)+$6}')
  echo "Lines of change: $loc"
  echo "lines_of_change=$loc" >> $GITHUB_OUTPUT
  shell: /usr/bin/bash -e {0}
Lines of change: 2
```

**Please add a release note if necessary**:

```release-note
Update `pr-labeler` and `testing-needed` GitHub actions to exclude generated files when calculating LoC.
```