### PR TITLE
🐛 Have EnsureDisksHaveControllers() alloc unit numbers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/vmware/govmomi v0.31.1-0.20240730173452-49b88eb9917f
 	// * https://github.com/vmware-tanzu/vm-operator/security/dependabot/24
 	golang.org/x/text v0.16.0
+	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d
 	k8s.io/api v0.31.0
 	k8s.io/apiextensions-apiserver v0.31.0
 	k8s.io/apimachinery v0.31.0
@@ -79,7 +80,6 @@ require (
 	golang.org/x/sys v0.21.0 // indirect
 	golang.org/x/term v0.21.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
-	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect

--- a/pkg/providers/vsphere/virtualmachine/configspec.go
+++ b/pkg/providers/vsphere/virtualmachine/configspec.go
@@ -175,8 +175,6 @@ func CreateConfigSpecForPlacement(
 
 	// Add a dummy disk for placement: PlaceVmsXCluster expects there to always be at least one disk.
 	// Until we're in a position to have the OVF envelope here, add a dummy disk satisfy it.
-	// Note: UnitNumber is required for PlaceVmsXCluster w/ VpxdVmxGeneration fss enabled.
-	// PlaceVmsXCluster is not used with Instance Storage, so UnitNumber is not required for volumes below.
 	configSpec.DeviceChange = append(configSpec.DeviceChange, &vimtypes.VirtualDeviceConfigSpec{
 		Operation:     vimtypes.VirtualDeviceConfigSpecOperationAdd,
 		FileOperation: vimtypes.VirtualDeviceConfigSpecFileOperationCreate,
@@ -225,7 +223,6 @@ func CreateConfigSpecForPlacement(
 	//  - boot disks from OVA
 	//  - storage profile/class
 	//  - PVC volumes
-	//  - Network devices (meh for now b/c of wcp constraints)
 	//  - anything in ExtraConfig matter here?
 	//  - any way to do the cluster modules for anti-affinity?
 	//  - whatever else I'm forgetting

--- a/pkg/providers/vsphere/virtualmachine/configspec_test.go
+++ b/pkg/providers/vsphere/virtualmachine/configspec_test.go
@@ -496,8 +496,8 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 		})
 		It("ConfigSpec contains expected InstanceStorage devices", func() {
 			Expect(configSpec.DeviceChange).To(HaveLen(5))
-			assertInstanceStorageDeviceChange(configSpec.DeviceChange[1], 256, storagePolicyID)
-			assertInstanceStorageDeviceChange(configSpec.DeviceChange[2], 512, storagePolicyID)
+			assertInstanceStorageDeviceChange(configSpec.DeviceChange[1], 1, 256, storagePolicyID)
+			assertInstanceStorageDeviceChange(configSpec.DeviceChange[2], 2, 512, storagePolicyID)
 		})
 	})
 
@@ -584,6 +584,7 @@ var _ = Describe("ConfigSpecFromVMClassDevices", func() {
 
 func assertInstanceStorageDeviceChange(
 	deviceChange vimtypes.BaseVirtualDeviceConfigSpec,
+	expectedUnitNumber int32,
 	expectedSizeGB int,
 	expectedStoragePolicyID string) {
 
@@ -593,6 +594,8 @@ func assertInstanceStorageDeviceChange(
 
 	dev, ok := dc.Device.(*vimtypes.VirtualDisk)
 	Expect(ok).To(BeTrue())
+	Expect(dev.UnitNumber).ToNot(BeNil())
+	Expect(*dev.UnitNumber).To(Equal(expectedUnitNumber))
 	Expect(dev.CapacityInBytes).To(BeEquivalentTo(expectedSizeGB * 1024 * 1024 * 1024))
 
 	Expect(dc.Profile).To(HaveLen(1))

--- a/pkg/util/ensure_disk_controller_test.go
+++ b/pkg/util/ensure_disk_controller_test.go
@@ -44,7 +44,7 @@ var _ = DescribeTable(
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError(expectedErr))
 		} else {
-			Expect(configSpec).To(Equal(expectedConfigSpec))
+			Expect(configSpec).To(BeComparableTo(expectedConfigSpec))
 		}
 	},
 
@@ -135,6 +135,7 @@ var _ = DescribeTable(
 					Device: &vimtypes.VirtualDisk{
 						VirtualDevice: vimtypes.VirtualDevice{
 							ControllerKey: 1000,
+							UnitNumber:    ptr.To[int32](0),
 						},
 					},
 				},
@@ -173,6 +174,7 @@ var _ = DescribeTable(
 					Device: &vimtypes.VirtualDisk{
 						VirtualDevice: vimtypes.VirtualDevice{
 							ControllerKey: -1,
+							UnitNumber:    ptr.To[int32](0),
 						},
 					},
 				},
@@ -193,6 +195,65 @@ var _ = DescribeTable(
 					},
 				},
 			},
+		},
+	),
+
+	Entry(
+		"attach disks to multiple new PVSCSI controllers when adding disks in ConfigSpec and existing device includes only PCI controller",
+		&vimtypes.VirtualMachineConfigSpec{
+			Version:      vmx20,
+			DeviceChange: generateDeviceChangesForDefaultVirtualDisk(17), // maxDisksPerSCSIController+1
+		},
+		[]vimtypes.BaseVirtualDevice{
+			&vimtypes.VirtualPCIController{
+				VirtualController: vimtypes.VirtualController{
+					VirtualDevice: vimtypes.VirtualDevice{
+						Key: 100,
+					},
+				},
+			},
+		},
+		nil,
+		&vimtypes.VirtualMachineConfigSpec{
+			Version: vmx20,
+			DeviceChange: joinSlices(
+				generateDeviceChangesForVirtualDisk(16, -1),
+				generateDeviceChangesForVirtualDisk(1, -2),
+				[]vimtypes.BaseVirtualDeviceConfigSpec{
+					&vimtypes.VirtualDeviceConfigSpec{
+						Operation: vimtypes.VirtualDeviceConfigSpecOperationAdd,
+						Device: &vimtypes.ParaVirtualSCSIController{
+							VirtualSCSIController: vimtypes.VirtualSCSIController{
+								VirtualController: vimtypes.VirtualController{
+									VirtualDevice: vimtypes.VirtualDevice{
+										ControllerKey: 100,
+										Key:           -1,
+									},
+									BusNumber: 0,
+								},
+								HotAddRemove: ptr.To(true),
+								SharedBus:    vimtypes.VirtualSCSISharingNoSharing,
+							},
+						},
+					},
+					&vimtypes.VirtualDeviceConfigSpec{
+						Operation: vimtypes.VirtualDeviceConfigSpecOperationAdd,
+						Device: &vimtypes.ParaVirtualSCSIController{
+							VirtualSCSIController: vimtypes.VirtualSCSIController{
+								VirtualController: vimtypes.VirtualController{
+									VirtualDevice: vimtypes.VirtualDevice{
+										ControllerKey: 100,
+										Key:           -2,
+									},
+									BusNumber: 1,
+								},
+								HotAddRemove: ptr.To(true),
+								SharedBus:    vimtypes.VirtualSCSISharingNoSharing,
+							},
+						},
+					},
+				},
+			),
 		},
 	),
 
