### PR TITLE
:bug: Fix typo in kubebuilder annotation for manager ClusterRole

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -42,7 +42,7 @@ rules:
 - apiGroups:
   - admissionregistration.k8s.io
   resources:
-  - validatingwebhookconfiguration
+  - validatingwebhookconfigurations
   verbs:
   - get
   - list

--- a/controllers/infra/validatingwebhookconfiguration/validatingwebhookconfiguration_controller.go
+++ b/controllers/infra/validatingwebhookconfiguration/validatingwebhookconfiguration_controller.go
@@ -94,7 +94,7 @@ type Reconciler struct {
 	Recorder record.Recorder
 }
 
-// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfiguration,verbs=get;list;watch
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=get;list;watch
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
 	ctx = pkgcfg.JoinContext(ctx, r.Context)


### PR DESCRIPTION


**What does this PR do, and why is it needed?**

This PR fixes a typo in the kubebuilder annotation in `validatingwebhookconfiguration_controller` that will cause manager pods to go into `CrashLoopBackOff`


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

**Please add a release note if necessary**:


```release-note
NONE
```