### PR TITLE
✨ Add VirtualMachineSpec.InstanceUUID

### DIFF
--- a/api/v1alpha1/virtualmachine_conversion.go
+++ b/api/v1alpha1/virtualmachine_conversion.go
@@ -934,6 +934,10 @@ func restore_v1alpha3_VirtualMachineReadinessProbeSpec(
 	}
 }
 
+func restore_v1alpha3_VirtualMachineInstanceUUID(dst, src *vmopv1.VirtualMachine) {
+	dst.Spec.InstanceUUID = src.Spec.InstanceUUID
+}
+
 func restore_v1alpha3_VirtualMachineBiosUUID(dst, src *vmopv1.VirtualMachine) {
 	dst.Spec.BiosUUID = src.Spec.BiosUUID
 }

--- a/api/v1alpha1/virtualmachine_conversion_test.go
+++ b/api/v1alpha1/virtualmachine_conversion_test.go
@@ -214,7 +214,8 @@ func TestVirtualMachineConversion(t *testing.T) {
 					ResourcePolicyName: "my-resource-policy",
 				},
 				MinHardwareVersion: 42,
-				BiosUUID:           uuid.New().String(),
+				InstanceUUID:       uuid.NewString(),
+				BiosUUID:           uuid.NewString(),
 			},
 		}
 

--- a/api/v1alpha1/zz_generated.conversion.go
+++ b/api/v1alpha1/zz_generated.conversion.go
@@ -2080,6 +2080,7 @@ func autoConvert_v1alpha3_VirtualMachineSpec_To_v1alpha1_VirtualMachineSpec(in *
 	// WARNING: in.Advanced requires manual conversion: does not exist in peer-type
 	// WARNING: in.Reserved requires manual conversion: does not exist in peer-type
 	out.MinHardwareVersion = in.MinHardwareVersion
+	// WARNING: in.InstanceUUID requires manual conversion: does not exist in peer-type
 	// WARNING: in.BiosUUID requires manual conversion: does not exist in peer-type
 	return nil
 }

--- a/api/v1alpha2/virtualmachine_conversion.go
+++ b/api/v1alpha2/virtualmachine_conversion.go
@@ -162,6 +162,10 @@ func Convert_v1alpha2_VirtualMachine_To_v1alpha3_VirtualMachine(in *VirtualMachi
 	return nil
 }
 
+func restore_v1alpha3_VirtualMachineInstanceUUID(dst, src *vmopv1.VirtualMachine) {
+	dst.Spec.InstanceUUID = src.Spec.InstanceUUID
+}
+
 func restore_v1alpha3_VirtualMachineBiosUUID(dst, src *vmopv1.VirtualMachine) {
 	dst.Spec.BiosUUID = src.Spec.BiosUUID
 }
