### PR TITLE
✨ Perennial properties

### DIFF
--- a/pkg/providers/vsphere/constants/constants.go
+++ b/pkg/providers/vsphere/constants/constants.go
@@ -8,11 +8,13 @@ import (
 )
 
 const (
-	ExtraConfigTrue            = "TRUE"
-	ExtraConfigFalse           = "FALSE"
-	ExtraConfigUnset           = ""
-	ExtraConfigGuestInfoPrefix = "guestinfo."
-	ExtraConfigRunContainerKey = "RUN.container"
+	ExtraConfigTrue               = "TRUE"
+	ExtraConfigFalse              = "FALSE"
+	ExtraConfigUnset              = ""
+	ExtraConfigGuestInfoPrefix    = "guestinfo."
+	ExtraConfigRunContainerKey    = "RUN.container"
+	ExtraConfigVMServiceName      = "vmservice.name"
+	ExtraConfigVMServiceNamespace = "vmservice.namespace"
 
 	// VCVMAnnotation Annotation placed on the VM.
 	VCVMAnnotation = "Virtual Machine managed by the vSphere Virtual Machine service"

--- a/pkg/providers/vsphere/session/session.go
+++ b/pkg/providers/vsphere/session/session.go
@@ -4,6 +4,8 @@
 package session
 
 import (
+	"fmt"
+
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -28,13 +30,11 @@ func (s *Session) invokeFsrVirtualMachine(vmCtx pkgctx.VirtualMachineContext, re
 
 	task, err := internal.VirtualMachineFSR(vmCtx, resVM.MoRef(), s.Client.VimClient())
 	if err != nil {
-		vmCtx.Logger.Error(err, "InvokeFSR call failed")
-		return err
+		return fmt.Errorf("failed to invoke FSR: %w", err)
 	}
 
 	if err = task.Wait(vmCtx); err != nil {
-		vmCtx.Logger.Error(err, "InvokeFSR task failed")
-		return err
+		return fmt.Errorf("failed to wait on FSR task: %w", err)
 	}
 
 	return nil

--- a/pkg/providers/vsphere/session/session_vm_update_test.go
+++ b/pkg/providers/vsphere/session/session_vm_update_test.go
@@ -1709,3 +1709,125 @@ var _ = Describe("UpdateVirtualMachine", func() {
 		})
 	})
 })
