### PR TITLE
🐛 Check for valid image OS image labels keys and values

### DIFF
--- a/pkg/util/image/status_to_label_test.go
+++ b/pkg/util/image/status_to_label_test.go
@@ -47,11 +47,20 @@ var _ = Describe("SyncStatusToLabels", func() {
 		})
 	})
 
+	When("the status has the OS ID that is not valid label value", func() {
+		BeforeEach(func() {
+			status.OSInfo.ID = "-100"
+		})
+		It("should not have the OS ID", func() {
+			Expect(obj.GetLabels()).To(BeEmpty())
+		})
+	})
+
 	When("the status has the OS type", func() {
 		BeforeEach(func() {
 			status.OSInfo.Type = "linux"
 		})
-		It("should have the OS ID label", func() {
+		It("should have the OS type label", func() {
 			Expect(obj.GetLabels()).To(HaveLen(1))
 			Expect(obj.GetLabels()).To(HaveKeyWithValue(
 				vmopv1.VirtualMachineImageOSTypeLabel,
@@ -59,15 +68,33 @@ var _ = Describe("SyncStatusToLabels", func() {
 		})
 	})
 
+	When("the status has the OS type that is not valid label value", func() {
+		BeforeEach(func() {
+			status.OSInfo.Type = "linux!"
+		})
+		It("should not have the OS type label", func() {
+			Expect(obj.GetLabels()).To(BeEmpty())
+		})
+	})
+
 	When("the status has the OS version", func() {
 		BeforeEach(func() {
 			status.OSInfo.Version = "5"
 		})
-		It("should have the OS ID label", func() {
+		It("should have the OS version label", func() {
 			Expect(obj.GetLabels()).To(HaveLen(1))
 			Expect(obj.GetLabels()).To(HaveKeyWithValue(
 				vmopv1.VirtualMachineImageOSVersionLabel,
 				status.OSInfo.Version))
+		})
+	})
+
+	When("the status has the OS version that is not valid label value", func() {
+		BeforeEach(func() {
+			status.OSInfo.Version = "5."
+		})
+		It("should not have the OS version label", func() {
+			Expect(obj.GetLabels()).To(BeEmpty())
 		})
 	})
 
@@ -80,6 +107,18 @@ var _ = Describe("SyncStatusToLabels", func() {
 			Expect(obj.GetLabels()).To(HaveKeyWithValue(
 				vmopv1.VirtualMachineImageCapabilityLabel+"cloud-init",
 				"true"))
+			Expect(obj.GetLabels()).To(HaveKeyWithValue(
+				vmopv1.VirtualMachineImageCapabilityLabel+"nvidia-vgpu",
+				"true"))
+		})
+	})
+
+	When("the status has an invalid capabilities label key", func() {
+		BeforeEach(func() {
+			status.Capabilities = []string{"cloud-init!", "nvidia-vgpu"}
+		})
+		It("should have just the valid capability label key", func() {
+			Expect(obj.GetLabels()).To(HaveLen(1))
 			Expect(obj.GetLabels()).To(HaveKeyWithValue(
 				vmopv1.VirtualMachineImageCapabilityLabel+"nvidia-vgpu",
 				"true"))


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

These values come from the CL Item which may not be valid k8s label values. Don't try to assign the label if the value is invalid since we won't be able to update the k8s image.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:


```release-note
The VirtualMachineImage OS ID, Version, and Type labels will only be add if the corresponding values are valid Kubernetes label values.
```