### PR TITLE
🌱 resize: Remove DevOps overrides from CPU/Memory resize

### DIFF
--- a/pkg/providers/vsphere/session/session_vm_update.go
+++ b/pkg/providers/vsphere/session/session_vm_update.go
@@ -934,8 +934,11 @@ func (s *Session) resizeVMWhenPoweredStateOff(
 		}
 	}
 
-	if err := vmopv1util.OverwriteResizeConfigSpec(vmCtx, *vmCtx.VM, *moVM.Config, &configSpec); err != nil {
-		return false, err
+	if pkgcfg.FromContext(vmCtx).Features.VMResize {
+		err := vmopv1util.OverwriteResizeConfigSpec(vmCtx, *vmCtx.VM, *moVM.Config, &configSpec)
+		if err != nil {
+			return false, err
+		}
 	}
 
 	refetchProps := false


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

This defers updating the VMs configuration of these fields to the pre-power on reconfigure like it currently done today. The power off resizing will only care about CPU and memory until we enable full resizing.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note
NONE
```