### PR TITLE
:seedling: Allow SRM to change network of a registered VM for test failover

### DIFF
--- a/pkg/backup/api/backup_types.go
+++ b/pkg/backup/api/backup_types.go
@@ -3,6 +3,9 @@
 
 package api
 
+// GroupName specifies the group name for VM operator.
+const GroupName = "vmoperator.vmware.com"
+
 // ToPersistentVolumeAccessModes returns a string slice from a slice of T.
 // This is useful when converting a slice of corev1.PersistentVolumeAccessMode
 // to a string slice.
@@ -105,4 +108,20 @@ const (
 	// specifying this key, backup/restore and/or disaster recovery solutions are
 	// responsible to register the VM with Supervisor.
 	DisableAutoRegistrationExtraConfigKey = "vmservice.virtualmachine.disableAutomaticRegistration"
+
+	// TestFailoverLabelKey label signifies that a VirtualMachine is going through
+	// a test recovery plan scenario. Typically, this involves failing over a VM
+	// to a dedicated temporary network so as to not exhaust, and cause IP address
+	// collisions with the production network. This label on a VirtualMachine
+	// custom resource allows vendors to change the VM's network interface to
+	// connect to the test network after the VM is registered post a failover.
+	//
+	// VM operator does not support mutable networks, so this label allows only
+	// select vendors (e.g., SRM) to support recovery plan test workflows while we
+	// build support for true network mutability.
+	//
+	// The value of this label does not matter. Its presence is considered a
+	// sufficient evidence to indicate that the virtual machine is going through
+	// test fail-over.
+	TestFailoverLabelKey = "virtualmachine." + GroupName + "/test-failover"
 )

--- a/webhooks/virtualmachine/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator.go
@@ -33,6 +33,7 @@ import (
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	"github.com/vmware-tanzu/vm-operator/api/v1alpha3/sysprep"
+	backupapi "github.com/vmware-tanzu/vm-operator/pkg/backup/api"
 	"github.com/vmware-tanzu/vm-operator/pkg/builder"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	"github.com/vmware-tanzu/vm-operator/pkg/constants"
@@ -1193,6 +1194,12 @@ func (v validator) validateImmutableNetwork(ctx *pkgctx.WebhookRequestContext, v
 
 	if len(oldInterfaces) != len(newInterfaces) {
 		return append(allErrs, field.Forbidden(p.Child("interfaces"), "network interfaces cannot be added or removed"))
+	}
+
+	// Skip comparing interfaces if this is a test fail-over to allow vendors to
+	// connect network each interface to test network.
+	if _, ok := vm.Labels[backupapi.TestFailoverLabelKey]; ok {
+		return allErrs
 	}
 
 	for i := range newInterfaces {


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

SRM (Site Reliability Manager) needs to be able to change a VM's network interface to connect to the test failover network.  This change skips part of the validation webhook if a predefined test failover label is present on the VM resource.  This change introduces a label (as opposed to an annotation) because we want to allow server side indexing so clients can filter and operate on all VMs that are part of a test failover.  This will help with debuggability, and cleanup of test failed over VMs. 

A test failover does not need to add new interfaces, so keep that check as is.

**Testing Done**
- Existing unit tests as well as newly added tests
- Manually tested by loading VM operator in an env 
  - Without the label
```
root@4214a043bbff661bcddbde32adee61b3 [ ~ ]# kubectl patch vm -n parunesh-ns srm-vm --type='json' -p='[{"op": "replace", "path": "/spec/network/interfaces/1/network/name", "value": "my-subnet-2"}]' 
Error from server (spec.network.interfaces[1].network: Forbidden: field is immutable): admission webhook "default.validating.virtualmachine.v1alpha3.vmoperator.vmware.com" denied the request: spec.network.interfaces[1].network: Forbidden: field is immutable
```

  - Edit the VM to apply the label 
```
root@4214a043bbff661bcddbde32adee61b3 [ ~ ]# k edit vm -n parunesh-ns srm-vm virtualmachine.vmoperator.vmware.com/srm-vm edited
```

  - Verify that edits are allowed 
```
root@4214a043bbff661bcddbde32adee61b3 [ ~ ]# kubectl patch vm -n parunesh-ns srm-vm --type='json' -p='[{"op": "replace", "path": "/spec/network/interfaces/1/network/name", "value": "my-subnet-2"}]' virtualmachine.vmoperator.vmware.com/srm-vm patched
```


**Are there any special notes for your reviewer**:

This is needed specifically for SRM (and possibly other vendors exercising a test failover).  As such, I have called out in the API docs that it is not an otherwise supported workflow.


**Please add a release note if necessary**:

```release-note
Allow SRM to change network of a registered VM for test failover
```