@@ -205,6 +209,7 @@ func (src *VirtualMachine) ConvertTo(dstRaw ctrlconversion.Hub) error {
 	// BEGIN RESTORE
 
 	restore_v1alpha3_VirtualMachineImage(dst, restored)
+	restore_v1alpha3_VirtualMachineInstanceUUID(dst, restored)
 	restore_v1alpha3_VirtualMachineBiosUUID(dst, restored)
 	restore_v1alpha3_VirtualMachineBootstrapCloudInitInstanceID(dst, restored)
 	restore_v1alpha3_VirtualMachineSpecNetworkDomainName(dst, restored)

--- a/api/v1alpha2/zz_generated.conversion.go
+++ b/api/v1alpha2/zz_generated.conversion.go
@@ -3196,6 +3196,7 @@ func autoConvert_v1alpha3_VirtualMachineSpec_To_v1alpha2_VirtualMachineSpec(in *
 	out.Advanced = (*VirtualMachineAdvancedSpec)(unsafe.Pointer(in.Advanced))
 	out.Reserved = (*VirtualMachineReservedSpec)(unsafe.Pointer(in.Reserved))
 	out.MinHardwareVersion = in.MinHardwareVersion
+	// WARNING: in.InstanceUUID requires manual conversion: does not exist in peer-type
 	// WARNING: in.BiosUUID requires manual conversion: does not exist in peer-type
 	return nil
 }

--- a/api/v1alpha3/virtualmachine_types.go
+++ b/api/v1alpha3/virtualmachine_types.go
@@ -449,6 +449,17 @@ type VirtualMachineSpec struct {
 	// +optional
 	// +kubebuilder:validation:Format:=uuid
 
+	// InstanceUUID describes the desired Instance UUID for a VM.
+	// If omitted, this field defaults to a random UUID.
+	// This value is only used for the VM Instance UUID,
+	// it is not used within cloudInit.
+	// This identifier is used by VirtualCenter to uniquely identify all
+	// virtual machine instances, including those that may share the same BIOS UUID.
+	InstanceUUID string `json:"instanceUUID,omitempty"`
+
+	// +optional
+	// +kubebuilder:validation:Format:=uuid
+
 	// BiosUUID describes the desired BIOS UUID for a VM.
 	// If omitted, this field defaults to a random UUID.
 	// When the bootstrap provider is Cloud-Init, this value is used as the

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachinereplicasets.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachinereplicasets.yaml
@@ -1040,6 +1040,16 @@ spec:
                           spec.image are both non-empty, then they must refer to the same
                           resource or an error is returned.
                         type: string
+                      instanceUUID:
+                        description: |-
+                          InstanceUUID describes the desired Instance UUID for a VM.
+                          If omitted, this field defaults to a random UUID.
+                          This value is only used for the VM Instance UUID,
+                          it is not used within cloudInit.
+                          This identifier is used by VirtualCenter to uniquely identify all
+                          virtual machine instances, including those that may share the same BIOS UUID.
+                        format: uuid
+                        type: string
                       minHardwareVersion:
                         description: |-
                           MinHardwareVersion describes the desired, minimum hardware version.

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -4034,6 +4034,16 @@ spec:
                   spec.image are both non-empty, then they must refer to the same
                   resource or an error is returned.
                 type: string
+              instanceUUID:
+                description: |-
+                  InstanceUUID describes the desired Instance UUID for a VM.
+                  If omitted, this field defaults to a random UUID.
+                  This value is only used for the VM Instance UUID,
+                  it is not used within cloudInit.
+                  This identifier is used by VirtualCenter to uniquely identify all
+                  virtual machine instances, including those that may share the same BIOS UUID.
+                format: uuid
+                type: string
               minHardwareVersion:
                 description: |-
                   MinHardwareVersion describes the desired, minimum hardware version.

--- a/controllers/virtualmachine/virtualmachine_controller.go
+++ b/controllers/virtualmachine/virtualmachine_controller.go
@@ -158,6 +158,13 @@ func classToVMMapperFn(ctx *pkgctx.ControllerManagerContext, c client.Client, is
 }
 
 func upgradeSchema(ctx *pkgctx.VirtualMachineContext) {
+	// If empty, this VM was created before v1alpha3 added the spec.instanceUUID field.
+	if ctx.VM.Spec.InstanceUUID == "" && ctx.VM.Status.InstanceUUID != "" {
+		ctx.VM.Spec.InstanceUUID = ctx.VM.Status.InstanceUUID
+		ctx.Logger.Info("Upgrade VirtualMachine spec",
+			"instanceUUID", ctx.VM.Spec.InstanceUUID)
+	}
+
 	// If empty, this VM was created before v1alpha3 added the spec.biosUUID field.
 	if ctx.VM.Spec.BiosUUID == "" && ctx.VM.Status.BiosUUID != "" {
 		ctx.VM.Spec.BiosUUID = ctx.VM.Status.BiosUUID

--- a/pkg/providers/vsphere/virtualmachine/configspec.go
+++ b/pkg/providers/vsphere/virtualmachine/configspec.go
@@ -42,10 +42,14 @@ func CreateConfigSpec(
 	}
 
 	// spec.biosUUID is only set when creating a VM and is immutable.
-	// These two fields should not be updated for existing VMs.
+	// This field should not be updated for existing VMs.
 	if id := vmCtx.VM.Spec.BiosUUID; id != "" {
 		configSpec.Uuid = id
-		configSpec.InstanceUuid = string(vmCtx.VM.UID)
+	}
+	// spec.instanceUUID is only set when creating a VM and is immutable.
+	// This field should not be updated for existing VMs.
+	if id := vmCtx.VM.Spec.InstanceUUID; id != "" {
+		configSpec.InstanceUuid = id
 	}
 
 	hardwareVersion := determineHardwareVersion(vmCtx.VM, &configSpec, vmImageStatus)

--- a/pkg/providers/vsphere/virtualmachine/configspec_test.go
+++ b/pkg/providers/vsphere/virtualmachine/configspec_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/google/uuid"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
@@ -54,8 +53,8 @@ var _ = Describe("CreateConfigSpec", func() {
 
 		vm = builder.DummyVirtualMachine()
 		vm.Name = vmName
-		vm.UID = types.UID(uuid.New().String())
-		vm.Spec.BiosUUID = uuid.New().String()
+		vm.Spec.InstanceUUID = uuid.NewString()
+		vm.Spec.BiosUUID = uuid.NewString()
 		// Explicitly set these in the tests.
 		vm.Spec.Volumes = nil
 		vm.Spec.MinHardwareVersion = 0
@@ -97,8 +96,9 @@ var _ = Describe("CreateConfigSpec", func() {
 			})
 		})
 
-		When("VM has no bios uuid", func() {
+		When("VM has no bios or instance uuid", func() {
 			BeforeEach(func() {
+				vm.Spec.InstanceUUID = ""
 				vm.Spec.BiosUUID = ""
 			})
 
@@ -108,11 +108,11 @@ var _ = Describe("CreateConfigSpec", func() {
 			})
 		})
 
-		When("VM has bios uuid", func() {
+		When("VM has bios and instance uuid", func() {
 			It("config spec has expected uuids", func() {
 				Expect(configSpec.Uuid).ToNot(BeEmpty())
 				Expect(configSpec.Uuid).To(Equal(vm.Spec.BiosUUID))
-				Expect(configSpec.InstanceUuid).To(BeEquivalentTo(vm.UID))
+				Expect(configSpec.InstanceUuid).To(BeEquivalentTo(vm.Spec.InstanceUUID))
 			})
 		})
 

--- a/webhooks/virtualmachine/mutation/virtualmachine_mutator_intg_test.go
+++ b/webhooks/virtualmachine/mutation/virtualmachine_mutator_intg_test.go
@@ -114,6 +114,55 @@ func intgTestsMutating() {
 		})
 	})
 
+	Context("SetDefaultInstanceUUID", func() {
+		When("Creating VirtualMachine", func() {
+			When("When VM InstanceUUID is empty", func() {
+				BeforeEach(func() {
+					ctx.vm.Spec.InstanceUUID = ""
+				})
+
+				It("Should set InstanceUUID", func() {
+					Expect(ctx.Client.Create(ctx, ctx.vm)).To(Succeed())
+
+					vm := &vmopv1.VirtualMachine{}
+					Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(ctx.vm), vm)).To(Succeed())
+					Expect(vm.Spec.InstanceUUID).ToNot(BeEmpty())
+				})
+			})
+			When("When VM InstanceUUID is not empty", func() {
+				var id = uuid.NewString()
+
+				BeforeEach(func() {
+					ctx.vm.Spec.InstanceUUID = id
+				})
+
+				It("Should not mutate InstanceUUID", func() {
+					Expect(ctx.Client.Create(ctx, ctx.vm)).To(Succeed())
+					vm := &vmopv1.VirtualMachine{}
+					Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(ctx.vm), vm)).To(Succeed())
+					Expect(vm.Spec.InstanceUUID).To(Equal(id))
+				})
+			})
+		})
+
+		When("Updating VirtualMachine", func() {
+			var id = uuid.NewString()
+
+			BeforeEach(func() {
+				ctx.vm.Spec.InstanceUUID = id
+				Expect(ctx.Client.Create(ctx, ctx.vm)).To(Succeed())
+			})
+
+			It("Should not mutate InstanceUUID", func() {
+				vm := &vmopv1.VirtualMachine{}
+				Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(ctx.vm), vm)).To(Succeed())
+				Expect(ctx.Client.Update(ctx, vm)).To(Succeed())
+				Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(ctx.vm), vm)).To(Succeed())
+				Expect(vm.Spec.InstanceUUID).To(Equal(id))
+			})
+		})
+	})
+
 	Context("SetDefaultBiosUUID", func() {
 		When("Creating VirtualMachine", func() {
 			When("When VM BiosUUID is empty", func() {
@@ -130,7 +179,7 @@ func intgTestsMutating() {
 				})
 			})
 			When("When VM BiosUUID is not empty", func() {
-				var id = uuid.New().String()
+				var id = uuid.NewString()
 
 				BeforeEach(func() {
 					ctx.vm.Spec.BiosUUID = id
@@ -146,7 +195,7 @@ func intgTestsMutating() {
 		})
 
 		When("Updating VirtualMachine", func() {
-			var id = uuid.New().String()
+			var id = uuid.NewString()
 
 			BeforeEach(func() {
 				ctx.vm.Spec.BiosUUID = id

--- a/webhooks/virtualmachine/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator.go
@@ -1015,6 +1015,10 @@ func (v validator) validateImmutableFields(ctx *pkgctx.WebhookRequestContext, vm
 	if oldVM.Spec.BiosUUID != "" {
 		allErrs = append(allErrs, validation.ValidateImmutableField(vm.Spec.BiosUUID, oldVM.Spec.BiosUUID, specPath.Child("biosUUID"))...)
 	}
+	// New VMs always have non-empty instanceUUID. Existing VMs being upgraded may have an empty instanceUUID.
+	if oldVM.Spec.InstanceUUID != "" {
+		allErrs = append(allErrs, validation.ValidateImmutableField(vm.Spec.InstanceUUID, oldVM.Spec.InstanceUUID, specPath.Child("instanceUUID"))...)
+	}
 	allErrs = append(allErrs, v.validateImmutableReserved(ctx, vm, oldVM)...)
 	allErrs = append(allErrs, v.validateImmutableNetwork(ctx, vm, oldVM)...)
 


### PR DESCRIPTION
For VM Import, we want the desired instance UUID to match the underlying instance UUID of the VM

Note: needs #492 merged before doc update