### PR TITLE
:seedling: Introduce an annotation for unconditional opt into backup

### DIFF
--- a/api/v1alpha3/virtualmachine_types.go
+++ b/api/v1alpha3/virtualmachine_types.go
@@ -177,6 +177,16 @@ const (
 	// specifying this key, backup/restore and/or disaster recovery solutions are
 	// responsible to register the VM with Supervisor.
 	DisableAutoRegistrationExtraConfigKey = "vmservice.virtualmachine.disableAutomaticRegistration"
+
+	// ForceEnableBackupAnnotation is an annotation that instructs VM operator to
+	// ignore all exclusion rules and persist the configuration of the resource in
+	// virtual machine in relevant ExtraConfig fields.
+	//
+	// This is an experimental flag which only guarantees that the configuration
+	// of the VirtualMachine resource will be persisted in the virtual machine on
+	// vSphere.  There is no guarantee that the registration of the VM will be
+	// successful post a restore or failover operation.
+	ForceEnableBackupAnnotation = GroupName + "/force-enable-backup"
 )
 
 const (

--- a/pkg/providers/vsphere/vmprovider_vm.go
+++ b/pkg/providers/vsphere/vmprovider_vm.go
@@ -41,6 +41,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/vmlifecycle"
 	"github.com/vmware-tanzu/vm-operator/pkg/topology"
 	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/annotations"
 	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 	vmopv1util "github.com/vmware-tanzu/vm-operator/pkg/util/vmopv1"
 )
@@ -518,9 +519,10 @@ func (vs *vSphereVMProvider) updateVirtualMachine(
 		}
 	}
 
-	// Back up the VM at the end after a successful update.
-	// Skip TKG VMs since they are backed up differently than VM Service VMs.
-	if !kubeutil.HasCAPILabels(vmCtx.VM.Labels) {
+	// Back up the VM at the end after a successful update.  TKG nodes are skipped
+	// from backup unless they specify the annotation to opt into backup.
+	if !kubeutil.HasCAPILabels(vmCtx.VM.Labels) ||
+		annotations.HasForceEnableBackup(vmCtx.VM) {
 		vmCtx.Logger.V(4).Info("Backing up VM Service managed VM")
 
 		diskUUIDToPVC, err := GetAttachedDiskUUIDToPVC(vmCtx, vs.k8sClient)

--- a/pkg/providers/vsphere/vmprovider_vm_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_test.go
@@ -1298,6 +1298,27 @@ func vmTests() {
 					Expect(ecMap).ToNot(HaveKey(vmopv1.VMResourceYAMLExtraConfigKey))
 				})
 			})
+			It("TKG VM that has opt-in annotation gets the backup EC", func() {
+				if vm.Labels == nil {
+					vm.Labels = make(map[string]string)
+				}
+				vm.Labels[kubeutil.CAPVClusterRoleLabelKey] = ""
+				vm.Labels[kubeutil.CAPWClusterRoleLabelKey] = ""
+
+				vm.Annotations[vmopv1.ForceEnableBackupAnnotation] = "true"
+
+				vcVM, err := createOrUpdateAndGetVcVM(ctx, vm)
+				Expect(err).ToNot(HaveOccurred())
+
+				var o mo.VirtualMachine
+				Expect(vcVM.Properties(ctx, vcVM.Reference(), nil, &o)).To(Succeed())
+
+				By("has backup ExtraConfig key", func() {
+					Expect(o.Config.ExtraConfig).ToNot(BeNil())
+					ecMap := pkgutil.OptionValues(o.Config.ExtraConfig).StringMap()
+					Expect(ecMap).To(HaveKey(vmopv1.VMResourceYAMLExtraConfigKey))
+				})
+			})
 
 			Context("VM Class with PCI passthrough devices", func() {
 				BeforeEach(func() {

--- a/pkg/util/annotations/helpers.go
+++ b/pkg/util/annotations/helpers.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package annotations
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+)
+
+func HasForceEnableBackup(o metav1.Object) bool {
+	return hasAnnotation(o, vmopv1.ForceEnableBackupAnnotation)
+}
+
+func hasAnnotation(o metav1.Object, annotation string) bool {
+	annotations := o.GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+
+	_, ok := annotations[annotation]
+	return ok
+}

--- a/pkg/util/annotations/helpers_test.go
+++ b/pkg/util/annotations/helpers_test.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package annotations_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/annotations"
+)
+
+var _ = DescribeTable(
+	"HasForceEnableBackup",
+	func(in map[string]string, out bool) {
+		vm := &vmopv1.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: in,
+			},
+		}
+		actual := annotations.HasForceEnableBackup(vm)
+		Expect(actual).To(Equal(out))
+	},
+	Entry("nil", nil, false),
+	Entry("not present", map[string]string{"foo": "bar"}, false),
+	Entry("present but empty ", map[string]string{vmopv1.ForceEnableBackupAnnotation: ""}, true),
+	Entry("present and not empty ", map[string]string{vmopv1.ForceEnableBackupAnnotation: "true"}, true),
+)


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Today, we have certain exclusion rules in place that govern whether or not we persist the configuration of VirtualMachine in the ExtraConfig for use by backup/restore or disaster recovery solutions.  However, there might be cases where an entity wants to explicitly opt into backup.

This change introduces an annotation that can be placed on the VirtualMachine resource that lets VM operator skip the exclusion checks when determining whether or not to store the VM's config in ExtraConfig.


**Please add a release note if necessary**:

```release-note
 Introduce an annotation for unconditional opt into backup
```