### PR TITLE
🐛 Export container image with full version

### DIFF
--- a/hack/build-container.sh
+++ b/hack/build-container.sh
@@ -71,7 +71,7 @@ build() {
 
     if [ -n "${OUT_FILE:-}" ]; then
         mkdir -p "$(dirname "${OUT_FILE}")"
-        "${CRI_BIN}" save "${IMAGE}":"${IMAGE_TAG}" -o "${OUT_FILE}"
+        "${CRI_BIN}" save "${IMAGE}":"${IMAGE_VERSION}" -o "${OUT_FILE}"
     fi
 }
 


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch updates the build-container.sh script to export the image using its full version rather than "latest".


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
The Makefile image-build target now exports the image with its full version.
```