### PR TITLE
🌱 Generate topology API CRDs & rm from infra yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,6 +296,11 @@ generate-external-manifests: ## Generate manifests for the external types for te
 		crd:crdVersions=v1 \
 		output:crd:dir=$(EXTERNAL_CRD_ROOT) \
 		output:none
+	$(CONTROLLER_GEN) \
+		paths=github.com/vmware-tanzu/vm-operator/external/tanzu-topology/... \
+		crd:crdVersions=v1 \
+		output:crd:dir=$(EXTERNAL_CRD_ROOT) \
+		output:none
 
 .PHONY: generate-go-conversions
 generate-go-conversions: ## Generate conversions go code

--- a/config/crd/external-crds/topology.tanzu.vmware.com_availabilityzones.yaml
+++ b/config/crd/external-crds/topology.tanzu.vmware.com_availabilityzones.yaml
@@ -1,9 +1,9 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: availabilityzones.topology.tanzu.vmware.com
 spec:
   group: topology.tanzu.vmware.com
@@ -19,18 +19,24 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: AvailabilityZone is the schema for the AvailabilityZone resource
-          for the vSphere topology API.
+        description: |-
+          AvailabilityZone is the schema for the AvailabilityZone resource for the
+          vSphere topology API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -38,44 +44,46 @@ spec:
             description: AvailabilityZoneSpec defines the desired state of AvailabilityZone.
             properties:
               clusterComputeResourceMoIDs:
-                description: ClusterComputeResourceMoIDs are the managed object IDs
-                  of the vSphere ClusterComputeResources represented by this availability
-                  zone.
+                description: |-
+                  ClusterComputeResourceMoIDs are the managed object IDs of the vSphere
+                  ClusterComputeResources represented by this availability zone.
                 items:
                   type: string
                 type: array
               clusterComputeResourceMoId:
-                description: ClusterComputeResourceMoId is the managed object ID of
-                  the vSphere ClusterComputeResource represented by this availability
-                  zone.
+                description: |-
+                  ClusterComputeResourceMoId is the managed object ID of the vSphere
+                  ClusterComputeResource represented by this availability zone.
                 type: string
               namespaces:
                 additionalProperties:
-                  description: NamespaceInfo contains identifying information about
-                    the vSphere resources used to represent a Kubernetes namespace
-                    on individual vSphere Zones.
+                  description: |-
+                    NamespaceInfo contains identifying information about the vSphere resources
+                    used to represent a Kubernetes namespace on individual vSphere Zones.
                   properties:
                     folderMoId:
-                      description: FolderMoId is the managed object ID of the vSphere
-                        Folder for a Namespace. Folders are global and not per-vSphere
-                        Cluster, but the FolderMoId is stored here, alongside the
-                        PoolMoId for convenience.
+                      description: |-
+                        FolderMoId is the managed object ID of the vSphere Folder for a
+                        Namespace. Folders are global and not per-vSphere Cluster, but the
+                        FolderMoId is stored here, alongside the PoolMoId for convenience.
                       type: string
                     poolMoIDs:
-                      description: PoolMoIDs are the managed object ID of the vSphere
-                        ResourcePools for a Namespace in an individual vSphere Zone.
-                        A zone may be comprised of multiple ResourcePools.
+                      description: |-
+                        PoolMoIDs are the managed object ID of the vSphere ResourcePools for a
+                        Namespace in an individual vSphere Zone. A zone may be comprised of
+                        multiple ResourcePools.
                       items:
                         type: string
                       type: array
                     poolMoId:
-                      description: PoolMoId is the managed object ID of the vSphere
-                        ResourcePool for a Namespace on an individual vSphere Cluster.
+                      description: |-
+                        PoolMoId is the managed object ID of the vSphere ResourcePool for a
+                        Namespace on an individual vSphere Cluster.
                       type: string
                   type: object
-                description: Namespaces is a map that enables querying information
-                  about the vSphere objects that make up a Kubernetes Namespace based
-                  on its name.
+                description: |-
+                  Namespaces is a map that enables querying information about the vSphere
+                  objects that make up a Kubernetes Namespace based on its name.
                 type: object
             type: object
           status:
@@ -86,9 +94,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/external-crds/topology.tanzu.vmware.com_vspherezones.yaml
+++ b/config/crd/external-crds/topology.tanzu.vmware.com_vspherezones.yaml
@@ -1,9 +1,9 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: vspherezones.topology.tanzu.vmware.com
 spec:
   group: topology.tanzu.vmware.com
@@ -17,18 +17,24 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: VSphereZone is the schema for the VSphereZone resource for the
+        description: |-
+          VSphereZone is the schema for the VSphereZone resource for the
           vSphere Zone.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -47,9 +53,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -11,8 +11,6 @@ resources:
 - ../rbac
 - ../webhook
 - ../certmanager
-- ../crd/external-crds/topology.tanzu.vmware.com_availabilityzones.yaml
-- ../crd/external-crds/topology.tanzu.vmware.com_vspherezones.yaml
 
 patchesStrategicMerge:
 - manager_default_container_patch.yaml

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ replace (
 	github.com/envoyproxy/go-control-plane => github.com/envoyproxy/go-control-plane v0.9.4
 	github.com/envoyproxy/protoc-gen-validate => github.com/envoyproxy/protoc-gen-validate v0.1.0
 	github.com/vmware-tanzu/vm-operator/api => ./api
+	github.com/vmware-tanzu/vm-operator/external/ncp => ./external/ncp
+	github.com/vmware-tanzu/vm-operator/external/tanzu-topology => ./external/tanzu-topology
 	github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels => ./pkg/constants/testlabels
 )
 
@@ -87,7 +89,3 @@ require (
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 )
-
-replace github.com/vmware-tanzu/vm-operator/external/tanzu-topology => ./external/tanzu-topology
-
-replace github.com/vmware-tanzu/vm-operator/external/ncp => ./external/ncp


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch updates the generate-external target to always generate the topology API CRDs from externa/tanzu-topology as well as removes those same CRDs from the VM Operator infrastructure YAML. This allows a separate workflow for installing the topology APIs to a Supervisor.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
The VM Operator infrastructure YAML no longer includes the topology APIs.
```