### PR TITLE
:sparkles: VirtualMachineReplicaSet CRUD/Scale Up Scale Down support

### DIFF
--- a/config/crd/bases/vmoperator.vmware.com_virtualmachinereplicasets.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachinereplicasets.yaml
@@ -12,22 +12,25 @@ spec:
     listKind: VirtualMachineReplicaSetList
     plural: virtualmachinereplicasets
     shortNames:
+    - vmrs
     - vmreplicaset
     singular: virtualmachinereplicaset
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.replicas
+    - description: Total number of non-terminated virtual machines targeted by this
+        VirtualMachineReplicaSet
+      jsonPath: .status.replicas
       name: Replicas
-      priority: 1
       type: integer
-    - jsonPath: .status.readyReplicas
-      name: Ready-Replicas
-      priority: 1
+    - description: Total number of ready virtual machines targeted by this VirtualMachineReplicaSet
+      jsonPath: .status.readyReplicas
+      name: Ready
       type: integer
-    - jsonPath: .status.availableReplicas
-      name: Available-Replicas
-      type: integer
+    - description: Time duration since creation of VirtualMachineReplicaSet
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha3
     schema:
       openAPIV3Schema:
@@ -54,14 +57,13 @@ spec:
           spec:
             description: VirtualMachineReplicaSetSpec is the specification of a VirtualMachineReplicaSet.
             properties:
-              minReadySeconds:
+              deletePolicy:
                 description: |-
-                  Minimum number of seconds for which a newly created replica virtual
-                  machine should be ready for it to be considered available.
-                  Defaults to 0 (virtual machine will be considered available as soon as it
-                  is ready).
-                format: int32
-                type: integer
+                  DeletePolicy defines the policy used to identify nodes to delete when downscaling.
+                  Only supported deletion policy is "Random".
+                enum:
+                - Random
+                type: string
               replicas:
                 default: 1
                 description: |-
@@ -75,6 +77,9 @@ spec:
                   Selector is a label to query over virtual machines that should match the
                   replica count. A virtual machine's label keys and values must match in order
                   to be controlled by this VirtualMachineReplicaSet.
+
+
+                  It must match the VirtualMachine template's labels.
                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
                 properties:
                   matchExpressions:
@@ -1771,12 +1776,6 @@ spec:
               VirtualMachineReplicaSetStatus represents the observed state of a
               VirtualMachineReplicaSet resource.
             properties:
-              availableReplicas:
-                description: |-
-                  AvailableReplicas is the number of available replicas (ready for at
-                  least minReadySeconds) for this VirtualMachineReplicaSet.
-                format: int32
-                type: integer
               conditions:
                 description: |-
                   Conditions represents the latest available observations of a

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -323,6 +323,14 @@ rules:
 - apiGroups:
   - vmoperator.vmware.com
   resources:
+  - virtualmachinereplicasets/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - vmoperator.vmware.com
+  resources:
   - virtualmachines
   verbs:
   - create

--- a/controllers/virtualmachinereplicaset/virtualmachinereplicaset_controller.go
+++ b/controllers/virtualmachinereplicaset/virtualmachinereplicaset_controller.go
@@ -1,4 +1,20 @@
-// Copyright (c) 2019-2024 VMware, Inc. All Rights Reserved.
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package virtualmachinereplicaset
@@ -6,11 +22,16 @@ package virtualmachinereplicaset
 import (
 	"context"
 	"fmt"
+	"maps"
 	"reflect"
 	"strings"
+	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	apierrorsutil "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -22,12 +43,27 @@ import (
 	"github.com/go-logr/logr"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
-
+	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/patch"
 	"github.com/vmware-tanzu/vm-operator/pkg/prober"
 	"github.com/vmware-tanzu/vm-operator/pkg/record"
+	"github.com/vmware-tanzu/vm-operator/pkg/util"
+)
+
+var (
+	// stateConfirmationTimeout is the amount of time allowed to wait for desired
+	// state. This is used to ensure a VirtualMachine reaches its desired state
+	// within a time period.
+	stateConfirmationTimeout = 10 * time.Second
+
+	// stateConfirmationInterval is the amount of time between polling
+	// attempts for the desired state.
+	stateConfirmationInterval = 100 * time.Millisecond
+
+	// replicaSetKind contains the schema.GroupVersionKind for the VirtualMachineReplicaSet type.
+	replicaSetKind = vmopv1.SchemeGroupVersion.WithKind("VirtualMachineReplicaSet")
 )
 
 const (
@@ -56,22 +92,21 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		Watches(&vmopv1.VirtualMachine{},
 			handler.EnqueueRequestsFromMapFunc(r.VMToReplicaSets(ctx)),
 		).
-		// TODO: Should we also watch the volumes so we get an event for changes
-		// to a volume mounted to a VM that is part of a ReplicaSet?
 		WithOptions(controller.Options{MaxConcurrentReconciles: ctx.MaxConcurrentReconciles}).
 		Complete(r)
-
 }
 
