### PR TITLE
🌱 Add validations to minHardwareVersion to not exceed max supported hardware version

### DIFF
--- a/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
@@ -1928,6 +1928,24 @@ func unitTestsValidateCreate() {
 			),
 		)
 	})
+
+	Context("HardwareVersion", func() {
+
+		DescribeTable("MinHardwareVersion", doTest,
+			Entry("disallow greater than max valid hardware version",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						ctx.vm.Spec.MinHardwareVersion = 22
+						ctx.vm.Spec.PowerState = vmopv1.VirtualMachinePowerStateOff
+					},
+					validate: doValidateWithMsg(
+						`spec.minHardwareVersion: Invalid value: 22: should be less than or equal to 21`,
+					),
+					expectAllowed: false,
+				},
+			),
+		)
+	})
 }
 
 func unitTestsValidateUpdate() {
@@ -2480,6 +2498,19 @@ func unitTestsValidateUpdate() {
 	Context("HardwareVersion", func() {
 
 		DescribeTable("MinHardwareVersion", doTest,
+			Entry("disallow greater than max valid hardware version",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						ctx.vm.Spec.MinHardwareVersion = 22
+						ctx.vm.Spec.PowerState = vmopv1.VirtualMachinePowerStateOff
+					},
+					validate: doValidateWithMsg(
+						`spec.minHardwareVersion: Invalid value: 22: should be less than or equal to 21`,
+					),
+					expectAllowed: false,
+				},
+			),
+
 			Entry("allow same version",
 				testParams{
 					setup: func(ctx *unitValidatingWebhookContext) {


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This change adds validations for maximum supported hardware version in the VM spec minHardwareVersion. We will need update this everytime we pull in govmomi types that exposes a newer hardware version that VM Service can support.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # N/A


**Are there any special notes for your reviewer**:

Adding kubebuilder:validations for the Maximum cannot handle create/update with brownfield API versions v1a1/a2 VMs.


**Please add a release note if necessary**:

```
Validate minHardwareVersion when creating or updating VMs to prevent setting field to an unsupported version.
```