### PR TITLE
🌱 Set default EncryptionClass on VM when available

### DIFF
--- a/pkg/util/kube/crypto.go
+++ b/pkg/util/kube/crypto.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package kube
+
+import (
+	"context"
+	"fmt"
+
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	byokv1 "github.com/vmware-tanzu/vm-operator/external/byok/api/v1alpha1"
+)
+
+const (
+	// DefaultEncryptionClassLabelName is the name of the label that identifies
+	// the default EncryptionClass in a given namespace.
+	DefaultEncryptionClassLabelName = "encryption.vmware.com/default"
+
+	// DefaultEncryptionClassLabelValue is the value of the label that
+	// identifies the default EncryptionClass in a given namespace.
+	DefaultEncryptionClassLabelValue = "true"
+)
+
+var (
+	// ErrNoDefaultEncryptionClass is returned by the
+	// GetDefaultEncryptionClassForNamespace method if there are no
+	// EncryptionClasses in a given namespace marked as default.
+	ErrNoDefaultEncryptionClass = fmt.Errorf(
+		"no EncryptionClass resource has the label %q: %q",
+		DefaultEncryptionClassLabelName, DefaultEncryptionClassLabelValue)
+
+	// ErrMultipleDefaultEncryptionClasses is returned by the
+	// GetDefaultEncryptionClassForNamespace method if more than one
+	// EncryptionClass in a given namespace are marked as default.
+	ErrMultipleDefaultEncryptionClasses = fmt.Errorf(
+		"multiple EncryptionClass resources have the label %q: %q",
+		DefaultEncryptionClassLabelName, DefaultEncryptionClassLabelValue)
+)
+
+// GetDefaultEncryptionClassForNamespace returns the default EncryptionClass for
+// the provided namespace.
+func GetDefaultEncryptionClassForNamespace(
+	ctx context.Context,
+	k8sClient ctrlclient.Client,
+	namespace string) (byokv1.EncryptionClass, error) {
+
+	if ctx == nil {
+		panic("context is nil")
+	}
+	if k8sClient == nil {
+		panic("k8sClient is nil")
+	}
+	if namespace == "" {
+		panic("namespace is empty")
+	}
+
+	var list byokv1.EncryptionClassList
+	if err := k8sClient.List(
+		ctx,
+		&list,
+		ctrlclient.InNamespace(namespace),
+		ctrlclient.MatchingLabels{
+			DefaultEncryptionClassLabelName: DefaultEncryptionClassLabelValue,
+		}); err != nil {
+
+		return byokv1.EncryptionClass{}, err
+	}
+	if len(list.Items) == 0 {
+		return byokv1.EncryptionClass{}, ErrNoDefaultEncryptionClass
+	}
+	if len(list.Items) > 1 {
+		return byokv1.EncryptionClass{}, ErrMultipleDefaultEncryptionClasses
+	}
+	return list.Items[0], nil
+}