+
+var _ = Describe("UpdateVMGuestIDReconfiguredCondition", func() {
+
+	var (
+		vmCtx      pkgctx.VirtualMachineContext
+		vmopVM     vmopv1.VirtualMachine
+		configSpec vimtypes.VirtualMachineConfigSpec
+		taskInfo   *vimtypes.TaskInfo
+	)
+
+	BeforeEach(func() {
+		// Init VM with the condition set to verify it's actually deleted.
+		vmopVM = vmopv1.VirtualMachine{
+			Status: vmopv1.VirtualMachineStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   vmopv1.GuestIDReconfiguredCondition,
+						Status: metav1.ConditionFalse,
+					},
+				},
+			},
+		}
+		vmCtx = pkgctx.VirtualMachineContext{
+			VM: &vmopVM,
+		}
+		configSpec = vimtypes.VirtualMachineConfigSpec{}
+		taskInfo = &vimtypes.TaskInfo{}
+	})
+
+	JustBeforeEach(func() {
+		session.UpdateVMGuestIDReconfiguredCondition(vmCtx.VM, configSpec, taskInfo)
+	})
+
+	Context("ConfigSpec doesn't have a guest ID", func() {
+
+		BeforeEach(func() {
+			configSpec.GuestId = ""
+		})
+
+		It("should delete the existing VM's guest ID condition", func() {
+			Expect(conditions.Get(&vmopVM, vmopv1.GuestIDReconfiguredCondition)).To(BeNil())
+		})
+	})
+
+	Context("ConfigSpec has a guest ID", func() {
+
+		BeforeEach(func() {
+			configSpec.GuestId = "test-guest-id-value"
+		})
+
+		When("TaskInfo is nil", func() {
+
+			BeforeEach(func() {
+				taskInfo = nil
+			})
+
+			It("should delete the VM's guest ID condition", func() {
+				Expect(conditions.Get(&vmopVM, vmopv1.GuestIDReconfiguredCondition)).To(BeNil())
+			})
+		})
+
+		When("TaskInfo.Error is nil", func() {
+
+			BeforeEach(func() {
+				taskInfo.Error = nil
+			})
+
+			It("should delete the VM's guest ID condition", func() {
+				Expect(conditions.Get(&vmopVM, vmopv1.GuestIDReconfiguredCondition)).To(BeNil())
+			})
+		})
+
+		When("TaskInfo.Error.Fault is not an InvalidPropertyFault", func() {
+
+			BeforeEach(func() {
+				taskInfo.Error = &vimtypes.LocalizedMethodFault{
+					Fault: &vimtypes.InvalidName{
+						Name: "some-invalid-name",
+					},
+				}
+			})
+
+			It("should delete the VM's guest ID condition", func() {
+				Expect(conditions.Get(&vmopVM, vmopv1.GuestIDReconfiguredCondition)).To(BeNil())
+			})
+		})
+
+		When("TaskInfo.Error contains an invalid property error NOT about guestID", func() {
+
+			BeforeEach(func() {
+				taskInfo.Error = &vimtypes.LocalizedMethodFault{
+					Fault: &vimtypes.InvalidArgument{
+						InvalidProperty: "config.version",
+					},
+				}
+			})
+
+			It("should delete the VM's guest ID condition", func() {
+				Expect(conditions.Get(&vmopVM, vmopv1.GuestIDReconfiguredCondition)).To(BeNil())
+			})
+		})
+
+		When("TaskInfo.Error contains an invalid property error of guestID", func() {
+
+			BeforeEach(func() {
+				taskInfo.Error = &vimtypes.LocalizedMethodFault{
+					Fault: &vimtypes.InvalidArgument{
+						InvalidProperty: "configSpec.guestId",
+					},
+				}
+			})
+
+			It("should set the VM's guest ID condition to false with the invalid value in the reason", func() {
+				c := conditions.Get(&vmopVM, vmopv1.GuestIDReconfiguredCondition)
+				Expect(c).NotTo(BeNil())
+				Expect(c.Status).To(Equal(metav1.ConditionFalse))
+				Expect(c.Reason).To(Equal("Invalid"))
+				Expect(c.Message).To(Equal("The specified guest ID value is not supported: test-guest-id-value"))
+			})
+		})
+	})
+})

--- a/pkg/providers/vsphere/virtualmachine/configspec.go
+++ b/pkg/providers/vsphere/virtualmachine/configspec.go
@@ -42,6 +42,19 @@ func CreateConfigSpec(
 		Type:         vmopv1.ManagedByExtensionType,
 	}
 
