### PR TITLE
🌱 Add the vCenter UUID annotation on the VM

### DIFF
--- a/api/v1alpha3/virtualmachine_types.go
+++ b/api/v1alpha3/virtualmachine_types.go
@@ -139,7 +139,7 @@ const (
 
 	// VirtualMachineSameVMClassResizeAnnotation is an annotation that indicates the VM
 	// should be resized as the class it points to changes.
-	VirtualMachineSameVMClassResizeAnnotation = GroupName + "/same-vm-class-resize "
+	VirtualMachineSameVMClassResizeAnnotation = GroupName + "/same-vm-class-resize"
 )
 
 const (
@@ -161,6 +161,12 @@ const (
 	// PVCDiskDataExtraConfigKey is the ExtraConfig key to persist the VM's
 	// PVC disk data in JSON, compressed using gzip and base64-encoded.
 	PVCDiskDataExtraConfigKey = "vmservice.virtualmachine.pvc.disk.data"
+)
+
+const (
+	// ManagerID on a VirtualMachine contains the UUID of the
+	// VMware vCenter (VC) that is managing this virtual machine.
+	ManagerID = GroupName + "/manager-id"
 )
 
 const (

--- a/pkg/providers/vsphere/vmprovider_vm.go
+++ b/pkg/providers/vsphere/vmprovider_vm.go
@@ -91,6 +91,14 @@ func (vs *vSphereVMProvider) CreateOrUpdateVirtualMachine(
 		return err
 	}
 
+	// Set the VC UUID annotation on the VM before attempting creation or
+	// update. Among other things, the annotation facilitates differential handling
+	// of restore and fail-over operations.
+	if vm.Annotations == nil {
+		vm.Annotations = make(map[string]string)
+	}
+	vm.Annotations[vmopv1.ManagerID] = client.VimClient().ServiceContent.About.InstanceUuid
+
 	vcVM, err := vs.getVM(vmCtx, client, false)
 	if err != nil {
 		return err

--- a/pkg/providers/vsphere/vmprovider_vm_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_test.go
@@ -1180,6 +1180,10 @@ func vmTests() {
 				var o mo.VirtualMachine
 				Expect(vcVM.Properties(ctx, vcVM.Reference(), nil, &o)).To(Succeed())
 
+				By("has VC UUID annotation set", func() {
+					Expect(vm.Annotations).Should(HaveKeyWithValue(vmopv1.ManagerID, ctx.VCClient.Client.ServiceContent.About.InstanceUuid))
+				})
+
 				By("has expected Status values", func() {
 					Expect(vm.Status.PowerState).To(Equal(vm.Spec.PowerState))
 					Expect(vm.Status.Host).ToNot(BeEmpty())


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This change adds the vCenter annotation on the VirtualMachine custom resource.  Among other things, this annotation can be used to determine whether a VM is being restored on the same vCenter where it was originally created.

**Please add a release note if necessary**:

```release-note
Add vCenter UUID annotation on the VM
```