### PR TITLE
🌱 Remove "A2" suffix from dummy object function names

### DIFF
--- a/controllers/virtualmachinepublishrequest/virtualmachinepublishrequest_controller_intg_test.go
+++ b/controllers/virtualmachinepublishrequest/virtualmachinepublishrequest_controller_intg_test.go
@@ -81,7 +81,7 @@ func intgTestsReconcile() {
 
 		cl = builder.DummyContentLibrary("dummy-cl", ctx.Namespace, "dummy-cl-uuid")
 
-		vmPubReq = builder.DummyVirtualMachinePublishRequestA2(
+		vmPubReq = builder.DummyVirtualMachinePublishRequest(
 			"dummy-vmpub", ctx.Namespace,
 			vm.Name,
 			"dummy-item",
@@ -210,7 +210,7 @@ func intgTestsReconcile() {
 						clItem := utils.DummyContentLibraryItem("dummy-clitem", ctx.Namespace)
 						Expect(ctx.Client.Create(ctx, clItem)).To(Succeed())
 
-						vmi := builder.DummyVirtualMachineImageA2("dummy-image")
+						vmi := builder.DummyVirtualMachineImage("dummy-image")
 						vmi.Namespace = ctx.Namespace
 						Expect(ctx.Client.Create(ctx, vmi)).To(Succeed())
 						targetName := vmPubReq.Spec.Target.Item.Name

--- a/controllers/virtualmachinepublishrequest/virtualmachinepublishrequest_controller_unit_test.go
+++ b/controllers/virtualmachinepublishrequest/virtualmachinepublishrequest_controller_unit_test.go
@@ -69,7 +69,7 @@ func unitTestsReconcile() {
 			},
 		}
 
-		vmpub = builder.DummyVirtualMachinePublishRequestA2("dummy-vmpub", vm.Namespace, vm.Name, "dummy-item", "dummy-cl")
+		vmpub = builder.DummyVirtualMachinePublishRequest("dummy-vmpub", vm.Namespace, vm.Name, "dummy-item", "dummy-cl")
 		cl = builder.DummyContentLibrary("dummy-cl", vm.Namespace, "dummy-id")
 	})
 
@@ -473,7 +473,7 @@ func unitTestsReconcile() {
 
 					When("VirtualMachineImage is available", func() {
 						JustBeforeEach(func() {
-							vmi := builder.DummyVirtualMachineImageA2("dummy-image")
+							vmi := builder.DummyVirtualMachineImage("dummy-image")
 							vmi.Namespace = vmpub.Namespace
 							Expect(ctx.Client.Create(ctx, vmi)).To(Succeed())
 							vmi.Status.ProviderItemID = itemID

--- a/controllers/volume/volume_controller_intg_test.go
+++ b/controllers/volume/volume_controller_intg_test.go
@@ -245,7 +245,7 @@ func intgTestsReconcile() {
 				config.InstanceStorage.PVPlacementFailedTTL = 0
 			})
 
-			vm.Spec.Volumes = append(vm.Spec.Volumes, builder.DummyInstanceStorageVirtualMachineVolumesA2()...)
+			vm.Spec.Volumes = append(vm.Spec.Volumes, builder.DummyInstanceStorageVirtualMachineVolumes()...)
 			vm.Labels = map[string]string{constants.InstanceStorageLabelKey: "true"}
 			Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
 

--- a/pkg/providers/vsphere/contentlibrary/content_library_utils_test.go
+++ b/pkg/providers/vsphere/contentlibrary/content_library_utils_test.go
@@ -111,7 +111,7 @@ var _ = Describe("UpdateVmiWithOvfEnvelope", func() {
 			},
 		}
 
-		image = builder.DummyVirtualMachineImageA2("dummy-image")
+		image = builder.DummyVirtualMachineImage("dummy-image")
 	})
 
 	AfterEach(func() {

--- a/pkg/providers/vsphere/placement/cluster_placement_test.go
+++ b/pkg/providers/vsphere/placement/cluster_placement_test.go
@@ -64,7 +64,7 @@ var _ = Describe("ParsePlaceVMResponse", func() {
 	BeforeEach(func() {
 		vmCtx = pkgctx.VirtualMachineContext{
 			Context: context.TODO(),
-			VM:      builder.DummyVirtualMachineA2(),
+			VM:      builder.DummyVirtualMachine(),
 			Logger:  suite.GetLogger(),
 		}
 	})

--- a/pkg/providers/vsphere/placement/zone_placement_test.go
+++ b/pkg/providers/vsphere/placement/zone_placement_test.go
@@ -78,7 +78,7 @@ func vcSimPlacement() {
 	BeforeEach(func() {
 		testConfig = builder.VCSimTestConfig{}
 
-		vm = builder.DummyVirtualMachineA2()
+		vm = builder.DummyVirtualMachine()
 		vm.Name = "placement-test"
 
 		// Other than the name ConfigSpec contents don't matter for vcsim.
@@ -203,7 +203,7 @@ func vcSimPlacement() {
 
 		BeforeEach(func() {
 			testConfig.WithInstanceStorage = true
-			builder.AddDummyInstanceStorageVolumeA2(vm)
+			builder.AddDummyInstanceStorageVolume(vm)
 			testConfig.NumFaultDomains = 1 // Only support for non-HA "HA"
 		})
 

--- a/pkg/providers/vsphere/vcenter/getvm_test.go
+++ b/pkg/providers/vsphere/vcenter/getvm_test.go
@@ -36,7 +36,7 @@ func getVM() {
 		ctx = suite.NewTestContextForVCSim(builder.VCSimTestConfig{})
 		nsInfo = ctx.CreateWorkloadNamespace()
 
-		vm := builder.DummyVirtualMachineA2()
+		vm := builder.DummyVirtualMachine()
 		vm.Name = "getvm-test"
 		vm.Namespace = nsInfo.Namespace
 

--- a/pkg/providers/vsphere/virtualmachine/backup_test.go
+++ b/pkg/providers/vsphere/virtualmachine/backup_test.go
@@ -60,7 +60,7 @@ func backupTests() {
 
 	Context("Backup VM Resource YAML", func() {
 		BeforeEach(func() {
-			vm := builder.DummyVirtualMachineA2()
+			vm := builder.DummyVirtualMachine()
 			vmCtx.VM = vm
 		})
 
@@ -240,7 +240,7 @@ func backupTests() {
 			}
 		)
 		BeforeEach(func() {
-			vm := builder.DummyVirtualMachineA2()
+			vm := builder.DummyVirtualMachine()
 			vmCtx.VM = vm
 		})
 

--- a/pkg/providers/vsphere/virtualmachine/configspec_test.go
+++ b/pkg/providers/vsphere/virtualmachine/configspec_test.go
@@ -47,12 +47,12 @@ var _ = Describe("CreateConfigSpec", func() {
 	)
 
 	BeforeEach(func() {
-		vmClass := builder.DummyVirtualMachineClassA2()
+		vmClass := builder.DummyVirtualMachineClassGenName()
 		vmClassSpec = &vmClass.Spec
 		vmImageStatus = &vmopv1.VirtualMachineImageStatus{Firmware: "efi"}
 		minCPUFreq = 2500
 
-		vm = builder.DummyVirtualMachineA2()
+		vm = builder.DummyVirtualMachine()
 		vm.Name = vmName
 		vm.UID = types.UID(uuid.New().String())
 		vm.Spec.BiosUUID = uuid.New().String()
@@ -350,7 +350,7 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 		baseConfigSpec = vimtypes.VirtualMachineConfigSpec{}
 		storageClassesToIDs = map[string]string{}
 
-		vm := builder.DummyVirtualMachineA2()
+		vm := builder.DummyVirtualMachine()
 		vmCtx = pkgctx.VirtualMachineContext{
 			Context: pkgcfg.NewContext(),
 			Logger:  suite.GetLogger().WithValues("vmName", vm.GetName()),
@@ -433,7 +433,7 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 				config.Features.InstanceStorage = true
 			})
 
-			builder.AddDummyInstanceStorageVolumeA2(vmCtx.VM)
+			builder.AddDummyInstanceStorageVolume(vmCtx.VM)
 			storageClassesToIDs[builder.DummyStorageClassName] = storagePolicyID
 		})
 		It("ConfigSpec contains expected InstanceStorage devices", func() {

--- a/pkg/providers/vsphere/virtualmachine/delete_test.go
+++ b/pkg/providers/vsphere/virtualmachine/delete_test.go
@@ -32,7 +32,7 @@ func deleteTests() {
 		vmCtx = pkgctx.VirtualMachineContext{
 			Context: ctx,
 			Logger:  suite.GetLogger().WithValues("vmName", vcVM.Name()),
-			VM:      builder.DummyVirtualMachineA2(),
+			VM:      builder.DummyVirtualMachine(),
 		}
 	})
 

--- a/pkg/providers/vsphere/virtualmachine/publish_test.go
+++ b/pkg/providers/vsphere/virtualmachine/publish_test.go
@@ -37,10 +37,10 @@ func publishTests() {
 		vcVM, err = ctx.Finder.VirtualMachine(ctx, "DC0_C0_RP0_VM0")
 		Expect(err).ToNot(HaveOccurred())
 
-		vm = builder.DummyVirtualMachineA2()
+		vm = builder.DummyVirtualMachine()
 		vm.Status.UniqueID = vcVM.Reference().Value
 		cl = builder.DummyContentLibrary("dummy-cl", "dummy-ns", ctx.ContentLibraryID)
-		vmPub = builder.DummyVirtualMachinePublishRequestA2("dummy-vmpub", "dummy-ns",
+		vmPub = builder.DummyVirtualMachinePublishRequest("dummy-vmpub", "dummy-ns",
 			vcVM.Name(), "dummy-item-name", "dummy-cl")
 		vmPub.Status.SourceRef = &vmPub.Spec.Source
 		vmPub.Status.TargetRef = &vmPub.Spec.Target

--- a/pkg/providers/vsphere/vmlifecycle/update_status_test.go
+++ b/pkg/providers/vsphere/vmlifecycle/update_status_test.go
@@ -35,7 +35,7 @@ var _ = Describe("UpdateStatus", func() {
 	BeforeEach(func() {
 		ctx = suite.NewTestContextForVCSim(builder.VCSimTestConfig{})
 
-		vm := builder.DummyVirtualMachineA2()
+		vm := builder.DummyVirtualMachine()
 		vm.Name = "update-status-test"
 
 		vmCtx = pkgctx.VirtualMachineContext{

--- a/pkg/providers/vsphere/vmprovider_vm2_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm2_test.go
@@ -62,8 +62,8 @@ func vmE2ETests() {
 			WithContentLibrary: true,
 		}
 
-		vm = builder.DummyBasicVirtualMachineA2("test-vm", "")
-		vmClass = builder.DummyVirtualMachineClassA2()
+		vm = builder.DummyBasicVirtualMachine("test-vm", "")
+		vmClass = builder.DummyVirtualMachineClassGenName()
 	})
 
 	JustBeforeEach(func() {

--- a/pkg/providers/vsphere/vmprovider_vm_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_test.go
@@ -87,8 +87,8 @@ func vmTests() {
 		)
 
 		BeforeEach(func() {
-			vmClass = builder.DummyVirtualMachineClassA2()
-			vm = builder.DummyBasicVirtualMachineA2("test-vm", "")
+			vmClass = builder.DummyVirtualMachineClassGenName()
+			vm = builder.DummyBasicVirtualMachine("test-vm", "")
 
 			// Reduce diff from old tests: by default don't create an NIC.
 			if vm.Spec.Network == nil {
@@ -116,7 +116,7 @@ func vmTests() {
 				vsphere.SkipVMImageCLProviderCheck = true
 
 				// Use the default VM created by vcsim as the source.
-				clusterVMImage = builder.DummyClusterVirtualMachineImageA2("DC0_C0_RP0_VM0")
+				clusterVMImage = builder.DummyClusterVirtualMachineImage("DC0_C0_RP0_VM0")
 				Expect(ctx.Client.Create(ctx, clusterVMImage)).To(Succeed())
 				conditions.MarkTrue(clusterVMImage, vmopv1.ReadyConditionType)
 				Expect(ctx.Client.Status().Update(ctx, clusterVMImage)).To(Succeed())

--- a/pkg/providers/vsphere/vmprovider_vm_utils_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_utils_test.go
@@ -35,7 +35,7 @@ func vmUtilTests() {
 	)
 
 	BeforeEach(func() {
-		vm := builder.DummyBasicVirtualMachineA2("test-vm", "dummy-ns")
+		vm := builder.DummyBasicVirtualMachine("test-vm", "dummy-ns")
 
 		vmCtx = pkgctx.VirtualMachineContext{
 			Context: pkgcfg.WithConfig(pkgcfg.Config{MaxDeployThreadsOnProvider: 16}),
@@ -59,7 +59,7 @@ func vmUtilTests() {
 		)
 
 		BeforeEach(func() {
-			vmClass = builder.DummyVirtualMachineClass2A2("dummy-vm-class")
+			vmClass = builder.DummyVirtualMachineClass("dummy-vm-class")
 			vmClass.Namespace = vmCtx.VM.Namespace
 			vmCtx.VM.Spec.ClassName = vmClass.Name
 		})
@@ -100,10 +100,10 @@ func vmUtilTests() {
 		)
 
 		BeforeEach(func() {
-			nsVMImage = builder.DummyVirtualMachineImageA2(builder.DummyVMIID)
+			nsVMImage = builder.DummyVirtualMachineImage(builder.DummyVMIID)
 			nsVMImage.Namespace = vmCtx.VM.Namespace
 			conditions.MarkTrue(nsVMImage, vmopv1.ReadyConditionType)
-			clusterVMImage = builder.DummyClusterVirtualMachineImageA2(builder.DummyVMIID)
+			clusterVMImage = builder.DummyClusterVirtualMachineImage(builder.DummyVMIID)
 			conditions.MarkTrue(clusterVMImage, vmopv1.ReadyConditionType)
 		})
 
@@ -810,7 +810,7 @@ func vmUtilTests() {
 		}
 
 		BeforeEach(func() {
-			vmClass = builder.DummyVirtualMachineClassA2()
+			vmClass = builder.DummyVirtualMachineClassGenName()
 		})
 
 		When("InstanceStorage FFS is enabled", func() {
@@ -823,7 +823,7 @@ func vmUtilTests() {
 
 			When("Instance Volume is added in VM Class", func() {
 				BeforeEach(func() {
-					vmClass.Spec.Hardware.InstanceStorage = builder.DummyInstanceStorageA2()
+					vmClass.Spec.Hardware.InstanceStorage = builder.DummyInstanceStorage()
 				})
 
 				It("Instance Volumes should be added", func() {

--- a/pkg/util/vmopv1/vm_test.go
+++ b/pkg/util/vmopv1/vm_test.go
@@ -67,14 +67,14 @@ var _ = Describe("ResolveImageName", func() {
 		namespace = actualNamespace
 
 		newNsImgFn := func(id, name string) *vmopv1.VirtualMachineImage {
-			img := builder.DummyVirtualMachineImageA2(id)
+			img := builder.DummyVirtualMachineImage(id)
 			img.Namespace = actualNamespace
 			img.Status.Name = name
 			return img
 		}
 
 		newClImgFn := func(id, name string) *vmopv1.ClusterVirtualMachineImage {
-			img := builder.DummyClusterVirtualMachineImageA2(id)
+			img := builder.DummyClusterVirtualMachineImage(id)
 			img.Status.Name = name
 			return img
 		}

--- a/test/builder/util.go
+++ b/test/builder/util.go
@@ -7,116 +7,21 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"crypto/rand"
-	"crypto/rsa"
-	"crypto/x509"
-	"encoding/pem"
 	"io"
 	"os"
 	"path/filepath"
 
-	corev1 "k8s.io/api/core/v1"
-	storagev1 "k8s.io/api/storage/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/yaml"
-
-	imgregv1a1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha1"
-
-	vmopv1a1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
-	topologyv1 "github.com/vmware-tanzu/vm-operator/external/tanzu-topology/api/v1alpha1"
-	cnsstoragev1 "github.com/vmware-tanzu/vm-operator/external/vsphere-csi-driver/pkg/syncer/cnsoperator/apis/storagepolicy/v1alpha1"
-)
-
-const (
-	DummyVMIID                = "vmi-0123456789"
-	DummyImageName            = "dummy-image-name"
-	DummyClassName            = "dummyClassName"
-	DummyVolumeName           = "dummy-volume-name"
-	DummyPVCName              = "dummyPVCName"
-	DummyDistroVersion        = "dummyDistroVersion"
-	DummyOSType               = "centosGuest"
-	DummyStorageClassName     = "dummy-storage-class"
-	DummyResourceQuotaName    = "dummy-resource-quota"
-	DummyAvailabilityZoneName = "dummy-availability-zone"
 )
 
 var (
 	converter runtime.UnstructuredConverter = runtime.DefaultUnstructuredConverter
 )
-
-func DummyStorageClass() *storagev1.StorageClass {
-	return &storagev1.StorageClass{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: DummyStorageClassName,
-		},
-		Provisioner: "foo",
-		Parameters: map[string]string{
-			"storagePolicyID": "id42",
-		},
-	}
-}
-
-func DummyResourceQuota(namespace, rlName string) *corev1.ResourceQuota {
-	return &corev1.ResourceQuota{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      DummyResourceQuotaName,
-			Namespace: namespace,
-		},
-		Spec: corev1.ResourceQuotaSpec{
-			Hard: corev1.ResourceList{
-				corev1.ResourceName(rlName): resource.MustParse("1"),
-			},
-		},
-	}
-}
-
-func DummyAvailabilityZone() *topologyv1.AvailabilityZone {
-	return DummyNamedAvailabilityZone(DummyAvailabilityZoneName)
-}
-
-func DummyNamedAvailabilityZone(name string) *topologyv1.AvailabilityZone {
-	return &topologyv1.AvailabilityZone{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-		Spec: topologyv1.AvailabilityZoneSpec{
-			ClusterComputeResourceMoIDs: []string{"cluster"},
-			Namespaces:                  map[string]topologyv1.NamespaceInfo{},
-		},
-	}
-}
-
-func DummyWebConsoleRequest(namespace, wcrName, vmName, pubKey string) *vmopv1a1.WebConsoleRequest {
-	return &vmopv1a1.WebConsoleRequest{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      wcrName,
-			Namespace: namespace,
-		},
-		Spec: vmopv1a1.WebConsoleRequestSpec{
-			VirtualMachineName: vmName,
-			PublicKey:          pubKey,
-		},
-	}
-}
-
-func WebConsoleRequestKeyPair() (privateKey *rsa.PrivateKey, publicKeyPem string) {
-	privateKey, _ = rsa.GenerateKey(rand.Reader, 2048)
-	publicKey := privateKey.PublicKey
-	publicKeyPem = string(pem.EncodeToMemory(
-		&pem.Block{
-			Type:  "PUBLIC KEY",
-			Bytes: x509.MarshalPKCS1PublicKey(&publicKey),
-		},
-	))
-	return privateKey, publicKeyPem
-}
 
 func ToUnstructured(obj runtime.Object) (*unstructured.Unstructured, error) {
 	content, err := converter.ToUnstructured(obj)
@@ -127,88 +32,6 @@ func ToUnstructured(obj runtime.Object) (*unstructured.Unstructured, error) {
 	u := &unstructured.Unstructured{}
 	u.SetUnstructuredContent(content)
 	return u, nil
-}
-
-func DummyPersistentVolumeClaim() *corev1.PersistentVolumeClaim {
-	var storageClass = "dummy-storage-class"
-	return &corev1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   "validate-webhook-pvc",
-			Labels: make(map[string]string),
-		},
-		Spec: corev1.PersistentVolumeClaimSpec{
-			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
-			Resources: corev1.VolumeResourceRequirements{
-				Requests: corev1.ResourceList{
-					corev1.ResourceStorage: resource.MustParse("5Gi"),
-				},
-			},
-			StorageClassName: &storageClass,
-		},
-	}
-}
-
-func DummyContentLibrary(name, namespace, uuid string) *imgregv1a1.ContentLibrary {
-	return &imgregv1a1.ContentLibrary{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-		Spec: imgregv1a1.ContentLibrarySpec{
-			UUID:     types.UID(uuid),
-			Writable: true,
-		},
-		Status: imgregv1a1.ContentLibraryStatus{
-			Conditions: []imgregv1a1.Condition{
-				{
-					Type:   imgregv1a1.ReadyCondition,
-					Status: corev1.ConditionTrue,
-				},
-			},
-		},
-	}
-}
-
-func DummyClusterContentLibrary(name, uuid string) *imgregv1a1.ClusterContentLibrary {
-	return &imgregv1a1.ClusterContentLibrary{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-		Spec: imgregv1a1.ClusterContentLibrarySpec{
-			UUID: types.UID(uuid),
-		},
-	}
-}
-
-func DummyStoragePolicyQuota(quotaName, quotaNs, className string) *cnsstoragev1.StoragePolicyQuota {
-	return &cnsstoragev1.StoragePolicyQuota{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      quotaName,
-			Namespace: quotaNs,
-		},
-		Spec: cnsstoragev1.StoragePolicyQuotaSpec{StoragePolicyId: "uuid-abcd-1234"},
-		Status: cnsstoragev1.StoragePolicyQuotaStatus{
-			SCLevelQuotaStatuses: []cnsstoragev1.SCLevelQuotaStatus{
-				{
-					StorageClassName: className,
-				},
-			},
-			ResourceTypeLevelQuotaStatuses: []cnsstoragev1.ResourceTypeLevelQuotaStatus{
-				{
-					ResourceExtensionName: "volume.cns.vsphere.vmware.com",
-					ResourceTypeSCLevelQuotaStatuses: []cnsstoragev1.SCLevelQuotaStatus{{
-						StorageClassName: className,
-					}},
-				},
-				{
-					ResourceExtensionName: "volume.cns.vsphere.vmware.com",
-					ResourceTypeSCLevelQuotaStatuses: []cnsstoragev1.SCLevelQuotaStatus{{
-						StorageClassName: className + "-abcde",
-					}},
-				},
-			},
-		},
-	}
 }
 
 func applyFeatureStateFnsToCRD(

--- a/test/builder/vcsim_test_context.go
+++ b/test/builder/vcsim_test_context.go
@@ -425,7 +425,7 @@ func (c *TestContextForVCSim) setupContentLibrary(config VCSimTestConfig) {
 			"images", "ttylinux-pc_i486-16.1.ovf"))
 
 	// The image isn't quite as prod but sufficient for what we need here ATM.
-	clusterVMImage := DummyClusterVirtualMachineImageA2(c.ContentLibraryImageName)
+	clusterVMImage := DummyClusterVirtualMachineImage(c.ContentLibraryImageName)
 	clusterVMImage.Spec.ProviderRef = &common.LocalObjectRef{
 		Kind: "ClusterContentLibraryItem",
 	}
@@ -462,7 +462,7 @@ func (c *TestContextForVCSim) ContentLibraryItemTemplate(srcVMName, templateName
 	Expect(err).ToNot(HaveOccurred())
 
 	// Create the expected VirtualMachineImage for the template.
-	clusterVMImage := DummyClusterVirtualMachineImageA2(templateName)
+	clusterVMImage := DummyClusterVirtualMachineImage(templateName)
 	clusterVMImage.Spec.ProviderRef.Kind = "ClusterContentLibraryItem"
 	Expect(c.Client.Create(c, clusterVMImage)).To(Succeed())
 	clusterVMImage.Status.ProviderItemID = itemID
@@ -652,7 +652,7 @@ func (c *TestContextForVCSim) CreateVirtualMachineSetResourcePolicyA2(
 	name string,
 	nsInfo WorkloadNamespaceInfo) (*vmopv1.VirtualMachineSetResourcePolicy, *object.Folder) {
 
-	resourcePolicy := DummyVirtualMachineSetResourcePolicy2A2(name, nsInfo.Namespace)
+	resourcePolicy := DummyVirtualMachineSetResourcePolicy2(name, nsInfo.Namespace)
 	Expect(c.Client.Create(c, resourcePolicy)).To(Succeed())
 
 	folder := c.createVirtualMachineSetResourcePolicyCommon(

--- a/webhooks/virtualmachine/mutation/virtualmachine_mutator_intg_test.go
+++ b/webhooks/virtualmachine/mutation/virtualmachine_mutator_intg_test.go
@@ -47,7 +47,7 @@ func newIntgMutatingWebhookContext() *intgMutatingWebhookContext {
 		IntegrationTestContext: *suite.NewIntegrationTestContext(),
 	}
 
-	ctx.vm = builder.DummyVirtualMachineA2()
+	ctx.vm = builder.DummyVirtualMachine()
 	ctx.vm.Namespace = ctx.Namespace
 
 	return ctx
@@ -62,7 +62,7 @@ func intgTestsMutating() {
 	BeforeEach(func() {
 		ctx = newIntgMutatingWebhookContext()
 
-		img = builder.DummyVirtualMachineImageA2(builder.DummyVMIID)
+		img = builder.DummyVirtualMachineImage(builder.DummyVMIID)
 		img.Namespace = ctx.vm.Namespace
 		Expect(ctx.Client.Create(ctx, img)).To(Succeed())
 		img.Status.Name = ctx.vm.Spec.ImageName

--- a/webhooks/virtualmachine/mutation/virtualmachine_mutator_unit_test.go
+++ b/webhooks/virtualmachine/mutation/virtualmachine_mutator_unit_test.go
@@ -49,7 +49,7 @@ type unitMutationWebhookContext struct {
 }
 
 func newUnitTestContextForMutatingWebhook() *unitMutationWebhookContext {
-	vm := builder.DummyVirtualMachineA2()
+	vm := builder.DummyVirtualMachine()
 	obj, err := builder.ToUnstructured(vm)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -368,14 +368,14 @@ func unitTestsMutating() {
 		)
 
 		newNsImgFn := func(id, name string) *vmopv1.VirtualMachineImage {
-			img := builder.DummyVirtualMachineImageA2(id)
+			img := builder.DummyVirtualMachineImage(id)
 			img.Namespace = ctx.vm.Namespace
 			img.Status.Name = name
 			return img
 		}
 
 		newClImgFn := func(id, name string) *vmopv1.ClusterVirtualMachineImage {
-			img := builder.DummyClusterVirtualMachineImageA2(id)
+			img := builder.DummyClusterVirtualMachineImage(id)
 			img.Status.Name = name
 			return img
 		}

--- a/webhooks/virtualmachine/validation/virtualmachine_validator_intg_test.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator_intg_test.go
@@ -62,7 +62,7 @@ func newIntgValidatingWebhookContext() *intgValidatingWebhookContext {
 		IntegrationTestContext: *suite.NewIntegrationTestContext(),
 	}
 
-	ctx.vm = builder.DummyVirtualMachineA2()
+	ctx.vm = builder.DummyVirtualMachine()
 	ctx.vm.Namespace = ctx.Namespace
 
 	return ctx

--- a/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
@@ -100,7 +100,7 @@ type unitValidatingWebhookContext struct {
 }
 
 func newUnitTestContextForValidatingWebhook(isUpdate bool) *unitValidatingWebhookContext {
-	vm := builder.DummyVirtualMachineA2()
+	vm := builder.DummyVirtualMachine()
 	vm.Name = "dummy-vm"
 	vm.Namespace = "dummy-vm-namespace-for-webhook-validation"
 	obj, err := builder.ToUnstructured(vm)
@@ -193,7 +193,7 @@ func unitTestsValidateCreate() {
 		}
 
 		if args.withInstanceStorageVolumes {
-			instanceStorageVolumes := builder.DummyInstanceStorageVirtualMachineVolumesA2()
+			instanceStorageVolumes := builder.DummyInstanceStorageVirtualMachineVolumes()
 			ctx.vm.Spec.Volumes = append(ctx.vm.Spec.Volumes, instanceStorageVolumes...)
 		}
 
@@ -1759,11 +1759,11 @@ func unitTestsValidateUpdate() {
 		}
 
 		if args.withInstanceStorageVolumes {
-			instanceStorageVolumes := builder.DummyInstanceStorageVirtualMachineVolumesA2()
+			instanceStorageVolumes := builder.DummyInstanceStorageVirtualMachineVolumes()
 			ctx.vm.Spec.Volumes = append(ctx.vm.Spec.Volumes, instanceStorageVolumes...)
 		}
 		if args.changeInstanceStorageVolume {
-			instanceStorageVolumes := builder.DummyInstanceStorageVirtualMachineVolumesA2()
+			instanceStorageVolumes := builder.DummyInstanceStorageVirtualMachineVolumes()
 			ctx.oldVM.Spec.Volumes = append(ctx.oldVM.Spec.Volumes, instanceStorageVolumes...)
 			instanceStorageVolumes[0].Name += updateSuffix
 			ctx.vm.Spec.Volumes = append(ctx.vm.Spec.Volumes, instanceStorageVolumes...)

--- a/webhooks/virtualmachineclass/mutation/virtualmachineclass_mutator_intg_test.go
+++ b/webhooks/virtualmachineclass/mutation/virtualmachineclass_mutator_intg_test.go
@@ -38,7 +38,7 @@ func newIntgMutatingWebhookContext() *intgMutatingWebhookContext {
 		IntegrationTestContext: *suite.NewIntegrationTestContext(),
 	}
 
-	ctx.vmClass = builder.DummyVirtualMachineClassA2()
+	ctx.vmClass = builder.DummyVirtualMachineClassGenName()
 	ctx.vmClass.Namespace = ctx.Namespace
 
 	return ctx

--- a/webhooks/virtualmachineclass/mutation/virtualmachineclass_mutator_unit_test.go
+++ b/webhooks/virtualmachineclass/mutation/virtualmachineclass_mutator_unit_test.go
@@ -36,7 +36,7 @@ type unitMutationWebhookContext struct {
 }
 
 func newUnitTestContextForMutatingWebhook() *unitMutationWebhookContext {
-	vmClass := builder.DummyVirtualMachineClassA2()
+	vmClass := builder.DummyVirtualMachineClassGenName()
 	obj, err := builder.ToUnstructured(vmClass)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/webhooks/virtualmachineclass/validation/virtualmachineclass_validator_intg_test.go
+++ b/webhooks/virtualmachineclass/validation/virtualmachineclass_validator_intg_test.go
@@ -50,7 +50,7 @@ func newIntgValidatingWebhookContext() *intgValidatingWebhookContext {
 		IntegrationTestContext: *suite.NewIntegrationTestContext(),
 	}
 
-	ctx.vmClass = builder.DummyVirtualMachineClassA2()
+	ctx.vmClass = builder.DummyVirtualMachineClassGenName()
 	ctx.vmClass.Namespace = ctx.Namespace
 
 	return ctx

--- a/webhooks/virtualmachineclass/validation/virtualmachineclass_validator_unit_test.go
+++ b/webhooks/virtualmachineclass/validation/virtualmachineclass_validator_unit_test.go
@@ -59,7 +59,7 @@ type unitValidatingWebhookContext struct {
 }
 
 func newUnitTestContextForValidatingWebhook(isUpdate bool) *unitValidatingWebhookContext {
-	vmClass := builder.DummyVirtualMachineClassA2()
+	vmClass := builder.DummyVirtualMachineClassGenName()
 	obj, err := builder.ToUnstructured(vmClass)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/webhooks/virtualmachinepublishrequest/validation/virtualmachinepublishrequest_validator_intg_test.go
+++ b/webhooks/virtualmachinepublishrequest/validation/virtualmachinepublishrequest_validator_intg_test.go
@@ -58,7 +58,7 @@ func newIntgValidatingWebhookContext() *intgValidatingWebhookContext {
 		IntegrationTestContext: *suite.NewIntegrationTestContext(),
 	}
 
-	ctx.vmPub = builder.DummyVirtualMachinePublishRequestA2("dummy-vmpub", ctx.Namespace, "dummy-vm",
+	ctx.vmPub = builder.DummyVirtualMachinePublishRequest("dummy-vmpub", ctx.Namespace, "dummy-vm",
 		"dummy-item", "dummy-cl")
 	return ctx
 }

--- a/webhooks/virtualmachinepublishrequest/validation/virtualmachinepublishrequest_validator_unit_test.go
+++ b/webhooks/virtualmachinepublishrequest/validation/virtualmachinepublishrequest_validator_unit_test.go
@@ -61,12 +61,12 @@ type unitValidatingWebhookContext struct {
 }
 
 func newUnitTestContextForValidatingWebhook(isUpdate bool) *unitValidatingWebhookContext {
-	vm := builder.DummyVirtualMachineA2()
+	vm := builder.DummyVirtualMachine()
 	vm.Name = "dummy-vm"
 	vm.Namespace = "dummy-ns"
 	cl := builder.DummyContentLibrary("dummy-cl", "dummy-ns", "dummy-uuid")
 
-	vmPub := builder.DummyVirtualMachinePublishRequestA2("dummy-vmpub", "dummy-ns", vm.Name,
+	vmPub := builder.DummyVirtualMachinePublishRequest("dummy-vmpub", "dummy-ns", vm.Name,
 		"dummy-item", cl.Name)
 	obj, err := builder.ToUnstructured(vmPub)
 	Expect(err).ToNot(HaveOccurred())

--- a/webhooks/virtualmachineservice/mutation/virtualmachineservice_mutator_intg_test.go
+++ b/webhooks/virtualmachineservice/mutation/virtualmachineservice_mutator_intg_test.go
@@ -39,7 +39,7 @@ func newIntgMutatingWebhookContext() *intgMutatingWebhookContext {
 		IntegrationTestContext: *suite.NewIntegrationTestContext(),
 	}
 
-	ctx.vmService = builder.DummyVirtualMachineServiceA2()
+	ctx.vmService = builder.DummyVirtualMachineService()
 	ctx.vmService.Namespace = ctx.Namespace
 
 	return ctx

--- a/webhooks/virtualmachineservice/mutation/virtualmachineservice_mutator_unit_test.go
+++ b/webhooks/virtualmachineservice/mutation/virtualmachineservice_mutator_unit_test.go
@@ -35,7 +35,7 @@ type unitMutationWebhookContext struct {
 }
 
 func newUnitTestContextForMutatingWebhook() *unitMutationWebhookContext {
-	vmService := builder.DummyVirtualMachineServiceA2()
+	vmService := builder.DummyVirtualMachineService()
 	obj, err := builder.ToUnstructured(vmService)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/webhooks/virtualmachineservice/validation/virtualmachineservice_validator_intg_test.go
+++ b/webhooks/virtualmachineservice/validation/virtualmachineservice_validator_intg_test.go
@@ -58,7 +58,7 @@ func newIntgValidatingWebhookContext() *intgValidatingWebhookContext {
 		IntegrationTestContext: *suite.NewIntegrationTestContext(),
 	}
 
-	ctx.vmService = builder.DummyVirtualMachineServiceA2()
+	ctx.vmService = builder.DummyVirtualMachineService()
 	ctx.vmService.Namespace = ctx.Namespace
 
 	return ctx

--- a/webhooks/virtualmachineservice/validation/virtualmachineservice_validator_unit_test.go
+++ b/webhooks/virtualmachineservice/validation/virtualmachineservice_validator_unit_test.go
@@ -56,7 +56,7 @@ type unitValidatingWebhookContext struct {
 }
 
 func newUnitTestContextForValidatingWebhook(isUpdate bool) *unitValidatingWebhookContext {
-	vmService := builder.DummyVirtualMachineServiceA2()
+	vmService := builder.DummyVirtualMachineService()
 	obj, err := builder.ToUnstructured(vmService)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/webhooks/virtualmachinesetresourcepolicy/validation/virtualmachinesetresourcepolicy_validator_intg_test.go
+++ b/webhooks/virtualmachinesetresourcepolicy/validation/virtualmachinesetresourcepolicy_validator_intg_test.go
@@ -62,7 +62,7 @@ func newIntgValidatingWebhookContext() *intgValidatingWebhookContext {
 		IntegrationTestContext: *suite.NewIntegrationTestContext(),
 	}
 
-	ctx.vmRP = builder.DummyVirtualMachineSetResourcePolicyA2()
+	ctx.vmRP = builder.DummyVirtualMachineSetResourcePolicy()
 	ctx.vmRP.Namespace = ctx.Namespace
 
 	return ctx

--- a/webhooks/virtualmachinesetresourcepolicy/validation/virtualmachinesetresourcepolicy_validator_unit_test.go
+++ b/webhooks/virtualmachinesetresourcepolicy/validation/virtualmachinesetresourcepolicy_validator_unit_test.go
@@ -58,7 +58,7 @@ type unitValidatingWebhookContext struct {
 }
 
 func newUnitTestContextForValidatingWebhook(isUpdate bool) *unitValidatingWebhookContext {
-	vmRP := builder.DummyVirtualMachineSetResourcePolicyA2()
+	vmRP := builder.DummyVirtualMachineSetResourcePolicy()
 	obj, err := builder.ToUnstructured(vmRP)
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

I used the A2 suffix during the v1a2 work where we had to deal with both v1a1 and v1a2 at the same time. That is behind us so clean up the names.

Move all the functions into their own file since they are not really util'ish.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:


```release-note
NONE
```