--- a/pkg/util/kube/crypto_test.go
+++ b/pkg/util/kube/crypto_test.go
@@ -1,0 +1,274 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package kube_test
+
+import (
+	"context"
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	byokv1 "github.com/vmware-tanzu/vm-operator/external/byok/api/v1alpha1"
+	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+var _ = Describe("GetDefaultEncryptionClassForNamespace", func() {
+	const (
+		name1      = "my-encryption-class-1"
+		name2      = "my-encryption-class-2"
+		namespace1 = "my-namespace-1"
+		namespace2 = "my-namespace-2"
+		namespace3 = "my-namespace-3"
+	)
+	var (
+		ctx               context.Context
+		k8sClient         ctrlclient.Client
+		namespace         string
+		withFuncs         interceptor.Funcs
+		withObjs          []ctrlclient.Object
+		labelsWithDefault map[string]string
+	)
+	BeforeEach(func() {
+		ctx = context.Background()
+		withObjs = nil
+		withFuncs = interceptor.Funcs{}
+		namespace = namespace3
+		labelsWithDefault = map[string]string{
+			kubeutil.DefaultEncryptionClassLabelName: kubeutil.DefaultEncryptionClassLabelValue,
+		}
+	})
+	JustBeforeEach(func() {
+		k8sClient = builder.NewFakeClientWithInterceptors(
+			withFuncs, withObjs...)
+	})
+	Context("panic expected", func() {
+		When("context is nil", func() {
+			JustBeforeEach(func() {
+				ctx = nil
+			})
+			It("should panic", func() {
+				Expect(func() {
+					_, _ = kubeutil.GetDefaultEncryptionClassForNamespace(
+						ctx,
+						k8sClient,
+						namespace)
+				}).To(PanicWith("context is nil"))
+			})
+		})
+		When("k8sClient is nil", func() {
+			JustBeforeEach(func() {
+				k8sClient = nil
+			})
+			It("should panic", func() {
+				Expect(func() {
+					_, _ = kubeutil.GetDefaultEncryptionClassForNamespace(
+						ctx,
+						k8sClient,
+						namespace)
+				}).To(PanicWith("k8sClient is nil"))
+			})
+		})
+		When("namespace is empty", func() {
+			JustBeforeEach(func() {
+				namespace = ""
+			})
+			It("should panic", func() {
+				Expect(func() {
+					_, _ = kubeutil.GetDefaultEncryptionClassForNamespace(
+						ctx,
+						k8sClient,
+						namespace)
+				}).To(PanicWith("namespace is empty"))
+			})
+		})
+	})
+
+	Context("panic not expected", func() {
+		var (
+			err      error
+			obj      byokv1.EncryptionClass
+			emptyObj byokv1.EncryptionClass
+		)
+		JustBeforeEach(func() {
+			obj, err = kubeutil.GetDefaultEncryptionClassForNamespace(
+				ctx, k8sClient, namespace)
+		})
+		When("there are no EncryptionClasses", func() {
+			It("should not return an EncryptionClass", func() {
+				Expect(err).To(MatchError(kubeutil.ErrNoDefaultEncryptionClass))
+				Expect(obj).To(Equal(emptyObj))
+			})
+		})
+		When("there are no EncryptionClasses in the given namespace", func() {
+			BeforeEach(func() {
+				withObjs = append(withObjs,
+					&byokv1.EncryptionClass{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: namespace1,
+							Name:      name1,
+						},
+					},
+					&byokv1.EncryptionClass{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: namespace2,
+							Name:      name1,
+						},
+					},
+					&byokv1.EncryptionClass{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: namespace2,
+							Name:      name2,
+						},
+					},
+				)
+			})
+			It("should not return an EncryptionClass", func() {
+				Expect(err).To(MatchError(kubeutil.ErrNoDefaultEncryptionClass))
+				Expect(obj).To(Equal(emptyObj))
+			})
+		})
+		When("there is a default EncryptionClass in a different namespace", func() {
+			BeforeEach(func() {
+				withObjs = append(withObjs,
+					&byokv1.EncryptionClass{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: namespace1,
+							Name:      name1,
+							Labels:    labelsWithDefault,
+						},
+					},
+					&byokv1.EncryptionClass{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: namespace2,
+							Name:      name1,
+						},
+					},
+					&byokv1.EncryptionClass{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: namespace2,
+							Name:      name2,
+							Labels:    labelsWithDefault,
+						},
+					},
+					&byokv1.EncryptionClass{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: namespace,
+							Name:      name1,
+						},
+					},
+				)
+			})
+			It("should not return an EncryptionClass", func() {
+				Expect(err).To(MatchError(kubeutil.ErrNoDefaultEncryptionClass))
+				Expect(obj).To(Equal(emptyObj))
+			})
+		})
+		When("there is a default EncryptionClass", func() {
+			BeforeEach(func() {
+				withObjs = append(withObjs,
+					&byokv1.EncryptionClass{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: namespace1,
+							Name:      name1,
+							Labels:    labelsWithDefault,
+						},
+					},
+					&byokv1.EncryptionClass{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: namespace2,
+							Name:      name1,
+						},
+					},
+					&byokv1.EncryptionClass{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: namespace2,
+							Name:      name2,
+							Labels:    labelsWithDefault,
+						},
+					},
+					&byokv1.EncryptionClass{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: namespace,
+							Name:      name1,
+							Labels:    labelsWithDefault,
+						},
+					},
+				)
+			})
+			It("should return an EncryptionClass", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(obj.Namespace).To(Equal(namespace))
+				Expect(obj.Name).To(Equal(name1))
+			})
+		})
+
+		When("there are multiple default EncryptionClasses in the same namespace", func() {
+			BeforeEach(func() {
+				withObjs = append(withObjs,
+					&byokv1.EncryptionClass{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: namespace1,
+							Name:      name1,
+							Labels:    labelsWithDefault,
+						},
+					},
+					&byokv1.EncryptionClass{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: namespace2,
+							Name:      name1,
+						},
+					},
+					&byokv1.EncryptionClass{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: namespace2,
+							Name:      name2,
+							Labels:    labelsWithDefault,
+						},
+					},
+					&byokv1.EncryptionClass{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: namespace,
+							Name:      name1,
+							Labels:    labelsWithDefault,
+						},
+					},
+					&byokv1.EncryptionClass{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: namespace,
+							Name:      name2,
+							Labels:    labelsWithDefault,
+						},
+					},
+				)
+			})
+			It("should return ErrMultipleDefaultEncryptionClasses", func() {
+				Expect(err).To(MatchError(kubeutil.ErrMultipleDefaultEncryptionClasses))
+				Expect(obj).To(Equal(emptyObj))
+			})
+		})
+
+		When("there is an error listing EncryptionClasses", func() {
+			BeforeEach(func() {
+				withFuncs.List = func(
+					ctx context.Context,
+					client ctrlclient.WithWatch,
+					list ctrlclient.ObjectList,
+					opts ...ctrlclient.ListOption) error {
+
+					return errors.New(fakeString)
+				}
+			})
+			It("should return an error", func() {
+				Expect(err).To(MatchError(fakeString))
+				Expect(obj).To(Equal(emptyObj))
+			})
+		})
+	})
+})

