### PR TITLE
🌱 StoragePolicyQuota controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ config/crd/external-crds/netoperator.vmware.com_*
 
 # Do not vendor the storage-policy-quota CRDs.
 config/crd/external-crds/cns.vmware.com_*
+!config/crd/external-crds/cns.vmware.com_storagepolicyquotas.yaml
+!config/crd/external-crds/cns.vmware.com_storagepolicyusages.yaml
 
 .DS_Store
 .cache

--- a/config/crd/external-crds/cns.vmware.com_storagepolicyquotas.yaml
+++ b/config/crd/external-crds/cns.vmware.com_storagepolicyquotas.yaml
@@ -1,0 +1,156 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: storagepolicyquotas.cns.vmware.com
+spec:
+  group: cns.vmware.com
+  names:
+    kind: StoragePolicyQuota
+    listKind: StoragePolicyQuotaList
+    plural: storagepolicyquotas
+    singular: storagepolicyquota
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: StoragePolicyQuota is the Schema for the storagepolicyquotas
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: StoragePolicyQuotaSpec defines the desired state of StoragePolicyQuota
+            properties:
+              limit:
+                anyOf:
+                - type: integer
+                - type: string
+                description: |-
+                  Total limit of storage across all types of storage resources
+                  for given storage policy within given namespace
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+              storagePolicyId:
+                description: ID of the storage policy
+                maxLength: 128
+                type: string
+                x-kubernetes-validations:
+                - message: StoragePolicyId is immutable
+                  rule: self == oldSelf
+            required:
+            - storagePolicyId
+            type: object
+          status:
+            description: StoragePolicyQuotaStatus defines the observed state of StoragePolicyQuota
+            properties:
+              extensions:
+                description: Storage quota usage details per storage object type for
+                  given storage policy
+                items:
+                  properties:
+                    extensionName:
+                      description: Name of service extension associated with resource
+                        kind to be provisioned
+                      maxLength: 64
+                      type: string
+                    extensionQuotaUsage:
+                      description: Storage usage details per storage class level for
+                        given object kind
+                      items:
+                        description: SCLevelQuotaStatus gives storage quota usage
+                          per Kubernetes storage class
+                        properties:
+                          scQuotaUsage:
+                            description: Storage quota usage details for given Kubernetes
+                              storage class
+                            properties:
+                              reserved:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Storage quota that is reserved for storage
+                                  resource(s) that are being provisioned
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              used:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Storage quota that is already used by
+                                  storage resource(s) that have been provisioned
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          storageClassName:
+                            description: Name of the Kubernetes StorageClass
+                            maxLength: 64
+                            type: string
+                        required:
+                        - storageClassName
+                        type: object
+                      type: array
+                  required:
+                  - extensionName
+                  type: object
+                type: array
+              total:
+                description: Storage quota usage details per storage class level for
+                  given storage policy
+                items:
+                  description: SCLevelQuotaStatus gives storage quota usage per Kubernetes
+                    storage class
+                  properties:
+                    scQuotaUsage:
+                      description: Storage quota usage details for given Kubernetes
+                        storage class
+                      properties:
+                        reserved:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Storage quota that is reserved for storage
+                            resource(s) that are being provisioned
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        used:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Storage quota that is already used by storage
+                            resource(s) that have been provisioned
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    storageClassName:
+                      description: Name of the Kubernetes StorageClass
+                      maxLength: 64
+                      type: string
+                  required:
+                  - storageClassName
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/crd/external-crds/cns.vmware.com_storagepolicyusages.yaml
+++ b/config/crd/external-crds/cns.vmware.com_storagepolicyusages.yaml
@@ -1,0 +1,114 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: storagepolicyusages.cns.vmware.com
+spec:
+  group: cns.vmware.com
+  names:
+    kind: StoragePolicyUsage
+    listKind: StoragePolicyUsageList
+    plural: storagepolicyusages
+    singular: storagepolicyusage
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: StoragePolicyUsage is the Schema for the storagepolicyusages
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: StoragePolicyUsageSpec defines the desired state of StoragePolicyUsage
+            properties:
+              resourceApiGroup:
+                description: |-
+                  APIGroup is the group for the resource being referenced.
+                  If it is not specified, the specified ResourceKind must be in the core API group.
+                  For resources not in the core API group, this field is required.
+                type: string
+                x-kubernetes-validations:
+                - message: ResourceAPIgroup is immutable
+                  rule: self == oldSelf
+              resourceExtensionName:
+                description: Name of service extension for given storage resource
+                  type
+                type: string
+                x-kubernetes-validations:
+                - message: ResourceExtensionName is immutable
+                  rule: self == oldSelf
+              resourceKind:
+                description: Type of resource being referenced
+                maxLength: 64
+                type: string
+                x-kubernetes-validations:
+                - message: ResourceKind is immutable
+                  rule: self == oldSelf
+              storageClassName:
+                description: name of K8S storage class associated with given storage
+                  policy
+                maxLength: 64
+                type: string
+                x-kubernetes-validations:
+                - message: StorageClassName is immutable
+                  rule: self == oldSelf
+              storagePolicyId:
+                description: ID of the storage policy
+                maxLength: 128
+                type: string
+                x-kubernetes-validations:
+                - message: StoragePolicyId is immutable
+                  rule: self == oldSelf
+            required:
+            - resourceExtensionName
+            - resourceKind
+            - storageClassName
+            - storagePolicyId
+            type: object
+          status:
+            description: StoragePolicyUsageStatus defines the observed state of StoragePolicyUsage
+            properties:
+              quotaUsage:
+                description: Storage usage details per storage object type for given
+                  storage policy
+                properties:
+                  reserved:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: Storage quota that is reserved for storage resource(s)
+                      that are being provisioned
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  used:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: Storage quota that is already used by storage resource(s)
+                      that have been provisioned
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -118,9 +118,36 @@ rules:
   resources:
   - storagepolicyquotas
   verbs:
