### PR TITLE
:bug: Revert to returning early if the pause annotation is present on the VM

### DIFF
--- a/controllers/virtualmachine/virtualmachine_controller.go
+++ b/controllers/virtualmachine/virtualmachine_controller.go
@@ -303,10 +303,9 @@ func requeueDelay(ctx *pkgctx.VirtualMachineContext) time.Duration {
 func (r *Reconciler) ReconcileDelete(ctx *pkgctx.VirtualMachineContext) (reterr error) {
 	ctx.Logger.Info("Reconciling VirtualMachine Deletion")
 
-	// If the VM reconciliation has been paused by the developer,
-	// skip deletion and return.
+	// Return early if the VM reconciliation is paused.
 	if _, exists := ctx.VM.Annotations[vmopv1.PauseAnnotation]; exists {
-		ctx.Logger.Info("VirtualMachine is not deleted because devops paused this VM")
+		ctx.Logger.Info("Skipping deletion since VirtualMachine contains the pause annotation")
 		return nil
 	}
 
@@ -341,6 +340,12 @@ func (r *Reconciler) ReconcileDelete(ctx *pkgctx.VirtualMachineContext) (reterr 
 
 // ReconcileNormal processes a level trigger for this VM: create if it doesn't exist otherwise update the existing VM.
 func (r *Reconciler) ReconcileNormal(ctx *pkgctx.VirtualMachineContext) (reterr error) {
+	// Return early if the VM reconciliation is paused.
+	if _, exists := ctx.VM.Annotations[vmopv1.PauseAnnotation]; exists {
+		ctx.Logger.Info("Skipping reconciliation since VirtualMachine contains the pause annotation")
+		return nil
+	}
+
 	if !controllerutil.ContainsFinalizer(ctx.VM, finalizerName) {
 
 		// If the object has the deprecated finalizer, remove it.

--- a/controllers/virtualmachine/virtualmachine_controller_unit_test.go
+++ b/controllers/virtualmachine/virtualmachine_controller_unit_test.go
@@ -113,6 +113,13 @@ func unitTestsReconcile() {
 				vm.Finalizers = nil
 			})
 
+			It("will not set the finalizer when the VM contains the pause annotation", func() {
+				vm.Annotations[vmopv1.PauseAnnotation] = "true"
+				err := reconciler.ReconcileNormal(vmCtx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(vm.GetFinalizers()).ToNot(ContainElement(finalizer))
+			})
+
 			It("will set finalizer", func() {
 				err := reconciler.ReconcileNormal(vmCtx)
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

In the recent changes to support the break-glass admin overrides, we changed the behavior of the pause annotation for regular (non delete) reconciles so that we now _always_ add the finalizer regardless of the pause annotation.

This change fixes this by reverting the old behavior of returning early if the pause annotation is present.  This also means that now both reconcile methods (Create/Update and Delete) behave consistently when this annotation is present.

**Please add a release note if necessary**:

```release-note
Revert to returning early if the pause annotation is present on the VM
```