--- a/pkg/util/kube/storage.go
+++ b/pkg/util/kube/storage.go
@@ -178,18 +178,15 @@ func IsEncryptedStorageClass(
 	}
 
 	var (
-		obj      corev1.ConfigMap
+		obj    corev1.ConfigMap
+		objKey = ctrlclient.ObjectKey{
+			Namespace: pkgcfg.FromContext(ctx).PodNamespace,
+			Name:      internal.EncryptedStorageClassNamesConfigMapName,
+		}
 		ownerRef = internal.GetOwnerRefForStorageClass(storageClass)
 	)
 
-	if err := k8sClient.Get(
-		ctx,
-		ctrlclient.ObjectKey{
-			Namespace: pkgcfg.FromContext(ctx).PodNamespace,
-			Name:      internal.EncryptedStorageClassNamesConfigMapName,
-		},
-		&obj); err != nil {
-
+	if err := k8sClient.Get(ctx, objKey, &obj); err != nil {
 		return false, ctrlclient.IgnoreNotFound(err)
 	}
 

--- a/webhooks/virtualmachine/mutation/virtualmachine_mutator_suite_test.go
+++ b/webhooks/virtualmachine/mutation/virtualmachine_mutator_suite_test.go
@@ -18,6 +18,10 @@ var suite = builder.NewTestSuiteForMutatingWebhookWithContext(
 	pkgcfg.WithConfig(
 		pkgcfg.Config{
 			BuildVersion: "v1",
+			Features: pkgcfg.FeatureStates{
+				BringYourOwnEncryptionKey: true,
+			},
+			PodNamespace: "default",
 		}),
 	mutation.AddToManager,
 	mutation.NewMutator,


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch updates the VirtualMachine mutation webhook to set the default EncryptionClass on VMs when the StorageClass supports encryption and a default EncryptionClass is available in the VM's namespace.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```