### PR TITLE
🌱 Replace gopkg.in/yaml.v3 with sigs.k8s.io/yaml

### DIFF
--- a/controllers/infra/configmap/infra_configmap.go
+++ b/controllers/infra/configmap/infra_configmap.go
@@ -6,9 +6,9 @@ package configmap
 import (
 	"fmt"
 
-	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 )
 
 const (

--- a/controllers/infra/configmap/infra_configmap_controller_intg_test.go
+++ b/controllers/infra/configmap/infra_configmap_controller_intg_test.go
@@ -8,10 +8,10 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"gopkg.in/yaml.v3"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/yaml"
 
 	"github.com/vmware-tanzu/vm-operator/controllers/infra/configmap"
 	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,6 @@ require (
 	github.com/vmware/govmomi v0.31.1-0.20240520223415-3550ac2646bd
 	// * https://github.com/vmware-tanzu/vm-operator/security/dependabot/24
 	golang.org/x/text v0.15.0
-	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.30.0
 	k8s.io/apiextensions-apiserver v0.30.0
 	k8s.io/apimachinery v0.30.0
@@ -83,6 +82,7 @@ require (
 	google.golang.org/protobuf v1.34.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect

--- a/pkg/providers/vsphere/vmlifecycle/bootstrap_cloudinit.go
+++ b/pkg/providers/vsphere/vmlifecycle/bootstrap_cloudinit.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	vimtypes "github.com/vmware/govmomi/vim25/types"
-	"gopkg.in/yaml.v3"
+	"sigs.k8s.io/yaml"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"

--- a/pkg/providers/vsphere/vmlifecycle/bootstrap_cloudinit_test.go
+++ b/pkg/providers/vsphere/vmlifecycle/bootstrap_cloudinit_test.go
@@ -11,8 +11,8 @@ import (
 	. "github.com/onsi/gomega"
 
 	vimtypes "github.com/vmware/govmomi/vim25/types"
-	"gopkg.in/yaml.v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	vmopv1cloudinit "github.com/vmware-tanzu/vm-operator/api/v1alpha3/cloudinit"

--- a/pkg/util/cloudinit/cloudconfig.go
+++ b/pkg/util/cloudinit/cloudconfig.go
@@ -10,8 +10,8 @@ import (
 	"fmt"
 	"strconv"
 
-	"gopkg.in/yaml.v3"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 
 	"github.com/vmware-tanzu/vm-operator/api/v1alpha3/cloudinit"
 	"github.com/vmware-tanzu/vm-operator/api/v1alpha3/common"
@@ -165,14 +165,12 @@ func MarshalYAML(
 	fmt.Fprintln(&w1, "#cloud-config")
 	fmt.Fprintln(&w1, "")
 
-	var w2 bytes.Buffer
-	enc := yaml.NewEncoder(&w2)
-	enc.SetIndent(2)
-	if err := enc.Encode(out); err != nil {
+	w2, err := yaml.Marshal(out)
+	if err != nil {
 		return "", err
 	}
 
-	data := w2.String()
+	data := string(w2)
 	if data == emptyYAMLObject {
 		return "", nil
 	}
@@ -254,7 +252,7 @@ func copyWriteFile(
 	out.Permissions = in.Permissions
 }
 
-func (ccu *cloudConfigUsers) MarshalYAML() (any, error) {
+func (ccu cloudConfigUsers) MarshalJSON() ([]byte, error) {
 	if len(ccu.users) == 0 {
 		return nil, nil
 	}
@@ -265,14 +263,14 @@ func (ccu *cloudConfigUsers) MarshalYAML() (any, error) {
 	for i := range ccu.users {
 		result = append(result, ccu.users[i])
 	}
-	return result, nil
+	return json.Marshal(result)
 }
 
-func (ccu cloudConfigRunCmd) MarshalYAML() (any, error) {
+func (ccu cloudConfigRunCmd) MarshalJSON() ([]byte, error) {
 	if ccu.singleString != "" {
-		return ccu.singleString, nil
+		return json.Marshal(ccu.singleString)
 	} else if len(ccu.listOfStrings) > 0 {
-		return ccu.listOfStrings, nil
+		return json.Marshal(ccu.listOfStrings)
 	}
 	return nil, nil
 }

--- a/pkg/util/cloudinit/cloudconfig_test.go
+++ b/pkg/util/cloudinit/cloudconfig_test.go
@@ -54,7 +54,7 @@ var _ = Describe("CloudConfig MarshalYAML", func() {
 		})
 		It("Should return user data", func() {
 			Expect(err).ToNot(HaveOccurred())
-			Expect(data).To(Equal("## template: jinja\n#cloud-config\n\nusers:\n  - name: bob.wilson\n"))
+			Expect(data).To(Equal("## template: jinja\n#cloud-config\n\nusers:\n- name: bob.wilson\n"))
 		})
 	})
 
@@ -512,150 +512,150 @@ const cloudConfigWithNoDefaultUser = `## template: jinja
 #cloud-config
 
 users:
-  - hashed_passwd: "0123456789"
-    name: bob.wilson
+- hashed_passwd: "0123456789"
+  name: bob.wilson
 write_files:
-  - content: world
-    path: /hello
-  - content: there
-    path: /hi
+- content: world
+  path: /hello
+- content: there
+  path: /hi
 `
 
 const cloudConfigWithDefaultUser = `## template: jinja
 #cloud-config
 
 users:
-  - default
-  - hashed_passwd: "0123456789"
-    name: bob.wilson
+- default
+- hashed_passwd: "0123456789"
+  name: bob.wilson
 write_files:
-  - content: world
-    path: /hello
-  - content: there
-    path: /hi
+- content: world
+  path: /hello
+- content: there
+  path: /hi
 `
 
 const cloudConfigWithWithRunCmds = `## template: jinja
 #cloud-config
 
-users:
-  - hashed_passwd: "0123456789"
-    name: bob.wilson
 runcmd:
-  - ls /
-  - - ls
-    - -a
-    - -l
-    - /
-  - - echo
-    - hello, world.
+- ls /
+- - ls
+  - -a
+  - -l
+  - /
+- - echo
+  - hello, world.
+users:
+- hashed_passwd: "0123456789"
+  name: bob.wilson
 `
 
 const cloudConfigWithEmptyFileContent = `## template: jinja
 #cloud-config
 
 users:
-  - hashed_passwd: "0123456789"
-    name: bob.wilson
+- hashed_passwd: "0123456789"
+  name: bob.wilson
 write_files:
-  - content: world
-    path: /hello
-  - content: there
-    path: /hi
-  - append: true
-    defer: true
-    encoding: text/plain
-    path: /foo
-    permissions: "0644"
+- content: world
+  path: /hello
+- content: there
+  path: /hi
+- append: true
+  defer: true
+  encoding: text/plain
+  path: /foo
+  permissions: "0644"
 `
 
 const cloudConfigWithAllPossibleValues = `## template: jinja
 #cloud-config
 
-users:
-  - create_groups: false
-    expiredate: 9999-99-99
-    gecos: gecos
-    groups:
-      - group1
-      - group2
-    hashed_passwd: "0123456789"
-    homedir: /home/bob.wilson
-    inactive: "1"
-    lock_passwd: false
-    name: bob.wilson
-    no_create_home: false
-    no_log_init: false
-    primary_group: group1
-    selinux_user: bob.wilson
-    shell: /bin/bash
-    snapuser: bob.wilson
-    ssh_authorized_keys:
-      - key1
-      - key2
-    ssh_import_id:
-      - id1
-      - id2
-    ssh_redirect_user: false
-    sudo: sudoyou?
-    system: false
-    uid: 123
-  - create_groups: true
-    expiredate: 9999-99-99
-    gecos: gecos
-    groups:
-      - group1
-      - group2
-    homedir: /home/rob.wilson
-    inactive: "10"
-    lock_passwd: true
-    name: rob.wilson
-    no_create_home: true
-    no_log_init: true
-    passwd: password
-    primary_group: group1
-    selinux_user: rob.wilson
-    shell: /bin/bash
-    snapuser: rob.wilson
-    ssh_authorized_keys:
-      - key1
-      - key2
-    ssh_import_id:
-      - id1
-      - id2
-    ssh_redirect_user: true
-    sudo: sudoyou?
-    system: true
-    uid: 123
 runcmd:
-  - ls /
-  - - ls
-    - -a
-    - -l
-    - /
-  - - echo
-    - hello, world.
-write_files:
-  - append: true
-    content: world
-    defer: true
-    encoding: text/plain
-    owner: bob.wilson:bob.wilson
-    path: /hello
-    permissions: "0644"
-  - content: there
-    encoding: text/plain
-    owner: rob.wilson:rob.wilson
-    path: /hi
-    permissions: "0755"
-  - append: true
-    content: |-
-      a multi-line
-      document
-    defer: true
-    encoding: text/plain
-    owner: bob.wilson:bob.wilson
-    path: /doc
-    permissions: "0644"
+- ls /
+- - ls
+  - -a
+  - -l
+  - /
+- - echo
+  - hello, world.
 ssh_pwauth: true
+users:
+- create_groups: false
+  expiredate: 9999-99-99
+  gecos: gecos
+  groups:
+  - group1
+  - group2
+  hashed_passwd: "0123456789"
+  homedir: /home/bob.wilson
+  inactive: "1"
+  lock_passwd: false
+  name: bob.wilson
+  no_create_home: false
+  no_log_init: false
+  primary_group: group1
+  selinux_user: bob.wilson
+  shell: /bin/bash
+  snapuser: bob.wilson
+  ssh_authorized_keys:
+  - key1
+  - key2
+  ssh_import_id:
+  - id1
+  - id2
+  ssh_redirect_user: false
+  sudo: sudoyou?
+  system: false
+  uid: 123
+- create_groups: true
+  expiredate: 9999-99-99
+  gecos: gecos
+  groups:
+  - group1
+  - group2
+  homedir: /home/rob.wilson
+  inactive: "10"
+  lock_passwd: true
+  name: rob.wilson
+  no_create_home: true
+  no_log_init: true
+  passwd: password
+  primary_group: group1
+  selinux_user: rob.wilson
+  shell: /bin/bash
+  snapuser: rob.wilson
+  ssh_authorized_keys:
+  - key1
+  - key2
+  ssh_import_id:
+  - id1
+  - id2
+  ssh_redirect_user: true
+  sudo: sudoyou?
+  system: true
+  uid: 123
+write_files:
+- append: true
+  content: world
+  defer: true
+  encoding: text/plain
+  owner: bob.wilson:bob.wilson
+  path: /hello
+  permissions: "0644"
+- content: there
+  encoding: text/plain
+  owner: rob.wilson:rob.wilson
+  path: /hi
+  permissions: "0755"
+- append: true
+  content: |-
+    a multi-line
+    document
+  defer: true
+  encoding: text/plain
+  owner: bob.wilson:bob.wilson
+  path: /doc
+  permissions: "0644"
 `

--- a/pkg/util/cloudinit/validate/validate.go
+++ b/pkg/util/cloudinit/validate/validate.go
@@ -6,8 +6,8 @@ package validate
 import (
 	"encoding/json"
 
-	"gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/yaml"
 
 	"github.com/vmware-tanzu/vm-operator/api/v1alpha3/cloudinit"
 	"github.com/vmware-tanzu/vm-operator/api/v1alpha3/common"


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch replaces all uses of `gopkg.in/yaml.v3` with `sigs.k8s.io/yaml`. This change is to ensure there is a singular convention for how objects are marshaled/unmarshled to/from YAML within VM Operator, regardless of whether they are Kubernetes runtime objects. The package `sigs.k8s.io/yaml` is in fact just a wrapper around `gopkg.in/yaml.vN`, with the additional logic of first marshaling the objects to JSON before converting them to YAML.



**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Replace gopkg.in/yaml.v3 with sigs.k8s.io/yaml
```