### PR TITLE
📖 Clarify storage class requirement for crypto.encryptionClassName API

### DIFF
--- a/api/v1alpha3/virtualmachine_types.go
+++ b/api/v1alpha3/virtualmachine_types.go
@@ -344,6 +344,9 @@ type VirtualMachineCryptoSpec struct {
 	// If the underlying vSphere platform does not have a default key provider,
 	// then this field is required when specifying an encryption storage class
 	// and/or a VM Class with a vTPM.
+	//
+	// If this field is set, spec.storageClass must use an encryption-enabled
+	// storage class.
 	EncryptionClassName string `json:"encryptionClassName,omitempty"`
 
 	// +optional

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachinereplicasets.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachinereplicasets.yaml
@@ -1034,6 +1034,9 @@ spec:
                               If the underlying vSphere platform does not have a default key provider,
                               then this field is required when specifying an encryption storage class
                               and/or a VM Class with a vTPM.
+
+                              If this field is set, spec.storageClass must use an encryption-enabled
+                              storage class.
                             type: string
                           useDefaultKeyProvider:
                             default: true

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -3818,6 +3818,9 @@ spec:
                       If the underlying vSphere platform does not have a default key provider,
                       then this field is required when specifying an encryption storage class
                       and/or a VM Class with a vTPM.
+
+                      If this field is set, spec.storageClass must use an encryption-enabled
+                      storage class.
                     type: string
                   useDefaultKeyProvider:
                     default: true

--- a/docs/ref/api/v1alpha3.md
+++ b/docs/ref/api/v1alpha3.md
@@ -826,7 +826,10 @@ minus any virtual disks, will be encrypted.
 
 If the underlying vSphere platform does not have a default key provider,
 then this field is required when specifying an encryption storage class
-and/or a VM Class with a vTPM. |
+and/or a VM Class with a vTPM.
+
+If this field is set, spec.storageClass must use an encryption-enabled
+storage class. |
 | `useDefaultKeyProvider` _boolean_ | UseDefaultKeyProvider describes the desired behavior for when an explicit
 EncryptionClass is not provided.
 

--- a/webhooks/virtualmachine/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator.go
@@ -514,6 +514,9 @@ func (v validator) validateCrypto(
 		allErrs = append(allErrs, field.InternalError(encClassNamePath, err))
 
 	} else if !ok {
+		// Return an error on the "vm.Spec.Crypto.EncryptionClassName" path
+		// instead of "vm.Spec.StorageClass" because the storage class is
+		// invalid due to the user's choice of encryption class name.
 		allErrs = append(allErrs, field.Invalid(
 			encClassNamePath,
 			vm.Spec.Crypto.EncryptionClassName,


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR updates the API doc for the `crypto.encryptionClassName` field to reflect the validation logic in the VM webhook, which requires an encrypted storage class when this field is set. It also adds a comment in the webhook code explaining why the error is returned on `encryptionClassName` even though the validation checks the storage class.

**Which issue(s) is/are addressed by this PR?**

Fixes N/A.

**Are there any special notes for your reviewer**:

We should probably return both fields in the validating webhook result once K8s supports combining field errors.

**Please add a release note if necessary**:

```release-note
Clarify storage class requirement for crypto.encryptionClassName API
```

<!-- readthedocs-preview vm-operator start -->
----
📚 Documentation preview 📚: https://vm-operator--747.org.readthedocs.build/en/747/

<!-- readthedocs-preview vm-operator end -->