### PR TITLE
🌱 Remove resize console preferences

### DIFF
--- a/pkg/util/resize/configspec.go
+++ b/pkg/util/resize/configspec.go
@@ -33,7 +33,6 @@ func CreateResizeConfigSpec(
 	compareCPUPerfCounter(ci, cs, &outCS)
 	compareLatencySensitivity(ci, cs, &outCS)
 	compareExtraConfig(ci, cs, &outCS)
-	compareConsolePreferences(ci, cs, &outCS)
 	compareFlags(ci, cs, &outCS)
 	compareMemoryAllocation(ci, cs, &outCS)
 	compareMemoryHotAdd(ci, cs, &outCS)
@@ -213,45 +212,6 @@ func compareExtraConfig(
 	outCS *vimtypes.VirtualMachineConfigSpec) {
 
 	outCS.ExtraConfig = pkgutil.OptionValues(ci.ExtraConfig).Diff(cs.ExtraConfig...)
-}
-
-// compareConsolePreferences compares the console preferences settings in the Config Spec.
-func compareConsolePreferences(
-	ci vimtypes.VirtualMachineConfigInfo,
-	cs vimtypes.VirtualMachineConfigSpec,
-	outCS *vimtypes.VirtualMachineConfigSpec) {
-
-	if cs.ConsolePreferences == nil {
-		return
-	}
-
-	if ci.ConsolePreferences == nil {
-		// If configInfo console preferences is nil, there is nothing to compare.
-		// set desired values from configSpec if they are non-nil.
-		if cs.ConsolePreferences.PowerOnWhenOpened != nil ||
-			cs.ConsolePreferences.CloseOnPowerOffOrSuspend != nil ||
-			cs.ConsolePreferences.EnterFullScreenOnPowerOn != nil {
-			outCS.ConsolePreferences = &vimtypes.VirtualMachineConsolePreferences{
-				PowerOnWhenOpened:        cs.ConsolePreferences.PowerOnWhenOpened,
-				EnterFullScreenOnPowerOn: cs.ConsolePreferences.EnterFullScreenOnPowerOn,
-				CloseOnPowerOffOrSuspend: cs.ConsolePreferences.CloseOnPowerOffOrSuspend,
-			}
-		}
-
-		return
-	}
-
-	// If both configInfo and configSpec have non-nil console preferences, compare and set
-	// the desired.
-	outCS.ConsolePreferences = &vimtypes.VirtualMachineConsolePreferences{}
-	cmpPtr(ci.ConsolePreferences.PowerOnWhenOpened, cs.ConsolePreferences.PowerOnWhenOpened, &outCS.ConsolePreferences.PowerOnWhenOpened)
-	cmpPtr(ci.ConsolePreferences.EnterFullScreenOnPowerOn, cs.ConsolePreferences.EnterFullScreenOnPowerOn, &outCS.ConsolePreferences.EnterFullScreenOnPowerOn)
-	cmpPtr(ci.ConsolePreferences.CloseOnPowerOffOrSuspend, cs.ConsolePreferences.CloseOnPowerOffOrSuspend, &outCS.ConsolePreferences.CloseOnPowerOffOrSuspend)
-
-	// if desired preferences has all nil (ie) there was no change, nil out the console preferences to prevent unwanted reconfigures.
-	if reflect.DeepEqual(outCS.ConsolePreferences, &vimtypes.VirtualMachineConsolePreferences{}) {
-		outCS.ConsolePreferences = nil
-	}
 }
 
 // compareFlags compares the flag info settings in the Config Spec.

--- a/pkg/util/resize/configspec_test.go
+++ b/pkg/util/resize/configspec_test.go
@@ -235,46 +235,6 @@ var _ = Describe("CreateResizeConfigSpec", func() {
 			ConfigSpec{ExtraConfig: []vimtypes.BaseOptionValue{&vimtypes.OptionValue{Key: "foo", Value: "bar"}}},
 			ConfigSpec{}),
 
-		Entry("Console Preferences needs updating -- configInfo console preferences nil",
-			ConfigInfo{},
-			ConfigSpec{
-				ConsolePreferences: &vimtypes.VirtualMachineConsolePreferences{
-					EnterFullScreenOnPowerOn: truePtr,
-					PowerOnWhenOpened:        falsePtr,
-				}},
-			ConfigSpec{
-				ConsolePreferences: &vimtypes.VirtualMachineConsolePreferences{
-					EnterFullScreenOnPowerOn: truePtr,
-					PowerOnWhenOpened:        falsePtr,
-				}}),
-		Entry("Console Preferences needs updating -- configInfo console preferences set",
-			ConfigInfo{
-				ConsolePreferences: &vimtypes.VirtualMachineConsolePreferences{
-					PowerOnWhenOpened: truePtr,
-				}},
-			ConfigSpec{
-				ConsolePreferences: &vimtypes.VirtualMachineConsolePreferences{
-					EnterFullScreenOnPowerOn: truePtr,
-					PowerOnWhenOpened:        falsePtr,
-				}},
-			ConfigSpec{
-				ConsolePreferences: &vimtypes.VirtualMachineConsolePreferences{
-					EnterFullScreenOnPowerOn: truePtr,
-					PowerOnWhenOpened:        falsePtr,
-				}}),
-		Entry("Console Preferences does not need updating",
-			ConfigInfo{
-				ConsolePreferences: &vimtypes.VirtualMachineConsolePreferences{
-					EnterFullScreenOnPowerOn: truePtr,
-					PowerOnWhenOpened:        falsePtr,
-				}},
-			ConfigSpec{
-				ConsolePreferences: &vimtypes.VirtualMachineConsolePreferences{
-					EnterFullScreenOnPowerOn: truePtr,
-					PowerOnWhenOpened:        falsePtr,
-				}},
-			ConfigSpec{}),
-
 		Entry("Flags do not need updating",
 			ConfigInfo{Flags: vimtypes.VirtualMachineFlagInfo{
 				CbrcCacheEnabled:    truePtr,


### PR DESCRIPTION



**What does this PR do, and why is it needed?**

vSphere doesn't support legacy console preferences anymore. Hence, VM service doesn't have to.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # N/A


**Are there any special notes for your reviewer**:

N/A


**Please add a release note if necessary**:

```
Remove Resize Console Preferences support as vSphere doesn't support it.

```