### PR TITLE
✨ Introduce ExtraConfig key for enable automatic registration

### DIFF
--- a/api/backup/backup.go
+++ b/api/backup/backup.go
@@ -25,3 +25,26 @@ type ClassicDiskData struct {
 	// Filename is the datastore path to the virtual disk.
 	FileName string
 }
+
+const (
+	// EnableAutoRegistrationExtraConfigKey is the ExtraConfig key that can be
+	// set on a virtual machine to opt-into the automatic registration workflow.
+	//
+	// A "registration" refers to adopting a virtual machine so it is managed by
+	// VM operator on Supervisor. Typically, this involves creating a new
+	// VirtualMachine resource, or updating an existing VirtualMachine resource on
+	// Supervisor to conform to the virtual machine on vSphere.
+	//
+	// After a restore from a backup/restore vendor, or a failover from a disaster recovery
+	// solution, vCenter automatically attempts to register the restored virtual machine with
+	// Supervisor. This is referred to as "automatic registration" workflow.
+	//
+	// Virtual machines can opt-into this workflow by specifying this key. If this key is not
+	// set to a positive value, backup/restore or disaster recovery solutions are responsible
+	// to register the VM with Supervisor.
+	//
+	// Any of the following values for this ExtraConfig key result in the virtual
+	// machine participating in automatic registration:
+	// "1", "on", "t", "true", "y", or "yes".
+	EnableAutoRegistrationExtraConfigKey = "vmservice.virtualmachine.enableAutomaticRegistration"
+)


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Now that we are moving to an opt-in vs opt-out workflow for automatic registration, introduce an ExtraConfig key that allows VMs to participate in this workflow.

Eventually, we will remove the disableAutoRegistration ExtraConfig key once all references have been ported over to this key.


**Please add a release note if necessary**:
```release-note
 Introduce ExtraConfig key for enable automatic registration
```