### PR TITLE
🌱 Remove use of deprecated kustomize symbols

### DIFF
--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -15,10 +15,10 @@ metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
   namespace: system
 spec:
-  # $(WEBHOOK_SERVICE_NAME) and $(WEBHOOK_SERVICE_NAMESPACE) will be substituted by kustomize
+  # WEBHOOK_SERVICE_NAME_PLACEHOLDER and WEBHOOK_SERVICE_NAMESPACE_PLACEHOLDER will be substituted by kustomize
   dnsNames:
-  - $(WEBHOOK_SERVICE_NAME).$(WEBHOOK_SERVICE_NAMESPACE).svc
-  - $(WEBHOOK_SERVICE_NAME).$(WEBHOOK_SERVICE_NAMESPACE).svc.cluster.local
+  - WEBHOOK_SERVICE_NAME_PLACEHOLDER.WEBHOOK_SERVICE_NAMESPACE_PLACEHOLDER.svc
+  - WEBHOOK_SERVICE_NAME_PLACEHOLDER.WEBHOOK_SERVICE_NAMESPACE_PLACEHOLDER.svc.cluster.local
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -1,6 +1,9 @@
-# This kustomization.yaml is not intended to be run by itself,
-# since it depends on service name and namespace that are out of this kustomize package.
-# It should be run by config/default
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+configurations:
+- kustomizeconfig.yaml
+
 resources:
 - bases/vmoperator.vmware.com_clustervirtualmachineimages.yaml
 - bases/vmoperator.vmware.com_contentsources.yaml
@@ -16,40 +19,26 @@ resources:
 - bases/vmoperator.vmware.com_webconsolerequests.yaml
 - bases/vmoperator.vmware.com_virtualmachinewebconsolerequests.yaml
 - bases/vmoperator.vmware.com_virtualmachinereplicasets.yaml
-# +kubebuilder:scaffold:crdkustomizeresource
 
 patches:
 - path: patches/crd_preserveUnknownFields.yaml
   target:
     kind: CustomResourceDefinition
 
-patchesStrategicMerge:
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
-# patches here are for enabling the conversion webhook for each CRD
-- patches/webhook_in_clustervirtualmachineimages.yaml
-- patches/webhook_in_virtualmachineclasses.yaml
-- patches/webhook_in_virtualmachineimages.yaml
-- patches/webhook_in_virtualmachinepublishrequests.yaml
-- patches/webhook_in_virtualmachines.yaml
-- patches/webhook_in_virtualmachineservices.yaml
-- patches/webhook_in_virtualmachinesetresourcepolicies.yaml
-#- patches/webhook_in_virtualmachinereplicasets.yaml
-#- patches/webhook_in_virtualmachinewebconsolerequests.yaml
-# +kubebuilder:scaffold:crdkustomizewebhookpatch
+# [WEBHOOK]
+- path: patches/webhook_in_clustervirtualmachineimages.yaml
+- path: patches/webhook_in_virtualmachineclasses.yaml
+- path: patches/webhook_in_virtualmachineimages.yaml
+- path: patches/webhook_in_virtualmachinepublishrequests.yaml
+- path: patches/webhook_in_virtualmachines.yaml
+- path: patches/webhook_in_virtualmachineservices.yaml
+- path: patches/webhook_in_virtualmachinesetresourcepolicies.yaml
 
-# [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
-# patches here are for enabling the CA injection for each CRD
-- patches/cainjection_in_clustervirtualmachineimages.yaml
-- patches/cainjection_in_virtualmachineclasses.yaml
-- patches/cainjection_in_virtualmachineimages.yaml
-- patches/cainjection_in_virtualmachinepublishrequests.yaml
-- patches/cainjection_in_virtualmachines.yaml
-- patches/cainjection_in_virtualmachineservices.yaml
-- patches/cainjection_in_virtualmachinesetresourcepolicies.yaml
-#- patches/cainjection_in_virtualmachinereplicasets.yaml
-#- patches/cainjection_in_virtualmachinewebconsolerequests.yaml
-# +kubebuilder:scaffold:crdkustomizecainjectionpatch
-
-# the following config is for teaching kustomize how to do kustomization for CRDs.
-configurations:
-- kustomizeconfig.yaml
+# [CERTMANAGER]
+- path: patches/cainjection_in_clustervirtualmachineimages.yaml
+- path: patches/cainjection_in_virtualmachineclasses.yaml
+- path: patches/cainjection_in_virtualmachineimages.yaml
+- path: patches/cainjection_in_virtualmachinepublishrequests.yaml
+- path: patches/cainjection_in_virtualmachines.yaml
+- path: patches/cainjection_in_virtualmachineservices.yaml
+- path: patches/cainjection_in_virtualmachinesetresourcepolicies.yaml

