### PR TITLE
:seedling: Update VPC APIs to latest v4.0.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/prometheus/client_golang v1.19.1
 	github.com/vmware-tanzu/image-registry-operator-api v0.0.0-20240509202721-f6552612433a
 	github.com/vmware-tanzu/net-operator-api v0.0.0-20240523152550-862e2c4eb0e0
-	github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20240812063009-106e8b213b74
+	github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20240902045731-00a14868c72d
 	github.com/vmware-tanzu/vm-operator/api v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/vm-operator/external/byok v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/vm-operator/external/ncp v0.0.0-00010101000000-000000000000

--- a/go.sum
+++ b/go.sum
@@ -457,8 +457,8 @@ github.com/vmware-tanzu/image-registry-operator-api v0.0.0-20240509202721-f65526
 github.com/vmware-tanzu/image-registry-operator-api v0.0.0-20240509202721-f6552612433a/go.mod h1:zn/ponkeFUViyBDhYp9OKFPqEGWYrsR71Pn9/aTCvSI=
 github.com/vmware-tanzu/net-operator-api v0.0.0-20240523152550-862e2c4eb0e0 h1:ymNjvIbvYrk+hyNw6+Gat7XI/8z/15eqSD7CLG7VkOI=
 github.com/vmware-tanzu/net-operator-api v0.0.0-20240523152550-862e2c4eb0e0/go.mod h1:w6QJGm3crIA16ZIz1FVQXD2NVeJhOgGXxW05RbVTSTo=
-github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20240812063009-106e8b213b74 h1:dPqBrSgbZmHNZPvYLCcWWSJssAPOZ1GLg0oeUPVSZxU=
-github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20240812063009-106e8b213b74/go.mod h1:Q4JzNkNMvjo7pXtlB5/R3oME4Nhah7fAObWgghVmtxk=
+github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20240902045731-00a14868c72d h1:6pMXrQmTYpu5FipoQ9fT4FJG3VPMMbBoIi6h3KvdQc8=
+github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20240902045731-00a14868c72d/go.mod h1:Q4JzNkNMvjo7pXtlB5/R3oME4Nhah7fAObWgghVmtxk=
 github.com/vmware/govmomi v0.31.1-0.20240730173452-49b88eb9917f h1:lKzA28fIcNkcZgQdgP8YXaGZQcDMLNrwE9CyMyRKQNg=
 github.com/vmware/govmomi v0.31.1-0.20240730173452-49b88eb9917f/go.mod h1:oHzAQ1r6152zYDGcUqeK+EO8LhKo5wjtvWZBGHws2Hc=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
VPC APIs have made below changes so VMOP needs to update as well. Per my evaluation, these changes don't affect VMOP. All CRD changes are merged to NSX Operator v4.2.0 branch(for VC main).
- VPCNetworkConfiguration change: https://github.com/vmware-tanzu/nsx-operator/commit/a627525885a153833ac506e563d837fffbccedf3
- SubnetPort change: https://github.com/vmware-tanzu/nsx-operator/commit/567ccf01634d1b1b69a12950bbbbfae47b669cab
- Subnet/SubnetSet change: https://github.com/vmware-tanzu/nsx-operator/commit/4e4decd56d10720d662eb4e23c78e2eeec65a363
- IPAddressAllocation change: https://github.com/vmware-tanzu/nsx-operator/commit/b4c6c00303d5852e896c7e7cd2f99c81df059cc5

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes N/A


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

```release-note
NONE
```