### PR TITLE
:seedling: Temporarily disable markdown & shell lint jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,23 +12,25 @@ on:
     branches:
     - main
 
+#jobs:
+#
+#  lint-markdown:
+#    runs-on: ubuntu-latest
+#    steps:
+#    - name: Check out code
+#      uses: actions/checkout@v4
+#    - name: Lint Markdown
+#      run: make lint-markdown
+#
+#  lint-shell:
+#    runs-on: ubuntu-latest
+#    steps:
+#    - name: Check out code
+#      uses: actions/checkout@v4
+#    - name: Lint Shell
+#      run: make lint-shell
+
 jobs:
-
-  lint-markdown:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Check out code
-      uses: actions/checkout@v4
-    - name: Lint Markdown
-      run: make lint-markdown
-
-  lint-shell:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Check out code
-      uses: actions/checkout@v4
-    - name: Lint Shell
-      run: make lint-shell
 
   verify-docs:
     needs:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->

`gcr.io/cluster-api-provider-vsphere` project has been deleted. Temporarily disabling jobs while this image finds a new home

```
/usr/bin/podman run --rm -t -v "$(pwd)":/build:ro gcr.io/cluster-api-provider-vsphere/extra/shellcheck
Trying to pull gcr.io/cluster-api-provider-vsphere/extra/shellcheck:latest...
Error: initializing source docker://gcr.io/cluster-api-provider-vsphere/extra/shellcheck:latest: unable to retrieve auth token: invalid username/password: denied: Project cluster-api-provider-vsphere has been deleted.
make: *** [Makefile:258: lint-shell] Error 125
```

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note

```