### PR TITLE
🌱 Exclude ./api from coverage (but still test it)

### DIFF
--- a/hack/test.sh
+++ b/hack/test.sh
@@ -13,24 +13,28 @@ set -x
 # script is located.
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
-COVERAGE_FILE="${1:-}"
+GO_TEST_FLAGS+=("-v")           # verbose
+GO_TEST_FLAGS+=("-r")           # recursive
+GO_TEST_FLAGS+=("--race")       # check for possible races
+GO_TEST_FLAGS+=("--keep-going") # do not fail on the first error
 
-GO_TEST_FLAGS=("-v" "-r" "--race" "--keep-going")
-
+# Only run tests that match given labels if LABEL_FILTER is non-empty.
 if [ -n "${LABEL_FILTER:-}" ]; then
   GO_TEST_FLAGS+=("--label-filter" "${LABEL_FILTER:-}")
 fi
 
-# The first argument is the name of the coverage file to use.
-if [ -n "${COVERAGE_FILE}" ]; then
-  GO_TEST_FLAGS+=("--cover")
-  GO_TEST_FLAGS+=("--covermode=atomic")
-  GO_TEST_FLAGS+=("--coverprofile=${COVERAGE_FILE}")
+# Coverage is always enabled, it is just not always recorded to an output file.
+GO_TEST_FLAGS+=("--cover")
+GO_TEST_FLAGS+=("--covermode=atomic")
+
+# Record coverage to an output file if COVERAGE_FILE is non-empty.
+if [ -n "${COVERAGE_FILE:-}" ]; then
+  GO_TEST_FLAGS+=("--coverprofile=${COVERAGE_FILE:-}")
 fi
 
 # Run the tests.
 # shellcheck disable=SC2086
-ginkgo "${GO_TEST_FLAGS[@]+"${GO_TEST_FLAGS[@]}"}" || TEST_CMD_EXIT_CODE="${?}"
+ginkgo "${GO_TEST_FLAGS[@]+"${GO_TEST_FLAGS[@]}"}" "${@:-}" || TEST_CMD_EXIT_CODE="${?}"
 
 # TEST_CMD_EXIT_CODE may be set to 2 if there are any tests marked as
 # pending/skipped. This pattern is used by developers to leave test


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch excludes the `./api` module from coverage. This is because there is too much generated code in the API schemas that is not able to be tested due to the way the code is generated. For example, in `./api/v1alpha2/zz_generated.conversions.go`:

```go
func RegisterConversions(s *runtime.Scheme) error {
	if err := s.AddGeneratedConversionFunc((*ClusterVirtualMachineImage)(nil), (*v1alpha3.ClusterVirtualMachineImage)(nil), func(a, b interface{}, scope conversion.Scope) error {
		return Convert_v1alpha2_ClusterVirtualMachineImage_To_v1alpha3_ClusterVirtualMachineImage(a.(*ClusterVirtualMachineImage), b.(*v1alpha3.ClusterVirtualMachineImage), scope)
	}); err != nil {
		return err
	}
```

There are hundreds of these in the `v1alpha1`, `v1alpha2`, and `v1alpha3` schema packages, and for each one, there is no way to cover the logic where an error is returned due to the generated code.

Instead of having the API module cause the project's overall coverage metric dip into less-than-ideal numbers, this patch excludes the API module from coverage. Please note:

* The API module is *still* tested, and the `test` and `test-nocover` targets *will* fail if the API tests fail. 
* The API module is *still* reporting coverage, just not as part of the `cover.out` file that informs the PR results.

    The `test-api` target still uses `./hack/test.sh` which now defaults to using the `--cover` flag. However, `./hack/test.sh` only records the coverage results to a file if one is specified in the environment variable `COVERAGE_FILE`. Regardless if the results are emitted to a file, they are always available on `stdout`, including in GitHub action workflows ([example](https://github.com/vmware-tanzu/vm-operator/actions/runs/9287926215/job/25558137575?pr=540#step:5:126)).
 
The only difference is that the API module is no longer counted towards overall code coverage for the project.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Still test ./api, but exclude it from coverage due to all the generated code
```