### PR TITLE
🐛 Set bus number when adding SATA controllers for CD-ROM assignment

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/vmware-tanzu/vm-operator/external/tanzu-topology v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/vm-operator/pkg/backup/api v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels v0.0.0-00010101000000-000000000000
-	github.com/vmware/govmomi v0.31.1-0.20241029205713-bbb6349a977c
+	github.com/vmware/govmomi v0.31.1-0.20241031174243-82b4ad661180
 	golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc
 	// * https://github.com/vmware-tanzu/vm-operator/security/dependabot/24
 	golang.org/x/text v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -467,8 +467,8 @@ github.com/vmware-tanzu/net-operator-api v0.0.0-20240523152550-862e2c4eb0e0 h1:y
 github.com/vmware-tanzu/net-operator-api v0.0.0-20240523152550-862e2c4eb0e0/go.mod h1:w6QJGm3crIA16ZIz1FVQXD2NVeJhOgGXxW05RbVTSTo=
 github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20240902045731-00a14868c72d h1:6pMXrQmTYpu5FipoQ9fT4FJG3VPMMbBoIi6h3KvdQc8=
 github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20240902045731-00a14868c72d/go.mod h1:Q4JzNkNMvjo7pXtlB5/R3oME4Nhah7fAObWgghVmtxk=
-github.com/vmware/govmomi v0.31.1-0.20241029205713-bbb6349a977c h1:sEdqrNYGMO7w0RcNxJL6wa2yQ+RWLEMrMEl0qT2yzPI=
-github.com/vmware/govmomi v0.31.1-0.20241029205713-bbb6349a977c/go.mod h1:uoLVU9zlXC4p4GmLVG+ZJmBC0Gn3Q7mytOJvi39OhxA=
+github.com/vmware/govmomi v0.31.1-0.20241031174243-82b4ad661180 h1:EnF983cbd8pmpi1tvADVIQst/YMlU6tEZYF192gWsho=
+github.com/vmware/govmomi v0.31.1-0.20241031174243-82b4ad661180/go.mod h1:uoLVU9zlXC4p4GmLVG+ZJmBC0Gn3Q7mytOJvi39OhxA=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR updates the CD-ROM assignment to use govmomi's [CreateSATAController()](https://github.com/vmware/govmomi/blob/82b4ad6611804783301025a78fd26d0224ed594f/object/virtual_device_list.go#L401-L412) function when adding a new SATA controller. This ensures that new SATA controllers are created with a proper *bus number*. Otherwise, adding two or more SATA controllers would fail due to duplicate bus numbers (default with 0) among these controllers.

**Which issue(s) is/are addressed by this PR?**

Fix N/A.

**Are there any special notes for your reviewer**:

This change is verified by:
- Adding new tests (maintaining 100% code coverage of the `cdrmo.go` file).
- Successfully deploying and powering on a VM Service VM with max supported CD-ROMs (2 IDE * 2 + 4 SATA * 30 = **124**):

```console
$ kubectl get vm -n sdiliyaer-test 124-cdrom
NAME        POWER-STATE   AGE
124-cdrom   PoweredOn     8m15s

$ govc device.ls -json -vm 124-cdrom cdrom-\* | jq '.devices | length'
124
```

<details>
<summary>Complete SATA controllers list with CD-ROMs assigned</summary>

```console
$ govc device.info -json -vm 124-cdrom ahci-\*  | jq '.devices |= sort_by(.key)'
{
  "devices": [
    {
      "name": "ahci-15000",
      "type": "VirtualAHCIController",
      "key": 15000,
      "deviceInfo": {
        "label": "SATA controller 0",
        "summary": "AHCI"
      },
      "slotInfo": {
        "pciSlotNumber": 32
      },
      "controllerKey": 100,
      "unitNumber": 24,
      "busNumber": 0,
      "device": [
        16017,
        16020,
        16009,
        16000,
        16012,
        16004,
        16021,
        16013,
        16005,
        16006,
        16010,
        16011,
        16027,
        16022,
        16028,
        16001,
        16029,
        16007,
        16008,
        16014,
        16002,
        16023,
        16024,
        16025,
        16026,
        16015,
        16016,
        16003,
        16018,
        16019
      ]
    },
    {
      "name": "ahci-15001",
      "type": "VirtualAHCIController",
      "key": 15001,
      "deviceInfo": {
        "label": "SATA controller 1",
        "summary": "AHCI"
      },
      "slotInfo": {
        "pciSlotNumber": 33
      },
      "controllerKey": 100,
      "unitNumber": 25,
      "busNumber": 1,
      "device": [
        16036,
        16040,
        16032,
        16042,
        16050,
        16051,
        16057,
        16037,
        16038,
        16058,
        16052,
        16033,
        16034,
        16045,
        16046,
        16039,
        16043,
        16047,
        16035,
        16059,
        16030,
        16031,
        16053,
        16054,
        16041,
        16055,
        16048,
        16049,
        16044,
        16056
      ]
    },
    {
      "name": "ahci-15002",
      "type": "VirtualAHCIController",
      "key": 15002,
      "deviceInfo": {
        "label": "SATA controller 2",
        "summary": "AHCI"
      },
      "slotInfo": {
        "pciSlotNumber": 34
      },
      "controllerKey": 100,
      "unitNumber": 26,
      "busNumber": 2,
      "device": [
        16065,
        16071,
        16089,
        16085,
        16086,
        16066,
        16067,
        16077,
        16072,
        16078,
        16087,
        16079,
        16073,
        16060,
        16061,
        16074,
        16075,
        16082,
        16080,
        16083,
        16070,
        16068,
        16069,
        16084,
        16081,
        16063,
        16088,
        16076,
        16062,
        16064
      ]
    },
    {
      "name": "ahci-15003",
      "type": "VirtualAHCIController",
      "key": 15003,
      "deviceInfo": {
        "label": "SATA controller 3",
        "summary": "AHCI"
      },
      "slotInfo": {
        "pciSlotNumber": 35
      },
      "controllerKey": 100,
      "unitNumber": 27,
      "busNumber": 3,
      "device": [
        16109,
        16098,
        16110,
        16105,
        16099,
        16100,
        16106,
        16107,
        16093,
        16108,
        16094,
        16111,
        16112,
        16095,
        16101,
        16117,
        16118,
        16090,
        16096,
        16091,
        16097,
        16092,
        16114,
        16113,
        16115,
        16102,
        16119,
        16103,
        16116,
        16104
      ]
    }
  ]
}
```

</details>

**Please add a release note if necessary**:

```release-note
Set bus number when adding SATA controllers for CD-ROM assignment.
```