### PR TITLE
🌱 Add image type in VirtualMachineImage and ClusterVirtualMachineImage status

### DIFF
--- a/api/v1alpha1/zz_generated.conversion.go
+++ b/api/v1alpha1/zz_generated.conversion.go
@@ -1430,6 +1430,7 @@ func autoConvert_v1alpha3_VirtualMachineImageStatus_To_v1alpha1_VirtualMachineIm
 	} else {
 		out.Conditions = nil
 	}
+	// WARNING: in.Type requires manual conversion: does not exist in peer-type
 	return nil
 }
 

--- a/api/v1alpha2/virtualmachineimage_conversion.go
+++ b/api/v1alpha2/virtualmachineimage_conversion.go
@@ -4,10 +4,16 @@
 package v1alpha2
 
 import (
+	apiconversion "k8s.io/apimachinery/pkg/conversion"
 	ctrlconversion "sigs.k8s.io/controller-runtime/pkg/conversion"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 )
+
+func Convert_v1alpha3_VirtualMachineImageStatus_To_v1alpha2_VirtualMachineImageStatus(
+	in *vmopv1.VirtualMachineImageStatus, out *VirtualMachineImageStatus, s apiconversion.Scope) error {
+	return autoConvert_v1alpha3_VirtualMachineImageStatus_To_v1alpha2_VirtualMachineImageStatus(in, out, s)
+}
 
 // ConvertTo converts this VirtualMachineImage to the Hub version.
 func (src *VirtualMachineImage) ConvertTo(dstRaw ctrlconversion.Hub) error {

--- a/api/v1alpha2/zz_generated.conversion.go
+++ b/api/v1alpha2/zz_generated.conversion.go
@@ -404,11 +404,6 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*v1alpha3.VirtualMachineImageStatus)(nil), (*VirtualMachineImageStatus)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1alpha3_VirtualMachineImageStatus_To_v1alpha2_VirtualMachineImageStatus(a.(*v1alpha3.VirtualMachineImageStatus), b.(*VirtualMachineImageStatus), scope)
-	}); err != nil {
-		return err
-	}
 	if err := s.AddGeneratedConversionFunc((*VirtualMachineList)(nil), (*v1alpha3.VirtualMachineList)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1alpha2_VirtualMachineList_To_v1alpha3_VirtualMachineList(a.(*VirtualMachineList), b.(*v1alpha3.VirtualMachineList), scope)
 	}); err != nil {
@@ -914,6 +909,11 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
+	if err := s.AddConversionFunc((*v1alpha3.VirtualMachineImageStatus)(nil), (*VirtualMachineImageStatus)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1alpha3_VirtualMachineImageStatus_To_v1alpha2_VirtualMachineImageStatus(a.(*v1alpha3.VirtualMachineImageStatus), b.(*VirtualMachineImageStatus), scope)
+	}); err != nil {
+		return err
+	}
 	if err := s.AddConversionFunc((*v1alpha3.VirtualMachineNetworkConfigDNSStatus)(nil), (*VirtualMachineNetworkConfigDNSStatus)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1alpha3_VirtualMachineNetworkConfigDNSStatus_To_v1alpha2_VirtualMachineNetworkConfigDNSStatus(a.(*v1alpha3.VirtualMachineNetworkConfigDNSStatus), b.(*VirtualMachineNetworkConfigDNSStatus), scope)
 	}); err != nil {
@@ -971,7 +971,17 @@ func Convert_v1alpha3_ClusterVirtualMachineImage_To_v1alpha2_ClusterVirtualMachi
 
 func autoConvert_v1alpha2_ClusterVirtualMachineImageList_To_v1alpha3_ClusterVirtualMachineImageList(in *ClusterVirtualMachineImageList, out *v1alpha3.ClusterVirtualMachineImageList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]v1alpha3.ClusterVirtualMachineImage)(unsafe.Pointer(&in.Items))
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]v1alpha3.ClusterVirtualMachineImage, len(*in))
+		for i := range *in {
+			if err := Convert_v1alpha2_ClusterVirtualMachineImage_To_v1alpha3_ClusterVirtualMachineImage(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
 	return nil
 }
 
@@ -982,7 +992,17 @@ func Convert_v1alpha2_ClusterVirtualMachineImageList_To_v1alpha3_ClusterVirtualM
 
 func autoConvert_v1alpha3_ClusterVirtualMachineImageList_To_v1alpha2_ClusterVirtualMachineImageList(in *v1alpha3.ClusterVirtualMachineImageList, out *ClusterVirtualMachineImageList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]ClusterVirtualMachineImage)(unsafe.Pointer(&in.Items))
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]ClusterVirtualMachineImage, len(*in))
+		for i := range *in {
+			if err := Convert_v1alpha3_ClusterVirtualMachineImage_To_v1alpha2_ClusterVirtualMachineImage(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
 	return nil
 }
 
@@ -1811,7 +1831,17 @@ func Convert_v1alpha3_VirtualMachineImage_To_v1alpha2_VirtualMachineImage(in *v1
 
 func autoConvert_v1alpha2_VirtualMachineImageList_To_v1alpha3_VirtualMachineImageList(in *VirtualMachineImageList, out *v1alpha3.VirtualMachineImageList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]v1alpha3.VirtualMachineImage)(unsafe.Pointer(&in.Items))
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]v1alpha3.VirtualMachineImage, len(*in))
+		for i := range *in {
+			if err := Convert_v1alpha2_VirtualMachineImage_To_v1alpha3_VirtualMachineImage(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
 	return nil
 }
 
@@ -1822,7 +1852,17 @@ func Convert_v1alpha2_VirtualMachineImageList_To_v1alpha3_VirtualMachineImageLis
 
 func autoConvert_v1alpha3_VirtualMachineImageList_To_v1alpha2_VirtualMachineImageList(in *v1alpha3.VirtualMachineImageList, out *VirtualMachineImageList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]VirtualMachineImage)(unsafe.Pointer(&in.Items))
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]VirtualMachineImage, len(*in))
+		for i := range *in {
+			if err := Convert_v1alpha3_VirtualMachineImage_To_v1alpha2_VirtualMachineImage(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
 	return nil
 }
 
@@ -1941,12 +1981,8 @@ func autoConvert_v1alpha3_VirtualMachineImageStatus_To_v1alpha2_VirtualMachineIm
 	out.ProviderContentVersion = in.ProviderContentVersion
 	out.ProviderItemID = in.ProviderItemID
 	out.Conditions = *(*[]v1.Condition)(unsafe.Pointer(&in.Conditions))
+	// WARNING: in.Type requires manual conversion: does not exist in peer-type
 	return nil
-}
-
-// Convert_v1alpha3_VirtualMachineImageStatus_To_v1alpha2_VirtualMachineImageStatus is an autogenerated conversion function.
-func Convert_v1alpha3_VirtualMachineImageStatus_To_v1alpha2_VirtualMachineImageStatus(in *v1alpha3.VirtualMachineImageStatus, out *VirtualMachineImageStatus, s conversion.Scope) error {
-	return autoConvert_v1alpha3_VirtualMachineImageStatus_To_v1alpha2_VirtualMachineImageStatus(in, out, s)
 }
 
 func autoConvert_v1alpha2_VirtualMachineList_To_v1alpha3_VirtualMachineList(in *VirtualMachineList, out *v1alpha3.VirtualMachineList, s conversion.Scope) error {

--- a/api/v1alpha3/virtualmachineimage_types.go
+++ b/api/v1alpha3/virtualmachineimage_types.go
@@ -218,6 +218,11 @@ type VirtualMachineImageStatus struct {
 
 	// Conditions describes the observed conditions for this image.
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
+
+	// +optional
+	//
+	// Type describes the content library item type (OVF or ISO) of the image.
+	Type string `json:"type,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -225,6 +230,7 @@ type VirtualMachineImageStatus struct {
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Display Name",type="string",JSONPath=".status.name"
+// +kubebuilder:printcolumn:name="Type",type="string",JSONPath=".status.type"
 // +kubebuilder:printcolumn:name="Image Version",type="string",JSONPath=".status.productInfo.version"
 // +kubebuilder:printcolumn:name="OS Name",type="string",JSONPath=".status.osInfo.type"
 // +kubebuilder:printcolumn:name="OS Version",type="string",JSONPath=".status.osInfo.version"
@@ -262,6 +268,7 @@ type VirtualMachineImageList struct {
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Display Name",type="string",JSONPath=".status.name"
+// +kubebuilder:printcolumn:name="Type",type="string",JSONPath=".status.type"
 // +kubebuilder:printcolumn:name="Image Version",type="string",JSONPath=".status.productInfo.version"
 // +kubebuilder:printcolumn:name="OS Name",type="string",JSONPath=".status.osInfo.type"
 // +kubebuilder:printcolumn:name="OS Version",type="string",JSONPath=".status.osInfo.version"

--- a/config/crd/bases/vmoperator.vmware.com_clustervirtualmachineimages.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_clustervirtualmachineimages.yaml
@@ -596,6 +596,9 @@ spec:
     - jsonPath: .status.name
       name: Display Name
       type: string
+    - jsonPath: .status.type
+      name: Type
+      type: string
     - jsonPath: .status.productInfo.version
       name: Image Version
       type: string
@@ -867,6 +870,10 @@ spec:
                   ProviderItemID describes the ID of the provider item that this image corresponds to.
                   If the provider of this image is a Content Library, this ID will be that of the
                   corresponding Content Library item.
+                type: string
+              type:
+                description: Type describes the content library item type (OVF or
+                  ISO) of the image.
                 type: string
               vmwareSystemProperties:
                 description: |-

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachineimages.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachineimages.yaml
@@ -597,6 +597,9 @@ spec:
     - jsonPath: .status.name
       name: Display Name
       type: string
+    - jsonPath: .status.type
+      name: Type
+      type: string
     - jsonPath: .status.productInfo.version
       name: Image Version
       type: string
@@ -870,6 +873,10 @@ spec:
                   ProviderItemID describes the ID of the provider item that this image corresponds to.
                   If the provider of this image is a Content Library, this ID will be that of the
                   corresponding Content Library item.
+                type: string
+              type:
+                description: Type describes the content library item type (OVF or
+                  ISO) of the image.
                 type: string
               vmwareSystemProperties:
                 description: |-

--- a/controllers/contentlibrary/clustercontentlibraryitem/clustercontentlibraryitem_controller.go
+++ b/controllers/contentlibrary/clustercontentlibraryitem/clustercontentlibraryitem_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2022-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package clustercontentlibraryitem
@@ -293,6 +293,7 @@ func (r *Reconciler) setUpCVMIFromCCLItem(ctx *pkgctx.ClusterContentLibraryItemC
 
 	cvmi.Status.Name = cclItem.Status.Name
 	cvmi.Status.ProviderItemID = string(cclItem.Spec.UUID)
+	cvmi.Status.Type = string(cclItem.Status.Type)
 
 	return utils.AddContentLibraryRefToAnnotation(cvmi, ctx.CCLItem.Status.ContentLibraryRef)
 }

--- a/controllers/contentlibrary/clustercontentlibraryitem/clustercontentlibraryitem_controller_unit_test.go
+++ b/controllers/contentlibrary/clustercontentlibraryitem/clustercontentlibraryitem_controller_unit_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2022-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package clustercontentlibraryitem_test
@@ -320,6 +320,7 @@ func assertCVMImageFromCCLItem(
 		Expect(cvmi.Status.Name).To(Equal(cclItem.Status.Name))
 		Expect(cvmi.Status.ProviderItemID).To(BeEquivalentTo(cclItem.Spec.UUID))
 		Expect(cvmi.Status.ProviderContentVersion).To(Equal(cclItem.Status.ContentVersion))
+		Expect(cvmi.Status.Type).To(BeEquivalentTo(cclItem.Status.Type))
 
 		Expect(conditions.IsTrue(cvmi, vmopv1.ReadyConditionType)).To(BeTrue())
 	})

--- a/controllers/contentlibrary/contentlibraryitem/contentlibraryitem_controller.go
+++ b/controllers/contentlibrary/contentlibraryitem/contentlibraryitem_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2022-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package contentlibraryitem
@@ -261,6 +261,7 @@ func (r *Reconciler) setUpVMIFromCLItem(ctx *pkgctx.ContentLibraryItemContext) e
 	}
 	vmi.Status.Name = clItem.Status.Name
 	vmi.Status.ProviderItemID = string(clItem.Spec.UUID)
+	vmi.Status.Type = string(clItem.Status.Type)
 
 	return utils.AddContentLibraryRefToAnnotation(vmi, ctx.CLItem.Status.ContentLibraryRef)
 }

--- a/controllers/contentlibrary/contentlibraryitem/contentlibraryitem_controller_unit_test.go
+++ b/controllers/contentlibrary/contentlibraryitem/contentlibraryitem_controller_unit_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2022-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package contentlibraryitem_test
@@ -298,6 +298,7 @@ func assertVMImageFromCLItem(
 		Expect(vmi.Status.Name).To(Equal(clItem.Status.Name))
 		Expect(vmi.Status.ProviderItemID).To(BeEquivalentTo(clItem.Spec.UUID))
 		Expect(vmi.Status.ProviderContentVersion).To(Equal(clItem.Status.ContentVersion))
+		Expect(vmi.Status.Type).To(BeEquivalentTo(clItem.Status.Type))
 
 		Expect(conditions.IsTrue(vmi, vmopv1.ReadyConditionType)).To(BeTrue())
 	})

--- a/docs/ref/api/v1alpha3.md
+++ b/docs/ref/api/v1alpha3.md
@@ -905,6 +905,7 @@ Library, this will be the version of the corresponding Content Library item. |
 If the provider of this image is a Content Library, this ID will be that of the
 corresponding Content Library item. |
 | `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#condition-v1-meta) array_ | Conditions describes the observed conditions for this image. |
+| `type` _string_ | Type describes the content library item type (OVF or ISO) of the image. |
 
 ### VirtualMachineNetworkConfigDHCPOptionsStatus
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR introduces a new `type` field in v1alpha3 VM image status and displays it in the kubectl output print columns.  
This enables users to quickly check the image type without fetching the corresponding content library item from the image CR.

```console
$ kubectl get vmi -n sdiliyaer-test
NAME                    DISPLAY NAME                                  TYPE   IMAGE VERSION   OS NAME                 OS VERSION   HARDWARE VERSION   CAPABILITIES
vmi-59d0c8cad9fa84376   centos-stream-8-vmservice-v1alpha1.20210528   OVF                    centos8_64Guest         8            17
vmi-613b445de62052870   ubuntu-23.10-live-server-amd64                ISO

$ kubectl get cvmi
NAME                    DISPLAY NAME                                             TYPE   IMAGE VERSION             OS NAME               OS VERSION   HARDWARE VERSION
vmi-4a40dfdd5a412fcd4   photon-3-amd64-vmi-k8s-v1.26.5---vmware.2-fips.1-tkg.1   OVF    v1.26.5+vmware.2-fips.1   vmwarePhoton64Guest                17
vmi-613b445de62052870   ubuntu-23.10-live-server-amd64                           ISO
```

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes N/A.

**Are there any special notes for your reviewer**:

N/A.

**Please add a release note if necessary**:

```release-note
Store image type in v1alpha3 VirtualMachineImage and ClusterVirtualMachineImage status.
```

<!-- readthedocs-preview vm-operator start -->
----
📚 Documentation preview 📚: https://vm-operator--616.org.readthedocs.build/en/616/

<!-- readthedocs-preview vm-operator end -->