### PR TITLE
🌱 Resize Annotation and ManagedBy fields

### DIFF
--- a/pkg/util/resize/configspec.go
+++ b/pkg/util/resize/configspec.go
@@ -25,6 +25,8 @@ func CreateResizeConfigSpec(
 
 	outCS := vimtypes.VirtualMachineConfigSpec{}
 
+	compareAnnotation(ci, cs, &outCS)
+	compareManagedBy(ci, cs, &outCS)
 	compareHardware(ci, cs, &outCS)
 	compareCPUAllocation(ci, cs, &outCS)
 	compareCPUHotAddOrRemove(ci, cs, &outCS)
@@ -33,6 +35,30 @@ func CreateResizeConfigSpec(
 	compareLatencySensitivity(ci, cs, &outCS)
 
 	return outCS, nil
+}
+
+// compareAnnotation compares the ConfigInfo.Annotation.
+func compareAnnotation(
+	ci vimtypes.VirtualMachineConfigInfo,
+	cs vimtypes.VirtualMachineConfigSpec,
+	outCS *vimtypes.VirtualMachineConfigSpec) {
+
+	if ci.Annotation == "" {
+		// Only change the Annotation if it is currently unset.
+		outCS.Annotation = cs.Annotation
+	}
+}
+
+// compareManagedBy compares the ConfigInfo.ManagedBy.
+func compareManagedBy(
+	ci vimtypes.VirtualMachineConfigInfo,
+	cs vimtypes.VirtualMachineConfigSpec,
+	outCS *vimtypes.VirtualMachineConfigSpec) {
+
+	if ci.ManagedBy == nil {
+		// Only change the ManagedBy if it is currently unset.
+		outCS.ManagedBy = cs.ManagedBy
+	}
 }
 
 // compareHardware compares the ConfigInfo.Hardware.

--- a/pkg/util/resize/configspec_test.go
+++ b/pkg/util/resize/configspec_test.go
@@ -25,7 +25,7 @@ var _ = Describe("CreateResizeConfigSpec", func() {
 	ctx := context.Background()
 	truePtr, falsePtr := vimtypes.NewBool(true), vimtypes.NewBool(false)
 
-	DescribeTable("ConfigInfo.Hardware",
+	DescribeTable("ConfigInfo",
 		func(
 			ci vimtypes.VirtualMachineConfigInfo,
 			cs, expectedCS vimtypes.VirtualMachineConfigSpec) {
@@ -35,10 +35,28 @@ var _ = Describe("CreateResizeConfigSpec", func() {
 			Expect(reflect.DeepEqual(actualCS, expectedCS)).To(BeTrue(), cmp.Diff(actualCS, expectedCS))
 		},
 
-		Entry("Empty Hardware needs no updating",
-			ConfigInfo{Hardware: vimtypes.VirtualHardware{}},
+		Entry("Empty needs no updating",
+			ConfigInfo{},
 			ConfigSpec{},
 			ConfigSpec{}),
+
+		Entry("Annotation is currently set",
+			ConfigInfo{Annotation: "my-annotation"},
+			ConfigSpec{},
+			ConfigSpec{}),
+		Entry("Annotation is currently unset",
+			ConfigInfo{},
+			ConfigSpec{Annotation: "my-annotation"},
+			ConfigSpec{Annotation: "my-annotation"}),
+
+		Entry("ManagedBy is currently set",
+			ConfigInfo{ManagedBy: &vimtypes.ManagedByInfo{Type: "my-managed-by"}},
+			ConfigSpec{},
+			ConfigSpec{}),
+		Entry("ManagedBy is currently unset",
+			ConfigInfo{},
+			ConfigSpec{ManagedBy: &vimtypes.ManagedByInfo{Type: "my-managed-by"}},
+			ConfigSpec{ManagedBy: &vimtypes.ManagedByInfo{Type: "my-managed-by"}}),
 
 		Entry("NumCPUs needs updating",
 			ConfigInfo{Hardware: vimtypes.VirtualHardware{NumCPU: 2}},


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

This is some low hanging fruit needed to replace the pre-power on reconfigure with resize.

The behavior of these fields is a little different than others: only potentially update them if it is currently unset.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note
NONE
```