### PR TITLE
✨ Emit distinct create/update VM events

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -70,6 +70,8 @@ linters-settings:
         pkg: github.com/vmware-tanzu/vm-operator/pkg/config
       - alias: pkgctx
         pkg: github.com/vmware-tanzu/vm-operator/pkg/context
+      - alias: ctxop
+        pkg: github.com/vmware-tanzu/vm-operator/pkg/context/operation
       - alias: pkgmgr
         pkg: github.com/vmware-tanzu/vm-operator/pkg/manager
       - alias: pkgutil

--- a/pkg/context/operation/operation_context.go
+++ b/pkg/context/operation/operation_context.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package operation
+
+import (
+	"context"
+	"sync"
+)
+
+type contextKeyType uint8
+
+const contextKeyValue contextKeyType = 0
+
+type operationType uint8
+
+const (
+	none operationType = iota
+	create
+	update
+)
+
+type operation struct {
+	sync.RWMutex
+	typ3 operationType
+}
+
+// IsCreate returns whether or not this is a create operation.
+func IsCreate(ctx context.Context) bool {
+	return fromContext(ctx) == create
+}
+
+// IsUpdate returns whether or not this is an update operation.
+func IsUpdate(ctx context.Context) bool {
+	return fromContext(ctx) == update
+}
+
+// MarkCreate indicates to the call stack this is a create operation.
+func MarkCreate(ctx context.Context) {
+	setType(ctx, create)
+}
+
+// MarkUpdate indicates to the call stack this is an update operation.
+// This will be a no-op if MarkCreate was already called.
+func MarkUpdate(ctx context.Context) {
+	setType(ctx, update)
+}
+
+func fromContext(ctx context.Context) operationType {
+	if ctx == nil {
+		panic("context is nil")
+	}
+	obj := ctx.Value(contextKeyValue)
+	if obj == nil {
+		panic("operation is missing from context")
+	}
+	data := obj.(*operation)
+	data.RLock()
+	defer data.RUnlock()
+	return data.typ3
+}
+
+func setType(ctx context.Context, r operationType) {
+	if ctx == nil {
+		panic("context is nil")
+	}
+	obj := ctx.Value(contextKeyValue)
+	if obj == nil {
+		panic("operation is missing from context")
+	}
+	data := obj.(*operation)
+	data.Lock()
+	defer data.Unlock()
+
+	if data.typ3 != create {
+		data.typ3 = r
+	}
+}
+
+// WithContext returns a new operation context.
+func WithContext(parent context.Context) context.Context {
+	if parent == nil {
+		panic("parent context is nil")
+	}
+	return context.WithValue(
+		parent,
+		contextKeyValue,
+		&operation{})
+}
+
+// JoinContext returns a new context that contains the operation from the right
+// or left side of the context, with the right taking precedence.
+// This function is thread-safe.
+func JoinContext(left, right context.Context) context.Context {
+	if left == nil {
+		panic("left context is nil")
+	}
+	if right == nil {
+		panic("right context is nil")
+	}
+
+	leftObj := left.Value(contextKeyValue)
+	rightObj := right.Value(contextKeyValue)
+
+	if leftObj == nil && rightObj == nil {
+		panic("operation is missing from context")
+	}
+
+	if leftObj != nil && rightObj == nil {
+		// The left context has the operation and the right does not, so just
+		// return the left context.
+		return left
+	}
+
+	// The right context has the operation, so return a new context with the
+	// operation in it.
+	return context.WithValue(left, contextKeyValue, rightObj.(*operation))
+}

