### PR TITLE
🐛 Fix coverage for both patch packages

### DIFF
--- a/controllers/virtualmachinewebconsolerequest/v1alpha1/patch/suite_test.go
+++ b/controllers/virtualmachinewebconsolerequest/v1alpha1/patch/suite_test.go
@@ -32,7 +32,7 @@ const (
 var suite = builder.NewTestSuite()
 
 func TestPatch(t *testing.T) {
-	suite.Register(t, "Patch Suite", intgTests, nil)
+	suite.Register(t, "Patch Suite", intgTests, unitTests)
 }
 
 var _ = BeforeSuite(suite.BeforeSuite)

--- a/controllers/virtualmachinewebconsolerequest/v1alpha1/patch/utils_test.go
+++ b/controllers/virtualmachinewebconsolerequest/v1alpha1/patch/utils_test.go
@@ -17,211 +17,219 @@ limitations under the License.
 package patch
 
 import (
-	"testing"
-
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	vmopv1a1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 )
 
-func TestToUnstructured(t *testing.T) {
-	t.Run("with a typed object", func(t *testing.T) {
-		g := NewWithT(t)
-		// Test with a typed object.
-		obj := &vmopv1a1.VirtualMachine{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "cluster-1",
-				Namespace: "namespace-1",
-			},
-			Spec: vmopv1a1.VirtualMachineSpec{
-				ImageName: "foo",
-			},
-		}
-		newObj, err := toUnstructured(obj)
-		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(newObj.GetName()).To(Equal(obj.Name))
-		g.Expect(newObj.GetNamespace()).To(Equal(obj.Namespace))
+func unitTests() {
+	Context("ToUnstructured", func() {
 
-		// Change a spec field and validate that it stays the same in the incoming object.
-		g.Expect(unstructured.SetNestedField(newObj.Object, false, "spec", "paused")).To(Succeed())
-		g.Expect(obj.Spec.ImageName).To(Equal("foo"))
+		Context("with a typed object", func() {
+			It("should succeed", func() {
+				// Test with a typed object.
+				obj := &vmopv1a1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cluster-1",
+						Namespace: "namespace-1",
+					},
+					Spec: vmopv1a1.VirtualMachineSpec{
+						ImageName: "foo",
+					},
+				}
+				newObj, err := toUnstructured(obj)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(newObj.GetName()).To(Equal(obj.Name))
+				Expect(newObj.GetNamespace()).To(Equal(obj.Namespace))
+
+				// Change a spec field and validate that it stays the same in the incoming object.
+				Expect(unstructured.SetNestedField(newObj.Object, false, "spec", "paused")).To(Succeed())
+				Expect(obj.Spec.ImageName).To(Equal("foo"))
+			})
+		})
 	})
 
-	t.Run("with an unstructured object", func(t *testing.T) {
-		g := NewWithT(t)
-
-		obj := &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": "test.x.y.z/v1",
-				"metadata": map[string]interface{}{
-					"name":      "test-1",
-					"namespace": "namespace-1",
-				},
-				"spec": map[string]interface{}{
-					"paused": true,
-				},
-			},
-		}
-
-		newObj, err := toUnstructured(obj)
-		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(newObj.GetName()).To(Equal(obj.GetName()))
-		g.Expect(newObj.GetNamespace()).To(Equal(obj.GetNamespace()))
-
-		// Validate that the maps point to different addresses.
-		g.Expect(obj.Object).ToNot(BeIdenticalTo(newObj.Object))
-
-		// Change a spec field and validate that it stays the same in the incoming object.
-		g.Expect(unstructured.SetNestedField(newObj.Object, false, "spec", "paused")).To(Succeed())
-		pausedValue, _, err := unstructured.NestedBool(obj.Object, "spec", "paused")
-		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(pausedValue).To(BeTrue())
-
-		// Change the name of the new object and make sure it doesn't change it the old one.
-		newObj.SetName("test-2")
-		g.Expect(obj.GetName()).To(Equal("test-1"))
-	})
-}
-
-func TestUnsafeFocusedUnstructured(t *testing.T) {
-	t.Run("focus=spec, should only return spec and common fields", func(t *testing.T) {
-		g := NewWithT(t)
-
-		obj := &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": "test.x.y.z/v1",
-				"kind":       "TestCluster",
-				"metadata": map[string]interface{}{
-					"name":      "test-1",
-					"namespace": "namespace-1",
-				},
-				"spec": map[string]interface{}{
-					"paused": true,
-				},
-				"status": map[string]interface{}{
-					"infrastructureReady": true,
-					"conditions": []interface{}{
-						map[string]interface{}{
-							"type":   "Ready",
-							"status": "True",
-						},
+	Context("with an unstructured object", func() {
+		It("should succeed", func() {
+			obj := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "test.x.y.z/v1",
+					"metadata": map[string]interface{}{
+						"name":      "test-1",
+						"namespace": "namespace-1",
+					},
+					"spec": map[string]interface{}{
+						"paused": true,
 					},
 				},
-			},
-		}
+			}
 
-		newObj := unsafeUnstructuredCopy(obj, specPatch, true)
+			newObj, err := toUnstructured(obj)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(newObj.GetName()).To(Equal(obj.GetName()))
+			Expect(newObj.GetNamespace()).To(Equal(obj.GetNamespace()))
 
-		// Validate that common fields are always preserved.
-		g.Expect(newObj.Object["apiVersion"]).To(Equal(obj.Object["apiVersion"]))
-		g.Expect(newObj.Object["kind"]).To(Equal(obj.Object["kind"]))
-		g.Expect(newObj.Object["metadata"]).To(Equal(obj.Object["metadata"]))
+			// Validate that the maps point to different addresses.
+			Expect(obj.Object).ToNot(BeIdenticalTo(newObj.Object))
 
-		// Validate that the spec has been preserved.
-		g.Expect(newObj.Object["spec"]).To(Equal(obj.Object["spec"]))
+			// Change a spec field and validate that it stays the same in the incoming object.
+			Expect(unstructured.SetNestedField(newObj.Object, false, "spec", "paused")).To(Succeed())
+			pausedValue, _, err := unstructured.NestedBool(obj.Object, "spec", "paused")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pausedValue).To(BeTrue())
 
-		// Validate that the status is nil, but preserved in the original object.
-		g.Expect(newObj.Object["status"]).To(BeNil())
-		g.Expect(obj.Object["status"]).ToNot(BeNil())
-		g.Expect(obj.Object["status"].(map[string]interface{})["conditions"]).ToNot(BeNil())
+			// Change the name of the new object and make sure it doesn't change it the old one.
+			newObj.SetName("test-2")
+			Expect(obj.GetName()).To(Equal("test-1"))
+		})
 	})
 
