### PR TITLE
🌱 Watch crypto state

### DIFF
--- a/pkg/util/vsphere/watcher/watcher.go
+++ b/pkg/util/vsphere/watcher/watcher.go
@@ -25,6 +25,8 @@ import (
 func DefaultWatchedPropertyPaths() []string {
 	return []string{
 		"config.extraConfig",
+		"config.hardware.device",
+		"config.keyId",
 		"guest.ipStack",
 		"guest.net",
 		"summary.config.name",


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch adds a watch on `config.keyId` and `config.hardware.device` to ensure VMs are reconciled when the underlying crypto state of the VM or its devices change.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

@dougm and I agree that while watching `config.hardware.device` seems broad, the devices should actually not change all that often. It is necessary to watch these to know when any PVCs are rekeyed.


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```