### PR TITLE
🌱 Compare basic ConfigSpec.Hardware fields for resize

### DIFF
--- a/pkg/util/resize/configspec.go
+++ b/pkg/util/resize/configspec.go
@@ -19,28 +19,36 @@ func CreateResizeConfigSpec(
 
 	outCS := vimtypes.VirtualMachineConfigSpec{}
 
-	compareNumCpus(ci, cs, &outCS)
-	compareMemoryMB(ci, cs, &outCS)
+	compareHardware(ci, cs, &outCS)
 
 	return outCS, nil
 }
 
-func compareNumCpus(
+// compareHardware compares the ConfigSpec.Hardware.
+func compareHardware(
 	ci vimtypes.VirtualMachineConfigInfo,
 	cs vimtypes.VirtualMachineConfigSpec,
 	outCS *vimtypes.VirtualMachineConfigSpec) {
 
-	if ci.Hardware.NumCPU != cs.NumCPUs {
-		outCS.NumCPUs = cs.NumCPUs
+	cmp(ci.Hardware.NumCPU, cs.NumCPUs, &outCS.NumCPUs)
+	cmp(ci.Hardware.NumCoresPerSocket, cs.NumCoresPerSocket, &outCS.NumCoresPerSocket)
+	// outCS.AutoCoresPerSocket = ...
+	cmp(int64(ci.Hardware.MemoryMB), cs.MemoryMB, &outCS.MemoryMB)
+	cmpPtr(ci.Hardware.VirtualICH7MPresent, cs.VirtualICH7MPresent, &outCS.VirtualICH7MPresent)
+	cmpPtr(ci.Hardware.VirtualSMCPresent, cs.VirtualSMCPresent, &outCS.VirtualSMCPresent)
+	// outCS.Device = ...
+	cmp(ci.Hardware.MotherboardLayout, cs.MotherboardLayout, &outCS.MotherboardLayout)
+	cmp(ci.Hardware.SimultaneousThreads, cs.SimultaneousThreads, &outCS.SimultaneousThreads)
+}
+
+func cmp[T comparable](a, b T, c *T) {
+	if a != b {
+		*c = b
 	}
 }
 
-func compareMemoryMB(
-	ci vimtypes.VirtualMachineConfigInfo,
-	cs vimtypes.VirtualMachineConfigSpec,
-	outCS *vimtypes.VirtualMachineConfigSpec) {
-
-	if int64(ci.Hardware.MemoryMB) != cs.MemoryMB {
-		outCS.MemoryMB = cs.MemoryMB
+func cmpPtr[T comparable](a *T, b *T, c **T) {
+	if (a == nil || b == nil) || *a != *b {
+		*c = b
 	}
 }

--- a/pkg/util/resize/configspec_test.go
+++ b/pkg/util/resize/configspec_test.go
@@ -22,8 +22,9 @@ type ConfigInfo = vimtypes.VirtualMachineConfigInfo
 var _ = Describe("CreateResizeConfigSpec", func() {
 
 	ctx := context.Background()
+	truePtr, falsePtr := vimtypes.NewBool(true), vimtypes.NewBool(false)
 
-	DescribeTable("Simple fields",
+	DescribeTable("ConfigInfo.Hardware",
 		func(
 			ci vimtypes.VirtualMachineConfigInfo,
 			cs, expectedCS vimtypes.VirtualMachineConfigSpec) {
@@ -32,6 +33,11 @@ var _ = Describe("CreateResizeConfigSpec", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(reflect.DeepEqual(actualCS, expectedCS)).To(BeTrue(), cmp.Diff(actualCS, expectedCS))
 		},
+
+		Entry("Empty Hardware needs no updating",
+			ConfigInfo{Hardware: vimtypes.VirtualHardware{}},
+			ConfigSpec{},
+			ConfigSpec{}),
 
 		Entry("NumCPUs needs updating",
 			ConfigInfo{Hardware: vimtypes.VirtualHardware{NumCPU: 2}},
@@ -42,6 +48,15 @@ var _ = Describe("CreateResizeConfigSpec", func() {
 			ConfigSpec{NumCPUs: 4},
 			ConfigSpec{}),
 
+		Entry("NumCoresPerSocket needs updating",
+			ConfigInfo{Hardware: vimtypes.VirtualHardware{NumCoresPerSocket: 2}},
+			ConfigSpec{NumCoresPerSocket: 4},
+			ConfigSpec{NumCoresPerSocket: 4}),
+		Entry("NumCoresPerSocket does not need updating",
+			ConfigInfo{Hardware: vimtypes.VirtualHardware{NumCoresPerSocket: 4}},
+			ConfigSpec{NumCoresPerSocket: 4},
+			ConfigSpec{}),
+
 		Entry("MemoryMB needs updating",
 			ConfigInfo{Hardware: vimtypes.VirtualHardware{MemoryMB: 512}},
 			ConfigSpec{NumCPUs: 1024},
@@ -49,6 +64,50 @@ var _ = Describe("CreateResizeConfigSpec", func() {
 		Entry("MemoryMB does not need updating",
 			ConfigInfo{Hardware: vimtypes.VirtualHardware{MemoryMB: 1024}},
 			ConfigSpec{MemoryMB: 1024},
+			ConfigSpec{}),
+
+		Entry("VirtualICH7MPresent needs updating",
+			ConfigInfo{Hardware: vimtypes.VirtualHardware{VirtualICH7MPresent: truePtr}},
+			ConfigSpec{VirtualICH7MPresent: falsePtr},
+			ConfigSpec{VirtualICH7MPresent: falsePtr}),
+		Entry("VirtualICH7MPresent needs updating",
+			ConfigInfo{Hardware: vimtypes.VirtualHardware{VirtualICH7MPresent: nil}},
+			ConfigSpec{VirtualICH7MPresent: falsePtr},
+			ConfigSpec{VirtualICH7MPresent: falsePtr}),
+		Entry("VirtualICH7MPresent does not need updating",
+			ConfigInfo{Hardware: vimtypes.VirtualHardware{VirtualICH7MPresent: truePtr}},
+			ConfigSpec{VirtualICH7MPresent: truePtr},
+			ConfigSpec{}),
+
+		Entry("VirtualSMCPresent needs updating",
+			ConfigInfo{Hardware: vimtypes.VirtualHardware{VirtualSMCPresent: truePtr}},
+			ConfigSpec{VirtualSMCPresent: falsePtr},
+			ConfigSpec{VirtualSMCPresent: falsePtr}),
+		Entry("VirtualSMCPresent needs updating",
+			ConfigInfo{Hardware: vimtypes.VirtualHardware{VirtualSMCPresent: nil}},
+			ConfigSpec{VirtualSMCPresent: falsePtr},
+			ConfigSpec{VirtualSMCPresent: falsePtr}),
+		Entry("VirtualSMCPresent does not need updating",
+			ConfigInfo{Hardware: vimtypes.VirtualHardware{VirtualSMCPresent: truePtr}},
+			ConfigSpec{VirtualSMCPresent: truePtr},
+			ConfigSpec{}),
+
+		Entry("MotherboardLayout needs updating",
+			ConfigInfo{Hardware: vimtypes.VirtualHardware{MotherboardLayout: "foo"}},
+			ConfigSpec{MotherboardLayout: "i440bxHostBridge"},
+			ConfigSpec{MotherboardLayout: "i440bxHostBridge"}),
+		Entry("MotherboardLayout does not needs updating",
+			ConfigInfo{Hardware: vimtypes.VirtualHardware{MotherboardLayout: "i440bxHostBridge"}},
+			ConfigSpec{MotherboardLayout: "i440bxHostBridge"},
+			ConfigSpec{}),
+
+		Entry("SimultaneousThreads needs updating",
+			ConfigInfo{Hardware: vimtypes.VirtualHardware{SimultaneousThreads: 8}},
+			ConfigSpec{SimultaneousThreads: 16},
+			ConfigSpec{SimultaneousThreads: 16}),
+		Entry("SimultaneousThreads does not need updating",
+			ConfigInfo{Hardware: vimtypes.VirtualHardware{SimultaneousThreads: 8}},
+			ConfigSpec{SimultaneousThreads: 8},
 			ConfigSpec{}),
 	)
 })


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

For the fields that are either comparable or bool pointer and have an equivalent field in the ConfigInfo, compare then during resize. This is mostly just a start on how to best start comparing all the fields in the ConfigSpec/ConfigInfo.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:



**Please add a release note if necessary**:

```release-note
NONE
```