### PR TITLE
🐛 Stop adding ":detaching" to volumes more than once

### DIFF
--- a/controllers/virtualmachine/volume/volume_controller.go
+++ b/controllers/virtualmachine/volume/volume_controller.go
@@ -854,7 +854,11 @@ func (r *Reconciler) preserveOrphanedAttachmentStatus(
 	var volumeStatus []vmopv1.VirtualMachineVolumeStatus
 	for _, volume := range ctx.VM.Status.Volumes {
 		if attachment, ok := uuidAttachments[volume.DiskUUID]; ok {
-			volumeStatus = append(volumeStatus, attachmentToVolumeStatus(volume.Name+":detaching", attachment))
+			volName := volume.Name
+			if !strings.HasSuffix(volName, ":detaching") {
+				volName += ":detaching"
+			}
+			volumeStatus = append(volumeStatus, attachmentToVolumeStatus(volName, attachment))
 		}
 	}
 


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This fix prevents ":detaching" from being appended to the names of volumes being detached from VMs more than once.

This bug could account for rapid memory growth in VM Operator. For example, see this [Go playground](https://go.dev/play/p/q55HeO1oMHw):

```golang
package main

import (
	"fmt"
	"unsafe"
)

func sizeOfStr(s string) uintptr {
	return uintptr(len(s)) + unsafe.Sizeof(s)
}

func main() {
	name := "my-volume"
	for i := 0; i < 1000; i++ {
		fmt.Printf("i=%d, len=%d, sizeof=%d\n", i, len(name), sizeOfStr(name))
		name = name + ":detaching"
	}
}
```

By the end of this program's execution, we see:

```
i=997, len=9979, sizeof=9995
i=998, len=9989, sizeof=10005
i=999, len=9999, sizeof=10015
```

Thus, a volume detaching `N` times would take up `N*10` bytes in memory. Therefore:

| `N` of times detached | Memory usage |
|:---:|:---:|
| `10` | `100b` |
| `100` | `1Kb` |
| `1000` | `10Kb` |
| `10000` | `100Kb` |

Now, imagine there are multiple volumes where `V` is the number of volumes, and the formula becomes `V*N*10`:

| `V`olume count | `N` of times detached | Memory usage |
|:---:|:---:|:---:|
| `100` | `10` | `10Kb` |
| `1000` | `10` | `97Kb` |
| `10000` | `10` | `976Kb` |
| `100000` | `10` | `9.5Mb` |

As evidenced, the memory could grow rather quickly.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Fix memory leak in the name of a volume being detached
```