### PR TITLE
✨ Reconcile VMs on async signal

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -160,11 +160,20 @@ rules:
   resources:
   - availabilityzones
   - availabilityzones/status
-  - zones
   - zones/status
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - topology.tanzu.vmware.com
+  resources:
+  - zones
+  verbs:
+  - get
+  - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - vmoperator.vmware.com

--- a/controllers/infra/controllers.go
+++ b/controllers/infra/controllers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/controllers/infra/node"
 	"github.com/vmware-tanzu/vm-operator/controllers/infra/secret"
 	"github.com/vmware-tanzu/vm-operator/controllers/infra/validatingwebhookconfiguration"
+	"github.com/vmware-tanzu/vm-operator/controllers/infra/zone"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 )
@@ -33,7 +34,12 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 	}
 	if pkgcfg.FromContext(ctx).Features.UnifiedStorageQuota {
 		if err := validatingwebhookconfiguration.AddToManager(ctx, mgr); err != nil {
-			return fmt.Errorf("failed to initialize storagepolicyusage webhook controller: %w", err)
+			return fmt.Errorf("failed to initialize validatingwebhookconfiguration webhook controller: %w", err)
+		}
+	}
+	if pkgcfg.FromContext(ctx).Features.WorkloadDomainIsolation {
+		if err := zone.AddToManager(ctx, mgr); err != nil {
+			return fmt.Errorf("failed to initialize infra zone controller: %w", err)
 		}
 	}
 

--- a/controllers/infra/zone/zone_controller.go
+++ b/controllers/infra/zone/zone_controller.go
@@ -1,0 +1,162 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package zone
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/go-logr/logr"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	topologyv1 "github.com/vmware-tanzu/vm-operator/external/tanzu-topology/api/v1alpha1"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
+	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/patch"
+	"github.com/vmware-tanzu/vm-operator/pkg/record"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/watcher"
+)
+
+// SkipNameValidation is used for testing to allow multiple controllers with the
+// same name since Controller-Runtime has a global singleton registry to
+// prevent controllers with the same name, even if attached to different
+// managers.
+var SkipNameValidation *bool
+
+// AddToManager adds this package's controller to the provided manager.
+func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) error {
+	var (
+		controlledType     = &topologyv1.Zone{}
+		controlledTypeName = reflect.TypeOf(controlledType).Elem().Name()
+
+		controllerNameShort = fmt.Sprintf("%s-controller", strings.ToLower(controlledTypeName))
+		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
+	)
+
+	r := NewReconciler(
+		ctx,
+		mgr.GetClient(),
+		ctrl.Log.WithName("controllers").WithName(controlledTypeName),
+		record.New(mgr.GetEventRecorderFor(controllerNameLong)),
+	)
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(controlledType).
+		WithOptions(controller.Options{
+			SkipNameValidation: SkipNameValidation,
+		}).
+		Complete(r)
+}
+
+func NewReconciler(
+	ctx context.Context,
+	client client.Client,
+	logger logr.Logger,
+	recorder record.Recorder) *Reconciler {
+
+	return &Reconciler{
+		Context:  ctx,
+		Client:   client,
+		Logger:   logger,
+		Recorder: recorder,
+	}
+}
+
+// Finalizer is the finalizer placed on Zone objects by VM Operator.
+const Finalizer = "vmoperator.vmware.com/finalizer"
+
+// Reconciler reconciles a StoragePolicyQuota object.
+type Reconciler struct {
+	client.Client
+	Context  context.Context
+	Logger   logr.Logger
+	Recorder record.Recorder
+}
+
+// +kubebuilder:rbac:groups=topology.tanzu.vmware.com,resources=zones,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=topology.tanzu.vmware.com,resources=zones/status,verbs=get
+
+func (r *Reconciler) Reconcile(
+	ctx context.Context,
+	req ctrl.Request) (_ ctrl.Result, reterr error) {
+
+	ctx = pkgcfg.JoinContext(ctx, r.Context)
+	ctx = watcher.JoinContext(ctx, r.Context)
+
+	var obj topologyv1.Zone
+	if err := r.Get(ctx, req.NamespacedName, &obj); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	patchHelper, err := patch.NewHelper(&obj, r.Client)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	defer func() {
+		if err := patchHelper.Patch(ctx, &obj); err != nil {
+			if reterr == nil {
+				reterr = err
+			} else {
+				reterr = fmt.Errorf("%w,%w", err, reterr)
+			}
+		}
+	}()
+
+	if !obj.DeletionTimestamp.IsZero() {
+		return r.ReconcileDelete(ctx, &obj)
+	}
+
+	return r.ReconcileNormal(ctx, &obj)
+}
+
+func (r *Reconciler) ReconcileDelete(
+	ctx context.Context,
+	obj *topologyv1.Zone) (ctrl.Result, error) {
+
+	if controllerutil.ContainsFinalizer(obj, Finalizer) {
+		if val := obj.Spec.ManagedVMs.FolderMoID; val != "" {
+			if err := watcher.Remove(
+				ctx,
+				vimtypes.ManagedObjectReference{
+					Type:  "Folder",
+					Value: val,
+				},
+				fmt.Sprintf("%s/%s", obj.Namespace, obj.Name)); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+		controllerutil.RemoveFinalizer(obj, Finalizer)
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *Reconciler) ReconcileNormal(
+	ctx context.Context,
+	obj *topologyv1.Zone) (ctrl.Result, error) {
+
+	if !controllerutil.ContainsFinalizer(obj, Finalizer) {
+		// The finalizer is not added until we are able to successfully
+		// add a watch to the zone's VM Service folder.
+		if val := obj.Spec.ManagedVMs.FolderMoID; val != "" {
+			if err := watcher.Add(
+				ctx,
+				vimtypes.ManagedObjectReference{
+					Type:  "Folder",
+					Value: val,
+				},
+				fmt.Sprintf("%s/%s", obj.Namespace, obj.Name)); err != nil {
+				return ctrl.Result{}, err
+			}
+			controllerutil.AddFinalizer(obj, Finalizer)
+		}
+	}
+	return ctrl.Result{}, nil
+}

--- a/controllers/infra/zone/zone_controller_suite_test.go
+++ b/controllers/infra/zone/zone_controller_suite_test.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package zone_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/vmware-tanzu/vm-operator/controllers/infra/zone"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
+)
+
+func TestZoneController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Zone Controller Test Suite")
+}
+
+var _ = BeforeSuite(func() {
+	zone.SkipNameValidation = ptr.To(true)
+})

--- a/controllers/infra/zone/zone_controller_test.go
+++ b/controllers/infra/zone/zone_controller_test.go
@@ -1,0 +1,306 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package zone_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/vmware/govmomi/object"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	"github.com/vmware-tanzu/vm-operator/controllers/infra/zone"
+	topologyv1 "github.com/vmware-tanzu/vm-operator/external/tanzu-topology/api/v1alpha1"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
+	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+	providerfake "github.com/vmware-tanzu/vm-operator/pkg/providers/fake"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
+	vsclient "github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/client"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/watcher"
+	vmwatcher "github.com/vmware-tanzu/vm-operator/services/vm-watcher"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+	"github.com/vmware-tanzu/vm-operator/test/testutil"
+)
+
+var _ = Describe(
+	"Reconcile",
+	Label(
+		testlabels.Controller,
+		testlabels.EnvTest,
+		testlabels.V1Alpha3,
+	),
+	func() {
+
+		var (
+			ctx       context.Context
+			vcSimCtx  *builder.IntegrationTestContextForVCSim
+			provider  *providerfake.VMProvider
+			initEnvFn builder.InitVCSimEnvFn
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			ctx = logr.NewContext(ctx, testutil.GinkgoLogr(4))
+		})
+
+		JustBeforeEach(func() {
+			ctx = pkgcfg.WithContext(ctx, pkgcfg.Default())
+			ctx = pkgcfg.UpdateContext(
+				ctx,
+				func(config *pkgcfg.Config) {
+					config.Features.WorkloadDomainIsolation = true
+				},
+			)
+			ctx = cource.WithContext(ctx)
+			ctx = watcher.WithContext(ctx)
+
+			provider = providerfake.NewVMProvider()
+			provider.VSphereClientFn = func(ctx context.Context) (*vsclient.Client, error) {
+				return vsclient.NewClient(ctx, vcSimCtx.VCClientConfig)
+			}
+
+			vcSimCtx = builder.NewIntegrationTestContextForVCSim(
+				ctx,
+				builder.VCSimTestConfig{
+					WithWorkloadIsolation: pkgcfg.FromContext(ctx).Features.WorkloadDomainIsolation,
+				},
+				func(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) error {
+					if err := vmwatcher.AddToManager(ctx, mgr); err != nil {
+						return err
+					}
+					return zone.AddToManager(ctx, mgr)
+				},
+				func(ctx *pkgctx.ControllerManagerContext, _ ctrlmgr.Manager) error {
+					ctx.VMProvider = provider
+					return nil
+				},
+				initEnvFn)
+			Expect(vcSimCtx).ToNot(BeNil())
+
+			vcSimCtx.BeforeEach()
+
+			ctx = vcSimCtx
+		})
+
+		AfterEach(func() {
+			vcSimCtx.AfterEach()
+		})
+
+		When("new zones are added", func() {
+			var (
+				nsInfo builder.WorkloadNamespaceInfo
+			)
+
+			JustBeforeEach(func() {
+				nsInfo = vcSimCtx.CreateWorkloadNamespace()
+
+				By("ensure all zones have finalizers", func() {
+					Eventually(func(g Gomega) {
+						var obj topologyv1.ZoneList
+						g.Expect(vcSimCtx.Client.List(ctx, &obj, ctrlclient.InNamespace(nsInfo.Namespace))).To(Succeed())
+						g.Expect(obj.Items).To(HaveLen(vcSimCtx.ZoneCount))
+						g.Expect(obj.Items).ToNot(BeEmpty())
+						for i := range obj.Items {
+							g.Expect(obj.Items[i].Finalizers).To(ConsistOf([]string{zone.Finalizer}))
+						}
+					}).Should(Succeed())
+				})
+			})
+
+			When("no vms exist in the zone's vm service folder", func() {
+
+				const (
+					vmName     = "my-vm-1"
+					fakeString = "fake"
+				)
+
+				var (
+					vm *object.VirtualMachine
+				)
+
+				BeforeEach(func() {
+					initEnvFn = func(ctx *builder.IntegrationTestContextForVCSim) {
+						vmList, err := ctx.Finder.VirtualMachineList(ctx, "*")
+						Expect(err).ToNot(HaveOccurred())
+						Expect(vmList).ToNot(BeEmpty())
+						vm = vmList[0]
+
+						dcFolders, err := ctx.Datacenter.Folders(ctx)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(dcFolders).ToNot(BeNil())
+						Expect(dcFolders.VmFolder).ToNot(BeNil())
+
+						By("creating vm in k8s", func() {
+							obj := builder.DummyBasicVirtualMachine(
+								vmName,
+								ctx.NSInfo.Namespace)
+							Expect(ctx.Client.Create(ctx, obj)).To(Succeed())
+						})
+
+						By("moving vm into the root folder", func() {
+							t, err := dcFolders.VmFolder.MoveInto(
+								ctx,
+								[]vimtypes.ManagedObjectReference{vm.Reference()})
+							Expect(err).ToNot(HaveOccurred())
+							Expect(t).ToNot(BeNil())
+							Expect(t.Wait(ctx)).To(Succeed())
+						})
+
+						By("adding namespacedName to vm's extraConfig", func() {
+							t, err := vm.Reconfigure(ctx, vimtypes.VirtualMachineConfigSpec{
+								ExtraConfig: []vimtypes.BaseOptionValue{
+									&vimtypes.OptionValue{
+										Key:   "vmservice.namespacedName",
+										Value: ctx.NSInfo.Namespace + "/" + vmName,
+									},
+								},
+							})
+							Expect(err).ToNot(HaveOccurred())
+							Expect(t).ToNot(BeNil())
+							Expect(t.Wait(ctx)).To(Succeed())
+						})
+					}
+				})
+
+				Specify("no reconcile requests should be enqueued for vms", func() {
+					chanSource := cource.FromContext(ctx, "VirtualMachine")
+					Consistently(chanSource).ShouldNot(Receive())
+				})
+
+				When("the vm is relocated into the zone's folder", func() {
+					JustBeforeEach(func() {
+						t, err := nsInfo.Folder.MoveInto(
+							ctx,
+							[]vimtypes.ManagedObjectReference{vm.Reference()})
+						Expect(err).ToNot(HaveOccurred())
+						Expect(t).ToNot(BeNil())
+						Expect(t.Wait(ctx)).To(Succeed())
+					})
+					Specify("a reconcile request should be enqueued for vm", func() {
+						chanSource := cource.FromContext(ctx, "VirtualMachine")
+						var e event.GenericEvent
+						Eventually(chanSource).Should(Receive(&e, Equal(event.GenericEvent{
+							Object: &vmopv1.VirtualMachine{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: vcSimCtx.NSInfo.Namespace,
+									Name:      vmName,
+								},
+							},
+						})))
+					})
+
+					When("a single zone with the vm's folder is removed", func() {
+						JustBeforeEach(func() {
+							var list topologyv1.ZoneList
+							Expect(vcSimCtx.Client.List(
+								ctx,
+								&list,
+								ctrlclient.InNamespace(nsInfo.Namespace))).To(Succeed())
+
+							for i := range list.Items {
+								z := &list.Items[i]
+								if z.Spec.ManagedVMs.FolderMoID == nsInfo.Folder.Reference().Value {
+									Expect(z).ToNot(BeNil())
+									Expect(vcSimCtx.Client.Delete(ctx, z)).To(Succeed())
+									Eventually(func(g Gomega) {
+										key := ctrlclient.ObjectKeyFromObject(z)
+										g.Expect(vcSimCtx.Client.Get(vcSimCtx, key, z)).ToNot(Succeed())
+									}).Should(Succeed())
+									break
+								}
+							}
+						})
+
+						Specify("a change to the vm should cause it to be reconciled", func() {
+							// Pull any events off of the source channel for 10
+							// seconds. This should give the zone enough time to be
+							// removed.
+							chanSource := cource.FromContext(ctx, "VirtualMachine")
+							Eventually(func(g Gomega) {
+								g.Expect(chanSource).ToNot(Receive())
+							}, time.Second*10).Should(Succeed())
+
+							t, err := vm.Reconfigure(ctx, vimtypes.VirtualMachineConfigSpec{
+								ExtraConfig: []vimtypes.BaseOptionValue{
+									&vimtypes.OptionValue{
+										Key:   "guestinfo.ipaddr",
+										Value: "1.2.3.4",
+									},
+								},
+							})
+							Expect(err).ToNot(HaveOccurred())
+							Expect(t).ToNot(BeNil())
+							Expect(t.Wait(ctx)).To(Succeed())
+
+							var e event.GenericEvent
+							Eventually(chanSource).Should(Receive(&e, Equal(event.GenericEvent{
+								Object: &vmopv1.VirtualMachine{
+									ObjectMeta: metav1.ObjectMeta{
+										Namespace: vcSimCtx.NSInfo.Namespace,
+										Name:      vmName,
+									},
+								},
+							})))
+						})
+					})
+
+					When("all zones with the vm's folder are removed", func() {
+						JustBeforeEach(func() {
+							var list topologyv1.ZoneList
+							Expect(vcSimCtx.Client.List(
+								ctx,
+								&list,
+								ctrlclient.InNamespace(nsInfo.Namespace))).To(Succeed())
+
+							for i := range list.Items {
+								z := &list.Items[i]
+								if z.Spec.ManagedVMs.FolderMoID == nsInfo.Folder.Reference().Value {
+									Expect(z).ToNot(BeNil())
+									Expect(vcSimCtx.Client.Delete(ctx, z)).To(Succeed())
+									Eventually(func(g Gomega) {
+										key := ctrlclient.ObjectKeyFromObject(z)
+										g.Expect(vcSimCtx.Client.Get(vcSimCtx, key, z)).ToNot(Succeed())
+									}).Should(Succeed())
+								}
+							}
+						})
+
+						Specify("a change to the vm should not cause it to be reconciled", func() {
+							// Pull any events off of the source channel for 10
+							// seconds. This should give the zones enough time to be
+							// removed.
+							chanSource := cource.FromContext(ctx, "VirtualMachine")
+							Eventually(func(g Gomega) {
+								g.Expect(chanSource).ToNot(Receive())
+							}, time.Second*10).Should(Succeed())
+
+							t, err := vm.Reconfigure(ctx, vimtypes.VirtualMachineConfigSpec{
+								ExtraConfig: []vimtypes.BaseOptionValue{
+									&vimtypes.OptionValue{
+										Key:   "guestinfo.ipaddr",
+										Value: "1.2.3.4",
+									},
+								},
+							})
+							Expect(err).ToNot(HaveOccurred())
+							Expect(t).ToNot(BeNil())
+							Expect(t.Wait(ctx)).To(Succeed())
+
+							Consistently(chanSource).ShouldNot(Receive())
+						})
+					})
+				})
+			})
+		})
+	})

