### PR TITLE
🌱 Add NCP protocol annotation if NCP port health check

### DIFF
--- a/controllers/virtualmachineservice/providers/loadbalancer_provider_test.go
+++ b/controllers/virtualmachineservice/providers/loadbalancer_provider_test.go
@@ -100,8 +100,8 @@ var _ = Describe(
 				vmServiceAnnotations, err := lbProvider.GetServiceAnnotations(ctx, vmService)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(vmServiceAnnotations).ToNot(BeNil())
-				port := vmServiceAnnotations[ServiceLoadBalancerHealthCheckNodePortTagKey]
-				Expect(port).To(Equal("30012"))
+				Expect(vmServiceAnnotations).To(HaveKeyWithValue(NCPHealthCheckNodePortKey, "30012"))
+				Expect(vmServiceAnnotations).To(HaveKeyWithValue(NCPHealthCheckProtocolKey, NCPHealthCheckProtocolValueTCP))
 			})
 		})
 
@@ -126,7 +126,8 @@ var _ = Describe(
 				vmServiceAnnotations, err := lbProvider.GetToBeRemovedServiceAnnotations(ctx, vmService)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(vmServiceAnnotations).ToNot(BeNil())
-				Expect(vmServiceAnnotations).To(HaveKey(ServiceLoadBalancerHealthCheckNodePortTagKey))
+				Expect(vmServiceAnnotations).To(HaveKeyWithValue(NCPHealthCheckNodePortKey, ""))
+				Expect(vmServiceAnnotations).To(HaveKeyWithValue(NCPHealthCheckProtocolKey, ""))
 			})
 		})
 

--- a/controllers/virtualmachineservice/virtualmachineservice_controller.go
+++ b/controllers/virtualmachineservice/virtualmachineservice_controller.go
@@ -305,8 +305,9 @@ func (r *ReconcileVirtualMachineService) virtualMachineToVirtualMachineServiceMa
 	}
 }
 
-// Set labels and annotations on the Service from the VirtualMachineService. Some loadbalancer providers (currently
-// only NCP) need to filter or translate labels and annotations too.
+// Set labels and annotations on the Service from the VirtualMachineService.
+// Some loadbalancer providers (currently only NCP) need to filter or translate
+// labels and annotations too.
 func (r *ReconcileVirtualMachineService) setServiceAnnotationsAndLabels(
 	ctx *pkgctx.VirtualMachineServiceContext,
 	service *corev1.Service) error {


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch adds the NCP TCP protocol annotation to Services.Type=LB if the health check port is specified.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Add "ncp/healthCheckProtocol": tcp to Services.Type=LB annotations if a health check port is specified for VirtualMachineServices when the network topology is NCP.
```