### PR TITLE
🐛 Fix verify-codegen.sh to get exit code correctly

### DIFF
--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -10,8 +10,8 @@ set -o pipefail
 # script is located.
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
-if ! make generate; then
-  exit_code="${?}"
+make generate || exit_code="${?}"
+if [ "${exit_code:-0}" -ne 0 ]; then
 
   # Please note the following heredoc uses leading tabs to allow
   # the contents to be indented with the if/fi statement. For
@@ -55,8 +55,8 @@ else
   exit "${exit_code}"
 fi
 
-if ! make generate-go-conversions; then
-  exit_code="${?}"
+make generate-go-conversions || exit_code="${?}"
+if [ "${exit_code:-0}" -ne 0 ]; then
 
   # Please note the following heredoc uses leading tabs to allow
   # the contents to be indented with the if/fi statement. For


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR fixes a bug in the verify-codegen.sh to get the actual exit code from the executed make commands. This ensures that the verify-codegen GitHub workflow job terminates with the correct exit code when the make generate commands fail.

**Are there any special notes for your reviewer**:

The previous code would always capture the exit code as 0, e.g.:

```bash
if ! false; then echo "${?}"; else echo "fine"; fi;
```

would print out "0" even though the `false` command exits with `1`.


See https://github.com/vmware-tanzu/vm-operator/actions/runs/9098850495/job/25010046314?pr=519 where the `make generate` fails with an error message printed out, but the GitHub workflow was reported as successful. 

**Please add a release note if necessary**:

```release-note
Fix verify-codegen.sh used in GitHub CI workflow to exit correctly.
```