--- a/controllers/virtualmachine/virtualmachine/virtualmachine_controller_suite_test.go
+++ b/controllers/virtualmachine/virtualmachine/virtualmachine_controller_suite_test.go
@@ -11,11 +11,12 @@ import (
 
 	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
 
-	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachine"
+	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachine/virtualmachine"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	providerfake "github.com/vmware-tanzu/vm-operator/pkg/providers/fake"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
@@ -38,6 +39,9 @@ func TestVirtualMachine(t *testing.T) {
 	suite.Register(t, "VirtualMachine controller suite", intgTests, unitTests)
 }
 
-var _ = BeforeSuite(suite.BeforeSuite)
+var _ = BeforeSuite(func() {
+	virtualmachine.SkipNameValidation = ptr.To(true)
+	suite.BeforeSuite()
+})
 
 var _ = AfterSuite(suite.AfterSuite)

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/vmware-tanzu/vm-operator/external/tanzu-topology v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/vm-operator/pkg/backup/api v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels v0.0.0-00010101000000-000000000000
-	github.com/vmware/govmomi v0.31.1-0.20240920193643-44d4fb3e244a
+	github.com/vmware/govmomi v0.31.1-0.20241007160036-e2e45b83ca96
 	// * https://github.com/vmware-tanzu/vm-operator/security/dependabot/24
 	golang.org/x/text v0.18.0
 	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d

--- a/go.sum
+++ b/go.sum
@@ -459,8 +459,8 @@ github.com/vmware-tanzu/net-operator-api v0.0.0-20240523152550-862e2c4eb0e0 h1:y
 github.com/vmware-tanzu/net-operator-api v0.0.0-20240523152550-862e2c4eb0e0/go.mod h1:w6QJGm3crIA16ZIz1FVQXD2NVeJhOgGXxW05RbVTSTo=
 github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20240902045731-00a14868c72d h1:6pMXrQmTYpu5FipoQ9fT4FJG3VPMMbBoIi6h3KvdQc8=
 github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20240902045731-00a14868c72d/go.mod h1:Q4JzNkNMvjo7pXtlB5/R3oME4Nhah7fAObWgghVmtxk=
-github.com/vmware/govmomi v0.31.1-0.20240920193643-44d4fb3e244a h1:Jic9T6J204z/7Ic5LW9VEJoptVgnCMZ7VYzejvawi5A=
-github.com/vmware/govmomi v0.31.1-0.20240920193643-44d4fb3e244a/go.mod h1:IOv5nTXCPqH9qVJAlRuAGffogaLsNs8aF+e7vLgsHJU=
+github.com/vmware/govmomi v0.31.1-0.20241007160036-e2e45b83ca96 h1:hPmMT++dG2lyz5X1sZpdrDzmhOW9PfpVLLw5M+K9GSI=
+github.com/vmware/govmomi v0.31.1-0.20241007160036-e2e45b83ca96/go.mod h1:BMg0+hyipJp9CbrlRRstnCgSmiAlDow5jWmQYlqOhIs=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -99,6 +99,11 @@ type Config struct {
 	// LogSensitiveData means that logs will potentially contain sensitive data
 	// such as passwords. Defaults to false.
 	LogSensitiveData bool
+
+	// AsyncSignalDisabled may be set to false to disable the vm-watcher service
+	// used to reconcile VirtualMachine objects if their backend state has
+	// changed.
+	AsyncSignalDisabled bool
 }
 
 // GetMaxDeployThreadsOnProvider returns MaxDeployThreadsOnProvider if it is >0

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -37,6 +37,7 @@ func Default() Config {
 		LeaderElectionID:             defaultPrefix + "controller-manager-runtime",
 		MaxCreateVMsOnProvider:       80,
 		MaxConcurrentReconciles:      1,
+		AsyncSignalDisabled:          false,
 		CreateVMRequeueDelay:         10 * time.Second,
 		PoweredOnVMHasIPRequeueDelay: 10 * time.Second,
 		NetworkProviderType:          NetworkProviderTypeNamed,

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -27,6 +27,7 @@ func FromEnv() Config {
 	setBool(env.VSphereNetworking, &config.VSphereNetworking)
 	setStringSlice(env.PrivilegedUsers, &config.PrivilegedUsers)
 	setBool(env.LogSensitiveData, &config.LogSensitiveData)
+	setBool(env.AsyncSignalDisabled, &config.AsyncSignalDisabled)
 
 	setDuration(env.InstanceStoragePVPlacementFailedTTL, &config.InstanceStorage.PVPlacementFailedTTL)
 	setFloat64(env.InstanceStorageJitterMaxFactor, &config.InstanceStorage.JitterMaxFactor)

--- a/pkg/config/env/env.go
+++ b/pkg/config/env/env.go
@@ -24,6 +24,7 @@ const (
 	ContentAPIWaitDuration
 	JSONExtraConfig
 	LogSensitiveData
+	AsyncSignalDisabled
 	InstanceStoragePVPlacementFailedTTL
 	InstanceStorageJitterMaxFactor
 	InstanceStorageSeedRequeueDuration
@@ -107,6 +108,8 @@ func (n VarName) String() string {
 		return "JSON_EXTRA_CONFIG"
 	case LogSensitiveData:
 		return "LOG_SENSITIVE_DATA"
+	case AsyncSignalDisabled:
+		return "ASYNC_SIGNAL_DISABLED"
 	case InstanceStoragePVPlacementFailedTTL:
 		return "INSTANCE_STORAGE_PV_PLACEMENT_FAILED_TTL"
 	case InstanceStorageJitterMaxFactor:

--- a/pkg/config/env_test.go
+++ b/pkg/config/env_test.go
@@ -76,6 +76,7 @@ var _ = Describe(
 					Expect(os.Setenv("RATE_LIMIT_BURST", "112")).To(Succeed())
 					Expect(os.Setenv("SYNC_PERIOD", "113h")).To(Succeed())
 					Expect(os.Setenv("MAX_CONCURRENT_RECONCILES", "114")).To(Succeed())
+					Expect(os.Setenv("ASYNC_SIGNAL_DISABLED", "true")).To(Succeed())
 					Expect(os.Setenv("LEADER_ELECTION_ID", "115")).To(Succeed())
 					Expect(os.Setenv("POD_NAME", "116")).To(Succeed())
 					Expect(os.Setenv("POD_NAMESPACE", "117")).To(Succeed())
@@ -124,6 +125,7 @@ var _ = Describe(
 						RateLimitBurst:               112,
 						SyncPeriod:                   113 * time.Hour,
 						MaxConcurrentReconciles:      114,
+						AsyncSignalDisabled:          true,
 						LeaderElectionID:             "115",
 						PodName:                      "116",
 						PodNamespace:                 "117",

--- a/pkg/constants/testlabels/test_labels.go
+++ b/pkg/constants/testlabels/test_labels.go
@@ -31,6 +31,9 @@ const (
 	// NSXT describes a test related to NSXT.
 	NSXT = "nsxt"
 
+	// Service describes a test related to a service (non-Controller runnable).
+	Service = "service"
+
 	// Update describes a test related to update logic.
 	Update = "update"
 

--- a/pkg/context/generic/generic_context.go
+++ b/pkg/context/generic/generic_context.go
@@ -74,6 +74,28 @@ func WithContext[T any, K comparable](
 	)
 }
 
+// ExecWithContext executes the provided function while holding the lock on
+// the context.
+func ExecWithContext[T any, K comparable](
+	ctx context.Context,
+	key K,
+	exeV func(val T)) {
+
+	if ctx == nil {
+		panic("context is nil")
+	}
+	obj := ctx.Value(key)
+	if obj == nil {
+		panic("value is missing from context")
+	}
+
+	m := obj.(*contextData[T])
+	m.Lock()
+	defer m.Unlock()
+
+	exeV(m.data)
+}
+
 // NewContext returns a new context with the data in the specified key.
 func NewContext[T any, K comparable](key K, newT func() T) context.Context {
 	return WithContext(context.Background(), key, newT)

--- a/pkg/providers/fake/fake_vm_provider.go
+++ b/pkg/providers/fake/fake_vm_provider.go
@@ -17,6 +17,7 @@ import (
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
+	vsclient "github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/client"
 )
 
 // This Fake Provider is supposed to simulate an actual VM provider.
@@ -55,6 +56,7 @@ type funcs struct {
 	GetTasksByActIDFn func(ctx context.Context, actID string) (tasksInfo []vimtypes.TaskInfo, retErr error)
 
 	DoesProfileSupportEncryptionFn func(ctx context.Context, profileID string) (bool, error)
+	VSphereClientFn                func(context.Context) (*vsclient.Client, error)
 }
 
 type VMProvider struct {
@@ -372,6 +374,16 @@ func (s *VMProvider) DoesProfileSupportEncryption(
 		return fn(ctx, profileID)
 	}
 	return false, nil
+}
+
+func (s *VMProvider) VSphereClient(ctx context.Context) (*vsclient.Client, error) {
+	s.Lock()
+	defer s.Unlock()
+
+	if fn := s.VSphereClientFn; fn != nil {
+		return fn(ctx)
+	}
+	return nil, nil
 }
 
 func NewVMProvider() *VMProvider {

--- a/pkg/providers/vm_provider_interface.go
+++ b/pkg/providers/vm_provider_interface.go
@@ -8,11 +8,12 @@ import (
 
 	"github.com/vmware/govmomi/vapi/library"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	imgregv1a1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha1"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/client"
 )
 
 // VirtualMachineProviderInterface is a pluggable interface for VM Providers.
@@ -37,7 +38,7 @@ type VirtualMachineProviderInterface interface {
 
 	GetItemFromLibraryByName(ctx context.Context, contentLibrary, itemName string) (*library.Item, error)
 	UpdateContentLibraryItem(ctx context.Context, itemID, newName string, newDescription *string) error
-	SyncVirtualMachineImage(ctx context.Context, cli, vmi client.Object) error
+	SyncVirtualMachineImage(ctx context.Context, cli, vmi ctrlclient.Object) error
 
 	GetTasksByActID(ctx context.Context, actID string) (tasksInfo []vimtypes.TaskInfo, retErr error)
 
@@ -45,4 +46,7 @@ type VirtualMachineProviderInterface interface {
 	// supports encryption by checking whether or not the underlying policy
 	// contains any IOFILTERs.
 	DoesProfileSupportEncryption(ctx context.Context, profileID string) (bool, error)
+
+	// VSphereClient returns the provider's vSphere client.
+	VSphereClient(context.Context) (*client.Client, error)
 }

--- a/pkg/providers/vsphere/vmprovider.go
+++ b/pkg/providers/vsphere/vmprovider.go
@@ -36,6 +36,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/record"
 	"github.com/vmware-tanzu/vm-operator/pkg/topology"
 	"github.com/vmware-tanzu/vm-operator/pkg/util"
+	vsclient "github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/client"
 )
 
 const (
@@ -439,4 +440,14 @@ func (vs *vSphereVMProvider) DoesProfileSupportEncryption(
 	}
 
 	return c.PbmClient().SupportsEncryption(ctx, profileID)
+}
+
+func (vs *vSphereVMProvider) VSphereClient(
+	ctx context.Context) (*vsclient.Client, error) {
+
+	c, err := vs.getVcClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return c.Client, nil
 }

--- a/pkg/util/kube/cource/cource_context.go
+++ b/pkg/util/kube/cource/cource_context.go
@@ -20,6 +20,16 @@ type contextValueType map[any]chan event.GenericEvent
 
 // FromContext creates or gets the channel for the specified key.
 func FromContext(ctx context.Context, key any) chan event.GenericEvent {
+	return FromContextWithBuffer(ctx, key, 0)
+}
+
+// FromContextWithBuffer creates or gets the buffered channel for the specified
+// key and buffer size.
+func FromContextWithBuffer(
+	ctx context.Context,
+	key any,
+	buffer int) chan event.GenericEvent {
+
 	return ctxgen.FromContext(
 		ctx,
 		contextKeyValue,
@@ -27,7 +37,7 @@ func FromContext(ctx context.Context, key any) chan event.GenericEvent {
 			if c, ok := val[key]; ok {
 				return c
 			}
-			c := make(chan event.GenericEvent)
+			c := make(chan event.GenericEvent, buffer)
 			val[key] = c
 			return c
 		})

--- a/pkg/util/kube/cource/cource_context_test.go
+++ b/pkg/util/kube/cource/cource_context_test.go
@@ -51,6 +51,46 @@ var _ = Describe("FromContext", func() {
 	})
 })
 
+var _ = Describe("FromContextWithBuffer", func() {
+	var (
+		ctx context.Context
+		key any
+	)
+	BeforeEach(func() {
+		ctx = context.Background()
+		key = "1"
+	})
+	When("ctx is nil", func() {
+		BeforeEach(func() {
+			ctx = nil
+		})
+		It("should panic", func() {
+			fn := func() {
+				_ = cource.FromContextWithBuffer(ctx, key, 100)
+			}
+			Expect(fn).To(PanicWith("context is nil"))
+		})
+	})
+	When("value is missing from context", func() {
+		It("should panic", func() {
+			fn := func() {
+				_ = cource.FromContextWithBuffer(ctx, key, 100)
+			}
+			Expect(fn).To(PanicWith("value is missing from context"))
+		})
+	})
+	When("map is present in context", func() {
+		BeforeEach(func() {
+			ctx = cource.NewContext()
+		})
+		It("should return a channel", func() {
+			chanObj := cource.FromContextWithBuffer(ctx, key, 100)
+			Expect(chanObj).ToNot(BeNil())
+			Expect(cource.FromContextWithBuffer(ctx, key, 100)).To(BeIdenticalTo(chanObj))
+		})
+	})
+})
+
 var _ = Describe("ValidateContext", func() {
 	var (
 		ctx context.Context

--- a/pkg/util/vsphere/watcher/watcher.go
+++ b/pkg/util/vsphere/watcher/watcher.go
@@ -1,0 +1,656 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package watcher
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/go-logr/logr"
+
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/view"
+	"github.com/vmware/govmomi/vim25"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+
+	backupapi "github.com/vmware-tanzu/vm-operator/pkg/backup/api"
+)
+
+// DefaultWatchedPropertyPaths returns the default set of property paths to
+// watch.
+func DefaultWatchedPropertyPaths() []string {
+	return []string{
+		"config.extraConfig",
+		"guest.ipStack",
+		"guest.net",
+		"summary.config.name",
+		"summary.guest",
+		"summary.overallStatus",
+		"summary.runtime.host",
+		"summary.runtime.powerState",
+		"summary.storage.timestamp",
+	}
+}
+
+const extraConfigNamespacedNameKey = "vmservice.namespacedName"
+
+// defaultIgnoredExtraConfigKeys returns the default set of extra config keys to
+// ignore.
+var defaultIgnoredExtraConfigKeys = []string{
+	backupapi.AdditionalResourcesYAMLExtraConfigKey,
+	backupapi.BackupVersionExtraConfigKey,
+	backupapi.ClassicDiskDataExtraConfigKey,
+	backupapi.DisableAutoRegistrationExtraConfigKey,
+	backupapi.EnableAutoRegistrationExtraConfigKey,
+	backupapi.PVCDiskDataExtraConfigKey,
+	backupapi.VMResourceYAMLExtraConfigKey,
+	"govcsim",
+	"guestinfo.metadata",
+	"guestinfo.metadata.encoding",
+	"guestinfo.userdata",
+	"guestinfo.userdata.encoding",
+	"guestinfo.vendordata",
+	"guestinfo.vendordata.encoding",
+	extraConfigNamespacedNameKey,
+}
+
+type moRef = vimtypes.ManagedObjectReference
+
+type lookupNamespacedNameFn func(context.Context, moRef) (string, string, bool)
+
+type Result struct {
+	// Namespace is the namespace to which the VirtualMachine resource belongs.
+	Namespace string
+
+	// Name is the name of the VirtualMachine resource.
+	Name string
+
+	// Ref is the ManagedObjectReference for the VM in vSphere.
+	Ref moRef
+
+	// Verified is true if the VirtualMachine resource identified by Namespace
+	// and Name has already been verified to exist in this Kubernetes cluster.
+	Verified bool
+}
+
+type Watcher struct {
+	mu sync.Mutex
+
+	cancel func()
+
+	client *vim25.Client
+
+	vm *view.Manager
+	lv *view.ListView
+	cv map[moRef]*view.ContainerView
+
+	// cvr is used to count the number of times a container has been added to
+	// the list view. If the Remove function is called on a container with a ref
+	// count of one, then the container will be removed from the list view and
+	// destroyed.
+	cvr map[moRef]map[string]struct{}
+
+	pc *property.Collector
+	pf *property.Filter
+
+	ignoredExtraConfigKeys map[string]struct{}
+	lookupNamespacedName   lookupNamespacedNameFn
+
+	err   error
+	errMu sync.RWMutex
+
+	chanDone   chan struct{}
+	chanResult chan Result
+}
+
+// Done returns a channel that is closed when the watcher is shutdown.
+func (w *Watcher) Done() <-chan struct{} {
+	return w.chanDone
+}
+
+// Result returns a channel on which new results are received.
+func (w *Watcher) Result() <-chan Result {
+	return w.chanResult
+}
+
+// Err returns the error that caused the watcher to stop.
+func (w *Watcher) Err() error {
+	w.errMu.RLock()
+	err := w.err
+	w.errMu.RUnlock()
+	return err
+}
+
+func (w *Watcher) setErr(err error) {
+	w.errMu.Lock()
+	w.err = err
+	w.errMu.Unlock()
+}
+
+func newWatcher(
+	ctx context.Context,
+	client *vim25.Client,
+	watchedPropertyPaths []string,
+	additionalIgnoredExtraConfigKeys []string,
+	lookupNamespacedName lookupNamespacedNameFn,
+	containerRefs ...moRef) (*Watcher, error) {
+
+	if watchedPropertyPaths == nil {
+		watchedPropertyPaths = DefaultWatchedPropertyPaths()
+	}
+	ignoredExtraConfigKeys := slices.Concat(
+		defaultIgnoredExtraConfigKeys,
+		additionalIgnoredExtraConfigKeys)
+
+	// Get the view manager.
+	vm := view.NewManager(client)
+
+	// For each container reference, create a container view and add it to
+	// the list view's initial list of members.
+	cvs, cvr, err := toContainerViewMap(ctx, vm, containerRefs...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a new list view used to monitor all of the containers to which
+	// VM Service VMs belong.
+	lv, err := vm.CreateListView(ctx, toMoRefs(cvs))
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a new property collector to watch for changes.
+	pc, err := property.DefaultCollector(client).Create(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a new property filter that uses the list view created up above.
+	pf, err := pc.CreateFilter(
+		ctx,
+		viewToVM(lv.Reference(), watchedPropertyPaths))
+	if err != nil {
+		return nil, err
+	}
+
+	return &Watcher{
+		chanDone:               make(chan struct{}),
+		chanResult:             make(chan Result),
+		client:                 client,
+		pc:                     pc,
+		pf:                     pf,
+		vm:                     vm,
+		lv:                     lv,
+		cv:                     cvs,
+		cvr:                    cvr,
+		ignoredExtraConfigKeys: toSet(ignoredExtraConfigKeys),
+		lookupNamespacedName:   lookupNamespacedName,
+	}, nil
+}
+
+func (w *Watcher) close() {
+	w.mu.Lock()
+	w.cancel()
+	close(w.chanDone)
+	w.mu.Unlock()
+
+	_ = w.pf.Destroy(context.Background())
+	_ = w.pc.Destroy(context.Background())
+	_ = w.lv.Destroy(context.Background())
+	for _, cv := range w.cv {
+		_ = cv.Destroy(context.Background())
+	}
+
+	w.pf = nil
+	w.pc = nil
+	w.cv = nil
+	w.cvr = nil
+	w.lv = nil
+	w.vm = nil
+	w.client = nil
+	w.lookupNamespacedName = nil
+}
+
+// Start begins watching a vSphere server for updates to VM Service managed VMs.
+// If watchedPropertyPaths is nil, DefaultWatchedPropertyPaths will be used.
+// The containerRefs parameter may be used to start the watcher with an initial
+// list of entities to watch.
+func Start(
+	ctx context.Context,
+	client *vim25.Client,
+	watchedPropertyPaths []string,
+	additionalIgnoredExtraConfigKeys []string,
+	lookupNamespacedName lookupNamespacedNameFn,
+	containerRefs ...moRef) (*Watcher, error) {
+
+	logger := logr.FromContextOrDiscard(ctx).WithName("vSphereWatcher")
+	ctx = logr.NewContext(ctx, logger)
+
+	w, err := newWatcher(
+		ctx,
+		client,
+		watchedPropertyPaths,
+		additionalIgnoredExtraConfigKeys,
+		lookupNamespacedName,
+		containerRefs...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Update the context with this watcher.
+	setContext(ctx, w)
+
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithCancel(ctx)
+	w.cancel = cancel
+
+	go func() {
+		defer func() {
+			w.close()
+
+			// Remove this watcher from the context. While there is no watcher
+			// in the context, calls to Add/Remove will fail.
+			setContext(ctx, nil)
+		}()
+
+		if err := w.pc.WaitForUpdatesEx(
+			ctx,
+			&property.WaitOptions{},
+			func(ou []vimtypes.ObjectUpdate) bool {
+				return w.onUpdate(ctx, ou)
+			}); err != nil {
+
+			w.setErr(err)
+		}
+	}()
+
+	return w, nil
+}
+
+const (
+	virtualMachineType               = "VirtualMachine"
+	configPropPath                   = "config"
+	extraConfigPropPath              = configPropPath + ".extraConfig"
+	extraConfigNamespaceNameKey      = "vmservice.namespacedName"
+	extraConfigNamespaceNamePropPath = extraConfigPropPath + `["` + extraConfigNamespaceNameKey + `"]`
+)
+
+type objUpdate struct {
+	kind    vimtypes.ObjectUpdateKind
+	changes []vimtypes.PropertyChange
+}
+
+func (w *Watcher) onUpdate(
+	ctx context.Context,
+	ou []vimtypes.ObjectUpdate) bool {
+
+	logger := logr.FromContextOrDiscard(ctx)
+	logger.V(4).Info("onUpdate", "objectUpdates", ou)
+
+	updates := map[moRef]objUpdate{}
+
+	for i := range ou {
+		oui := ou[i]
+		if oui.Kind != vimtypes.ObjectUpdateKindLeave {
+			if v, ok := updates[oui.Obj]; !ok {
+				updates[oui.Obj] = objUpdate{
+					kind:    oui.Kind,
+					changes: oui.ChangeSet,
+				}
+			} else {
+				v.changes = append(v.changes, oui.ChangeSet...)
+				updates[oui.Obj] = v
+			}
+		}
+	}
+
+	for obj, update := range updates {
+		if err := w.onObject(
+			ctx,
+			obj,
+			update); err != nil {
+
+			w.setErr(err)
+			return true
+		}
+	}
+
+	return false
+}
+
+func (w *Watcher) onObject(
+	ctx context.Context,
+	obj moRef,
+	update objUpdate) error {
+
+	logger := logr.FromContextOrDiscard(ctx).
+		V(4).
+		WithName("onObject").
+		WithValues("obj", obj)
+
+	var (
+		namespace string
+		name      string
+		verified  bool
+	)
+
+	// This update will be skipped if after removing all of the changes for
+	// the ignoredExtraConfigKeys there is nothing left.
+	var ignoredChanges int
+	for i := range update.changes {
+		c := update.changes[i]
+		ignore := false
+		if c.Name == extraConfigPropPath {
+			if aov, ok := c.Val.(vimtypes.ArrayOfOptionValue); ok {
+				ignore, namespace, name = checkExtraConfig(
+					aov, w.ignoredExtraConfigKeys)
+			}
+		}
+		if ignore {
+			ignoredChanges++
+		}
+	}
+	if ignoredChanges == len(update.changes) {
+		return nil
+	}
+
+	if w.lookupNamespacedName != nil {
+		if namespace == "" || name == "" || update.kind == vimtypes.ObjectUpdateKindEnter {
+			namespace, name, verified = w.lookupNamespacedName(ctx, obj)
+		}
+	}
+
+	if update.kind == vimtypes.ObjectUpdateKindEnter && verified {
+		// The behavior of Controller-Runtime to sync all objects upon startup
+		// will cause *existing* VMs to be reconciled. Therefore, do not emit a
+		// result when the object is entering the scope of the watcher and the
+		// corresponding Kubernetes object already exists with a matching
+		// status.uniqueID field.
+		return nil
+	}
+
+	if namespace == "" || name == "" {
+		var content []vimtypes.ObjectContent
+		err := property.DefaultCollector(w.client).RetrieveOne(
+			ctx,
+			obj,
+			[]string{extraConfigNamespaceNamePropPath},
+			&content,
+		)
+		if err != nil {
+			return err
+		}
+		namespace, name = namespacedNameFromObjContent(content)
+	}
+
+	if namespace != "" && name != "" {
+		r := Result{
+			Namespace: namespace,
+			Name:      name,
+			Ref:       obj,
+			Verified:  verified,
+		}
+
+		logger.Info("sending result", "result", r)
+
+		go func(r Result) {
+			w.chanResult <- r
+		}(r)
+	}
+
+	return nil
+}
+
+func checkExtraConfig(
+	aov vimtypes.ArrayOfOptionValue,
+	ignoredKeys map[string]struct{}) (ignore bool, namespace, name string) {
+
+	hasNonIgnoredKey := false
+
+	for j := range aov.OptionValue {
+		if ov := aov.OptionValue[j].GetOptionValue(); ov != nil {
+			// Get the namespace and name of the VM from the changes
+			// if they are present there.
+			if ov.Key == extraConfigNamespacedNameKey {
+				if namespace == "" || name == "" {
+					if s, ok := ov.Value.(string); ok {
+						namespace, name = namespacedNameFromString(s)
+					}
+				}
+			}
+			// Note if the key cannot be ignored.
+			if _, ok := ignoredKeys[ov.Key]; !ok {
+				hasNonIgnoredKey = true
+			}
+			if hasNonIgnoredKey && (namespace != "" && name != "") {
+				break
+			}
+		}
+	}
+
+	return !hasNonIgnoredKey, namespace, name
+}
+
+func (w *Watcher) add(ctx context.Context, ref moRef, id string) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.pc == nil {
+		// The property collector is nil means the watcher is closed/stopped;
+		// return early.
+		return nil
+	}
+
+	if _, ok := w.cv[ref]; ok {
+		w.cvr[ref][id] = struct{}{}
+		return nil
+	}
+
+	cv, err := w.vm.CreateContainerView(
+		ctx,
+		ref,
+		[]string{virtualMachineType},
+		true)
+	if err != nil {
+		return err
+	}
+
+	if _, err := w.lv.Add(
+		ctx,
+		[]vimtypes.ManagedObjectReference{cv.Reference()}); err != nil {
+
+		if err2 := cv.Destroy(context.Background()); err2 != nil {
+			return fmt.Errorf(
+				"failed to destroy container view after adding "+
+					"it to list failed: addErr=%w, destroyErr=%w", err, err2)
+		}
+
+		return err
+	}
+
+	w.cv[ref] = cv
+	if w.cvr[ref] == nil {
+		w.cvr[ref] = map[string]struct{}{}
+	}
+	w.cvr[ref][id] = struct{}{}
+
+	return nil
+}
+
+func (w *Watcher) remove(_ context.Context, ref moRef, id string) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.pc == nil {
+		// The property collector is nil means the watcher is closed/stopped;
+		// return early.
+		return nil
+	}
+
+	cv, ok := w.cv[ref]
+	if !ok {
+		return nil
+	}
+
+	// Only remove the container from the list view if it has a ref count of
+	// one.
+	if len(w.cvr[ref]) > 1 {
+		delete(w.cvr[ref], id)
+		return nil
+	}
+
+	_, err := w.lv.Remove(context.Background(), []moRef{cv.Reference()})
+	if err != nil {
+		return err
+	}
+
+	if err := cv.Destroy(context.Background()); err != nil {
+		return err
+	}
+
+	delete(w.cv, ref)
+	delete(w.cvr[ref], id)
+
+	return nil
+}
+
+func toContainerViewMap(
+	ctx context.Context,
+	vm *view.Manager,
+	containerRefs ...moRef) (map[moRef]*view.ContainerView, map[moRef]map[string]struct{}, error) {
+
+	var (
+		cvMap     = map[moRef]*view.ContainerView{}
+		cvRefsMap = map[moRef]map[string]struct{}{}
+	)
+
+	if len(containerRefs) == 0 {
+		return cvMap, cvRefsMap, nil
+	}
+
+	var resultErr error
+	for i := range containerRefs {
+		if _, ok := cvMap[containerRefs[i]]; ok {
+			// Ignore duplicates.
+			continue
+		}
+		cv, err := vm.CreateContainerView(
+			ctx,
+			containerRefs[i],
+			[]string{virtualMachineType},
+			true)
+		if err != nil {
+			resultErr = err
+			break
+		}
+		cvMap[containerRefs[i]] = cv
+		cvRefsMap[containerRefs[i]] = map[string]struct{}{}
+	}
+
+	if resultErr != nil {
+		// There was an error creating container views, so make sure to clean up
+		// any views that *were* created before returning.
+		for _, cv := range cvMap {
+			if err := cv.Destroy(context.Background()); err != nil {
+				resultErr = fmt.Errorf("%w,%w", resultErr, err)
+			}
+		}
+		return nil, nil, resultErr
+	}
+
+	return cvMap, cvRefsMap, nil
+}
+
+func namespacedNameFromString(s string) (string, string) {
+	if p := strings.Split(s, "/"); len(p) == 2 {
+		return p[0], p[1]
+	}
+	return "", ""
+}
+
+func namespacedNameFromObjContent(
+	oc []vimtypes.ObjectContent) (string, string) {
+
+	for i := range oc {
+		for j := range oc[i].PropSet {
+			dp := oc[i].PropSet[j]
+			if dp.Name == extraConfigNamespaceNamePropPath {
+				if ov, ok := dp.Val.(vimtypes.OptionValue); ok {
+					if v, ok := ov.Value.(string); ok {
+						return namespacedNameFromString(v)
+					}
+				}
+			}
+		}
+	}
+	return "", ""
+}
+
+func viewToVM(ref moRef, watchedPropertyPaths []string) vimtypes.CreateFilter {
+	return vimtypes.CreateFilter{
+		Spec: vimtypes.PropertyFilterSpec{
+			ObjectSet: []vimtypes.ObjectSpec{
+				{
+					Obj:  ref,
+					Skip: &[]bool{true}[0],
+					SelectSet: []vimtypes.BaseSelectionSpec{
+						// ListView --> ContainerView
+						&vimtypes.TraversalSpec{
+							Type: "ListView",
+							Path: "view",
+							SelectSet: []vimtypes.BaseSelectionSpec{
+								&vimtypes.SelectionSpec{
+									Name: "visitViews",
+								},
+							},
+						},
+						// ContainerView --> VM
+						&vimtypes.TraversalSpec{
+							SelectionSpec: vimtypes.SelectionSpec{
+								Name: "visitViews",
+							},
+							Type: "ContainerView",
+							Path: "view",
+						},
+					},
+				},
+			},
+			PropSet: []vimtypes.PropertySpec{
+				{
+					Type:    virtualMachineType,
+					PathSet: watchedPropertyPaths,
+				},
+			},
+		},
+	}
+}
+
+type hasRef interface {
+	Reference() moRef
+}
+
+func toMoRefs[M ~map[K]V, K comparable, V hasRef](m M) []moRef {
+	if len(m) == 0 {
+		return nil
+	}
+	r := make([]moRef, 0, len(m))
+	for _, v := range m {
+		r = append(r, v.Reference())
+	}
+	return r
+}
+
+func toSet[K comparable](s []K) map[K]struct{} {
+	if len(s) == 0 {
+		return nil
+	}
+	r := make(map[K]struct{}, len(s))
+	for i := range s {
+		r[s[i]] = struct{}{}
+	}
+	return r
+}

--- a/pkg/util/vsphere/watcher/watcher_context.go
+++ b/pkg/util/vsphere/watcher/watcher_context.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package watcher
+
+import (
+	"context"
+	"errors"
+
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
+	ctxgen "github.com/vmware-tanzu/vm-operator/pkg/context/generic"
+)
+
+type contextKeyType uint8
+
+const contextKeyValue contextKeyType = 0
+
+type contextValueType = *Watcher
+
+// setContext assigns the add/remove functions to the context.
+func setContext(
+	parent context.Context,
+	newVal contextValueType) {
+	ctxgen.SetContext(
+		parent,
+		contextKeyValue,
+		func(curVal contextValueType) contextValueType {
+			return newVal
+		})
+}
+
+// WithContext returns a new context with a new functions object.
+func WithContext(parent context.Context) context.Context {
+	return ctxgen.WithContext(
+		parent,
+		contextKeyValue,
+		func() contextValueType {
+			return nil
+		})
+}
+
+// NewContext returns a new context with a new functions object.
+func NewContext() context.Context {
+	return WithContext(context.Background())
+}
+
+// ValidateContext returns true if the provided context contains the functions
+// object.
+func ValidateContext(ctx context.Context) bool {
+	return ctxgen.ValidateContext[contextValueType](ctx, contextKeyValue)
+}
+
+// JoinContext returns a new context that contains a reference to the functions
+// object from the specified context.
+// This function panics if the provided context does not contain a functions
+// object.
+// This function is thread-safe.
+func JoinContext(left, right context.Context) context.Context {
+	return ctxgen.JoinContext(
+		left,
+		right,
+		contextKeyValue,
+		func(dst, src contextValueType) contextValueType {
+			return src
+		})
+}
+
+// Add starts watching a container to which VirtualMachine resources may belong,
+// such as a Folder, Cluster, ResourcePool, etc.
+func Add(ctx context.Context, ref moRef, id string) (err error) {
+	if pkgcfg.FromContext(ctx).AsyncSignalDisabled {
+		return nil
+	}
+	ctxgen.ExecWithContext(
+		ctx,
+		contextKeyValue,
+		func(w contextValueType) {
+			if w == nil {
+				err = errors.New("no watcher")
+			} else {
+				err = w.add(ctx, ref, id)
+			}
+		})
+	return
+}
+
+// Remove stops watching a container to which VirtualMachine resources may
+// belong, such as a Folder, Cluster, ResourcePool, etc.
+func Remove(ctx context.Context, ref moRef, id string) (err error) {
+	if pkgcfg.FromContext(ctx).AsyncSignalDisabled {
+		return nil
+	}
+	ctxgen.ExecWithContext(
+		ctx,
+		contextKeyValue,
+		func(w contextValueType) {
+			if w == nil {
+				err = errors.New("no watcher")
+			} else {
+				err = w.remove(ctx, ref, id)
+			}
+		})
+	return
+}

--- a/pkg/util/vsphere/watcher/watcher_context_test.go
+++ b/pkg/util/vsphere/watcher/watcher_context_test.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package watcher_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/watcher"
+)
+
+var _ = Describe("JoinContext", func() {
+	var (
+		left  context.Context
+		right context.Context
+	)
+	BeforeEach(func() {
+		left = context.Background()
+		right = context.Background()
+	})
+	When("left context is nil", func() {
+		BeforeEach(func() {
+			left = nil
+		})
+		It("should panic", func() {
+			fn := func() {
+				_ = watcher.JoinContext(left, right)
+			}
+			Expect(fn).To(PanicWith("left context is nil"))
+		})
+	})
+	When("right context is nil", func() {
+		BeforeEach(func() {
+			right = nil
+		})
+		It("should panic", func() {
+			fn := func() {
+				_ = watcher.JoinContext(left, right)
+			}
+			Expect(fn).To(PanicWith("right context is nil"))
+		})
+	})
+	When("value is missing from context", func() {
+		It("should panic", func() {
+			fn := func() {
+				_ = watcher.JoinContext(left, right)
+			}
+			Expect(fn).To(PanicWith("value is missing from context"))
+		})
+	})
+	When("the left context has a channels object", func() {
+		BeforeEach(func() {
+			left = watcher.NewContext()
+		})
+		It("should return the left context", func() {
+			ctx := watcher.JoinContext(left, right)
+			Expect(ctx).ToNot(BeNil())
+		})
+	})
+	When("the right context has a channels object", func() {
+		BeforeEach(func() {
+			right = watcher.NewContext()
+		})
+		It("should return a new context", func() {
+			ctx := watcher.JoinContext(left, right)
+			Expect(ctx).ToNot(BeNil())
+			Expect(watcher.ValidateContext(ctx)).To(BeTrue())
+		})
+	})
+	When("both contexts have a channels object", func() {
+		BeforeEach(func() {
+			left = watcher.NewContext()
+			right = watcher.NewContext()
+		})
+		It("should return a new context", func() {
+			ctx := watcher.JoinContext(left, right)
+			Expect(ctx).ToNot(BeNil())
+			Expect(watcher.ValidateContext(ctx)).To(BeTrue())
+		})
+	})
+})
+
+var _ = Describe("WithContext", func() {
+	When("parent is nil", func() {
+		It("should panic", func() {
+			fn := func() {
+				//nolint:staticcheck
+				_ = watcher.WithContext(nil)
+			}
+			Expect(fn).To(PanicWith("parent context is nil"))
+		})
+	})
+	When("parent is not nil", func() {
+		It("should return a context", func() {
+			ctx := watcher.NewContext()
+			Expect(ctx).ToNot(BeNil())
+		})
+	})
+})
+
+var _ = Describe("Add", func() {
+	When("there is no watcher", func() {
+		It("should fail", func() {
+			Expect(watcher.Add(
+				watcher.WithContext(pkgcfg.NewContext()),
+				vimtypes.ManagedObjectReference{},
+				"fake",
+			)).To(MatchError("no watcher"))
+		})
+	})
+})
+
+var _ = Describe("Remove", func() {
+	When("there is no watcher", func() {
+		It("should fail", func() {
+			Expect(watcher.Remove(
+				watcher.WithContext(pkgcfg.NewContext()),
+				vimtypes.ManagedObjectReference{},
+				"fake",
+			)).To(MatchError("no watcher"))
+		})
+	})
+})

--- a/pkg/util/vsphere/watcher/watcher_suite_test.go
+++ b/pkg/util/vsphere/watcher/watcher_suite_test.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package watcher_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestWatcher(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "vSphere Watcher Suite")
+}

--- a/pkg/util/vsphere/watcher/watcher_test.go
+++ b/pkg/util/vsphere/watcher/watcher_test.go
@@ -1,0 +1,625 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package watcher_test
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"net"
+	"net/url"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/simulator"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/watcher"
+	"github.com/vmware-tanzu/vm-operator/test/testutil"
+)
+
+const (
+	fakeStr = "fake"
+)
+
+var _ = Describe("Start", func() {
+	var (
+		ctx             context.Context
+		cancel          context.CancelFunc
+		model           *simulator.Model
+		server          *simulator.Server
+		client          *govmomi.Client
+		w               *watcher.Watcher
+		closeServerOnce sync.Once
+
+		cluster1 *object.ClusterComputeResource
+		cluster2 *object.ClusterComputeResource
+
+		cluster1vm1 *object.VirtualMachine
+		cluster1vm2 *object.VirtualMachine
+		cluster2vm1 *object.VirtualMachine
+
+		lookupFnVerified bool
+	)
+
+	addNamespaceName := func(
+		vm *object.VirtualMachine,
+		namespace, name string) {
+
+		t, err := vm.Reconfigure(
+			ctx,
+			vimtypes.VirtualMachineConfigSpec{
+				ExtraConfig: []vimtypes.BaseOptionValue{
+					&vimtypes.OptionValue{
+						Key:   "vmservice.namespacedName",
+						Value: namespace + "/" + name,
+					},
+				},
+			},
+		)
+		ExpectWithOffset(1, err).ShouldNot(HaveOccurred())
+		ExpectWithOffset(1, t.WaitEx(ctx)).To(Succeed())
+	}
+
+	BeforeEach(func() {
+		ctx = pkgcfg.NewContext()
+		ctx, cancel = context.WithCancel(ctx)
+		ctx = logr.NewContext(ctx, testutil.GinkgoLogr(4))
+		ctx = watcher.WithContext(ctx)
+
+		closeServerOnce = sync.Once{}
+
+		lookupFnVerified = false
+
+		model = simulator.VPX()
+		model.Datacenter = 1
+		model.Cluster = 2
+		model.ClusterHost = 3
+		model.Host = 0
+		model.Machine = 2
+		model.Autostart = false
+
+		if model.Service == nil {
+			Expect(model.Create()).To(Succeed())
+			model.Service.TLS = &tls.Config{}
+		}
+
+		model.Service.RegisterEndpoints = true
+		server = model.Service.NewServer()
+
+		var err error
+		client, err = govmomi.NewClient(ctx, server.URL, true)
+		Expect(err).ToNot(HaveOccurred())
+
+		finder := find.NewFinder(client.Client)
+		datacenter, err := finder.DatacenterOrDefault(ctx, "*")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(datacenter).ToNot(BeNil())
+
+		folder, err := finder.DefaultFolder(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(folder).ToNot(BeNil())
+
+		clusters, err := finder.ClusterComputeResourceList(ctx, "*")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(clusters).To(HaveLen(2))
+		cluster1 = clusters[0]
+		cluster2 = clusters[1]
+
+		var (
+			cluster1vms []*object.VirtualMachine
+			cluster2vms []*object.VirtualMachine
+		)
+		vms, err := finder.VirtualMachineList(ctx, "*")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(vms).To(HaveLen(4))
+		for i := range vms {
+			vm := vms[i]
+			host, err := vm.HostSystem(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			pool, err := host.ResourcePool(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			owner, err := pool.Owner(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			if owner.Reference() == cluster1.Reference() {
+				cluster1vms = append(cluster1vms, vm)
+			} else {
+				cluster2vms = append(cluster2vms, vm)
+			}
+		}
+
+		Expect(cluster1vms).To(HaveLen(2))
+		Expect(cluster2vms).To(HaveLen(2))
+		cluster1vm1 = cluster1vms[0]
+		cluster1vm2 = cluster1vms[1]
+		cluster2vm1 = cluster2vms[0]
+	})
+
+	JustBeforeEach(func() {
+		var err error
+		w, err = watcher.Start(
+			ctx,
+			client.Client,
+			nil,
+			[]string{
+				"ignoredKey1",
+				"ignoredKey1",
+				"ignoredKey2",
+			},
+			func(
+				_ context.Context,
+				moRef vimtypes.ManagedObjectReference) (string, string, bool) {
+
+				if moRef == cluster2vm1.Reference() {
+					return "my-namespace-4", "my-name-1", lookupFnVerified
+				}
+				return "", "", false
+			},
+			cluster1.Reference())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(w).ToNot(BeNil())
+	})
+
+	AfterEach(func() {
+		cancel()
+		Eventually(w.Done(), time.Second*5).Should(BeClosed())
+		_ = client.Logout(ctx)
+		closeServerOnce.Do(server.Close)
+		model.Remove()
+	})
+
+	assertResult := func(
+		vm *object.VirtualMachine,
+		namespace, name string) {
+
+		var result watcher.Result
+		EventuallyWithOffset(1, w.Result(), time.Second*5).Should(
+			Receive(&result, Equal(watcher.Result{
+				Namespace: namespace,
+				Name:      name,
+				Ref:       vm.Reference(),
+			})))
+	}
+
+	assertNoError := func() {
+		ConsistentlyWithOffset(1, w.Err()).Should(BeNil())
+	}
+
+	assertNoResult := func() {
+		ConsistentlyWithOffset(1, w.Result()).ShouldNot(Receive())
+	}
+
+	assertError := func() {
+		EventuallyWithOffset(1, func() error { return w.Err() }).ShouldNot(BeNil())
+
+		var urlErr *url.Error
+		ExpectWithOffset(1, errors.As(w.Err(), &urlErr)).To(BeTrue())
+		ExpectWithOffset(1, urlErr.Op).To(Equal("Post"))
+
+		switch tErr := urlErr.Err.(type) {
+		case *net.OpError:
+			ExpectWithOffset(1, tErr.Op).To(Equal("dial"))
+			ExpectWithOffset(1, tErr.Net).To(Equal("tcp"))
+			ExpectWithOffset(1, tErr.Err).ToNot(BeNil())
+			var sysErr *os.SyscallError
+			ExpectWithOffset(1, errors.As(tErr.Err, &sysErr)).To(BeTrue())
+			ExpectWithOffset(1, sysErr.Syscall).To(Equal("connect"))
+		default:
+			ExpectWithOffset(1, tErr).To(HaveOccurred())
+		}
+	}
+
+	When("the context is cancelled", FlakeAttempts(5), func() {
+		JustBeforeEach(func() {
+			cancel()
+		})
+		When("no vms have namespace/name information", func() {
+			Specify("no error or result should be returned", func() {
+				assertNoError()
+				assertNoResult()
+			})
+		})
+		When("one vm has namespace/name information", func() {
+			BeforeEach(func() {
+				addNamespaceName(cluster1vm1, "my-namespace-1", "my-name-1")
+			})
+			Specify("no error or result is returned", func() {
+				assertNoError()
+				assertNoResult()
+			})
+		})
+	})
+
+	When("the connection to vSphere is interrupted", FlakeAttempts(5), func() {
+		JustBeforeEach(func() {
+			closeServerOnce.Do(server.Close)
+		})
+
+		When("no vms have namespace/name information", func() {
+			Specify("an error should be returned", func() {
+				assertError()
+				assertNoResult()
+			})
+		})
+
+		When("a vm has namespace/name information", func() {
+			BeforeEach(func() {
+				addNamespaceName(cluster1vm1, "my-namespace-1", "my-name-1")
+			})
+			Specify("an error should be returned", func() {
+				assertError()
+				assertNoResult()
+			})
+		})
+	})
+
+	When("no vms have namespace/name information", func() {
+		Specify("no error or results", func() {
+			assertNoError()
+			assertNoResult()
+		})
+	})
+
+	When("one vm has namespace/name information", func() {
+		BeforeEach(func() {
+			addNamespaceName(cluster1vm1, "my-namespace-1", "my-name-1")
+		})
+		Specify("the result channel should receive a result", func() {
+			// Assert that a result is signaled due to the VM entering the
+			// scope of the watcher.
+			assertResult(cluster1vm1, "my-namespace-1", "my-name-1")
+
+			// Assert no more results are signaled.
+			assertNoResult()
+
+			// Assert no error either.
+			assertNoError()
+		})
+
+		When("the vm is powered on", func() {
+			Specify("the result channel should receive a result", func() {
+				// Assert that a result is signaled due to the VM entering the
+				// scope of the watcher.
+				assertResult(cluster1vm1, "my-namespace-1", "my-name-1")
+
+				// Assert no results are signaled until the VM's power state is
+				// updated.
+				assertNoResult()
+
+				// Power on the VM.
+				t, err := cluster1vm1.PowerOn(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(t.Wait(ctx)).To(Succeed())
+
+				// Assert a result is signaled as a result of the PowerOn op.
+				assertResult(cluster1vm1, "my-namespace-1", "my-name-1")
+
+				// Assert no more results are signaled.
+				assertNoResult()
+
+				// Assert no error either.
+				assertNoError()
+			})
+		})
+
+		When("the only change is for ignored extraConfig keys", func() {
+			Specify("no result should be received", func() {
+				// Assert that a result is signaled due to the VM entering the
+				// scope of the watcher.
+				assertResult(cluster1vm1, "my-namespace-1", "my-name-1")
+
+				// Assert no more results are signaled.
+				assertNoResult()
+
+				// Add both of the ignored extraConfig keys.
+				t, err := cluster1vm1.Reconfigure(
+					ctx,
+					vimtypes.VirtualMachineConfigSpec{
+						ExtraConfig: []vimtypes.BaseOptionValue{
+							&vimtypes.OptionValue{
+								Key:   "ignoredKey1",
+								Value: fakeStr,
+							},
+							&vimtypes.OptionValue{
+								Key:   "ignoredKey2",
+								Value: fakeStr,
+							},
+						},
+					},
+				)
+				ExpectWithOffset(1, err).ShouldNot(HaveOccurred())
+				ExpectWithOffset(1, t.WaitEx(ctx)).To(Succeed())
+
+				// Assert no more results are signaled.
+				assertNoResult()
+
+				// Assert no error either.
+				assertNoError()
+			})
+		})
+
+		When("there is a change to a non-ignored extraConfig key", func() {
+			Specify("a result should be received", func() {
+				// Assert that a result is signaled due to the VM entering the
+				// scope of the watcher.
+				assertResult(cluster1vm1, "my-namespace-1", "my-name-1")
+
+				// Assert no more results are signaled.
+				assertNoResult()
+
+				// Add a mixture of ignored and non-ignored keys.
+				t, err := cluster1vm1.Reconfigure(
+					ctx,
+					vimtypes.VirtualMachineConfigSpec{
+						ExtraConfig: []vimtypes.BaseOptionValue{
+							&vimtypes.OptionValue{
+								Key:   "ignoredKey1",
+								Value: fakeStr,
+							},
+							&vimtypes.OptionValue{
+								Key:   "guestinfo.fromTheGuest",
+								Value: "1.2.3.4",
+							},
+							&vimtypes.OptionValue{
+								Key:   "ignoredKey2",
+								Value: fakeStr,
+							},
+						},
+					},
+				)
+				ExpectWithOffset(1, err).ShouldNot(HaveOccurred())
+				ExpectWithOffset(1, t.WaitEx(ctx)).To(Succeed())
+
+				// Assert that a result is signaled due to the VM entering the
+				// scope of the watcher.
+				assertResult(cluster1vm1, "my-namespace-1", "my-name-1")
+
+				// Assert no more results are signaled.
+				assertNoResult()
+
+				// Assert no error either.
+				assertNoError()
+			})
+		})
+
+		When("the container is removed from the watcher", func() {
+			Specify("no result should be received", func() {
+				// Assert that a result is signaled due to the VM entering the
+				// scope of the watcher.
+				assertResult(cluster1vm1, "my-namespace-1", "my-name-1")
+
+				// Assert no more results are signaled.
+				assertNoResult()
+
+				// Remove the cluster from the scope of the watcher.
+				Expect(watcher.Remove(ctx, cluster1.Reference(), fakeStr)).To(Succeed())
+
+				// Add a non-ignored ExtraConfig key.
+				t, err := cluster1vm1.Reconfigure(
+					ctx,
+					vimtypes.VirtualMachineConfigSpec{
+						ExtraConfig: []vimtypes.BaseOptionValue{
+							&vimtypes.OptionValue{
+								Key:   "guestinfo.fromTheGuest",
+								Value: "1.2.3.4",
+							},
+							&vimtypes.OptionValue{
+								Key:   "ignoredKey2",
+								Value: fakeStr,
+							},
+						},
+					},
+				)
+				ExpectWithOffset(1, err).ShouldNot(HaveOccurred())
+				ExpectWithOffset(1, t.WaitEx(ctx)).To(Succeed())
+
+				// Assert no error either.
+				assertNoError()
+
+				// Assert no more results are signaled.
+				assertNoResult()
+			})
+		})
+
+		When("the container has multiple adds", func() {
+			JustBeforeEach(func() {
+				Expect(watcher.Add(ctx, cluster1.Reference(), fakeStr+"1")).To(Succeed())
+				Expect(watcher.Add(ctx, cluster1.Reference(), fakeStr+"2")).To(Succeed())
+				Expect(watcher.Add(ctx, cluster1.Reference(), fakeStr+"3")).To(Succeed())
+			})
+			Specify("it should need an equal number of removes before it stops being watched", func() {
+				// Assert that a result is signaled due to the VM entering the
+				// scope of the watcher.
+				assertResult(cluster1vm1, "my-namespace-1", "my-name-1")
+
+				// Assert no more results are signaled.
+				assertNoResult()
+
+				// Remove the cluster from the scope of the watcher.
+				Expect(watcher.Remove(ctx, cluster1.Reference(), fakeStr+"1")).To(Succeed())
+
+				// Add a non-ignored ExtraConfig key.
+				t, err := cluster1vm1.Reconfigure(
+					ctx,
+					vimtypes.VirtualMachineConfigSpec{
+						ExtraConfig: []vimtypes.BaseOptionValue{
+							&vimtypes.OptionValue{
+								Key:   "guestinfo.1",
+								Value: "1",
+							},
+						},
+					},
+				)
+				ExpectWithOffset(1, err).ShouldNot(HaveOccurred())
+				ExpectWithOffset(1, t.WaitEx(ctx)).To(Succeed())
+
+				// Assert no error either.
+				assertNoError()
+
+				// Assert that a result is signaled due to there still being a
+				// ref on the container and thus it is still being watched.
+				assertResult(cluster1vm1, "my-namespace-1", "my-name-1")
+
+				// Assert no more results are signaled.
+				assertNoResult()
+
+				//
+				// Do this again.
+				//
+				Expect(watcher.Remove(ctx, cluster1.Reference(), fakeStr+"2")).To(Succeed())
+				t, err = cluster1vm1.Reconfigure(
+					ctx,
+					vimtypes.VirtualMachineConfigSpec{
+						ExtraConfig: []vimtypes.BaseOptionValue{
+							&vimtypes.OptionValue{
+								Key:   "guestinfo.2",
+								Value: "1",
+							},
+						},
+					},
+				)
+				ExpectWithOffset(1, err).ShouldNot(HaveOccurred())
+				ExpectWithOffset(1, t.WaitEx(ctx)).To(Succeed())
+				assertNoError()
+				assertResult(cluster1vm1, "my-namespace-1", "my-name-1")
+				assertNoResult()
+
+				//
+				// Remove the container a third time, and it should finally be
+				// be removed from the watch.
+				//
+				Expect(watcher.Remove(ctx, cluster1.Reference(), fakeStr+"3")).To(Succeed())
+				t, err = cluster1vm1.Reconfigure(
+					ctx,
+					vimtypes.VirtualMachineConfigSpec{
+						ExtraConfig: []vimtypes.BaseOptionValue{
+							&vimtypes.OptionValue{
+								Key:   "guestinfo.3",
+								Value: "1",
+							},
+						},
+					},
+				)
+				ExpectWithOffset(1, err).ShouldNot(HaveOccurred())
+				ExpectWithOffset(1, t.WaitEx(ctx)).To(Succeed())
+				assertNoError()
+				assertNoResult()
+			})
+		})
+	})
+
+	When("multiple vms have namespace/name information", func() {
+		BeforeEach(func() {
+			addNamespaceName(cluster1vm1, "my-namespace-1", "my-name-1")
+			addNamespaceName(cluster1vm2, "my-namespace-2", "my-name-2")
+		})
+		Specify("the result channel should receive multiple results", func() {
+			var (
+				result1 watcher.Result
+				result2 watcher.Result
+			)
+
+			Eventually(w.Result(), time.Second*3).Should(Receive(&result1))
+			Eventually(w.Result(), time.Second*5).Should(Receive(&result2))
+
+			// Assert that two results are signaled due to the VMs entering the
+			// scope of the watcher.
+			Expect([]watcher.Result{
+				result1,
+				result2,
+			}).To(ConsistOf(
+				watcher.Result{
+					Namespace: "my-namespace-2",
+					Name:      "my-name-2",
+					Ref:       cluster1vm2.Reference(),
+				},
+				watcher.Result{
+					Namespace: "my-namespace-1",
+					Name:      "my-name-1",
+					Ref:       cluster1vm1.Reference(),
+				},
+			))
+
+			// Assert no more results are signaled.
+			assertNoResult()
+
+			// Assert no error either.
+			assertNoError()
+		})
+	})
+
+	When("a vm is destroyed", func() {
+		BeforeEach(func() {
+			addNamespaceName(cluster1vm1, "my-namespace-1", "my-name-1")
+		})
+		Specify("the result channel should not receive a result when the vm is deleted", func() {
+			// Assert that a result is signaled due to the VM entering the
+			// scope of the watcher.
+			assertResult(cluster1vm1, "my-namespace-1", "my-name-1")
+
+			// Delete the VM.
+			t, err := cluster1vm1.Destroy(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(t.Wait(ctx)).To(Succeed())
+
+			// Assert a result is not signaled as a result of the Delete
+			// operation.
+			assertNoResult()
+
+			// Assert no error either.
+			assertNoError()
+		})
+	})
+
+	When("a vm is a member of a container not being watched", func() {
+		Specify("no result or error should be received", func() {
+			assertNoResult()
+			assertNoError()
+		})
+
+		When("the container is added to the watcher", func() {
+			JustBeforeEach(func() {
+				Expect(watcher.Add(ctx, cluster2.Reference(), fakeStr)).To(Succeed())
+			})
+			When("the lookup function returns verified=false", func() {
+				Specify("the result channel should receive a result", func() {
+					// Assert that a result is signaled due to the VM entering the
+					// scope of the watcher.
+					//
+					// Please note the result's namespaced name is not set on the
+					// VM, but obtained from the lookup function.
+					assertResult(cluster2vm1, "my-namespace-4", "my-name-1")
+
+					// Assert no more results are signaled.
+					assertNoResult()
+
+					// Assert no error either.
+					assertNoError()
+				})
+			})
+			When("the lookup function returns verified=true", func() {
+				BeforeEach(func() {
+					lookupFnVerified = true
+				})
+				Specify("the result channel should not receive a result", func() {
+					// Assert no result is signalled because the object entered
+					// the watcher in a verified state.
+					assertNoResult()
+
+					// Assert no error either.
+					assertNoError()
+				})
+			})
+		})
+	})
+})

--- a/services/services.go
+++ b/services/services.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package services
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
+	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+	vmwatcher "github.com/vmware-tanzu/vm-operator/services/vm-watcher"
+)
+
+// AddToManager adds all services to the provided manager.
+func AddToManager(
+	ctx *pkgctx.ControllerManagerContext,
+	mgr manager.Manager) error {
+
+	if !pkgcfg.FromContext(ctx).AsyncSignalDisabled {
+		if err := vmwatcher.AddToManager(ctx, mgr); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/services/vm-watcher/vm_watcher_service.go
+++ b/services/vm-watcher/vm_watcher_service.go
@@ -1,0 +1,218 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package vmwatcher
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	topologyv1 "github.com/vmware-tanzu/vm-operator/external/tanzu-topology/api/v1alpha1"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
+	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/providers"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
+	vsphereclient "github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/client"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/watcher"
+)
+
+// AddToManager adds this package's runnable to the provided manager.
+func AddToManager(
+	ctx *pkgctx.ControllerManagerContext,
+	mgr manager.Manager) error {
+
+	// Index the VM's MoRef ID set in status. This is used by the vm-watcher
+	// service to quickly indirect a MoRefs to a Namespace/Name.
+	if err := mgr.GetFieldIndexer().IndexField(
+		ctx,
+		&vmopv1.VirtualMachine{},
+		"status.uniqueID",
+		func(rawObj ctrlclient.Object) []string {
+			vm := rawObj.(*vmopv1.VirtualMachine)
+			return []string{vm.Status.UniqueID}
+		}); err != nil {
+		return err
+	}
+
+	return mgr.Add(New(ctx, mgr.GetClient(), ctx.VMProvider))
+}
+
+type Service struct {
+	ctrlclient.Client
+	ctx      context.Context
+	provider providers.VirtualMachineProviderInterface
+}
+
+func New(
+	ctx context.Context,
+	client ctrlclient.Client,
+	provider providers.VirtualMachineProviderInterface) manager.Runnable {
+
+	return Service{
+		Client:   client,
+		ctx:      ctx,
+		provider: provider,
+	}
+}
+
+var _ manager.LeaderElectionRunnable = Service{}
+
+func (s Service) NeedLeaderElection() bool {
+	return true
+}
+
+func (s Service) Start(ctx context.Context) error {
+	ctx = cource.JoinContext(ctx, s.ctx)
+	ctx = watcher.JoinContext(ctx, s.ctx)
+	ctx = pkgcfg.JoinContext(ctx, s.ctx)
+
+	ctx = logr.NewContext(
+		ctx,
+		logr.FromContextOrDiscard(s.ctx).WithName("VMWatcherService"))
+
+	for ctx.Err() == nil {
+		if err := s.waitForChanges(ctx); err != nil {
+			// If waitForChanges failed because of an invalid login or auth
+			// error, then do not treat the error as fatal. This allows the
+			// loop to run again, kicking off another watcher with what should
+			// be updated credentials.
+			if !vsphereclient.IsInvalidLogin(err) &&
+				!vsphereclient.IsNotAuthenticatedError(err) {
+
+				return err
+			}
+		}
+	}
+	return ctx.Err()
+}
+
+var emptyResult watcher.Result
+
+func (s Service) vmFolderRefs(ctx context.Context) ([]vimtypes.ManagedObjectReference, error) {
+	// Get a list of all the folders that can contain VM Service VMs.
+	var (
+		zones topologyv1.ZoneList
+		frefs []vimtypes.ManagedObjectReference
+		moids = map[string]struct{}{}
+	)
+	if err := s.Client.List(ctx, &zones); err != nil {
+		return nil, err
+	}
+	for i := range zones.Items {
+		z := zones.Items[i]
+		if v := z.Spec.ManagedVMs.FolderMoID; v != "" {
+			if _, ok := moids[v]; !ok {
+				moids[v] = struct{}{}
+				frefs = append(frefs, vimtypes.ManagedObjectReference{
+					Type:  "Folder",
+					Value: v,
+				})
+			}
+		}
+	}
+
+	return frefs, nil
+}
+
+func (s Service) waitForChanges(ctx context.Context) error {
+	var (
+		logger     = logr.FromContextOrDiscard(ctx)
+		chanSource = cource.FromContextWithBuffer(ctx, "VirtualMachine", 100)
+	)
+
+	vcClient, err := s.provider.VSphereClient(ctx)
+	if err != nil {
+		return err
+	}
+	logger.Info("got vsphere client")
+
+	refs, err := s.vmFolderRefs(ctx)
+	if err != nil {
+		return err
+	}
+	logger.Info("got vm service folders", "refs", refs)
+
+	// Start the watcher.
+	w, err := watcher.Start(
+		ctx,
+		vcClient.VimClient(),
+		nil,
+		nil,
+		s.lookupNamespacedName,
+		refs...)
+	if err != nil {
+		return err
+	}
+
+	logger.Info("started watching vms")
+
+	for {
+		select {
+		case result := <-w.Result():
+			if result == emptyResult {
+				logger.Info("received empty result, watcher is closed")
+				return w.Err()
+			}
+
+			if !result.Verified {
+				// Validate the vm exists on this cluster.
+				result.Verified = s.Get(
+					ctx,
+					ctrlclient.ObjectKey{
+						Namespace: result.Namespace,
+						Name:      result.Name,
+					},
+					&vmopv1.VirtualMachine{}) == nil
+			}
+
+			if !result.Verified {
+				logger.V(4).Info(
+					"received result but unable to validate vm",
+					"result", result)
+				continue
+			}
+
+			// Enqueue a reconcile request for the VM.
+			logger.V(4).Info("received result", "result", result)
+			chanSource <- event.GenericEvent{
+				Object: &vmopv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: result.Namespace,
+						Name:      result.Name,
+					},
+				},
+			}
+
+		case <-w.Done():
+			return w.Err()
+		}
+	}
+}
+
+// lookupNamespacedName looks up the namespace and name for a given MoRef using
+// the Kubernetes client's cache, where the "status.uniqueID" field of VMs are
+// indexed for fast lookup.
+func (s Service) lookupNamespacedName(
+	ctx context.Context,
+	moRef vimtypes.ManagedObjectReference) (string, string, bool) {
+
+	var list vmopv1.VirtualMachineList
+	if err := s.Client.List(
+		ctx,
+		&list,
+		ctrlclient.MatchingFields{"status.uniqueID": moRef.Value}); err == nil {
+
+		if len(list.Items) == 1 {
+			return list.Items[0].Namespace, list.Items[0].Name, true
+		}
+	}
+
+	return "", "", false
+}

--- a/services/vm-watcher/vm_watcher_service_suite_test.go
+++ b/services/vm-watcher/vm_watcher_service_suite_test.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package vmwatcher_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestVMWatcherService(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "VM Watcher Service Test Suite")
+}

--- a/services/vm-watcher/vm_watcher_service_test.go
+++ b/services/vm-watcher/vm_watcher_service_test.go
@@ -1,0 +1,458 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package vmwatcher_test
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/vmware/govmomi/object"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
+	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+	providerfake "github.com/vmware-tanzu/vm-operator/pkg/providers/fake"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
+	vsclient "github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/client"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/watcher"
+	vmwatcher "github.com/vmware-tanzu/vm-operator/services/vm-watcher"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+	"github.com/vmware-tanzu/vm-operator/test/testutil"
+)
+
+var _ = Describe(
+	"Start", Label(
+		testlabels.EnvTest,
+		testlabels.Service,
+		testlabels.V1Alpha3,
+	),
+	func() {
+
+		var (
+			ctx               context.Context
+			vcSimCtx          *builder.IntegrationTestContextForVCSim
+			provider          *providerfake.VMProvider
+			initEnvFn         builder.InitVCSimEnvFn
+			vsClientMu        sync.RWMutex
+			vsClient          *vsclient.Client
+			numNewClientCalls int32
+		)
+
+		BeforeEach(func() {
+			numNewClientCalls = 0
+			vsClient = nil
+			vsClientMu = sync.RWMutex{}
+			ctx = context.Background()
+			ctx = logr.NewContext(ctx, testutil.GinkgoLogr(4))
+		})
+
+		JustBeforeEach(func() {
+			ctx = pkgcfg.WithContext(ctx, pkgcfg.Default())
+			ctx = pkgcfg.UpdateContext(
+				ctx,
+				func(config *pkgcfg.Config) {
+					config.Features.WorkloadDomainIsolation = true
+				},
+			)
+			ctx = cource.WithContext(ctx)
+			ctx = watcher.WithContext(ctx)
+
+			provider = providerfake.NewVMProvider()
+			provider.VSphereClientFn = func(ctx context.Context) (*vsclient.Client, error) {
+				vsClientMu.Lock()
+				defer vsClientMu.Unlock()
+
+				atomic.AddInt32(&numNewClientCalls, 1)
+				var err error
+				vsClient, err = vsclient.NewClient(ctx, vcSimCtx.VCClientConfig)
+				return vsClient, err
+			}
+
+			vcSimCtx = builder.NewIntegrationTestContextForVCSim(
+				ctx,
+				builder.VCSimTestConfig{
+					WithWorkloadIsolation: pkgcfg.FromContext(ctx).Features.WorkloadDomainIsolation,
+				},
+				vmwatcher.AddToManager,
+				func(ctx *pkgctx.ControllerManagerContext, _ ctrlmgr.Manager) error {
+					ctx.VMProvider = provider
+					return nil
+				},
+				initEnvFn)
+			Expect(vcSimCtx).ToNot(BeNil())
+
+			vcSimCtx.BeforeEach()
+		})
+
+		AfterEach(func() {
+			vcSimCtx.AfterEach()
+		})
+
+		When("the client is no longer authenticated", func() {
+			var (
+				oldVSClient *vsclient.Client
+			)
+			BeforeEach(func() {
+				oldVSClient = nil
+			})
+			JustBeforeEach(func() {
+				func() {
+					vsClientMu.RLock()
+					defer vsClientMu.RUnlock()
+
+					oldVSClient = vsClient
+				}()
+
+				Eventually(func(g Gomega) {
+					vsClientMu.RLock()
+					defer vsClientMu.RUnlock()
+
+					g.Expect(vsClient.Valid()).To(BeTrue())
+					g.Expect(atomic.LoadInt32(&numNewClientCalls)).To(Equal(int32(1)))
+				}).Should(Succeed())
+
+				By("log out the client session", func() {
+					vsClientMu.Lock()
+					defer vsClientMu.Unlock()
+
+					vsClient.Logout(vcSimCtx)
+				})
+			})
+			Specify("the service should be restarted", func() {
+				Eventually(func(g Gomega) {
+					vsClientMu.RLock()
+					defer vsClientMu.RUnlock()
+
+					g.Expect(vsClient.Valid()).To(BeTrue())
+					g.Expect(vsClient).ToNot(BeIdenticalTo(oldVSClient))
+					g.Expect(atomic.LoadInt32(&numNewClientCalls)).To(Equal(int32(2)))
+				}).Should(Succeed())
+			})
+		})
+
+		When("the credentials are rotated", func() {
+			var (
+				oldUser     string
+				oldPass     string
+				oldVSClient *vsclient.Client
+			)
+			BeforeEach(func() {
+				oldUser = ""
+				oldPass = ""
+				oldVSClient = nil
+			})
+			JustBeforeEach(func() {
+				By("store the old client", func() {
+					vsClientMu.RLock()
+					defer vsClientMu.RUnlock()
+
+					oldVSClient = vsClient
+				})
+
+				Eventually(func(g Gomega) {
+					vsClientMu.RLock()
+					defer vsClientMu.RUnlock()
+
+					g.Expect(vsClient.Valid()).To(BeTrue())
+					g.Expect(atomic.LoadInt32(&numNewClientCalls)).To(Equal(int32(1)))
+				}).Should(Succeed())
+
+				By("invalidate the credentials", func() {
+					vsClientMu.Lock()
+					defer vsClientMu.Unlock()
+
+					oldUser = vcSimCtx.VCClientConfig.Username
+					oldPass = vcSimCtx.VCClientConfig.Password
+					vcSimCtx.VCClientConfig.Username = ""
+					vcSimCtx.VCClientConfig.Password = ""
+				})
+
+				By("log out the client session", func() {
+					vsClientMu.Lock()
+					defer vsClientMu.Unlock()
+
+					vsClient.Logout(vcSimCtx)
+				})
+			})
+
+			Specify("the service should be restarted once the password is rotated", func() {
+				Eventually(func(g Gomega) {
+					vsClientMu.RLock()
+					defer vsClientMu.RUnlock()
+
+					g.Expect(vsClient.Valid()).To(BeFalse())
+					g.Expect(atomic.LoadInt32(&numNewClientCalls)).To(BeNumerically(">=", int32(2)))
+				}).Should(Succeed())
+
+				By("fix the credentials", func() {
+					vsClientMu.Lock()
+					defer vsClientMu.Unlock()
+
+					vcSimCtx.VCClientConfig.Username = oldUser
+					vcSimCtx.VCClientConfig.Password = oldPass
+				})
+
+				Eventually(func(g Gomega) {
+					vsClientMu.RLock()
+					defer vsClientMu.RUnlock()
+
+					g.Expect(vsClient.Valid()).To(BeTrue())
+					g.Expect(vsClient).ToNot(BeIdenticalTo(oldVSClient))
+					g.Expect(atomic.LoadInt32(&numNewClientCalls)).To(BeNumerically(">=", int32(3)))
+				}).Should(Succeed())
+			})
+		})
+
+		When("the port is invalid", func() {
+			JustBeforeEach(func() {
+				vcSimCtx.Suite.StartErrExpected = true
+
+				Eventually(func(g Gomega) {
+					vsClientMu.RLock()
+					defer vsClientMu.RUnlock()
+
+					g.Expect(vsClient.Valid()).To(BeTrue())
+					g.Expect(atomic.LoadInt32(&numNewClientCalls)).To(Equal(int32(1)))
+				}).Should(Succeed())
+
+				By("invalidate the port", func() {
+					vsClientMu.Lock()
+					defer vsClientMu.Unlock()
+
+					vcSimCtx.VCClientConfig.Port = "1"
+				})
+
+				By("log out the client session", func() {
+					vsClientMu.Lock()
+					defer vsClientMu.Unlock()
+
+					vsClient.Logout(vcSimCtx)
+				})
+			})
+
+			Specify("the service should fail", func() {
+				Eventually(func(g Gomega) {
+					g.Expect(vcSimCtx.Suite.StartErr()).To(HaveOccurred())
+					g.Expect(atomic.LoadInt32(&numNewClientCalls)).To(Equal(int32(2)))
+				}).Should(Succeed())
+			})
+		})
+
+		When("there is a vm in the zone's folder", func() {
+
+			const (
+				vmName = "my-vm-1"
+			)
+
+			When("the vm has the namespacedName in extraConfig", func() {
+				var (
+					vm *object.VirtualMachine
+				)
+
+				BeforeEach(func() {
+					initEnvFn = func(ctx *builder.IntegrationTestContextForVCSim) {
+						vmList, err := ctx.Finder.VirtualMachineList(ctx, "*")
+						Expect(err).ToNot(HaveOccurred())
+						Expect(vmList).ToNot(BeEmpty())
+						vm = vmList[0]
+
+						By("creating vm in k8s", func() {
+							By("creating vm in k8s", func() {
+								obj := builder.DummyBasicVirtualMachine(
+									vmName,
+									ctx.NSInfo.Namespace)
+								Expect(ctx.Client.Create(ctx, obj)).To(Succeed())
+							})
+						})
+
+						By("moving vm into zone's folder", func() {
+							t, err := vm.Relocate(ctx, vimtypes.VirtualMachineRelocateSpec{
+								Folder: ptr.To(ctx.NSInfo.Folder.Reference()),
+							}, vimtypes.VirtualMachineMovePriorityDefaultPriority)
+							Expect(err).ToNot(HaveOccurred())
+							Expect(t).ToNot(BeNil())
+							Expect(t.Wait(ctx)).To(Succeed())
+						})
+
+						By("adding namespacedName to vm's extraConfig", func() {
+							t, err := vm.Reconfigure(ctx, vimtypes.VirtualMachineConfigSpec{
+								ExtraConfig: []vimtypes.BaseOptionValue{
+									&vimtypes.OptionValue{
+										Key:   "vmservice.namespacedName",
+										Value: ctx.NSInfo.Namespace + "/" + vmName,
+									},
+								},
+							})
+							Expect(err).ToNot(HaveOccurred())
+							Expect(t).ToNot(BeNil())
+							Expect(t.Wait(ctx)).To(Succeed())
+						})
+					}
+				})
+
+				Specify("a reconcile request should be received", func() {
+					chanSource := cource.FromContext(ctx, "VirtualMachine")
+					var e event.GenericEvent
+					Eventually(chanSource).Should(Receive(&e, Equal(event.GenericEvent{
+						Object: &vmopv1.VirtualMachine{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: vcSimCtx.NSInfo.Namespace,
+								Name:      vmName,
+							},
+						},
+					})))
+				})
+
+				When("the vm is reconfigured", func() {
+
+					Specify("a second reconcile request should be received", func() {
+						chanSource := cource.FromContext(ctx, "VirtualMachine")
+						var e1 event.GenericEvent
+						Eventually(chanSource).Should(Receive(&e1, Equal(event.GenericEvent{
+							Object: &vmopv1.VirtualMachine{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: vcSimCtx.NSInfo.Namespace,
+									Name:      vmName,
+								},
+							},
+						})))
+
+						t, err := vm.Reconfigure(ctx, vimtypes.VirtualMachineConfigSpec{
+							ExtraConfig: []vimtypes.BaseOptionValue{
+								&vimtypes.OptionValue{
+									Key:   "guestinfo.ipaddr",
+									Value: "1.2.3.4",
+								},
+							},
+						})
+						Expect(err).ToNot(HaveOccurred())
+						Expect(t).ToNot(BeNil())
+						Expect(t.Wait(ctx)).To(Succeed())
+
+						var e2 event.GenericEvent
+						Eventually(chanSource).Should(Receive(&e2, Equal(event.GenericEvent{
+							Object: &vmopv1.VirtualMachine{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: vcSimCtx.NSInfo.Namespace,
+									Name:      vmName,
+								},
+							},
+						})))
+					})
+
+					When("the namespacedName has an invalid namespace", func() {
+						Specify("a second reconcile request should not be received", func() {
+							chanSource := cource.FromContext(ctx, "VirtualMachine")
+							var e1 event.GenericEvent
+							Eventually(chanSource).Should(Receive(&e1, Equal(event.GenericEvent{
+								Object: &vmopv1.VirtualMachine{
+									ObjectMeta: metav1.ObjectMeta{
+										Namespace: vcSimCtx.NSInfo.Namespace,
+										Name:      vmName,
+									},
+								},
+							})))
+
+							t, err := vm.Reconfigure(ctx, vimtypes.VirtualMachineConfigSpec{
+								ExtraConfig: []vimtypes.BaseOptionValue{
+									&vimtypes.OptionValue{
+										Key:   "guestinfo.ipaddr",
+										Value: "1.2.3.4",
+									},
+									&vimtypes.OptionValue{
+										Key:   "vmservice.namespacedName",
+										Value: "invalid/" + vmName,
+									},
+								},
+							})
+							Expect(err).ToNot(HaveOccurred())
+							Expect(t).ToNot(BeNil())
+							Expect(t.Wait(ctx)).To(Succeed())
+
+							Consistently(chanSource).ShouldNot(Receive())
+						})
+					})
+				})
+			})
+
+			When("the vm does not have the namespacedName in extraConfig", func() {
+				When("the vm's status.uniqueID is in the manager's cache", func() {
+					BeforeEach(func() {
+						initEnvFn = func(ctx *builder.IntegrationTestContextForVCSim) {
+							vmList, err := ctx.Finder.VirtualMachineList(ctx, "*")
+							Expect(err).ToNot(HaveOccurred())
+							Expect(vmList).ToNot(BeEmpty())
+							vm := vmList[0]
+
+							By("creating vm in k8s", func() {
+								obj := builder.DummyBasicVirtualMachine(
+									vmName,
+									ctx.NSInfo.Namespace)
+								Expect(ctx.Client.Create(ctx, obj)).To(Succeed())
+								obj.Status.UniqueID = vm.Reference().Value
+								Expect(ctx.Client.Status().Update(ctx, obj)).To(Succeed())
+							})
+
+							By("moving vm into zone's folder", func() {
+								t, err := vm.Relocate(ctx, vimtypes.VirtualMachineRelocateSpec{
+									Folder: ptr.To(ctx.NSInfo.Folder.Reference()),
+								}, vimtypes.VirtualMachineMovePriorityDefaultPriority)
+								Expect(err).ToNot(HaveOccurred())
+								Expect(t).ToNot(BeNil())
+								Expect(t.Wait(ctx)).To(Succeed())
+							})
+						}
+					})
+
+					Specify("a reconcile request should not be received because the VM entered the watcher's scope already verified", func() {
+						chanSource := cource.FromContext(ctx, "VirtualMachine")
+						Consistently(chanSource, time.Second*5).ShouldNot(Receive())
+					})
+				})
+
+				When("the vm's status.uniqueID is not in the manager's cache", func() {
+					BeforeEach(func() {
+						initEnvFn = func(ctx *builder.IntegrationTestContextForVCSim) {
+							vmList, err := ctx.Finder.VirtualMachineList(ctx, "*")
+							Expect(err).ToNot(HaveOccurred())
+							Expect(vmList).ToNot(BeEmpty())
+							vm := vmList[0]
+
+							By("creating vm in k8s", func() {
+								obj := builder.DummyBasicVirtualMachine(
+									vmName,
+									ctx.NSInfo.Namespace)
+								Expect(ctx.Client.Create(ctx, obj)).To(Succeed())
+							})
+
+							By("moving vm into zone's folder", func() {
+								t, err := vm.Relocate(ctx, vimtypes.VirtualMachineRelocateSpec{
+									Folder: ptr.To(ctx.NSInfo.Folder.Reference()),
+								}, vimtypes.VirtualMachineMovePriorityDefaultPriority)
+								Expect(err).ToNot(HaveOccurred())
+								Expect(t).ToNot(BeNil())
+								Expect(t.Wait(ctx)).To(Succeed())
+							})
+						}
+					})
+					Specify("a reconcile request should not be received", func() {
+						chanSource := cource.FromContext(ctx, "VirtualMachine")
+						Consistently(chanSource, time.Second*5).ShouldNot(Receive())
+					})
+				})
+			})
+		})
+	})

--- a/test/testutil/util.go
+++ b/test/testutil/util.go
@@ -11,6 +11,9 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
+	"github.com/onsi/ginkgo/v2" //nolint:depguard
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -109,4 +112,18 @@ type unwrappableError interface {
 
 type unwrappableErrorSlice interface {
 	Unwrap() []error
+}
+
+// GinkgoLogr returns a new logr.Logger that uses the GinkgoWriter with the
+// specified verbosity.
+func GinkgoLogr(v int) logr.Logger {
+	return funcr.New(func(prefix, args string) {
+		if prefix == "" {
+			_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "%s\n", args)
+		} else {
+			_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "%s %s\n", prefix, args)
+		}
+	}, funcr.Options{
+		Verbosity: v,
+	})
 }


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This patch adds support for reconciling VMs when their state has changed on the underlying platform, ex. vSphere. There are three primary components:

* the watcher -- emits results on a channel monitored by...
* the service -- receives results and enqueues reconcile requests
* the zone controller -- adds/removes zone folders to/from the watcher

Please note, the environment variable `ASYNC_SIGNAL_DISABLED` may be set to a truth-y string value, ex. "true", to completely disable the async signal logic, regardless of the feature state switch.

### Watcher

The watcher is located in `pkg/util/vsphere/watcher` and watches one or more vSphere entities that can contain VMs, ex. a `Folder`, `ClusterComputeResource`, `HostSystem`, etc.. The watcher is initialized with a set of these entities and creates a `ContainerView` for each. These are added to the watcher's `ListView`, which enables entities to be added/removed later while the watcher is running. The watcher is signaled when a VM enters the view of the watcher or when a VM has a change to one of the on the following properties:

- `config.extraConfig` -- Signal when the guest changes something in `guestinfo`.
- `guest.ipStack` -- Signal on changes to the network state.
- `guest.net` -- Signal on changes to the network state.
- `summary.config.name` -- A way to detect when the VM enters the scope of the watch.
- `summary.guest` -- Signal on any changes to the guest.
- `summary.overallStatus` -- Signal on changes to the VM's status.
- `summary.runtime.host` -- Signal when the host on which a VM is running has been changed.
- `summary.runtime.powerState` -- Signal when the VM's power state is changed.
- `summary.storage.timestamp` -- Signal when the VM's storage information (capacity, used, etc.) has changed.

Not all changes to extraConfig cause the watcher to emit a result. The following extraConfig keys are ignored:

- backupapi.AdditionalResourcesYAMLExtraConfigKey
- backupapi.BackupVersionExtraConfigKey
- backupapi.ClassicDiskDataExtraConfigKey
- backupapi.DisableAutoRegistrationExtraConfigKey
- backupapi.EnableAutoRegistrationExtraConfigKey
- backupapi.PVCDiskDataExtraConfigKey
- backupapi.VMResourceYAMLExtraConfigKey
- "govcsim"
- "guestinfo.metadata"
- "guestinfo.metadata.encoding"
- "guestinfo.userdata"
- "guestinfo.userdata.encoding"
- "guestinfo.vendordata"
- "guestinfo.vendordata.encoding"
- "vmservice.namespacedName"

Additional keys may be ignored as well, but these are ignored by default in order to prevent an infinite loop:

- VM controller receives reconcile request -->
- VM controller reconfigures VM -->
- VM Op reconfigures VM --> 
- watcher sees change -->
- watcher emits result -->
- service sees result -->
- service enqueues reconcile request -->
- VM controller receives reconcile request, causing a loop.

When the watcher notices a VM enter its view or with a change, the watcher must get the namespace and name for the VM. This happens one of three ways:

1. The change itself includes the namespace and name in the extraConfig
2. The watcher looks up the namespace and name from the manager's cache, where the field `status.uniqueID` is now an indexed field.
3. Finally, the watcher retrieves the property `config.extraConfig["vmservice.namespacedName"]` from the vSphere server.

If the namespace and name can be determined, the watcher checks if the VM already exists in Kubernetes with a `status.uniqueID` field and if the update type was the VM entering the view of the watcher. If these conditions are met, no result is emitted for this VM. This prevents double-reconciling VMs when the Controller-Manager starts up for the first time. During start-up, the Controller-Manager automatically reconciles all objects watched by controllers. Since all VMs would also be entering the view of watchers, this would cause a large-scale double-reconcile. Therefore, this logic skips emitting results on startup for VMs that are already deployed.

If the namespace and name are non-empty, the update types was `Enter` and the VM has an empty `status.uniqueID` field or the update type was `Modify`, the watcher emits a result on a channel watched by the next component, the service.


### Service

The service is located in `services/vm-watcher` and is responsible for:

* keeping an instance of the watcher running
* receiving results from the watcher and enqueuing reconcile requests

The service will always start a new instance of the watcher as long as the reason the previous instance failed was due to a login/auth error. This is to handle the case of credential rotation.

The service starts a watcher with an initial set of entities to watch that includes the ManagedObject ID for each `Folder` that can contain VM Service VMs. These folder IDs are gathered by listing all `Zone` resources on the cluster and collecting the value of `spec.managedVMs.folderMoID`.

The service monitors results from the watcher. Upon receiving a result, the service determines if the reported VM is valid, and if so, a reconcile request is enqueued.

### Zone controller

The zone controller is located in `controllers/infra/zone` and reconciles `topologyv1.Zone` resources.

When a zone resource without a deletion timestamp is reconciled, the controller adds a finalizer to it and adds the zone's vm service folder to the list of the entities monitored by the watcher.

When a zone resource with a non-zero deletion timestamp is reconciled, the controller removes the zone's vm service folder from the list of the entities monitored by the watcher and removes the finalizer.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

* We may want to remove [`summary.storage.timestamp`](https://dp-downloads.broadcom.com/api-content/apis/API_VWSA_001/8.0U3/html/ReferenceGuides/vim.vm.Summary.StorageSummary.html) as this may result in too many reconciles. I will look into how often the storage summary is updated.
* @bryanv Please note, the watcher prevents double-reconciling VMs when the Controller-Manager starts. The documentation for the watcher component up above describes how.

**Please add a release note if necessary**:

```release-note
Reconcile VMs when their state changes on underlying platform
```