### PR TITLE
🌱 Drop managedFields and last-applied-config annotation from backup

### DIFF
--- a/pkg/providers/vsphere/virtualmachine/backup.go
+++ b/pkg/providers/vsphere/virtualmachine/backup.go
@@ -169,6 +169,7 @@ func BackupVirtualMachine(opts BackupVirtualMachineOptions) (result error) {
 			copyVM := opts.VMCtx.VM.DeepCopy()
 			setBackupVersionAnnotation(copyVM, opts.BackupVersion)
 			// Backup the updated VM's YAML with encoding and compression.
+			trimBackupFields(copyVM)
 			encodedVMYaml, err := getEncodedVMYaml(copyVM)
 			if err != nil {
 				opts.VMCtx.Logger.Error(err, "failed to get VM resource yaml for backup")
@@ -271,12 +272,26 @@ func getDesiredVMResourceYAMLForBackup(
 		return "", err
 	}
 
+	// Use a copy to avoid modifying the VM object at the end of reconciliation.
+	copyVM := vm.DeepCopy()
+	trimBackupFields(copyVM)
+
 	// Backup the updated VM's YAML with encoding and compression.
-	return getEncodedVMYaml(vm)
+	return getEncodedVMYaml(copyVM)
 }
 
+// trimBackupFields removes the object fields that are not necessary for backup.
+func trimBackupFields(obj client.Object) {
+	if annotations := obj.GetAnnotations(); len(annotations) > 0 {
+		delete(annotations, corev1.LastAppliedConfigAnnotation)
+		obj.SetAnnotations(annotations)
+	}
+
+	obj.SetManagedFields(nil)
+}
+
+// getEncodedVMYaml returns the encoded and gzipped YAML of the given VM object.
 func getEncodedVMYaml(vm *vmopv1.VirtualMachine) (string, error) {
-	// Backup the updated VM's YAML with encoding and compression.
 	vmYAML, err := k8syaml.Marshal(vm)
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal VM into YAML %+v: %v", vm, err)
@@ -304,9 +319,13 @@ func isVMBackupUpToDate(vm *vmopv1.VirtualMachine, backup string) (bool, error) 
 		return false, err
 	}
 
+	// Do not compare LastAppliedConfigAnnotation as it's not in the backup.
+	curAnnotations := maps.Clone(vm.Annotations)
+	delete(curAnnotations, corev1.LastAppliedConfigAnnotation)
+
 	return vm.Generation == backupVM.Generation &&
 		maps.Equal(vm.Labels, backupVM.Labels) &&
-		maps.Equal(vm.Annotations, backupVM.Annotations), nil
+		maps.Equal(curAnnotations, backupVM.Annotations), nil
 }
 
 // getDesiredAdditionalResourceYAMLForBackup returns the encoded and gzipped
@@ -339,6 +358,7 @@ func getDesiredAdditionalResourceYAMLForBackup(
 	// Use "---" as the separator if more than one resource is passed.
 	var sb strings.Builder
 	for i, resource := range resources {
+		trimBackupFields(resource)
 		marshaledYaml, err := k8syaml.Marshal(resource)
 		if err != nil {
 			return "", fmt.Errorf("failed to marshal object %q: %v", resource.GetName(), err)


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Persisting last-applied-config annotation and managed fields could doubles the size of the strings we are handling during backup.  Drop those when recording backup.

**Which issue(s) is/are addressed by this PR?**

Fixes N/A.

**Are there any special notes for your reviewer**:

- Updated unit tests to reflect this change and also verified backup data in an internal testbed:

```console
# Deployed a VM with last-applied annotation and managed fields:
$ kubectl get vm -n sdiliyaer-test test-vm -o yaml --show-managed-fields
apiVersion: vmoperator.vmware.com/v1alpha3
kind: VirtualMachine
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"vmoperator.vmware.com/v1alpha1","kind":"VirtualMachine","metadata":{"name":"test-vm","namespace":"sdiliyaer-test"},"spec":{"className":"best-effort-small","imageName":"ubuntu-impish-21.10-cloudimg","powerState":"poweredOn","storageClass":"wcpglobal-storage-profile","vmMetadata":{"secretName":"test-bootstrap-data","transport":"CloudInit"}}}
  managedFields:
  - apiVersion: vmoperator.vmware.com/v1alpha1
    fieldsType: FieldsV1
    fieldsV1:
...

# Confirmed neither last-applied annotation nor managed fields in the VM YAML backup:
$ govc vm.info -e 'test-vm' | grep vmservice.virtualmachine.resource.yaml | awk '{print $2}' | base64 -d | gunzip | yq eval '.metadata | keys' -
- annotations
- creationTimestamp
- finalizers
- generation
- labels
- name
- namespace
- resourceVersion
- uid

$ govc vm.info -e 'test-vm' | grep vmservice.virtualmachine.resource.yaml | awk '{print $2}' | base64 -d | gunzip | yq eval '.metadata.annotations | keys' -
- virtualmachine.vmoperator.vmware.com/first-boot-done
- vmoperator.vmware.com/created-at-build-version
- vmoperator.vmware.com/created-at-schema-version
- vmoperator.vmware.com/manager-id
```

- Verified the same result for additional bootstrap resources and incremental backups as well.

**Please add a release note if necessary**:

```release-note
Drop managedFields and last-applied-config from backup.
```