@@ -227,6 +288,7 @@ var _ = DescribeTable(
 					Device: &vimtypes.VirtualDisk{
 						VirtualDevice: vimtypes.VirtualDevice{
 							ControllerKey: -1,
+							UnitNumber:    ptr.To[int32](0),
 						},
 					},
 				},
@@ -285,6 +347,7 @@ var _ = DescribeTable(
 					Device: &vimtypes.VirtualDisk{
 						VirtualDevice: vimtypes.VirtualDevice{
 							ControllerKey: -1,
+							UnitNumber:    ptr.To[int32](0),
 						},
 					},
 				},
@@ -343,6 +406,7 @@ var _ = DescribeTable(
 					Device: &vimtypes.VirtualDisk{
 						VirtualDevice: vimtypes.VirtualDevice{
 							ControllerKey: -1,
+							UnitNumber:    ptr.To[int32](0),
 						},
 					},
 				},
@@ -396,6 +460,7 @@ var _ = DescribeTable(
 					Device: &vimtypes.VirtualDisk{
 						VirtualDevice: vimtypes.VirtualDevice{
 							ControllerKey: -1,
+							UnitNumber:    ptr.To[int32](0),
 						},
 					},
 				},
@@ -449,6 +514,7 @@ var _ = DescribeTable(
 					Device: &vimtypes.VirtualDisk{
 						VirtualDevice: vimtypes.VirtualDevice{
 							ControllerKey: -1,
+							UnitNumber:    ptr.To[int32](0),
 						},
 					},
 				},
