### PR TITLE
🌱 Disallow PVCs with WaitForFirstConsumer StorageClass

### DIFF
--- a/controllers/virtualmachine/volume/volume_controller.go
+++ b/controllers/virtualmachine/volume/volume_controller.go
@@ -742,7 +742,7 @@ func (r *Reconciler) processAttachments(
 	// still exist are included in the Status. This is more than a little odd.
 	volumeStatuses = append(volumeStatuses, r.preserveOrphanedAttachmentStatus(ctx, orphanedAttachments)...)
 
-	// Remove any managed volumes volumes from the existing status.
+	// Remove any managed volumes from the existing status.
 	ctx.VM.Status.Volumes = slices.DeleteFunc(ctx.VM.Status.Volumes,
 		func(e vmopv1.VirtualMachineVolumeStatus) bool {
 			return e.Type != vmopv1.VirtualMachineStorageDiskTypeClassic

--- a/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
@@ -1219,6 +1219,64 @@ func unitTestsValidateCreate() {
 		})
 	})
 
+	Context("Volumes", func() {
+		DescribeTable("PVC with StorageClass",
+			doTest,
+			Entry("Immediate",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						sc := builder.DummyStorageClass()
+						sc.VolumeBindingMode = ptr.To(storagev1.VolumeBindingImmediate)
+						Expect(ctx.Client.Create(ctx, sc)).To(Succeed())
+						pvc := builder.DummyPersistentVolumeClaim()
+						pvc.Namespace = ctx.vm.Namespace
+						pvc.Spec.StorageClassName = &sc.Name
+						Expect(ctx.Client.Create(ctx, pvc)).To(Succeed())
+
+						ctx.vm.Spec.Volumes = append(ctx.vm.Spec.Volumes, vmopv1.VirtualMachineVolume{
+							Name: "test-vol",
+							VirtualMachineVolumeSource: vmopv1.VirtualMachineVolumeSource{
+								PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
+									PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+										ClaimName: pvc.Name,
+									},
+								},
+							},
+						})
+					},
+					expectAllowed: true,
+				},
+			),
+
+			Entry("WaitForFirstConsumer",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						sc := builder.DummyStorageClass()
+						sc.VolumeBindingMode = ptr.To(storagev1.VolumeBindingWaitForFirstConsumer)
+						Expect(ctx.Client.Create(ctx, sc)).To(Succeed())
+						pvc := builder.DummyPersistentVolumeClaim()
+						pvc.Namespace = ctx.vm.Namespace
+						pvc.Spec.StorageClassName = &sc.Name
+						Expect(ctx.Client.Create(ctx, pvc)).To(Succeed())
+
+						ctx.vm.Spec.Volumes = append(ctx.vm.Spec.Volumes, vmopv1.VirtualMachineVolume{
+							Name: "test-vol",
+							VirtualMachineVolumeSource: vmopv1.VirtualMachineVolumeSource{
+								PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
+									PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+										ClaimName: pvc.Name,
+									},
+								},
+							},
+						})
+					},
+					validate: doValidateWithMsg(
+						`spec.volumes[1].persistentVolumeClaim: Forbidden: PVC with WaitForFirstConsumer StorageClass is not supported for VirtualMachines`),
+				},
+			),
+		)
+	})
+
 	Context("Bootstrap", func() {
 
 		DescribeTable("bootstrap create", doTest,
@@ -3539,6 +3597,64 @@ func unitTestsValidateUpdate() {
 			},
 		),
 	)
+
+	Context("Volumes", func() {
+		DescribeTable("PVC with StorageClass",
+			doTest,
+			Entry("Immediate",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						sc := builder.DummyStorageClass()
+						sc.VolumeBindingMode = ptr.To(storagev1.VolumeBindingImmediate)
+						Expect(ctx.Client.Create(ctx, sc)).To(Succeed())
+						pvc := builder.DummyPersistentVolumeClaim()
+						pvc.Namespace = ctx.vm.Namespace
+						pvc.Spec.StorageClassName = &sc.Name
+						Expect(ctx.Client.Create(ctx, pvc)).To(Succeed())
+
+						ctx.vm.Spec.Volumes = append(ctx.vm.Spec.Volumes, vmopv1.VirtualMachineVolume{
+							Name: "test-vol",
+							VirtualMachineVolumeSource: vmopv1.VirtualMachineVolumeSource{
+								PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
+									PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+										ClaimName: pvc.Name,
+									},
+								},
+							},
+						})
+					},
+					expectAllowed: true,
+				},
+			),
+
+			Entry("WaitForFirstConsumer",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						sc := builder.DummyStorageClass()
+						sc.VolumeBindingMode = ptr.To(storagev1.VolumeBindingWaitForFirstConsumer)
+						Expect(ctx.Client.Create(ctx, sc)).To(Succeed())
+						pvc := builder.DummyPersistentVolumeClaim()
+						pvc.Namespace = ctx.vm.Namespace
+						pvc.Spec.StorageClassName = &sc.Name
+						Expect(ctx.Client.Create(ctx, pvc)).To(Succeed())
+
+						ctx.vm.Spec.Volumes = append(ctx.vm.Spec.Volumes, vmopv1.VirtualMachineVolume{
+							Name: "test-vol",
+							VirtualMachineVolumeSource: vmopv1.VirtualMachineVolumeSource{
+								PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
+									PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+										ClaimName: pvc.Name,
+									},
+								},
+							},
+						})
+					},
+					validate: doValidateWithMsg(
+						`spec.volumes[1].persistentVolumeClaim: Forbidden: PVC with WaitForFirstConsumer StorageClass is not supported for VirtualMachines`),
+				},
+			),
+		)
+	})
 }
 
 func unitTestsValidateDelete() {


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

CSI does not support this for VMs at the moment since it does not wait for VMs to be placed. CSI doesn't produce a very helpful error message for this condition, and there is an ask to provide immediate feedback so put this best-effort check in the validation webhook.

This uses field. Forbidden instead of field.NotSupported since the later does not take a string to provide a useful error message.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #

**Are there any special notes for your reviewer**:

Temp/quick fix - I'm not otherwise a huge fan of this being here

**Please add a release note if necessary**:

```release-note
PVCs with a WaitForFirstConsumer StorageClass are not supported for VirtualMachines.
```