### PR TITLE
🌱 Go 1.22.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: ci
 
 env:
-  GO_VERSION: 1.22.4
+  GO_VERSION: 1.22.5
 
 on:
   pull_request:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Go version used to build the binaries.
-ARG GO_VERSION=1.22.4
+ARG GO_VERSION=1.22.5
 
 ## Docker image used to build the binaries.
 FROM golang:${GO_VERSION} as builder

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/vm-operator/api
 
-go 1.22.4
+go 1.22.5
 
 replace github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels => ../pkg/constants/testlabels
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/vm-operator
 
-go 1.22.4
+go 1.22.5
 
 replace (
 	github.com/envoyproxy/go-control-plane => github.com/envoyproxy/go-control-plane v0.9.4

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/vm-operator/hack/tools
 
-go 1.22.4
+go 1.22.5
 
 require (
 	github.com/AlekSi/gocov-xml v1.1.0


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Go 1.22.5 is required to addresses the vulncheck errors due to https://pkg.go.dev/vuln/GO-2024-2963.

```
Vulnerability #1: GO-2024-2963
    Denial of service due to improper 100-continue handling in net/http
  More info: https://pkg.go.dev/vuln/GO-2024-2963
  Standard library
    Found in: net/http@go1.22.4
    Fixed in: net/http@go1.22.5
```

**Which issue(s) is/are addressed by this PR?**

Fixes https://pkg.go.dev/vuln/GO-2024-2963


**Are there any special notes for your reviewer**:

None.


**Please add a release note if necessary**:

```release-note
Upgrade VM Operator to golang 1.22.5
```