+  - delete
   - get
   - list
   - watch
+- apiGroups:
+  - cns.vmware.com
+  resources:
+  - storagepolicyquotas/status
+  verbs:
+  - get
+- apiGroups:
+  - cns.vmware.com
+  resources:
+  - storagepolicyusages
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cns.vmware.com
+  resources:
+  - storagepolicyusages/status
+  verbs:
+  - get
+  - patch
+  - update
 - apiGroups:
   - imageregistry.vmware.com
   resources:

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/vmware-tanzu/vm-operator/controllers/contentlibrary"
 	"github.com/vmware-tanzu/vm-operator/controllers/infra"
+	spq "github.com/vmware-tanzu/vm-operator/controllers/storagepolicyquota"
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachine"
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachineclass"
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachinepublishrequest"
@@ -29,6 +30,9 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 	}
 	if err := infra.AddToManager(ctx, mgr); err != nil {
 		return fmt.Errorf("failed to initialize Infra controllers: %w", err)
+	}
+	if err := spq.AddToManager(ctx, mgr); err != nil {
+		return fmt.Errorf("failed to initialize StoragePolicyQuota controller: %w", err)
 	}
 	if err := virtualmachine.AddToManager(ctx, mgr); err != nil {
 		return fmt.Errorf("failed to initialize VirtualMachine controller: %w", err)

--- a/controllers/storagepolicyquota/storagepolicyquota_controller.go
+++ b/controllers/storagepolicyquota/storagepolicyquota_controller.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package storagepolicyquota
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	spqv1 "github.com/vmware-tanzu/vm-operator/external/storage-policy-quota/api/v1alpha1"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
+	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/record"
+	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
+)
+
+// AddToManager adds this package's controller to the provided manager.
+func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) error {
+	var (
+		controlledType     = &spqv1.StoragePolicyQuota{}
+		controlledTypeName = reflect.TypeOf(controlledType).Elem().Name()
+
+		controllerNameShort = fmt.Sprintf("%s-controller", strings.ToLower(controlledTypeName))
+		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
+	)
+
+	r := NewReconciler(
+		ctx,
+		mgr.GetClient(),
+		ctrl.Log.WithName("controllers").WithName(controlledTypeName),
+		record.New(mgr.GetEventRecorderFor(controllerNameLong)),
+	)
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(controlledType).
+		Complete(r)
+}
+
+func NewReconciler(
+	ctx context.Context,
+	client client.Client,
+	logger logr.Logger,
+	recorder record.Recorder) *Reconciler {
+
+	return &Reconciler{
+		Context:  ctx,
+		Client:   client,
+		Logger:   logger,
+		Recorder: recorder,
+	}
+}
+
+// Reconciler reconciles a StoragePolicyQuota object.
+type Reconciler struct {
+	client.Client
+	Context  context.Context
+	Logger   logr.Logger
+	Recorder record.Recorder
+}
+
+//
+// Please note, the delete permissions are required on storagepolicyquotas
+// because it is set as the ControllerOwnerReference for the created
+// StoragePolicyUsage resource. If a controller owner reference does not have
+// delete on the owner, then a 422 (unprocessable entity) is returned.
+//
+
+// +kubebuilder:rbac:groups=cns.vmware.com,resources=storagepolicyquotas,verbs=get;list;watch;delete
+// +kubebuilder:rbac:groups=cns.vmware.com,resources=storagepolicyquotas/status,verbs=get
+// +kubebuilder:rbac:groups=cns.vmware.com,resources=storagepolicyusages,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=cns.vmware.com,resources=storagepolicyusages/status,verbs=get;update;patch
+
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
+	ctx = pkgcfg.JoinContext(ctx, r.Context)
+
+	var obj spqv1.StoragePolicyQuota
+	if err := r.Get(ctx, req.NamespacedName, &obj); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	logger := ctrl.Log.WithName("StoragePolicyQuota").WithValues("name", req.NamespacedName)
+
+	// Ensure the GVK for the object is synced back into the object since
+	// the object's APIVersion and Kind fields may be used later.
+	kubeutil.MustSyncGVKToObject(&obj, r.Scheme())
+
+	if !obj.DeletionTimestamp.IsZero() {
+		// Noop.
+		return ctrl.Result{}, nil
+	}
+
+	if err := r.ReconcileNormal(ctx, logger, obj); err != nil {
+		logger.Error(err, "Failed to reconcile StoragePolicyQuota")
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *Reconciler) ReconcileNormal(
+	ctx context.Context,
+	logger logr.Logger,
+	src spqv1.StoragePolicyQuota) error {
+
+	dst := spqv1.StoragePolicyUsage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kubeutil.StoragePolicyUsageNameFromQuotaName(src.Name),
+			Namespace: src.Namespace,
+		},
+	}
+
+	fn := func() error {
+		if err := ctrlutil.SetControllerReference(
+			&src, &dst, r.Scheme()); err != nil {
+
+			return err
+		}
+
+		dst.Spec.StorageClassName = src.Name
+		dst.Spec.StoragePolicyId = src.Spec.StoragePolicyId
+		dst.Spec.ResourceAPIgroup = ptr.To(spqv1.GroupVersion.Group)
+		dst.Spec.ResourceKind = "StoragePolicyQuota"
+		dst.Spec.ResourceExtensionName = "vmservice.cns.vsphere.vmware.com"
+
+		return nil
+	}
+
+	_, err := ctrlutil.CreateOrPatch(ctx, r.Client, &dst, fn)
+
+	return err
+}