@@ -527,6 +593,7 @@ var _ = DescribeTable(
 					Device: &vimtypes.VirtualDisk{
 						VirtualDevice: vimtypes.VirtualDevice{
 							ControllerKey: -1,
+							UnitNumber:    ptr.To[int32](0),
 						},
 					},
 				},
@@ -609,6 +676,7 @@ var _ = DescribeTable(
 					Device: &vimtypes.VirtualDisk{
 						VirtualDevice: vimtypes.VirtualDevice{
 							ControllerKey: -1,
+							UnitNumber:    ptr.To[int32](0),
 						},
 					},
 				},
@@ -665,6 +733,7 @@ var _ = DescribeTable(
 					Device: &vimtypes.VirtualDisk{
 						VirtualDevice: vimtypes.VirtualDevice{
 							ControllerKey: -1,
+							UnitNumber:    ptr.To[int32](0),
 						},
 					},
 				},
@@ -709,6 +778,7 @@ var _ = DescribeTable(
 					Device: &vimtypes.VirtualDisk{
 						VirtualDevice: vimtypes.VirtualDevice{
 							ControllerKey: -2,
+							UnitNumber:    ptr.To[int32](0),
 						},
 					},
 				},
@@ -783,6 +853,7 @@ var _ = DescribeTable(
 					Device: &vimtypes.VirtualDisk{
 						VirtualDevice: vimtypes.VirtualDevice{
 							ControllerKey: -51,
+							UnitNumber:    ptr.To[int32](0),
 						},
 					},
 				},
@@ -835,6 +906,7 @@ var _ = DescribeTable(
 					Device: &vimtypes.VirtualDisk{
 						VirtualDevice: vimtypes.VirtualDevice{
 							ControllerKey: -1,
+							UnitNumber:    ptr.To[int32](0),
 						},
 					},
 				},
