### PR TITLE
🐛 Fix make generate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -262,7 +262,7 @@ generate: ## Generate code
 .PHONY: generate-go
 generate-go: $(CONTROLLER_GEN)
 generate-go: ## Generate golang sources
-	go generate ./api/...
+	go -C ./api generate ./...
 	$(CONTROLLER_GEN) \
 		paths=github.com/vmware-tanzu/vm-operator/api/... \
 		object:headerFile=./hack/boilerplate/boilerplate.generatego.txt

--- a/api/v1alpha3/virtualmachine_types.go
+++ b/api/v1alpha3/virtualmachine_types.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2024-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate go run ../../pkg/gen/guestosid/guestosid.go v1alpha3 zz_virtualmachine_guestosid_generated.go
+//go:generate go -C ../.. run ./pkg/gen/guestosid/guestosid.go v1alpha3 ./api/v1alpha3/zz_virtualmachine_guestosid_generated.go
 
 package v1alpha3
 


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch fixes an issue with the make generate target. Specifically, "go generate ./api/...". This used to work in Go 1.21, but it no longer works across modules in Go 1.22. This patch fixes the issue.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```