--- a/controllers/storagepolicyquota/storagepolicyquota_controller_suite_test.go
+++ b/controllers/storagepolicyquota/storagepolicyquota_controller_suite_test.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2020-2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package storagepolicyquota_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+
+	"github.com/vmware-tanzu/vm-operator/controllers/storagepolicyquota"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
+	"github.com/vmware-tanzu/vm-operator/pkg/manager"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+var suite = builder.NewTestSuiteForControllerWithContext(
+	pkgcfg.NewContextWithDefaultConfig(),
+	storagepolicyquota.AddToManager,
+	manager.InitializeProvidersNoopFn)
+
+func TestStoragePolicyQuota(t *testing.T) {
+	suite.Register(t, "StoragePolicyQuota controller suite", intgTests, unitTests)
+}
+
+var _ = BeforeSuite(suite.BeforeSuite)
+
+var _ = AfterSuite(suite.AfterSuite)

--- a/controllers/storagepolicyquota/storagepolicyusage_controller_intg_test.go
+++ b/controllers/storagepolicyquota/storagepolicyusage_controller_intg_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package storagepolicyquota_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	spqv1 "github.com/vmware-tanzu/vm-operator/external/storage-policy-quota/api/v1alpha1"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
+	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+func intgTests() {
+	Describe(
+		"Reconcile",
+		Label(
+			testlabels.Controller,
+			testlabels.EnvTest,
+		),
+		intgTestsReconcile,
+	)
+}
+
+func intgTestsReconcile() {
+	var (
+		ctx    *builder.IntegrationTestContext
+		src    *spqv1.StoragePolicyQuota
+		srcKey types.NamespacedName
+	)
+
+	BeforeEach(func() {
+		ctx = suite.NewIntegrationTestContext()
+
+		src = &spqv1.StoragePolicyQuota{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-quota",
+				Namespace: ctx.Namespace,
+			},
+			Spec: spqv1.StoragePolicyQuotaSpec{
+				StoragePolicyId: "my-policy-id",
+			},
+		}
+		srcKey = client.ObjectKeyFromObject(src)
+	})
+
+	AfterEach(func() {
+		ctx.AfterEach()
+	})
+
+	Context("Reconcile", func() {
+		BeforeEach(func() {
+			Expect(ctx.Client.Create(ctx, src)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			err := ctx.Client.Delete(ctx, src)
+			Expect(err == nil || apierrors.IsNotFound(err)).To(BeTrue())
+		})
+
+		It("should result in the creation of a StoragePolicyUsage resource", func() {
+			Eventually(func(g Gomega) {
+				var src spqv1.StoragePolicyQuota
+				g.Expect(ctx.Client.Get(ctx, srcKey, &src)).To(Succeed())
+
+				var dst spqv1.StoragePolicyUsage
+				dstKey := client.ObjectKey{
+					Namespace: ctx.Namespace,
+					Name:      kubeutil.StoragePolicyUsageNameFromQuotaName(srcKey.Name),
+				}
+				g.Expect(ctx.Client.Get(ctx, dstKey, &dst)).To(Succeed())
+
+				g.Expect(dst.OwnerReferences).To(Equal([]metav1.OwnerReference{
+					{
+						APIVersion:         spqv1.GroupVersion.String(),
+						Kind:               "StoragePolicyQuota",
+						Name:               src.Name,
+						UID:                src.UID,
+						Controller:         ptr.To(true),
+						BlockOwnerDeletion: ptr.To(true),
+					},
+				}))
+				g.Expect(dst.Spec.StoragePolicyId).To(Equal(src.Spec.StoragePolicyId))
+				g.Expect(dst.Spec.StorageClassName).To(Equal(src.Name))
+				g.Expect(dst.Spec.ResourceAPIgroup).To(Equal(ptr.To(spqv1.GroupVersion.Group)))
+				g.Expect(dst.Spec.ResourceKind).To(Equal("StoragePolicyQuota"))
+				g.Expect(dst.Spec.ResourceExtensionName).To(Equal("vmservice.cns.vsphere.vmware.com"))
+			}).Should(Succeed())
+		})
+	})
+}

