### PR TITLE
🌱 Check image ready condition before mounting ISO

### DIFF
--- a/pkg/providers/vsphere/session/session_vm_update_test.go
+++ b/pkg/providers/vsphere/session/session_vm_update_test.go
@@ -1625,7 +1625,7 @@ var _ = Describe("UpdateVirtualMachine", func() {
 
 				JustBeforeEach(func() {
 					// Add required objects to get CD-ROM backing file name.
-					objs := builder.DummyImageAndItemObjectsForCdromBacking(vmiName, vmCtx.VM.Namespace, vmiKind, vmiFileName, ctx.ContentLibraryIsoItemID, true, true, "ISO")
+					objs := builder.DummyImageAndItemObjectsForCdromBacking(vmiName, vmCtx.VM.Namespace, vmiKind, vmiFileName, ctx.ContentLibraryIsoItemID, true, true, true, "ISO")
 					for _, obj := range objs {
 						Expect(ctx.Client.Create(ctx, obj)).To(Succeed())
 					}

--- a/test/builder/dummies.go
+++ b/test/builder/dummies.go
@@ -562,7 +562,7 @@ func DummyVirtualMachineWebConsoleRequest(namespace, wcrName, vmName, pubKey str
 
 func DummyImageAndItemObjectsForCdromBacking(
 	name, ns, kind, storageURI, libItemUUID string,
-	imgHasProviderRef, itemObjExists bool,
+	imgReady, imgHasProviderRef, itemObjExists bool,
 	itemType imgregv1a1.ContentLibraryItemType) []ctrlclient.Object {
 	var imageObj, itemObj ctrlclient.Object
 
@@ -572,6 +572,18 @@ func DummyImageAndItemObjectsForCdromBacking(
 	if imgHasProviderRef {
 		imgSpec.ProviderRef = &vmopv1common.LocalObjectRef{
 			Name: name,
+		}
+	}
+
+	imgStatus := vmopv1.VirtualMachineImageStatus{
+		Type: string(itemType),
+	}
+	if imgReady {
+		imgStatus.Conditions = []metav1.Condition{
+			{
+				Type:   vmopv1.ReadyConditionType,
+				Status: metav1.ConditionTrue,
+			},
 		}
 	}
 
@@ -594,7 +606,8 @@ func DummyImageAndItemObjectsForCdromBacking(
 				Name:      name,
 				Namespace: ns,
 			},
-			Spec: imgSpec,
+			Spec:   imgSpec,
+			Status: imgStatus,
 		}
 
 		itemObj = &imgregv1a1.ContentLibraryItem{
@@ -610,7 +623,8 @@ func DummyImageAndItemObjectsForCdromBacking(
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
-			Spec: imgSpec,
+			Spec:   imgSpec,
+			Status: imgStatus,
 		}
 
 		itemObj = &imgregv1a1.ClusterContentLibraryItem{


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR updates the CD-ROM reconciliation to verify image's ready condition before retrieving ISO backing files. This prevents mounting unready ISO files to VMs. Also moving this logic into a separate function for better code readability.

**Which issue(s) is/are addressed by this PR?**

Fixes N/A.

**Are there any special notes for your reviewer**:

- Added new unit tests to maintain 100% code coverage of the `cdrom.go` file:

```console
$ go tool cover -func=/tmp/coverage.out | grep pkg/providers/vsphere/virtualmachine/cdrom.go
github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/virtualmachine/cdrom.go:33:			UpdateCdromDeviceChanges			100.0%
github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/virtualmachine/cdrom.go:118:			UpdateConfigSpecCdromDeviceConnection		100.0%
github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/virtualmachine/cdrom.go:169:			getBackingFileNameByImageRef			100.0%
github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/virtualmachine/cdrom.go:219:			processImage					100.0%
github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/virtualmachine/cdrom.go:272:			getCdromByBackingFileName			100.0%
github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/virtualmachine/cdrom.go:295:			createNewCdrom					100.0%
github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/virtualmachine/cdrom.go:322:			ensureAllCdromsHaveControllers			100.0%
github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/virtualmachine/cdrom.go:357:			addNewAHCIController				100.0%
github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/virtualmachine/cdrom.go:409:			updateCurCdromsConnectionState			100.0%
```

- Deployed the change to an internal testbed and verified the expected error from mounting incorrect image:

```console
# When image condition is not ready
E1017 18:20:14.617078       1 controller.go:316] "Reconciler error" err="updating state failed with update CD-ROM device changes error: error getting backing file name by image ref {VirtualMachineImage vmi-ee3680132b89bcc26}: image condition is not ready: &Condition{Type:Ready,Status:False,ObservedGeneration:0,LastTransitionTime:2024-10-17 16:35:10 +0000 UTC,Reason:True,Message:,}"...

# When image type is not ISO
E1017 18:24:16.557709       1 controller.go:316] "Reconciler error" err="updating state failed with update CD-ROM device changes error: error getting backing file name by image ref {VirtualMachineImage vmi-ee3680132b89bcc26}: image type \"OVF\" is not ISO" ...
```

**Please add a release note if necessary**:

```release-note
Check image ready condition and type before mounting ISO.
```