### PR TITLE
🌱  Avoid endless retry if StorageClass does not have policy ID

### DIFF
--- a/controllers/storageclass/storageclass_controller.go
+++ b/controllers/storageclass/storageclass_controller.go
@@ -100,7 +100,9 @@ func (r *Reconciler) ReconcileNormal(
 
 	policyID, err := kubeutil.GetStoragePolicyID(*obj)
 	if err != nil {
-		return err
+		logr.FromContextOrDiscard(ctx).Error(err, "failed to get storage policy ID")
+		// Don't return an error: an update to the StorageClass will cause a reconcile.
+		return nil
 	}
 
 	ok, err := r.vmProvider.DoesProfileSupportEncryption(ctx, policyID)

--- a/controllers/storageclass/storageclass_controller_unit_test.go
+++ b/controllers/storageclass/storageclass_controller_unit_test.go
@@ -110,13 +110,9 @@ func unitTestsReconcile() {
 
 	When("Normal", func() {
 		When("no storage policy ID", func() {
-			It("should return an error", func() {
-				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError(
-					kubeutil.ErrMissingParameter{
-						StorageClassName: "my-storage-class",
-						ParameterName:    "storagePolicyID",
-					}))
+			It("should not return an error", func() {
+				// StorageClass update will cause a reconcile so don't need to return an error.
+				Expect(err).ToNot(HaveOccurred())
 			})
 		})
 		When("not encrypted", func() {


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

If a StorageClass does not have a storagePolicyID, don't return an error from the Reconcile so we don't go into an endless error retry because an update to the StorageClass will cause a reconcile anyways.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note
NONE
```