### PR TITLE
🌱 Use controller-runtime built-in pprof server

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -95,6 +95,7 @@ func New(ctx context.Context, opts Options) (Manager, error) {
 			Port:    opts.WebhookServiceContainerPort,
 		}),
 		HealthProbeBindAddress:  opts.HealthProbeBindAddress,
+		PprofBindAddress:        opts.PprofBindAddress,
 		LeaderElection:          opts.LeaderElectionEnabled,
 		LeaderElectionID:        opts.LeaderElectionID,
 		LeaderElectionNamespace: opts.PodNamespace,

--- a/pkg/manager/options.go
+++ b/pkg/manager/options.go
@@ -50,6 +50,10 @@ type Options struct {
 	// for serving health probes
 	HealthProbeBindAddress string
 
+	// PprofBindAddress is the address that the controller should bind to for
+	// serving pprof endpoints.
+	PprofBindAddress string
+
 	// SyncPeriod is the amount of time to wait between syncing the local
 	// object cache with the API server.
 	SyncPeriod time.Duration


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

controller-runtime can be configured to start the pprof server so use that instead of our own code.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

**Please add a release note if necessary**:


```release-note
NONE
```