### PR TITLE
✨ Support building cross-arch images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,22 @@ jobs:
     - name: Vulncheck Go
       run: make vulncheck-go
 
+  build-image:
+    needs:
+    - verify-go-modules
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+    - name: Install Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ env.GO_VERSION }}
+        cache: true
+        cache-dependency-path: '**/go.sum'
+    - name: Build Image
+      run: GOOS=linux GOARCH=amd64 make image-build
+
   build-manager:
     needs:
     - verify-go-modules

--- a/hack/build-container.sh
+++ b/hack/build-container.sh
@@ -15,27 +15,87 @@ IMAGE=
 IMAGE_TAG=
 BUILD_NUMBER=
 
+if [ -z "${GOHOSTOS:-}" ] || [ -z "${GOHOSTARCH:-}" ]; then
+    if ! command -v go >/dev/null 2>&1; then
+        echo "GOHOSTOS and/or GOHOSTARCH are unset and golang is not detected" 1>&2
+        exit 1
+    fi
+fi
+
+GOHOSTOS="${GOHOSTOS:-$(go env GOHOSTOS)}"
+GOHOSTARCH="${GOHOSTARCH:-$(go env GOHOSTARCH)}"
+
+GOOS=linux
+GOARCH="${GOARCH:-${GOHOSTARCH}}"
+
 usage() {
-    echo "Usage: $(basename "${0}") -i image -t imageTag [-n buildNumber] [-c commit] [-b branch] [-v version]"
+    echo "Usage: $(basename "${0}") -i image -t imageTag [-n buildNumber] [-c commit] [-b branch] [-v version] [-o outFile]"
     exit 1
 }
 
-build() {
-    GOOS=linux
-    echo "GOOS=${GOOS} GOARCH=${GOARCH}"
+build_docker() {
+    if [ "${GOOS}" = "${GOHOSTOS}" ] && [ "${GOARCH}" = "${GOHOSTARCH}" ]; then
+
+        "${CRI_BIN}" build . \
+            -t "${IMAGE}":"${IMAGE_TAG}" \
+            -t "${IMAGE}":"${BUILD_NUMBER}" \
+            -t "${IMAGE}":"${BUILD_VERSION}" \
+            --build-arg BUILD_BRANCH="${BUILD_BRANCH}" \
+            --build-arg BUILD_COMMIT="${BUILD_COMMIT}" \
+            --build-arg BUILD_NUMBER="${BUILD_NUMBER}" \
+            --build-arg BUILD_VERSION="${BUILD_VERSION}"
+
+    elif docker buildx version >/dev/null 2>&1; then
+
+        "${CRI_BIN}" buildx build . \
+            -t "${IMAGE}":"${IMAGE_TAG}" \
+            -t "${IMAGE}":"${BUILD_NUMBER}" \
+            -t "${IMAGE}":"${BUILD_VERSION}" \
+            --platform "${GOOS}/${GOARCH}" \
+            --build-arg BUILD_BRANCH="${BUILD_BRANCH}" \
+            --build-arg BUILD_COMMIT="${BUILD_COMMIT}" \
+            --build-arg BUILD_NUMBER="${BUILD_NUMBER}" \
+            --build-arg BUILD_VERSION="${BUILD_VERSION}"
+
+    else
+
+        echo "docker buildx is not installed" 1>&2
+        exit 1
+
+    fi
+}
+
+build_podman() {
     "${CRI_BIN}" build . \
         -t "${IMAGE}":"${IMAGE_TAG}" \
         -t "${IMAGE}":"${BUILD_NUMBER}" \
         -t "${IMAGE}":"${BUILD_VERSION}" \
+        --os "${GOOS}" --arch "${GOARCH}" \
         --build-arg BUILD_BRANCH="${BUILD_BRANCH}" \
         --build-arg BUILD_COMMIT="${BUILD_COMMIT}" \
         --build-arg BUILD_NUMBER="${BUILD_NUMBER}" \
-        --build-arg BUILD_VERSION="${BUILD_VERSION}" \
-        --build-arg TARGETOS="${GOOS}" \
-        --build-arg TARGETARCH="${GOARCH}"
+        --build-arg BUILD_VERSION="${BUILD_VERSION}"
 }
 
-while getopts ":i:t:n:c:b:v:" opt ; do
+build() {
+    echo "GOOS=${GOOS} GOARCH=${GOARCH}"
+
+    if [[ "${CRI_BIN}" == *"podman"* ]]; then
+        build_podman
+    elif [[ "${CRI_BIN}" == *"docker"* ]]; then
+        build_docker
+    else
+        echo "unsupported cri: '${CRI_BIN}'" 1>&2
+        exit 1
+    fi
+
+    if [ -n "${OUT_FILE:-}" ]; then
+        mkdir -p "$(dirname "${OUT_FILE}")"
+        "${CRI_BIN}" save "${IMAGE}":"${IMAGE_TAG}" -o "${OUT_FILE}"
+    fi
+}
+
+while getopts ":i:t:n:c:b:v:o:" opt ; do
     case $opt in
         "i" ) IMAGE="${OPTARG}" ;;
         "t" ) IMAGE_TAG="${OPTARG}" ;;
@@ -43,6 +103,7 @@ while getopts ":i:t:n:c:b:v:" opt ; do
         "c" ) BUILD_COMMIT="${OPTARG}" ;;
         "n" ) BUILD_NUMBER="${OPTARG}" ;;
         "v" ) BUILD_VERSION="${OPTARG}" ;;
+        "o" ) OUT_FILE="${OPTARG}" ;;
         \? ) usage ;;
     esac
 done


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch adds support for building images targeting an architecture different than the host's by specifying GOARCH with the desired architecture. For example, the following command will build a linux/amd64 image, even when executed on an Apple silicon mac:

    GOARCH=amd64 make image-build

Please note, this feature requires either Podman or a version of Docker that supports buildx.

This patch also:

- Renames all the `docker-*` targets to `image-*`. The docker aliases are retained for backwards-compatibility.
- Saves any images built with the `image-build` target to the file `artifacts/vmoperator-controller-GOOS_GOARCH.tar`.
- Adds a GitHub action that verifies the `linux/amd64` image can be successfully built using `GOOS=linux GOARCH=amd64 make image-build` ([example](https://github.com/vmware-tanzu/vm-operator/actions/runs/11581241952/job/32241551604?pr=783))


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Support building cross-architecture images with the Makefile target "image-build".
```