### PR TITLE
🐛 Set VirtualDisk.UnitNumber when placing with multiple clusters

### DIFF
--- a/pkg/providers/vsphere/virtualmachine/configspec.go
+++ b/pkg/providers/vsphere/virtualmachine/configspec.go
@@ -148,13 +148,16 @@ func CreateConfigSpecForPlacement(
 
 	// Add a dummy disk for placement: PlaceVmsXCluster expects there to always be at least one disk.
 	// Until we're in a position to have the OVF envelope here, add a dummy disk satisfy it.
+	// Note: UnitNumber is required for PlaceVmsXCluster w/ VpxdVmxGeneration fss enabled.
+	// PlaceVmsXCluster is not used with Instance Storage, so UnitNumber is not required for volumes below.
 	configSpec.DeviceChange = append(configSpec.DeviceChange, &vimtypes.VirtualDeviceConfigSpec{
 		Operation:     vimtypes.VirtualDeviceConfigSpecOperationAdd,
 		FileOperation: vimtypes.VirtualDeviceConfigSpecFileOperationCreate,
 		Device: &vimtypes.VirtualDisk{
 			CapacityInBytes: 1024 * 1024,
 			VirtualDevice: vimtypes.VirtualDevice{
-				Key: -42,
+				Key:        -42,
+				UnitNumber: ptr.To[int32](0),
 				Backing: &vimtypes.VirtualDiskFlatVer2BackingInfo{
 					ThinProvisioned: ptr.To(true),
 				},

--- a/pkg/providers/vsphere/virtualmachine/configspec_test.go
+++ b/pkg/providers/vsphere/virtualmachine/configspec_test.go
@@ -445,8 +445,10 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 			Expect(ok).To(BeTrue())
 			*/
 			dSpec2 := configSpec.DeviceChange[1].GetVirtualDeviceConfigSpec()
-			_, ok = dSpec2.Device.(*vimtypes.VirtualDisk)
+			disk, ok := dSpec2.Device.(*vimtypes.VirtualDisk)
 			Expect(ok).To(BeTrue())
+			Expect(disk.UnitNumber).ToNot(BeNil())
+			Expect(*disk.UnitNumber).To(Equal(int32(0)))
 
 			dSpec3 := configSpec.DeviceChange[2].GetVirtualDeviceConfigSpec()
 			_, ok = dSpec3.Device.(*vimtypes.VirtualPCIController)


### PR DESCRIPTION
UnitNumber is required for PlaceVmsXCluster w/ VpxdVmxGeneration fss enabled
