### PR TITLE
:sparkles: Support DHCP for VPC networking

### DIFF
--- a/pkg/providers/vsphere/network/network.go
+++ b/pkg/providers/vsphere/network/network.go
@@ -93,7 +93,7 @@ var (
 //     but eventually we should Watch() these resources. Note though, that in the very
 //     common case, the CR is reconciled before our poll timeout, so that does save us
 //     from bailing out of the Reconcile.
-//   - Both NCP and NetOP CR Status inform us of the backing and IPAM info. However, for
+//   - NCP, NetOP and VPC CR Status inform us of the backing and IPAM info. However, for
 //     our InterfaceSpec we allow for DHCP but neither NCP nor NetOP has a way for us to
 //     mark the CR to don't do IPAM or to check DHCP is even enabled on the network. So
 //     this burns an IP, and the user must know that DHCP is actually configured.
@@ -660,25 +660,22 @@ func vpcSubnetPortToResult(
 	}
 
 	ipConfigs := []NetworkInterfaceIPConfig{}
-	if macAddr := subnetPort.Status.NetworkInterfaceConfig.MACAddress; len(macAddr) == 0 {
-		// NSX Operator's way of saying DHCP.
-	} else {
-		// IPAddresses have CIDR format.
-		for _, ipAddr := range subnetPort.Status.NetworkInterfaceConfig.IPAddresses {
-			if ipAddr.IPAddress == "" {
-				continue
-			}
 
-			ip, _, _ := net.ParseCIDR(ipAddr.IPAddress)
-			isIPv4 := ip.To4() != nil
-			ipConfig := NetworkInterfaceIPConfig{
-				IPCIDR:  ipAddr.IPAddress,
-				IsIPv4:  isIPv4,
-				Gateway: ipAddr.Gateway,
-			}
-
-			ipConfigs = append(ipConfigs, ipConfig)
+	for _, ipAddr := range subnetPort.Status.NetworkInterfaceConfig.IPAddresses {
+		// An empty ipAddress is NSX Operator's way of saying DHCP.
+		if ipAddr.IPAddress == "" {
+			continue
 		}
+		// IPAddresses have CIDR format.
+		ip, _, _ := net.ParseCIDR(ipAddr.IPAddress)
+		isIPv4 := ip.To4() != nil
+		ipConfig := NetworkInterfaceIPConfig{
+			IPCIDR:  ipAddr.IPAddress,
+			IsIPv4:  isIPv4,
+			Gateway: ipAddr.Gateway,
+		}
+
+		ipConfigs = append(ipConfigs, ipConfig)
 	}
 
 	result := &NetworkInterfaceResult{


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This patch supports DHCP for VPC networking. VM Operator expect SubnetPort that uses DHCP to have `Status.NetworkInterfaceConfig.MACAddress` to be empty if Subnet/SubnetSet is configured for DHCP. This is the current SubnetPort status. https://github.com/vmware-tanzu/nsx-operator/issues/559 tracks the effort to return nil ipAddress for DHCP SubnetPort.
```
networkInterfaceConfig:
    ipAddresses:
    - gateway: 172.26.1.193
      ipAddress: /26
    logicalSwitchUUID: a22d4111-e7da-4396-94b7-ee80a1c25494
```

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes N/A

**Are there any special notes for your reviewer**:

Manual testing done on a VPC testbed:
1. Create Subnet/SubnetSet that uses DHCP (same works with DHCP + CIDR, note that only Subnet can specify CIDR)
```
apiVersion: nsx.vmware.com/v1alpha1
kind: Subnet
metadata:
  name: test-subnet-dhcp
  namespace: yiyi-ns
spec:
  DHCPConfig:
    enableDHCP: true
---
apiVersion: nsx.vmware.com/v1alpha1
kind: Subnet
metadata:
  name: test-subnet-dhcp-cidr-20
  namespace: yiyi-ns
spec:
  ipv4SubnetSize: 64
  ipAddresses:
  - 172.26.128.0/24
  accessMode: Private
  DHCPConfig:
    enableDHCP: true
```
2. Deploy VM Service VM with above subnet using CloudInit bootstrap(note that images don't have dhclient installed, not gonna work)
3. VM successfully got IP address
```
  network:
    config:
      dns:
        hostName: test-vm-ubuntu-dhcp
      interfaces:
      - ip:
          dhcp:
            ip4:
              enabled: true
        name: eth0
    interfaces:
    - deviceKey: 4000
      ip:
        addresses:
        - address: 172.26.1.195
          state: preferred
        - address: fe80::250:56ff:fe9b:1569
          state: unknown
        macAddr: 00:50:56:9b:15:69
      name: eth0
    ipStacks:
    - dns:
        domainName: .
        hostName: test-vm-ubuntu-dhcp
        searchDomains:
        - .
      ipRoutes:
      - gateway:
          address: 172.26.1.193
          device: "0"
        networkAddress: 0.0.0.0/0
      - gateway:
          device: "0"
        networkAddress: 172.26.1.192/26
    primaryIP4: 172.26.1.195
```
**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Support DHCP for VPC networking
```