### PR TITLE
🌱 Add image type label in VMI and CVMI objects

### DIFF
--- a/api/v1alpha3/virtualmachineimage_types.go
+++ b/api/v1alpha3/virtualmachineimage_types.go
@@ -33,6 +33,12 @@ const (
 )
 
 const (
+	// VirtualMachineImageTypeLabel is the label key for the type of the image
+	// (e.g. OVF, ISO, etc.).
+	VirtualMachineImageTypeLabel = "image." + GroupName + "/type"
+)
+
+const (
 	// VMIContentLibRefAnnotation is the key for the annotation that stores the content library
 	// reference for VMI and CVMI down conversion.
 	VMIContentLibRefAnnotation = "vmoperator.vmware.com/conversion-content-lib-ref"

--- a/controllers/contentlibrary/clustercontentlibraryitem/clustercontentlibraryitem_controller.go
+++ b/controllers/contentlibrary/clustercontentlibraryitem/clustercontentlibraryitem_controller.go
@@ -329,9 +329,9 @@ func (r *Reconciler) syncImageContent(ctx *pkgctx.ClusterContentLibraryItemConte
 		cvmi.Status.ProviderContentVersion = latestVersion
 	}
 
-	// Sync the image's OS information and capabilities to the resource's labels
-	// to make it easier for clients to search for images based on OS info and
-	// image capabilities.
+	// Sync the image's type, OS information and capabilities to the resource's
+	// labels to make it easier for clients to search for images based on type,
+	// OS info or image capabilities.
 	imgutil.SyncStatusToLabels(cvmi, cvmi.Status)
 
 	r.Recorder.EmitEvent(cvmi, "Update", err, false)

--- a/controllers/contentlibrary/contentlibraryitem/contentlibraryitem_controller.go
+++ b/controllers/contentlibrary/contentlibraryitem/contentlibraryitem_controller.go
@@ -297,9 +297,9 @@ func (r *Reconciler) syncImageContent(ctx *pkgctx.ContentLibraryItemContext) err
 		vmi.Status.ProviderContentVersion = latestVersion
 	}
 
-	// Sync the image's OS information and capabilities to the resource's labels
-	// to make it easier for clients to search for images based on OS info and
-	// image capabilities.
+	// Sync the image's type, OS information and capabilities to the resource's
+	// labels to make it easier for clients to search for images based on type,
+	// OS info or image capabilities.
 	imgutil.SyncStatusToLabels(vmi, vmi.Status)
 
 	r.Recorder.EmitEvent(vmi, "Update", err, false)

