### PR TITLE
🌱 Refactor VM Op imports out of util/vsphere/vm

### DIFF
--- a/pkg/providers/vsphere/session/session_vm_update.go
+++ b/pkg/providers/vsphere/session/session_vm_update.go
@@ -529,7 +529,7 @@ func (s *Session) prePowerOnVMConfigSpec(
 	configSpec.DeviceChange = append(configSpec.DeviceChange, pciDeviceChanges...)
 
 	if pkgcfg.FromContext(vmCtx).Features.IsoSupport {
-		cdromDeviceChanges, err := vmutil.UpdateCdromDeviceChanges(vmCtx, s.Client.RestClient(), s.K8sClient, virtualDevices)
+		cdromDeviceChanges, err := virtualmachine.UpdateCdromDeviceChanges(vmCtx, s.Client.RestClient(), s.K8sClient, virtualDevices)
 		if err != nil {
 			return nil, fmt.Errorf("update CD-ROM device changes error: %w", err)
 		}
@@ -795,7 +795,7 @@ func (s *Session) poweredOnVMReconfigure(
 	UpdateConfigSpecChangeBlockTracking(vmCtx, config, configSpec, nil, vmCtx.VM.Spec)
 
 	if pkgcfg.FromContext(vmCtx).Features.IsoSupport {
-		if err := vmutil.UpdateConfigSpecCdromDeviceConnection(vmCtx, s.Client.RestClient(), s.K8sClient, config, configSpec); err != nil {
+		if err := virtualmachine.UpdateConfigSpecCdromDeviceConnection(vmCtx, s.Client.RestClient(), s.K8sClient, config, configSpec); err != nil {
 			return false, fmt.Errorf("update CD-ROM device connection error: %w", err)
 		}
 	}
@@ -1235,7 +1235,7 @@ func (s *Session) UpdateVirtualMachine(
 func isVMPaused(vmCtx pkgctx.VirtualMachineContext) bool {
 	vm := vmCtx.VM
 
-	adminPaused := vmutil.IsPausedByAdmin(vmCtx.MoVM)
+	adminPaused := virtualmachine.IsPausedByAdmin(vmCtx.MoVM)
 	devopsPaused := annotations.HasPaused(vm)
 
 	if adminPaused || devopsPaused {

--- a/pkg/providers/vsphere/virtualmachine/cdrom.go
+++ b/pkg/providers/vsphere/virtualmachine/cdrom.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package vm
+package virtualmachine
 
 import (
 	"fmt"

--- a/pkg/providers/vsphere/virtualmachine/cdrom_test.go
+++ b/pkg/providers/vsphere/virtualmachine/cdrom_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package vm_test
+package virtualmachine_test
 
 import (
 	"path"
@@ -21,9 +21,9 @@ import (
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/virtualmachine"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	pkgclient "github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/client"
-	vmutil "github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/vm"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 	"github.com/vmware-tanzu/vm-operator/test/testutil"
 )
@@ -86,7 +86,7 @@ func cdromTests() {
 			})
 
 			JustBeforeEach(func() {
-				result, resultErr = vmutil.UpdateCdromDeviceChanges(vmCtx, restClient, k8sClient, curDevices)
+				result, resultErr = virtualmachine.UpdateCdromDeviceChanges(vmCtx, restClient, k8sClient, curDevices)
 				Expect(resultErr).ToNot(HaveOccurred())
 			})
 
@@ -394,7 +394,7 @@ func cdromTests() {
 			JustBeforeEach(func() {
 				k8sClient = builder.NewFakeClient(k8sInitObjs...)
 
-				result, resultErr = vmutil.UpdateCdromDeviceChanges(vmCtx, restClient, k8sClient, curDevices)
+				result, resultErr = virtualmachine.UpdateCdromDeviceChanges(vmCtx, restClient, k8sClient, curDevices)
 				Expect(resultErr).To(HaveOccurred())
 			})
 
@@ -771,7 +771,7 @@ func cdromTests() {
 		})
 
 		JustBeforeEach(func() {
-			updateErr = vmutil.UpdateConfigSpecCdromDeviceConnection(vmCtx, restClient, k8sClient, configInfo, configSpec)
+			updateErr = virtualmachine.UpdateConfigSpecCdromDeviceConnection(vmCtx, restClient, k8sClient, configInfo, configSpec)
 		})
 
 		Context("Happy Path (no error occurs)", func() {
@@ -886,7 +886,7 @@ func cdromTests() {
 			JustBeforeEach(func() {
 				k8sClient = builder.NewFakeClient(k8sInitObjs...)
 
-				updateErr = vmutil.UpdateConfigSpecCdromDeviceConnection(vmCtx, restClient, k8sClient, configInfo, configSpec)
+				updateErr = virtualmachine.UpdateConfigSpecCdromDeviceConnection(vmCtx, restClient, k8sClient, configInfo, configSpec)
 			})
 
 			// These test cases are similar to those in UpdateCdromDeviceChanges.

--- a/pkg/providers/vsphere/virtualmachine/delete.go
+++ b/pkg/providers/vsphere/virtualmachine/delete.go
@@ -38,7 +38,7 @@ func DeleteVirtualMachine(
 		return err
 	}
 	// Throw an error to distinguish from successful deletion.
-	if paused := vmutil.IsPausedByAdmin(vmCtx.MoVM); paused {
+	if paused := IsPausedByAdmin(vmCtx.MoVM); paused {
 		if vmCtx.VM.Labels == nil {
 			vmCtx.VM.Labels = make(map[string]string)
 		}

--- a/pkg/providers/vsphere/virtualmachine/extraconfig.go
+++ b/pkg/providers/vsphere/virtualmachine/extraconfig.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package virtualmachine
+
+import (
+	"strings"
+
+	"github.com/vmware/govmomi/vim25/mo"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/constants"
+)
+
+func IsPausedByAdmin(moVM mo.VirtualMachine) bool {
+	for i := range moVM.Config.ExtraConfig {
+		if o := moVM.Config.ExtraConfig[i].GetOptionValue(); o != nil {
+			if o.Key == vmopv1.PauseVMExtraConfigKey {
+				if value, ok := o.Value.(string); ok {
+					return strings.ToUpper(value) == constants.ExtraConfigTrue
+				}
+			}
+		}
+	}
+	return false
+}

--- a/pkg/providers/vsphere/virtualmachine/extraconfig_test.go
+++ b/pkg/providers/vsphere/virtualmachine/extraconfig_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package virtualmachine_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/vmware/govmomi/vim25/mo"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/constants"
+	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/virtualmachine"
+	vmutil "github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/vm"
+)
+
+func extraConfigTests() {
+	getVMMoRef := func() vimtypes.ManagedObjectReference {
+		return vimtypes.ManagedObjectReference{
+			Type:  "VirtualMachine",
+			Value: "vm-44",
+		}
+	}
+	Context("IsPausedByAdmin", func() {
+		var (
+			mgdObj mo.VirtualMachine
+		)
+
+		BeforeEach(func() {
+			moRef := getVMMoRef()
+			mgdObj = vmutil.ManagedObjectFromMoRef(moRef)
+			mgdObj.Config = &vimtypes.VirtualMachineConfigInfo{
+				ExtraConfig: []vimtypes.BaseOptionValue{},
+			}
+		})
+
+		It("should return false when PauseVMExtraConfigKey is not set", func() {
+			Expect(virtualmachine.IsPausedByAdmin(mgdObj)).To(BeFalse())
+		})
+
+		It("should return false when PauseVMExtraConfigKey is set to False", func() {
+			mgdObj.Config.ExtraConfig = append(mgdObj.Config.ExtraConfig, &vimtypes.OptionValue{
+				Key:   vmopv1.PauseVMExtraConfigKey,
+				Value: constants.ExtraConfigFalse,
+			})
+
+			Expect(virtualmachine.IsPausedByAdmin(mgdObj)).To(BeFalse())
+		})
+
+		It("should return false when PauseVMExtraConfigKey is set to 1", func() {
+			mgdObj.Config.ExtraConfig = append(mgdObj.Config.ExtraConfig, &vimtypes.OptionValue{
+				Key:   vmopv1.PauseVMExtraConfigKey,
+				Value: 1,
+			})
+
+			Expect(virtualmachine.IsPausedByAdmin(mgdObj)).To(BeFalse())
+		})
+
+		It("should return true when PauseVMExtraConfigKey is set to 'true'", func() {
+			mgdObj.Config.ExtraConfig = append(mgdObj.Config.ExtraConfig, &vimtypes.OptionValue{
+				Key:   vmopv1.PauseVMExtraConfigKey,
+				Value: "true",
+			})
+
+			Expect(virtualmachine.IsPausedByAdmin(mgdObj)).To(BeTrue())
+		})
+
+		It("should return true when PauseVMExtraConfigKey is set to 'True'", func() {
+			mgdObj.Config.ExtraConfig = append(mgdObj.Config.ExtraConfig, &vimtypes.OptionValue{
+				Key:   vmopv1.PauseVMExtraConfigKey,
+				Value: "True",
+			})
+
+			Expect(virtualmachine.IsPausedByAdmin(mgdObj)).To(BeTrue())
+		})
+
+		It("should return true when PauseVMExtraConfigKey is set to 'TRUE'", func() {
+			mgdObj.Config.ExtraConfig = append(mgdObj.Config.ExtraConfig, &vimtypes.OptionValue{
+				Key:   vmopv1.PauseVMExtraConfigKey,
+				Value: constants.ExtraConfigTrue,
+			})
+
+			Expect(virtualmachine.IsPausedByAdmin(mgdObj)).To(BeTrue())
+		})
+	})
+}

--- a/pkg/providers/vsphere/virtualmachine/virtualmachine_suite_test.go
+++ b/pkg/providers/vsphere/virtualmachine/virtualmachine_suite_test.go
@@ -18,6 +18,8 @@ func vcSimTests() {
 	Describe("Publish", Label(testlabels.VCSim), publishTests)
 	Describe("Backup", Label(testlabels.VCSim), backupTests)
 	Describe("GuestInfo", Label(testlabels.VCSim), guestInfoTests)
+	Describe("CD-ROM", Label(testlabels.VCSim), cdromTests)
+	Describe("ExtraConfig", Label(testlabels.VCSim), extraConfigTests)
 }
 
 var suite = builder.NewTestSuite()

--- a/pkg/util/vsphere/vm/vm.go
+++ b/pkg/util/vsphere/vm/vm.go
@@ -4,14 +4,9 @@
 package vm
 
 import (
-	"strings"
-
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/mo"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
-
-	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
-	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/constants"
 )
 
 func ManagedObjectFromMoRef(moRef vimtypes.ManagedObjectReference) mo.VirtualMachine {
@@ -26,17 +21,4 @@ func ManagedObjectFromMoRef(moRef vimtypes.ManagedObjectReference) mo.VirtualMac
 
 func ManagedObjectFromObject(obj *object.VirtualMachine) mo.VirtualMachine {
 	return ManagedObjectFromMoRef(obj.Reference())
-}
-
-func IsPausedByAdmin(moVM mo.VirtualMachine) bool {
-	for i := range moVM.Config.ExtraConfig {
-		if o := moVM.Config.ExtraConfig[i].GetOptionValue(); o != nil {
-			if o.Key == vmopv1.PauseVMExtraConfigKey {
-				if value, ok := o.Value.(string); ok {
-					return strings.ToUpper(value) == constants.ExtraConfigTrue
-				}
-			}
-		}
-	}
-	return false
 }

--- a/pkg/util/vsphere/vm/vm_suite_test.go
+++ b/pkg/util/vsphere/vm/vm_suite_test.go
@@ -12,12 +12,13 @@ import (
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
+const doesNotExist = "does-not-exist"
+
 func vcSimTests() {
 	Describe("Power State", Label(testlabels.VCSim), powerStateTests)
 	Describe("Hardware Version", Label(testlabels.VCSim), hardwareVersionTests)
 	Describe("Managed Object", managedObjectTests)
 	Describe("Guest ID", guestIDTests)
-	Describe("CD ROM", Label(testlabels.VCSim), cdromTests)
 }
 
 var suite = builder.NewTestSuite()

--- a/pkg/util/vsphere/vm/vm_test.go
+++ b/pkg/util/vsphere/vm/vm_test.go
@@ -8,15 +8,10 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/vmware/govmomi/object"
-	"github.com/vmware/govmomi/vim25/mo"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 
-	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
-	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/constants"
 	vmutil "github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/vm"
 )
-
-const doesNotExist = "does-not-exist"
 
 func managedObjectTests() {
 	getVMMoRef := func() vimtypes.ManagedObjectReference {
@@ -34,68 +29,6 @@ func managedObjectTests() {
 	Context("ManagedObjectFromObject", func() {
 		It("should return a mo.VirtualMachine from the provided object.VirtualMachine", func() {
 			Expect(vmutil.ManagedObjectFromObject(object.NewVirtualMachine(nil, getVMMoRef())).Reference()).To(Equal(getVMMoRef()))
-		})
-	})
-	Context("IsPausedByAdmin", func() {
-		var (
-			mgdObj mo.VirtualMachine
-		)
-
-		BeforeEach(func() {
-			moRef := getVMMoRef()
-			mgdObj = vmutil.ManagedObjectFromMoRef(moRef)
-			mgdObj.Config = &vimtypes.VirtualMachineConfigInfo{
-				ExtraConfig: []vimtypes.BaseOptionValue{},
-			}
-		})
-
-		It("should return false when PauseVMExtraConfigKey is not set", func() {
-			Expect(vmutil.IsPausedByAdmin(mgdObj)).To(BeFalse())
-		})
-
-		It("should return false when PauseVMExtraConfigKey is set to False", func() {
-			mgdObj.Config.ExtraConfig = append(mgdObj.Config.ExtraConfig, &vimtypes.OptionValue{
-				Key:   vmopv1.PauseVMExtraConfigKey,
-				Value: constants.ExtraConfigFalse,
-			})
-
-			Expect(vmutil.IsPausedByAdmin(mgdObj)).To(BeFalse())
-		})
-
-		It("should return false when PauseVMExtraConfigKey is set to 1", func() {
-			mgdObj.Config.ExtraConfig = append(mgdObj.Config.ExtraConfig, &vimtypes.OptionValue{
-				Key:   vmopv1.PauseVMExtraConfigKey,
-				Value: 1,
-			})
-
-			Expect(vmutil.IsPausedByAdmin(mgdObj)).To(BeFalse())
-		})
-
-		It("should return true when PauseVMExtraConfigKey is set to 'true'", func() {
-			mgdObj.Config.ExtraConfig = append(mgdObj.Config.ExtraConfig, &vimtypes.OptionValue{
-				Key:   vmopv1.PauseVMExtraConfigKey,
-				Value: "true",
-			})
-
-			Expect(vmutil.IsPausedByAdmin(mgdObj)).To(BeTrue())
-		})
-
-		It("should return true when PauseVMExtraConfigKey is set to 'True'", func() {
-			mgdObj.Config.ExtraConfig = append(mgdObj.Config.ExtraConfig, &vimtypes.OptionValue{
-				Key:   vmopv1.PauseVMExtraConfigKey,
-				Value: "True",
-			})
-
-			Expect(vmutil.IsPausedByAdmin(mgdObj)).To(BeTrue())
-		})
-
-		It("should return true when PauseVMExtraConfigKey is set to 'TRUE'", func() {
-			mgdObj.Config.ExtraConfig = append(mgdObj.Config.ExtraConfig, &vimtypes.OptionValue{
-				Key:   vmopv1.PauseVMExtraConfigKey,
-				Value: constants.ExtraConfigTrue,
-			})
-
-			Expect(vmutil.IsPausedByAdmin(mgdObj)).To(BeTrue())
 		})
 	})
 }


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch removes the package imports from util/vsphere/vm that reference the VM Op API or Kubernetes code. The package util/vsphere/vm is meant to be pure vSphere code, and should never reference anything related to Kubernetes.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```