### PR TITLE
🌱 Generic context

### DIFF
--- a/pkg/context/generic/generic_context.go
+++ b/pkg/context/generic/generic_context.go
@@ -1,0 +1,146 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package generic
+
+import (
+	"context"
+	"sync"
+)
+
+type contextData[T any] struct {
+	sync.Mutex
+	data T
+}
+
+// SetContext sets the data in the context.
+func SetContext[T any, K comparable](
+	ctx context.Context,
+	key K,
+	setT func(curT T) T) {
+
+	if ctx == nil {
+		panic("context is nil")
+	}
+	obj := ctx.Value(key)
+	if obj == nil {
+		panic("value is missing from context")
+	}
+
+	m := obj.(*contextData[T])
+	m.Lock()
+	defer m.Unlock()
+
+	m.data = setT(m.data)
+}
+
+// FromContext returns the data from the context.
+func FromContext[T any, K comparable, V any](
+	ctx context.Context,
+	key K,
+	getV func(val T) V) V {
+
+	if ctx == nil {
+		panic("context is nil")
+	}
+	obj := ctx.Value(key)
+	if obj == nil {
+		panic("value is missing from context")
+	}
+
+	m := obj.(*contextData[T])
+	m.Lock()
+	defer m.Unlock()
+
+	return getV(m.data)
+}
+
+// WithContext returns a new context with the data in the specified key.
+func WithContext[T any, K comparable](
+	parent context.Context,
+	key K,
+	newT func() T) context.Context {
+
+	if parent == nil {
+		panic("parent context is nil")
+	}
+
+	return context.WithValue(
+		parent,
+		key,
+		&contextData[T]{
+			data: newT(),
+		},
+	)
+}
+
+// NewContext returns a new context with the data in the specified key.
+func NewContext[T any, K comparable](key K, newT func() T) context.Context {
+	return WithContext(context.Background(), key, newT)
+}
+
+// ValidateContext returns true if the provided context contains the data at the
+// specified key.
+func ValidateContext[T any, K comparable](ctx context.Context, key K) bool {
+	if ctx == nil {
+		panic("context is nil")
+	}
+	obj := ctx.Value(key)
+	if obj == nil {
+		return false
+	}
+	_, ok := obj.(*contextData[T])
+	return ok
+}
+
+// JoinContext returns a new context that contains a reference the data at
+// the specified key.
+// This function panics if the provided context does not contain the data.
+// This function is thread-safe.
+func JoinContext[T any, K comparable](
+	left, right context.Context,
+	key K,
+	copyT func(dstT, srcT T) T) context.Context {
+
+	if left == nil {
+		panic("left context is nil")
+	}
+	if right == nil {
+		panic("right context is nil")
+	}
+
+	leftObj := left.Value(key)
+	rightObj := right.Value(key)
+
+	if leftObj == nil && rightObj == nil {
+		panic("value is missing from context")
+	}
+
+	if leftObj != nil && rightObj == nil {
+		// The left context has the value and the right does not, so just return
+		// the left context.
+		return left
+	}
+
+	if leftObj == nil && rightObj != nil {
+		// The right context has the value and the left does not, so return a
+		// new context with the value in it.
+		return context.WithValue(left, key, rightObj.(*contextData[T]))
+	}
+
+	// Both contexts have the value, so the left context is returned after the
+	// value from the right context is used to overwrite the value from the
+	// left.
+
+	leftVal := leftObj.(*contextData[T])
+	rightVal := rightObj.(*contextData[T])
+
+	leftVal.Lock()
+	rightVal.Lock()
+	defer leftVal.Unlock()
+	defer rightVal.Unlock()
+
+	leftVal.data = copyT(leftVal.data, rightVal.data)
+
+	return left
+}

