### PR TITLE
✨Resize: Memory Reservation Locked to Max

### DIFF
--- a/pkg/util/resize/configspec_test.go
+++ b/pkg/util/resize/configspec_test.go
@@ -462,6 +462,85 @@ var _ = Describe("CreateResizeConfigSpec", func() {
 			ConfigInfo{VmxStatsCollectionEnabled: falsePtr},
 			ConfigSpec{VmxStatsCollectionEnabled: truePtr},
 			ConfigSpec{VmxStatsCollectionEnabled: truePtr}),
+
+		Entry("Memory Reservation Locked to Max needs updating",
+			ConfigInfo{MemoryReservationLockedToMax: falsePtr},
+			ConfigSpec{MemoryReservationLockedToMax: truePtr},
+			ConfigSpec{MemoryReservationLockedToMax: truePtr}),
+		Entry("Memory Reservation Locked to Max needs updating -- not set in config info",
+			ConfigInfo{},
+			ConfigSpec{MemoryReservationLockedToMax: truePtr},
+			ConfigSpec{MemoryReservationLockedToMax: truePtr}),
+		Entry("Memory Reservation Locked to Max does not need updating",
+			ConfigInfo{MemoryReservationLockedToMax: falsePtr},
+			ConfigSpec{MemoryReservationLockedToMax: falsePtr},
+			ConfigSpec{}),
+		Entry("Memory Reservation Locked to Max cannot be false with PCI pass-through devices in spec",
+			ConfigInfo{},
+			ConfigSpec{
+				MemoryReservationLockedToMax: falsePtr,
+				DeviceChange: []vimtypes.BaseVirtualDeviceConfigSpec{
+					&vimtypes.VirtualDeviceConfigSpec{
+						Operation: vimtypes.VirtualDeviceConfigSpecOperationAdd,
+						Device: &vimtypes.VirtualPCIPassthrough{
+							VirtualDevice: vimtypes.VirtualDevice{
+								Key: -200,
+								Backing: &vimtypes.VirtualPCIPassthroughVmiopBackingInfo{
+									Vgpu: "profile-from-configspec",
+								},
+							},
+						},
+					},
+				},
+			},
+			ConfigSpec{
+				MemoryReservationLockedToMax: truePtr,
+				DeviceChange: []vimtypes.BaseVirtualDeviceConfigSpec{
+					&vimtypes.VirtualDeviceConfigSpec{
+						Operation: vimtypes.VirtualDeviceConfigSpecOperationAdd,
+						Device: &vimtypes.VirtualPCIPassthrough{
+							VirtualDevice: vimtypes.VirtualDevice{
+								Key: -200,
+								Backing: &vimtypes.VirtualPCIPassthroughVmiopBackingInfo{
+									Vgpu: "profile-from-configspec",
+								},
+							},
+						},
+					},
+				},
+			}),
+		Entry("Memory Reservation Locked to Max can be unset with PCI pass-through devices in spec",
+			ConfigInfo{MemoryReservationLockedToMax: truePtr},
+			ConfigSpec{
+				DeviceChange: []vimtypes.BaseVirtualDeviceConfigSpec{
+					&vimtypes.VirtualDeviceConfigSpec{
+						Operation: vimtypes.VirtualDeviceConfigSpecOperationAdd,
+						Device: &vimtypes.VirtualPCIPassthrough{
+							VirtualDevice: vimtypes.VirtualDevice{
+								Key: -200,
+								Backing: &vimtypes.VirtualPCIPassthroughVmiopBackingInfo{
+									Vgpu: "profile-from-configspec",
+								},
+							},
+						},
+					},
+				},
+			},
+			ConfigSpec{
+				DeviceChange: []vimtypes.BaseVirtualDeviceConfigSpec{
+					&vimtypes.VirtualDeviceConfigSpec{
+						Operation: vimtypes.VirtualDeviceConfigSpecOperationAdd,
+						Device: &vimtypes.VirtualPCIPassthrough{
+							VirtualDevice: vimtypes.VirtualDevice{
+								Key: -200,
+								Backing: &vimtypes.VirtualPCIPassthroughVmiopBackingInfo{
+									Vgpu: "profile-from-configspec",
+								},
+							},
+						},
+					},
+				},
+			}),
 	)
 
 	type giveMeDeviceFn = func() vimtypes.BaseVirtualDevice


### PR DESCRIPTION


**What does this PR do, and why is it needed?**

Support reconfiguring VMs with the Memory Reservation Locked to Max. Additionally, this change makes sure that the setting cannot be accidentally set to false when the desired config spec has PCI passthrough devices


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # N/A


**Are there any special notes for your reviewer**:

N/A


**Please add a release note if necessary**:

```
Support resize of Memory Reservation Locked to Max
```