### PR TITLE
🐛 Fix validate classless vm on update

### DIFF
--- a/webhooks/virtualmachine/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator.go
@@ -418,7 +418,18 @@ func (v validator) validateClassOnUpdate(ctx *pkgctx.WebhookRequestContext, vm, 
 	}
 
 	if vm.Spec.ClassName == "" {
-		allErrs = append(allErrs, field.Required(field.NewPath("spec", "className"), ""))
+		if pkgcfg.FromContext(ctx).Features.VMImportNewNet {
+			if !ctx.IsPrivilegedAccount {
+				// Restrict creating classless VM resources to privileged users.
+				allErrs = append(
+					allErrs,
+					field.Required(field.NewPath("spec", "className"), ""))
+			}
+		} else {
+			allErrs = append(
+				allErrs,
+				field.Required(field.NewPath("spec", "className"), ""))
+		}
 	}
 
 	return allErrs


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch fixes the validation webhook for updating classless VMs. The enabling of the Resize CPU FSS caused this validation to fail for importing classless VMs since the VM controller uses the deferred patch helper. The patch helper was failing to patch VMs with no class since the validation webhook prevented patches with empty class names.



**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```