### PR TITLE
✨ Resize Miscellaneous bool configSpec fields

### DIFF
--- a/pkg/util/resize/configspec.go
+++ b/pkg/util/resize/configspec.go
@@ -38,6 +38,10 @@ func CreateResizeConfigSpec(
 	compareFlags(ci, cs, &outCS)
 	compareMemoryAllocation(ci, cs, &outCS)
 	compareMemoryHotAdd(ci, cs, &outCS)
+	compareFixedPassthruHotPlug(ci, cs, &outCS)
+	compareNestedHVEnabled(ci, cs, &outCS)
+	compareSevEnabled(ci, cs, &outCS)
+	compareVmxStatsCollectionEnabled(ci, cs, &outCS)
 
 	return outCS, nil
 }
@@ -425,6 +429,38 @@ func compareMemoryHotAdd(
 	cs vimtypes.VirtualMachineConfigSpec,
 	outCS *vimtypes.VirtualMachineConfigSpec) {
 	cmpPtr(ci.MemoryHotAddEnabled, cs.MemoryHotAddEnabled, &outCS.MemoryHotAddEnabled)
+}
+
+// compareFixedPassthruHotPlug compares the fixed pass-through hot plug enabled setting in the config spec.
+func compareFixedPassthruHotPlug(
+	ci vimtypes.VirtualMachineConfigInfo,
+	cs vimtypes.VirtualMachineConfigSpec,
+	outCS *vimtypes.VirtualMachineConfigSpec) {
+	cmpPtr(ci.FixedPassthruHotPlugEnabled, cs.FixedPassthruHotPlugEnabled, &outCS.FixedPassthruHotPlugEnabled)
+}
+
+// compareNestedHVEnabled compares the nested hardware-assisted virtualization setting in the config spec.
+func compareNestedHVEnabled(
+	ci vimtypes.VirtualMachineConfigInfo,
+	cs vimtypes.VirtualMachineConfigSpec,
+	outCS *vimtypes.VirtualMachineConfigSpec) {
+	cmpPtr(ci.NestedHVEnabled, cs.NestedHVEnabled, &outCS.NestedHVEnabled)
+}
+
+// compareSevEnabled compare the SEV (Secure Encryption Virtualization) setting in the config spec.
+func compareSevEnabled(
+	ci vimtypes.VirtualMachineConfigInfo,
+	cs vimtypes.VirtualMachineConfigSpec,
+	outCS *vimtypes.VirtualMachineConfigSpec) {
+	cmpPtr(ci.SevEnabled, cs.SevEnabled, &outCS.SevEnabled)
+}
+
+// compareVmxStatsCollectionEnabled compares the VMX stats collection setting in the config spec.
+func compareVmxStatsCollectionEnabled(
+	ci vimtypes.VirtualMachineConfigInfo,
+	cs vimtypes.VirtualMachineConfigSpec,
+	outCS *vimtypes.VirtualMachineConfigSpec) {
+	cmpPtr(ci.VmxStatsCollectionEnabled, cs.VmxStatsCollectionEnabled, &outCS.VmxStatsCollectionEnabled)
 }
 
 func cmp[T comparable](a, b T, c *T) {

--- a/pkg/util/resize/configspec_test.go
+++ b/pkg/util/resize/configspec_test.go
@@ -426,6 +426,42 @@ var _ = Describe("CreateResizeConfigSpec", func() {
 			ConfigInfo{MemoryHotAddEnabled: falsePtr},
 			ConfigSpec{MemoryHotAddEnabled: falsePtr},
 			ConfigSpec{}),
+
+		Entry("Fixed pass-through hot plug enabled setting does not need updating",
+			ConfigInfo{FixedPassthruHotPlugEnabled: falsePtr},
+			ConfigSpec{FixedPassthruHotPlugEnabled: falsePtr},
+			ConfigSpec{}),
+		Entry("Fixed pass-through hot plug enabled setting needs updating",
+			ConfigInfo{FixedPassthruHotPlugEnabled: falsePtr},
+			ConfigSpec{FixedPassthruHotPlugEnabled: truePtr},
+			ConfigSpec{FixedPassthruHotPlugEnabled: truePtr}),
+
+		Entry("Nested hardware-assisted virtualization setting does not need updating",
+			ConfigInfo{NestedHVEnabled: falsePtr},
+			ConfigSpec{NestedHVEnabled: falsePtr},
+			ConfigSpec{}),
+		Entry("Nested hardware-assisted virtualization setting needs updating",
+			ConfigInfo{NestedHVEnabled: falsePtr},
+			ConfigSpec{NestedHVEnabled: truePtr},
+			ConfigSpec{NestedHVEnabled: truePtr}),
+
+		Entry("SEV (Secure Encryption Virtualization) setting does not need updating",
+			ConfigInfo{SevEnabled: falsePtr},
+			ConfigSpec{SevEnabled: falsePtr},
+			ConfigSpec{}),
+		Entry("SEV (Secure Encryption Virtualization) setting needs updating",
+			ConfigInfo{SevEnabled: falsePtr},
+			ConfigSpec{SevEnabled: truePtr},
+			ConfigSpec{SevEnabled: truePtr}),
+
+		Entry("VMX stats collection setting does not need updating",
+			ConfigInfo{VmxStatsCollectionEnabled: falsePtr},
+			ConfigSpec{VmxStatsCollectionEnabled: falsePtr},
+			ConfigSpec{}),
+		Entry("VMX stats collection setting needs updating",
+			ConfigInfo{VmxStatsCollectionEnabled: falsePtr},
+			ConfigSpec{VmxStatsCollectionEnabled: truePtr},
+			ConfigSpec{VmxStatsCollectionEnabled: truePtr}),
 	)
 
 	type giveMeDeviceFn = func() vimtypes.BaseVirtualDevice


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This change supports the resize of some boolean configSpec fields namely
-FixedPassthruHotPlugEnabled
-NestedHVEnabled
-SevEnabled
-VmxStatsCollectionEnabled


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # N/A


**Are there any special notes for your reviewer**:

N/A


**Please add a release note if necessary**:


```
Support resize of FixedPassthruHotPlugEnabled, NestedHVEnabled, SevEnabled, VmxStatsCollectionEnabled
```