### PR TITLE
✨ Restrict cache for all ConfigMap/Secret objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ config/crd/external-crds/cns.vmware.com_*
 
 .DS_Store
 .cache
+ginkgo.report
 
 # Mkdocs
 /.site/

--- a/controllers/infra/capability/infra_capability_controller.go
+++ b/controllers/infra/capability/infra_capability_controller.go
@@ -12,10 +12,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sigs.k8s.io/controller-runtime/pkg/source"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -23,7 +21,6 @@ import (
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	"github.com/vmware-tanzu/vm-operator/pkg/config/capabilities"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
-	pkgmgr "github.com/vmware-tanzu/vm-operator/pkg/manager"
 	"github.com/vmware-tanzu/vm-operator/pkg/record"
 	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
@@ -38,72 +35,42 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
 	)
 
-	cache, err := pkgmgr.NewNamespacedCacheForObject(
-		mgr,
-		&ctx.SyncPeriod,
-		controlledType,
-		capabilities.WCPClusterCapabilitiesConfigMapObjKey.Namespace)
-	if err != nil {
-		return err
-	}
-
 	r := NewReconciler(
 		ctx,
-		cache,
+		mgr.GetClient(),
 		ctrl.Log.WithName("controllers").WithName(controllerName),
 		record.New(mgr.GetEventRecorderFor(controllerNameLong)),
 	)
 
-	// This controller is also run on the non-leaders (webhooks) pods too
-	// so capabilities updates are reflected there.
-	c, err := controller.New(controllerName, mgr, controller.Options{
-		Reconciler:              r,
-		MaxConcurrentReconciles: 1,
-		NeedLeaderElection:      ptr.To(false),
-	})
-	if err != nil {
-		return err
-	}
+	return ctrl.NewControllerManagedBy(mgr).
+		For(controlledType).
+		WithEventFilter(kubeutil.MatchNamePredicate(capabilities.WCPClusterCapabilitiesConfigMapName)).
+		WithEventFilter(predicate.ResourceVersionChangedPredicate{}).
+		WithOptions(controller.TypedOptions[reconcile.Request]{
+			MaxConcurrentReconciles: 1,
+			NeedLeaderElection:      ptr.To(false),
+		}).
+		Complete(r)
 
-	return c.Watch(source.Kind(
-		cache,
-		controlledType,
-		&handler.TypedEnqueueRequestForObject[*corev1.ConfigMap]{},
-		predicate.TypedFuncs[*corev1.ConfigMap]{
-			CreateFunc: func(e event.TypedCreateEvent[*corev1.ConfigMap]) bool {
-				return e.Object.Name == capabilities.WCPClusterCapabilitiesConfigMapObjKey.Name
-			},
-			UpdateFunc: func(e event.TypedUpdateEvent[*corev1.ConfigMap]) bool {
-				return e.ObjectOld.Name == capabilities.WCPClusterCapabilitiesConfigMapObjKey.Name
-			},
-			DeleteFunc: func(e event.TypedDeleteEvent[*corev1.ConfigMap]) bool {
-				return false
-			},
-			GenericFunc: func(e event.TypedGenericEvent[*corev1.ConfigMap]) bool {
-				return false
-			},
-		},
-		kubeutil.TypedResourceVersionChangedPredicate[*corev1.ConfigMap]{},
-	))
 }
 
 func NewReconciler(
 	ctx context.Context,
-	cache client.Reader,
+	client client.Client,
 	logger logr.Logger,
 	recorder record.Recorder) *Reconciler {
 
 	return &Reconciler{
+		Client:   client,
 		Context:  ctx,
-		Cache:    cache,
 		Logger:   logger,
 		Recorder: recorder,
 	}
 }
 
 type Reconciler struct {
+	client.Client
 	Context  context.Context
-	Cache    client.Reader
 	Logger   logr.Logger
 	Recorder record.Recorder
 }
@@ -127,7 +94,7 @@ func (r *Reconciler) reconcileWcpClusterCapabilitiesConfig(ctx context.Context, 
 		"isAsyncSVUpgrade", oldFeatures.SVAsyncUpgrade)
 
 	cm := &corev1.ConfigMap{}
-	if err := r.Cache.Get(ctx, req.NamespacedName, cm); err != nil {
+	if err := r.Client.Get(ctx, req.NamespacedName, cm); err != nil {
 		return client.IgnoreNotFound(err)
 	}
 

--- a/controllers/infra/configmap/infra_configmap_controller.go
+++ b/controllers/infra/configmap/infra_configmap_controller.go
@@ -11,18 +11,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
-	pkgmgr "github.com/vmware-tanzu/vm-operator/pkg/manager"
 	"github.com/vmware-tanzu/vm-operator/pkg/record"
 	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 )
@@ -45,40 +39,10 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		ctx.VMProvider,
 	)
 