--- a/pkg/context/generic/generic_context_test.go
+++ b/pkg/context/generic/generic_context_test.go
@@ -1,0 +1,588 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package generic_test
+
+import (
+	"context"
+	"maps"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	ctxgen "github.com/vmware-tanzu/vm-operator/pkg/context/generic"
+)
+
+type simpleContextKeyType uint8
+
+const simpleContextKeyValue simpleContextKeyType = 0
+
+type simpleContextValueType uint8
+
+const (
+	simpleContextValue0 simpleContextValueType = iota
+	simpleContextValue1
+	simpleContextValue2
+)
+
+//nolint:unparam
+func simpleSetContext(parent context.Context, newVal simpleContextValueType) {
+	ctxgen.SetContext(
+		parent,
+		simpleContextKeyValue,
+		func(curVal simpleContextValueType) simpleContextValueType {
+			return newVal
+		})
+}
+
+func simpleFromContext(ctx context.Context) simpleContextValueType {
+	return ctxgen.FromContext(
+		ctx,
+		simpleContextKeyValue,
+		func(val simpleContextValueType) simpleContextValueType {
+			return val
+		})
+}
+
+func simpleWithContext(parent context.Context) context.Context {
+	return ctxgen.WithContext(
+		parent,
+		simpleContextKeyValue,
+		func() simpleContextValueType { return simpleContextValue0 })
+}
+
+func simpleNewContext() context.Context {
+	return ctxgen.NewContext(
+		simpleContextKeyValue,
+		func() simpleContextValueType { return simpleContextValue0 })
+}
+
+func simpleValidateContext(ctx context.Context) bool {
+	return ctxgen.ValidateContext[simpleContextValueType](ctx, simpleContextKeyValue)
+}
+
+func simpleJoinContext(left, right context.Context) context.Context {
+	return ctxgen.JoinContext(
+		left,
+		right,
+		simpleContextKeyValue,
+		func(dst, src simpleContextValueType) simpleContextValueType {
+			return src
+		})
+}
+
+var _ = Describe("SimpleType", func() {
+
+	Describe("SetContext", func() {
+		var (
+			ctx context.Context
+		)
+		BeforeEach(func() {
+			ctx = context.Background()
+		})
+
+		When("ctx is nil", func() {
+			BeforeEach(func() {
+				ctx = nil
+			})
+			It("should panic", func() {
+				fn := func() {
+					simpleSetContext(ctx, simpleContextValue1)
+				}
+				Expect(fn).To(PanicWith("context is nil"))
+			})
+		})
+		When("value is missing from context", func() {
+			It("should panic", func() {
+				fn := func() {
+					simpleSetContext(ctx, simpleContextValue1)
+				}
+				Expect(fn).To(PanicWith("value is missing from context"))
+			})
+		})
+		When("value is present in context", func() {
+			BeforeEach(func() {
+				ctx = simpleNewContext()
+				simpleSetContext(ctx, simpleContextValue1)
+			})
+			It("should set value", func() {
+				simpleSetContext(ctx, simpleContextValue1)
+				Expect(simpleFromContext(ctx)).To(Equal(simpleContextValue1))
+			})
+		})
+	})
+
+	Describe("FromContext", func() {
+		var (
+			ctx context.Context
+		)
+		BeforeEach(func() {
+			ctx = context.Background()
+		})
+
+		When("ctx is nil", func() {
+			BeforeEach(func() {
+				ctx = nil
+			})
+			It("should panic", func() {
+				fn := func() {
+					_ = simpleFromContext(ctx)
+				}
+				Expect(fn).To(PanicWith("context is nil"))
+			})
+		})
+		When("value is missing from context", func() {
+			It("should panic", func() {
+				fn := func() {
+					_ = simpleFromContext(ctx)
+				}
+				Expect(fn).To(PanicWith("value is missing from context"))
+			})
+		})
+		When("value is present in context", func() {
+			BeforeEach(func() {
+				ctx = simpleNewContext()
+			})
+			It("should return the value", func() {
+				Expect(simpleFromContext(ctx)).To(Equal(simpleContextValue0))
+			})
+		})
+	})
+
+	Describe("ValidateContext", func() {
+		var (
+			ctx context.Context
+		)
+		BeforeEach(func() {
+			ctx = context.Background()
+		})
+		When("ctx is nil", func() {
+			BeforeEach(func() {
+				ctx = nil
+			})
+			It("should panic", func() {
+				fn := func() {
+					_ = simpleValidateContext(ctx)
+				}
+				Expect(fn).To(PanicWith("context is nil"))
+			})
+		})
+		When("value is missing from context", func() {
+			It("should return false", func() {
+				Expect(simpleValidateContext(ctx)).To(BeFalse())
+			})
+		})
+		When("map is present in context", func() {
+			BeforeEach(func() {
+				ctx = simpleNewContext()
+			})
+			It("should return true", func() {
+				Expect(simpleValidateContext(ctx)).To(BeTrue())
+			})
+		})
+	})
+
+	Describe("JoinContext", func() {
+		var (
+			left  context.Context
+			right context.Context
+		)
+		BeforeEach(func() {
+			left = context.Background()
+			right = context.Background()
+		})
+		When("left context is nil", func() {
+			BeforeEach(func() {
+				left = nil
+			})
+			It("should panic", func() {
+				fn := func() {
+					_ = simpleJoinContext(left, right)
+				}
+				Expect(fn).To(PanicWith("left context is nil"))
+			})
+		})
+		When("right context is nil", func() {
+			BeforeEach(func() {
+				right = nil
+			})
+			It("should panic", func() {
+				fn := func() {
+					_ = simpleJoinContext(left, right)
+				}
+				Expect(fn).To(PanicWith("right context is nil"))
+			})
+		})
+		When("value is missing from context", func() {
+			It("should panic", func() {
+				fn := func() {
+					_ = simpleJoinContext(left, right)
+				}
+				Expect(fn).To(PanicWith("value is missing from context"))
+			})
+		})
+		When("the left context has the value", func() {
+			BeforeEach(func() {
+				left = simpleNewContext()
+			})
+			It("should return the left context", func() {
+				ctx := simpleJoinContext(left, right)
+				Expect(ctx).ToNot(BeNil())
+				Expect(simpleValidateContext(ctx)).To(BeTrue())
+				Expect(ctx).To(Equal(left))
+			})
+		})
+		When("the right context has the value", func() {
+			BeforeEach(func() {
+				right = simpleNewContext()
+			})
+			It("should return a new context", func() {
+				ctx := simpleJoinContext(left, right)
+				Expect(ctx).ToNot(BeNil())
+				Expect(simpleValidateContext(ctx)).To(BeTrue())
+			})
+		})
+		When("both contexts have the value", func() {
+			var (
+				v0 simpleContextValueType
+			)
+			BeforeEach(func() {
+				left = simpleNewContext()
+				right = simpleNewContext()
+
+				_ = simpleFromContext(left)
+				v0 = simpleFromContext(right)
+			})
+			It("should return the left context with key/value pairs from the right", func() {
+				ctx := simpleJoinContext(left, right)
+				Expect(ctx).ToNot(BeNil())
+				Expect(simpleValidateContext(ctx)).To(BeTrue())
+				Expect(ctx).To(Equal(left))
+				Expect(simpleFromContext(left)).To(Equal(v0))
+			})
+		})
+	})
+
+	Describe("NewContext", func() {
+		It("should return a valid context", func() {
+			Expect(simpleValidateContext(simpleNewContext())).To(BeTrue())
+		})
+	})
+
+	Describe("WithContext", func() {
+		When("parent is nil", func() {
+			It("should panic", func() {
+				fn := func() {
+					//nolint:staticcheck
+					_ = simpleWithContext(nil)
+				}
+				Expect(fn).To(PanicWith("parent context is nil"))
+			})
+		})
+		When("parent is not nil", func() {
+			It("should return a context", func() {
+				ctx := simpleWithContext(context.Background())
+				Expect(ctx).ToNot(BeNil())
+			})
+		})
+	})
+
+})
+
+type complexContextKeyType uint8
+
+const complexContextKeyValue complexContextKeyType = 0
+
+type complexContextValueType map[uint8]uint8
+
+func complexSetContext(parent context.Context, key, val uint8) {
+	ctxgen.SetContext(
+		parent,
+		complexContextKeyValue,
+		func(curVal complexContextValueType) complexContextValueType {
+			curVal[key] = val
+			return curVal
+		})
+}
+
+func complexFromContext(ctx context.Context, key uint8) uint8 {
+	return ctxgen.FromContext(
+		ctx,
+		complexContextKeyValue,
+		func(val complexContextValueType) uint8 {
+			return val[key]
+		})
+}
+
+func complexWithContext(parent context.Context) context.Context {
+	return ctxgen.WithContext(
+		parent,
+		complexContextKeyValue,
+		func() complexContextValueType { return complexContextValueType{} })
+}
+
+func complexNewContext() context.Context {
+	return ctxgen.NewContext(
+		complexContextKeyValue,
+		func() complexContextValueType { return complexContextValueType{} })
+}
+
+func complexValidateContext(ctx context.Context) bool {
+	return ctxgen.ValidateContext[complexContextValueType](ctx, complexContextKeyValue)
+}
+
+func complexJoinContext(left, right context.Context) context.Context {
+	return ctxgen.JoinContext(
+		left,
+		right,
+		complexContextKeyValue,
+		func(dst, src complexContextValueType) complexContextValueType {
+			maps.Copy(dst, src)
+			return dst
+		})
+}
+
+var _ = Describe("ComplexType", func() {
+	Describe("SetContext", func() {
+		var (
+			ctx context.Context
+			key uint8
+			val uint8
+		)
+		BeforeEach(func() {
+			ctx = context.Background()
+			key = 0
+			val = 1
+		})
+
+		When("ctx is nil", func() {
+			BeforeEach(func() {
+				ctx = nil
+			})
+			It("should panic", func() {
+				fn := func() {
+					complexSetContext(ctx, key, val)
+				}
+				Expect(fn).To(PanicWith("context is nil"))
+			})
+		})
+		When("value is missing from context", func() {
+			It("should panic", func() {
+				fn := func() {
+					complexSetContext(ctx, key, val)
+				}
+				Expect(fn).To(PanicWith("value is missing from context"))
+			})
+		})
+		When("value is present in context", func() {
+			BeforeEach(func() {
+				ctx = complexNewContext()
+				complexSetContext(ctx, key, val)
+			})
+			It("should set value", func() {
+				complexSetContext(ctx, key, val)
+				Expect(complexFromContext(ctx, key)).To(Equal(val))
+			})
+		})
+	})
+
+	Describe("FromContext", func() {
+		var (
+			ctx context.Context
+			key uint8
+			val uint8
+		)
+		BeforeEach(func() {
+			ctx = context.Background()
+			key = 0
+			val = 0
+		})
+
+		When("ctx is nil", func() {
+			BeforeEach(func() {
+				ctx = nil
+			})
+			It("should panic", func() {
+				fn := func() {
+					_ = complexFromContext(ctx, key)
+				}
+				Expect(fn).To(PanicWith("context is nil"))
+			})
+		})
+		When("value is missing from context", func() {
+			It("should panic", func() {
+				fn := func() {
+					_ = complexFromContext(ctx, key)
+				}
+				Expect(fn).To(PanicWith("value is missing from context"))
+			})
+		})
+		When("value is present in context", func() {
+			BeforeEach(func() {
+				ctx = complexNewContext()
+			})
+			It("should return the value", func() {
+				Expect(complexFromContext(ctx, key)).To(Equal(val))
+			})
+		})
+	})
+
+	Describe("ValidateContext", func() {
+		var (
+			ctx context.Context
+		)
+		BeforeEach(func() {
+			ctx = context.Background()
+		})
+		When("ctx is nil", func() {
+			BeforeEach(func() {
+				ctx = nil
+			})
+			It("should panic", func() {
+				fn := func() {
+					_ = complexValidateContext(ctx)
+				}
+				Expect(fn).To(PanicWith("context is nil"))
+			})
+		})
+		When("value is missing from context", func() {
+			It("should return false", func() {
+				Expect(complexValidateContext(ctx)).To(BeFalse())
+			})
+		})
+		When("map is present in context", func() {
+			BeforeEach(func() {
+				ctx = complexNewContext()
+			})
+			It("should return true", func() {
+				Expect(complexValidateContext(ctx)).To(BeTrue())
+			})
+		})
+	})
+
+	Describe("JoinContext", func() {
+		var (
+			left  context.Context
+			right context.Context
+		)
+		BeforeEach(func() {
+			left = context.Background()
+			right = context.Background()
+		})
+		When("left context is nil", func() {
+			BeforeEach(func() {
+				left = nil
+			})
+			It("should panic", func() {
+				fn := func() {
+					_ = complexJoinContext(left, right)
+				}
+				Expect(fn).To(PanicWith("left context is nil"))
+			})
+		})
+		When("right context is nil", func() {
+			BeforeEach(func() {
+				right = nil
+			})
+			It("should panic", func() {
+				fn := func() {
+					_ = complexJoinContext(left, right)
+				}
+				Expect(fn).To(PanicWith("right context is nil"))
+			})
+		})
+		When("value is missing from context", func() {
+			It("should panic", func() {
+				fn := func() {
+					_ = complexJoinContext(left, right)
+				}
+				Expect(fn).To(PanicWith("value is missing from context"))
+			})
+		})
+		When("the left context has the value", func() {
+			BeforeEach(func() {
+				left = complexNewContext()
+			})
+			It("should return the left context", func() {
+				ctx := complexJoinContext(left, right)
+				Expect(ctx).ToNot(BeNil())
+				Expect(complexValidateContext(ctx)).To(BeTrue())
+				Expect(ctx).To(Equal(left))
+			})
+		})
+		When("the right context has the value", func() {
+			BeforeEach(func() {
+				right = complexNewContext()
+			})
+			It("should return a new context", func() {
+				ctx := complexJoinContext(left, right)
+				Expect(ctx).ToNot(BeNil())
+				Expect(complexValidateContext(ctx)).To(BeTrue())
+			})
+		})
+		When("both contexts have the value", func() {
+			var (
+				k0 uint8
+				k1 uint8
+				k2 uint8
+				v0 uint8
+				v1 uint8
+				v2 uint8
+				v3 uint8
+				v4 uint8
+			)
+			BeforeEach(func() {
+				k0 = 0
+				k1 = 1
+				k2 = 2
+				v0 = 0
+				v1 = 1
+				v2 = 2
+				v3 = 3
+				v4 = 4
+
+				left = complexNewContext()
+				right = complexNewContext()
+
+				complexSetContext(left, k0, v0)
+				complexSetContext(left, k1, v1)
+				complexSetContext(left, k2, v2)
+				complexSetContext(right, k0, v3)
+				complexSetContext(right, k1, v4)
+			})
+			It("should return the left context with key/value pairs from the right", func() {
+				ctx := complexJoinContext(left, right)
+				Expect(ctx).ToNot(BeNil())
+				Expect(complexValidateContext(ctx)).To(BeTrue())
+				Expect(ctx).To(Equal(left))
+				Expect(complexFromContext(left, k0)).To(Equal(v3))
+				Expect(complexFromContext(left, k1)).To(Equal(v4))
+				Expect(complexFromContext(left, k2)).To(Equal(v2))
+			})
+		})
+	})
+
+	Describe("NewContext", func() {
+		It("should return a valid context", func() {
+			Expect(complexValidateContext(complexNewContext())).To(BeTrue())
+		})
+	})
+
+	Describe("WithContext", func() {
+		When("parent is nil", func() {
+			It("should panic", func() {
+				fn := func() {
+					//nolint:staticcheck
+					_ = complexWithContext(nil)
+				}
+				Expect(fn).To(PanicWith("parent context is nil"))
+			})
+		})
+		When("parent is not nil", func() {
+			It("should return a context", func() {
+				ctx := complexWithContext(context.Background())
+				Expect(ctx).ToNot(BeNil())
+			})
+		})
+	})
+})

