### PR TITLE
✨ Support PVCs with BYOK

### DIFF
--- a/controllers/virtualmachine/volume/volume_controller.go
+++ b/controllers/virtualmachine/volume/volume_controller.go
@@ -525,6 +525,11 @@ func (r *Reconciler) createInstanceStoragePVC(
 		},
 	}
 
+	if c := ctx.VM.Spec.Crypto; c != nil && c.EncryptionClassName != "" {
+		// Assign the InstanceStorage PVC the same EncryptionClass as the VM.
+		pvc.Annotations[constants.EncryptionClassNameAnnotation] = c.EncryptionClassName
+	}
+
 	if err := controllerutil.SetControllerReference(ctx.VM, pvc, r.Client.Scheme()); err != nil {
 		// This is an unexpected error.
 		return fmt.Errorf("cannot set controller reference on PersistentVolumeClaim: %w", err)

--- a/pkg/providers/vsphere/constants/constants.go
+++ b/pkg/providers/vsphere/constants/constants.go
@@ -68,6 +68,11 @@ const (
 	CloudInitGuestInfoUserdata         = "guestinfo.userdata"
 	CloudInitGuestInfoUserdataEncoding = "guestinfo.userdata.encoding"
 
+	// EncryptionClassNameAnnotation specifies the name of an EncryptionClass
+	// resource. This is used by APIs that participate in BYOK but cannot modify
+	// their spec to do so, such as the PersistentVolumeClaim API.
+	EncryptionClassNameAnnotation = "encryption.vmware.com/encryption-class-name"
+
 	// InstanceStoragePVCNamePrefix prefix of auto-generated PVC names.
 	InstanceStoragePVCNamePrefix = "instance-pvc-"
 	// InstanceStorageLabelKey identifies resources related to instance storage.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch includes two changes:

1. The first change removes the validation that prevents PVCs from being attached to VMs that are encrypted with `spec.crypto.encryptionClassName`.
2. The second change ensures Instance Storage PVCs created on behalf of VMs using BYOK will have the annotation `encryption.vmware.com/encryption-class-name` set to the value of the VM's `spec.crypto.encryptionClassName` field. This annotation on the PVC allows CSI to know which `EncryptionClass` to use to encrypt the volume.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    3. If a release note is not required, please write "NONE".
-->

```release-note
Support EncryptionClass for Instance Storage and PersistentVolumeClaims
```