### PR TITLE
🌱 GitHub action to verify WCP manifests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,30 @@ jobs:
     - name: Verify codegen
       run: make verify-codegen
 
+  verify-manifests:
+    needs:
+    - verify-go-modules
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+    - name: Install Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ env.GO_VERSION }}
+        cache: true
+        cache-dependency-path: '**/go.sum'
+    - name: Create kind cluster
+      id: create_kind_cluster
+      run: make kind-up
+      env:
+        KIND_IMAGE: kindest/node:v1.31.1
+    - name: Verify the manifests
+      run: make verify-wcp-manifests
+    - name: Destroy kind cluster
+      run: make kind-down
+      if: steps.create_kind_cluster.outcome == 'success'
+
   lint-go:
     needs:
     - verify-go-modules

--- a/hack/deploy-local-certmanager.sh
+++ b/hack/deploy-local-certmanager.sh
@@ -6,17 +6,11 @@ set -o pipefail
 set -o nounset
 set -x
 
-# Exit with a non-zero exit code and an error message if
-# the CERT_MANAGER_URL is not set.
-CERT_MANAGER_URL="${CERT_MANAGER_URL:?}"
+CERT_MANAGER_URL="${CERT_MANAGER_URL:-https://github.com/cert-manager/cert-manager/releases/download/v1.16.1/cert-manager.yaml}"
+CERT_MANAGER_YAML="artifacts/cert-manager.yaml"
 
-mkdir -p artifacts
+mkdir -p "$(dirname "${CERT_MANAGER_YAML}")"
 
-# Since we modify the PATH var at the beginning of Makefile, kustomize
-# should always be available.
-kustomize build \
-  --load-restrictor LoadRestrictionsNone \
-  "${CERT_MANAGER_URL}" \
-  >artifacts/cert-manager.yaml
+curl -Lo "${CERT_MANAGER_YAML}" "${CERT_MANAGER_URL}"
 
-kubectl apply -f artifacts/cert-manager.yaml
+kubectl apply -f "${CERT_MANAGER_YAML}"

--- a/hack/deploy-local.sh
+++ b/hack/deploy-local.sh
@@ -7,20 +7,30 @@
 set -o errexit
 set -o pipefail
 set -o nounset
+set -x
 
-YAML=$1
+# VERIFY_MANIFESTS is set to a non-empty value if the only thing this file
+# should be doing is verifying the YAML can be successfully applied to a Kind
+# cluster. When this is set, we do not wait to verify that deployments,
+# webhooks, pods, etc. are online. The only thing about which we care is if
+# "kubectl apply" succeeded.
+VERIFY_MANIFESTS="${VERIFY_MANIFESTS:-}"
+
+YAML="${1}"
 KUBECTL="kubectl"
 
 VMOP_NAMESPACE="vmware-system-vmop"
 VMOP_DEPLOYMENT="vmware-system-vmop-controller-manager"
 
 DEPLOYMENT_EXISTS=""
-if $KUBECTL get deployment -n ${VMOP_NAMESPACE} ${VMOP_DEPLOYMENT} >/dev/null 2>&1; then
-  DEPLOYMENT_EXISTS=1
+if [ -z "${VERIFY_MANIFESTS:-}" ]; then
+  if $KUBECTL get deployment -n ${VMOP_NAMESPACE} ${VMOP_DEPLOYMENT} >/dev/null 2>&1; then
+    DEPLOYMENT_EXISTS=1
+  fi
 fi
 
-# Deploy and check cert-manager
-CERTMANAGER_NAMESPACE="vmware-system-cert-manager"
+# Check to see if cert-manager exists.
+CERTMANAGER_NAMESPACE="${CERTMANAGER_NAMESPACE:-cert-manager}"
 CERTMANAGER_DEPLOYMENTS=(
   cert-manager
   cert-manager-cainjector
@@ -33,25 +43,34 @@ if $KUBECTL get deployment -n "${CERTMANAGER_NAMESPACE}" "${CERTMANAGER_DEPLOYME
 fi
 if [[ -z $CERTMAN_EXISTS ]]; then
   ./hack/deploy-local-certmanager.sh
+
   for dep in "${CERTMANAGER_DEPLOYMENTS[@]}"; do
     $KUBECTL rollout status -n "${CERTMANAGER_NAMESPACE}" deployment "${dep}"
   done
 
   # TODO Find a better way to wait for this...
-  echo $'\nSleeping for 60s - waiting for webhooks to be initialized\n'
+  echo $'\nSleeping for 1m - waiting for cert-manager webhooks to be initialized\n'
   sleep 60
 fi
 
-# Hack to reduce the number of replicas deployed from 3 to 1
-# when deploying onto a single node kind cluster.
-NODE_COUNT=$(kubectl get node --no-headers 2>/dev/null | wc -l)
-if [ "$NODE_COUNT" -eq 1 ]; then
-  sed -i -e 's/replicas: 3/replicas: 1/g' "$YAML"
-  # remove the generated '-e' file on Mac
-  rm -f "$YAML-e"
+if [ -z "${VERIFY_MANIFESTS:-}" ]; then
+  # Hack to reduce the number of replicas deployed from 3 to 1
+  # when deploying onto a single node kind cluster.
+  NODE_COUNT=$(kubectl get node --no-headers 2>/dev/null | wc -l)
+  if [ "$NODE_COUNT" -eq 1 ]; then
+    sed -i -e 's/replicas: 3/replicas: 1/g' "$YAML"
+    # remove the generated '-e' file on Mac
+    rm -f "$YAML-e"
+  fi
 fi
 
+# Apply the infrastructure YAML.
 $KUBECTL apply -f "$YAML"
+
+# If VERIFY_MANIFESTS is set then we can go ahead and exit.
+if [ -n "${VERIFY_MANIFESTS:-}" ]; then
+  exit 0
+fi
 
 if [[ -n $DEPLOYMENT_EXISTS ]]; then
   $KUBECTL rollout restart -n ${VMOP_NAMESPACE} deployment ${VMOP_DEPLOYMENT}
@@ -63,7 +82,7 @@ until $KUBECTL wait --for=condition=Ready -n vmware-system-vmop cert/vmware-syst
 done
 
 if [[ $# -eq 2 ]]; then
-  VMCLASSES_YAML=$2
+  VMCLASSES_YAML="${2}"
   # Hack that retries applying the default VM Classes until the
   # validating webhook is available.
   VMOP_VMCLASSES_ATTEMPTS=0


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch adds support for a GitHub action that verifies the WCP manifests by deploying a Kind cluster and ensuring the WCP manifests can be applied to the cluster successfully.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

Verified on my fork at https://github.com/akutz/vm-operator/actions/runs/11386366887/job/31678406635.


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Add GitHub action to verify the WCP manifests
```