### PR TITLE
✨ Update VM mutating/validating webhook related to CD-ROM spec

### DIFF
--- a/test/builder/dummies.go
+++ b/test/builder/dummies.go
@@ -41,6 +41,11 @@ const (
 	DummyAvailabilityZoneName = "dummy-availability-zone"
 )
 
+const (
+	vmiKind  = "VirtualMachineImage"
+	cvmiKind = "Cluster" + vmiKind
+)
+
 func DummyStorageClass() *storagev1.StorageClass {
 	return &storagev1.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
@@ -282,7 +287,7 @@ func DummyBasicVirtualMachine(name, namespace string) *vmopv1.VirtualMachine {
 		},
 		Spec: vmopv1.VirtualMachineSpec{
 			Image: &vmopv1.VirtualMachineImageRef{
-				Kind: "VirtualMachineImage",
+				Kind: vmiKind,
 				Name: DummyVMIID,
 			},
 			ImageName:    DummyImageName,
@@ -306,7 +311,7 @@ func DummyVirtualMachine() *vmopv1.VirtualMachine {
 		},
 		Spec: vmopv1.VirtualMachineSpec{
 			Image: &vmopv1.VirtualMachineImageRef{
-				Kind: "VirtualMachineImage",
+				Kind: vmiKind,
 				Name: DummyVMIID,
 			},
 			ImageName:          DummyImageName,
@@ -332,6 +337,26 @@ func DummyVirtualMachine() *vmopv1.VirtualMachine {
 					{
 						Name: "eth0",
 					},
+				},
+			},
+			Cdrom: []vmopv1.VirtualMachineCdromSpec{
+				{
+					Name: "cdrom1",
+					Image: vmopv1.VirtualMachineImageRef{
+						Kind: vmiKind,
+						Name: DummyVMIID,
+					},
+					Connected:         true,
+					AllowGuestControl: true,
+				},
+				{
+					Name: "cdrom2",
+					Image: vmopv1.VirtualMachineImageRef{
+						Kind: cvmiKind,
+						Name: DummyVMIID,
+					},
+					Connected:         true,
+					AllowGuestControl: true,
 				},
 			},
 		},
@@ -360,7 +385,7 @@ func DummyVirtualMachineReplicaSet() *vmopv1.VirtualMachineReplicaSet {
 				},
 				Spec: vmopv1.VirtualMachineSpec{
 					Image: &vmopv1.VirtualMachineImageRef{
-						Kind: "VirtualMachineImage",
+						Kind: vmiKind,
 						Name: DummyVMIID,
 					},
 					ImageName:  DummyImageName,
@@ -542,7 +567,7 @@ func DummyImageAndItemObjectsForCdromBacking(
 		},
 	}
 
-	if kind == "VirtualMachineImage" {
+	if kind == vmiKind {
 		imageObj = &vmopv1.VirtualMachineImage{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,

--- a/webhooks/virtualmachine/validation/virtualmachine_validator_intg_test.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator_intg_test.go
@@ -12,6 +12,7 @@ import (
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	"github.com/vmware-tanzu/vm-operator/api/v1alpha3/common"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
@@ -61,6 +62,9 @@ func newIntgValidatingWebhookContext() *intgValidatingWebhookContext {
 	ctx := &intgValidatingWebhookContext{
 		IntegrationTestContext: *suite.NewIntegrationTestContext(),
 	}
+	pkgcfg.SetContext(suite, func(config *pkgcfg.Config) {
+		config.Features.IsoSupport = true
+	})
 
 	ctx.vm = builder.DummyVirtualMachine()
 	ctx.vm.Namespace = ctx.Namespace


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR adds required webhook code to mutate and validate a VM with the `vm.spec.cdrom` field as listed below:
- [Mutation] Add default CD-ROM name and image kind if not provided.
- [Mutation] Set VM's image name from CD-ROM image name if the former is not provided.
- [Validation] Disallow creating (or updating when the VM is powered off) multiple CD-ROMs with duplicate image backing.
- [Validation] Disallow adding/removing/updating CD-ROM when the VM is powered on (except for changing connection state only).

**Which issue(s) is/are addressed by this PR?**

Fixes N/A.

**Are there any special notes for your reviewer**:

- Manually verified all the above cases in an internal testbed with this PR deployed.
- Updated the VM mutation and validation tests with 100% coverage of the new code:

```console
$ go tool cover -func=/tmp/mutation-coverage.out | grep -e SetDefaultCdromNameAndImgKind -e SetImageNameFromCdrom
github.com/vmware-tanzu/vm-operator/webhooks/virtualmachine/mutation/virtualmachine_mutator.go:489:	SetDefaultCdromNameAndImgKind	100.0%
github.com/vmware-tanzu/vm-operator/webhooks/virtualmachine/mutation/virtualmachine_mutator.go:505:	SetImageNameFromCdrom		100.0%

$ go tool cover -func=/tmp/validation-coverage.out | grep -e validateCdrom -e validateCdromWhenPoweredOn
github.com/vmware-tanzu/vm-operator/webhooks/virtualmachine/validation/virtualmachine_validator.go:1286:	validateCdrom				100.0%
github.com/vmware-tanzu/vm-operator/webhooks/virtualmachine/validation/virtualmachine_validator.go:1329:	validateCdromWhenPoweredOn		100.0%
```



**Please add a release note if necessary**:

```release-note
Update VM mutating/validating webhook related to CD-ROM spec.
```