### PR TITLE
🐛 Fix issue reading infra config map tags

### DIFF
--- a/controllers/infra/configmap/infra_configmap.go
+++ b/controllers/infra/configmap/infra_configmap.go
@@ -24,8 +24,8 @@ const (
 )
 
 type WcpClusterConfig struct {
-	VcPNID string `yaml:"vc_pnid"`
-	VcPort string `yaml:"vc_port"`
+	VcPNID string `json:"vc_pnid"`
+	VcPort string `json:"vc_port"`
 }
 
 // ParseWcpClusterConfig builds and returns the cluster config.

--- a/controllers/infra/configmap/infra_configmap_test.go
+++ b/controllers/infra/configmap/infra_configmap_test.go
@@ -4,6 +4,8 @@
 package configmap_test
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -72,5 +74,24 @@ func unitTestsWcpConfig() {
 				Expect(config.VcPort).To(Equal(port))
 			})
 		})
+
+		Context("valid data directly", func() {
+			pnid := "foo-pnid"
+			port := "foo-port"
+
+			BeforeEach(func() {
+				data = map[string]string{
+					"wcp-cluster-config.yaml": fmt.Sprintf("\"vc_pnid\": %s\n\"vc_port\": %s", pnid, port),
+				}
+			})
+
+			It("returns expected config", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(config).ToNot(BeNil())
+				Expect(config.VcPNID).To(Equal(pnid))
+				Expect(config.VcPort).To(Equal(port))
+			})
+		})
 	})
+
 }


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch fixes an issue reading the infra config map due to the switch to sigs.k8s.io/yaml for marshaling/unmarshaling. It uses JSON tags instead of YAML tags. A test was also added to validate this.



**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```