-	t.Run("focus=status w/ condition-setter object, should only return status (without conditions) and common fields", func(t *testing.T) {
-		g := NewWithT(t)
+	Context("UnsafeFocusedUnstructured", func() {
 
-		obj := &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": "test.x.y.z/v1",
-				"kind":       "TestCluster",
-				"metadata": map[string]interface{}{
-					"name":      "test-1",
-					"namespace": "namespace-1",
-				},
-				"spec": map[string]interface{}{
-					"paused": true,
-				},
-				"status": map[string]interface{}{
-					"infrastructureReady": true,
-					"conditions": []interface{}{
-						map[string]interface{}{
-							"type":   "Ready",
-							"status": "True",
+		Context("focus=spec", func() {
+
+			It("should only return spec and common fields", func() {
+				obj := &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "test.x.y.z/v1",
+						"kind":       "TestCluster",
+						"metadata": map[string]interface{}{
+							"name":      "test-1",
+							"namespace": "namespace-1",
+						},
+						"spec": map[string]interface{}{
+							"paused": true,
+						},
+						"status": map[string]interface{}{
+							"infrastructureReady": true,
+							"conditions": []interface{}{
+								map[string]interface{}{
+									"type":   "Ready",
+									"status": "True",
+								},
+							},
 						},
 					},
-				},
-			},
-		}
+				}
 
-		newObj := unsafeUnstructuredCopy(obj, statusPatch, true)
+				newObj := unsafeUnstructuredCopy(obj, specPatch, true)
 
-		// Validate that common fields are always preserved.
-		g.Expect(newObj.Object["apiVersion"]).To(Equal(obj.Object["apiVersion"]))
-		g.Expect(newObj.Object["kind"]).To(Equal(obj.Object["kind"]))
-		g.Expect(newObj.Object["metadata"]).To(Equal(obj.Object["metadata"]))
+				// Validate that common fields are always preserved.
+				Expect(newObj.Object["apiVersion"]).To(Equal(obj.Object["apiVersion"]))
+				Expect(newObj.Object["kind"]).To(Equal(obj.Object["kind"]))
+				Expect(newObj.Object["metadata"]).To(Equal(obj.Object["metadata"]))
 
-		// Validate that spec is nil in the new object, but still exists in the old copy.
-		g.Expect(newObj.Object["spec"]).To(BeNil())
-		g.Expect(obj.Object["spec"]).To(Equal(map[string]interface{}{
-			"paused": true,
-		}))
+				// Validate that the spec has been preserved.
+				Expect(newObj.Object["spec"]).To(Equal(obj.Object["spec"]))
 
-		// Validate that the status has been copied, without conditions.
-		g.Expect(newObj.Object["status"]).To(HaveLen(1))
-		g.Expect(newObj.Object["status"].(map[string]interface{})["infrastructureReady"]).To(Equal(true))
-		g.Expect(newObj.Object["status"].(map[string]interface{})["conditions"]).To(BeNil())
+				// Validate that the status is nil, but preserved in the original object.
+				Expect(newObj.Object["status"]).To(BeNil())
+				Expect(obj.Object["status"]).ToNot(BeNil())
+				Expect(obj.Object["status"].(map[string]interface{})["conditions"]).ToNot(BeNil())
+			})
+		})
 
-		// When working with conditions, the inner map is going to be removed from the original object.
-		g.Expect(obj.Object["status"].(map[string]interface{})["conditions"]).To(BeNil())
-	})
+		Context("focus=status w/ condition-setter object", func() {
 
-	t.Run("focus=status w/o condition-setter object, should only return status and common fields", func(t *testing.T) {
-		g := NewWithT(t)
+			It("should only return status (without conditions) and common fields", func() {
+				obj := &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "test.x.y.z/v1",
+						"kind":       "TestCluster",
+						"metadata": map[string]interface{}{
+							"name":      "test-1",
+							"namespace": "namespace-1",
+						},
+						"spec": map[string]interface{}{
+							"paused": true,
+						},
+						"status": map[string]interface{}{
+							"infrastructureReady": true,
+							"conditions": []interface{}{
+								map[string]interface{}{
+									"type":   "Ready",
+									"status": "True",
+								},
+							},
+						},
+					},
+				}
 
-		obj := &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": "test.x.y.z/v1",
-				"kind":       "TestCluster",
-				"metadata": map[string]interface{}{
-					"name":      "test-1",
-					"namespace": "namespace-1",
-				},
-				"spec": map[string]interface{}{
+				newObj := unsafeUnstructuredCopy(obj, statusPatch, true)
+
+				// Validate that common fields are always preserved.
+				Expect(newObj.Object["apiVersion"]).To(Equal(obj.Object["apiVersion"]))
+				Expect(newObj.Object["kind"]).To(Equal(obj.Object["kind"]))
+				Expect(newObj.Object["metadata"]).To(Equal(obj.Object["metadata"]))
+
+				// Validate that spec is nil in the new object, but still exists in the old copy.
+				Expect(newObj.Object["spec"]).To(BeNil())
+				Expect(obj.Object["spec"]).To(Equal(map[string]interface{}{
+					"paused": true,
+				}))
+
+				// Validate that the status has been copied, without conditions.
+				Expect(newObj.Object["status"]).To(HaveLen(1))
+				Expect(newObj.Object["status"].(map[string]interface{})["infrastructureReady"]).To(Equal(true))
+				Expect(newObj.Object["status"].(map[string]interface{})["conditions"]).To(BeNil())
+
+				// When working with conditions, the inner map is going to be removed from the original object.
+				Expect(obj.Object["status"].(map[string]interface{})["conditions"]).To(BeNil())
+			})
+		})
+
+		Context("focus=status w/o condition-setter object", func() {
+
+			It("should only return status and common fields", func() {
+				obj := &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "test.x.y.z/v1",
+						"kind":       "TestCluster",
+						"metadata": map[string]interface{}{
+							"name":      "test-1",
+							"namespace": "namespace-1",
+						},
+						"spec": map[string]interface{}{
+							"paused": true,
+							"other":  "field",
+						},
+						"status": map[string]interface{}{
+							"infrastructureReady": true,
+							"conditions": []interface{}{
+								map[string]interface{}{
+									"type":   "Ready",
+									"status": "True",
+								},
+							},
+						},
+					},
+				}
+
+				newObj := unsafeUnstructuredCopy(obj, statusPatch, false)
+
+				// Validate that spec is nil in the new object, but still exists in the old copy.
+				Expect(newObj.Object["spec"]).To(BeNil())
+				Expect(obj.Object["spec"]).To(Equal(map[string]interface{}{
 					"paused": true,
 					"other":  "field",
-				},
-				"status": map[string]interface{}{
-					"infrastructureReady": true,
-					"conditions": []interface{}{
-						map[string]interface{}{
-							"type":   "Ready",
-							"status": "True",
-						},
-					},
-				},
-			},
-		}
+				}))
 
