### PR TITLE
🐛 Plumb logger into async VM watcher service

### DIFF
--- a/services/vm-watcher/vm_watcher_service.go
+++ b/services/vm-watcher/vm_watcher_service.go
@@ -41,7 +41,10 @@ func AddToManager(
 		return err
 	}
 
-	return mgr.Add(New(ctx, mgr.GetClient(), ctx.VMProvider))
+	return mgr.Add(New(
+		logr.NewContext(ctx, ctx.Logger),
+		mgr.GetClient(),
+		ctx.VMProvider))
 }
 
 type Service struct {


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch fixes how the logger was plumbed into the async VM watcher service.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Ensure the async VM watcher service has a reference to the logger.
```