### PR TITLE
:seedling: Do not fall back to using filenames for PVC disk backup

### DIFF
--- a/pkg/providers/vsphere/virtualmachine/backup_test.go
+++ b/pkg/providers/vsphere/virtualmachine/backup_test.go
@@ -12,11 +12,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
-	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/vmware/govmomi/object"
-	"github.com/vmware/govmomi/simulator"
 	"github.com/vmware/govmomi/vim25/mo"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 
@@ -689,22 +687,6 @@ func backupTests() {
 							verifyBackupDataInExtraConfig(ctx, vcVM, vmopv1.BackupVersionExtraConfigKey, vT2, false)
 							Expect(vmCtx.VM.Annotations[vmopv1.VirtualMachineBackupVersionAnnotation]).To(Equal(vT2))
 						}
-
-						By("detect disk file backing change", func() {
-							vm := simulator.Map.Get(vcVM.Reference()).(*simulator.VirtualMachine)
-							deviceList := object.VirtualDeviceList(vm.Config.Hardware.Device)
-
-							for _, device := range deviceList.SelectByType((*vimtypes.VirtualDisk)(nil)) {
-								disk := device.(*vimtypes.VirtualDisk)
-								if b, ok := disk.Backing.(*vimtypes.VirtualDiskFlatVer2BackingInfo); ok {
-									b.Uuid = uuid.NewString()
-									break
-								}
-							}
-
-							Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
-							verifyBackupDataInExtraConfig(ctx, vcVM, vmopv1.PVCDiskDataExtraConfigKey, string(diskDataJSON), true)
-						})
 					})
 				})
 			})


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

When recording PVC disk data for the backup, we added code that first checks disks by their filenames first before falling back to using UUIDs.  This was done to support partial (disk only restore).

Since partial restore no longer relies on the PVC disk data, we no longer need to do this.  The current code also has a side effect of not handling disks restored with a new PVC name.



**Are there any special notes for your reviewer**:

This effectively reverts the commit: c3a0c36.


**Please add a release note if necessary**:
```release-note
Do not fall back to using filenames for PVC disk backup
```