-		newObj := unsafeUnstructuredCopy(obj, statusPatch, false)
+				// Validate that common fields are always preserved.
+				Expect(newObj.Object["apiVersion"]).To(Equal(obj.Object["apiVersion"]))
+				Expect(newObj.Object["kind"]).To(Equal(obj.Object["kind"]))
+				Expect(newObj.Object["metadata"]).To(Equal(obj.Object["metadata"]))
 
-		// Validate that spec is nil in the new object, but still exists in the old copy.
-		g.Expect(newObj.Object["spec"]).To(BeNil())
-		g.Expect(obj.Object["spec"]).To(Equal(map[string]interface{}{
-			"paused": true,
-			"other":  "field",
-		}))
+				// Validate that the status has been copied, without conditions.
+				Expect(newObj.Object["status"]).To(HaveLen(2))
+				Expect(newObj.Object["status"]).To(Equal(obj.Object["status"]))
 
-		// Validate that common fields are always preserved.
-		g.Expect(newObj.Object["apiVersion"]).To(Equal(obj.Object["apiVersion"]))
-		g.Expect(newObj.Object["kind"]).To(Equal(obj.Object["kind"]))
-		g.Expect(newObj.Object["metadata"]).To(Equal(obj.Object["metadata"]))
-
-		// Validate that the status has been copied, without conditions.
-		g.Expect(newObj.Object["status"]).To(HaveLen(2))
-		g.Expect(newObj.Object["status"]).To(Equal(obj.Object["status"]))
-
-		// Make sure that we didn't modify the incoming object if this object isn't a condition setter.
-		g.Expect(obj.Object["status"].(map[string]interface{})["conditions"]).ToNot(BeNil())
+				// Make sure that we didn't modify the incoming object if this object isn't a condition setter.
+				Expect(obj.Object["status"].(map[string]interface{})["conditions"]).ToNot(BeNil())
+			})
+		})
 	})
 }

