### PR TITLE
🐛 Skip resizing ISO VM boot disk

### DIFF
--- a/api/v1alpha3/virtualmachine_types.go
+++ b/api/v1alpha3/virtualmachine_types.go
@@ -708,6 +708,9 @@ type VirtualMachineAdvancedSpec struct {
 	// the guest to take advantage of the additional capacity. Finally, changing
 	// the size of the VM's boot disk, even increasing it, could adversely
 	// affect the VM.
+	//
+	// Please note this field is ignored if the VM is deployed from an ISO with
+	// CD-ROM devices attached.
 	BootDiskCapacity *resource.Quantity `json:"bootDiskCapacity,omitempty"`
 
 	// +optional

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachinereplicasets.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachinereplicasets.yaml
@@ -174,6 +174,9 @@ spec:
                               the guest to take advantage of the additional capacity. Finally, changing
                               the size of the VM's boot disk, even increasing it, could adversely
                               affect the VM.
+
+                              Please note this field is ignored if the VM is deployed from an ISO with
+                              CD-ROM devices attached.
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
                           changeBlockTracking:

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -2964,6 +2964,9 @@ spec:
                       the guest to take advantage of the additional capacity. Finally, changing
                       the size of the VM's boot disk, even increasing it, could adversely
                       affect the VM.
+
+                      Please note this field is ignored if the VM is deployed from an ISO with
+                      CD-ROM devices attached.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   changeBlockTracking:

--- a/pkg/providers/vsphere/session/session_vm.go
+++ b/pkg/providers/vsphere/session/session_vm.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2018-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package session
@@ -23,6 +23,12 @@ func updateVirtualDiskDeviceChanges(
 
 	capacity := advanced.BootDiskCapacity
 	if capacity == nil || capacity.IsZero() {
+		return nil, nil
+	}
+
+	// Skip resizing ISO VMs with attached CD-ROMs as their boot disks are FCDs
+	// and should be managed by PVCs.
+	if len(vmCtx.VM.Spec.Cdrom) > 0 {
 		return nil, nil
 	}
 

--- a/pkg/providers/vsphere/vmlifecycle/create_clone.go
+++ b/pkg/providers/vsphere/vmlifecycle/create_clone.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2023-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package vmlifecycle
@@ -165,6 +165,12 @@ func resizeBootDiskDeviceChange(
 
 	capacity := advanced.BootDiskCapacity
 	if capacity == nil || capacity.IsZero() {
+		return nil
+	}
+
+	// Skip resizing ISO VMs with attached CD-ROMs as their boot disks are FCDs
+	// and should be managed by PVCs.
+	if len(vmCtx.VM.Spec.Cdrom) > 0 {
 		return nil
 	}
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR updates the `bootDiskCapacity` reconciliation process to skip resizing boot disks for ISO VMs since they're managed by PVCs. It also updates the API docs to reflect this behavior.

**Which issue(s) is/are addressed by this PR?**

Fixes N/A.


**Are there any special notes for your reviewer**:

We're not enforcing this via webhook to minimize changes to the current ISO workflow. A future release may introduce this enforcement or add support for resizing ISO VM boot disks.

**Please add a release note if necessary**:

```release-note
Skip resizing ISO VM boot disk and update API docs.
```

<!-- readthedocs-preview vm-operator start -->
----
📚 Documentation preview 📚: https://vm-operator--732.org.readthedocs.build/en/732/

<!-- readthedocs-preview vm-operator end -->