### PR TITLE
🐛 Add FSS_WCP_MOBILITY_VM_IMPORT_NEW_NET to yaml

### DIFF
--- a/config/local/vmoperator/local_env_var_patch.yaml
+++ b/config/local/vmoperator/local_env_var_patch.yaml
@@ -23,6 +23,9 @@ spec:
           value: "false"
         - name: FSS_WCP_TKG_Multiple_CL
           value: "false"
+        - name: FSS_WCP_MOBILITY_VM_IMPORT_NEW_NET
+          value: "false"
+
         #
         # Feature state switch flags beneath this line are enabled on main and
         # only retained in this file because it is used by internal testing to

--- a/config/wcp/vmoperator/manager_env_var_patch.yaml
+++ b/config/wcp/vmoperator/manager_env_var_patch.yaml
@@ -64,6 +64,12 @@
     name: FSS_WCP_VMSERVICE_RESIZE
     value: "<FSS_WCP_VMSERVICE_RESIZE_VALUE>"
 
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: FSS_WCP_MOBILITY_VM_IMPORT_NEW_NET
+    value: "<FSS_WCP_MOBILITY_VM_IMPORT_NEW_NET_VALUE>"
+
 #
 # Feature state switch flags beneath this line are enabled on main and only
 # retained in this file because it is used by internal testing to determine the


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch fixes a bug where the FSS for the feature FSS_WCP_MOBILITY_VM_IMPORT_NEW_NET was added into pkg/config but not to the deployment YAML.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```