### PR TITLE
🌱 Aggregate CreateOrPatch errors during StoragePolicyQuota reconcile

### DIFF
--- a/controllers/storagepolicyquota/storagepolicyquota_controller.go
+++ b/controllers/storagepolicyquota/storagepolicyquota_controller.go
@@ -5,6 +5,7 @@ package storagepolicyquota
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -135,6 +136,7 @@ func (r *Reconciler) ReconcileNormal(
 	}
 
 	// Create the StoragePolicyUsage resources.
+	var errs []error
 	for i := range objs {
 		dst := spqv1.StoragePolicyUsage{
 			ObjectMeta: metav1.ObjectMeta{
@@ -167,9 +169,9 @@ func (r *Reconciler) ReconcileNormal(
 			&dst,
 			fn); err != nil {
 
-			return err
+			errs = append(errs, err)
 		}
 	}
 
-	return err
+	return errors.Join(errs...)
 }

--- a/controllers/storagepolicyquota/storagepolicyquota_controller_unit_test.go
+++ b/controllers/storagepolicyquota/storagepolicyquota_controller_unit_test.go
@@ -44,6 +44,7 @@ func unitTestsReconcile() {
 		storageQuotaName = "my-storage-quota"
 		storageClassName = "my-storage-class"
 		storagePolicyID  = "my-storage-policy"
+		caBundle         = "fake-ca-bundle"
 	)
 
 	var (
@@ -75,7 +76,7 @@ func unitTestsReconcile() {
 			Webhooks: []admissionv1.ValidatingWebhook{
 				{
 					ClientConfig: admissionv1.WebhookClientConfig{
-						CABundle: []byte("fake-ca-bundle"),
+						CABundle: []byte(caBundle),
 					},
 				},
 			},
@@ -173,6 +174,7 @@ func unitTestsReconcile() {
 				ExpectWithOffset(1, obj.Spec.ResourceKind).To(Equal("VirtualMachine"))
 				ExpectWithOffset(1, obj.Spec.StorageClassName).To(Equal(storageClassName))
 				ExpectWithOffset(1, obj.Spec.StoragePolicyId).To(Equal(storagePolicyID))
+				ExpectWithOffset(1, obj.Spec.CABundle).To(Equal([]byte(caBundle)))
 			}
 
 			When("a StoragePolicyUsage resource does not exist", func() {


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

If there is some create or patch error for one StoragePolicyUsage don't return early from the reconcile: the others may succeed. This was prompted by the double take the reconcile ending with a "return err" where by the end err is always nil.

While here, add missing assertion for the expected CABundle.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note
NONE
```