### PR TITLE
🌱 Change APIGroup for VPC

### DIFF
--- a/api/v1alpha1/virtualmachine_conversion.go
+++ b/api/v1alpha1/virtualmachine_conversion.go
@@ -278,10 +278,10 @@ func convert_v1alpha1_NetworkInterface_To_v1alpha3_NetworkInterfaceSpec(
 		out.Network.TypeMeta.APIVersion = "vmware.com/v1alpha1"
 		out.Network.TypeMeta.Kind = "VirtualNetwork"
 	case "nsx-t-subnet":
-		out.Network.TypeMeta.APIVersion = "nsx.vmware.com/v1alpha1"
+		out.Network.TypeMeta.APIVersion = "crd.nsx.vmware.com/v1alpha1"
 		out.Network.TypeMeta.Kind = "Subnet"
 	case "nsx-t-subnetset":
-		out.Network.TypeMeta.APIVersion = "nsx.vmware.com/v1alpha1"
+		out.Network.TypeMeta.APIVersion = "crd.nsx.vmware.com/v1alpha1"
 		out.Network.TypeMeta.Kind = "SubnetSet"
 	}
 

--- a/api/v1alpha1/virtualmachine_conversion_test.go
+++ b/api/v1alpha1/virtualmachine_conversion_test.go
@@ -113,7 +113,7 @@ func TestVirtualMachineConversion(t *testing.T) {
 							Network: &vmopv1common.PartialObjectRef{
 								TypeMeta: metav1.TypeMeta{
 									Kind:       "Subnet",
-									APIVersion: "nsx.vmware.com/v1alpha1",
+									APIVersion: "crd.nsx.vmware.com/v1alpha1",
 								},
 								Name: "segment-subnet",
 							},
@@ -124,7 +124,7 @@ func TestVirtualMachineConversion(t *testing.T) {
 							Network: &vmopv1common.PartialObjectRef{
 								TypeMeta: metav1.TypeMeta{
 									Kind:       "SubnetSet",
-									APIVersion: "nsx.vmware.com/v1alpha1",
+									APIVersion: "crd.nsx.vmware.com/v1alpha1",
 								},
 								Name: "segment-subnetset",
 							},

--- a/api/v1alpha2/virtualmachine_conversion_test.go
+++ b/api/v1alpha2/virtualmachine_conversion_test.go
@@ -135,7 +135,7 @@ func TestVirtualMachineConversion(t *testing.T) {
 							Network: &vmopv1common.PartialObjectRef{
 								TypeMeta: metav1.TypeMeta{
 									Kind:       "Subnet",
-									APIVersion: "nsx.vmware.com/v1alpha1",
+									APIVersion: "crd.nsx.vmware.com/v1alpha1",
 								},
 								Name: "segment-subnet",
 							},
@@ -146,7 +146,7 @@ func TestVirtualMachineConversion(t *testing.T) {
 							Network: &vmopv1common.PartialObjectRef{
 								TypeMeta: metav1.TypeMeta{
 									Kind:       "SubnetSet",
-									APIVersion: "nsx.vmware.com/v1alpha1",
+									APIVersion: "crd.nsx.vmware.com/v1alpha1",
 								},
 								Name: "segment-subnetset",
 							},

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -149,6 +149,26 @@ rules:
   - patch
   - update
 - apiGroups:
+  - crd.nsx.vmware.com
+  resources:
+  - subnetports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - crd.nsx.vmware.com
+  resources:
+  - subnetports/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - imageregistry.vmware.com
   resources:
   - clustercontentlibraryitems
@@ -208,26 +228,6 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - nsx.vmware.com
-  resources:
-  - subnetports
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - nsx.vmware.com
-  resources:
-  - subnetports/status
-  verbs:
-  - get
-  - patch
-  - update
 - apiGroups:
   - storage.k8s.io
   resources:

--- a/controllers/virtualmachine/virtualmachine_controller.go
+++ b/controllers/virtualmachine/virtualmachine_controller.go
@@ -227,8 +227,8 @@ type Reconciler struct {
 // +kubebuilder:rbac:groups=netoperator.vmware.com,resources=networkinterfaces,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=cns.vmware.com,resources=storagepolicyquotas,verbs=get;list;watch
-// +kubebuilder:rbac:groups=nsx.vmware.com,resources=subnetports,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=nsx.vmware.com,resources=subnetports/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=crd.nsx.vmware.com,resources=subnetports,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=crd.nsx.vmware.com,resources=subnetports/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=events;configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=resourcequotas;namespaces,verbs=get;list;watch
 

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/prometheus/client_golang v1.19.1
 	github.com/vmware-tanzu/image-registry-operator-api v0.0.0-20240509202721-f6552612433a
 	github.com/vmware-tanzu/net-operator-api v0.0.0-20240523152550-862e2c4eb0e0
-	github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20240424021250-778eb97fa048
+	github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20240730023032-0784c0791081
 	github.com/vmware-tanzu/vm-operator/api v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/vm-operator/external/ncp v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/vm-operator/external/storage-policy-quota v0.0.0-00010101000000-000000000000

--- a/go.sum
+++ b/go.sum
@@ -452,8 +452,8 @@ github.com/vmware-tanzu/image-registry-operator-api v0.0.0-20240509202721-f65526
 github.com/vmware-tanzu/image-registry-operator-api v0.0.0-20240509202721-f6552612433a/go.mod h1:zn/ponkeFUViyBDhYp9OKFPqEGWYrsR71Pn9/aTCvSI=
 github.com/vmware-tanzu/net-operator-api v0.0.0-20240523152550-862e2c4eb0e0 h1:ymNjvIbvYrk+hyNw6+Gat7XI/8z/15eqSD7CLG7VkOI=
 github.com/vmware-tanzu/net-operator-api v0.0.0-20240523152550-862e2c4eb0e0/go.mod h1:w6QJGm3crIA16ZIz1FVQXD2NVeJhOgGXxW05RbVTSTo=
-github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20240424021250-778eb97fa048 h1:dNjyb0tpct5XqYEuEGhAQbFCiIxRcXBu7mxopOCHl5g=
-github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20240424021250-778eb97fa048/go.mod h1:Q4JzNkNMvjo7pXtlB5/R3oME4Nhah7fAObWgghVmtxk=
+github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20240730023032-0784c0791081 h1:WWnBDG4TSi4T4PhLqi5k+YRNCIuEV4n+5PXawg0enls=
+github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20240730023032-0784c0791081/go.mod h1:Q4JzNkNMvjo7pXtlB5/R3oME4Nhah7fAObWgghVmtxk=
 github.com/vmware/govmomi v0.31.1-0.20240705205608-769897c38965 h1:Ondrh/FI1FM+5CRnbMp3TRu9VFqaoPKYnCdC/1o5PtA=
 github.com/vmware/govmomi v0.31.1-0.20240705205608-769897c38965/go.mod h1:mtGWtM+YhTADHlCgJBiskSRPOZRsN9MSjPzaZLte/oQ=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -19,7 +19,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
 	imgregv1a1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha1"
-	vpcv1alpha1 "github.com/vmware-tanzu/nsx-operator/pkg/apis/nsx.vmware.com/v1alpha1"
+	vpcv1alpha1 "github.com/vmware-tanzu/nsx-operator/pkg/apis/crd.nsx.vmware.com/v1alpha1"
 
 	netopv1alpha1 "github.com/vmware-tanzu/net-operator-api/api/v1alpha1"
 	ncpv1alpha1 "github.com/vmware-tanzu/vm-operator/external/ncp/api/v1alpha1"

--- a/pkg/providers/vsphere/network/network.go
+++ b/pkg/providers/vsphere/network/network.go
@@ -24,7 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	netopv1alpha1 "github.com/vmware-tanzu/net-operator-api/api/v1alpha1"
-	vpcv1alpha1 "github.com/vmware-tanzu/nsx-operator/pkg/apis/nsx.vmware.com/v1alpha1"
+	vpcv1alpha1 "github.com/vmware-tanzu/nsx-operator/pkg/apis/crd.nsx.vmware.com/v1alpha1"
 	ncpv1alpha1 "github.com/vmware-tanzu/vm-operator/external/ncp/api/v1alpha1"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"

--- a/pkg/providers/vsphere/network/network_test.go
+++ b/pkg/providers/vsphere/network/network_test.go
@@ -15,7 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	netopv1alpha1 "github.com/vmware-tanzu/net-operator-api/api/v1alpha1"
-	vpcv1alpha1 "github.com/vmware-tanzu/nsx-operator/pkg/apis/nsx.vmware.com/v1alpha1"
+	vpcv1alpha1 "github.com/vmware-tanzu/nsx-operator/pkg/apis/crd.nsx.vmware.com/v1alpha1"
 	ncpv1alpha1 "github.com/vmware-tanzu/vm-operator/external/ncp/api/v1alpha1"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
@@ -637,7 +637,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 							Name: networkName,
 							TypeMeta: metav1.TypeMeta{
 								Kind:       "SubnetSet",
-								APIVersion: "nsx.vmware.com/v1alpha1",
+								APIVersion: "crd.nsx.vmware.com/v1alpha1",
 							},
 						},
 					},

--- a/pkg/providers/vsphere/vmprovider_vm2_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm2_test.go
@@ -16,7 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	netopv1alpha1 "github.com/vmware-tanzu/net-operator-api/api/v1alpha1"
-	vpcv1alpha1 "github.com/vmware-tanzu/nsx-operator/pkg/apis/nsx.vmware.com/v1alpha1"
+	vpcv1alpha1 "github.com/vmware-tanzu/nsx-operator/pkg/apis/crd.nsx.vmware.com/v1alpha1"
 	ncpv1alpha1 "github.com/vmware-tanzu/vm-operator/external/ncp/api/v1alpha1"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
@@ -384,7 +384,7 @@ func vmE2ETests() {
 							Name: networkName,
 							TypeMeta: metav1.TypeMeta{
 								Kind:       "Subnet",
-								APIVersion: "nsx.vmware.com/v1alpha1",
+								APIVersion: "crd.nsx.vmware.com/v1alpha1",
 							},
 						},
 					},

--- a/test/builder/fake.go
+++ b/test/builder/fake.go
@@ -11,7 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	imgregv1a1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha1"
-	vpcv1alpha1 "github.com/vmware-tanzu/nsx-operator/pkg/apis/nsx.vmware.com/v1alpha1"
+	vpcv1alpha1 "github.com/vmware-tanzu/nsx-operator/pkg/apis/crd.nsx.vmware.com/v1alpha1"
 
 	netopv1alpha1 "github.com/vmware-tanzu/net-operator-api/api/v1alpha1"
 	ncpv1alpha1 "github.com/vmware-tanzu/vm-operator/external/ncp/api/v1alpha1"

--- a/webhooks/virtualmachine/mutation/virtualmachine_mutator.go
+++ b/webhooks/virtualmachine/mutation/virtualmachine_mutator.go
@@ -23,7 +23,7 @@ import (
 	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	vpcv1alpha1 "github.com/vmware-tanzu/nsx-operator/pkg/apis/nsx.vmware.com/v1alpha1"
+	vpcv1alpha1 "github.com/vmware-tanzu/nsx-operator/pkg/apis/crd.nsx.vmware.com/v1alpha1"
 
 	netopv1alpha1 "github.com/vmware-tanzu/net-operator-api/api/v1alpha1"
 	ncpv1alpha1 "github.com/vmware-tanzu/vm-operator/external/ncp/api/v1alpha1"

--- a/webhooks/virtualmachine/mutation/virtualmachine_mutator_unit_test.go
+++ b/webhooks/virtualmachine/mutation/virtualmachine_mutator_unit_test.go
@@ -158,7 +158,7 @@ func unitTestsMutating() {
 					Expect(ctx.vm.Spec.Network.Interfaces[0].Name).Should(Equal("eth0"))
 					Expect(ctx.vm.Spec.Network.Interfaces[0].Network).ShouldNot(BeNil())
 					Expect(ctx.vm.Spec.Network.Interfaces[0].Network.Kind).Should(Equal("SubnetSet"))
-					Expect(ctx.vm.Spec.Network.Interfaces[0].Network.APIVersion).Should(Equal("nsx.vmware.com/v1alpha1"))
+					Expect(ctx.vm.Spec.Network.Interfaces[0].Network.APIVersion).Should(Equal("crd.nsx.vmware.com/v1alpha1"))
 				})
 			})
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
For tenant manager support, there is a design to support APIService for VPC, and the plan is to use APIGroup `nsx.vmware.com`. So NSX Operator decided to change VPC CRDs APIGroup to `crd.nsx.vmware.com`. What affects VMOP is:
- securitypolicies.crd.nsx.vmware.com
- subnets.crd.nsx.vmware.com
- subnetsets.crd.nsx.vmware.com
- subnetports.crd.nsx.vmware.com

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes N/A


**Are there any special notes for your reviewer**:

It will go after https://github.com/vmware-tanzu/nsx-operator/pull/638 with updated imported api.


**Please add a release note if necessary**:

```release-note
NONE
```