### PR TITLE
:sparkles: Add ValidatingWebhookConfiguration controller

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -40,6 +40,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfiguration
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - cns.vmware.com
   resources:
   - cnsnodevmattachments

--- a/controllers/infra/controllers.go
+++ b/controllers/infra/controllers.go
@@ -12,6 +12,8 @@ import (
 	"github.com/vmware-tanzu/vm-operator/controllers/infra/configmap"
 	"github.com/vmware-tanzu/vm-operator/controllers/infra/node"
 	"github.com/vmware-tanzu/vm-operator/controllers/infra/secret"
+	"github.com/vmware-tanzu/vm-operator/controllers/infra/validatingwebhookconfiguration"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 )
 
@@ -28,6 +30,11 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 	}
 	if err := secret.AddToManager(ctx, mgr); err != nil {
 		return fmt.Errorf("failed to initialize infra secret controller: %w", err)
+	}
+	if pkgcfg.FromContext(ctx).Features.UnifiedStorageQuota {
+		if err := validatingwebhookconfiguration.AddToManager(ctx, mgr); err != nil {
+			return fmt.Errorf("failed to initialize storagepolicyusage webhook controller: %w", err)
+		}
 	}
 
 	return nil

--- a/controllers/infra/validatingwebhookconfiguration/validatingwebhookconfiguration_controller.go
+++ b/controllers/infra/validatingwebhookconfiguration/validatingwebhookconfiguration_controller.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package validatingwebhookconfiguration
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/go-logr/logr"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	spqv1 "github.com/vmware-tanzu/vm-operator/external/storage-policy-quota/api/v1alpha2"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
+	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+	pkgmgr "github.com/vmware-tanzu/vm-operator/pkg/manager"
+	"github.com/vmware-tanzu/vm-operator/pkg/record"
+	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
+	spqutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube/spq"
+)
+
+// AddToManager adds this package's controller to the provided manager.
+func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) error {
+	var (
+		controlledType     = &admissionv1.ValidatingWebhookConfiguration{}
+		controlledTypeName = reflect.TypeOf(controlledType).Elem().Name()
+
+		controllerNameShort = fmt.Sprintf("%s-controller", strings.ToLower(controlledTypeName))
+		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
+	)
+
+	r := NewReconciler(
+		ctx,
+		mgr.GetClient(),
+		ctrl.Log.WithName("controllers").WithName(controlledTypeName),
+		record.New(mgr.GetEventRecorderFor(controllerNameLong)),
+	)
+
+	c, err := controller.New(controllerNameShort, mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	cache, err := pkgmgr.NewNamespacedCacheForObject(mgr, &ctx.SyncPeriod, controlledType)
+	if err != nil {
+		return err
+	}
+
+	return c.Watch(source.Kind(cache, controlledType, &handler.TypedEnqueueRequestForObject[*admissionv1.ValidatingWebhookConfiguration]{},
+		predicate.TypedFuncs[*admissionv1.ValidatingWebhookConfiguration]{
+			CreateFunc: func(e event.TypedCreateEvent[*admissionv1.ValidatingWebhookConfiguration]) bool {
+				return e.Object.GetName() == spqutil.ValidatingWebhookConfigName
+			},
+			UpdateFunc: func(e event.TypedUpdateEvent[*admissionv1.ValidatingWebhookConfiguration]) bool {
+				return e.ObjectOld.GetName() == spqutil.ValidatingWebhookConfigName
+			},
+			DeleteFunc: func(e event.TypedDeleteEvent[*admissionv1.ValidatingWebhookConfiguration]) bool {
+				return false
+			},
+			GenericFunc: func(e event.TypedGenericEvent[*admissionv1.ValidatingWebhookConfiguration]) bool {
+				return false
+			},
+		},
+		kubeutil.TypedResourceVersionChangedPredicate[*admissionv1.ValidatingWebhookConfiguration]{},
+	))
+}
+
+func NewReconciler(ctx context.Context, client client.Client, logger logr.Logger, recorder record.Recorder) *Reconciler {
+
+	return &Reconciler{
+		Context:  ctx,
+		Client:   client,
+		Logger:   logger,
+		Recorder: recorder,
+	}
+}
+
+// Reconciler reconciles a ValidatingWebhookConfiguration object.
+type Reconciler struct {
+	client.Client
+	Context  context.Context
+	Logger   logr.Logger
+	Recorder record.Recorder
+}
+
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfiguration,verbs=get;list;watch
+
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
+	ctx = pkgcfg.JoinContext(ctx, r.Context)
+
+	if req.Name != spqutil.ValidatingWebhookConfigName {
+		r.Logger.Error(nil, "Reconcile called for unexpected object", "name", req.Name)
+		return ctrl.Result{}, nil
+	}
+	return ctrl.Result{}, r.ReconcileNormal(ctx, req)
+}
+
+func (r *Reconciler) ReconcileNormal(ctx context.Context, req ctrl.Request) error {
+	r.Logger.Info("Reconciling validating webhook configuration", "name", req.Name)
+
+	caBundle, err := spqutil.GetWebhookCABundle(ctx, r.Client)
+	if err != nil {
+		return err
+	}
+
+	spuList := &spqv1.StoragePolicyUsageList{}
+	if err := r.Client.List(ctx, spuList); err != nil {
+		return fmt.Errorf("unable to list StoragePolicyUsage objects: %w", err)
+	}
+
+	for _, spu := range spuList.Items {
+		if spu.Spec.ResourceExtensionName == spqutil.StoragePolicyQuotaExtensionName {
+			if !bytes.Equal(spu.Spec.CABundle, caBundle) {
+				spuPatch := client.MergeFrom(spu.DeepCopy())
+				spu.Spec.CABundle = caBundle
+
+				if err := r.Client.Patch(ctx, &spu, spuPatch); err != nil {
+					return fmt.Errorf("unable to patch StoragePolicyUsage object: %w", err)
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/controllers/infra/validatingwebhookconfiguration/validatingwebhookconfiguration_controller_intg_test.go
+++ b/controllers/infra/validatingwebhookconfiguration/validatingwebhookconfiguration_controller_intg_test.go
@@ -1,0 +1,218 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package validatingwebhookconfiguration_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	spqv1 "github.com/vmware-tanzu/vm-operator/external/storage-policy-quota/api/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
+	spqutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube/spq"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+func intgTests() {
+	Describe(
+		"Reconcile",
+		Label(
+			testlabels.Controller,
+			testlabels.EnvTest,
+		),
+		intgTestsReconcile,
+	)
+}
+
+func intgTestsReconcile() {
+
+	const (
+		secretName = "vmware-system-vmop-serving-cert"
+		vmSPUName  = "vm-spu"
+		pvcSPUName = "pvc-spu"
+	)
+
+	var (
+		ctx                            *builder.IntegrationTestContext
+		caBundle                       []byte
+		validatingWebhookConfiguration *admissionv1.ValidatingWebhookConfiguration
+	)
+
+	BeforeEach(func() {
+		ctx = suite.NewIntegrationTestContext()
+		caBundle = []byte("fake-ca-bundle")
+
+		validatingWebhookConfiguration = &admissionv1.ValidatingWebhookConfiguration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: spqutil.ValidatingWebhookConfigName,
+				Annotations: map[string]string{
+					"cert-manager.io/inject-ca-from": fmt.Sprintf("%s/vmware-system-vmop-serving-cert", ctx.Namespace),
+				},
+			},
+			Webhooks: []admissionv1.ValidatingWebhook{
+				{
+					AdmissionReviewVersions: []string{"v1beta1", "v1"},
+					ClientConfig: admissionv1.WebhookClientConfig{
+						Service: &admissionv1.ServiceReference{
+							Name:      "vmware-system-vmop-webhook-service",
+							Namespace: "vmware-system-vmop",
+							Path:      ptr.To("/default-validate-vmoperator-vmware-com-v1alpha3-virtualmachine"),
+						},
+						CABundle: caBundle,
+					},
+					FailurePolicy: ptr.To(admissionv1.Fail),
+					Name:          "default.validating.virtualmachine.v1alpha3.vmoperator.vmware.com",
+					SideEffects:   ptr.To(admissionv1.SideEffectClassNone),
+				},
+			},
+		}
+	})
+
+	AfterEach(func() {
+		Expect(ctx.Client.Delete(ctx, validatingWebhookConfiguration)).To(Succeed())
+
+		caBundle = nil
+		validatingWebhookConfiguration = nil
+
+		ctx.AfterEach()
+	})
+
+	JustBeforeEach(func() {
+		// Different resourceExtensionName
+		pvcSPU := &spqv1.StoragePolicyUsage{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      pvcSPUName,
+				Namespace: ctx.Namespace,
+			},
+			Spec: spqv1.StoragePolicyUsageSpec{
+				StorageClassName:      builder.DummyStorageClassName,
+				StoragePolicyId:       "dummy-storage-policy-id",
+				ResourceExtensionName: "fake.cns.vsphere.vmware.com",
+				CABundle:              []byte("invalid-resource-ca-bundle"),
+			},
+		}
+		Expect(ctx.Client.Create(ctx, pvcSPU)).To(Succeed())
+
+		// Same resourceExtensionName
+		vmSPU := &spqv1.StoragePolicyUsage{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      vmSPUName,
+				Namespace: ctx.Namespace,
+			},
+			Spec: spqv1.StoragePolicyUsageSpec{
+				StorageClassName:      builder.DummyStorageClassName,
+				StoragePolicyId:       "dummy-storage-policy-id",
+				ResourceExtensionName: spqutil.StoragePolicyQuotaExtensionName,
+				CABundle:              []byte("initial-ca-bundle"),
+			},
+		}
+		Expect(ctx.Client.Create(ctx, vmSPU)).To(Succeed())
+	})
+
+	Context("CABundle from ValidatingWebhookConfig", func() {
+
+		When("ValidatingWebhookConfiguration is created", func() {
+
+			It("should update the correct resources and leave others untouched", func() {
+				// Create ValidatingWebhookConfiguration
+				Expect(ctx.Client.Create(ctx, validatingWebhookConfiguration)).To(Succeed())
+				// SPU for vm should be updated with new CABundle, while that for pvc should be left alone
+				Eventually(func(g Gomega) {
+					pvcSPU := &spqv1.StoragePolicyUsage{}
+					g.Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: pvcSPUName, Namespace: ctx.Namespace}, pvcSPU)).To(Succeed())
+
+					g.Expect(pvcSPU.Spec.CABundle).NotTo(Equal(validatingWebhookConfiguration.Webhooks[0].ClientConfig.CABundle))
+					g.Expect(pvcSPU.Spec.CABundle).To(Equal([]byte("invalid-resource-ca-bundle")))
+
+					vmSPU := &spqv1.StoragePolicyUsage{}
+					g.Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: vmSPUName, Namespace: ctx.Namespace}, vmSPU)).To(Succeed())
+
+					g.Expect(vmSPU.Spec.CABundle).NotTo(Equal([]byte("initial-ca-bundle")))
+					g.Expect(vmSPU.Spec.CABundle).To(Equal(caBundle))
+				}).Should(Succeed())
+			})
+		})
+
+		When("ValidatingWebhookConfiguration is updated", func() {
+
+			BeforeEach(func() {
+				// Create ValidatingWebhookConfiguration
+				Expect(ctx.Client.Create(ctx, validatingWebhookConfiguration)).To(Succeed())
+			})
+
+			It("should update the correct resources and leave others untouched", func() {
+				// Update ValidatingWebhookConfiguration with new CABundle
+				webhookConfiguration := &admissionv1.ValidatingWebhookConfiguration{}
+				Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: spqutil.ValidatingWebhookConfigName}, webhookConfiguration)).To(Succeed())
+
+				webhookConfiguration.Webhooks[0].ClientConfig.CABundle = []byte("updated-ca-bundle")
+				Expect(ctx.Client.Update(ctx, webhookConfiguration)).To(Succeed())
+
+				// SPU for vm should be updated with new CABundle, while that for pvc should be left alone
+				Eventually(func(g Gomega) {
+					pvcSPU := &spqv1.StoragePolicyUsage{}
+					g.Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: pvcSPUName, Namespace: ctx.Namespace}, pvcSPU)).To(Succeed())
+
+					g.Expect(pvcSPU.Spec.CABundle).NotTo(Equal(webhookConfiguration.Webhooks[0].ClientConfig.CABundle))
+					g.Expect(pvcSPU.Spec.CABundle).To(Equal([]byte("invalid-resource-ca-bundle")))
+
+					vmSPU := &spqv1.StoragePolicyUsage{}
+					g.Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: vmSPUName, Namespace: ctx.Namespace}, vmSPU)).To(Succeed())
+
+					g.Expect(vmSPU.Spec.CABundle).NotTo(Equal(caBundle))
+					g.Expect(vmSPU.Spec.CABundle).To(Equal(webhookConfiguration.Webhooks[0].ClientConfig.CABundle))
+				}).Should(Succeed())
+			})
+		})
+	})
+
+	Context("CABundle from Secret", func() {
+		var certSecret *corev1.Secret
+
+		BeforeEach(func() {
+			validatingWebhookConfiguration.Webhooks = []admissionv1.ValidatingWebhook{}
+
+			certSecret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: ctx.Namespace,
+				},
+				Data: map[string][]byte{
+					"ca.crt": caBundle,
+				},
+			}
+
+			Expect(ctx.Client.Create(ctx, certSecret)).To(Succeed())
+		})
+
+		When("ValidatingWebhookConfiguration is created", func() {
+
+			It("should update the correct resources and leave others untouched", func() {
+				// Create ValidatingWebhookConfiguration
+				Expect(ctx.Client.Create(ctx, validatingWebhookConfiguration)).To(Succeed())
+				// SPU for vm should be updated with new CABundle, while that for pvc should be left alone
+				Eventually(func(g Gomega) {
+					pvcSPU := &spqv1.StoragePolicyUsage{}
+					g.Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: pvcSPUName, Namespace: ctx.Namespace}, pvcSPU)).To(Succeed())
+
+					g.Expect(pvcSPU.Spec.CABundle).NotTo(Equal(certSecret.Data["ca.crt"]))
+					g.Expect(pvcSPU.Spec.CABundle).To(Equal([]byte("invalid-resource-ca-bundle")))
+
+					vmSPU := &spqv1.StoragePolicyUsage{}
+					g.Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: vmSPUName, Namespace: ctx.Namespace}, vmSPU)).To(Succeed())
+
+					g.Expect(vmSPU.Spec.CABundle).NotTo(Equal([]byte("initial-ca-bundle")))
+					g.Expect(vmSPU.Spec.CABundle).To(Equal(caBundle))
+				}).Should(Succeed())
+			})
+		})
+	})
+}

