### PR TITLE
✨ Deprecate ProbeManager for non-TCP probes

### DIFF
--- a/pkg/record/recorder_context.go
+++ b/pkg/record/recorder_context.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package record
+
+import (
+	"context"
+
+	ctxgen "github.com/vmware-tanzu/vm-operator/pkg/context/generic"
+)
+
+type contextKeyType uint8
+
+const contextKeyValue contextKeyType = 0
+
+type contextValueType = Recorder
+
+// FromContext returns the recorder from the specified context.
+func FromContext(ctx context.Context) contextValueType {
+	return ctxgen.FromContext(
+		ctx,
+		contextKeyValue,
+		func(val contextValueType) contextValueType {
+			return val
+		})
+}
+
+// WithContext returns a new recorder context.
+func WithContext(parent context.Context, val contextValueType) context.Context {
+	if val == nil {
+		panic("recorder is nil")
+	}
+	return ctxgen.WithContext(
+		parent,
+		contextKeyValue,
+		func() contextValueType { return val })
+}

--- a/pkg/record/recorder_context_test.go
+++ b/pkg/record/recorder_context_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package record_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	apirecord "k8s.io/client-go/tools/record"
+
+	"github.com/vmware-tanzu/vm-operator/pkg/record"
+)
+
+var _ = Describe("WithContext", func() {
+	var (
+		left    context.Context
+		leftVal record.Recorder
+	)
+	BeforeEach(func() {
+		left = context.Background()
+		leftVal = record.New(apirecord.NewFakeRecorder(0))
+	})
+	When("parent is nil", func() {
+		BeforeEach(func() {
+			left = nil
+		})
+		It("should panic", func() {
+			fn := func() {
+				_ = record.WithContext(left, leftVal)
+			}
+			Expect(fn).To(PanicWith("parent context is nil"))
+		})
+	})
+	When("parent is not nil", func() {
+		When("value is nil", func() {
+			BeforeEach(func() {
+				leftVal = nil
+			})
+			It("should panic", func() {
+				fn := func() {
+					_ = record.WithContext(left, leftVal)
+				}
+				Expect(fn).To(PanicWith("recorder is nil"))
+			})
+		})
+		When("value is not nil", func() {
+			It("should return a new context", func() {
+				ctx := record.WithContext(left, leftVal)
+				Expect(ctx).ToNot(BeNil())
+				Expect(record.FromContext(ctx)).To(Equal(leftVal))
+			})
+		})
+	})
+})

--- a/pkg/util/vsphere/watcher/watcher.go
+++ b/pkg/util/vsphere/watcher/watcher.go
@@ -29,6 +29,7 @@ func DefaultWatchedPropertyPaths() []string {
 		"config.keyId",
 		"guest.ipStack",
 		"guest.net",
+		"guestHeartbeatStatus",
 		"summary.config.name",
 		"summary.guest",
 		"summary.overallStatus",

--- a/test/builder/vcsim_test_context.go
+++ b/test/builder/vcsim_test_context.go
@@ -297,6 +297,8 @@ func newTestContextForVCSim(
 
 	fakeRecorder, _ := NewFakeRecorder()
 
+	parentCtx = record.WithContext(parentCtx, fakeRecorder)
+
 	ctx := &TestContextForVCSim{
 		UnitTestContext: NewUnitTestContextWithParentContext(parentCtx, initObjects...),
 		PodNamespace:    "vmop-pod-test",
@@ -312,6 +314,7 @@ func newTestContextForVCSim(
 	ctx.ClustersPerZone = clustersPerZone
 	// TODO: this can be removed once FSS_WCP_WORKLOAD_DOMAIN_ISOLATION enabled.
 	ctx.withWorkloadIsolation = config.WithWorkloadIsolation
+
 	return ctx
 }
 


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch deprecates the use of ProbeManager for non-TCP probes when the AsyncSignal feature is enabled. This is because VMs will be reconciled as soon as their heartbeat or guestinfo information is updated, and thus readiness can be determined in the normal VM reconcile loop.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
The ProbeManager framework is deprecated for non-TCP probes when async signal is enabled.
```