### PR TITLE
✨ Add vm.spec.guestID API and its implementation

### DIFF
--- a/api/v1alpha1/virtualmachine_conversion.go
+++ b/api/v1alpha1/virtualmachine_conversion.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2023-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package v1alpha1
@@ -964,6 +964,10 @@ func restore_v1alpha3_VirtualMachineBootstrapCloudInitInstanceID(
 	dst.Spec.Bootstrap.CloudInit.InstanceID = iid
 }
 
+func restore_v1alpha3_VirtualMachineGuestID(dst, src *vmopv1.VirtualMachine) {
+	dst.Spec.GuestID = src.Spec.GuestID
+}
+
 func convert_v1alpha1_PreReqsReadyCondition_to_v1alpha3_Conditions(
 	dst *vmopv1.VirtualMachine) []metav1.Condition {
 
@@ -1184,6 +1188,8 @@ func (src *VirtualMachine) ConvertTo(dstRaw ctrlconversion.Hub) error {
 	restore_v1alpha3_VirtualMachineReadinessProbeSpec(dst, restored)
 	restore_v1alpha3_VirtualMachineBiosUUID(dst, restored)
 	restore_v1alpha3_VirtualMachineBootstrapCloudInitInstanceID(dst, restored)
+	restore_v1alpha3_VirtualMachineInstanceUUID(dst, restored)
+	restore_v1alpha3_VirtualMachineGuestID(dst, restored)
 
 	// END RESTORE
 

--- a/api/v1alpha1/virtualmachine_conversion_test.go
+++ b/api/v1alpha1/virtualmachine_conversion_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2023-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package v1alpha1_test
@@ -216,6 +216,7 @@ func TestVirtualMachineConversion(t *testing.T) {
 				MinHardwareVersion: 42,
 				InstanceUUID:       uuid.NewString(),
 				BiosUUID:           uuid.NewString(),
+				GuestID:            "my-guest-id",
 			},
 		}
 

--- a/api/v1alpha1/zz_generated.conversion.go
+++ b/api/v1alpha1/zz_generated.conversion.go
@@ -2082,6 +2082,7 @@ func autoConvert_v1alpha3_VirtualMachineSpec_To_v1alpha1_VirtualMachineSpec(in *
 	out.MinHardwareVersion = in.MinHardwareVersion
 	// WARNING: in.InstanceUUID requires manual conversion: does not exist in peer-type
 	// WARNING: in.BiosUUID requires manual conversion: does not exist in peer-type
+	// WARNING: in.GuestID requires manual conversion: does not exist in peer-type
 	return nil
 }
 

--- a/api/v1alpha2/virtualmachine_conversion.go
+++ b/api/v1alpha2/virtualmachine_conversion.go
@@ -193,6 +193,10 @@ func restore_v1alpha3_VirtualMachineBootstrapCloudInitInstanceID(
 	dst.Spec.Bootstrap.CloudInit.InstanceID = iid
 }
 
+func restore_v1alpha3_VirtualMachineGuestID(dst, src *vmopv1.VirtualMachine) {
+	dst.Spec.GuestID = src.Spec.GuestID
+}
+
 // ConvertTo converts this VirtualMachine to the Hub version.
 func (src *VirtualMachine) ConvertTo(dstRaw ctrlconversion.Hub) error {
 	dst := dstRaw.(*vmopv1.VirtualMachine)
@@ -213,6 +217,7 @@ func (src *VirtualMachine) ConvertTo(dstRaw ctrlconversion.Hub) error {
 	restore_v1alpha3_VirtualMachineBiosUUID(dst, restored)
 	restore_v1alpha3_VirtualMachineBootstrapCloudInitInstanceID(dst, restored)
 	restore_v1alpha3_VirtualMachineSpecNetworkDomainName(dst, restored)
+	restore_v1alpha3_VirtualMachineGuestID(dst, restored)
 
 	// END RESTORE
 

--- a/api/v1alpha2/virtualmachine_conversion_test.go
+++ b/api/v1alpha2/virtualmachine_conversion_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -235,6 +236,9 @@ func TestVirtualMachineConversion(t *testing.T) {
 					ResourcePolicyName: "my-resource-policy",
 				},
 				MinHardwareVersion: 42,
+				InstanceUUID:       uuid.NewString(),
+				BiosUUID:           uuid.NewString(),
+				GuestID:            "my-guest-id",
 			},
 		}
 

--- a/api/v1alpha2/zz_generated.conversion.go
+++ b/api/v1alpha2/zz_generated.conversion.go
@@ -3168,6 +3168,7 @@ func autoConvert_v1alpha3_VirtualMachineSpec_To_v1alpha2_VirtualMachineSpec(in *
 	out.MinHardwareVersion = in.MinHardwareVersion
 	// WARNING: in.InstanceUUID requires manual conversion: does not exist in peer-type
 	// WARNING: in.BiosUUID requires manual conversion: does not exist in peer-type
+	// WARNING: in.GuestID requires manual conversion: does not exist in peer-type
 	return nil
 }
 

--- a/api/v1alpha3/virtualmachine_types.go
+++ b/api/v1alpha3/virtualmachine_types.go
@@ -49,6 +49,10 @@ const (
 	// GuestBootstrapCondition exposes the status of guest bootstrap from within
 	// the guest OS, when available.
 	GuestBootstrapCondition = "GuestBootstrap"
+
+	// GuestIDCondition exposes the status of the guest ID configuration, when
+	// specified in the VirtualMachineSpec.
+	GuestIDCondition = "GuestID"
 )
 
 const (
@@ -484,6 +488,26 @@ type VirtualMachineSpec struct {
 	// When the bootstrap provider is Cloud-Init, this value is used as the
 	// default value for spec.bootstrap.cloudInit.instanceID if it is omitted.
 	BiosUUID string `json:"biosUUID,omitempty"`
+
+	// +optional
+
+	// GuestID describes the desired guest operating system identifier for a VM.
+	//
+	// The logic that determines the guest ID is as follows:
+	//
+	// 1. If this field is set, then its value is used.
+	// 2. Otherwise, if the VirtualMachineClass used to deploy the VM contains a
+	//    non-empty guest ID, then it is used.
+	// 3. Finally, if this field is still undetermined, and the VM is deployed
+	// from an OVF template that defines a guest ID, then that value is used.
+	//
+	// Please refer to https://bit.ly/4elnjP3 for a complete list of supported
+	// guest operating system identifiers.
+	//
+	// Please note that this field is immutable after the VM is powered on.
+	// To change the guest ID after the VM is powered on, the VM must be powered
+	// off and then powered on again with the updated guest ID spec.
+	GuestID string `json:"guestID,omitempty"`
 }
 
 // VirtualMachineReservedSpec describes a set of VM configuration options

--- a/api/v1alpha3/virtualmachine_types.go
+++ b/api/v1alpha3/virtualmachine_types.go
@@ -50,9 +50,9 @@ const (
 	// the guest OS, when available.
 	GuestBootstrapCondition = "GuestBootstrap"
 
-	// GuestIDCondition exposes the status of the guest ID configuration, when
-	// specified in the VirtualMachineSpec.
-	GuestIDCondition = "GuestID"
+	// GuestIDReconfiguredCondition exposes the status of guest ID
+	// reconfiguration after a VM has been created, when available.
+	GuestIDReconfiguredCondition = "GuestIDReconfigured"
 )
 
 const (

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachinereplicasets.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachinereplicasets.yaml
@@ -997,6 +997,29 @@ spec:
                           an existing VM on the underlying platform that was not deployed from a
                           VM class.
                         type: string
+                      guestID:
+                        description: |-
+                          GuestID describes the desired guest operating system identifier for a VM.
+
+
+                          The logic that determines the guest ID is as follows:
+
+
+                          1. If this field is set, then its value is used.
+                          2. Otherwise, if the VirtualMachineClass used to deploy the VM contains a
+                             non-empty guest ID, then it is used.
+                          3. Finally, if this field is still undetermined, and the VM is deployed
+                          from an OVF template that defines a guest ID, then that value is used.
+
+
+                          Please refer to https://bit.ly/4elnjP3 for a complete list of supported
+                          guest operating system identifiers.
+
+
+                          Please note that this field is immutable after the VM is powered on.
+                          To change the guest ID after the VM is powered on, the VM must be powered
+                          off and then powered on again with the updated guest ID spec.
+                        type: string
                       image:
                         description: |-
                           Image describes the reference to the VirtualMachineImage or

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -3984,6 +3984,29 @@ spec:
                   an existing VM on the underlying platform that was not deployed from a
                   VM class.
                 type: string
+              guestID:
+                description: |-
+                  GuestID describes the desired guest operating system identifier for a VM.
+
+
+                  The logic that determines the guest ID is as follows:
+
+
+                  1. If this field is set, then its value is used.
+                  2. Otherwise, if the VirtualMachineClass used to deploy the VM contains a
+                     non-empty guest ID, then it is used.
+                  3. Finally, if this field is still undetermined, and the VM is deployed
+                  from an OVF template that defines a guest ID, then that value is used.
+
+
+                  Please refer to https://bit.ly/4elnjP3 for a complete list of supported
+                  guest operating system identifiers.
+
+
+                  Please note that this field is immutable after the VM is powered on.
+                  To change the guest ID after the VM is powered on, the VM must be powered
+                  off and then powered on again with the updated guest ID spec.
+                type: string
               image:
                 description: |-
                   Image describes the reference to the VirtualMachineImage or

--- a/docs/concepts/workloads/vm.md
+++ b/docs/concepts/workloads/vm.md
@@ -438,3 +438,20 @@ The value of `spec.biosUUID` is used to set the vSphere VM `config.uuid` field, 
 ``` bash
 govc vm.info -vm.uuid $(k get vm -o jsonpath='{.spec.biosUUID}' -n $ns $name)
 ```
+
+## Guest IDs
+
+The `spec.guestID` is an optional field that can be used to specify the guest operating system identifier when creating a new VM or powering on an existing VM.
+
+A complete list of supported guest IDs can be found [here](https://dp-downloads.broadcom.com/api-content/apis/API_VWSA_001/8.0U2/html/SDK/vsphere-ws/docs/ReferenceGuide/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html).
+
+The `govc` command can be used to query the currently supported guest IDs for a given vSphere environment:
+
+``` bash
+$ govc vm.option.info -cluster CLUSTER_NAME
+...
+almalinux_64Guest           AlmaLinux (64-bit)
+rockylinux_64Guest          Rocky Linux (64-bit)
+windows2022srvNext_64Guest  Microsoft Windows Server 2025 (64-bit)
+...
+```

--- a/docs/ref/api/v1alpha3.md
+++ b/docs/ref/api/v1alpha3.md
@@ -2240,6 +2240,26 @@ virtual machine instances, including those that may share the same BIOS UUID. |
 If omitted, this field defaults to a random UUID.
 When the bootstrap provider is Cloud-Init, this value is used as the
 default value for spec.bootstrap.cloudInit.instanceID if it is omitted. |
+| `guestID` _string_ | GuestID describes the desired guest operating system identifier for a VM.
+
+
+The logic that determines the guest ID is as follows:
+
+
+1. If this field is set, then its value is used.
+2. Otherwise, if the VirtualMachineClass used to deploy the VM contains a
+   non-empty guest ID, then it is used.
+3. Finally, if this field is still undetermined, and the VM is deployed
+from an OVF template that defines a guest ID, then that value is used.
+
+
+Please refer to https://bit.ly/4elnjP3 for a complete list of supported
+guest operating system identifiers.
+
+
+Please note that this field is immutable after the VM is powered on.
+To change the guest ID after the VM is powered on, the VM must be powered
+off and then powered on again with the updated guest ID spec. |
 
 ### VirtualMachineStatus
 

--- a/pkg/providers/vsphere/resources/vm.go
+++ b/pkg/providers/vsphere/resources/vm.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2018-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package resources
@@ -75,20 +75,20 @@ func (vm *VirtualMachine) Clone(ctx context.Context, folder *object.Folder, clon
 	return &ref, nil
 }
 
-func (vm *VirtualMachine) Reconfigure(ctx context.Context, configSpec *vimtypes.VirtualMachineConfigSpec) error {
+func (vm *VirtualMachine) Reconfigure(ctx context.Context, configSpec *vimtypes.VirtualMachineConfigSpec) (*vimtypes.TaskInfo, error) {
 	vm.logger.V(5).Info("Reconfiguring VM", "configSpec", configSpec)
 
 	reconfigureTask, err := vm.vcVirtualMachine.Reconfigure(ctx, *configSpec)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	_, err = reconfigureTask.WaitForResult(ctx, nil)
+	taskInfo, err := reconfigureTask.WaitForResult(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("reconfigure VM task failed: %w", err)
+		return taskInfo, fmt.Errorf("reconfigure VM task failed: %w", err)
 	}
 
-	return nil
+	return nil, nil
 }
 
 func (vm *VirtualMachine) GetProperties(ctx context.Context, properties []string) (*mo.VirtualMachine, error) {

--- a/pkg/providers/vsphere/session/session_vm_update.go
+++ b/pkg/providers/vsphere/session/session_vm_update.go
@@ -607,7 +607,7 @@ func (s *Session) prePowerOnVMReconfigure(
 		}
 
 		taskInfo, err := resVM.Reconfigure(vmCtx, configSpec)
-		vmutil.UpdateVMGuestIDCondition(vmCtx, *configSpec, taskInfo)
+		vmutil.UpdateVMGuestIDReconfiguredCondition(vmCtx, *configSpec, taskInfo)
 		if err != nil {
 			vmCtx.Logger.Error(err, "pre power on reconfigure failed")
 			return err

--- a/pkg/providers/vsphere/session/session_vm_update_test.go
+++ b/pkg/providers/vsphere/session/session_vm_update_test.go
@@ -19,6 +19,7 @@ import (
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	"github.com/vmware-tanzu/vm-operator/api/v1alpha3/common"
+	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	pkgctxfake "github.com/vmware-tanzu/vm-operator/pkg/context/fake"
@@ -1196,6 +1197,58 @@ var _ = Describe("Update ConfigSpec", func() {
 			})
 		})
 	})
+
+	Context("UpdateConfigSpecGuestID", func() {
+		const fakeGuestID = "fakeGuestID"
+		var vmSpecGuestID string
+
+		JustBeforeEach(func() {
+			session.UpdateConfigSpecGuestID(config, configSpec, vmSpecGuestID)
+		})
+
+		When("VM spec guestID is empty", func() {
+			BeforeEach(func() {
+				vmSpecGuestID = ""
+			})
+
+			It("should not set guestID in configSpec", func() {
+				Expect(configSpec.GuestId).To(BeEmpty())
+			})
+		})
+
+		When("VM spec guestID is not empty and VM ConfigInfo guestID is empty", func() {
+			BeforeEach(func() {
+				vmSpecGuestID = fakeGuestID
+				config.GuestId = ""
+			})
+
+			It("should set guestID in configSpec", func() {
+				Expect(configSpec.GuestId).To(Equal(vmSpecGuestID))
+			})
+		})
+
+		When("VM spec guestID is different from the VM ConfigInfo guestID", func() {
+			BeforeEach(func() {
+				vmSpecGuestID = fakeGuestID
+				config.GuestId = "some-other-guestID"
+			})
+
+			It("should set guestID in configSpec", func() {
+				Expect(configSpec.GuestId).To(Equal(vmSpecGuestID))
+			})
+		})
+
+		When("VM spec guestID already matches VM ConfigInfo guestID", func() {
+			BeforeEach(func() {
+				config.GuestId = fakeGuestID
+				vmSpecGuestID = fakeGuestID
+			})
+
+			It("should not set guestID in configSpec", func() {
+				Expect(configSpec.GuestId).To(BeEmpty())
+			})
+		})
+	})
 })
 
 var _ = Describe("UpdateVirtualMachine", func() {
@@ -1567,6 +1620,49 @@ var _ = Describe("UpdateVirtualMachine", func() {
 							Expect(nics).To(HaveLen(1))
 							Expect(nics[0]).To(BeAssignableToTypeOf(&vimtypes.VirtualVmxnet3{}))
 						})
+					})
+				})
+			})
+
+			When("VM.Spec.GuestID is changed", func() {
+
+				When("the guest ID is invalid", func() {
+
+					BeforeEach(func() {
+						vm.Spec.GuestID = "invalid-guest-id"
+					})
+
+					It("should return an error and set the VM's Guest ID condition false", func() {
+						errMsg := "reconfigure VM task failed"
+						err := sess.UpdateVirtualMachine(vmCtx, vcVM, getUpdateArgs, getResizeArgs)
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).To(ContainSubstring(errMsg))
+						c := conditions.Get(vm, vmopv1.GuestIDCondition)
+						Expect(c).ToNot(BeNil())
+						expectedCondition := conditions.FalseCondition(
+							vmopv1.GuestIDCondition,
+							"Invalid",
+							"The specified guest ID value is not supported: invalid-guest-id",
+						)
+						Expect(*c).To(conditions.MatchCondition(*expectedCondition))
+					})
+				})
+
+				When("the guest ID is valid", func() {
+
+					BeforeEach(func() {
+						vm.Spec.GuestID = "vmwarePhoton64Guest"
+					})
+
+					It("should power on the VM with the specified guest ID and set VM's PrePowerOnReconfigureReady condition true", func() {
+						Expect(sess.UpdateVirtualMachine(vmCtx, vcVM, getUpdateArgs, getResizeArgs)).To(Succeed())
+						Expect(vcVM.Properties(ctx, vcVM.Reference(), vmProps, &vmCtx.MoVM)).To(Succeed())
+						Expect(vmCtx.MoVM.Runtime.PowerState).To(Equal(vimtypes.VirtualMachinePowerStatePoweredOn))
+						Expect(vmCtx.MoVM.Config.GuestId).To(Equal("vmwarePhoton64Guest"))
+						c := conditions.Get(vm, vmopv1.GuestIDCondition)
+						Expect(c).ToNot(BeNil())
+						expectedCondition := conditions.TrueCondition(vmopv1.GuestIDCondition)
+						Expect(*c).To(conditions.MatchCondition(*expectedCondition))
 					})
 				})
 			})

