### PR TITLE
🌱 Reduce Volume controller log spam while creating VMs

### DIFF
--- a/controllers/volume/volume_controller.go
+++ b/controllers/volume/volume_controller.go
@@ -299,7 +299,9 @@ func (r *Reconciler) ReconcileNormal(ctx *pkgctx.VolumeContext) error {
 	if ctx.VM.Status.BiosUUID == "" {
 		// CSI requires the BiosUUID to match up the attachment request with the VM. Defer here
 		// until it is set by the VirtualMachine controller.
-		ctx.Logger.Info("VM Status does not yet have BiosUUID. Deferring volume attachment")
+		if len(ctx.VM.Spec.Volumes) != 0 {
+			ctx.Logger.Info("VM Status does not yet have BiosUUID. Deferring volume attachment")
+		}
 		return nil
 	}
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Only log while waiting for the VM to be created - as determined by the Status.BiosUUID being set - if the VM has volumes.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

**Please add a release note if necessary**:


```release-note
NONE
```