### PR TITLE
🐛 Update async logging / fix NPE in crypt reconciler

### DIFF
--- a/controllers/virtualmachine/virtualmachine/virtualmachine_controller_intg_test.go
+++ b/controllers/virtualmachine/virtualmachine/virtualmachine_controller_intg_test.go
@@ -19,6 +19,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2/textlogger"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -378,6 +379,13 @@ var _ = Describe(
 		})
 
 		JustBeforeEach(func() {
+			ctx = logr.NewContext(
+				context.Background(),
+				textlogger.NewLogger(textlogger.NewConfig(
+					textlogger.Verbosity(2),
+					textlogger.Output(GinkgoWriter),
+				)))
+
 			ctx = pkgcfg.WithContext(ctx, pkgcfg.Default())
 			ctx = pkgcfg.UpdateContext(
 				ctx,

--- a/pkg/util/vsphere/watcher/watcher.go
+++ b/pkg/util/vsphere/watcher/watcher.go
@@ -214,7 +214,8 @@ func Start(
 	containerRefs ...moRef) (*Watcher, error) {
 
 	logger := logr.FromContextOrDiscard(ctx).WithName("vSphereWatcher")
-	ctx = logr.NewContext(ctx, logger)
+
+	logger.Info("Started watching VMs")
 
 	w, err := newWatcher(
 		ctx,
@@ -275,7 +276,7 @@ func (w *Watcher) onUpdate(
 	ou []vimtypes.ObjectUpdate) bool {
 
 	logger := logr.FromContextOrDiscard(ctx)
-	logger.V(4).Info("onUpdate", "objectUpdates", ou)
+	logger.V(4).Info("OnUpdate", "objectUpdates", ou)
 
 	updates := map[moRef]objUpdate{}
 
@@ -314,7 +315,6 @@ func (w *Watcher) onObject(
 	update objUpdate) error {
 
 	logger := logr.FromContextOrDiscard(ctx).
-		V(4).
 		WithName("onObject").
 		WithValues("obj", obj)
 
@@ -381,7 +381,7 @@ func (w *Watcher) onObject(
 			Verified:  verified,
 		}
 
-		logger.Info("sending result", "result", r)
+		logger.V(4).Info("Sending result", "result", r)
 
 		go func(r Result) {
 			w.chanResult <- r

--- a/pkg/vmconfig/crypto/crypto_reconciler_post.go
+++ b/pkg/vmconfig/crypto/crypto_reconciler_post.go
@@ -18,24 +18,21 @@ import (
 func (r reconciler) OnResult(
 	ctx context.Context,
 	vm *vmopv1.VirtualMachine,
-	moVM mo.VirtualMachine,
+	_ mo.VirtualMachine,
 	resultErr error) error {
+
+	if resultErr == nil {
+		return nil
+	}
 
 	if ctx == nil {
 		panic("context is nil")
-	}
-	if moVM.Config == nil {
-		panic("moVM.config is nil")
 	}
 	if vm == nil {
 		panic("vm is nil")
 	}
 
 	state := internal.FromContext(ctx)
-
-	if resultErr == nil {
-		return nil
-	}
 
 	// Determine the message to put on the condition.
 	var msgs []string

--- a/pkg/vmconfig/crypto/crypto_reconciler_post_test.go
+++ b/pkg/vmconfig/crypto/crypto_reconciler_post_test.go
@@ -56,6 +56,9 @@ var _ = Describe("OnResult", Label(testlabels.Crypto), func() {
 	}
 
 	When("it should panic", func() {
+		BeforeEach(func() {
+			reconfigErr = errors.New(fakeString)
+		})
 		When("ctx is nil", func() {
 			BeforeEach(func() {
 				ctx = nil
@@ -65,18 +68,6 @@ var _ = Describe("OnResult", Label(testlabels.Crypto), func() {
 					_ = r.OnResult(ctx, vm, moVM, reconfigErr)
 				}
 				Expect(fn).To(PanicWith("context is nil"))
-			})
-		})
-
-		When("moVM.config is nil", func() {
-			BeforeEach(func() {
-				moVM.Config = nil
-			})
-			It("should panic", func() {
-				fn := func() {
-					_ = r.OnResult(ctx, vm, moVM, reconfigErr)
-				}
-				Expect(fn).To(PanicWith("moVM.config is nil"))
 			})
 		})
 

--- a/services/vm-watcher/vm_watcher_service_test.go
+++ b/services/vm-watcher/vm_watcher_service_test.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2/textlogger"
 
 	"github.com/vmware/govmomi/object"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
@@ -30,7 +31,6 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/watcher"
 	vmwatcher "github.com/vmware-tanzu/vm-operator/services/vm-watcher"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
-	"github.com/vmware-tanzu/vm-operator/test/testutil"
 )
 
 var _ = Describe(
@@ -55,8 +55,12 @@ var _ = Describe(
 			numNewClientCalls = 0
 			vsClient = nil
 			vsClientMu = sync.RWMutex{}
-			ctx = context.Background()
-			ctx = logr.NewContext(ctx, testutil.GinkgoLogr(4))
+			ctx = logr.NewContext(
+				context.Background(),
+				textlogger.NewLogger(textlogger.NewConfig(
+					textlogger.Verbosity(4),
+					textlogger.Output(GinkgoWriter),
+				)))
 		})
 
 		JustBeforeEach(func() {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch:

* Updates the logging for the async signal components.
* Fixes a panic in the crypto reconciler's `OnResult` func that can happen if a VM create fails or properties are not fetched and OnResult is called with a nil `moVM.Config` field.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

* Depends on #777, will rebase once that has merged.
* This PR has been validated on a real testbed.
* This PR's `HEAD` commit is 3639448373c9f561e2547b759b1f1dea98b0224c, which can be seen in the log below:

    ```
    version="0.1.0+d683393+1.8.6+36394483+80628379" 
    ```

    The `36394483` proves the log is from the indicated commit/PR. The log also demonstrates a successful startup of VM Operator:

    ```shell
    # k -n vmware-system-vmop logs vmware-system-vmop-controller-manager-6b996f4b45-vj76p -c manager
    I1027 22:40:46.392226       1 main.go:61] "Starting VM Operator controller" logger="setup" version="0.1.0+d683393+1.8.6+36394483+80628379" buildnumber="80628379" buildtype="dev" commit="d683393"
    I1027 22:40:46.393051       1 main.go:96] "Initial features from environment" logger="setup" features={"IsoSupport":true,"InstanceStorage":false,"K8sWorkloadMgmtAPI":false,"PodVMOnStretchedSupervisor":true,"TKGMultipleCL":true,"UnifiedStorageQuota":false,"VMResize":false,"VMResizeCPUMemory":true,"VMImportNewNet":false,"WorkloadDomainIsolation":true,"VMIncrementalRestore":false,"BringYourOwnEncryptionKey":true,"SVAsyncUpgrade":false,"SimplifiedEnablement":false}
    I1027 22:40:46.448726       1 main.go:106] "Initial features from capabilities" logger="setup" features={"IsoSupport":true,"InstanceStorage":false,"K8sWorkloadMgmtAPI":false,"PodVMOnStretchedSupervisor":true,"TKGMultipleCL":true,"UnifiedStorageQuota":false,"VMResize":false,"VMResizeCPUMemory":true,"VMImportNewNet":false,"WorkloadDomainIsolation":true,"VMIncrementalRestore":false,"BringYourOwnEncryptionKey":true,"SVAsyncUpgrade":false,"SimplifiedEnablement":false}
    I1027 22:40:46.450041       1 main.go:130] "Configuring rate limiter" logger="setup" QPS=500 burst=1000
    I1027 22:40:46.450127       1 main.go:264] "Waiting for webhook certificates" logger="setup"
    I1027 22:40:46.450367       1 main.go:322] "Creating controller manager" logger="setup"
    I1027 22:40:46.476378       1 webhook.go:186] "skip registering a mutating webhook, object does not implement admission.Defaulter or WithDefaulter wasn't called" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha1, Kind=VirtualMachine"
    I1027 22:40:46.476494       1 webhook.go:225] "skip registering a validating webhook, object does not implement admission.Validator or WithValidator wasn't called" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha1, Kind=VirtualMachine"
    I1027 22:40:46.477185       1 server.go:183] "Registering webhook" logger="controller-runtime.webhook" path="/convert"
    I1027 22:40:46.477195       1 webhook.go:241] "Conversion webhook enabled" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha1, Kind=VirtualMachine"
    I1027 22:40:46.477240       1 webhook.go:186] "skip registering a mutating webhook, object does not implement admission.Defaulter or WithDefaulter wasn't called" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha1, Kind=VirtualMachineClass"
    I1027 22:40:46.477250       1 webhook.go:225] "skip registering a validating webhook, object does not implement admission.Validator or WithValidator wasn't called" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha1, Kind=VirtualMachineClass"
    I1027 22:40:46.477295       1 webhook.go:241] "Conversion webhook enabled" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha1, Kind=VirtualMachineClass"
    I1027 22:40:46.479060       1 webhook.go:186] "skip registering a mutating webhook, object does not implement admission.Defaulter or WithDefaulter wasn't called" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha1, Kind=VirtualMachineImage"
    I1027 22:40:46.479151       1 webhook.go:225] "skip registering a validating webhook, object does not implement admission.Validator or WithValidator wasn't called" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha1, Kind=VirtualMachineImage"
    I1027 22:40:46.479253       1 webhook.go:241] "Conversion webhook enabled" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha1, Kind=VirtualMachineImage"
    I1027 22:40:46.479265       1 webhook.go:186] "skip registering a mutating webhook, object does not implement admission.Defaulter or WithDefaulter wasn't called" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha1, Kind=VirtualMachinePublishRequest"
    I1027 22:40:46.479277       1 webhook.go:225] "skip registering a validating webhook, object does not implement admission.Validator or WithValidator wasn't called" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha1, Kind=VirtualMachinePublishRequest"
    I1027 22:40:46.479324       1 webhook.go:241] "Conversion webhook enabled" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha1, Kind=VirtualMachinePublishRequest"
    I1027 22:40:46.479331       1 webhook.go:186] "skip registering a mutating webhook, object does not implement admission.Defaulter or WithDefaulter wasn't called" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha1, Kind=VirtualMachineService"
    I1027 22:40:46.479340       1 webhook.go:225] "skip registering a validating webhook, object does not implement admission.Validator or WithValidator wasn't called" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha1, Kind=VirtualMachineService"
    I1027 22:40:46.479440       1 webhook.go:241] "Conversion webhook enabled" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha1, Kind=VirtualMachineService"
    I1027 22:40:46.479453       1 webhook.go:186] "skip registering a mutating webhook, object does not implement admission.Defaulter or WithDefaulter wasn't called" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha1, Kind=VirtualMachineSetResourcePolicy"
    I1027 22:40:46.479462       1 webhook.go:225] "skip registering a validating webhook, object does not implement admission.Validator or WithValidator wasn't called" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha1, Kind=VirtualMachineSetResourcePolicy"
    I1027 22:40:46.479517       1 webhook.go:241] "Conversion webhook enabled" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha1, Kind=VirtualMachineSetResourcePolicy"
    I1027 22:40:46.479975       1 webhook.go:186] "skip registering a mutating webhook, object does not implement admission.Defaulter or WithDefaulter wasn't called" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha2, Kind=VirtualMachine"
    I1027 22:40:46.479992       1 webhook.go:225] "skip registering a validating webhook, object does not implement admission.Validator or WithValidator wasn't called" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha2, Kind=VirtualMachine"
    I1027 22:40:46.480060       1 webhook.go:241] "Conversion webhook enabled" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha2, Kind=VirtualMachine"
    I1027 22:40:46.480069       1 webhook.go:186] "skip registering a mutating webhook, object does not implement admission.Defaulter or WithDefaulter wasn't called" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha2, Kind=VirtualMachineClass"
    I1027 22:40:46.480075       1 webhook.go:225] "skip registering a validating webhook, object does not implement admission.Validator or WithValidator wasn't called" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha2, Kind=VirtualMachineClass"
    I1027 22:40:46.480111       1 webhook.go:241] "Conversion webhook enabled" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha2, Kind=VirtualMachineClass"
    I1027 22:40:46.480118       1 webhook.go:186] "skip registering a mutating webhook, object does not implement admission.Defaulter or WithDefaulter wasn't called" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha2, Kind=VirtualMachineImage"
    I1027 22:40:46.480131       1 webhook.go:225] "skip registering a validating webhook, object does not implement admission.Validator or WithValidator wasn't called" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha2, Kind=VirtualMachineImage"
    I1027 22:40:46.480164       1 webhook.go:241] "Conversion webhook enabled" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha2, Kind=VirtualMachineImage"
    I1027 22:40:46.480170       1 webhook.go:186] "skip registering a mutating webhook, object does not implement admission.Defaulter or WithDefaulter wasn't called" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha2, Kind=VirtualMachinePublishRequest"
    I1027 22:40:46.480227       1 webhook.go:225] "skip registering a validating webhook, object does not implement admission.Validator or WithValidator wasn't called" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha2, Kind=VirtualMachinePublishRequest"
    I1027 22:40:46.480266       1 webhook.go:241] "Conversion webhook enabled" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha2, Kind=VirtualMachinePublishRequest"
    I1027 22:40:46.480272       1 webhook.go:186] "skip registering a mutating webhook, object does not implement admission.Defaulter or WithDefaulter wasn't called" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha2, Kind=VirtualMachineService"
    I1027 22:40:46.480279       1 webhook.go:225] "skip registering a validating webhook, object does not implement admission.Validator or WithValidator wasn't called" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha2, Kind=VirtualMachineService"
    I1027 22:40:46.480314       1 webhook.go:241] "Conversion webhook enabled" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha2, Kind=VirtualMachineService"
    I1027 22:40:46.480359       1 webhook.go:186] "skip registering a mutating webhook, object does not implement admission.Defaulter or WithDefaulter wasn't called" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha2, Kind=VirtualMachineSetResourcePolicy"
    I1027 22:40:46.480368       1 webhook.go:225] "skip registering a validating webhook, object does not implement admission.Validator or WithValidator wasn't called" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha2, Kind=VirtualMachineSetResourcePolicy"
    I1027 22:40:46.480402       1 webhook.go:241] "Conversion webhook enabled" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha2, Kind=VirtualMachineSetResourcePolicy"
    I1027 22:40:46.480409       1 webhook.go:186] "skip registering a mutating webhook, object does not implement admission.Defaulter or WithDefaulter wasn't called" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha2, Kind=VirtualMachineWebConsoleRequest"
    I1027 22:40:46.480414       1 webhook.go:225] "skip registering a validating webhook, object does not implement admission.Validator or WithValidator wasn't called" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha2, Kind=VirtualMachineWebConsoleRequest"
    I1027 22:40:46.480461       1 webhook.go:241] "Conversion webhook enabled" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha2, Kind=VirtualMachineWebConsoleRequest"
    I1027 22:40:46.480472       1 webhook.go:186] "skip registering a mutating webhook, object does not implement admission.Defaulter or WithDefaulter wasn't called" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha3, Kind=VirtualMachine"
    I1027 22:40:46.480480       1 webhook.go:225] "skip registering a validating webhook, object does not implement admission.Validator or WithValidator wasn't called" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha3, Kind=VirtualMachine"
    I1027 22:40:46.480514       1 webhook.go:241] "Conversion webhook enabled" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha3, Kind=VirtualMachine"
    I1027 22:40:46.480566       1 webhook.go:186] "skip registering a mutating webhook, object does not implement admission.Defaulter or WithDefaulter wasn't called" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha3, Kind=VirtualMachineClass"
    I1027 22:40:46.480574       1 webhook.go:225] "skip registering a validating webhook, object does not implement admission.Validator or WithValidator wasn't called" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha3, Kind=VirtualMachineClass"
    I1027 22:40:46.480865       1 webhook.go:241] "Conversion webhook enabled" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha3, Kind=VirtualMachineClass"
    I1027 22:40:46.480878       1 webhook.go:186] "skip registering a mutating webhook, object does not implement admission.Defaulter or WithDefaulter wasn't called" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha3, Kind=VirtualMachineImage"
    I1027 22:40:46.480884       1 webhook.go:225] "skip registering a validating webhook, object does not implement admission.Validator or WithValidator wasn't called" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha3, Kind=VirtualMachineImage"
    I1027 22:40:46.480916       1 webhook.go:241] "Conversion webhook enabled" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha3, Kind=VirtualMachineImage"
    I1027 22:40:46.480922       1 webhook.go:186] "skip registering a mutating webhook, object does not implement admission.Defaulter or WithDefaulter wasn't called" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha3, Kind=VirtualMachinePublishRequest"
    I1027 22:40:46.480928       1 webhook.go:225] "skip registering a validating webhook, object does not implement admission.Validator or WithValidator wasn't called" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha3, Kind=VirtualMachinePublishRequest"
    I1027 22:40:46.480963       1 webhook.go:241] "Conversion webhook enabled" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha3, Kind=VirtualMachinePublishRequest"
    I1027 22:40:46.480992       1 webhook.go:186] "skip registering a mutating webhook, object does not implement admission.Defaulter or WithDefaulter wasn't called" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha3, Kind=VirtualMachineService"
    I1027 22:40:46.481109       1 webhook.go:225] "skip registering a validating webhook, object does not implement admission.Validator or WithValidator wasn't called" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha3, Kind=VirtualMachineService"
    I1027 22:40:46.481153       1 webhook.go:241] "Conversion webhook enabled" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha3, Kind=VirtualMachineService"
    I1027 22:40:46.481162       1 webhook.go:186] "skip registering a mutating webhook, object does not implement admission.Defaulter or WithDefaulter wasn't called" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha3, Kind=VirtualMachineSetResourcePolicy"
    I1027 22:40:46.481171       1 webhook.go:225] "skip registering a validating webhook, object does not implement admission.Validator or WithValidator wasn't called" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha3, Kind=VirtualMachineSetResourcePolicy"
    I1027 22:40:46.481208       1 webhook.go:241] "Conversion webhook enabled" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha3, Kind=VirtualMachineSetResourcePolicy"
    I1027 22:40:46.481217       1 webhook.go:186] "skip registering a mutating webhook, object does not implement admission.Defaulter or WithDefaulter wasn't called" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha3, Kind=VirtualMachineWebConsoleRequest"
    I1027 22:40:46.481226       1 webhook.go:225] "skip registering a validating webhook, object does not implement admission.Validator or WithValidator wasn't called" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha3, Kind=VirtualMachineWebConsoleRequest"
    I1027 22:40:46.481860       1 webhook.go:241] "Conversion webhook enabled" logger="controller-runtime.builder" GVK="vmoperator.vmware.com/v1alpha3, Kind=VirtualMachineWebConsoleRequest"
    I1027 22:40:46.482050       1 server.go:183] "Registering webhook" logger="controller-runtime.webhook" path="/default-validate--v1-persistentvolumeclaim"
    I1027 22:40:46.482370       1 server.go:183] "Registering webhook" logger="controller-runtime.webhook" path="/default-mutate-vmoperator-vmware-com-v1alpha3-virtualmachine"
    I1027 22:40:46.482549       1 server.go:183] "Registering webhook" logger="controller-runtime.webhook" path="/default-validate-vmoperator-vmware-com-v1alpha3-virtualmachine"
    I1027 22:40:46.492662       1 server.go:183] "Registering webhook" logger="controller-runtime.webhook" path="/default-mutate-vmoperator-vmware-com-v1alpha3-virtualmachineclass"
    I1027 22:40:46.492851       1 server.go:183] "Registering webhook" logger="controller-runtime.webhook" path="/default-validate-vmoperator-vmware-com-v1alpha3-virtualmachineclass"
    I1027 22:40:46.492947       1 server.go:183] "Registering webhook" logger="controller-runtime.webhook" path="/default-validate-vmoperator-vmware-com-v1alpha3-virtualmachinepublishrequest"
    I1027 22:40:46.493090       1 server.go:183] "Registering webhook" logger="controller-runtime.webhook" path="/default-mutate-vmoperator-vmware-com-v1alpha3-virtualmachineservice"
    I1027 22:40:46.493197       1 server.go:183] "Registering webhook" logger="controller-runtime.webhook" path="/default-validate-vmoperator-vmware-com-v1alpha3-virtualmachineservice"
    I1027 22:40:46.493302       1 server.go:183] "Registering webhook" logger="controller-runtime.webhook" path="/default-validate-vmoperator-vmware-com-v1alpha3-virtualmachinesetresourcepolicy"
    I1027 22:40:46.493365       1 server.go:183] "Registering webhook" logger="controller-runtime.webhook" path="/default-validate-vmoperator-vmware-com-v1alpha3-virtualmachinewebconsolerequest"
    I1027 22:40:46.493404       1 server.go:183] "Registering webhook" logger="controller-runtime.webhook" path="/default-validate-vmoperator-vmware-com-v1alpha1-webconsolerequest"
    I1027 22:40:46.493483       1 main.go:340] "Setting up webhook server TLS config" logger="setup"
    I1027 22:40:46.493492       1 main.go:357] "Adding readiness check to controller manager" logger="setup"
    I1027 22:40:46.493525       1 main.go:83] "Starting controller manager" logger="setup"
    I1027 22:40:46.495678       1 server.go:83] "starting server" name="pprof" addr="[::]:8073"
    I1027 22:40:46.495862       1 server.go:83] "starting server" name="health probe" addr="[::]:9445"
    I1027 22:40:46.496360       1 server.go:191] "Starting webhook server" logger="controller-runtime.webhook"
    I1027 22:40:46.496945       1 server.go:208] "Starting metrics server" logger="controller-runtime.metrics"
    I1027 22:40:46.497594       1 certwatcher.go:161] "Updated current TLS certificate" logger="controller-runtime.certwatcher"
    I1027 22:40:46.497831       1 server.go:242] "Serving webhook server" logger="controller-runtime.webhook" host="" port=9878
    I1027 22:40:46.497905       1 server.go:247] "Serving metrics server" logger="controller-runtime.metrics" bindAddress="127.0.0.1:8083" secure=false
    I1027 22:40:46.497741       1 envvar.go:172] "Feature gate default state" feature="WatchListClient" enabled=false
    I1027 22:40:46.497971       1 envvar.go:172] "Feature gate default state" feature="InformerResourceVersion" enabled=false
    I1027 22:40:46.498164       1 certwatcher.go:115] "Starting certificate watcher" logger="controller-runtime.certwatcher"
    I1027 22:40:46.504669       1 reflector.go:368] Caches populated for *v1alpha3.ClusterVirtualMachineImage from pkg/mod/k8s.io/client-go@v0.31.0/tools/cache/reflector.go:243
    I1027 22:40:46.505410       1 reflector.go:368] Caches populated for *v1alpha1.CnsNodeVmAttachment from pkg/mod/k8s.io/client-go@v0.31.0/tools/cache/reflector.go:243
    I1027 22:40:46.519622       1 reflector.go:368] Caches populated for *v1alpha3.VirtualMachine from pkg/mod/k8s.io/client-go@v0.31.0/tools/cache/reflector.go:243
    I1027 22:40:46.539797       1 reflector.go:368] Caches populated for *v1alpha3.VirtualMachineImage from pkg/mod/k8s.io/client-go@v0.31.0/tools/cache/reflector.go:243
    I1027 22:40:46.600320       1 leaderelection.go:254] attempting to acquire leader lease vmware-system-vmop/vmware-system-vmop-controller-manager-runtime...
    I1027 22:40:46.600743       1 controller.go:175] "Starting EventSource" controller="capability-configmap" source="kind source: *v1.ConfigMap"
    I1027 22:40:46.600859       1 controller.go:183] "Starting Controller" controller="capability-configmap"
    I1027 22:40:46.609004       1 reflector.go:368] Caches populated for *v1.ConfigMap from pkg/mod/k8s.io/client-go@v0.31.0/tools/cache/reflector.go:243
    I1027 22:40:46.702257       1 controller.go:217] "Starting workers" controller="capability-configmap" worker count=1
    I1027 22:41:03.332310       1 leaderelection.go:268] successfully acquired lease vmware-system-vmop/vmware-system-vmop-controller-manager-runtime
    I1027 22:41:03.333789       1 controller.go:175] "Starting EventSource" controller="clustercontentlibraryitem" controllerGroup="imageregistry.vmware.com" controllerKind="ClusterContentLibraryItem" source="kind source: *v1alpha1.ClusterContentLibraryItem"
    I1027 22:41:03.333956       1 controller.go:183] "Starting Controller" controller="clustercontentlibraryitem" controllerGroup="imageregistry.vmware.com" controllerKind="ClusterContentLibraryItem"
    I1027 22:41:03.334089       1 controller.go:175] "Starting EventSource" controller="infra-configmap" source="kind source: *v1.ConfigMap"
    I1027 22:41:03.334157       1 controller.go:183] "Starting Controller" controller="infra-configmap"
    I1027 22:41:03.334888       1 controller.go:175] "Starting EventSource" controller="contentlibraryitem" controllerGroup="imageregistry.vmware.com" controllerKind="ContentLibraryItem" source="kind source: *v1alpha1.ContentLibraryItem"
    I1027 22:41:03.335066       1 controller.go:183] "Starting Controller" controller="contentlibraryitem" controllerGroup="imageregistry.vmware.com" controllerKind="ContentLibraryItem"
    I1027 22:41:03.335813       1 prober_manager.go:132] "Start VirtualMachine Probe Manager" logger="virtualmachine-prober-manager"
    I1027 22:41:03.335876       1 prober_manager.go:135] "Starting readiness workers" logger="virtualmachine-prober-manager" count=5
    I1027 22:41:03.335826       1 controller.go:175] "Starting EventSource" controller="infra-secret" source="kind source: *v1.Secret"
    I1027 22:41:03.335988       1 controller.go:183] "Starting Controller" controller="infra-secret"
    I1027 22:41:03.336347       1 controller.go:175] "Starting EventSource" controller="infra-node" controllerGroup="" controllerKind="Node" source="kind source: *v1.Node"
    I1027 22:41:03.336372       1 controller.go:183] "Starting Controller" controller="infra-node" controllerGroup="" controllerKind="Node"
    I1027 22:41:03.336613       1 controller.go:175] "Starting EventSource" controller="zone" controllerGroup="topology.tanzu.vmware.com" controllerKind="Zone" source="kind source: *v1alpha1.Zone"
    I1027 22:41:03.336712       1 controller.go:175] "Starting EventSource" controller="volume" source="kind source: *v1alpha3.VirtualMachine"
    I1027 22:41:03.336722       1 controller.go:183] "Starting Controller" controller="zone" controllerGroup="topology.tanzu.vmware.com" controllerKind="Zone"
    I1027 22:41:03.336789       1 controller.go:175] "Starting EventSource" controller="volume" source="kind source: *v1alpha1.CnsNodeVmAttachment"
    I1027 22:41:03.336808       1 controller.go:183] "Starting Controller" controller="volume"
    I1027 22:41:03.337011       1 recorder.go:104] "420feb4f9a135687990e15e2715ae59e_fc2f3843-3539-4488-adcc-473e97e59bf9 became leader" logger="events" type="Normal" object={"kind":"Lease","namespace":"vmware-system-vmop","name":"vmware-system-vmop-controller-manager-runtime","uid":"114b3065-3bdf-417e-adc7-133ef95e9806","apiVersion":"coordination.k8s.io/v1","resourceVersion":"3850546"} reason="LeaderElection"
    I1027 22:41:03.337675       1 controller.go:175] "Starting EventSource" controller="virtualmachine" controllerGroup="vmoperator.vmware.com" controllerKind="VirtualMachine" source="kind source: *v1alpha3.VirtualMachine"
    I1027 22:41:03.337735       1 controller.go:175] "Starting EventSource" controller="virtualmachine" controllerGroup="vmoperator.vmware.com" controllerKind="VirtualMachine" source="kind source: *v1alpha3.VirtualMachineClass"
    I1027 22:41:03.337792       1 controller.go:175] "Starting EventSource" controller="virtualmachine" controllerGroup="vmoperator.vmware.com" controllerKind="VirtualMachine" source="kind source: *v1alpha1.EncryptionClass"
    I1027 22:41:03.337881       1 controller.go:175] "Starting EventSource" controller="virtualmachine" controllerGroup="vmoperator.vmware.com" controllerKind="VirtualMachine" source="channel source: 0xc000447b20"
    I1027 22:41:03.338022       1 controller.go:183] "Starting Controller" controller="virtualmachine" controllerGroup="vmoperator.vmware.com" controllerKind="VirtualMachine"
    I1027 22:41:03.338321       1 controller.go:175] "Starting EventSource" controller="virtualmachineclass" controllerGroup="vmoperator.vmware.com" controllerKind="VirtualMachineClass" source="kind source: *v1alpha3.VirtualMachineClass"
    I1027 22:41:03.338343       1 controller.go:183] "Starting Controller" controller="virtualmachineclass" controllerGroup="vmoperator.vmware.com" controllerKind="VirtualMachineClass"
    I1027 22:41:03.339117       1 vm_watcher_service.go:79] "Starting VM watcher service" logger="vmware-system-vmop-controller-manager-6b996f4b45-vj76p.VMWatcherService"
    I1027 22:41:03.339694       1 controller.go:175] "Starting EventSource" controller="virtualmachinesetresourcepolicy" controllerGroup="vmoperator.vmware.com" controllerKind="VirtualMachineSetResourcePolicy" source="kind source: *v1alpha3.VirtualMachineSetResourcePolicy"
    I1027 22:41:03.339737       1 controller.go:183] "Starting Controller" controller="virtualmachinesetresourcepolicy" controllerGroup="vmoperator.vmware.com" controllerKind="VirtualMachineSetResourcePolicy"
    I1027 22:41:03.339810       1 controller.go:175] "Starting EventSource" controller="virtualmachineservice" controllerGroup="vmoperator.vmware.com" controllerKind="VirtualMachineService" source="kind source: *v1alpha3.VirtualMachineService"
    I1027 22:41:03.339838       1 controller.go:175] "Starting EventSource" controller="virtualmachineservice" controllerGroup="vmoperator.vmware.com" controllerKind="VirtualMachineService" source="kind source: *v1.Service"
    I1027 22:41:03.339857       1 controller.go:175] "Starting EventSource" controller="virtualmachineservice" controllerGroup="vmoperator.vmware.com" controllerKind="VirtualMachineService" source="kind source: *v1.Endpoints"
    I1027 22:41:03.339864       1 controller.go:175] "Starting EventSource" controller="virtualmachineservice" controllerGroup="vmoperator.vmware.com" controllerKind="VirtualMachineService" source="kind source: *v1alpha3.VirtualMachine"
    I1027 22:41:03.339872       1 controller.go:183] "Starting Controller" controller="virtualmachineservice" controllerGroup="vmoperator.vmware.com" controllerKind="VirtualMachineService"
    I1027 22:41:03.340108       1 controller.go:175] "Starting EventSource" controller="storageclass" controllerGroup="storage.k8s.io" controllerKind="StorageClass" source="kind source: *v1.StorageClass"
    I1027 22:41:03.340126       1 controller.go:183] "Starting Controller" controller="storageclass" controllerGroup="storage.k8s.io" controllerKind="StorageClass"
    I1027 22:41:03.340277       1 controller.go:175] "Starting EventSource" controller="virtualmachinepublishrequest" controllerGroup="vmoperator.vmware.com" controllerKind="VirtualMachinePublishRequest" source="kind source: *v1alpha3.VirtualMachinePublishRequest"
    I1027 22:41:03.340718       1 controller.go:175] "Starting EventSource" controller="virtualmachinewebconsolerequest" controllerGroup="vmoperator.vmware.com" controllerKind="VirtualMachineWebConsoleRequest" source="kind source: *v1alpha3.VirtualMachineWebConsoleRequest"
    I1027 22:41:03.340772       1 controller.go:183] "Starting Controller" controller="virtualmachinewebconsolerequest" controllerGroup="vmoperator.vmware.com" controllerKind="VirtualMachineWebConsoleRequest"
    I1027 22:41:03.340871       1 controller.go:175] "Starting EventSource" controller="webconsolerequest" controllerGroup="vmoperator.vmware.com" controllerKind="WebConsoleRequest" source="kind source: *v1alpha1.WebConsoleRequest"
    I1027 22:41:03.340887       1 controller.go:183] "Starting Controller" controller="webconsolerequest" controllerGroup="vmoperator.vmware.com" controllerKind="WebConsoleRequest"
    I1027 22:41:03.340296       1 controller.go:175] "Starting EventSource" controller="virtualmachinepublishrequest" controllerGroup="vmoperator.vmware.com" controllerKind="VirtualMachinePublishRequest" source="kind source: *v1alpha3.VirtualMachineImage"
    I1027 22:41:03.341027       1 controller.go:183] "Starting Controller" controller="virtualmachinepublishrequest" controllerGroup="vmoperator.vmware.com" controllerKind="VirtualMachinePublishRequest"
    I1027 22:41:03.363288       1 reflector.go:368] Caches populated for *v1alpha3.VirtualMachineService from pkg/mod/k8s.io/client-go@v0.31.0/tools/cache/reflector.go:243
    I1027 22:41:03.366958       1 reflector.go:368] Caches populated for *v1.ConfigMap from pkg/mod/k8s.io/client-go@v0.31.0/tools/cache/reflector.go:243
    I1027 22:41:03.367959       1 reflector.go:368] Caches populated for *v1alpha1.ClusterContentLibraryItem from pkg/mod/k8s.io/client-go@v0.31.0/tools/cache/reflector.go:243
    I1027 22:41:03.368643       1 reflector.go:368] Caches populated for *v1alpha3.VirtualMachineClass from pkg/mod/k8s.io/client-go@v0.31.0/tools/cache/reflector.go:243
    I1027 22:41:03.373192       1 reflector.go:368] Caches populated for *v1.Service from pkg/mod/k8s.io/client-go@v0.31.0/tools/cache/reflector.go:243
    I1027 22:41:03.373443       1 reflector.go:368] Caches populated for *v1.Secret from pkg/mod/k8s.io/client-go@v0.31.0/tools/cache/reflector.go:243
    I1027 22:41:03.373798       1 reflector.go:368] Caches populated for *v1alpha3.VirtualMachineWebConsoleRequest from pkg/mod/k8s.io/client-go@v0.31.0/tools/cache/reflector.go:243
    I1027 22:41:03.378011       1 reflector.go:368] Caches populated for *v1alpha1.Zone from pkg/mod/k8s.io/client-go@v0.31.0/tools/cache/reflector.go:243
    I1027 22:41:03.379465       1 client.go:180] "Creating new vim Client" logger="vmware-system-vmop-controller-manager-6b996f4b45-vj76p.VMWatcherService.NewVimClient" VcPNID="lvn-dvm-10-192-87-148.dvm.lvn.broadcom.net" VcPort="443"
    I1027 22:41:03.389013       1 reflector.go:368] Caches populated for *v1alpha1.WebConsoleRequest from pkg/mod/k8s.io/client-go@v0.31.0/tools/cache/reflector.go:243
    I1027 22:41:03.405472       1 reflector.go:368] Caches populated for *v1.StorageClass from pkg/mod/k8s.io/client-go@v0.31.0/tools/cache/reflector.go:243
    I1027 22:41:03.406750       1 reflector.go:368] Caches populated for *v1.Node from pkg/mod/k8s.io/client-go@v0.31.0/tools/cache/reflector.go:243
    I1027 22:41:03.406997       1 reflector.go:368] Caches populated for *v1alpha3.VirtualMachinePublishRequest from pkg/mod/k8s.io/client-go@v0.31.0/tools/cache/reflector.go:243
    I1027 22:41:03.412496       1 reflector.go:368] Caches populated for *v1.Endpoints from pkg/mod/k8s.io/client-go@v0.31.0/tools/cache/reflector.go:243
    I1027 22:41:03.414181       1 reflector.go:368] Caches populated for *v1alpha3.VirtualMachineSetResourcePolicy from pkg/mod/k8s.io/client-go@v0.31.0/tools/cache/reflector.go:243
    I1027 22:41:03.414801       1 reflector.go:368] Caches populated for *v1alpha1.EncryptionClass from pkg/mod/k8s.io/client-go@v0.31.0/tools/cache/reflector.go:243
    I1027 22:41:03.416137       1 reflector.go:368] Caches populated for *v1alpha1.ContentLibraryItem from pkg/mod/k8s.io/client-go@v0.31.0/tools/cache/reflector.go:243
    I1027 22:41:03.451465       1 controller.go:217] "Starting workers" controller="infra-configmap" worker count=1
    I1027 22:41:03.451826       1 controller.go:217] "Starting workers" controller="infra-secret" worker count=1
    I1027 22:41:03.451948       1 controller.go:217] "Starting workers" controller="clustercontentlibraryitem" controllerGroup="imageregistry.vmware.com" controllerKind="ClusterContentLibraryItem" worker count=20
    I1027 22:41:03.452519       1 infra_secret_controller.go:134] "Reconciling updated VM Operator credentials" logger="controllers.infra-secret" secret="vmware-system-vmop/wcp-vmop-sa-vc-auth"
    I1027 22:41:03.452979       1 infra_configmap_controller.go:128] "Reconciling WCP Cluster Config" logger="controllers.infra-configmap" configMap="kube-system/wcp-cluster-config"
    I1027 22:41:03.453925       1 controller.go:217] "Starting workers" controller="virtualmachineclass" controllerGroup="vmoperator.vmware.com" controllerKind="VirtualMachineClass" worker count=1
    I1027 22:41:03.470294       1 controller.go:217] "Starting workers" controller="volume" worker count=20
    I1027 22:41:03.472217       1 volume_controller.go:294] "Reconciling VirtualMachine for processing volumes" logger="Volumes" name="my-namespace-1/not-encrypted"
    I1027 22:41:03.473055       1 volume_controller.go:294] "Reconciling VirtualMachine for processing volumes" logger="Volumes" name="dougm/crypto-test-with-class"
    I1027 22:41:03.473237       1 volume_controller.go:296] "Finished Reconciling VirtualMachine for processing volumes" logger="Volumes" name="dougm/crypto-test-with-class"
    I1027 22:41:03.474723       1 volume_controller.go:294] "Reconciling VirtualMachine for processing volumes" logger="Volumes" name="my-namespace-1/encrypted-w-default-kms"
    I1027 22:41:03.475362       1 volume_controller.go:296] "Finished Reconciling VirtualMachine for processing volumes" logger="Volumes" name="my-namespace-1/encrypted-w-default-kms"
    I1027 22:41:03.476873       1 volume_controller.go:294] "Reconciling VirtualMachine for processing volumes" logger="Volumes" name="my-namespace-1/encrypted-w-enc-class"
    I1027 22:41:03.477783       1 volume_controller.go:296] "Finished Reconciling VirtualMachine for processing volumes" logger="Volumes" name="my-namespace-1/encrypted-w-enc-class"
    I1027 22:41:03.468508       1 virtualmachine_controller.go:194] "Returning VM reconcile requests due to VirtualMachineClass watch" logger="vmware-system-vmop-controller-manager-6b996f4b45-vj76p" name="best-effort-xsmall" namespace="dougm" requests=[{"Namespace":"dougm","Name":"crypto-test-with-class"}]
    I1027 22:41:03.479257       1 virtualmachine_controller.go:194] "Returning VM reconcile requests due to VirtualMachineClass watch" logger="vmware-system-vmop-controller-manager-6b996f4b45-vj76p" name="best-effort-small" namespace="my-namespace-1" requests=[{"Namespace":"my-namespace-1","Name":"encrypted-w-default-kms"},{"Namespace":"my-namespace-1","Name":"encrypted-w-enc-class"},{"Namespace":"my-namespace-1","Name":"not-encrypted"}]
    I1027 22:41:03.481744       1 client.go:152] "Creating new REST Client" logger="vmware-system-vmop-controller-manager-6b996f4b45-vj76p.VMWatcherService.newRestClient" VcPNID="lvn-dvm-10-192-87-148.dvm.lvn.broadcom.net" VcPort="443"
    I1027 22:41:03.492563       1 reflector.go:368] Caches populated for *v1.PersistentVolumeClaim from pkg/mod/k8s.io/client-go@v0.31.0/tools/cache/reflector.go:243
    I1027 22:41:03.505437       1 controller.go:217] "Starting workers" controller="virtualmachine" controllerGroup="vmoperator.vmware.com" controllerKind="VirtualMachine" worker count=20
    I1027 22:41:03.506177       1 virtualmachine_controller.go:416] "Reconciling VirtualMachine" logger="VirtualMachine" name="my-namespace-1/encrypted-w-enc-class"
    I1027 22:41:03.506180       1 virtualmachine_controller.go:416] "Reconciling VirtualMachine" logger="VirtualMachine" name="my-namespace-1/not-encrypted"
    I1027 22:41:03.506247       1 virtualmachine_controller.go:416] "Reconciling VirtualMachine" logger="VirtualMachine" name="my-namespace-1/encrypted-w-default-kms"
    I1027 22:41:03.506667       1 virtualmachine_controller.go:416] "Reconciling VirtualMachine" logger="VirtualMachine" name="dougm/crypto-test-with-class"
    I1027 22:41:03.507324       1 controller.go:217] "Starting workers" controller="virtualmachinesetresourcepolicy" controllerGroup="vmoperator.vmware.com" controllerKind="VirtualMachineSetResourcePolicy" worker count=1
    I1027 22:41:03.517491       1 vm_watcher_service.go:135] "Got vsphere client" logger="vmware-system-vmop-controller-manager-6b996f4b45-vj76p.VMWatcherService"
    I1027 22:41:03.517908       1 client.go:293] "vsphere client logging out from" logger="Logout" controller="infra-secret" object="vmware-system-vmop/wcp-vmop-sa-vc-auth" namespace="vmware-system-vmop" name="wcp-vmop-sa-vc-auth" reconcileID="388b3283-8d0e-4d1a-adda-2e49145d93fc" VC="lvn-dvm-10-192-87-148.dvm.lvn.broadcom.net:443"
    I1027 22:41:03.518157       1 vm_watcher_service.go:141] "Got vm service folders" logger="vmware-system-vmop-controller-manager-6b996f4b45-vj76p.VMWatcherService" refs=[{"type":"Folder","value":"group-v291"},{"type":"Folder","value":"group-v314"},{"type":"Folder","value":"group-v72"},{"type":"Folder","value":"group-v75"}]
    I1027 22:41:03.518459       1 watcher.go:218] "Started watching VMs" logger="vmware-system-vmop-controller-manager-6b996f4b45-vj76p.VMWatcherService.vSphereWatcher"
    I1027 22:41:03.529019       1 client.go:180] "Creating new vim Client" logger="NewVimClient" controller="virtualmachine" controllerGroup="vmoperator.vmware.com" controllerKind="VirtualMachine" VirtualMachine="my-namespace-1/encrypted-w-enc-class" namespace="my-namespace-1" name="encrypted-w-enc-class" reconcileID="a246a579-8d56-4e8a-9b68-48d6fec348c7" VcPNID="lvn-dvm-10-192-87-148.dvm.lvn.broadcom.net" VcPort="443"
    I1027 22:41:03.578717       1 volume_controller.go:296] "Finished Reconciling VirtualMachine for processing volumes" logger="Volumes" name="my-namespace-1/not-encrypted"
    I1027 22:41:03.580878       1 client.go:152] "Creating new REST Client" logger="newRestClient" controller="virtualmachine" controllerGroup="vmoperator.vmware.com" controllerKind="VirtualMachine" VirtualMachine="my-namespace-1/encrypted-w-enc-class" namespace="my-namespace-1" name="encrypted-w-enc-class" reconcileID="a246a579-8d56-4e8a-9b68-48d6fec348c7" VcPNID="lvn-dvm-10-192-87-148.dvm.lvn.broadcom.net" VcPort="443"
    I1027 22:41:03.583021       1 controller.go:217] "Starting workers" controller="webconsolerequest" controllerGroup="vmoperator.vmware.com" controllerKind="WebConsoleRequest" worker count=1
    I1027 22:41:03.583065       1 controller.go:217] "Starting workers" controller="virtualmachinewebconsolerequest" controllerGroup="vmoperator.vmware.com" controllerKind="VirtualMachineWebConsoleRequest" worker count=1
    I1027 22:41:03.583084       1 controller.go:217] "Starting workers" controller="zone" controllerGroup="topology.tanzu.vmware.com" controllerKind="Zone" worker count=1
    I1027 22:41:03.584445       1 controller.go:217] "Starting workers" controller="virtualmachineservice" controllerGroup="vmoperator.vmware.com" controllerKind="VirtualMachineService" worker count=20
    I1027 22:41:03.594092       1 controller.go:217] "Starting workers" controller="virtualmachinepublishrequest" controllerGroup="vmoperator.vmware.com" controllerKind="VirtualMachinePublishRequest" worker count=20
    I1027 22:41:03.594178       1 controller.go:217] "Starting workers" controller="storageclass" controllerGroup="storage.k8s.io" controllerKind="StorageClass" worker count=1
    I1027 22:41:03.594476       1 controller.go:217] "Starting workers" controller="infra-node" controllerGroup="" controllerKind="Node" worker count=1
    I1027 22:41:03.594509       1 infra_node_controller.go:98] "Received reconcile request" logger="controllers.infra-node" namespace="" name="420f312b5f83f813f7ad0c0b1f79d347"
    I1027 22:41:03.594979       1 controller.go:217] "Starting workers" controller="contentlibraryitem" controllerGroup="imageregistry.vmware.com" controllerKind="ContentLibraryItem" worker count=20
    I1027 22:41:03.628494       1 vm_watcher_service.go:135] "Got vsphere client" logger="vmware-system-vmop-controller-manager-6b996f4b45-vj76p.VMWatcherService"
    I1027 22:41:03.628584       1 vm_watcher_service.go:141] "Got vm service folders" logger="vmware-system-vmop-controller-manager-6b996f4b45-vj76p.VMWatcherService" refs=[{"type":"Folder","value":"group-v291"},{"type":"Folder","value":"group-v314"},{"type":"Folder","value":"group-v72"},{"type":"Folder","value":"group-v75"}]
    I1027 22:41:03.628610       1 watcher.go:218] "Started watching VMs" logger="vmware-system-vmop-controller-manager-6b996f4b45-vj76p.VMWatcherService.vSphereWatcher"
    ```
    
    * The `watcher.go` file now emits logs as expected, even the `V(4)` logs when `-v=4` is added to the container's `args:` field.
    * The NPE no longer occurs.

**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```