### PR TITLE
🐛 Fix NPE when converting partial inline sysprep

### DIFF
--- a/api/v1alpha2/sysprep/conversion/v1alpha2/sysprep_conversion.go
+++ b/api/v1alpha2/sysprep/conversion/v1alpha2/sysprep_conversion.go
@@ -4,6 +4,7 @@
 package v1alpha2
 
 import (
+	"reflect"
 	"unsafe"
 
 	apiconversion "k8s.io/apimachinery/pkg/conversion"
@@ -17,7 +18,9 @@ import (
 func Convert_sysprep_Sysprep_To_sysprep_Sysprep(
 	in *vmopv1a2sysprep.Sysprep, out *vmopv1sysprep.Sysprep, s apiconversion.Scope) error {
 
-	out.GUIRunOnce = (*vmopv1sysprep.GUIRunOnce)(unsafe.Pointer(&in.GUIRunOnce))
+	if !reflect.DeepEqual(in.GUIRunOnce, vmopv1a2sysprep.GUIRunOnce{}) {
+		out.GUIRunOnce = (*vmopv1sysprep.GUIRunOnce)(unsafe.Pointer(&in.GUIRunOnce))
+	}
 	out.GUIUnattended = (*vmopv1sysprep.GUIUnattended)(unsafe.Pointer(in.GUIUnattended))
 	out.LicenseFilePrintData = (*vmopv1sysprep.LicenseFilePrintData)(unsafe.Pointer(in.LicenseFilePrintData))
 	out.UserData = (*vmopv1sysprep.UserData)(unsafe.Pointer(in.UserData))

--- a/api/v1alpha2/sysprep/conversion/v1alpha3/sysprep_conversion.go
+++ b/api/v1alpha2/sysprep/conversion/v1alpha3/sysprep_conversion.go
@@ -17,7 +17,9 @@ import (
 func Convert_sysprep_Sysprep_To_sysprep_Sysprep(
 	in *vmopv1sysprep.Sysprep, out *vmopv1a2sysprep.Sysprep, s apiconversion.Scope) error {
 
-	out.GUIRunOnce = *(*vmopv1a2sysprep.GUIRunOnce)(unsafe.Pointer(in.GUIRunOnce))
+	if in.GUIRunOnce != nil {
+		out.GUIRunOnce = *(*vmopv1a2sysprep.GUIRunOnce)(unsafe.Pointer(in.GUIRunOnce))
+	}
 	out.GUIUnattended = (*vmopv1a2sysprep.GUIUnattended)(unsafe.Pointer(in.GUIUnattended))
 	out.LicenseFilePrintData = (*vmopv1a2sysprep.LicenseFilePrintData)(unsafe.Pointer(in.LicenseFilePrintData))
 	out.UserData = (*vmopv1a2sysprep.UserData)(unsafe.Pointer(in.UserData))

--- a/api/v1alpha2/virtualmachine_conversion_test.go
+++ b/api/v1alpha2/virtualmachine_conversion_test.go
@@ -480,7 +480,6 @@ func TestVirtualMachineConversion(t *testing.T) {
 					Sysprep: &vmopv1.VirtualMachineBootstrapSysprepSpec{
 						Sysprep: &vmopv1sysprep.Sysprep{
 							Identification: &vmopv1sysprep.Identification{},
-							GUIRunOnce:     &vmopv1sysprep.GUIRunOnce{},
 						},
 					},
 				}
@@ -581,6 +580,31 @@ func TestVirtualMachineConversion(t *testing.T) {
 					g.Expect(apiequality.Semantic.DeepEqual(hub, tc.outHub)).To(BeTrue(), cmp.Diff(hub, tc.outHub))
 				})
 			}
+		})
+	})
+
+	t.Run("VirtualMachine and partial inline sysprep", func(t *testing.T) {
+		t.Run("hub-spoke-hub", func(t *testing.T) {
+			g := NewWithT(t)
+			hub := vmopv1.VirtualMachine{
+				Spec: vmopv1.VirtualMachineSpec{
+					Bootstrap: &vmopv1.VirtualMachineBootstrapSpec{
+						Sysprep: &vmopv1.VirtualMachineBootstrapSysprepSpec{
+							Sysprep: &vmopv1sysprep.Sysprep{
+								UserData: &vmopv1sysprep.UserData{
+									FullName: "test-user",
+									OrgName:  "test-org",
+									ProductID: &vmopv1sysprep.ProductIDSecretKeySelector{
+										Key:  "product_id",
+										Name: "vm-w9w4mn9xr2",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			hubSpokeHub(g, &hub, &vmopv1.VirtualMachine{}, &vmopv1a2.VirtualMachine{})
 		})
 	})
 }


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch fixes an NPE when doing conversion between v1a2 and v1a3 VMs that have partial inline sysprep configs.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```