--- a/pkg/context/operation/operation_context_test.go
+++ b/pkg/context/operation/operation_context_test.go
@@ -1,0 +1,281 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package operation_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
+)
+
+var _ = Describe("IsCreate", func() {
+	var (
+		ctx context.Context
+	)
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+	When("ctx is nil", func() {
+		BeforeEach(func() {
+			ctx = nil
+		})
+		It("should panic", func() {
+			fn := func() {
+				_ = ctxop.IsCreate(ctx)
+			}
+			Expect(fn).To(PanicWith("context is nil"))
+		})
+	})
+	When("operation is missing from context", func() {
+		It("should panic", func() {
+			fn := func() {
+				_ = ctxop.IsCreate(ctx)
+			}
+			Expect(fn).To(PanicWith("operation is missing from context"))
+		})
+	})
+	When("operation is present in context", func() {
+		BeforeEach(func() {
+			ctx = ctxop.WithContext(context.Background())
+		})
+		It("should return a operation", func() {
+			Expect(ctxop.IsCreate(ctx)).To(BeFalse())
+		})
+	})
+})
+
+var _ = Describe("IsUpdate", func() {
+	var (
+		ctx context.Context
+	)
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+	When("ctx is nil", func() {
+		BeforeEach(func() {
+			ctx = nil
+		})
+		It("should panic", func() {
+			fn := func() {
+				_ = ctxop.IsUpdate(ctx)
+			}
+			Expect(fn).To(PanicWith("context is nil"))
+		})
+	})
+	When("operation is missing from context", func() {
+		It("should panic", func() {
+			fn := func() {
+				_ = ctxop.IsUpdate(ctx)
+			}
+			Expect(fn).To(PanicWith("operation is missing from context"))
+		})
+	})
+	When("operation is present in context", func() {
+		BeforeEach(func() {
+			ctx = ctxop.WithContext(context.Background())
+		})
+		It("should return a operation", func() {
+			Expect(ctxop.IsUpdate(ctx)).To(BeFalse())
+		})
+	})
+})
+
+var _ = Describe("MarkCreate", func() {
+	var (
+		ctx context.Context
+	)
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+	When("ctx is nil", func() {
+		BeforeEach(func() {
+			ctx = nil
+		})
+		It("should panic", func() {
+			fn := func() {
+				ctxop.MarkCreate(ctx)
+			}
+			Expect(fn).To(PanicWith("context is nil"))
+		})
+	})
+	When("operation is missing from context", func() {
+		It("should panic", func() {
+			fn := func() {
+				ctxop.MarkCreate(ctx)
+			}
+			Expect(fn).To(PanicWith("operation is missing from context"))
+		})
+	})
+	When("operation is present in context", func() {
+		var ok bool
+		BeforeEach(func() {
+			ctx = ctxop.WithContext(context.Background())
+		})
+		JustBeforeEach(func() {
+			ctxop.MarkCreate(ctx)
+			ok = ctxop.IsCreate(ctx)
+		})
+		When("operation is not yet marked", func() {
+			It("should mark the operation", func() {
+				Expect(ok).To(BeTrue())
+			})
+		})
+		When("operation is already marked update", func() {
+			BeforeEach(func() {
+				ctxop.MarkUpdate(ctx)
+			})
+			It("should override the existing operation", func() {
+				Expect(ok).To(BeTrue())
+			})
+		})
+	})
+})
+
+var _ = Describe("MarkUpdate", func() {
+	var (
+		ctx context.Context
+	)
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+	When("ctx is nil", func() {
+		BeforeEach(func() {
+			ctx = nil
+		})
+		It("should panic", func() {
+			fn := func() {
+				ctxop.MarkUpdate(ctx)
+			}
+			Expect(fn).To(PanicWith("context is nil"))
+		})
+	})
+	When("operation is missing from context", func() {
+		It("should panic", func() {
+			fn := func() {
+				ctxop.MarkUpdate(ctx)
+			}
+			Expect(fn).To(PanicWith("operation is missing from context"))
+		})
+	})
+	When("operation is present in context", func() {
+		var ok bool
+		BeforeEach(func() {
+			ctx = ctxop.WithContext(context.Background())
+		})
+		JustBeforeEach(func() {
+			ctxop.MarkUpdate(ctx)
+			ok = ctxop.IsUpdate(ctx)
+		})
+		When("operation is not yet marked", func() {
+			It("should mark the operation", func() {
+				Expect(ok).To(BeTrue())
+			})
+		})
+		When("operation is already marked create", func() {
+			BeforeEach(func() {
+				ctxop.MarkCreate(ctx)
+			})
+			It("should not override the existing operation", func() {
+				Expect(ok).To(BeFalse())
+			})
+		})
+	})
+})
+
+var _ = Describe("JoinContext", func() {
+	var (
+		left  context.Context
+		right context.Context
+	)
+	BeforeEach(func() {
+		left = context.Background()
+		right = context.Background()
+	})
+	When("left context is nil", func() {
+		BeforeEach(func() {
+			left = nil
+		})
+		It("should panic", func() {
+			fn := func() {
+				_ = ctxop.JoinContext(left, right)
+			}
+			Expect(fn).To(PanicWith("left context is nil"))
+		})
+	})
+	When("right context is nil", func() {
+		BeforeEach(func() {
+			right = nil
+		})
+		It("should panic", func() {
+			fn := func() {
+				_ = ctxop.JoinContext(left, right)
+			}
+			Expect(fn).To(PanicWith("right context is nil"))
+		})
+	})
+	When("operation is missing from context", func() {
+		It("should panic", func() {
+			fn := func() {
+				_ = ctxop.JoinContext(left, right)
+			}
+			Expect(fn).To(PanicWith("operation is missing from context"))
+		})
+	})
+	When("the left context has a operation", func() {
+		BeforeEach(func() {
+			left = ctxop.WithContext(context.Background())
+			ctxop.MarkCreate(left)
+			ctxop.MarkUpdate(left)
+		})
+		It("should return the left context", func() {
+			ctx := ctxop.JoinContext(left, right)
+			Expect(ctx).ToNot(BeNil())
+			Expect(ctxop.IsCreate(ctx)).To(BeTrue())
+		})
+	})
+	When("the right context has a operation", func() {
+		BeforeEach(func() {
+			right = ctxop.WithContext(context.Background())
+			ctxop.MarkCreate(right)
+		})
+		It("should return a new context", func() {
+			ctx := ctxop.JoinContext(left, right)
+			Expect(ctx).ToNot(BeNil())
+			Expect(ctxop.IsCreate(ctx)).To(BeTrue())
+		})
+	})
+	When("both contexts have a operation", func() {
+		BeforeEach(func() {
+			left = ctxop.WithContext(context.Background())
+			right = ctxop.WithContext(context.Background())
+			ctxop.MarkUpdate(right)
+		})
+		It("should return the left context with operation from the right", func() {
+			ctx := ctxop.JoinContext(left, right)
+			Expect(ctx).ToNot(BeNil())
+			Expect(ctxop.IsUpdate(ctx)).To(BeTrue())
+		})
+	})
+})
+
+var _ = Describe("WithContext", func() {
+	When("parent is nil", func() {
+		It("should panic", func() {
+			fn := func() {
+				//nolint:staticcheck
+				_ = ctxop.WithContext(nil)
+			}
+			Expect(fn).To(PanicWith("parent context is nil"))
+		})
+	})
+	When("parent is not nil", func() {
+		It("should return a context", func() {
+			ctx := ctxop.WithContext(context.Background())
+			Expect(ctx).ToNot(BeNil())
+		})
+	})
+})

