### PR TITLE
🌱 Support MMIO ExtraConfig during resize

### DIFF
--- a/pkg/util/option_values.go
+++ b/pkg/util/option_values.go
@@ -6,6 +6,7 @@ package util
 import (
 	"fmt"
 	"reflect"
+	"slices"
 
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 )
@@ -28,6 +29,13 @@ func OptionValuesFromMap[T any](in map[string]T) OptionValues {
 		i++
 	}
 	return out
+}
+
+// Delete removes elements with the given key, returning the new list.
+func (ov OptionValues) Delete(key string) OptionValues {
+	return slices.DeleteFunc(ov, func(optVal vimtypes.BaseOptionValue) bool {
+		return optVal.GetOptionValue() != nil && optVal.GetOptionValue().Key == key
+	})
 }
 
 // Get returns the value if exists, otherwise nil is returned. The second return
@@ -117,6 +125,10 @@ func (ov OptionValues) merge(in OptionValues, overwrite bool) OptionValues {
 		out        OptionValues
 		outOptVals = map[string]*vimtypes.OptionValue{}
 	)
+
+	if len(in) == 0 {
+		return ov
+	}
 
 	// Init the out slice from the left side.
 	if len(ov) > 0 {

--- a/pkg/util/option_values_test.go
+++ b/pkg/util/option_values_test.go
@@ -23,8 +23,6 @@ var _ = Describe("OptionValues", func() {
 		sz1   = "1"
 		sz2   = "2"
 		sz3   = "3"
-		sz4   = "4"
-		sz5   = "5"
 		i32_1 = int32(1)
 		u64_2 = uint64(2)
 		f32_3 = float32(3)
@@ -89,6 +87,63 @@ var _ = Describe("OptionValues", func() {
 					&vimtypes.OptionValue{Key: szb, Value: pu64_2},
 					&vimtypes.OptionValue{Key: szc, Value: pf32_3},
 				))
+			})
+		})
+	})
+
+	Context("Delete", func() {
+		When("receiver is nil", func() {
+			It("should return nil", func() {
+				var (
+					left, out pkgutil.OptionValues
+				)
+
+				left = nil
+
+				Expect(func() { out = left.Delete("") }).ToNot(Panic())
+				Expect(out).To(BeNil())
+			})
+		})
+
+		When("receiver is not nil", func() {
+			When("key does not exist", func() {
+				It("should return same list", func() {
+					var (
+						left, out pkgutil.OptionValues
+					)
+
+					left = pkgutil.OptionValues{
+						&vimtypes.OptionValue{Key: sza, Value: sz1},
+						&vimtypes.OptionValue{Key: szb, Value: sz2},
+						&vimtypes.OptionValue{Key: szc, Value: sz3},
+					}
+
+					out = left.Delete(szd)
+					Expect(out).To(ConsistOf(
+						&vimtypes.OptionValue{Key: sza, Value: sz1},
+						&vimtypes.OptionValue{Key: szb, Value: sz2},
+						&vimtypes.OptionValue{Key: szc, Value: sz3},
+					))
+				})
+			})
+			When("key does exist", func() {
+				It("should return list with key removed", func() {
+					var (
+						left, out pkgutil.OptionValues
+					)
+
+					left = pkgutil.OptionValues{
+						&vimtypes.OptionValue{Key: sza, Value: sz1},
+						&vimtypes.OptionValue{Key: szb, Value: sz2},
+						&vimtypes.OptionValue{Key: szc, Value: sz3},
+					}
+
+					out = left.Delete(sza)
+					Expect(out).To(ConsistOf(
+						&vimtypes.OptionValue{Key: szb, Value: sz2},
+						&vimtypes.OptionValue{Key: szc, Value: sz3},
+					))
+				})
 			})
 		})
 	})

--- a/pkg/util/vmopv1/resize_devops.go
+++ b/pkg/util/vmopv1/resize_devops.go
@@ -9,6 +9,8 @@ import (
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/constants"
+	"github.com/vmware-tanzu/vm-operator/pkg/util"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 )
 
@@ -23,5 +25,74 @@ func OverwriteResizeConfigSpec(
 		ptr.OverwriteWithUser(&cs.ChangeTrackingEnabled, adv.ChangeBlockTracking, ci.ChangeTrackingEnabled)
 	}
 
+	overrideExtraConfig(vm, ci, cs)
+
 	return nil
+}
+
+func overrideExtraConfig(
+	vm vmopv1.VirtualMachine,
+	ci vimtypes.VirtualMachineConfigInfo,
+	cs *vimtypes.VirtualMachineConfigSpec) {
+
+	var toMerge []vimtypes.BaseOptionValue
+
+	toMerge = append(toMerge, overrideMMIOSize(vm, ci, cs)...)
+
+	cs.ExtraConfig = util.OptionValues(cs.ExtraConfig).Merge(toMerge...)
+}
+
+func overrideMMIOSize(
+	vm vmopv1.VirtualMachine,
+	ci vimtypes.VirtualMachineConfigInfo,
+	cs *vimtypes.VirtualMachineConfigSpec) []vimtypes.BaseOptionValue {
+
+	// TODO: This is essentially what the old code checked and should be OK for most situations but
+	//  can be improved: we might be removing the existing passthru devices so we wouldn't really
+	//  need to set this (and maybe remove the EC fields instead).
+	if !hasvGPUOrDDPIODevicesInVM(ci) && !util.HasVirtualPCIPassthroughDeviceChange(cs.DeviceChange) {
+		return nil
+	}
+
+	mmIOSize := vm.Annotations[constants.PCIPassthruMMIOOverrideAnnotation]
+	if mmIOSize == "" {
+		mmIOSize = constants.PCIPassthruMMIOSizeDefault
+	}
+	if mmIOSize == "0" {
+		return nil
+	}
+
+	mmioEC := []vimtypes.BaseOptionValue{
+		&vimtypes.OptionValue{Key: constants.PCIPassthruMMIOSizeExtraConfigKey, Value: mmIOSize},
+		&vimtypes.OptionValue{Key: constants.PCIPassthruMMIOExtraConfigKey, Value: constants.ExtraConfigTrue},
+	}
+
+	var out []vimtypes.BaseOptionValue //nolint:prealloc
+	curEC := util.OptionValues(ci.ExtraConfig)
+
+	for _, ov := range mmioEC {
+		k, v := ov.GetOptionValue().Key, ov.GetOptionValue().Value
+
+		if vv, ok := curEC.GetString(k); ok && v == vv {
+			// Current value is already the desired value. Remove any update.
+			cs.ExtraConfig = util.OptionValues(cs.ExtraConfig).Delete(k)
+			continue
+		}
+
+		out = append(out, ov)
+	}
+
+	return out
+}
+
+func hasvGPUOrDDPIODevicesInVM(
+	config vimtypes.VirtualMachineConfigInfo) bool {
+
+	if len(util.SelectNvidiaVgpu(config.Hardware.Device)) > 0 {
+		return true
+	}
+	if len(util.SelectDynamicDirectPathIO(config.Hardware.Device)) > 0 {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

The MMIO memory size can be set via an annotation on the VM, that then results in two entries being added to the VM's ExtraConfig.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #

**Are there any special notes for your reviewer**:

Another small step to replacing the pre power on reconfigure with resize.

**Please add a release note if necessary**:

```release-note
NONE
```