### PR TITLE
:sparkles: Define new unified storage quota management plugin webhook

### DIFF
--- a/webhooks/unifiedstoragequota/validation/unifiedstoragequota_validator.go
+++ b/webhooks/unifiedstoragequota/validation/unifiedstoragequota_validator.go
@@ -1,0 +1,347 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package validation
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	v1 "k8s.io/api/admission/v1"
+	"k8s.io/api/admission/v1beta1"
+	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	"github.com/vmware-tanzu/vm-operator/pkg/builder"
+	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/record"
+)
+
+const (
+	webhookName            = "vmservice.cns.vsphere.vmware.com"
+	webhookPath            = "/getrequestedcapacityforvirtualmachine"
+	scParamStoragePolicyID = "storagePolicyID"
+)
+
+// RequestedCapacity represents response body returned by this webhook to the SPQ webhook.
+type RequestedCapacity struct {
+	// Capacity represents the size to be reserved for the given resource
+	Capacity resource.Quantity `json:"capacity"`
+
+	// StorageClassName represents the StorageClass associated with the given resource
+	StorageClassName string `json:"storageClassName"`
+
+	// StoragePolicyID represents the StoragePolicyId associated with the given resource
+	StoragePolicyID string `json:"storagePolicyId"`
+
+	// Reason indicates the cause for returning capacity as 0
+	Reason string `json:"reason,omitempty"`
+}
+
+type CapacityResponse struct {
+	RequestedCapacity
+	admission.Response
+}
+
+type RequestedCapacityHandler struct {
+	*pkgctx.WebhookContext
+	admission.Decoder
+
+	Client    client.Client
+	Converter runtime.UnstructuredConverter
+}
+
+// AddToManager adds the webhook to the provided manager.
+func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) error {
+	webhookNameLong := fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, webhookName)
+
+	// Build the webhookContext.
+	webhookContext := &pkgctx.WebhookContext{
+		Context:            ctx,
+		Name:               webhookName,
+		Namespace:          ctx.Namespace,
+		ServiceAccountName: ctx.ServiceAccountName,
+		Recorder:           record.New(mgr.GetEventRecorderFor(webhookNameLong)),
+		Logger:             ctx.Logger.WithName(webhookName),
+	}
+	// Initialize the webhook's decoder.
+	decoder := admission.NewDecoder(mgr.GetScheme())
+
+	handler := &RequestedCapacityHandler{
+		Client:         mgr.GetClient(),
+		Converter:      runtime.DefaultUnstructuredConverter,
+		Decoder:        decoder,
+		WebhookContext: webhookContext,
+	}
+	mgr.GetWebhookServer().Register(webhookPath, handler)
+
+	return nil
+}
+
+func (h *RequestedCapacityHandler) Handle(req admission.Request) CapacityResponse {
+	var (
+		obj, oldObj   *unstructured.Unstructured
+		handleRequest func(ctx *pkgctx.WebhookRequestContext) CapacityResponse
+	)
+
+	if req.Operation == v1.Create {
+		obj = &unstructured.Unstructured{}
+		if err := h.DecodeRaw(req.Object, obj); err != nil {
+			return CapacityResponse{Response: webhook.Errored(http.StatusBadRequest, err)}
+		}
+		handleRequest = h.HandleCreate
+	}
+	if req.Operation == v1.Update {
+		obj = &unstructured.Unstructured{}
+		if err := h.DecodeRaw(req.Object, obj); err != nil {
+			return CapacityResponse{Response: webhook.Errored(http.StatusBadRequest, err)}
+		}
+		oldObj = &unstructured.Unstructured{}
+		if err := h.DecodeRaw(req.OldObject, oldObj); err != nil {
+			return CapacityResponse{Response: webhook.Errored(http.StatusBadRequest, err)}
+		}
+		handleRequest = h.HandleUpdate
+	}
+
+	if obj == nil {
+		return CapacityResponse{Response: webhook.Allowed(string(req.Operation))}
+	}
+
+	webhookRequestContext := &pkgctx.WebhookRequestContext{
+		WebhookContext: h.WebhookContext,
+		Op:             req.Operation,
+		Obj:            obj,
+		OldObj:         oldObj,
+		UserInfo:       req.UserInfo,
+		Logger:         h.WebhookContext.Logger.WithName(obj.GetNamespace()).WithName(obj.GetName()),
+	}
+
+	return handleRequest(webhookRequestContext)
+}
+
+// HandleCreate returns the Boot Disk capacity from the corresponding VMI/CVMI for the VM object in the AdmissionRequest.
+func (h *RequestedCapacityHandler) HandleCreate(ctx *pkgctx.WebhookRequestContext) CapacityResponse {
+	vm := &vmopv1.VirtualMachine{}
+	if err := h.Converter.FromUnstructured(ctx.Obj.UnstructuredContent(), vm); err != nil {
+		return CapacityResponse{Response: webhook.Errored(http.StatusBadRequest, err)}
+	}
+
+	scName := vm.Spec.StorageClass
+
+	sc := &storagev1.StorageClass{}
+	if err := h.Client.Get(ctx, client.ObjectKey{Name: scName}, sc); err != nil {
+		if apierrors.IsNotFound(err) {
+			return CapacityResponse{Response: webhook.Errored(http.StatusNotFound, err)}
+		}
+		return CapacityResponse{Response: webhook.Errored(http.StatusInternalServerError, err)}
+	}
+
+	if vm.Spec.Image == nil {
+		return CapacityResponse{Response: webhook.Errored(http.StatusBadRequest, errors.New("vm.Spec.Image is required"))}
+	}
+	vmiName := vm.Spec.Image.Name
+	var imageStatus vmopv1.VirtualMachineImageStatus
+
+	switch vm.Spec.Image.Kind {
+	case "VirtualMachineImage":
+		vmi := &vmopv1.VirtualMachineImage{}
+		if err := h.Client.Get(ctx, client.ObjectKey{Namespace: vm.Namespace, Name: vmiName}, vmi); err != nil {
+			if apierrors.IsNotFound(err) {
+				return CapacityResponse{Response: webhook.Errored(http.StatusNotFound, err)}
+			}
+			return CapacityResponse{Response: webhook.Errored(http.StatusInternalServerError, err)}
+		}
+		imageStatus = vmi.Status
+	case "ClusterVirtualMachineImage":
+		cvmi := &vmopv1.ClusterVirtualMachineImage{}
+		if err := h.Client.Get(ctx, client.ObjectKey{Name: vmiName}, cvmi); err != nil {
+			if apierrors.IsNotFound(err) {
+				return CapacityResponse{Response: webhook.Errored(http.StatusNotFound, err)}
+			}
+			return CapacityResponse{Response: webhook.Errored(http.StatusInternalServerError, err)}
+		}
+		imageStatus = cvmi.Status
+	default:
+		return CapacityResponse{Response: webhook.Errored(http.StatusBadRequest, fmt.Errorf("unsupported image kind %s", vm.Spec.Image.Kind))}
+	}
+
+	if len(imageStatus.Disks) < 1 || imageStatus.Disks[0].Capacity == nil {
+		return CapacityResponse{Response: webhook.Errored(http.StatusNotFound, errors.New("boot disk not found in image status"))}
+	}
+	capacity := imageStatus.Disks[0].Capacity
+
+	return CapacityResponse{
+		RequestedCapacity: RequestedCapacity{
+			Capacity:         *capacity,
+			StorageClassName: scName,
+			// If this parameter does not exist, then it is not necessarily an error condition. Return
+			// an empty value for StoragePolicyID and let Storage Policy Quota extension service decide
+			// what to do.
+			StoragePolicyID: sc.Parameters[scParamStoragePolicyID],
+		},
+		Response: webhook.Allowed(""),
+	}
+}
+
+// HandleUpdate checks for any positive difference in boot disk size and returns that difference.
+//   - If both vm and oldVM have Spec.Advanced.BootDiskCapacity set, then only return a positive difference.
+//   - If vm has Spec.Advanced.BootDiskCapacity set, while it is not set for oldVM, then use the first classic disk in
+//     oldVM.Status.Volumes as this basis for comparison, again returning only a positive difference.
+//   - If vm does not have Spec.Advanced.BootDiskCapacity set, then return an empty response.
+func (h *RequestedCapacityHandler) HandleUpdate(ctx *pkgctx.WebhookRequestContext) CapacityResponse {
+	if !ctx.Obj.GetDeletionTimestamp().IsZero() {
+		return CapacityResponse{Response: admission.Allowed(builder.AdmitMesgUpdateOnDeleting)}
+	}
+	vm := &vmopv1.VirtualMachine{}
+	if err := h.Converter.FromUnstructured(ctx.Obj.UnstructuredContent(), vm); err != nil {
+		return CapacityResponse{Response: webhook.Errored(http.StatusBadRequest, err)}
+	}
+
+	oldVM := &vmopv1.VirtualMachine{}
+	if err := h.Converter.FromUnstructured(ctx.OldObj.UnstructuredContent(), oldVM); err != nil {
+		return CapacityResponse{Response: webhook.Errored(http.StatusBadRequest, err)}
+	}
+
+	var capacity, oldCapacity *resource.Quantity
+
+	if vm.Spec.Advanced == nil || vm.Spec.Advanced.BootDiskCapacity == nil {
+		return CapacityResponse{Response: webhook.Allowed("")}
+	}
+
+	capacity = vm.Spec.Advanced.BootDiskCapacity
+
+	if oldVM.Spec.Advanced == nil || oldVM.Spec.Advanced.BootDiskCapacity == nil {
+		oldCapacity = resource.NewQuantity(0, resource.BinarySI)
+		for _, volume := range oldVM.Status.Volumes {
+			if volume.Type == vmopv1.VirtualMachineStorageDiskTypeClassic {
+				if volume.Limit != nil {
+					oldCapacity = volume.Limit
+					break
+				}
+			}
+		}
+	} else {
+		oldCapacity = oldVM.Spec.Advanced.BootDiskCapacity
+	}
+
+	if capacity.Cmp(*oldCapacity) != 1 {
+		return CapacityResponse{Response: webhook.Allowed("")}
+	}
+	capacity.Sub(*oldCapacity)
+
+	scName := vm.Spec.StorageClass
+	sc := &storagev1.StorageClass{}
+	if err := h.Client.Get(ctx, client.ObjectKey{Name: scName}, sc); err != nil {
+		if apierrors.IsNotFound(err) {
+			return CapacityResponse{Response: webhook.Errored(http.StatusNotFound, err)}
+		}
+		return CapacityResponse{Response: webhook.Errored(http.StatusInternalServerError, err)}
+	}
+
+	return CapacityResponse{
+		RequestedCapacity: RequestedCapacity{
+			Capacity:         *capacity,
+			StorageClassName: scName,
+			// If this parameter does not exist, then it is not necessarily an error condition. Return
+			// an empty value for StoragePolicyID and let Storage Policy Quota extension service decide
+			// what to do.
+			StoragePolicyID: sc.Parameters[scParamStoragePolicyID],
+		},
+		Response: webhook.Allowed(""),
+	}
+}
+
+var admissionScheme = runtime.NewScheme()
+var admissionCodecs = serializer.NewCodecFactory(admissionScheme)
+
+const maxRequestSize = int64(7 * 1024 * 1024)
+
+func init() {
+	utilruntime.Must(v1.AddToScheme(admissionScheme))
+	utilruntime.Must(v1beta1.AddToScheme(admissionScheme))
+}
+
+func (h *RequestedCapacityHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Body == nil || r.Body == http.NoBody {
+		err := errors.New("request body is empty")
+		h.WebhookContext.Logger.Error(err, "bad request")
+		h.WriteResponse(w, CapacityResponse{Response: webhook.Errored(http.StatusBadRequest, err)})
+		return
+	}
+
+	defer func(Body io.ReadCloser) {
+		_ = Body.Close()
+	}(r.Body)
+
+	limitedReader := &io.LimitedReader{R: r.Body, N: maxRequestSize}
+	body, err := io.ReadAll(limitedReader)
+	if err != nil {
+		h.WebhookContext.Logger.Error(err, "unable to read the body from the incoming request")
+		h.WriteResponse(w, CapacityResponse{Response: webhook.Errored(http.StatusBadRequest, err)})
+		return
+	}
+	if limitedReader.N <= 0 {
+		err := fmt.Errorf("request entity is too large; limit is %d bytes", maxRequestSize)
+		h.WebhookContext.Logger.Error(err, "unable to read the body from the incoming request; limit reached")
+		h.WriteResponse(w, CapacityResponse{Response: webhook.Errored(http.StatusRequestEntityTooLarge, err)})
+		return
+	}
+
+	// verify the content type is accurate
+	if contentType := r.Header.Get("Content-Type"); contentType != "application/json" {
+		err = fmt.Errorf("contentType=%s, expected application/json", contentType)
+		h.WebhookContext.Logger.Error(err, "unable to process a request with unknown content type")
+		h.WriteResponse(w, CapacityResponse{Response: webhook.Errored(http.StatusBadRequest, err)})
+		return
+	}
+
+	req := admission.Request{}
+	ar := unversionedAdmissionReview{}
+	// avoid an extra copy
+	ar.Request = &req.AdmissionRequest
+	ar.SetGroupVersionKind(v1.SchemeGroupVersion.WithKind("AdmissionReview"))
+	_, _, err = admissionCodecs.UniversalDeserializer().Decode(body, nil, &ar)
+	if err != nil {
+		h.WebhookContext.Logger.Error(err, "unable to decode the request")
+		h.WriteResponse(w, CapacityResponse{Response: webhook.Errored(http.StatusBadRequest, err)})
+		return
+	}
+	h.WebhookContext.Logger.V(5).Info("received request")
+
+	h.WriteResponse(w, h.Handle(req))
+}
+
+func (h *RequestedCapacityHandler) WriteResponse(w http.ResponseWriter, response CapacityResponse) {
+	if !response.Response.Allowed {
+		response.Reason = response.Response.Result.Message
+		w.WriteHeader(int(response.Response.Result.Code))
+	}
+	if err := json.NewEncoder(w).Encode(response.RequestedCapacity); err != nil {
+		h.WebhookContext.Logger.Error(err, "unable to encode and write the response")
+
+		serverError := webhook.Errored(http.StatusInternalServerError, err)
+		if err = json.NewEncoder(w).Encode(v1.AdmissionReview{Response: &serverError.AdmissionResponse}); err != nil {
+			h.WebhookContext.Logger.Error(err, "still unable to encode and write the InternalServerError response")
+		}
+	}
+}
+
+// unversionedAdmissionReview is used to decode both v1 and v1beta1 AdmissionReview types.
+type unversionedAdmissionReview struct {
+	v1.AdmissionReview
+}
+
+var _ runtime.Object = &unversionedAdmissionReview{}

