### PR TITLE
🌱 Increase coverage for web-console-validation server from 51-->100%

### DIFF
--- a/pkg/webconsolevalidation/server.go
+++ b/pkg/webconsolevalidation/server.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2022-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package webconsolevalidation
@@ -20,19 +20,28 @@ import (
 // K8sClient is used to get the webconsolerequest resource from UUID and namespace.
 var K8sClient ctrlclient.Client
 
+// Function variables to allow for mocking in tests.
+var (
+	InClusterConfig = rest.InClusterConfig
+	NewClient       = ctrlclient.New
+	AddToScheme     = vmopv1a1.AddToScheme
+)
+
 // InitServer initializes a K8sClient used by the web-console validation server.
 func InitServer() error {
-	restConfig, err := rest.InClusterConfig()
+	restConfig, err := InClusterConfig()
 	if err != nil {
 		return err
 	}
 
 	scheme := runtime.NewScheme()
-	if err = vmopv1a1.AddToScheme(scheme); err != nil {
+	if err := AddToScheme(scheme); err != nil {
 		return err
 	}
 
-	ctrlruntimeClient, err := ctrlclient.New(restConfig, ctrlclient.Options{Scheme: scheme})
+	ctrlruntimeClient, err := NewClient(restConfig, ctrlclient.Options{
+		Scheme: scheme,
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/webconsolevalidation/server_test.go
+++ b/pkg/webconsolevalidation/server_test.go
@@ -1,16 +1,21 @@
-// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2022-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package webconsolevalidation_test
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	vmopv1a1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachinewebconsolerequest/v1alpha1"
@@ -20,10 +25,119 @@ import (
 
 func serverUnitTests() {
 
-	Describe("web-console validation server unit tests", func() {
+	Context("InitServer", func() {
 
 		var (
-			initObjects []client.Object
+			originalInClusterConfig func() (*rest.Config, error)
+			originalNewClient       func(config *rest.Config, options ctrlclient.Options) (ctrlclient.Client, error)
+			originalAddToScheme     func(*runtime.Scheme) error
+		)
+
+		BeforeEach(func() {
+			originalInClusterConfig = webconsolevalidation.InClusterConfig
+			originalNewClient = webconsolevalidation.NewClient
+			originalAddToScheme = webconsolevalidation.AddToScheme
+
+			// Init all the function variables to return without any error.
+			webconsolevalidation.InClusterConfig = func() (*rest.Config, error) {
+				return &rest.Config{}, nil
+			}
+			webconsolevalidation.NewClient = func(*rest.Config, ctrlclient.Options) (ctrlclient.Client, error) {
+				return builder.NewFakeClient(), nil
+			}
+			webconsolevalidation.AddToScheme = func(*runtime.Scheme) error {
+				return nil
+			}
+		})
+
+		AfterEach(func() {
+			webconsolevalidation.InClusterConfig = originalInClusterConfig
+			webconsolevalidation.NewClient = originalNewClient
+			webconsolevalidation.AddToScheme = originalAddToScheme
+		})
+
+		When("InClusterConfig returns an error", func() {
+
+			It("should return the error", func() {
+				webconsolevalidation.InClusterConfig = func() (*rest.Config, error) {
+					return nil, errors.New("in-cluster config error")
+				}
+
+				err := webconsolevalidation.InitServer()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("in-cluster config error"))
+			})
+
+		})
+
+		When("AddToScheme returns an error", func() {
+
+			It("should return the error", func() {
+				webconsolevalidation.AddToScheme = func(*runtime.Scheme) error {
+					return errors.New("add to scheme error")
+				}
+
+				err := webconsolevalidation.InitServer()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("add to scheme error"))
+			})
+
+		})
+
+		When("NewClient returns an error", func() {
+
+			It("should return the error", func() {
+				webconsolevalidation.NewClient = func(config *rest.Config, options ctrlclient.Options) (ctrlclient.Client, error) {
+					return nil, errors.New("new client error")
+				}
+
+				err := webconsolevalidation.InitServer()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("new client error"))
+			})
+
+		})
+
+		When("Everything works as expected", func() {
+
+			It("should initialize a K8sClient successfully", func() {
+				Expect(webconsolevalidation.InitServer()).To(Succeed())
+				Expect(webconsolevalidation.K8sClient).NotTo(BeNil())
+			})
+
+		})
+	})
+
+	Context("RunServer", func() {
+
+		It("should start the server at the given address and path", func(done Done) {
+			addr := "localhost:8080"
+			path := "/validate"
+
+			go func() {
+				Expect(webconsolevalidation.RunServer(addr, path)).To(Succeed())
+			}()
+
+			// Wait for the server to start.
+			time.Sleep(100 * time.Millisecond)
+
+			resp, err := http.Get("http://" + addr + path)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp).NotTo(BeNil())
+			// Verify the server path is correct.
+			Expect(resp.StatusCode).NotTo(Equal(http.StatusNotFound))
+			Expect(resp.Body).NotTo(BeNil())
+			Expect(resp.Body.Close()).To(Succeed())
+
+			close(done)
+		}, 1.0) // Time out this after 1 second.
+
+	})
+
+	Context("HandleWebConsoleValidation", func() {
+
+		var (
+			initObjects []ctrlclient.Object
 		)
 
 		JustBeforeEach(func() {
@@ -52,21 +166,33 @@ func serverUnitTests() {
 
 		})
 
-		Context("requests with a uuid param set", func() {
+		Context("requests with all params set", func() {
 
 			BeforeEach(func() {
 				wcr := &vmopv1a1.WebConsoleRequest{}
-				wcr.Namespace = "dummy-namespace"
+				wcr.Namespace = "test-namespace"
 				wcr.Labels = map[string]string{
-					v1alpha1.UUIDLabelKey: "dummy-uuid-1234",
+					v1alpha1.UUIDLabelKey: "test-uuid-1234",
 				}
 				initObjects = append(initObjects, wcr)
+			})
+
+			When("an error occurs while getting the WebConsoleRequest resource", func() {
+
+				It("should return http.StatusInternalServerError (500)", func() {
+					// Use the default fake client to cause an error when getting the CR.
+					webconsolevalidation.K8sClient = fake.NewFakeClient()
+					url := "/?uuid=test-uuid-1234&namespace=test-namespace"
+					responseCode := fakeValidationRequest(url)
+					Expect(responseCode).To(Equal(http.StatusInternalServerError))
+				})
+
 			})
 
 			When("UUID matches an existing WebConsoleRequest resource", func() {
 
 				It("should return http.StatusOK (200)", func() {
-					url := "/?uuid=dummy-uuid-1234&namespace=dummy-namespace"
+					url := "/?uuid=test-uuid-1234&namespace=test-namespace"
 					responseCode := fakeValidationRequest(url)
 					Expect(responseCode).To(Equal(http.StatusOK))
 				})
@@ -76,7 +202,7 @@ func serverUnitTests() {
 			When("Namespace doesn't match any WebConsoleRequest resource", func() {
 
 				It("should return http.StatusForbidden (403)", func() {
-					url := "/?uuid=dummy-uuid-1234&namespace=non-existent-namespace"
+					url := "/?uuid=test-uuid-1234&namespace=non-existent-namespace"
 					responseCode := fakeValidationRequest(url)
 					Expect(responseCode).To(Equal(http.StatusForbidden))
 				})
@@ -86,7 +212,7 @@ func serverUnitTests() {
 			When("UUID doesn't match any WebConsoleRequest resource", func() {
 
 				It("should return http.StatusForbidden (403)", func() {
-					url := "/?uuid=non-existent-uuid&namespace=dummy-namespace"
+					url := "/?uuid=non-existent-uuid&namespace=test-namespace"
 					responseCode := fakeValidationRequest(url)
 					Expect(responseCode).To(Equal(http.StatusForbidden))
 				})
@@ -101,10 +227,13 @@ func serverUnitTests() {
 func fakeValidationRequest(url string) int {
 	responseRecorder := httptest.NewRecorder()
 	handler := http.HandlerFunc(webconsolevalidation.HandleWebConsoleValidation)
-	testRequest, _ := http.NewRequest("GET", url, nil)
+	testRequest, err := http.NewRequest("GET", url, nil)
+	Expect(err).NotTo(HaveOccurred())
 	handler.ServeHTTP(responseRecorder, testRequest)
 	response := responseRecorder.Result()
-	_ = response.Body.Close()
+	Expect(response).NotTo(BeNil())
+	Expect(response.Body).NotTo(BeNil())
+	Expect(response.Body.Close()).To(Succeed())
 
 	return response.StatusCode
 }


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This patch increases the code coverage for the `pkg/webconsolevalidation` package from 51 to 100%.

```console
$ ./hack/test.sh ./pkg/webconsolevalidation
...

PASS
coverage: 100.0% of statements
composite coverage: 100.0% of statements
```

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`

**Are there any special notes for your reviewer**:

**Please add a release note if necessary**:

```release-note
NONE
```