### PR TITLE
🌱 Remove duplicate vmopv1.AddToScheme() call

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -52,7 +52,6 @@ func New(ctx context.Context, opts Options) (Manager, error) {
 	opts.defaults()
 
 	_ = clientgoscheme.AddToScheme(opts.Scheme)
-	_ = vmopv1.AddToScheme(opts.Scheme)
 	_ = ncpv1alpha1.AddToScheme(opts.Scheme)
 	_ = cnsv1alpha1.AddToScheme(opts.Scheme)
 	_ = netopv1alpha1.AddToScheme(opts.Scheme)


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

The hub version schema is added with the spokes' schema right after this.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note
NONE
```