### PR TITLE
🐛 Only set vmPathName when using ISO image

### DIFF
--- a/pkg/providers/vsphere/vmprovider_vm.go
+++ b/pkg/providers/vsphere/vmprovider_vm.go
@@ -333,6 +333,9 @@ func (vs *vSphereVMProvider) vmCreatePathName(
 	vcClient *vcclient.Client,
 	createArgs *VMCreateArgs) error {
 
+	if len(vmCtx.VM.Spec.Cdrom) == 0 {
+		return nil // only needed when deploying ISO library items
+	}
 	if createArgs.StorageProfileID == "" {
 		return nil
 	}
@@ -342,8 +345,6 @@ func (vs *vSphereVMProvider) vmCreatePathName(
 	if createArgs.ConfigSpec.Files.VmPathName != "" {
 		return nil
 	}
-
-	// TODO: we should only do this when deploying ISO library items
 
 	vc := vcClient.VimClient()
 

--- a/pkg/providers/vsphere/vmprovider_vm_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_test.go
@@ -332,6 +332,7 @@ func vmTests() {
 					propName        = "config.name"
 					propPowerState  = "runtime.powerState"
 					propExtraConfig = "config.extraConfig"
+					propPathName    = "config.files.vmPathName"
 				)
 				var (
 					err           error
@@ -380,6 +381,16 @@ func vmTests() {
 						default:
 							panic(fmt.Sprintf("invalid power state: %s", vm.Spec.PowerState))
 						}
+					})
+				})
+				When("getting "+propPathName, func() {
+					BeforeEach(func() {
+						propertyPaths = []string{propPathName}
+					})
+					It("should not be set", func() {
+						Expect(err).ToNot(HaveOccurred())
+						Expect(result).To(HaveLen(1))
+						Expect(result[propName]).To(BeNil()) // should only be set if cdrom is present
 					})
 				})
 			})
@@ -2096,6 +2107,13 @@ func vmTests() {
 			vm.Spec.Image.Kind = cvmiKind
 			vm.Spec.Image.Name = clusterVMImage.Name
 			vm.Spec.StorageClass = ctx.StorageClassName
+			vm.Spec.Cdrom = []vmopv1.VirtualMachineCdromSpec{{
+				Name: "cdrom0",
+				Image: vmopv1.VirtualMachineImageRef{
+					Name: cvmiKind,
+					Kind: clusterVMImage.Name,
+				},
+			}}
 		})
 
 		Context("return config", func() {


### PR DESCRIPTION
The storage policy datastore query is only needed for ISO images.
