### PR TITLE
✨ Resize fields: CPU affinity, hot add, hot remove, latency sensitivity, perf counter, resource allocation

### DIFF
--- a/pkg/util/resize/configspec.go
+++ b/pkg/util/resize/configspec.go
@@ -5,6 +5,8 @@ package resize
 
 import (
 	"context"
+	"reflect"
+	"slices"
 
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 )
@@ -20,6 +22,11 @@ func CreateResizeConfigSpec(
 	outCS := vimtypes.VirtualMachineConfigSpec{}
 
 	compareHardware(ci, cs, &outCS)
+	compareCPUAllocation(ci, cs, &outCS)
+	compareCPUHotAddOrRemove(ci, cs, &outCS)
+	compareCPUAffinity(ci, cs, &outCS)
+	compareCPUPerfCounter(ci, cs, &outCS)
+	compareLatencySensitivity(ci, cs, &outCS)
 
 	return outCS, nil
 }
@@ -39,6 +46,120 @@ func compareHardware(
 	// outCS.Device = ...
 	cmp(ci.Hardware.MotherboardLayout, cs.MotherboardLayout, &outCS.MotherboardLayout)
 	cmp(ci.Hardware.SimultaneousThreads, cs.SimultaneousThreads, &outCS.SimultaneousThreads)
+}
+
+// compareCPUAllocation compares CPU resource allocation.
+func compareCPUAllocation(
+	ci vimtypes.VirtualMachineConfigInfo,
+	cs vimtypes.VirtualMachineConfigSpec,
+	outCS *vimtypes.VirtualMachineConfigSpec) {
+	// nothing to change
+	if cs.CpuAllocation == nil {
+		return
+	}
+
+	ciCPUAllocation := ci.CpuAllocation
+	csCPUAllocation := cs.CpuAllocation
+
+	var cpuReservation *int64
+	if csCPUAllocation.Reservation != nil {
+		if ciCPUAllocation == nil || ciCPUAllocation.Reservation == nil || *ciCPUAllocation.Reservation != *csCPUAllocation.Reservation {
+			cpuReservation = csCPUAllocation.Reservation
+		}
+	}
+
+	var cpuLimit *int64
+	if csCPUAllocation.Limit != nil {
+		if ciCPUAllocation == nil || ciCPUAllocation.Limit == nil || *ciCPUAllocation.Limit != *csCPUAllocation.Limit {
+			cpuLimit = csCPUAllocation.Limit
+		}
+	}
+
+	var cpuShares *vimtypes.SharesInfo
+	if csCPUAllocation.Shares != nil {
+		if ciCPUAllocation == nil || ciCPUAllocation.Shares == nil ||
+			ciCPUAllocation.Shares.Level != csCPUAllocation.Shares.Level ||
+			(csCPUAllocation.Shares.Level == vimtypes.SharesLevelCustom && ciCPUAllocation.Shares.Shares != csCPUAllocation.Shares.Shares) {
+			cpuShares = csCPUAllocation.Shares
+		}
+	}
+
+	if cpuReservation != nil || cpuLimit != nil || cpuShares != nil {
+		outCS.CpuAllocation = &vimtypes.ResourceAllocationInfo{}
+
+		if cpuReservation != nil {
+			outCS.CpuAllocation.Reservation = cpuReservation
+		}
+
+		if cpuLimit != nil {
+			outCS.CpuAllocation.Limit = cpuLimit
+		}
+
+		if cpuShares != nil {
+			outCS.CpuAllocation.Shares = cpuShares
+		}
+	}
+}
+
+// compareCPUHotAddOrRemove compares CPU hot add and remove enabled.
+func compareCPUHotAddOrRemove(
+	ci vimtypes.VirtualMachineConfigInfo,
+	cs vimtypes.VirtualMachineConfigSpec,
+	outCS *vimtypes.VirtualMachineConfigSpec) {
+	cmpPtr(ci.CpuHotAddEnabled, cs.CpuHotAddEnabled, &outCS.CpuHotAddEnabled)
+	cmpPtr(ci.CpuHotRemoveEnabled, cs.CpuHotRemoveEnabled, &outCS.CpuHotRemoveEnabled)
+}
+
+// compareCPUPerfCounter compares virtual CPU performance counter enablement.
+func compareCPUPerfCounter(
+	ci vimtypes.VirtualMachineConfigInfo,
+	cs vimtypes.VirtualMachineConfigSpec,
+	outCS *vimtypes.VirtualMachineConfigSpec) {
+	cmpPtr(ci.VPMCEnabled, cs.VPMCEnabled, &outCS.VPMCEnabled)
+}
+
+// compareCPUAffinity compares CPU affinity settings in ConfigSpec.
+func compareCPUAffinity(
+	ci vimtypes.VirtualMachineConfigInfo,
+	cs vimtypes.VirtualMachineConfigSpec,
+	outCS *vimtypes.VirtualMachineConfigSpec) {
+
+	if cs.CpuAffinity == nil {
+		return
+	}
+
+	if ci.CpuAffinity == nil {
+		outCS.CpuAffinity = cs.CpuAffinity
+	}
+
+	if ci.CpuAffinity != nil {
+		slices.Sort(ci.CpuAffinity.AffinitySet)
+		slices.Sort(cs.CpuAffinity.AffinitySet)
+		if !reflect.DeepEqual(ci.CpuAffinity.AffinitySet, cs.CpuAffinity.AffinitySet) {
+			outCS.CpuAffinity = cs.CpuAffinity
+		}
+	}
+}
+
+// compareLatencySensitivity compares the latency-sensitivity of the virtual machine.
+func compareLatencySensitivity(
+	ci vimtypes.VirtualMachineConfigInfo,
+	cs vimtypes.VirtualMachineConfigSpec,
+	outCS *vimtypes.VirtualMachineConfigSpec) {
+
+	if cs.LatencySensitivity == nil {
+		return
+	}
+
+	if ci.LatencySensitivity == nil ||
+		ci.LatencySensitivity.Sensitivity != cs.LatencySensitivity.Sensitivity ||
+		ci.LatencySensitivity.Level != cs.LatencySensitivity.Level {
+		outCS.LatencySensitivity = &vimtypes.LatencySensitivity{
+			Level: cs.LatencySensitivity.Level,
+			// deprecated since vsphere 5.5
+			//Sensitivity: cs.LatencySensitivity.Sensitivity,
+		}
+	}
 }
 
 func cmp[T comparable](a, b T, c *T) {

--- a/pkg/util/resize/configspec_test.go
+++ b/pkg/util/resize/configspec_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/resize"
 )
 