-// VMToReplicaSets is a mapper function to be used to enqueue requests for reconciliation for VirtualMachineSetReplicaSets that might adopt a VM.
-func (r *Reconciler) VMToReplicaSets(ctx *pkgctx.ControllerManagerContext) func(_ context.Context, o client.Object) []reconcile.Request {
+// VMToReplicaSets is a mapper function to be used to enqueue requests for
+// reconciliation for VirtualMachineSetReplicaSets that might adopt a VM.
+func (r *Reconciler) VMToReplicaSets(
+	ctx *pkgctx.ControllerManagerContext) func(_ context.Context, o client.Object) []reconcile.Request {
 
-	// If the replica VM already has a controller reference, return early. If
-	// not, enqueue a reconcile if the VM matches the selector specified in the
-	// ReplicaSet. Note that we don't support adopting a replica since that
-	// might involve relocating it across compute and storage entities -- which
-	// is not supported. Instead, we emit a Condition on the ReplicaSet resource
-	// indicating it has orphaned replicas.
+	// If the replica VM already has a controller reference, return early. If not,
+	// enqueue a reconcile if the VM matches the selector specified in the
+	// ReplicaSet.
+	// Note that we don't support adopting a replica since that might
+	// involve moving it across compute and storage entities -- which may not
+	// be possible.
 	return func(_ context.Context, o client.Object) []reconcile.Request {
 		result := []ctrl.Request{}
 		vm, ok := o.(*vmopv1.VirtualMachine)
@@ -79,21 +114,19 @@ func (r *Reconciler) VMToReplicaSets(ctx *pkgctx.ControllerManagerContext) func(
 			panic(fmt.Sprintf("Expected a VirtualMachine, but got a %T", o))
 		}
 
-		// If this VM already has a controller reference, no reconciles are
-		// queued.
-		for _, ref := range vm.ObjectMeta.GetOwnerReferences() {
-			if ref.Controller != nil && *ref.Controller {
-				return nil
-			}
+		// If this VM already has a controller reference, no reconcile requests
+		// are queued.
+		if metav1.GetControllerOfNoCopy(vm) != nil {
+			return nil
 		}
 
-		vmrsss, err := r.getReplicaSetsForVM(ctx, vm)
+		vmrss, err := r.getReplicaSetsForVM(ctx, vm)
 		if err != nil {
 			ctx.Logger.Error(err, "Failed getting VM ReplicaSets for VM")
 			return nil
 		}
 
-		for _, rs := range vmrsss {
+		for _, rs := range vmrss {
 			name := client.ObjectKey{Name: rs.Name, Namespace: rs.Namespace}
 			result = append(result, ctrl.Request{NamespacedName: name})
 		}
@@ -109,7 +142,8 @@ func (r *Reconciler) getReplicaSetsForVM(
 	vm *vmopv1.VirtualMachine) ([]*vmopv1.VirtualMachineReplicaSet, error) {
 
 	if len(vm.Labels) == 0 {
-		return nil, fmt.Errorf("vm %v has no labels, This is unexpected", client.ObjectKeyFromObject(vm))
+		// VMs managed by VirtualMachineReplicaSet are always expected to have labels set.
+		return nil, nil
 	}
 
 	rsList := &vmopv1.VirtualMachineReplicaSetList{}
@@ -118,9 +152,8 @@ func (r *Reconciler) getReplicaSetsForVM(
 	}
 
 	var rss []*vmopv1.VirtualMachineReplicaSet
-	for idx := range rsList.Items {
-		rs := &rsList.Items[idx]
-
+	for _, rs := range rsList.Items {
+		rs := rs
 		selector, err := metav1.LabelSelectorAsSelector(rs.Spec.Selector)
 		if err != nil {
 			continue
@@ -131,7 +164,7 @@ func (r *Reconciler) getReplicaSetsForVM(
 		}
 
 		if selector.Matches(labels.Set(vm.Labels)) {
-			rss = append(rss, rs)
+			rss = append(rss, &rs)
 		}
 	}
 
@@ -163,6 +196,7 @@ type Reconciler struct {
 }
 
 // +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachinereplicasets,verbs=create;get;list;watch;update;patch;
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachinereplicasets/status,verbs=get;update;patch
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
 	ctx = pkgcfg.JoinContext(ctx, r.Context)
@@ -180,7 +214,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 
 	patchHelper, err := patch.NewHelper(rs, r.Client)
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to init patch helper for %s: %w", rsCtx, err)
+		return ctrl.Result{}, fmt.Errorf("failed to init patch helper for %s: %w", rsCtx.String(), err)
 	}
 
 	defer func() {
@@ -201,38 +235,455 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 		return ctrl.Result{}, err
 	}
 
-	if err := r.ReconcileNormal(rsCtx); err != nil {
+	result, err := r.ReconcileNormal(rsCtx)
+	if err != nil {
 		rsCtx.Logger.Error(err, "Failed to reconcile VirtualMachineReplicaSet")
 		return ctrl.Result{}, err
+	}
+
+	return result, nil
+}
+
+func (r *Reconciler) ReconcileDelete(ctx *pkgctx.VirtualMachineReplicaSetContext) error {
+	ctx.Logger.Info("Reconciling VirtualMachineReplicaSet Deletion")
+
+	if controllerutil.ContainsFinalizer(ctx.ReplicaSet, finalizerName) {
+		defer func() {
+			r.Recorder.EmitEvent(ctx.ReplicaSet, "Delete", nil, false)
+		}()
+
+		controllerutil.RemoveFinalizer(ctx.ReplicaSet, finalizerName)
+	}
+
+	return nil
+}
+
+// adoptOrphan sets the VirtualMachineReplicaSet as a controller OwnerReference
+// to the VirtualMachine.
+func (r *Reconciler) adoptOrphan(
+	ctx *pkgctx.VirtualMachineReplicaSetContext,
+	rs *vmopv1.VirtualMachineReplicaSet,
+	vm *vmopv1.VirtualMachine) error {
+
+	patch := client.MergeFrom(vm.DeepCopy())
+	newRef := *metav1.NewControllerRef(rs, vmopv1.SchemeGroupVersion.WithKind("VirtualMachineReplicaSet"))
+	vm.OwnerReferences = append(vm.OwnerReferences, newRef)
+	return r.Client.Patch(ctx, vm, patch)
+}
+
+func (r *Reconciler) ReconcileNormal(ctx *pkgctx.VirtualMachineReplicaSetContext) (ctrl.Result, error) {
+	if !controllerutil.ContainsFinalizer(ctx.ReplicaSet, finalizerName) {
+		// Set the finalizer and return so the object is patched immediately.
+		controllerutil.AddFinalizer(ctx.ReplicaSet, finalizerName)
+		return ctrl.Result{}, nil
+	}
+
+	ctx.Logger.Info("Reconciling VirtualMachineReplicaSet")
+
+	if ctx.ReplicaSet.Labels == nil {
+		ctx.ReplicaSet.Labels = make(map[string]string)
+	}
+
+	if ctx.ReplicaSet.Spec.Selector.MatchLabels == nil {
+		ctx.ReplicaSet.Spec.Selector.MatchLabels = make(map[string]string)
+	}
+
+	if ctx.ReplicaSet.Spec.Template.Labels == nil {
+		ctx.ReplicaSet.Spec.Template.Labels = make(map[string]string)
+	}
+
+	selectorMap, err := metav1.LabelSelectorAsMap(ctx.ReplicaSet.Spec.Selector)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf(
+			"failed to convert VirtualMachineReplicaSet %q label selector to a map: %w",
+			ctx.ReplicaSet.Name, err)
+	}
+
+	// Get all VirtualMachines linked to this VirtualMachineReplicaSet.
+	allVMs := &vmopv1.VirtualMachineList{}
+	if err := r.Client.List(ctx,
+		allVMs,
+		client.InNamespace(ctx.ReplicaSet.Namespace),
+		client.MatchingLabels(selectorMap),
+	); err != nil {
+		return ctrl.Result{},
+			fmt.Errorf("failed to list virtual machines matched by the VirtualMachineReplicaSet. selector: %q, err: %v",
+				selectorMap, err)
+	}
+
+	// Filter out irrelevant VirtualMachines (i.e. IsControlledBy something else) and
+	// claim orphaned machines.
+	// Note that claim does not mean that we will try to conform the VM to meet the
+	// desired spec since that might involve moving the VM across
+	// compute and storage boundaries.
+	// VirtualMachines in deleted state are not excluded.
+	filteredVMs := make([]*vmopv1.VirtualMachine, 0, len(allVMs.Items))
+	for idx := range allVMs.Items {
+		vm := &allVMs.Items[idx]
+
+		// Attempt to adopt VirtualMachine if it has no controller references.
+		if metav1.GetControllerOfNoCopy(vm) == nil {
+			if err := r.adoptOrphan(ctx, ctx.ReplicaSet, vm); err != nil {
+				ctx.Logger.Error(err, "VirtualMachineReplicaSet failed to adopt VirtualMachine", "vm", vm.Name)
+				r.Recorder.Warnf(ctx.ReplicaSet, "FailedAdopt", "Failed to adopt VirtualMachine %q: %v", vm.Name, err)
+
+				continue
+			}
+			ctx.Logger.Info("Adopted VirtualMachine", "vm", vm.Name)
+			r.Recorder.Eventf(ctx.ReplicaSet, "SuccessfulAdopt", "Adopted VirtualMachine %q", vm.Name)
+		} else if !metav1.IsControlledBy(vm, ctx.ReplicaSet) {
+			// Skip this VirtualMachine if it is controlled by someone else.
+			continue
+		}
+
+		filteredVMs = append(filteredVMs, vm)
+	}
+
+	// If not already present, add a label specifying the VirtualMachineReplicaSet name to VirtualMachines.
+	for _, vm := range filteredVMs {
+		// Note: MustEqualValue is used here as the value of this label will be
+		// a hash if the VirtualMachineReplicaSet name is longer than 63 characters.
+		if rsName, ok := vm.Labels[vmopv1.VirtualMachineReplicaSetNameLabel]; ok &&
+			MustEqualValue(ctx.ReplicaSet.Name, rsName) {
+
+			continue
+		}
+
+		// Label not present, patch the VirtualMachine.
+		helper, err := patch.NewHelper(vm, r.Client)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to create patch helper to apply %s label to VirtualMachine %q: %w",
+				vmopv1.VirtualMachineReplicaSetNameLabel, vm.Name, err)
+		}
+
+		// MustFormatValue is used here as the value of this label will be a
+		// hash if the VirtualMachineReplicaSet name is longer than max allowed
+		// label value length of 63 characters.
+		vm.Labels[vmopv1.VirtualMachineReplicaSetNameLabel] = util.MustFormatValue(ctx.ReplicaSet.Name)
+
+		if err := helper.Patch(ctx, vm); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to apply %s label to VirtualMachine %q: %w",
+				vmopv1.VirtualMachineReplicaSetNameLabel, vm.Name, err)
+		}
+
+		ctx.Logger.V(5).Info(
+			"Updated VirtualMachine with the VirtualMachineReplicaSet name label",
+			"vm", vm,
+			"key", vmopv1.VirtualMachineReplicaSetNameLabel,
+			"value", util.MustFormatValue(ctx.ReplicaSet.Name))
+
+		// TODO: Propagate the Deployment label from Deployment to replica set to VirtualMachine if
+		// it is set on the replica set.
+	}
+
+	// TODO: Handle in place propagation of fields to machines before syncing replicas.
+
+	syncErr := r.syncReplicas(ctx, ctx.ReplicaSet, filteredVMs)
+
+	// Update the status of the VirtualMachineReplicaSet even in case of error
+	// since syncing might have resulted in replicas being added or removed.
+	r.updateStatus(ctx, ctx.ReplicaSet, filteredVMs)
+
+	if syncErr != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to sync VirtualMachineReplicaSet replicas: %w", syncErr)
+	}
+
+	var replicas int32
+	if ctx.ReplicaSet.Spec.Replicas != nil {
+		replicas = *ctx.ReplicaSet.Spec.Replicas
+	}
+
+	// Queue faster reconciles until all replicas are available.
+	if ctx.ReplicaSet.Status.ReadyReplicas != replicas {
+		return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
 	}
 
 	return ctrl.Result{}, nil
 }
 
-func (r *Reconciler) ReconcileNormal(ctx *pkgctx.VirtualMachineReplicaSetContext) error {
-	if !controllerutil.ContainsFinalizer(ctx.ReplicaSet, finalizerName) {
-		// Set the finalizer and return immediately so the object is patched immediately.
-		controllerutil.AddFinalizer(ctx.ReplicaSet, finalizerName)
-		return nil
+// MustEqualValue returns true if the replica set name equals either the label
+// value or its hashed value.
+func MustEqualValue(rsName, labelValue string) bool {
+	return labelValue == util.MustFormatValue(rsName)
+}
+
+// getNewVirtualMachine creates a new VirtualMachine object. The name of the newly created resource is going
+// to be created by the API server, we set the generateName field.
+func (r *Reconciler) getNewVirtualMachine(rs *vmopv1.VirtualMachineReplicaSet) *vmopv1.VirtualMachine {
+	vm := &vmopv1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: fmt.Sprintf("%s-", rs.Name),
+			// Note: by setting the ownerRef on creation we signal to the
+			// VirtualMachine controller that this is not a stand-alone VM.
+			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(rs, replicaSetKind)},
+			Namespace:       rs.Namespace,
+			Labels: map[string]string{
+				vmopv1.VirtualMachineReplicaSetNameLabel: util.MustFormatValue(rs.Name),
+			},
+			Annotations: rs.Spec.Template.Annotations,
+		},
+		Spec: rs.Spec.Template.Spec,
 	}
 
-	ctx.Logger.Info("Reconciling VirtualMachineReplicaSet")
+	vm.Labels = getLabelsFromVMReplicaSet(rs)
+
+	vm.Annotations = getAnnotationsFromReplicaSet(rs)
+
+	// TODO: Propagate the VirtualMachineDeploymentNameLabel from VirtualMachineReplicaSet to VirtualMachines if it exists.
+
+	return vm
+}
+
+func getLabelsFromVMReplicaSet(rs *vmopv1.VirtualMachineReplicaSet) map[string]string {
+	labels := make(map[string]string, len(rs.Spec.Template.Labels))
+
+	// Copy over the labels from the template
+	maps.Copy(labels, rs.Spec.Template.Labels)
+
+	// Ensure that the ReplicaSetLabel is always present.
+	labels[vmopv1.VirtualMachineReplicaSetNameLabel] = util.MustFormatValue(rs.Name)
+
+	return labels
+}
+
+func getAnnotationsFromReplicaSet(rs *vmopv1.VirtualMachineReplicaSet) map[string]string {
+	annotations := make(map[string]string, len(rs.Spec.Template.Annotations))
+
+	// Copy over the labels from the template
+	maps.Copy(annotations, rs.Spec.Template.Annotations)
+
+	return annotations
+}
+
+// syncReplicas scales VirtualMachine resources up or down.
+func (r *Reconciler) syncReplicas(
+	ctx *pkgctx.VirtualMachineReplicaSetContext,
+	rs *vmopv1.VirtualMachineReplicaSet,
+	vms []*vmopv1.VirtualMachine) error {
+
+	if rs.Spec.Replicas == nil {
+		return fmt.Errorf("the Replicas field in Spec for VirtualMachineReplicaSet %v is nil, this should not be allowed", rs.Name)
+	}
+	diff := len(vms) - int(*(rs.Spec.Replicas))
+	switch {
+	case diff < 0:
+		diff *= -1
+		ctx.Logger.Info("ReplicaSet is scaling up",
+			"currentReplicas", len(vms),
+			"desiredReplicas", *rs.Spec.Replicas,
+			"vmsToBeCreated", diff,
+		)
+
+		var (
+			vmList []*vmopv1.VirtualMachine
+			errs   []error
+		)
+
+		for i := 0; i < diff; i++ {
+			vm := r.getNewVirtualMachine(rs)
+			log := ctx.Logger.WithValues("vm", vm.Name)
+			log.Info("Creating VM", "index", i+1, "totalVMsToBeCreated", diff)
+
+			if err := r.Client.Create(ctx, vm); err != nil {
+				log.Error(err, "Error while creating VirtualMachine")
+				r.Recorder.Warnf(rs, "FailedCreate", "Failed to create VirtualMachine: %v", err)
+				errs = append(errs, err)
+				conditions.MarkFalse(
+					rs,
+					vmopv1.VirtualMachinesCreatedCondition,
+					vmopv1.VirtualMachineCreationFailedReason,
+					err.Error(),
+				)
+				continue
+			}
+
+			log.V(5).Info("Created VM", "index", i+1, "totalVMsToBeCreated", diff)
+			r.Recorder.Eventf(rs, "SuccessfulCreate", "Created vm %q", vm.Name)
+			vmList = append(vmList, vm)
+		}
+
+		if len(errs) > 0 {
+			return apierrorsutil.NewAggregate(errs)
+		}
+
+		return r.waitForVMCreation(ctx, vmList)
+	case diff > 0:
+		ctx.Logger.Info("ReplicaSet is scaling down",
+			"currentReplicas", len(vms),
+			"desiredReplicas", *(rs.Spec.Replicas),
+			"vmsToBeCreated", diff,
+			"deletePolicy", "oldestFirst",
+		)
+
+		deletePriorityFunc, err := getDeletePriorityFunc(rs)
+		if err != nil {
+			return err
+		}
+
+		var errs []error
+		vmsToDelete := getMachinesToDeletePrioritized(vms, diff, deletePriorityFunc)
+		for i, vm := range vmsToDelete {
+			log := ctx.Logger.WithValues("vm", vm.Name)
+			if vm.GetDeletionTimestamp().IsZero() {
+				log.Info("Deleting VM to scale down replicaset", "index", i+1, "totalVMsToBeDeleted", diff)
+
+				if err := r.Client.Delete(ctx, vm); err != nil {
+					log.Error(err, "Unable to delete VM")
+					r.Recorder.Warnf(rs, "FailedDelete", "Failed to delete VM %q: %v", vm.Name, err)
+					errs = append(errs, err)
+					continue
+				}
+				log.V(5).Info("Deleted VM", "index", i+1, "totalVMsToBeDeleted", diff)
+				r.Recorder.Eventf(rs, "SuccessfulDelete", "Deleted VM %q", vm.Name)
+			} else {
+				log.Info("Waiting for VM to be deleted", "index", i+1, "totalVMsToBeDeleted", diff)
+			}
+		}
+
+		if len(errs) > 0 {
+			return apierrorsutil.NewAggregate(errs)
+		}
+		return r.waitForVMDeletion(ctx, vmsToDelete)
+	}
 
 	return nil
 }
 
