### PR TITLE
✨ Support async create VM

### DIFF
--- a/controllers/virtualmachine/virtualmachine/virtualmachine_controller_suite_test.go
+++ b/controllers/virtualmachine/virtualmachine/virtualmachine_controller_suite_test.go
@@ -28,6 +28,8 @@ var suite = builder.NewTestSuiteForControllerWithContext(
 			config.SyncPeriod = 60 * time.Minute
 			config.CreateVMRequeueDelay = 1 * time.Second
 			config.PoweredOnVMHasIPRequeueDelay = 1 * time.Second
+			config.AsyncSignalDisabled = true
+			config.AsyncCreateDisabled = true
 		})),
 	virtualmachine.AddToManager,
 	func(ctx *pkgctx.ControllerManagerContext, _ ctrlmgr.Manager) error {

--- a/controllers/virtualmachinereplicaset/virtualmachinereplicaset_controller_intg_test.go
+++ b/controllers/virtualmachinereplicaset/virtualmachinereplicaset_controller_intg_test.go
@@ -19,7 +19,7 @@ import (
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	vmopv1common "github.com/vmware-tanzu/vm-operator/api/v1alpha3/common"
 	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
-
+	providerfake "github.com/vmware-tanzu/vm-operator/pkg/providers/fake"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
@@ -124,13 +124,15 @@ func intgTestsReconcile() {
 		dummyInstanceUUID := "instanceUUID1234"
 
 		BeforeEach(func() {
-			intgFakeVMProvider.Lock()
-			intgFakeVMProvider.CreateOrUpdateVirtualMachineFn = func(ctx context.Context, vm *vmopv1.VirtualMachine) error {
-				// Used below just to check for something in the Status is updated.
-				vm.Status.InstanceUUID = dummyInstanceUUID
-				return nil
-			}
-			intgFakeVMProvider.Unlock()
+			providerfake.SetCreateOrUpdateFunction(
+				ctx,
+				intgFakeVMProvider,
+				func(ctx context.Context, vm *vmopv1.VirtualMachine) error {
+					// Used below just to check for something in the Status is
+					// updated.
+					vm.Status.InstanceUUID = dummyInstanceUUID
+					return nil
+				})
 		})
 
 		AfterEach(func() {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -100,10 +100,23 @@ type Config struct {
 	// such as passwords. Defaults to false.
 	LogSensitiveData bool
 
-	// AsyncSignalDisabled may be set to false to disable the vm-watcher service
+	// AsyncSignalDisabled may be set to true to disable the vm-watcher service
 	// used to reconcile VirtualMachine objects if their backend state has
 	// changed.
+	//
+	// Please note, this flag has no impact if Features.WorkloadDomainIsolation
+	// is false.
+	//
+	// Defaults to false.
 	AsyncSignalDisabled bool
+
+	// AsyncCreateDisabled may be set to true to disable non-blocking create
+	// operations.
+	//
+	// Please note, this flag has no impact if AsyncSignalDisabled is true.
+	//
+	// Defaults to false.
+	AsyncCreateDisabled bool
 }
 
 // GetMaxDeployThreadsOnProvider returns MaxDeployThreadsOnProvider if it is >0

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -38,6 +38,7 @@ func Default() Config {
 		MaxCreateVMsOnProvider:       80,
 		MaxConcurrentReconciles:      1,
 		AsyncSignalDisabled:          false,
+		AsyncCreateDisabled:          false,
 		CreateVMRequeueDelay:         10 * time.Second,
 		PoweredOnVMHasIPRequeueDelay: 10 * time.Second,
 		NetworkProviderType:          NetworkProviderTypeNamed,

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -28,6 +28,7 @@ func FromEnv() Config {
 	setStringSlice(env.PrivilegedUsers, &config.PrivilegedUsers)
 	setBool(env.LogSensitiveData, &config.LogSensitiveData)
 	setBool(env.AsyncSignalDisabled, &config.AsyncSignalDisabled)
+	setBool(env.AsyncCreateDisabled, &config.AsyncCreateDisabled)
 
 	setDuration(env.InstanceStoragePVPlacementFailedTTL, &config.InstanceStorage.PVPlacementFailedTTL)
 	setFloat64(env.InstanceStorageJitterMaxFactor, &config.InstanceStorage.JitterMaxFactor)

--- a/pkg/config/env/env.go
+++ b/pkg/config/env/env.go
@@ -25,6 +25,7 @@ const (
 	JSONExtraConfig
 	LogSensitiveData
 	AsyncSignalDisabled
+	AsyncCreateDisabled
 	InstanceStoragePVPlacementFailedTTL
 	InstanceStorageJitterMaxFactor
 	InstanceStorageSeedRequeueDuration
@@ -110,6 +111,8 @@ func (n VarName) String() string {
 		return "LOG_SENSITIVE_DATA"
 	case AsyncSignalDisabled:
 		return "ASYNC_SIGNAL_DISABLED"
+	case AsyncCreateDisabled:
+		return "ASYNC_CREATE_DISABLED"
 	case InstanceStoragePVPlacementFailedTTL:
 		return "INSTANCE_STORAGE_PV_PLACEMENT_FAILED_TTL"
 	case InstanceStorageJitterMaxFactor:

--- a/pkg/config/env_test.go
+++ b/pkg/config/env_test.go
@@ -77,6 +77,7 @@ var _ = Describe(
 					Expect(os.Setenv("SYNC_PERIOD", "113h")).To(Succeed())
 					Expect(os.Setenv("MAX_CONCURRENT_RECONCILES", "114")).To(Succeed())
 					Expect(os.Setenv("ASYNC_SIGNAL_DISABLED", "true")).To(Succeed())
+					Expect(os.Setenv("ASYNC_CREATE_DISABLED", "true")).To(Succeed())
 					Expect(os.Setenv("LEADER_ELECTION_ID", "115")).To(Succeed())
 					Expect(os.Setenv("POD_NAME", "116")).To(Succeed())
 					Expect(os.Setenv("POD_NAMESPACE", "117")).To(Succeed())
@@ -126,6 +127,7 @@ var _ = Describe(
 						SyncPeriod:                   113 * time.Hour,
 						MaxConcurrentReconciles:      114,
 						AsyncSignalDisabled:          true,
+						AsyncCreateDisabled:          true,
 						LeaderElectionID:             "115",
 						PodName:                      "116",
 						PodNamespace:                 "117",

--- a/pkg/providers/vsphere/vmlifecycle/create.go
+++ b/pkg/providers/vsphere/vmlifecycle/create.go
@@ -10,7 +10,6 @@ import (
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
-	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 )
 
 // CreateArgs contains the arguments needed to create a VM.
@@ -33,8 +32,6 @@ func CreateVirtualMachine(
 	vimClient *vim25.Client,
 	finder *find.Finder,
 	createArgs *CreateArgs) (*vimtypes.ManagedObjectReference, error) {
-
-	ctxop.MarkCreate(vmCtx)
 
 	if createArgs.UseContentLibrary {
 		return deployFromContentLibrary(vmCtx, restClient, vimClient, createArgs)

--- a/pkg/providers/vsphere/vmprovider_vm2_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm2_test.go
@@ -70,6 +70,7 @@ func vmE2ETests() {
 	JustBeforeEach(func() {
 		ctx = suite.NewTestContextForVCSim(testConfig, initObjects...)
 		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+			config.AsyncSignalDisabled = true
 			config.MaxDeployThreadsOnProvider = 1
 		})
 		vmProvider = vsphere.NewVSphereVMProviderFromClient(ctx, ctx.Client, ctx.Recorder)
@@ -137,10 +138,10 @@ func vmE2ETests() {
 		})
 
 		It("DoIt without an NPE", func() {
-			err := vmProvider.CreateOrUpdateVirtualMachine(ctx, vm)
+			err := createOrUpdateVM(ctx, vmProvider, vm)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = vmProvider.CreateOrUpdateVirtualMachine(ctx, vm)
+			err = createOrUpdateVM(ctx, vmProvider, vm)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(vm.Status.UniqueID).ToNot(BeEmpty())
@@ -188,7 +189,7 @@ func vmE2ETests() {
 			})
 
 			It("DoIt", func() {
-				err := vmProvider.CreateOrUpdateVirtualMachine(ctx, vm)
+				err := createOrUpdateVM(ctx, vmProvider, vm)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
 				Expect(conditions.IsFalse(vm, vmopv1.VirtualMachineConditionNetworkReady)).To(BeTrue())
@@ -222,7 +223,7 @@ func vmE2ETests() {
 					Expect(ctx.Client.Status().Update(ctx, netInterface)).To(Succeed())
 				})
 
-				err = vmProvider.CreateOrUpdateVirtualMachine(ctx, vm)
+				err = createOrUpdateVM(ctx, vmProvider, vm)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("has expected conditions", func() {
@@ -296,7 +297,7 @@ func vmE2ETests() {
 			})
 
 			It("DoIt", func() {
-				err := vmProvider.CreateOrUpdateVirtualMachine(ctx, vm)
+				err := createOrUpdateVM(ctx, vmProvider, vm)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
 				Expect(conditions.IsFalse(vm, vmopv1.VirtualMachineConditionNetworkReady)).To(BeTrue())
@@ -331,7 +332,7 @@ func vmE2ETests() {
 					Expect(ctx.Client.Status().Update(ctx, netInterface)).To(Succeed())
 				})
 
-				err = vmProvider.CreateOrUpdateVirtualMachine(ctx, vm)
+				err = createOrUpdateVM(ctx, vmProvider, vm)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("has expected conditions", func() {
@@ -407,7 +408,7 @@ func vmE2ETests() {
 			})
 
 			It("DoIt", func() {
-				err := vmProvider.CreateOrUpdateVirtualMachine(ctx, vm)
+				err := createOrUpdateVM(ctx, vmProvider, vm)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("subnetPort is not ready yet"))
 				Expect(conditions.IsFalse(vm, vmopv1.VirtualMachineConditionNetworkReady)).To(BeTrue())
@@ -439,7 +440,7 @@ func vmE2ETests() {
 					Expect(ctx.Client.Status().Update(ctx, subnetPort)).To(Succeed())
 				})
 
-				err = vmProvider.CreateOrUpdateVirtualMachine(ctx, vm)
+				err = createOrUpdateVM(ctx, vmProvider, vm)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("has expected conditions", func() {

--- a/pkg/providers/vsphere/vsphere_suite_test.go
+++ b/pkg/providers/vsphere/vsphere_suite_test.go
@@ -4,10 +4,19 @@
 package vsphere_test
 
 import (
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
+	"github.com/vmware/govmomi/object"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
+	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
+	"github.com/vmware-tanzu/vm-operator/pkg/providers"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
@@ -31,3 +40,85 @@ func TestVSphereProvider(t *testing.T) {
 var _ = BeforeSuite(suite.BeforeSuite)
 
 var _ = AfterSuite(suite.AfterSuite)
+
+func createOrUpdateVM(
+	ctx *builder.TestContextForVCSim,
+	provider providers.VirtualMachineProviderInterface,
+	vm *vmopv1.VirtualMachine) error {
+
+	if pkgcfg.FromContext(ctx).Features.WorkloadDomainIsolation {
+		if !pkgcfg.FromContext(ctx).AsyncSignalDisabled {
+			if !pkgcfg.FromContext(ctx).AsyncCreateDisabled {
+				By("non-blocking createOrUpdateVM")
+				return createOrUpdateVMAsync(ctx, provider, vm)
+			}
+		}
+	}
+
+	By("blocking createOrUpdateVM")
+	return provider.CreateOrUpdateVirtualMachine(ctx, vm)
+}
+
+func createOrUpdateAndGetVcVM(
+	ctx *builder.TestContextForVCSim,
+	provider providers.VirtualMachineProviderInterface,
+	vm *vmopv1.VirtualMachine) (*object.VirtualMachine, error) {
+
+	if err := createOrUpdateVM(ctx, provider, vm); err != nil {
+		return nil, err
+	}
+
+	ExpectWithOffset(1, vm.Status.UniqueID).ToNot(BeEmpty())
+	vcVM := ctx.GetVMFromMoID(vm.Status.UniqueID)
+	ExpectWithOffset(1, vcVM).ToNot(BeNil())
+	return vcVM, nil
+}
+
+func createOrUpdateVMAsync(
+	testCtx *builder.TestContextForVCSim,
+	provider providers.VirtualMachineProviderInterface,
+	vm *vmopv1.VirtualMachine) error {
+
+	// This ensures there is no current operation set on the context.
+	ctx := ctxop.WithContext(testCtx)
+
+	chanErr, err := provider.CreateOrUpdateVirtualMachineAsync(ctx, vm)
+	if err != nil {
+		return err
+	}
+
+	// Unlike the VM controller, this test helper blocks until the async
+	// parts of CreateOrUpdateVM are complete. This is to avoid a large
+	// refactor for now.
+	for err2 := range chanErr {
+		if err2 != nil {
+			if err == nil {
+				err = err2
+			} else {
+				err = fmt.Errorf("%w,%w", err, err2)
+			}
+		}
+	}
+	if err != nil {
+		return err
+	}
+
+	if ctxop.IsCreate(ctx) {
+		// The async create operation does not fall-through to the
+		// update logic, so we need to call CreateOrUpdateVirtualMachine
+		// a second time to cause the update.
+		ExpectWithOffset(1, testCtx.Client.Get(
+			ctx,
+			client.ObjectKeyFromObject(vm),
+			vm)).To(Succeed())
+
+		if _, err := provider.CreateOrUpdateVirtualMachineAsync(
+			ctx,
+			vm); err != nil {
+
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch introduces an async variant on the provider's `CreateOrUpdateVirtualMachine` function. This new function, `CreateOrUpdateVirtualMachineAsync`, returns `<-chan error, error`, for when a non-blocking create is used.

Please note, support for async create is only enabled when the async signal feature is enabled. This is because the new async create workflow no longer:

- Falls into a post-create reconfigure, instead allowing async signal to enqueue a new reconcile when the create has completed.
- Requeues the VM after N time based on the VM's state, ex. when the VM is powered on and does not yet have an IP address. This also now relies on async signal when the feature is enabled.

While a non-blocking create does mean the reconciler threads are no longer consumed by create operations, it does not mean VM Op will allow unbounded, concurrent creates. Because each non-blocking create operation consumes a goroutine, the number of concurrent create operations is still limited. The limit is the same as the number of threads previously allowed to do create operations. The difference is, with async create disabled, if 16 threads are doing creates, that is 16 threads that cannot do anything else. With async create enabled, if 16 goroutines are doing create, there are still 16 reconciler threads available to do other things.

This features requires the WorkloadDomainIsolation feature to be enabled and for the environment variable `ASYNC_SIGNAL_DISABLED` to be unset or set to a non-truth-y value. Even if those conditions are met, the environment variable `ASYNC_CREATE_DISABLED` may be set to a truth-y value in order to fall back to the previous behavior.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

This is WiP while I:

- [x] ~~Fix any lingering unit/integration test issues~~
- [x] ~~Replace mention of "create threads" with "create goroutines"~~
- [x] ~~Validation this on a real testbed~~

    ```shell
    $ kubectl -n vmware-system-vmop get pods --no-headers | grep manager | awk '{print $1}' | xargs kubectl -n vmware-system-vmop logs -cmanager | grep 'blocking create'
    I1030 12:53:20.335746       1 vmprovider_vm.go:191] "Doing a non-blocking create" logger="vsphere" vmName="my-namespace-1/cyphr-1"
    I1030 12:53:20.441368       1 vmprovider_vm.go:191] "Doing a non-blocking create" logger="vsphere" vmName="my-namespace-1/clear-1"
    I1030 12:53:20.594433       1 vmprovider_vm.go:191] "Doing a non-blocking create" logger="vsphere" vmName="my-namespace-1/cyphr-1"
    I1030 12:53:20.664159       1 vmprovider_vm.go:191] "Doing a non-blocking create" logger="vsphere" vmName="my-namespace-1/clear-1"
    I1030 12:53:20.708884       1 vmprovider_vm.go:191] "Doing a non-blocking create" logger="vsphere" vmName="my-namespace-1/cyphr-1"
    I1030 12:53:20.789895       1 vmprovider_vm.go:191] "Doing a non-blocking create" logger="vsphere" vmName="my-namespace-1/clear-1"
    ```

    ![image](https://github.com/user-attachments/assets/91841cd4-b17b-4862-a7e9-1c40e8864e6b)

    ![image](https://github.com/user-attachments/assets/bd774dc2-667f-45fa-a09c-d60369fa2a3f)

    Per the log, this obviously has the issue of duplicate creates, although it must be stated the only result of this is an error in the task collector that the item already exists. Anyway, the next action item will remove the duplicates.

- [x] ~~Prevent overlapping creates for the same VM~~

    There is now a single async create op per VM:

    ```shell
    $ kubectl -n vmware-system-vmop get pods --no-headers | grep manager | awk '{print $1}' | xargs kubectl -n vmware-system-vmop logs -cmanager | grep 'blocking create'
    I1030 14:17:28.160553       1 vmprovider_vm.go:208] "Doing a non-blocking create" logger="vsphere" vmName="my-namespace-1/cyphr-1"
    I1030 14:17:28.174597       1 vmprovider_vm.go:208] "Doing a non-blocking create" logger="vsphere" vmName="my-namespace-1/clear-1"
    ```

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Support asynchronous creation of VMs with non-blocking call to Content Library DeployOVF.
```