-	c, err := controller.New(controllerName, mgr, controller.Options{Reconciler: r})
-	if err != nil {
-		return err
-	}
-
-	cache, err := pkgmgr.NewNamespacedCacheForObject(
-		mgr,
-		&ctx.SyncPeriod,
-		controlledType,
-		WcpClusterConfigMapNamespace)
-	if err != nil {
-		return err
-	}
-
-	return c.Watch(source.Kind(
-		cache,
-		controlledType,
-		&handler.TypedEnqueueRequestForObject[*corev1.ConfigMap]{},
-		predicate.TypedFuncs[*corev1.ConfigMap]{
-			CreateFunc: func(e event.TypedCreateEvent[*corev1.ConfigMap]) bool {
-				return e.Object.GetName() == WcpClusterConfigMapName
-			},
-			UpdateFunc: func(e event.TypedUpdateEvent[*corev1.ConfigMap]) bool {
-				return e.ObjectOld.GetName() == WcpClusterConfigMapName
-			},
-			DeleteFunc: func(e event.TypedDeleteEvent[*corev1.ConfigMap]) bool {
-				return false
-			},
-			GenericFunc: func(e event.TypedGenericEvent[*corev1.ConfigMap]) bool {
-				return false
-			},
-		},
-		kubeutil.TypedResourceVersionChangedPredicate[*corev1.ConfigMap]{},
-	))
+	return ctrl.NewControllerManagedBy(mgr).
+		For(controlledType).
+		WithEventFilter(kubeutil.MatchNamePredicate(WcpClusterConfigMapName)).
+		Complete(r)
 }
 
 type provider interface {

--- a/controllers/infra/secret/infra_secret_controller_intg_test.go
+++ b/controllers/infra/secret/infra_secret_controller_intg_test.go
@@ -53,6 +53,8 @@ func intgTestsReconcile() {
 		)
 
 		BeforeEach(func() {
+			atomic.StoreInt32(&called, 0)
+
 			obj = &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: ctx.PodNamespace,
@@ -73,7 +75,6 @@ func intgTestsReconcile() {
 		AfterEach(func() {
 			err := ctx.Client.Delete(ctx, obj)
 			Expect(err == nil || apierrors.IsNotFound(err)).To(BeTrue())
-			atomic.StoreInt32(&called, 0)
 		})
 
 		When("created", func() {
@@ -91,9 +92,10 @@ func intgTestsReconcile() {
 				})
 				It("should not be reconciled", func() {
 					Consistently(func() int32 {
-						// NOTE: ResetVcClient() won't be called during the reconcile because the
-						// obj namespace won't match the pod's namespace. It is bad news if you see
-						// "Reconciling unexpected object" in the logs.
+						// NOTE: ResetVcClient() will not be called during the
+						// reconcile because the object's namespace will not
+						// match the pod's namespace. It is bad news if
+						// "Reconciling unexpected object" is in the logs.
 						return atomic.LoadInt32(&called)
 					}).Should(Equal(int32(0)))
 				})
@@ -120,9 +122,10 @@ func intgTestsReconcile() {
 				})
 				It("should not be reconciled", func() {
 					Consistently(func() int32 {
-						// NOTE: ResetVcClient() won't be called during the reconcile because the
-						// obj namespace won't match the pod's namespace. It is bad news if you see
-						// "Reconciling unexpected object" in the logs.
+						// NOTE: ResetVcClient() will not be called during the
+						// reconcile because the object's namespace will not
+						// match the pod's namespace. It is bad news if
+						// "Reconciling unexpected object" is in the logs.
 						return atomic.LoadInt32(&called)
 					}).Should(Equal(int32(0)))
 				})

--- a/pkg/manager/cache.go
+++ b/pkg/manager/cache.go
@@ -112,8 +112,8 @@ func GetNamespaceCacheConfigs(namespaces ...string) map[string]ctrlcache.Config 
 	}
 	nsc := make(map[string]ctrlcache.Config, len(namespaces))
 	for i := range namespaces {
-		if v := namespaces[i]; v != "" {
-			nsc[v] = ctrlcache.Config{}
+		if namespaces[i] != "" {
+			nsc[namespaces[i]] = ctrlcache.Config{}
 		}
 	}
 	return nsc

--- a/pkg/util/kube/predicates.go
+++ b/pkg/util/kube/predicates.go
@@ -266,3 +266,31 @@ func isNil(arg any) bool {
 	}
 	return false
 }
+
+type matchNamePredicate[T client.Object] struct {
+	name string
+}
+
+// MatchNamePredicate returns a predicate that only allows objects with names
+// that match the provided value.
+func MatchNamePredicate(
+	name string) predicate.TypedPredicate[client.Object] {
+
+	return matchNamePredicate[client.Object]{name: name}
+}
+
+func (p matchNamePredicate[T]) Create(e event.TypedCreateEvent[T]) bool {
+	return e.Object.GetName() == p.name
+}
+
+func (p matchNamePredicate[T]) Delete(e event.TypedDeleteEvent[T]) bool {
+	return e.Object.GetName() == p.name
+}
+
+func (p matchNamePredicate[T]) Update(e event.TypedUpdateEvent[T]) bool {
+	return e.ObjectOld.GetName() == p.name
+}
+
+func (p matchNamePredicate[T]) Generic(e event.TypedGenericEvent[T]) bool {
+	return e.Object.GetName() == p.name
+}


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch updates the manager cache for VM Operator so that ConfigMap/Secret resources from the kube-system and VM Op pod namespaces are cached, but ConfigMap/Secret resources in any other namespace are *not* cached.

This patch means controllers that access ConfigMap/Secret resources in these namespaces no longer need to create separate caches. Instead, all controllers may use the manager client unless for some other reason.
<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

The tests in `controllers/infra/secret/infra_secret_controller_intg_test.go` related to checking the value of `called` validates the expected behavior.


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Restrict caching of ConfigMap and Secret resources to kube-system and the VM Operator pod namespaces.
```