### PR TITLE
🌱 Skip syncing VMI content for non-OVF type content library items

### DIFF
--- a/pkg/providers/vsphere/vmprovider_test.go
+++ b/pkg/providers/vsphere/vmprovider_test.go
@@ -1,15 +1,22 @@
-// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2022-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package vsphere_test
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/vmware/govmomi/vapi/library"
+	"k8s.io/apimachinery/pkg/types"
+
+	imgregv1a1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha1"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
 	vsphere "github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
 	"github.com/vmware-tanzu/vm-operator/pkg/util"
@@ -83,6 +90,112 @@ func initOvfCacheAndLockPoolTests() {
 				// So the lock should be different when the item is expired and deleted from pool.
 				return ovfLockPool.Get(itemID) != curItemLock
 			}, 5*time.Second, 1*time.Second).Should(BeTrue())
+		})
+	})
+}
+
+func syncVirtualMachineImageTests() {
+	var (
+		ctx        *builder.TestContextForVCSim
+		testConfig builder.VCSimTestConfig
+		vmProvider providers.VirtualMachineProviderInterface
+	)
+
+	BeforeEach(func() {
+		testConfig.WithContentLibrary = true
+		ctx = suite.NewTestContextForVCSim(testConfig)
+		vmProvider = vsphere.NewVSphereVMProviderFromClient(ctx, ctx.Client, ctx.Recorder)
+	})
+
+	AfterEach(func() {
+		ctx.AfterEach()
+	})
+
+	When("content library item is an unexpected K8s object type", func() {
+		It("should return an error", func() {
+			err := vmProvider.SyncVirtualMachineImage(ctx, &imgregv1a1.ContentLibrary{}, &vmopv1.VirtualMachineImage{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("unexpected content library item K8s object type %T", &imgregv1a1.ContentLibrary{})))
+		})
+	})
+
+	When("content library item is not an OVF type", func() {
+		It("should exit early without updating VM Image status", func() {
+			isoItem := &imgregv1a1.ContentLibraryItem{
+				Status: imgregv1a1.ContentLibraryItemStatus{
+					Type: imgregv1a1.ContentLibraryItemTypeIso,
+				},
+			}
+			var vmi vmopv1.VirtualMachineImage
+			Expect(vmProvider.SyncVirtualMachineImage(ctx, isoItem, &vmi)).To(Succeed())
+			Expect(vmi.Status).To(Equal(vmopv1.VirtualMachineImageStatus{}))
+		})
+	})
+
+	When("content library item is an OVF type but it fails to get the OVF envelope", func() {
+		It("should return an error", func() {
+			ovfItem := &imgregv1a1.ContentLibraryItem{
+				Spec: imgregv1a1.ContentLibraryItemSpec{
+					// Use an invalid item ID to fail to get the OVF envelope.
+					UUID: "invalid-library-ID",
+				},
+				Status: imgregv1a1.ContentLibraryItemStatus{
+					Type: imgregv1a1.ContentLibraryItemTypeOvf,
+				},
+			}
+			err := vmProvider.SyncVirtualMachineImage(ctx, ovfItem, &vmopv1.VirtualMachineImage{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to get OVF envelope for library item \"invalid-library-ID\""))
+		})
+	})
+
+	When("content library item is an OVF type but the OVF envelope is nil", func() {
+		It("should return an error", func() {
+			libraryItem := library.Item{
+				Name: "test-image-ovf-empty",
+				// Use a non-OVF type here to cause the retrieved OVF envelope to be nil.
+				Type:      "empty",
+				LibraryID: ctx.ContentLibraryID,
+			}
+			itemID := builder.CreateContentLibraryItem(
+				ctx,
+				library.NewManager(ctx.RestClient),
+				libraryItem,
+				"",
+			)
+			Expect(itemID).NotTo(BeEmpty())
+
+			ovfItem := &imgregv1a1.ContentLibraryItem{
+				Spec: imgregv1a1.ContentLibraryItemSpec{
+					UUID: types.UID(itemID),
+				},
+				Status: imgregv1a1.ContentLibraryItemStatus{
+					Type: imgregv1a1.ContentLibraryItemTypeOvf,
+				},
+			}
+			err := vmProvider.SyncVirtualMachineImage(ctx, ovfItem, &vmopv1.VirtualMachineImage{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("OVF envelope is nil for library item %q", itemID)))
+		})
+	})
+
+	When("content library item is an OVF type with valid OVF envelope", func() {
+		It("should return success and update VM Image status accordingly", func() {
+			ovfItem := &imgregv1a1.ContentLibraryItem{
+				Spec: imgregv1a1.ContentLibraryItemSpec{
+					UUID: types.UID(ctx.ContentLibraryItemID),
+				},
+				Status: imgregv1a1.ContentLibraryItemStatus{
+					Type: imgregv1a1.ContentLibraryItemTypeOvf,
+				},
+			}
+			var vmi vmopv1.VirtualMachineImage
+			Expect(vmProvider.SyncVirtualMachineImage(ctx, ovfItem, &vmi)).To(Succeed())
+			Expect(vmi.Status.Firmware).To(Equal("efi"))
+			Expect(vmi.Status.HardwareVersion).NotTo(BeNil())
+			Expect(*vmi.Status.HardwareVersion).To(Equal(int32(9)))
+			Expect(vmi.Status.OSInfo.ID).To(Equal("36"))
+			Expect(vmi.Status.OSInfo.Type).To(Equal("otherLinuxGuest"))
 		})
 	})
 }

