### PR TITLE
🐛 Handle disk backing changes when backing up PVCDiskData

### DIFF
--- a/pkg/providers/vsphere/virtualmachine/backup.go
+++ b/pkg/providers/vsphere/virtualmachine/backup.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"path"
 	"strconv"
 	"strings"
 
@@ -380,10 +381,36 @@ func getDesiredDiskDataForBackup(
 		classicDiskData []vmopbackup.ClassicDiskData
 	)
 
+	// Vendor's partial restore (e.g. single disk) method may create a new,
+	// non-FCD disk. The restored disk has new UUID and lives the the VM's
+	// directory, not the fcd/ directory. Given that FCD disk names are unique,
+	// we consult the backup data to compare using `FileName` before `Uuid`.
+	pvcDiskDataPrevious := make(map[string]vmopbackup.PVCDiskData)
+	curBackup, ok := extraConfig.GetString(vmopv1.PVCDiskDataExtraConfigKey)
+	if ok {
+		decoded, err := pkgutil.TryToDecodeBase64Gzip([]byte(curBackup))
+		if err != nil {
+			return "", "", err
+		}
+
+		var data []vmopbackup.PVCDiskData
+		dec := json.NewDecoder(strings.NewReader(decoded))
+		if err = dec.Decode(&data); err != nil {
+			return "", "", err
+		}
+
+		for _, pvc := range data {
+			pvcDiskDataPrevious[path.Base(pvc.FileName)] = pvc
+		}
+	}
+
 	for _, device := range deviceList.SelectByType((*vimtypes.VirtualDisk)(nil)) {
 		if disk, ok := device.(*vimtypes.VirtualDisk); ok {
 			if b, ok := disk.Backing.(*vimtypes.VirtualDiskFlatVer2BackingInfo); ok {
-				if pvc, ok := opts.DiskUUIDToPVC[b.Uuid]; ok {
+				if disk, ok := pvcDiskDataPrevious[path.Base(b.FileName)]; ok {
+					disk.FileName = b.FileName
+					pvcDiskData = append(pvcDiskData, disk)
+				} else if pvc, ok := opts.DiskUUIDToPVC[b.Uuid]; ok {
 					pvcDiskData = append(pvcDiskData, vmopbackup.PVCDiskData{
 						FileName:    b.FileName,
 						PVCName:     pvc.Name,
@@ -408,7 +435,6 @@ func getDesiredDiskDataForBackup(
 	}
 
 	// Return an empty string to skip backup if PVC disk data is unchanged.
-	curBackup, _ := extraConfig.GetString(vmopv1.PVCDiskDataExtraConfigKey)
 	if pvcDiskDataBackup == curBackup {
 		pvcDiskDataBackup = ""
 	}

--- a/pkg/providers/vsphere/virtualmachine/backup_test.go
+++ b/pkg/providers/vsphere/virtualmachine/backup_test.go
@@ -11,9 +11,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/simulator"
 	"github.com/vmware/govmomi/vim25/mo"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 
@@ -666,6 +668,22 @@ func backupTests() {
 							verifyBackupDataInExtraConfig(ctx, vcVM, vmopv1.BackupVersionExtraConfigKey, vT2, false)
 							Expect(vmCtx.VM.Annotations[vmopv1.VirtualMachineBackupVersionAnnotation]).To(Equal(vT2))
 						}
+
+						By("detect disk file backing change", func() {
+							vm := simulator.Map.Get(vcVM.Reference()).(*simulator.VirtualMachine)
+							deviceList := object.VirtualDeviceList(vm.Config.Hardware.Device)
+
+							for _, device := range deviceList.SelectByType((*vimtypes.VirtualDisk)(nil)) {
+								disk := device.(*vimtypes.VirtualDisk)
+								if b, ok := disk.Backing.(*vimtypes.VirtualDiskFlatVer2BackingInfo); ok {
+									b.Uuid = uuid.NewString()
+									break
+								}
+							}
+
+							Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
+							verifyBackupDataInExtraConfig(ctx, vcVM, vmopv1.PVCDiskDataExtraConfigKey, string(diskDataJSON), true)
+						})
 					})
 				})
 			})


### PR DESCRIPTION
Vendor's partial restore (e.g. single disk) method may create a new, non-FCD disk. The restored disk has new UUID and lives the the VM's directory, not the fcd/ directory. Given that FCD disk names are unique, we consult the backup data to compare using `FileName` before `Uuid`.
