### PR TITLE
🌱 Remove lock on vm watcher

### DIFF
--- a/config/local/vmoperator/local_env_var_patch.yaml
+++ b/config/local/vmoperator/local_env_var_patch.yaml
@@ -9,6 +9,8 @@ spec:
       containers:
       - name: manager
         env:
+        - name: ASYNC_SIGNAL_DISABLED
+          value: "false"
         - name: VSPHERE_NETWORKING
           value: "false"
         - name: FSS_WCP_INSTANCE_STORAGE

--- a/config/wcp/vmoperator/manager_env_var_patch.yaml
+++ b/config/wcp/vmoperator/manager_env_var_patch.yaml
@@ -43,6 +43,12 @@
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
+    name: ASYNC_SIGNAL_DISABLED
+    value: "false"
+
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
     name: FSS_PODVMONSTRETCHEDSUPERVISOR
     value: "<FSS_PODVMONSTRETCHEDSUPERVISOR>"
 

--- a/controllers/infra/zone/zone_controller.go
+++ b/controllers/infra/zone/zone_controller.go
@@ -130,7 +130,10 @@ func (r *Reconciler) ReconcileDelete(
 					Value: val,
 				},
 				fmt.Sprintf("%s/%s", obj.Namespace, obj.Name)); err != nil {
-				return ctrl.Result{}, err
+
+				if err != watcher.ErrAsyncSignalDisabled {
+					return ctrl.Result{}, err
+				}
 			}
 		}
 		controllerutil.RemoveFinalizer(obj, Finalizer)
@@ -153,7 +156,10 @@ func (r *Reconciler) ReconcileNormal(
 					Value: val,
 				},
 				fmt.Sprintf("%s/%s", obj.Namespace, obj.Name)); err != nil {
-				return ctrl.Result{}, err
+
+				if err != watcher.ErrAsyncSignalDisabled {
+					return ctrl.Result{}, err
+				}
 			}
 			controllerutil.AddFinalizer(obj, Finalizer)
 		}

--- a/pkg/util/vsphere/watcher/watcher_context.go
+++ b/pkg/util/vsphere/watcher/watcher_context.go
@@ -65,18 +65,28 @@ func JoinContext(left, right context.Context) context.Context {
 		})
 }
 
+var (
+	// ErrAsyncSignalDisabled is returned from the Add/Remove functions if they
+	// are called while async signal is disabled.
+	ErrAsyncSignalDisabled = errors.New("async signal disabled")
+
+	// ErrNoWatcher is returned from the Add/Remove functions if they are called
+	// without a watcher in the context.
+	ErrNoWatcher = errors.New("no watcher")
+)
+
 // Add starts watching a container to which VirtualMachine resources may belong,
 // such as a Folder, Cluster, ResourcePool, etc.
 func Add(ctx context.Context, ref moRef, id string) (err error) {
 	if pkgcfg.FromContext(ctx).AsyncSignalDisabled {
-		return nil
+		return ErrAsyncSignalDisabled
 	}
 	ctxgen.ExecWithContext(
 		ctx,
 		contextKeyValue,
 		func(w contextValueType) {
 			if w == nil {
-				err = errors.New("no watcher")
+				err = ErrNoWatcher
 			} else {
 				err = w.add(ctx, ref, id)
 			}
@@ -88,14 +98,14 @@ func Add(ctx context.Context, ref moRef, id string) (err error) {
 // belong, such as a Folder, Cluster, ResourcePool, etc.
 func Remove(ctx context.Context, ref moRef, id string) (err error) {
 	if pkgcfg.FromContext(ctx).AsyncSignalDisabled {
-		return nil
+		return ErrAsyncSignalDisabled
 	}
 	ctxgen.ExecWithContext(
 		ctx,
 		contextKeyValue,
 		func(w contextValueType) {
 			if w == nil {
-				err = errors.New("no watcher")
+				err = ErrNoWatcher
 			} else {
 				err = w.remove(ctx, ref, id)
 			}

--- a/pkg/util/vsphere/watcher/watcher_context_test.go
+++ b/pkg/util/vsphere/watcher/watcher_context_test.go
@@ -110,9 +110,20 @@ var _ = Describe("Add", func() {
 				watcher.WithContext(pkgcfg.NewContext()),
 				vimtypes.ManagedObjectReference{},
 				"fake",
-			)).To(MatchError("no watcher"))
+			)).To(MatchError(watcher.ErrNoWatcher))
 		})
 	})
+	When("async signal is disabled", func() {
+		It("should fail", func() {
+			Expect(watcher.Add(
+				watcher.WithContext(pkgcfg.WithConfig(
+					pkgcfg.Config{AsyncSignalDisabled: true})),
+				vimtypes.ManagedObjectReference{},
+				"fake",
+			)).To(MatchError(watcher.ErrAsyncSignalDisabled))
+		})
+	})
+
 })
 
 var _ = Describe("Remove", func() {
@@ -122,7 +133,17 @@ var _ = Describe("Remove", func() {
 				watcher.WithContext(pkgcfg.NewContext()),
 				vimtypes.ManagedObjectReference{},
 				"fake",
-			)).To(MatchError("no watcher"))
+			)).To(MatchError(watcher.ErrNoWatcher))
+		})
+	})
+	When("async signal is disabled", func() {
+		It("should fail", func() {
+			Expect(watcher.Remove(
+				watcher.WithContext(pkgcfg.WithConfig(
+					pkgcfg.Config{AsyncSignalDisabled: true})),
+				vimtypes.ManagedObjectReference{},
+				"fake",
+			)).To(MatchError(watcher.ErrAsyncSignalDisabled))
 		})
 	})
 })


### PR DESCRIPTION


**What does this PR do, and why is it needed?**

This patch removes the lock from the vm watcher, making it more performant and safer since the lock is no longer held when closing the watcher and/or adding/removing references, during which network requests can be made. There is no need for a lock anymore since the vim objects are not set to nil when the watcher is closed. They will still be garbage collected when the watcher itself goes out of scope.

This patch also explicitly defines the `ASYNC_SIGNAL_DISABLED` env var in the deployment YAML to make it clear how to disable this feature.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```