### PR TITLE
🌱 Support kustomize-wcp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -537,6 +537,18 @@ kustomize-local-vcsim: YAML_OUT=$(LOCAL_YAML)
 kustomize-local-vcsim: prereqs generate-manifests $(KUSTOMIZE)
 kustomize-local-vcsim: kustomize-x ## Kustomize for local-vcsim cluster
 
+.PHONY: kustomize-wcp
+kustomize-wcp: CONFIG_TYPE=wcp
+kustomize-wcp: YAML_OUT=$(LOCAL_YAML)
+kustomize-wcp: prereqs generate-manifests $(KUSTOMIZE)
+kustomize-wcp: kustomize-x ## Kustomize for wcp cluster
+
+.PHONY: kustomize-wcp-no-configmap
+kustomize-wcp-no-configmap: CONFIG_TYPE=wcp-no-configmap
+kustomize-wcp-no-configmap: YAML_OUT=$(LOCAL_YAML)
+kustomize-wcp-no-configmap: prereqs generate-manifests $(KUSTOMIZE)
+kustomize-wcp-no-configmap: kustomize-x ## Kustomize for wcp cluster sans configmap
+
 
 ## --------------------------------------
 ## Development - kind


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch (re)introduces support for the Makefile targets kustomize-wcp and kustomize-wcp-no-configmap.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Support Makefile target kustomize-wcp
```