### PR TITLE
✨ Support for imageless VirtualMachine resources

### DIFF
--- a/api/v1alpha3/virtualmachine_types.go
+++ b/api/v1alpha3/virtualmachine_types.go
@@ -242,6 +242,11 @@ type VirtualMachineSpec struct {
 	// Please also note, when creating a new VirtualMachine, if this field and
 	// spec.imageName are both non-empty, then they must refer to the same
 	// resource or an error is returned.
+	//
+	// Please note, this field *may* be empty if the VM was imported instead of
+	// deployed by VM Operator. An imported VirtualMachine resource references
+	// an existing VM on the underlying platform that was not deployed from a
+	// VM image.
 	Image *VirtualMachineImageRef `json:"image,omitempty"`
 
 	// +optional
@@ -268,6 +273,11 @@ type VirtualMachineSpec struct {
 	// Please also note, when creating a new VirtualMachine, if this field and
 	// spec.image are both non-empty, then they must refer to the same
 	// resource or an error is returned.
+	//
+	// Please note, this field *may* be empty if the VM was imported instead of
+	// deployed by VM Operator. An imported VirtualMachine resource references
+	// an existing VM on the underlying platform that was not deployed from a
+	// VM image.
 	ImageName string `json:"imageName,omitempty"`
 
 	// +optional

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachinereplicasets.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachinereplicasets.yaml
@@ -1003,6 +1003,12 @@ spec:
                           Please also note, when creating a new VirtualMachine, if this field and
                           spec.imageName are both non-empty, then they must refer to the same
                           resource or an error is returned.
+
+
+                          Please note, this field *may* be empty if the VM was imported instead of
+                          deployed by VM Operator. An imported VirtualMachine resource references
+                          an existing VM on the underlying platform that was not deployed from a
+                          VM image.
                         properties:
                           kind:
                             description: |-
@@ -1045,6 +1051,12 @@ spec:
                           Please also note, when creating a new VirtualMachine, if this field and
                           spec.image are both non-empty, then they must refer to the same
                           resource or an error is returned.
+
+
+                          Please note, this field *may* be empty if the VM was imported instead of
+                          deployed by VM Operator. An imported VirtualMachine resource references
+                          an existing VM on the underlying platform that was not deployed from a
+                          VM image.
                         type: string
                       instanceUUID:
                         description: |-

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -3997,6 +3997,12 @@ spec:
                   Please also note, when creating a new VirtualMachine, if this field and
                   spec.imageName are both non-empty, then they must refer to the same
                   resource or an error is returned.
+
+
+                  Please note, this field *may* be empty if the VM was imported instead of
+                  deployed by VM Operator. An imported VirtualMachine resource references
+                  an existing VM on the underlying platform that was not deployed from a
+                  VM image.
                 properties:
                   kind:
                     description: |-
@@ -4039,6 +4045,12 @@ spec:
                   Please also note, when creating a new VirtualMachine, if this field and
                   spec.image are both non-empty, then they must refer to the same
                   resource or an error is returned.
+
+
+                  Please note, this field *may* be empty if the VM was imported instead of
+                  deployed by VM Operator. An imported VirtualMachine resource references
+                  an existing VM on the underlying platform that was not deployed from a
+                  VM image.
                 type: string
               instanceUUID:
                 description: |-

--- a/pkg/providers/vsphere/vmprovider_vm_utils.go
+++ b/pkg/providers/vsphere/vmprovider_vm_utils.go
@@ -125,6 +125,15 @@ func getVirtualMachineClassFromClassName(
 	return obj, nil
 }
 
+// GetVirtualMachineImageSpecAndStatus returns either the VirtualMachineImage
+// or ClusterVirtualMachineImage resource, as well as its spec and status, for
+// the resource used to deploy a VM.
+//
+// Please note, this function is *not* designed to be invoked in the "update"
+// VM workflow. This function assumes it is only ever invoked as part of the
+// "create" workflow. For example, spec.image *can* be nil during the update
+// workflow for imported VMs, and that is perfectly legal. However, this
+// function marks a VM in error during the create workflow if spec.image is nil.
 func GetVirtualMachineImageSpecAndStatus(
 	vmCtx pkgctx.VirtualMachineContext,
 	k8sClient ctrlclient.Client) (ctrlclient.Object, vmopv1.VirtualMachineImageSpec, vmopv1.VirtualMachineImageStatus, error) {

--- a/pkg/util/vmopv1/vm.go
+++ b/pkg/util/vmopv1/vm.go
@@ -209,3 +209,9 @@ func HasPVC(vm vmopv1.VirtualMachine) bool {
 func IsClasslessVM(vm vmopv1.VirtualMachine) bool {
 	return vm.Spec.ClassName == ""
 }
+
+// IsImagelessVM returns true if the provided VM was not deployed from a VM
+// image.
+func IsImagelessVM(vm vmopv1.VirtualMachine) bool {
+	return vm.Spec.Image == nil && vm.Spec.ImageName == ""
+}

--- a/pkg/util/vmopv1/vm_test.go
+++ b/pkg/util/vmopv1/vm_test.go
@@ -443,3 +443,52 @@ var _ = DescribeTable("IsClasslessVM",
 		false,
 	),
 )
+
+var _ = DescribeTable("IsImageLessVM",
+	func(
+		vm vmopv1.VirtualMachine,
+		expected bool,
+	) {
+		Ω(vmopv1util.IsImagelessVM(vm)).Should(Equal(expected))
+	},
+	Entry(
+		"spec.image is nil and spec.imageName is empty",
+		vmopv1.VirtualMachine{
+			Spec: vmopv1.VirtualMachineSpec{
+				Image:     nil,
+				ImageName: "",
+			},
+		},
+		true,
+	),
+	Entry(
+		"spec.image is not nil and spec.imageName is empty",
+		vmopv1.VirtualMachine{
+			Spec: vmopv1.VirtualMachineSpec{
+				Image:     &vmopv1.VirtualMachineImageRef{},
+				ImageName: "",
+			},
+		},
+		false,
+	),
+	Entry(
+		"spec.image is nil and spec.imageName is non-empty",
+		vmopv1.VirtualMachine{
+			Spec: vmopv1.VirtualMachineSpec{
+				Image:     nil,
+				ImageName: "non-empty",
+			},
+		},
+		false,
+	),
+	Entry(
+		"spec.image is not nil and spec.imageName is non-empty",
+		vmopv1.VirtualMachine{
+			Spec: vmopv1.VirtualMachineSpec{
+				Image:     &vmopv1.VirtualMachineImageRef{},
+				ImageName: "non-empty",
+			},
+		},
+		false,
+	),
+)

--- a/webhooks/virtualmachine/validation/virtualmachine_validator_intg_test.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator_intg_test.go
@@ -74,7 +74,7 @@ func intgTestsValidateCreate() {
 		invalid          = "invalid"
 		vmiKind          = "VirtualMachineImage"
 		cvmiKind         = "Cluster" + vmiKind
-		invalidImageKind = "supported: " + vmiKind + ", " + cvmiKind
+		invalidImageKind = "supported: " + vmiKind + "; " + cvmiKind
 	)
 
 	var (


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch introduces support for VirtualMachine resources that were not originally deployed by VM Service, and therefore do not have an associated VirtualMachineImage.



**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

Please note that unlike #510, this change does not synthesize a fake image based on the existing VM. This is because the only time the VM Image resource is ever read is during create, IFF the VM cannot be found in the inventory. Since this never happens for imported VMs, there is never a call to `GetVirtualMachineImageSpecAndStatus`.


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Support for managing VirtualMachine resources sans valid value for spec.image as long as VM already exists in underlying platform.
```