@@ -108,6 +109,99 @@ var _ = Describe("CreateResizeConfigSpec", func() {
 		Entry("SimultaneousThreads does not need updating",
 			ConfigInfo{Hardware: vimtypes.VirtualHardware{SimultaneousThreads: 8}},
 			ConfigSpec{SimultaneousThreads: 8},
+			ConfigSpec{}),
+
+		Entry("CPU allocation (reservation, limit, shares) settings needs updating",
+			ConfigInfo{
+				CpuAllocation: &vimtypes.ResourceAllocationInfo{
+					Reservation: ptr.To(int64(100)),
+					Limit:       ptr.To(int64(100)),
+					Shares:      &vimtypes.SharesInfo{Level: vimtypes.SharesLevelNormal},
+				}},
+			ConfigSpec{
+				CpuAllocation: &vimtypes.ResourceAllocationInfo{
+					Reservation: ptr.To(int64(200)),
+					Limit:       ptr.To(int64(200)),
+					Shares:      &vimtypes.SharesInfo{Level: vimtypes.SharesLevelCustom, Shares: 50},
+				}},
+			ConfigSpec{
+				CpuAllocation: &vimtypes.ResourceAllocationInfo{
+					Reservation: ptr.To(int64(200)),
+					Limit:       ptr.To(int64(200)),
+					Shares:      &vimtypes.SharesInfo{Level: vimtypes.SharesLevelCustom, Shares: 50},
+				}}),
+		Entry("CPU allocation (reservation, limit, shares) settings needs updating - empty to values set ",
+			ConfigInfo{
+				CpuAllocation: &vimtypes.ResourceAllocationInfo{}},
+			ConfigSpec{
+				CpuAllocation: &vimtypes.ResourceAllocationInfo{
+					Reservation: ptr.To(int64(200)),
+					Limit:       ptr.To(int64(200)),
+					Shares:      &vimtypes.SharesInfo{Level: vimtypes.SharesLevelNormal},
+				}},
+			ConfigSpec{
+				CpuAllocation: &vimtypes.ResourceAllocationInfo{
+					Reservation: ptr.To(int64(200)),
+					Limit:       ptr.To(int64(200)),
+					Shares:      &vimtypes.SharesInfo{Level: vimtypes.SharesLevelNormal},
+				}}),
+		Entry("CPU allocation (reservation,limit,shares) settings does not need updating",
+			ConfigInfo{
+				CpuAllocation: &vimtypes.ResourceAllocationInfo{
+					Reservation: ptr.To(int64(100)),
+					Limit:       ptr.To(int64(100)),
+					Shares:      &vimtypes.SharesInfo{Level: vimtypes.SharesLevelNormal},
+				}},
+			ConfigSpec{
+				CpuAllocation: &vimtypes.ResourceAllocationInfo{
+					Reservation: ptr.To(int64(100)),
+					Limit:       ptr.To(int64(100)),
+					Shares:      &vimtypes.SharesInfo{Level: vimtypes.SharesLevelNormal},
+				}},
+			ConfigSpec{}),
+
+		Entry("CPU Hot Add/Remove needs updating false to true",
+			ConfigInfo{CpuHotAddEnabled: falsePtr, CpuHotRemoveEnabled: falsePtr},
+			ConfigSpec{CpuHotAddEnabled: truePtr, CpuHotRemoveEnabled: truePtr},
+			ConfigSpec{CpuHotAddEnabled: truePtr, CpuHotRemoveEnabled: truePtr}),
+		Entry("CPU Hot Add/Remove needs updating nil to true",
+			ConfigInfo{},
+			ConfigSpec{CpuHotAddEnabled: truePtr, CpuHotRemoveEnabled: truePtr},
+			ConfigSpec{CpuHotAddEnabled: truePtr, CpuHotRemoveEnabled: truePtr}),
+		Entry("CPU Hot Add/Remove does not need updating",
+			ConfigInfo{CpuHotAddEnabled: falsePtr, CpuHotRemoveEnabled: falsePtr},
+			ConfigSpec{CpuHotAddEnabled: falsePtr, CpuHotRemoveEnabled: falsePtr},
+			ConfigSpec{}),
+
+		Entry("CPU affinity settings needs updating value change",
+			ConfigInfo{CpuAffinity: &vimtypes.VirtualMachineAffinityInfo{AffinitySet: []int32{2, 3}}},
+			ConfigSpec{CpuAffinity: &vimtypes.VirtualMachineAffinityInfo{AffinitySet: []int32{1, 3}}},
+			ConfigSpec{CpuAffinity: &vimtypes.VirtualMachineAffinityInfo{AffinitySet: []int32{1, 3}}}),
+		Entry("CPU affinity settings needs updating - remove existing",
+			ConfigInfo{CpuAffinity: &vimtypes.VirtualMachineAffinityInfo{AffinitySet: []int32{2, 3}}},
+			ConfigSpec{CpuAffinity: &vimtypes.VirtualMachineAffinityInfo{AffinitySet: []int32{}}},
+			ConfigSpec{CpuAffinity: &vimtypes.VirtualMachineAffinityInfo{AffinitySet: []int32{}}}),
+		Entry("CPU affinity settings does not need updating",
+			ConfigInfo{CpuAffinity: &vimtypes.VirtualMachineAffinityInfo{AffinitySet: []int32{1, 2, 3}}},
+			ConfigSpec{CpuAffinity: &vimtypes.VirtualMachineAffinityInfo{AffinitySet: []int32{3, 1, 2}}},
+			ConfigSpec{}),
+
+		Entry("CPU perf counter settings does not need updating",
+			ConfigInfo{VPMCEnabled: falsePtr},
+			ConfigSpec{VPMCEnabled: falsePtr},
+			ConfigSpec{}),
+		Entry("CPU perf counter settings needs updating",
+			ConfigInfo{VPMCEnabled: falsePtr},
+			ConfigSpec{VPMCEnabled: truePtr},
+			ConfigSpec{VPMCEnabled: truePtr}),
+
+		Entry("Latency sensitivity settings needs updating",
+			ConfigInfo{LatencySensitivity: &vimtypes.LatencySensitivity{Level: vimtypes.LatencySensitivitySensitivityLevelLow}},
+			ConfigSpec{LatencySensitivity: &vimtypes.LatencySensitivity{Level: vimtypes.LatencySensitivitySensitivityLevelMedium}},
+			ConfigSpec{LatencySensitivity: &vimtypes.LatencySensitivity{Level: vimtypes.LatencySensitivitySensitivityLevelMedium}}),
+		Entry("Latency sensitivity settings does not need updating",
+			ConfigInfo{LatencySensitivity: &vimtypes.LatencySensitivity{Level: vimtypes.LatencySensitivitySensitivityLevelLow}},
+			ConfigSpec{LatencySensitivity: &vimtypes.LatencySensitivity{Level: vimtypes.LatencySensitivitySensitivityLevelLow}},
 			ConfigSpec{}),
 	)
 })


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This change adds support for resize when some of the fields in the configSpec are modified. Namely,
- CPU affinity
- CPU hot add and remove
- CPU latency sensitivity
- CPU perf counter (VPMC)
- CPU resource allocation

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # N/A


**Are there any special notes for your reviewer**:
N/A


**Please add a release note if necessary**:

```
Support resizing fields: CPU affinity, hot add, hot remove, latency sensitivity, perf counter, resource allocation

```