### PR TITLE
✨ Plumb through basic end to end resize

### DIFF
--- a/pkg/providers/vsphere/vmprovider_vm_resize_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_resize_test.go
@@ -1,0 +1,170 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package vsphere_test
+
+import (
+	"bytes"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
+	"github.com/vmware-tanzu/vm-operator/pkg/providers"
+	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+func vmResizeTests() {
+
+	var (
+		initObjects []client.Object
+		testConfig  builder.VCSimTestConfig
+		ctx         *builder.TestContextForVCSim
+		vmProvider  providers.VirtualMachineProviderInterface
+		nsInfo      builder.WorkloadNamespaceInfo
+	)
+
+	BeforeEach(func() {
+		testConfig = builder.VCSimTestConfig{
+			WithContentLibrary: true,
+			WithVMResize:       true,
+			WithNetworkEnv:     builder.NetworkEnvNamed,
+		}
+	})
+
+	JustBeforeEach(func() {
+		ctx = suite.NewTestContextForVCSim(testConfig, initObjects...)
+		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+			config.MaxDeployThreadsOnProvider = 1
+		})
+		vmProvider = vsphere.NewVSphereVMProviderFromClient(ctx, ctx.Client, ctx.Recorder)
+		nsInfo = ctx.CreateWorkloadNamespace()
+	})
+
+	AfterEach(func() {
+		ctx.AfterEach()
+		ctx = nil
+		initObjects = nil
+		vmProvider = nil
+		nsInfo = builder.WorkloadNamespaceInfo{}
+	})
+
+	encodedConfigSpec := func(cs vimtypes.VirtualMachineConfigSpec) []byte {
+		var w bytes.Buffer
+		enc := vimtypes.NewJSONEncoder(&w)
+		Expect(enc.Encode(cs)).To(Succeed())
+		return w.Bytes()
+	}
+
+	createOrUpdateAndGetVcVM := func(
+		ctx *builder.TestContextForVCSim,
+		vm *vmopv1.VirtualMachine) (*object.VirtualMachine, error) {
+
+		err := vmProvider.CreateOrUpdateVirtualMachine(ctx, vm)
+		if err != nil {
+			return nil, err
+		}
+
+		ExpectWithOffset(1, vm.Status.UniqueID).ToNot(BeEmpty())
+		vcVM := ctx.GetVMFromMoID(vm.Status.UniqueID)
+		ExpectWithOffset(1, vcVM).ToNot(BeNil())
+		return vcVM, nil
+	}
+
+	createVMClass := func(cs vimtypes.VirtualMachineConfigSpec, name ...string) *vmopv1.VirtualMachineClass {
+		var class *vmopv1.VirtualMachineClass
+		if len(name) == 1 {
+			class = builder.DummyVirtualMachineClass(name[0])
+		} else {
+			class = builder.DummyVirtualMachineClassGenName()
+		}
+		class.Namespace = nsInfo.Namespace
+		class.Spec.ConfigSpec = encodedConfigSpec(cs)
+		class.Spec.Hardware.Cpus = int64(cs.NumCPUs)
+		class.Spec.Hardware.Memory = resource.MustParse(fmt.Sprintf("%dMi", cs.MemoryMB))
+		ExpectWithOffset(1, ctx.Client.Create(ctx, class)).To(Succeed())
+		return class
+	}
+
+	Context("Resize VM", func() {
+
+		var (
+			vm         *vmopv1.VirtualMachine
+			vmClass    *vmopv1.VirtualMachineClass
+			configSpec vimtypes.VirtualMachineConfigSpec
+		)
+
+		BeforeEach(func() {
+			vm = builder.DummyBasicVirtualMachine("test-vm", "")
+
+			configSpec = vimtypes.VirtualMachineConfigSpec{}
+			configSpec.NumCPUs = 1
+			configSpec.MemoryMB = 512
+		})
+
+		JustBeforeEach(func() {
+			vmClass = createVMClass(configSpec, "initial-class")
+
+			clusterVMImage := &vmopv1.ClusterVirtualMachineImage{}
+			Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: ctx.ContentLibraryImageName}, clusterVMImage)).To(Succeed())
+
+			vm.Namespace = nsInfo.Namespace
+			vm.Spec.ClassName = vmClass.Name
+			vm.Spec.ImageName = clusterVMImage.Name
+			vm.Spec.Image.Kind = cvmiKind
+			vm.Spec.Image.Name = clusterVMImage.Name
+			vm.Spec.PowerState = vmopv1.VirtualMachinePowerStateOff
+			vm.Spec.StorageClass = ctx.StorageClassName
+
+			_, err := createOrUpdateAndGetVcVM(ctx, vm)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		Context("NumCPUs", func() {
+			BeforeEach(func() {
+				configSpec.NumCPUs = 2
+			})
+
+			It("Resizes", func() {
+				cs := configSpec
+				cs.NumCPUs = 42
+				vm.Spec.ClassName = createVMClass(cs).Name
+
+				vcVM, err := createOrUpdateAndGetVcVM(ctx, vm)
+				Expect(err).ToNot(HaveOccurred())
+
+				var o mo.VirtualMachine
+				Expect(vcVM.Properties(ctx, vcVM.Reference(), nil, &o)).To(Succeed())
+				Expect(o.Config.Hardware.NumCPU).To(BeEquivalentTo(42))
+			})
+		})
+
+		Context("MemoryMB", func() {
+			BeforeEach(func() {
+				configSpec.MemoryMB = 1024
+			})
+
+			It("Resizes", func() {
+				cs := configSpec
+				cs.MemoryMB = 8192
+				vm.Spec.ClassName = createVMClass(cs).Name
+
+				vcVM, err := createOrUpdateAndGetVcVM(ctx, vm)
+				Expect(err).ToNot(HaveOccurred())
+
+				var o mo.VirtualMachine
+				Expect(vcVM.Properties(ctx, vcVM.Reference(), nil, &o)).To(Succeed())
+				Expect(o.Config.Hardware.MemoryMB).To(BeEquivalentTo(8192))
+			})
+		})
+	})
+}

