### PR TITLE
✨ Resize: Guest Monitoring (GMM) and Encrypted vMotion modes

### DIFF
--- a/pkg/util/resize/configspec.go
+++ b/pkg/util/resize/configspec.go
@@ -45,6 +45,7 @@ func CreateResizeConfigSpec(
 	compareVmxStatsCollectionEnabled(ci, cs, &outCS)
 	compareMemoryReservationLockedToMax(ci, cs, &outCS)
 	compareGMM(ci, cs, &outCS)
+	compareEncryptionModes(ci, cs, &outCS)
 
 	return outCS, nil
 }
@@ -427,7 +428,7 @@ func compareMemoryAllocation(
 	}
 }
 
-// compareMemoryHotAdd compares Memory hot add enablement.
+// compareMemoryHotAdd compares the memory hot add enabled settings.
 func compareMemoryHotAdd(
 	ci vimtypes.VirtualMachineConfigInfo,
 	cs vimtypes.VirtualMachineConfigSpec,
@@ -484,6 +485,7 @@ func compareMemoryReservationLockedToMax(
 	cmpPtr(ci.MemoryReservationLockedToMax, memLockedMax, &outCS.MemoryReservationLockedToMax)
 }
 
+// compareGMM compares the guest monitoring mode.
 func compareGMM(
 	ci vimtypes.VirtualMachineConfigInfo,
 	cs vimtypes.VirtualMachineConfigSpec,
@@ -500,6 +502,25 @@ func compareGMM(
 			GmmAppliance: cs.GuestMonitoringModeInfo.GmmAppliance,
 		}
 	}
+}
+
+// compareEncryptionModes compares the encrypted vMotion modes in the config spec.
+func compareEncryptionModes(
+	ci vimtypes.VirtualMachineConfigInfo,
+	cs vimtypes.VirtualMachineConfigSpec,
+	outCS *vimtypes.VirtualMachineConfigSpec) {
+	if cs.MigrateEncryption == "" && cs.FtEncryptionMode == "" {
+		return
+	}
+
+	if cs.MigrateEncryption != "" {
+		cmp(ci.MigrateEncryption, cs.MigrateEncryption, &outCS.MigrateEncryption)
+	}
+
+	// SKN: Should encrypted fault tolerance modes be supported?
+	// if cs.FtEncryptionMode != "" {
+	//	cmp(ci.FtEncryptionMode, cs.FtEncryptionMode, &outCS.FtEncryptionMode)
+	//}
 }
 
 func cmp[T comparable](a, b T, c *T) {

--- a/pkg/util/resize/configspec.go
+++ b/pkg/util/resize/configspec.go
@@ -44,6 +44,7 @@ func CreateResizeConfigSpec(
 	compareSevEnabled(ci, cs, &outCS)
 	compareVmxStatsCollectionEnabled(ci, cs, &outCS)
 	compareMemoryReservationLockedToMax(ci, cs, &outCS)
+	compareGMM(ci, cs, &outCS)
 
 	return outCS, nil
 }
@@ -481,6 +482,24 @@ func compareMemoryReservationLockedToMax(
 	}
 
 	cmpPtr(ci.MemoryReservationLockedToMax, memLockedMax, &outCS.MemoryReservationLockedToMax)
+}
+
+func compareGMM(
+	ci vimtypes.VirtualMachineConfigInfo,
+	cs vimtypes.VirtualMachineConfigSpec,
+	outCS *vimtypes.VirtualMachineConfigSpec) {
+	if cs.GuestMonitoringModeInfo == nil {
+		return
+	}
+
+	if ci.GuestMonitoringModeInfo == nil ||
+		ci.GuestMonitoringModeInfo.GmmFile != cs.GuestMonitoringModeInfo.GmmFile ||
+		ci.GuestMonitoringModeInfo.GmmAppliance != cs.GuestMonitoringModeInfo.GmmAppliance {
+		outCS.GuestMonitoringModeInfo = &vimtypes.VirtualMachineGuestMonitoringModeInfo{
+			GmmFile:      cs.GuestMonitoringModeInfo.GmmFile,
+			GmmAppliance: cs.GuestMonitoringModeInfo.GmmAppliance,
+		}
+	}
 }
 
 func cmp[T comparable](a, b T, c *T) {

--- a/pkg/util/resize/configspec_test.go
+++ b/pkg/util/resize/configspec_test.go
@@ -582,6 +582,19 @@ var _ = Describe("CreateResizeConfigSpec", func() {
 					GmmAppliance: "bar",
 				}},
 			ConfigSpec{}),
