### PR TITLE
🌱 Override resize ConfigSpec fields from VM Spec

### DIFF
--- a/pkg/providers/vsphere/session/session_vm_update.go
+++ b/pkg/providers/vsphere/session/session_vm_update.go
@@ -29,6 +29,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/vmlifecycle"
 	"github.com/vmware-tanzu/vm-operator/pkg/util"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/resize"
+	vmopv1util "github.com/vmware-tanzu/vm-operator/pkg/util/vmopv1"
 	vmutil "github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/vm"
 )
 
@@ -859,6 +860,13 @@ func (s *Session) resizeVMWhenPoweredStateOff(
 		*moVM.Config,
 		resizeArgs.ConfigSpec)
 	if err != nil {
+		return false, err
+	}
+
+	if err := vmopv1util.OverrideResizeConfigSpec(
+		vmCtx,
+		*vmCtx.VM,
+		&cs); err != nil {
 		return false, err
 	}
 

--- a/pkg/providers/vsphere/vmprovider_vm_resize_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_resize_test.go
@@ -166,5 +166,27 @@ func vmResizeTests() {
 				Expect(o.Config.Hardware.MemoryMB).To(BeEquivalentTo(8192))
 			})
 		})
+
+		Context("Devops Overrides", func() {
+
+			Context("ChangeBlockTracking", func() {
+				BeforeEach(func() {
+					configSpec.ChangeTrackingEnabled = vimtypes.NewBool(false)
+				})
+
+				It("Overrides", func() {
+					vm.Spec.Advanced = &vmopv1.VirtualMachineAdvancedSpec{
+						ChangeBlockTracking: vimtypes.NewBool(true),
+					}
+
+					vcVM, err := createOrUpdateAndGetVcVM(ctx, vm)
+					Expect(err).ToNot(HaveOccurred())
+
+					var o mo.VirtualMachine
+					Expect(vcVM.Properties(ctx, vcVM.Reference(), nil, &o)).To(Succeed())
+					Expect(o.Config.ChangeTrackingEnabled).To(HaveValue(BeTrue()))
+				})
+			})
+		})
 	})
 }

--- a/pkg/util/resize/configspec_test.go
+++ b/pkg/util/resize/configspec_test.go
@@ -59,8 +59,8 @@ var _ = Describe("CreateResizeConfigSpec", func() {
 
 		Entry("MemoryMB needs updating",
 			ConfigInfo{Hardware: vimtypes.VirtualHardware{MemoryMB: 512}},
-			ConfigSpec{NumCPUs: 1024},
-			ConfigSpec{NumCPUs: 1024}),
+			ConfigSpec{MemoryMB: 1024},
+			ConfigSpec{MemoryMB: 1024}),
 		Entry("MemoryMB does not need updating",
 			ConfigInfo{Hardware: vimtypes.VirtualHardware{MemoryMB: 1024}},
 			ConfigSpec{MemoryMB: 1024},

--- a/pkg/util/vmopv1/resize_devops.go
+++ b/pkg/util/vmopv1/resize_devops.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package vmopv1
+
+import (
+	"context"
+
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+)
+
+// OverrideResizeConfigSpec applies any set fields in the VM Spec to the ConfigSpec.
+func OverrideResizeConfigSpec(
+	_ context.Context,
+	vm vmopv1.VirtualMachine,
+	cs *vimtypes.VirtualMachineConfigSpec) error {
+
+	if adv := vm.Spec.Advanced; adv != nil {
+		overridePtrField(adv.ChangeBlockTracking, &cs.ChangeTrackingEnabled)
+	}
+
+	return nil
+}
+
+func overridePtrField[T any](a *T, b **T) {
+	if a != nil {
+		*b = a
+	}
+}

--- a/pkg/util/vmopv1/resize_devops_test.go
+++ b/pkg/util/vmopv1/resize_devops_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package vmopv1_test
+
+import (
+	"context"
+	"reflect"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/google/go-cmp/cmp"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	vmopv1util "github.com/vmware-tanzu/vm-operator/pkg/util/vmopv1"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+type ConfigSpec = vimtypes.VirtualMachineConfigSpec
+
+var _ = Describe("OverrideResizeConfigSpec", func() {
+
+	ctx := context.Background()
+	truePtr, falsePtr := vimtypes.NewBool(true), vimtypes.NewBool(false)
+
+	vmAdvSpec := func(advSpec vmopv1.VirtualMachineAdvancedSpec) vmopv1.VirtualMachine {
+		vm := builder.DummyVirtualMachine()
+		vm.Spec.Advanced = &advSpec
+		return *vm
+	}
+
+	DescribeTable("Resize Overrides",
+		func(vm vmopv1.VirtualMachine,
+			cs, expectedCS vimtypes.VirtualMachineConfigSpec) {
+
+			err := vmopv1util.OverrideResizeConfigSpec(ctx, vm, &cs)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(reflect.DeepEqual(cs, expectedCS)).To(BeTrue(), cmp.Diff(cs, expectedCS))
+		},
+
+		Entry("Empty AdvancedSpec",
+			vmAdvSpec(vmopv1.VirtualMachineAdvancedSpec{}),
+			ConfigSpec{},
+			ConfigSpec{}),
+
+		Entry("CBT not set in VM Spec but in ConfigSpec",
+			vmAdvSpec(vmopv1.VirtualMachineAdvancedSpec{}),
+			ConfigSpec{ChangeTrackingEnabled: truePtr},
+			ConfigSpec{ChangeTrackingEnabled: truePtr}),
+		Entry("CBT set in VM Spec takes precedence over ConfigSpec",
+			vmAdvSpec(vmopv1.VirtualMachineAdvancedSpec{ChangeBlockTracking: falsePtr}),
+			ConfigSpec{ChangeTrackingEnabled: truePtr},
+			ConfigSpec{ChangeTrackingEnabled: falsePtr}),
+		Entry("CBT set in VM Spec but not in ConfigSpec",
+			vmAdvSpec(vmopv1.VirtualMachineAdvancedSpec{ChangeBlockTracking: truePtr}),
+			ConfigSpec{},
+			ConfigSpec{ChangeTrackingEnabled: truePtr}),
+	)
+})


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

For certain fields in the ConfigSpec, there are fields that a user can set in the VM Spec that take precedence over what is set in the VM Class ConfigSpec.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:



**Please add a release note if necessary**:

```release-note
NONE
```