-func (r *Reconciler) ReconcileDelete(ctx *pkgctx.VirtualMachineReplicaSetContext) (reterr error) {
-	if controllerutil.ContainsFinalizer(ctx.ReplicaSet, finalizerName) {
-		defer func() {
-			r.Recorder.EmitEvent(ctx.ReplicaSet, "Delete", reterr, false)
-		}()
+func (r *Reconciler) waitForVMDeletion(ctx *pkgctx.VirtualMachineReplicaSetContext, vmList []*vmopv1.VirtualMachine) error {
+	for _, vm := range vmList {
+		pollErr := wait.PollUntilContextTimeout(ctx, stateConfirmationInterval, stateConfirmationTimeout, false, func(ctx context.Context) (bool, error) {
+			m := &vmopv1.VirtualMachine{}
+			key := client.ObjectKey{Namespace: vm.Namespace, Name: vm.Name}
+			err := r.Client.Get(ctx, key, m)
+			if apierrors.IsNotFound(err) || !m.DeletionTimestamp.IsZero() {
+				return true, nil
+			}
+			return false, err
+		})
 
-		// Handle deletion of replicas
+		if pollErr != nil {
+			ctx.Logger.Error(pollErr, "Failed waiting for VirtualMachine to be deleted", "vm", vm.Name)
+			return fmt.Errorf("failed waiting for VirtualMachine %q to be deleted: %w", vm.Name, pollErr)
+		}
+	}
+	return nil
+}
 
-		controllerutil.RemoveFinalizer(ctx.ReplicaSet, finalizerName)
+func (r *Reconciler) waitForVMCreation(ctx *pkgctx.VirtualMachineReplicaSetContext, vmList []*vmopv1.VirtualMachine) error {
+	for _, vm := range vmList {
+		pollErr := wait.PollUntilContextTimeout(ctx, stateConfirmationInterval, stateConfirmationTimeout, false, func(ctx context.Context) (bool, error) {
+			key := client.ObjectKey{Namespace: vm.Namespace, Name: vm.Name}
+			if err := r.Client.Get(ctx, key, &vmopv1.VirtualMachine{}); err != nil {
+				if apierrors.IsNotFound(err) {
+					return false, nil
+				}
+				return false, err
+			}
+
+			return true, nil
+		})
+
+		if pollErr != nil {
+			ctx.Logger.Error(pollErr, "Failed waiting for VirtualMachine to be created", "vm", vm.Name)
+			return fmt.Errorf("failed waiting for VirtualMachine: %q to be created: %w", vm.Name, pollErr)
+		}
 	}
 
-	ctx.Logger.Info("Finished Reconciling VirtualMachineReplicaSet Deletion")
-
 	return nil
+}
+
+// updateStatus updates the Status field of the VirtualMachineReplicaSet.
+func (r *Reconciler) updateStatus(
+	ctx *pkgctx.VirtualMachineReplicaSetContext,
+	rs *vmopv1.VirtualMachineReplicaSet,
+	filteredVMs []*vmopv1.VirtualMachine) {
+
+	newStatus := rs.Status.DeepCopy()
+
+	// Count the number of VMs that are matched by the replica set selector.
+	// Note that the matching VMs may have more labels than what is specified
+	// in the template.
+	fullyLabeledReplicasCount := 0
+	readyReplicasCount := 0
+	desiredReplicas := *rs.Spec.Replicas
+	// Create a selector from labels since that is significantly faster at scale
+	// and initializing a selector directly.
+	templateLabel := labels.Set(rs.Spec.Template.Labels).AsSelectorPreValidated()
+
+	for _, vm := range filteredVMs {
+		if templateLabel.Matches(labels.Set(vm.Labels)) {
+			fullyLabeledReplicasCount++
+		}
+
+		// TODO: Figure out an equivalent of Ready condition on the VirtualMachine
+		// resource so we can populate the ready and available replicas in the Status.
+		// For now, we count all replicas as ready and available.
+		readyReplicasCount++
+
+	}
+
+	newStatus.Replicas = int32(len(filteredVMs))
+	newStatus.FullyLabeledReplicas = int32(fullyLabeledReplicasCount)
+	newStatus.ReadyReplicas = int32(readyReplicasCount)
+
+	// Copy the newly calculated status into the VirtualMachineReplicaSet.
+	if rs.Status.Replicas != newStatus.Replicas ||
+		rs.Status.FullyLabeledReplicas != newStatus.FullyLabeledReplicas ||
+		rs.Status.ReadyReplicas != newStatus.ReadyReplicas ||
+		rs.Generation != rs.Status.ObservedGeneration {
+
+		ctx.Logger.Info("Updating status",
+			"replicaCountOld", rs.Status.Replicas,
+			"replicaCountNew", newStatus.Replicas,
+			"replicaCountDesired", desiredReplicas,
+			"fullyLabeledReplicaCountOld", rs.Status.FullyLabeledReplicas,
+			"fullyLabeledReplicaCountNew", newStatus.FullyLabeledReplicas,
+			"readyReplicasOld", rs.Status.ReadyReplicas,
+			"readyReplicasNew", newStatus.ReadyReplicas,
+			"observedGenerationOld", rs.Status.ObservedGeneration,
+			"observedGenerationNew", newStatus.ObservedGeneration)
+
+		// Save the generation number we acted on, otherwise we might wrongfully indicate
+		// that we've seen a spec update when we retry.
+		newStatus.ObservedGeneration = rs.Generation
+		newStatus.DeepCopyInto(&rs.Status)
+	}
+
+	switch {
+	// We are scaling up
+	case newStatus.Replicas < desiredReplicas:
+		conditions.MarkFalse(
+			rs,
+			vmopv1.ResizedCondition,
+			vmopv1.ScalingUpReason,
+			"Scaling up VirtualMachineReplicaSet to %d replicas (currentReplicas %d)",
+			desiredReplicas,
+			newStatus.Replicas)
+	// We are scaling down
+	case newStatus.Replicas > desiredReplicas:
+		conditions.MarkFalse(
+			rs,
+			vmopv1.ResizedCondition,
+			vmopv1.ScalingDownReason,
+			"Scaling down VirtualMachineReplicaSet to %d replicas (currentReplicas %d)",
+			desiredReplicas,
+			newStatus.Replicas)
+		// This means that we have sufficient number of VirtualMachine objects.
+		conditions.MarkTrue(rs, vmopv1.VirtualMachinesCreatedCondition)
+	// We have reached the desired number of replicas.
+	default:
+		// Make sure last resize operation is marked as completed.
+		// Note that resize is only marked complete when all the VirtualMachine
+		// objects have their Ready condition set.
+
+		if newStatus.ReadyReplicas == newStatus.Replicas {
+			if conditions.IsFalse(rs, vmopv1.ResizedCondition) {
+				ctx.Logger.Info("All the replicas are ready", "replicas", newStatus.ReadyReplicas)
+			}
+			conditions.MarkTrue(rs, vmopv1.ResizedCondition)
+		}
+		// This means that we have sufficient number of VirtualMachine objects.
+		conditions.MarkTrue(rs, vmopv1.VirtualMachinesCreatedCondition)
+	}
+	// TODO: Set aggregate condition based on the condition of the individual Virtual Machines
 }

--- a/controllers/virtualmachinereplicaset/virtualmachinereplicaset_controller_intg_test.go
+++ b/controllers/virtualmachinereplicaset/virtualmachinereplicaset_controller_intg_test.go
@@ -1,0 +1,233 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package virtualmachinereplicaset_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	vmopv1common "github.com/vmware-tanzu/vm-operator/api/v1alpha3/common"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
+
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+const (
+	finalizerName = "virtualmachinereplicaset.vmoperator.vmware.com"
+)
+
+func intgTests() {
+	Describe(
+		"Reconcile",
+		Label(
+			testlabels.Controller,
+			testlabels.EnvTest,
+			testlabels.V1Alpha3,
+		),
+		intgTestsReconcile,
+	)
+}
+
+func intgTestsReconcile() {
+
+	var (
+		ctx *builder.IntegrationTestContext
+
+		rs    *vmopv1.VirtualMachineReplicaSet
+		rsKey types.NamespacedName
+	)
+
+	BeforeEach(func() {
+		ctx = suite.NewIntegrationTestContext()
+		rs = &vmopv1.VirtualMachineReplicaSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dummy-replicaset",
+				Namespace: ctx.Namespace,
+			},
+			Spec: vmopv1.VirtualMachineReplicaSetSpec{
+				Replicas: ptrTo(int32(2)),
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"appname": "db",
+					},
+				},
+				Template: vmopv1.VirtualMachineTemplateSpec{
+					ObjectMeta: vmopv1common.ObjectMeta{
+						Labels: map[string]string{
+							"appname": "db",
+						},
+						Annotations: make(map[string]string),
+					},
+					Spec: vmopv1.VirtualMachineSpec{
+						ImageName:  "dummy-image",
+						ClassName:  "dummy-class",
+						PowerState: vmopv1.VirtualMachinePowerStateOn,
+						Network: &vmopv1.VirtualMachineNetworkSpec{
+							Interfaces: []vmopv1.VirtualMachineNetworkInterfaceSpec{
+								{
+									Name: "eth0",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		rsKey = types.NamespacedName{Name: rs.Name, Namespace: rs.Namespace}
+	})
+
+	AfterEach(func() {
+		ctx.AfterEach()
+		ctx = nil
+		intgFakeVMProvider.Reset()
+	})
+
+	getVirtualMachineReplicaSet := func(ctx *builder.IntegrationTestContext, objKey types.NamespacedName) *vmopv1.VirtualMachineReplicaSet {
+		rs := &vmopv1.VirtualMachineReplicaSet{}
+		if err := ctx.Client.Get(ctx, objKey, rs); err != nil {
+			return nil
+		}
+		return rs
+	}
+
+	waitForReplicaSetFinalizer := func(ctx *builder.IntegrationTestContext, objKey types.NamespacedName) {
+		EventuallyWithOffset(1, func() []string {
+			if rs := getVirtualMachineReplicaSet(ctx, objKey); rs != nil {
+				return rs.GetFinalizers()
+			}
+			return nil
+		}).Should(ContainElement(finalizerName), "waiting for VirtualMachineReplicaSet finalizer")
+	}
+
+	ensureReplicas := func(ctx *builder.IntegrationTestContext, labels map[string]string, desiredReplicas int) {
+		Eventually(func(g Gomega) int {
+			vmList := &vmopv1.VirtualMachineList{}
+			err := ctx.Client.List(ctx, vmList, client.InNamespace(ctx.Namespace), client.MatchingLabels(labels))
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(vmList).ToNot(BeNil())
+			return len(vmList.Items)
+		}, 10*time.Second, 1*time.Second).Should(Equal(desiredReplicas))
+	}
+
+	Context("Reconcile", func() {
+		dummyInstanceUUID := "instanceUUID1234"
+
+		BeforeEach(func() {
+			intgFakeVMProvider.Lock()
+			intgFakeVMProvider.CreateOrUpdateVirtualMachineFn = func(ctx context.Context, vm *vmopv1.VirtualMachine) error {
+				// Used below just to check for something in the Status is updated.
+				vm.Status.InstanceUUID = dummyInstanceUUID
+				return nil
+			}
+			intgFakeVMProvider.Unlock()
+		})
+
+		AfterEach(func() {
+			By("Delete VirtualMachineReplicaSet", func() {
+				if err := ctx.Client.Delete(ctx, rs); err == nil {
+					rs := &vmopv1.VirtualMachineReplicaSet{}
+					// If ReplicaSet is still around because of finalizer, try to cleanup for next test.
+					if err := ctx.Client.Get(ctx, rsKey, rs); err == nil && len(rs.Finalizers) > 0 {
+						rs.Finalizers = nil
+						_ = ctx.Client.Update(ctx, rs)
+					}
+				} else {
+					Expect(apierrors.IsNotFound(err)).To(BeTrue())
+				}
+			})
+
+			// Integration tests use env-test which only starts API server.
+			// Since garbage collection is handled by kube-controller-manager, we
+			// can't really test that all replicas have been garbage collected
+			// once the replica set has been deleted.
+		})
+
+		It("Reconciles after VirtualMachineReplicaSet creation", func() {
+			Expect(ctx.Client.Create(ctx, rs)).To(Succeed())
+
+			By("VirtualMachineReplicaSet should have finalizer added", func() {
+				waitForReplicaSetFinalizer(ctx, rsKey)
+			})
+
+			By("Sufficient replicas must be created", func() {
+				ensureReplicas(ctx, rs.Spec.Selector.MatchLabels, int(*rs.Spec.Replicas))
+			})
+		})
+
+		It("Scale up VirtualMachineReplicaSet", func() {
+			Expect(ctx.Client.Create(ctx, rs)).To(Succeed())
+
+			By("VirtualMachineReplicaSet should have finalizer added", func() {
+				waitForReplicaSetFinalizer(ctx, rsKey)
+			})
+
+			By("Sufficient replicas must be created", func() {
+				ensureReplicas(ctx, rs.Spec.Selector.MatchLabels, int(*rs.Spec.Replicas))
+			})
+
+			By("Modifying the spec.replicas", func() {
+				_, err := controllerutil.CreateOrPatch(ctx, ctx.Client, rs, func() error {
+					numReplicas := *rs.Spec.Replicas + 1
+					rs.Spec.Replicas = &numReplicas
+					return nil
+				})
+				Expect(err).ToNot(HaveOccurred())
+				ensureReplicas(ctx, rs.Spec.Selector.MatchLabels, int(*rs.Spec.Replicas))
+			})
+		})
+
+		It("Scale down VirtualMachineReplicaSet", func() {
+			Expect(ctx.Client.Create(ctx, rs)).To(Succeed())
+
+			By("VirtualMachineReplicaSet should have finalizer added", func() {
+				waitForReplicaSetFinalizer(ctx, rsKey)
+			})
+
+			By("Sufficient replicas must be created", func() {
+				ensureReplicas(ctx, rs.Spec.Selector.MatchLabels, int(*rs.Spec.Replicas))
+			})
+
+			By("Modifying the spec.replicas", func() {
+				_, err := controllerutil.CreateOrPatch(ctx, ctx.Client, rs, func() error {
+					numReplicas := *rs.Spec.Replicas - 1
+					rs.Spec.Replicas = &numReplicas
+					return nil
+				})
+				Expect(err).ToNot(HaveOccurred())
+
+				ensureReplicas(ctx, rs.Spec.Selector.MatchLabels, int(*rs.Spec.Replicas))
+			})
+		})
+
+		It("Reconciles after VirtualMachineReplicaSet deletion", func() {
+			Expect(ctx.Client.Create(ctx, rs)).To(Succeed())
+			// Wait for initial reconcile.
+			waitForReplicaSetFinalizer(ctx, rsKey)
+
+			Expect(ctx.Client.Delete(ctx, rs)).To(Succeed())
+			By("Finalizer should be removed after deletion", func() {
+				Eventually(func() []string {
+					if vm := getVirtualMachineReplicaSet(ctx, rsKey); vm != nil {
+						return vm.GetFinalizers()
+					}
+					return nil
+				}).ShouldNot(ContainElement(finalizerName))
+			})
+		})
+	})
+}
+
+func ptrTo[T any](t T) *T {
+	return &t
+}

--- a/controllers/virtualmachinereplicaset/virtualmachinereplicaset_controller_suite_test.go
+++ b/controllers/virtualmachinereplicaset/virtualmachinereplicaset_controller_suite_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package virtualmachinereplicaset_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+
+	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachinereplicaset"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
+	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+	providerfake "github.com/vmware-tanzu/vm-operator/pkg/providers/fake"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+var intgFakeVMProvider = providerfake.NewVMProvider()
+
+var suite = builder.NewTestSuiteForControllerWithContext(
+	pkgcfg.NewContextWithDefaultConfig(),
+	virtualmachinereplicaset.AddToManager,
+	func(ctx *pkgctx.ControllerManagerContext, _ ctrlmgr.Manager) error {
+		ctx.VMProvider = intgFakeVMProvider
+		return nil
+	})
+
+func TestVirtualMachine(t *testing.T) {
+	suite.Register(t, "VirtualMachineReplicaSet controller suite", intgTests, nil)
+}
+
+var _ = BeforeSuite(suite.BeforeSuite)
+
+var _ = AfterSuite(suite.AfterSuite)

--- a/controllers/virtualmachinereplicaset/virtualmachinereplicaset_delete_policy.go
+++ b/controllers/virtualmachinereplicaset/virtualmachinereplicaset_delete_policy.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package virtualmachinereplicaset
+
+import (
+	"sort"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+)
+
+type (
+	deletePriority     float64
+	deletePriorityFunc func(machine *vmopv1.VirtualMachine) deletePriority
+)
+
+const (
+	mustDelete    deletePriority = 100.0
+	couldDelete   deletePriority = 50.0
+	mustNotDelete deletePriority = 0.0
+)
+
+func randomDeletePolicy(vm *vmopv1.VirtualMachine) deletePriority {
+	if !vm.DeletionTimestamp.IsZero() {
+		return mustDelete
+	}
+
+	// TODO: when we support a Ready/healthy condition, that should have a
+	// higher priority for deletion.  For now, all VMs that are not marked
+	// for deletion get the same priority.
+	return couldDelete
+}
+
+type sortableMachines struct {
+	machines []*vmopv1.VirtualMachine
+	priority deletePriorityFunc
+}
+
+func (m sortableMachines) Len() int      { return len(m.machines) }
+func (m sortableMachines) Swap(i, j int) { m.machines[i], m.machines[j] = m.machines[j], m.machines[i] }
+func (m sortableMachines) Less(i, j int) bool {
+	priorityI, priorityJ := m.priority(m.machines[i]), m.priority(m.machines[j])
+	if priorityI == priorityJ {
+		// In cases where the priority is identical, it should be ensured that
+		// the same machine order is returned each time.
+		// Ordering by name is a simple way to do this.
+		return m.machines[i].Name < m.machines[j].Name
+	}
+	return priorityJ < priorityI // high to low
+}
+
+func getMachinesToDeletePrioritized(filteredMachines []*vmopv1.VirtualMachine, diff int, fun deletePriorityFunc) []*vmopv1.VirtualMachine {
+	if diff >= len(filteredMachines) {
+		return filteredMachines
+	} else if diff <= 0 {
+		return []*vmopv1.VirtualMachine{}
+	}
+
+	sortable := sortableMachines{
+		machines: filteredMachines,
+		priority: fun,
+	}
+	sort.Sort(sortable)
+
+	return sortable.machines[:diff]
+}
+
+// TODO(muchhals): Needed when we add delete priority field.
+func getDeletePriorityFunc(_ *vmopv1.VirtualMachineReplicaSet) (deletePriorityFunc, error) {
+	// TODO: Expand when we start supporting other delete policies.
+	return randomDeletePolicy, nil
+}

--- a/pkg/util/replicaset_label.go
+++ b/pkg/util/replicaset_label.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"encoding/base64"
+	"fmt"
+	"hash/fnv"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+func FormatValue(str string) (string, error) {
+	// Check if it is a standard Kubernetes label value
+	if len(validation.IsValidLabelValue(str)) == 0 {
+		return str, nil
+	}
+
+	hasher := fnv.New32a()
+	if _, err := hasher.Write([]byte(str)); err != nil {
+		// At time of writing the implementation of fnv's Write function can never return an error.
+		// If a future Go version changes the implementation, this code panics.
+		return "", err
+	}
+
+	return fmt.Sprintf("hash_%s_z", base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString(hasher.Sum(nil))), nil
+}
+
+// MustFormatValue returns the passed value if it meets the standards for a
+// Kubernetes label value. Otherwise, it returns a hash which meets the
+// requirements.
+// A copy of the method used by cluster-api for MachineSets.
+func MustFormatValue(str string) string {
+	val, err := FormatValue(str)
+	if err != nil {
+		panic(err)
+	}
+
+	return val
+}

--- a/pkg/util/replicaset_label_test.go
+++ b/pkg/util/replicaset_label_test.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package util_test
+
+import (
+	"encoding/base64"
+	"fmt"
+	"hash/fnv"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/vmware-tanzu/vm-operator/pkg/util"
+)
+
+var _ = Describe("FormatValue", func() {
+	Context("input is a valid label value", func() {
+		It("returns the input label", func() {
+			inputLabel := "valid-k8s-label-value"
+			ret, err := util.FormatValue(inputLabel)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ret).To(Equal(inputLabel))
+		})
+	})
+
+	Context("input is not a valid label", func() {
+		It("returns a hashed value", func() {
+			inputLabel := strings.Repeat("a", 100)
+			actual, err := util.FormatValue(inputLabel)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual).To(Not(Equal(inputLabel)))
+
+			hasher := fnv.New32a()
+			_, err = hasher.Write([]byte(inputLabel))
+			Expect(err).ToNot(HaveOccurred())
+			expected := fmt.Sprintf("hash_%s_z", base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString(hasher.Sum(nil)))
+
+			Expect(actual).To(Equal(expected))
+		})
+	})
+})
+
+var _ = Describe("MustFormatValue", func() {
+	Context("input is not a valid label", func() {
+		It("does not panic, returns a hashed value", func() {
+			inputLabel := strings.Repeat("a", 100)
+			actual := util.MustFormatValue(inputLabel)
+			Expect(actual).To(Not(Equal(inputLabel)))
+
+			hasher := fnv.New32a()
+			_, err := hasher.Write([]byte(inputLabel))
+			Expect(err).ToNot(HaveOccurred())
+			expected := fmt.Sprintf("hash_%s_z", base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString(hasher.Sum(nil)))
+
+			Expect(actual).To(Equal(expected))
+		})
+	})
+})


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This commit adds support for creating, deleting and scaling a VirtualMachineReplicaSet resource.  When a VirtualMachineReplicaSet is created, it is reconciled to create the desired number of virtual machine replicas specified in its spec.

Similarly, during scale out/scale in, the controller reconciles the replicas to match the desired state by either creating or deleting VirtualMachine objects.  Note that a new replica is only created when the controller detect that it requires a new replica (as opposed to a rollout that is triggered via modification of the template spec in a Deployment).

When the VirtualMachineReplicaSet resource is deleted, all of its owned virtual machine replicas are also cleaned up.  The controller relies on the Kubernetes garbage collection mechanism for this.

This change also adds support for deletion policies which can used used to determine how the controller picks a virtual machine to delete from the list of replicas that it controls during a scale in/down. The only supported policy for now is "Random" where all VMs that are not in deleting state get equal weight and the controller can pick any one of them randomly.  If a VM is already marked for deletion, that gets the highest deletion priority.

In several places, I have added a TODO to revisit since ReplicaSets offer an ability to signal when an application can be considered "available".  That is dependent on a "Ready" condition that is exposed by the replicas.  Since we don't have a consistent way to do that, I have removed the support for indicating availability of a VM replica set in the Status.  Consequently, the `MinReadySeconds` field from the spec is also removed since that is used to signal availability. These can be added in a followup.

### Testing Done:

1. Create a VirtualMachineReplicaSet

2. Get the resource to ensure all replicas ready
```
k get vmreplicaset -n parunesh-ns test-rs
NAME      REPLICAS   READY   AGE
test-rs   3          3       3m57s
```

3. Scale down the replica set
```
k scale vmreplicaset -n parunesh-ns test-rs --replicas=1
virtualmachinereplicaset.vmoperator.vmware.com/test-rs scaled
```

4. Ensure scale down has cleaned up replicas:
```
k get vmreplicaset -n parunesh-ns test-rs  -o wide
NAME      REPLICAS   READY   AGE
test-rs   1          1       5m15s

k get vm -n parunesh-ns
NAME            POWER-STATE   AGE
test-rs-zmdmm   PoweredOn     3m38s
```

5. Scale up the replica set
```
k scale vmreplicaset -n parunesh-ns test-rs --replicas=2
virtualmachinereplicaset.vmoperator.vmware.com/test-rs scaled
```

6. Ensure scaled up has created new replicas
```
k get vmreplicaset -n parunesh-ns test-rs  -o wide
NAME      REPLICAS   READY   AGE
test-rs   2          2       7m1s

k get vm -n parunesh-ns
NAME            POWER-STATE   AGE
test-rs-r9slq   PoweredOn     44s
test-rs-zmdmm   PoweredOn     4m57s
```

7. Delete the replica set and ensure all replicas are deleted.
```
k delete vmreplicaset -n parunesh-ns test-rs
virtualmachinereplicaset.vmoperator.vmware.com "test-rs" deleted

k get vm -n parunesh-ns
No resources found in parunesh-ns namespace.
```


**Are there any special notes for your reviewer**:

None.


**Please add a release note if necessary**:
```release-note
Add support for VirtualMachineReplicaSet CRUD and Scale up/down
```