### PR TITLE
🌱 Make pkg/util/ptr.Overwrite more generic

### DIFF
--- a/pkg/util/ptr/ptr.go
+++ b/pkg/util/ptr/ptr.go
@@ -3,6 +3,10 @@
 
 package ptr
 
+import (
+	"reflect"
+)
+
 // To returns a pointer to t.
 func To[T any](t T) *T {
 	return &t
@@ -40,14 +44,28 @@ func Equal[T comparable](a, b *T) bool {
 	return *a == *b
 }
 
-// Overwrite copies src to dst as long as src is non-nil.
-func Overwrite[T any](dst **T, src *T) bool {
+// Overwrite copies src to dst if:
+// - src is a non-nil channel, function, interface, map, pointer, or slice
+// - src is any other type of value
+// Please note, this function panics if dst is nil.
+func Overwrite[T any](dst *T, src T) {
 	if dst == nil {
-		return false
+		panic("dst is nil")
 	}
-	if src != nil {
+
+	valueOfSrc := reflect.ValueOf(src)
+	switch valueOfSrc.Kind() {
+	case reflect.Chan,
+		reflect.Func,
+		reflect.Interface,
+		reflect.Map,
+		reflect.Pointer,
+		reflect.Slice:
+
+		if !valueOfSrc.IsNil() {
+			*dst = src
+		}
+	default:
 		*dst = src
-		return true
 	}
-	return false
 }

--- a/pkg/util/ptr/ptr_test.go
+++ b/pkg/util/ptr/ptr_test.go
@@ -17,11 +17,11 @@ var _ = DescribeTable(
 	func(in any, expected any) {
 		switch in.(type) {
 		case string:
-			Ω(ptr.To(in.(string))).To(Equal(expected.(*string)))
+			Expect(ptr.To(in.(string))).To(Equal(expected.(*string)))
 		case int32:
-			Ω(ptr.To(in.(int32))).To(Equal(expected.(*int32)))
+			Expect(ptr.To(in.(int32))).To(Equal(expected.(*int32)))
 		case *byte:
-			Ω(ptr.To(in.(*byte))).To(Equal(expected.(**byte)))
+			Expect(ptr.To(in.(*byte))).To(Equal(expected.(**byte)))
 		default:
 			panic(fmt.Sprintf("unexpected type: %T", in))
 		}
@@ -36,11 +36,11 @@ var _ = DescribeTable(
 	func(in any, expected any) {
 		switch in.(type) {
 		case *string:
-			Ω(ptr.Deref(in.(*string))).To(Equal(expected.(string)))
+			Expect(ptr.Deref(in.(*string))).To(Equal(expected.(string)))
 		case *int32:
-			Ω(ptr.Deref(in.(*int32))).To(Equal(expected.(int32)))
+			Expect(ptr.Deref(in.(*int32))).To(Equal(expected.(int32)))
 		case **byte:
-			Ω(ptr.Deref(in.(**byte))).To(Equal(expected.(*byte)))
+			Expect(ptr.Deref(in.(**byte))).To(Equal(expected.(*byte)))
 		default:
 			panic(fmt.Sprintf("unexpected type: %T", in))
 		}
@@ -55,11 +55,11 @@ var _ = DescribeTable(
 	func(in any, def any, expected any) {
 		switch in.(type) {
 		case *string:
-			Ω(ptr.DerefWithDefault(in.(*string), def.(string))).To(Equal(expected.(string)))
+			Expect(ptr.DerefWithDefault(in.(*string), def.(string))).To(Equal(expected.(string)))
 		case *int32:
-			Ω(ptr.DerefWithDefault(in.(*int32), def.(int32))).To(Equal(expected.(int32)))
+			Expect(ptr.DerefWithDefault(in.(*int32), def.(int32))).To(Equal(expected.(int32)))
 		case **byte:
-			Ω(ptr.DerefWithDefault(in.(**byte), def.(*byte))).To(Equal(expected.(*byte)))
+			Expect(ptr.DerefWithDefault(in.(**byte), def.(*byte))).To(Equal(expected.(*byte)))
 		default:
 			panic(fmt.Sprintf("unexpected type: %T", in))
 		}
@@ -78,11 +78,11 @@ var _ = DescribeTable(
 	func(a any, b any, expected bool) {
 		switch a.(type) {
 		case *string:
-			Ω(ptr.Equal(a.(*string), b.(*string))).To(Equal(expected))
+			Expect(ptr.Equal(a.(*string), b.(*string))).To(Equal(expected))
 		case *int32:
-			Ω(ptr.Equal(a.(*int32), b.(*int32))).To(Equal(expected))
+			Expect(ptr.Equal(a.(*int32), b.(*int32))).To(Equal(expected))
 		case **byte:
-			Ω(ptr.Equal(a.(**byte), b.(**byte))).To(Equal(expected))
+			Expect(ptr.Equal(a.(**byte), b.(**byte))).To(Equal(expected))
 		default:
 			panic(fmt.Sprintf("unexpected type: %T", a))
 		}
@@ -98,37 +98,95 @@ var _ = DescribeTable(
 	Entry("**byte - neq - diff val", &[]*byte{&[]byte{byte(1)}[0]}[0], &[]*byte{&[]byte{byte(2)}[0]}[0], false),
 )
 
+const dstIsNil = "dst is nil"
+
 var _ = DescribeTable(
 	"Overwrite",
-	func(dst any, src any, expectedResult bool, expectedValue any) {
-		switch dst.(type) {
-		case **string:
-			Ω(ptr.Overwrite(dst.(**string), src.(*string))).To(Equal(expectedResult))
-			if expectedValue == nil {
-				Ω(dst.(**string)).To(BeNil())
-			} else {
-				Ω(**(dst.(**string))).To(Equal(expectedValue.(string)))
+	func(dst any, src any, expectedValue any, expectPanic bool) {
+		switch src.(type) {
+		case string:
+			fn := func() {
+				ptr.Overwrite(dst.(*string), src.(string))
 			}
-		case **int32:
-			Ω(ptr.Overwrite(dst.(**int32), src.(*int32))).To(Equal(expectedResult))
-			if expectedValue == nil {
-				Ω(dst.(**int32)).To(BeNil())
+			if expectPanic {
+				Expect(fn).Should(PanicWith(dstIsNil))
 			} else {
-				Ω(**(dst.(**int32))).To(Equal(expectedValue.(int32)))
+				fn()
+				if expectedValue == nil {
+					Expect(dst.(*string)).To(BeNil())
+				} else {
+					Expect(*(dst.(*string))).To(Equal(expectedValue.(string)))
+				}
 			}
-		case ***byte:
-			Ω(ptr.Overwrite(dst.(***byte), src.(**byte))).To(Equal(expectedResult))
-			if expectedValue == nil {
-				Ω(dst.(***byte)).To(BeNil())
+		case *string:
+			fn := func() {
+				ptr.Overwrite(dst.(**string), src.(*string))
+			}
+			if expectPanic {
+				Expect(fn).Should(PanicWith(dstIsNil))
 			} else {
-				Ω(***(dst.(***byte))).To(Equal(expectedValue.(**byte)))
+				fn()
+				if expectedValue == nil {
+					Expect(dst.(**string)).To(BeNil())
+				} else {
+					Expect(**(dst.(**string))).To(Equal(expectedValue.(string)))
+				}
+			}
+		case int32:
+			fn := func() {
+				ptr.Overwrite(dst.(*int32), src.(int32))
+			}
+			if expectPanic {
+				Expect(fn).Should(PanicWith(dstIsNil))
+			} else {
+				fn()
+				if expectedValue == nil {
+					Expect(dst.(*int32)).To(BeNil())
+				} else {
+					Expect(*(dst.(*int32))).To(Equal(expectedValue.(int32)))
+				}
+			}
+		case *int32:
+			fn := func() {
+				ptr.Overwrite(dst.(**int32), src.(*int32))
+			}
+			if expectPanic {
+				Expect(fn).Should(PanicWith(dstIsNil))
+			} else {
+				fn()
+				if expectedValue == nil {
+					Expect(dst.(**int32)).To(BeNil())
+				} else {
+					Expect(**(dst.(**int32))).To(Equal(expectedValue.(int32)))
+				}
+			}
+		case **byte:
+			fn := func() {
+				ptr.Overwrite(dst.(***byte), src.(**byte))
+			}
+			if expectPanic {
+				Expect(fn).Should(PanicWith(dstIsNil))
+			} else {
+				fn()
+				if expectedValue == nil {
+					Expect(dst.(***byte)).To(BeNil())
+				} else {
+					Expect(***(dst.(***byte))).To(Equal(expectedValue.(byte)))
+				}
 			}
 		default:
 			panic(fmt.Sprintf("unexpected type: %T", dst))
 		}
 	},
-	Entry("**string - dst is nil", []**string{nil}[0], &[]string{"hello"}[0], false, nil),
-	Entry("**string - dst is not nil, src is not empty", &[]*string{&[]string{""}[0]}[0], &[]string{"hello"}[0], true, "hello"),
-	Entry("**string - dst is not empty, src is nil", &[]*string{&[]string{"hello"}[0]}[0], []*string{nil}[0], false, "hello"),
-	Entry("**int32 - dst is not empty, src is not empty", &[]*int32{&[]int32{int32(1)}[0]}[0], &[]int32{int32(2)}[0], true, int32(2)),
+	Entry("string - dst is nil", []*string{nil}[0], "hello", nil, true),
+	Entry("*string - dst is nil", []**string{nil}[0], &[]string{"hello"}[0], nil, true),
+	Entry("string - dst is not nil, src is empty", &[]string{"hello"}[0], "", "", false),
+	Entry("*string - dst is not nil, src is not empty", &[]*string{&[]string{""}[0]}[0], &[]string{"hello"}[0], "hello", false),
+	Entry("int32 - dst is nil", []*int32{nil}[0], int32(1), nil, true),
+	Entry("*int32 - dst is nil", []**int32{nil}[0], &[]int32{int32(1)}[0], nil, true),
+	Entry("int32 - dst is not empty, src is empty", &[]int32{int32(1)}[0], int32(0), int32(0), false),
+	Entry("*int32 - dst is not empty, src is not empty", &[]*int32{&[]int32{int32(1)}[0]}[0], &[]int32{int32(2)}[0], int32(2), false),
+	Entry("**byte - dst is nil", []***byte{nil}[0], &[]*byte{&[]byte{byte(1)}[0]}[0], nil, true),
+	Entry("**byte - dst is not empty, src is not empty", &[]**byte{&[]*byte{&[]byte{byte(1)}[0]}[0]}[0], &[]*byte{&[]byte{byte(2)}[0]}[0], byte(2), false),
+	Entry("**byte - dst is not empty, src is empty", &[]**byte{&[]*byte{&[]byte{byte(1)}[0]}[0]}[0], &[]*byte{&[]byte{byte(0)}[0]}[0], byte(0), false),
 )


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch updates the Overwrite[T any] function from pkg/util/ptr to be more generic such that it can take pointers or primitives.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Update pkg/util/ptr.Overwrite[T any] to accept pointers *or* primitives.
```