### PR TITLE
🐛 Sync subscribed ISO library item before connecting CD-ROM

### DIFF
--- a/pkg/providers/vsphere/session/session_vm_update.go
+++ b/pkg/providers/vsphere/session/session_vm_update.go
@@ -528,9 +528,9 @@ func (s *Session) prePowerOnVMConfigSpec(
 	configSpec.DeviceChange = append(configSpec.DeviceChange, pciDeviceChanges...)
 
 	if pkgcfg.FromContext(vmCtx).Features.IsoSupport {
-		cdromDeviceChanges, err := vmutil.UpdateCdromDeviceChanges(vmCtx, s.K8sClient, virtualDevices)
+		cdromDeviceChanges, err := vmutil.UpdateCdromDeviceChanges(vmCtx, s.Client.RestClient(), s.K8sClient, virtualDevices)
 		if err != nil {
-			return nil, fmt.Errorf("failed to update CD-ROM device changes: %w", err)
+			return nil, fmt.Errorf("update CD-ROM device changes error: %w", err)
 		}
 		configSpec.DeviceChange = append(configSpec.DeviceChange, cdromDeviceChanges...)
 	}
@@ -793,8 +793,8 @@ func (s *Session) poweredOnVMReconfigure(
 	UpdateConfigSpecChangeBlockTracking(vmCtx, config, configSpec, nil, vmCtx.VM.Spec)
 
 	if pkgcfg.FromContext(vmCtx).Features.IsoSupport {
-		if err := vmutil.UpdateConfigSpecCdromDeviceConnection(vmCtx, s.K8sClient, config, configSpec); err != nil {
-			return false, fmt.Errorf("failed to update CD-ROM device connection: %w", err)
+		if err := vmutil.UpdateConfigSpecCdromDeviceConnection(vmCtx, s.Client.RestClient(), s.K8sClient, config, configSpec); err != nil {
+			return false, fmt.Errorf("update CD-ROM device connection error: %w", err)
 		}
 	}
 

--- a/pkg/util/vsphere/vm/suite_test.go
+++ b/pkg/util/vsphere/vm/suite_test.go
@@ -17,7 +17,7 @@ func vcSimTests() {
 	Describe("Hardware Version", Label(testlabels.VCSim), hardwareVersionTests)
 	Describe("Managed Object", managedObjectTests)
 	Describe("Guest ID", guestIDTests)
-	Describe("CD ROM", cdromTests)
+	Describe("CD ROM", Label(testlabels.VCSim), cdromTests)
 }
 
 var suite = builder.NewTestSuite()

--- a/test/builder/dummies.go
+++ b/test/builder/dummies.go
@@ -559,18 +559,22 @@ func DummyVirtualMachineWebConsoleRequest(namespace, wcrName, vmName, pubKey str
 }
 
 func DummyImageAndItemObjectsForCdromBacking(
-	name, ns, kind, storageURI string,
+	name, ns, kind, storageURI, libItemUUID string,
 	imgHasProviderRef, itemObjExists bool,
 	itemType imgregv1a1.ContentLibraryItemType) []ctrlclient.Object {
 	var imageObj, itemObj ctrlclient.Object
 
 	// Populate minimal fields in image and content library item objects to
-	// retrieve CD-ROM backing file name.
+	// be able to sync and retrieve CD-ROM backing file name.
 	imgSpec := vmopv1.VirtualMachineImageSpec{}
 	if imgHasProviderRef {
 		imgSpec.ProviderRef = &vmopv1common.LocalObjectRef{
 			Name: name,
 		}
+	}
+
+	itemSpec := imgregv1a1.ContentLibraryItemSpec{
+		UUID: types.UID(libItemUUID),
 	}
 
 	itemStatus := imgregv1a1.ContentLibraryItemStatus{
@@ -596,6 +600,7 @@ func DummyImageAndItemObjectsForCdromBacking(
 				Name:      name,
 				Namespace: ns,
 			},
+			Spec:   itemSpec,
 			Status: itemStatus,
 		}
 	} else {
@@ -610,6 +615,7 @@ func DummyImageAndItemObjectsForCdromBacking(
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
+			Spec:   itemSpec,
 			Status: itemStatus,
 		}
 	}


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This patch updates the CD-ROM reconciliation workflow to ensure the ISO-type library item is synced, which is required to connect a CD-ROM that's backed by such an item from a subscribed content library.

To save data storage, the sync is only triggered when the CD-ROM has a "connected" spec and the backing content library file is not cached.

**Are there any special notes for your reviewer**:

The `cdrom_test.file` has been updated to maintain 100% coverage:

```console
$ go test -coverprofile=/tmp/coverage.out -run ^TestVSphereVirtualMachine$ github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/vm
ok  	github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/vm	102.026s	coverage: 86.1% of statements

$ go tool cover -func=/tmp/coverage.out | grep pkg/util/vsphere/vm/cdrom.go
github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/vm/cdrom.go:30:		UpdateCdromDeviceChanges		100.0%
github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/vm/cdrom.go:107:		UpdateConfigSpecCdromDeviceConnection	100.0%
github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/vm/cdrom.go:160:		getBackingFileNameByImageRef		100.0%
github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/vm/cdrom.go:232:		getCdromByBackingFileName		100.0%
github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/vm/cdrom.go:255:		createNewCdrom				100.0%
github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/vm/cdrom.go:282:		ensureAllCdromsHaveControllers		100.0%
github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/vm/cdrom.go:317:		addNewAHCIController			100.0%
github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/vm/cdrom.go:368:		updateCurCdromsConnectionState		100.0%
```

**Please add a release note if necessary**:

```release-note
Sync subscribed ISO library item before connecting CD-ROM.
```