### PR TITLE
🐛  Ignore VM Class specified default guestID "otherGuest64"

### DIFF
--- a/pkg/providers/vsphere/virtualmachine/configspec.go
+++ b/pkg/providers/vsphere/virtualmachine/configspec.go
@@ -115,9 +115,8 @@ func CreateConfigSpec(
 		}
 	}
 
-	// Initially set the guest ID in ConfigSpec to ensure VM is created with the expected guest ID.
+	// If VM Spec guestID is specified, initially set the guest ID in ConfigSpec to ensure VM is created with the expected guest ID.
 	// Afterwards, only update it if the VM spec guest ID differs from the VM's existing ConfigInfo.
-	// If the class also specifies a guest ID, it will be overridden by the VM spec guest ID.
 	if guestID := vmCtx.VM.Spec.GuestID; guestID != "" {
 		configSpec.GuestId = guestID
 	}

--- a/pkg/util/configspec.go
+++ b/pkg/util/configspec.go
@@ -139,6 +139,7 @@ func SanitizeVMClassConfigSpec(
 	// These are unique for each VM.
 	configSpec.Uuid = ""
 	configSpec.InstanceUuid = ""
+	configSpec.GuestId = ""
 
 	// Empty Files as they usually ref files in disk
 	configSpec.Files = nil

--- a/pkg/util/configspec_test.go
+++ b/pkg/util/configspec_test.go
@@ -262,6 +262,7 @@ var _ = Describe("SanitizeVMClassConfigSpec", func() {
 			Name:         "dummy-VM",
 			Annotation:   "test-annotation",
 			Uuid:         "uuid",
+			GuestId:      "dummy-guestID",
 			InstanceUuid: "instanceUUID",
 			Files:        &vimtypes.VirtualMachineFileInfo{},
 			VmProfile: []vimtypes.BaseVirtualMachineProfileSpec{
@@ -344,6 +345,7 @@ var _ = Describe("SanitizeVMClassConfigSpec", func() {
 		Expect(configSpec.Annotation).To(Equal("test-annotation"))
 		Expect(configSpec.Uuid).To(BeEmpty())
 		Expect(configSpec.InstanceUuid).To(BeEmpty())
+		Expect(configSpec.GuestId).To(BeEmpty())
 		Expect(configSpec.Files).To(BeNil())
 		Expect(configSpec.VmProfile).To(BeEmpty())
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

The VM Class specified guestID is not supported. Ignore if set.

The guestID is either specified explicity by
- the VM spec (or)
- falls back to the VM Image/OVF

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # N/A


**Are there any special notes for your reviewer**:

N/A


**Please add a release note if necessary**:

```
Ignore VM Class provided guestID
```