### PR TITLE
🌱  Allow CAPV to still create VMs in draining zones

### DIFF
--- a/webhooks/virtualmachine/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -1128,22 +1129,22 @@ func (v validator) validateAvailabilityZone(ctx *pkgctx.WebhookRequestContext, v
 	}
 
 	// Validate the name of the provided availability zone.
-	zoneLabelVal := vm.Labels[topology.KubernetesTopologyZoneLabelKey]
-	if zoneLabelVal != "" {
+	if zoneName := vm.Labels[topology.KubernetesTopologyZoneLabelKey]; zoneName != "" {
 		if pkgcfg.FromContext(ctx).Features.WorkloadDomainIsolation {
-			// Validate the name of the provided zone.
-			// It is the same name as az.
-			zone, err := topology.GetZone(ctx.Context, v.client, zoneLabelVal, vm.Namespace)
+			// Validate the name of the provided zone. It is the same name as az.
+			zone, err := topology.GetZone(ctx.Context, v.client, zoneName, vm.Namespace)
 			if err != nil {
-				return append(allErrs, field.Invalid(zoneLabelPath, zoneLabelVal, err.Error()))
+				return append(allErrs, field.Invalid(zoneLabelPath, zoneName, err.Error()))
 			}
-			// prevent new VirtualMachines created on marked zone by SSO users.
-			if !ctx.IsPrivilegedAccount && !zone.DeletionTimestamp.IsZero() {
-				return append(allErrs, field.Invalid(zoneLabelPath, zoneLabelVal, invalidZone))
+			// Prevent new VirtualMachines created on marked zone by SSO users.
+			if !zone.DeletionTimestamp.IsZero() {
+				if !ctx.IsPrivilegedAccount && !isCAPVServiceAccount(ctx.UserInfo.Username) {
+					return append(allErrs, field.Invalid(zoneLabelPath, zoneName, invalidZone))
+				}
 			}
 		} else {
-			if _, err := topology.GetAvailabilityZone(ctx.Context, v.client, zoneLabelVal); err != nil {
-				return append(allErrs, field.Invalid(zoneLabelPath, zoneLabelVal, err.Error()))
+			if _, err := topology.GetAvailabilityZone(ctx.Context, v.client, zoneName); err != nil {
+				return append(allErrs, field.Invalid(zoneLabelPath, zoneName, err.Error()))
 			}
 		}
 	}
@@ -1368,4 +1369,11 @@ func validateCdromWhenPoweredOn(
 	}
 
 	return allErrs
+}
+
+var capvDefaultServiceAccount = regexp.MustCompile("^system:serviceaccount:svc-tkg-domain-[^:]+:default$")
+
+// isCAPVServiceAccount checks if the username matches that of the CAPV service account.
+func isCAPVServiceAccount(username string) bool {
+	return capvDefaultServiceAccount.Match([]byte(username))
 }

--- a/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
@@ -329,7 +329,7 @@ func unitTestsValidateCreate() {
 						zoneName := builder.DummyZoneName
 						ctx.vm.Labels[topology.KubernetesTopologyZoneLabelKey] = zoneName
 						zone := &topologyv1.Zone{}
-						Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: zoneName, Namespace: dummyNamespaceName}, zone))
+						Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: zoneName, Namespace: dummyNamespaceName}, zone)).To(Succeed())
 						zone.Finalizers = []string{"test"}
 						Expect(ctx.Client.Update(ctx, zone)).To(Succeed())
 						Expect(ctx.Client.Delete(ctx, zone)).To(Succeed())
@@ -347,7 +347,25 @@ func unitTestsValidateCreate() {
 						zoneName := builder.DummyZoneName
 						ctx.vm.Labels[topology.KubernetesTopologyZoneLabelKey] = zoneName
 						zone := &topologyv1.Zone{}
-						Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: zoneName, Namespace: dummyNamespaceName}, zone))
+						Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: zoneName, Namespace: dummyNamespaceName}, zone)).To(Succeed())
+						zone.Finalizers = []string{"test"}
+						Expect(ctx.Client.Update(ctx, zone)).To(Succeed())
+						Expect(ctx.Client.Delete(ctx, zone)).To(Succeed())
+					},
+					expectAllowed: true,
+				},
+			),
+			Entry("when Workload Domain Isolation FSS enabled, should allow when VM created by CAPV that specifies a zone being deleted",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+							config.Features.WorkloadDomainIsolation = true
+							ctx.UserInfo.Username = "system:serviceaccount:svc-tkg-domain-c52:default"
+						})
+						zoneName := builder.DummyZoneName
+						ctx.vm.Labels[topology.KubernetesTopologyZoneLabelKey] = zoneName
+						zone := &topologyv1.Zone{}
+						Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: zoneName, Namespace: dummyNamespaceName}, zone)).To(Succeed())
 						zone.Finalizers = []string{"test"}
 						Expect(ctx.Client.Update(ctx, zone)).To(Succeed())
 						Expect(ctx.Client.Delete(ctx, zone)).To(Succeed())


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

CAPV needs to be able to provision VMs in draining zones prior to the zone being deleted.

Since TKG is now managed via kapp it does not have a well-known NS so we cannot hard code the service account name like we do with other accounts. This check does not need to be fool proof in the sense that this is advisory and everything in the zone is eventually going to be deleted.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

**Please add a release note if necessary**:

```release-note
NONE
```