--- a/pkg/patch/suite_test.go
+++ b/pkg/patch/suite_test.go
@@ -32,7 +32,7 @@ const (
 var suite = builder.NewTestSuite()
 
 func TestPatch(t *testing.T) {
-	suite.Register(t, "Patch Suite", intgTests, nil)
+	suite.Register(t, "Patch Suite", intgTests, unitTests)
 }
 
 var _ = BeforeSuite(suite.BeforeSuite)

--- a/pkg/patch/utils_test.go
+++ b/pkg/patch/utils_test.go
@@ -17,211 +17,219 @@ limitations under the License.
 package patch
 
 import (
-	"testing"
-
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 )
 
-func TestToUnstructured(t *testing.T) {
-	t.Run("with a typed object", func(t *testing.T) {
-		g := NewWithT(t)
-		// Test with a typed object.
-		obj := &vmopv1.VirtualMachine{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "cluster-1",
-				Namespace: "namespace-1",
-			},
-			Spec: vmopv1.VirtualMachineSpec{
-				ImageName: "foo",
-			},
-		}
-		newObj, err := toUnstructured(obj)
-		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(newObj.GetName()).To(Equal(obj.Name))
-		g.Expect(newObj.GetNamespace()).To(Equal(obj.Namespace))
+func unitTests() {
+	Context("ToUnstructured", func() {
 
-		// Change a spec field and validate that it stays the same in the incoming object.
-		g.Expect(unstructured.SetNestedField(newObj.Object, false, "spec", "paused")).To(Succeed())
-		g.Expect(obj.Spec.ImageName).To(Equal("foo"))
+		Context("with a typed object", func() {
+			It("should succeed", func() {
+				// Test with a typed object.
+				obj := &vmopv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cluster-1",
+						Namespace: "namespace-1",
+					},
+					Spec: vmopv1.VirtualMachineSpec{
+						ImageName: "foo",
+					},
+				}
+				newObj, err := toUnstructured(obj)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(newObj.GetName()).To(Equal(obj.Name))
+				Expect(newObj.GetNamespace()).To(Equal(obj.Namespace))
+
+				// Change a spec field and validate that it stays the same in the incoming object.
+				Expect(unstructured.SetNestedField(newObj.Object, false, "spec", "paused")).To(Succeed())
+				Expect(obj.Spec.ImageName).To(Equal("foo"))
+			})
+		})
 	})
 
-	t.Run("with an unstructured object", func(t *testing.T) {
-		g := NewWithT(t)
-
-		obj := &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": "test.x.y.z/v1",
-				"metadata": map[string]interface{}{
-					"name":      "test-1",
-					"namespace": "namespace-1",
-				},
-				"spec": map[string]interface{}{
-					"paused": true,
-				},
-			},
-		}
-
-		newObj, err := toUnstructured(obj)
-		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(newObj.GetName()).To(Equal(obj.GetName()))
-		g.Expect(newObj.GetNamespace()).To(Equal(obj.GetNamespace()))
-
-		// Validate that the maps point to different addresses.
-		g.Expect(obj.Object).ToNot(BeIdenticalTo(newObj.Object))
-
-		// Change a spec field and validate that it stays the same in the incoming object.
-		g.Expect(unstructured.SetNestedField(newObj.Object, false, "spec", "paused")).To(Succeed())
-		pausedValue, _, err := unstructured.NestedBool(obj.Object, "spec", "paused")
-		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(pausedValue).To(BeTrue())
-
-		// Change the name of the new object and make sure it doesn't change it the old one.
-		newObj.SetName("test-2")
-		g.Expect(obj.GetName()).To(Equal("test-1"))
-	})
-}
-
-func TestUnsafeFocusedUnstructured(t *testing.T) {
-	t.Run("focus=spec, should only return spec and common fields", func(t *testing.T) {
-		g := NewWithT(t)
-
-		obj := &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": "test.x.y.z/v1",
-				"kind":       "TestCluster",
-				"metadata": map[string]interface{}{
-					"name":      "test-1",
-					"namespace": "namespace-1",
-				},
-				"spec": map[string]interface{}{
-					"paused": true,
-				},
-				"status": map[string]interface{}{
-					"infrastructureReady": true,
-					"conditions": []interface{}{
-						map[string]interface{}{
-							"type":   "Ready",
-							"status": "True",
-						},
+	Context("with an unstructured object", func() {
+		It("should succeed", func() {
+			obj := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "test.x.y.z/v1",
+					"metadata": map[string]interface{}{
+						"name":      "test-1",
+						"namespace": "namespace-1",
+					},
+					"spec": map[string]interface{}{
+						"paused": true,
 					},
 				},
-			},
-		}
+			}
 
-		newObj := unsafeUnstructuredCopy(obj, specPatch, true)
+			newObj, err := toUnstructured(obj)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(newObj.GetName()).To(Equal(obj.GetName()))
+			Expect(newObj.GetNamespace()).To(Equal(obj.GetNamespace()))
 
-		// Validate that common fields are always preserved.
-		g.Expect(newObj.Object["apiVersion"]).To(Equal(obj.Object["apiVersion"]))
-		g.Expect(newObj.Object["kind"]).To(Equal(obj.Object["kind"]))
-		g.Expect(newObj.Object["metadata"]).To(Equal(obj.Object["metadata"]))
+			// Validate that the maps point to different addresses.
+			Expect(obj.Object).ToNot(BeIdenticalTo(newObj.Object))
 
-		// Validate that the spec has been preserved.
-		g.Expect(newObj.Object["spec"]).To(Equal(obj.Object["spec"]))
+			// Change a spec field and validate that it stays the same in the incoming object.
+			Expect(unstructured.SetNestedField(newObj.Object, false, "spec", "paused")).To(Succeed())
+			pausedValue, _, err := unstructured.NestedBool(obj.Object, "spec", "paused")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pausedValue).To(BeTrue())
 
-		// Validate that the status is nil, but preserved in the original object.
-		g.Expect(newObj.Object["status"]).To(BeNil())
-		g.Expect(obj.Object["status"]).ToNot(BeNil())
-		g.Expect(obj.Object["status"].(map[string]interface{})["conditions"]).ToNot(BeNil())
+			// Change the name of the new object and make sure it doesn't change it the old one.
+			newObj.SetName("test-2")
+			Expect(obj.GetName()).To(Equal("test-1"))
+		})
 	})
 
