### PR TITLE
🌱 Use VAPI ActivationID with DeployOVF

### DIFF
--- a/pkg/providers/vsphere/virtualmachine/publish.go
+++ b/pkg/providers/vsphere/virtualmachine/publish.go
@@ -5,7 +5,6 @@ package virtualmachine
 
 import (
 	"fmt"
-	"net/http"
 
 	"github.com/vmware/govmomi/vapi/rest"
 	"github.com/vmware/govmomi/vapi/vcenter"
@@ -14,13 +13,11 @@ import (
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
 )
 
 const (
 	sourceVirtualMachineType = "VirtualMachine"
-
-	// vAPICtxActIDHttpHeader represents the http header in vAPI to pass down the activation ID.
-	vAPICtxActIDHttpHeader = "vapi-ctx-actid"
 
 	itemDescriptionFormat = "virtualmachinepublishrequest.vmoperator.vmware.com: %s\n"
 )
@@ -59,6 +56,7 @@ func CreateOVF(
 
 	// Use vmpublish uid as the act id passed down to the content library service, so that we can track
 	// the task status by the act id.
-	ctxHeader := client.WithHeader(vmCtx, http.Header{vAPICtxActIDHttpHeader: []string{actID}})
-	return vcenter.NewManager(client).CreateOVF(ctxHeader, ovf)
+	return vcenter.NewManager(client).CreateOVF(
+		pkgutil.WithVAPIActivationID(vmCtx, client, actID),
+		ovf)
 }

--- a/pkg/providers/vsphere/vmlifecycle/create_contentlibrary.go
+++ b/pkg/providers/vsphere/vmlifecycle/create_contentlibrary.go
@@ -59,7 +59,10 @@ func deployOVF(
 
 	vmCtx.Logger.Info("Deploying OVF Library Item", "itemID", item.ID, "itemName", item.Name, "deploy", deploy)
 
-	return vcenter.NewManager(restClient).DeployLibraryItem(vmCtx, item.ID, deploy)
+	return vcenter.NewManager(restClient).DeployLibraryItem(
+		util.WithVAPIActivationID(vmCtx, restClient, vmCtx.VM.Spec.InstanceUUID),
+		item.ID,
+		deploy)
 }
 
 func createVM(

--- a/pkg/util/vapi.go
+++ b/pkg/util/vapi.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/vmware/govmomi/vapi/rest"
+)
+
+// vapiActivationIDHeader is the HTTP header to pass to a VAPI API in order
+// to influence the activationID of the vim.Task spawned by the VAPI API.
+const vapiActivationIDHeader = "vapi-ctx-actid"
+
+// WithVAPIActivationID adds the specified id to the context to be used as the
+// VAPI REST client's activation ID -- the value assigned to the activationId
+// field to the vim.Task the VAPI API may spawn.
+func WithVAPIActivationID(
+	ctx context.Context,
+	client *rest.Client,
+	id string) context.Context {
+
+	return client.WithHeader(
+		ctx,
+		http.Header{vapiActivationIDHeader: []string{id}},
+	)
+}


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch updates the DeployOVF call to use the VAPI activationID header. The value is set to the VM's instance UUID. This means the vim.Task that Content Library spawns to track the actual DeployOVF operation will have its activationId field set to the value of vm.spec.instanceUUID. Thus VM Operator can find and track the task, even though the DeployOVF call is blocking and does not return a task ID.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Use vm.spec.instanceUUID as the VAPI activation ID when calling ContentLibrary's DeployOVF API.
```