### PR TITLE
🐛 ExtraConfig keys as OptionVals when getting props / prober

### DIFF
--- a/pkg/prober/probe/guestinfo.go
+++ b/pkg/prober/probe/guestinfo.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"regexp"
 
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+
 	"github.com/vmware-tanzu/vm-operator/pkg/prober/context"
 )
 
@@ -65,9 +67,15 @@ func (gip guestInfoProber) Probe(ctx *context.ProbeContext) (Result, error) {
 			continue
 		}
 
-		val, ok := valObj.(string)
+		obj, ok := valObj.(vimtypes.OptionValue)
 		if !ok {
-			val = fmt.Sprintf("%s", valObj)
+			return Failure, nil
+		}
+
+		// If the value is not a string, then format it as a string.
+		val, ok := obj.Value.(string)
+		if !ok {
+			val = fmt.Sprintf("%v", obj.Value)
 		}
 
 		if !expectedValRx.MatchString(val) {

--- a/pkg/prober/probe/guestinfo_test.go
+++ b/pkg/prober/probe/guestinfo_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	vimtypes "github.com/vmware/govmomi/vim25/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -96,11 +97,17 @@ var _ = Describe("Guest info probe", func() {
 		toKey := func(s string) string {
 			return fmt.Sprintf(`config.extraConfig["guestinfo.%s"]`, s)
 		}
+		toVal := func(k, v string) vimtypes.OptionValue {
+			return vimtypes.OptionValue{
+				Key:   toKey(k),
+				Value: v,
+			}
+		}
 
 		Context("Key does not exist in GuestInfo", func() {
 			BeforeEach(func() {
 				fakeProvider.guestInfo = map[string]any{
-					toKey("key1"): "ignored-because-no-value-in-action",
+					toKey("key1"): toVal("key1", "ignored-because-no-value-in-action"),
 				}
 
 				guestInfoAction = []vmopv1.GuestInfoAction{
@@ -119,7 +126,7 @@ var _ = Describe("Guest info probe", func() {
 		Context("Matches key when value is not set", func() {
 			BeforeEach(func() {
 				fakeProvider.guestInfo = map[string]any{
-					toKey("key1"): "ignored-because-no-value-in-action",
+					toKey("key1"): toVal("key1", "ignored-because-no-value-in-action"),
 				}
 
 				guestInfoAction = []vmopv1.GuestInfoAction{
@@ -137,7 +144,9 @@ var _ = Describe("Guest info probe", func() {
 
 		Context("Matches key and has plain string value", func() {
 			BeforeEach(func() {
-				fakeProvider.guestInfo = map[string]any{toKey("key2"): "vmware"}
+				fakeProvider.guestInfo = map[string]any{
+					toKey("key2"): toVal("key2", "vmware"),
+				}
 			})
 
 			Context("Values match", func() {
@@ -176,7 +185,7 @@ var _ = Describe("Guest info probe", func() {
 		Context("Matches key and has regex value", func() {
 			BeforeEach(func() {
 				fakeProvider.guestInfo = map[string]any{
-					toKey("key3"): "aaaaa",
+					toKey("key3"): toVal("key3", "aaaaa"),
 				}
 
 			})


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch updates the GuestInfo prober to correctly treat ExtraConfig properties retrieved by their key index as OptionValue types instead of thinking their value is returned directly.

Additionally, tests that use vC Sim have been added for the provider's GetVMProperties function that validate the new assumption about retrieving indexed ExtraConfig keys.



**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Fix bug (ish) with GuestInfo prober that incorrectly treated indexed keys as strings instead of OptionValues
```