--- a/webhooks/unifiedstoragequota/validation/unifiedstoragequota_validator_intg_test.go
+++ b/webhooks/unifiedstoragequota/validation/unifiedstoragequota_validator_intg_test.go
@@ -1,0 +1,290 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package validation_test
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	v1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+	"github.com/vmware-tanzu/vm-operator/webhooks/unifiedstoragequota/validation"
+)
+
+const (
+	url         = "https://127.0.0.1:%d/getrequestedcapacityforvirtualmachine"
+	contentType = "application/json"
+)
+
+func intgTests() {
+
+	Describe(
+		"Create",
+		Label(
+			testlabels.Create,
+			testlabels.EnvTest,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		intgTestsValidateCreate,
+	)
+	Describe(
+		"Update",
+		Label(
+			testlabels.Update,
+			testlabels.EnvTest,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		intgTestsValidateUpdate,
+	)
+}
+
+func intgTestsValidateCreate() {
+	var (
+		ctx *builder.IntegrationTestContext
+
+		ar          *admissionv1.AdmissionReview
+		sc          *v1.StorageClass
+		vm, oldVM   *vmopv1.VirtualMachine
+		obj, oldObj []byte
+
+		r *validation.RequestedCapacity
+
+		httpClient = &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			},
+		}
+	)
+
+	BeforeEach(func() {
+		ctx = suite.NewIntegrationTestContext()
+
+		vm = builder.DummyVirtualMachine()
+		vm.Name = dummyVMName
+		vm.Namespace = ctx.Namespace
+
+		sc = builder.DummyStorageClass()
+		Expect(ctx.Client.Create(ctx, sc)).To(Succeed())
+
+		vm.Spec.StorageClass = sc.Name
+
+		ar = &admissionv1.AdmissionReview{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "AdmissionReview",
+				APIVersion: "admission.k8s.io/v1",
+			},
+			Request: &admissionv1.AdmissionRequest{
+				Operation: admissionv1.Create,
+			},
+		}
+
+	})
+
+	AfterEach(func() {
+		Expect(ctx.Client.Delete(ctx, sc)).To(Succeed())
+
+		ctx.AfterEach()
+		ctx = nil
+	})
+
+	JustBeforeEach(func() {
+		var (
+			err  error
+			resp *http.Response
+		)
+
+		obj, _ = json.Marshal(vm)
+		Expect(err).NotTo(HaveOccurred())
+
+		oldObj, _ = json.Marshal(oldVM)
+		Expect(err).NotTo(HaveOccurred())
+
+		ar.Request.Object.Raw = obj
+		ar.Request.OldObject.Raw = oldObj
+
+		port := suite.GetManager().GetWebhookServer().(*webhook.DefaultServer).Options.Port
+		body, _ := json.Marshal(ar)
+
+		resp, err = httpClient.Post(fmt.Sprintf(url, port), contentType, bytes.NewBuffer(body))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+		r = &validation.RequestedCapacity{}
+		Expect(json.NewDecoder(resp.Body).Decode(r)).To(Succeed())
+
+		Expect(resp.Body.Close()).To(Succeed())
+	})
+
+	When("create is called", func() {
+		var imageStatus vmopv1.VirtualMachineImageStatus
+
+		BeforeEach(func() {
+			imageStatus = vmopv1.VirtualMachineImageStatus{
+				Disks: []vmopv1.VirtualMachineImageDiskInfo{
+					{
+						Capacity: resource.NewQuantity(10*1024*1024*1024, resource.BinarySI),
+					},
+				},
+			}
+		})
+
+		When("vm uses VirtualMachineImage", func() {
+			var vmi *vmopv1.VirtualMachineImage
+
+			BeforeEach(func() {
+				vmi = builder.DummyVirtualMachineImage(builder.DummyVMIName)
+				vmi.Namespace = ctx.Namespace
+
+				Expect(ctx.Client.Create(ctx, vmi)).To(Succeed())
+
+				vmi.Status = imageStatus
+				Expect(ctx.Client.Status().Update(ctx, vmi)).To(Succeed())
+			})
+
+			It("should return the correct capacity from the VMI", func() {
+				Expect(r.Capacity.String()).To(Equal(vmi.Status.Disks[0].Capacity.String()))
+			})
+		})
+
+		When("vm uses ClusterVirtualMachineImage", func() {
+			var cvmi *vmopv1.ClusterVirtualMachineImage
+
+			BeforeEach(func() {
+				vm.Spec.Image.Kind = "ClusterVirtualMachineImage"
+				vm.Spec.Image.Name = builder.DummyCVMIName
+
+				cvmi = builder.DummyClusterVirtualMachineImage(builder.DummyCVMIName)
+				Expect(ctx.Client.Create(ctx, cvmi)).To(Succeed())
+
+				cvmi.Status = imageStatus
+				Expect(ctx.Client.Status().Update(ctx, cvmi)).To(Succeed())
+			})
+
+			It("should return the correct capacity from the CVMI", func() {
+				Expect(r.Capacity.String()).To(Equal(cvmi.Status.Disks[0].Capacity.String()))
+			})
+		})
+	})
+}
+
+func intgTestsValidateUpdate() {
+	var (
+		ctx *builder.IntegrationTestContext
+
+		ar          *admissionv1.AdmissionReview
+		sc          *v1.StorageClass
+		vm, oldVM   *vmopv1.VirtualMachine
+		obj, oldObj []byte
+
+		r *validation.RequestedCapacity
+
+		httpClient = &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			},
+		}
+	)
+
+	BeforeEach(func() {
+		ctx = suite.NewIntegrationTestContext()
+
+		vm = builder.DummyVirtualMachine()
+		vm.Name = dummyVMName
+		vm.Namespace = ctx.Namespace
+
+		sc = builder.DummyStorageClass()
+		Expect(ctx.Client.Create(ctx, sc)).To(Succeed())
+
+		vm.Spec.StorageClass = sc.Name
+
+		vm.Spec.Advanced = &vmopv1.VirtualMachineAdvancedSpec{
+			BootDiskCapacity: resource.NewQuantity(10*1024*1024*1024, resource.BinarySI),
+		}
+
+		oldVM = vm.DeepCopy()
+
+		ar = &admissionv1.AdmissionReview{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "AdmissionReview",
+				APIVersion: "admission.k8s.io/v1",
+			},
+			Request: &admissionv1.AdmissionRequest{
+				Operation: admissionv1.Update,
+			},
+		}
+
+	})
+
+	AfterEach(func() {
+		Expect(ctx.Client.Delete(ctx, sc)).To(Succeed())
+
+		ctx.AfterEach()
+		ctx = nil
+	})
+
+	JustBeforeEach(func() {
+		var (
+			err  error
+			resp *http.Response
+		)
+
+		obj, err = json.Marshal(vm)
+		Expect(err).NotTo(HaveOccurred())
+
+		oldObj, err = json.Marshal(oldVM)
+		Expect(err).NotTo(HaveOccurred())
+
+		ar.Request.Object.Raw = obj
+		ar.Request.OldObject.Raw = oldObj
+
+		port := suite.GetManager().GetWebhookServer().(*webhook.DefaultServer).Options.Port
+		body, _ := json.Marshal(ar)
+
+		resp, err = httpClient.Post(fmt.Sprintf(url, port), contentType, bytes.NewBuffer(body))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+		r = &validation.RequestedCapacity{}
+		Expect(json.NewDecoder(resp.Body).Decode(r)).To(Succeed())
+
+		Expect(resp.Body.Close()).To(Succeed())
+	})
+
+	When("update is called", func() {
+		When("boot disk size has not changed", func() {
+
+			It("should return an empty response", func() {
+				Expect(r.Capacity.String()).To(Equal("0"))
+			})
+		})
+
+		When("boot disk size has changed", func() {
+			BeforeEach(func() {
+				vm.Spec.Advanced = &vmopv1.VirtualMachineAdvancedSpec{
+					BootDiskCapacity: resource.NewQuantity(15*1024*1024*1024, resource.BinarySI),
+				}
+			})
+
+			It("should return the correct capacity as the updated boot disk size", func() {
+				expected := resource.NewQuantity(5*1024*1024*1024, resource.BinarySI)
+				Expect(r.Capacity.String()).To(Equal(expected.String()))
+			})
+		})
+	})
+}

