### PR TITLE
🌱 Add last VM Resize annotation

### DIFF
--- a/pkg/util/vmopv1/resize.go
+++ b/pkg/util/vmopv1/resize.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package vmopv1
+
+import (
+	"encoding/json"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+)
+
+const (
+	// LastResizedAnnotationKey denotes the VM Class that the VM was last resized from.
+	LastResizedAnnotationKey = "vmoperator.vmware.com/last-resized-vm-class"
+)
+
+type lastResizedAnnotation struct {
+	Name       string
+	UID        string
+	Generation int64
+}
+
+// SetResizeAnnotation sets the resize annotation to match the given class.
+func SetResizeAnnotation(
+	vm *vmopv1.VirtualMachine,
+	vmClass vmopv1.VirtualMachineClass) error {
+
+	b, err := json.Marshal(lastResizedAnnotation{
+		Name:       vmClass.Name,
+		UID:        string(vmClass.UID),
+		Generation: vmClass.Generation,
+	})
+	if err != nil {
+		return err
+	}
+
+	if vm.Annotations == nil {
+		vm.Annotations = make(map[string]string)
+	}
+
+	vm.Annotations[LastResizedAnnotationKey] = string(b)
+	return nil
+}
+
+// GetResizeAnnotation returns the VM Class Name, UID, Generation, and true from the last resize annotation
+// if present. Otherwise returns false.
+func GetResizeAnnotation(vm vmopv1.VirtualMachine) (name, uid string, generation int64, ok bool) {
+	val, exists := vm.Annotations[LastResizedAnnotationKey]
+	if !exists {
+		return
+	}
+
+	var v lastResizedAnnotation
+	if err := json.Unmarshal([]byte(val), &v); err != nil {
+		return
+	}
+
+	return v.Name, v.UID, v.Generation, true
+}

--- a/pkg/util/vmopv1/resize_test.go
+++ b/pkg/util/vmopv1/resize_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package vmopv1_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	vmopv1util "github.com/vmware-tanzu/vm-operator/pkg/util/vmopv1"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+var _ = Describe("SetResizeAnnotation", func() {
+
+	var (
+		vm      *vmopv1.VirtualMachine
+		vmClass vmopv1.VirtualMachineClass
+	)
+
+	BeforeEach(func() {
+		vm = builder.DummyVirtualMachine()
+
+		vmClass = *builder.DummyVirtualMachineClass("my-class")
+		vmClass.UID = "my-uid"
+		vmClass.Generation = 42
+	})
+
+	It("Sets expected annotation", func() {
+		err := vmopv1util.SetResizeAnnotation(vm, vmClass)
+		Expect(err).ToNot(HaveOccurred())
+		val, ok := vm.Annotations[vmopv1util.LastResizedAnnotationKey]
+		Expect(ok).To(BeTrue())
+		Expect(val).To(MatchJSON(`{"Name":"my-class","UID":"my-uid","Generation":42}`))
+	})
+})
+
+var _ = Describe("GetResizeAnnotation", func() {
+
+	var (
+		vm      *vmopv1.VirtualMachine
+		vmClass vmopv1.VirtualMachineClass
+	)
+
+	BeforeEach(func() {
+		vm = builder.DummyVirtualMachine()
+
+		vmClass = *builder.DummyVirtualMachineClass("my-class")
+		vmClass.UID = "my-uid"
+		vmClass.Generation = 42
+	})
+
+	When("Resize annotation is not present", func() {
+		It("Returns expected values", func() {
+			className, uid, generation, ok := vmopv1util.GetResizeAnnotation(*vm)
+			Expect(ok).To(BeFalse())
+			Expect(className).To(BeEmpty())
+			Expect(uid).To(BeEmpty())
+			Expect(generation).To(BeZero())
+		})
+	})
+
+	When("Resize annotation is present", func() {
+		BeforeEach(func() {
+			Expect(vmopv1util.SetResizeAnnotation(vm, vmClass)).To(Succeed())
+		})
+
+		It("Returns expected values", func() {
+			className, uid, generation, ok := vmopv1util.GetResizeAnnotation(*vm)
+			Expect(ok).To(BeTrue())
+			Expect(className).To(Equal(vmClass.Name))
+			Expect(uid).To(BeEquivalentTo(vmClass.UID))
+			Expect(generation).To(Equal(vmClass.Generation))
+		})
+	})
+})


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This annotation will be used for VM resizing to keep track of which and at what revision a VM was last resize from.

Add very basic Set/Get methods for this. This is really just to get what & how is stored in the annotation out there.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

Just very basic get/set functions for now. This will all be built on later.

**Please add a release note if necessary**:

```release-note
NONE
```