--- a/pkg/providers/vsphere/vsphere_suite_test.go
+++ b/pkg/providers/vsphere/vsphere_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2021-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package vsphere_test
@@ -16,6 +16,7 @@ var suite = builder.NewTestSuite()
 func vcSimTests() {
 	Describe("CPUFreq", cpuFreqTests)
 	Describe("InitOvfCacheAndLockPool", initOvfCacheAndLockPoolTests)
+	Describe("SyncVirtualMachineImage", syncVirtualMachineImageTests)
 	Describe("ResourcePolicyTests", resourcePolicyTests)
 	Describe("VirtualMachine", vmTests)
 	Describe("VirtualMachineE2E", vmE2ETests)

--- a/test/builder/vcsim_test_context.go
+++ b/test/builder/vcsim_test_context.go
@@ -121,6 +121,7 @@ type TestContextForVCSim struct {
 	// When WithContentLibrary is true:
 	ContentLibraryImageName string
 	ContentLibraryID        string
+	ContentLibraryItemID    string
 
 	// When WithoutStorageClass is false:
 	StorageClassName string
@@ -432,14 +433,16 @@ func (c *TestContextForVCSim) setupContentLibrary(config VCSimTestConfig) {
 	}
 	c.ContentLibraryImageName = libraryItem.Name
 
-	itemID := createContentLibraryItem(
+	itemID := CreateContentLibraryItem(
 		c,
 		libMgr,
 		libraryItem,
 		path.Join(
 			testutil.GetRootDirOrDie(),
 			"test", "builder", "testdata",
-			"images", "ttylinux-pc_i486-16.1.ovf"))
+			"images", "ttylinux-pc_i486-16.1.ovf"),
+	)
+	c.ContentLibraryItemID = itemID
 
 	// The image isn't quite as prod but sufficient for what we need here ATM.
 	clusterVMImage := DummyClusterVirtualMachineImage(c.ContentLibraryImageName)
@@ -487,7 +490,7 @@ func (c *TestContextForVCSim) ContentLibraryItemTemplate(srcVMName, templateName
 	Expect(c.Client.Status().Update(c, clusterVMImage)).To(Succeed())
 }
 
-func createContentLibraryItem(
+func CreateContentLibraryItem(
 	ctx context.Context,
 	libMgr *library.Manager,
 	libraryItem library.Item,
@@ -534,7 +537,9 @@ func createContentLibraryItem(
 
 		return libMgr.Client.Upload(ctx, f, u, &p)
 	}
-	Expect(uploadFunc(itemPath)).To(Succeed())
+	if itemPath != "" {
+		Expect(uploadFunc(itemPath)).To(Succeed())
+	}
 	Expect(libMgr.CompleteLibraryItemUpdateSession(ctx, sessionID)).To(Succeed())
 
 	return itemID


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This patch updates the vSphere VM provider to return early when syncing VM Image content for non-OVF type library items. This avoids unnecessary VC calls to fetch files when reconciling non-OVF type images (e.g. ISO).  
This patch also adds some tests to verify the existing `SyncVirtualMachineImage` function, aiming to increase the overall coverage for `pkg/providers/vsphere`.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes N/A

**Are there any special notes for your reviewer**:

N/A.

**Please add a release note if necessary**:

```release-note
Skip syncing VMI content for non-OVF type content library items.
```