### PR TITLE
🐛 BYOK: Add vm controller permission for watching encryptionclasses

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -176,6 +176,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - vmencryption.vmware.com
+  resources:
+  - encryptionclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - vmoperator.vmware.com
   resources:
   - clustervirtualmachineimages

--- a/controllers/virtualmachine/virtualmachine/virtualmachine_controller.go
+++ b/controllers/virtualmachine/virtualmachine/virtualmachine_controller.go
@@ -312,6 +312,7 @@ type Reconciler struct {
 // +kubebuilder:rbac:groups=crd.nsx.vmware.com,resources=subnetports/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=events;configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=resourcequotas;namespaces,verbs=get;list;watch
+// +kubebuilder:rbac:groups=vmencryption.vmware.com,resources=encryptionclasses,verbs=get;list;watch
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
 	ctx = pkgcfg.JoinContext(ctx, r.Context)


### PR DESCRIPTION
Otherwise results in CLBO with FSS_WCP_VMSERVICE_BYOK=true due to:
> Failed to watch *v1alpha1.EncryptionClass:... encryptionclasses.vmencryption.vmware.com is forbidden