--- a/pkg/providers/vsphere/virtualmachine/backup.go
+++ b/pkg/providers/vsphere/virtualmachine/backup.go
@@ -110,7 +110,7 @@ func BackupVirtualMachine(opts BackupVirtualMachineOptions) error {
 		configSpec := &vimtypes.VirtualMachineConfigSpec{
 			ExtraConfig: ecToUpdate,
 		}
-		if err := resVM.Reconfigure(opts.VMCtx, configSpec); err != nil {
+		if _, err := resVM.Reconfigure(opts.VMCtx, configSpec); err != nil {
 			opts.VMCtx.Logger.Error(err, "failed to update VM ExtraConfig with latest backup data")
 			return err
 		}

--- a/pkg/providers/vsphere/virtualmachine/configspec.go
+++ b/pkg/providers/vsphere/virtualmachine/configspec.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2022-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package virtualmachine
@@ -113,6 +113,13 @@ func CreateConfigSpec(
 			lim := MemoryQuantityToMb(vmClassSpec.Policies.Resources.Limits.Memory)
 			configSpec.MemoryAllocation.Limit = &lim
 		}
+	}
+
+	// Initially set the guest ID in ConfigSpec to ensure VM is created with the expected guest ID.
+	// Afterwards, only update it if the VM spec guest ID differs from the VM's existing ConfigInfo.
+	// If the class also specifies a guest ID, it will be overridden by the VM spec guest ID.
+	if guestID := vmCtx.VM.Spec.GuestID; guestID != "" {
+		configSpec.GuestId = guestID
 	}
 
 	return configSpec

--- a/pkg/providers/vsphere/virtualmachine/configspec_test.go
+++ b/pkg/providers/vsphere/virtualmachine/configspec_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2022-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package virtualmachine_test
@@ -23,7 +23,10 @@ import (
 )
 
 var _ = Describe("CreateConfigSpec", func() {
-	const vmName = "dummy-vm"
+	const (
+		vmName      = "dummy-vm"
+		fakeGuestID = "fake-guest-id"
+	)
 
 	var (
 		vm              *vmopv1.VirtualMachine
@@ -135,6 +138,16 @@ var _ = Describe("CreateConfigSpec", func() {
 
 			It("config spec has expected version for PVCs", func() {
 				Expect(configSpec.Version).To(Equal(vimtypes.VMX15.String()))
+			})
+		})
+
+		When("VM spec has guestID set", func() {
+			BeforeEach(func() {
+				vm.Spec.GuestID = fakeGuestID
+			})
+
+			It("config spec has the expected guestID set", func() {
+				Expect(configSpec.GuestId).To(Equal(fakeGuestID))
 			})
 		})
 	})
@@ -332,6 +345,16 @@ var _ = Describe("CreateConfigSpec", func() {
 						Expect(configSpec.Version).To(Equal(vimtypes.MaxValidHardwareVersion.String()))
 					})
 				})
