### PR TITLE
🌱 Change EncryptionClass API group

### DIFF
--- a/config/crd/external-crds/encryption.vmware.com_encryptionclasses.yaml
+++ b/config/crd/external-crds/encryption.vmware.com_encryptionclasses.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.1
-  name: encryptionclasses.vmencryption.vmware.com
+  name: encryptionclasses.encryption.vmware.com
 spec:
-  group: vmencryption.vmware.com
+  group: encryption.vmware.com
   names:
     kind: EncryptionClass
     listKind: EncryptionClassList

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -108,6 +108,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - encryption.vmware.com
+  resources:
+  - encryptionclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - iaas.vmware.com
   resources:
   - capabilities
@@ -188,14 +196,6 @@ rules:
   - list
   - patch
   - update
-  - watch
-- apiGroups:
-  - vmencryption.vmware.com
-  resources:
-  - encryptionclasses
-  verbs:
-  - get
-  - list
   - watch
 - apiGroups:
   - vmoperator.vmware.com

--- a/controllers/virtualmachine/virtualmachine/virtualmachine_controller.go
+++ b/controllers/virtualmachine/virtualmachine/virtualmachine_controller.go
@@ -312,7 +312,7 @@ type Reconciler struct {
 // +kubebuilder:rbac:groups=crd.nsx.vmware.com,resources=subnetports/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=events;configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=resourcequotas;namespaces,verbs=get;list;watch
-// +kubebuilder:rbac:groups=vmencryption.vmware.com,resources=encryptionclasses,verbs=get;list;watch
+// +kubebuilder:rbac:groups=encryption.vmware.com,resources=encryptionclasses,verbs=get;list;watch
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
 	ctx = pkgcfg.JoinContext(ctx, r.Context)

--- a/external/byok/api/v1alpha1/doc.go
+++ b/external/byok/api/v1alpha1/doc.go
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // +kubebuilder:object:generate=true
-// +groupName=vmencryption.vmware.com
+// +groupName=encryption.vmware.com
 
-// Package v1alpha1 contains API Schema definitions for the vmencryption
-// v1alpha1 API group.
+// Package v1alpha1 contains API Schema definitions for the encryption v1alpha1
+// API group.
 package v1alpha1

--- a/external/byok/api/v1alpha1/groupversion_info.go
+++ b/external/byok/api/v1alpha1/groupversion_info.go
@@ -10,7 +10,7 @@ import (
 )
 
 // GroupName specifies the group name used to register the objects.
-const GroupName = "vmencryption.vmware.com"
+const GroupName = "encryption.vmware.com"
 
 var (
 	// GroupVersion is group version used to register these objects.


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch updates the API group of the EncryptionClass API to be `encryption.vmware.com`.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```