### PR TITLE
🌱 OptionValues helper

### DIFF
--- a/pkg/providers/vsphere/session/session_vm_update.go
+++ b/pkg/providers/vsphere/session/session_vm_update.go
@@ -326,8 +326,9 @@ func UpdateConfigSpecExtraConfig(
 		// with the class config spec extra config (ie) class config spec extra
 		// config keys takes precedence over the desired config spec extra
 		// config keys.
-		combinedExtraConfig := util.AppendNewExtraConfigValues(classConfigSpec.ExtraConfig, extraConfig)
-		extraConfig = util.ExtraConfigToMap(combinedExtraConfig)
+		extraConfig = util.OptionValues(classConfigSpec.ExtraConfig).
+			Append(util.OptionValuesFromMap(extraConfig)...).
+			StringMap()
 	}
 
 	// Note if the VM uses both LinuxPrep and vAppConfig. This is used in the
@@ -367,7 +368,8 @@ func UpdateConfigSpecExtraConfig(
 	// Update the ConfigSpec's ExtraConfig property with the results from
 	// above. Please note this *may* include keys with empty values. This
 	// indicates to vSphere that a key/value pair should be removed.
-	configSpec.ExtraConfig = util.MergeExtraConfig(config.ExtraConfig, extraConfig)
+	configSpec.ExtraConfig = util.OptionValues(config.ExtraConfig).
+		Diff(util.OptionValuesFromMap(extraConfig)...)
 }
 
 func isLinuxPrepAndVAppConfig(vm *vmopv1.VirtualMachine) bool {

--- a/pkg/providers/vsphere/session/session_vm_update.go
+++ b/pkg/providers/vsphere/session/session_vm_update.go
@@ -28,7 +28,7 @@ import (
 	res "github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/resources"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/virtualmachine"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/vmlifecycle"
-	"github.com/vmware-tanzu/vm-operator/pkg/util"
+	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/resize"
 	vmopv1util "github.com/vmware-tanzu/vm-operator/pkg/util/vmopv1"
 	vmutil "github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/vm"
@@ -326,8 +326,8 @@ func UpdateConfigSpecExtraConfig(
 		// with the class config spec extra config (ie) class config spec extra
 		// config keys takes precedence over the desired config spec extra
 		// config keys.
-		extraConfig = util.OptionValues(classConfigSpec.ExtraConfig).
-			Append(util.OptionValuesFromMap(extraConfig)...).
+		extraConfig = pkgutil.OptionValues(classConfigSpec.ExtraConfig).
+			Append(pkgutil.OptionValuesFromMap(extraConfig)...).
 			StringMap()
 	}
 
@@ -368,8 +368,8 @@ func UpdateConfigSpecExtraConfig(
 	// Update the ConfigSpec's ExtraConfig property with the results from
 	// above. Please note this *may* include keys with empty values. This
 	// indicates to vSphere that a key/value pair should be removed.
-	configSpec.ExtraConfig = util.OptionValues(config.ExtraConfig).
-		Diff(util.OptionValuesFromMap(extraConfig)...)
+	configSpec.ExtraConfig = pkgutil.OptionValues(config.ExtraConfig).
+		Diff(pkgutil.OptionValuesFromMap(extraConfig)...)
 }
 
 func isLinuxPrepAndVAppConfig(vm *vmopv1.VirtualMachine) bool {
@@ -395,10 +395,10 @@ func hasvGPUOrDDPIODevicesInVM(config *vimtypes.VirtualMachineConfigInfo) bool {
 	if config == nil {
 		return false
 	}
-	if len(util.SelectNvidiaVgpu(config.Hardware.Device)) > 0 {
+	if len(pkgutil.SelectNvidiaVgpu(config.Hardware.Device)) > 0 {
 		return true
 	}
-	if len(util.SelectDynamicDirectPathIO(config.Hardware.Device)) > 0 {
+	if len(pkgutil.SelectDynamicDirectPathIO(config.Hardware.Device)) > 0 {
 		return true
 	}
 	return false
@@ -418,7 +418,7 @@ func hasvGPUOrDDPIODevicesInVMClass(
 	}
 
 	if configSpec != nil {
-		return util.HasVirtualPCIPassthroughDeviceChange(configSpec.DeviceChange)
+		return pkgutil.HasVirtualPCIPassthroughDeviceChange(configSpec.DeviceChange)
 	}
 
 	return false
@@ -572,8 +572,8 @@ func (s *Session) prePowerOnVMConfigSpec(
 	configSpec.DeviceChange = append(configSpec.DeviceChange, ethCardDeviceChanges...)
 
 	var expectedPCIDevices []vimtypes.BaseVirtualDevice
-	if configSpecDevs := util.DevicesFromConfigSpec(&updateArgs.ConfigSpec); len(configSpecDevs) > 0 {
-		pciPassthruFromConfigSpec := util.SelectVirtualPCIPassthrough(configSpecDevs)
+	if configSpecDevs := pkgutil.DevicesFromConfigSpec(&updateArgs.ConfigSpec); len(configSpecDevs) > 0 {
+		pciPassthruFromConfigSpec := pkgutil.SelectVirtualPCIPassthrough(configSpecDevs)
 		expectedPCIDevices = virtualmachine.CreatePCIDevicesFromConfigSpec(pciPassthruFromConfigSpec)
 	}
 
@@ -633,9 +633,9 @@ func (s *Session) ensureNetworkInterfaces(
 
 	var networkDevices []vimtypes.BaseVirtualDevice
 	if configSpec != nil {
-		networkDevices = util.SelectDevices[vimtypes.BaseVirtualDevice](
-			util.DevicesFromConfigSpec(configSpec),
-			util.IsEthernetCard,
+		networkDevices = pkgutil.SelectDevices[vimtypes.BaseVirtualDevice](
+			pkgutil.DevicesFromConfigSpec(configSpec),
+			pkgutil.IsEthernetCard,
 		)
 	}
 

--- a/pkg/providers/vsphere/session/session_vm_update_test.go
+++ b/pkg/providers/vsphere/session/session_vm_update_test.go
@@ -273,7 +273,7 @@ var _ = Describe("Update ConfigSpec", func() {
 				vm,
 				globalExtraConfig)
 
-			ecMap = util.ExtraConfigToMap(configSpec.ExtraConfig)
+			ecMap = util.OptionValues(configSpec.ExtraConfig).StringMap()
 		})
 
 		Context("Empty input", func() {

--- a/pkg/providers/vsphere/session/session_vm_update_test.go
+++ b/pkg/providers/vsphere/session/session_vm_update_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/constants"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/session"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/virtualmachine"
-	"github.com/vmware-tanzu/vm-operator/pkg/util"
+	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	pkgclient "github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/client"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
@@ -273,7 +273,7 @@ var _ = Describe("Update ConfigSpec", func() {
 				vm,
 				globalExtraConfig)
 
-			ecMap = util.OptionValues(configSpec.ExtraConfig).StringMap()
+			ecMap = pkgutil.OptionValues(configSpec.ExtraConfig).StringMap()
 		})
 
 		Context("Empty input", func() {

--- a/pkg/providers/vsphere/virtualmachine/backup.go
+++ b/pkg/providers/vsphere/virtualmachine/backup.go
@@ -20,7 +20,7 @@ import (
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	res "github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/resources"
-	"github.com/vmware-tanzu/vm-operator/pkg/util"
+	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
 )
 
 // BackupVirtualMachineOptions contains the options for BackupVirtualMachine.
@@ -54,8 +54,8 @@ func BackupVirtualMachine(opts BackupVirtualMachineOptions) error {
 		return err
 	}
 
-	curExCfg := util.OptionValues(moVM.Config.ExtraConfig)
-	var ecToUpdate util.OptionValues
+	curExCfg := pkgutil.OptionValues(moVM.Config.ExtraConfig)
+	var ecToUpdate pkgutil.OptionValues
 
 	vmYAML, err := getDesiredVMResourceYAMLForBackup(opts.VMCtx.VM, curExCfg)
 	if err != nil {
@@ -125,7 +125,7 @@ func BackupVirtualMachine(opts BackupVirtualMachineOptions) error {
 // given VM, or an empty string if the existing backup is already up-to-date.
 func getDesiredVMResourceYAMLForBackup(
 	vm *vmopv1.VirtualMachine,
-	extraConfig util.OptionValues) (string, error) {
+	extraConfig pkgutil.OptionValues) (string, error) {
 
 	curBackup, _ := extraConfig.GetString(vmopv1.VMResourceYAMLExtraConfigKey)
 	isUpToDate, err := isVMBackupUpToDate(vm, curBackup)
@@ -139,7 +139,7 @@ func getDesiredVMResourceYAMLForBackup(
 		return "", fmt.Errorf("failed to marshal VM into YAML %+v: %v", vm, err)
 	}
 
-	return util.EncodeGzipBase64(string(vmYAML))
+	return pkgutil.EncodeGzipBase64(string(vmYAML))
 }
 
 // isVMBackupUpToDate returns true if none of the following fields of the VM are
@@ -150,7 +150,7 @@ func isVMBackupUpToDate(vm *vmopv1.VirtualMachine, backup string) (bool, error) 
 		return false, nil
 	}
 
-	backupYAML, err := util.TryToDecodeBase64Gzip([]byte(backup))
+	backupYAML, err := pkgutil.TryToDecodeBase64Gzip([]byte(backup))
 	if err != nil {
 		return false, err
 	}
@@ -175,7 +175,7 @@ func isVMBackupUpToDate(vm *vmopv1.VirtualMachine, backup string) (bool, error) 
 // already up-to-date (checked by comparing the resource versions).
 func getDesiredAdditionalResourceYAMLForBackup(
 	resources []client.Object,
-	extraConfig util.OptionValues) (string, error) {
+	extraConfig pkgutil.OptionValues) (string, error) {
 
 	curBackup, _ := extraConfig.GetString(vmopv1.AdditionalResourcesYAMLExtraConfigKey)
 	backupVers, err := getBackupResourceVersions(curBackup)
@@ -208,7 +208,7 @@ func getDesiredAdditionalResourceYAMLForBackup(
 	}
 
 	resourcesYAML := strings.Join(marshaledStrs, "\n---\n")
-	return util.EncodeGzipBase64(resourcesYAML)
+	return pkgutil.EncodeGzipBase64(resourcesYAML)
 }
 
 // getBackupResourceVersions gets the resource version of each object in
@@ -218,7 +218,7 @@ func getBackupResourceVersions(ecResourceData string) (map[string]string, error)
 		return nil, nil
 	}
 
-	decoded, err := util.TryToDecodeBase64Gzip([]byte(ecResourceData))
+	decoded, err := pkgutil.TryToDecodeBase64Gzip([]byte(ecResourceData))
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +242,7 @@ func getBackupResourceVersions(ecResourceData string) (map[string]string, error)
 
 func getDesiredPVCDiskDataForBackup(
 	opts BackupVirtualMachineOptions,
-	extraConfig util.OptionValues) (string, error) {
+	extraConfig pkgutil.OptionValues) (string, error) {
 
 	// Return an empty string to skip backup if no disk uuid to PVC is specified.
 	if len(opts.DiskUUIDToPVC) == 0 {
@@ -273,7 +273,7 @@ func getDesiredPVCDiskDataForBackup(
 	if err != nil {
 		return "", err
 	}
-	diskDataBackup, err := util.EncodeGzipBase64(string(diskDataJSON))
+	diskDataBackup, err := pkgutil.EncodeGzipBase64(string(diskDataJSON))
 	if err != nil {
 		return "", err
 	}

--- a/pkg/providers/vsphere/virtualmachine/backup_test.go
+++ b/pkg/providers/vsphere/virtualmachine/backup_test.go
@@ -20,7 +20,7 @@ import (
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/virtualmachine"
-	"github.com/vmware-tanzu/vm-operator/pkg/util"
+	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
@@ -86,7 +86,7 @@ func backupTests() {
 				oldVM.ObjectMeta.Generation = 1
 				oldVMYAML, err := yaml.Marshal(oldVM)
 				Expect(err).NotTo(HaveOccurred())
-				vmYAMLEncoded, err := util.EncodeGzipBase64(string(oldVMYAML))
+				vmYAMLEncoded, err := pkgutil.EncodeGzipBase64(string(oldVMYAML))
 				Expect(err).NotTo(HaveOccurred())
 
 				_, err = vcVM.Reconfigure(vmCtx, vimtypes.VirtualMachineConfigSpec{
@@ -122,7 +122,7 @@ func backupTests() {
 				oldVM.ObjectMeta.Annotations = map[string]string{"foo": "bar"}
 				oldVMYAML, err := yaml.Marshal(oldVM)
 				Expect(err).NotTo(HaveOccurred())
-				vmYAMLEncoded, err := util.EncodeGzipBase64(string(oldVMYAML))
+				vmYAMLEncoded, err := pkgutil.EncodeGzipBase64(string(oldVMYAML))
 				Expect(err).NotTo(HaveOccurred())
 
 				_, err = vcVM.Reconfigure(vmCtx, vimtypes.VirtualMachineConfigSpec{
@@ -157,7 +157,7 @@ func backupTests() {
 				oldVM.ObjectMeta.Labels = map[string]string{"foo": "bar"}
 				oldVMYAML, err := yaml.Marshal(oldVM)
 				Expect(err).NotTo(HaveOccurred())
-				vmYAMLEncoded, err := util.EncodeGzipBase64(string(oldVMYAML))
+				vmYAMLEncoded, err := pkgutil.EncodeGzipBase64(string(oldVMYAML))
 				Expect(err).NotTo(HaveOccurred())
 
 				_, err = vcVM.Reconfigure(vmCtx, vimtypes.VirtualMachineConfigSpec{
@@ -194,7 +194,7 @@ func backupTests() {
 				vmYAML, err := yaml.Marshal(vmCtx.VM)
 				Expect(err).NotTo(HaveOccurred())
 				vmBackupStr = string(vmYAML)
-				vmYAMLEncoded, err := util.EncodeGzipBase64(vmBackupStr)
+				vmYAMLEncoded, err := pkgutil.EncodeGzipBase64(vmBackupStr)
 				Expect(err).NotTo(HaveOccurred())
 
 				_, err = vcVM.Reconfigure(vmCtx, vimtypes.VirtualMachineConfigSpec{
@@ -266,7 +266,7 @@ func backupTests() {
 				oldRes := secretRes.DeepCopy()
 				oldResYAML, err := yaml.Marshal(oldRes)
 				Expect(err).NotTo(HaveOccurred())
-				yamlEncoded, err := util.EncodeGzipBase64(string(oldResYAML))
+				yamlEncoded, err := pkgutil.EncodeGzipBase64(string(oldResYAML))
 				Expect(err).NotTo(HaveOccurred())
 
 				_, err = vcVM.Reconfigure(vmCtx, vimtypes.VirtualMachineConfigSpec{
@@ -304,7 +304,7 @@ func backupTests() {
 				resYAML, err := yaml.Marshal(secretRes)
 				Expect(err).NotTo(HaveOccurred())
 				backupStr = string(resYAML)
-				yamlEncoded, err := util.EncodeGzipBase64(backupStr)
+				yamlEncoded, err := pkgutil.EncodeGzipBase64(backupStr)
 				Expect(err).NotTo(HaveOccurred())
 
 				_, err = vcVM.Reconfigure(vmCtx, vimtypes.VirtualMachineConfigSpec{
@@ -414,7 +414,7 @@ func verifyBackupDataInExtraConfig(
 	Expect(objVM).NotTo(BeNil())
 	var moVM mo.VirtualMachine
 	Expect(objVM.Properties(ctx, objVM.Reference(), []string{"config.extraConfig"}, &moVM)).To(Succeed())
-	ecMap := util.OptionValues(moVM.Config.ExtraConfig).StringMap()
+	ecMap := pkgutil.OptionValues(moVM.Config.ExtraConfig).StringMap()
 
 	// Verify the expected key doesn't exist in ExtraConfig if the expected value is empty.
 	if expectedValDecoded == "" {
@@ -425,7 +425,7 @@ func verifyBackupDataInExtraConfig(
 	// Verify the expected key exists in ExtraConfig and the decoded values match.
 	Expect(ecMap).To(HaveKey(expectedKey))
 	ecValRaw := ecMap[expectedKey]
-	ecValDecoded, err := util.TryToDecodeBase64Gzip([]byte(ecValRaw))
+	ecValDecoded, err := pkgutil.TryToDecodeBase64Gzip([]byte(ecValRaw))
 	Expect(err).NotTo(HaveOccurred())
 	Expect(ecValDecoded).To(Equal(expectedValDecoded))
 }

--- a/pkg/providers/vsphere/virtualmachine/backup_test.go
+++ b/pkg/providers/vsphere/virtualmachine/backup_test.go
@@ -414,7 +414,7 @@ func verifyBackupDataInExtraConfig(
 	Expect(objVM).NotTo(BeNil())
 	var moVM mo.VirtualMachine
 	Expect(objVM.Properties(ctx, objVM.Reference(), []string{"config.extraConfig"}, &moVM)).To(Succeed())
-	ecMap := util.ExtraConfigToMap(moVM.Config.ExtraConfig)
+	ecMap := util.OptionValues(moVM.Config.ExtraConfig).StringMap()
 
 	// Verify the expected key doesn't exist in ExtraConfig if the expected value is empty.
 	if expectedValDecoded == "" {

--- a/pkg/providers/vsphere/vmlifecycle/bootstrap_cloudinit.go
+++ b/pkg/providers/vsphere/vmlifecycle/bootstrap_cloudinit.go
@@ -16,7 +16,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/constants"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/internal"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/network"
-	"github.com/vmware-tanzu/vm-operator/pkg/util"
+	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/cloudinit"
 )
 
@@ -190,7 +190,7 @@ func GetCloudInitPrepCustSpec(
 
 	if userdata != "" {
 		// Ensure the data is normalized first to plain-text.
-		plainText, err := util.TryToDecodeBase64Gzip([]byte(userdata))
+		plainText, err := pkgutil.TryToDecodeBase64Gzip([]byte(userdata))
 		if err != nil {
 			return nil, nil, fmt.Errorf("decoding cloud-init prep userdata failed: %w", err)
 		}
@@ -227,12 +227,12 @@ func GetCloudInitGuestInfoCustSpec(
 	config *vimtypes.VirtualMachineConfigInfo,
 	metadata, userdata string) (*vimtypes.VirtualMachineConfigSpec, error) {
 
-	encodedMetadata, err := util.EncodeGzipBase64(metadata)
+	encodedMetadata, err := pkgutil.EncodeGzipBase64(metadata)
 	if err != nil {
 		return nil, fmt.Errorf("encoding cloud-init metadata failed: %w", err)
 	}
 
-	extraConfig := util.OptionValues{
+	extraConfig := pkgutil.OptionValues{
 		&vimtypes.OptionValue{
 			Key:   constants.CloudInitGuestInfoMetadata,
 			Value: encodedMetadata,
@@ -245,12 +245,12 @@ func GetCloudInitGuestInfoCustSpec(
 
 	if userdata != "" {
 		// Ensure the data is normalized first to plain-text.
-		plainText, err := util.TryToDecodeBase64Gzip([]byte(userdata))
+		plainText, err := pkgutil.TryToDecodeBase64Gzip([]byte(userdata))
 		if err != nil {
 			return nil, fmt.Errorf("decoding cloud-init userdata failed: %w", err)
 		}
 
-		encodedUserdata, err := util.EncodeGzipBase64(plainText)
+		encodedUserdata, err := pkgutil.EncodeGzipBase64(plainText)
 		if err != nil {
 			return nil, fmt.Errorf("encoding cloud-init userdata failed: %w", err)
 		}
@@ -268,7 +268,7 @@ func GetCloudInitGuestInfoCustSpec(
 	}
 
 	configSpec := &vimtypes.VirtualMachineConfigSpec{
-		ExtraConfig: util.OptionValues(config.ExtraConfig).Diff(extraConfig...),
+		ExtraConfig: pkgutil.OptionValues(config.ExtraConfig).Diff(extraConfig...),
 	}
 
 	if config.VAppConfig != nil && config.VAppConfig.GetVmConfigInfo() != nil {

--- a/pkg/providers/vsphere/vmlifecycle/bootstrap_cloudinit_test.go
+++ b/pkg/providers/vsphere/vmlifecycle/bootstrap_cloudinit_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/internal"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/network"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/vmlifecycle"
-	"github.com/vmware-tanzu/vm-operator/pkg/util"
+	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/cloudinit"
 )
 
@@ -143,13 +143,13 @@ var _ = Describe("CloudInit Bootstrap", func() {
 					Expect(configSpec.VAppConfigRemoved).ToNot(BeNil())
 					Expect(*configSpec.VAppConfigRemoved).To(BeTrue())
 
-					extraConfig := util.OptionValues(configSpec.ExtraConfig).StringMap()
+					extraConfig := pkgutil.OptionValues(configSpec.ExtraConfig).StringMap()
 					Expect(extraConfig).To(HaveLen(4))
 					Expect(extraConfig).To(HaveKey(constants.CloudInitGuestInfoMetadata))
 					Expect(extraConfig).To(HaveKeyWithValue(constants.CloudInitGuestInfoMetadataEncoding, "gzip+base64"))
-					act, err := util.TryToDecodeBase64Gzip([]byte(extraConfig[constants.CloudInitGuestInfoUserdata]))
+					act, err := pkgutil.TryToDecodeBase64Gzip([]byte(extraConfig[constants.CloudInitGuestInfoUserdata]))
 					Expect(err).ToNot(HaveOccurred())
-					exp, err := util.TryToDecodeBase64Gzip([]byte("H4sIADOdWGYAA03MSQ6EIBBA0X2doiJrex5sLmNQygZTAoEyXL9Jr1z/vK8UCm2JjZDG1YfVgJo57rafY1j8F2AvlIuGHp0pjuyYTCnVauwu19v98Xy9h08HiMFs7TDF6VQ9lxigZi80Lp7pr9tOKIjGGjPbBpIRp/HsiDkeuzjKdOgefimuS0mkAAAA"))
+					exp, err := pkgutil.TryToDecodeBase64Gzip([]byte("H4sIADOdWGYAA03MSQ6EIBBA0X2doiJrex5sLmNQygZTAoEyXL9Jr1z/vK8UCm2JjZDG1YfVgJo57rafY1j8F2AvlIuGHp0pjuyYTCnVauwu19v98Xy9h08HiMFs7TDF6VQ9lxigZi80Lp7pr9tOKIjGGjPbBpIRp/HsiDkeuzjKdOgefimuS0mkAAAA"))
 					Expect(err).ToNot(HaveOccurred())
 					Expect(act).To(Equal(exp))
 					Expect(extraConfig).To(HaveKeyWithValue(constants.CloudInitGuestInfoUserdataEncoding, "gzip+base64"))
@@ -166,13 +166,13 @@ var _ = Describe("CloudInit Bootstrap", func() {
 					Expect(configSpec).ToNot(BeNil())
 					Expect(configSpec.VAppConfigRemoved).To(BeNil())
 
-					extraConfig := util.OptionValues(configSpec.ExtraConfig).StringMap()
+					extraConfig := pkgutil.OptionValues(configSpec.ExtraConfig).StringMap()
 					Expect(extraConfig).To(HaveLen(4))
 					Expect(extraConfig).To(HaveKey(constants.CloudInitGuestInfoMetadata))
 					Expect(extraConfig).To(HaveKeyWithValue(constants.CloudInitGuestInfoMetadataEncoding, "gzip+base64"))
-					act, err := util.TryToDecodeBase64Gzip([]byte(extraConfig[constants.CloudInitGuestInfoUserdata]))
+					act, err := pkgutil.TryToDecodeBase64Gzip([]byte(extraConfig[constants.CloudInitGuestInfoUserdata]))
 					Expect(err).ToNot(HaveOccurred())
-					exp, err := util.TryToDecodeBase64Gzip([]byte("H4sIAH2dWGYAA03MSw6DMAxF0blXYcGY/j80m0GGmCbIJCgxyvYbdcTsSVfvtC0qr5uQssHFh4WgnSTutptimP0XYM+csoEOLc+0i9blKDu2w0Y5F2uwuVxv98fz9e4/DSAGWqs1xvFUvOQYoCSvPMxe+O9UWDmowRKT2HrYSJ3Bs2OReOzqOPGhe/gBk57Cza4AAAA="))
+					exp, err := pkgutil.TryToDecodeBase64Gzip([]byte("H4sIAH2dWGYAA03MSw6DMAxF0blXYcGY/j80m0GGmCbIJCgxyvYbdcTsSVfvtC0qr5uQssHFh4WgnSTutptimP0XYM+csoEOLc+0i9blKDu2w0Y5F2uwuVxv98fz9e4/DSAGWqs1xvFUvOQYoCSvPMxe+O9UWDmowRKT2HrYSJ3Bs2OReOzqOPGhe/gBk57Cza4AAAA="))
 					Expect(err).ToNot(HaveOccurred())
 					Expect(act).To(Equal(exp))
 					Expect(extraConfig).To(HaveKeyWithValue(constants.CloudInitGuestInfoUserdataEncoding, "gzip+base64"))
@@ -189,13 +189,13 @@ var _ = Describe("CloudInit Bootstrap", func() {
 					Expect(configSpec).ToNot(BeNil())
 					Expect(configSpec.VAppConfigRemoved).To(BeNil())
 
-					extraConfig := util.OptionValues(configSpec.ExtraConfig).StringMap()
+					extraConfig := pkgutil.OptionValues(configSpec.ExtraConfig).StringMap()
 					Expect(extraConfig).To(HaveLen(4))
 					Expect(extraConfig).To(HaveKey(constants.CloudInitGuestInfoMetadata))
 					Expect(extraConfig).To(HaveKeyWithValue(constants.CloudInitGuestInfoMetadataEncoding, "gzip+base64"))
-					act, err := util.TryToDecodeBase64Gzip([]byte(extraConfig[constants.CloudInitGuestInfoUserdata]))
+					act, err := pkgutil.TryToDecodeBase64Gzip([]byte(extraConfig[constants.CloudInitGuestInfoUserdata]))
 					Expect(err).ToNot(HaveOccurred())
-					exp, err := util.TryToDecodeBase64Gzip([]byte("H4sIANedWGYAA02OSw6EIBBE932Kjm7Hcf4fLmMQ2gHTggGM1x/EjatXnUpVV11jomlmmUjgaN0ooVbsF90o7wb7AwiLU5MW0CBHbDM2AZjRyB1csFukjC+nIWZ/wtUH1mdYIoW4dRgZDeluljGuWmB1ud7uj+fr/flWOebklGf0vj+vlqN3sAabqBssU0nnTYlcEnttDswyGYFteXb0k6FAB9/CHw2+gEbpAAAA"))
+					exp, err := pkgutil.TryToDecodeBase64Gzip([]byte("H4sIANedWGYAA02OSw6EIBBE932Kjm7Hcf4fLmMQ2gHTggGM1x/EjatXnUpVV11jomlmmUjgaN0ooVbsF90o7wb7AwiLU5MW0CBHbDM2AZjRyB1csFukjC+nIWZ/wtUH1mdYIoW4dRgZDeluljGuWmB1ud7uj+fr/flWOebklGf0vj+vlqN3sAabqBssU0nnTYlcEnttDswyGYFteXb0k6FAB9/CHw2+gEbpAAAA"))
 					Expect(err).ToNot(HaveOccurred())
 					Expect(act).To(Equal(exp))
 					Expect(extraConfig).To(HaveKeyWithValue(constants.CloudInitGuestInfoUserdataEncoding, "gzip+base64"))
@@ -243,7 +243,7 @@ var _ = Describe("CloudInit Bootstrap", func() {
 					Expect(configSpec).ToNot(BeNil())
 					Expect(configSpec.VAppConfigRemoved).To(BeNil())
 
-					extraConfig := util.OptionValues(configSpec.ExtraConfig).StringMap()
+					extraConfig := pkgutil.OptionValues(configSpec.ExtraConfig).StringMap()
 					Expect(extraConfig).To(HaveLen(4))
 					Expect(extraConfig).To(HaveKey(constants.CloudInitGuestInfoMetadata)) // TODO: Better assertion (reduce w/ GetCloudInitMetadata)
 					Expect(extraConfig).To(HaveKeyWithValue(constants.CloudInitGuestInfoMetadataEncoding, "gzip+base64"))
@@ -266,7 +266,7 @@ var _ = Describe("CloudInit Bootstrap", func() {
 						Expect(err).ToNot(HaveOccurred())
 						Expect(configSpec).ToNot(BeNil())
 
-						extraConfig := util.OptionValues(configSpec.ExtraConfig).StringMap()
+						extraConfig := pkgutil.OptionValues(configSpec.ExtraConfig).StringMap()
 						Expect(extraConfig).To(HaveLen(4))
 						Expect(extraConfig).To(HaveKey(constants.CloudInitGuestInfoMetadata)) // TODO: Better assertion (reduce w/ GetCloudInitMetadata)
 						Expect(extraConfig).To(HaveKeyWithValue(constants.CloudInitGuestInfoMetadataEncoding, "gzip+base64"))
@@ -274,7 +274,7 @@ var _ = Describe("CloudInit Bootstrap", func() {
 						Expect(extraConfig).To(HaveKey(constants.CloudInitGuestInfoUserdata))
 						Expect(extraConfig).To(HaveKeyWithValue(constants.CloudInitGuestInfoUserdataEncoding, "gzip+base64"))
 
-						data, err := util.TryToDecodeBase64Gzip([]byte(extraConfig[constants.CloudInitGuestInfoUserdata]))
+						data, err := pkgutil.TryToDecodeBase64Gzip([]byte(extraConfig[constants.CloudInitGuestInfoUserdata]))
 						Expect(err).ToNot(HaveOccurred())
 						Expect(data).To(Equal(otherUserData))
 					})
@@ -402,7 +402,7 @@ var _ = Describe("CloudInit Bootstrap", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(configSpec).ToNot(BeNil())
 
-				extraConfig := util.OptionValues(configSpec.ExtraConfig).StringMap()
+				extraConfig := pkgutil.OptionValues(configSpec.ExtraConfig).StringMap()
 				Expect(extraConfig).To(HaveLen(2))
 				Expect(extraConfig).To(HaveKeyWithValue(constants.CloudInitGuestInfoMetadata, "H4sIAAAAAAAA/0rOyS9N0c3MyyzRzU0tSUxJLEkEAAAA//8BAAD//wEq0o4TAAAA"))
 				Expect(extraConfig).To(HaveKeyWithValue(constants.CloudInitGuestInfoMetadataEncoding, "gzip+base64"))
@@ -414,7 +414,7 @@ var _ = Describe("CloudInit Bootstrap", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(configSpec).ToNot(BeNil())
 
-				extraConfig := util.OptionValues(configSpec.ExtraConfig).StringMap()
+				extraConfig := pkgutil.OptionValues(configSpec.ExtraConfig).StringMap()
 				Expect(extraConfig).To(HaveLen(4))
 				Expect(extraConfig).To(HaveKeyWithValue(constants.CloudInitGuestInfoMetadata, "H4sIAAAAAAAA/0rOyS9N0c3MyyzRzU0tSUxJLEkEAAAA//8BAAD//wEq0o4TAAAA"))
 				Expect(extraConfig).To(HaveKeyWithValue(constants.CloudInitGuestInfoMetadataEncoding, "gzip+base64"))
@@ -432,7 +432,7 @@ var _ = Describe("CloudInit Bootstrap", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(configSpec).ToNot(BeNil())
 
-				extraConfig := util.OptionValues(configSpec.ExtraConfig).StringMap()
+				extraConfig := pkgutil.OptionValues(configSpec.ExtraConfig).StringMap()
 				Expect(extraConfig).To(HaveLen(4))
 				Expect(extraConfig).To(HaveKeyWithValue(constants.CloudInitGuestInfoMetadata, "H4sIAAAAAAAA/0rOyS9N0c3MyyzRzU0tSUxJLEkEAAAA//8BAAD//wEq0o4TAAAA"))
 				Expect(extraConfig).To(HaveKeyWithValue(constants.CloudInitGuestInfoMetadataEncoding, "gzip+base64"))
@@ -443,7 +443,7 @@ var _ = Describe("CloudInit Bootstrap", func() {
 
 		Context("With gzipped, base64-encoded userdata but no encoding specified", func() {
 			BeforeEach(func() {
-				data, err := util.EncodeGzipBase64(cloudInitUserdata)
+				data, err := pkgutil.EncodeGzipBase64(cloudInitUserdata)
 				Expect(err).ToNot(HaveOccurred())
 				userData = data
 			})
@@ -452,7 +452,7 @@ var _ = Describe("CloudInit Bootstrap", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(configSpec).ToNot(BeNil())
 
-				extraConfig := util.OptionValues(configSpec.ExtraConfig).StringMap()
+				extraConfig := pkgutil.OptionValues(configSpec.ExtraConfig).StringMap()
 				Expect(extraConfig).To(HaveLen(4))
 				Expect(extraConfig).To(HaveKeyWithValue(constants.CloudInitGuestInfoMetadata, "H4sIAAAAAAAA/0rOyS9N0c3MyyzRzU0tSUxJLEkEAAAA//8BAAD//wEq0o4TAAAA"))
 				Expect(extraConfig).To(HaveKeyWithValue(constants.CloudInitGuestInfoMetadataEncoding, "gzip+base64"))
@@ -555,7 +555,7 @@ var _ = Describe("CloudInit Bootstrap", func() {
 
 		Context("With gzipped, base64-encoded userdata but no encoding specified", func() {
 			BeforeEach(func() {
-				data, err := util.EncodeGzipBase64(cloudInitUserdata)
+				data, err := pkgutil.EncodeGzipBase64(cloudInitUserdata)
 				Expect(err).ToNot(HaveOccurred())
 				userData = data
 			})

--- a/pkg/providers/vsphere/vmlifecycle/bootstrap_cloudinit_test.go
+++ b/pkg/providers/vsphere/vmlifecycle/bootstrap_cloudinit_test.go
@@ -143,7 +143,7 @@ var _ = Describe("CloudInit Bootstrap", func() {
 					Expect(configSpec.VAppConfigRemoved).ToNot(BeNil())
 					Expect(*configSpec.VAppConfigRemoved).To(BeTrue())
 
-					extraConfig := util.ExtraConfigToMap(configSpec.ExtraConfig)
+					extraConfig := util.OptionValues(configSpec.ExtraConfig).StringMap()
 					Expect(extraConfig).To(HaveLen(4))
 					Expect(extraConfig).To(HaveKey(constants.CloudInitGuestInfoMetadata))
 					Expect(extraConfig).To(HaveKeyWithValue(constants.CloudInitGuestInfoMetadataEncoding, "gzip+base64"))
@@ -166,7 +166,7 @@ var _ = Describe("CloudInit Bootstrap", func() {
 					Expect(configSpec).ToNot(BeNil())
 					Expect(configSpec.VAppConfigRemoved).To(BeNil())
 
-					extraConfig := util.ExtraConfigToMap(configSpec.ExtraConfig)
+					extraConfig := util.OptionValues(configSpec.ExtraConfig).StringMap()
 					Expect(extraConfig).To(HaveLen(4))
 					Expect(extraConfig).To(HaveKey(constants.CloudInitGuestInfoMetadata))
 					Expect(extraConfig).To(HaveKeyWithValue(constants.CloudInitGuestInfoMetadataEncoding, "gzip+base64"))
@@ -189,7 +189,7 @@ var _ = Describe("CloudInit Bootstrap", func() {
 					Expect(configSpec).ToNot(BeNil())
 					Expect(configSpec.VAppConfigRemoved).To(BeNil())
 
-					extraConfig := util.ExtraConfigToMap(configSpec.ExtraConfig)
+					extraConfig := util.OptionValues(configSpec.ExtraConfig).StringMap()
 					Expect(extraConfig).To(HaveLen(4))
 					Expect(extraConfig).To(HaveKey(constants.CloudInitGuestInfoMetadata))
 					Expect(extraConfig).To(HaveKeyWithValue(constants.CloudInitGuestInfoMetadataEncoding, "gzip+base64"))
@@ -243,7 +243,7 @@ var _ = Describe("CloudInit Bootstrap", func() {
 					Expect(configSpec).ToNot(BeNil())
 					Expect(configSpec.VAppConfigRemoved).To(BeNil())
 
-					extraConfig := util.ExtraConfigToMap(configSpec.ExtraConfig)
+					extraConfig := util.OptionValues(configSpec.ExtraConfig).StringMap()
 					Expect(extraConfig).To(HaveLen(4))
 					Expect(extraConfig).To(HaveKey(constants.CloudInitGuestInfoMetadata)) // TODO: Better assertion (reduce w/ GetCloudInitMetadata)
 					Expect(extraConfig).To(HaveKeyWithValue(constants.CloudInitGuestInfoMetadataEncoding, "gzip+base64"))
@@ -266,7 +266,7 @@ var _ = Describe("CloudInit Bootstrap", func() {
 						Expect(err).ToNot(HaveOccurred())
 						Expect(configSpec).ToNot(BeNil())
 
-						extraConfig := util.ExtraConfigToMap(configSpec.ExtraConfig)
+						extraConfig := util.OptionValues(configSpec.ExtraConfig).StringMap()
 						Expect(extraConfig).To(HaveLen(4))
 						Expect(extraConfig).To(HaveKey(constants.CloudInitGuestInfoMetadata)) // TODO: Better assertion (reduce w/ GetCloudInitMetadata)
 						Expect(extraConfig).To(HaveKeyWithValue(constants.CloudInitGuestInfoMetadataEncoding, "gzip+base64"))
@@ -402,7 +402,7 @@ var _ = Describe("CloudInit Bootstrap", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(configSpec).ToNot(BeNil())
 
-				extraConfig := util.ExtraConfigToMap(configSpec.ExtraConfig)
+				extraConfig := util.OptionValues(configSpec.ExtraConfig).StringMap()
 				Expect(extraConfig).To(HaveLen(2))
 				Expect(extraConfig).To(HaveKeyWithValue(constants.CloudInitGuestInfoMetadata, "H4sIAAAAAAAA/0rOyS9N0c3MyyzRzU0tSUxJLEkEAAAA//8BAAD//wEq0o4TAAAA"))
 				Expect(extraConfig).To(HaveKeyWithValue(constants.CloudInitGuestInfoMetadataEncoding, "gzip+base64"))
@@ -414,7 +414,7 @@ var _ = Describe("CloudInit Bootstrap", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(configSpec).ToNot(BeNil())
 
-				extraConfig := util.ExtraConfigToMap(configSpec.ExtraConfig)
+				extraConfig := util.OptionValues(configSpec.ExtraConfig).StringMap()
 				Expect(extraConfig).To(HaveLen(4))
 				Expect(extraConfig).To(HaveKeyWithValue(constants.CloudInitGuestInfoMetadata, "H4sIAAAAAAAA/0rOyS9N0c3MyyzRzU0tSUxJLEkEAAAA//8BAAD//wEq0o4TAAAA"))
 				Expect(extraConfig).To(HaveKeyWithValue(constants.CloudInitGuestInfoMetadataEncoding, "gzip+base64"))
@@ -432,7 +432,7 @@ var _ = Describe("CloudInit Bootstrap", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(configSpec).ToNot(BeNil())
 
-				extraConfig := util.ExtraConfigToMap(configSpec.ExtraConfig)
+				extraConfig := util.OptionValues(configSpec.ExtraConfig).StringMap()
 				Expect(extraConfig).To(HaveLen(4))
 				Expect(extraConfig).To(HaveKeyWithValue(constants.CloudInitGuestInfoMetadata, "H4sIAAAAAAAA/0rOyS9N0c3MyyzRzU0tSUxJLEkEAAAA//8BAAD//wEq0o4TAAAA"))
 				Expect(extraConfig).To(HaveKeyWithValue(constants.CloudInitGuestInfoMetadataEncoding, "gzip+base64"))
@@ -452,7 +452,7 @@ var _ = Describe("CloudInit Bootstrap", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(configSpec).ToNot(BeNil())
 
-				extraConfig := util.ExtraConfigToMap(configSpec.ExtraConfig)
+				extraConfig := util.OptionValues(configSpec.ExtraConfig).StringMap()
 				Expect(extraConfig).To(HaveLen(4))
 				Expect(extraConfig).To(HaveKeyWithValue(constants.CloudInitGuestInfoMetadata, "H4sIAAAAAAAA/0rOyS9N0c3MyyzRzU0tSUxJLEkEAAAA//8BAAD//wEq0o4TAAAA"))
 				Expect(extraConfig).To(HaveKeyWithValue(constants.CloudInitGuestInfoMetadataEncoding, "gzip+base64"))

--- a/pkg/providers/vsphere/vmprovider_vm.go
+++ b/pkg/providers/vsphere/vmprovider_vm.go
@@ -37,7 +37,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/virtualmachine"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/vmlifecycle"
 	"github.com/vmware-tanzu/vm-operator/pkg/topology"
-	"github.com/vmware-tanzu/vm-operator/pkg/util"
+	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
 	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 	vmopv1util "github.com/vmware-tanzu/vm-operator/pkg/util/vmopv1"
 )
@@ -1033,7 +1033,7 @@ func (vs *vSphereVMProvider) vmCreateGenConfigSpecExtraConfig(
 		ecMap[k] = renderTemplateFn(k, v)
 	}
 
-	if util.HasVirtualPCIPassthroughDeviceChange(createArgs.ConfigSpec.DeviceChange) {
+	if pkgutil.HasVirtualPCIPassthroughDeviceChange(createArgs.ConfigSpec.DeviceChange) {
 		mmioSize := vmCtx.VM.Annotations[constants.PCIPassthruMMIOOverrideAnnotation]
 		if mmioSize == "" {
 			mmioSize = constants.PCIPassthruMMIOSizeDefault
@@ -1046,9 +1046,9 @@ func (vs *vSphereVMProvider) vmCreateGenConfigSpecExtraConfig(
 
 	// The ConfigSpec's current ExtraConfig values (that came from the class)
 	// take precedence over what was set here.
-	createArgs.ConfigSpec.ExtraConfig = util.OptionValues(
+	createArgs.ConfigSpec.ExtraConfig = pkgutil.OptionValues(
 		createArgs.ConfigSpec.ExtraConfig).
-		Append(util.OptionValuesFromMap(ecMap)...)
+		Append(pkgutil.OptionValuesFromMap(ecMap)...)
 
 	// Leave constants.VMOperatorV1Alpha1ExtraConfigKey for the update path (if that's still even needed)
 
@@ -1076,7 +1076,7 @@ func (vs *vSphereVMProvider) vmCreateGenConfigSpecZipNetworkInterfaces(
 	createArgs *VMCreateArgs) error {
 
 	if vmCtx.VM.Spec.Network == nil || vmCtx.VM.Spec.Network.Disabled {
-		util.RemoveDevicesFromConfigSpec(&createArgs.ConfigSpec, util.IsEthernetCard)
+		pkgutil.RemoveDevicesFromConfigSpec(&createArgs.ConfigSpec, pkgutil.IsEthernetCard)
 		return nil
 	}
 
@@ -1085,7 +1085,7 @@ func (vs *vSphereVMProvider) vmCreateGenConfigSpecZipNetworkInterfaces(
 
 	for idx := range createArgs.ConfigSpec.DeviceChange {
 		spec := createArgs.ConfigSpec.DeviceChange[idx].GetVirtualDeviceConfigSpec()
-		if spec == nil || !util.IsEthernetCard(spec.Device) {
+		if spec == nil || !pkgutil.IsEthernetCard(spec.Device) {
 			continue
 		}
 

--- a/pkg/providers/vsphere/vmprovider_vm.go
+++ b/pkg/providers/vsphere/vmprovider_vm.go
@@ -1044,8 +1044,11 @@ func (vs *vSphereVMProvider) vmCreateGenConfigSpecExtraConfig(
 		}
 	}
 
-	// The ConfigSpec's current ExtraConfig values (that came from the class) take precedence over what was set here.
-	createArgs.ConfigSpec.ExtraConfig = util.AppendNewExtraConfigValues(createArgs.ConfigSpec.ExtraConfig, ecMap)
+	// The ConfigSpec's current ExtraConfig values (that came from the class)
+	// take precedence over what was set here.
+	createArgs.ConfigSpec.ExtraConfig = util.OptionValues(
+		createArgs.ConfigSpec.ExtraConfig).
+		Append(util.OptionValuesFromMap(ecMap)...)
 
 	// Leave constants.VMOperatorV1Alpha1ExtraConfigKey for the update path (if that's still even needed)
 

--- a/pkg/providers/vsphere/vmprovider_vm_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_test.go
@@ -1256,7 +1256,8 @@ func vmTests() {
 
 				By("has expected backup ExtraConfig key", func() {
 					Expect(o.Config.ExtraConfig).ToNot(BeNil())
-					ecMap := util.ExtraConfigToMap(o.Config.ExtraConfig)
+
+					ecMap := util.OptionValues(o.Config.ExtraConfig).StringMap()
 					Expect(ecMap).To(HaveKey(vmopv1.VMResourceYAMLExtraConfigKey))
 				})
 
@@ -1278,7 +1279,7 @@ func vmTests() {
 
 				By("does not have any backup ExtraConfig key", func() {
 					Expect(o.Config.ExtraConfig).ToNot(BeNil())
-					ecMap := util.ExtraConfigToMap(o.Config.ExtraConfig)
+					ecMap := util.OptionValues(o.Config.ExtraConfig).StringMap()
 					Expect(ecMap).ToNot(HaveKey(vmopv1.VMResourceYAMLExtraConfigKey))
 				})
 			})

--- a/pkg/providers/vsphere/vmprovider_vm_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/instancestorage"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/virtualmachine"
 	"github.com/vmware-tanzu/vm-operator/pkg/topology"
-	"github.com/vmware-tanzu/vm-operator/pkg/util"
+	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
 	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
@@ -1257,7 +1257,7 @@ func vmTests() {
 				By("has expected backup ExtraConfig key", func() {
 					Expect(o.Config.ExtraConfig).ToNot(BeNil())
 
-					ecMap := util.OptionValues(o.Config.ExtraConfig).StringMap()
+					ecMap := pkgutil.OptionValues(o.Config.ExtraConfig).StringMap()
 					Expect(ecMap).To(HaveKey(vmopv1.VMResourceYAMLExtraConfigKey))
 				})
 
@@ -1279,7 +1279,7 @@ func vmTests() {
 
 				By("does not have any backup ExtraConfig key", func() {
 					Expect(o.Config.ExtraConfig).ToNot(BeNil())
-					ecMap := util.OptionValues(o.Config.ExtraConfig).StringMap()
+					ecMap := pkgutil.OptionValues(o.Config.ExtraConfig).StringMap()
 					Expect(ecMap).ToNot(HaveKey(vmopv1.VMResourceYAMLExtraConfigKey))
 				})
 			})

--- a/pkg/util/configspec.go
+++ b/pkg/util/configspec.go
@@ -163,69 +163,6 @@ func RemoveDevicesFromConfigSpec(configSpec *vimtypes.VirtualMachineConfigSpec, 
 	configSpec.DeviceChange = targetDevChanges
 }
 
-// AppendNewExtraConfigValues add the new extra config values if not already present in the extra config.
-func AppendNewExtraConfigValues(
-	extraConfig []vimtypes.BaseOptionValue,
-	newECMap map[string]string) []vimtypes.BaseOptionValue {
-
-	ecMap := make(map[string]vimtypes.AnyType)
-	for _, opt := range extraConfig {
-		if optValue := opt.GetOptionValue(); optValue != nil {
-			ecMap[optValue.Key] = optValue.Value
-		}
-	}
-
-	// Only add fields that aren't already in the ExtraConfig.
-	var newExtraConfig []vimtypes.BaseOptionValue
-	for k, v := range newECMap {
-		if _, exists := ecMap[k]; !exists {
-			newExtraConfig = append(newExtraConfig, &vimtypes.OptionValue{Key: k, Value: v})
-		}
-	}
-
-	return append(extraConfig, newExtraConfig...)
-}
-
-// ExtraConfigToMap converts the ExtraConfig to a map with string values.
-func ExtraConfigToMap(input []vimtypes.BaseOptionValue) (output map[string]string) {
-	output = make(map[string]string)
-	for _, opt := range input {
-		if optValue := opt.GetOptionValue(); optValue != nil {
-			// Only set string type values
-			if val, ok := optValue.Value.(string); ok {
-				output[optValue.Key] = val
-			}
-		}
-	}
-	return
-}
-
-// MergeExtraConfig adds the key/value to the ExtraConfig if the key is not
-// present or the new value is different than the existing value.
-// It returns the newly added ExtraConfig.
-// Please note the result *may* include keys with empty values. This indicates
-// to vSphere to remove the key/value pair.
-func MergeExtraConfig(
-	existingExtraConfig []vimtypes.BaseOptionValue,
-	newKeyValuePairs map[string]string) []vimtypes.BaseOptionValue {
-
-	var mergedExtraConfig []vimtypes.BaseOptionValue
-	existingExtraConfigKeyValuePairs := ExtraConfigToMap(existingExtraConfig)
-
-	for nk, nv := range newKeyValuePairs {
-		if ev, ok := existingExtraConfigKeyValuePairs[nk]; !ok || nv != ev {
-			mergedExtraConfig = append(
-				mergedExtraConfig,
-				&vimtypes.OptionValue{
-					Key:   nk,
-					Value: nv,
-				})
-		}
-	}
-
-	return mergedExtraConfig
-}
-
 // EnsureMinHardwareVersionInConfigSpec ensures that the hardware version in the
 // ConfigSpec is at least equal to the passed minimum hardware version value.
 func EnsureMinHardwareVersionInConfigSpec(

--- a/pkg/util/configspec_test.go
+++ b/pkg/util/configspec_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/vmware/govmomi/vim25/xml"
 
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
-	"github.com/vmware-tanzu/vm-operator/pkg/util"
+	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 )
 
@@ -45,7 +45,7 @@ var _ = Describe("DevicesFromConfigSpec", func() {
 	})
 
 	JustBeforeEach(func() {
-		devOut = util.DevicesFromConfigSpec(configSpec)
+		devOut = pkgutil.DevicesFromConfigSpec(configSpec)
 	})
 
 	When("a ConfigSpec has a nil DeviceChange property", func() {
@@ -109,7 +109,7 @@ var _ = Describe("ConfigSpec Util", func() {
 	Context("MarshalConfigSpecToXML", func() {
 		It("marshals and unmarshal to the same spec", func() {
 			inputSpec := vimtypes.VirtualMachineConfigSpec{Name: "dummy-VM"}
-			bytes, err := util.MarshalConfigSpecToXML(inputSpec)
+			bytes, err := pkgutil.MarshalConfigSpecToXML(inputSpec)
 			Expect(err).ShouldNot(HaveOccurred())
 			var outputSpec vimtypes.VirtualMachineConfigSpec
 			err = xml.Unmarshal(bytes, &outputSpec)
@@ -119,7 +119,7 @@ var _ = Describe("ConfigSpec Util", func() {
 
 		It("marshals spec correctly to expected base64 encoded XML", func() {
 			inputSpec := vimtypes.VirtualMachineConfigSpec{Name: "dummy-VM"}
-			bytes, err := util.MarshalConfigSpecToXML(inputSpec)
+			bytes, err := pkgutil.MarshalConfigSpecToXML(inputSpec)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(base64.StdEncoding.EncodeToString(bytes)).To(Equal("PG9iaiB4bWxuczp2aW0yNT0idXJuOnZpbTI1I" +
 				"iB4bWxuczp4c2k9Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvWE1MU2NoZW1hLWluc3RhbmNlIiB4c2k6dHlwZT0idmltMjU6Vmlyd" +
@@ -165,14 +165,14 @@ var _ = Describe("ConfigSpec Util", func() {
 		When("minimum hardware version is unset", func() {
 			It("does not change the existing value of the configSpec's version", func() {
 				configSpec := &vimtypes.VirtualMachineConfigSpec{Version: "vmx-15"}
-				util.EnsureMinHardwareVersionInConfigSpec(configSpec, 0)
+				pkgutil.EnsureMinHardwareVersionInConfigSpec(configSpec, 0)
 
 				Expect(configSpec.Version).To(Equal("vmx-15"))
 			})
 
 			It("does not set the configSpec's version", func() {
 				configSpec := &vimtypes.VirtualMachineConfigSpec{}
-				util.EnsureMinHardwareVersionInConfigSpec(configSpec, 0)
+				pkgutil.EnsureMinHardwareVersionInConfigSpec(configSpec, 0)
 
 				Expect(configSpec.Version).To(BeEmpty())
 			})
@@ -180,21 +180,21 @@ var _ = Describe("ConfigSpec Util", func() {
 
 		It("overrides the hardware version if the existing version is lesser", func() {
 			configSpec := &vimtypes.VirtualMachineConfigSpec{Version: "vmx-15"}
-			util.EnsureMinHardwareVersionInConfigSpec(configSpec, 17)
+			pkgutil.EnsureMinHardwareVersionInConfigSpec(configSpec, 17)
 
 			Expect(configSpec.Version).To(Equal("vmx-17"))
 		})
 
 		It("sets the hardware version if the existing version is unset", func() {
 			configSpec := &vimtypes.VirtualMachineConfigSpec{}
-			util.EnsureMinHardwareVersionInConfigSpec(configSpec, 16)
+			pkgutil.EnsureMinHardwareVersionInConfigSpec(configSpec, 16)
 
 			Expect(configSpec.Version).To(Equal("vmx-16"))
 		})
 
 		It("overrides the hardware version if the existing version is set incorrectly", func() {
 			configSpec := &vimtypes.VirtualMachineConfigSpec{Version: "foo"}
-			util.EnsureMinHardwareVersionInConfigSpec(configSpec, 17)
+			pkgutil.EnsureMinHardwareVersionInConfigSpec(configSpec, 17)
 
 			Expect(configSpec.Version).To(Equal("vmx-17"))
 		})
@@ -242,7 +242,7 @@ var _ = Describe("RemoveDevicesFromConfigSpec", func() {
 		})
 
 		It("config spec deviceChanges empty", func() {
-			util.RemoveDevicesFromConfigSpec(configSpec, fn)
+			pkgutil.RemoveDevicesFromConfigSpec(configSpec, fn)
 			Expect(configSpec.DeviceChange).To(BeEmpty())
 		})
 	})
@@ -332,7 +332,7 @@ var _ = Describe("SanitizeVMClassConfigSpec", func() {
 	})
 
 	It("returns expected sanitized ConfigSpec", func() {
-		util.SanitizeVMClassConfigSpec(ctx, configSpec)
+		pkgutil.SanitizeVMClassConfigSpec(ctx, configSpec)
 
 		Expect(configSpec.Name).To(Equal("dummy-VM"))
 		Expect(configSpec.Annotation).ToNot(BeEmpty())

--- a/pkg/util/configspec_test.go
+++ b/pkg/util/configspec_test.go
@@ -248,28 +248,6 @@ var _ = Describe("RemoveDevicesFromConfigSpec", func() {
 	})
 })
 
-var _ = Describe("AppendNewExtraConfigValues", func() {
-
-	It("only adds new values not already in the ExtraConfig", func() {
-		ec := []vimtypes.BaseOptionValue{
-			&vimtypes.OptionValue{
-				Key:   "key1",
-				Value: "keep-me",
-			},
-		}
-
-		newECMap := map[string]string{
-			"key1": "should-be-ignored",
-			"key2": "add-me",
-		}
-
-		newExtraConfig := util.AppendNewExtraConfigValues(ec, newECMap)
-		Expect(newExtraConfig).To(HaveLen(2))
-		Expect(newExtraConfig).To(ContainElement(&vimtypes.OptionValue{Key: "key1", Value: "keep-me"}))
-		Expect(newExtraConfig).To(ContainElement(&vimtypes.OptionValue{Key: "key2", Value: "add-me"}))
-	})
-})
-
 var _ = Describe("SanitizeVMClassConfigSpec", func() {
 	var (
 		ctx        context.Context
@@ -387,94 +365,6 @@ var _ = Describe("SanitizeVMClassConfigSpec", func() {
 		backing, ok := dev.Backing.(*vimtypes.VirtualDiskRawDiskMappingVer1BackingInfo)
 		Expect(ok).To(BeTrue())
 		Expect(backing.LunUuid).To(Equal("dummy-uuid"))
-	})
-})
-
-var _ = Describe("ExtraConfigToMap", func() {
-	var (
-		extraConfig    []vimtypes.BaseOptionValue
-		extraConfigMap map[string]string
-	)
-	BeforeEach(func() {
-		extraConfig = []vimtypes.BaseOptionValue{}
-	})
-	JustBeforeEach(func() {
-		extraConfigMap = util.ExtraConfigToMap(extraConfig)
-	})
-
-	Context("Empty extraConfig", func() {
-		It("Return empty map", func() {
-			Expect(extraConfigMap).To(HaveLen(0))
-		})
-	})
-
-	Context("With extraConfig", func() {
-		BeforeEach(func() {
-			extraConfig = append(extraConfig, &vimtypes.OptionValue{Key: "key1", Value: "value1"})
-			extraConfig = append(extraConfig, &vimtypes.OptionValue{Key: "key2", Value: "value2"})
-		})
-		It("Return valid map", func() {
-			Expect(extraConfigMap).To(HaveLen(2))
-			Expect(extraConfigMap["key1"]).To(Equal("value1"))
-			Expect(extraConfigMap["key2"]).To(Equal("value2"))
-		})
-	})
-})
-
-var _ = Describe("MergeExtraConfig", func() {
-	var (
-		extraConfig []vimtypes.BaseOptionValue
-		newMap      map[string]string
-		merged      []vimtypes.BaseOptionValue
-	)
-	BeforeEach(func() {
-		extraConfig = []vimtypes.BaseOptionValue{
-			&vimtypes.OptionValue{Key: "existingkey1", Value: "existingvalue1"},
-			&vimtypes.OptionValue{Key: "existingkey2", Value: "existingvalue2"},
-		}
-		newMap = map[string]string{}
-	})
-	JustBeforeEach(func() {
-		merged = util.MergeExtraConfig(extraConfig, newMap)
-	})
-
-	Context("Empty newMap", func() {
-		It("Return empty merged", func() {
-			Expect(merged).To(BeEmpty())
-		})
-	})
-
-	Context("NewMap with existing key and same value", func() {
-		BeforeEach(func() {
-			newMap["existingkey1"] = "existingvalue1"
-		})
-		It("Return empty merged", func() {
-			Expect(merged).To(BeEmpty())
-		})
-	})
-
-	Context("NewMap with existing key and new value", func() {
-		BeforeEach(func() {
-			newMap["existingkey1"] = "newvalue1"
-		})
-		It("Return merged map", func() {
-			Expect(merged).To(HaveLen(1))
-			mergedMap := util.ExtraConfigToMap(merged)
-			Expect(mergedMap["existingkey1"]).To(Equal("newvalue1"))
-		})
-	})
-
-	Context("NewMap with new keys", func() {
-		BeforeEach(func() {
-			newMap["newkey1"] = "newvalue1"
-			newMap["newkey2"] = "newvalue2"
-		})
-		It("Return merged map", func() {
-			Expect(merged).To(HaveLen(2))
-			mergedMap := util.ExtraConfigToMap(merged)
-			Expect(mergedMap["newkey1"]).To(Equal("newvalue1"))
-			Expect(mergedMap["newkey2"]).To(Equal("newvalue2"))
-		})
 	})
 })
 

--- a/pkg/util/option_values.go
+++ b/pkg/util/option_values.go
@@ -1,0 +1,199 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"fmt"
+	"reflect"
+
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+)
+
+// OptionValues simplifies manipulation of properties that are arrays of
+// vimtypes.BaseOptionValue, such as ExtraConfig.
+type OptionValues []vimtypes.BaseOptionValue
+
+// OptionValuesFromMap returns a new OptionValues object from the provided map.
+func OptionValuesFromMap[T any](in map[string]T) OptionValues {
+	if len(in) == 0 {
+		return nil
+	}
+	var (
+		i   int
+		out = make(OptionValues, len(in))
+	)
+	for k, v := range in {
+		out[i] = &vimtypes.OptionValue{Key: k, Value: v}
+		i++
+	}
+	return out
+}
+
+// Get returns the value if exists, otherwise nil is returned. The second return
+// value is a flag indicating whether the value exists or nil was the actual
+// value.
+func (ov OptionValues) Get(key string) (any, bool) {
+	if ov == nil {
+		return nil, false
+	}
+	for i := range ov {
+		if optVal := ov[i].GetOptionValue(); optVal != nil {
+			if optVal.Key == key {
+				return optVal.Value, true
+			}
+		}
+	}
+	return nil, false
+}
+
+// GetString returns the value as a string if the value exists.
+func (ov OptionValues) GetString(key string) (string, bool) {
+	if ov == nil {
+		return "", false
+	}
+	for i := range ov {
+		if optVal := ov[i].GetOptionValue(); optVal != nil {
+			if optVal.Key == key {
+				return getOptionValueAsString(optVal.Value), true
+			}
+		}
+	}
+	return "", false
+}
+
+// Additions returns a diff that includes only the elements from the provided
+// list that do not already exist.
+func (ov OptionValues) Additions(in ...vimtypes.BaseOptionValue) OptionValues {
+	return ov.diff(in, true)
+}
+
+// Diff returns a diff that includes the elements from the provided list that do
+// not already exist or have different values.
+func (ov OptionValues) Diff(in ...vimtypes.BaseOptionValue) OptionValues {
+	return ov.diff(in, false)
+}
+
+func (ov OptionValues) diff(in OptionValues, addOnly bool) OptionValues {
+	if ov == nil && in == nil {
+		return nil
+	}
+	var (
+		out         OptionValues
+		leftOptVals = ov.Map()
+	)
+	for i := range in {
+		if rightOptVal := in[i].GetOptionValue(); rightOptVal != nil {
+			k, v := rightOptVal.Key, rightOptVal.Value
+			if ov == nil {
+				out = append(out, &vimtypes.OptionValue{Key: k, Value: v})
+			} else if leftOptVal, ok := leftOptVals[k]; !ok {
+				out = append(out, &vimtypes.OptionValue{Key: k, Value: v})
+			} else if !addOnly && v != leftOptVal {
+				out = append(out, &vimtypes.OptionValue{Key: k, Value: v})
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// Merge adds the provided item(s), overwriting any existing values.
+func (ov OptionValues) Merge(in ...vimtypes.BaseOptionValue) OptionValues {
+	return ov.merge(in, true)
+}
+
+// Append adds the provided item(s) as long as a key does not conflict with an
+// existing item.
+func (ov OptionValues) Append(in ...vimtypes.BaseOptionValue) OptionValues {
+	return ov.merge(in, false)
+}
+
+func (ov OptionValues) merge(in OptionValues, overwrite bool) OptionValues {
+
+	var (
+		out        OptionValues
+		outOptVals = map[string]*vimtypes.OptionValue{}
+	)
+
+	// Init the out slice from the left side.
+	if len(ov) > 0 {
+		for i := range ov {
+			if optVal := ov[i].GetOptionValue(); optVal != nil {
+				kv := &vimtypes.OptionValue{Key: optVal.Key, Value: optVal.Value}
+				out = append(out, kv)
+				outOptVals[optVal.Key] = kv
+			}
+		}
+	}
+
+	// Merge or append the right side.
+	for i := range in {
+		if rightOptVal := in[i].GetOptionValue(); rightOptVal != nil {
+			k, v := rightOptVal.Key, rightOptVal.Value
+			if outOptVal, ok := outOptVals[k]; !ok {
+				out = append(out, &vimtypes.OptionValue{Key: k, Value: v})
+			} else if overwrite {
+				outOptVal.Value = v
+			}
+		}
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+
+	return out
+}
+
+// Map returns the list of option values as a map.
+func (ov OptionValues) Map() map[string]any {
+	if len(ov) == 0 {
+		return nil
+	}
+	out := map[string]any{}
+	for i := range ov {
+		if optVal := ov[i].GetOptionValue(); optVal != nil {
+			out[optVal.Key] = optVal.Value
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// StringMap returns the list of option values as a map where the values are
+// strings.
+func (ov OptionValues) StringMap() map[string]string {
+	if len(ov) == 0 {
+		return nil
+	}
+	out := map[string]string{}
+	for i := range ov {
+		if optVal := ov[i].GetOptionValue(); optVal != nil {
+			out[optVal.Key] = getOptionValueAsString(optVal.Value)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func getOptionValueAsString(val any) string {
+	switch tval := val.(type) {
+	case string:
+		return tval
+	default:
+		if rv := reflect.ValueOf(val); rv.Kind() == reflect.Pointer {
+			if rv.IsNil() {
+				return ""
+			}
+			return fmt.Sprintf("%v", rv.Elem().Interface())
+		}
+		return fmt.Sprintf("%v", tval)
+	}
+}

--- a/pkg/util/option_values_test.go
+++ b/pkg/util/option_values_test.go
@@ -1,0 +1,781 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package util_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+
+	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
+)
+
+var _ = Describe("OptionValues", func() {
+
+	const (
+		sza   = "a"
+		szb   = "b"
+		szc   = "c"
+		szd   = "d"
+		sze   = "e"
+		sz1   = "1"
+		sz2   = "2"
+		sz3   = "3"
+		sz4   = "4"
+		sz5   = "5"
+		i32_1 = int32(1)
+		u64_2 = uint64(2)
+		f32_3 = float32(3)
+		f64_4 = float64(4)
+		b_5   = byte(5) //nolint:revive,stylecheck
+	)
+
+	var (
+		psz1   = &[]string{sz1}[0]
+		pu64_2 = &[]uint64{u64_2}[0]
+		pf32_3 = &[]float32{f32_3}[0]
+		pb_5   = &[]byte{b_5}[0] //nolint:revive,stylecheck
+	)
+
+	Context("OptionValuesFromMap", func() {
+		When("input is nil", func() {
+			It("should return nil", func() {
+				out := pkgutil.OptionValuesFromMap[any](nil)
+				Expect(out).To(BeNil())
+			})
+		})
+		When("source values are all strings", func() {
+			It("should return an OptionValues", func() {
+				in := map[string]string{
+					sza: sz1,
+					szb: sz2,
+					szc: sz3,
+				}
+				out := pkgutil.OptionValuesFromMap(in)
+				Expect(out).To(ConsistOf(
+					&vimtypes.OptionValue{Key: sza, Value: sz1},
+					&vimtypes.OptionValue{Key: szb, Value: sz2},
+					&vimtypes.OptionValue{Key: szc, Value: sz3},
+				))
+			})
+		})
+		When("source values include numbers", func() {
+			It("should return an OptionValues", func() {
+				in := map[string]any{
+					sza: i32_1,
+					szb: u64_2,
+					szc: f32_3,
+				}
+				out := pkgutil.OptionValuesFromMap(in)
+				Expect(out).To(ConsistOf(
+					&vimtypes.OptionValue{Key: sza, Value: i32_1},
+					&vimtypes.OptionValue{Key: szb, Value: u64_2},
+					&vimtypes.OptionValue{Key: szc, Value: f32_3},
+				))
+			})
+		})
+		When("source values include pointers", func() {
+			It("should return an OptionValues", func() {
+				in := map[string]any{
+					sza: psz1,
+					szb: pu64_2,
+					szc: pf32_3,
+				}
+				out := pkgutil.OptionValuesFromMap(in)
+				Expect(out).To(ConsistOf(
+					&vimtypes.OptionValue{Key: sza, Value: psz1},
+					&vimtypes.OptionValue{Key: szb, Value: pu64_2},
+					&vimtypes.OptionValue{Key: szc, Value: pf32_3},
+				))
+			})
+		})
+	})
+
+	Context("Get", func() {
+		When("receiver is nil", func() {
+			It("should return nil, false", func() {
+				var (
+					left pkgutil.OptionValues
+					val  any
+					ok   bool
+				)
+
+				left = nil
+
+				Expect(func() { val, ok = left.Get("") }).ToNot(Panic())
+				Expect(val).To(BeNil())
+				Expect(ok).To(BeFalse())
+			})
+		})
+		When("receiver is not nil", func() {
+			When("key does not exist", func() {
+				It("should return nil, false", func() {
+					var (
+						left pkgutil.OptionValues
+						val  any
+						ok   bool
+					)
+
+					left = pkgutil.OptionValues{}
+
+					val, ok = left.Get("")
+					Expect(val).To(BeNil())
+					Expect(ok).To(BeFalse())
+				})
+			})
+			When("key does exist", func() {
+				It("should return the value, true", func() {
+					var (
+						left pkgutil.OptionValues
+						val  any
+						ok   bool
+					)
+
+					left = pkgutil.OptionValues{
+						&vimtypes.OptionValue{Key: sza, Value: sz1},
+					}
+
+					val, ok = left.Get(sza)
+					Expect(val).To(Equal(sz1))
+					Expect(ok).To(BeTrue())
+				})
+			})
+			When("data includes a nil interface value", func() {
+				It("should return the value, true", func() {
+					var (
+						left pkgutil.OptionValues
+						val  any
+						ok   bool
+					)
+
+					left = pkgutil.OptionValues{
+						nillableOptionValue{},
+						&vimtypes.OptionValue{Key: sza, Value: sz1},
+					}
+
+					val, ok = left.Get(sza)
+					Expect(val).To(Equal(sz1))
+					Expect(ok).To(BeTrue())
+				})
+			})
+		})
+	})
+
+	Context("GetString", func() {
+		When("receiver is nil", func() {
+			It("should return \"\", false", func() {
+				var (
+					left pkgutil.OptionValues
+					val  string
+					ok   bool
+				)
+
+				left = nil
+
+				Expect(func() { val, ok = left.GetString("") }).ToNot(Panic())
+				Expect(val).To(BeEmpty())
+				Expect(ok).To(BeFalse())
+			})
+		})
+		When("receiver is not nil", func() {
+			When("key does not exist", func() {
+				It("should return \"\", false", func() {
+					var (
+						left pkgutil.OptionValues
+						val  string
+						ok   bool
+					)
+
+					left = pkgutil.OptionValues{}
+
+					val, ok = left.GetString("")
+					Expect(val).To(BeEmpty())
+					Expect(ok).To(BeFalse())
+				})
+			})
+			When("key does exist", func() {
+				It("should return the value, true", func() {
+					var (
+						left pkgutil.OptionValues
+						val  string
+						ok   bool
+					)
+
+					left = pkgutil.OptionValues{
+						&vimtypes.OptionValue{Key: sza, Value: sz1},
+					}
+
+					val, ok = left.GetString(sza)
+					Expect(val).To(Equal(sz1))
+					Expect(ok).To(BeTrue())
+				})
+			})
+			When("data includes a nil interface value", func() {
+				It("should return the value, true", func() {
+					var (
+						left pkgutil.OptionValues
+						val  string
+						ok   bool
+					)
+
+					left = pkgutil.OptionValues{
+						nillableOptionValue{},
+						&vimtypes.OptionValue{Key: sza, Value: sz1},
+					}
+
+					val, ok = left.GetString(sza)
+					Expect(val).To(Equal(sz1))
+					Expect(ok).To(BeTrue())
+				})
+			})
+			When("data includes a *string", func() {
+				Context("that is nil", func() {
+					It("should return \"\", true", func() {
+						var (
+							left pkgutil.OptionValues
+							val  string
+							ok   bool
+						)
+
+						left = pkgutil.OptionValues{
+							&vimtypes.OptionValue{Key: sza, Value: (*string)(nil)},
+						}
+
+						val, ok = left.GetString(sza)
+						Expect(val).To(BeEmpty())
+						Expect(ok).To(BeTrue())
+					})
+				})
+				Context("that is not nil", func() {
+					It("should return the value, true", func() {
+						var (
+							left pkgutil.OptionValues
+							val  string
+							ok   bool
+						)
+
+						left = pkgutil.OptionValues{
+							nillableOptionValue{},
+							&vimtypes.OptionValue{Key: sza, Value: psz1},
+						}
+
+						val, ok = left.GetString(sza)
+						Expect(val).To(Equal(sz1))
+						Expect(ok).To(BeTrue())
+					})
+				})
+			})
+			When("data includes a number", func() {
+				It("should return the value, true", func() {
+					var (
+						left pkgutil.OptionValues
+						val  string
+						ok   bool
+					)
+
+					left = pkgutil.OptionValues{
+						nillableOptionValue{},
+						&vimtypes.OptionValue{Key: sza, Value: i32_1},
+					}
+
+					val, ok = left.GetString(sza)
+					Expect(val).To(Equal(sz1))
+					Expect(ok).To(BeTrue())
+				})
+			})
+		})
+	})
+
+	Context("Map", func() {
+		When("receiver is nil", func() {
+			It("should return nil", func() {
+				var (
+					left pkgutil.OptionValues
+					out  map[string]any
+				)
+
+				left = nil
+
+				Expect(func() { out = left.Map() }).ToNot(Panic())
+				Expect(out).To(BeNil())
+			})
+		})
+		When("receiver is not nil", func() {
+			When("there is data", func() {
+				It("should return a map", func() {
+					var (
+						left pkgutil.OptionValues
+						out  map[string]any
+					)
+
+					left = pkgutil.OptionValues{
+						&vimtypes.OptionValue{Key: sza, Value: sz1},
+					}
+
+					out = left.Map()
+					Expect(out).To(HaveLen(1))
+					Expect(out).To(HaveKeyWithValue(sza, sz1))
+				})
+			})
+			When("data is just a nil interface value", func() {
+				It("should return nil", func() {
+					var (
+						left pkgutil.OptionValues
+						out  map[string]any
+					)
+
+					left = pkgutil.OptionValues{
+						nillableOptionValue{},
+					}
+
+					out = left.Map()
+					Expect(out).To(BeNil())
+				})
+			})
+		})
+	})
+
+	Context("StringMap", func() {
+		When("receiver is nil", func() {
+			It("should return nil", func() {
+				var (
+					left pkgutil.OptionValues
+					out  map[string]string
+				)
+
+				left = nil
+
+				Expect(func() { out = left.StringMap() }).ToNot(Panic())
+				Expect(out).To(BeNil())
+			})
+		})
+		When("receiver is not nil", func() {
+			When("there is data", func() {
+				It("should return a map", func() {
+					var (
+						left pkgutil.OptionValues
+						out  map[string]string
+					)
+
+					left = pkgutil.OptionValues{
+						&vimtypes.OptionValue{Key: sza, Value: sz1},
+						&vimtypes.OptionValue{Key: szb, Value: u64_2},
+						&vimtypes.OptionValue{Key: szc, Value: f32_3},
+					}
+
+					out = left.StringMap()
+					Expect(out).To(HaveLen(3))
+					Expect(out).To(HaveKeyWithValue(sza, sz1))
+					Expect(out).To(HaveKeyWithValue(szb, sz2))
+					Expect(out).To(HaveKeyWithValue(szc, sz3))
+				})
+			})
+			When("data is just a nil interface value", func() {
+				It("should return nil", func() {
+					var (
+						left pkgutil.OptionValues
+						out  map[string]string
+					)
+
+					left = pkgutil.OptionValues{
+						nillableOptionValue{},
+					}
+
+					out = left.StringMap()
+					Expect(out).To(BeNil())
+				})
+			})
+		})
+	})
+
+	Context("Additions", func() {
+		When("receiver is nil", func() {
+			When("input is nil", func() {
+				It("should return nil", func() {
+					var (
+						left  pkgutil.OptionValues
+						right pkgutil.OptionValues
+						out   pkgutil.OptionValues
+					)
+
+					left = nil
+					right = nil
+
+					Expect(func() { out = left.Additions(right...) }).ToNot(Panic())
+					Expect(out).To(BeNil())
+				})
+			})
+			When("input is not nil", func() {
+				It("should return additions", func() {
+					var (
+						left  pkgutil.OptionValues
+						right pkgutil.OptionValues
+						out   pkgutil.OptionValues
+					)
+
+					left = nil
+					right = pkgutil.OptionValues{
+						&vimtypes.OptionValue{Key: szb, Value: ""},
+						&vimtypes.OptionValue{Key: szd, Value: f64_4},
+						&vimtypes.OptionValue{Key: sze, Value: pb_5},
+					}
+
+					Expect(func() { out = left.Additions(right...) }).ToNot(Panic())
+					Expect(out).To(HaveLen(3))
+					Expect(out).To(HaveExactElements(
+						&vimtypes.OptionValue{Key: szb, Value: ""},
+						&vimtypes.OptionValue{Key: szd, Value: f64_4},
+						&vimtypes.OptionValue{Key: sze, Value: pb_5},
+					))
+				})
+			})
+		})
+		When("receiver is not nil", func() {
+			When("input is nil", func() {
+				It("should return nil", func() {
+					var (
+						left  pkgutil.OptionValues
+						right pkgutil.OptionValues
+						out   pkgutil.OptionValues
+					)
+
+					left = pkgutil.OptionValuesFromMap(map[string]string{
+						sza: sz1,
+						szb: sz2,
+						szc: sz3,
+					})
+					right = nil
+
+					out = left.Additions(right...)
+					Expect(out).To(BeNil())
+				})
+			})
+			When("input is not nil", func() {
+				It("should return additions", func() {
+					var (
+						left  pkgutil.OptionValues
+						right pkgutil.OptionValues
+						out   pkgutil.OptionValues
+					)
+
+					left = pkgutil.OptionValuesFromMap(map[string]string{
+						sza: sz1,
+						szb: sz2,
+						szc: sz3,
+					})
+					right = pkgutil.OptionValues{
+
+						&vimtypes.OptionValue{Key: szb, Value: ""},
+						&vimtypes.OptionValue{Key: szd, Value: f64_4},
+						&vimtypes.OptionValue{Key: sze, Value: pb_5},
+					}
+
+					out = left.Additions(right...)
+					Expect(out).To(HaveLen(2))
+					Expect(out).To(HaveExactElements(
+						&vimtypes.OptionValue{Key: szd, Value: f64_4},
+						&vimtypes.OptionValue{Key: sze, Value: pb_5},
+					))
+				})
+			})
+		})
+	})
+
+	Context("Diff", func() {
+		When("receiver is nil", func() {
+			When("input is nil", func() {
+				It("should return nil", func() {
+					var (
+						left  pkgutil.OptionValues
+						right pkgutil.OptionValues
+						out   pkgutil.OptionValues
+					)
+
+					left = nil
+					right = nil
+
+					Expect(func() { out = left.Diff(right...) }).ToNot(Panic())
+					Expect(out).To(BeNil())
+				})
+			})
+			When("input is not nil", func() {
+				It("should return diff", func() {
+					var (
+						left  pkgutil.OptionValues
+						right pkgutil.OptionValues
+						out   pkgutil.OptionValues
+					)
+
+					left = nil
+					right = pkgutil.OptionValues{
+						&vimtypes.OptionValue{Key: szb, Value: ""},
+						&vimtypes.OptionValue{Key: szd, Value: f64_4},
+						&vimtypes.OptionValue{Key: sze, Value: pb_5},
+					}
+
+					Expect(func() { out = left.Diff(right...) }).ToNot(Panic())
+					Expect(out).To(HaveLen(3))
+					Expect(out).To(HaveExactElements(
+						&vimtypes.OptionValue{Key: szb, Value: ""},
+						&vimtypes.OptionValue{Key: szd, Value: f64_4},
+						&vimtypes.OptionValue{Key: sze, Value: pb_5},
+					))
+				})
+			})
+		})
+		When("receiver is not nil", func() {
+			When("input is nil", func() {
+				It("should return nil", func() {
+					var (
+						left  pkgutil.OptionValues
+						right pkgutil.OptionValues
+						out   pkgutil.OptionValues
+					)
+
+					left = pkgutil.OptionValuesFromMap(map[string]string{
+						sza: sz1,
+						szb: sz2,
+						szc: sz3,
+					})
+					right = nil
+
+					out = left.Diff(right...)
+					Expect(out).To(BeNil())
+				})
+			})
+			When("input is not nil", func() {
+				It("should return diff", func() {
+					var (
+						left  pkgutil.OptionValues
+						right pkgutil.OptionValues
+						out   pkgutil.OptionValues
+					)
+
+					left = pkgutil.OptionValuesFromMap(map[string]string{
+						sza: sz1,
+						szb: sz2,
+						szc: sz3,
+					})
+					right = pkgutil.OptionValues{
+						&vimtypes.OptionValue{Key: szb, Value: ""},
+						&vimtypes.OptionValue{Key: szd, Value: f64_4},
+						&vimtypes.OptionValue{Key: sze, Value: pb_5},
+					}
+
+					out = left.Diff(right...)
+					Expect(out).To(HaveLen(3))
+					Expect(out).To(HaveExactElements(
+						&vimtypes.OptionValue{Key: szb, Value: ""},
+						&vimtypes.OptionValue{Key: szd, Value: f64_4},
+						&vimtypes.OptionValue{Key: sze, Value: pb_5},
+					))
+				})
+			})
+		})
+	})
+
+	Context("Merge", func() {
+		When("receiver is nil", func() {
+			When("input is nil", func() {
+				It("should not panic", func() {
+					var (
+						left  pkgutil.OptionValues
+						right pkgutil.OptionValues
+						out   pkgutil.OptionValues
+					)
+
+					left = nil
+					right = nil
+
+					Expect(func() { out = left.Merge(right...) }).ToNot(Panic())
+					Expect(out).To(BeNil())
+				})
+			})
+			When("input is not nil", func() {
+				It("should not panic", func() {
+					var (
+						left  pkgutil.OptionValues
+						right pkgutil.OptionValues
+						out   pkgutil.OptionValues
+					)
+
+					left = nil
+					right = pkgutil.OptionValues{
+						&vimtypes.OptionValue{Key: szb, Value: ""},
+						&vimtypes.OptionValue{Key: szd, Value: f64_4},
+						&vimtypes.OptionValue{Key: sze, Value: pb_5},
+					}
+
+					Expect(func() { out = left.Merge(right...) }).ToNot(Panic())
+					Expect(out).To(ConsistOf(
+						&vimtypes.OptionValue{Key: szb, Value: ""},
+						&vimtypes.OptionValue{Key: szd, Value: f64_4},
+						&vimtypes.OptionValue{Key: sze, Value: pb_5},
+					))
+				})
+			})
+		})
+		When("receiver is not nil", func() {
+			When("input is nil", func() {
+				It("should not modify the original data", func() {
+					var (
+						left  pkgutil.OptionValues
+						right pkgutil.OptionValues
+						out   pkgutil.OptionValues
+					)
+
+					left = pkgutil.OptionValuesFromMap(map[string]string{
+						sza: sz1,
+						szb: sz2,
+						szc: sz3,
+					})
+					right = nil
+
+					out = left.Merge(right...)
+					Expect(out).To(ConsistOf(
+						&vimtypes.OptionValue{Key: sza, Value: sz1},
+						&vimtypes.OptionValue{Key: szb, Value: sz2},
+						&vimtypes.OptionValue{Key: szc, Value: sz3},
+					))
+
+				})
+			})
+			When("input is not nil", func() {
+				It("should merge the data", func() {
+					var (
+						left  pkgutil.OptionValues
+						right pkgutil.OptionValues
+						out   pkgutil.OptionValues
+					)
+
+					left = pkgutil.OptionValuesFromMap(map[string]string{
+						sza: sz1,
+						szb: sz2,
+						szc: sz3,
+					})
+					right = pkgutil.OptionValues{
+						&vimtypes.OptionValue{Key: szb, Value: ""},
+						&vimtypes.OptionValue{Key: szd, Value: f64_4},
+						&vimtypes.OptionValue{Key: sze, Value: pb_5},
+					}
+
+					out = left.Merge(right...)
+					Expect(out).To(ConsistOf(
+						&vimtypes.OptionValue{Key: sza, Value: sz1},
+						&vimtypes.OptionValue{Key: szb, Value: ""},
+						&vimtypes.OptionValue{Key: szc, Value: sz3},
+						&vimtypes.OptionValue{Key: szd, Value: f64_4},
+						&vimtypes.OptionValue{Key: sze, Value: pb_5},
+					))
+				})
+			})
+		})
+	})
+
+	Context("Append", func() {
+		When("receiver is nil", func() {
+			When("input is nil", func() {
+				It("should not panic", func() {
+					var (
+						left  pkgutil.OptionValues
+						right pkgutil.OptionValues
+						out   pkgutil.OptionValues
+					)
+
+					left = nil
+					right = nil
+
+					Expect(func() { out = left.Append(right...) }).ToNot(Panic())
+					Expect(out).To(BeNil())
+				})
+			})
+			When("input is not nil", func() {
+				It("should not panic", func() {
+					var (
+						left  pkgutil.OptionValues
+						right pkgutil.OptionValues
+						out   pkgutil.OptionValues
+					)
+
+					left = nil
+					right = pkgutil.OptionValues{
+						&vimtypes.OptionValue{Key: szb, Value: ""},
+						&vimtypes.OptionValue{Key: szd, Value: f64_4},
+						&vimtypes.OptionValue{Key: sze, Value: pb_5},
+					}
+
+					Expect(func() { out = left.Append(right...) }).ToNot(Panic())
+					Expect(out).To(ConsistOf(
+						&vimtypes.OptionValue{Key: szb, Value: ""},
+						&vimtypes.OptionValue{Key: szd, Value: f64_4},
+						&vimtypes.OptionValue{Key: sze, Value: pb_5},
+					))
+				})
+			})
+		})
+		When("receiver is not nil", func() {
+			When("input is nil", func() {
+				It("should not modify the original data", func() {
+					var (
+						left  pkgutil.OptionValues
+						right pkgutil.OptionValues
+						out   pkgutil.OptionValues
+					)
+
+					left = pkgutil.OptionValuesFromMap(map[string]string{
+						sza: sz1,
+						szb: sz2,
+						szc: sz3,
+					})
+					right = nil
+
+					out = left.Append(right...)
+					Expect(out).To(ConsistOf(
+						&vimtypes.OptionValue{Key: sza, Value: sz1},
+						&vimtypes.OptionValue{Key: szb, Value: sz2},
+						&vimtypes.OptionValue{Key: szc, Value: sz3},
+					))
+
+				})
+			})
+			When("input is not nil", func() {
+				It("should append the data", func() {
+					var (
+						left  pkgutil.OptionValues
+						right pkgutil.OptionValues
+						out   pkgutil.OptionValues
+					)
+
+					left = pkgutil.OptionValuesFromMap(map[string]string{
+						sza: sz1,
+						szb: sz2,
+						szc: sz3,
+					})
+					right = pkgutil.OptionValues{
+						&vimtypes.OptionValue{Key: szb, Value: ""},
+						&vimtypes.OptionValue{Key: szd, Value: f64_4},
+						&vimtypes.OptionValue{Key: sze, Value: pb_5},
+					}
+
+					out = left.Append(right...)
+					Expect(out).To(ConsistOf(
+						&vimtypes.OptionValue{Key: sza, Value: sz1},
+						&vimtypes.OptionValue{Key: szb, Value: sz2},
+						&vimtypes.OptionValue{Key: szc, Value: sz3},
+						&vimtypes.OptionValue{Key: szd, Value: f64_4},
+						&vimtypes.OptionValue{Key: sze, Value: pb_5},
+					))
+				})
+			})
+		})
+	})
+
+})
+
+type nillableOptionValue struct{}
+
+func (ov nillableOptionValue) GetOptionValue() *vimtypes.OptionValue {
+	return nil
+}

--- a/pkg/util/resize/configspec.go
+++ b/pkg/util/resize/configspec.go
@@ -291,12 +291,7 @@ func compareExtraConfig(
 	cs vimtypes.VirtualMachineConfigSpec,
 	outCS *vimtypes.VirtualMachineConfigSpec) {
 
-	if len(cs.ExtraConfig) == 0 {
-		return
-	}
-
-	extraConfig := util.ExtraConfigToMap(cs.ExtraConfig)
-	outCS.ExtraConfig = util.MergeExtraConfig(ci.ExtraConfig, extraConfig)
+	outCS.ExtraConfig = util.OptionValues(ci.ExtraConfig).Diff(cs.ExtraConfig...)
 }
 
 // compareConsolePreferences compares the console preferences settings in the Config Spec.

--- a/pkg/util/resize/configspec.go
+++ b/pkg/util/resize/configspec.go
@@ -12,7 +12,7 @@ import (
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/virtualmachine"
-	"github.com/vmware-tanzu/vm-operator/pkg/util"
+	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
 )
 
 // CreateResizeConfigSpec takes the current VM state in the ConfigInfo and compares it to the
@@ -90,7 +90,7 @@ func compareHardwareDevices(
 	// The VM's current virtual devices.
 	deviceList := object.VirtualDeviceList(ci.Hardware.Device)
 	// The VM's desired virtual devices.
-	csDeviceList := util.DevicesFromConfigSpec(&cs)
+	csDeviceList := pkgutil.DevicesFromConfigSpec(&cs)
 
 	var deviceChanges []vimtypes.BaseVirtualDeviceConfigSpec
 
@@ -103,9 +103,9 @@ func compareHardwareDevices(
 func comparePCIDevices(
 	currentPCIDevices, desiredPCIDevices []vimtypes.BaseVirtualDevice) []vimtypes.BaseVirtualDeviceConfigSpec {
 
-	currentPassthruPCIDevices := util.SelectVirtualPCIPassthrough(currentPCIDevices)
+	currentPassthruPCIDevices := pkgutil.SelectVirtualPCIPassthrough(currentPCIDevices)
 
-	pciPassthruFromConfigSpec := util.SelectVirtualPCIPassthrough(desiredPCIDevices)
+	pciPassthruFromConfigSpec := pkgutil.SelectVirtualPCIPassthrough(desiredPCIDevices)
 	expectedPCIDevices := virtualmachine.CreatePCIDevicesFromConfigSpec(pciPassthruFromConfigSpec)
 
 	var deviceChanges []vimtypes.BaseVirtualDeviceConfigSpec
@@ -291,7 +291,7 @@ func compareExtraConfig(
 	cs vimtypes.VirtualMachineConfigSpec,
 	outCS *vimtypes.VirtualMachineConfigSpec) {
 
-	outCS.ExtraConfig = util.OptionValues(ci.ExtraConfig).Diff(cs.ExtraConfig...)
+	outCS.ExtraConfig = pkgutil.OptionValues(ci.ExtraConfig).Diff(cs.ExtraConfig...)
 }
 
 // compareConsolePreferences compares the console preferences settings in the Config Spec.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch introduces the type OptionValues in "pkg/util". This new type simplifies working with []vimtypes.BaseOptionValue properties such as ExtraConfig.

@dougm , it occurs to me after writing this ... should this just be in GoVmomi?


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #570


**Are there any special notes for your reviewer**:

Please note there are _two_ commits for this PR:

1. The actual business logic.
2. A patch where the files affected from the previous patch have their `pkg/util` packages imported according to the correct rules as `pkgutil`. 

This enables reviewers to focus on the business logic patch separately, making it easier to see what actually changed.


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    4. If a release note is not required, please write "NONE".
-->

```release-note
Introduce pkg/util.OptionValues for working with properties like ExtraConfig
```