--- a/controllers/contentlibrary/utils/utils.go
+++ b/controllers/contentlibrary/utils/utils.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2022-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package utils
@@ -13,7 +13,7 @@ import (
 
 	imgregv1a1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha1"
 
-	"github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 )
 
 // GetImageFieldNameFromItem returns the Image field name in format of "vmi-<uuid>"
@@ -65,7 +65,7 @@ func AddContentLibraryRefToAnnotation(to client.Object, ref *imgregv1a1.NameAndK
 	if annotations == nil {
 		annotations = map[string]string{}
 	}
-	annotations[v1alpha2.VMIContentLibRefAnnotation] = string(data)
+	annotations[vmopv1.VMIContentLibRefAnnotation] = string(data)
 	to.SetAnnotations(annotations)
 
 	return nil

--- a/pkg/util/image/status_to_label_test.go
+++ b/pkg/util/image/status_to_label_test.go
@@ -29,136 +29,125 @@ var _ = Describe("SyncStatusToLabels", func() {
 		imgutil.SyncStatusToLabels(obj, status)
 	})
 
-	When("the status does not have any info", func() {
-		It("should not set any labels", func() {
-			Expect(obj.GetLabels()).To(BeNil())
-		})
-	})
+	Context("VMI doesn't have any labels set from status", func() {
 
-	When("the status has the OS ID", func() {
-		BeforeEach(func() {
-			status.OSInfo.ID = "photon64"
-		})
-		It("should have the OS ID label", func() {
-			Expect(obj.GetLabels()).To(HaveLen(1))
-			Expect(obj.GetLabels()).To(HaveKeyWithValue(
-				vmopv1.VirtualMachineImageOSIDLabel,
-				status.OSInfo.ID))
-		})
-	})
-
-	When("the status has the OS ID that is not valid label value", func() {
-		BeforeEach(func() {
-			status.OSInfo.ID = "-100"
-		})
-		It("should not have the OS ID", func() {
-			Expect(obj.GetLabels()).To(BeEmpty())
-		})
-	})
-
-	When("the status has the OS type", func() {
-		BeforeEach(func() {
-			status.OSInfo.Type = "linux"
-		})
-		It("should have the OS type label", func() {
-			Expect(obj.GetLabels()).To(HaveLen(1))
-			Expect(obj.GetLabels()).To(HaveKeyWithValue(
-				vmopv1.VirtualMachineImageOSTypeLabel,
-				status.OSInfo.Type))
-		})
-	})
-
-	When("the status has the OS type that is not valid label value", func() {
-		BeforeEach(func() {
-			status.OSInfo.Type = "linux!"
-		})
-		It("should not have the OS type label", func() {
-			Expect(obj.GetLabels()).To(BeEmpty())
-		})
-	})
-
-	When("the status has the OS version", func() {
-		BeforeEach(func() {
-			status.OSInfo.Version = "5"
-		})
-		It("should have the OS version label", func() {
-			Expect(obj.GetLabels()).To(HaveLen(1))
-			Expect(obj.GetLabels()).To(HaveKeyWithValue(
-				vmopv1.VirtualMachineImageOSVersionLabel,
-				status.OSInfo.Version))
-		})
-	})
-
-	When("the status has the OS version that is not valid label value", func() {
-		BeforeEach(func() {
-			status.OSInfo.Version = "5."
-		})
-		It("should not have the OS version label", func() {
-			Expect(obj.GetLabels()).To(BeEmpty())
-		})
-	})
-
-	When("the status has two capabilities", func() {
-		BeforeEach(func() {
-			status.Capabilities = []string{"cloud-init", "nvidia-vgpu"}
-		})
-		It("should have the capability labels", func() {
-			Expect(obj.GetLabels()).To(HaveLen(2))
-			Expect(obj.GetLabels()).To(HaveKeyWithValue(
-				vmopv1.VirtualMachineImageCapabilityLabel+"cloud-init",
-				"true"))
-			Expect(obj.GetLabels()).To(HaveKeyWithValue(
-				vmopv1.VirtualMachineImageCapabilityLabel+"nvidia-vgpu",
-				"true"))
-		})
-	})
-
-	When("the status has an invalid capabilities label key", func() {
-		BeforeEach(func() {
-			status.Capabilities = []string{"cloud-init!", "nvidia-vgpu"}
-		})
-		It("should have just the valid capability label key", func() {
-			Expect(obj.GetLabels()).To(HaveLen(1))
-			Expect(obj.GetLabels()).To(HaveKeyWithValue(
-				vmopv1.VirtualMachineImageCapabilityLabel+"nvidia-vgpu",
-				"true"))
-		})
-	})
-
-	When("the status has OS info and capabilities", func() {
-		BeforeEach(func() {
-			status.OSInfo.ID = "photon64"
-			status.OSInfo.Type = "linux"
-			status.OSInfo.Version = "5"
-			status.Capabilities = []string{"cloud-init", "nvidia-vgpu"}
-		})
-		It("should have the capability labels", func() {
-			Expect(obj.GetLabels()).To(HaveLen(5))
-			Expect(obj.GetLabels()).To(HaveKeyWithValue(
-				vmopv1.VirtualMachineImageOSIDLabel,
-				status.OSInfo.ID))
-			Expect(obj.GetLabels()).To(HaveKeyWithValue(
-				vmopv1.VirtualMachineImageOSTypeLabel,
-				status.OSInfo.Type))
-			Expect(obj.GetLabels()).To(HaveKeyWithValue(
-				vmopv1.VirtualMachineImageOSVersionLabel,
-				status.OSInfo.Version))
-			Expect(obj.GetLabels()).To(HaveKeyWithValue(
-				vmopv1.VirtualMachineImageCapabilityLabel+"cloud-init",
-				"true"))
-			Expect(obj.GetLabels()).To(HaveKeyWithValue(
-				vmopv1.VirtualMachineImageCapabilityLabel+"nvidia-vgpu",
-				"true"))
-		})
-
-		When("the object already has labels", func() {
-			BeforeEach(func() {
-				obj.SetLabels(map[string]string{"hello": "world", "fu": "bar"})
+		When("the status does not have any info", func() {
+			It("should not set any labels", func() {
+				Expect(obj.GetLabels()).To(BeEmpty())
 			})
-			It("should not remove the existing labels", func() {
-				Expect(obj.GetLabels()).To(HaveLen(7))
-				Expect(obj.GetLabels()).To(HaveKeyWithValue("hello", "world"))
-				Expect(obj.GetLabels()).To(HaveKeyWithValue("fu", "bar"))
+		})
+
+		When("the status has the image type", func() {
+			BeforeEach(func() {
+				status.Type = "ISO"
+			})
+			It("should have the image type label", func() {
+				Expect(obj.GetLabels()).To(HaveLen(1))
+				Expect(obj.GetLabels()).To(HaveKeyWithValue(
+					vmopv1.VirtualMachineImageTypeLabel,
+					status.Type))
+			})
+		})
+
+		When("the status has the OS ID", func() {
+			BeforeEach(func() {
+				status.OSInfo.ID = "photon64"
+			})
+			It("should have the OS ID label", func() {
+				Expect(obj.GetLabels()).To(HaveLen(1))
+				Expect(obj.GetLabels()).To(HaveKeyWithValue(
+					vmopv1.VirtualMachineImageOSIDLabel,
+					status.OSInfo.ID))
+			})
+		})
+
+		When("the status has the OS ID that is not valid label value", func() {
+			BeforeEach(func() {
+				status.OSInfo.ID = "-100"
+			})
+			It("should not have the OS ID", func() {
+				Expect(obj.GetLabels()).To(BeEmpty())
+			})
+		})
+
+		When("the status has the OS type", func() {
+			BeforeEach(func() {
+				status.OSInfo.Type = "linux"
+			})
+			It("should have the OS type label", func() {
+				Expect(obj.GetLabels()).To(HaveLen(1))
+				Expect(obj.GetLabels()).To(HaveKeyWithValue(
+					vmopv1.VirtualMachineImageOSTypeLabel,
+					status.OSInfo.Type))
+			})
+		})
+
+		When("the status has the OS type that is not valid label value", func() {
+			BeforeEach(func() {
+				status.OSInfo.Type = "linux!"
+			})
+			It("should not have the OS type label", func() {
+				Expect(obj.GetLabels()).To(BeEmpty())
+			})
+		})
+
+		When("the status has the OS version", func() {
+			BeforeEach(func() {
+				status.OSInfo.Version = "5"
+			})
+			It("should have the OS version label", func() {
+				Expect(obj.GetLabels()).To(HaveLen(1))
+				Expect(obj.GetLabels()).To(HaveKeyWithValue(
+					vmopv1.VirtualMachineImageOSVersionLabel,
+					status.OSInfo.Version))
+			})
+		})
+
+		When("the status has the OS version that is not valid label value", func() {
+			BeforeEach(func() {
+				status.OSInfo.Version = "5."
+			})
+			It("should not have the OS version label", func() {
+				Expect(obj.GetLabels()).To(BeEmpty())
+			})
+		})
+
+		When("the status has two capabilities", func() {
+			BeforeEach(func() {
+				status.Capabilities = []string{"cloud-init", "nvidia-vgpu"}
+			})
+			It("should have the capability labels", func() {
+				Expect(obj.GetLabels()).To(HaveLen(2))
+				Expect(obj.GetLabels()).To(HaveKeyWithValue(
+					vmopv1.VirtualMachineImageCapabilityLabel+"cloud-init",
+					"true"))
+				Expect(obj.GetLabels()).To(HaveKeyWithValue(
+					vmopv1.VirtualMachineImageCapabilityLabel+"nvidia-vgpu",
+					"true"))
+			})
+		})
+
+		When("the status has an invalid capabilities label key", func() {
+			BeforeEach(func() {
+				status.Capabilities = []string{"cloud-init!", "nvidia-vgpu"}
+			})
+			It("should have just the valid capability label key", func() {
+				Expect(obj.GetLabels()).To(HaveLen(1))
+				Expect(obj.GetLabels()).To(HaveKeyWithValue(
+					vmopv1.VirtualMachineImageCapabilityLabel+"nvidia-vgpu",
+					"true"))
+			})
+		})
+
+		When("the status has OS info and capabilities", func() {
+			BeforeEach(func() {
+				status.OSInfo.ID = "photon64"
+				status.OSInfo.Type = "linux"
+				status.OSInfo.Version = "5"
+				status.Capabilities = []string{"cloud-init", "nvidia-vgpu"}
+			})
+			It("should have the capability labels", func() {
+				Expect(obj.GetLabels()).To(HaveLen(5))
 				Expect(obj.GetLabels()).To(HaveKeyWithValue(
 					vmopv1.VirtualMachineImageOSIDLabel,
 					status.OSInfo.ID))
@@ -175,7 +164,101 @@ var _ = Describe("SyncStatusToLabels", func() {
 					vmopv1.VirtualMachineImageCapabilityLabel+"nvidia-vgpu",
 					"true"))
 			})
+
+			When("the object already has other labels", func() {
+				BeforeEach(func() {
+					obj.SetLabels(map[string]string{"hello": "world", "fu": "bar"})
+				})
+				It("should not remove the existing labels", func() {
+					Expect(obj.GetLabels()).To(HaveLen(7))
+					Expect(obj.GetLabels()).To(HaveKeyWithValue("hello", "world"))
+					Expect(obj.GetLabels()).To(HaveKeyWithValue("fu", "bar"))
+					Expect(obj.GetLabels()).To(HaveKeyWithValue(
+						vmopv1.VirtualMachineImageOSIDLabel,
+						status.OSInfo.ID))
+					Expect(obj.GetLabels()).To(HaveKeyWithValue(
+						vmopv1.VirtualMachineImageOSTypeLabel,
+						status.OSInfo.Type))
+					Expect(obj.GetLabels()).To(HaveKeyWithValue(
+						vmopv1.VirtualMachineImageOSVersionLabel,
+						status.OSInfo.Version))
+					Expect(obj.GetLabels()).To(HaveKeyWithValue(
+						vmopv1.VirtualMachineImageCapabilityLabel+"cloud-init",
+						"true"))
+					Expect(obj.GetLabels()).To(HaveKeyWithValue(
+						vmopv1.VirtualMachineImageCapabilityLabel+"nvidia-vgpu",
+						"true"))
+				})
+			})
 		})
 	})
 
+	Context("VMI already has labels set from status", func() {
+		BeforeEach(func() {
+			obj.SetLabels(map[string]string{
+				// Image status related labels.
+				vmopv1.VirtualMachineImageTypeLabel:                      "ISO",
+				vmopv1.VirtualMachineImageOSIDLabel:                      "photon64",
+				vmopv1.VirtualMachineImageOSTypeLabel:                    "linux",
+				vmopv1.VirtualMachineImageOSVersionLabel:                 "5",
+				vmopv1.VirtualMachineImageCapabilityLabel + "cloud-init": "true",
+				// Other labels.
+				"hello": "world",
+				"fu":    "bar",
+			})
+		})
+
+		When("the status does not have any info", func() {
+			It("should remove only image status related labels", func() {
+				Expect(obj.GetLabels()).To(HaveLen(2))
+				Expect(obj.GetLabels()).To(HaveKeyWithValue("hello", "world"))
+				Expect(obj.GetLabels()).To(HaveKeyWithValue("fu", "bar"))
+			})
+		})
+
+		When("the status has invalid updates", func() {
+			BeforeEach(func() {
+				status.Type = "ISO!"
+				status.OSInfo.ID = "photon64!"
+				status.OSInfo.Type = "linux!"
+				status.OSInfo.Version = "5."
+				status.Capabilities = []string{"cloud-init!"}
+			})
+			It("should remove only image status related labels", func() {
+				Expect(obj.GetLabels()).To(HaveLen(2))
+				Expect(obj.GetLabels()).To(HaveKeyWithValue("hello", "world"))
+				Expect(obj.GetLabels()).To(HaveKeyWithValue("fu", "bar"))
+			})
+		})
+
+		When("the status has valid updates", func() {
+			BeforeEach(func() {
+				status.Type = "OVF"
+				status.OSInfo.ID = "windows64"
+				status.OSInfo.Type = "windows"
+				status.OSInfo.Version = "6"
+				status.Capabilities = []string{"cloudbase-init"}
+			})
+			It("should update only image status related labels", func() {
+				Expect(obj.GetLabels()).To(HaveLen(7))
+				Expect(obj.GetLabels()).To(HaveKeyWithValue(
+					vmopv1.VirtualMachineImageTypeLabel,
+					status.Type))
+				Expect(obj.GetLabels()).To(HaveKeyWithValue(
+					vmopv1.VirtualMachineImageOSIDLabel,
+					status.OSInfo.ID))
+				Expect(obj.GetLabels()).To(HaveKeyWithValue(
+					vmopv1.VirtualMachineImageOSTypeLabel,
+					status.OSInfo.Type))
+				Expect(obj.GetLabels()).To(HaveKeyWithValue(
+					vmopv1.VirtualMachineImageOSVersionLabel,
+					status.OSInfo.Version))
+				Expect(obj.GetLabels()).To(HaveKeyWithValue(
+					vmopv1.VirtualMachineImageCapabilityLabel+"cloudbase-init",
+					"true"))
+				Expect(obj.GetLabels()).To(HaveKeyWithValue("hello", "world"))
+				Expect(obj.GetLabels()).To(HaveKeyWithValue("fu", "bar"))
+			})
+		})
+	})
 })


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR adds image type info as labels to VMI & CVMI objects so that they can be filtered by label selector from the client side. It also updates the `SyncStatusToLabels` function to remove any labels if the values from image status is empty or invalid.

**Which issue(s) is/are addressed by this PR?**:

Fixes N/A.

**Are there any special notes for your reviewer**:

- Added tests to maintain 100% coverage:

```console
ok  	github.com/vmware-tanzu/vm-operator/pkg/util/image	0.481s	coverage: 100.0% of statements
```
 
- Deployed the change to an internal testbed and verified expected labels in both VMI and CVMI objects:

```console
$ kubectl get cvmi -o json | jq '.items[] | {"image.vmoperator.vmware.com/type": .metadata.labels["image.vmoperator.vmware.com/type"], ".status.type": .status.type}'
{
  "image.vmoperator.vmware.com/type": "ISO",
  ".status.type": "ISO"
}
{
  "image.vmoperator.vmware.com/type": "OVF",
  ".status.type": "OVF"
}

$ kubectl get vmi -n sdiliyaer-test -o json | jq '.items[] | {"image.vmoperator.vmware.com/type": .metadata.labels["image.vmoperator.vmware.com/type"], ".status.type": .status.type}'
{
  "image.vmoperator.vmware.com/type": "OVF",
  ".status.type": "OVF"
}
{
  "image.vmoperator.vmware.com/type": "ISO",
  ".status.type": "ISO"
}
```

**Please add a release note if necessary**:

```release-note
Add image type label in VMI and CVMI objects.
```