### PR TITLE
🐛 Only CPU/Memory resize when actually needed

### DIFF
--- a/webhooks/virtualmachine/mutation/virtualmachine_mutator.go
+++ b/webhooks/virtualmachine/mutation/virtualmachine_mutator.go
@@ -469,7 +469,7 @@ func SetLastResizeAnnotation(
 	ctx *pkgctx.WebhookRequestContext,
 	vm, oldVM *vmopv1.VirtualMachine) (bool, error) {
 
-	if !pkgcfg.FromContext(ctx).Features.VMResize {
+	if f := pkgcfg.FromContext(ctx).Features; !f.VMResize && !f.VMResizeCPUMemory {
 		return false, nil
 	}
 

--- a/webhooks/virtualmachine/mutation/virtualmachine_mutator_unit_test.go
+++ b/webhooks/virtualmachine/mutation/virtualmachine_mutator_unit_test.go
@@ -1105,56 +1105,67 @@ func unitTestsMutating() {
 	Describe("SetLastResizeAnnotation", func() {
 		const newClassName = "my-new-class"
 
-		var (
-			oldVM *vmopv1.VirtualMachine
+		DescribeTableSubtree("Resize Tests",
+			func(fullResize bool) {
+				var (
+					oldVM *vmopv1.VirtualMachine
+				)
+
+				BeforeEach(func() {
+					pkgcfg.UpdateContext(ctx, func(config *pkgcfg.Config) {
+						if fullResize {
+							config.Features.VMResize = true
+						} else {
+							config.Features.VMResizeCPUMemory = true
+						}
+					})
+					oldVM = ctx.vm.DeepCopy()
+				})
+
+				When("vm ClassName does not change", func() {
+					It("does not set last-resize annotation", func() {
+						updated, err := mutation.SetLastResizeAnnotation(&ctx.WebhookRequestContext, ctx.vm, oldVM)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(updated).To(BeFalse())
+
+						_, _, _, exists := vmopv1util.GetLastResizedAnnotation(*ctx.vm)
+						Expect(exists).To(BeFalse())
+					})
+				})
+
+				When("existing vm ClassName changes", func() {
+					It("set last-resize annotation", func() {
+						ctx.vm.Spec.ClassName = newClassName
+
+						updated, err := mutation.SetLastResizeAnnotation(&ctx.WebhookRequestContext, ctx.vm, oldVM)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(updated).To(BeTrue())
+
+						className, _, _, exists := vmopv1util.GetLastResizedAnnotation(*ctx.vm)
+						Expect(exists).To(BeTrue())
+						Expect(className).To(Equal(oldVM.Spec.ClassName))
+					})
+				})
+
+				When("vm already has last-resize annotation", func() {
+					It("annotation is not changed", func() {
+						vmClass := builder.DummyVirtualMachineClass("my-class")
+						vmopv1util.MustSetLastResizedAnnotation(ctx.vm, *vmClass)
+
+						updated, err := mutation.SetLastResizeAnnotation(&ctx.WebhookRequestContext, ctx.vm, oldVM)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(updated).To(BeFalse())
+
+						className, _, _, exists := vmopv1util.GetLastResizedAnnotation(*ctx.vm)
+						Expect(exists).To(BeTrue())
+						Expect(className).To(Equal(vmClass.Name))
+					})
+				})
+			},
+
+			Entry("Full", true),
+			Entry("CPU & Memory", false),
 		)
-
-		BeforeEach(func() {
-			pkgcfg.UpdateContext(ctx, func(config *pkgcfg.Config) {
-				config.Features.VMResize = true
-			})
-			oldVM = ctx.vm.DeepCopy()
-		})
-
-		When("vm ClassName does not change", func() {
-			It("does not set last-resize annotation", func() {
-				updated, err := mutation.SetLastResizeAnnotation(&ctx.WebhookRequestContext, ctx.vm, oldVM)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(updated).To(BeFalse())
-
-				_, _, _, exists := vmopv1util.GetLastResizedAnnotation(*ctx.vm)
-				Expect(exists).To(BeFalse())
-			})
-		})
-
-		When("existing vm ClassName changes", func() {
-			It("set last-resize annotation", func() {
-				ctx.vm.Spec.ClassName = newClassName
-
-				updated, err := mutation.SetLastResizeAnnotation(&ctx.WebhookRequestContext, ctx.vm, oldVM)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(updated).To(BeTrue())
-
-				className, _, _, exists := vmopv1util.GetLastResizedAnnotation(*ctx.vm)
-				Expect(exists).To(BeTrue())
-				Expect(className).To(Equal(oldVM.Spec.ClassName))
-			})
-		})
-
-		When("vm already has last-resize annotation", func() {
-			It("annotation is not changed", func() {
-				vmClass := builder.DummyVirtualMachineClass("my-class")
-				vmopv1util.MustSetLastResizedAnnotation(ctx.vm, *vmClass)
-
-				updated, err := mutation.SetLastResizeAnnotation(&ctx.WebhookRequestContext, ctx.vm, oldVM)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(updated).To(BeFalse())
-
-				className, _, _, exists := vmopv1util.GetLastResizedAnnotation(*ctx.vm)
-				Expect(exists).To(BeTrue())
-				Expect(className).To(Equal(vmClass.Name))
-			})
-		})
 	})
 
 	Describe("SetDefaultCdromImgKindOnCreate", func() {


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

Guard the CPU/Memory limited resize by the ResizeNeeded() check. Note that we're only covering CPU/Memory specific resizing here: the other UpdateFoo() were previously there, and this seems the best compromise when having to switch from full resize to hacking in the CPU/Memory limited resize in the old Session update path.

Reorg the resize specific vm_provider tests to better group related tests, and reduce some magic numbers.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note
NONE
```