### PR TITLE
🌱 Support system:masters for IsPrivilegedUser

### DIFF
--- a/pkg/builder/auth.go
+++ b/pkg/builder/auth.go
@@ -12,10 +12,21 @@ import (
 func IsPrivilegedAccount(
 	ctx *pkgctx.WebhookContext, userInfo authv1.UserInfo) bool {
 
-	username := userInfo.Username
+	// Per https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles,
+	// any user that belongs to the group "system:masters" is a cluster-admin.
+	for i := range userInfo.Groups {
+		if userInfo.Groups[i] == "system:masters" {
+			return true
+		}
+	}
 
+	username := userInfo.Username
 	if strings.EqualFold(username, kubeAdminUser) {
 		return true
+	}
+
+	if ctx == nil {
+		return false
 	}
 
 	// Users specified by Pod's environment variable "PRIVILEGED_USERS" are

--- a/pkg/builder/auth_test.go
+++ b/pkg/builder/auth_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package builder_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	authv1 "k8s.io/api/authentication/v1"
+
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
+	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+
+	"github.com/vmware-tanzu/vm-operator/pkg/builder"
+)
+
+var _ = DescribeTable("IsPrivilegedAccount",
+	func(ctx *pkgctx.WebhookContext, userInfo authv1.UserInfo, expected bool) {
+		Ω(builder.IsPrivilegedAccount(ctx, userInfo)).To(Equal(expected))
+	},
+	Entry(
+		"empty inputs",
+		&pkgctx.WebhookContext{Context: pkgcfg.NewContext()},
+		authv1.UserInfo{},
+		false,
+	),
+	Entry(
+		"belongs to system:masters group",
+		&pkgctx.WebhookContext{},
+		authv1.UserInfo{
+			Groups: []string{"system:masters"},
+		},
+		true,
+	),
+	Entry(
+		"is kubernetes-admin user",
+		&pkgctx.WebhookContext{},
+		authv1.UserInfo{
+			Username: "kubernetes-admin",
+		},
+		true,
+	),
+	Entry(
+		"is in priv user list",
+		&pkgctx.WebhookContext{
+			Context: pkgcfg.WithConfig(pkgcfg.Config{
+				PrivilegedUsers: "hello,world,fubar",
+			}),
+		},
+		authv1.UserInfo{
+			Username: "world",
+		},
+		true,
+	),
+	Entry(
+		"is service account",
+		&pkgctx.WebhookContext{
+			Context:            pkgcfg.NewContext(),
+			Namespace:          "my-ns",
+			ServiceAccountName: "my-svc-acct",
+		},
+		authv1.UserInfo{
+			Username: "system:serviceaccount:my-ns:my-svc-acct",
+		},
+		true,
+	),
+)

--- a/pkg/builder/builder_suite_test.go
+++ b/pkg/builder/builder_suite_test.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package builder_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/klog/v2"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func init() {
+	klog.SetOutput(GinkgoWriter)
+	logf.SetLogger(klog.Background())
+}
+
+func TestKube(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Builder Test Suite")
+}


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch updates the IsPrivilegedUser function for webhooks to support the membership in the system:masters group as signal the user is privileged. This is consistent with the Kubernetes documentation at
https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles.

This also means the integration tests in this project that depend on envtest will now access the API server as an admin.

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

This blocks https://github.com/vmware-tanzu/vm-operator/pull/518 since it has a failing IT that expects the client to be an admin.

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Treat membership in system:masters group as signal the user is privileged
```