+	// Ensure ExtraConfig contains the name/namespace of the VM's Kubernetes
+	// resource.
+	configSpec.ExtraConfig = util.OptionValues(configSpec.ExtraConfig).Merge(
+		&vimtypes.OptionValue{
+			Key:   constants.ExtraConfigVMServiceName,
+			Value: vmCtx.VM.Name,
+		},
+		&vimtypes.OptionValue{
+			Key:   constants.ExtraConfigVMServiceNamespace,
+			Value: vmCtx.VM.Namespace,
+		},
+	)
+
 	// spec.biosUUID is only set when creating a VM and is immutable.
 	// This field should not be updated for existing VMs.
 	if id := vmCtx.VM.Spec.BiosUUID; id != "" {

--- a/pkg/util/resize/configspec.go
+++ b/pkg/util/resize/configspec.go
@@ -25,7 +25,6 @@ func CreateResizeConfigSpec(
 	outCS := vimtypes.VirtualMachineConfigSpec{}
 
 	compareAnnotation(ci, cs, &outCS)
-	compareManagedBy(ci, cs, &outCS)
 	compareHardware(ci, cs, &outCS)
 	CompareCPUAllocation(ci, cs, &outCS)
 	compareCPUHotAddOrRemove(ci, cs, &outCS)
@@ -79,18 +78,6 @@ func compareAnnotation(
 	if ci.Annotation == "" {
 		// Only change the Annotation if it is currently unset.
 		outCS.Annotation = cs.Annotation
-	}
-}
-
-// compareManagedBy compares the ConfigInfo.ManagedBy.
-func compareManagedBy(
-	ci vimtypes.VirtualMachineConfigInfo,
-	cs vimtypes.VirtualMachineConfigSpec,
-	outCS *vimtypes.VirtualMachineConfigSpec) {
-
-	if ci.ManagedBy == nil {
-		// Only change the ManagedBy if it is currently unset.
-		outCS.ManagedBy = cs.ManagedBy
 	}
 }
 

--- a/pkg/util/resize/configspec_test.go
+++ b/pkg/util/resize/configspec_test.go
@@ -49,15 +49,6 @@ var _ = Describe("CreateResizeConfigSpec", func() {
 			ConfigSpec{Annotation: "my-annotation"},
 			ConfigSpec{Annotation: "my-annotation"}),
 
-		Entry("ManagedBy is currently set",
-			ConfigInfo{ManagedBy: &vimtypes.ManagedByInfo{Type: "my-managed-by"}},
-			ConfigSpec{},
-			ConfigSpec{}),
-		Entry("ManagedBy is currently unset",
-			ConfigInfo{},
-			ConfigSpec{ManagedBy: &vimtypes.ManagedByInfo{Type: "my-managed-by"}},
-			ConfigSpec{ManagedBy: &vimtypes.ManagedByInfo{Type: "my-managed-by"}}),
-
 		Entry("NumCPUs needs updating",
 			ConfigInfo{Hardware: vimtypes.VirtualHardware{NumCPU: 2}},
 			ConfigSpec{NumCPUs: 4},

--- a/pkg/util/vsphere/vm/guest_id.go
+++ b/pkg/util/vsphere/vm/guest_id.go
@@ -4,55 +4,26 @@
 package vm
 
 import (
-	"fmt"
 	"strings"
 
 	vimtypes "github.com/vmware/govmomi/vim25/types"
-
-	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
-	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
-	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 )
 
 // GuestIDProperty is the property name for the guest ID in the config spec.
 const GuestIDProperty = "configSpec.guestId"
 
-// UpdateVMGuestIDReconfiguredCondition deletes the VM's GuestIDReconfigured
-// condition if the configSpec doesn't contain a guestID, or if the taskInfo
-// does not contain an invalid guestID property error. Otherwise, it sets the
-// condition to false with the invalid guest ID property value in the reason.
-func UpdateVMGuestIDReconfiguredCondition(
-	vmctx pkgctx.VirtualMachineContext,
-	configSpec vimtypes.VirtualMachineConfigSpec,
-	taskInfo *vimtypes.TaskInfo) {
-	if configSpec.GuestId == "" {
-		conditions.Delete(vmctx.VM, vmopv1.GuestIDReconfiguredCondition)
-		return
+// IsTaskInfoErrorInvalidGuestID returns true if the provided taskInfo contains
+// an error with a fault that indicates the underlying cause is an invalid guest
+// ID.
+func IsTaskInfoErrorInvalidGuestID(taskInfo *vimtypes.TaskInfo) bool {
+	if taskInfo == nil {
+		return false
 	}
-
-	var invalidGuestID bool
-
-	defer func() {
-		if invalidGuestID {
-			conditions.MarkFalse(
-				vmctx.VM,
-				vmopv1.GuestIDReconfiguredCondition,
-				"Invalid",
-				fmt.Sprintf("The specified guest ID value is not supported: %s",
-					configSpec.GuestId))
-		} else {
-			conditions.Delete(vmctx.VM, vmopv1.GuestIDReconfiguredCondition)
-		}
-	}()
-
-	if taskInfo == nil || taskInfo.Error == nil {
-		return
+	if taskInfo.Error == nil {
+		return false
 	}
-
-	fault, ok := taskInfo.Error.Fault.(*vimtypes.InvalidArgument)
-	if !ok {
-		return
+	if f, ok := taskInfo.Error.Fault.(*vimtypes.InvalidArgument); ok {
+		return strings.Contains(f.InvalidProperty, GuestIDProperty)
 	}
-
-	invalidGuestID = strings.Contains(fault.InvalidProperty, GuestIDProperty)
+	return false
 }

--- a/pkg/util/vsphere/vm/guest_id_test.go
+++ b/pkg/util/vsphere/vm/guest_id_test.go
@@ -8,135 +8,62 @@ import (
 	. "github.com/onsi/gomega"
 
 	vimtypes "github.com/vmware/govmomi/vim25/types"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
-	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
-	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	vmutil "github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/vm"
 )
 
 func guestIDTests() {
-
-	Context("UpdateVMGuestIDReconfiguredCondition", func() {
-
-		var (
-			vmCtx      pkgctx.VirtualMachineContext
-			vmopVM     vmopv1.VirtualMachine
-			configSpec vimtypes.VirtualMachineConfigSpec
-			taskInfo   *vimtypes.TaskInfo
-		)
-
-		BeforeEach(func() {
-			// Init VM with the condition set to verify it's actually deleted.
-			vmopVM = vmopv1.VirtualMachine{
-				Status: vmopv1.VirtualMachineStatus{
-					Conditions: []metav1.Condition{
-						{
-							Type:   vmopv1.GuestIDReconfiguredCondition,
-							Status: metav1.ConditionFalse,
-						},
+	DescribeTable("IsTaskInfoErrorInvalidGuestID",
+		func(taskInfo *vimtypes.TaskInfo, expected bool) {
+			Expect(vmutil.IsTaskInfoErrorInvalidGuestID(taskInfo)).To(Equal(expected))
+		},
+		Entry(
+			"taskInfo is nil",
+			nil,
+			false,
+		),
+		Entry(
+			"taskInfo.Error is nil",
+			&vimtypes.TaskInfo{},
+			false,
+		),
+		Entry(
+			"taskInfo.Error.Fault is nil",
+			&vimtypes.TaskInfo{
+				Error: &vimtypes.LocalizedMethodFault{},
+			},
+			false,
+		),
+		Entry(
+			"taskInfo.Error.Fault is not InvalidArgument",
+			&vimtypes.TaskInfo{
+				Error: &vimtypes.LocalizedMethodFault{
+					Fault: &vimtypes.AdminDisabled{},
+				},
+			},
+			false,
+		),
+		Entry(
+			"taskInfo.Error.Fault is InvalidArgument with wrong property",
+			&vimtypes.TaskInfo{
+				Error: &vimtypes.LocalizedMethodFault{
+					Fault: &vimtypes.InvalidArgument{
+						InvalidProperty: "configSpec.name",
 					},
 				},
-			}
-			vmCtx = pkgctx.VirtualMachineContext{
-				VM: &vmopVM,
-			}
-			configSpec = vimtypes.VirtualMachineConfigSpec{}
-			taskInfo = &vimtypes.TaskInfo{}
-		})
-
-		JustBeforeEach(func() {
-			vmutil.UpdateVMGuestIDReconfiguredCondition(vmCtx, configSpec, taskInfo)
-		})
-
-		Context("ConfigSpec doesn't have a guest ID", func() {
-
-			BeforeEach(func() {
-				configSpec.GuestId = ""
-			})
-
-			It("should delete the existing VM's guest ID condition", func() {
-				Expect(conditions.Get(&vmopVM, vmopv1.GuestIDReconfiguredCondition)).To(BeNil())
-			})
-		})
-
-		Context("ConfigSpec has a guest ID", func() {
-
-			BeforeEach(func() {
-				configSpec.GuestId = "test-guest-id-value"
-			})
-
-			When("TaskInfo is nil", func() {
-
-				BeforeEach(func() {
-					taskInfo = nil
-				})
-
-				It("should delete the VM's guest ID condition", func() {
-					Expect(conditions.Get(&vmopVM, vmopv1.GuestIDReconfiguredCondition)).To(BeNil())
-				})
-			})
-
-			When("TaskInfo.Error is nil", func() {
-
-				BeforeEach(func() {
-					taskInfo.Error = nil
-				})
-
-				It("should delete the VM's guest ID condition", func() {
-					Expect(conditions.Get(&vmopVM, vmopv1.GuestIDReconfiguredCondition)).To(BeNil())
-				})
-			})
-
-			When("TaskInfo.Error.Fault is not an InvalidPropertyFault", func() {
-
-				BeforeEach(func() {
-					taskInfo.Error = &vimtypes.LocalizedMethodFault{
-						Fault: &vimtypes.InvalidName{
-							Name: "some-invalid-name",
-						},
-					}
-				})
-
-				It("should delete the VM's guest ID condition", func() {
-					Expect(conditions.Get(&vmopVM, vmopv1.GuestIDReconfiguredCondition)).To(BeNil())
-				})
-			})
-
-			When("TaskInfo.Error contains an invalid property error NOT about guestID", func() {
-
-				BeforeEach(func() {
-					taskInfo.Error = &vimtypes.LocalizedMethodFault{
-						Fault: &vimtypes.InvalidArgument{
-							InvalidProperty: "config.version",
-						},
-					}
-				})
-
-				It("should delete the VM's guest ID condition", func() {
-					Expect(conditions.Get(&vmopVM, vmopv1.GuestIDReconfiguredCondition)).To(BeNil())
-				})
-			})
-
-			When("TaskInfo.Error contains an invalid property error of guestID", func() {
-
-				BeforeEach(func() {
-					taskInfo.Error = &vimtypes.LocalizedMethodFault{
-						Fault: &vimtypes.InvalidArgument{
-							InvalidProperty: "configSpec.guestId",
-						},
-					}
-				})
-
-				It("should set the VM's guest ID condition to false with the invalid value in the reason", func() {
-					c := conditions.Get(&vmopVM, vmopv1.GuestIDReconfiguredCondition)
-					Expect(c).NotTo(BeNil())
-					Expect(c.Status).To(Equal(metav1.ConditionFalse))
-					Expect(c.Reason).To(Equal("Invalid"))
-					Expect(c.Message).To(Equal("The specified guest ID value is not supported: test-guest-id-value"))
-				})
-			})
-		})
-	})
+			},
+			false,
+		),
+		Entry(
+			"taskInfo.Error.Fault is InvalidArgument with guestID",
+			&vimtypes.TaskInfo{
+				Error: &vimtypes.LocalizedMethodFault{
+					Fault: &vimtypes.InvalidArgument{
+						InvalidProperty: vmutil.GuestIDProperty,
+					},
+				},
+			},
+			true,
+		),
+	)
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch does three things:

1. The VM object's namespace and name are stored in ExtraConfig as the keys `vmservice.namespace` and `vmservice.name`.

2. The VM's vSphere property `config.managedBy` is _always_ set to reflect the VM is managed by VM Service if it is not set to this value.

3. There is now support for *always* ensuring certain properties are set during each reconcile, regardless of the VM's power state or whether or not the VM is paused by the admin. For example, the aforementioned namespace/name ExtraConfig keys are included, as well as the VM's `config.managedBy` property.



**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Support perennial properties
```