### PR TITLE
🐛 Fix how crypto detects device sans policy

### DIFF
--- a/pkg/vmconfig/crypto/crypto_reconciler_pre_test.go
+++ b/pkg/vmconfig/crypto/crypto_reconciler_pre_test.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/vmware/govmomi/crypto"
+	"github.com/vmware/govmomi/pbm/simulator"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/mo"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
@@ -172,6 +173,9 @@ var _ = Describe("Reconcile", Label(testlabels.Crypto), func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "my-storage-class-2",
 				UID:  types.UID(uuid.NewString()),
+			},
+			Parameters: map[string]string{
+				"storagePolicyID": simulator.DefaultEncryptionProfileID,
 			},
 		}
 
@@ -735,6 +739,11 @@ var _ = Describe("Reconcile", Label(testlabels.Crypto), func() {
 										},
 										Device:    &vimtypes.VirtualDisk{},
 										Operation: vimtypes.VirtualDeviceConfigSpecOperationAdd,
+										Profile: []vimtypes.BaseVirtualMachineProfileSpec{
+											&vimtypes.VirtualMachineDefinedProfileSpec{
+												ProfileId: "fake",
+											},
+										},
 									},
 								}
 							})
@@ -759,10 +768,7 @@ var _ = Describe("Reconcile", Label(testlabels.Crypto), func() {
 										Operation: vimtypes.VirtualDeviceConfigSpecOperationAdd,
 										Profile: []vimtypes.BaseVirtualMachineProfileSpec{
 											&vimtypes.VirtualMachineDefinedProfileSpec{
-												ProfileData: &vimtypes.VirtualMachineProfileRawData{
-													ExtensionKey: "com.vmware.vim.sips",
-													ObjectData:   profileWithIOFilters,
-												},
+												ProfileId: simulator.DefaultEncryptionProfileID,
 											},
 										},
 									},
@@ -833,10 +839,7 @@ var _ = Describe("Reconcile", Label(testlabels.Crypto), func() {
 											Operation: vimtypes.VirtualDeviceConfigSpecOperationAdd,
 											Profile: []vimtypes.BaseVirtualMachineProfileSpec{
 												&vimtypes.VirtualMachineDefinedProfileSpec{
-													ProfileData: &vimtypes.VirtualMachineProfileRawData{
-														ExtensionKey: "com.vmware.vim.sips",
-														ObjectData:   profileWithIOFilters,
-													},
+													ProfileId: simulator.DefaultEncryptionProfileID,
 												},
 											},
 										},
@@ -907,10 +910,7 @@ var _ = Describe("Reconcile", Label(testlabels.Crypto), func() {
 											Operation: vimtypes.VirtualDeviceConfigSpecOperationAdd,
 											Profile: []vimtypes.BaseVirtualMachineProfileSpec{
 												&vimtypes.VirtualMachineDefinedProfileSpec{
-													ProfileData: &vimtypes.VirtualMachineProfileRawData{
-														ExtensionKey: "com.vmware.vim.sips",
-														ObjectData:   profileWithIOFilters,
-													},
+													ProfileId: simulator.DefaultEncryptionProfileID,
 												},
 											},
 										},
@@ -937,10 +937,7 @@ var _ = Describe("Reconcile", Label(testlabels.Crypto), func() {
 											Operation: vimtypes.VirtualDeviceConfigSpecOperationAdd,
 											Profile: []vimtypes.BaseVirtualMachineProfileSpec{
 												&vimtypes.VirtualMachineDefinedProfileSpec{
-													ProfileData: &vimtypes.VirtualMachineProfileRawData{
-														ExtensionKey: "com.vmware.vim.sips",
-														ObjectData:   profileWithIOFilters,
-													},
+													ProfileId: simulator.DefaultEncryptionProfileID,
 												},
 											},
 										},
@@ -968,10 +965,7 @@ var _ = Describe("Reconcile", Label(testlabels.Crypto), func() {
 											Operation: vimtypes.VirtualDeviceConfigSpecOperationAdd,
 											Profile: []vimtypes.BaseVirtualMachineProfileSpec{
 												&vimtypes.VirtualMachineDefinedProfileSpec{
-													ProfileData: &vimtypes.VirtualMachineProfileRawData{
-														ExtensionKey: "com.vmware.vim.sips",
-														ObjectData:   profileWithIOFilters,
-													},
+													ProfileId: simulator.DefaultEncryptionProfileID,
 												},
 											},
 										},
@@ -1144,25 +1138,3 @@ func getSnapshotInfoWithLinearChain() *vimtypes.VirtualMachineSnapshotInfo {
 		},
 	}
 }
-
-const profileWithIOFilters = `<?xml version="1.0" encoding="UTF-8"?>
-<storageProfile xsi:type="StorageProfile">
-    <constraints>
-        <subProfiles>
-            <capability>
-                <capabilityId>
-                    <id>vmwarevmcrypt@encryption</id>
-                    <namespace>IOFILTERS</namespace>
-                    <constraint></constraint>
-                </capabilityId>
-            </capability>
-            <name>Rule-Set 1: IOFILTERS</name>
-        </subProfiles>
-    </constraints>
-    <createdBy>None</createdBy>
-    <creationTime>1970-01-01T00:00:00Z</creationTime>
-    <lastUpdatedTime>1970-01-01T00:00:00Z</lastUpdatedTime>
-    <generationId>1</generationId>
-    <name>None</name>
-    <profileId>Phony Profile ID</profileId>
-</storageProfile>`


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch fixes how the crypto logic detects whether or not a device is being added/edited sans policy that supports encryption.

Previously this happened via a direct IOFILTERS check, but that may not be set in the profile on the device. Instead the profile ID must be used to query whether or not the profile supports encryption.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```