### PR TITLE
🌱 Add FSS_WCP_SIMPLIFIED_ENABLEMENT

### DIFF
--- a/config/local/vmoperator/local_env_var_patch.yaml
+++ b/config/local/vmoperator/local_env_var_patch.yaml
@@ -37,6 +37,8 @@ spec:
           value: "false"
         - name: FSS_WCP_SUPERVISOR_ASYNC_UPGRADE
           value: "false"
+        - name: FSS_WCP_SIMPLIFIED_ENABLEMENT
+          value: "false"
 
         #
         # Feature state switch flags beneath this line are enabled on main and

--- a/config/wcp/vmoperator/manager_env_var_patch.yaml
+++ b/config/wcp/vmoperator/manager_env_var_patch.yaml
@@ -106,6 +106,11 @@
     name: FSS_WCP_SUPERVISOR_ASYNC_UPGRADE
     value: "<FSS_WCP_SUPERVISOR_ASYNC_UPGRADE_VALUE>"
 
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: FSS_WCP_SIMPLIFIED_ENABLEMENT
+    value: "<FSS_WCP_SIMPLIFIED_ENABLEMENT_VALUE>"
 #
 # Feature state switch flags beneath this line are enabled on main and only
 # retained in this file because it is used by internal testing to determine the

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -129,6 +129,7 @@ type FeatureStates struct {
 	VMIncrementalRestore      bool // FSS_WCP_VMSERVICE_INCREMENTAL_RESTORE
 	BringYourOwnEncryptionKey bool // FSS_WCP_VMSERVICE_BYOK
 	SVAsyncUpgrade            bool // FSS_WCP_SUPERVISOR_ASYNC_UPGRADE
+	SimplifiedEnablement      bool // FSS_WCP_SIMPLIFIED_ENABLEMENT
 }
 
 type InstanceStorage struct {

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -61,6 +61,7 @@ func FromEnv() Config {
 	setBool(env.FSSVMImportNewNet, &config.Features.VMImportNewNet)
 	setBool(env.FSSVMIncrementalRestore, &config.Features.VMIncrementalRestore)
 	setBool(env.FSSBringYourOwnEncryptionKey, &config.Features.BringYourOwnEncryptionKey)
+	setBool(env.FSSSimplifiedEnablement, &config.Features.SimplifiedEnablement)
 
 	setBool(env.FSSSVAsyncUpgrade, &config.Features.SVAsyncUpgrade)
 	if !config.Features.SVAsyncUpgrade {

--- a/pkg/config/env/env.go
+++ b/pkg/config/env/env.go
@@ -56,6 +56,7 @@ const (
 	FSSVMIncrementalRestore
 	FSSBringYourOwnEncryptionKey
 	FSSSVAsyncUpgrade
+	FSSSimplifiedEnablement
 
 	_varNameEnd
 )
@@ -170,6 +171,8 @@ func (n VarName) String() string {
 		return "FSS_WCP_VMSERVICE_BYOK"
 	case FSSSVAsyncUpgrade:
 		return "FSS_WCP_SUPERVISOR_ASYNC_UPGRADE"
+	case FSSSimplifiedEnablement:
+		return "FSS_WCP_SIMPLIFIED_ENABLEMENT"
 	}
 	panic("unknown environment variable")
 }

--- a/pkg/config/env_test.go
+++ b/pkg/config/env_test.go
@@ -99,6 +99,7 @@ var _ = Describe(
 					Expect(os.Setenv("FSS_WCP_VMSERVICE_INCREMENTAL_RESTORE", "true")).To(Succeed())
 					Expect(os.Setenv("FSS_WCP_VMSERVICE_BYOK", "true")).To(Succeed())
 					Expect(os.Setenv("FSS_WCP_SUPERVISOR_ASYNC_UPGRADE", "false")).To(Succeed())
+					Expect(os.Setenv("FSS_WCP_SIMPLIFIED_ENABLEMENT", "true")).To(Succeed())
 					Expect(os.Setenv("CREATE_VM_REQUEUE_DELAY", "125h")).To(Succeed())
 					Expect(os.Setenv("POWERED_ON_VM_HAS_IP_REQUEUE_DELAY", "126h")).To(Succeed())
 				})
@@ -146,6 +147,7 @@ var _ = Describe(
 							BringYourOwnEncryptionKey: true,
 							SVAsyncUpgrade:            false, // Capability gate so tested below
 							WorkloadDomainIsolation:   true,
+							SimplifiedEnablement:      true,
 						},
 						CreateVMRequeueDelay:         125 * time.Hour,
 						PoweredOnVMHasIPRequeueDelay: 126 * time.Hour,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->
This change adds the feature state switch for WCP Simplified Enablement to vm operator. 
This is a precursor to a change which will have vm-operator web console use an API Server DNS name to login in instead of a virtual IP if a load balancer is not provided. However, we want for this change to be FSS guarded.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```