### PR TITLE
🐛 Revert "Merge pull request #584 from akutz/feature/vmsvc-ncp-health-check"

### DIFF
--- a/controllers/virtualmachineservice/providers/loadbalancer_provider.go
+++ b/controllers/virtualmachineservice/providers/loadbalancer_provider.go
@@ -16,12 +16,9 @@ import (
 
 const (
 	NSXTLoadBalancer = "nsx-t-lb"
-	NSXTServiceProxy = "nsx-t"
 
-	NCPHealthCheckNodePortKey      = "ncp/healthCheckNodePort"
-	NCPHealthCheckProtocolKey      = "ncp/healthCheckProtocol"
-	NCPHealthCheckProtocolValueTCP = "tcp"
-
+	ServiceLoadBalancerHealthCheckNodePortTagKey = "ncp/healthCheckNodePort"
+	NSXTServiceProxy                             = "nsx-t"
 	// LabelServiceProxyName indicates that an alternative service proxy will implement
 	// this Service. Copied from kubernetes pkg/proxy/apis/well_known_labels.go to avoid
 	// k8s dependency.
@@ -142,11 +139,7 @@ func (nl *NsxtLoadbalancerProvider) GetServiceAnnotations(ctx context.Context, v
 	res := make(map[string]string)
 
 	if healthCheckNodePortString, ok := vmService.Annotations[utils.AnnotationServiceHealthCheckNodePortKey]; ok {
-		res[NCPHealthCheckNodePortKey] = healthCheckNodePortString
-
-		// If a health check port is specified then also specify the protocol as
-		// TCP.
-		res[NCPHealthCheckProtocolKey] = NCPHealthCheckProtocolValueTCP
+		res[ServiceLoadBalancerHealthCheckNodePortTagKey] = healthCheckNodePortString
 	}
 
 	return res, nil
@@ -160,8 +153,7 @@ func (nl *NsxtLoadbalancerProvider) GetToBeRemovedServiceAnnotations(ctx context
 	// When healthCheckNodePort is NOT present, the corresponding NSX-T
 	// annotation should be cleared as well
 	if _, ok := vmService.Annotations[utils.AnnotationServiceHealthCheckNodePortKey]; !ok {
-		res[NCPHealthCheckNodePortKey] = ""
-		res[NCPHealthCheckProtocolKey] = ""
+		res[ServiceLoadBalancerHealthCheckNodePortTagKey] = ""
 	}
 
 	return res, nil

--- a/controllers/virtualmachineservice/providers/loadbalancer_provider_test.go
+++ b/controllers/virtualmachineservice/providers/loadbalancer_provider_test.go
@@ -100,8 +100,8 @@ var _ = Describe(
 				vmServiceAnnotations, err := lbProvider.GetServiceAnnotations(ctx, vmService)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(vmServiceAnnotations).ToNot(BeNil())
-				Expect(vmServiceAnnotations).To(HaveKeyWithValue(NCPHealthCheckNodePortKey, "30012"))
-				Expect(vmServiceAnnotations).To(HaveKeyWithValue(NCPHealthCheckProtocolKey, NCPHealthCheckProtocolValueTCP))
+				port := vmServiceAnnotations[ServiceLoadBalancerHealthCheckNodePortTagKey]
+				Expect(port).To(Equal("30012"))
 			})
 		})
 
@@ -126,8 +126,7 @@ var _ = Describe(
 				vmServiceAnnotations, err := lbProvider.GetToBeRemovedServiceAnnotations(ctx, vmService)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(vmServiceAnnotations).ToNot(BeNil())
-				Expect(vmServiceAnnotations).To(HaveKeyWithValue(NCPHealthCheckNodePortKey, ""))
-				Expect(vmServiceAnnotations).To(HaveKeyWithValue(NCPHealthCheckProtocolKey, ""))
+				Expect(vmServiceAnnotations).To(HaveKey(ServiceLoadBalancerHealthCheckNodePortTagKey))
 			})
 		})
 

--- a/controllers/virtualmachineservice/virtualmachineservice_controller.go
+++ b/controllers/virtualmachineservice/virtualmachineservice_controller.go
@@ -305,9 +305,8 @@ func (r *ReconcileVirtualMachineService) virtualMachineToVirtualMachineServiceMa
 	}
 }
 
-// Set labels and annotations on the Service from the VirtualMachineService.
-// Some loadbalancer providers (currently only NCP) need to filter or translate
-// labels and annotations too.
+// Set labels and annotations on the Service from the VirtualMachineService. Some loadbalancer providers (currently
+// only NCP) need to filter or translate labels and annotations too.
 func (r *ReconcileVirtualMachineService) setServiceAnnotationsAndLabels(
 	ctx *pkgctx.VirtualMachineServiceContext,
 	service *corev1.Service) error {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This reverts commit 8905a4c8117437d4ebd4313115073dfe3c6ead5f, reversing changes made to 50afa4dcbbf610c7b48e24dcd7e7aea98238d625.

According to @DanielXiao:

> Previously some changes were made on on NCP for LB healthcheck and we were asked to use `"ncp/healthCheckNodePort": "6443"` if we want to enable LB healthcheck on kube-apiserver. During POC, we found vm-operator manage this annotation with VMService annotation `"virtualmachineservice.vmoperator.vmware.com/service.healthCheckNodePort"` but a HTTP healthcheck is created unexpectedly because lack of the NCP protocol annotation `"ncp/healthCheckProtocol": "tcp"`.
>
> Then we requested you to add this annotation. This is actually a feature regression because annotation `"ncp/healthCheckNodePort"` is designed for `“externalTrafficPolicy: Local”` type [Service](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer) and we started to support this [feature](https://docs.vmware.com/en/VMware-vSphere/7.0/rn/vmware-vsphere-with-tanzu-70-release-notes/index.html#What's%20New%20March%2009,%202021) from vSphere 7. 

Anyway, the point is, this was the wrong annotation. I informed @DanielXiao that we would:

* Revert 8905a4c8117437d4ebd4313115073dfe3c6ead5f
* Wait until their team has a design document stating the correct, intended behavior, before we make any more changes to VM Operator


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Reverts #584 
```