### PR TITLE
Allow imageless VM creation when Incremental Restore FSS is enabled

### DIFF
--- a/webhooks/virtualmachine/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator.go
@@ -360,8 +360,10 @@ func (v validator) validateImageOnCreate(ctx *pkgctx.WebhookRequestContext, vm *
 	)
 
 	switch {
+	// Imageless VMs are only allowed if the Mobility Import VM, or the Incremental restore FSS is supported.
 	case vmopv1util.IsImagelessVM(*vm) &&
-		pkgcfg.FromContext(ctx).Features.VMImportNewNet:
+		(pkgcfg.FromContext(ctx).Features.VMImportNewNet ||
+			pkgcfg.FromContext(ctx).Features.VMIncrementalRestore):
 
 		// Restrict creating imageless VM resources to privileged users.
 		if !ctx.IsPrivilegedAccount {


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Currently, we allow imageless VM creation when importing a VM is supported.  However, after a VM is restored by a VADP based vendor or a DR solution, the destination vCenter and Supervisor might not be the same as the primary.  As such, any references to images might be stale.

This change modifies the existing code to allow imageless VMs if the VM operator supports restoring into existing VMs.


**Please add a release note if necessary**:

```release-note
Allow imageless VM creation when Incremental Restore FSS is enabled
```