### PR TITLE
Revert "Go 1.22.7" back to "Go 1.22.5"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: ci
 
 env:
-  GO_VERSION: 1.22.7
+  GO_VERSION: 1.22.5
 
 on:
   pull_request:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Go version used to build the binaries.
-ARG GO_VERSION=1.22.7
+ARG GO_VERSION=1.22.5
 
 ## Docker image used to build the binaries.
 FROM golang:${GO_VERSION} as builder

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/vm-operator/api
 
-go 1.22.7
+go 1.22.5
 
 require (
 	github.com/google/go-cmp v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/vm-operator
 
-go 1.22.7
+go 1.22.5
 
 replace (
 	github.com/envoyproxy/go-control-plane => github.com/envoyproxy/go-control-plane v0.9.4

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/vm-operator/hack/tools
 
-go 1.22.7
+go 1.22.5
 
 require (
 	github.com/AlekSi/gocov-xml v1.1.0


### PR DESCRIPTION
This reverts commit 9652755c88c0fd41581aa7b561b2ea13a3dd3eed.

**What does this PR do, and why is it needed?**

Going back to Go 1.22.5 until we have a release cayman-go branch internally with 1.22.7. We will need to live with the vulncheck error until then. 

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # N/A


**Are there any special notes for your reviewer**:
Waiting to see if we can get a cayman_go release branch with 1.22.7 sooner. DO NOT MERGE this PR until then

**Please add a release note if necessary**:


```
NONE
```