### PR TITLE
:seedling: Update vcsim tests under WCP_Workload_Domain_Isolation

### DIFF
--- a/pkg/providers/vsphere/placement/zone_placement_test.go
+++ b/pkg/providers/vsphere/placement/zone_placement_test.go
@@ -89,7 +89,7 @@ func vcSimPlacement() {
 
 	JustBeforeEach(func() {
 		ctx = suite.NewTestContextForVCSim(testConfig, initObjects...)
-		nsInfo = ctx.CreateWorkloadNamespace(testConfig)
+		nsInfo = ctx.CreateWorkloadNamespace()
 
 		vm.Namespace = nsInfo.Namespace
 

--- a/pkg/providers/vsphere/placement/zone_placement_test.go
+++ b/pkg/providers/vsphere/placement/zone_placement_test.go
@@ -89,7 +89,7 @@ func vcSimPlacement() {
 
 	JustBeforeEach(func() {
 		ctx = suite.NewTestContextForVCSim(testConfig, initObjects...)
-		nsInfo = ctx.CreateWorkloadNamespace()
+		nsInfo = ctx.CreateWorkloadNamespace(testConfig)
 
 		vm.Namespace = nsInfo.Namespace
 
@@ -106,164 +106,342 @@ func vcSimPlacement() {
 		initObjects = nil
 	})
 
-	Context("Zone placement", func() {
+	Describe("When FSS_WCP_WORKLOAD_DOMAIN_ISOLATION enabled", func() {
+		BeforeEach(func() {
+			testConfig = builder.VCSimTestConfig{
+				WithWorkloadIsolation: true,
+			}
 
-		Context("zone already assigned", func() {
-			zoneName := "in the zone"
+			Context("Zone placement", func() {
 
-			JustBeforeEach(func() {
-				vm.Labels[topology.KubernetesTopologyZoneLabelKey] = zoneName
+				Context("zone already assigned", func() {
+					zoneName := "in the zone"
+
+					JustBeforeEach(func() {
+						vm.Labels[topology.KubernetesTopologyZoneLabelKey] = zoneName
+					})
+
+					It("returns success with same zone", func() {
+						result, err := placement.Placement(vmCtx, ctx.Client, ctx.VCClient.Client, configSpec, "")
+						Expect(err).ToNot(HaveOccurred())
+						Expect(result).ToNot(BeNil())
+						Expect(result.ZonePlacement).To(BeTrue())
+						Expect(result.ZoneName).To(Equal(zoneName))
+						Expect(result.HostMoRef).To(BeNil())
+						Expect(vm.Labels).To(HaveKeyWithValue(topology.KubernetesTopologyZoneLabelKey, zoneName))
+
+						// Current contract is the caller must look this up based on the pre-assigned zone but
+						// we might want to change that later.
+						Expect(result.PoolMoRef.Value).To(BeEmpty())
+					})
+				})
+
+				Context("no placement candidates", func() {
+					JustBeforeEach(func() {
+						vm.Namespace = "does-not-exist"
+					})
+
+					It("returns an error", func() {
+						result, err := placement.Placement(vmCtx, ctx.Client, ctx.VCClient.Client, configSpec, "")
+						Expect(err).To(MatchError("no placement candidates available"))
+						Expect(result).To(BeNil())
+					})
+				})
+
+				It("returns success", func() {
+					result, err := placement.Placement(vmCtx, ctx.Client, ctx.VCClient.Client, configSpec, "")
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(result.ZonePlacement).To(BeTrue())
+					Expect(result.ZoneName).To(BeElementOf(ctx.ZoneNames))
+					Expect(result.PoolMoRef.Value).ToNot(BeEmpty())
+					Expect(result.HostMoRef).To(BeNil())
+
+					nsRP := ctx.GetResourcePoolForNamespace(vm.Namespace, result.ZoneName, "")
+					Expect(nsRP).ToNot(BeNil())
+					Expect(result.PoolMoRef.Value).To(Equal(nsRP.Reference().Value))
+				})
+
+				Context("Only one zone exists", func() {
+					BeforeEach(func() {
+						testConfig.NumFaultDomains = 1
+					})
+
+					It("returns success", func() {
+						result, err := placement.Placement(vmCtx, ctx.Client, ctx.VCClient.Client, configSpec, "")
+						Expect(err).ToNot(HaveOccurred())
+
+						Expect(result.ZonePlacement).To(BeTrue())
+						Expect(result.ZoneName).To(BeElementOf(ctx.ZoneNames))
+						Expect(result.PoolMoRef.Value).ToNot(BeEmpty())
+						Expect(result.HostMoRef).To(BeNil())
+
+						nsRP := ctx.GetResourcePoolForNamespace(vm.Namespace, result.ZoneName, "")
+						Expect(nsRP).ToNot(BeNil())
+						Expect(result.PoolMoRef.Value).To(Equal(nsRP.Reference().Value))
+					})
+				})
+
+				Context("VM is in child RP via ResourcePolicy", func() {
+					It("returns success", func() {
+						resourcePolicy, _ := ctx.CreateVirtualMachineSetResourcePolicyA2("my-child-rp", nsInfo)
+						Expect(resourcePolicy).ToNot(BeNil())
+						childRPName := resourcePolicy.Spec.ResourcePool.Name
+						Expect(childRPName).ToNot(BeEmpty())
+						vmCtx.VM.Spec.Reserved = &vmopv1.VirtualMachineReservedSpec{
+							ResourcePolicyName: resourcePolicy.Name,
+						}
+
+						result, err := placement.Placement(vmCtx, ctx.Client, ctx.VCClient.Client, configSpec, childRPName)
+						Expect(err).ToNot(HaveOccurred())
+
+						Expect(result.ZonePlacement).To(BeTrue())
+						Expect(result.ZoneName).To(BeElementOf(ctx.ZoneNames))
+
+						childRP := ctx.GetResourcePoolForNamespace(vm.Namespace, result.ZoneName, childRPName)
+						Expect(childRP).ToNot(BeNil())
+						Expect(result.PoolMoRef.Value).To(Equal(childRP.Reference().Value))
+					})
+				})
 			})
 
-			It("returns success with same zone", func() {
-				result, err := placement.Placement(vmCtx, ctx.Client, ctx.VCClient.Client, configSpec, "")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(result).ToNot(BeNil())
-				Expect(result.ZonePlacement).To(BeTrue())
-				Expect(result.ZoneName).To(Equal(zoneName))
-				Expect(result.HostMoRef).To(BeNil())
-				Expect(vm.Labels).To(HaveKeyWithValue(topology.KubernetesTopologyZoneLabelKey, zoneName))
+			Context("Instance Storage Placement", func() {
 
-				// Current contract is the caller must look this up based on the pre-assigned zone but
-				// we might want to change that later.
-				Expect(result.PoolMoRef.Value).To(BeEmpty())
-			})
-		})
+				BeforeEach(func() {
+					testConfig.WithInstanceStorage = true
+					builder.AddDummyInstanceStorageVolume(vm)
+					testConfig.NumFaultDomains = 1 // Only support for non-HA "HA"
+				})
 
-		Context("no placement candidates", func() {
-			JustBeforeEach(func() {
-				vm.Namespace = "does-not-exist"
-			})
+				When("host already assigned", func() {
+					const hostMoID = "foobar-host-42"
 
-			It("returns an error", func() {
-				result, err := placement.Placement(vmCtx, ctx.Client, ctx.VCClient.Client, configSpec, "")
-				Expect(err).To(MatchError("no placement candidates available"))
-				Expect(result).To(BeNil())
-			})
-		})
+					BeforeEach(func() {
+						vm.Labels[topology.KubernetesTopologyZoneLabelKey] = "my-zone"
+						vm.Annotations[constants.InstanceStorageSelectedNodeMOIDAnnotationKey] = hostMoID
+					})
 
-		It("returns success", func() {
-			result, err := placement.Placement(vmCtx, ctx.Client, ctx.VCClient.Client, configSpec, "")
-			Expect(err).ToNot(HaveOccurred())
+					It("returns success with same host", func() {
+						result, err := placement.Placement(vmCtx, ctx.Client, ctx.VCClient.Client, configSpec, "")
+						Expect(err).ToNot(HaveOccurred())
 
-			Expect(result.ZonePlacement).To(BeTrue())
-			Expect(result.ZoneName).To(BeElementOf(ctx.ZoneNames))
-			Expect(result.PoolMoRef.Value).ToNot(BeEmpty())
-			Expect(result.HostMoRef).To(BeNil())
+						Expect(result.InstanceStoragePlacement).To(BeTrue())
+						Expect(result.HostMoRef).ToNot(BeNil())
+						Expect(result.HostMoRef.Value).To(Equal(hostMoID))
+					})
+				})
 
-			nsRP := ctx.GetResourcePoolForNamespace(vm.Namespace, result.ZoneName, "")
-			Expect(nsRP).ToNot(BeNil())
-			Expect(result.PoolMoRef.Value).To(Equal(nsRP.Reference().Value))
-		})
+				It("returns success", func() {
+					result, err := placement.Placement(vmCtx, ctx.Client, ctx.VCClient.Client, configSpec, "")
+					Expect(err).ToNot(HaveOccurred())
 
-		Context("Only one zone exists", func() {
-			BeforeEach(func() {
-				testConfig.NumFaultDomains = 1
-			})
+					Expect(result.ZonePlacement).To(BeTrue())
+					Expect(result.ZoneName).ToNot(BeEmpty())
 
-			It("returns success", func() {
-				result, err := placement.Placement(vmCtx, ctx.Client, ctx.VCClient.Client, configSpec, "")
-				Expect(err).ToNot(HaveOccurred())
+					Expect(result.InstanceStoragePlacement).To(BeTrue())
+					Expect(result.HostMoRef).ToNot(BeNil())
+					Expect(result.HostMoRef.Value).ToNot(BeEmpty())
 
-				Expect(result.ZonePlacement).To(BeTrue())
-				Expect(result.ZoneName).To(BeElementOf(ctx.ZoneNames))
-				Expect(result.PoolMoRef.Value).ToNot(BeEmpty())
-				Expect(result.HostMoRef).To(BeNil())
+					nsRP := ctx.GetResourcePoolForNamespace(vm.Namespace, result.ZoneName, "")
+					Expect(nsRP).ToNot(BeNil())
+					Expect(result.PoolMoRef.Value).To(Equal(nsRP.Reference().Value))
+				})
 
-				nsRP := ctx.GetResourcePoolForNamespace(vm.Namespace, result.ZoneName, "")
-				Expect(nsRP).ToNot(BeNil())
-				Expect(result.PoolMoRef.Value).To(Equal(nsRP.Reference().Value))
-			})
-		})
+				Context("VM is in child RP via ResourcePolicy", func() {
+					It("returns success", func() {
+						resourcePolicy, _ := ctx.CreateVirtualMachineSetResourcePolicyA2("my-child-rp", nsInfo)
+						Expect(resourcePolicy).ToNot(BeNil())
+						childRPName := resourcePolicy.Spec.ResourcePool.Name
+						Expect(childRPName).ToNot(BeEmpty())
+						vmCtx.VM.Spec.Reserved = &vmopv1.VirtualMachineReservedSpec{
+							ResourcePolicyName: resourcePolicy.Name,
+						}
 
-		Context("VM is in child RP via ResourcePolicy", func() {
-			It("returns success", func() {
-				resourcePolicy, _ := ctx.CreateVirtualMachineSetResourcePolicyA2("my-child-rp", nsInfo)
-				Expect(resourcePolicy).ToNot(BeNil())
-				childRPName := resourcePolicy.Spec.ResourcePool.Name
-				Expect(childRPName).ToNot(BeEmpty())
-				vmCtx.VM.Spec.Reserved = &vmopv1.VirtualMachineReservedSpec{
-					ResourcePolicyName: resourcePolicy.Name,
-				}
+						result, err := placement.Placement(vmCtx, ctx.Client, ctx.VCClient.Client, configSpec, childRPName)
+						Expect(err).ToNot(HaveOccurred())
 
-				result, err := placement.Placement(vmCtx, ctx.Client, ctx.VCClient.Client, configSpec, childRPName)
-				Expect(err).ToNot(HaveOccurred())
+						Expect(result.ZonePlacement).To(BeTrue())
+						Expect(result.ZoneName).To(BeElementOf(ctx.ZoneNames))
 
-				Expect(result.ZonePlacement).To(BeTrue())
-				Expect(result.ZoneName).To(BeElementOf(ctx.ZoneNames))
+						Expect(result.InstanceStoragePlacement).To(BeTrue())
+						Expect(result.HostMoRef).ToNot(BeNil())
+						Expect(result.HostMoRef.Value).ToNot(BeEmpty())
 
-				childRP := ctx.GetResourcePoolForNamespace(vm.Namespace, result.ZoneName, childRPName)
-				Expect(childRP).ToNot(BeNil())
-				Expect(result.PoolMoRef.Value).To(Equal(childRP.Reference().Value))
+						childRP := ctx.GetResourcePoolForNamespace(vm.Namespace, result.ZoneName, childRPName)
+						Expect(childRP).ToNot(BeNil())
+						Expect(result.PoolMoRef.Value).To(Equal(childRP.Reference().Value))
+					})
+				})
 			})
 		})
 	})
-
-	Context("Instance Storage Placement", func() {
-
+	// TODO: Delete tests when FSS_WCP_WORKLOAD_DOMAIN_ISOLATION enabled.
+	Describe("When FSS_WCP_WORKLOAD_DOMAIN_ISOLATION disabled", func() {
 		BeforeEach(func() {
-			testConfig.WithInstanceStorage = true
-			builder.AddDummyInstanceStorageVolume(vm)
-			testConfig.NumFaultDomains = 1 // Only support for non-HA "HA"
-		})
+			testConfig = builder.VCSimTestConfig{
+				WithWorkloadIsolation: false,
+			}
 
-		When("host already assigned", func() {
-			const hostMoID = "foobar-host-42"
+			Context("Zone placement", func() {
 
-			BeforeEach(func() {
-				vm.Labels[topology.KubernetesTopologyZoneLabelKey] = "my-zone"
-				vm.Annotations[constants.InstanceStorageSelectedNodeMOIDAnnotationKey] = hostMoID
+				Context("zone already assigned", func() {
+					zoneName := "in the zone"
+
+					JustBeforeEach(func() {
+						vm.Labels[topology.KubernetesTopologyZoneLabelKey] = zoneName
+					})
+
+					It("returns success with same zone", func() {
+						result, err := placement.Placement(vmCtx, ctx.Client, ctx.VCClient.Client, configSpec, "")
+						Expect(err).ToNot(HaveOccurred())
+						Expect(result).ToNot(BeNil())
+						Expect(result.ZonePlacement).To(BeTrue())
+						Expect(result.ZoneName).To(Equal(zoneName))
+						Expect(result.HostMoRef).To(BeNil())
+						Expect(vm.Labels).To(HaveKeyWithValue(topology.KubernetesTopologyZoneLabelKey, zoneName))
+
+						// Current contract is the caller must look this up based on the pre-assigned zone but
+						// we might want to change that later.
+						Expect(result.PoolMoRef.Value).To(BeEmpty())
+					})
+				})
+
+				Context("no placement candidates", func() {
+					JustBeforeEach(func() {
+						vm.Namespace = "does-not-exist"
+					})
+
+					It("returns an error", func() {
+						result, err := placement.Placement(vmCtx, ctx.Client, ctx.VCClient.Client, configSpec, "")
+						Expect(err).To(MatchError("no placement candidates available"))
+						Expect(result).To(BeNil())
+					})
+				})
+
+				It("returns success", func() {
+					result, err := placement.Placement(vmCtx, ctx.Client, ctx.VCClient.Client, configSpec, "")
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(result.ZonePlacement).To(BeTrue())
+					Expect(result.ZoneName).To(BeElementOf(ctx.ZoneNames))
+					Expect(result.PoolMoRef.Value).ToNot(BeEmpty())
+					Expect(result.HostMoRef).To(BeNil())
+
+					nsRP := ctx.GetResourcePoolForNamespace(vm.Namespace, result.ZoneName, "")
+					Expect(nsRP).ToNot(BeNil())
+					Expect(result.PoolMoRef.Value).To(Equal(nsRP.Reference().Value))
+				})
+
+				Context("Only one zone exists", func() {
+					BeforeEach(func() {
+						testConfig.NumFaultDomains = 1
+					})
+
+					It("returns success", func() {
+						result, err := placement.Placement(vmCtx, ctx.Client, ctx.VCClient.Client, configSpec, "")
+						Expect(err).ToNot(HaveOccurred())
+
+						Expect(result.ZonePlacement).To(BeTrue())
+						Expect(result.ZoneName).To(BeElementOf(ctx.ZoneNames))
+						Expect(result.PoolMoRef.Value).ToNot(BeEmpty())
+						Expect(result.HostMoRef).To(BeNil())
+
+						nsRP := ctx.GetResourcePoolForNamespace(vm.Namespace, result.ZoneName, "")
+						Expect(nsRP).ToNot(BeNil())
+						Expect(result.PoolMoRef.Value).To(Equal(nsRP.Reference().Value))
+					})
+				})
+
+				Context("VM is in child RP via ResourcePolicy", func() {
+					It("returns success", func() {
+						resourcePolicy, _ := ctx.CreateVirtualMachineSetResourcePolicyA2("my-child-rp", nsInfo)
+						Expect(resourcePolicy).ToNot(BeNil())
+						childRPName := resourcePolicy.Spec.ResourcePool.Name
+						Expect(childRPName).ToNot(BeEmpty())
+						vmCtx.VM.Spec.Reserved = &vmopv1.VirtualMachineReservedSpec{
+							ResourcePolicyName: resourcePolicy.Name,
+						}
+
+						result, err := placement.Placement(vmCtx, ctx.Client, ctx.VCClient.Client, configSpec, childRPName)
+						Expect(err).ToNot(HaveOccurred())
+
+						Expect(result.ZonePlacement).To(BeTrue())
+						Expect(result.ZoneName).To(BeElementOf(ctx.ZoneNames))
+
+						childRP := ctx.GetResourcePoolForNamespace(vm.Namespace, result.ZoneName, childRPName)
+						Expect(childRP).ToNot(BeNil())
+						Expect(result.PoolMoRef.Value).To(Equal(childRP.Reference().Value))
+					})
+				})
 			})
 
-			It("returns success with same host", func() {
-				result, err := placement.Placement(vmCtx, ctx.Client, ctx.VCClient.Client, configSpec, "")
-				Expect(err).ToNot(HaveOccurred())
+			Context("Instance Storage Placement", func() {
 
-				Expect(result.InstanceStoragePlacement).To(BeTrue())
-				Expect(result.HostMoRef).ToNot(BeNil())
-				Expect(result.HostMoRef.Value).To(Equal(hostMoID))
-			})
-		})
+				BeforeEach(func() {
+					testConfig.WithInstanceStorage = true
+					builder.AddDummyInstanceStorageVolume(vm)
+					testConfig.NumFaultDomains = 1 // Only support for non-HA "HA"
+				})
 
-		It("returns success", func() {
-			result, err := placement.Placement(vmCtx, ctx.Client, ctx.VCClient.Client, configSpec, "")
-			Expect(err).ToNot(HaveOccurred())
+				When("host already assigned", func() {
+					const hostMoID = "foobar-host-42"
 
-			Expect(result.ZonePlacement).To(BeTrue())
-			Expect(result.ZoneName).ToNot(BeEmpty())
+					BeforeEach(func() {
+						vm.Labels[topology.KubernetesTopologyZoneLabelKey] = "my-zone"
+						vm.Annotations[constants.InstanceStorageSelectedNodeMOIDAnnotationKey] = hostMoID
+					})
 
-			Expect(result.InstanceStoragePlacement).To(BeTrue())
-			Expect(result.HostMoRef).ToNot(BeNil())
-			Expect(result.HostMoRef.Value).ToNot(BeEmpty())
+					It("returns success with same host", func() {
+						result, err := placement.Placement(vmCtx, ctx.Client, ctx.VCClient.Client, configSpec, "")
+						Expect(err).ToNot(HaveOccurred())
 
-			nsRP := ctx.GetResourcePoolForNamespace(vm.Namespace, result.ZoneName, "")
-			Expect(nsRP).ToNot(BeNil())
-			Expect(result.PoolMoRef.Value).To(Equal(nsRP.Reference().Value))
-		})
+						Expect(result.InstanceStoragePlacement).To(BeTrue())
+						Expect(result.HostMoRef).ToNot(BeNil())
+						Expect(result.HostMoRef.Value).To(Equal(hostMoID))
+					})
+				})
 
-		Context("VM is in child RP via ResourcePolicy", func() {
-			It("returns success", func() {
-				resourcePolicy, _ := ctx.CreateVirtualMachineSetResourcePolicyA2("my-child-rp", nsInfo)
-				Expect(resourcePolicy).ToNot(BeNil())
-				childRPName := resourcePolicy.Spec.ResourcePool.Name
-				Expect(childRPName).ToNot(BeEmpty())
-				vmCtx.VM.Spec.Reserved = &vmopv1.VirtualMachineReservedSpec{
-					ResourcePolicyName: resourcePolicy.Name,
-				}
+				It("returns success", func() {
+					result, err := placement.Placement(vmCtx, ctx.Client, ctx.VCClient.Client, configSpec, "")
+					Expect(err).ToNot(HaveOccurred())
 
-				result, err := placement.Placement(vmCtx, ctx.Client, ctx.VCClient.Client, configSpec, childRPName)
-				Expect(err).ToNot(HaveOccurred())
+					Expect(result.ZonePlacement).To(BeTrue())
+					Expect(result.ZoneName).ToNot(BeEmpty())
 
-				Expect(result.ZonePlacement).To(BeTrue())
-				Expect(result.ZoneName).To(BeElementOf(ctx.ZoneNames))
+					Expect(result.InstanceStoragePlacement).To(BeTrue())
+					Expect(result.HostMoRef).ToNot(BeNil())
+					Expect(result.HostMoRef.Value).ToNot(BeEmpty())
 
-				Expect(result.InstanceStoragePlacement).To(BeTrue())
-				Expect(result.HostMoRef).ToNot(BeNil())
-				Expect(result.HostMoRef.Value).ToNot(BeEmpty())
+					nsRP := ctx.GetResourcePoolForNamespace(vm.Namespace, result.ZoneName, "")
+					Expect(nsRP).ToNot(BeNil())
+					Expect(result.PoolMoRef.Value).To(Equal(nsRP.Reference().Value))
+				})
 
-				childRP := ctx.GetResourcePoolForNamespace(vm.Namespace, result.ZoneName, childRPName)
-				Expect(childRP).ToNot(BeNil())
-				Expect(result.PoolMoRef.Value).To(Equal(childRP.Reference().Value))
+				Context("VM is in child RP via ResourcePolicy", func() {
+					It("returns success", func() {
+						resourcePolicy, _ := ctx.CreateVirtualMachineSetResourcePolicyA2("my-child-rp", nsInfo)
+						Expect(resourcePolicy).ToNot(BeNil())
+						childRPName := resourcePolicy.Spec.ResourcePool.Name
+						Expect(childRPName).ToNot(BeEmpty())
+						vmCtx.VM.Spec.Reserved = &vmopv1.VirtualMachineReservedSpec{
+							ResourcePolicyName: resourcePolicy.Name,
+						}
+
+						result, err := placement.Placement(vmCtx, ctx.Client, ctx.VCClient.Client, configSpec, childRPName)
+						Expect(err).ToNot(HaveOccurred())
+
+						Expect(result.ZonePlacement).To(BeTrue())
+						Expect(result.ZoneName).To(BeElementOf(ctx.ZoneNames))
+
+						Expect(result.InstanceStoragePlacement).To(BeTrue())
+						Expect(result.HostMoRef).ToNot(BeNil())
+						Expect(result.HostMoRef.Value).ToNot(BeEmpty())
+
+						childRP := ctx.GetResourcePoolForNamespace(vm.Namespace, result.ZoneName, childRPName)
+						Expect(childRP).ToNot(BeNil())
+						Expect(result.PoolMoRef.Value).To(Equal(childRP.Reference().Value))
+					})
+				})
 			})
 		})
 	})

--- a/pkg/providers/vsphere/vcenter/folder_test.go
+++ b/pkg/providers/vsphere/vcenter/folder_test.go
@@ -32,7 +32,7 @@ func getFolderByMoID() {
 			WithWorkloadIsolation: true,
 		}
 		ctx = suite.NewTestContextForVCSim(testConfig)
-		nsInfo = ctx.CreateWorkloadNamespace(testConfig)
+		nsInfo = ctx.CreateWorkloadNamespace()
 	})
 
 	AfterEach(func() {
@@ -72,7 +72,7 @@ func createDeleteExistsFolder() {
 		}
 
 		ctx = suite.NewTestContextForVCSim(testConfig)
-		nsInfo = ctx.CreateWorkloadNamespace(testConfig)
+		nsInfo = ctx.CreateWorkloadNamespace()
 		parentFolderMoID = nsInfo.Folder.Reference().Value
 	})
 

--- a/pkg/providers/vsphere/vcenter/folder_test.go
+++ b/pkg/providers/vsphere/vcenter/folder_test.go
@@ -22,13 +22,17 @@ func folderTests() {
 func getFolderByMoID() {
 
 	var (
-		ctx    *builder.TestContextForVCSim
-		nsInfo builder.WorkloadNamespaceInfo
+		ctx        *builder.TestContextForVCSim
+		nsInfo     builder.WorkloadNamespaceInfo
+		testConfig builder.VCSimTestConfig
 	)
 
 	BeforeEach(func() {
-		ctx = suite.NewTestContextForVCSim(builder.VCSimTestConfig{})
-		nsInfo = ctx.CreateWorkloadNamespace()
+		testConfig = builder.VCSimTestConfig{
+			WithWorkloadIsolation: true,
+		}
+		ctx = suite.NewTestContextForVCSim(testConfig)
+		nsInfo = ctx.CreateWorkloadNamespace(testConfig)
 	})
 
 	AfterEach(func() {
@@ -55,15 +59,20 @@ func getFolderByMoID() {
 func createDeleteExistsFolder() {
 
 	var (
-		ctx    *builder.TestContextForVCSim
-		nsInfo builder.WorkloadNamespaceInfo
+		ctx        *builder.TestContextForVCSim
+		nsInfo     builder.WorkloadNamespaceInfo
+		testConfig builder.VCSimTestConfig
 
 		parentFolderMoID string
 	)
 
 	BeforeEach(func() {
-		ctx = suite.NewTestContextForVCSim(builder.VCSimTestConfig{})
-		nsInfo = ctx.CreateWorkloadNamespace()
+		testConfig = builder.VCSimTestConfig{
+			WithWorkloadIsolation: true,
+		}
+
+		ctx = suite.NewTestContextForVCSim(testConfig)
+		nsInfo = ctx.CreateWorkloadNamespace(testConfig)
 		parentFolderMoID = nsInfo.Folder.Reference().Value
 	})
 

--- a/pkg/providers/vsphere/vcenter/getvm_test.go
+++ b/pkg/providers/vsphere/vcenter/getvm_test.go
@@ -26,15 +26,20 @@ func getVM() {
 	const vcVMName = "DC0_C0_RP0_VM0"
 
 	var (
-		ctx    *builder.TestContextForVCSim
-		nsInfo builder.WorkloadNamespaceInfo
+		ctx        *builder.TestContextForVCSim
+		nsInfo     builder.WorkloadNamespaceInfo
+		testConfig builder.VCSimTestConfig
 
 		vmCtx pkgctx.VirtualMachineContext
 	)
 
 	BeforeEach(func() {
-		ctx = suite.NewTestContextForVCSim(builder.VCSimTestConfig{})
-		nsInfo = ctx.CreateWorkloadNamespace()
+		testConfig = builder.VCSimTestConfig{
+			WithWorkloadIsolation: true,
+		}
+
+		ctx = suite.NewTestContextForVCSim(testConfig)
+		nsInfo = ctx.CreateWorkloadNamespace(testConfig)
 
 		vm := builder.DummyVirtualMachine()
 		vm.Name = "getvm-test"

--- a/pkg/providers/vsphere/vcenter/getvm_test.go
+++ b/pkg/providers/vsphere/vcenter/getvm_test.go
@@ -39,7 +39,7 @@ func getVM() {
 		}
 
 		ctx = suite.NewTestContextForVCSim(testConfig)
-		nsInfo = ctx.CreateWorkloadNamespace(testConfig)
+		nsInfo = ctx.CreateWorkloadNamespace()
 
 		vm := builder.DummyVirtualMachine()
 		vm.Name = "getvm-test"

--- a/pkg/providers/vsphere/vcenter/resourcepool_test.go
+++ b/pkg/providers/vsphere/vcenter/resourcepool_test.go
@@ -34,7 +34,7 @@ func getResourcePoolTests() {
 		}
 
 		ctx = suite.NewTestContextForVCSim(testConfig)
-		nsInfo = ctx.CreateWorkloadNamespace(testConfig)
+		nsInfo = ctx.CreateWorkloadNamespace()
 		nsRP = ctx.GetResourcePoolForNamespace(nsInfo.Namespace, "", "")
 	})
 
@@ -118,7 +118,7 @@ func createDeleteExistResourcePoolChild() {
 		}
 
 		ctx = suite.NewTestContextForVCSim(testConfig)
-		nsInfo = ctx.CreateWorkloadNamespace(testConfig)
+		nsInfo = ctx.CreateWorkloadNamespace()
 		nsRP = ctx.GetResourcePoolForNamespace(nsInfo.Namespace, "", "")
 
 		parentRPMoID = nsRP.Reference().Value

--- a/pkg/providers/vsphere/vcenter/resourcepool_test.go
+++ b/pkg/providers/vsphere/vcenter/resourcepool_test.go
@@ -22,14 +22,19 @@ func resourcePoolTests() {
 
 func getResourcePoolTests() {
 	var (
-		ctx    *builder.TestContextForVCSim
-		nsInfo builder.WorkloadNamespaceInfo
-		nsRP   *object.ResourcePool
+		ctx        *builder.TestContextForVCSim
+		nsInfo     builder.WorkloadNamespaceInfo
+		nsRP       *object.ResourcePool
+		testConfig builder.VCSimTestConfig
 	)
 
 	BeforeEach(func() {
-		ctx = suite.NewTestContextForVCSim(builder.VCSimTestConfig{})
-		nsInfo = ctx.CreateWorkloadNamespace()
+		testConfig = builder.VCSimTestConfig{
+			WithWorkloadIsolation: true,
+		}
+
+		ctx = suite.NewTestContextForVCSim(testConfig)
+		nsInfo = ctx.CreateWorkloadNamespace(testConfig)
 		nsRP = ctx.GetResourcePoolForNamespace(nsInfo.Namespace, "", "")
 	})
 
@@ -98,17 +103,22 @@ func getResourcePoolTests() {
 func createDeleteExistResourcePoolChild() {
 
 	var (
-		ctx    *builder.TestContextForVCSim
-		nsInfo builder.WorkloadNamespaceInfo
-		nsRP   *object.ResourcePool
+		ctx        *builder.TestContextForVCSim
+		nsInfo     builder.WorkloadNamespaceInfo
+		nsRP       *object.ResourcePool
+		testConfig builder.VCSimTestConfig
 
 		parentRPMoID   string
 		resourcePolicy *vmopv1.VirtualMachineSetResourcePolicy
 	)
 
 	BeforeEach(func() {
-		ctx = suite.NewTestContextForVCSim(builder.VCSimTestConfig{})
-		nsInfo = ctx.CreateWorkloadNamespace()
+		testConfig = builder.VCSimTestConfig{
+			WithWorkloadIsolation: true,
+		}
+
+		ctx = suite.NewTestContextForVCSim(testConfig)
+		nsInfo = ctx.CreateWorkloadNamespace(testConfig)
 		nsRP = ctx.GetResourcePoolForNamespace(nsInfo.Namespace, "", "")
 
 		parentRPMoID = nsRP.Reference().Value

--- a/pkg/providers/vsphere/vmprovider_resourcepolicy_test.go
+++ b/pkg/providers/vsphere/vmprovider_resourcepolicy_test.go
@@ -51,7 +51,8 @@ func resourcePolicyTests() {
 
 		BeforeEach(func() {
 			testConfig = builder.VCSimTestConfig{
-				NumFaultDomains: 3,
+				NumFaultDomains:       3,
+				WithWorkloadIsolation: true,
 			}
 		})
 
@@ -59,7 +60,7 @@ func resourcePolicyTests() {
 			ctx = suite.NewTestContextForVCSim(testConfig, initObjects...)
 			vmProvider = vsphere.NewVSphereVMProviderFromClient(ctx, ctx.Client, ctx.Recorder)
 
-			nsInfo = ctx.CreateWorkloadNamespace()
+			nsInfo = ctx.CreateWorkloadNamespace(testConfig)
 		})
 
 		AfterEach(func() {

--- a/pkg/providers/vsphere/vmprovider_resourcepolicy_test.go
+++ b/pkg/providers/vsphere/vmprovider_resourcepolicy_test.go
@@ -60,7 +60,7 @@ func resourcePolicyTests() {
 			ctx = suite.NewTestContextForVCSim(testConfig, initObjects...)
 			vmProvider = vsphere.NewVSphereVMProviderFromClient(ctx, ctx.Client, ctx.Recorder)
 
-			nsInfo = ctx.CreateWorkloadNamespace(testConfig)
+			nsInfo = ctx.CreateWorkloadNamespace()
 		})
 
 		AfterEach(func() {

--- a/pkg/providers/vsphere/vmprovider_vm2_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm2_test.go
@@ -73,7 +73,7 @@ func vmE2ETests() {
 			config.MaxDeployThreadsOnProvider = 1
 		})
 		vmProvider = vsphere.NewVSphereVMProviderFromClient(ctx, ctx.Client, ctx.Recorder)
-		nsInfo = ctx.CreateWorkloadNamespace(testConfig)
+		nsInfo = ctx.CreateWorkloadNamespace()
 
 		vmClass.Namespace = nsInfo.Namespace
 		Expect(ctx.Client.Create(ctx, vmClass)).To(Succeed())

--- a/pkg/providers/vsphere/vmprovider_vm2_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm2_test.go
@@ -59,7 +59,8 @@ func vmE2ETests() {
 		network.RetryTimeout = 1 * time.Millisecond
 
 		testConfig = builder.VCSimTestConfig{
-			WithContentLibrary: true,
+			WithContentLibrary:    true,
+			WithWorkloadIsolation: true,
 		}
 
 		vm = builder.DummyBasicVirtualMachine("test-vm", "")
@@ -72,7 +73,7 @@ func vmE2ETests() {
 			config.MaxDeployThreadsOnProvider = 1
 		})
 		vmProvider = vsphere.NewVSphereVMProviderFromClient(ctx, ctx.Client, ctx.Recorder)
-		nsInfo = ctx.CreateWorkloadNamespace()
+		nsInfo = ctx.CreateWorkloadNamespace(testConfig)
 
 		vmClass.Namespace = nsInfo.Namespace
 		Expect(ctx.Client.Create(ctx, vmClass)).To(Succeed())

--- a/pkg/providers/vsphere/vmprovider_vm_resize_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_resize_test.go
@@ -36,8 +36,9 @@ func vmResizeTests() {
 
 	BeforeEach(func() {
 		testConfig = builder.VCSimTestConfig{
-			WithContentLibrary: true,
-			WithNetworkEnv:     builder.NetworkEnvNamed,
+			WithContentLibrary:    true,
+			WithNetworkEnv:        builder.NetworkEnvNamed,
+			WithWorkloadIsolation: true,
 		}
 	})
 
@@ -47,7 +48,7 @@ func vmResizeTests() {
 			config.MaxDeployThreadsOnProvider = 1
 		})
 		vmProvider = vsphere.NewVSphereVMProviderFromClient(ctx, ctx.Client, ctx.Recorder)
-		nsInfo = ctx.CreateWorkloadNamespace()
+		nsInfo = ctx.CreateWorkloadNamespace(testConfig)
 	})
 
 	AfterEach(func() {

--- a/pkg/providers/vsphere/vmprovider_vm_resize_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_resize_test.go
@@ -48,7 +48,7 @@ func vmResizeTests() {
 			config.MaxDeployThreadsOnProvider = 1
 		})
 		vmProvider = vsphere.NewVSphereVMProviderFromClient(ctx, ctx.Client, ctx.Recorder)
-		nsInfo = ctx.CreateWorkloadNamespace(testConfig)
+		nsInfo = ctx.CreateWorkloadNamespace()
 	})
 
 	AfterEach(func() {

--- a/pkg/providers/vsphere/vmprovider_vm_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_test.go
@@ -61,7 +61,8 @@ func vmTests() {
 
 	BeforeEach(func() {
 		testConfig = builder.VCSimTestConfig{
-			WithContentLibrary: true,
+			WithContentLibrary:    true,
+			WithWorkloadIsolation: true,
 		}
 	})
 
@@ -71,7 +72,7 @@ func vmTests() {
 			config.MaxDeployThreadsOnProvider = 1
 		})
 		vmProvider = vsphere.NewVSphereVMProviderFromClient(ctx, ctx.Client, ctx.Recorder)
-		nsInfo = ctx.CreateWorkloadNamespace()
+		nsInfo = ctx.CreateWorkloadNamespace(testConfig)
 	})
 
 	AfterEach(func() {

--- a/pkg/providers/vsphere/vmprovider_vm_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_test.go
@@ -72,7 +72,7 @@ func vmTests() {
 			config.MaxDeployThreadsOnProvider = 1
 		})
 		vmProvider = vsphere.NewVSphereVMProviderFromClient(ctx, ctx.Client, ctx.Recorder)
-		nsInfo = ctx.CreateWorkloadNamespace(testConfig)
+		nsInfo = ctx.CreateWorkloadNamespace()
 	})
 
 	AfterEach(func() {

--- a/test/builder/vcsim_test_context.go
+++ b/test/builder/vcsim_test_context.go
@@ -88,6 +88,9 @@ type VCSimTestConfig struct {
 	// always required; the Datastore is only needed for gce2e.
 	WithoutStorageClass bool
 
+	// WithWorkloadIsolation enables FSS_WCP_WORKLOAD_DOMAIN_ISOLATION
+	WithWorkloadIsolation bool
+
 	// WithJSONExtraConfig enables additional ExtraConfig that is included when
 	// creating a VM.
 	WithJSONExtraConfig string
@@ -218,7 +221,7 @@ func (c *TestContextForVCSim) AfterEach() {
 	c.UnitTestContext.AfterEach()
 }
 
-func (c *TestContextForVCSim) CreateWorkloadNamespace() WorkloadNamespaceInfo {
+func (c *TestContextForVCSim) CreateWorkloadNamespace(config VCSimTestConfig) WorkloadNamespaceInfo {
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "workload-",
@@ -249,14 +252,31 @@ func (c *TestContextForVCSim) CreateWorkloadNamespace() WorkloadNamespaceInfo {
 		for _, rp := range nsRPs {
 			nsInfo.PoolMoIDs = append(nsInfo.PoolMoIDs, rp.Reference().Value)
 		}
-
-		az := &topologyv1.AvailabilityZone{}
-		Expect(c.Client.Get(c, client.ObjectKey{Name: azName}, az)).To(Succeed())
-		if az.Spec.Namespaces == nil {
-			az.Spec.Namespaces = map[string]topologyv1.NamespaceInfo{}
+		// When FSS_WCP_WORKLOAD_DOMAIN_ISOLATION is disabled, AvailabilityZone stores namespace info.
+		if !config.WithWorkloadIsolation {
+			az := &topologyv1.AvailabilityZone{}
+			Expect(c.Client.Get(c, client.ObjectKey{Name: azName}, az)).To(Succeed())
+			if az.Spec.Namespaces == nil {
+				az.Spec.Namespaces = map[string]topologyv1.NamespaceInfo{}
+			}
+			az.Spec.Namespaces[ns.Name] = nsInfo
+			Expect(c.Client.Update(c, az)).To(Succeed())
+			// When FSS_WCP_WORKLOAD_DOMAIN_ISOLATION is enabled, Namespaced Zone stores namespace info.
+		} else {
+			zone := &topologyv1.Zone{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      azName,
+					Namespace: ns.Name,
+				},
+				Spec: topologyv1.ZoneSpec{
+					ManagedVMs: topologyv1.VSphereEntityInfo{
+						FolderMoID: nsInfo.FolderMoId,
+						PoolMoIDs:  nsInfo.PoolMoIDs,
+					},
+				},
+			}
+			Expect(c.Client.Create(c, zone)).To(Succeed())
 		}
-		az.Spec.Namespaces[ns.Name] = nsInfo
-		Expect(c.Client.Update(c, az)).To(Succeed())
 	}
 
 	resourceQuota := &corev1.ResourceQuota{
@@ -309,6 +329,7 @@ func (c *TestContextForVCSim) setupEnv(config VCSimTestConfig) {
 		cc.Features.InstanceStorage = config.WithInstanceStorage
 		cc.Features.VMResize = config.WithVMResize
 		cc.Features.VMResizeCPUMemory = config.WithVMResizeCPUMemory
+		cc.Features.WorkloadDomainIsolation = config.WithWorkloadIsolation
 	})
 }
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This patch updates vcsim tests when WCP_Workload_Domain_Isolation enabled. 
- Updated `CreateWorkloadNamespace` to create namespaced Zone CR when FSS enabled.
- Test both FSS enabled/disabled for `zone_placement_test.go`.
- Test only FSS enabled for `folder_test.go`, `vmprovider_resourcepolicy_test.go` ect because they only cares `nsInfo.Namespace` during tests.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # N/A


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note
NONE
```