--- a/config/crd/patches/cainjection_in_clustervirtualmachineimages.yaml
+++ b/config/crd/patches/cainjection_in_clustervirtualmachineimages.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(WEBHOOK_CERTIFICATE_NAMESPACE)/$(WEBHOOK_CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: WEBHOOK_CERTIFICATE_NAMESPACE_PLACEHOLDER/WEBHOOK_CERTIFICATE_NAME_PLACEHOLDER
   name: clustervirtualmachineimages.vmoperator.vmware.com

--- a/config/crd/patches/cainjection_in_virtualmachineclasses.yaml
+++ b/config/crd/patches/cainjection_in_virtualmachineclasses.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(WEBHOOK_CERTIFICATE_NAMESPACE)/$(WEBHOOK_CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: WEBHOOK_CERTIFICATE_NAMESPACE_PLACEHOLDER/WEBHOOK_CERTIFICATE_NAME_PLACEHOLDER
   name: virtualmachineclasses.vmoperator.vmware.com

--- a/config/crd/patches/cainjection_in_virtualmachineimages.yaml
+++ b/config/crd/patches/cainjection_in_virtualmachineimages.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(WEBHOOK_CERTIFICATE_NAMESPACE)/$(WEBHOOK_CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: WEBHOOK_CERTIFICATE_NAMESPACE_PLACEHOLDER/WEBHOOK_CERTIFICATE_NAME_PLACEHOLDER
   name: virtualmachineimages.vmoperator.vmware.com

--- a/config/crd/patches/cainjection_in_virtualmachinepublishrequests.yaml
+++ b/config/crd/patches/cainjection_in_virtualmachinepublishrequests.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(WEBHOOK_CERTIFICATE_NAMESPACE)/$(WEBHOOK_CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: WEBHOOK_CERTIFICATE_NAMESPACE_PLACEHOLDER/WEBHOOK_CERTIFICATE_NAME_PLACEHOLDER
   name: virtualmachinepublishrequests.vmoperator.vmware.com

--- a/config/crd/patches/cainjection_in_virtualmachinereplicasets.yaml
+++ b/config/crd/patches/cainjection_in_virtualmachinereplicasets.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(WEBHOOK_CERTIFICATE_NAMESPACE)/$(WEBHOOK_CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: WEBHOOK_CERTIFICATE_NAMESPACE_PLACEHOLDER/WEBHOOK_CERTIFICATE_NAME_PLACEHOLDER
   name: virtualmachinereplicasets.vmoperator.vmware.com

--- a/config/crd/patches/cainjection_in_virtualmachines.yaml
+++ b/config/crd/patches/cainjection_in_virtualmachines.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(WEBHOOK_CERTIFICATE_NAMESPACE)/$(WEBHOOK_CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: WEBHOOK_CERTIFICATE_NAMESPACE_PLACEHOLDER/WEBHOOK_CERTIFICATE_NAME_PLACEHOLDER
   name: virtualmachines.vmoperator.vmware.com

--- a/config/crd/patches/cainjection_in_virtualmachineservices.yaml
+++ b/config/crd/patches/cainjection_in_virtualmachineservices.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(WEBHOOK_CERTIFICATE_NAMESPACE)/$(WEBHOOK_CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: WEBHOOK_CERTIFICATE_NAMESPACE_PLACEHOLDER/WEBHOOK_CERTIFICATE_NAME_PLACEHOLDER
   name: virtualmachineservices.vmoperator.vmware.com

--- a/config/crd/patches/cainjection_in_virtualmachinesetresourcepolicies.yaml
+++ b/config/crd/patches/cainjection_in_virtualmachinesetresourcepolicies.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(WEBHOOK_CERTIFICATE_NAMESPACE)/$(WEBHOOK_CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: WEBHOOK_CERTIFICATE_NAMESPACE_PLACEHOLDER/WEBHOOK_CERTIFICATE_NAME_PLACEHOLDER
   name: virtualmachinesetresourcepolicies.vmoperator.vmware.com

--- a/config/crd/patches/cainjection_in_virtualmachinewebconsolerequests.yaml
+++ b/config/crd/patches/cainjection_in_virtualmachinewebconsolerequests.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(WEBHOOK_CERTIFICATE_NAMESPACE)/$(WEBHOOK_CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: WEBHOOK_CERTIFICATE_NAMESPACE_PLACEHOLDER/WEBHOOK_CERTIFICATE_NAME_PLACEHOLDER
   name: virtualmachinewebconsolerequests.vmoperator.vmware.com

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -13,116 +13,44 @@ resources:
 - ../certmanager
 - ../crd/external-crds/encryption.vmware.com_encryptionclasses.yaml
 
-patchesStrategicMerge:
-- manager_default_container_patch.yaml
-- manager_auth_proxy_patch.yaml
-- manager_webhook_patch.yaml
-- manager_replicas_patch.yaml
-- manager_pod_info_patch.yaml
-- manager_tolerations_patch.yaml
-- manager_update_strategy_patch.yaml
-- manager_leader_election_id_patch.yaml
-- manager_max_concurrent_reconciles_patch.yaml
-
-vars:
-- name: LEADER_ELECTION_ID
-  objref:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: controller-manager
-  fieldref:
-    fieldpath: metadata.name
-- name: WEBHOOK_SERVICE_NAMESPACE
-  objref:
-    apiVersion: v1
-    kind: Service
-    name: webhook-service
-  fieldref:
-    fieldpath: metadata.namespace
-- name: WEBHOOK_SERVICE_NAME
-  objref:
-    apiVersion: v1
-    kind: Service
-    name: webhook-service
-  fieldref:
-    fieldpath: metadata.name
-- name: WEBHOOK_SERVICE_CONTAINER_PORT
-  objref:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: controller-manager
-  fieldref:
-    # Note that this assumes "manager" is containers[0] and the webhook port is ports[0]
-    fieldpath: spec.template.spec.containers[0].ports[0].containerPort
-- name: WEBHOOK_CERTIFICATE_NAMESPACE # namespace of the certificate CR
-  objref:
-    kind: Certificate
-    group: cert-manager.io
-    version: v1
-    name: serving-cert # this name should match the one in certificate.yaml
-  fieldref:
-    fieldpath: metadata.namespace
-- name: WEBHOOK_CERTIFICATE_NAME
-  objref:
-    kind: Certificate
-    group: cert-manager.io
-    version: v1
-    name: serving-cert # this name should match the one in certificate.yaml
-- name: WEBHOOK_SECRET_NAMESPACE
-  objref:
-    kind: Certificate
-    group: cert-manager.io
-    version: v1
-    name: serving-cert # this name should match the one in certificate.yaml
-  fieldref:
-    fieldpath: metadata.namespace
-- name: WEBHOOK_SECRET_NAME
-  objref:
-    kind: Certificate
-    group: cert-manager.io
-    version: v1
-    name: serving-cert # this name should match the one in certificate.yaml
-  fieldref:
-    fieldpath: spec.secretName
-- name: WEB_CONSOLE_VALIDATOR_CONTAINER_PORT
-  objref:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: web-console-validator
-  fieldref:
-    # Note that this assumes "web-console-validator" is containers[0] and port is ports[0]
-    fieldpath: spec.template.spec.containers[0].ports[0].containerPort
+patches:
+- path: manager_default_container_patch.yaml
+- path: manager_auth_proxy_patch.yaml
+- path: manager_webhook_patch.yaml
+- path: manager_replicas_patch.yaml
+- path: manager_pod_info_patch.yaml
+- path: manager_tolerations_patch.yaml
+- path: manager_update_strategy_patch.yaml
+- path: manager_leader_election_id_patch.yaml
+- path: manager_max_concurrent_reconciles_patch.yaml
 
 replacements:
-  - source:
+- source:
+    fieldPath: spec.template.spec.containers.[name=manager].ports.[name=webhook-server].containerPort
+    group: apps
+    version: v1
+    kind: Deployment
+    namespace: system
+    name: controller-manager
+  targets:
+  - select:
+      group: apps
+      version: v1
+      kind: Deployment
+      namespace: system
+      name: controller-manager
+    fieldPaths:
+    - spec.template.spec.containers.[name=manager].env.[name=WEBHOOK_SERVICE_CONTAINER_PORT].value
+- source:
+    fieldPath: spec.template.spec.containers.[name=manager].volumeMounts.[name=cert].mountPath
+    group: apps
+    version: v1
+    kind: Deployment
+    namespace: system
+    name: controller-manager
+  targets:
+  - select:
       kind: Deployment
       name: controller-manager
-      fieldPath: metadata.annotations.[webhooks.vmoperator.vmware.com/service-container-port]
-    targets:
-    - select:
-        kind: Deployment
-        name: controller-manager
-      fieldPaths:
-      - spec.template.spec.containers.[name=manager].env.[name=WEBHOOK_SERVICE_CONTAINER_PORT].value
-  - source:
-      kind: Deployment
-      name: controller-manager
-      fieldPath: metadata.annotations.[webhooks.vmoperator.vmware.com/secret-volume-mount-path]
-    targets:
-    - select:
-        kind: Deployment
-        name: controller-manager
-      fieldPaths:
-      - spec.template.spec.containers.[name=manager].env.[name=WEBHOOK_SECRET_VOLUME_MOUNT_PATH].value
-      - spec.template.spec.containers.[name=manager].volumeMounts.0.mountPath
-  - source:
-      kind: Deployment
-      name: controller-manager
-      fieldPath: metadata.annotations.[webhooks.vmoperator.vmware.com/secret-volume-name]
-    targets:
-    - select:
-        kind: Deployment
-        name: controller-manager
-      fieldPaths:
-      - spec.template.spec.containers.[name=manager].volumeMounts.0.name
-      - spec.template.spec.volumes.0.name
+    fieldPaths:
+    - spec.template.spec.containers.[name=manager].env.[name=WEBHOOK_SECRET_VOLUME_MOUNT_PATH].value

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -22,4 +22,4 @@ spec:
         - "--v=10"
         ports:
         - containerPort: 8443
-          name: https
+          name: metrics-server

--- a/config/default/manager_leader_election_id_patch.yaml
+++ b/config/default/manager_leader_election_id_patch.yaml
@@ -10,4 +10,4 @@ spec:
       - name: manager
         env:
         - name: LEADER_ELECTION_ID
-          value: $(LEADER_ELECTION_ID)-runtime
+          value: LEADER_ELECTION_ID_PLACEHOLDER-runtime

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -3,12 +3,6 @@ kind: Deployment
 metadata:
   name: controller-manager
   namespace: system
-  annotations:
-    # These are not annotations necessary at deploy time, rather they are used as constants in Kustomize
-    # Note that webhooks.vmoperator.vmware.com/service-container-port needs to be consistent with the containerPort int constant below
-    webhooks.vmoperator.vmware.com/service-container-port: "9878"
-    webhooks.vmoperator.vmware.com/secret-volume-mount-path: /tmp/k8s-webhook-server/serving-certs
-    webhooks.vmoperator.vmware.com/secret-volume-name: cert
 spec:
   template:
     spec:
@@ -17,21 +11,18 @@ spec:
       - name: manager
         env:
         - name: WEBHOOK_SERVICE_NAMESPACE
-          value: $(WEBHOOK_SERVICE_NAMESPACE)
+          value: WEBHOOK_SERVICE_NAMESPACE_PLACEHOLDER
         - name: WEBHOOK_SERVICE_NAME
-          value: $(WEBHOOK_SERVICE_NAME)
+          value: WEBHOOK_SERVICE_NAME_PLACEHOLDER
         - name: WEBHOOK_SECRET_NAMESPACE
-          value: $(WEBHOOK_SECRET_NAMESPACE)
+          value: WEBHOOK_SECRET_NAMESPACE_PLACEHOLDER
         - name: WEBHOOK_SECRET_NAME
-          value: $(WEBHOOK_SECRET_NAME)
+          value: WEBHOOK_SECRET_NAME_PLACEHOLDER
         - name: WEBHOOK_SECRET_VOLUME_MOUNT_PATH
           value: WEBHOOK_SECRET_VOLUME_MOUNT_PATH_VALUE
         - name: WEBHOOK_SERVICE_CONTAINER_PORT
           value: WEBHOOK_SERVICE_CONTAINER_PORT_STRING
         ports:
-        # This value is used as the int constant for webhook port across our YAML
-        # String constant for the same port is webhooks.vmoperator.vmware.com/service-container-port above. The two should be consistent.
-        # Note also there's an assumption in kustomization.yaml that this is ports[0]
         - containerPort: 9878
           name: webhook-server
           protocol: TCP
@@ -43,11 +34,11 @@ spec:
             path: /readyz
             port: health-probe
         volumeMounts:
-        - mountPath: WEBHOOK_SECRET_VOLUME_MOUNT_PATH_VALUE
-          name: WEBHOOK_SECRET_VOLUME_NAME
+        - name: cert
+          mountPath: /tmp/k8s-webhook-server/serving-certs
           readOnly: true
       volumes:
-      - name: WEBHOOK_SECRET_VOLUME_NAME
+      - name: cert
         secret:
           defaultMode: 420
-          secretName: $(WEBHOOK_SECRET_NAME)
+          secretName: WEBHOOK_SECRET_NAME_PLACEHOLDER

--- a/config/local-vcsim/kustomization.yaml
+++ b/config/local-vcsim/kustomization.yaml
@@ -1,12 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-- ../local
-
 resources:
+- ../local
 - sc.yaml
 - lb-xds.yaml
+
+components:
+- ../replacements
 
 patches:
 - target:
@@ -34,5 +35,4 @@ patches:
     namespace: vmware-system-vmop
   path: remove-node-selector-patch.yaml
 
-patchesStrategicMerge:
-  - vcsim-patch.yaml
+- path: vcsim-patch.yaml

--- a/config/local/kustomization.yaml
+++ b/config/local/kustomization.yaml
@@ -2,3 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ./vmoperator/
+
+components:
+- ../replacements
+

--- a/config/local/vmoperator/kustomization.yaml
+++ b/config/local/vmoperator/kustomization.yaml
@@ -23,14 +23,12 @@ resources:
 - ../../crd/external-crds/imageregistry.vmware.com_contentlibraryitems.yaml
 - ../../crd/external-crds/netoperator.vmware.com_networkinterfaces.yaml
 
-patchesStrategicMerge:
-- cpu_resources_patch.yaml
-- revision_history_limit.yaml
-- local_env_var_patch.yaml
-
-patchesJson6902:
+patches:
 - path: namespace_patch.yaml
   target:
     version: v1
     kind: Namespace
     name: system
+- path: cpu_resources_patch.yaml
+- path: revision_history_limit.yaml
+- path: local_env_var_patch.yaml

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -9,6 +9,6 @@ spec:
   ports:
   - name: https
     port: 8443
-    targetPort: https
+    targetPort: metrics-server
   selector:
     control-plane: controller-manager

--- a/config/replacements/kustomization.yaml
+++ b/config/replacements/kustomization.yaml
@@ -1,0 +1,332 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+replacements:
+
+# LEADER_ELECTION_ID
+- source:
+    fieldPath: metadata.name
+    group: apps
+    version: v1
+    kind: Deployment
+    namespace: system
+    name: controller-manager
+  targets:
+  - fieldPaths:
+    - spec.template.spec.containers.[name=manager].env.[name=LEADER_ELECTION_ID].value
+    options:
+      delimiter: '-'
+    select:
+      group: apps
+      version: v1
+      kind: Deployment
+      namespace: system
+      name: controller-manager
+
+# WEBHOOK_SERVICE_NAME
+- source:
+    fieldPath: metadata.name
+    version: v1
+    kind: Service
+    namespace: system
+    name: webhook-service
+  targets:
+  - fieldPaths:
+    - spec.template.spec.containers.[name=manager].env.[name=WEBHOOK_SERVICE_NAME].value
+    select:
+      group: apps
+      version: v1
+      kind: Deployment
+      namespace: system
+      name: controller-manager
+  - fieldPaths:
+    - spec.dnsNames.0
+    options:
+      delimiter: .
+      index: 0
+    select:
+      version: v1
+      group: cert-manager.io
+      kind: Certificate
+      namespace: system
+      name: serving-cert
+  - fieldPaths:
+    - spec.dnsNames.1
+    options:
+      delimiter: .
+      index: 0
+    select:
+      version: v1
+      group: cert-manager.io
+      kind: Certificate
+      namespace: system
+      name: serving-cert
+
+# WEBHOOK_SERVICE_NAMESPACE
+- source:
+    fieldPath: metadata.namespace
+    version: v1
+    kind: Service
+    namespace: system
+    name: webhook-service
+  targets:
+  - fieldPaths:
+    - spec.template.spec.containers.[name=manager].env.[name=WEBHOOK_SERVICE_NAMESPACE].value
+    select:
+      group: apps
+      version: v1
+      kind: Deployment
+      namespace: system
+      name: controller-manager
+  - fieldPaths:
+    - spec.dnsNames.0
+    options:
+      delimiter: .
+      index: 1
+    select:
+      version: v1
+      group: cert-manager.io
+      kind: Certificate
+      namespace: system
+      name: serving-cert
+  - fieldPaths:
+    - spec.dnsNames.1
+    options:
+      delimiter: .
+      index: 1
+    select:
+      version: v1
+      group: cert-manager.io
+      kind: Certificate
+      namespace: system
+      name: serving-cert
+
+# WEBHOOK_CERTIFICATE_NAME
+- source:
+    fieldPath: metadata.name
+    version: v1
+    group: cert-manager.io
+    kind: Certificate
+    namespace: system
+    name: serving-cert
+  targets:
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+      index: 1
+    select:
+      group: admissionregistration.k8s.io
+      version: v1
+      kind: MutatingWebhookConfiguration
+      name: mutating-webhook-configuration
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+      index: 1
+    select:
+      group: admissionregistration.k8s.io
+      version: v1
+      kind: ValidatingWebhookConfiguration
+      name: validating-webhook-configuration
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+      index: 1
+    select:
+      group: apiextensions.k8s.io
+      version: v1
+      kind: CustomResourceDefinition
+      name: clustervirtualmachineimages.vmoperator.vmware.com
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+      index: 1
+    select:
+      group: apiextensions.k8s.io
+      version: v1
+      kind: CustomResourceDefinition
+      name: virtualmachineclasses.vmoperator.vmware.com
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+      index: 1
+    select:
+      group: apiextensions.k8s.io
+      version: v1
+      kind: CustomResourceDefinition
+      name: virtualmachineimages.vmoperator.vmware.com
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+      index: 1
+    select:
+      group: apiextensions.k8s.io
+      version: v1
+      kind: CustomResourceDefinition
+      name: virtualmachinepublishrequests.vmoperator.vmware.com
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+      index: 1
+    select:
+      group: apiextensions.k8s.io
+      version: v1
+      kind: CustomResourceDefinition
+      name: virtualmachines.vmoperator.vmware.com
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+      index: 1
+    select:
+      group: apiextensions.k8s.io
+      version: v1
+      kind: CustomResourceDefinition
+      name: virtualmachineservices.vmoperator.vmware.com
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+      index: 1
+    select:
+      group: apiextensions.k8s.io
+      version: v1
+      kind: CustomResourceDefinition
+      name: virtualmachinesetresourcepolicies.vmoperator.vmware.com
+
+
+# WEBHOOK_SECRET_NAME
+- source:
+    fieldPath: spec.secretName
+    version: v1
+    group: cert-manager.io
+    kind: Certificate
+    namespace: system
+    name: serving-cert
+  targets:
+  - fieldPaths:
+    - spec.template.spec.containers.[name=manager].env.[name=WEBHOOK_SECRET_NAME].value
+    - spec.template.spec.volumes.[name=cert].secret.secretName
+    select:
+      group: apps
+      version: v1
+      kind: Deployment
+      namespace: system
+      name: controller-manager
+
+
+# WEBHOOK_CERTIFICATE_NAMESPACE
+# WEBHOOK_SECRET_NAMESPACE
+- source:
+    fieldPath: metadata.namespace
+    version: v1
+    group: cert-manager.io
+    kind: Certificate
+    namespace: system
+    name: serving-cert
+  targets:
+  - fieldPaths:
+    - spec.template.spec.containers.[name=manager].env.[name=WEBHOOK_SECRET_NAMESPACE].value
+    select:
+      group: apps
+      version: v1
+      kind: Deployment
+      namespace: system
+      name: controller-manager
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+      index: 0
+    select:
+      group: admissionregistration.k8s.io
+      version: v1
+      kind: MutatingWebhookConfiguration
+      name: mutating-webhook-configuration
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+      index: 0
+    select:
+      group: admissionregistration.k8s.io
+      version: v1
+      kind: ValidatingWebhookConfiguration
+      name: validating-webhook-configuration
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+      index: 0
+    select:
+      group: apiextensions.k8s.io
+      version: v1
+      kind: CustomResourceDefinition
+      name: clustervirtualmachineimages.vmoperator.vmware.com
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+      index: 0
+    select:
+      group: apiextensions.k8s.io
+      version: v1
+      kind: CustomResourceDefinition
+      name: virtualmachineclasses.vmoperator.vmware.com
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+      index: 0
+    select:
+      group: apiextensions.k8s.io
+      version: v1
+      kind: CustomResourceDefinition
+      name: virtualmachineimages.vmoperator.vmware.com
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+      index: 0
+    select:
+      group: apiextensions.k8s.io
+      version: v1
+      kind: CustomResourceDefinition
+      name: virtualmachinepublishrequests.vmoperator.vmware.com
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+      index: 0
+    select:
+      group: apiextensions.k8s.io
+      version: v1
+      kind: CustomResourceDefinition
+      name: virtualmachines.vmoperator.vmware.com
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+      index: 0
+    select:
+      group: apiextensions.k8s.io
+      version: v1
+      kind: CustomResourceDefinition
+      name: virtualmachineservices.vmoperator.vmware.com
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+      index: 0
+    select:
+      group: apiextensions.k8s.io
+      version: v1
+      kind: CustomResourceDefinition
+      name: virtualmachinesetresourcepolicies.vmoperator.vmware.com

--- a/config/wcp-no-configmap/kustomization.yaml
+++ b/config/wcp-no-configmap/kustomization.yaml
@@ -1,4 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
 resources:
 - ./../wcp/vmoperator
+
+components:
+- ../replacements

--- a/config/wcp/kustomization.yaml
+++ b/config/wcp/kustomization.yaml
@@ -1,5 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
 resources:
 - ./vmoperator
 - ./configmaps
+
+components:
+- ../replacements

--- a/config/wcp/vmoperator/kustomization.yaml
+++ b/config/wcp/vmoperator/kustomization.yaml
@@ -19,18 +19,19 @@ resources:
 - privileged_psp_role.yaml
 - privileged_psp_role_binding.yaml
 
-patchesStrategicMerge:
-# Applied for both manager and web-console-validator deployments.
-- image_patch.yaml
-- network_patch.yaml
-- anti_affinity_patch.yaml
-- cpu_resources_patch.yaml
-# Applied for the manager deployment only.
-- certs_volume_patch.yaml
-- manager_metrics_scrape_patch.yaml
-- service_metrics_port_patch.yaml
+patches:
 
-patchesJson6902:
+# Applied for both manager and web-console-validator deployments.
+- path: image_patch.yaml
+- path: network_patch.yaml
+- path: anti_affinity_patch.yaml
+- path: cpu_resources_patch.yaml
+
+# Applied for the manager deployment only.
+- path: certs_volume_patch.yaml
+- path: manager_metrics_scrape_patch.yaml
+- path: service_metrics_port_patch.yaml
+
 - path: web_console_validator_patch.yaml
   target:
     group: apps

--- a/config/wcp/vmoperator/service_metrics_port_patch.yaml
+++ b/config/wcp/vmoperator/service_metrics_port_patch.yaml
@@ -9,5 +9,5 @@ spec:
   ports:
   - name: https
     port: 9848
-    targetPort: https
+    targetPort: metrics-server
   - $patch: replace

--- a/config/web-console-validator/web_console_validator.yaml
+++ b/config/web-console-validator/web_console_validator.yaml
@@ -33,6 +33,7 @@ spec:
             memory: 50Mi
         ports:
         - containerPort: 9868
+          name: wcv-server
         env:
         - name: POD_NAMESPACE
           valueFrom:
@@ -68,6 +69,6 @@ spec:
   ports:
   - name: http
     port: 80
-    targetPort: $(WEB_CONSOLE_VALIDATOR_CONTAINER_PORT)
+    targetPort: wcv-server
   selector:
     app: web-console-validator

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,14 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+configurations:
+- kustomizeconfig.yaml
+
 resources:
 - service.yaml
 - manifests.yaml
 - storage_quota_webhook_configuration.yaml
 
-patchesStrategicMerge:
-- manifests_label_patch.yaml
-- webhookcainjection_patch.yaml
-
-configurations:
-- kustomizeconfig.yaml
+patches:
+- path: manifests_label_patch.yaml
+- path: webhookcainjection_patch.yaml

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -8,6 +8,6 @@ spec:
   ports:
   - name: https
     port: 443
-    targetPort: $(WEBHOOK_SERVICE_CONTAINER_PORT)
+    targetPort: webhook-server
   selector:
     control-plane: controller-manager

--- a/config/webhook/webhookcainjection_patch.yaml
+++ b/config/webhook/webhookcainjection_patch.yaml
@@ -6,11 +6,11 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: mutating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: $(WEBHOOK_CERTIFICATE_NAMESPACE)/$(WEBHOOK_CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: WEBHOOK_CERTIFICATE_NAMESPACE_PLACEHOLDER/WEBHOOK_CERTIFICATE_NAME_PLACEHOLDER
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: $(WEBHOOK_CERTIFICATE_NAMESPACE)/$(WEBHOOK_CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: WEBHOOK_CERTIFICATE_NAMESPACE_PLACEHOLDER/WEBHOOK_CERTIFICATE_NAME_PLACEHOLDER


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch updates the use of Kustomize to no longer use the deprecated symbols, ex. vars, patchesStrategicMerge, and patchesJson6902. These have been replaced with replacements and patches (respectively).



**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

To validate this I ran `make kustomize-local` and applied it to a local Kind cluster to ensure the YAML was valid. I also ran the same on `main` and compared the results to the PR:

### Local Deployment

```shell
diff -u config/local/infrastructure-components-original.yaml config/local/infrastructure-components.yaml
```

```diff
--- config/local/infrastructure-components-original.yaml	2024-10-15 12:08:48.362923758 -0500
+++ config/local/infrastructure-components.yaml	2024-10-16 13:47:53.555437716 -0500
@@ -13688,7 +13688,7 @@
   ports:
   - name: https
     port: 8443
-    targetPort: https
+    targetPort: metrics-server
   selector:
     control-plane: controller-manager
 ---
@@ -13703,7 +13703,7 @@
   ports:
   - name: http
     port: 80
-    targetPort: 9868
+    targetPort: wcv-server
   selector:
     app: web-console-validator
 ---
@@ -13716,7 +13716,7 @@
   ports:
   - name: https
     port: 443
-    targetPort: 9878
+    targetPort: webhook-server
   selector:
     control-plane: controller-manager
 ---
@@ -13725,9 +13725,6 @@
 metadata:
   annotations:
     kubectl.kubernetes.io/default-container: manager
-    webhooks.vmoperator.vmware.com/secret-volume-mount-path: /tmp/k8s-webhook-server/serving-certs
-    webhooks.vmoperator.vmware.com/secret-volume-name: cert
-    webhooks.vmoperator.vmware.com/service-container-port: "9878"
   labels:
     control-plane: controller-manager
     controller-tools.k8s.io: "1.0"
@@ -13871,7 +13868,7 @@
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443
-          name: https
+          name: metrics-server
       nodeSelector:
         node-role.kubernetes.io/control-plane: ""
       terminationGracePeriodSeconds: 10
@@ -13933,6 +13930,7 @@
         name: web-console-validator
         ports:
         - containerPort: 9868
+          name: wcv-server
         resources:
           limits:
             cpu: 100m
```

### WCP Deployment

```shell
diff -u config/wcp/infrastructure-components-original.yaml config/wcp/infrastructure-components.yaml
```

```diff
--- config/wcp/infrastructure-components-original.yaml	2024-10-15 12:07:58.960034322 -0500
+++ config/wcp/infrastructure-components.yaml	2024-10-16 13:49:40.977703430 -0500
@@ -12926,7 +12926,7 @@
   ports:
   - name: https
     port: 9848
-    targetPort: https
+    targetPort: metrics-server
   selector:
     control-plane: controller-manager
 ---
@@ -12941,7 +12941,7 @@
   ports:
   - name: http
     port: 80
-    targetPort: 9868
+    targetPort: wcv-server
   selector:
     app: web-console-validator
 ---
@@ -12954,7 +12954,7 @@
   ports:
   - name: https
     port: 443
-    targetPort: 9878
+    targetPort: webhook-server
   selector:
     control-plane: controller-manager
 ---
@@ -12963,9 +12963,6 @@
 metadata:
   annotations:
     kubectl.kubernetes.io/default-container: manager
-    webhooks.vmoperator.vmware.com/secret-volume-mount-path: /tmp/k8s-webhook-server/serving-certs
-    webhooks.vmoperator.vmware.com/secret-volume-name: cert
-    webhooks.vmoperator.vmware.com/service-container-port: "9878"
   labels:
     control-plane: controller-manager
     controller-tools.k8s.io: "1.0"
@@ -13133,7 +13130,7 @@
         name: kube-rbac-proxy
         ports:
         - containerPort: 9848
-          name: https
+          name: metrics-server
       hostNetwork: true
       nodeSelector:
         node-role.kubernetes.io/control-plane: ""
@@ -13210,6 +13207,7 @@
         name: web-console-validator
         ports:
         - containerPort: 9868
+          name: wcv-server
         resources:
           limits:
             cpu: 100m
```

I also checked `local-vcsim` and `wcp-no-configmap`, I just did not list them here. It is as expected, which means the changes are fine.


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Replace deprecated kustomize symbols with components, replacements, and patches
```