### PR TITLE
🌱 Change Backup version to use UnixMilli()

### DIFF
--- a/pkg/providers/vsphere/vmprovider_vm.go
+++ b/pkg/providers/vsphere/vmprovider_vm.go
@@ -553,7 +553,7 @@ func (vs *vSphereVMProvider) updateVirtualMachine(
 			VcVM:                vcVM,
 			DiskUUIDToPVC:       diskUUIDToPVC,
 			AdditionalResources: additionalResources,
-			BackupVersion:       fmt.Sprint(time.Now().Unix()),
+			BackupVersion:       fmt.Sprint(time.Now().UnixMilli()),
 			ClassicDiskUUIDs:    GetAttachedClassicDiskUUIDs(vmCtx),
 		}
 		if err := virtualmachine.BackupVirtualMachine(backupOpts); err != nil {


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This change fixes the backup version to use time in milliseconds since a backup can happen within the same second.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # N/A


**Are there any special notes for your reviewer**:
N/A

**Please add a release note if necessary**:

```
NONE
```