--- a/controllers/infra/validatingwebhookconfiguration/validatingwebhookconfiguration_controller_suite_test.go
+++ b/controllers/infra/validatingwebhookconfiguration/validatingwebhookconfiguration_controller_suite_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package validatingwebhookconfiguration_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+
+	"github.com/vmware-tanzu/vm-operator/controllers/infra/validatingwebhookconfiguration"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
+	"github.com/vmware-tanzu/vm-operator/pkg/manager"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+var suite = builder.NewTestSuiteForControllerWithContext(
+	cource.WithContext(
+		pkgcfg.UpdateContext(
+			pkgcfg.NewContext(),
+			func(config *pkgcfg.Config) {
+				config.Features.PodVMOnStretchedSupervisor = true
+			},
+		),
+	),
+	validatingwebhookconfiguration.AddToManager,
+	manager.InitializeProvidersNoopFn)
+
+func TestWebhookConfiguration(t *testing.T) {
+	suite.Register(t, "ValidatingWebhookConfiguration controller suite", intgTests, unitTests)
+}
+
+var _ = BeforeSuite(suite.BeforeSuite)
+
+var _ = AfterSuite(suite.AfterSuite)

--- a/controllers/infra/validatingwebhookconfiguration/validatingwebhookconfiguration_controller_unit_test.go
+++ b/controllers/infra/validatingwebhookconfiguration/validatingwebhookconfiguration_controller_unit_test.go
@@ -1,0 +1,256 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package validatingwebhookconfiguration_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/vmware-tanzu/vm-operator/controllers/infra/validatingwebhookconfiguration"
+	spqv1 "github.com/vmware-tanzu/vm-operator/external/storage-policy-quota/api/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
+	spqutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube/spq"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+func unitTests() {
+	Describe(
+		"Reconcile",
+		Label(
+			testlabels.Controller,
+		),
+		unitTestsReconcile,
+	)
+}
+
+func unitTestsReconcile() {
+	const (
+		secretName      = "vmware-system-vmop-serving-cert"
+		secretNamespace = "vmware-system-vmop"
+	)
+	var (
+		ctx         *builder.UnitTestContextForController
+		withObjects []client.Object
+
+		reconciler *validatingwebhookconfiguration.Reconciler
+
+		certSecret                     *corev1.Secret
+		validatingWebhookConfiguration *admissionv1.ValidatingWebhookConfiguration
+		spu                            *spqv1.StoragePolicyUsage
+	)
+
+	BeforeEach(func() {
+		withObjects = []client.Object{}
+
+		certSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: secretNamespace,
+			},
+			Data: map[string][]byte{
+				"ca.crt": []byte("fake-ca-bundle"),
+			},
+		}
+
+		spu = &spqv1.StoragePolicyUsage{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "fake-spu-name",
+				Namespace: "fake-spu-namespace",
+			},
+			Spec: spqv1.StoragePolicyUsageSpec{
+				ResourceExtensionName: spqutil.StoragePolicyQuotaExtensionName,
+			},
+		}
+
+		validatingWebhookConfiguration = &admissionv1.ValidatingWebhookConfiguration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: spqutil.ValidatingWebhookConfigName,
+				Annotations: map[string]string{
+					"cert-manager.io/inject-ca-from": "vmware-system-vmop/vmware-system-vmop-serving-cert",
+				},
+			},
+			Webhooks: []admissionv1.ValidatingWebhook{},
+		}
+	})
+
+	JustBeforeEach(func() {
+		withObjects = append(withObjects, certSecret, validatingWebhookConfiguration, spu)
+		ctx = suite.NewUnitTestContextForController(withObjects...)
+		reconciler = validatingwebhookconfiguration.NewReconciler(ctx, ctx.Client, ctx.Logger, ctx.Recorder)
+	})
+
+	Context("Reconcile", func() {
+		var (
+			err  error
+			name string
+		)
+
+		BeforeEach(func() {
+			err = nil
+			name = spqutil.ValidatingWebhookConfigName
+		})
+
+		JustBeforeEach(func() {
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name: name,
+				}})
+		})
+
+		When("Reconcile is called with invalid name", func() {
+			BeforeEach(func() {
+				name = "fakeName"
+			})
+
+			It("should return nil error", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		When("ValidatingWebhookConfiguration is not found", func() {
+			errMsg := `validatingwebhookconfigurations.admissionregistration.k8s.io "vmware-system-vmop-validating-webhook-configuration" not found`
+
+			BeforeEach(func() {
+				validatingWebhookConfiguration = &admissionv1.ValidatingWebhookConfiguration{}
+			})
+
+			It("should return an error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(errMsg))
+			})
+		})
+
+		When("certificate annotation is not present", func() {
+			BeforeEach(func() {
+				delete(validatingWebhookConfiguration.Annotations, "cert-manager.io/inject-ca-from")
+			})
+
+			It("should return an error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("unable to get annotation for key"))
+			})
+		})
+
+		When("certificate annotation is present with empty value", func() {
+			BeforeEach(func() {
+				validatingWebhookConfiguration.Annotations["cert-manager.io/inject-ca-from"] = ""
+			})
+
+			It("should return an error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("unable to get annotation for key"))
+			})
+		})
+
+		When("certificate annotation is present and missing namespace", func() {
+			BeforeEach(func() {
+				validatingWebhookConfiguration.Annotations["cert-manager.io/inject-ca-from"] = "vmware-system-vmop-serving-cert"
+			})
+
+			It("should not return an error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("unable to get namespace and name for key"))
+			})
+		})
+
+		When("certificate Secret is not found", func() {
+			BeforeEach(func() {
+				certSecret.Name = "fake"
+			})
+
+			It("should return an error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(`secrets "vmware-system-vmop-serving-cert" not found`))
+			})
+		})
+
+		When("secret is missing ca.crt", func() {
+			BeforeEach(func() {
+				delete(certSecret.Data, "ca.crt")
+			})
+
+			It("should return an error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("unable to get CA bundle from secret"))
+			})
+		})
+
+		When("ca.crt is empty", func() {
+			BeforeEach(func() {
+				certSecret.Data["ca.crt"] = []byte("")
+			})
+
+			It("should return an error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("unable to get CA bundle from secret"))
+			})
+		})
+
+		Context("update SPU docs", func() {
+			JustBeforeEach(func() {
+				Expect(err).To(BeNil())
+				err = ctx.Client.Get(ctx, client.ObjectKeyFromObject(spu), spu)
+
+				Expect(err).To(BeNil())
+			})
+
+			When("no SPU docs exist for vmservice", func() {
+				BeforeEach(func() {
+					spu.Spec.ResourceExtensionName = "fake.cns.vsphere.vmware.com"
+					spu.Spec.CABundle = []byte("fake.cns.vsphere.vmware.com")
+				})
+
+				It("should not update caBundle", func() {
+					Expect(spu.Spec.CABundle).To(Equal([]byte("fake.cns.vsphere.vmware.com")))
+				})
+			})
+
+			When("SPU caBundle matches contents of secret", func() {
+				BeforeEach(func() {
+					spu.Spec.CABundle = certSecret.Data["ca.crt"]
+				})
+
+				It("should not update caBundle", func() {
+					Expect(spu.Spec.CABundle).To(Equal(certSecret.Data["ca.crt"]))
+				})
+			})
+
+			When("SPU caBundle does not match contents of secret", func() {
+				BeforeEach(func() {
+					spu.Spec.CABundle = []byte("outdated-fake-ca-bundle")
+				})
+
+				It("should update caBundle", func() {
+					Expect(spu.Spec.CABundle).NotTo(Equal([]byte("outdated-fake-ca-bundle")))
+					Expect(spu.Spec.CABundle).To(Equal(certSecret.Data["ca.crt"]))
+				})
+			})
+
+			When("webhooks slice is non-empty", func() {
+				BeforeEach(func() {
+					validatingWebhookConfiguration.Webhooks = []admissionv1.ValidatingWebhook{
+						{
+							ClientConfig: admissionv1.WebhookClientConfig{
+								CABundle: []byte("fake-ca-bundle"),
+							},
+						},
+					}
+					spu.Spec.CABundle = []byte("outdated-fake-ca-bundle")
+				})
+
+				It("should get caBundle from first non-empty entry in slice and update caBundle", func() {
+					Expect(spu.Spec.CABundle).NotTo(Equal([]byte("outdated-fake-ca-bundle")))
+					Expect(spu.Spec.CABundle).To(Equal(certSecret.Data["ca.crt"]))
+				})
+			})
+		})
+	})
+}

--- a/controllers/virtualmachine/storagepolicyusage/storagepolicyusage_controller.go
+++ b/controllers/virtualmachine/storagepolicyusage/storagepolicyusage_controller.go
@@ -67,7 +67,7 @@ func NewReconciler(
 	}
 }
 
-// Reconciler reconciles a VirtualMachineClass object.
+// Reconciler reconciles a StoragePolicyUsage object.
 type Reconciler struct {
 	client.Client
 	Context  context.Context


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Add ValidatingWebhookConfiguration controller to watch vm-operator's ValidatingWebhookConfiguration for changes and update the CA Bundle of any StoragePolicyUsage accordingly.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:


```release-note
Allow Storage Quota Extension Service to communicate with Storage Quota webhook
```