### PR TITLE
🌱 Default GOTOOLCHAIN to LOCAL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,12 @@ GOHOSTOSARCH := $(GOHOSTOS)_$(GOHOSTARCH)
 export GOOS ?= $(GOHOSTOS)
 export GOARCH ?= $(GOHOSTARCH)
 
+# Default GOTOOLCHAIN to the one on the system instead of downloading whatever
+# the go.mod file(s) specify. This fixes an issue of when the build happens
+# behind a firewall or when GOSUMDB=off and the toolchain cannot be verified,
+# and thus a potential download fails.
+export GOTOOLCHAIN ?= local
+
 # The directory in which this Makefile is located. Please note this will not
 # behave correctly if the path to any Makefile in the list contains any spaces.
 ROOT_DIR ?= $(dir $(realpath $(lastword $(MAKEFILE_LIST))))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch defaults `GOTOOLCHAIN` to `local` to use the Go version on the system and avoid downloading the one specified in the Go module. For more information on `GOTOOLCHAIN`, please see https://go.dev/doc/toolchain.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

This change _will_ force developers to have the correct Go version installed locally. For example, if Go 1.22.3 is installed and `make modules` is executed, then the following error occurs:

```shell
go: go.mod requires go >= 1.22.4 (running go 1.22.3; GOTOOLCHAIN=local)
make: *** [Makefile:253: modules] Error 1
```

I _think_ this is an acceptable change in behavior as it forces folks to have the correct toolchain installed for the project. If nothing else, it will ensure everyone's IDE integrations use the Gopls language server at the correct version.

Plus, if someone *really* does not not like this, they can just do `export GOTOOLCHAIN=auto` in their shell or profile, which will override the `Makefile` statement `GOTOOLCHAIN ?= local`.

**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Default GOTOOLCHAIN to LOCAL
```