### PR TITLE
🌱 Add FSS_STORAGE_QUOTA_M2 to manifests

### DIFF
--- a/config/local/vmoperator/local_env_var_patch.yaml
+++ b/config/local/vmoperator/local_env_var_patch.yaml
@@ -31,6 +31,8 @@ spec:
           value: "false"
         - name: FSS_WCP_VMSERVICE_INCREMENTAL_RESTORE
           value: "false"
+        - name: FSS_STORAGE_QUOTA_M2
+          value: "false"
 
         #
         # Feature state switch flags beneath this line are enabled on main and

--- a/config/wcp/vmoperator/manager_env_var_patch.yaml
+++ b/config/wcp/vmoperator/manager_env_var_patch.yaml
@@ -87,6 +87,13 @@
   value:
     name: FSS_WCP_VMSERVICE_INCREMENTAL_RESTORE
     value: "<FSS_WCP_VMSERVICE_INCREMENTAL_RESTORE_VALUE>"
+
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: FSS_STORAGE_QUOTA_M2
+    value: "<FSS_STORAGE_QUOTA_M2>"
+
 #
 # Feature state switch flags beneath this line are enabled on main and only
 # retained in this file because it is used by internal testing to determine the


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch adds the FSS_STORAGE_QUOTA_M2 env var to the VM Op manifests that allows the value to be plumbed through from other components.
<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Add FSS_STORAGE_QUOTA_M2 to manifests
```