### PR TITLE
🌱 Resize Brownfield VMs

### DIFF
--- a/pkg/util/resize/configspec.go
+++ b/pkg/util/resize/configspec.go
@@ -103,6 +103,8 @@ func compareHardwareDevices(
 func comparePCIDevices(
 	currentPCIDevices, desiredPCIDevices []vimtypes.BaseVirtualDevice) []vimtypes.BaseVirtualDeviceConfigSpec {
 
+	currentPassthruPCIDevices := util.SelectVirtualPCIPassthrough(currentPCIDevices)
+
 	pciPassthruFromConfigSpec := util.SelectVirtualPCIPassthrough(desiredPCIDevices)
 	expectedPCIDevices := virtualmachine.CreatePCIDevicesFromConfigSpec(pciPassthruFromConfigSpec)
 
@@ -113,7 +115,7 @@ func comparePCIDevices(
 		expectedBackingType := reflect.TypeOf(expectedBacking)
 
 		var matchingIdx = -1
-		for idx, curDev := range currentPCIDevices {
+		for idx, curDev := range currentPassthruPCIDevices {
 			curBacking := curDev.GetVirtualDevice().Backing
 			if curBacking == nil || reflect.TypeOf(curBacking) != expectedBackingType {
 				continue
@@ -152,12 +154,12 @@ func comparePCIDevices(
 			})
 		} else {
 			// There could be multiple vGPUs with same BackingInfo. Remove current device if matching found.
-			currentPCIDevices = append(currentPCIDevices[:matchingIdx], currentPCIDevices[matchingIdx+1:]...)
+			currentPassthruPCIDevices = append(currentPassthruPCIDevices[:matchingIdx], currentPassthruPCIDevices[matchingIdx+1:]...)
 		}
 	}
 	// Remove any unmatched existing devices.
-	removeDeviceChanges := make([]vimtypes.BaseVirtualDeviceConfigSpec, 0, len(currentPCIDevices))
-	for _, dev := range currentPCIDevices {
+	removeDeviceChanges := make([]vimtypes.BaseVirtualDeviceConfigSpec, 0, len(currentPassthruPCIDevices))
+	for _, dev := range currentPassthruPCIDevices {
 		removeDeviceChanges = append(removeDeviceChanges, &vimtypes.VirtualDeviceConfigSpec{
 			Operation: vimtypes.VirtualDeviceConfigSpecOperationRemove,
 			Device:    dev,

--- a/pkg/util/resize/configspec_test.go
+++ b/pkg/util/resize/configspec_test.go
@@ -305,6 +305,13 @@ var _ = Describe("CreateResizeConfigSpec", func() {
 
 	type giveMeDeviceFn = func() vimtypes.BaseVirtualDevice
 
+	vmxnet3Device := func() giveMeDeviceFn {
+		return func() vimtypes.BaseVirtualDevice {
+			// Just a dummy device w/o backing until we need that.
+			return &vimtypes.VirtualVmxnet3{}
+		}
+	}
+
 	vGPUDevice := func(profileName string) giveMeDeviceFn {
 		return func() vimtypes.BaseVirtualDevice {
 			return &vimtypes.VirtualPCIPassthrough{
@@ -354,6 +361,10 @@ var _ = Describe("CreateResizeConfigSpec", func() {
 			})
 
 			JustBeforeEach(func() {
+				// Add another device so we can assert that it doesn't get removed.
+				d := vmxnet3Device()()
+				ci.Hardware.Device = append(ci.Hardware.Device, d)
+
 				actualCS, err := resize.CreateResizeConfigSpec(ctx, ci, cs)
 				Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

VMs prior to the resize feature will not have the last-resize annotation that we will set on new VMs at create time. When the ClassName changes set the last-resized annotation so we'll evaluate a resize when the VM powerstate allows.

Add a quick for a braino and last second refactor that caused us to match all devices instead of just PCI passthru devices. I need to do some more clean up and refactoring of the tests to make this more natural to test.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note
NONE
```