### PR TITLE
🌱 Upgrade go1.22.4 to address vulnerability GO-2024-2887

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: ci
 
 env:
-  GO_VERSION: 1.22.3
+  GO_VERSION: 1.22.4
 
 on:
   pull_request:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Go version used to build the binaries.
-ARG GO_VERSION=1.22.3
+ARG GO_VERSION=1.22.4
 
 ## Docker image used to build the binaries.
 FROM golang:${GO_VERSION} as builder

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,8 +1,6 @@
 module github.com/vmware-tanzu/vm-operator/api
 
-go 1.22.0
-
-toolchain go1.22.3
+go 1.22.4
 
 replace github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels => ../pkg/constants/testlabels
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/vmware-tanzu/vm-operator
 
-go 1.22.0
-
-toolchain go1.22.3
+go 1.22.4
 
 replace (
 	github.com/envoyproxy/go-control-plane => github.com/envoyproxy/go-control-plane v0.9.4

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,8 +1,6 @@
 module github.com/vmware-tanzu/vm-operator/hack/tools
 
-go 1.22.0
-
-toolchain go1.22.3
+go 1.22.4
 
 require (
 	github.com/AlekSi/gocov-xml v1.1.0


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR upgrades to go1.22.4 to address a vulnerability reported in the `net/netip` package (before go1.21.11, from go1.22.0-0 before go1.22.4).

**Which issue(s) is/are addressed by this PR?**:

Fixes https://pkg.go.dev/vuln/GO-2024-2887

**Are there any special notes for your reviewer**:

Any existing PR should be rebased after this change is merged to pass the vulncheck-go GitHub Action job.

**Please add a release note if necessary**:

```release-note
Upgrade to go 1.22.4 version.
```