### PR TITLE
🌱 Go 1.22.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: ci
 
 env:
-  GO_VERSION: 1.21.9
+  GO_VERSION: 1.22.3
 
 on:
   pull_request:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Go version used to build the binaries.
-ARG GO_VERSION=1.21.9
+ARG GO_VERSION=1.22.3
 
 ## Docker image used to build the binaries.
 FROM golang:${GO_VERSION} as builder


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch updates the GitHub workflow to build VM Operator using Golang 1.22.3. This patch also updates the project's Dockerfile to use Golang 1.22.3 as well.

Please note, the go.mod files are not updated because the project's modules do not require anything from Go 1.22. Until such time, the project *can* still be built using Go 1.21.

This patch also addresses the vulncheck errors due to https://pkg.go.dev/vuln/GO-2024-2824.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #461 


**Are there any special notes for your reviewer**:

Replaces https://github.com/vmware-tanzu/vm-operator/pull/461


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Build VM Operator with golang 1.22.3
```