### PR TITLE
🐛 Match VMs if class name is empty in predicate

### DIFF
--- a/pkg/util/kube/predicates.go
+++ b/pkg/util/kube/predicates.go
@@ -121,6 +121,9 @@ func (r *vmForVMClassPredicate) matches(obj runtime.Object) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	if className == "" && r.opts.MatchIfVMClassNotFound {
+		return true, nil
+	}
 	if !ok {
 		return false, fmt.Errorf("spec.className not found for %s", vm)
 	}


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch updates the VM Class predicate used by the VM controller to match if the class cannot be found due to the name being empty.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Do not filter VMs with empty class names in VM Class predicate
```