### PR TITLE
🐛 Set CPU/mem limit to -1 if reservation & no limit

### DIFF
--- a/pkg/providers/vsphere/virtualmachine/configspec.go
+++ b/pkg/providers/vsphere/virtualmachine/configspec.go
@@ -110,6 +110,8 @@ func CreateConfigSpec(
 		if !res.Limits.Cpu.IsZero() {
 			lim := CPUQuantityToMhz(vmClassSpec.Policies.Resources.Limits.Cpu, minFreq)
 			configSpec.CpuAllocation.Limit = &lim
+		} else {
+			configSpec.CpuAllocation.Limit = ptr.To[int64](-1)
 		}
 	} else if configSpec.CpuAllocation == nil {
 		// Default to best effort.
@@ -139,6 +141,8 @@ func CreateConfigSpec(
 		if !res.Limits.Memory.IsZero() {
 			lim := MemoryQuantityToMb(vmClassSpec.Policies.Resources.Limits.Memory)
 			configSpec.MemoryAllocation.Limit = &lim
+		} else {
+			configSpec.MemoryAllocation.Limit = ptr.To[int64](-1)
 		}
 	} else if configSpec.MemoryAllocation == nil {
 		// Default to best effort.

--- a/pkg/providers/vsphere/virtualmachine/configspec_test.go
+++ b/pkg/providers/vsphere/virtualmachine/configspec_test.go
@@ -121,6 +121,23 @@ var _ = Describe("CreateConfigSpec", func() {
 					Expect(configSpec.MemoryAllocation.Reservation).To(HaveValue(BeEquivalentTo(0)))
 				})
 			})
+
+			Context("VM Class has request but no limits", func() {
+				BeforeEach(func() {
+					vmClassSpec.Policies.Resources.Limits = vmopv1.VirtualMachineResourceSpec{}
+				})
+
+				It("returns expected config spec", func() {
+					Expect(configSpec.CpuAllocation.Shares).ToNot(BeNil())
+					Expect(configSpec.CpuAllocation.Shares.Level).To(Equal(vimtypes.SharesLevelNormal))
+					Expect(configSpec.CpuAllocation.Limit).To(HaveValue(BeEquivalentTo(-1)))
+					Expect(configSpec.CpuAllocation.Reservation).To(HaveValue(BeEquivalentTo(2684354560000)))
+					Expect(configSpec.MemoryAllocation.Shares).ToNot(BeNil())
+					Expect(configSpec.MemoryAllocation.Shares.Level).To(Equal(vimtypes.SharesLevelNormal))
+					Expect(configSpec.MemoryAllocation.Limit).To(HaveValue(BeEquivalentTo(-1)))
+					Expect(configSpec.MemoryAllocation.Reservation).To(HaveValue(BeEquivalentTo(2048)))
+				})
+			})
 		})
 
 		When("VM has no bios or instance uuid", func() {


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch addresses an issue with vSphere placement APIs that expect the optional Limit field for CPU/Memory allocation to be set to -1 if there is a requested reservation and no limit. vSphere *should* be fine if the Limit field is omitted since it is optional, but while that is being chased down, this work-around addresses the issue.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Set CPU/memory limit to -1 for non-empty reservations
```