### PR TITLE
:seedling: Specify GO_VERSION in Dockerfile for podman

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Go version used to build the binaries.
-ARG GO_VERSION=1.23
+ARG GO_VERSION=1.23.2
 
 ## Docker image used to build the binaries.
 FROM golang:${GO_VERSION} as builder


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This change specified GO_VERSION to `1.23.2` for podman to pull image so that `make docker-build` can work with go 1.23.

```
$ podman pull docker.io/library/golang:1.23
Trying to pull docker.io/library/golang:1.23...
Error: initializing source docker://golang:1.23: reading manifest 1.23 in docker.io/library/golang: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
```

```
$ podman pull docker.io/library/golang:1.23.2
Trying to pull docker.io/library/golang:1.23.2...
Getting image source signatures
Copying blob sha256:f29d27dc8b2154be83283c4791da25b0264a9dc8484dfad644d065af56c19b72
Copying blob sha256:da802df85c965baeca9d39869f9e2cbb3dc844d4627f413bfbb2f2c3d6055988
Copying blob sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1
Copying blob sha256:7d98d813d54f6207a57721008a4081378343ad8f1b2db66c121406019171805b
Copying blob sha256:b09bd0f8c72b1f7a4ca636b5aedb92a1eabce22f4608ea90f57daea57e43663a
Copying blob sha256:7aadc5092c3b7a865666b14bef3d4d038282b19b124542f1a158c98ea8c1ed1b
Copying blob sha256:2ac1f1163629431c9f488c4d6ff6afb5c73021839723b50bafe245663ad3d9df
Copying config sha256:17f4a873f3508262a7dfb2924949f7f9056ad3001bca21453453fdba5cdfe8af
Writing manifest to image destination
17f4a873f3508262a7dfb2924949f7f9056ad3001bca21453453fdba5cdfe8af
```
**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

Testing done to load vmop image onto testbed
```
$ make docker-build
$ podman save localhost/vmoperator-controller:latest  > vmop.tar
$ hack/deploy-wcp.sh -T https://jenkins-vcf-wcp-dev.devops.broadcom.net/job/dev-nsxvpc/xxx/artifact/testbedInfo.json vmop.tar
```

**Please add a release note if necessary**:

```release-note
NONE
```