+
+		Entry("Encrypted vMotion mode does not need updating",
+			ConfigInfo{MigrateEncryption: "disabled"},
+			ConfigSpec{MigrateEncryption: "disabled"},
+			ConfigSpec{}),
+		Entry("Encrypted vMotion mode needs updating",
+			ConfigInfo{MigrateEncryption: "disabled"},
+			ConfigSpec{MigrateEncryption: "opportunistic"},
+			ConfigSpec{MigrateEncryption: "opportunistic"}),
+		Entry("Encrypted vMotion mode needs updating -- configInfo migrate encryption unset",
+			ConfigInfo{},
+			ConfigSpec{MigrateEncryption: "required"},
+			ConfigSpec{MigrateEncryption: "required"}),
 	)
 
 	type giveMeDeviceFn = func() vimtypes.BaseVirtualDevice

--- a/pkg/util/resize/configspec_test.go
+++ b/pkg/util/resize/configspec_test.go
@@ -541,6 +541,47 @@ var _ = Describe("CreateResizeConfigSpec", func() {
 					},
 				},
 			}),
+
+		Entry("GMM needs updating -- config info GMM empty",
+			ConfigInfo{},
+			ConfigSpec{
+				GuestMonitoringModeInfo: &vimtypes.VirtualMachineGuestMonitoringModeInfo{
+					GmmFile:      "foo",
+					GmmAppliance: "bar",
+				}},
+			ConfigSpec{
+				GuestMonitoringModeInfo: &vimtypes.VirtualMachineGuestMonitoringModeInfo{
+					GmmFile:      "foo",
+					GmmAppliance: "bar",
+				}}),
+		Entry("GMM needs updating",
+			ConfigInfo{
+				GuestMonitoringModeInfo: &vimtypes.VirtualMachineGuestMonitoringModeInfo{
+					GmmFile:      "bat",
+					GmmAppliance: "man",
+				}},
+			ConfigSpec{
+				GuestMonitoringModeInfo: &vimtypes.VirtualMachineGuestMonitoringModeInfo{
+					GmmFile:      "foo",
+					GmmAppliance: "bar",
+				}},
+			ConfigSpec{
+				GuestMonitoringModeInfo: &vimtypes.VirtualMachineGuestMonitoringModeInfo{
+					GmmFile:      "foo",
+					GmmAppliance: "bar",
+				}}),
+		Entry("GMM does not need updating",
+			ConfigInfo{
+				GuestMonitoringModeInfo: &vimtypes.VirtualMachineGuestMonitoringModeInfo{
+					GmmFile:      "foo",
+					GmmAppliance: "bar",
+				}},
+			ConfigSpec{
+				GuestMonitoringModeInfo: &vimtypes.VirtualMachineGuestMonitoringModeInfo{
+					GmmFile:      "foo",
+					GmmAppliance: "bar",
+				}},
+			ConfigSpec{}),
 	)
 
 	type giveMeDeviceFn = func() vimtypes.BaseVirtualDevice


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This PR adds support for resizing GMM (guest monitoring mode) and encrypted vMotion modes

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # N/A


**Are there any special notes for your reviewer**:
N/A


**Please add a release note if necessary**:
```
Resize Guest Monitoring Mode and Encrypted vMotion modes

```