### PR TITLE
🐛  Fix NPE in checking VM paused by admin

### DIFF
--- a/pkg/providers/vsphere/virtualmachine/extraconfig.go
+++ b/pkg/providers/vsphere/virtualmachine/extraconfig.go
@@ -13,12 +13,17 @@ import (
 )
 
 func IsPausedByAdmin(moVM mo.VirtualMachine) bool {
-	for i := range moVM.Config.ExtraConfig {
-		if o := moVM.Config.ExtraConfig[i].GetOptionValue(); o != nil {
+	if moVM.Config == nil {
+		return false
+	}
+
+	for _, ec := range moVM.Config.ExtraConfig {
+		if o := ec.GetOptionValue(); o != nil {
 			if o.Key == vmopv1.PauseVMExtraConfigKey {
 				if value, ok := o.Value.(string); ok {
 					return strings.ToUpper(value) == constants.ExtraConfigTrue
 				}
+				return false
 			}
 		}
 	}

--- a/pkg/providers/vsphere/virtualmachine/extraconfig_test.go
+++ b/pkg/providers/vsphere/virtualmachine/extraconfig_test.go
@@ -36,6 +36,16 @@ func extraConfigTests() {
 			}
 		})
 
+		It("should return false when VM's Config is nil", func() {
+			mgdObj.Config = nil
+			Expect(virtualmachine.IsPausedByAdmin(mgdObj)).To(BeFalse())
+		})
+
+		It("should return false when VM's Config.ExtraConfig is nil", func() {
+			mgdObj.Config.ExtraConfig = nil
+			Expect(virtualmachine.IsPausedByAdmin(mgdObj)).To(BeFalse())
+		})
+
 		It("should return false when PauseVMExtraConfigKey is not set", func() {
 			Expect(virtualmachine.IsPausedByAdmin(mgdObj)).To(BeFalse())
 		})


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR fixes an potential NPE when the `mo.VirtualMachine` has a nil `Config *types.VirtualMachineConfigInfo` when checking if the VM is paused by VI Admin.

**Which issue(s) is/are addressed by this PR?**

Fixes N/A.

**Are there any special notes for your reviewer**:

This issue was reported from an internal test (3434725). 

**Please add a release note if necessary**:

```release-note
Fix NPE in checking if VM is paused by admin with nil config.
```