### PR TITLE
:bug: Update finalizers to conform to upstream standards

### DIFF
--- a/controllers/contentlibrary/clustercontentlibraryitem/clustercontentlibraryitem_controller_intg_test.go
+++ b/controllers/contentlibrary/clustercontentlibraryitem/clustercontentlibraryitem_controller_intg_test.go
@@ -49,7 +49,7 @@ func intgTestsReconcile() {
 		Eventually(func(g Gomega) {
 			item := &imgregv1a1.ClusterContentLibraryItem{}
 			g.Expect(ctx.Client.Get(ctx, objKey, item)).To(Succeed())
-			g.Expect(item.Finalizers).To(ContainElement(utils.ClusterContentLibraryItemVmopFinalizer))
+			g.Expect(item.Finalizers).To(ContainElement(utils.CCLItemFinalizer))
 		}).Should(Succeed(), "waiting for ClusterContentLibraryItem finalizer")
 	}
 

--- a/controllers/contentlibrary/clustercontentlibraryitem/clustercontentlibraryitem_controller_unit_test.go
+++ b/controllers/contentlibrary/clustercontentlibraryitem/clustercontentlibraryitem_controller_unit_test.go
@@ -73,7 +73,7 @@ func unitTestsReconcile() {
 
 		cclItem = utils.DummyClusterContentLibraryItem(utils.ItemFieldNamePrefix + "-dummy")
 		// Add our finalizer so ReconcileNormal() does not return early.
-		cclItem.Finalizers = []string{utils.ClusterContentLibraryItemVmopFinalizer}
+		cclItem.Finalizers = []string{utils.CCLItemFinalizer}
 	})
 
 	JustBeforeEach(func() {
@@ -109,7 +109,7 @@ func unitTestsReconcile() {
 			It("should add the finalizer", func() {
 				Expect(reconciler.ReconcileNormal(cclItemCtx)).To(Succeed())
 
-				Expect(cclItem.Finalizers).To(ContainElement(utils.ClusterContentLibraryItemVmopFinalizer))
+				Expect(cclItem.Finalizers).To(ContainElement(utils.CCLItemFinalizer))
 			})
 		})
 
@@ -287,10 +287,10 @@ func unitTestsReconcile() {
 	Context("ReconcileDelete", func() {
 
 		It("should remove the finalizer from ClusterContentLibraryItem resource", func() {
-			Expect(cclItem.Finalizers).To(ContainElement(utils.ClusterContentLibraryItemVmopFinalizer))
+			Expect(cclItem.Finalizers).To(ContainElement(utils.CCLItemFinalizer))
 
 			Expect(reconciler.ReconcileDelete(cclItemCtx)).To(Succeed())
-			Expect(cclItem.Finalizers).ToNot(ContainElement(utils.ClusterContentLibraryItemVmopFinalizer))
+			Expect(cclItem.Finalizers).ToNot(ContainElement(utils.CCLItemFinalizer))
 		})
 	})
 }

--- a/controllers/contentlibrary/contentlibraryitem/contentlibraryitem_controller_intg_test.go
+++ b/controllers/contentlibrary/contentlibraryitem/contentlibraryitem_controller_intg_test.go
@@ -46,7 +46,7 @@ func intgTestsReconcile() {
 		Eventually(func(g Gomega) {
 			item := &imgregv1a1.ContentLibraryItem{}
 			g.Expect(ctx.Client.Get(ctx, objKey, item)).To(Succeed())
-			g.Expect(item.Finalizers).To(ContainElement(utils.ContentLibraryItemVmopFinalizer))
+			g.Expect(item.Finalizers).To(ContainElement(utils.CLItemFinalizer))
 		}).Should(Succeed(), "waiting for ContentLibraryItem finalizer")
 	}
 

--- a/controllers/contentlibrary/contentlibraryitem/contentlibraryitem_controller_unit_test.go
+++ b/controllers/contentlibrary/contentlibraryitem/contentlibraryitem_controller_unit_test.go
@@ -74,7 +74,7 @@ func unitTestsReconcile() {
 		}
 
 		clItem = utils.DummyContentLibraryItem(utils.ItemFieldNamePrefix+"-dummy", "dummy-ns")
-		clItem.Finalizers = []string{utils.ContentLibraryItemVmopFinalizer}
+		clItem.Finalizers = []string{utils.CLItemFinalizer}
 	})
 
 	JustBeforeEach(func() {
@@ -109,7 +109,7 @@ func unitTestsReconcile() {
 			It("should add the finalizer", func() {
 				Expect(reconciler.ReconcileNormal(clItemCtx)).To(Succeed())
 
-				Expect(clItem.Finalizers).To(ContainElement(utils.ContentLibraryItemVmopFinalizer))
+				Expect(clItem.Finalizers).To(ContainElement(utils.CLItemFinalizer))
 			})
 		})
 
@@ -265,10 +265,10 @@ func unitTestsReconcile() {
 	Context("ReconcileDelete", func() {
 
 		It("should remove the finalizer from ContentLibraryItem resource", func() {
-			Expect(clItem.Finalizers).To(ContainElement(utils.ContentLibraryItemVmopFinalizer))
+			Expect(clItem.Finalizers).To(ContainElement(utils.CLItemFinalizer))
 
 			Expect(reconciler.ReconcileDelete(clItemCtx)).To(Succeed())
-			Expect(clItem.Finalizers).ToNot(ContainElement(utils.ContentLibraryItemVmopFinalizer))
+			Expect(clItem.Finalizers).ToNot(ContainElement(utils.CLItemFinalizer))
 		})
 	})
 }

--- a/controllers/contentlibrary/utils/constants.go
+++ b/controllers/contentlibrary/utils/constants.go
@@ -11,8 +11,10 @@ const (
 	ContentLibraryKind            = "ContentLibrary"
 	ContentLibraryItemKind        = "ContentLibraryItem"
 
-	ContentLibraryItemVmopFinalizer        = "contentlibraryitem.vmoperator.vmware.com"
-	ClusterContentLibraryItemVmopFinalizer = "clustercontentlibraryitem.vmoperator.vmware.com"
+	CLItemFinalizer            = "vmoperator.vmware.com/contentlibraryitem"
+	DeprecatedCLItemFinalizer  = "contentlibraryitem.vmoperator.vmware.com"
+	CCLItemFinalizer           = "clustercontentlibraryitem.vmoperator.vmware.com"
+	DeprecatedCCLItemFinalizer = "vmoperator.vmware.com/clustercontentlibraryitem"
 
 	// TKGServiceTypeLabelKeyPrefix is a label prefix used to identify
 	// labels that contain information about the type of service provided

--- a/controllers/virtualmachine/virtualmachine_controller_unit_test.go
+++ b/controllers/virtualmachine/virtualmachine_controller_unit_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
-const finalizer = "virtualmachine.vmoperator.vmware.com"
+const finalizer = "vmoperator.vmware.com/virtualmachine"
 
 func unitTests() {
 	Describe(

--- a/controllers/virtualmachinepublishrequest/virtualmachinepublishrequest_controller_unit_test.go
+++ b/controllers/virtualmachinepublishrequest/virtualmachinepublishrequest_controller_unit_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
-const finalizerName = "virtualmachinepublishrequest.vmoperator.vmware.com"
+const finalizerName = "vmoperator.vmware.com/virtualmachinepublishrequest"
 
 func unitTests() {
 	Describe(

--- a/controllers/virtualmachineservice/virtualmachineservice_controller_intg_test.go
+++ b/controllers/virtualmachineservice/virtualmachineservice_controller_intg_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	finalizerName = "virtualmachineservice.vmoperator.vmware.com"
+	finalizerName = "vmoperator.vmware.com/virtualmachineservice"
 )
 
 func intgTests() {

--- a/controllers/virtualmachinesetresourcepolicy/virtualmachinesetresourcepolicy_controller_unit_test.go
+++ b/controllers/virtualmachinesetresourcepolicy/virtualmachinesetresourcepolicy_controller_unit_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	finalizer = "virtualmachinesetresourcepolicy.vmoperator.vmware.com"
+	finalizer = "vmoperator.vmware.com/virtualmachinesetresourcepolicy"
 )
 
 func unitTests() {

--- a/test/builder/dummies.go
+++ b/test/builder/dummies.go
@@ -447,7 +447,7 @@ func DummyVirtualMachinePublishRequest(name, namespace, sourceName, itemName, cl
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       name,
 			Namespace:  namespace,
-			Finalizers: []string{"virtualmachinepublishrequest.vmoperator.vmware.com"},
+			Finalizers: []string{"vmoperator.vmware.com/virtualmachinepublishrequest"},
 		},
 		Spec: vmopv1.VirtualMachinePublishRequestSpec{
 			Source: vmopv1.VirtualMachinePublishRequestSource{


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Finalizers on Kubernetes resources are expected to be fully qualified domain names.  API server validations had a bug where they would skip validating the format of finalizers on CRDs.  That bug: https://github.com/kubernetes/kubernetes/issues/119445 has been fixed recently in 1.29.  As a result, we are now seeing warnings for all finalizers on all resources in our controllers.

This change fixes the finalizer strings to conform to upstream standards. For now, we will have to maintain two finalizers if the controller is reconciling resources that were created by old VM operator.

## Testing Done:
```
root@42081df27b4c6563c62b6641e6fbf74d [ ~ ]# k get vm -n parunesh-ns -o=jsonpath={.items[].metadata.finalizers} | jq [
  "vmoperator.vmware.com/virtualmachine"
]
```

**Are there any special notes for your reviewer**:
N/A

**Please add a release note if necessary**:
```release-note
Update finalizers to conform to upstream standards
```