### PR TITLE
🐛 Start infra capability controller for non-leader pods too

### DIFF
--- a/controllers/infra/capability/infra_capability_controller_suite_test.go
+++ b/controllers/infra/capability/infra_capability_controller_suite_test.go
@@ -7,25 +7,16 @@ package capability_test
 import (
 	"testing"
 
-	"github.com/vmware-tanzu/vm-operator/controllers/infra/capability"
-
 	. "github.com/onsi/ginkgo/v2"
 
-	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
-
-	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
-	providerfake "github.com/vmware-tanzu/vm-operator/pkg/providers/fake"
+	"github.com/vmware-tanzu/vm-operator/controllers/infra/capability"
+	"github.com/vmware-tanzu/vm-operator/pkg/manager"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
-var provider = providerfake.NewVMProvider()
-
 var suite = builder.NewTestSuiteForController(
 	capability.AddToManager,
-	func(ctx *pkgctx.ControllerManagerContext, _ ctrlmgr.Manager) error {
-		ctx.VMProvider = provider
-		return nil
-	},
+	manager.InitializeProvidersNoopFn,
 )
 
 func TestClusterCapabilityController(t *testing.T) {

--- a/controllers/infra/capability/infra_capability_controller_unit_test.go
+++ b/controllers/infra/capability/infra_capability_controller_unit_test.go
@@ -50,7 +50,6 @@ func unitTestsReconcile() {
 			ctx.Client,
 			ctx.Logger,
 			ctx.Recorder,
-			ctx.VMProvider,
 		)
 
 		configMap = &corev1.ConfigMap{


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

We want capabilities updates to be reflected in the non-leader pod as well so the webhooks are aware of the current enabled capabilities.

Remove the VMProvider from the infra capability controller. It was not used, and we don't want it on the non-leader pods due to VC session limits (and it would need the other infra controllers to be non-leader as well to pick up cred rotations)

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note
NONE
```