### PR TITLE
🌱 resize: update VM Status.Class after resizing

### DIFF
--- a/pkg/providers/vsphere/session/session_vm_update.go
+++ b/pkg/providers/vsphere/session/session_vm_update.go
@@ -19,6 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	vmopv1common "github.com/vmware-tanzu/vm-operator/api/v1alpha3/common"
 	"github.com/vmware-tanzu/vm-operator/pkg"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
@@ -633,6 +634,12 @@ func (s *Session) prePowerOnVMReconfigure(
 
 		if vmResizeEnabled {
 			vmopv1util.MustSetLastResizedAnnotation(vmCtx.VM, updateArgs.VMClass)
+
+			vmCtx.VM.Status.Class = &vmopv1common.LocalObjectRef{
+				APIVersion: vmopv1.SchemeGroupVersion.String(),
+				Kind:       "VirtualMachineClass",
+				Name:       updateArgs.VMClass.Name,
+			}
 		}
 	}
 
@@ -938,6 +945,14 @@ func (s *Session) resizeVMWhenPoweredStateOff(
 
 	if needsResize {
 		vmopv1util.MustSetLastResizedAnnotation(vmCtx.VM, *resizeArgs.VMClass)
+	}
+
+	if resizeArgs.VMClass != nil {
+		vmCtx.VM.Status.Class = &vmopv1common.LocalObjectRef{
+			APIVersion: vmopv1.SchemeGroupVersion.String(),
+			Kind:       "VirtualMachineClass",
+			Name:       resizeArgs.VMClass.Name,
+		}
 	}
 
 	return refetchProps, nil

--- a/pkg/providers/vsphere/vmlifecycle/update_status_test.go
+++ b/pkg/providers/vsphere/vmlifecycle/update_status_test.go
@@ -17,6 +17,7 @@ import (
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	vmopv1common "github.com/vmware-tanzu/vm-operator/api/v1alpha3/common"
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/network"
@@ -1013,10 +1014,18 @@ var _ = Describe("UpdateStatus", func() {
 			Expect(conditions.IsTrue(vmCtx.VM, vmopv1.VirtualMachineConditionCreated)).To(BeTrue())
 		})
 
-		Context("Has Class", func() {
-			It("Back fills Status.Class", func() {
-				Expect(vmCtx.VM.Status.Class).ToNot(BeNil())
-				Expect(vmCtx.VM.Status.Class.Name).To(Equal(builder.DummyClassName))
+		Context("When FSS_WCP_VMSERVICE_RESIZE is not enabled", func() {
+			BeforeEach(func() {
+				pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+					config.Features.VMResize = false
+				})
+			})
+
+			Context("Has Class", func() {
+				It("Back fills Status.Class", func() {
+					Expect(vmCtx.VM.Status.Class).ToNot(BeNil())
+					Expect(vmCtx.VM.Status.Class.Name).To(Equal(builder.DummyClassName))
+				})
 			})
 		})
 


### PR DESCRIPTION


**What does this PR do, and why is it needed?**

After a resize update the VM Status.Class to reflect the updated class that was just applied.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note
NONE
```