### PR TITLE
🌱 Rename resize related condition to ClassConfigurationSynced

### DIFF
--- a/api/v1alpha2/virtualmachine_types.go
+++ b/api/v1alpha2/virtualmachine_types.go
@@ -42,9 +42,9 @@ const (
 	// VirtualMachineConditionCreated indicates that the VM has been created.
 	VirtualMachineConditionCreated = "VirtualMachineCreated"
 
-	// VirtualMachineConfigurationSynced indicates that the VM's current configuration is synced to the
+	// VirtualMachineClassConfigurationSynced indicates that the VM's current configuration is synced to the
 	// current version of its VirtualMachineClass.
-	VirtualMachineConfigurationSynced = "VirtualMachineConfigurationSynced"
+	VirtualMachineClassConfigurationSynced = "VirtualMachineClassConfigurationSynced"
 )
 
 const (

--- a/api/v1alpha3/virtualmachine_types.go
+++ b/api/v1alpha3/virtualmachine_types.go
@@ -48,9 +48,9 @@ const (
 	// VirtualMachineConditionCreated indicates that the VM has been created.
 	VirtualMachineConditionCreated = "VirtualMachineCreated"
 
-	// VirtualMachineConfigurationSynced indicates that the VM's current configuration is synced to the
+	// VirtualMachineClassConfigurationSynced indicates that the VM's current configuration is synced to the
 	// current version of its VirtualMachineClass.
-	VirtualMachineConfigurationSynced = "VirtualMachineConfigurationSynced"
+	VirtualMachineClassConfigurationSynced = "VirtualMachineClassConfigurationSynced"
 )
 
 const (

--- a/pkg/providers/vsphere/vmlifecycle/update_status.go
+++ b/pkg/providers/vsphere/vmlifecycle/update_status.go
@@ -425,7 +425,7 @@ func MarkVMClassConfigurationSynced(
 
 	className := vm.Spec.ClassName
 	if className == "" {
-		conditions.Delete(vm, vmopv1.VirtualMachineConfigurationSynced)
+		conditions.Delete(vm, vmopv1.VirtualMachineClassConfigurationSynced)
 		return
 	}
 
@@ -437,17 +437,17 @@ func MarkVMClassConfigurationSynced(
 	if !exists || lraName == "" {
 		_, sameClassResize := vm.Annotations[vmopv1.VirtualMachineSameVMClassResizeAnnotation]
 		if sameClassResize {
-			conditions.MarkFalse(vm, vmopv1.VirtualMachineConfigurationSynced, "SameClassResize", "")
+			conditions.MarkFalse(vm, vmopv1.VirtualMachineClassConfigurationSynced, "SameClassResize", "")
 		} else {
 			// Brownfield VM so just marked as synced.
-			conditions.MarkTrue(vm, vmopv1.VirtualMachineConfigurationSynced)
+			conditions.MarkTrue(vm, vmopv1.VirtualMachineClassConfigurationSynced)
 		}
 		return
 	}
 
 	if vm.Spec.ClassName != lraName {
 		// Most common need resize case.
-		conditions.MarkFalse(vm, vmopv1.VirtualMachineConfigurationSynced, "ClassNameChanged", "")
+		conditions.MarkFalse(vm, vmopv1.VirtualMachineClassConfigurationSynced, "ClassNameChanged", "")
 		return
 	}
 
@@ -462,17 +462,17 @@ func MarkVMClassConfigurationSynced(
 	vmClass := vmopv1.VirtualMachineClass{}
 	if err := k8sClient.Get(ctx, ctrlclient.ObjectKey{Name: className, Namespace: vm.Namespace}, &vmClass); err != nil {
 		if apierrors.IsNotFound(err) {
-			conditions.MarkUnknown(vm, vmopv1.VirtualMachineConfigurationSynced, "ClassNotFound", "")
+			conditions.MarkUnknown(vm, vmopv1.VirtualMachineClassConfigurationSynced, "ClassNotFound", "")
 		} else {
-			conditions.MarkUnknown(vm, vmopv1.VirtualMachineConfigurationSynced, err.Error(), "")
+			conditions.MarkUnknown(vm, vmopv1.VirtualMachineClassConfigurationSynced, err.Error(), "")
 		}
 		return
 	}
 
 	if string(vmClass.UID) == lraUID && vmClass.Generation == lraGeneration {
-		conditions.MarkTrue(vm, vmopv1.VirtualMachineConfigurationSynced)
+		conditions.MarkTrue(vm, vmopv1.VirtualMachineClassConfigurationSynced)
 	} else {
-		conditions.MarkFalse(vm, vmopv1.VirtualMachineConfigurationSynced, "ClassUpdated", "")
+		conditions.MarkFalse(vm, vmopv1.VirtualMachineClassConfigurationSynced, "ClassUpdated", "")
 	}
 }
 

--- a/pkg/providers/vsphere/vmprovider_vm_resize_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_resize_test.go
@@ -140,7 +140,7 @@ func vmResizeTests() {
 		ExpectWithOffset(1, vm.Status.Class.Name).To(Equal(class.Name), "Status.Class.Name")
 
 		if inSync {
-			ExpectWithOffset(1, conditions.IsTrue(vm, vmopv1.VirtualMachineConfigurationSynced)).To(BeTrue(), "Synced Condition")
+			ExpectWithOffset(1, conditions.IsTrue(vm, vmopv1.VirtualMachineClassConfigurationSynced)).To(BeTrue(), "Synced Condition")
 		}
 	}
 
@@ -494,7 +494,7 @@ func vmResizeTests() {
 
 					assertExpectedResizedClassFields(vm, vmClass, false)
 
-					c := conditions.Get(vm, vmopv1.VirtualMachineConfigurationSynced)
+					c := conditions.Get(vm, vmopv1.VirtualMachineClassConfigurationSynced)
 					Expect(c).ToNot(BeNil())
 					Expect(c.Status).To(Equal(metav1.ConditionFalse))
 					Expect(c.Reason).To(Equal("ClassNameChanged"))
@@ -526,7 +526,7 @@ func vmResizeTests() {
 
 					assertExpectedResizedClassFields(vm, vmClass, false)
 
-					c := conditions.Get(vm, vmopv1.VirtualMachineConfigurationSynced)
+					c := conditions.Get(vm, vmopv1.VirtualMachineClassConfigurationSynced)
 					Expect(c).ToNot(BeNil())
 					Expect(c.Status).To(Equal(metav1.ConditionFalse))
 					Expect(c.Reason).To(Equal("ClassUpdated"))
@@ -590,7 +590,7 @@ func vmResizeTests() {
 						assertExpectedNoReservationFields(o)
 
 						Expect(vm.Annotations).ToNot(HaveKey(vmopv1util.LastResizedAnnotationKey))
-						Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConfigurationSynced)).To(BeTrue())
+						Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineClassConfigurationSynced)).To(BeTrue())
 					})
 
 					vm.Annotations[vmopv1.VirtualMachineSameVMClassResizeAnnotation] = ""
@@ -634,7 +634,7 @@ func vmResizeTests() {
 						assertExpectedNoReservationFields(o)
 					})
 
