### PR TITLE
🌱 Remove ClusterModule & Content Library clients from vSphere client

### DIFF
--- a/pkg/providers/vsphere/client/client.go
+++ b/pkg/providers/vsphere/client/client.go
@@ -6,17 +6,13 @@ package client
 import (
 	"context"
 
-	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/clustermodules"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/config"
-	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/contentlibrary"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/client"
 )
 
 type Client struct {
 	*client.Client
-	contentLibClient contentlibrary.Provider
-	clusterModClient clustermodules.Provider
-	config           *config.VSphereVMProviderConfig
+	config *config.VSphereVMProviderConfig
 }
 
 // NewClient creates a new Client. As a side effect, it creates a vim25 client
@@ -40,19 +36,9 @@ func NewClient(
 	}
 
 	return &Client{
-		Client:           c,
-		contentLibClient: contentlibrary.NewProvider(ctx, c.RestClient()),
-		clusterModClient: clustermodules.NewProvider(c.RestClient()),
-		config:           config,
+		Client: c,
+		config: config,
 	}, nil
-}
-
-func (c *Client) ContentLibClient() contentlibrary.Provider {
-	return c.contentLibClient
-}
-
-func (c *Client) ClusterModuleClient() clustermodules.Provider {
-	return c.clusterModClient
 }
 
 func (c *Client) Config() *config.VSphereVMProviderConfig {

--- a/pkg/providers/vsphere/session/session_vm_update.go
+++ b/pkg/providers/vsphere/session/session_vm_update.go
@@ -840,7 +840,8 @@ func (s *Session) attachClusterModule(
 		return fmt.Errorf("ClusterModule %s not found", clusterModuleName)
 	}
 
-	return s.Client.ClusterModuleClient().AddMoRefToModule(vmCtx, moduleUUID, resVM.MoRef())
+	clusterModuleProvider := clustermodules.NewProvider(s.Client.RestClient())
+	return clusterModuleProvider.AddMoRefToModule(vmCtx, moduleUUID, resVM.MoRef())
 }
 
 func (s *Session) resizeVMWhenPoweredStateOff(

--- a/pkg/providers/vsphere/vmlifecycle/create.go
+++ b/pkg/providers/vsphere/vmlifecycle/create.go
@@ -9,7 +9,6 @@ import (
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
-	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/contentlibrary"
 )
 
 // CreateArgs contains the arguments needed to create a VM.
@@ -28,13 +27,12 @@ type CreateArgs struct {
 
 func CreateVirtualMachine(
 	vmCtx pkgctx.VirtualMachineContext,
-	clClient contentlibrary.Provider,
 	restClient *rest.Client,
 	finder *find.Finder,
 	createArgs *CreateArgs) (*vimtypes.ManagedObjectReference, error) {
 
 	if createArgs.UseContentLibrary {
-		return deployFromContentLibrary(vmCtx, clClient, restClient, createArgs)
+		return deployFromContentLibrary(vmCtx, restClient, createArgs)
 	}
 
 	return cloneVMFromInventory(vmCtx, finder, createArgs)

--- a/pkg/providers/vsphere/vmlifecycle/create_contentlibrary.go
+++ b/pkg/providers/vsphere/vmlifecycle/create_contentlibrary.go
@@ -80,13 +80,13 @@ func deployVMTX(
 
 func deployFromContentLibrary(
 	vmCtx pkgctx.VirtualMachineContext,
-	clClient contentlibrary.Provider,
 	restClient *rest.Client,
 	createArgs *CreateArgs) (*vimtypes.ManagedObjectReference, error) {
 
 	// This call is needed to get the item type. We could avoid going to CL here, and
 	// instead get the item type via the {Cluster}ContentLibrary CR for the image.
-	item, err := clClient.GetLibraryItemID(vmCtx, createArgs.ProviderItemID)
+	contentLibraryProvider := contentlibrary.NewProvider(vmCtx, restClient)
+	item, err := contentLibraryProvider.GetLibraryItemID(vmCtx, createArgs.ProviderItemID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/providers/vsphere/vmprovider.go
+++ b/pkg/providers/vsphere/vmprovider.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2023 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2018-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package vsphere
@@ -234,7 +234,8 @@ func (vs *vSphereVMProvider) getOvfEnvelope(
 			return nil, err
 		}
 
-		ovfEnvelope, err := client.ContentLibClient().RetrieveOvfEnvelopeByLibraryItemID(ctx, itemID)
+		contentLibraryProvider := contentlibrary.NewProvider(ctx, client.RestClient())
+		ovfEnvelope, err := contentLibraryProvider.RetrieveOvfEnvelopeByLibraryItemID(ctx, itemID)
 		if err != nil || ovfEnvelope == nil {
 			return nil, err
 		}
@@ -262,7 +263,8 @@ func (vs *vSphereVMProvider) GetItemFromLibraryByName(ctx context.Context,
 		return nil, err
 	}
 
-	return client.ContentLibClient().GetLibraryItem(ctx, contentLibrary, itemName, false)
+	contentLibraryProvider := contentlibrary.NewProvider(ctx, client.RestClient())
+	return contentLibraryProvider.GetLibraryItem(ctx, contentLibrary, itemName, false)
 }
 
 func (vs *vSphereVMProvider) UpdateContentLibraryItem(ctx context.Context, itemID, newName string, newDescription *string) error {
@@ -273,7 +275,8 @@ func (vs *vSphereVMProvider) UpdateContentLibraryItem(ctx context.Context, itemI
 		return err
 	}
 
-	return client.ContentLibClient().UpdateLibraryItem(ctx, itemID, newName, newDescription)
+	contentLibraryProvider := contentlibrary.NewProvider(ctx, client.RestClient())
+	return contentLibraryProvider.UpdateLibraryItem(ctx, itemID, newName, newDescription)
 }
 
 func (vs *vSphereVMProvider) getOpID(vm *vmopv1.VirtualMachine, operation string) string {

--- a/pkg/providers/vsphere/vmprovider_resourcepolicy.go
+++ b/pkg/providers/vsphere/vmprovider_resourcepolicy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2020-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package vsphere
@@ -47,7 +47,8 @@ func (vs *vSphereVMProvider) IsVirtualMachineSetResourcePolicyReady(
 		return false, err
 	}
 
-	modulesExist, err := vs.doClusterModulesExist(ctx, client.ClusterModuleClient(), clusterRef.Reference(), resourcePolicy)
+	clusterModuleProvider := clustermodules.NewProvider(client.RestClient())
+	modulesExist, err := vs.doClusterModulesExist(ctx, clusterModuleProvider, clusterRef.Reference(), resourcePolicy)
 	if err != nil {
 		return false, err
 	}
@@ -92,7 +93,8 @@ func (vs *vSphereVMProvider) CreateOrUpdateVirtualMachineSetResourcePolicy(
 
 		clusterRef, err := vcenter.GetResourcePoolOwnerMoRef(ctx, vimClient, rpMoID)
 		if err == nil {
-			err = vs.createClusterModules(ctx, client.ClusterModuleClient(), clusterRef.Reference(), resourcePolicy)
+			clusterModuleProvider := clustermodules.NewProvider(client.RestClient())
+			err = vs.createClusterModules(ctx, clusterModuleProvider, clusterRef.Reference(), resourcePolicy)
 		}
 		if err != nil {
 			errs = append(errs, err)
@@ -127,7 +129,8 @@ func (vs *vSphereVMProvider) DeleteVirtualMachineSetResourcePolicy(
 		}
 	}
 
-	errs = append(errs, vs.deleteClusterModules(ctx, client.ClusterModuleClient(), resourcePolicy)...)
+	clusterModuleProvider := clustermodules.NewProvider(client.RestClient())
+	errs = append(errs, vs.deleteClusterModules(ctx, clusterModuleProvider, resourcePolicy)...)
 
 	if err := vcenter.DeleteChildFolder(ctx, vimClient, folderMoID, resourcePolicy.Spec.Folder); err != nil {
 		errs = append(errs, err)

--- a/pkg/providers/vsphere/vmprovider_vm.go
+++ b/pkg/providers/vsphere/vmprovider_vm.go
@@ -27,6 +27,7 @@ import (
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	vcclient "github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/client"
+	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/clustermodules"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/constants"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/network"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/placement"
@@ -355,7 +356,6 @@ func (vs *vSphereVMProvider) createVirtualMachine(
 
 	moRef, err := vmlifecycle.CreateVirtualMachine(
 		vmCtx,
-		vcClient.ContentLibClient(),
 		vcClient.RestClient(),
 		vcClient.Finder(),
 		&createArgs.CreateArgs)
@@ -641,7 +641,8 @@ func (vs *vSphereVMProvider) vmCreateIsReady(
 
 	if policy := createArgs.ResourcePolicy; policy != nil {
 		// TODO: May want to do this as to filter the placement candidates.
-		exists, err := vs.doClusterModulesExist(vmCtx, vcClient.ClusterModuleClient(), createArgs.ClusterMoRef, policy)
+		clusterModuleProvider := clustermodules.NewProvider(vcClient.RestClient())
+		exists, err := vs.doClusterModulesExist(vmCtx, clusterModuleProvider, createArgs.ClusterMoRef, policy)
 		if err != nil {
 			return err
 		} else if !exists {


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch removes the ClusterModule and ContentLibrary clients from the vSphere client. Instead, those clients are instantiated where they are used. This simplifies the dependency graph for the pkg/providers/vsphere/client package, making it easier to move towards a future without the provider model.



**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```