### PR TITLE
:seedling: Update the Infra Capability Controller UT variable's scope

### DIFF
--- a/controllers/infra/capability/infra_capability_controller_unit_test.go
+++ b/controllers/infra/capability/infra_capability_controller_unit_test.go
@@ -33,11 +33,9 @@ func unitTests() {
 func unitTestsReconcile() {
 	var (
 		ctx *builder.UnitTestContextForController
-		obj client.ObjectKey
 
 		reconciler *capability.Reconciler
 		configMap  *corev1.ConfigMap
-		data       map[string]string
 	)
 
 	const (
@@ -68,13 +66,12 @@ func unitTestsReconcile() {
 	AfterEach(func() {
 		ctx.AfterEach()
 		ctx = nil
-		data = nil
 	})
 
 	Context("Reconcile", func() {
 		When("configmap with different name enters the reconcile", func() {
 			It("should not reconcile wcp cluster capabilities config and return back", func() {
-				obj = client.ObjectKey{Namespace: dummyWCPClusterCapabilitiesNamespace, Name: dummyWCPClusterCapabilitiesConfigMapName}
+				obj := client.ObjectKey{Namespace: dummyWCPClusterCapabilitiesNamespace, Name: dummyWCPClusterCapabilitiesConfigMapName}
 				_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: obj})
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -83,7 +80,7 @@ func unitTestsReconcile() {
 		When("configmap does not exists", func() {
 			It("should return false", func() {
 				Expect(ctx.Client.Delete(ctx, configMap)).To(Succeed())
-				obj = client.ObjectKey{Namespace: configMap.Namespace, Name: configMap.Name}
+				obj := client.ObjectKey{Namespace: configMap.Namespace, Name: configMap.Name}
 				_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: obj})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pkgcfg.FromContext(ctx).Features.TKGMultipleCL).To(BeFalse())
@@ -92,7 +89,7 @@ func unitTestsReconcile() {
 
 		When("configmap Data is empty", func() {
 			It("should return false", func() {
-				obj = client.ObjectKey{Namespace: configMap.Namespace, Name: configMap.Name}
+				obj := client.ObjectKey{Namespace: configMap.Namespace, Name: configMap.Name}
 				_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: obj})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pkgcfg.FromContext(ctx).Features.TKGMultipleCL).To(BeFalse())
@@ -101,7 +98,7 @@ func unitTestsReconcile() {
 
 		When("configmap Data is invalid", func() {
 			BeforeEach(func() {
-				data = map[string]string{
+				data := map[string]string{
 					capability.TKGMultipleCLCapabilityKey: "not-valid",
 				}
 				configMap.Data = data
@@ -109,7 +106,7 @@ func unitTestsReconcile() {
 			})
 
 			It("should return false", func() {
-				obj = client.ObjectKey{Namespace: configMap.Namespace, Name: configMap.Name}
+				obj := client.ObjectKey{Namespace: configMap.Namespace, Name: configMap.Name}
 				_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: obj})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pkgcfg.FromContext(ctx).Features.TKGMultipleCL).To(BeFalse())
@@ -118,7 +115,7 @@ func unitTestsReconcile() {
 
 		When("configmap data is valid", func() {
 			BeforeEach(func() {
-				data = map[string]string{
+				data := map[string]string{
 					capability.TKGMultipleCLCapabilityKey: "true",
 				}
 				configMap.Data = data
@@ -126,7 +123,7 @@ func unitTestsReconcile() {
 			})
 
 			It("should return true", func() {
-				obj = client.ObjectKey{Namespace: configMap.Namespace, Name: configMap.Name}
+				obj := client.ObjectKey{Namespace: configMap.Namespace, Name: configMap.Name}
 				_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: obj})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pkgcfg.FromContext(ctx).Features.TKGMultipleCL).To(BeTrue())


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR will address the nit review comment provided as a part of [#587](https://github.com/vmware-tanzu/vm-operator/pull/587 ).

Here, we're lowering down the scope of obj, data variables from `infra_capability_controller_unit_test.go`

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

NONE