### PR TITLE
✨ Implement Backup-version for Incremental Restore support

### DIFF
--- a/api/v1alpha3/virtualmachine_types.go
+++ b/api/v1alpha3/virtualmachine_types.go
@@ -166,6 +166,15 @@ const (
 	// PVC disk data in JSON, compressed using gzip and base64-encoded.
 	PVCDiskDataExtraConfigKey = "vmservice.virtualmachine.pvc.disk.data"
 
+	// BackupVersionExtraConfigKey is the ExtraConfig key that indicates
+	// the version of the VM's last backup. It is a monotonically increasing counter and
+	// is only supposed to be used by IaaS control plane and vCenter for virtual machine registration
+	// post a restore operation.
+	//
+	// The BackupVersionExtraConfigKey on the vSphere VM and the VirtualMachineBackupVersionAnnotation
+	// on the VM resource in Supervisor indicate whether the backups are in sync.
+	BackupVersionExtraConfigKey = "vmservice.virtualmachine.backupVersion"
+
 	// DisableAutoRegistrationExtraConfigKey is the ExtraConfig key that can be
 	// set to "true" (case insensitive) on a virtual machine to opt-out of the
 	// automatic registration workflow.
@@ -191,6 +200,15 @@ const (
 	// vSphere.  There is no guarantee that the registration of the VM will be
 	// successful post a restore or failover operation.
 	ForceEnableBackupAnnotation = GroupName + "/force-enable-backup"
+
+	// VirtualMachineBackupVersionAnnotation is an annotation that indicates the VM's
+	// last backup version. It is a monotonically increasing counter and
+	// is only supposed to be used by IaaS control plane and vCenter for virtual machine registration
+	// post a restore operation.
+	//
+	// The VirtualMachineBackupVersionAnnotation on the VM resource in Supervisor and the BackupVersionExtraConfigKey on the vSphere VM
+	// indicate whether the backups are in sync.
+	VirtualMachineBackupVersionAnnotation = GroupName + "/backup-version"
 )
 
 const (

--- a/pkg/providers/vsphere/vmprovider_vm.go
+++ b/pkg/providers/vsphere/vmprovider_vm.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"text/template"
+	"time"
 
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/pbm"
@@ -543,6 +544,7 @@ func (vs *vSphereVMProvider) updateVirtualMachine(
 			VcVM:                vcVM,
 			DiskUUIDToPVC:       diskUUIDToPVC,
 			AdditionalResources: additionalResources,
+			BackupVersion:       fmt.Sprint(time.Now().Unix()),
 		}
 		if err := virtualmachine.BackupVirtualMachine(backupOpts); err != nil {
 			vmCtx.Logger.Error(err, "failed to backup VM")

--- a/test/builder/vcsim_test_context.go
+++ b/test/builder/vcsim_test_context.go
@@ -83,6 +83,9 @@ type VCSimTestConfig struct {
 	// WithVMResize enables the FSS_WCP_VMSERVICE_RESIZE_CPU_MEMORY FSS.
 	WithVMResizeCPUMemory bool
 
+	// WithVMIncrementalRestore enables the FSS_WCP_VMSERVICE_INCREMENTAL_RESTORE FSS.
+	WithVMIncrementalRestore bool
+
 	// WithoutStorageClass disables the storage class required, meaning that the
 	// Datastore will be used instead. In WCP production the storage class is
 	// always required; the Datastore is only needed for gce2e.
@@ -337,6 +340,7 @@ func (c *TestContextForVCSim) setupEnv(config VCSimTestConfig) {
 		cc.Features.VMResizeCPUMemory = config.WithVMResizeCPUMemory
 		cc.Features.WorkloadDomainIsolation = config.WithWorkloadIsolation
 		cc.Features.IsoSupport = config.WithISOSupport
+		cc.Features.VMIncrementalRestore = config.WithVMIncrementalRestore
 	})
 }
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This change
- Introduces a new annotation and an extraConfig Key to track the latest backup-version
- The backup version is a monotonically increasing number which uses the time.Now().Unix() method.
- Skip backup when backupVersion drift is detected (ie) backup version annotation > current backup extraConfig version. This indicates a restore being tried. backup will retry until the drift is fixed by a registration.
- Do backup when backupVersion annotation doesn't exist (or) when backupVersion and current backup extraconfig keys match (or) backup version annotation < extraConfig backup version.
- Update and persists a new version when a change is detected during each backup.
- Testing for the above.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # N/A


**Are there any special notes for your reviewer**:

Manual testing: 

Backup version annotation populated on the VM resource:
> apiVersion: vmoperator.vmware.com/v1alpha3
> kind: VirtualMachine
> metadata:
>   annotations:
>     kubectl.kubernetes.io/last-applied-configuration: |
>       {"apiVersion":"vmoperator.vmware.com/v1alpha1","kind":"VirtualMachine","metadata":{"annotations":{},"name":"ubuntu-impish-new","namespace":"prod-vmsvc-reco-vds-3769"},"spec":{"className":"best-effort-small","imageName":"vmi-81f7a0f6aaee2bde6","networkInterfaces":[{"networkType":"vsphere-distributed"}],"powerState":"poweredOn","storageClass":"wcpglobal-storage-profile"}}
>     virtualmachine.vmoperator.vmware.com/first-boot-done: "true"
>     vmoperator.vmware.com/backup-version: "1723070407"
>     vmoperator.vmware.com/created-at-build-version: 1.8.6-309-g92143d52
>     vmoperator.vmware.com/created-at-schema-version: v1alpha3

**Please add a release note if necessary**:

```
Implement the backup-version extra config key and annotation workflows for Incremental restore
```