### PR TITLE
:seedling: Clean up duplicate nameservers when deployed with multiple NICs

### DIFF
--- a/pkg/providers/vsphere/vmlifecycle/bootstrap.go
+++ b/pkg/providers/vsphere/vmlifecycle/bootstrap.go
@@ -195,7 +195,7 @@ func GetBootstrapArgs(
 		}
 
 		if len(bsa.DNSServers) == 0 {
-			// GOSC will this for its global config.
+			// GOSC will set this for its global config.
 			bsa.DNSServers = ns
 		}
 

--- a/pkg/providers/vsphere/vmlifecycle/update_status.go
+++ b/pkg/providers/vsphere/vmlifecycle/update_status.go
@@ -240,7 +240,7 @@ func convertNetDNSConfigInfo(dnsConfig *vimtypes.NetDnsConfigInfo) *vmopv1.Virtu
 		DomainName:    dnsConfig.DomainName,
 		HostName:      dnsConfig.HostName,
 		Nameservers:   util.Dedupe(dnsConfig.IpAddress),
-		SearchDomains: dnsConfig.SearchDomain,
+		SearchDomains: util.Dedupe(dnsConfig.SearchDomain),
 	}
 }
 

--- a/pkg/providers/vsphere/vmlifecycle/update_status.go
+++ b/pkg/providers/vsphere/vmlifecycle/update_status.go
@@ -239,7 +239,7 @@ func convertNetDNSConfigInfo(dnsConfig *vimtypes.NetDnsConfigInfo) *vmopv1.Virtu
 		DHCP:          dnsConfig.Dhcp,
 		DomainName:    dnsConfig.DomainName,
 		HostName:      dnsConfig.HostName,
-		Nameservers:   dnsConfig.IpAddress,
+		Nameservers:   util.Dedupe(dnsConfig.IpAddress),
 		SearchDomains: dnsConfig.SearchDomain,
 	}
 }

