### PR TITLE
🌱 Fixes for Bring Your Own Key (BYOK) provider

### DIFF
--- a/pkg/providers/vsphere/vmprovider_vm.go
+++ b/pkg/providers/vsphere/vmprovider_vm.go
@@ -1097,7 +1097,7 @@ func (vs *vSphereVMProvider) vmCreateGenConfigSpec(
 				vs.vcClient.VimClient(),
 				vmCtx.VM,
 				vmCtx.MoVM,
-				&configSpec); err != nil {
+				&createArgs.ConfigSpec); err != nil {
 
 				return err
 			}

--- a/pkg/providers/vsphere/vmprovider_vm_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_test.go
@@ -1566,7 +1566,12 @@ func vmTests() {
 							It("should succeed", func() {
 								_, err := createOrUpdateAndGetVcVM(ctx, vm)
 								Expect(err).ToNot(HaveOccurred())
+								Expect(vm.Status.Crypto).To(BeNil())
+
+								_, err = createOrUpdateAndGetVcVM(ctx, vm)
+								Expect(err).ToNot(HaveOccurred())
 								Expect(vm.Status.Crypto).ToNot(BeNil())
+
 								Expect(vm.Status.Crypto.Encrypted).To(HaveExactElements(
 									[]vmopv1.VirtualMachineEncryptionType{
 										vmopv1.VirtualMachineEncryptionTypeConfig,
@@ -1587,7 +1592,12 @@ func vmTests() {
 							It("should succeed", func() {
 								_, err := createOrUpdateAndGetVcVM(ctx, vm)
 								Expect(err).ToNot(HaveOccurred())
+								Expect(vm.Status.Crypto).To(BeNil())
+
+								_, err = createOrUpdateAndGetVcVM(ctx, vm)
+								Expect(err).ToNot(HaveOccurred())
 								Expect(vm.Status.Crypto).ToNot(BeNil())
+
 								Expect(vm.Status.Crypto.Encrypted).To(HaveExactElements(
 									[]vmopv1.VirtualMachineEncryptionType{
 										vmopv1.VirtualMachineEncryptionTypeConfig,
@@ -1609,7 +1619,12 @@ func vmTests() {
 						It("should succeed", func() {
 							_, err := createOrUpdateAndGetVcVM(ctx, vm)
 							Expect(err).ToNot(HaveOccurred())
+							Expect(vm.Status.Crypto).To(BeNil())
+
+							_, err = createOrUpdateAndGetVcVM(ctx, vm)
+							Expect(err).ToNot(HaveOccurred())
 							Expect(vm.Status.Crypto).ToNot(BeNil())
+
 							Expect(vm.Status.Crypto.Encrypted).To(HaveExactElements(
 								[]vmopv1.VirtualMachineEncryptionType{
 									vmopv1.VirtualMachineEncryptionTypeConfig,
@@ -1645,7 +1660,12 @@ func vmTests() {
 								It("should succeed", func() {
 									_, err := createOrUpdateAndGetVcVM(ctx, vm)
 									Expect(err).ToNot(HaveOccurred())
+									Expect(vm.Status.Crypto).To(BeNil())
+
+									_, err = createOrUpdateAndGetVcVM(ctx, vm)
+									Expect(err).ToNot(HaveOccurred())
 									Expect(vm.Status.Crypto).ToNot(BeNil())
+
 									Expect(vm.Status.Crypto.Encrypted).To(HaveExactElements(
 										[]vmopv1.VirtualMachineEncryptionType{
 											vmopv1.VirtualMachineEncryptionTypeConfig,
@@ -1691,7 +1711,12 @@ func vmTests() {
 							It("should succeed", func() {
 								_, err := createOrUpdateAndGetVcVM(ctx, vm)
 								Expect(err).ToNot(HaveOccurred())
+								Expect(vm.Status.Crypto).To(BeNil())
+
+								_, err = createOrUpdateAndGetVcVM(ctx, vm)
+								Expect(err).ToNot(HaveOccurred())
 								Expect(vm.Status.Crypto).ToNot(BeNil())
+
 								Expect(vm.Status.Crypto.Encrypted).To(HaveExactElements(
 									[]vmopv1.VirtualMachineEncryptionType{
 										vmopv1.VirtualMachineEncryptionTypeConfig,
@@ -1713,7 +1738,12 @@ func vmTests() {
 							It("should succeed", func() {
 								_, err := createOrUpdateAndGetVcVM(ctx, vm)
 								Expect(err).ToNot(HaveOccurred())
+								Expect(vm.Status.Crypto).To(BeNil())
+
+								_, err = createOrUpdateAndGetVcVM(ctx, vm)
+								Expect(err).ToNot(HaveOccurred())
 								Expect(vm.Status.Crypto).ToNot(BeNil())
+
 								Expect(vm.Status.Crypto.Encrypted).To(HaveExactElements(
 									[]vmopv1.VirtualMachineEncryptionType{
 										vmopv1.VirtualMachineEncryptionTypeConfig,
@@ -1736,7 +1766,12 @@ func vmTests() {
 						It("should succeed", func() {
 							_, err := createOrUpdateAndGetVcVM(ctx, vm)
 							Expect(err).ToNot(HaveOccurred())
+							Expect(vm.Status.Crypto).To(BeNil())
+
+							_, err = createOrUpdateAndGetVcVM(ctx, vm)
+							Expect(err).ToNot(HaveOccurred())
 							Expect(vm.Status.Crypto).ToNot(BeNil())
+
 							Expect(vm.Status.Crypto.Encrypted).To(HaveExactElements(
 								[]vmopv1.VirtualMachineEncryptionType{
 									vmopv1.VirtualMachineEncryptionTypeConfig,
@@ -1759,7 +1794,12 @@ func vmTests() {
 							It("should succeed", func() {
 								_, err := createOrUpdateAndGetVcVM(ctx, vm)
 								Expect(err).ToNot(HaveOccurred())
+								Expect(vm.Status.Crypto).To(BeNil())
+
+								_, err = createOrUpdateAndGetVcVM(ctx, vm)
+								Expect(err).ToNot(HaveOccurred())
 								Expect(vm.Status.Crypto).ToNot(BeNil())
+
 								Expect(vm.Status.Crypto.Encrypted).To(HaveExactElements(
 									[]vmopv1.VirtualMachineEncryptionType{
 										vmopv1.VirtualMachineEncryptionTypeConfig,

--- a/pkg/vmconfig/crypto/crypto_reconciler.go
+++ b/pkg/vmconfig/crypto/crypto_reconciler.go
@@ -63,8 +63,10 @@ func SprintfStateNotSynced(op string, msgs ...string) string {
 type Reason uint8
 
 const (
-	ReasonEncryptionClassNotFound Reason = 1 << iota
+	ReasonInternalError Reason = 1 << iota
+	ReasonEncryptionClassNotFound
 	ReasonEncryptionClassInvalid
+	ReasonNoDefaultKeyProvider
 	ReasonInvalidState
 	ReasonInvalidChanges
 	ReasonReconfigureError
@@ -77,10 +79,14 @@ func (r Reason) MaxValue() Reason {
 
 func (r Reason) StringValue() string {
 	switch r {
+	case ReasonInternalError:
+		return "InternalError"
 	case ReasonEncryptionClassNotFound:
 		return "EncryptionClassNotFound"
 	case ReasonEncryptionClassInvalid:
 		return "EncryptionClassInvalid"
+	case ReasonNoDefaultKeyProvider:
+		return "NoDefaultKeyProvider"
 	case ReasonInvalidState:
 		return "InvalidState"
 	case ReasonInvalidChanges:

--- a/pkg/vmconfig/crypto/crypto_reconciler_post_test.go
+++ b/pkg/vmconfig/crypto/crypto_reconciler_post_test.go
@@ -119,194 +119,26 @@ var _ = Describe("OnResult", Label(testlabels.Crypto), func() {
 			})
 		})
 
-		Context("succeeded", func() {
-			When("crypto was not involved", func() {
-				BeforeEach(func() {
-					internal.SetOperation(ctx, "updating unencrypted")
+		Context("with a soap error", func() {
+			BeforeEach(func() {
+				reconfigErr = soap.WrapSoapFault(&soap.Fault{
+					Detail: struct {
+						Fault vimtypes.AnyType "xml:\",any,typeattr\""
+					}{
+						Fault: nil,
+					},
 				})
-				When("vm does not already have crypto synced condition", func() {
-					BeforeEach(func() {
-						conditions.Delete(vm, vmopv1.VirtualMachineEncryptionSynced)
-					})
-					It("should leave the condition alone", func() {
-						Expect(err).ToNot(HaveOccurred())
-						Expect(conditions.Has(vm, vmopv1.VirtualMachineEncryptionSynced)).To(BeFalse())
-					})
-				})
-				When("vm does already have crypto synced condition", func() {
-					When("existing condition is true", func() {
-						BeforeEach(func() {
-							conditions.MarkTrue(vm, vmopv1.VirtualMachineEncryptionSynced)
-						})
-						It("should leave the condition alone", func() {
-							Expect(err).ToNot(HaveOccurred())
-							Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineEncryptionSynced)).To(BeTrue())
-						})
-					})
-					When("existing condition is false", func() {
-						BeforeEach(func() {
-							conditions.MarkFalse(vm, vmopv1.VirtualMachineEncryptionSynced, "fake", "fake")
-						})
-						It("should leave the condition alone", func() {
-							Expect(err).ToNot(HaveOccurred())
-							Expect(conditions.IsFalse(vm, vmopv1.VirtualMachineEncryptionSynced)).To(BeTrue())
-						})
-					})
-				})
-
-				When("status.crypto is not nil", func() {
-					BeforeEach(func() {
-						vm.Status.Crypto = &vmopv1.VirtualMachineCryptoStatus{
-							Encrypted: []vmopv1.VirtualMachineEncryptionType{
-								"invalid1",
-								"invalid2",
-							},
-							ProviderID: "invalid-provider-id",
-							KeyID:      "invalid-key-id",
-						}
-					})
-					When("vm is not encrypted", func() {
-						It("should clear status.crypto", func() {
-							Expect(vm.Status.Crypto).To(BeNil())
-						})
-					})
-					When("vm was already encrypted using storage class or vTPM", func() {
-						BeforeEach(func() {
-							moVM.Config.KeyId = &vimtypes.CryptoKeyId{
-								KeyId: "123",
-								ProviderId: &vimtypes.KeyProviderId{
-									Id: "abc",
-								},
-							}
-						})
-
-						When("vm is encrypted using storage class", func() {
-							BeforeEach(func() {
-								internal.MarkEncryptedStorageClass(ctx)
-							})
-							It("should update status.crypto", func() {
-								Expect(vm.Status.Crypto).ToNot(BeNil())
-								Expect(vm.Status.Crypto).To(Equal(&vmopv1.VirtualMachineCryptoStatus{
-									Encrypted: []vmopv1.VirtualMachineEncryptionType{
-										vmopv1.VirtualMachineEncryptionTypeConfig,
-										vmopv1.VirtualMachineEncryptionTypeDisks,
-									},
-									ProviderID: "abc",
-									KeyID:      "123",
-								}))
-							})
-						})
-						When("vm is encrypted using vTPM", func() {
-							BeforeEach(func() {
-								moVM.Config.Hardware.Device = []vimtypes.BaseVirtualDevice{
-									&vimtypes.VirtualTPM{},
-								}
-							})
-							It("should update status.crypto", func() {
-								Expect(vm.Status.Crypto).ToNot(BeNil())
-								Expect(vm.Status.Crypto).To(Equal(&vmopv1.VirtualMachineCryptoStatus{
-									Encrypted: []vmopv1.VirtualMachineEncryptionType{
-										vmopv1.VirtualMachineEncryptionTypeConfig,
-									},
-									ProviderID: "abc",
-									KeyID:      "123",
-								}))
-							})
-						})
-					})
-				})
-
 			})
-			When("crypto was involved", func() {
-				BeforeEach(func() {
-					internal.SetOperation(ctx, "encrypting")
-				})
-				When("vm does not already have crypto synced condition", func() {
-					BeforeEach(func() {
-						conditions.Delete(vm, vmopv1.VirtualMachineEncryptionSynced)
-					})
-					It("should set the condition to true", func() {
-						Expect(err).ToNot(HaveOccurred())
-						Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineEncryptionSynced)).To(BeTrue())
-					})
-				})
-				When("vm does already have crypto synced condition", func() {
-					When("existing condition is true", func() {
-						BeforeEach(func() {
-							conditions.MarkTrue(vm, vmopv1.VirtualMachineEncryptionSynced)
-						})
-						It("should set the condition to true", func() {
-							Expect(err).ToNot(HaveOccurred())
-							Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineEncryptionSynced)).To(BeTrue())
-						})
-					})
-					When("existing condition is false", func() {
-						BeforeEach(func() {
-							conditions.MarkFalse(vm, vmopv1.VirtualMachineEncryptionSynced, "fake", "fake")
-						})
-						It("should set the condition to true", func() {
-							Expect(err).ToNot(HaveOccurred())
-							Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineEncryptionSynced)).To(BeTrue())
-						})
-					})
-				})
-				When("vm was encrypted using storage class or vTPM", func() {
-					BeforeEach(func() {
-						moVM.Config.KeyId = &vimtypes.CryptoKeyId{
-							KeyId: "123",
-							ProviderId: &vimtypes.KeyProviderId{
-								Id: "abc",
-							},
-						}
-					})
-
-					When("vm was encrypted using storage class", func() {
-						BeforeEach(func() {
-							internal.MarkEncryptedStorageClass(ctx)
-						})
-						It("should set status.crypto", func() {
-							Expect(vm.Status.Crypto).ToNot(BeNil())
-							Expect(vm.Status.Crypto).To(Equal(&vmopv1.VirtualMachineCryptoStatus{
-								Encrypted: []vmopv1.VirtualMachineEncryptionType{
-									vmopv1.VirtualMachineEncryptionTypeConfig,
-									vmopv1.VirtualMachineEncryptionTypeDisks,
-								},
-								ProviderID: "abc",
-								KeyID:      "123",
-							}))
-						})
-					})
-					When("vm was encrypted using vTPM", func() {
-						BeforeEach(func() {
-							moVM.Config.Hardware.Device = []vimtypes.BaseVirtualDevice{
-								&vimtypes.VirtualTPM{},
-							}
-						})
-						It("should set status.crypto", func() {
-							Expect(vm.Status.Crypto).ToNot(BeNil())
-							Expect(vm.Status.Crypto).To(Equal(&vmopv1.VirtualMachineCryptoStatus{
-								Encrypted: []vmopv1.VirtualMachineEncryptionType{
-									vmopv1.VirtualMachineEncryptionTypeConfig,
-								},
-								ProviderID: "abc",
-								KeyID:      "123",
-							}))
-						})
-					})
-				})
+			It("should not return an error or set any conditions", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(conditions.Has(vm, vmopv1.VirtualMachineEncryptionSynced)).To(BeFalse())
 			})
 		})
 
-		When("failed", func() {
-			Context("with a soap error", func() {
+		Context("with a task error", func() {
+			Context("and is a nil LocalizedMethodFault", func() {
 				BeforeEach(func() {
-					reconfigErr = soap.WrapSoapFault(&soap.Fault{
-						Detail: struct {
-							Fault vimtypes.AnyType "xml:\",any,typeattr\""
-						}{
-							Fault: nil,
-						},
-					})
+					reconfigErr = task.Error{}
 				})
 				It("should not return an error or set any conditions", func() {
 					Expect(err).ToNot(HaveOccurred())
@@ -314,251 +146,274 @@ var _ = Describe("OnResult", Label(testlabels.Crypto), func() {
 				})
 			})
 
-			Context("with a task error", func() {
-				Context("and is a nil LocalizedMethodFault", func() {
-					BeforeEach(func() {
-						reconfigErr = task.Error{}
-					})
-					It("should not return an error or set any conditions", func() {
-						Expect(err).ToNot(HaveOccurred())
-						Expect(conditions.Has(vm, vmopv1.VirtualMachineEncryptionSynced)).To(BeFalse())
-					})
+			Context("and is an unknown fault", func() {
+				BeforeEach(func() {
+					reconfigErr = task.Error{
+						LocalizedMethodFault: &vimtypes.LocalizedMethodFault{},
+					}
 				})
+				It("should not return an error or set any conditions", func() {
+					Expect(err).ToNot(HaveOccurred())
+					Expect(conditions.Has(vm, vmopv1.VirtualMachineEncryptionSynced)).To(BeFalse())
+				})
+			})
 
-				Context("and is an unknown fault", func() {
+			DescribeTable("and is a single, known fault",
+				func(
+					currentCryptoState *vimtypes.CryptoKeyId,
+					operation string,
+					fault vimtypes.BaseMethodFault,
+					expectedConditionMessage,
+					localizedMessage string,
+					msgKeys []string) {
+
+					vm := &vmopv1.VirtualMachine{}
+
+					mf := fault.GetMethodFault()
+					for i := range msgKeys {
+						mf.FaultMessage = append(
+							mf.FaultMessage,
+							vimtypes.LocalizableMessage{
+								Key: msgKeys[i],
+							})
+					}
+
+					internal.SetOperation(ctx, operation)
+
+					Expect(r.OnResult(
+						ctx,
+						vm,
+						mo.VirtualMachine{
+							Config: &vimtypes.VirtualMachineConfigInfo{
+								KeyId: currentCryptoState,
+							},
+						},
+						task.Error{
+							LocalizedMethodFault: &vimtypes.LocalizedMethodFault{
+								Fault:            fault,
+								LocalizedMessage: localizedMessage,
+							},
+						})).To(Succeed())
+
+					assertStateNotSynced(vm, expectedConditionMessage)
+				},
+
+				joinTableEntries(
+					getMethodFaultTableEntries(
+						func() vimtypes.BaseMethodFault { return &vimtypes.GenericVmConfigFault{} },
+						"specify a valid key",
+						"",
+						"msg.vigor.enc.keyNotFound",
+					),
+
+					getMethodFaultTableEntries(
+						func() vimtypes.BaseMethodFault { return &vimtypes.GenericVmConfigFault{} },
+						"specify a key that can be located",
+						"",
+						"msg.keysafe.locator",
+					),
+					getMethodFaultTableEntries(
+						func() vimtypes.BaseMethodFault { return &vimtypes.GenericVmConfigFault{} },
+						"add vTPM",
+						"",
+						"msg.vtpm.add.notEncrypted",
+					),
+					getMethodFaultTableEntries(
+						func() vimtypes.BaseMethodFault { return &vimtypes.GenericVmConfigFault{} },
+						"have vTPM",
+						"",
+						"msg.vigor.enc.required.vtpm",
+					),
+					getMethodFaultTableEntries(
+						func() vimtypes.BaseMethodFault { return &vimtypes.GenericVmConfigFault{} },
+						"specify a valid key and specify a key that can be located",
+						"",
+						"msg.vigor.enc.keyNotFound",
+						"msg.keysafe.locator",
+					),
+					getMethodFaultTableEntries(
+						func() vimtypes.BaseMethodFault { return &vimtypes.GenericVmConfigFault{} },
+						"specify a valid key, specify a key that can be located, and add vTPM",
+						"",
+						"msg.vigor.enc.keyNotFound",
+						"msg.keysafe.locator",
+						"msg.vtpm.add.notEncrypted",
+					),
+
+					getMethodFaultTableEntries(
+						func() vimtypes.BaseMethodFault { return &vimtypes.SystemError{} },
+						"specify a valid key",
+						"Error creating disk Key locator",
+					),
+					getMethodFaultTableEntries(
+						func() vimtypes.BaseMethodFault { return &vimtypes.SystemError{} },
+						"specify a key that can be located",
+						"Key locator error",
+					),
+					getMethodFaultTableEntries(
+						func() vimtypes.BaseMethodFault { return &vimtypes.SystemError{} },
+						"not specify encryption bundle",
+						"Key required for encryption.bundle.",
+					),
+
+					getMethodFaultTableEntries(
+						func() vimtypes.BaseMethodFault { return &vimtypes.NotSupported{} },
+						"not have encryption IO filter",
+						"",
+						"msg.disk.policyChangeFailure",
+					),
+
+					getMethodFaultTableEntries(
+						func() vimtypes.BaseMethodFault { return &vimtypes.InvalidDeviceOperation{} },
+						"not specify encrypted disk",
+						"",
+						"msg.hostd.deviceSpec.enc.encrypted",
+					),
+					getMethodFaultTableEntries(
+						func() vimtypes.BaseMethodFault { return &vimtypes.InvalidDeviceOperation{} },
+						"not specify decrypted disk",
+						"",
+						"msg.hostd.deviceSpec.enc.notEncrypted",
+					),
+					getMethodFaultTableEntries(
+						func() vimtypes.BaseMethodFault { return &vimtypes.InvalidDeviceOperation{} },
+						"not add/remove device sans crypto spec",
+						"",
+						"fake.msg.id",
+					),
+
+					getMethodFaultTableEntries(
+						func() vimtypes.BaseMethodFault { return &vimtypes.InvalidArgument{} },
+						"not set secret key",
+						"",
+						"config.extraConfig[\"dataFileKey\"]",
+					),
+
+					getMethodFaultTableEntries(
+						func() vimtypes.BaseMethodFault { return &vimtypes.InvalidDeviceSpec{} },
+						"have encryption IO filter",
+						"",
+						"msg.hostd.deviceSpec.enc.badPolicy",
+					),
+					getMethodFaultTableEntries(
+						func() vimtypes.BaseMethodFault { return &vimtypes.InvalidDeviceSpec{} },
+						"not apply only to disk",
+						"",
+						"msg.hostd.deviceSpec.enc.notDisk",
+					),
+					getMethodFaultTableEntries(
+						func() vimtypes.BaseMethodFault { return &vimtypes.InvalidDeviceSpec{} },
+						"not have disk with shared backing",
+						"",
+						"msg.hostd.deviceSpec.enc.sharedBacking",
+					),
+					getMethodFaultTableEntries(
+						func() vimtypes.BaseMethodFault { return &vimtypes.InvalidDeviceSpec{} },
+						"not have raw disk mapping",
+						"",
+						"msg.hostd.deviceSpec.enc.notFile",
+					),
+					getMethodFaultTableEntries(
+						func() vimtypes.BaseMethodFault { return &vimtypes.InvalidDeviceSpec{} },
+						"not add encrypted disk",
+						"",
+						"msg.hostd.configSpec.enc.mismatch",
+					),
+					getMethodFaultTableEntries(
+						func() vimtypes.BaseMethodFault { return &vimtypes.InvalidDeviceSpec{} },
+						"not add plain disk",
+						"",
+						"msg.hostd.deviceSpec.add.noencrypt",
+					),
+
+					getMethodFaultTableEntries(
+						func() vimtypes.BaseMethodFault { return &vimtypes.InvalidVmConfig{} },
+						"not have snapshots",
+						"",
+						"msg.hostd.configSpec.enc.snapshots",
+					),
+					getMethodFaultTableEntries(
+						func() vimtypes.BaseMethodFault { return &vimtypes.InvalidVmConfig{} },
+						"not have only disk snapshots",
+						"",
+						"msg.hostd.deviceSpec.enc.diskChain",
+					),
+					getMethodFaultTableEntries(
+						func() vimtypes.BaseMethodFault { return &vimtypes.InvalidVmConfig{} },
+						"not be encrypted",
+						"",
+						"msg.hostd.configSpec.enc.notEncrypted",
+					),
+					getMethodFaultTableEntries(
+						func() vimtypes.BaseMethodFault { return &vimtypes.InvalidVmConfig{} },
+						"be encrypted",
+						"",
+						"msg.hostd.configSpec.enc.encrypted",
+					),
+					getMethodFaultTableEntries(
+						func() vimtypes.BaseMethodFault { return &vimtypes.InvalidVmConfig{} },
+						"have vm and disks with different encryption states",
+						"",
+						"msg.hostd.configSpec.enc.mismatch",
+					),
+				),
+			)
+
+			Context("and is multiple, known faults", func() {
+				BeforeEach(func() {
+					internal.SetOperation(ctx, "updating unencrypted")
+				})
+				When("there are two faults", func() {
 					BeforeEach(func() {
 						reconfigErr = task.Error{
-							LocalizedMethodFault: &vimtypes.LocalizedMethodFault{},
-						}
-					})
-					It("should not return an error or set any conditions", func() {
-						Expect(err).ToNot(HaveOccurred())
-						Expect(conditions.Has(vm, vmopv1.VirtualMachineEncryptionSynced)).To(BeFalse())
-					})
-				})
-
-				DescribeTable("and is a single, known fault",
-					func(
-						currentCryptoState *vimtypes.CryptoKeyId,
-						operation string,
-						fault vimtypes.BaseMethodFault,
-						expectedConditionMessage,
-						localizedMessage string,
-						msgKeys []string) {
-
-						vm := &vmopv1.VirtualMachine{}
-
-						mf := fault.GetMethodFault()
-						for i := range msgKeys {
-							mf.FaultMessage = append(
-								mf.FaultMessage,
-								vimtypes.LocalizableMessage{
-									Key: msgKeys[i],
-								})
-						}
-
-						internal.SetOperation(ctx, operation)
-
-						Expect(r.OnResult(
-							ctx,
-							vm,
-							mo.VirtualMachine{
-								Config: &vimtypes.VirtualMachineConfigInfo{
-									KeyId: currentCryptoState,
+							LocalizedMethodFault: &vimtypes.LocalizedMethodFault{
+								LocalizedMessage: "Key locator error",
+								Fault: &vimtypes.SystemError{
+									RuntimeFault: vimtypes.RuntimeFault{
+										MethodFault: vimtypes.MethodFault{
+											FaultCause: &vimtypes.LocalizedMethodFault{
+												Fault: &vimtypes.NotSupported{
+													RuntimeFault: vimtypes.RuntimeFault{
+														MethodFault: vimtypes.MethodFault{
+															FaultMessage: []vimtypes.LocalizableMessage{
+																{
+																	Key: "msg.disk.policyChangeFailure",
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
 								},
 							},
-							task.Error{
-								LocalizedMethodFault: &vimtypes.LocalizedMethodFault{
-									Fault:            fault,
-									LocalizedMessage: localizedMessage,
-								},
-							})).To(Succeed())
-
-						assertStateNotSynced(vm, expectedConditionMessage)
-					},
-
-					joinTableEntries(
-						getMethodFaultTableEntries(
-							func() vimtypes.BaseMethodFault { return &vimtypes.GenericVmConfigFault{} },
-							"specify a valid key",
-							"",
-							"msg.vigor.enc.keyNotFound",
-						),
-
-						getMethodFaultTableEntries(
-							func() vimtypes.BaseMethodFault { return &vimtypes.GenericVmConfigFault{} },
-							"specify a key that can be located",
-							"",
-							"msg.keysafe.locator",
-						),
-						getMethodFaultTableEntries(
-							func() vimtypes.BaseMethodFault { return &vimtypes.GenericVmConfigFault{} },
-							"add vTPM",
-							"",
-							"msg.vtpm.add.notEncrypted",
-						),
-						getMethodFaultTableEntries(
-							func() vimtypes.BaseMethodFault { return &vimtypes.GenericVmConfigFault{} },
-							"have vTPM",
-							"",
-							"msg.vigor.enc.required.vtpm",
-						),
-						getMethodFaultTableEntries(
-							func() vimtypes.BaseMethodFault { return &vimtypes.GenericVmConfigFault{} },
-							"specify a valid key and specify a key that can be located",
-							"",
-							"msg.vigor.enc.keyNotFound",
-							"msg.keysafe.locator",
-						),
-						getMethodFaultTableEntries(
-							func() vimtypes.BaseMethodFault { return &vimtypes.GenericVmConfigFault{} },
-							"specify a valid key, specify a key that can be located, and add vTPM",
-							"",
-							"msg.vigor.enc.keyNotFound",
-							"msg.keysafe.locator",
-							"msg.vtpm.add.notEncrypted",
-						),
-
-						getMethodFaultTableEntries(
-							func() vimtypes.BaseMethodFault { return &vimtypes.SystemError{} },
-							"specify a valid key",
-							"Error creating disk Key locator",
-						),
-						getMethodFaultTableEntries(
-							func() vimtypes.BaseMethodFault { return &vimtypes.SystemError{} },
-							"specify a key that can be located",
-							"Key locator error",
-						),
-						getMethodFaultTableEntries(
-							func() vimtypes.BaseMethodFault { return &vimtypes.SystemError{} },
-							"not specify encryption bundle",
-							"Key required for encryption.bundle.",
-						),
-
-						getMethodFaultTableEntries(
-							func() vimtypes.BaseMethodFault { return &vimtypes.NotSupported{} },
-							"not have encryption IO filter",
-							"",
-							"msg.disk.policyChangeFailure",
-						),
-
-						getMethodFaultTableEntries(
-							func() vimtypes.BaseMethodFault { return &vimtypes.InvalidDeviceOperation{} },
-							"not specify encrypted disk",
-							"",
-							"msg.hostd.deviceSpec.enc.encrypted",
-						),
-						getMethodFaultTableEntries(
-							func() vimtypes.BaseMethodFault { return &vimtypes.InvalidDeviceOperation{} },
-							"not specify decrypted disk",
-							"",
-							"msg.hostd.deviceSpec.enc.notEncrypted",
-						),
-						getMethodFaultTableEntries(
-							func() vimtypes.BaseMethodFault { return &vimtypes.InvalidDeviceOperation{} },
-							"not add/remove device sans crypto spec",
-							"",
-							"fake.msg.id",
-						),
-
-						getMethodFaultTableEntries(
-							func() vimtypes.BaseMethodFault { return &vimtypes.InvalidArgument{} },
-							"not set secret key",
-							"",
-							"config.extraConfig[\"dataFileKey\"]",
-						),
-
-						getMethodFaultTableEntries(
-							func() vimtypes.BaseMethodFault { return &vimtypes.InvalidDeviceSpec{} },
-							"have encryption IO filter",
-							"",
-							"msg.hostd.deviceSpec.enc.badPolicy",
-						),
-						getMethodFaultTableEntries(
-							func() vimtypes.BaseMethodFault { return &vimtypes.InvalidDeviceSpec{} },
-							"not apply only to disk",
-							"",
-							"msg.hostd.deviceSpec.enc.notDisk",
-						),
-						getMethodFaultTableEntries(
-							func() vimtypes.BaseMethodFault { return &vimtypes.InvalidDeviceSpec{} },
-							"not have disk with shared backing",
-							"",
-							"msg.hostd.deviceSpec.enc.sharedBacking",
-						),
-						getMethodFaultTableEntries(
-							func() vimtypes.BaseMethodFault { return &vimtypes.InvalidDeviceSpec{} },
-							"not have raw disk mapping",
-							"",
-							"msg.hostd.deviceSpec.enc.notFile",
-						),
-						getMethodFaultTableEntries(
-							func() vimtypes.BaseMethodFault { return &vimtypes.InvalidDeviceSpec{} },
-							"not add encrypted disk",
-							"",
-							"msg.hostd.configSpec.enc.mismatch",
-						),
-						getMethodFaultTableEntries(
-							func() vimtypes.BaseMethodFault { return &vimtypes.InvalidDeviceSpec{} },
-							"not add plain disk",
-							"",
-							"msg.hostd.deviceSpec.add.noencrypt",
-						),
-
-						getMethodFaultTableEntries(
-							func() vimtypes.BaseMethodFault { return &vimtypes.InvalidVmConfig{} },
-							"not have snapshots",
-							"",
-							"msg.hostd.configSpec.enc.snapshots",
-						),
-						getMethodFaultTableEntries(
-							func() vimtypes.BaseMethodFault { return &vimtypes.InvalidVmConfig{} },
-							"not have only disk snapshots",
-							"",
-							"msg.hostd.deviceSpec.enc.diskChain",
-						),
-						getMethodFaultTableEntries(
-							func() vimtypes.BaseMethodFault { return &vimtypes.InvalidVmConfig{} },
-							"not be encrypted",
-							"",
-							"msg.hostd.configSpec.enc.notEncrypted",
-						),
-						getMethodFaultTableEntries(
-							func() vimtypes.BaseMethodFault { return &vimtypes.InvalidVmConfig{} },
-							"be encrypted",
-							"",
-							"msg.hostd.configSpec.enc.encrypted",
-						),
-						getMethodFaultTableEntries(
-							func() vimtypes.BaseMethodFault { return &vimtypes.InvalidVmConfig{} },
-							"have vm and disks with different encryption states",
-							"",
-							"msg.hostd.configSpec.enc.mismatch",
-						),
-					),
-				)
-
-				Context("and is multiple, known faults", func() {
+						}
+					})
+					It("should return nil error and set a condition with the expected message", func() {
+						Expect(err).ToNot(HaveOccurred())
+						assertStateNotSynced(vm, "Must specify a key that can be located and not have encryption IO filter when updating unencrypted vm")
+					})
+				})
+				When("there are three faults", func() {
 					BeforeEach(func() {
-						internal.SetOperation(ctx, "updating unencrypted")
-					})
-					When("there are two faults", func() {
-						BeforeEach(func() {
-							reconfigErr = task.Error{
-								LocalizedMethodFault: &vimtypes.LocalizedMethodFault{
-									LocalizedMessage: "Key locator error",
-									Fault: &vimtypes.SystemError{
-										RuntimeFault: vimtypes.RuntimeFault{
-											MethodFault: vimtypes.MethodFault{
-												FaultCause: &vimtypes.LocalizedMethodFault{
-													Fault: &vimtypes.NotSupported{
-														RuntimeFault: vimtypes.RuntimeFault{
-															MethodFault: vimtypes.MethodFault{
-																FaultMessage: []vimtypes.LocalizableMessage{
-																	{
-																		Key: "msg.disk.policyChangeFailure",
-																	},
+						reconfigErr = task.Error{
+							LocalizedMethodFault: &vimtypes.LocalizedMethodFault{
+								LocalizedMessage: "Key locator error",
+								Fault: &vimtypes.SystemError{
+									RuntimeFault: vimtypes.RuntimeFault{
+										MethodFault: vimtypes.MethodFault{
+											FaultCause: &vimtypes.LocalizedMethodFault{
+												Fault: &vimtypes.NotSupported{
+													RuntimeFault: vimtypes.RuntimeFault{
+														MethodFault: vimtypes.MethodFault{
+															FaultMessage: []vimtypes.LocalizableMessage{
+																{
+																	Key: "msg.disk.policyChangeFailure",
 																},
+															},
+															FaultCause: &vimtypes.LocalizedMethodFault{
+																Fault: &vimtypes.InvalidPowerState{},
 															},
 														},
 													},
@@ -567,47 +422,12 @@ var _ = Describe("OnResult", Label(testlabels.Crypto), func() {
 										},
 									},
 								},
-							}
-						})
-						It("should return nil error and set a condition with the expected message", func() {
-							Expect(err).ToNot(HaveOccurred())
-							assertStateNotSynced(vm, "Must specify a key that can be located and not have encryption IO filter when updating unencrypted vm")
-						})
+							},
+						}
 					})
-					When("there are three faults", func() {
-						BeforeEach(func() {
-							reconfigErr = task.Error{
-								LocalizedMethodFault: &vimtypes.LocalizedMethodFault{
-									LocalizedMessage: "Key locator error",
-									Fault: &vimtypes.SystemError{
-										RuntimeFault: vimtypes.RuntimeFault{
-											MethodFault: vimtypes.MethodFault{
-												FaultCause: &vimtypes.LocalizedMethodFault{
-													Fault: &vimtypes.NotSupported{
-														RuntimeFault: vimtypes.RuntimeFault{
-															MethodFault: vimtypes.MethodFault{
-																FaultMessage: []vimtypes.LocalizableMessage{
-																	{
-																		Key: "msg.disk.policyChangeFailure",
-																	},
-																},
-																FaultCause: &vimtypes.LocalizedMethodFault{
-																	Fault: &vimtypes.InvalidPowerState{},
-																},
-															},
-														},
-													},
-												},
-											},
-										},
-									},
-								},
-							}
-						})
-						It("should return nil error and set a condition with the expected message", func() {
-							Expect(err).ToNot(HaveOccurred())
-							assertStateNotSynced(vm, "Must specify a key that can be located, not have encryption IO filter, and be powered off when updating unencrypted vm")
-						})
+					It("should return nil error and set a condition with the expected message", func() {
+						Expect(err).ToNot(HaveOccurred())
+						assertStateNotSynced(vm, "Must specify a key that can be located, not have encryption IO filter, and be powered off when updating unencrypted vm")
 					})
 				})
 			})

--- a/pkg/vmconfig/crypto/internal/crypto_reconciler_context.go
+++ b/pkg/vmconfig/crypto/internal/crypto_reconciler_context.go
@@ -14,8 +14,7 @@ type ContextKeyType uint8
 const ContextKeyValue ContextKeyType = 0
 
 type State struct {
-	Operation      string
-	IsEncStorClass bool
+	Operation string
 }
 
 func FromContext(ctx context.Context) State {
@@ -33,16 +32,6 @@ func SetOperation(ctx context.Context, op string) {
 		ContextKeyValue,
 		func(val State) State {
 			val.Operation = op
-			return val
-		})
-}
-
-func MarkEncryptedStorageClass(ctx context.Context) {
-	ctxgen.SetContext(
-		ctx,
-		ContextKeyValue,
-		func(val State) State {
-			val.IsEncStorClass = true
 			return val
 		})
 }


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**
 
This patch adds several fixes/updates for the BYOK feature:
    
* Support for deploying unencrypted VMs with default key provider

    This patch adds support for deploying unencrypted VMs even when there is a default key provider present on the system. This is a change from the previous behavior that would disallow deploying a VM on a non-encryption storage class or sans vTPM if there was a default key provider present. This would in effect enforce the need for encryption and its requirements. This patch treats new VMs as special and allows it to skip encryption IFF:
    
    - the discovered provider is the default
    - there is no vTPM
    - the storage class does not support encryption
    
* Fixes a bug where a VM encrypted with the default key provider would get rekeyed over and over and over again.
* Fixes a bug where the wrong ConfigSpec was being updated when creating a VM.



**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```