### PR TITLE
✨ Ensure NICs are connected / start connected

### DIFF
--- a/pkg/util/vmopv1/resize_overwrite.go
+++ b/pkg/util/vmopv1/resize_overwrite.go
@@ -33,6 +33,7 @@ func OverwriteResizeConfigSpec(
 
 	overwriteGuestID(vm, ci, cs)
 	overwriteExtraConfig(vm, ci, cs)
+	ReconcileNetworkDeviceConnectionState(&ci, cs)
 
 	return nil
 }
@@ -241,6 +242,107 @@ func updateV1Alpha1CompatibleEC(
 
 	return []vimtypes.BaseOptionValue{
 		&vimtypes.OptionValue{Key: constants.VMOperatorV1Alpha1ExtraConfigKey, Value: constants.VMOperatorV1Alpha1ConfigEnabled},
+	}
+}
+
+// ReconcileNetworkDeviceConnectionState ensures the VMs network interface
+// devices are connected and start connected. Please note, this function should
+// only modify the configSpec if:
+//   - there is a network device in configInfo that is not connected or does not
+//     start connected and is not being removed in the configSpec.
+//   - there is a new network device in configSpec (i.e. it has a negative
+//     device key) and is not marked connected or not marked as starting
+//     connected.
+//
+// The ci parameter may be nil when this function is used to ensure the correct
+// behavior for a ConfigSpec used to create a new VM.
+func ReconcileNetworkDeviceConnectionState(
+	ci *vimtypes.VirtualMachineConfigInfo,
+	cs *vimtypes.VirtualMachineConfigSpec) {
+
+	// Get a list of current NICs.
+	curDevLst := []*vimtypes.VirtualEthernetCard{}
+	curDevMap := map[int32]*vimtypes.VirtualEthernetCard{}
+	if ci != nil {
+		for i := range ci.Hardware.Device {
+			if bd, ok := ci.Hardware.Device[i].(vimtypes.BaseVirtualEthernetCard); ok {
+				d := bd.GetVirtualEthernetCard()
+				curDevMap[d.Key] = d
+				curDevLst = append(curDevLst, d)
+			}
+		}
+	}
+
+	// Parse the ConfigSpec for new/modified NICs.
+	modDevs := map[int32]*vimtypes.VirtualEthernetCard{}
+	if cs != nil {
+		for i := range cs.DeviceChange {
+			ds := cs.DeviceChange[i].GetVirtualDeviceConfigSpec()
+			if bd, ok := ds.Device.(vimtypes.BaseVirtualEthernetCard); ok {
+				d := bd.GetVirtualEthernetCard()
+				if _, ok := curDevMap[d.Key]; ok {
+					//
+					// NIC already exists.
+					//
+					if ds.Operation == vimtypes.VirtualDeviceConfigSpecOperationRemove {
+						//
+						// NIC is being removed.
+						//
+						delete(curDevMap, d.Key)
+					} else {
+						//
+						// NIC is being updated.
+						//
+						modDevs[d.Key] = d
+					}
+				} else {
+					//
+					// NIC is being added, ensure it is connected.
+					//
+					if d.Connectable == nil {
+						d.Connectable = &vimtypes.VirtualDeviceConnectInfo{}
+					}
+					d.Connectable.StartConnected = true
+					d.Connectable.Connected = true
+				}
+			}
+		}
+	}
+
+	// Ensure all current NICs are connected and start connected.
+	for _, d := range curDevLst {
+		if _, ok := curDevMap[d.Key]; ok {
+
+			if d.Connectable == nil ||
+				!d.Connectable.Connected ||
+				!d.Connectable.StartConnected {
+
+				connectable := d.Connectable
+				if connectable == nil {
+					connectable = &vimtypes.VirtualDeviceConnectInfo{}
+				}
+				connectable.Connected = true
+				connectable.StartConnected = true
+
+				// The NIC is either not connected or not set to start
+				// connected.
+				if md, ok := modDevs[d.Key]; ok {
+					// The NIC is already part of the ConfigSpec, so update
+					// it there so its connection state information is
+					// correct.
+					md.Connectable = connectable
+				} else if cs != nil {
+					// Add the NIC to the ConfigSpec to ensure it is
+					// connected and starts connected.
+					d.Connectable = connectable
+					cs.DeviceChange = append(cs.DeviceChange,
+						&vimtypes.VirtualDeviceConfigSpec{
+							Operation: vimtypes.VirtualDeviceConfigSpecOperationEdit,
+							Device:    d,
+						})
+				}
+			}
+		}
 	}
 }
 


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch adds support for VM Op ensuring NICs are always connected and start connected for VMs that are not paused either by an Admin or DevOps user.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

@bryanv, please note that I ensured all the actual meat and potatoes logic is in the new resize location. 


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Ensure NICs are connected for VMs not paused by admin or DevOps users.
```