### PR TITLE
🐛 Use API reader when fetching PVCs for backup

### DIFF
--- a/pkg/manager/init/init_providers.go
+++ b/pkg/manager/init/init_providers.go
@@ -19,6 +19,6 @@ func InitializeProviders(
 
 	vmProviderName := fmt.Sprintf("%s/%s/vmProvider", ctx.Namespace, ctx.Name)
 	recorder := record.New(mgr.GetEventRecorderFor(vmProviderName))
-	ctx.VMProvider = vsphere2.NewVSphereVMProviderFromClient(ctx, mgr.GetClient(), recorder)
+	ctx.VMProvider = vsphere2.NewVSphereVMProviderFromClient(ctx, mgr.GetClient(), mgr.GetAPIReader(), recorder)
 	return nil
 }

--- a/pkg/providers/vsphere/vmprovider.go
+++ b/pkg/providers/vsphere/vmprovider.go
@@ -58,6 +58,7 @@ type VersionedOVFEnvelope struct {
 
 type vSphereVMProvider struct {
 	k8sClient         ctrlclient.Client
+	k8sAPIReader      ctrlclient.Reader
 	eventRecorder     record.Recorder
 	globalExtraConfig map[string]string
 	minCPUFreq        uint64
@@ -71,6 +72,7 @@ type vSphereVMProvider struct {
 func NewVSphereVMProviderFromClient(
 	ctx context.Context,
 	client ctrlclient.Client,
+	apiReader ctrlclient.Reader,
 	recorder record.Recorder) providers.VirtualMachineProviderInterface {
 
 	ovfCache, ovfLockPool := InitOvfCacheAndLockPool(
@@ -78,6 +80,7 @@ func NewVSphereVMProviderFromClient(
 
 	return &vSphereVMProvider{
 		k8sClient:         client,
+		k8sAPIReader:      apiReader,
 		eventRecorder:     recorder,
 		globalExtraConfig: getExtraConfig(ctx),
 		ovfCache:          ovfCache,

--- a/pkg/providers/vsphere/vmprovider_resourcepolicy_test.go
+++ b/pkg/providers/vsphere/vmprovider_resourcepolicy_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2021-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package vsphere_test
@@ -58,7 +58,7 @@ func resourcePolicyTests() {
 
 		JustBeforeEach(func() {
 			ctx = suite.NewTestContextForVCSim(testConfig, initObjects...)
-			vmProvider = vsphere.NewVSphereVMProviderFromClient(ctx, ctx.Client, ctx.Recorder)
+			vmProvider = vsphere.NewVSphereVMProviderFromClient(ctx, ctx.Client, ctx.Client, ctx.Recorder)
 
 			nsInfo = ctx.CreateWorkloadNamespace()
 		})

--- a/pkg/providers/vsphere/vmprovider_test.go
+++ b/pkg/providers/vsphere/vmprovider_test.go
@@ -37,7 +37,7 @@ func cpuFreqTests() {
 
 	JustBeforeEach(func() {
 		ctx = suite.NewTestContextForVCSim(testConfig)
-		vmProvider = vsphere.NewVSphereVMProviderFromClient(ctx, ctx.Client, ctx.Recorder)
+		vmProvider = vsphere.NewVSphereVMProviderFromClient(ctx, ctx.Client, ctx.Client, ctx.Recorder)
 	})
 
 	AfterEach(func() {
@@ -104,7 +104,7 @@ func syncVirtualMachineImageTests() {
 	BeforeEach(func() {
 		testConfig.WithContentLibrary = true
 		ctx = suite.NewTestContextForVCSim(testConfig)
-		vmProvider = vsphere.NewVSphereVMProviderFromClient(ctx, ctx.Client, ctx.Recorder)
+		vmProvider = vsphere.NewVSphereVMProviderFromClient(ctx, ctx.Client, ctx.Client, ctx.Recorder)
 	})
 
 	AfterEach(func() {

--- a/pkg/providers/vsphere/vmprovider_vm.go
+++ b/pkg/providers/vsphere/vmprovider_vm.go
@@ -536,7 +536,7 @@ func (vs *vSphereVMProvider) updateVirtualMachine(
 		annotations.HasForceEnableBackup(vmCtx.VM) {
 		vmCtx.Logger.V(4).Info("Backing up VM Service managed VM")
 
-		diskUUIDToPVC, err := GetAttachedDiskUUIDToPVC(vmCtx, vs.k8sClient)
+		diskUUIDToPVC, err := GetAttachedDiskUUIDToPVC(vmCtx, vs.k8sAPIReader)
 		if err != nil {
 			vmCtx.Logger.Error(err, "failed to get disk uuid to PVC mapping for backup")
 			return err

--- a/pkg/providers/vsphere/vmprovider_vm2_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm2_test.go
@@ -72,7 +72,7 @@ func vmE2ETests() {
 		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
 			config.MaxDeployThreadsOnProvider = 1
 		})
-		vmProvider = vsphere.NewVSphereVMProviderFromClient(ctx, ctx.Client, ctx.Recorder)
+		vmProvider = vsphere.NewVSphereVMProviderFromClient(ctx, ctx.Client, ctx.Client, ctx.Recorder)
 		nsInfo = ctx.CreateWorkloadNamespace()
 
 		vmClass.Namespace = nsInfo.Namespace

--- a/pkg/providers/vsphere/vmprovider_vm_resize_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_resize_test.go
@@ -49,7 +49,7 @@ func vmResizeTests() {
 		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
 			config.MaxDeployThreadsOnProvider = 1
 		})
-		vmProvider = vsphere.NewVSphereVMProviderFromClient(ctx, ctx.Client, ctx.Recorder)
+		vmProvider = vsphere.NewVSphereVMProviderFromClient(ctx, ctx.Client, ctx.Client, ctx.Recorder)
 		nsInfo = ctx.CreateWorkloadNamespace()
 	})
 

--- a/pkg/providers/vsphere/vmprovider_vm_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_test.go
@@ -73,7 +73,7 @@ func vmTests() {
 		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
 			config.MaxDeployThreadsOnProvider = 1
 		})
-		vmProvider = vsphere.NewVSphereVMProviderFromClient(ctx, ctx.Client, ctx.Recorder)
+		vmProvider = vsphere.NewVSphereVMProviderFromClient(ctx, ctx.Client, ctx.Client, ctx.Recorder)
 		nsInfo = ctx.CreateWorkloadNamespace()
 	})
 

--- a/pkg/providers/vsphere/vmprovider_vm_utils.go
+++ b/pkg/providers/vsphere/vmprovider_vm_utils.go
@@ -543,9 +543,10 @@ func GetVMClassConfigSpec(
 
 // GetAttachedDiskUUIDToPVC returns a map of disk UUID to PVC object for all
 // attached disks by checking the VM's spec and status of volumes.
+// It uses the API reader to avoid implicit caching of all PVC objects.
 func GetAttachedDiskUUIDToPVC(
 	vmCtx pkgctx.VirtualMachineContext,
-	k8sClient ctrlclient.Client) (map[string]corev1.PersistentVolumeClaim, error) {
+	apiReader ctrlclient.Reader) (map[string]corev1.PersistentVolumeClaim, error) {
 
 	if len(vmCtx.VM.Spec.Volumes) == 0 {
 		return nil, nil
@@ -576,7 +577,7 @@ func GetAttachedDiskUUIDToPVC(
 
 		pvcObj := corev1.PersistentVolumeClaim{}
 		objKey := ctrlclient.ObjectKey{Name: pvcName, Namespace: vmCtx.VM.Namespace}
-		if err := k8sClient.Get(vmCtx, objKey, &pvcObj); err != nil {
+		if err := apiReader.Get(vmCtx, objKey, &pvcObj); err != nil {
 			return nil, err
 		}
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

The current use of `client.Get()` in the backup workflow inadvertently watches and caches all PVCs, increasing memory usage (see https://github.com/kubernetes-sigs/controller-runtime/issues/1222 for more details).

This PR switches to the API reader to avoid this implicit caching when fetching PVCs for backup.

**Which issue(s) is/are addressed by this PR?**:

Fixes N/A.

**Are there any special notes for your reviewer**:

N/A.


**Please add a release note if necessary**:

```release-note
Use API reader when fetching PVCs for backup.
```