### PR TITLE
✨ Strip managed fields for cached objects

### DIFF
--- a/controllers/virtualmachineservice/virtualmachineservice_controller.go
+++ b/controllers/virtualmachineservice/virtualmachineservice_controller.go
@@ -391,7 +391,7 @@ func (r *ReconcileVirtualMachineService) createOrUpdateService(ctx *pkgctx.Virtu
 		},
 	}
 
-	result, err := controllerutil.CreateOrUpdate(ctx, r.Client, service, func() error {
+	result, err := controllerutil.CreateOrPatch(ctx, r.Client, service, func() error {
 		if err := controllerutil.SetControllerReference(vmService, service, r.Client.Scheme()); err != nil {
 			return err
 		}

--- a/pkg/manager/cache.go
+++ b/pkg/manager/cache.go
@@ -35,9 +35,10 @@ func NewLabelSelectorCacheForObject(
 
 	cache, err := ctrlcache.New(mgr.GetConfig(),
 		ctrlcache.Options{
-			Scheme:     mgr.GetScheme(),
-			Mapper:     mgr.GetRESTMapper(),
-			SyncPeriod: resync,
+			Scheme:           mgr.GetScheme(),
+			Mapper:           mgr.GetRESTMapper(),
+			DefaultTransform: ctrlcache.TransformStripManagedFields(),
+			SyncPeriod:       resync,
 			ByObject: map[ctrlclient.Object]ctrlcache.ByObject{
 				object: {
 					Label: selector,
@@ -70,9 +71,10 @@ func NewNamespacedCacheForObject(
 
 	cache, err := ctrlcache.New(mgr.GetConfig(),
 		ctrlcache.Options{
-			Scheme:     mgr.GetScheme(),
-			Mapper:     mgr.GetRESTMapper(),
-			SyncPeriod: resync,
+			Scheme:           mgr.GetScheme(),
+			Mapper:           mgr.GetRESTMapper(),
+			DefaultTransform: ctrlcache.TransformStripManagedFields(),
+			SyncPeriod:       resync,
 			ByObject: map[ctrlclient.Object]ctrlcache.ByObject{
 				object: {
 					Namespaces: GetNamespaceCacheConfigs(namespaces...),

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -72,6 +72,7 @@ func New(ctx context.Context, opts Options) (Manager, error) {
 		Scheme: opts.Scheme,
 		Cache: cache.Options{
 			DefaultNamespaces: GetNamespaceCacheConfigs(opts.WatchNamespace),
+			DefaultTransform:  cache.TransformStripManagedFields(),
 			SyncPeriod:        &opts.SyncPeriod,
 		},
 		Client: client.Options{

--- a/pkg/providers/vsphere/network/network.go
+++ b/pkg/providers/vsphere/network/network.go
@@ -312,7 +312,7 @@ func createNetOPNetworkInterface(
 		}
 	}
 
-	_, err := controllerutil.CreateOrUpdate(vmCtx, client, netIf, func() error {
+	_, err := controllerutil.CreateOrPatch(vmCtx, client, netIf, func() error {
 		if err := controllerutil.SetOwnerReference(vmCtx.VM, netIf, client.Scheme()); err != nil {
 			// If this fails we likely have an object name collision, and we're in a tough spot.
 			return err
@@ -480,7 +480,7 @@ func createNCPNetworkInterface(
 		}
 	}
 
-	_, err := controllerutil.CreateOrUpdate(vmCtx, client, vnetIf, func() error {
+	_, err := controllerutil.CreateOrPatch(vmCtx, client, vnetIf, func() error {
 		if err := controllerutil.SetOwnerReference(vmCtx.VM, vnetIf, client.Scheme()); err != nil {
 			return err
 		}
@@ -615,7 +615,7 @@ func createVPCNetworkInterface(
 		return nil, fmt.Errorf("network kind %q is not supported for VPC", networkRefType.Kind)
 	}
 
-	_, err := controllerutil.CreateOrUpdate(vmCtx, client, vpcSubnetPort, func() error {
+	_, err := controllerutil.CreateOrPatch(vmCtx, client, vpcSubnetPort, func() error {
 		if err := controllerutil.SetOwnerReference(vmCtx.VM, vpcSubnetPort, client.Scheme()); err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch adds support for stripping managed fields for objects entering the cache. The controller-runtime [documentation for this transformer](https://github.com/kubernetes-sigs/controller-runtime/blob/38546806f2faf5973e3321a7bd5bb3afdbb5767d/pkg/cache/cache.go#L350-L362) states:

> If you are not explicitly accessing managedFields from your code, setting this as `DefaultTransform` on the cache can lead to significant reduction in memory usage.

as well as the PR, https://github.com/kubernetes-sigs/controller-runtime/pull/2791, which states:

> There are no known issues when using this as a `DefaultTransform` unless there is explicit code to access objects `ManagedFields` and can lead to a significant reduction in memory usage.

Given that VM Operator never directly accesses the managed fields for any object, there is no reason we should not be using this transformer.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

I would appreciate @sbueringer taking a look to make sure this change was implemented as intended. Thanks!


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Reduce memory usage by stripping managed fields from the cache
```