### PR TITLE
✨Resize Flags: CBRC Cache Enabled

### DIFF
--- a/pkg/util/resize/configspec.go
+++ b/pkg/util/resize/configspec.go
@@ -35,6 +35,7 @@ func CreateResizeConfigSpec(
 	compareLatencySensitivity(ci, cs, &outCS)
 	compareExtraConfig(ci, cs, &outCS)
 	compareConsolePreferences(ci, cs, &outCS)
+	compareFlags(ci, cs, &outCS)
 
 	return outCS, nil
 }
@@ -332,6 +333,24 @@ func compareConsolePreferences(
 	// if desired preferences has all nil (ie) there was no change, nil out the console preferences to prevent unwanted reconfigures.
 	if reflect.DeepEqual(outCS.ConsolePreferences, &vimtypes.VirtualMachineConsolePreferences{}) {
 		outCS.ConsolePreferences = nil
+	}
+}
+
+// compareFlags compares the flag info settings in the Config Spec.
+func compareFlags(
+	ci vimtypes.VirtualMachineConfigInfo,
+	cs vimtypes.VirtualMachineConfigSpec,
+	outCS *vimtypes.VirtualMachineConfigSpec) {
+	if cs.Flags == nil {
+		return
+	}
+
+	outCS.Flags = &vimtypes.VirtualMachineFlagInfo{}
+	cmpPtr(ci.Flags.CbrcCacheEnabled, cs.Flags.CbrcCacheEnabled, &outCS.Flags.CbrcCacheEnabled)
+	// look at each flag from flagInfo and add based on requirements
+
+	if reflect.DeepEqual(outCS.Flags, &vimtypes.VirtualMachineFlagInfo{}) {
+		outCS.Flags = nil
 	}
 }
 

--- a/pkg/util/resize/configspec_test.go
+++ b/pkg/util/resize/configspec_test.go
@@ -274,6 +274,33 @@ var _ = Describe("CreateResizeConfigSpec", func() {
 					PowerOnWhenOpened:        falsePtr,
 				}},
 			ConfigSpec{}),
+
+		Entry("CbrcCacheEnabled flag does not need updating",
+			ConfigInfo{Flags: vimtypes.VirtualMachineFlagInfo{
+				CbrcCacheEnabled: truePtr,
+			}},
+			ConfigSpec{Flags: &vimtypes.VirtualMachineFlagInfo{
+				CbrcCacheEnabled: truePtr,
+			}},
+			ConfigSpec{}),
+		Entry("CbrcCacheEnabled flag needs updating -- configInfo has no flags",
+			ConfigInfo{},
+			ConfigSpec{Flags: &vimtypes.VirtualMachineFlagInfo{
+				CbrcCacheEnabled: truePtr,
+			}},
+			ConfigSpec{Flags: &vimtypes.VirtualMachineFlagInfo{
+				CbrcCacheEnabled: truePtr,
+			}}),
+		Entry("CbrcCacheEnabled flag needs updating",
+			ConfigInfo{Flags: vimtypes.VirtualMachineFlagInfo{
+				CbrcCacheEnabled: falsePtr,
+			}},
+			ConfigSpec{Flags: &vimtypes.VirtualMachineFlagInfo{
+				CbrcCacheEnabled: truePtr,
+			}},
+			ConfigSpec{Flags: &vimtypes.VirtualMachineFlagInfo{
+				CbrcCacheEnabled: truePtr,
+			}}),
 	)
 
 	type giveMeDeviceFn = func() vimtypes.BaseVirtualDevice


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

If the flag is set, Common CBRC (Content Based Read Cache) digest cache is enabled for the virtual machine.
Common CBRC cache is shared between the hot added disks in the VM


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # N/A


**Are there any special notes for your reviewer**:

N/A


**Please add a release note if necessary**:

```
Resize CBRC Cache Enabled
```