### PR TITLE
🌱 SetAnnotation() after pause annotation rename conversion

### DIFF
--- a/api/v1alpha1/virtualmachine_conversion.go
+++ b/api/v1alpha1/virtualmachine_conversion.go
@@ -1211,6 +1211,7 @@ func Convert_v1alpha1_VirtualMachine_To_v1alpha3_VirtualMachine(in *VirtualMachi
 		// This would also remove the annotation if someone created a
 		// v1a1 VM with "pause-reconcile" annotation.
 		delete(annotations, PauseAnnotation)
+		out.GetObjectMeta().SetAnnotations(annotations)
 	}
 
 	return nil

--- a/api/v1alpha2/virtualmachine_conversion.go
+++ b/api/v1alpha2/virtualmachine_conversion.go
@@ -231,6 +231,7 @@ func Convert_v1alpha2_VirtualMachine_To_v1alpha3_VirtualMachine(in *VirtualMachi
 		// This would also remove the annotation if someone created a
 		// v1a1 VM with "pause-reconcile" annotation.
 		delete(annotations, PauseAnnotation)
+		out.GetObjectMeta().SetAnnotations(annotations)
 	}
 
 	return nil

--- a/api/v1alpha2/virtualmachine_conversion_test.go
+++ b/api/v1alpha2/virtualmachine_conversion_test.go
@@ -678,4 +678,32 @@ func TestVirtualMachineConversion(t *testing.T) {
 			})
 		})
 	})
+
+	t.Run("VirtualMachine pauseAnnotation rename", func(t *testing.T) {
+		t.Run("VirtualMachine hub-spoke-hub after pauseAnnotation rename", func(t *testing.T) {
+			g := NewWithT(t)
+			hub := vmopv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{vmopv1.PauseAnnotation: "true"},
+				},
+			}
+			hubSpokeHub(g, &hub, &vmopv1.VirtualMachine{}, &vmopv1a2.VirtualMachine{})
+		})
+
+		t.Run("VirtualMachine hub-spoke pauseAnnotation rename", func(t *testing.T) {
+			g := NewWithT(t)
+			hub := vmopv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{vmopv1.PauseAnnotation: "true"},
+				},
+			}
+
+			var spoke vmopv1a2.VirtualMachine
+			g.Expect(spoke.ConvertFrom(&hub)).To(Succeed())
+			anno := hub.GetAnnotations()
+			g.Expect(anno).ToNot(BeNil())
+			g.Expect(anno[vmopv1a2.PauseAnnotation]).To(Equal("true"))
+			g.Expect(anno).ShouldNot(HaveKey(vmopv1.PauseAnnotation))
+		})
+	})
 }


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
- SetAnnotation() after pause annotation rename from v1a1/a2 <-> a3.
- Also adds an additional test for v1a1ConfigMapAnnotation being set

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # N/A


**Are there any special notes for your reviewer**:

N/A

**Please add a release note if necessary**:

```
NONE
```