-	t.Run("focus=status w/ condition-setter object, should only return status (without conditions) and common fields", func(t *testing.T) {
-		g := NewWithT(t)
+	Context("UnsafeFocusedUnstructured", func() {
 
-		obj := &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": "test.x.y.z/v1",
-				"kind":       "TestCluster",
-				"metadata": map[string]interface{}{
-					"name":      "test-1",
-					"namespace": "namespace-1",
-				},
-				"spec": map[string]interface{}{
-					"paused": true,
-				},
-				"status": map[string]interface{}{
-					"infrastructureReady": true,
-					"conditions": []interface{}{
-						map[string]interface{}{
-							"type":   "Ready",
-							"status": "True",
+		Context("focus=spec", func() {
+
+			It("should only return spec and common fields", func() {
+				obj := &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "test.x.y.z/v1",
+						"kind":       "TestCluster",
+						"metadata": map[string]interface{}{
+							"name":      "test-1",
+							"namespace": "namespace-1",
+						},
+						"spec": map[string]interface{}{
+							"paused": true,
+						},
+						"status": map[string]interface{}{
+							"infrastructureReady": true,
+							"conditions": []interface{}{
+								map[string]interface{}{
+									"type":   "Ready",
+									"status": "True",
+								},
+							},
 						},
 					},
-				},
-			},
-		}
+				}
 
-		newObj := unsafeUnstructuredCopy(obj, statusPatch, true)
+				newObj := unsafeUnstructuredCopy(obj, specPatch, true)
 
-		// Validate that common fields are always preserved.
-		g.Expect(newObj.Object["apiVersion"]).To(Equal(obj.Object["apiVersion"]))
-		g.Expect(newObj.Object["kind"]).To(Equal(obj.Object["kind"]))
-		g.Expect(newObj.Object["metadata"]).To(Equal(obj.Object["metadata"]))
+				// Validate that common fields are always preserved.
+				Expect(newObj.Object["apiVersion"]).To(Equal(obj.Object["apiVersion"]))
+				Expect(newObj.Object["kind"]).To(Equal(obj.Object["kind"]))
+				Expect(newObj.Object["metadata"]).To(Equal(obj.Object["metadata"]))
 
-		// Validate that spec is nil in the new object, but still exists in the old copy.
-		g.Expect(newObj.Object["spec"]).To(BeNil())
-		g.Expect(obj.Object["spec"]).To(Equal(map[string]interface{}{
-			"paused": true,
-		}))
+				// Validate that the spec has been preserved.
+				Expect(newObj.Object["spec"]).To(Equal(obj.Object["spec"]))
 
-		// Validate that the status has been copied, without conditions.
-		g.Expect(newObj.Object["status"]).To(HaveLen(1))
-		g.Expect(newObj.Object["status"].(map[string]interface{})["infrastructureReady"]).To(Equal(true))
-		g.Expect(newObj.Object["status"].(map[string]interface{})["conditions"]).To(BeNil())
+				// Validate that the status is nil, but preserved in the original object.
+				Expect(newObj.Object["status"]).To(BeNil())
+				Expect(obj.Object["status"]).ToNot(BeNil())
+				Expect(obj.Object["status"].(map[string]interface{})["conditions"]).ToNot(BeNil())
+			})
+		})
 
-		// When working with conditions, the inner map is going to be removed from the original object.
-		g.Expect(obj.Object["status"].(map[string]interface{})["conditions"]).To(BeNil())
-	})
+		Context("focus=status w/ condition-setter object", func() {
 
-	t.Run("focus=status w/o condition-setter object, should only return status and common fields", func(t *testing.T) {
-		g := NewWithT(t)
+			It("should only return status (without conditions) and common fields", func() {
+				obj := &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "test.x.y.z/v1",
+						"kind":       "TestCluster",
+						"metadata": map[string]interface{}{
+							"name":      "test-1",
+							"namespace": "namespace-1",
+						},
+						"spec": map[string]interface{}{
+							"paused": true,
+						},
+						"status": map[string]interface{}{
+							"infrastructureReady": true,
+							"conditions": []interface{}{
+								map[string]interface{}{
+									"type":   "Ready",
+									"status": "True",
+								},
+							},
+						},
+					},
+				}
 
-		obj := &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": "test.x.y.z/v1",
-				"kind":       "TestCluster",
-				"metadata": map[string]interface{}{
-					"name":      "test-1",
-					"namespace": "namespace-1",
-				},
-				"spec": map[string]interface{}{
+				newObj := unsafeUnstructuredCopy(obj, statusPatch, true)
+
+				// Validate that common fields are always preserved.
+				Expect(newObj.Object["apiVersion"]).To(Equal(obj.Object["apiVersion"]))
+				Expect(newObj.Object["kind"]).To(Equal(obj.Object["kind"]))
+				Expect(newObj.Object["metadata"]).To(Equal(obj.Object["metadata"]))
+
+				// Validate that spec is nil in the new object, but still exists in the old copy.
+				Expect(newObj.Object["spec"]).To(BeNil())
+				Expect(obj.Object["spec"]).To(Equal(map[string]interface{}{
+					"paused": true,
+				}))
+
+				// Validate that the status has been copied, without conditions.
+				Expect(newObj.Object["status"]).To(HaveLen(1))
+				Expect(newObj.Object["status"].(map[string]interface{})["infrastructureReady"]).To(Equal(true))
+				Expect(newObj.Object["status"].(map[string]interface{})["conditions"]).To(BeNil())
+
+				// When working with conditions, the inner map is going to be removed from the original object.
+				Expect(obj.Object["status"].(map[string]interface{})["conditions"]).To(BeNil())
+			})
+		})
+
+		Context("focus=status w/o condition-setter object", func() {
+
+			It("should only return status and common fields", func() {
+				obj := &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "test.x.y.z/v1",
+						"kind":       "TestCluster",
+						"metadata": map[string]interface{}{
+							"name":      "test-1",
+							"namespace": "namespace-1",
+						},
+						"spec": map[string]interface{}{
+							"paused": true,
+							"other":  "field",
+						},
+						"status": map[string]interface{}{
+							"infrastructureReady": true,
+							"conditions": []interface{}{
+								map[string]interface{}{
+									"type":   "Ready",
+									"status": "True",
+								},
+							},
+						},
+					},
+				}
+
+				newObj := unsafeUnstructuredCopy(obj, statusPatch, false)
+
+				// Validate that spec is nil in the new object, but still exists in the old copy.
+				Expect(newObj.Object["spec"]).To(BeNil())
+				Expect(obj.Object["spec"]).To(Equal(map[string]interface{}{
 					"paused": true,
 					"other":  "field",
-				},
-				"status": map[string]interface{}{
-					"infrastructureReady": true,
-					"conditions": []interface{}{
-						map[string]interface{}{
-							"type":   "Ready",
-							"status": "True",
-						},
-					},
-				},
-			},
-		}
+				}))
 