--- a/webhooks/unifiedstoragequota/validation/unifiedstoragequota_validator_suite_test.go
+++ b/webhooks/unifiedstoragequota/validation/unifiedstoragequota_validator_suite_test.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package validation_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+
+	"github.com/vmware-tanzu/vm-operator/webhooks/unifiedstoragequota/validation"
+)
+
+// suite is used for unit and integration testing this webhook.
+var suite = builder.NewTestSuiteForValidatingWebhookWithContext(
+	pkgcfg.NewContext(),
+	validation.AddToManager,
+	nil,
+	"vmservice.cns.vsphere.vmware.com")
+
+func TestWebhook(t *testing.T) {
+	suite.Register(t, "Validation webhook suite", intgTests, nil)
+}
+
+var _ = BeforeSuite(suite.BeforeSuite)
+
+var _ = AfterSuite(suite.AfterSuite)

--- a/webhooks/unifiedstoragequota/validation/unifiedstoragequota_validator_unit_test.go
+++ b/webhooks/unifiedstoragequota/validation/unifiedstoragequota_validator_unit_test.go
@@ -1,0 +1,1200 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package validation_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	admissionv1 "k8s.io/api/admission/v1"
+	v1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	"github.com/vmware-tanzu/vm-operator/pkg/context/fake"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+	"github.com/vmware-tanzu/vm-operator/webhooks/unifiedstoragequota/validation"
+)
+
+const (
+	dummyVMName        = "dummy-vm"
+	dummyNamespaceName = "dummy-vm-namespace-for-webhook-validation"
+)
+
+func TestRequestedCapacityHandler_HandleCreate(t *testing.T) {
+	type testCase struct {
+		description    string
+		vm             *vmopv1.VirtualMachine
+		sc             *v1.StorageClass
+		vmi            *vmopv1.VirtualMachineImage
+		cvmi           *vmopv1.ClusterVirtualMachineImage
+		interceptors   interceptor.Funcs
+		dummyConverter *DummyConverter
+		dummyDecoder   DummyDecoder
+		allowed        bool
+		status         int32
+		expected       validation.RequestedCapacity
+	}
+
+	testCases := []testCase{
+		{
+			description: "Error converting from unstructured",
+			vm:          builder.DummyVirtualMachine(),
+			dummyConverter: &DummyConverter{
+				converter: runtime.DefaultUnstructuredConverter,
+				shouldErr: true,
+			},
+			dummyDecoder: DummyDecoder{
+				decoder:   admission.NewDecoder(builder.NewScheme()),
+				shouldErr: false,
+			},
+			allowed:  false,
+			status:   http.StatusBadRequest,
+			expected: validation.RequestedCapacity{},
+		},
+		{
+			description: "Storage Class not found",
+			vm:          builder.DummyVirtualMachine(),
+			dummyConverter: &DummyConverter{
+				converter: runtime.DefaultUnstructuredConverter,
+				shouldErr: false,
+			},
+			dummyDecoder: DummyDecoder{
+				decoder:   admission.NewDecoder(builder.NewScheme()),
+				shouldErr: false,
+			},
+			allowed:  false,
+			status:   http.StatusNotFound,
+			expected: validation.RequestedCapacity{},
+		},
+		{
+			description: "Error getting storage class",
+			vm:          builder.DummyVirtualMachine(),
+			sc:          builder.DummyStorageClass(),
+			interceptors: interceptor.Funcs{
+				Get: func(
+					ctx context.Context,
+					client ctrlclient.WithWatch,
+					key ctrlclient.ObjectKey,
+					obj ctrlclient.Object,
+					opts ...ctrlclient.GetOption) error {
+
+					if _, ok := obj.(*v1.StorageClass); ok {
+						return errors.New("fake error")
+					}
+
+					return client.Get(ctx, key, obj, opts...)
+				},
+			},
+			dummyConverter: &DummyConverter{
+				converter: runtime.DefaultUnstructuredConverter,
+				shouldErr: false,
+			},
+			dummyDecoder: DummyDecoder{
+				decoder:   admission.NewDecoder(builder.NewScheme()),
+				shouldErr: false,
+			},
+			allowed:  false,
+			status:   http.StatusInternalServerError,
+			expected: validation.RequestedCapacity{},
+		},
+		{
+			description: "Image is nil",
+			vm:          &vmopv1.VirtualMachine{},
+			sc:          builder.DummyStorageClass(),
+			dummyConverter: &DummyConverter{
+				converter: runtime.DefaultUnstructuredConverter,
+				shouldErr: false,
+			},
+			dummyDecoder: DummyDecoder{
+				decoder:   admission.NewDecoder(builder.NewScheme()),
+				shouldErr: false,
+			},
+			allowed:  false,
+			status:   http.StatusBadRequest,
+			expected: validation.RequestedCapacity{},
+		},
+		{
+			description: "VMI not found",
+			vm:          builder.DummyVirtualMachine(),
+			sc:          builder.DummyStorageClass(),
+			dummyConverter: &DummyConverter{
+				converter: runtime.DefaultUnstructuredConverter,
+				shouldErr: false,
+			},
+			dummyDecoder: DummyDecoder{
+				decoder:   admission.NewDecoder(builder.NewScheme()),
+				shouldErr: false,
+			},
+			allowed:  false,
+			status:   http.StatusNotFound,
+			expected: validation.RequestedCapacity{},
+		},
+		{
+			description: "Error getting VMI",
+			vm:          builder.DummyVirtualMachine(),
+			sc:          builder.DummyStorageClass(),
+			vmi:         builder.DummyVirtualMachineImage(builder.DummyVMIName),
+			interceptors: interceptor.Funcs{
+				Get: func(
+					ctx context.Context,
+					client ctrlclient.WithWatch,
+					key ctrlclient.ObjectKey,
+					obj ctrlclient.Object,
+					opts ...ctrlclient.GetOption) error {
+
+					if _, ok := obj.(*vmopv1.VirtualMachineImage); ok {
+						return errors.New("fake error")
+					}
+
+					return client.Get(ctx, key, obj, opts...)
+				},
+			},
+			dummyConverter: &DummyConverter{
+				converter: runtime.DefaultUnstructuredConverter,
+				shouldErr: false,
+			},
+			dummyDecoder: DummyDecoder{
+				decoder:   admission.NewDecoder(builder.NewScheme()),
+				shouldErr: false,
+			},
+			allowed:  false,
+			status:   http.StatusInternalServerError,
+			expected: validation.RequestedCapacity{},
+		},
+		{
+			description: "CVMI not found",
+			vm: &vmopv1.VirtualMachine{
+				Spec: vmopv1.VirtualMachineSpec{
+					Image: &vmopv1.VirtualMachineImageRef{
+						Kind: "ClusterVirtualMachineImage",
+					},
+				},
+			},
+			sc: builder.DummyStorageClass(),
+			dummyConverter: &DummyConverter{
+				converter: runtime.DefaultUnstructuredConverter,
+				shouldErr: false,
+			},
+			dummyDecoder: DummyDecoder{
+				decoder:   admission.NewDecoder(builder.NewScheme()),
+				shouldErr: false,
+			},
+			allowed:  false,
+			status:   http.StatusNotFound,
+			expected: validation.RequestedCapacity{},
+		},
+		{
+			description: "Error getting CVMI",
+			vm: &vmopv1.VirtualMachine{
+				Spec: vmopv1.VirtualMachineSpec{
+					Image: &vmopv1.VirtualMachineImageRef{
+						Kind: "ClusterVirtualMachineImage",
+					},
+				},
+			},
+			sc:   builder.DummyStorageClass(),
+			cvmi: builder.DummyClusterVirtualMachineImage(builder.DummyVMIName),
+			interceptors: interceptor.Funcs{
+				Get: func(
+					ctx context.Context,
+					client ctrlclient.WithWatch,
+					key ctrlclient.ObjectKey,
+					obj ctrlclient.Object,
+					opts ...ctrlclient.GetOption) error {
+
+					if _, ok := obj.(*vmopv1.ClusterVirtualMachineImage); ok {
+						return errors.New("fake error")
+					}
+
+					return client.Get(ctx, key, obj, opts...)
+				},
+			},
+			dummyConverter: &DummyConverter{
+				converter: runtime.DefaultUnstructuredConverter,
+				shouldErr: false,
+			},
+			dummyDecoder: DummyDecoder{
+				decoder:   admission.NewDecoder(builder.NewScheme()),
+				shouldErr: false,
+			},
+			allowed:  false,
+			status:   http.StatusInternalServerError,
+			expected: validation.RequestedCapacity{},
+		},
+		{
+			description: "Disks is empty in image status",
+			vm:          builder.DummyVirtualMachine(),
+			sc:          builder.DummyStorageClass(),
+			vmi:         builder.DummyVirtualMachineImage(builder.DummyVMIName),
+			dummyConverter: &DummyConverter{
+				converter: runtime.DefaultUnstructuredConverter,
+				shouldErr: false,
+			},
+			dummyDecoder: DummyDecoder{
+				decoder:   admission.NewDecoder(builder.NewScheme()),
+				shouldErr: false,
+			},
+			allowed:  false,
+			status:   http.StatusNotFound,
+			expected: validation.RequestedCapacity{},
+		},
+		{
+			description: "Boot disk has empty capacity",
+			vm:          builder.DummyVirtualMachine(),
+			sc:          builder.DummyStorageClass(),
+			vmi: &vmopv1.VirtualMachineImage{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: builder.DummyVMIName,
+				},
+				Status: vmopv1.VirtualMachineImageStatus{
+					Name: builder.DummyVMIName,
+					ProductInfo: vmopv1.VirtualMachineImageProductInfo{
+						FullVersion: builder.DummyDistroVersion,
+					},
+					OSInfo: vmopv1.VirtualMachineImageOSInfo{
+						Type: builder.DummyOSType,
+					},
+					Disks: []vmopv1.VirtualMachineImageDiskInfo{
+						{
+							Capacity: nil,
+						},
+					},
+				},
+			},
+			dummyConverter: &DummyConverter{
+				converter: runtime.DefaultUnstructuredConverter,
+				shouldErr: false,
+			},
+			dummyDecoder: DummyDecoder{
+				decoder:   admission.NewDecoder(builder.NewScheme()),
+				shouldErr: false,
+			},
+			allowed:  false,
+			status:   http.StatusNotFound,
+			expected: validation.RequestedCapacity{},
+		},
+		{
+			description: "vm uses vmi",
+			vm:          builder.DummyVirtualMachine(),
+			sc:          builder.DummyStorageClass(),
+			vmi: &vmopv1.VirtualMachineImage{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      builder.DummyVMIName,
+					Namespace: dummyNamespaceName,
+				},
+				Status: vmopv1.VirtualMachineImageStatus{
+					Name: builder.DummyVMIName,
+					ProductInfo: vmopv1.VirtualMachineImageProductInfo{
+						FullVersion: builder.DummyDistroVersion,
+					},
+					OSInfo: vmopv1.VirtualMachineImageOSInfo{
+						Type: builder.DummyOSType,
+					},
+					Disks: []vmopv1.VirtualMachineImageDiskInfo{
+						{
+							Capacity: resource.NewQuantity(10*1024*1024*1024, resource.BinarySI),
+						},
+					},
+				},
+			},
+			dummyConverter: &DummyConverter{
+				converter: runtime.DefaultUnstructuredConverter,
+				shouldErr: false,
+			},
+			dummyDecoder: DummyDecoder{
+				decoder:   admission.NewDecoder(builder.NewScheme()),
+				shouldErr: false,
+			},
+			allowed: true,
+			status:  http.StatusOK,
+			expected: validation.RequestedCapacity{
+				Capacity:         *resource.NewQuantity(10*1024*1024*1024, resource.BinarySI),
+				StoragePolicyID:  "id42",
+				StorageClassName: "dummy-storage-class",
+			},
+		},
+		{
+			description: "vm uses cvmi",
+			vm: &vmopv1.VirtualMachine{
+				Spec: vmopv1.VirtualMachineSpec{
+					Image: &vmopv1.VirtualMachineImageRef{
+						Name: builder.DummyVMIName,
+						Kind: "ClusterVirtualMachineImage",
+					},
+				},
+			},
+			sc: builder.DummyStorageClass(),
+			cvmi: &vmopv1.ClusterVirtualMachineImage{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: builder.DummyVMIName,
+				},
+				Status: vmopv1.VirtualMachineImageStatus{
+					Name: builder.DummyVMIName,
+					ProductInfo: vmopv1.VirtualMachineImageProductInfo{
+						FullVersion: builder.DummyDistroVersion,
+					},
+					OSInfo: vmopv1.VirtualMachineImageOSInfo{
+						Type: builder.DummyOSType,
+					},
+					Disks: []vmopv1.VirtualMachineImageDiskInfo{
+						{
+							Capacity: resource.NewQuantity(10*1024*1024*1024, resource.BinarySI),
+						},
+					},
+				},
+			},
+			dummyConverter: &DummyConverter{
+				converter: runtime.DefaultUnstructuredConverter,
+				shouldErr: false,
+			},
+			dummyDecoder: DummyDecoder{
+				decoder:   admission.NewDecoder(builder.NewScheme()),
+				shouldErr: false,
+			},
+			allowed: true,
+			status:  http.StatusOK,
+			expected: validation.RequestedCapacity{
+				Capacity:         *resource.NewQuantity(10*1024*1024*1024, resource.BinarySI),
+				StoragePolicyID:  "id42",
+				StorageClassName: "dummy-storage-class",
+			},
+		},
+		{
+			description: "invalid image kind",
+			vm: &vmopv1.VirtualMachine{
+				Spec: vmopv1.VirtualMachineSpec{
+					Image: &vmopv1.VirtualMachineImageRef{
+						Name: builder.DummyVMIName,
+						Kind: "INVALID",
+					},
+				},
+			},
+			sc: builder.DummyStorageClass(),
+			dummyConverter: &DummyConverter{
+				converter: runtime.DefaultUnstructuredConverter,
+				shouldErr: false,
+			},
+			dummyDecoder: DummyDecoder{
+				decoder:   admission.NewDecoder(builder.NewScheme()),
+				shouldErr: false,
+			},
+			allowed:  false,
+			status:   http.StatusBadRequest,
+			expected: validation.RequestedCapacity{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			tc.vm.Name = dummyVMName
+			tc.vm.Namespace = dummyNamespaceName
+
+			var objects []ctrlclient.Object
+			if tc.sc != nil {
+				objects = append(objects, tc.sc)
+				tc.vm.Spec.StorageClass = tc.sc.Name
+			}
+			if tc.vmi != nil {
+				objects = append(objects, tc.vmi)
+			}
+			if tc.cvmi != nil {
+				objects = append(objects, tc.cvmi)
+			}
+			obj, _ := builder.ToUnstructured(tc.vm)
+
+			var oldObj *unstructured.Unstructured
+
+			fakeClient := builder.NewFakeClientWithInterceptors(tc.interceptors, objects...)
+			fakeManagerContext := fake.NewControllerManagerContext()
+			fakeWebhookContext := fake.NewWebhookContext(fakeManagerContext)
+
+			fakeWebhookRequestContext := fake.NewWebhookRequestContext(fakeWebhookContext, obj, oldObj)
+
+			fakeHandler := &validation.RequestedCapacityHandler{
+				Client:         fakeClient,
+				WebhookContext: fakeWebhookContext,
+				Converter:      tc.dummyConverter,
+				Decoder:        tc.dummyDecoder,
+			}
+			resp := fakeHandler.HandleCreate(fakeWebhookRequestContext)
+
+			g := NewWithT(t)
+
+			g.Expect(resp.Allowed).To(Equal(tc.allowed))
+			g.Expect(resp.Result.Code).To(Equal(tc.status))
+
+			g.Expect(resp.Capacity.String()).To(Equal(tc.expected.Capacity.String()))
+			g.Expect(resp.StoragePolicyID).To(Equal(tc.expected.StoragePolicyID))
+			g.Expect(resp.StorageClassName).To(Equal(tc.expected.StorageClassName))
+		})
+	}
+}
+
+func TestRequestedCapacityHandler_HandleUpdate(t *testing.T) {
+	type testCase struct {
+		description    string
+		vm             *vmopv1.VirtualMachine
+		sc             *v1.StorageClass
+		bootDisk       *vmopv1.VirtualMachineAdvancedSpec
+		oldBootDisk    *vmopv1.VirtualMachineAdvancedSpec
+		interceptors   interceptor.Funcs
+		dummyConverter *DummyConverter
+		dummyDecoder   DummyDecoder
+		allowed        bool
+		status         int32
+		expected       validation.RequestedCapacity
+	}
+
+	testCases := []testCase{
+		{
+			description: "error converting obj from unstructured",
+			vm:          builder.DummyVirtualMachine(),
+			sc:          builder.DummyStorageClass(),
+			bootDisk: &vmopv1.VirtualMachineAdvancedSpec{
+				BootDiskCapacity: resource.NewQuantity(10*1024*1024*1024, resource.BinarySI),
+			},
+			oldBootDisk: &vmopv1.VirtualMachineAdvancedSpec{
+				BootDiskCapacity: resource.NewQuantity(15*1024*1024*1024, resource.BinarySI),
+			},
+			dummyConverter: &DummyConverter{
+				converter:    runtime.DefaultUnstructuredConverter,
+				invocations:  0,
+				shouldErr:    true,
+				errThreshold: 0,
+			},
+			dummyDecoder: DummyDecoder{
+				decoder:   admission.NewDecoder(builder.NewScheme()),
+				shouldErr: false,
+			},
+			allowed:  false,
+			status:   http.StatusBadRequest,
+			expected: validation.RequestedCapacity{},
+		},
+		{
+			description: "error converting old obj from unstructured",
+			vm:          builder.DummyVirtualMachine(),
+			sc:          builder.DummyStorageClass(),
+			bootDisk: &vmopv1.VirtualMachineAdvancedSpec{
+				BootDiskCapacity: resource.NewQuantity(10*1024*1024*1024, resource.BinarySI),
+			},
+			oldBootDisk: &vmopv1.VirtualMachineAdvancedSpec{
+				BootDiskCapacity: resource.NewQuantity(15*1024*1024*1024, resource.BinarySI),
+			},
+			dummyConverter: &DummyConverter{
+				converter:    runtime.DefaultUnstructuredConverter,
+				invocations:  0,
+				shouldErr:    true,
+				errThreshold: 1,
+			},
+			dummyDecoder: DummyDecoder{
+				decoder:   admission.NewDecoder(builder.NewScheme()),
+				shouldErr: false,
+			},
+			allowed:  false,
+			status:   http.StatusBadRequest,
+			expected: validation.RequestedCapacity{},
+		},
+		{
+			description: "updated boot disk size is nil",
+			vm:          builder.DummyVirtualMachine(),
+			sc:          builder.DummyStorageClass(),
+			bootDisk:    nil,
+			oldBootDisk: &vmopv1.VirtualMachineAdvancedSpec{
+				BootDiskCapacity: resource.NewQuantity(15*1024*1024*1024, resource.BinarySI),
+			},
+			dummyConverter: &DummyConverter{
+				converter: runtime.DefaultUnstructuredConverter,
+				shouldErr: false,
+			},
+			dummyDecoder: DummyDecoder{
+				decoder:   admission.NewDecoder(builder.NewScheme()),
+				shouldErr: false,
+			},
+			allowed:  true,
+			status:   http.StatusOK,
+			expected: validation.RequestedCapacity{},
+		},
+		{
+			description: "old boot disk size is nil, no change in capacity",
+			vm:          dummyVMWithStatusVolumes(),
+			sc:          builder.DummyStorageClass(),
+			bootDisk: &vmopv1.VirtualMachineAdvancedSpec{
+				BootDiskCapacity: resource.NewQuantity(10*1024*1024*1024, resource.BinarySI),
+			},
+			oldBootDisk: nil,
+			dummyConverter: &DummyConverter{
+				converter: runtime.DefaultUnstructuredConverter,
+				shouldErr: false,
+			},
+			dummyDecoder: DummyDecoder{
+				decoder:   admission.NewDecoder(builder.NewScheme()),
+				shouldErr: false,
+			},
+			allowed:  true,
+			status:   http.StatusOK,
+			expected: validation.RequestedCapacity{},
+		},
+		{
+			description: "old boot disk size is nil, no volumes",
+			vm:          builder.DummyVirtualMachine(),
+			sc:          builder.DummyStorageClass(),
+			bootDisk: &vmopv1.VirtualMachineAdvancedSpec{
+				BootDiskCapacity: resource.NewQuantity(10*1024*1024*1024, resource.BinarySI),
+			},
+			oldBootDisk: nil,
+			dummyConverter: &DummyConverter{
+				converter: runtime.DefaultUnstructuredConverter,
+				shouldErr: false,
+			},
+			dummyDecoder: DummyDecoder{
+				decoder:   admission.NewDecoder(builder.NewScheme()),
+				shouldErr: false,
+			},
+			allowed: true,
+			status:  http.StatusOK,
+			expected: validation.RequestedCapacity{
+				Capacity:         *resource.NewQuantity(10*1024*1024*1024, resource.BinarySI),
+				StoragePolicyID:  "id42",
+				StorageClassName: "dummy-storage-class",
+			},
+		},
+		{
+			description: "change in boot disk size, increase",
+			vm:          builder.DummyVirtualMachine(),
+			sc:          builder.DummyStorageClass(),
+			bootDisk: &vmopv1.VirtualMachineAdvancedSpec{
+				BootDiskCapacity: resource.NewQuantity(15*1024*1024*1024, resource.BinarySI),
+			},
+			oldBootDisk: &vmopv1.VirtualMachineAdvancedSpec{
+				BootDiskCapacity: resource.NewQuantity(10*1024*1024*1024, resource.BinarySI),
+			},
+			dummyConverter: &DummyConverter{
+				converter: runtime.DefaultUnstructuredConverter,
+				shouldErr: false,
+			},
+			dummyDecoder: DummyDecoder{
+				decoder:   admission.NewDecoder(builder.NewScheme()),
+				shouldErr: false,
+			},
+			allowed: true,
+			status:  http.StatusOK,
+			expected: validation.RequestedCapacity{
+				Capacity:         *resource.NewQuantity(5*1024*1024*1024, resource.BinarySI),
+				StoragePolicyID:  "id42",
+				StorageClassName: "dummy-storage-class",
+			},
+		},
+		{
+			description: "change in boot disk size, decrease",
+			vm:          builder.DummyVirtualMachine(),
+			sc:          builder.DummyStorageClass(),
+			bootDisk: &vmopv1.VirtualMachineAdvancedSpec{
+				BootDiskCapacity: resource.NewQuantity(10*1024*1024*1024, resource.BinarySI),
+			},
+			oldBootDisk: &vmopv1.VirtualMachineAdvancedSpec{
+				BootDiskCapacity: resource.NewQuantity(15*1024*1024*1024, resource.BinarySI),
+			},
+			dummyConverter: &DummyConverter{
+				converter: runtime.DefaultUnstructuredConverter,
+				shouldErr: false,
+			},
+			dummyDecoder: DummyDecoder{
+				decoder:   admission.NewDecoder(builder.NewScheme()),
+				shouldErr: false,
+			},
+			allowed:  true,
+			status:   http.StatusOK,
+			expected: validation.RequestedCapacity{},
+		},
+		{
+			description: "no change in boot disk size",
+			vm:          builder.DummyVirtualMachine(),
+			bootDisk: &vmopv1.VirtualMachineAdvancedSpec{
+				BootDiskCapacity: resource.NewQuantity(10*1024*1024*1024, resource.BinarySI),
+			},
+			oldBootDisk: &vmopv1.VirtualMachineAdvancedSpec{
+				BootDiskCapacity: resource.NewQuantity(10*1024*1024*1024, resource.BinarySI),
+			},
+			dummyConverter: &DummyConverter{
+				converter: runtime.DefaultUnstructuredConverter,
+				shouldErr: false,
+			},
+			dummyDecoder: DummyDecoder{
+				decoder:   admission.NewDecoder(builder.NewScheme()),
+				shouldErr: false,
+			},
+			allowed:  true,
+			status:   http.StatusOK,
+			expected: validation.RequestedCapacity{},
+		},
+		{
+			description: "storage class not found",
+			vm:          builder.DummyVirtualMachine(),
+			bootDisk: &vmopv1.VirtualMachineAdvancedSpec{
+				BootDiskCapacity: resource.NewQuantity(15*1024*1024*1024, resource.BinarySI),
+			},
+			oldBootDisk: &vmopv1.VirtualMachineAdvancedSpec{
+				BootDiskCapacity: resource.NewQuantity(10*1024*1024*1024, resource.BinarySI),
+			},
+			dummyConverter: &DummyConverter{
+				converter: runtime.DefaultUnstructuredConverter,
+				shouldErr: false,
+			},
+			dummyDecoder: DummyDecoder{
+				decoder:   admission.NewDecoder(builder.NewScheme()),
+				shouldErr: false,
+			},
+			allowed:  false,
+			status:   http.StatusNotFound,
+			expected: validation.RequestedCapacity{},
+		},
+		{
+			description: "error getting storage class",
+			vm:          builder.DummyVirtualMachine(),
+			sc:          builder.DummyStorageClass(),
+			bootDisk: &vmopv1.VirtualMachineAdvancedSpec{
+				BootDiskCapacity: resource.NewQuantity(15*1024*1024*1024, resource.BinarySI),
+			},
+			oldBootDisk: &vmopv1.VirtualMachineAdvancedSpec{
+				BootDiskCapacity: resource.NewQuantity(10*1024*1024*1024, resource.BinarySI),
+			},
+			interceptors: interceptor.Funcs{
+				Get: func(
+					ctx context.Context,
+					client ctrlclient.WithWatch,
+					key ctrlclient.ObjectKey,
+					obj ctrlclient.Object,
+					opts ...ctrlclient.GetOption) error {
+					if _, ok := obj.(*v1.StorageClass); ok {
+						return errors.New("fake error")
+					}
+
+					return client.Get(ctx, key, obj, opts...)
+				},
+			},
+			dummyConverter: &DummyConverter{
+				converter: runtime.DefaultUnstructuredConverter,
+				shouldErr: false,
+			},
+			dummyDecoder: DummyDecoder{
+				decoder:   admission.NewDecoder(builder.NewScheme()),
+				shouldErr: false,
+			},
+			allowed:  false,
+			status:   http.StatusInternalServerError,
+			expected: validation.RequestedCapacity{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			tc.vm.Name = dummyVMName
+			tc.vm.Namespace = dummyNamespaceName
+			tc.vm.Spec.Advanced = tc.bootDisk
+
+			var objects []ctrlclient.Object
+			if tc.sc != nil {
+				objects = append(objects, tc.sc)
+				tc.vm.Spec.StorageClass = tc.sc.Name
+			}
+
+			obj, _ := builder.ToUnstructured(tc.vm)
+
+			var oldVM *vmopv1.VirtualMachine
+			var oldObj *unstructured.Unstructured
+			oldVM = tc.vm.DeepCopy()
+			oldVM.Spec.Advanced = tc.oldBootDisk
+			oldObj, _ = builder.ToUnstructured(oldVM)
+
+			fakeClient := builder.NewFakeClientWithInterceptors(tc.interceptors, objects...)
+			fakeManagerContext := fake.NewControllerManagerContext()
+			fakeWebhookContext := fake.NewWebhookContext(fakeManagerContext)
+
+			fakeWebhookRequestContext := fake.NewWebhookRequestContext(fakeWebhookContext, obj, oldObj)
+
+			fakeHandler := &validation.RequestedCapacityHandler{
+				Client:         fakeClient,
+				WebhookContext: fakeWebhookContext,
+				Converter:      tc.dummyConverter,
+				Decoder:        tc.dummyDecoder,
+			}
+			resp := fakeHandler.HandleUpdate(fakeWebhookRequestContext)
+
+			g := NewWithT(t)
+
+			g.Expect(resp.Allowed).To(Equal(tc.allowed))
+			g.Expect(resp.Result.Code).To(Equal(tc.status))
+
+			g.Expect(resp.Capacity.String()).To(Equal(tc.expected.Capacity.String()))
+			g.Expect(resp.StoragePolicyID).To(Equal(tc.expected.StoragePolicyID))
+			g.Expect(resp.StorageClassName).To(Equal(tc.expected.StorageClassName))
+		})
+	}
+}
+
+func TestRequestedCapacityHandler_Handle(t *testing.T) {
+	type testCase struct {
+		description  string
+		vm           *vmopv1.VirtualMachine
+		oldVM        *vmopv1.VirtualMachine
+		operation    admissionv1.Operation
+		interceptors interceptor.Funcs
+		allowed      bool
+		status       int32
+	}
+
+	testCases := []testCase{
+		{
+			description: "Create - Error decoding raw obj",
+			operation:   admissionv1.Create,
+			allowed:     false,
+			status:      http.StatusBadRequest,
+		},
+		{
+			description: "Update - Error decoding raw obj",
+			operation:   admissionv1.Update,
+			allowed:     false,
+			status:      http.StatusBadRequest,
+		},
+		{
+			description: "Update - Error decoding raw old obj",
+			vm:          builder.DummyVirtualMachine(),
+			operation:   admissionv1.Update,
+			allowed:     false,
+			status:      http.StatusBadRequest,
+		},
+		{
+			description: "Create",
+			vm:          builder.DummyVirtualMachine(),
+			operation:   admissionv1.Create,
+			allowed:     true,
+			status:      http.StatusOK,
+		},
+		{
+			description: "Update",
+			vm:          builder.DummyVirtualMachine(),
+			oldVM:       builder.DummyVirtualMachine(),
+			operation:   admissionv1.Update,
+			allowed:     true,
+			status:      http.StatusOK,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			sc := builder.DummyStorageClass()
+			vmi := builder.DummyVirtualMachineImage(builder.DummyVMIName)
+			vmi.Namespace = dummyNamespaceName
+			vmi.Status = vmopv1.VirtualMachineImageStatus{
+				Disks: []vmopv1.VirtualMachineImageDiskInfo{
+					{
+						Capacity: resource.NewQuantity(10*1024*1024*1024, resource.BinarySI),
+					},
+				},
+			}
+
+			if tc.vm != nil {
+				tc.vm.Name = dummyVMName
+				tc.vm.Namespace = dummyNamespaceName
+				tc.vm.Spec.StorageClass = sc.Name
+			}
+
+			objects := []ctrlclient.Object{
+				sc,
+				vmi,
+			}
+
+			fakeClient := builder.NewFakeClientWithInterceptors(tc.interceptors, objects...)
+			fakeManagerContext := fake.NewControllerManagerContext()
+			fakeWebhookContext := fake.NewWebhookContext(fakeManagerContext)
+
+			fakeHandler := &validation.RequestedCapacityHandler{
+				Client:         fakeClient,
+				WebhookContext: fakeWebhookContext,
+				Converter: &DummyConverter{
+					converter: runtime.DefaultUnstructuredConverter,
+					shouldErr: false,
+				},
+				Decoder: DummyDecoder{
+					decoder:   admission.NewDecoder(builder.NewScheme()),
+					shouldErr: false,
+				},
+			}
+
+			var obj, oldObj []byte
+
+			if tc.vm != nil {
+				obj, _ = json.Marshal(tc.vm)
+			}
+			if tc.oldVM != nil {
+				oldObj, _ = json.Marshal(tc.oldVM)
+			}
+
+			req := admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: tc.operation,
+					Object: runtime.RawExtension{
+						Raw: obj,
+					},
+					OldObject: runtime.RawExtension{
+						Raw: oldObj,
+					},
+				},
+			}
+
+			resp := fakeHandler.Handle(req)
+
+			g := NewWithT(t)
+
+			g.Expect(resp.Allowed).To(Equal(tc.allowed))
+			g.Expect(resp.Result.Code).To(Equal(tc.status))
+		})
+	}
+}
+
+func TestRequestedCapacityHandler_ServeHTTP(t *testing.T) {
+	type errTestCase struct {
+		description string
+		req         *http.Request
+		status      int32
+	}
+
+	errTestCases := []errTestCase{
+		{
+			description: "empty body should return BadRequest",
+			req:         &http.Request{Body: nil},
+			status:      http.StatusBadRequest,
+		},
+		{
+			description: "NoBody should return BadRequest",
+			req:         &http.Request{Body: http.NoBody},
+			status:      http.StatusBadRequest,
+		},
+		{
+			description: "undecodable body should return BadRequest",
+			req: &http.Request{
+				Header: http.Header{"Content-Type": []string{"application/json"}},
+				Body:   nopCloser{Reader: bytes.NewBufferString("{")},
+			},
+			status: http.StatusBadRequest,
+		},
+		{
+			description: "infinite body should return RequestEntityTooLarge",
+			req: &http.Request{
+				Header: http.Header{"Content-Type": []string{"application/json"}},
+				Method: http.MethodPost,
+				Body:   nopCloser{Reader: rand.Reader},
+			},
+			status: http.StatusRequestEntityTooLarge,
+		},
+		{
+			description: "wrong content-type should return BadRequest",
+			req: &http.Request{
+				Header: http.Header{"Content-Type": []string{"application/foo"}},
+				Body:   nopCloser{Reader: bytes.NewBuffer(nil)},
+			},
+			status: http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range errTestCases {
+		t.Run(tc.description, func(t *testing.T) {
+			fakeClient := builder.NewFakeClient()
+			fakeManagerContext := fake.NewControllerManagerContext()
+			fakeWebhookContext := fake.NewWebhookContext(fakeManagerContext)
+
+			fakeHandler := &validation.RequestedCapacityHandler{
+				Client:         fakeClient,
+				WebhookContext: fakeWebhookContext,
+				Converter: &DummyConverter{
+					converter: runtime.DefaultUnstructuredConverter,
+					shouldErr: false,
+				},
+				Decoder: DummyDecoder{
+					decoder:   admission.NewDecoder(builder.NewScheme()),
+					shouldErr: false,
+				},
+			}
+			resp := httptest.NewRecorder()
+
+			fakeHandler.ServeHTTP(resp, tc.req)
+
+			g := NewWithT(t)
+
+			g.Expect(resp.Code).To(Equal(int(tc.status)))
+		})
+	}
+
+	type testCase struct {
+		description string
+		operation   admissionv1.Operation
+		status      int32
+		expected    validation.RequestedCapacity
+	}
+
+	testCases := []testCase{
+		{
+			description: "should return correct response code and body on create",
+			operation:   admissionv1.Create,
+			status:      http.StatusOK,
+			expected: validation.RequestedCapacity{
+				Capacity:         *resource.NewQuantity(10*1024*1024*1024, resource.BinarySI),
+				StoragePolicyID:  "id42",
+				StorageClassName: "dummy-storage-class",
+			},
+		},
+		{
+			description: "should return correct response code and body on update",
+			operation:   admissionv1.Update,
+			status:      http.StatusOK,
+			expected:    validation.RequestedCapacity{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			sc := builder.DummyStorageClass()
+
+			vm := builder.DummyVirtualMachine()
+			vm.Name = dummyVMName
+			vm.Namespace = dummyNamespaceName
+			vm.Spec.StorageClass = sc.Name
+
+			oldVM := vm.DeepCopy()
+
+			vmi := builder.DummyVirtualMachineImage(builder.DummyVMIName)
+			vmi.Namespace = dummyNamespaceName
+			vmi.Status = vmopv1.VirtualMachineImageStatus{
+				Disks: []vmopv1.VirtualMachineImageDiskInfo{
+					{
+						Capacity: resource.NewQuantity(10*1024*1024*1024, resource.BinarySI),
+					},
+				},
+			}
+
+			objects := []ctrlclient.Object{
+				sc,
+				vmi,
+			}
+
+			fakeClient := builder.NewFakeClient(objects...)
+			fakeManagerContext := fake.NewControllerManagerContext()
+			fakeWebhookContext := fake.NewWebhookContext(fakeManagerContext)
+
+			fakeHandler := &validation.RequestedCapacityHandler{
+				Client:         fakeClient,
+				WebhookContext: fakeWebhookContext,
+				Converter: &DummyConverter{
+					converter: runtime.DefaultUnstructuredConverter,
+					shouldErr: false,
+				},
+				Decoder: DummyDecoder{
+					decoder:   admission.NewDecoder(builder.NewScheme()),
+					shouldErr: false,
+				},
+			}
+
+			var obj, oldObj []byte
+
+			obj, _ = json.Marshal(vm)
+			oldObj, _ = json.Marshal(oldVM)
+
+			ar := admissionv1.AdmissionReview{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "AdmissionReview",
+					APIVersion: "admission.k8s.io/v1",
+				},
+				Request: &admissionv1.AdmissionRequest{
+					Operation: tc.operation,
+					Object: runtime.RawExtension{
+						Raw: obj,
+					},
+					OldObject: runtime.RawExtension{
+						Raw: oldObj,
+					},
+				},
+			}
+
+			body, _ := json.Marshal(ar)
+
+			req := httptest.NewRequest(http.MethodPost, "/getrequestedcapacityforvirtualmachine", bytes.NewReader(body))
+			req.Header.Add("Content-Type", "application/json")
+
+			resp := httptest.NewRecorder()
+
+			fakeHandler.ServeHTTP(resp, req)
+
+			g := NewWithT(t)
+
+			g.Expect(resp.Code).To(Equal(int(tc.status)))
+
+			var actual *validation.RequestedCapacity
+			respBody := resp.Body.String()
+			err := json.Unmarshal([]byte(respBody), &actual)
+
+			g.Expect(err).NotTo(HaveOccurred())
+
+			g.Expect(actual.Capacity.String()).To(Equal(tc.expected.Capacity.String()))
+			g.Expect(actual.StoragePolicyID).To(Equal(tc.expected.StoragePolicyID))
+			g.Expect(actual.StorageClassName).To(Equal(tc.expected.StorageClassName))
+		})
+	}
+}
+
+func TestRequestedCapacityHandler_WriteResponse(t *testing.T) {
+	type testCase struct {
+		description string
+		err         error
+		allowed     bool
+		status      int32
+	}
+
+	testCases := []testCase{
+		{
+			description: "request not allowed should have correct reason and status code",
+			err:         errors.New("bad request"),
+			allowed:     false,
+			status:      http.StatusBadRequest,
+		},
+		{
+			description: "request allowed; should have correct status",
+			allowed:     true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			testResponse := validation.CapacityResponse{}
+
+			if tc.allowed {
+				testResponse.RequestedCapacity = validation.RequestedCapacity{
+					Capacity:         *resource.NewQuantity(10*1024*1024*1024, resource.BinarySI),
+					StoragePolicyID:  "id42",
+					StorageClassName: "dummy-storage-class",
+				}
+				testResponse.Response = webhook.Allowed("")
+			} else {
+				testResponse.Response = webhook.Errored(tc.status, tc.err)
+			}
+
+			w := httptest.NewRecorder()
+
+			fakeClient := builder.NewFakeClient()
+			fakeManagerContext := fake.NewControllerManagerContext()
+			fakeWebhookContext := fake.NewWebhookContext(fakeManagerContext)
+
+			fakeHandler := &validation.RequestedCapacityHandler{
+				Client:         fakeClient,
+				WebhookContext: fakeWebhookContext,
+				Converter: &DummyConverter{
+					converter: runtime.DefaultUnstructuredConverter,
+					shouldErr: false,
+				},
+				Decoder: DummyDecoder{
+					decoder:   admission.NewDecoder(builder.NewScheme()),
+					shouldErr: false,
+				},
+			}
+
+			fakeHandler.WriteResponse(w, testResponse)
+
+			g := NewWithT(t)
+
+			var actual *validation.RequestedCapacity
+			respBody := w.Body.String()
+			err := json.Unmarshal([]byte(respBody), &actual)
+
+			g.Expect(err).NotTo(HaveOccurred())
+
+			g.Expect(actual.Capacity.String()).To(Equal(testResponse.Capacity.String()))
+			g.Expect(actual.StoragePolicyID).To(Equal(testResponse.StoragePolicyID))
+			g.Expect(actual.StorageClassName).To(Equal(testResponse.StorageClassName))
+
+			if tc.allowed {
+				g.Expect(w.Code).To(Equal(http.StatusOK))
+				g.Expect(actual.Reason).To(BeEmpty())
+			} else {
+				g.Expect(w.Code).To(Equal(int(tc.status)))
+				g.Expect(actual.Reason).To(Equal(tc.err.Error()))
+			}
+		})
+	}
+}
+
+type DummyConverter struct {
+	converter    runtime.UnstructuredConverter
+	shouldErr    bool
+	invocations  int
+	errThreshold int
+}
+
+func (dc *DummyConverter) ToUnstructured(obj interface{}) (map[string]interface{}, error) {
+	return nil, nil
+}
+
+func (dc *DummyConverter) FromUnstructured(u map[string]interface{}, obj interface{}) error {
+	if dc.shouldErr {
+		if dc.invocations == dc.errThreshold {
+			return errors.New("fake error")
+		}
+		dc.invocations++
+	}
+	return dc.converter.FromUnstructured(u, obj)
+}
+
+type DummyDecoder struct {
+	decoder   admission.Decoder
+	shouldErr bool
+}
+
+func (dd DummyDecoder) Decode(req admission.Request, into runtime.Object) error {
+	return nil
+}
+
+func (dd DummyDecoder) DecodeRaw(rawObj runtime.RawExtension, into runtime.Object) error {
+	if dd.shouldErr {
+		return fmt.Errorf("fake")
+	}
+	if rawObj.Raw == nil {
+		return fmt.Errorf("fake")
+	}
+	err := dd.decoder.DecodeRaw(rawObj, into)
+
+	return err
+}
+
+type nopCloser struct {
+	io.Reader
+}
+
+func (nopCloser) Close() error { return nil }
+
+func dummyVMWithStatusVolumes() *vmopv1.VirtualMachine {
+	vm := builder.DummyVirtualMachine()
+	vm.Status.Volumes = []vmopv1.VirtualMachineVolumeStatus{
+		{
+			Type:  vmopv1.VirtualMachineStorageDiskTypeClassic,
+			Limit: resource.NewQuantity(10*1024*1024*1024, resource.BinarySI),
+		},
+	}
+
+	return vm
+}

