### PR TITLE
:bug: Correctly handle optional, nillable path in CEL expression

### DIFF
--- a/config/webhook/storage_quota_webhook_configuration.yaml
+++ b/config/webhook/storage_quota_webhook_configuration.yaml
@@ -48,5 +48,8 @@ webhooks:
     - virtualmachines
   sideEffects: None
   matchConditions:
-  - expression: oldObject.spec.advanced.bootDiskCapacity != object.spec.advanced.bootDiskCapacity
+  - expression: has(object.spec.advanced) && has(object.spec.advanced.bootDiskCapacity)
+      && ((!has(oldObject.spec.advanced) || !has(oldObject.spec.advanced.bootDiskCapacity))
+      || (has(oldObject.spec.advanced) && has(oldObject.spec.advanced.bootDiskCapacity)
+      && object.spec.advanced.bootDiskCapacity != oldObject.spec.advanced.bootDiskCapacity))
     name: boot-disk-change


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR fixes the CEL expression used in the ValidatingWebhookConfiguration used for the Storage Quota webhook allowing it to handle optional paths correctly


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:


```release-note
NONE
```