### PR TITLE
:seedling: Add ValidatingWebhookConfiguration for storage quota webhook

### DIFF
--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
 - service.yaml
 - manifests.yaml
+- storage_quota_webhook_configuration.yaml
 
 patchesStrategicMerge:
 - manifests_label_patch.yaml

--- a/config/webhook/storage_quota_webhook_configuration.yaml
+++ b/config/webhook/storage_quota_webhook_configuration.yaml
@@ -1,0 +1,52 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: vm-storage-quota-validating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: kube-system/storage-quota-serving-cert
+  labels:
+    "webhooks.vmoperator.vmware.com": "true"
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: storage-quota-webhook-service
+      namespace: kube-system
+      path: /validate-storage-quota
+  failurePolicy: Fail
+  name: quota-create.validating.virtualmachine.v1alpha3.vmoperator.vmware.com
+  rules:
+  - apiGroups:
+    - vmoperator.vmware.com
+    apiVersions:
+    - v1alpha3
+    operations:
+    - CREATE
+    resources:
+    - virtualmachines
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: storage-quota-webhook-service
+      namespace: kube-system
+      path: /validate-storage-quota
+  failurePolicy: Fail
+  name: quota-update.validating.virtualmachine.v1alpha3.vmoperator.vmware.com
+  rules:
+  - apiGroups:
+    - vmoperator.vmware.com
+    apiVersions:
+    - v1alpha3
+    operations:
+    - UPDATE
+    resources:
+    - virtualmachines
+  sideEffects: None
+  matchConditions:
+  - expression: oldObject.spec.advanced.bootDiskCapacity != object.spec.advanced.bootDiskCapacity
+    name: boot-disk-change


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR adds a ValidatingWebhookConfiguration to allow the storage quota webhook to be called upon create/update of virtual machines

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:


```release-note
NONE
```