-		newObj := unsafeUnstructuredCopy(obj, statusPatch, false)
+				// Validate that common fields are always preserved.
+				Expect(newObj.Object["apiVersion"]).To(Equal(obj.Object["apiVersion"]))
+				Expect(newObj.Object["kind"]).To(Equal(obj.Object["kind"]))
+				Expect(newObj.Object["metadata"]).To(Equal(obj.Object["metadata"]))
 
-		// Validate that spec is nil in the new object, but still exists in the old copy.
-		g.Expect(newObj.Object["spec"]).To(BeNil())
-		g.Expect(obj.Object["spec"]).To(Equal(map[string]interface{}{
-			"paused": true,
-			"other":  "field",
-		}))
+				// Validate that the status has been copied, without conditions.
+				Expect(newObj.Object["status"]).To(HaveLen(2))
+				Expect(newObj.Object["status"]).To(Equal(obj.Object["status"]))
 
-		// Validate that common fields are always preserved.
-		g.Expect(newObj.Object["apiVersion"]).To(Equal(obj.Object["apiVersion"]))
-		g.Expect(newObj.Object["kind"]).To(Equal(obj.Object["kind"]))
-		g.Expect(newObj.Object["metadata"]).To(Equal(obj.Object["metadata"]))
-
-		// Validate that the status has been copied, without conditions.
-		g.Expect(newObj.Object["status"]).To(HaveLen(2))
-		g.Expect(newObj.Object["status"]).To(Equal(obj.Object["status"]))
-
-		// Make sure that we didn't modify the incoming object if this object isn't a condition setter.
-		g.Expect(obj.Object["status"].(map[string]interface{})["conditions"]).ToNot(BeNil())
+				// Make sure that we didn't modify the incoming object if this object isn't a condition setter.
+				Expect(obj.Object["status"].(map[string]interface{})["conditions"]).ToNot(BeNil())
+			})
+		})
 	})
 }


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch fixes an issue in the `pkg/patch` and `controllers/virtualmachinewebconsolerequest/v1alpha1/patch` packages. Both packages would occasionally report only `16%` coverage instead of `78%`. For example, https://github.com/vmware-tanzu/vm-operator/pull/553 showed `pkg/patch` at `78%`, whereas
https://github.com/vmware-tanzu/vm-operator/pull/552 showed it at `16%`. When the lower coverage was detected, Ginkgo did not detect any tests in the package, ex.:

```shell
Running Suite: Patch Suite - /home/runner/work/vm-operator/vm-operator/pkg/patch
================================================================================
Random Seed: 1717175300

Will run 0 of 0 specs

Ran 0 of 0 Specs in 0.000 seconds
SUCCESS! -- 0 Passed | 0 Failed | 0 Pending | 0 Skipped
```

This was RCAd to be the mixing of the pure-Golang style testing versus Ginkgo. This patch updates both packags to use Ginkgo.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Fixes bug for running/reporting coverage for `pkg/patch` and `controllers/virtualmachinewebconsolerequest/v1alpha1/patch`
```