### PR TITLE
:seedling: Introduce the ExtraConfig key to allow opt-out from auto register

### DIFF
--- a/api/v1alpha3/virtualmachine_types.go
+++ b/api/v1alpha3/virtualmachine_types.go
@@ -161,6 +161,22 @@ const (
 	// PVCDiskDataExtraConfigKey is the ExtraConfig key to persist the VM's
 	// PVC disk data in JSON, compressed using gzip and base64-encoded.
 	PVCDiskDataExtraConfigKey = "vmservice.virtualmachine.pvc.disk.data"
+
+	// DisableAutoRegistrationExtraConfigKey is the ExtraConfig key that can be
+	// set to "true" (case insensitive) on a virtual machine to opt-out of the
+	// automatic registration workflow.
+	//
+	// A "registration" refers to adopting a virtual machine so it is managed by
+	// VM operator on Supervisor. Typically, this involves creating a new
+	// VirtualMachine resource, or updating an existing VirtualMachine resource on
+	// Supervisor to conform to the virtual machine on vSphere.
+	//
+	// After a restore from a backup restore vendor, or a failover from a disaster
+	// recovery solution, vCenter automatically attempts to register the restored
+	// virtual machine with Supervisor. If the automatic registration is skipped by
+	// specifying this key, backup/restore and/or disaster recovery solutions are
+	// responsible to register the VM with Supervisor.
+	DisableAutoRegistrationExtraConfigKey = "vmservice.virtualmachine.disableAutomaticRegistration"
 )
 
 const (


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Currently, we will unconditionally try to register a VM when it is restored using a backup/restore vendor, or a DR solution.  This isn't always ideal if the solution wants to prepare the infra, or customize the VM on vSphere before registering the VM with Supervisor.

This change introduces an ExtraConfig key that can be used to opt-out of the automatic registration workflow.

**Please add a release note if necessary**:

```release-note
Introduce the ExtraConfig key to allow opt-out from auto register
```