### PR TITLE
:seedling: Rename the pause-reconcile annotation to paused

### DIFF
--- a/api/v1alpha1/virtualmachine_conversion.go
+++ b/api/v1alpha1/virtualmachine_conversion.go
@@ -1138,6 +1138,19 @@ func Convert_v1alpha3_VirtualMachine_To_v1alpha1_VirtualMachine(in *vmopv1.Virtu
 	// necessary for later versions that don't support configMap based bootstrap.
 	delete(out.Annotations, vmopv1.V1alpha1ConfigMapTransportAnnotation)
 
+	// Handle the renaming of pause annotation on down convert.
+	if val, ok := in.Annotations[vmopv1.PauseAnnotation]; ok {
+		if out.Annotations == nil {
+			out.Annotations = make(map[string]string)
+		}
+		out.Annotations[PauseAnnotation] = val
+
+		// Remove the pause annotation corresponding to the Hub.
+		// This would also remove the annotation if someone created a
+		// v1a1 VM with "paused" annotation.
+		delete(out.Annotations, vmopv1.PauseAnnotation)
+	}
+
 	return nil
 }
 
@@ -1180,6 +1193,20 @@ func Convert_v1alpha1_VirtualMachine_To_v1alpha3_VirtualMachine(in *VirtualMachi
 			annotations[vmopv1.V1alpha1ConfigMapTransportAnnotation] = "true"
 			out.GetObjectMeta().SetAnnotations(annotations)
 		}
+	}
+
+	// Handle the renaming of pause annotation on up convert.
+	if val, ok := in.Annotations[PauseAnnotation]; ok {
+		annotations := out.GetAnnotations()
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		annotations[vmopv1.PauseAnnotation] = val
+
+		// Remove the pause annotation from v1alpha1.
+		// This would also remove the annotation if someone created a
+		// v1a1 VM with "pause-reconcile" annotation.
+		delete(annotations, PauseAnnotation)
 	}
 
 	return nil

--- a/api/v1alpha2/virtualmachine_conversion.go
+++ b/api/v1alpha2/virtualmachine_conversion.go
@@ -127,6 +127,18 @@ func Convert_v1alpha3_VirtualMachine_To_v1alpha2_VirtualMachine(
 		}
 	}
 
+	// Handle the renaming of pause annotation on down convert.
+	if val, ok := in.Annotations[vmopv1.PauseAnnotation]; ok {
+		if out.Annotations == nil {
+			out.Annotations = make(map[string]string)
+		}
+		out.Annotations[PauseAnnotation] = val
+		// Remove the pause annotation corresponding to the Hub.
+		// This would also remove the annotation if someone created a
+		// v1a2 VM with "paused" annotation.
+		delete(out.Annotations, vmopv1.PauseAnnotation)
+	}
+
 	return nil
 }
 
@@ -201,6 +213,20 @@ func Convert_v1alpha2_VirtualMachine_To_v1alpha3_VirtualMachine(in *VirtualMachi
 				}
 			}
 		}
+	}
+
+	// Handle the renaming of pause annotation on up convert.
+	if val, ok := in.Annotations[PauseAnnotation]; ok {
+		annotations := out.GetAnnotations()
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		annotations[vmopv1.PauseAnnotation] = val
+
+		// Remove the pause annotation from v1alpha1.
+		// This would also remove the annotation if someone created a
+		// v1a1 VM with "pause-reconcile" annotation.
+		delete(annotations, PauseAnnotation)
 	}
 
 	return nil

