### PR TITLE
:bug: Upgrade VMs for use with Instance ID Discovery

### DIFF
--- a/api/v1alpha3/virtualmachine_types.go
+++ b/api/v1alpha3/virtualmachine_types.go
@@ -447,7 +447,7 @@ type VirtualMachineSpec struct {
 	MinHardwareVersion int32 `json:"minHardwareVersion,omitempty"`
 
 	// +optional
-	// +kubebuilder:validation:Format:=uuid4
+	// +kubebuilder:validation:Format:=uuid
 
 	// BiosUUID describes the desired BIOS UUID for a VM.
 	// If omitted, this field defaults to a random UUID.

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachinereplicasets.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachinereplicasets.yaml
@@ -193,7 +193,7 @@ spec:
                           If omitted, this field defaults to a random UUID.
                           When the bootstrap provider is Cloud-Init, this value is used as the
                           default value for spec.bootstrap.cloudInit.instanceID if it is omitted.
-                        format: uuid4
+                        format: uuid
                         type: string
                       bootstrap:
                         description: |-

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -3193,7 +3193,7 @@ spec:
                   If omitted, this field defaults to a random UUID.
                   When the bootstrap provider is Cloud-Init, this value is used as the
                   default value for spec.bootstrap.cloudInit.instanceID if it is omitted.
-                format: uuid4
+                format: uuid
                 type: string
               bootstrap:
                 description: |-

--- a/controllers/virtualmachine/virtualmachine_controller.go
+++ b/controllers/virtualmachine/virtualmachine_controller.go
@@ -33,6 +33,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/prober"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
 	vspherevm "github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/virtualmachine"
+	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/vmlifecycle"
 	"github.com/vmware-tanzu/vm-operator/pkg/record"
 	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 )
@@ -168,9 +169,9 @@ func upgradeSchema(ctx *pkgctx.VirtualMachineContext) {
 	if bs := ctx.VM.Spec.Bootstrap; bs != nil {
 		if ci := bs.CloudInit; ci != nil {
 			if ci.InstanceID == "" {
-				ci.InstanceID = string(ctx.VM.UID)
+				iid := vmlifecycle.BootStrapCloudInitInstanceID(*ctx, ci)
 				ctx.Logger.Info("Upgrade VirtualMachine spec",
-					"bootstrap.cloudInit.instanceID", ci.InstanceID)
+					"bootstrap.cloudInit.instanceID", iid)
 			}
 		}
 	}

--- a/controllers/virtualmachine/virtualmachine_controller_intg_test.go
+++ b/controllers/virtualmachine/virtualmachine_controller_intg_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -143,6 +144,46 @@ func intgTestsReconcile() {
 					}
 					return ""
 				}, 4*time.Second).Should(Equal(expected))
+			})
+		})
+
+		When("VM schema needs upgrade", func() {
+			biosUUID := uuid.New().String()
+
+			BeforeEach(func() {
+				intgFakeVMProvider.Lock()
+				intgFakeVMProvider.CreateOrUpdateVirtualMachineFn = func(ctx context.Context, vm *vmopv1.VirtualMachine) error {
+					vm.Status.BiosUUID = biosUUID
+					return nil
+				}
+				intgFakeVMProvider.Unlock()
+			})
+
+			// NOTE: mutating webhook sets the default spec.biosUUID, but is not run in this test -
+			// leaving spec.biosUUID empty as it would be for a pre-v1alpha3 VM
+			It("will set spec.biosUUID", func() {
+				Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
+
+				Eventually(func() string {
+					if vm := getVirtualMachine(ctx, vmKey); vm != nil {
+						return vm.Spec.BiosUUID
+					}
+					return ""
+				}).Should(Equal(biosUUID), "waiting for expected biosUUID")
+			})
+
+			It("will set cloudInit.instanceID", func() {
+				vm.Spec.Bootstrap = &vmopv1.VirtualMachineBootstrapSpec{
+					CloudInit: &vmopv1.VirtualMachineBootstrapCloudInitSpec{},
+				}
+				Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
+
+				Eventually(func() string {
+					if vm = getVirtualMachine(ctx, vmKey); vm != nil {
+						return vm.Spec.Bootstrap.CloudInit.InstanceID
+					}
+					return ""
+				}).Should(Equal(string(vm.UID)), "waiting for expected instanceID")
 			})
 		})
 

--- a/webhooks/virtualmachine/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator.go
@@ -962,9 +962,23 @@ func (v validator) validatePowerStateOnUpdate(
 	return allErrs
 }
 
+func isBootstrapCloudInit(vm *vmopv1.VirtualMachine) bool {
+	if vm.Spec.Bootstrap == nil {
+		return false
+	}
+	return vm.Spec.Bootstrap.CloudInit != nil
+}
+
 func (v validator) validateUpdatesWhenPoweredOn(ctx *pkgctx.WebhookRequestContext, vm, oldVM *vmopv1.VirtualMachine) field.ErrorList {
 	var allErrs field.ErrorList
 	specPath := field.NewPath("spec")
+
+	// Permit upgrade of existing VM's instanceID, regardless of powerState
+	if isBootstrapCloudInit(oldVM) && isBootstrapCloudInit(vm) {
+		if oldVM.Spec.Bootstrap.CloudInit.InstanceID == "" {
+			oldVM.Spec.Bootstrap.CloudInit.InstanceID = vm.Spec.Bootstrap.CloudInit.InstanceID
+		}
+	}
 
 	if !equality.Semantic.DeepEqual(vm.Spec.Bootstrap, oldVM.Spec.Bootstrap) {
 		allErrs = append(allErrs, field.Forbidden(specPath.Child("bootstrap"), updatesNotAllowedWhenPowerOn))


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

For VMs created prior to v1alpha3, populate the new fields for use with discovery and B/R:
- spec.biosUUID
- cloudInit.instanceID
