### PR TITLE
:bug: Do not reconcile volumes if VM has pause annotation set

### DIFF
--- a/controllers/virtualmachine/volume/volume_controller.go
+++ b/controllers/virtualmachine/volume/volume_controller.go
@@ -41,6 +41,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/instancestorage"
 	"github.com/vmware-tanzu/vm-operator/pkg/record"
 	"github.com/vmware-tanzu/vm-operator/pkg/util"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/annotations"
 )
 
 const (
@@ -234,10 +235,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (_ ctr
 		VM:      vm,
 	}
 
+	if annotations.HasPaused(vm) {
+		volCtx.Logger.Info("Skipping reconciliation since VirtualMachine contains the pause annotation")
+		return ctrl.Result{}, nil
+	}
+
 	// If the VM has a pause reconcile label key, Skip volume reconciliation.
 	// Do not requeue the reconcile here since removing the pause label will trigger a reconcile anyway.
 	if val, ok := vm.Labels[vmopv1.PausedVMLabelKey]; ok {
-		volCtx.Logger.Info("Skipping reconciliation because a pause operation has been initiated on this VirtualMachine.", "paused by", val)
+		volCtx.Logger.Info("Skipping reconciliation because a pause operation has been initiated on this VirtualMachine.",
+			"pausedBy", val)
 		return ctrl.Result{}, nil
 	}
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Even if a VM has pause annotation set, we end up reconciling the volumes of a VM.  This results in volumes being detached from paused VMs.  This change fixes that behavior by returning early if the paused annotation is found on the VM.

**Please add a release note if necessary**:

```release-note
Do not reconcile volumes if VM has pause annotation set
```