### PR TITLE
🌱Remove BackupUpToDate Condition from the backup data

### DIFF
--- a/pkg/providers/vsphere/virtualmachine/backup.go
+++ b/pkg/providers/vsphere/virtualmachine/backup.go
@@ -166,6 +166,8 @@ func BackupVirtualMachine(opts BackupVirtualMachineOptions) (result error) {
 			// Use a copy of the VM object since the actual VM obj will be annotated if and once reconfigure succeeds.
 			copyVM := opts.VMCtx.VM.DeepCopy()
 			setBackupVersionAnnotation(copyVM, opts.BackupVersion)
+			// Remove the BackupUpToDateCondition from previous VM backup to remove ambiguity with newer backup version annotation.
+			conditions.Delete(copyVM, vmopv1.VirtualMachineBackupUpToDateCondition)
 			// Backup the updated VM's YAML with encoding and compression.
 			trimBackupFields(copyVM)
 			encodedVMYaml, err := getEncodedVMYaml(copyVM)

--- a/pkg/providers/vsphere/virtualmachine/backup_test.go
+++ b/pkg/providers/vsphere/virtualmachine/backup_test.go
@@ -193,6 +193,9 @@ func backupTests() {
 					JustBeforeEach(func() {
 						if IncrementalRestore {
 							vmCtx.VM.Annotations[vmopv1.VirtualMachineBackupVersionAnnotation] = vT2
+							vmCtx.VM.Status.Conditions = []metav1.Condition{
+								{Type: vmopv1.VirtualMachineBackupUpToDateCondition, Status: "True"},
+							}
 						}
 
 						oldVM := vmCtx.VM.DeepCopy()
@@ -234,6 +237,7 @@ func backupTests() {
 						}
 
 						Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
+						// getExpectedBackupObjectYaml empties the expected VM yaml's status
 						expectedVMYAML := getExpectedBackupObjectYAML(vmCtx.VM.DeepCopy())
 						verifyBackupDataInExtraConfig(ctx, vcVM, backupapi.VMResourceYAMLExtraConfigKey, expectedVMYAML, true)
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This changes is purely cosmetic and for debugging ease. The backupData will always end up having a condition pointing to the previous successful backup while the annotation would be the newer one. This removes the ambiguity.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #
N/A

**Are there any special notes for your reviewer**:

N/A


**Please add a release note if necessary**:

```
NONE
```