### PR TITLE
Use ResourcePool field out of the VM properties

### DIFF
--- a/pkg/providers/vsphere/session/session.go
+++ b/pkg/providers/vsphere/session/session.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 
 	"github.com/vmware/govmomi/find"
-	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
@@ -17,12 +17,10 @@ import (
 )
 
 type Session struct {
-	Client    *pkgclient.Client
-	K8sClient ctrlclient.Client
-	Finder    *find.Finder
-
-	// Fields only used during Update
-	Cluster *object.ClusterComputeResource
+	Client       *pkgclient.Client
+	K8sClient    ctrlclient.Client
+	Finder       *find.Finder
+	ClusterMoRef types.ManagedObjectReference
 }
 
 func (s *Session) invokeFsrVirtualMachine(vmCtx pkgctx.VirtualMachineContext, resVM *res.VirtualMachine) error {

--- a/pkg/providers/vsphere/session/session_vm_update.go
+++ b/pkg/providers/vsphere/session/session_vm_update.go
@@ -603,13 +603,12 @@ func (s *Session) ensureNetworkInterfaces(
 		)
 	}
 
-	clusterMoRef := s.Cluster.Reference()
 	results, err := network2.CreateAndWaitForNetworkInterfaces(
 		vmCtx,
 		s.K8sClient,
 		s.Client.VimClient(),
 		s.Finder,
-		&clusterMoRef,
+		&s.ClusterMoRef,
 		networkSpec.Interfaces)
 	if err != nil {
 		return network2.NetworkInterfaceResults{}, err
@@ -838,7 +837,7 @@ func (s *Session) attachClusterModule(
 	}
 
 	// Find ClusterModule UUID from the ResourcePolicy.
-	_, moduleUUID := clustermodules.FindClusterModuleUUID(vmCtx, clusterModuleName, s.Cluster.Reference(), resourcePolicy)
+	_, moduleUUID := clustermodules.FindClusterModuleUUID(vmCtx, clusterModuleName, s.ClusterMoRef, resourcePolicy)
 	if moduleUUID == "" {
 		return fmt.Errorf("ClusterModule %s not found", clusterModuleName)
 	}

--- a/pkg/providers/vsphere/vmlifecycle/update_status.go
+++ b/pkg/providers/vsphere/vmlifecycle/update_status.go
@@ -28,7 +28,7 @@ import (
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/network"
-	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/virtualmachine"
+	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/vcenter"
 	"github.com/vmware-tanzu/vm-operator/pkg/topology"
 	"github.com/vmware-tanzu/vm-operator/pkg/util"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
@@ -43,8 +43,9 @@ var (
 		"config.changeTrackingEnabled",
 		"config.extraConfig",
 		"config.hardware.device",
-		"guest",
+		"resourcePool",
 		"layoutEx",
+		"guest",
 		"summary",
 	}
 )
@@ -128,11 +129,11 @@ func UpdateStatus(
 
 	zoneName := vm.Labels[topology.KubernetesTopologyZoneLabelKey]
 	if zoneName == "" {
-		cluster, err := virtualmachine.GetVMClusterComputeResource(vmCtx, vcVM)
+		clusterMoRef, err := vcenter.GetResourcePoolOwnerMoRef(vmCtx, vcVM.Client(), vmCtx.MoVM.ResourcePool.Value)
 		if err != nil {
 			errs = append(errs, err)
 		} else {
-			zoneName, err = topology.LookupZoneForClusterMoID(vmCtx, k8sClient, cluster.Reference().Value)
+			zoneName, err = topology.LookupZoneForClusterMoID(vmCtx, k8sClient, clusterMoRef.Value)
 			if err != nil {
 				errs = append(errs, err)
 			} else {


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

We can save one RT in every reconcile since we have to fetch the VM properties anyways until we can really fix this old session code.

Update the session tests to use the same properties selector that is used in the prod code. For the short term update the sessions tests to use Summary.Runtime instead of Runtime for the power state. Longer term it would be better for these tests to not conflate the selector used for UpdateVirtualMachine() input and test assertions.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

GetVMClusterComputeResource() was called enough to show up in some profiling data (and its intermediate object.ResourcePool alloc)

**Please add a release note if necessary**:

```release-note
NONE
```