### PR TITLE
🌱 Introduce condition to indicate the status of latest backup

### DIFF
--- a/api/v1alpha3/virtualmachine_types.go
+++ b/api/v1alpha3/virtualmachine_types.go
@@ -154,6 +154,20 @@ const (
 	ManagedByExtensionType = "VirtualMachine"
 )
 
+const (
+	// VirtualMachineBackupUpToDateCondition exposes the status of the latest VirtualMachine Backup, when available.
+	VirtualMachineBackupUpToDateCondition = "VirtualMachineBackupUpToDate"
+
+	// VirtualMachineBackupPaused documents that VirtualMachine backup is paused.
+	// This can happen after the backing virtual machine is restored by a backup/restore vendor, or a failover operation
+	// by a data protection solution. In either of these operations, VM operator does not persist backup information and
+	// waits for the virtual machine to be (re)-registered with VM Service.
+	VirtualMachineBackupPausedReason = "VirtualMachineBackupPaused"
+
+	// VirtualMachineBackupFailed documents that the VirtualMachine backup failed due to an error.
+	VirtualMachineBackupFailedReason = "VirtualMachineBackupFailed"
+)
+
 // VirtualMachine backup/restore related constants.
 const (
 	// VMResourceYAMLExtraConfigKey is the ExtraConfig key to persist VM

--- a/pkg/providers/vsphere/virtualmachine/backup.go
+++ b/pkg/providers/vsphere/virtualmachine/backup.go
@@ -22,6 +22,7 @@ import (
 
 	vmopbackup "github.com/vmware-tanzu/vm-operator/api/backup"
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
@@ -44,7 +45,18 @@ type BackupVirtualMachineOptions struct {
 // - VM Kubernetes resource in YAMl.
 // - Additional VM-relevant Kubernetes resources in YAML, separated by "---".
 // - PVC disk data in JSON format (if DiskUUIDToPVC is not empty).
-func BackupVirtualMachine(opts BackupVirtualMachineOptions) error {
+func BackupVirtualMachine(opts BackupVirtualMachineOptions) (result error) {
+	defer func() {
+		if result != nil {
+			conditions.MarkFalse(
+				opts.VMCtx.VM,
+				vmopv1.VirtualMachineBackupUpToDateCondition,
+				vmopv1.VirtualMachineBackupFailedReason,
+				fmt.Sprintf("Failed to backup VM. err: %v", result.Error()),
+			)
+		}
+	}()
+
 	resVM := res.NewVMFromObject(opts.VcVM)
 	moVM, err := resVM.GetProperties(opts.VMCtx, []string{"config.extraConfig"})
 	if err != nil {
@@ -76,7 +88,12 @@ func BackupVirtualMachine(opts BackupVirtualMachineOptions) error {
 				 */
 				// restore is detected if doBackup is false with no errors. wait for vm registration.
 				if !canBackup {
-					// TODO: add a condition to indicate backup is paused
+					conditions.MarkFalse(
+						opts.VMCtx.VM,
+						vmopv1.VirtualMachineBackupUpToDateCondition,
+						vmopv1.VirtualMachineBackupPausedReason,
+						"A restore was detected",
+					)
 					return nil
 				}
 			}
@@ -149,7 +166,7 @@ func BackupVirtualMachine(opts BackupVirtualMachineOptions) error {
 			// Update the VMResourceYAMLExtraConfigKey to account for the new backup version annotation
 			// Use a copy of the VM object since the actual VM obj will be annotated if and once reconfigure succeeds.
 			copyVM := opts.VMCtx.VM.DeepCopy()
-			setLastBackupVersionAnnotation(copyVM, opts.BackupVersion)
+			setBackupVersionAnnotation(copyVM, opts.BackupVersion)
 			// Backup the updated VM's YAML with encoding and compression.
 			encodedVMYaml, err := getEncodedVMYaml(copyVM)
 			if err != nil {
@@ -198,8 +215,10 @@ func BackupVirtualMachine(opts BackupVirtualMachineOptions) error {
 
 		// Set the VirtualMachine's backup version annotation once reconfigure succeeds.
 		if pkgcfg.FromContext(opts.VMCtx).Features.VMIncrementalRestore {
-			setLastBackupVersionAnnotation(opts.VMCtx.VM, opts.BackupVersion)
-			// TODO: add a condition to indicate backup has resumed
+			setBackupVersionAnnotation(opts.VMCtx.VM, opts.BackupVersion)
+			c := conditions.TrueCondition(vmopv1.VirtualMachineBackupUpToDateCondition)
+			c.Message = fmt.Sprintf("Backup version: %s", opts.BackupVersion)
+			conditions.Set(opts.VMCtx.VM, c)
 		}
 
 		opts.VMCtx.Logger.Info("Successfully updated VM ExtraConfig with latest backup data")
@@ -434,7 +453,7 @@ func getDesiredDiskDataForBackup(
 	return pvcDiskDataBackup, classicDiskDataBackup, nil
 }
 
-func setLastBackupVersionAnnotation(vm *vmopv1.VirtualMachine, version string) {
+func setBackupVersionAnnotation(vm *vmopv1.VirtualMachine, version string) {
 	if vm.Annotations == nil {
 		vm.Annotations = map[string]string{}
 	}


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This change indicates the status of the latest backup as a condition on the VM resource to inform the latest backup.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # N/A


**Are there any special notes for your reviewer**:
Any suggestions for naming the condition welcome


**Please add a release note if necessary**:

```
Add condition to indicate the status of latest backup
```