### PR TITLE
✨WIP:Support NSX LoadBalancer healthcheck for VMService

### DIFF
--- a/controllers/virtualmachineservice/providers/loadbalancer_provider_test.go
+++ b/controllers/virtualmachineservice/providers/loadbalancer_provider_test.go
@@ -105,6 +105,32 @@ var _ = Describe(
 			})
 		})
 
+		Context("GetServiceAnnotations when VMService has endpointHealthCheckEnabled defined", func() {
+			BeforeEach(func() {
+				vmService = &vmopv1.VirtualMachineService{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "dummy-vmservice",
+						Namespace:   dummyNamespace,
+						Annotations: make(map[string]string),
+					},
+					Spec: vmopv1.VirtualMachineServiceSpec{
+						Type:         vmopv1.VirtualMachineServiceTypeClusterIP,
+						ClusterIP:    "TEST",
+						ExternalName: "TEST",
+					},
+				}
+				vmService.Annotations[utils.AnnotationServiceEndpointHealthCheckEnabledKey] = ""
+				lbProvider = NsxtLoadBalancerProvider()
+			})
+
+			It("should get nsx.vmware.com/lb-health-check in the annotation", func() {
+				vmServiceAnnotations, err := lbProvider.GetServiceAnnotations(ctx, vmService)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(vmServiceAnnotations).ToNot(BeNil())
+				Expect(vmServiceAnnotations).To(HaveKey(ServiceLoadBalancerEndpointHealthCheckEnabledTagKey))
+			})
+		})
+
 		Context("GetToBeRemovedServiceAnnotations when VMService does not have healthCheckNodePort defined", func() {
 			BeforeEach(func() {
 				vmService = &vmopv1.VirtualMachineService{
@@ -127,6 +153,31 @@ var _ = Describe(
 				Expect(err).ToNot(HaveOccurred())
 				Expect(vmServiceAnnotations).ToNot(BeNil())
 				Expect(vmServiceAnnotations).To(HaveKey(ServiceLoadBalancerHealthCheckNodePortTagKey))
+			})
+		})
+
+		Context("GetToBeRemovedServiceAnnotations when VMService does not have endpointHealthCheckEnabled defined", func() {
+			BeforeEach(func() {
+				vmService = &vmopv1.VirtualMachineService{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "dummy-vmservice",
+						Namespace:   dummyNamespace,
+						Annotations: make(map[string]string),
+					},
+					Spec: vmopv1.VirtualMachineServiceSpec{
+						Type:         vmopv1.VirtualMachineServiceTypeClusterIP,
+						ClusterIP:    "TEST",
+						ExternalName: "TEST",
+					},
+				}
+				lbProvider = NsxtLoadBalancerProvider()
+			})
+
+			It("should get nsx.vmware.com/lb-health-check in the to be removed annotation", func() {
+				vmServiceAnnotations, err := lbProvider.GetToBeRemovedServiceAnnotations(ctx, vmService)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(vmServiceAnnotations).ToNot(BeNil())
+				Expect(vmServiceAnnotations).To(HaveKey(ServiceLoadBalancerEndpointHealthCheckEnabledTagKey))
 			})
 		})
 

--- a/controllers/virtualmachineservice/utils/constants.go
+++ b/controllers/virtualmachineservice/utils/constants.go
@@ -5,5 +5,8 @@ package utils
 
 const (
 	AnnotationServiceExternalTrafficPolicyKey = "virtualmachineservice.vmoperator.vmware.com/service.externalTrafficPolicy"
-	AnnotationServiceHealthCheckNodePortKey   = "virtualmachineservice.vmoperator.vmware.com/service.healthCheckNodePort"
+	// AnnotationServiceHealthCheckNodePortKey is the key of the annotation that is used to set HTTP health check on the TKG Service's healthCheckNodePort when the Service is LoadBalancer type and externalTrafficPolicy is Local.
+	AnnotationServiceHealthCheckNodePortKey = "virtualmachineservice.vmoperator.vmware.com/service.healthCheckNodePort"
+	// AnnotationServiceEndpointHealthCheckEnabledKey is the key of the annotation that is used to enable health check on the VMService endpoint port. This is different from AnnotationServiceHealthCheckNodePortKey.
+	AnnotationServiceEndpointHealthCheckEnabledKey = "virtualmachineservice.vmoperator.vmware.com/service.endpointHealthCheckEnabled"
 )

--- a/controllers/virtualmachineservice/virtualmachineservice_controller.go
+++ b/controllers/virtualmachineservice/virtualmachineservice_controller.go
@@ -53,8 +53,9 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 	)
 
 	lbProviderType := pkgcfg.FromContext(ctx).LoadBalancerProvider
+	networkProvider := pkgcfg.FromContext(ctx).NetworkProviderType
 	if lbProviderType == "" {
-		if pkgcfg.FromContext(ctx).NetworkProviderType == pkgcfg.NetworkProviderTypeNSXT {
+		if networkProvider == pkgcfg.NetworkProviderTypeNSXT || networkProvider == pkgcfg.NetworkProviderTypeVPC {
 			lbProviderType = providers.NSXTLoadBalancer
 		}
 	}
@@ -367,7 +368,7 @@ func (r *ReconcileVirtualMachineService) setServiceAnnotationsAndLabels(
 	}
 
 	// Explicitly remove vm service managed annotations if needed
-	for _, k := range []string{utils.AnnotationServiceExternalTrafficPolicyKey, utils.AnnotationServiceHealthCheckNodePortKey} {
+	for _, k := range []string{utils.AnnotationServiceExternalTrafficPolicyKey, utils.AnnotationServiceHealthCheckNodePortKey, utils.AnnotationServiceEndpointHealthCheckEnabledKey} {
 		if _, exist := vmService.Annotations[k]; !exist {
 			if v, exist := service.Annotations[k]; exist {
 				ctx.Logger.V(5).Info("Removing annotation from Service", "key", k, "value", v)


### PR DESCRIPTION
Introduce an annotation on VMService to enable NSX LoadBalancer healthcheck on the endpoint port.

PR in CAPV: https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/3128
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
If annotation "virtualmachineservice.vmoperator.vmware.com/service.endpointHealthCheckEnabled" exists on VirtualMachineService, the NSX LoadBalancer healthcheck is enabled.  
```