--- a/api/v1alpha3/virtualmachine_types.go
+++ b/api/v1alpha3/virtualmachine_types.go
@@ -121,7 +121,7 @@ const (
 	// VM back to its intended state.
 	//
 	// The VM will not be reconciled again until this annotation is removed.
-	PauseAnnotation = GroupName + "/pause-reconcile"
+	PauseAnnotation = GroupName + "/paused"
 
 	// InstanceIDAnnotation is an annotation that can be applied to set Cloud-Init metadata Instance ID.
 	//

--- a/controllers/virtualmachine/virtualmachine/virtualmachine_controller.go
+++ b/controllers/virtualmachine/virtualmachine/virtualmachine_controller.go
@@ -35,6 +35,7 @@ import (
 	vspherevm "github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/virtualmachine"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/vmlifecycle"
 	"github.com/vmware-tanzu/vm-operator/pkg/record"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/annotations"
 	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
 	vmopv1util "github.com/vmware-tanzu/vm-operator/pkg/util/vmopv1"
@@ -318,9 +319,11 @@ func requeueDelay(ctx *pkgctx.VirtualMachineContext) time.Duration {
 func (r *Reconciler) ReconcileDelete(ctx *pkgctx.VirtualMachineContext) (reterr error) {
 	ctx.Logger.Info("Reconciling VirtualMachine Deletion")
 
-	// Return early if the VM reconciliation is paused.
-	if _, exists := ctx.VM.Annotations[vmopv1.PauseAnnotation]; exists {
+	// If the VM reconciliation has been paused by the developer,
+	// skip deletion and return.
+	if annotations.HasPaused(ctx.VM) {
 		ctx.Logger.Info("Skipping deletion since VirtualMachine contains the pause annotation")
+
 		return nil
 	}
 

--- a/pkg/providers/vsphere/session/session_vm_update.go
+++ b/pkg/providers/vsphere/session/session_vm_update.go
@@ -30,6 +30,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/virtualmachine"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/vmlifecycle"
 	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/annotations"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/resize"
 	vmopv1util "github.com/vmware-tanzu/vm-operator/pkg/util/vmopv1"
 	vmutil "github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/vm"
@@ -1233,11 +1234,10 @@ func (s *Session) UpdateVirtualMachine(
 
 // Source of truth is EC and Annotation.
 func isVMPaused(vmCtx pkgctx.VirtualMachineContext) bool {
-
 	vm := vmCtx.VM
 
 	adminPaused := vmutil.IsPausedByAdmin(vmCtx.MoVM)
-	_, devopsPaused := vm.Annotations[vmopv1.PauseAnnotation]
+	devopsPaused := annotations.HasPaused(vm)
 
 	if adminPaused || devopsPaused {
 		if vm.Labels == nil {

--- a/pkg/util/annotations/helpers.go
+++ b/pkg/util/annotations/helpers.go
@@ -13,6 +13,10 @@ func HasForceEnableBackup(o metav1.Object) bool {
 	return hasAnnotation(o, vmopv1.ForceEnableBackupAnnotation)
 }
 
+func HasPaused(o metav1.Object) bool {
+	return hasAnnotation(o, vmopv1.PauseAnnotation)
+}
+
 func hasAnnotation(o metav1.Object, annotation string) bool {
 	annotations := o.GetAnnotations()
 	if annotations == nil {

--- a/pkg/util/annotations/helpers_suite_test.go
+++ b/pkg/util/annotations/helpers_suite_test.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package annotations_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/klog/v2"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func init() {
+	klog.SetOutput(GinkgoWriter)
+	logf.SetLogger(klog.Background())
+}
+
+func TestPtr(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Annotations Util Test Suite")
+}

--- a/pkg/util/annotations/helpers_test.go
+++ b/pkg/util/annotations/helpers_test.go
@@ -14,6 +14,23 @@ import (
 )
 
 var _ = DescribeTable(
+	"HasPaused",
+	func(in map[string]string, out bool) {
+		vm := &vmopv1.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: in,
+			},
+		}
+		actual := annotations.HasPaused(vm)
+		Expect(actual).To(Equal(out))
+	},
+	Entry("nil", nil, false),
+	Entry("not present", map[string]string{"foo": "bar"}, false),
+	Entry("present but empty ", map[string]string{vmopv1.PauseAnnotation: ""}, true),
+	Entry("present and not empty ", map[string]string{vmopv1.PauseAnnotation: "true"}, true),
+)
+
+var _ = DescribeTable(
 	"HasForceEnableBackup",
 	func(in map[string]string, out bool) {
 		vm := &vmopv1.VirtualMachine{


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This change renames the "pause-reconcile" annotation used to pause the reconciliation of a VM to "paused".  This is consistent with other components using "paused" to indicate an entity being paused.

Additionally, introduce a helper package that can be used to check if an annotation is present (regardless of the value) in a readable way.

**Testing Done:**
1. Create a VM on v1alpha3 version with `paused` annotation set.
```
# k get --raw  https://127.0.0.1:6443/apis/vmoperator.vmware.com/v1alpha3/namespaces/parunesh-ns/virtualmachines/parunesh-vm | jq -r '.metadata.annotations | to_entries[] | select(.key == "vmoperator.vmware.com/paused")'
{
  "key": "vmoperator.vmware.com/paused",
  "value": "something"
}
```
2. Ensure that the VM doesn't have `pause-reconcile` annotation set
```
# k get --raw  https://127.0.0.1:6443/apis/vmoperator.vmware.com/v1alpha3/namespaces/parunesh-ns/virtualmachines/parunesh-vm | jq -r '.metadata.annotations | to_entries[] | select(.key == "vmoperator.vmware.com/pause-reconcile")'
#
```

3. Fetch the resource at v1alpha2 and v1alpha1 version and ensure that the `pause-reconcile` annotation is set.
```
# k get --raw  https://127.0.0.1:6443/apis/vmoperator.vmware.com/v1alpha2/namespaces/parunesh-ns/virtualmachines/parunesh-vm | jq -r '.metadata.annotations | to_entries[] | select(.key == "vmoperator.vmware.com/pause-reconcile")'
{
  "key": "vmoperator.vmware.com/pause-reconcile",
  "value": "something"
}
# k get --raw  https://127.0.0.1:6443/apis/vmoperator.vmware.com/v1alpha1/namespaces/parunesh-ns/virtualmachines/parunesh-vm | jq -r '.metadata.annotations | to_entries[] | select(.key == "vmoperator.vmware.com/pause-reconcile")'
{
  "key": "vmoperator.vmware.com/pause-reconcile",
  "value": "something"
}
```

**Please add a release note if necessary**:

```release-note
Rename the pause-reconcile annotation to paused
```