### PR TITLE
🐛 Fix v1a1 CloudInit with no user-data only ssh public keys

### DIFF
--- a/pkg/providers/vsphere/vmprovider_vm_utils.go
+++ b/pkg/providers/vsphere/vmprovider_vm_utils.go
@@ -318,6 +318,15 @@ func getSecretData(
 			}
 		}
 
+		if !found && isCloudInitSecret && resKey == "user-data" {
+			// Hack: If we didn't find the CloudInit userdata in any of secretKeys, look for
+			// ssh-public-keys. This is to allow v1a1 users that did not provide any userdata
+			// to continue to work. Note that in v1a2+, we use "user-data" as the key when
+			// converting from v1a1. In v1a2+ we have Bootstrap.CloudInit.SSHAuthorizedKeys as
+			// the formal way to specify this.
+			_, found = data["ssh-public-keys"]
+		}
+
 		if !found {
 			err := fmt.Errorf("required key %q not found in Secret %s", resKey, resName)
 			conditions.MarkFalse(vmCtx.VM, vmopv1.VirtualMachineConditionBootstrapReady, "RequiredKeyNotFound", err.Error())


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

The v1a1 VM Metadata (Bootstrap) didn't have a field to specify the CM or Secret key for the CloudInit userdata. In v1a2, we added a Key field, and that field is required so on version convert we use "user-data". However, that key - or any user data - may not exist in the CM or Secret and the user may only want to provide the default user SSH public keys, allow that to succeed.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #585 

**Are there any special notes for your reviewer**:

Workaround is to just add "user-data" to the CM or Secret Data

**Please add a release note if necessary**:

```release-note
A VM created at v1alpha1 using CloudInit with the CM/Secret containing only "ssh-public-keys" and no user-data will not error due to a missing key.
```