### PR TITLE
🌱 Add integration tests to cover VM create requeue delays

### DIFF
--- a/controllers/virtualmachine/virtualmachine_controller.go
+++ b/controllers/virtualmachine/virtualmachine_controller.go
@@ -271,13 +271,13 @@ func requeueDelay(ctx *pkgctx.VirtualMachineContext) time.Duration {
 	// If the VM is in Creating phase, the reconciler has run out of threads to Create VMs on the provider. Do not queue
 	// immediately to avoid exponential backoff.
 	if !conditions.IsTrue(ctx.VM, vmopv1.VirtualMachineConditionCreated) {
-		return 10 * time.Second
+		return pkgcfg.FromContext(ctx).CreateVMRequeueDelay
 	}
 
 	if ctx.VM.Status.PowerState == vmopv1.VirtualMachinePowerStateOn {
 		network := ctx.VM.Status.Network
 		if network == nil || (network.PrimaryIP4 == "" && network.PrimaryIP6 == "") {
-			return 10 * time.Second
+			return pkgcfg.FromContext(ctx).PoweredOnVMHasIPRequeueDelay
 		}
 	}
 

--- a/controllers/virtualmachine/virtualmachine_controller_suite_test.go
+++ b/controllers/virtualmachine/virtualmachine_controller_suite_test.go
@@ -5,6 +5,7 @@ package virtualmachine_test
 
 import (
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 
@@ -20,7 +21,11 @@ import (
 var intgFakeVMProvider = providerfake.NewVMProvider()
 
 var suite = builder.NewTestSuiteForControllerWithContext(
-	pkgcfg.NewContextWithDefaultConfig(),
+	pkgcfg.UpdateContext(pkgcfg.NewContextWithDefaultConfig(), func(config *pkgcfg.Config) {
+		config.SyncPeriod = 60 * time.Minute
+		config.CreateVMRequeueDelay = 1 * time.Second
+		config.PoweredOnVMHasIPRequeueDelay = 1 * time.Second
+	}),
 	virtualmachine.AddToManager,
 	func(ctx *pkgctx.ControllerManagerContext, _ ctrlmgr.Manager) error {
 		ctx.VMProvider = intgFakeVMProvider

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -54,6 +54,19 @@ type Config struct {
 	// the GetMaxDeployThreadsOnProvider function.
 	MaxDeployThreadsOnProvider int
 
+	// CreateVMRequeueDelay is the requeue delay that is used to retry a VM
+	// create that was unable to handled because MaxDeployThreadsOnProvider
+	// creates where already in progress.
+	// Defaults to 10 seconds.
+	CreateVMRequeueDelay time.Duration
+
+	// PoweredOnVMHasIPRequeueDelay is the requeue delay that is when a VM
+	// is powered on but does not yet have an IP assigned. This is used so
+	// the VM Status is updated sooner than waiting for the SyncPeriod to
+	// occur.
+	// Defaults to 10 seconds.
+	PoweredOnVMHasIPRequeueDelay time.Duration
+
 	NetworkProviderType  NetworkProviderType
 	VSphereNetworking    bool
 	LoadBalancerProvider string

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -35,6 +35,8 @@ func Default() Config {
 		LeaderElectionID:             defaultPrefix + "controller-manager-runtime",
 		MaxCreateVMsOnProvider:       80,
 		MaxConcurrentReconciles:      1,
+		CreateVMRequeueDelay:         10 * time.Second,
+		PoweredOnVMHasIPRequeueDelay: 10 * time.Second,
 		NetworkProviderType:          NetworkProviderTypeNamed,
 		PodName:                      defaultPrefix + "controller-manager",
 		PodNamespace:                 defaultPrefix + "system",

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -20,6 +20,8 @@ func FromEnv() Config {
 	setDuration(env.ContentAPIWaitDuration, &config.ContentAPIWait)
 	setString(env.DefaultVMClassControllerName, &config.DefaultVMClassControllerName)
 	setInt(env.MaxCreateVMsOnProvider, &config.MaxCreateVMsOnProvider)
+	setDuration(env.CreateVMRequeueDelay, &config.CreateVMRequeueDelay)
+	setDuration(env.PoweredOnVMHasIPRequeueDelay, &config.PoweredOnVMHasIPRequeueDelay)
 	setNetworkProviderType(env.NetworkProviderType, &config.NetworkProviderType)
 	setString(env.LoadBalancerProvider, &config.LoadBalancerProvider)
 	setBool(env.VSphereNetworking, &config.VSphereNetworking)

--- a/pkg/config/env/env.go
+++ b/pkg/config/env/env.go
@@ -15,6 +15,8 @@ const (
 
 	DefaultVMClassControllerName
 	MaxCreateVMsOnProvider
+	CreateVMRequeueDelay
+	PoweredOnVMHasIPRequeueDelay
 	PrivilegedUsers
 	NetworkProviderType
 	LoadBalancerProvider
@@ -80,6 +82,10 @@ func (n VarName) String() string {
 		return "DEFAULT_VM_CLASS_CONTROLLER_NAME"
 	case MaxCreateVMsOnProvider:
 		return "MAX_CREATE_VMS_ON_PROVIDER"
+	case CreateVMRequeueDelay:
+		return "CREATE_VM_REQUEUE_DELAY"
+	case PoweredOnVMHasIPRequeueDelay:
+		return "POWERED_ON_VM_HAS_IP_REQUEUE_DELAY"
 	case PrivilegedUsers:
 		return "PRIVILEGED_USERS"
 	case NetworkProviderType:

--- a/pkg/config/env_test.go
+++ b/pkg/config/env_test.go
@@ -93,6 +93,8 @@ var _ = Describe(
 					Expect(os.Setenv("FSS_WCP_TKG_Multiple_CL", "false")).To(Succeed())
 					Expect(os.Setenv("FSS_WCP_VMSERVICE_RESIZE", "true")).To(Succeed())
 					Expect(os.Setenv("FSS_WCP_MOBILITY_VM_IMPORT_NEW_NET", "true")).To(Succeed())
+					Expect(os.Setenv("CREATE_VM_REQUEUE_DELAY", "125h")).To(Succeed())
+					Expect(os.Setenv("POWERED_ON_VM_HAS_IP_REQUEUE_DELAY", "126h")).To(Succeed())
 				})
 				It("Should return a default config overridden by the environment", func() {
 					Expect(config).To(Equal(pkgcfg.Config{
@@ -133,6 +135,8 @@ var _ = Describe(
 							VMResize:           true,
 							VMImportNewNet:     true,
 						},
+						CreateVMRequeueDelay:         125 * time.Hour,
+						PoweredOnVMHasIPRequeueDelay: 126 * time.Hour,
 					}))
 				})
 			})


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

During the VM create and VM power on steps, we may need to requeue the VM for reconciliation internally. We do that via a RequeueAfter that controller runtime provides. Improve the integration test to cover these steps.

Parameterized the requeue delays values so they can be changed if needed if needed. When VM create is not blocking, and when we start to use the property.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:



**Please add a release note if necessary**:

```release-note
NONE
```