### PR TITLE
:book: Sync VirtualMachineReplicaSet API docs generated from CRDs

### DIFF
--- a/docs/ref/api/v1alpha2.md
+++ b/docs/ref/api/v1alpha2.md
@@ -759,7 +759,6 @@ _Appears in:_
 - [VirtualMachineClass](#virtualmachineclass)
 
 
-
 ### VirtualMachineImageOSInfo
 
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

I missed running `generate-api-docs` when adding the VirtualMachineReplicaSet APIs.  As a result, the markdown docs haven't been updated.  This change fixes that.

**Please add a release note if necessary**:

```release-note
NONE
```

<!-- readthedocs-preview vm-operator start -->
----
📚 Documentation preview 📚: https://vm-operator--580.org.readthedocs.build/en/580/

<!-- readthedocs-preview vm-operator end -->