### PR TITLE
🌱 Coverage thresholds; fail on below 80%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,13 +187,13 @@ jobs:
       with:
         filename: cover.xml
         badge: true
-        fail_below_min: false
+        fail_below_min: true
         format: markdown
         hide_branch_rate: false
         hide_complexity: true
         indicators: true
         output: both
-        thresholds: '60 80'
+        thresholds: '79 89' # really '80 90', but the values are not inclusive
     - name: Save pull request ID
       if: github.event_name == 'pull_request'
       env:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch updates the coverage thresholds to '80 90' where 80% is the minimum threshold and 90% is the *target* floor. This patch also updates the GitHub action so that the job will fail if the coverage dips below the 80% floor.


<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

~~It turns out the threshold values inclusive for failure detection, despite the documentation for [`fail_below_min`](https://github.com/irongut/CodeCoverageSummary?tab=readme-ov-file#fail_below_min):~~

> Fail the workflow if the overall Line Rate is below lower threshold - true or false (default). The default lower threshold is 50%, see [`thresholds`](https://github.com/irongut/CodeCoverageSummary?tab=readme-ov-file#thresholds).

It turns out the issue is caused by lack of precision in the coverage values. The actual coverage rate for our repository is `79.8537515896566%`. That is derived from dividing `7535 / 9436`, which produces `0.798537515896566`. Please see irongut/CodeCoverageSummary#68 and irongut/CodeCoverageSummary#78 for more information.

[From](https://github.com/vmware-tanzu/vm-operator/actions/runs/9371100846/job/25799638984#step:7:88) the failed job:

> **Summary** | **80%** (7535 / 9436) | ❌
> 
> _Minimum allowed line rate is `80%`_
> 
> FAIL: Overall line rate below minimum threshold of 80%.

Explain to me how the overall line rate is below `80%` when the summary indicates the overall rate is `80%` 😄 Anyway, I updated the range to `79-89`.

**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Fail GitHub actions if coverage dips below 80%.
```