### PR TITLE
✨ Resize ExtraConfig

### DIFF
--- a/pkg/util/resize/configspec.go
+++ b/pkg/util/resize/configspec.go
@@ -31,6 +31,7 @@ func CreateResizeConfigSpec(
 	compareCPUAffinity(ci, cs, &outCS)
 	compareCPUPerfCounter(ci, cs, &outCS)
 	compareLatencySensitivity(ci, cs, &outCS)
+	compareExtraConfig(ci, cs, &outCS)
 
 	return outCS, nil
 }
@@ -251,6 +252,21 @@ func compareLatencySensitivity(
 			//Sensitivity: cs.LatencySensitivity.Sensitivity,
 		}
 	}
+}
+
+// compareExtraConfig compares the extra config setting in the Config Spec to add new keys
+// or updates values for existing keys.
+func compareExtraConfig(
+	ci vimtypes.VirtualMachineConfigInfo,
+	cs vimtypes.VirtualMachineConfigSpec,
+	outCS *vimtypes.VirtualMachineConfigSpec) {
+
+	if len(cs.ExtraConfig) == 0 {
+		return
+	}
+
+	extraConfig := util.ExtraConfigToMap(cs.ExtraConfig)
+	outCS.ExtraConfig = util.MergeExtraConfig(ci.ExtraConfig, extraConfig)
 }
 
 func cmp[T comparable](a, b T, c *T) {

--- a/pkg/util/resize/configspec_test.go
+++ b/pkg/util/resize/configspec_test.go
@@ -203,6 +203,15 @@ var _ = Describe("CreateResizeConfigSpec", func() {
 			ConfigInfo{LatencySensitivity: &vimtypes.LatencySensitivity{Level: vimtypes.LatencySensitivitySensitivityLevelLow}},
 			ConfigSpec{LatencySensitivity: &vimtypes.LatencySensitivity{Level: vimtypes.LatencySensitivitySensitivityLevelLow}},
 			ConfigSpec{}),
+
+		Entry("Extra Config setting needs updating",
+			ConfigInfo{ExtraConfig: []vimtypes.BaseOptionValue{&vimtypes.OptionValue{Key: "foo", Value: "bar"}}},
+			ConfigSpec{ExtraConfig: []vimtypes.BaseOptionValue{&vimtypes.OptionValue{Key: "foo", Value: "bar1"}, &vimtypes.OptionValue{Key: "bat", Value: "man"}}},
+			ConfigSpec{ExtraConfig: []vimtypes.BaseOptionValue{&vimtypes.OptionValue{Key: "foo", Value: "bar1"}, &vimtypes.OptionValue{Key: "bat", Value: "man"}}}),
+		Entry("Extra Config setting does not need updating",
+			ConfigInfo{ExtraConfig: []vimtypes.BaseOptionValue{&vimtypes.OptionValue{Key: "foo", Value: "bar"}}},
+			ConfigSpec{ExtraConfig: []vimtypes.BaseOptionValue{&vimtypes.OptionValue{Key: "foo", Value: "bar"}}},
+			ConfigSpec{}),
 	)
 
 	type giveMeDeviceFn = func() vimtypes.BaseVirtualDevice


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This change supports resize of the VM's extra config settings when the class has differing key/value pairs.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #N/A


**Are there any special notes for your reviewer**:

N/A

**Please add a release note if necessary**:


```
Support extra Config resize
```