### PR TITLE
🌱 Go 1.22.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: ci
 
 env:
-  GO_VERSION: 1.22.5
+  GO_VERSION: 1.22.7
 
 on:
   pull_request:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Go version used to build the binaries.
-ARG GO_VERSION=1.22.5
+ARG GO_VERSION=1.22.7
 
 ## Docker image used to build the binaries.
 FROM golang:${GO_VERSION} as builder

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/vm-operator/api
 
-go 1.22.5
+go 1.22.7
 
 require (
 	github.com/google/go-cmp v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/vm-operator
 
-go 1.22.5
+go 1.22.7
 
 replace (
 	github.com/envoyproxy/go-control-plane => github.com/envoyproxy/go-control-plane v0.9.4

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/vm-operator/hack/tools
 
-go 1.22.5
+go 1.22.7
 
 require (
 	github.com/AlekSi/gocov-xml v1.1.0


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Go 1.22.7 is required to addresses the CI vulncheck error reported in https://pkg.go.dev/vuln/GO-2024-3106.

```console
Vulnerability #1: GO-2024-3106
    Stack exhaustion in Decoder.Decode in encoding/gob
  More info: https://pkg.go.dev/vuln/GO-2024-3106
  Standard library
    Found in: encoding/gob@go1.22.5
    Fixed in: encoding/gob@go1.22.7
    Example traces found:
Error:       #1: test/builder/test_suite.go:299:10: builder.TestSuite.Register calls ginkgo.RunSpecs, which eventually calls gob.Decoder.Decode
```

**Which issue(s) is/are addressed by this PR?**

Fixes https://pkg.go.dev/vuln/GO-2024-3106.


**Are there any special notes for your reviewer**:

N/A.

**Please add a release note if necessary**:

```release-note
Upgrade VM Operator to golang 1.22.7
```