-					c := conditions.Get(vm, vmopv1.VirtualMachineConfigurationSynced)
+					c := conditions.Get(vm, vmopv1.VirtualMachineClassConfigurationSynced)
 					Expect(c).ToNot(BeNil())
 					Expect(c.Status).To(Equal(metav1.ConditionFalse))
 					Expect(c.Reason).To(Equal("SameClassResize"))
@@ -721,7 +721,7 @@ func vmResizeTests() {
 				// BMV: TBD exactly what we should do in this case.
 				// Expect(vm.Status.Class).To(BeNil())
 
-				c := conditions.Get(vm, vmopv1.VirtualMachineConfigurationSynced)
+				c := conditions.Get(vm, vmopv1.VirtualMachineClassConfigurationSynced)
 				Expect(c).ToNot(BeNil())
 				Expect(c.Status).To(Equal(metav1.ConditionUnknown))
 				Expect(c.Reason).To(Equal("ClassNotFound"))
@@ -747,7 +747,7 @@ func vmResizeTests() {
 				Expect(o.Config.ChangeTrackingEnabled).To(HaveValue(BeTrue()))
 
 				Expect(vm.Status.Class).To(BeNil())
-				Expect(conditions.Get(vm, vmopv1.VirtualMachineConfigurationSynced)).To(BeNil())
+				Expect(conditions.Get(vm, vmopv1.VirtualMachineClassConfigurationSynced)).To(BeNil())
 			})
 		})
 	})


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

We may have other configuration - such as disk encryption - that is handled separately and don't want to confuse that with this condition.

The prior name would be better used as a roll up if we ever need that.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note
NONE
```