### PR TITLE
🐛 byok: validate encryption class keyID if specified

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/vmware-tanzu/vm-operator/external/tanzu-topology v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/vm-operator/pkg/backup/api v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels v0.0.0-00010101000000-000000000000
-	github.com/vmware/govmomi v0.31.1-0.20241025205634-def262db6acd
+	github.com/vmware/govmomi v0.31.1-0.20241029205713-bbb6349a977c
 	golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc
 	// * https://github.com/vmware-tanzu/vm-operator/security/dependabot/24
 	golang.org/x/text v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -467,8 +467,8 @@ github.com/vmware-tanzu/net-operator-api v0.0.0-20240523152550-862e2c4eb0e0 h1:y
 github.com/vmware-tanzu/net-operator-api v0.0.0-20240523152550-862e2c4eb0e0/go.mod h1:w6QJGm3crIA16ZIz1FVQXD2NVeJhOgGXxW05RbVTSTo=
 github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20240902045731-00a14868c72d h1:6pMXrQmTYpu5FipoQ9fT4FJG3VPMMbBoIi6h3KvdQc8=
 github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20240902045731-00a14868c72d/go.mod h1:Q4JzNkNMvjo7pXtlB5/R3oME4Nhah7fAObWgghVmtxk=
-github.com/vmware/govmomi v0.31.1-0.20241025205634-def262db6acd h1:7ANFT9+DBJR8gsFqheHSsq6nzjavRH0Dr+NX9EdcgPU=
-github.com/vmware/govmomi v0.31.1-0.20241025205634-def262db6acd/go.mod h1:uoLVU9zlXC4p4GmLVG+ZJmBC0Gn3Q7mytOJvi39OhxA=
+github.com/vmware/govmomi v0.31.1-0.20241029205713-bbb6349a977c h1:sEdqrNYGMO7w0RcNxJL6wa2yQ+RWLEMrMEl0qT2yzPI=
+github.com/vmware/govmomi v0.31.1-0.20241029205713-bbb6349a977c/go.mod h1:uoLVU9zlXC4p4GmLVG+ZJmBC0Gn3Q7mytOJvi39OhxA=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/pkg/vmconfig/crypto/crypto_reconciler_pre_test.go
+++ b/pkg/vmconfig/crypto/crypto_reconciler_pre_test.go
@@ -327,6 +327,22 @@ var _ = Describe("Reconcile", Label(testlabels.Crypto), func() {
 					})
 				})
 
+				When("the EncryptionClass specifies an invalid key id", func() {
+					BeforeEach(func() {
+						encClass.Spec.KeyProvider = provider1ID
+						encClass.Spec.KeyID = "invalid"
+					})
+					It("should return an error", func() {
+						Expect(err).To(HaveOccurred())
+						Expect(err).To(MatchError(pkgcrypto.ErrInvalidKeyID))
+						c := conditions.Get(vm, vmopv1.VirtualMachineEncryptionSynced)
+						Expect(c).ToNot(BeNil())
+						Expect(c.Status).To(Equal(metav1.ConditionFalse))
+						Expect(c.Reason).To(Equal(pkgcrypto.ReasonEncryptionClassInvalid.String()))
+						Expect(c.Message).To(Equal(pkgcrypto.ErrInvalidKeyID.Error()))
+					})
+				})
+
 				When("the EncryptionClass exists", func() {
 					When("the vm is being created with a vtpm", func() {
 						BeforeEach(func() {


### PR DESCRIPTION
56a5c8a2 removed keyID validation, as 'IsValidKey' used the ListKeys API which only returns keys cached in vCenter. The 'IsValidKey' impl now uses 'QueryCryptoKeyStatus' which checks keyID against the KMS.
