### PR TITLE
🌱 Skip default LinuxPrep bootstrap for ISO VM deployment

### DIFF
--- a/pkg/providers/vsphere/vmlifecycle/bootstrap.go
+++ b/pkg/providers/vsphere/vmlifecycle/bootstrap.go
@@ -67,7 +67,9 @@ func DoBootstrap(
 	if bootstrap == nil {
 		// V1ALPHA1: We had always defaulted to LinuxPrep w/ HwClockUTC=true.
 		// Now, try to just do that on Linux VMs.
-		if !isLinuxGuest(config.GuestId) {
+		// Skip if the VM has a CD-ROM as the Linux ISO-type image may not have
+		// the necessary tools to do the default LinuxPrep bootstrap.
+		if !isLinuxGuest(config.GuestId) || len(vmCtx.VM.Spec.Cdrom) > 0 {
 			vmCtx.Logger.V(6).Info("no bootstrap provider specified")
 			return nil
 		}


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR skips the default LinuxPrep bootstrap if a VM is deployed from ISO (i.e., having a CD-ROM attached). This avoids VM deployment errors when the Linux ISO-type image doesn't have vmtools installed.

**Which issue(s) is/are addressed by this PR?**

Fixes N/A.

**Are there any special notes for your reviewer**

Manually deployed a Linux ISO-type VM with this change in an internal testbed and verified the VM is powered on successfully without the default customization applied.

**Please add a release note if necessary**:

```release-note
Skip default LinuxPrep bootstrap for ISO VM deployment.
```