--- a/pkg/providers/vsphere/vmlifecycle/update_status_test.go
+++ b/pkg/providers/vsphere/vmlifecycle/update_status_test.go
@@ -323,7 +323,7 @@ var _ = Describe("UpdateStatus", func() {
 		})
 
 		Context("DNS", func() {
-			When("DNSConfig has duplicate IpAddress", func() {
+			When("DNSConfig has duplicate IpAddress and duplicate SearchDomain", func() {
 				BeforeEach(func() {
 					vmCtx.MoVM.Guest = &vimtypes.GuestInfo{
 						IpStack: []vimtypes.GuestStackInfo{
@@ -337,13 +337,17 @@ var _ = Describe("UpdateStatus", func() {
 										"10.211.0.1",
 										"10.211.0.2",
 									},
+									SearchDomain: []string{
+										"foo.local", "bar.local",
+										"foo.local", "bar.local",
+									},
 								},
 							},
 						},
 					}
 				})
 
-				It("Skips duplicate Nameservers", func() {
+				It("Skips duplicate Nameservers and duplicate SearchDomain", func() {
 					network := vmCtx.VM.Status.Network
 					Expect(network).ToNot(BeNil())
 					Expect(network.IPStacks).To(HaveLen(1))
@@ -352,6 +356,8 @@ var _ = Describe("UpdateStatus", func() {
 					Expect(network.IPStacks[0].DNS.DomainName).To(Equal("local.domain"))
 					Expect(network.IPStacks[0].DNS.Nameservers).To(HaveLen(2))
 					Expect(network.IPStacks[0].DNS.Nameservers).To(Equal([]string{"10.211.0.1", "10.211.0.2"}))
+					Expect(network.IPStacks[0].DNS.SearchDomains).To(HaveLen(2))
+					Expect(network.IPStacks[0].DNS.SearchDomains).To(Equal([]string{"foo.local", "bar.local"}))
 				})
 			})
 		})

--- a/pkg/util/network.go
+++ b/pkg/util/network.go
@@ -92,17 +92,17 @@ func IsValidDomainName(s string) bool {
 	return len(s) <= 253 && fqdnNameRx.MatchString(s)
 }
 
-func Dedupe(slice []string) []string {
+func Dedupe[T comparable](slice []T) []T {
 	// Create a map to track unique elements
-	seen := make(map[string]bool)
-	result := []string{}
+	seen := make(map[T]struct{})
+	result := []T{}
 
 	// Iterate over the slice
-	for _, str := range slice {
+	for _, item := range slice {
 		// Check if the element has been seen before
-		if !seen[str] {
-			seen[str] = true
-			result = append(result, str)
+		if _, exists := seen[item]; !exists {
+			seen[item] = struct{}{}
+			result = append(result, item)
 		}
 	}
 

--- a/pkg/util/network.go
+++ b/pkg/util/network.go
@@ -91,3 +91,20 @@ func IsValidDomainName(s string) bool {
 	// character, the domain name only has 253 characters of available space.
 	return len(s) <= 253 && fqdnNameRx.MatchString(s)
 }
+
+func Dedupe(slice []string) []string {
+	// Create a map to track unique elements
+	seen := make(map[string]bool)
+	result := []string{}
+
+	// Iterate over the slice
+	for _, str := range slice {
+		// Check if the element has been seen before
+		if !seen[str] {
+			seen[str] = true
+			result = append(result, str)
+		}
+	}
+
+	return result
+}

--- a/pkg/util/network_test.go
+++ b/pkg/util/network_test.go
@@ -65,3 +65,14 @@ var _ = DescribeTable("IsValidDomainName",
 	Entry("three segments", "a.b.com", true),
 	Entry("exceeds 253 chars", strings.Repeat("a", 254), false),
 )
+
+var _ = DescribeTable("Dedupe",
+	func(s []string, expected []string) {
+		Ω(util.Dedupe(s)).Should(Equal(expected))
+	},
+	Entry("empty string list", []string{}, []string{}),
+	Entry("unique one string list", []string{"1.1.2.2"}, []string{"1.1.2.2"}),
+	Entry("unique two string list", []string{"1.1.2.2", "1.2.3.4"}, []string{"1.1.2.2", "1.2.3.4"}),
+	Entry("duplicate two string list", []string{"1.1.2.2", "1.1.2.2", "1.2.3.4", "1.2.3.4"}, []string{"1.1.2.2", "1.2.3.4"}),
+	Entry("duplicate three string list", []string{"1.1.2.2", "1.2.3.4", "1.1.2.2", "1.2.3.4", "1.1.2.2", "1.2.3.4"}, []string{"1.1.2.2", "1.2.3.4"}),
+)


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This change cleans up duplicate nameservers when VM is deployed with multiple NICs. During validating multiple NICs VM deployment under VPC networking. We find GuestStackInfo will provide DNSConfig with duplicate ipAddresses and VMOP will parse that and return VM Status with the same duplicate nameservers. To provide better readability and reduce confusion, this patch will dedupe the field.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

Testing done:
1. Deploy a VM with multiple NICs under VPC
```
apiVersion: vmoperator.vmware.com/v1alpha3
kind: VirtualMachine
metadata:
  name: vm-subnet-subnetset-multi
  namespace: yiyi-ns
spec:
  className: best-effort-small
  imageName: ubuntu-jammy-22.04-cloudimg
  storageClass: wcpglobal-storage-profile
  network:
    interfaces:
    - name: eth1
      network:
        apiVersion: nsxoperator.vmware.com/v1alpha1
        kind: Subnet
        name: vmsvc-subnet-dhcp
    - name: eth2
      network:
        apiVersion: nsxoperator.vmware.com/v1alpha1
        kind: SubnetSet
        name: vm-default
```
2. Pre this change, VM status
```
  status:
    network:
      ipStacks:
  	- dns:
      	domainName: .
      	hostName: vm-subnet-subnetset-multi
      	nameservers:
      	- 192.19.189.10
      	- 192.19.189.20
      	- 192.19.189.10
      	- 192.19.189.20
      	searchDomains:
      	- .
```
3. After this change, VM status
```
  status:
    network:
      ipStacks:
  	- dns:
      	domainName: .
      	hostName: vm-subnet-subnetset-multi
      	nameservers:
      	- 192.19.189.10
      	- 192.19.189.20
      	searchDomains:
      	- .
```
**Please add a release note if necessary**:

```release-note
Clean up duplicate Nameservers when deployed with multiple NICs
```