--- a/pkg/context/generic/generic_suite_test.go
+++ b/pkg/context/generic/generic_suite_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package cource_test
+package generic_test
 
 import (
 	"testing"
@@ -20,5 +20,5 @@ func init() {
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Cource Util Test Suite")
+	RunSpecs(t, "Generic Context Test Suite")
 }

--- a/pkg/context/operation/operation_context.go
+++ b/pkg/context/operation/operation_context.go
@@ -5,25 +5,21 @@ package operation
 
 import (
 	"context"
-	"sync"
+
+	ctxgen "github.com/vmware-tanzu/vm-operator/pkg/context/generic"
 )
 
 type contextKeyType uint8
 
 const contextKeyValue contextKeyType = 0
 
-type operationType uint8
+type contextValueType uint8
 
 const (
-	none operationType = iota
+	none contextValueType = iota
 	create
 	update
 )
-
-type operation struct {
-	sync.RWMutex
-	typ3 operationType
-}
 
 // IsCreate returns whether or not this is a create operation.
 func IsCreate(ctx context.Context) bool {
@@ -46,73 +42,47 @@ func MarkUpdate(ctx context.Context) {
 	setType(ctx, update)
 }
 
-func fromContext(ctx context.Context) operationType {
-	if ctx == nil {
-		panic("context is nil")
-	}
-	obj := ctx.Value(contextKeyValue)
-	if obj == nil {
-		panic("operation is missing from context")
-	}
-	data := obj.(*operation)
-	data.RLock()
-	defer data.RUnlock()
-	return data.typ3
+func fromContext(ctx context.Context) contextValueType {
+	return ctxgen.FromContext[contextValueType](
+		ctx,
+		contextKeyValue,
+		func(val contextValueType) contextValueType {
+			return val
+		})
 }
 
-func setType(ctx context.Context, r operationType) {
-	if ctx == nil {
-		panic("context is nil")
-	}
-	obj := ctx.Value(contextKeyValue)
-	if obj == nil {
-		panic("operation is missing from context")
-	}
-	data := obj.(*operation)
-	data.Lock()
-	defer data.Unlock()
-
-	if data.typ3 != create {
-		data.typ3 = r
-	}
+func setType(ctx context.Context, newVal contextValueType) {
+	ctxgen.SetContext(
+		ctx,
+		contextKeyValue,
+		func(curVal contextValueType) contextValueType {
+			if curVal == create {
+				return curVal
+			}
+			return newVal
+		})
 }
 
 // WithContext returns a new operation context.
 func WithContext(parent context.Context) context.Context {
-	if parent == nil {
-		panic("parent context is nil")
-	}
-	return context.WithValue(
+	return ctxgen.WithContext(
 		parent,
 		contextKeyValue,
-		&operation{})
+		func() contextValueType { return none })
 }
 
 // JoinContext returns a new context that contains the operation from the right
 // or left side of the context, with the right taking precedence.
 // This function is thread-safe.
 func JoinContext(left, right context.Context) context.Context {
-	if left == nil {
-		panic("left context is nil")
-	}
-	if right == nil {
-		panic("right context is nil")
-	}
-
-	leftObj := left.Value(contextKeyValue)
-	rightObj := right.Value(contextKeyValue)
-
-	if leftObj == nil && rightObj == nil {
-		panic("operation is missing from context")
-	}
-
-	if leftObj != nil && rightObj == nil {
-		// The left context has the operation and the right does not, so just
-		// return the left context.
-		return left
-	}
-
-	// The right context has the operation, so return a new context with the
-	// operation in it.
-	return context.WithValue(left, contextKeyValue, rightObj.(*operation))
+	return ctxgen.JoinContext(
+		left,
+		right,
+		contextKeyValue,
+		func(dst, src contextValueType) contextValueType {
+			if dst == create {
+				return dst
+			}
+			return src
+		})
 }

--- a/pkg/context/operation/operation_context_test.go
+++ b/pkg/context/operation/operation_context_test.go
@@ -30,12 +30,12 @@ var _ = Describe("IsCreate", func() {
 			Expect(fn).To(PanicWith("context is nil"))
 		})
 	})
-	When("operation is missing from context", func() {
+	When("value is missing from context", func() {
 		It("should panic", func() {
 			fn := func() {
 				_ = ctxop.IsCreate(ctx)
 			}
-			Expect(fn).To(PanicWith("operation is missing from context"))
+			Expect(fn).To(PanicWith("value is missing from context"))
 		})
 	})
 	When("operation is present in context", func() {
@@ -66,12 +66,12 @@ var _ = Describe("IsUpdate", func() {
 			Expect(fn).To(PanicWith("context is nil"))
 		})
 	})
-	When("operation is missing from context", func() {
+	When("value is missing from context", func() {
 		It("should panic", func() {
 			fn := func() {
 				_ = ctxop.IsUpdate(ctx)
 			}
-			Expect(fn).To(PanicWith("operation is missing from context"))
+			Expect(fn).To(PanicWith("value is missing from context"))
 		})
 	})
 	When("operation is present in context", func() {
@@ -102,12 +102,12 @@ var _ = Describe("MarkCreate", func() {
 			Expect(fn).To(PanicWith("context is nil"))
 		})
 	})
-	When("operation is missing from context", func() {
+	When("value is missing from context", func() {
 		It("should panic", func() {
 			fn := func() {
 				ctxop.MarkCreate(ctx)
 			}
-			Expect(fn).To(PanicWith("operation is missing from context"))
+			Expect(fn).To(PanicWith("value is missing from context"))
 		})
 	})
 	When("operation is present in context", func() {
@@ -153,12 +153,12 @@ var _ = Describe("MarkUpdate", func() {
 			Expect(fn).To(PanicWith("context is nil"))
 		})
 	})
-	When("operation is missing from context", func() {
+	When("value is missing from context", func() {
 		It("should panic", func() {
 			fn := func() {
 				ctxop.MarkUpdate(ctx)
 			}
-			Expect(fn).To(PanicWith("operation is missing from context"))
+			Expect(fn).To(PanicWith("value is missing from context"))
 		})
 	})
 	When("operation is present in context", func() {
@@ -217,12 +217,12 @@ var _ = Describe("JoinContext", func() {
 			Expect(fn).To(PanicWith("right context is nil"))
 		})
 	})
-	When("operation is missing from context", func() {
+	When("value is missing from context", func() {
 		It("should panic", func() {
 			fn := func() {
 				_ = ctxop.JoinContext(left, right)
 			}
-			Expect(fn).To(PanicWith("operation is missing from context"))
+			Expect(fn).To(PanicWith("value is missing from context"))
 		})
 	})
 	When("the left context has a operation", func() {
@@ -252,12 +252,28 @@ var _ = Describe("JoinContext", func() {
 		BeforeEach(func() {
 			left = ctxop.WithContext(context.Background())
 			right = ctxop.WithContext(context.Background())
-			ctxop.MarkUpdate(right)
 		})
-		It("should return the left context with operation from the right", func() {
-			ctx := ctxop.JoinContext(left, right)
-			Expect(ctx).ToNot(BeNil())
-			Expect(ctxop.IsUpdate(ctx)).To(BeTrue())
+		When("the left operation is create and the right operation is update", func() {
+			BeforeEach(func() {
+				ctxop.MarkCreate(left)
+				ctxop.MarkUpdate(right)
+			})
+			It("should return the left context with operation from the left", func() {
+				ctx := ctxop.JoinContext(left, right)
+				Expect(ctx).ToNot(BeNil())
+				Expect(ctxop.IsCreate(ctx)).To(BeTrue())
+			})
+		})
+		When("the left operation is update and the right operation is create", func() {
+			BeforeEach(func() {
+				ctxop.MarkUpdate(left)
+				ctxop.MarkCreate(right)
+			})
+			It("should return the left context with operation from the right", func() {
+				ctx := ctxop.JoinContext(left, right)
+				Expect(ctx).ToNot(BeNil())
+				Expect(ctxop.IsCreate(ctx)).To(BeTrue())
+			})
 		})
 	})
 })

--- a/pkg/context/operation/operation_suite_test.go
+++ b/pkg/context/operation/operation_suite_test.go
@@ -18,7 +18,7 @@ func init() {
 	logf.SetLogger(klog.Background())
 }
 
-func TestKube(t *testing.T) {
+func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Operation Context Test Suite")
 }

--- a/pkg/providers/vsphere/virtualmachine/backup.go
+++ b/pkg/providers/vsphere/virtualmachine/backup.go
@@ -4,7 +4,6 @@
 package virtualmachine
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"maps"
@@ -207,7 +206,7 @@ func BackupVirtualMachine(opts BackupVirtualMachineOptions) (result error) {
 		// This ensures that the reconfigure done for storing the backup data
 		// does not indicate an update operation was triggered. While this does
 		// reconfigure the VM, it is not what "update" means to a user.
-		ctx := ctxop.JoinContext(opts.VMCtx, ctxop.WithContext(context.TODO()))
+		ctx := ctxop.WithContext(opts.VMCtx)
 
 		if _, err := resVM.Reconfigure(ctx, configSpec); err != nil {
 			opts.VMCtx.Logger.Error(err, "failed to update VM ExtraConfig with latest backup data")

--- a/pkg/util/kube/cource/cource_context_test.go
+++ b/pkg/util/kube/cource/cource_context_test.go
@@ -33,12 +33,12 @@ var _ = Describe("FromContext", func() {
 			Expect(fn).To(PanicWith("context is nil"))
 		})
 	})
-	When("map is missing from context", func() {
+	When("value is missing from context", func() {
 		It("should panic", func() {
 			fn := func() {
 				_ = cource.FromContext(ctx, key)
 			}
-			Expect(fn).To(PanicWith("map is missing from context"))
+			Expect(fn).To(PanicWith("value is missing from context"))
 		})
 	})
 	When("map is present in context", func() {
@@ -69,7 +69,7 @@ var _ = Describe("ValidateContext", func() {
 			Expect(fn).To(PanicWith("context is nil"))
 		})
 	})
-	When("map is missing from context", func() {
+	When("value is missing from context", func() {
 		It("should return false", func() {
 			Expect(cource.ValidateContext(ctx)).To(BeFalse())
 		})
@@ -115,12 +115,12 @@ var _ = Describe("JoinContext", func() {
 			Expect(fn).To(PanicWith("right context is nil"))
 		})
 	})
-	When("map is missing from context", func() {
+	When("value is missing from context", func() {
 		It("should panic", func() {
 			fn := func() {
 				_ = cource.JoinContext(left, right)
 			}
-			Expect(fn).To(PanicWith("map is missing from context"))
+			Expect(fn).To(PanicWith("value is missing from context"))
 		})
 	})
 	When("the left context has the map", func() {


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch introduces a generic context that may be used to quickly create context implementations that can share information up and down the call stack. The `cource` and `operation` contexts have been refactored to use the new generic context.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```