+			})
+		})
+
+		When("VM spec has guestID set", func() {
+			BeforeEach(func() {
+				vm.Spec.GuestID = fakeGuestID
+			})
+
+			It("config spec has the expected guestID set", func() {
+				Expect(configSpec.GuestId).To(Equal(fakeGuestID))
 			})
 		})
 	})

--- a/pkg/providers/vsphere/vmlifecycle/bootstrap.go
+++ b/pkg/providers/vsphere/vmlifecycle/bootstrap.go
@@ -236,7 +236,7 @@ func doReconfigure(
 	if !apiEquality.Semantic.DeepEqual(configSpec, defaultConfigSpec) {
 		logConfigSpec(vmCtx, *configSpec)
 
-		if err := resources.NewVMFromObject(vcVM).Reconfigure(vmCtx, configSpec); err != nil {
+		if _, err := resources.NewVMFromObject(vcVM).Reconfigure(vmCtx, configSpec); err != nil {
 			vmCtx.Logger.Error(err, "customization reconfigure failed")
 			return err
 		}

--- a/pkg/util/vmopv1/network.go
+++ b/pkg/util/vmopv1/network.go
@@ -5,6 +5,7 @@ package vmopv1
 
 import (
 	"net"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
@@ -74,15 +75,10 @@ func ValidateHostAndDomainName(vm vmopv1.VirtualMachine) *field.Error {
 			hostNameField, hostName, ErrInvalidHostNameIPWithDomainName)
 	}
 
-	//
-	// TODO(dilyar85) Please update this logic to also check for Windows via
-	//                spec.guestID when that is implemented.
-	//
+	isWindowsVM := strings.HasPrefix(vm.Spec.GuestID, "win") ||
+		(vm.Spec.Bootstrap != nil && vm.Spec.Bootstrap.Sysprep != nil)
 
-	if vm.Spec.Bootstrap != nil &&
-		vm.Spec.Bootstrap.Sysprep != nil &&
-		len(hostName) > 15 {
-
+	if isWindowsVM && len(hostName) > 15 {
 		return field.Invalid(
 			hostNameField, hostName, ErrInvalidHostNameWindows)
 	}

--- a/pkg/util/vmopv1/network_test.go
+++ b/pkg/util/vmopv1/network_test.go
@@ -112,7 +112,7 @@ var _ = Describe("ValidateHostAndDomainName", func() {
 			nil,
 		),
 		Entry(
-			"host name exceeds 15 characters on Windows",
+			"host name exceeds 15 characters on Windows (determined by sysprep)",
 			vmopv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: vmName,
@@ -128,12 +128,21 @@ var _ = Describe("ValidateHostAndDomainName", func() {
 			},
 			field.Invalid(fieldHostName, a16, vmopv1util.ErrInvalidHostNameWindows),
 		),
-
-		//
-		// TODO(dilyar85) Please add a test that specifies Windows via
-		//                spec.guestID when that is implemented.
-		//
-
+		Entry(
+			"host name exceeds 15 characters on Windows (determined by guest ID)",
+			vmopv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: vmName,
+				},
+				Spec: vmopv1.VirtualMachineSpec{
+					Network: &vmopv1.VirtualMachineNetworkSpec{
+						HostName: a16,
+					},
+					GuestID: "windows2022srvNext_64Guest",
+				},
+			},
+			field.Invalid(fieldHostName, a16, vmopv1util.ErrInvalidHostNameWindows),
+		),
 		Entry(
 			"host name exceeds 63 characters",
 			vmopv1.VirtualMachine{

--- a/pkg/util/vsphere/vm/guest_id.go
+++ b/pkg/util/vsphere/vm/guest_id.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package vm
+
+import (
+	"fmt"
+	"strings"
+
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
+	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+)
+
+// GuestIDProperty is the property name for the guest ID in the config spec.
+const GuestIDProperty = "configSpec.guestId"
+
+// UpdateVMGuestIDCondition updates the VM's GuestID condition to false if the
+// taskInfo contains an InvalidArgument fault with an invalid guest ID property.
+// Otherwise, it updates the condition to true.
+func UpdateVMGuestIDCondition(
+	vmctx pkgctx.VirtualMachineContext,
+	configSpec vimtypes.VirtualMachineConfigSpec,
+	taskInfo *vimtypes.TaskInfo) {
+	// Return early if the current configSpec does not have a guest ID.
+	if configSpec.GuestId == "" {
+		return
+	}
+
+	var invalidGuestID bool
+
+	defer func() {
+		if invalidGuestID {
+			conditions.MarkFalse(vmctx.VM, vmopv1.GuestIDCondition, "Invalid",
+				fmt.Sprintf("The specified guest ID value is not supported: %s",
+					configSpec.GuestId))
+		} else {
+			conditions.MarkTrue(vmctx.VM, vmopv1.GuestIDCondition)
+		}
+	}()
+
+	if taskInfo == nil || taskInfo.Error == nil {
+		return
+	}
+
+	fault, ok := taskInfo.Error.Fault.(*vimtypes.InvalidArgument)
+	if !ok {
+		return
+	}
+
+	invalidGuestID = strings.Contains(fault.InvalidProperty, GuestIDProperty)
+}

--- a/pkg/util/vsphere/vm/guest_id_test.go
+++ b/pkg/util/vsphere/vm/guest_id_test.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package vm_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
+	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+	vmutil "github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/vm"
+)
+
+func guestIDTests() {
+
+	Context("UpdateVMGuestIDCondition", func() {
+
+		var (
+			vmCtx      pkgctx.VirtualMachineContext
+			vmopVM     vmopv1.VirtualMachine
+			configSpec vimtypes.VirtualMachineConfigSpec
+			taskInfo   *vimtypes.TaskInfo
+		)
+
+		BeforeEach(func() {
+			vmopVM = vmopv1.VirtualMachine{}
+			vmCtx = pkgctx.VirtualMachineContext{
+				VM: &vmopVM,
+			}
+			configSpec = vimtypes.VirtualMachineConfigSpec{}
+			taskInfo = &vimtypes.TaskInfo{}
+		})
+
+		JustBeforeEach(func() {
+			vmutil.UpdateVMGuestIDCondition(vmCtx, configSpec, taskInfo)
+		})
+
+		Context("ConfigSpec doesn't have a guest ID", func() {
+
+			BeforeEach(func() {
+				configSpec.GuestId = ""
+				conditions.MarkFalse(&vmopVM, vmopv1.GuestIDCondition, "Invalid", "Invalid guest ID")
+			})
+
+			It("should not change the existing VM's guest ID condition", func() {
+				c := conditions.Get(&vmopVM, vmopv1.GuestIDCondition)
+				Expect(c).NotTo(BeNil())
+				Expect(c.Status).To(Equal(metav1.ConditionFalse))
+				Expect(c.Reason).To(Equal("Invalid"))
+				Expect(c.Message).To(Equal("Invalid guest ID"))
+			})
+		})
+
+		Context("ConfigSpec has a guest ID", func() {
+
+			BeforeEach(func() {
+				configSpec.GuestId = "test-guest-id-value"
+			})
+
+			When("TaskInfo is nil", func() {
+
+				BeforeEach(func() {
+					taskInfo = nil
+				})
+
+				It("should set the VM's guest ID condition to true", func() {
+					c := conditions.Get(&vmopVM, vmopv1.GuestIDCondition)
+					Expect(c).NotTo(BeNil())
+					Expect(c.Status).To(Equal(metav1.ConditionTrue))
+				})
+			})
+
+			When("TaskInfo.Error is nil", func() {
+
+				BeforeEach(func() {
+					taskInfo.Error = nil
+				})
+
+				It("should set the VM's guest ID condition to true", func() {
+					c := conditions.Get(&vmopVM, vmopv1.GuestIDCondition)
+					Expect(c).NotTo(BeNil())
+					Expect(c.Status).To(Equal(metav1.ConditionTrue))
+				})
+			})
+
+			When("TaskInfo.Error.Fault is not an InvalidPropertyFault", func() {
+
+				BeforeEach(func() {
+					taskInfo.Error = &vimtypes.LocalizedMethodFault{
+						Fault: &vimtypes.InvalidName{
+							Name: "some-invalid-name",
+						},
+					}
+				})
+
+				It("should set the VM's guest ID condition to true", func() {
+					c := conditions.Get(&vmopVM, vmopv1.GuestIDCondition)
+					Expect(c).NotTo(BeNil())
+					Expect(c.Status).To(Equal(metav1.ConditionTrue))
+				})
+			})
+
+			When("TaskInfo.Error contains an invalid property error", func() {
+
+				BeforeEach(func() {
+					taskInfo.Error = &vimtypes.LocalizedMethodFault{
+						Fault: &vimtypes.InvalidArgument{
+							InvalidProperty: "configSpec.guestId",
+						},
+					}
+				})
+
+				It("should set the VM's guest ID condition to false", func() {
+					c := conditions.Get(&vmopVM, vmopv1.GuestIDCondition)
+					Expect(c).NotTo(BeNil())
+					Expect(c.Status).To(Equal(metav1.ConditionFalse))
+					Expect(c.Reason).To(Equal("Invalid"))
+					Expect(c.Message).To(Equal("The specified guest ID value is not supported: test-guest-id-value"))
+				})
+			})
+		})
+	})
+}

--- a/pkg/util/vsphere/vm/suite_test.go
+++ b/pkg/util/vsphere/vm/suite_test.go
@@ -16,6 +16,7 @@ func vcSimTests() {
 	Describe("Power State", Label(testlabels.VCSim), powerStateTests)
 	Describe("Hardware Version", Label(testlabels.VCSim), hardwareVersionTests)
 	Describe("Managed Object", managedObjectTests)
+	Describe("Guest ID", guestIDTests)
 }
 
 var suite = builder.NewTestSuite()

--- a/webhooks/virtualmachine/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator.go
@@ -157,6 +157,7 @@ func (v validator) ValidateDelete(*pkgctx.WebhookRequestContext) admission.Respo
 //
 // Following fields can only be changed when the VM is powered off.
 //   - Bootstrap
+//   - GuestID
 func (v validator) ValidateUpdate(ctx *pkgctx.WebhookRequestContext) admission.Response {
 	vm, err := v.vmFromUnstructured(ctx.Obj)
 	if err != nil {
@@ -1024,6 +1025,10 @@ func (v validator) validateUpdatesWhenPoweredOn(ctx *pkgctx.WebhookRequestContex
 
 	if !equality.Semantic.DeepEqual(vm.Spec.Bootstrap, oldVM.Spec.Bootstrap) {
 		allErrs = append(allErrs, field.Forbidden(specPath.Child("bootstrap"), updatesNotAllowedWhenPowerOn))
+	}
+
+	if vm.Spec.GuestID != oldVM.Spec.GuestID {
+		allErrs = append(allErrs, field.Forbidden(specPath.Child("guestID"), updatesNotAllowedWhenPowerOn))
 	}
 
 	// TODO: More checks.

--- a/webhooks/virtualmachine/validation/virtualmachine_validator_intg_test.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator_intg_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2019-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package validation_test
@@ -287,6 +287,19 @@ func intgTestsValidateUpdate() {
 
 			It("does not reject the request", func() {
 				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		When("GuestID is updated", func() {
+			BeforeEach(func() {
+				ctx.vm.Spec.GuestID = "vmwarePhoton64Guest"
+			})
+
+			It("rejects the request", func() {
+				expectedReason := field.Forbidden(field.NewPath("spec", "guestID"),
+					"updates to this field is not allowed when VM power is on").Error()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(expectedReason))
 			})
 		})
 	})


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR includes the following changes:
- A new `vm.spec.guestID` API in v1alpha3 and related conversion in v1alpha1 and v1alpha2.
    - Also add the missing instanceUUID conversion in v1a1
- Doc updates for this new API.
- Deploy a VM with `configSpec.guestID` if it's set in the VM Spec.
- Reconfigure a VM with the updated guestID (different from VM's ConfigInfo) before powering it on.
- Disallow updating `vm.spec.guestID` if a VM is powered on.
- Tests to cover all the above implementations. 

Depending on if a VM has been created, the VM's condition will be updated when an unsupported guestID is specified:
- If the VM has not yet been created, the `VirtualMachineCreated` condition will be marked as false with a message indicating an invalid guestID.
- If the VM has been created, the `GuestIDReconfigured` condition will be marked as false. It will be marked as true when a valid guestID is passed afterwards.

**Testing Done**:

- Valid Guest ID:
```console
# Deploy a VM with spec.guestID set:
$ cat << EOF | kubectl apply -f -
apiVersion: vmoperator.vmware.com/v1alpha3
kind: VirtualMachine
metadata:
   name: test-vm-guest-id
   namespace: sdiliyaer-test
spec:
   className: best-effort-small
   imageName: ubuntu-impish-21.10-cloudimg
   storageClass: wcpglobal-storage-profile
   guestID: otherGuest64
EOF
virtualmachine.vmoperator.vmware.com/test-vm-guest-id created

# VM has the expected configSpec.guestID set:
$ govc vm.info -json test-vm-guest-id | jq '.virtualMachines[].config.guestId'
"otherGuest64"

# Update the guestID when VM is powered on (should be denied):
$ cat << EOF | kubectl apply -f -
apiVersion: vmoperator.vmware.com/v1alpha3
kind: VirtualMachine
metadata:
  name: test-vm-guest-id
  namespace: sdiliyaer-test
spec:
  className: best-effort-small
  imageName: ubuntu-impish-21.10-cloudimg
  storageClass: wcpglobal-storage-profile
  guestID: ubuntu64Guest
EOF
...
error when patching "STDIN": admission webhook "default.validating.virtualmachine.v1alpha3.vmoperator.vmware.com" denied the request: spec.guestID: Forbidden: updates to this field is not allowed when VM power is on

# Update the guestID when VM is powered off (should be allowed):
$ cat << EOF | kubectl apply -f -
apiVersion: vmoperator.vmware.com/v1alpha3
kind: VirtualMachine
metadata:
  name: test-vm-guest-id
  namespace: sdiliyaer-test
spec:
  className: best-effort-small
  imageName: ubuntu-impish-21.10-cloudimg
  storageClass: wcpglobal-storage-profile
  guestID: ubuntu64Guest
  powerState: PoweredOff
EOF
virtualmachine.vmoperator.vmware.com/test-vm-guest-id configured

# Power on the VM and confirm VM has the updated guestID:
$ govc vm.info -json test-vm-guest-id | jq '.virtualMachines[].config.guestId'\
"ubuntu64Guest"

# Confirm the VM has the expected guestID reconfigured condition set:
$ kubectl get vm -n sdiliyaer-test test-vm-guest-id -o json | jq '.status.conditions[] | select(.type == "GuestIDReconfigured")'
{
  "lastTransitionTime": "2024-06-13T18:16:31Z",
  "message": "",
  "reason": "True",
  "status": "True",
  "type": "GuestIDReconfigured"
}
```

- Invalid Guest ID:

```console
# Deploy a new VM with an invalid guestID:
$ kubectl get vm -n sdiliyaer-test test-vm-guest-id-invalid-2 -o json | jq '.status.conditions[] | select(.type == "VirtualMachineCreated")'
{
  "lastTransitionTime": "2024-06-13T18:19:38Z",
  "message": "deploy error: An invalid argument \"configSpec.guestId\" was specified.",
  "reason": "Error",
  "status": "False",
  "type": "VirtualMachineCreated"
}

# Update an existing VM with an invalid guestID:
$ kubectl get vm -n sdiliyaer-test test-vm-guest-id-invalid-2 -o json | jq '.status.conditions[] | select(.type == "GuestIDReconfigured")'
{
  "lastTransitionTime": "2024-06-13T18:21:46Z",
  "message": "The specified guest ID value is not supported: otherGuestInvalid",
  "reason": "Invalid",
  "status": "False",
  "type": "GuestIDReconfigured"
}

# Update the VM with a valid guestID:
$ kubectl get vm -n sdiliyaer-test test-vm-guest-id-invalid-2 -o json | jq '.status.conditions[] | select(.type == "GuestIDReconfigured")'
{
  "lastTransitionTime": "2024-06-13T18:23:24Z",
  "message": "",
  "reason": "True",
  "status": "True",
  "type": "GuestIDReconfigured"
}
```

**Are there any special notes for your reviewer**:

A separate change has been submitted internally to the vSphere Content Library service to avoid overwriting the VM's guestID from the OVF template.

**Please add a release note if necessary**:

```release-note
Introduce `vm.spec.guestID` API to specify a VM's guest operating system identifier.
```

<!-- readthedocs-preview vm-operator start -->
----
📚 Documentation preview 📚: https://vm-operator--563.org.readthedocs.build/en/563/

<!-- readthedocs-preview vm-operator end -->