### PR TITLE
✨ Handle VM Class Resize annotations

### DIFF
--- a/api/v1alpha3/virtualmachine_types.go
+++ b/api/v1alpha3/virtualmachine_types.go
@@ -132,6 +132,10 @@ const (
 	// V1alpha1ConfigMapTransportAnnotation is an annotation that indicates that the VM
 	// was created with the v1alpha1 API and specifies a configMap as the metadata transport resource type.
 	V1alpha1ConfigMapTransportAnnotation = GroupName + "/v1a1-configmap-md-transport"
+
+	// VirtualMachineSameVMClassResizeAnnotation is an annotation that indicates the VM
+	// should be resized as the class it points to changes.
+	VirtualMachineSameVMClassResizeAnnotation = GroupName + "/same-vm-class-resize "
 )
 
 const (

--- a/pkg/util/ptr/ptr.go
+++ b/pkg/util/ptr/ptr.go
@@ -69,3 +69,32 @@ func Overwrite[T any](dst *T, src T) {
 		*dst = src
 	}
 }
+
+// OverwriteWithUser overwrites the *dst with an optional user value depending on
+// if the value needs to be updated based on the current value.
+func OverwriteWithUser[T comparable](dst **T, user, current *T) {
+	if dst == nil {
+		panic("dst is nil")
+	}
+
+	// Determine what the ultimate desired value is. If set the user
+	// value takes precedence.
+	var desired *T
+	switch {
+	case user != nil:
+		desired = user
+	case *dst != nil:
+		desired = *dst
+	default:
+		// Leave *dst as-is.
+		return
+	}
+
+	if current == nil || *current != *desired {
+		// An update is required to the desired value.
+		*dst = desired
+	} else if *current == *desired {
+		// Already at the desired value so no update is required.
+		*dst = nil
+	}
+}

--- a/pkg/util/ptr/ptr_test.go
+++ b/pkg/util/ptr/ptr_test.go
@@ -190,3 +190,31 @@ var _ = DescribeTable(
 	Entry("**byte - dst is not empty, src is not empty", &[]**byte{&[]*byte{&[]byte{byte(1)}[0]}[0]}[0], &[]*byte{&[]byte{byte(2)}[0]}[0], byte(2), false),
 	Entry("**byte - dst is not empty, src is empty", &[]**byte{&[]*byte{&[]byte{byte(1)}[0]}[0]}[0], &[]*byte{&[]byte{byte(0)}[0]}[0], byte(0), false),
 )
+
+var _ = Describe("OverwriteWithUser", func() {
+	It("panics with nil dst", func() {
+		fn := func() {
+			ptr.OverwriteWithUser[int](nil, nil, nil)
+		}
+		Expect(fn).To(PanicWith(dstIsNil))
+	})
+})
+
+var _ = DescribeTable("OverwriteWithUser table",
+	func(dst *int, user *int, current *int, expectedDst *int) {
+		ptr.OverwriteWithUser(&dst, user, current)
+		if expectedDst == nil {
+			Expect(dst).To(BeNil())
+		} else {
+			Expect(dst).To(HaveValue(Equal(*expectedDst)))
+		}
+	},
+	Entry("Nil args", nil, nil, nil, nil),
+	Entry("Only *dst set", ptr.To(1), nil, nil, ptr.To(1)),
+	Entry("Only user value set", nil, ptr.To(1), nil, ptr.To(1)),
+	Entry("Only current value set", nil, nil, ptr.To(1), nil),
+	Entry("Set user value takes precedence", ptr.To(1), ptr.To(2), nil, ptr.To(2)),
+	Entry("*dst value matches current value", ptr.To(1), nil, ptr.To(1), nil),
+	Entry("User value matches current value", ptr.To(1), ptr.To(2), ptr.To(2), nil),
+	Entry("Set user value takes precedence & different from current value", ptr.To(1), ptr.To(2), ptr.To(3), ptr.To(2)),
+)

--- a/pkg/util/resize/configspec.go
+++ b/pkg/util/resize/configspec.go
@@ -31,7 +31,7 @@ func CreateResizeConfigSpec(
 	return outCS, nil
 }
 
-// compareHardware compares the ConfigSpec.Hardware.
+// compareHardware compares the ConfigInfo.Hardware.
 func compareHardware(
 	ci vimtypes.VirtualMachineConfigInfo,
 	cs vimtypes.VirtualMachineConfigSpec,

--- a/pkg/util/vmopv1/resize_devops.go
+++ b/pkg/util/vmopv1/resize_devops.go
@@ -12,14 +12,15 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 )
 
-// OverrideResizeConfigSpec applies any set fields in the VM Spec to the ConfigSpec.
-func OverrideResizeConfigSpec(
+// OverwriteResizeConfigSpec applies any set fields in the VM Spec to the ConfigSpec.
+func OverwriteResizeConfigSpec(
 	_ context.Context,
 	vm vmopv1.VirtualMachine,
+	ci vimtypes.VirtualMachineConfigInfo,
 	cs *vimtypes.VirtualMachineConfigSpec) error {
 
 	if adv := vm.Spec.Advanced; adv != nil {
-		ptr.Overwrite(&cs.ChangeTrackingEnabled, adv.ChangeBlockTracking)
+		ptr.OverwriteWithUser(&cs.ChangeTrackingEnabled, adv.ChangeBlockTracking, ci.ChangeTrackingEnabled)
 	}
 
 	return nil


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

This includes most of the infra around resize so that most of the remaining work is just being able to build the full resize Reconfigure ConfigSpec.

Improve the handling of user/devops fields by only updating the resize ConfigSpec if the current value - as from the ConfigInfo - is different.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note
NONE
```