### PR TITLE
🐛 Set min HW version when VM has vTPM

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -30,6 +30,10 @@ const (
 	// persistent volumes.
 	MinSupportedHWVersionForPVC = vimtypes.VMX15
 
+	// MinSupportedHWVersionForVTPM is the supported virtual hardware version
+	// for a Virtual Trusted Platform Module (vTPM).
+	MinSupportedHWVersionForVTPM = vimtypes.VMX14
+
 	// MinSupportedHWVersionForPCIPassthruDevices is the supported virtual
 	// hardware version for NVidia PCI devices.
 	MinSupportedHWVersionForPCIPassthruDevices = vimtypes.VMX17

--- a/pkg/providers/vsphere/placement/cluster_placement.go
+++ b/pkg/providers/vsphere/placement/cluster_placement.go
@@ -163,7 +163,7 @@ func ClusterPlaceVMForCreate(
 		HostRecommRequired: &needsHost,
 	}
 
-	vmCtx.Logger.V(6).Info("PlaceVmsXCluster request", "placementSpec", placementSpec)
+	vmCtx.Logger.V(4).Info("PlaceVmsXCluster request", "placementSpec", placementSpec)
 
 	resp, err := object.NewRootFolder(vcClient).PlaceVmsXCluster(vmCtx, placementSpec)
 	if err != nil {

--- a/pkg/util/vmopv1/vm_test.go
+++ b/pkg/util/vmopv1/vm_test.go
@@ -383,6 +383,25 @@ var _ = DescribeTable("DetermineHardwareVersion",
 		},
 		vimtypes.HardwareVersion(20),
 	),
+	Entry(
+		"spec.minHardwareVersion is 11, vm has vTPM, image version is 10",
+		vmopv1.VirtualMachine{
+			Spec: vmopv1.VirtualMachineSpec{
+				MinHardwareVersion: 11,
+			},
+		},
+		vimtypes.VirtualMachineConfigSpec{
+			DeviceChange: []vimtypes.BaseVirtualDeviceConfigSpec{
+				&vimtypes.VirtualDeviceConfigSpec{
+					Device: &vimtypes.VirtualTPM{},
+				},
+			},
+		},
+		vmopv1.VirtualMachineImageStatus{
+			HardwareVersion: &[]int32{10}[0],
+		},
+		pkgconst.MinSupportedHWVersionForVTPM,
+	),
 )
 
 var _ = DescribeTable("HasPVC",


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch ensures the minimum hardware version is set to vmx-14 when a VM has a vTPM.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Set minimum hardware version to vmx-14 when VM has vTPM
```