### PR TITLE
🐛 Fix panic when logging ConfigSpec w nil iface pointer

### DIFF
--- a/pkg/providers/vsphere/resources/vm.go
+++ b/pkg/providers/vsphere/resources/vm.go
@@ -4,7 +4,6 @@
 package resources
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 
@@ -16,6 +15,7 @@ import (
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
+	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
 	vmutil "github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/vm"
 )
 
@@ -85,14 +85,7 @@ func (vm *VirtualMachine) Reconfigure(
 
 	logger := logr.FromContextOrDiscard(ctx)
 
-	var w bytes.Buffer
-	enc := vimtypes.NewJSONEncoder(&w)
-	if err := enc.Encode(configSpec); err != nil {
-		logger.Error(err, "Failed to marshal ConfigSpec to JSON")
-		logger.Info("Reconfiguring VM", "configSpec", configSpec)
-	} else {
-		logger.Info("Reconfiguring VM", "configSpec", w.String())
-	}
+	logger.Info("Reconfiguring VM", "configSpec", pkgutil.SafeConfigSpecToString(configSpec))
 
 	reconfigureTask, err := vm.vcVirtualMachine.Reconfigure(ctx, *configSpec)
 	if err != nil {

--- a/pkg/providers/vsphere/vmlifecycle/bootstrap.go
+++ b/pkg/providers/vsphere/vmlifecycle/bootstrap.go
@@ -23,6 +23,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/network"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/resources"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/sysprep"
+	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/cloudinit"
 	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 )
@@ -340,7 +341,7 @@ func logConfigSpec(
 		configSpec = SanitizeConfigSpec(configSpec)
 	}
 
-	vmCtx.Logger.Info("Customization Reconfigure", "configSpec", configSpec)
+	vmCtx.Logger.Info("Customization Reconfigure", "configSpec", pkgutil.SafeConfigSpecToString(&configSpec))
 }
 
 func SanitizeConfigSpec(cs vimtypes.VirtualMachineConfigSpec) vimtypes.VirtualMachineConfigSpec {

--- a/pkg/providers/vsphere/vmlifecycle/bootstrap_vappconfig.go
+++ b/pkg/providers/vsphere/vmlifecycle/bootstrap_vappconfig.go
@@ -71,7 +71,7 @@ func GetOVFVAppConfigForConfigSpec(
 // GetMergedvAppConfigSpec prepares a vApp VmConfigSpec which will set the provided key/value fields.
 // Only fields marked userConfigurable and pre-existing on the VM (ie. originated from the OVF Image)
 // will be set, and all others will be ignored.
-func GetMergedvAppConfigSpec(inProps map[string]string, vmProps []vimtypes.VAppPropertyInfo) *vimtypes.VmConfigSpec {
+func GetMergedvAppConfigSpec(inProps map[string]string, vmProps []vimtypes.VAppPropertyInfo) vimtypes.BaseVmConfigSpec {
 	outProps := make([]vimtypes.VAppPropertySpec, 0)
 
 	for _, vmProp := range vmProps {

--- a/pkg/providers/vsphere/vmlifecycle/bootstrap_vappconfig_test.go
+++ b/pkg/providers/vsphere/vmlifecycle/bootstrap_vappconfig_test.go
@@ -204,10 +204,11 @@ var _ = Describe("GetMergedvAppConfigSpec", func() {
 
 	DescribeTable("returns expected props",
 		func(inProps map[string]string, vmProps []vimtypes.VAppPropertyInfo, expected *vimtypes.VmConfigSpec) {
-			vAppConfigSpec := vmlifecycle.GetMergedvAppConfigSpec(inProps, vmProps)
+			baseVAppConfigSpec := vmlifecycle.GetMergedvAppConfigSpec(inProps, vmProps)
 			if expected == nil {
-				Expect(vAppConfigSpec).To(BeNil())
+				Expect(baseVAppConfigSpec).To(BeNil())
 			} else {
+				vAppConfigSpec := baseVAppConfigSpec.GetVmConfigSpec()
 				Expect(vAppConfigSpec.Property).To(HaveLen(len(expected.Property)))
 				for i := range vAppConfigSpec.Property {
 					Expect(vAppConfigSpec.Property[i].Info.Key).To(Equal(expected.Property[i].Info.Key))

--- a/pkg/util/configspec_test.go
+++ b/pkg/util/configspec_test.go
@@ -879,3 +879,27 @@ var virtualMachineConfigInfoForTests vimtypes.VirtualMachineConfigInfo = vimtype
 	Pmem:         nil,
 	DeviceGroups: &vimtypes.VirtualMachineVirtualDeviceGroups{},
 }
+
+var _ = DescribeTable(
+	"SafeConfigSpecToString",
+	func(in *vimtypes.VirtualMachineConfigSpec, expected string) {
+		Expect(pkgutil.SafeConfigSpecToString(in)).To(Equal(expected))
+	},
+	Entry(
+		"nil ConfigSpec",
+		nil,
+		`null`,
+	),
+	Entry(
+		"empty ConfigSpec",
+		&vimtypes.VirtualMachineConfigSpec{},
+		`{"_typeName":"VirtualMachineConfigSpec"}`,
+	),
+	Entry(
+		"w interface field set to nil pointer",
+		&vimtypes.VirtualMachineConfigSpec{
+			VAppConfig: (*vimtypes.VmConfigSpec)(nil),
+		},
+		`{"vAppConfig":null}`,
+	),
+)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch fixes a panic that occurs when the vimtypes JSON encoder is used to log a ConfigSpec that includes a field of type interface set to a pointer w a nil value. This patch:

* Prevents the issue discovered in the `GetOVFVAppConfigForConfigSpec` to `GetMergedvAppConfigSpec` code path
* Adds support for `SafeConfigSpecToString` as a function that can be used to prevent this from ever happening again.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Do not panic when logging ConfigSpec that includes field of type interface set to pointer with nil value
```