@@ -900,6 +972,139 @@ var _ = DescribeTable(
 					Device: &vimtypes.VirtualDisk{
 						VirtualDevice: vimtypes.VirtualDevice{
 							ControllerKey: 1000,
+							UnitNumber:    ptr.To[int32](0),
+						},
+					},
+				},
+			},
+		},
+	),
+
+	Entry(
+		"attach disk that specifies unit and existing controller when adding disk and existing devices includes PCI and PVSCSI controllers",
+		&vimtypes.VirtualMachineConfigSpec{
+			Version: vmx20,
+			DeviceChange: []vimtypes.BaseVirtualDeviceConfigSpec{
+				&vimtypes.VirtualDeviceConfigSpec{
+					Operation: vimtypes.VirtualDeviceConfigSpecOperationAdd,
+					Device: &vimtypes.VirtualDisk{
+						VirtualDevice: vimtypes.VirtualDevice{
+							ControllerKey: 1000,
+							UnitNumber:    ptr.To[int32](4),
+						},
+					},
+				},
+			},
+		},
+		[]vimtypes.BaseVirtualDevice{
+			&vimtypes.VirtualPCIController{
+				VirtualController: vimtypes.VirtualController{
+					VirtualDevice: vimtypes.VirtualDevice{
+						Key: 100,
+					},
+				},
+			},
+			&vimtypes.ParaVirtualSCSIController{
+				VirtualSCSIController: vimtypes.VirtualSCSIController{
+					VirtualController: vimtypes.VirtualController{
+						VirtualDevice: vimtypes.VirtualDevice{
+							ControllerKey: 100,
+							Key:           1000,
+						},
+					},
+				},
+			},
+		},
+		nil,
+		&vimtypes.VirtualMachineConfigSpec{
+			Version: vmx20,
+			DeviceChange: []vimtypes.BaseVirtualDeviceConfigSpec{
+				&vimtypes.VirtualDeviceConfigSpec{
+					Operation: vimtypes.VirtualDeviceConfigSpecOperationAdd,
+					Device: &vimtypes.VirtualDisk{
+						VirtualDevice: vimtypes.VirtualDevice{
+							ControllerKey: 1000,
+							UnitNumber:    ptr.To[int32](4),
+						},
+					},
+				},
+			},
+		},
+	),
+
+	Entry(
+		"attach multiple disks, with one disk specifying unit number and existing controller when adding disk and existing devices includes PCI and PVSCSI controllers",
+		&vimtypes.VirtualMachineConfigSpec{
+			Version: vmx20,
+			DeviceChange: []vimtypes.BaseVirtualDeviceConfigSpec{
+				&vimtypes.VirtualDeviceConfigSpec{
+					Operation: vimtypes.VirtualDeviceConfigSpecOperationAdd,
+					Device:    &vimtypes.VirtualDisk{},
+				},
+				&vimtypes.VirtualDeviceConfigSpec{
+					Operation: vimtypes.VirtualDeviceConfigSpecOperationAdd,
+					Device:    &vimtypes.VirtualDisk{},
+				},
+				&vimtypes.VirtualDeviceConfigSpec{
+					Operation: vimtypes.VirtualDeviceConfigSpecOperationAdd,
+					Device: &vimtypes.VirtualDisk{
+						CapacityInBytes: 42, // Disk with this size should keep its reserved unit number.
+						VirtualDevice: vimtypes.VirtualDevice{
+							ControllerKey: 1000,
+							UnitNumber:    ptr.To[int32](1),
+						},
+					},
+				},
+			},
+		},
+		[]vimtypes.BaseVirtualDevice{
+			&vimtypes.VirtualPCIController{
+				VirtualController: vimtypes.VirtualController{
+					VirtualDevice: vimtypes.VirtualDevice{
+						Key: 100,
+					},
+				},
+			},
+			&vimtypes.ParaVirtualSCSIController{
+				VirtualSCSIController: vimtypes.VirtualSCSIController{
+					VirtualController: vimtypes.VirtualController{
+						VirtualDevice: vimtypes.VirtualDevice{
+							ControllerKey: 100,
+							Key:           1000,
+						},
+					},
+				},
+			},
+		},
+		nil,
+		&vimtypes.VirtualMachineConfigSpec{
+			Version: vmx20,
+			DeviceChange: []vimtypes.BaseVirtualDeviceConfigSpec{
+				&vimtypes.VirtualDeviceConfigSpec{
+					Operation: vimtypes.VirtualDeviceConfigSpecOperationAdd,
+					Device: &vimtypes.VirtualDisk{
+						VirtualDevice: vimtypes.VirtualDevice{
+							ControllerKey: 1000,
+							UnitNumber:    ptr.To[int32](0),
+						},
+					},
+				},
+				&vimtypes.VirtualDeviceConfigSpec{
+					Operation: vimtypes.VirtualDeviceConfigSpecOperationAdd,
+					Device: &vimtypes.VirtualDisk{
+						VirtualDevice: vimtypes.VirtualDevice{
+							ControllerKey: 1000,
+							UnitNumber:    ptr.To[int32](2),
+						},
+					},
+				},
+				&vimtypes.VirtualDeviceConfigSpec{
+					Operation: vimtypes.VirtualDeviceConfigSpecOperationAdd,
+					Device: &vimtypes.VirtualDisk{
+						CapacityInBytes: 42,
+						VirtualDevice: vimtypes.VirtualDevice{
+							ControllerKey: 1000,
+							UnitNumber:    ptr.To[int32](1),
 						},
 					},
 				},
@@ -946,6 +1151,7 @@ var _ = DescribeTable(
 					Device: &vimtypes.VirtualDisk{
 						VirtualDevice: vimtypes.VirtualDevice{
 							ControllerKey: 1000,
+							UnitNumber:    ptr.To[int32](0),
 						},
 					},
 				},
@@ -992,6 +1198,7 @@ var _ = DescribeTable(
 					Device: &vimtypes.VirtualDisk{
 						VirtualDevice: vimtypes.VirtualDevice{
 							ControllerKey: 1000,
+							UnitNumber:    ptr.To[int32](0),
 						},
 					},
 				},
@@ -1038,6 +1245,7 @@ var _ = DescribeTable(
 					Device: &vimtypes.VirtualDisk{
 						VirtualDevice: vimtypes.VirtualDevice{
 							ControllerKey: 1000,
+							UnitNumber:    ptr.To[int32](0),
 						},
 					},
 				},
@@ -1082,6 +1290,7 @@ var _ = DescribeTable(
 					Device: &vimtypes.VirtualDisk{
 						VirtualDevice: vimtypes.VirtualDevice{
 							ControllerKey: 1000,
+							UnitNumber:    ptr.To[int32](0),
 						},
 					},
 				},
@@ -1131,6 +1340,7 @@ var _ = DescribeTable(
 					Device: &vimtypes.VirtualDisk{
 						VirtualDevice: vimtypes.VirtualDevice{
 							ControllerKey: 15000,
+							UnitNumber:    ptr.To[int32](0),
 						},
 					},
 				},
@@ -1177,6 +1387,7 @@ var _ = DescribeTable(
 					Device: &vimtypes.VirtualDisk{
 						VirtualDevice: vimtypes.VirtualDevice{
 							ControllerKey: 15000,
+							UnitNumber:    ptr.To[int32](0),
 						},
 					},
 				},
@@ -1224,6 +1435,7 @@ var _ = DescribeTable(
 					Device: &vimtypes.VirtualDisk{
 						VirtualDevice: vimtypes.VirtualDevice{
 							ControllerKey: 31000,
+							UnitNumber:    ptr.To[int32](0),
 						},
 					},
 				},
@@ -1289,6 +1501,7 @@ var _ = DescribeTable(
 					Device: &vimtypes.VirtualDisk{
 						VirtualDevice: vimtypes.VirtualDevice{
 							ControllerKey: -10,
+							UnitNumber:    ptr.To[int32](0),
 						},
 					},
 				},
@@ -1351,6 +1564,7 @@ var _ = DescribeTable(
 					Device: &vimtypes.VirtualDisk{
 						VirtualDevice: vimtypes.VirtualDevice{
 							ControllerKey: -10,
+							UnitNumber:    ptr.To[int32](0),
 						},
 					},
 				},
@@ -1413,6 +1627,7 @@ var _ = DescribeTable(
 					Device: &vimtypes.VirtualDisk{
 						VirtualDevice: vimtypes.VirtualDevice{
 							ControllerKey: -10,
+							UnitNumber:    ptr.To[int32](0),
 						},
 					},
 				},
@@ -1475,6 +1690,7 @@ var _ = DescribeTable(
 					Device: &vimtypes.VirtualDisk{
 						VirtualDevice: vimtypes.VirtualDevice{
 							ControllerKey: -10,
+							UnitNumber:    ptr.To[int32](0),
 						},
 					},
 				},
@@ -1533,6 +1749,7 @@ var _ = DescribeTable(
 					Device: &vimtypes.VirtualDisk{
 						VirtualDevice: vimtypes.VirtualDevice{
 							ControllerKey: -10,
+							UnitNumber:    ptr.To[int32](0),
 						},
 					},
 				},
@@ -1598,6 +1815,7 @@ var _ = DescribeTable(
 					Device: &vimtypes.VirtualDisk{
 						VirtualDevice: vimtypes.VirtualDevice{
 							ControllerKey: -10,
+							UnitNumber:    ptr.To[int32](0),
 						},
 					},
 				},
@@ -1660,6 +1878,7 @@ var _ = DescribeTable(
 					Device: &vimtypes.VirtualDisk{
 						VirtualDevice: vimtypes.VirtualDevice{
 							ControllerKey: -10,
+							UnitNumber:    ptr.To[int32](0),
 						},
 					},
 				},
@@ -1721,6 +1940,7 @@ var _ = DescribeTable(
 					Device: &vimtypes.VirtualDisk{
 						VirtualDevice: vimtypes.VirtualDevice{
 							ControllerKey: -10,
+							UnitNumber:    ptr.To[int32](0),
 						},
 					},
 				},
@@ -1782,6 +2002,7 @@ var _ = DescribeTable(
 					Device: &vimtypes.VirtualDisk{
 						VirtualDevice: vimtypes.VirtualDevice{
 							ControllerKey: -1,
+							UnitNumber:    ptr.To[int32](0),
 						},
 					},
 				},
@@ -1879,6 +2100,7 @@ var _ = DescribeTable(
 					Device: &vimtypes.VirtualDisk{
 						VirtualDevice: vimtypes.VirtualDevice{
 							ControllerKey: -1,
+							UnitNumber:    ptr.To[int32](0),
 						},
 					},
 				},
@@ -1996,6 +2218,7 @@ var _ = DescribeTable(
 					Device: &vimtypes.VirtualDisk{
 						VirtualDevice: vimtypes.VirtualDevice{
 							ControllerKey: -1,
+							UnitNumber:    ptr.To[int32](0),
 						},
 					},
 				},
@@ -2113,6 +2336,7 @@ var _ = DescribeTable(
 					Device: &vimtypes.VirtualDisk{
 						VirtualDevice: vimtypes.VirtualDevice{
 							ControllerKey: -1,
+							UnitNumber:    ptr.To[int32](0),
 						},
 					},
 				},
@@ -2241,6 +2465,7 @@ var _ = DescribeTable(
 					Device: &vimtypes.VirtualDisk{
 						VirtualDevice: vimtypes.VirtualDevice{
 							ControllerKey: -1,
+							UnitNumber:    ptr.To[int32](0),
 						},
 					},
 				},
@@ -2440,6 +2665,7 @@ var _ = DescribeTable(
 					Device: &vimtypes.VirtualDisk{
 						VirtualDevice: vimtypes.VirtualDevice{
 							ControllerKey: -1,
+							UnitNumber:    ptr.To[int32](0),
 						},
 					},
 				},
@@ -2695,6 +2921,35 @@ var _ = DescribeTable(
 		fmt.Errorf("no controllers available"),
 		nil,
 	),
+
+	Entry(
+		"return an error that there are no available unit numbers when adding disks and existing devices includes PVSCSI and PCI controller",
+		&vimtypes.VirtualMachineConfigSpec{
+			Version:      vmx20,
+			DeviceChange: generateDeviceChangesForVirtualDiskWithJustController(17, 1000), // maxDisksPerSCSIController+1
+		},
+		[]vimtypes.BaseVirtualDevice{
+			&vimtypes.VirtualPCIController{
+				VirtualController: vimtypes.VirtualController{
+					VirtualDevice: vimtypes.VirtualDevice{
+						Key: 100,
+					},
+				},
+			},
+			&vimtypes.ParaVirtualSCSIController{
+				VirtualSCSIController: vimtypes.VirtualSCSIController{
+					VirtualController: vimtypes.VirtualController{
+						VirtualDevice: vimtypes.VirtualDevice{
+							ControllerKey: 100,
+							Key:           1000,
+						},
+					},
+				},
+			},
+		},
+		fmt.Errorf("no available unit number for controller key 1000"),
+		nil,
+	),
 )
 
 func joinSlices[T any](a []T, b ...[]T) []T {
@@ -2710,8 +2965,51 @@ func generateVirtualDisks(numDisks int, controllerKey int32) []vimtypes.BaseVirt
 		devices[i] = &vimtypes.VirtualDisk{
 			VirtualDevice: vimtypes.VirtualDevice{
 				ControllerKey: controllerKey,
+				UnitNumber:    ptr.To(int32(i)),
 			},
 		}
 	}
 	return devices
+}
+
+func generateDeviceChangesForDefaultVirtualDisk(numDisks int) []vimtypes.BaseVirtualDeviceConfigSpec {
+	devChanges := make([]vimtypes.BaseVirtualDeviceConfigSpec, numDisks)
+	for i := range numDisks {
+		devChanges[i] = &vimtypes.VirtualDeviceConfigSpec{
+			Operation: vimtypes.VirtualDeviceConfigSpecOperationAdd,
+			Device:    &vimtypes.VirtualDisk{},
+		}
+	}
+	return devChanges
+}
+
+func generateDeviceChangesForVirtualDiskWithJustController(numDisks int, controllerKey int32) []vimtypes.BaseVirtualDeviceConfigSpec {
+	devChanges := make([]vimtypes.BaseVirtualDeviceConfigSpec, numDisks)
+	for i := range numDisks {
+		devChanges[i] = &vimtypes.VirtualDeviceConfigSpec{
+			Operation: vimtypes.VirtualDeviceConfigSpecOperationAdd,
+			Device: &vimtypes.VirtualDisk{
+				VirtualDevice: vimtypes.VirtualDevice{
+					ControllerKey: controllerKey,
+				},
+			},
+		}
+	}
+	return devChanges
+}
+
+func generateDeviceChangesForVirtualDisk(numDisks int, controllerKey int32) []vimtypes.BaseVirtualDeviceConfigSpec {
+	devChanges := make([]vimtypes.BaseVirtualDeviceConfigSpec, numDisks)
+	for i := range numDisks {
+		devChanges[i] = &vimtypes.VirtualDeviceConfigSpec{
+			Operation: vimtypes.VirtualDeviceConfigSpecOperationAdd,
+			Device: &vimtypes.VirtualDisk{
+				VirtualDevice: vimtypes.VirtualDevice{
+					ControllerKey: controllerKey,
+					UnitNumber:    ptr.To(int32(i)),
+				},
+			},
+		}
+	}
+	return devChanges
 }


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Some VC placement changes now require the disks to have unit number assigned so update EnsureDisksHaveControllers()  to do that.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note
NONE
```