### PR TITLE
🌱 Remove old A2 function suffix

### DIFF
--- a/pkg/providers/vsphere/placement/zone_placement_test.go
+++ b/pkg/providers/vsphere/placement/zone_placement_test.go
@@ -219,7 +219,7 @@ func vcSimPlacement() {
 
 			Context("VM is in child RP via ResourcePolicy", func() {
 				It("returns success", func() {
-					resourcePolicy, _ := ctx.CreateVirtualMachineSetResourcePolicyA2("my-child-rp", nsInfo)
+					resourcePolicy, _ := ctx.CreateVirtualMachineSetResourcePolicy("my-child-rp", nsInfo)
 					Expect(resourcePolicy).ToNot(BeNil())
 					childRPName := resourcePolicy.Spec.ResourcePool.Name
 					Expect(childRPName).ToNot(BeEmpty())
@@ -303,7 +303,7 @@ func vcSimPlacement() {
 
 				Context("VM is in child RP via ResourcePolicy", func() {
 					It("returns success", func() {
-						resourcePolicy, _ := ctx.CreateVirtualMachineSetResourcePolicyA2("my-child-rp", nsInfo)
+						resourcePolicy, _ := ctx.CreateVirtualMachineSetResourcePolicy("my-child-rp", nsInfo)
 						Expect(resourcePolicy).ToNot(BeNil())
 						childRPName := resourcePolicy.Spec.ResourcePool.Name
 						Expect(childRPName).ToNot(BeEmpty())
@@ -411,7 +411,7 @@ func vcSimPlacement() {
 
 			Context("VM is in child RP via ResourcePolicy", func() {
 				It("returns success", func() {
-					resourcePolicy, _ := ctx.CreateVirtualMachineSetResourcePolicyA2("my-child-rp", nsInfo)
+					resourcePolicy, _ := ctx.CreateVirtualMachineSetResourcePolicy("my-child-rp", nsInfo)
 					Expect(resourcePolicy).ToNot(BeNil())
 					childRPName := resourcePolicy.Spec.ResourcePool.Name
 					Expect(childRPName).ToNot(BeEmpty())
@@ -496,7 +496,7 @@ func vcSimPlacement() {
 
 			Context("VM is in child RP via ResourcePolicy", func() {
 				It("returns success", func() {
-					resourcePolicy, _ := ctx.CreateVirtualMachineSetResourcePolicyA2("my-child-rp", nsInfo)
+					resourcePolicy, _ := ctx.CreateVirtualMachineSetResourcePolicy("my-child-rp", nsInfo)
 					Expect(resourcePolicy).ToNot(BeNil())
 					childRPName := resourcePolicy.Spec.ResourcePool.Name
 					Expect(childRPName).ToNot(BeEmpty())

--- a/pkg/providers/vsphere/vcenter/getvm_test.go
+++ b/pkg/providers/vsphere/vcenter/getvm_test.go
@@ -134,7 +134,7 @@ func getVM() {
 
 	Context("Gets VM with ResourcePolicy by inventory", func() {
 		BeforeEach(func() {
-			resourcePolicy, folder := ctx.CreateVirtualMachineSetResourcePolicyA2("getvm-test", nsInfo)
+			resourcePolicy, folder := ctx.CreateVirtualMachineSetResourcePolicy("getvm-test", nsInfo)
 			if vmCtx.VM.Spec.Reserved == nil {
 				vmCtx.VM.Spec.Reserved = &vmopv1.VirtualMachineReservedSpec{}
 			}

--- a/pkg/providers/vsphere/vcenter/resourcepool_test.go
+++ b/pkg/providers/vsphere/vcenter/resourcepool_test.go
@@ -75,7 +75,7 @@ func getResourcePoolTests() {
 	Context("GetChildResourcePool", func() {
 		It("returns success", func() {
 			// Quick way for a child RP is to create a VMSetResourcePolicy.
-			resourcePolicy, _ := ctx.CreateVirtualMachineSetResourcePolicyA2("my-child-rp", nsInfo)
+			resourcePolicy, _ := ctx.CreateVirtualMachineSetResourcePolicy("my-child-rp", nsInfo)
 			Expect(resourcePolicy).ToNot(BeNil())
 			childRPName := resourcePolicy.Spec.ResourcePool.Name
 			Expect(childRPName).ToNot(BeEmpty())
@@ -123,7 +123,7 @@ func createDeleteExistResourcePoolChild() {
 
 		parentRPMoID = nsRP.Reference().Value
 
-		resourcePolicy, _ = ctx.CreateVirtualMachineSetResourcePolicyA2("my-child-rp", nsInfo)
+		resourcePolicy, _ = ctx.CreateVirtualMachineSetResourcePolicy("my-child-rp", nsInfo)
 		Expect(resourcePolicy).ToNot(BeNil())
 	})
 

--- a/test/builder/vcsim_test_context.go
+++ b/test/builder/vcsim_test_context.go
@@ -949,7 +949,7 @@ func (c *TestContextForVCSim) GetAZClusterComputes(azName string) []*object.Clus
 	return ccrs
 }
 
-func (c *TestContextForVCSim) CreateVirtualMachineSetResourcePolicyA2(
+func (c *TestContextForVCSim) CreateVirtualMachineSetResourcePolicy(
 	name string,
 	nsInfo WorkloadNamespaceInfo) (*vmopv1.VirtualMachineSetResourcePolicy, *object.Folder) {
 


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

This is a leftover from when VCSim text context supported both v1a1 and v1a2 types during that transition.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note
NONE
```