### PR TITLE
🌱 resize: support same class annotation on brownfield VMs

### DIFF
--- a/pkg/util/vmopv1/resize.go
+++ b/pkg/util/vmopv1/resize.go
@@ -109,8 +109,10 @@ func ResizeNeeded(
 	if !exists || lra.Name == "" {
 		// The VM does not have the last resized annotation. Most likely this is an existing VM
 		// and the VM Spec.ClassName hasn't been changed (because the mutation webhook sets the
-		// annotation when it changes).
-		return false
+		// annotation when it changes). However, if the same class opt-in annotation is set, do
+		// a resize to sync this VM to its class.
+		_, ok := vm.Annotations[vmopv1.VirtualMachineSameVMClassResizeAnnotation]
+		return ok
 	}
 
 	if vm.Spec.ClassName != lra.Name {
@@ -120,7 +122,7 @@ func ResizeNeeded(
 
 	// Resizing as the class itself changes is only performed with an opt-in annotation
 	// because a change in the class could break existing VMs.
-	if _, exists := vm.Annotations[vmopv1.VirtualMachineSameVMClassResizeAnnotation]; exists {
+	if _, ok := vm.Annotations[vmopv1.VirtualMachineSameVMClassResizeAnnotation]; ok {
 		same := vmClass.UID == lra.UID && vmClass.Generation == lra.Generation
 		return !same
 	}

--- a/pkg/util/vmopv1/resize_test.go
+++ b/pkg/util/vmopv1/resize_test.go
@@ -131,6 +131,16 @@ var _ = Describe("ResizeNeeded", func() {
 		It("returns false", func() {
 			Expect(vmopv1util.ResizeNeeded(vm, vmClass)).To(BeFalse())
 		})
+
+		When("same-class annotation is present", func() {
+			BeforeEach(func() {
+				vm.Annotations[vmopv1.VirtualMachineSameVMClassResizeAnnotation] = ""
+			})
+
+			It("returns true", func() {
+				Expect(vmopv1util.ResizeNeeded(vm, vmClass)).To(BeTrue())
+			})
+		})
 	})
 
 	Context("Resize annotation is present", func() {


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

Allow an existing VM to be synced to the class that is currently points to when the opt-in annotation is present.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:


```release-note
NONE
```