### PR TITLE
🌱 resize: add condition to indicate if resize is available

### DIFF
--- a/api/v1alpha2/virtualmachine_types.go
+++ b/api/v1alpha2/virtualmachine_types.go
@@ -41,6 +41,10 @@ const (
 
 	// VirtualMachineConditionCreated indicates that the VM has been created.
 	VirtualMachineConditionCreated = "VirtualMachineCreated"
+
+	// VirtualMachineConfigurationSynced indicates that the VM's current configuration is synced to the
+	// current version of its VirtualMachineClass.
+	VirtualMachineConfigurationSynced = "VirtualMachineConfigurationSynced"
 )
 
 const (

--- a/api/v1alpha3/virtualmachine_types.go
+++ b/api/v1alpha3/virtualmachine_types.go
@@ -43,6 +43,10 @@ const (
 
 	// VirtualMachineConditionCreated indicates that the VM has been created.
 	VirtualMachineConditionCreated = "VirtualMachineCreated"
+
+	// VirtualMachineConfigurationSynced indicates that the VM's current configuration is synced to the
+	// current version of its VirtualMachineClass.
+	VirtualMachineConfigurationSynced = "VirtualMachineConfigurationSynced"
 )
 
 const (

--- a/pkg/providers/vsphere/vmlifecycle/update_status_test.go
+++ b/pkg/providers/vsphere/vmlifecycle/update_status_test.go
@@ -1055,7 +1055,6 @@ var _ = Describe("UpdateStatus", func() {
 			})
 		})
 	})
-
 })
 
 var _ = Describe("VirtualMachineTools Status to VM Status Condition", func() {

--- a/webhooks/virtualmachine/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator.go
@@ -404,7 +404,7 @@ func (v validator) validateClassOnCreate(ctx *pkgctx.WebhookRequestContext, vm *
 func (v validator) validateClassOnUpdate(ctx *pkgctx.WebhookRequestContext, vm, oldVM *vmopv1.VirtualMachine) field.ErrorList {
 	var allErrs field.ErrorList
 
-	if !pkgcfg.FromContext(ctx).Features.VMResize && !pkgcfg.FromContext(ctx).Features.VMResizeCPUMemory {
+	if f := pkgcfg.FromContext(ctx).Features; !f.VMResize && !f.VMResizeCPUMemory {
 		return append(allErrs,
 			validation.ValidateImmutableField(vm.Spec.ClassName, oldVM.Spec.ClassName, field.NewPath("spec", "className"))...)
 	}


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

If a resize is pending - likely because the VM is powered on and either the VM Spec.ClassName has been updated or the opt-in annotation is present and the class itself has changed - report that in a condition.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note
NONE
```