--- a/pkg/providers/vsphere/vsphere_suite_test.go
+++ b/pkg/providers/vsphere/vsphere_suite_test.go
@@ -19,6 +19,7 @@ func vcSimTests() {
 	Describe("ResourcePolicyTests", resourcePolicyTests)
 	Describe("VirtualMachine", vmTests)
 	Describe("VirtualMachineE2E", vmE2ETests)
+	Describe("VirtualMachineResize", vmResizeTests)
 	Describe("VirtualMachineUtilsTest", vmUtilTests)
 }
 

--- a/pkg/util/resize/configspec.go
+++ b/pkg/util/resize/configspec.go
@@ -3,12 +3,17 @@
 
 package resize
 
-import vimtypes "github.com/vmware/govmomi/vim25/types"
+import (
+	"context"
+
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+)
 
 // CreateResizeConfigSpec takes the current VM state in the ConfigInfo and compares it to the
 // desired state in the ConfigSpec, returning a ConfigSpec with any required changes to drive
 // the desired state.
 func CreateResizeConfigSpec(
+	_ context.Context,
 	ci vimtypes.VirtualMachineConfigInfo,
 	cs vimtypes.VirtualMachineConfigSpec) (vimtypes.VirtualMachineConfigSpec, error) {
 

--- a/pkg/util/resize/configspec_test.go
+++ b/pkg/util/resize/configspec_test.go
@@ -4,6 +4,7 @@
 package resize_test
 
 import (
+	"context"
 	"reflect"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -20,12 +21,14 @@ type ConfigInfo = vimtypes.VirtualMachineConfigInfo
 
 var _ = Describe("CreateResizeConfigSpec", func() {
 
+	ctx := context.Background()
+
 	DescribeTable("Simple fields",
 		func(
 			ci vimtypes.VirtualMachineConfigInfo,
 			cs, expectedCS vimtypes.VirtualMachineConfigSpec) {
 
-			actualCS, err := resize.CreateResizeConfigSpec(ci, cs)
+			actualCS, err := resize.CreateResizeConfigSpec(ctx, ci, cs)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(reflect.DeepEqual(actualCS, expectedCS)).To(BeTrue(), cmp.Diff(actualCS, expectedCS))
 		},

--- a/test/builder/vcsim_test_context.go
+++ b/test/builder/vcsim_test_context.go
@@ -77,6 +77,9 @@ type VCSimTestConfig struct {
 	// WithInstanceStorage enables the WCP_INSTANCE_STORAGE FSS.
 	WithInstanceStorage bool
 
+	// WithVMResize enables the FSS_WCP_VMSERVICE_RESIZE FSS.
+	WithVMResize bool
+
 	// WithoutStorageClass disables the storage class required, meaning that the
 	// Datastore will be used instead. In WCP production the storage class is
 	// always required; the Datastore is only needed for gce2e.
@@ -296,6 +299,7 @@ func (c *TestContextForVCSim) setupEnv(config VCSimTestConfig) {
 		cc.JSONExtraConfig = config.WithJSONExtraConfig
 
 		cc.Features.InstanceStorage = config.WithInstanceStorage
+		cc.Features.VMResize = config.WithVMResize
 	})
 }
 


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

This is just the minimal plumbing needed to go through resize when the VM is in steady-state off. Lots of supporting plumbing is still needed like handling the last resize annotation when the VM Class does not exist, and building the full ConfigSpec that includes expected network devices, but this lets us work on the end to end resize.

This also copies the existing getUpdateArgsFn hack that we have as a holdover from the old Session days that we'll likely need to clean up as we have time.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:



**Please add a release note if necessary**:

```release-note
NONE
```