### PR TITLE
🌱 Update vmservice.namespace|name to be single field

### DIFF
--- a/pkg/providers/vsphere/constants/constants.go
+++ b/pkg/providers/vsphere/constants/constants.go
@@ -8,13 +8,12 @@ import (
 )
 
 const (
-	ExtraConfigTrue               = "TRUE"
-	ExtraConfigFalse              = "FALSE"
-	ExtraConfigUnset              = ""
-	ExtraConfigGuestInfoPrefix    = "guestinfo."
-	ExtraConfigRunContainerKey    = "RUN.container"
-	ExtraConfigVMServiceName      = "vmservice.name"
-	ExtraConfigVMServiceNamespace = "vmservice.namespace"
+	ExtraConfigTrue                    = "TRUE"
+	ExtraConfigFalse                   = "FALSE"
+	ExtraConfigUnset                   = ""
+	ExtraConfigGuestInfoPrefix         = "guestinfo."
+	ExtraConfigRunContainerKey         = "RUN.container"
+	ExtraConfigVMServiceNamespacedName = "vmservice.namespacedName"
 
 	// VCVMAnnotation Annotation placed on the VM.
 	VCVMAnnotation = "Virtual Machine managed by the vSphere Virtual Machine service"

--- a/pkg/providers/vsphere/virtualmachine/configspec.go
+++ b/pkg/providers/vsphere/virtualmachine/configspec.go
@@ -46,12 +46,8 @@ func CreateConfigSpec(
 	// resource.
 	configSpec.ExtraConfig = util.OptionValues(configSpec.ExtraConfig).Merge(
 		&vimtypes.OptionValue{
-			Key:   constants.ExtraConfigVMServiceName,
-			Value: vmCtx.VM.Name,
-		},
-		&vimtypes.OptionValue{
-			Key:   constants.ExtraConfigVMServiceNamespace,
-			Value: vmCtx.VM.Namespace,
+			Key:   constants.ExtraConfigVMServiceNamespacedName,
+			Value: vmCtx.VM.NamespacedName(),
 		},
 	)
 

--- a/pkg/util/vmopv1/resize_overwrite.go
+++ b/pkg/util/vmopv1/resize_overwrite.go
@@ -128,34 +128,35 @@ func ensureNamespaceName(
 	curEC := util.OptionValues(ci.ExtraConfig).StringMap()
 	inEC := util.OptionValues(cs.ExtraConfig).StringMap()
 
-	fn := func(key string, expectedVal string) {
-		// Does the VM have the key set in EC?
-		if v, ok := curEC[key]; ok {
-			if v == expectedVal {
-				// The key is present and correct; is the ConfigSpec trying to
-				// set it again?
-				if _, ok := inEC[key]; ok {
-					// Remove the entry from the ConfigSpec.
-					cs.ExtraConfig = util.OptionValues(cs.ExtraConfig).Delete(key)
-				}
-			} else {
-				// The key is present but incorrect.
-				outEC = append(outEC, &vimtypes.OptionValue{
-					Key:   key,
-					Value: expectedVal,
-				})
-			}
-		} else {
-			// The key is not present.
-			outEC = append(outEC, &vimtypes.OptionValue{
-				Key:   key,
-				Value: expectedVal,
-			})
-		}
+	key := constants.ExtraConfigVMServiceNamespacedName
+	val := vm.NamespacedName()
+	if val == "/" {
+		val = ""
 	}
 
-	fn(constants.ExtraConfigVMServiceNamespace, vm.Namespace)
-	fn(constants.ExtraConfigVMServiceName, vm.Name)
+	// Does the VM have the key set in EC?
+	if v, ok := curEC[key]; ok {
+		if v == val {
+			// The key is present and correct; is the ConfigSpec trying to
+			// set it again?
+			if _, ok := inEC[key]; ok {
+				// Remove the entry from the ConfigSpec.
+				cs.ExtraConfig = util.OptionValues(cs.ExtraConfig).Delete(key)
+			}
+		} else {
+			// The key is present but incorrect.
+			outEC = append(outEC, &vimtypes.OptionValue{
+				Key:   key,
+				Value: val,
+			})
+		}
+	} else {
+		// The key is not present.
+		outEC = append(outEC, &vimtypes.OptionValue{
+			Key:   key,
+			Value: val,
+		})
+	}
 
 	return outEC
 }


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch updates the ExtraConfig properties `vmservice.namespace` and `vmservice.name` to be a single field, `vmservice.namespacedName`. This simplifies watching for changes based on this property.



**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```