--- a/controllers/storagepolicyquota/storagepolicyusage_controller_unit_test.go
+++ b/controllers/storagepolicyquota/storagepolicyusage_controller_unit_test.go
@@ -1,0 +1,210 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package storagepolicyquota_test
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	"github.com/vmware-tanzu/vm-operator/controllers/storagepolicyquota"
+	spqv1 "github.com/vmware-tanzu/vm-operator/external/storage-policy-quota/api/v1alpha1"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
+	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+func unitTests() {
+	Describe(
+		"Reconcile",
+		Label(
+			testlabels.Controller,
+		),
+		unitTestsReconcile,
+	)
+}
+
+func unitTestsReconcile() {
+	var (
+		initObjects []client.Object
+		ctx         *builder.UnitTestContextForController
+
+		reconciler *storagepolicyquota.Reconciler
+		src        *spqv1.StoragePolicyQuota
+	)
+
+	BeforeEach(func() {
+		initObjects = nil
+		src = &spqv1.StoragePolicyQuota{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dummy-quota",
+				Namespace: "dummy-namespace",
+			},
+		}
+	})
+
+	JustBeforeEach(func() {
+		initObjects = append(initObjects, src)
+		ctx = suite.NewUnitTestContextForController(initObjects...)
+		reconciler = storagepolicyquota.NewReconciler(
+			ctx,
+			ctx.Client,
+			ctx.Logger,
+			ctx.Recorder,
+		)
+	})
+
+	Context("Reconcile", func() {
+		var (
+			err       error
+			name      string
+			namespace string
+		)
+
+		BeforeEach(func() {
+			err = nil
+			name = src.Name
+			namespace = src.Namespace
+		})
+
+		JustBeforeEach(func() {
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: namespace,
+					Name:      name,
+				}})
+		})
+
+		// Please note it is not possible to validate garbage collection with
+		// the fake client or with envtest, because neither of them implement
+		// the Kubernetes garbage collector.
+		When("Deleted", func() {
+			BeforeEach(func() {
+				src.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+				src.Finalizers = append(src.Finalizers, "fake.com/finalizer")
+			})
+			It("returns success", func() {
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		When("Normal", func() {
+			assertStoragePolicyUsage := func(err error) {
+				ExpectWithOffset(1, err).ToNot(HaveOccurred())
+				var dst spqv1.StoragePolicyUsage
+				ExpectWithOffset(1, ctx.Client.Get(
+					ctx,
+					types.NamespacedName{
+						Namespace: namespace,
+						Name:      kubeutil.StoragePolicyUsageNameFromQuotaName(name),
+					},
+					&dst)).To(Succeed())
+				ExpectWithOffset(1, dst.Spec.ResourceAPIgroup).To(Equal(ptr.To(spqv1.GroupVersion.Group)))
+				ExpectWithOffset(1, dst.Spec.ResourceExtensionName).To(Equal("vmservice.cns.vsphere.vmware.com"))
+				ExpectWithOffset(1, dst.Spec.ResourceKind).To(Equal("StoragePolicyQuota"))
+				ExpectWithOffset(1, dst.Spec.StorageClassName).To(Equal(src.Name))
+				ExpectWithOffset(1, dst.Spec.StoragePolicyId).To(Equal(src.Spec.StoragePolicyId))
+			}
+
+			When("a StoragePolicyUsage resource does not exist", func() {
+				It("creates the resource", func() {
+					assertStoragePolicyUsage(err)
+				})
+			})
+			When("a StoragePolicyUsage resource does exist", func() {
+				var dst *spqv1.StoragePolicyUsage
+
+				BeforeEach(func() {
+					dst = &spqv1.StoragePolicyUsage{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: namespace,
+							Name:      kubeutil.StoragePolicyUsageNameFromQuotaName(name),
+						},
+						Spec: spqv1.StoragePolicyUsageSpec{
+							StoragePolicyId: src.Spec.StoragePolicyId,
+						},
+					}
+					initObjects = append(initObjects, dst)
+				})
+
+				When("the resource does not have a controller reference", func() {
+					It("patches the resource", func() {
+						assertStoragePolicyUsage(err)
+					})
+				})
+				When("the resource does have a controller reference", func() {
+					When("it is not the StoragePolicyQuota", func() {
+						BeforeEach(func() {
+							dst.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
+								{
+									APIVersion:         vmopv1.GroupName,
+									Kind:               "VirtualMachine",
+									Name:               "my-vm",
+									UID:                types.UID("1234"),
+									Controller:         ptr.To(true),
+									BlockOwnerDeletion: ptr.To(true),
+								},
+							}
+						})
+						It("returns an error", func() {
+							Expect(err).To(HaveOccurred())
+							Expect(err).To(MatchError(fmt.Sprintf(
+								"Object %s/%s is already owned by another %s controller %s",
+								dst.Namespace,
+								dst.Name,
+								"VirtualMachine",
+								"my-vm")))
+						})
+					})
+					When("it is the StoragePolicyQuota", func() {
+						BeforeEach(func() {
+							dst.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
+								{
+									APIVersion:         spqv1.GroupVersion.String(),
+									Kind:               "StoragePolicyQuota",
+									Name:               src.Name,
+									UID:                src.UID,
+									Controller:         ptr.To(true),
+									BlockOwnerDeletion: ptr.To(true),
+								},
+							}
+						})
+						It("patches the resource", func() {
+							assertStoragePolicyUsage(err)
+						})
+					})
+				})
+			})
+		})
+
+		When("Object not found", func() {
+			Context("name is invalid", func() {
+				BeforeEach(func() {
+					name = "invalid"
+				})
+				It("ignores the error", func() {
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+			Context("namespace is invalid", func() {
+				BeforeEach(func() {
+					namespace = "invalid"
+				})
+				It("ignores the error", func() {
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+	})
+
+}

--- a/pkg/util/kube/gvk.go
+++ b/pkg/util/kube/gvk.go
@@ -21,3 +21,15 @@ func SyncGVKToObject(obj runtime.Object, scheme *runtime.Scheme) error {
 	obj.GetObjectKind().SetGroupVersionKind(gvk)
 	return nil
 }
+
+// MustSyncGVKToObject synchronizes the group, version, and kind for a given
+// object back into the object by looking up the information from the provided
+// scheme.
+//
+// For more information, please see Update 1 from the following issue:
+// https://github.com/kubernetes-sigs/controller-runtime/issues/2382.
+func MustSyncGVKToObject(obj runtime.Object, scheme *runtime.Scheme) {
+	if err := SyncGVKToObject(obj, scheme); err != nil {
+		panic(err)
+	}
+}

--- a/pkg/util/kube/spq.go
+++ b/pkg/util/kube/spq.go
@@ -1,0 +1,10 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package kube
+
+// StoragePolicyUsageNameFromQuotaName returns the name of the
+// StoragePolicyUsage resource for a given StoragePolicyQuota resource name.
+func StoragePolicyUsageNameFromQuotaName(s string) string {
+	return s + "-vm-usage"
+}

--- a/pkg/util/kube/spq_test.go
+++ b/pkg/util/kube/spq_test.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package kube_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
+)
+
+var _ = DescribeTable("StoragePolicyUsageNameFromQuotaName",
+	func(s string, expected string) {
+		Ω(kubeutil.StoragePolicyUsageNameFromQuotaName(s)).Should(Equal(expected))
+	},
+	Entry("empty input", "", "-vm-usage"),
+	Entry("non-empty-input", "my-quota", "my-quota-vm-usage"),
+)


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch adds the controller that creates StoragePolicyUsage resources for StoragePolicyQuota resources applied to namespaces.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
StoragePolicyQuota controller creates StoragePolicyUsage resources for tracking VM usage
```