--- a/webhooks/unifiedstoragequota/webhooks.go
+++ b/webhooks/unifiedstoragequota/webhooks.go
@@ -1,0 +1,15 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package unifiedstoragequota
+
+import (
+	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
+
+	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/webhooks/unifiedstoragequota/validation"
+)
+
+func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) error {
+	return validation.AddToManager(ctx, mgr)
+}

--- a/webhooks/webhooks.go
+++ b/webhooks/webhooks.go
@@ -12,6 +12,7 @@ import (
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/webhooks/conversion"
 	"github.com/vmware-tanzu/vm-operator/webhooks/persistentvolumeclaim"
+	"github.com/vmware-tanzu/vm-operator/webhooks/unifiedstoragequota"
 	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachine"
 	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachineclass"
 	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachinepublishrequest"
@@ -51,6 +52,12 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) err
 	if pkgcfg.FromContext(ctx).Features.K8sWorkloadMgmtAPI {
 		if err := virtualmachinereplicaset.AddToManager(ctx, mgr); err != nil {
 			return fmt.Errorf("failed to initialize VirtualMachineReplicaSet webhooks: %w", err)
+		}
+	}
+
+	if pkgcfg.FromContext(ctx).Features.UnifiedStorageQuota {
+		if err := unifiedstoragequota.AddToManager(ctx, mgr); err != nil {
+			return fmt.Errorf("failed to initialize UnifiedStorageQuota webhooks: %w", err)
 		}
 	}
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->

Defines a new webhook server to act as the plug-in endpoint for the unified storage quota management admission webhook

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Support the unified storage quota extension service
```