### PR TITLE
🌱 Replace github.com/pkg/errors with stdlib errors

### DIFF
--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -4,7 +4,7 @@
 package controllers
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -25,36 +25,36 @@ import (
 // AddToManager adds all controllers to the provided manager.
 func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) error {
 	if err := contentlibrary.AddToManager(ctx, mgr); err != nil {
-		return errors.Wrap(err, "failed to initialize ContentLibrary controllers")
+		return fmt.Errorf("failed to initialize ContentLibrary controllers: %w", err)
 	}
 	if err := infra.AddToManager(ctx, mgr); err != nil {
-		return errors.Wrap(err, "failed to initialize Infra controllers")
+		return fmt.Errorf("failed to initialize Infra controllers: %w", err)
 	}
 	if err := virtualmachine.AddToManager(ctx, mgr); err != nil {
-		return errors.Wrap(err, "failed to initialize VirtualMachine controller")
+		return fmt.Errorf("failed to initialize VirtualMachine controller: %w", err)
 	}
 	if err := virtualmachineclass.AddToManager(ctx, mgr); err != nil {
-		return errors.Wrap(err, "failed to initialize VirtualMachineClass controller")
+		return fmt.Errorf("failed to initialize VirtualMachineClass controller: %w", err)
 	}
 	if err := virtualmachineservice.AddToManager(ctx, mgr); err != nil {
-		return errors.Wrap(err, "failed to initialize VirtualMachineService controller")
+		return fmt.Errorf("failed to initialize VirtualMachineService controller: %w", err)
 	}
 	if err := virtualmachinesetresourcepolicy.AddToManager(ctx, mgr); err != nil {
-		return errors.Wrap(err, "failed to initialize VirtualMachineSetResourcePolicy controller")
+		return fmt.Errorf("failed to initialize VirtualMachineSetResourcePolicy controller: %w", err)
 	}
 	if err := virtualmachinewebconsolerequest.AddToManager(ctx, mgr); err != nil {
-		return errors.Wrap(err, "failed to initialize VirtualMachineWebConsoleRequest controller")
+		return fmt.Errorf("failed to initialize VirtualMachineWebConsoleRequest controller: %w", err)
 	}
 	if err := volume.AddToManager(ctx, mgr); err != nil {
-		return errors.Wrap(err, "failed to initialize Volume controller")
+		return fmt.Errorf("failed to initialize Volume controller: %w", err)
 	}
 	if err := virtualmachinepublishrequest.AddToManager(ctx, mgr); err != nil {
-		return errors.Wrap(err, "failed to initialize VirtualMachinePublishRequest controller")
+		return fmt.Errorf("failed to initialize VirtualMachinePublishRequest controller: %w", err)
 	}
 
 	if pkgcfg.FromContext(ctx).Features.K8sWorkloadMgmtAPI {
 		if err := virtualmachinereplicaset.AddToManager(ctx, mgr); err != nil {
-			return errors.Wrap(err, "failed to initialize VirtualMachineReplicaSet controller")
+			return fmt.Errorf("failed to initialize VirtualMachineReplicaSet controller: %w", err)
 		}
 	}
 

--- a/controllers/infra/controllers.go
+++ b/controllers/infra/controllers.go
@@ -4,7 +4,8 @@
 package infra
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/vmware-tanzu/vm-operator/controllers/infra/configmap"
@@ -16,13 +17,13 @@ import (
 // AddToManager adds the controllers to the provided manager.
 func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) error {
 	if err := configmap.AddToManager(ctx, mgr); err != nil {
-		return errors.Wrap(err, "failed to initialize infra configmap controller")
+		return fmt.Errorf("failed to initialize infra configmap controller: %w", err)
 	}
 	if err := node.AddToManager(ctx, mgr); err != nil {
-		return errors.Wrap(err, "failed to initialize infra node controller")
+		return fmt.Errorf("failed to initialize infra node controller: %w", err)
 	}
 	if err := secret.AddToManager(ctx, mgr); err != nil {
-		return errors.Wrap(err, "failed to initialize infra secret controller")
+		return fmt.Errorf("failed to initialize infra secret controller: %w", err)
 	}
 
 	return nil

--- a/controllers/util/encoding/encoding.go
+++ b/controllers/util/encoding/encoding.go
@@ -6,9 +6,9 @@ package encoding
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"io"
 
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
@@ -36,7 +36,7 @@ func DecodeYAML(data []byte) (<-chan *unstructured.Unstructured, <-chan error) {
 				if err == io.EOF {
 					return
 				}
-				chanErr <- errors.Wrap(err, "failed to read yaml data")
+				chanErr <- fmt.Errorf("failed to read yaml data: %w", err)
 				return
 			}
 
@@ -57,7 +57,7 @@ func DecodeYAML(data []byte) (<-chan *unstructured.Unstructured, <-chan error) {
 
 			// Unmarshal the YAML document into the unstructured object.
 			if err := yaml.Unmarshal(buf, &obj.Object); err != nil {
-				chanErr <- errors.Wrap(err, "failed to unmarshal yaml data")
+				chanErr <- fmt.Errorf("failed to unmarshal yaml data: %w", err)
 				return
 			}
 

--- a/controllers/virtualmachine/virtualmachine_controller.go
+++ b/controllers/virtualmachine/virtualmachine_controller.go
@@ -5,11 +5,13 @@ package virtualmachine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlbuilder "sigs.k8s.io/controller-runtime/pkg/builder"
@@ -19,9 +21,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 
@@ -242,7 +241,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 
 	patchHelper, err := patch.NewHelper(vm, r.Client)
 	if err != nil {
-		return ctrl.Result{}, errors.Wrapf(err, "failed to init patch helper for %s", vmCtx.String())
+		return ctrl.Result{}, fmt.Errorf("failed to init patch helper for %s: %w", vmCtx, err)
 	}
 
 	defer func() {

--- a/controllers/virtualmachineclass/virtualmachineclass_controller.go
+++ b/controllers/virtualmachineclass/virtualmachineclass_controller.go
@@ -85,7 +85,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 
 	patchHelper, err := patch.NewHelper(vmClass, r.Client)
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to init patch helper for %s: %w", vmClassCtx.String(), err)
+		return ctrl.Result{}, fmt.Errorf("failed to init patch helper for %s: %w", vmClassCtx, err)
 	}
 	defer func() {
 		if err := patchHelper.Patch(ctx, vmClass); err != nil {

--- a/controllers/virtualmachinepublishrequest/virtualmachinepublishrequest_controller.go
+++ b/controllers/virtualmachinepublishrequest/virtualmachinepublishrequest_controller.go
@@ -5,6 +5,7 @@ package virtualmachinepublishrequest
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -23,7 +24,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	"github.com/vmware/govmomi/vapi/library"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 
@@ -217,7 +217,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 
 	patchHelper, err := patch.NewHelper(vmPublishReq, r.Client)
 	if err != nil {
-		return ctrl.Result{}, errors.Wrapf(err, "failed to init patch helper for %s", fmt.Sprintf("%s/%s", vmPublishReq.Namespace, vmPublishReq.Name))
+		return ctrl.Result{}, fmt.Errorf("failed to init patch helper for %s/%s: %w", vmPublishReq.Namespace, vmPublishReq.Name, err)
 	}
 
 	// the patch is skipped when the VirtualMachinePublishRequest.Status().Update
@@ -884,7 +884,7 @@ func (r *Reconciler) ReconcileNormal(ctx *pkgctx.VirtualMachinePublishRequestCon
 		err := r.publishVirtualMachine(ctx)
 		if err != nil {
 			ctx.Logger.Error(err, "failed to publish VirtualMachine")
-			return ctrl.Result{}, errors.Wrapf(err, "failed to publish VirtualMachine")
+			return ctrl.Result{}, fmt.Errorf("failed to publish VirtualMachine: %w", err)
 		}
 		return requeueResult(ctx), nil
 	}

--- a/controllers/virtualmachinereplicaset/virtualmachinereplicaset_controller.go
+++ b/controllers/virtualmachinereplicaset/virtualmachinereplicaset_controller.go
@@ -20,7 +20,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 
@@ -115,7 +114,7 @@ func (r *Reconciler) getReplicaSetsForVM(
 
 	rsList := &vmopv1.VirtualMachineReplicaSetList{}
 	if err := r.Client.List(ctx, rsList, client.InNamespace(vm.Namespace)); err != nil {
-		return nil, errors.Wrapf(err, "failed to list VirtualMachineReplicaSets")
+		return nil, fmt.Errorf("failed to list VirtualMachineReplicaSets: %w", err)
 	}
 
 	var rss []*vmopv1.VirtualMachineReplicaSet
@@ -181,7 +180,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 
 	patchHelper, err := patch.NewHelper(rs, r.Client)
 	if err != nil {
-		return ctrl.Result{}, errors.Wrapf(err, "failed to init patch helper for %s", rsCtx.String())
+		return ctrl.Result{}, fmt.Errorf("failed to init patch helper for %s: %w", rsCtx, err)
 	}
 
 	defer func() {

--- a/controllers/virtualmachinesetresourcepolicy/virtualmachinesetresourcepolicy_controller.go
+++ b/controllers/virtualmachinesetresourcepolicy/virtualmachinesetresourcepolicy_controller.go
@@ -9,7 +9,6 @@ import (
 	"reflect"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -152,7 +151,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 
 	patchHelper, err := patch.NewHelper(rp, r.Client)
 	if err != nil {
-		return ctrl.Result{}, errors.Wrapf(err, "failed to init patch helper for %s", rpCtx.String())
+		return ctrl.Result{}, fmt.Errorf("failed to init patch helper for %s: %w", rpCtx, err)
 	}
 	defer func() {
 		if err := patchHelper.Patch(ctx, rp); err != nil {

--- a/controllers/virtualmachinewebconsolerequest/v1alpha1/conditions/getter_test.go
+++ b/controllers/virtualmachinewebconsolerequest/v1alpha1/conditions/getter_test.go
@@ -18,12 +18,12 @@ limitations under the License.
 package conditions
 
 import (
+	"errors"
 	"testing"
 
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
 	"github.com/onsi/gomega/types"
-	"github.com/pkg/errors"
 
 	vmopv1a1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 )

--- a/controllers/virtualmachinewebconsolerequest/v1alpha1/conditions/patch.go
+++ b/controllers/virtualmachinewebconsolerequest/v1alpha1/conditions/patch.go
@@ -17,10 +17,10 @@ limitations under the License.
 package conditions
 
 import (
+	"fmt"
 	"reflect"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/pkg/errors"
 
 	vmopv1a1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 )
@@ -138,7 +138,7 @@ func (p Patch) Apply(latest Setter, options ...ApplyOption) error {
 			if latestCondition := Get(latest, conditionPatch.After.Type); latestCondition != nil {
 				// If latest and after agree on the change, then it is a conflict.
 				if !hasSameState(latestCondition, conditionPatch.After) {
-					return errors.Errorf("error patching conditions: The condition %q was modified by a different process and this caused a merge/AddCondition conflict: %v", conditionPatch.After.Type, cmp.Diff(latestCondition, conditionPatch.After))
+					return fmt.Errorf("error patching conditions: The condition %q was modified by a different process and this caused a merge/AddCondition conflict: %v", conditionPatch.After.Type, cmp.Diff(latestCondition, conditionPatch.After))
 				}
 				// otherwise, the latest is already as intended.
 				// NOTE: We are preserving LastTransitionTime from the latest in order to avoid altering the existing value.
@@ -158,14 +158,14 @@ func (p Patch) Apply(latest Setter, options ...ApplyOption) error {
 
 			// If the condition does not exist anymore on the latest, this is a conflict.
 			if latestCondition == nil {
-				return errors.Errorf("error patching conditions: The condition %q was deleted by a different process and this caused a merge/ChangeCondition conflict", conditionPatch.After.Type)
+				return fmt.Errorf("error patching conditions: The condition %q was deleted by a different process and this caused a merge/ChangeCondition conflict", conditionPatch.After.Type)
 			}
 
 			// If the condition on the latest is different from the base condition, check if
 			// the after state corresponds to the desired value. If not this is a conflict (unless we should ignore conflicts for this condition type).
 			if !reflect.DeepEqual(latestCondition, conditionPatch.Before) {
 				if !hasSameState(latestCondition, conditionPatch.After) {
-					return errors.Errorf("error patching conditions: The condition %q was modified by a different process and this caused a merge/ChangeCondition conflict: %v", conditionPatch.After.Type, cmp.Diff(latestCondition, conditionPatch.After))
+					return fmt.Errorf("error patching conditions: The condition %q was modified by a different process and this caused a merge/ChangeCondition conflict: %v", conditionPatch.After.Type, cmp.Diff(latestCondition, conditionPatch.After))
 				}
 				// Otherwise the latest is already as intended.
 				// NOTE: We are preserving LastTransitionTime from the latest in order to avoid altering the existing value.
@@ -185,7 +185,7 @@ func (p Patch) Apply(latest Setter, options ...ApplyOption) error {
 			// if so then this is a conflict.
 			if latestCondition := Get(latest, conditionPatch.Before.Type); latestCondition != nil {
 				if !hasSameState(latestCondition, conditionPatch.Before) {
-					return errors.Errorf("error patching conditions: The condition %q was modified by a different process and this caused a merge/RemoveCondition conflict: %v", conditionPatch.Before.Type, cmp.Diff(latestCondition, conditionPatch.Before))
+					return fmt.Errorf("error patching conditions: The condition %q was modified by a different process and this caused a merge/RemoveCondition conflict: %v", conditionPatch.Before.Type, cmp.Diff(latestCondition, conditionPatch.Before))
 				}
 			}
 			// Otherwise the latest and after agreed on the delete operation, so there's nothing to change.

--- a/controllers/virtualmachinewebconsolerequest/v1alpha1/conditions/setter_test.go
+++ b/controllers/virtualmachinewebconsolerequest/v1alpha1/conditions/setter_test.go
@@ -18,13 +18,13 @@ limitations under the License.
 package conditions
 
 import (
+	"errors"
 	"testing"
 	"time"
 
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
 	"github.com/onsi/gomega/types"
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/controllers/virtualmachinewebconsolerequest/v1alpha1/conditions/utils.go
+++ b/controllers/virtualmachinewebconsolerequest/v1alpha1/conditions/utils.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -36,17 +35,17 @@ var (
 func UnstructuredUnmarshalField(obj *unstructured.Unstructured, v interface{}, fields ...string) error {
 	value, found, err := unstructured.NestedFieldNoCopy(obj.Object, fields...)
 	if err != nil {
-		return errors.Wrapf(err, "failed to retrieve field %q from %q", strings.Join(fields, "."), obj.GroupVersionKind())
+		return fmt.Errorf("failed to retrieve field %q from %q: %w", strings.Join(fields, "."), obj.GroupVersionKind(), err)
 	}
 	if !found || value == nil {
 		return ErrUnstructuredFieldNotFound
 	}
 	valueBytes, err := json.Marshal(value)
 	if err != nil {
-		return errors.Wrapf(err, "failed to json-encode field %q value from %q", strings.Join(fields, "."), obj.GroupVersionKind())
+		return fmt.Errorf("failed to json-encode field %q value from %q: %w", strings.Join(fields, "."), obj.GroupVersionKind(), err)
 	}
 	if err := json.Unmarshal(valueBytes, v); err != nil {
-		return errors.Wrapf(err, "failed to json-decode field %q value from %q", strings.Join(fields, "."), obj.GroupVersionKind())
+		return fmt.Errorf("failed to json-decode field %q value from %q: %w", strings.Join(fields, "."), obj.GroupVersionKind(), err)
 	}
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -20,19 +20,19 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.18.0
 	github.com/vmware-tanzu/image-registry-operator-api v0.0.0-20230526154708-f67dac7c805f
 	github.com/vmware-tanzu/net-operator-api v0.0.0-20240523152550-862e2c4eb0e0
+	github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20240424021250-778eb97fa048
 	github.com/vmware-tanzu/vm-operator/api v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/vm-operator/external/ncp v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/vm-operator/external/tanzu-topology v0.0.0-00010101000000-000000000000
+	github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels v0.0.0-00010101000000-000000000000
 	github.com/vmware/govmomi v0.31.1-0.20240520223415-3550ac2646bd
 	// * https://github.com/vmware-tanzu/vm-operator/security/dependabot/24
-	golang.org/x/net v0.25.0 // indirect
 	golang.org/x/text v0.15.0
-	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.30.0
 	k8s.io/apiextensions-apiserver v0.30.0
 	k8s.io/apimachinery v0.30.0
@@ -41,12 +41,6 @@ require (
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	sigs.k8s.io/controller-runtime v0.18.2
 	sigs.k8s.io/yaml v1.4.0
-)
-
-require (
-	github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20240424021250-778eb97fa048
-	github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels v0.0.0-00010101000000-000000000000
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -74,16 +68,19 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.45.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect
+	golang.org/x/net v0.25.0 // indirect
 	golang.org/x/oauth2 v0.12.0 // indirect
 	golang.org/x/sys v0.20.0 // indirect
 	golang.org/x/term v0.20.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
 	golang.org/x/tools v0.21.0 // indirect
+	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.34.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/pkg/builder/mutating_webhook.go
+++ b/pkg/builder/mutating_webhook.go
@@ -5,13 +5,13 @@ package builder
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	"github.com/pkg/errors"
 	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/builder/validating_webhook.go
+++ b/pkg/builder/validating_webhook.go
@@ -5,11 +5,10 @@ package builder
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"

--- a/pkg/conditions/getter_test.go
+++ b/pkg/conditions/getter_test.go
@@ -18,12 +18,12 @@ limitations under the License.
 package conditions
 
 import (
+	"errors"
 	"testing"
 
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
 	"github.com/onsi/gomega/types"
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"

--- a/pkg/conditions/patch.go
+++ b/pkg/conditions/patch.go
@@ -17,10 +17,10 @@ limitations under the License.
 package conditions
 
 import (
+	"fmt"
 	"reflect"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -137,7 +137,7 @@ func (p Patch) Apply(latest Setter, options ...ApplyOption) error {
 			if latestCondition := Get(latest, conditionPatch.After.Type); latestCondition != nil {
 				// If latest and after agree on the change, then it is a conflict.
 				if !hasSameState(latestCondition, conditionPatch.After) {
-					return errors.Errorf("error patching conditions: The condition %q was modified by a different process and this caused a merge/AddCondition conflict: %v", conditionPatch.After.Type, cmp.Diff(latestCondition, conditionPatch.After))
+					return fmt.Errorf("error patching conditions: The condition %q was modified by a different process and this caused a merge/AddCondition conflict: %v", conditionPatch.After.Type, cmp.Diff(latestCondition, conditionPatch.After))
 				}
 				// otherwise, the latest is already as intended.
 				// NOTE: We are preserving LastTransitionTime from the latest in order to avoid altering the existing value.
@@ -157,14 +157,14 @@ func (p Patch) Apply(latest Setter, options ...ApplyOption) error {
 
 			// If the condition does not exist anymore on the latest, this is a conflict.
 			if latestCondition == nil {
-				return errors.Errorf("error patching conditions: The condition %q was deleted by a different process and this caused a merge/ChangeCondition conflict", conditionPatch.After.Type)
+				return fmt.Errorf("error patching conditions: The condition %q was deleted by a different process and this caused a merge/ChangeCondition conflict", conditionPatch.After.Type)
 			}
 
 			// If the condition on the latest is different from the base condition, check if
 			// the after state corresponds to the desired value. If not this is a conflict (unless we should ignore conflicts for this condition type).
 			if !reflect.DeepEqual(latestCondition, conditionPatch.Before) {
 				if !hasSameState(latestCondition, conditionPatch.After) {
-					return errors.Errorf("error patching conditions: The condition %q was modified by a different process and this caused a merge/ChangeCondition conflict: %v", conditionPatch.After.Type, cmp.Diff(latestCondition, conditionPatch.After))
+					return fmt.Errorf("error patching conditions: The condition %q was modified by a different process and this caused a merge/ChangeCondition conflict: %v", conditionPatch.After.Type, cmp.Diff(latestCondition, conditionPatch.After))
 				}
 				// Otherwise the latest is already as intended.
 				// NOTE: We are preserving LastTransitionTime from the latest in order to avoid altering the existing value.
@@ -184,7 +184,7 @@ func (p Patch) Apply(latest Setter, options ...ApplyOption) error {
 			// if so then this is a conflict.
 			if latestCondition := Get(latest, conditionPatch.Before.Type); latestCondition != nil {
 				if !hasSameState(latestCondition, conditionPatch.Before) {
-					return errors.Errorf("error patching conditions: The condition %q was modified by a different process and this caused a merge/RemoveCondition conflict: %v", conditionPatch.Before.Type, cmp.Diff(latestCondition, conditionPatch.Before))
+					return fmt.Errorf("error patching conditions: The condition %q was modified by a different process and this caused a merge/RemoveCondition conflict: %v", conditionPatch.Before.Type, cmp.Diff(latestCondition, conditionPatch.Before))
 				}
 			}
 			// Otherwise the latest and after agreed on the delete operation, so there's nothing to change.

--- a/pkg/conditions/setter_test.go
+++ b/pkg/conditions/setter_test.go
@@ -18,13 +18,13 @@ limitations under the License.
 package conditions
 
 import (
+	"errors"
 	"testing"
 	"time"
 
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
 	"github.com/onsi/gomega/types"
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"

--- a/pkg/conditions/utils.go
+++ b/pkg/conditions/utils.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -36,17 +35,17 @@ var (
 func UnstructuredUnmarshalField(obj *unstructured.Unstructured, v interface{}, fields ...string) error {
 	value, found, err := unstructured.NestedFieldNoCopy(obj.Object, fields...)
 	if err != nil {
-		return errors.Wrapf(err, "failed to retrieve field %q from %q", strings.Join(fields, "."), obj.GroupVersionKind())
+		return fmt.Errorf("failed to retrieve field %q from %q: %w", strings.Join(fields, "."), obj.GroupVersionKind(), err)
 	}
 	if !found || value == nil {
 		return ErrUnstructuredFieldNotFound
 	}
 	valueBytes, err := json.Marshal(value)
 	if err != nil {
-		return errors.Wrapf(err, "failed to json-encode field %q value from %q", strings.Join(fields, "."), obj.GroupVersionKind())
+		return fmt.Errorf("failed to json-encode field %q value from %q: %w", strings.Join(fields, "."), obj.GroupVersionKind(), err)
 	}
 	if err := json.Unmarshal(valueBytes, v); err != nil {
-		return errors.Wrapf(err, "failed to json-decode field %q value from %q", strings.Join(fields, "."), obj.GroupVersionKind())
+		return fmt.Errorf("failed to json-decode field %q value from %q: %w", strings.Join(fields, "."), obj.GroupVersionKind(), err)
 	}
 	return nil
 }

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -98,7 +97,7 @@ func New(ctx context.Context, opts Options) (Manager, error) {
 		NewCache:                opts.NewCache,
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to create manager")
+		return nil, fmt.Errorf("unable to create manager: %w", err)
 	}
 
 	// Build the controller manager pkgctx.
@@ -122,7 +121,7 @@ func New(ctx context.Context, opts Options) (Manager, error) {
 
 	// Add the requested items to the manager.
 	if err := opts.AddToManager(controllerManagerContext, mgr); err != nil {
-		return nil, errors.Wrap(err, "failed to add resources to the manager")
+		return nil, fmt.Errorf("failed to add resources to the manager: %w", err)
 	}
 
 	return &manager{

--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -16,10 +16,10 @@ package patch
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"time"
 
-	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -89,7 +89,7 @@ func (h *Helper) Patch(ctx context.Context, obj client.Object, opts ...Option) e
 		return err
 	}
 	if gvk != h.gvk {
-		return errors.Errorf("unmatched GroupVersionKind, expected %q got %q", h.gvk, gvk)
+		return fmt.Errorf("unmatched GroupVersionKind, expected %q got %q", h.gvk, gvk)
 	}
 
 	// Calculate the options.
@@ -185,11 +185,11 @@ func (h *Helper) patchStatusConditions(ctx context.Context, obj client.Object, f
 	// interface any longer, although this shouldn't happen because we already check when creating the patcher.
 	before, ok := h.beforeObject.(conditions.Getter)
 	if !ok {
-		return errors.Errorf("object %s doesn't satisfy conditions.Getter, cannot patch", before.GetObjectKind())
+		return fmt.Errorf("object %s doesn't satisfy conditions.Getter, cannot patch", before.GetObjectKind())
 	}
 	after, ok := obj.(conditions.Getter)
 	if !ok {
-		return errors.Errorf("object %s doesn't satisfy conditions.Getter, cannot patch", after.GetObjectKind())
+		return fmt.Errorf("object %s doesn't satisfy conditions.Getter, cannot patch", after.GetObjectKind())
 	}
 
 	// Store the diff from the before/after object, and return early if there are no changes.
@@ -218,7 +218,7 @@ func (h *Helper) patchStatusConditions(ctx context.Context, obj client.Object, f
 	return wait.ExponentialBackoff(backoff, func() (bool, error) {
 		latest, ok := before.DeepCopyObject().(conditions.Setter)
 		if !ok {
-			return false, errors.Errorf("object %s doesn't satisfy conditions.Setter, cannot patch", latest.GetObjectKind())
+			return false, fmt.Errorf("object %s doesn't satisfy conditions.Setter, cannot patch", latest.GetObjectKind())
 		}
 
 		// Get a new copy of the object.
@@ -278,13 +278,13 @@ func (h *Helper) calculateChanges(after client.Object) (map[string]bool, error) 
 	patch := client.MergeFrom(h.beforeObject)
 	diff, err := patch.Data(after)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to calculate patch data")
+		return nil, fmt.Errorf("failed to calculate patch data: %w", err)
 	}
 
 	// Unmarshal patch data into a local map.
 	patchDiff := map[string]interface{}{}
 	if err := json.Unmarshal(diff, &patchDiff); err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal patch data into a map")
+		return nil, fmt.Errorf("failed to unmarshal patch data into a map: %w", err)
 	}
 
 	// Return the map.
@@ -299,7 +299,7 @@ func checkNilObject(obj client.Object) error {
 	// If you're wondering why we need reflection to do this check, see https://golang.org/doc/faq#nil_error.
 	// TODO(vincepri): Remove this check and let it panic if used improperly in a future minor release.
 	if obj == nil || (reflect.ValueOf(obj).IsValid() && reflect.ValueOf(obj).IsNil()) {
-		return errors.Errorf("expected non-nil object")
+		return fmt.Errorf("expected non-nil object")
 	}
 	return nil
 }

--- a/pkg/prober/worker/readiness_worker.go
+++ b/pkg/prober/worker/readiness_worker.go
@@ -12,8 +12,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/pkg/errors"
-
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	"github.com/vmware-tanzu/vm-operator/pkg/patch"
@@ -105,7 +103,7 @@ func (w *readinessWorker) ProcessProbeResult(ctx *proberctx.ProbeContext, res pr
 		Conditions: []string{vmopv1.ReadyConditionType},
 	})
 	if err != nil {
-		return errors.Wrapf(err, "patched failed")
+		return fmt.Errorf("patched failed: %w", err)
 	}
 
 	return nil

--- a/pkg/providers/vsphere/credentials/credentials.go
+++ b/pkg/providers/vsphere/credentials/credentials.go
@@ -5,8 +5,9 @@ package credentials
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -24,7 +25,7 @@ func GetProviderCredentials(client ctrlclient.Client, namespace, secretName stri
 	secretKey := types.NamespacedName{Namespace: namespace, Name: secretName}
 	if err := client.Get(context.Background(), secretKey, secret); err != nil {
 		// Log message used by VMC LINT. Refer to before making changes
-		return nil, errors.Wrapf(err, "cannot find secret for provider credentials: %s", secretKey)
+		return nil, fmt.Errorf("cannot find secret for provider credentials: %s: %w", secretKey, err)
 	}
 
 	var credentials VSphereVMProviderCredentials

--- a/pkg/providers/vsphere/resources/vm.go
+++ b/pkg/providers/vsphere/resources/vm.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/mo"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
@@ -52,7 +51,7 @@ func (vm *VirtualMachine) Create(ctx context.Context, folder *object.Folder, poo
 
 	result, err := createTask.WaitForResult(ctx, nil)
 	if err != nil {
-		return errors.Wrapf(err, "create VM %q task failed", vm.Name)
+		return fmt.Errorf("create VM %q task failed: %w", vm.Name, err)
 	}
 
 	vm.vcVirtualMachine = object.NewVirtualMachine(folder.Client(), result.Result.(vimtypes.ManagedObjectReference))
@@ -69,7 +68,7 @@ func (vm *VirtualMachine) Clone(ctx context.Context, folder *object.Folder, clon
 
 	result, err := cloneTask.WaitForResult(ctx, nil)
 	if err != nil {
-		return nil, errors.Wrapf(err, "clone VM task failed")
+		return nil, fmt.Errorf("clone VM task failed: %w", err)
 	}
 
 	ref := result.Result.(vimtypes.ManagedObjectReference)
@@ -86,7 +85,7 @@ func (vm *VirtualMachine) Reconfigure(ctx context.Context, configSpec *vimtypes.
 
 	_, err = reconfigureTask.WaitForResult(ctx, nil)
 	if err != nil {
-		return errors.Wrapf(err, "reconfigure VM task failed")
+		return fmt.Errorf("reconfigure VM task failed: %w", err)
 	}
 
 	return nil
@@ -220,10 +219,10 @@ func (vm *VirtualMachine) Customize(ctx context.Context, spec vimtypes.Customiza
 		// Fetch fault messages for task.Error
 		fault := taskErr.Fault.GetMethodFault()
 		if fault != nil {
-			err = errors.Wrapf(err, "Fault messages: %v", fault.FaultMessage)
+			err = fmt.Errorf("fault messages: %v: %w", fault.FaultMessage, err)
 		}
 
-		return errors.Wrap(err, "Customization task failed")
+		return fmt.Errorf("customization task failed: %w", err)
 	}
 
 	return nil

--- a/pkg/providers/vsphere/storage/provisioning.go
+++ b/pkg/providers/vsphere/storage/provisioning.go
@@ -4,7 +4,8 @@
 package storage
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"github.com/vmware/govmomi/pbm"
 	pbmTypes "github.com/vmware/govmomi/pbm/types"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
@@ -72,7 +73,7 @@ func GetDiskProvisioningForProfile(
 
 	profiles, err := c.RetrieveContent(vmCtx, []pbmTypes.PbmProfileId{{UniqueId: storageProfileID}})
 	if err != nil {
-		return "", errors.Wrapf(err, "Failed to get storage profiles for ID: %s", storageProfileID)
+		return "", fmt.Errorf("failed to get storage profiles for ID: %s: %w", storageProfileID, err)
 	}
 
 	for _, p := range profiles {

--- a/pkg/providers/vsphere/virtualmachine/delete.go
+++ b/pkg/providers/vsphere/virtualmachine/delete.go
@@ -4,8 +4,10 @@
 package virtualmachine
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	"github.com/vmware/govmomi/object"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 
@@ -63,7 +65,7 @@ func DeleteVirtualMachine(
 		if taskInfo != nil {
 			vmCtx.Logger.V(5).Error(err, "destroy VM task failed", "taskInfo", taskInfo)
 		}
-		return errors.Wrapf(err, "destroy VM task failed")
+		return fmt.Errorf("destroy VM task failed: %w", err)
 	}
 
 	return nil

--- a/pkg/providers/vsphere/vmlifecycle/create_clone.go
+++ b/pkg/providers/vsphere/vmlifecycle/create_clone.go
@@ -6,7 +6,6 @@ package vmlifecycle
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
@@ -28,12 +27,12 @@ func cloneVMFromInventory(
 
 	srcVM, err := finder.VirtualMachine(vmCtx, srcVMName)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to find clone source VM: %s", srcVMName)
+		return nil, fmt.Errorf("failed to find clone source VM: %s: %w", srcVMName, err)
 	}
 
 	cloneSpec, err := createCloneSpec(vmCtx, createArgs, srcVM)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create CloneSpec")
+		return nil, fmt.Errorf("failed to create CloneSpec: %w", err)
 	}
 
 	// We always set cloneSpec.Location.Folder so use that to get the parent folder object.
@@ -46,7 +45,7 @@ func cloneVMFromInventory(
 
 	result, err := cloneTask.WaitForResult(vmCtx, nil)
 	if err != nil {
-		return nil, errors.Wrapf(err, "clone VM task failed")
+		return nil, fmt.Errorf("clone VM task failed: %w", err)
 	}
 
 	ref := result.Result.(vimtypes.ManagedObjectReference)

--- a/pkg/providers/vsphere/vmlifecycle/create_contentlibrary.go
+++ b/pkg/providers/vsphere/vmlifecycle/create_contentlibrary.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/vmware/govmomi/vapi/library"
 	"github.com/vmware/govmomi/vapi/rest"
 	"github.com/vmware/govmomi/vapi/vcenter"
@@ -97,6 +96,6 @@ func deployFromContentLibrary(
 	case library.ItemTypeVMTX:
 		return deployVMTX(vmCtx, restClient, item, createArgs)
 	default:
-		return nil, errors.Errorf("item %s not a supported type: %s", item.Name, item.Type)
+		return nil, fmt.Errorf("item %s not a supported type: %s", item.Name, item.Type)
 	}
 }

--- a/pkg/providers/vsphere/vmprovider.go
+++ b/pkg/providers/vsphere/vmprovider.go
@@ -13,7 +13,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/ovf"
 	"github.com/vmware/govmomi/task"
@@ -191,7 +190,7 @@ func (vs *vSphereVMProvider) SyncVirtualMachineImage(ctx context.Context, cli, v
 		itemID = string(cli.Spec.UUID)
 		contentVersion = cli.Status.ContentVersion
 	default:
-		return errors.Errorf("unexpected content library item type %T", cli)
+		return fmt.Errorf("unexpected content library item type %T", cli)
 	}
 
 	ovfEnvelope, err := vs.getOvfEnvelope(ctx, itemID, contentVersion)
@@ -392,7 +391,7 @@ func (vs *vSphereVMProvider) GetTasksByActID(ctx context.Context, actID string) 
 
 	collector, err := taskManager.CreateCollectorForTasks(ctx, filterSpec)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create collector for tasks")
+		return nil, fmt.Errorf("failed to create collector for tasks: %w", err)
 	}
 	defer func() {
 		err = collector.Destroy(ctx)

--- a/pkg/providers/vsphere/vmprovider_vm.go
+++ b/pkg/providers/vsphere/vmprovider_vm.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 	"text/template"
 
-	"github.com/pkg/errors"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25/mo"
@@ -159,7 +158,7 @@ func (vs *vSphereVMProvider) PublishVirtualMachine(
 
 	client, err := vs.getVcClient(ctx)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to get vCenter client")
+		return "", fmt.Errorf("failed to get vCenter client: %w", err)
 	}
 
 	itemID, err := virtualmachine.CreateOVF(vmCtx, client.RestClient(), vmPub, cl, actID)

--- a/pkg/util/vmopv1/vm.go
+++ b/pkg/util/vmopv1/vm.go
@@ -9,8 +9,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -108,7 +106,7 @@ func ResolveImageName(
 	case 1:
 		obj = &vmiList.Items[0]
 	default:
-		return nil, errors.Errorf(
+		return nil, fmt.Errorf(
 			"multiple VM images exist for %q in namespace scope", imgName)
 	}
 
@@ -124,13 +122,13 @@ func ResolveImageName(
 		break
 	case 1:
 		if obj != nil {
-			return nil, errors.Errorf(
+			return nil, fmt.Errorf(
 				"multiple VM images exist for %q in namespace and cluster scope",
 				imgName)
 		}
 		obj = &cvmiList.Items[0]
 	default:
-		return nil, errors.Errorf(
+		return nil, fmt.Errorf(
 			"multiple VM images exist for %q in cluster scope", imgName)
 	}
 

--- a/pkg/util/vsphere/client/client.go
+++ b/pkg/util/vsphere/client/client.go
@@ -5,11 +5,11 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/url"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/session"
@@ -154,7 +154,7 @@ func newRestClient(
 	// Initial login. This will also start the keepalive.
 	if err := restClient.Login(ctx, userInfo); err != nil {
 		// Log message used by VMC LINT. Refer to before making changes
-		return nil, errors.Wrapf(err, "login failed for url: %v", vimClient.URL())
+		return nil, fmt.Errorf("login failed for url: %v: %w", vimClient.URL(), err)
 	}
 
 	return restClient, nil
@@ -171,28 +171,28 @@ func NewVimClient(
 	log.Info("Creating new vim Client", "VcPNID", config.Host, "VcPort", config.Port)
 	soapURL, err := soap.ParseURL(net.JoinHostPort(config.Host, config.Port))
 	if err != nil {
-		return nil, nil, errors.Wrapf(
-			err, "failed to parse %s:%s", config.Host, config.Port)
+		return nil, nil, fmt.Errorf(
+			"failed to parse %s:%s: %w", config.Host, config.Port, err)
 	}
 
 	soapClient := soap.NewClient(soapURL, config.Insecure)
 	if config.CAFilePath != "" {
 		err = soapClient.SetRootCAs(config.CAFilePath)
 		if err != nil {
-			return nil, nil, errors.Wrapf(
-				err, "failed to set root CA %s", config.CAFilePath)
+			return nil, nil, fmt.Errorf(
+				"failed to set root CA %s: %w", config.CAFilePath, err)
 		}
 	}
 
 	vimClient, err := vim25.NewClient(ctx, soapClient)
 	if err != nil {
-		return nil, nil, errors.Wrapf(
-			err, "error creating a new vim client for url: %v", soapURL)
+		return nil, nil, fmt.Errorf(
+			"error creating a new vim client for url: %v: %w", soapURL, err)
 	}
 
 	if err := vimClient.UseServiceVersion(); err != nil {
-		return nil, nil, errors.Wrapf(
-			err, "error setting vim client version for url: %v", soapURL)
+		return nil, nil, fmt.Errorf(
+			"error setting vim client version for url: %v: %w", soapURL, err)
 	}
 
 	userInfo := url.UserPassword(config.Username, config.Password)
@@ -207,8 +207,8 @@ func NewVimClient(
 	// Initial login. This will also start the keepalive.
 	if err = sm.Login(ctx, userInfo); err != nil {
 		// Log message used by VMC LINT. Refer to before making changes
-		return nil, nil, errors.Wrapf(
-			err, "login failed for url: %v", soapURL)
+		return nil, nil, fmt.Errorf(
+			"login failed for url: %v: %w", soapURL, err)
 	}
 
 	return vimClient, sm, err
@@ -228,8 +228,8 @@ func newFinder(
 			Value: config.Datacenter,
 		})
 	if err != nil {
-		return nil, nil, errors.Wrapf(
-			err, "failed to find Datacenter %q", config.Datacenter)
+		return nil, nil, fmt.Errorf(
+			"failed to find Datacenter %q: %w", config.Datacenter, err)
 	}
 
 	dc := dcRef.(*object.Datacenter)

--- a/test/builder/test_suite.go
+++ b/test/builder/test_suite.go
@@ -22,7 +22,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -245,7 +244,7 @@ func newTestSuiteForWebhook(
 	// Create a temp directory for the certs needed for testing webhooks.
 	certDir, err := os.MkdirTemp(os.TempDir(), "")
 	if err != nil {
-		panic(errors.Wrap(err, "failed to create temp dir for certs"))
+		panic(fmt.Errorf("failed to create temp dir for certs: %w", err))
 	}
 	testSuite.certDir = certDir
 

--- a/webhooks/persistentvolumeclaim/validation/persistentvolumeclaim_validator.go
+++ b/webhooks/persistentvolumeclaim/validation/persistentvolumeclaim_validator.go
@@ -17,8 +17,6 @@ import (
 	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	"github.com/pkg/errors"
-
 	"github.com/vmware-tanzu/vm-operator/pkg/builder"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/constants"
@@ -49,7 +47,7 @@ var (
 func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) error {
 	hook, err := builder.NewValidatingWebhook(ctx, mgr, webHookName, NewValidator(mgr.GetClient()))
 	if err != nil {
-		return errors.Wrapf(err, "failed to create PersistentVolumeClaim validation webhook")
+		return fmt.Errorf("failed to create PersistentVolumeClaim validation webhook: %w", err)
 	}
 	mgr.GetWebhookServer().Register(hook.Path, hook)
 

--- a/webhooks/persistentvolumeclaim/webhook.go
+++ b/webhooks/persistentvolumeclaim/webhook.go
@@ -4,7 +4,8 @@
 package persistentvolumeclaim
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
 
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
@@ -13,7 +14,7 @@ import (
 
 func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) error {
 	if err := validation.AddToManager(ctx, mgr); err != nil {
-		return errors.Wrap(err, "failed to initialize validation webhook")
+		return fmt.Errorf("failed to initialize validation webhook: %w", err)
 	}
 	return nil
 }

--- a/webhooks/virtualmachine/mutation/virtualmachine_mutator.go
+++ b/webhooks/virtualmachine/mutation/virtualmachine_mutator.go
@@ -6,13 +6,13 @@ package mutation
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"reflect"
 	"strings"
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/pkg/errors"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -80,7 +80,7 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) err
 
 	hook, err := builder.NewMutatingWebhook(ctx, mgr, webHookName, NewMutator(mgr.GetClient()))
 	if err != nil {
-		return errors.Wrapf(err, "failed to create mutation webhook")
+		return fmt.Errorf("failed to create mutation webhook: %w", err)
 	}
 	mgr.GetWebhookServer().Register(hook.Path, hook)
 

--- a/webhooks/virtualmachine/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -86,7 +85,7 @@ const (
 func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) error {
 	hook, err := builder.NewValidatingWebhook(ctx, mgr, webHookName, NewValidator(mgr.GetClient()))
 	if err != nil {
-		return errors.Wrap(err, "failed to create VirtualMachine validation webhook")
+		return fmt.Errorf("failed to create VirtualMachine validation webhook: %w", err)
 	}
 	mgr.GetWebhookServer().Register(hook.Path, hook)
 

--- a/webhooks/virtualmachineclass/mutation/virtualmachineclass_mutator.go
+++ b/webhooks/virtualmachineclass/mutation/virtualmachineclass_mutator.go
@@ -5,10 +5,10 @@ package mutation
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"reflect"
 
-	"github.com/pkg/errors"
 	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -33,7 +33,7 @@ const (
 func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) error {
 	hook, err := builder.NewMutatingWebhook(ctx, mgr, webHookName, NewMutator(nil))
 	if err != nil {
-		return errors.Wrapf(err, "failed to create mutation webhook")
+		return fmt.Errorf("failed to create mutation webhook: %w", err)
 	}
 	mgr.GetWebhookServer().Register(hook.Path, hook)
 

--- a/webhooks/virtualmachineclass/validation/virtualmachineclass_validator.go
+++ b/webhooks/virtualmachineclass/validation/virtualmachineclass_validator.go
@@ -4,6 +4,7 @@
 package validation
 
 import (
+	"fmt"
 	"net/http"
 	"reflect"
 
@@ -16,8 +17,6 @@ import (
 	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
-
-	"github.com/pkg/errors"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 
@@ -41,7 +40,7 @@ const (
 func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) error {
 	hook, err := builder.NewValidatingWebhook(ctx, mgr, webHookName, NewValidator(mgr.GetClient()))
 	if err != nil {
-		return errors.Wrapf(err, "failed to create VirtualMachineClass validation webhook")
+		return fmt.Errorf("failed to create VirtualMachineClass validation webhook: %w", err)
 	}
 	mgr.GetWebhookServer().Register(hook.Path, hook)
 

--- a/webhooks/virtualmachinepublishrequest/validation/virtualmachinepublishrequest_validator.go
+++ b/webhooks/virtualmachinepublishrequest/validation/virtualmachinepublishrequest_validator.go
@@ -4,10 +4,10 @@
 package validation
 
 import (
+	"fmt"
 	"net/http"
 	"reflect"
 
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -40,7 +40,7 @@ const (
 func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) error {
 	hook, err := builder.NewValidatingWebhook(ctx, mgr, webHookName, NewValidator(mgr.GetClient()))
 	if err != nil {
-		return errors.Wrapf(err, "failed to create VirtualMachinePublishRequest validation webhook")
+		return fmt.Errorf("failed to create VirtualMachinePublishRequest validation webhook: %w", err)
 	}
 	mgr.GetWebhookServer().Register(hook.Path, hook)
 

--- a/webhooks/virtualmachinereplicaset/mutation/virtualmachinereplicaset_mutator.go
+++ b/webhooks/virtualmachinereplicaset/mutation/virtualmachinereplicaset_mutator.go
@@ -5,10 +5,10 @@ package mutation
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"reflect"
 
-	"github.com/pkg/errors"
 	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -31,7 +31,7 @@ const (
 func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) error {
 	hook, err := builder.NewMutatingWebhook(ctx, mgr, webHookName, NewMutator(nil))
 	if err != nil {
-		return errors.Wrapf(err, "failed to create mutation webhook")
+		return fmt.Errorf("failed to create mutation webhook: %w", err)
 	}
 	mgr.GetWebhookServer().Register(hook.Path, hook)
 

--- a/webhooks/virtualmachinereplicaset/validation/virtualmachinereplicaset_validator.go
+++ b/webhooks/virtualmachinereplicaset/validation/virtualmachinereplicaset_validator.go
@@ -19,8 +19,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	"github.com/pkg/errors"
-
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 
 	"github.com/vmware-tanzu/vm-operator/pkg/builder"
@@ -38,7 +36,7 @@ const (
 func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) error {
 	hook, err := builder.NewValidatingWebhook(ctx, mgr, webHookName, NewValidator(mgr.GetClient()))
 	if err != nil {
-		return errors.Wrapf(err, "failed to create VirtualMachineReplicaset validation webhook")
+		return fmt.Errorf("failed to create VirtualMachineReplicaset validation webhook: %w", err)
 	}
 	mgr.GetWebhookServer().Register(hook.Path, hook)
 

--- a/webhooks/virtualmachineservice/mutation/virtualmachineservice_mutator.go
+++ b/webhooks/virtualmachineservice/mutation/virtualmachineservice_mutator.go
@@ -5,10 +5,10 @@ package mutation
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"reflect"
 
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -32,7 +32,7 @@ const (
 func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) error {
 	hook, err := builder.NewMutatingWebhook(ctx, mgr, webHookName, NewMutator(nil))
 	if err != nil {
-		return errors.Wrapf(err, "failed to create mutation webhook")
+		return fmt.Errorf("failed to create mutation webhook: %w", err)
 	}
 	mgr.GetWebhookServer().Register(hook.Path, hook)
 

--- a/webhooks/virtualmachineservice/validation/virtualmachineservice_validator.go
+++ b/webhooks/virtualmachineservice/validation/virtualmachineservice_validator.go
@@ -10,7 +10,6 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	unversionedvalidation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -56,7 +55,7 @@ var (
 func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) error {
 	hook, err := builder.NewValidatingWebhook(ctx, mgr, webHookName, NewValidator(mgr.GetClient()))
 	if err != nil {
-		return errors.Wrapf(err, "failed to create VirtualMachineService validation webhook")
+		return fmt.Errorf("failed to create VirtualMachineService validation webhook: %w", err)
 	}
 	mgr.GetWebhookServer().Register(hook.Path, hook)
 

--- a/webhooks/virtualmachinesetresourcepolicy/validation/virtualmachinesetresourcepolicy_validator.go
+++ b/webhooks/virtualmachinesetresourcepolicy/validation/virtualmachinesetresourcepolicy_validator.go
@@ -4,6 +4,7 @@
 package validation
 
 import (
+	"fmt"
 	"net/http"
 	"reflect"
 
@@ -17,8 +18,6 @@ import (
 	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
-
-	"github.com/pkg/errors"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 
@@ -39,7 +38,7 @@ const (
 func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) error {
 	hook, err := builder.NewValidatingWebhook(ctx, mgr, webHookName, NewValidator(mgr.GetClient()))
 	if err != nil {
-		return errors.Wrapf(err, "failed to create VirtualMachineSetResourcePolicy validation webhook")
+		return fmt.Errorf("failed to create VirtualMachineSetResourcePolicy validation webhook: %w", err)
 	}
 	mgr.GetWebhookServer().Register(hook.Path, hook)
 

--- a/webhooks/virtualmachinewebconsolerequest/v1alpha1/validation/webconsolerequest_validator.go
+++ b/webhooks/virtualmachinewebconsolerequest/v1alpha1/validation/webconsolerequest_validator.go
@@ -6,10 +6,10 @@ package validation
 import (
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 	"net/http"
 	"reflect"
 
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -38,7 +38,7 @@ const (
 func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) error {
 	hook, err := builder.NewValidatingWebhook(ctx, mgr, webHookName, NewValidator(mgr.GetClient()))
 	if err != nil {
-		return errors.Wrapf(err, "failed to create webconsolerequest validation webhook")
+		return fmt.Errorf("failed to create webconsolerequest validation webhook: %w", err)
 	}
 	mgr.GetWebhookServer().Register(hook.Path, hook)
 	return nil

--- a/webhooks/virtualmachinewebconsolerequest/v1alpha1/webhooks.go
+++ b/webhooks/virtualmachinewebconsolerequest/v1alpha1/webhooks.go
@@ -4,7 +4,7 @@
 package v1alpha1
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -14,7 +14,7 @@ import (
 
 func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) error {
 	if err := validation.AddToManager(ctx, mgr); err != nil {
-		return errors.Wrap(err, "failed to initialize validation webhook")
+		return fmt.Errorf("failed to initialize validation webhook: %w", err)
 	}
 	return nil
 }

--- a/webhooks/virtualmachinewebconsolerequest/v1alpha2/validation/webconsolerequest_validator.go
+++ b/webhooks/virtualmachinewebconsolerequest/v1alpha2/validation/webconsolerequest_validator.go
@@ -6,10 +6,10 @@ package validation
 import (
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 	"net/http"
 	"reflect"
 
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -38,7 +38,7 @@ const (
 func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) error {
 	hook, err := builder.NewValidatingWebhook(ctx, mgr, webHookName, NewValidator(mgr.GetClient()))
 	if err != nil {
-		return errors.Wrapf(err, "failed to create virtualmachinewebconsolerequest validation webhook")
+		return fmt.Errorf("failed to create virtualmachinewebconsolerequest validation webhook: %w", err)
 	}
 	mgr.GetWebhookServer().Register(hook.Path, hook)
 	return nil

--- a/webhooks/virtualmachinewebconsolerequest/v1alpha2/webhooks.go
+++ b/webhooks/virtualmachinewebconsolerequest/v1alpha2/webhooks.go
@@ -4,7 +4,7 @@
 package v1alpha2
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -14,7 +14,7 @@ import (
 
 func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) error {
 	if err := validation.AddToManager(ctx, mgr); err != nil {
-		return errors.Wrap(err, "failed to initialize validation webhook")
+		return fmt.Errorf("failed to initialize validation webhook: %w", err)
 	}
 	return nil
 }

--- a/webhooks/webhooks.go
+++ b/webhooks/webhooks.go
@@ -4,7 +4,8 @@
 package webhooks
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
 
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
@@ -22,30 +23,30 @@ import (
 // AddToManager adds all webhooks and a certificate manager to the provided controller manager.
 func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) error {
 	if err := persistentvolumeclaim.AddToManager(ctx, mgr); err != nil {
-		return errors.Wrap(err, "failed to initialize PersistentVolumeClaim webhook")
+		return fmt.Errorf("failed to initialize PersistentVolumeClaim webhook: %w", err)
 	}
 	if err := virtualmachine.AddToManager(ctx, mgr); err != nil {
-		return errors.Wrap(err, "failed to initialize VirtualMachine webhooks")
+		return fmt.Errorf("failed to initialize VirtualMachine webhooks: %w", err)
 	}
 	if err := virtualmachineclass.AddToManager(ctx, mgr); err != nil {
-		return errors.Wrap(err, "failed to initialize VirtualMachineClass webhooks")
+		return fmt.Errorf("failed to initialize VirtualMachineClass webhooks: %w", err)
 	}
 	if err := virtualmachinepublishrequest.AddToManager(ctx, mgr); err != nil {
-		return errors.Wrap(err, "failed to initialize VirtualMachinePublishRequest webhooks")
+		return fmt.Errorf("failed to initialize VirtualMachinePublishRequest webhooks: %w", err)
 	}
 	if err := virtualmachineservice.AddToManager(ctx, mgr); err != nil {
-		return errors.Wrap(err, "failed to initialize VirtualMachineService webhooks")
+		return fmt.Errorf("failed to initialize VirtualMachineService webhooks: %w", err)
 	}
 	if err := virtualmachinesetresourcepolicy.AddToManager(ctx, mgr); err != nil {
-		return errors.Wrap(err, "failed to initialize VirtualMachineSetResourcePolicy webhooks")
+		return fmt.Errorf("failed to initialize VirtualMachineSetResourcePolicy webhooks: %w", err)
 	}
 	if err := virtualmachinewebconsolerequest.AddToManager(ctx, mgr); err != nil {
-		return errors.Wrap(err, "failed to initialize VirtualMachineWebConsoleRequest webhooks")
+		return fmt.Errorf("failed to initialize VirtualMachineWebConsoleRequest webhooks: %w", err)
 	}
 
 	if pkgcfg.FromContext(ctx).Features.K8sWorkloadMgmtAPI {
 		if err := virtualmachinereplicaset.AddToManager(ctx, mgr); err != nil {
-			return errors.Wrap(err, "failed to initialize VirtualMachineReplicaSet webhooks")
+			return fmt.Errorf("failed to initialize VirtualMachineReplicaSet webhooks: %w", err)
 		}
 	}
 


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch replaces the use of `github.com/pkg/errors` library with the stdlib `errors` package. The latter gained the ability to embed wrapped errors and unwrap them in Go 1.13. The only difference between the two packages is that github.com/pkg/errors also includes the stack trace.

The `Wrap` (https://github.com/pkg/errors/blob/614d223910a179a466c1767a985424175c39b465/errors.go#L181-L196) and `Wrapf` (https://github.com/pkg/errors/blob/614d223910a179a466c1767a985424175c39b465/errors.go#L198-L213) functions from github.com/pkg/errors would include the stack trace for up to 32 callers (https://github.com/pkg/errors/blob/5dd12d0cfe7f152f80558d591504ce685299311e/stack.go#L163-L169). If the error was formatted with `+v`, then the error would emit the stack trace (https://github.com/pkg/errors/blob/614d223910a179a466c1767a985424175c39b465/errors.go#L165-L179).

Given that VM Operator does not rely on this feature, it makes sense to deprecate the use of `github.com/pkg/errors` for the stdlib `errors` package instead. Please refer to https://pkg.go.dev/errors for more information on how to wrap, unwrap, and assert stdlib errors.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Replaces `github.com/pkg/errors` with stdlib `errors`
```