### PR TITLE
 📖 Update vApp template function names for v1a3

### DIFF
--- a/docs/concepts/workloads/guest.md
+++ b/docs/concepts/workloads/guest.md
@@ -542,16 +542,16 @@ spec:
       properties:
       - key: nameservers
         value:
-          value: "{{ (index .V1alpha2.Net.Nameservers 0) }}"
+          value: "{{ (index .V1alpha3.Net.Nameservers 0) }}"
       - key: management_ip
         value:
-          value: "{{ (index (index .V1alpha2.Net.Devices 0).IPAddresses 0) }}"
+          value: "{{ (index (index .V1alpha3.Net.Devices 0).IPAddresses 0) }}"
       - key: hostname
         value:
-          value: "{{ .V1alpha2.VM.Name }}"
+          value: "{{ .V1alpha3.VM.Name }}"
       - key: management_gateway
         value:
-          value: "{{ (index .V1alpha2.Net.Devices 0).Gateway4 }}"
+          value: "{{ (index .V1alpha3.Net.Devices 0).Gateway4 }}"
 ```
 
 ### Templating
@@ -566,20 +566,20 @@ The object provided to the template engine is the [`VirtualMachineTemplate`](htt
 
 The following table lists the functions VM Operator defines and passes into the template engine to make it easier to construct the information required for vApp properties:
 
-!!! note "`V1alpha1` Prefixed Template Functions"
+!!! note "`V1alpha1` and `V1alpha2` Prefixed Template Functions"
 
-    Please note the template functions beginning with `V1alpha1` are still supported, but users are encouraged to switch to the `V1alpha2` variants.
+    Please note the template functions beginning with `V1alpha1` and `V1alpha2` are still supported, but users are encouraged to switch to the `V1alpha3` variants.
 
 | Query name | Signature | Description |
 | -------- | -------- | -------- |
-| V1alpha2_FirstIP | `func () string` | Get the first, non-loopback IP address (formatted with network length) from the first NIC. |
-| V1alpha2_FirstIPFromNIC | `func (index int) string` | Get the first, non-loopback IP address (formatted with network length) from the n'th NIC. If the specified index is out-of-bounds, the template string is not parsed. |
-| V1alpha2_FormatIP | `func (IP string, netmask string) string` | This function may be used to format an IP address with or without a network prefix length. If the provided netmask is empty, then the IP address returned does not include a network length. If the provided netmask is non-empty, then it must be either a length, ex. `/24`, or decimal notation, ex. `255.255.255.0`. |
-| V1alpha2_FirstNicMacAddr | `func() (string, error)` | Get the MAC address from the first NIC. |
-| V1alpha2_FormatNameservers| `func (count int, delimiter string) string` | Format the first occurred count of nameservers with the provided delimiter. Specify a negative number to include all nameservers. |
-| V1alpha2_IP | `func(IP string) string` | Format an IP address with the default netmask CIDR. If the specified IP is invalid, the template string is not parsed. |
-| V1alpha2_IPsFromNIC | `func (index int) []string` | List all IPs, formatted with the network length, from the n'th NIC. If the specified index is out-of-bounds, the template string is not parsed. |
-| V1alpha2_SubnetMask | `func(cidr string) (string, error)` | Get a subnet mask from an IP address formatted with a network length. |
+| V1alpha3_FirstIP | `func () string` | Get the first, non-loopback IP address (formatted with network length) from the first NIC. |
+| V1alpha3_FirstIPFromNIC | `func (index int) string` | Get the first, non-loopback IP address (formatted with network length) from the n'th NIC. If the specified index is out-of-bounds, the template string is not parsed. |
+| V1alpha3_FormatIP | `func (IP string, netmask string) string` | This function may be used to format an IP address with or without a network prefix length. If the provided netmask is empty, then the IP address returned does not include a network length. If the provided netmask is non-empty, then it must be either a length, ex. `/24`, or decimal notation, ex. `255.255.255.0`. |
+| V1alpha3_FirstNicMacAddr | `func() (string, error)` | Get the MAC address from the first NIC. |
+| V1alpha3_FormatNameservers| `func (count int, delimiter string) string` | Format the first occurred count of nameservers with the provided delimiter. Specify a negative number to include all nameservers. |
+| V1alpha3_IP | `func(IP string) string` | Format an IP address with the default netmask CIDR. If the specified IP is invalid, the template string is not parsed. |
+| V1alpha3_IPsFromNIC | `func (index int) []string` | List all IPs, formatted with the network length, from the n'th NIC. If the specified index is out-of-bounds, the template string is not parsed. |
+| V1alpha3_SubnetMask | `func(cidr string) (string, error)` | Get a subnet mask from an IP address formatted with a network length. |
 
 ## Deprecated
 


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

b2c80d5fef added the v1a3 template fields and functions

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:


```release-note
Update docs to reference the v1alpha3 prefixed template functions and fields
```

<!-- readthedocs-preview vm-operator start -->
----
📚 Documentation preview 📚: https://vm-operator--652.org.readthedocs.build/en/652/

<!-- readthedocs-preview vm-operator end -->