--- a/pkg/context/operation/operation_suite_test.go
+++ b/pkg/context/operation/operation_suite_test.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package operation_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/klog/v2"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func init() {
+	klog.SetOutput(GinkgoWriter)
+	logf.SetLogger(klog.Background())
+}
+
+func TestKube(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Operation Context Test Suite")
+}

--- a/pkg/providers/vsphere/resources/vm.go
+++ b/pkg/providers/vsphere/resources/vm.go
@@ -15,6 +15,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 	vmutil "github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/vm"
 )
 
@@ -79,6 +80,8 @@ func (vm *VirtualMachine) Clone(ctx context.Context, folder *object.Folder, clon
 func (vm *VirtualMachine) Reconfigure(
 	ctx context.Context,
 	configSpec *vimtypes.VirtualMachineConfigSpec) (*vimtypes.TaskInfo, error) {
+
+	ctxop.MarkUpdate(ctx)
 
 	logger := logr.FromContextOrDiscard(ctx)
 
@@ -156,6 +159,8 @@ func (vm *VirtualMachine) SetPowerState(
 	desiredPowerState vmopv1.VirtualMachinePowerState,
 	desiredPowerOpMode vmopv1.VirtualMachinePowerOpMode) error {
 
+	ctxop.MarkUpdate(ctx)
+
 	_, err := vmutil.SetAndWaitOnPowerState(
 		ctx,
 		vm.VcVM().Client(),
@@ -215,6 +220,8 @@ func (vm *VirtualMachine) GetNetworkDevices(ctx context.Context) (object.Virtual
 
 func (vm *VirtualMachine) Customize(ctx context.Context, spec vimtypes.CustomizationSpec) error {
 	vm.logger.V(5).Info("Customize", "spec", spec)
+
+	ctxop.MarkUpdate(ctx)
 
 	customizeTask, err := vm.vcVirtualMachine.Customize(ctx, spec)
 	if err != nil {

--- a/pkg/providers/vsphere/virtualmachine/backup_test.go
+++ b/pkg/providers/vsphere/virtualmachine/backup_test.go
@@ -19,6 +19,7 @@ import (
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/virtualmachine"
 	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
@@ -112,6 +113,10 @@ func backupTests() {
 				newVMYAML, err := yaml.Marshal(vmCtx.VM)
 				Expect(err).NotTo(HaveOccurred())
 				verifyBackupDataInExtraConfig(ctx, vcVM, vmopv1.VMResourceYAMLExtraConfigKey, string(newVMYAML))
+
+				// Backing up the YAML should not result in an update op being
+				// flagged.
+				Expect(ctxop.IsUpdate(vmCtx)).To(BeFalse())
 			})
 		})
 

--- a/pkg/providers/vsphere/vmlifecycle/create.go
+++ b/pkg/providers/vsphere/vmlifecycle/create.go
@@ -10,6 +10,7 @@ import (
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 )
 
 // CreateArgs contains the arguments needed to create a VM.
@@ -32,6 +33,8 @@ func CreateVirtualMachine(
 	vimClient *vim25.Client,
 	finder *find.Finder,
 	createArgs *CreateArgs) (*vimtypes.ManagedObjectReference, error) {
+
+	ctxop.MarkCreate(vmCtx)
 
 	if createArgs.UseContentLibrary {
 		return deployFromContentLibrary(vmCtx, restClient, vimClient, createArgs)

--- a/pkg/providers/vsphere/vmprovider_vm.go
+++ b/pkg/providers/vsphere/vmprovider_vm.go
@@ -435,6 +435,7 @@ func (vs *vSphereVMProvider) createVirtualMachine(
 		vcClient.VimClient(),
 		vcClient.Finder(),
 		&createArgs.CreateArgs)
+
 	if err != nil {
 		vmCtx.Logger.Error(err, "CreateVirtualMachine failed")
 		conditions.MarkFalse(vmCtx.VM, vmopv1.VirtualMachineConditionCreated, "Error", err.Error())

--- a/pkg/util/vsphere/vm/power_state.go
+++ b/pkg/util/vsphere/vm/power_state.go
@@ -19,6 +19,7 @@ import (
 	"github.com/vmware/govmomi/vim25/mo"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 
+	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/vm/internal"
 )
 
@@ -526,6 +527,8 @@ func restart(
 		log.Info("Will not restart VM as desiredLastRestartTime is in the future")
 		return PowerOpResultNone, nil
 	}
+
+	ctxop.MarkUpdate(ctx)
 
 	switch powerOpBehavior {
 	case PowerOpBehaviorHard:

--- a/test/builder/unit_test_context.go
+++ b/test/builder/unit_test_context.go
@@ -16,6 +16,7 @@ import (
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/context/fake"
+	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 )
 
 // UnitTestContext is used for general purpose unit testing.
@@ -29,7 +30,7 @@ type UnitTestContext struct {
 func NewUnitTestContext(initObjects ...client.Object) *UnitTestContext {
 	fakeClient := NewFakeClient(initObjects...)
 	return &UnitTestContext{
-		Context: pkgcfg.NewContext(),
+		Context: ctxop.WithContext(pkgcfg.NewContext()),
 		Client:  fakeClient,
 		Scheme:  fakeClient.Scheme(),
 	}


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch adds support for emitting distinct events for VM create/ update operations, whether successful or otherwise.

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Creating/updating a VM now results in CreateSuccess, CreateFailure, UpdateSuccess, and UpdateFailure events.
```