### PR TITLE
:seedling: Include both vm_name and interface_name in VPCAttachmentRef

### DIFF
--- a/pkg/providers/vsphere/network/network.go
+++ b/pkg/providers/vsphere/network/network.go
@@ -626,7 +626,7 @@ func createVPCNetworkInterface(
 		if vpcSubnetPort.Annotations == nil {
 			vpcSubnetPort.Annotations = make(map[string]string)
 		}
-		vpcSubnetPort.Annotations[constants.VPCAttachmentRef] = "virtualmachine/" + vmCtx.VM.Name
+		vpcSubnetPort.Annotations[constants.VPCAttachmentRef] = "virtualmachine/" + vmCtx.VM.Name + "/" + interfaceSpec.Name
 		return nil
 	})
 

--- a/pkg/providers/vsphere/network/network_test.go
+++ b/pkg/providers/vsphere/network/network_test.go
@@ -659,7 +659,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 							Namespace: vm.Namespace,
 						},
 					}
-					annotationVal := "virtualmachine/" + vm.Name
+					annotationVal := "virtualmachine/" + vm.Name + "/" + interfaceName
 					Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(subnetPort), subnetPort)).To(Succeed())
 					Expect(subnetPort.Spec.SubnetSet).To(Equal(networkName))
 					Expect(subnetPort.Annotations).To(HaveKeyWithValue(constants.VPCAttachmentRef, annotationVal))


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
To accommodate NSX Operator's newly introduced `ExternalAddressBinding` CR, which is to associate an External IP to a VM that will eventually associate an external IP to subnet port. Their ask is for VM Operator to provide interface name in `VPCAttachmentRef`.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes N/A


**Are there any special notes for your reviewer**:
This change needs to be merge around the same time NSX Operator merges their change.


**Please add a release note if necessary**:

```release-note
NONE
```