### PR TITLE
🌱 OVF Cache Package

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ import (
 	pkgmgr "github.com/vmware-tanzu/vm-operator/pkg/manager"
 	pkgmgrinit "github.com/vmware-tanzu/vm-operator/pkg/manager/init"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/watcher"
 	"github.com/vmware-tanzu/vm-operator/services"
 	"github.com/vmware-tanzu/vm-operator/webhooks"
@@ -119,6 +120,7 @@ func initContext() {
 	ctx = pkgcfg.WithConfig(defaultConfig)
 	ctx = cource.WithContext(ctx)
 	ctx = watcher.WithContext(ctx)
+	ctx = ovfcache.WithContext(ctx)
 }
 
 func initRateLimiting() {

--- a/pkg/context/fake/fake_controller_manager_context.go
+++ b/pkg/context/fake/fake_controller_manager_context.go
@@ -11,13 +11,17 @@ import (
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	providerfake "github.com/vmware-tanzu/vm-operator/pkg/providers/fake"
 	"github.com/vmware-tanzu/vm-operator/pkg/record"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 )
 
 // NewControllerManagerContext returns a fake ControllerManagerContext for unit
 // testing reconcilers and webhooks with a fake client.
 func NewControllerManagerContext() *pkgctx.ControllerManagerContext {
+	ctx := pkgcfg.NewContext()
+	ctx = ovfcache.WithContext(ctx)
+
 	return &pkgctx.ControllerManagerContext{
-		Context:                 pkgcfg.NewContext(),
+		Context:                 ctx,
 		Logger:                  ctrllog.Log.WithName(ControllerManagerName),
 		Namespace:               ControllerManagerNamespace,
 		Name:                    ControllerManagerName,

--- a/pkg/providers/vsphere/vmprovider_vm_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/topology"
 	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
 	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	vmopv1util "github.com/vmware-tanzu/vm-operator/pkg/util/vmopv1"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmconfig"
@@ -74,6 +75,7 @@ func vmTests() {
 
 	BeforeEach(func() {
 		parentCtx = ctxop.WithContext(pkgcfg.NewContext())
+		parentCtx = ovfcache.WithContext(parentCtx)
 		pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
 			config.AsyncCreateDisabled = true
 			config.AsyncSignalDisabled = true

--- a/pkg/providers/vsphere/vsphere_suite_test.go
+++ b/pkg/providers/vsphere/vsphere_suite_test.go
@@ -24,7 +24,6 @@ var suite = builder.NewTestSuite()
 
 func vcSimTests() {
 	Describe("CPUFreq", cpuFreqTests)
-	Describe("InitOvfCacheAndLockPool", initOvfCacheAndLockPoolTests)
 	Describe("SyncVirtualMachineImage", syncVirtualMachineImageTests)
 	Describe("ResourcePolicyTests", resourcePolicyTests)
 	Describe("VirtualMachine", vmTests)

--- a/pkg/util/ovfcache/internal/ovfcache_internal.go
+++ b/pkg/util/ovfcache/internal/ovfcache_internal.go
@@ -1,0 +1,167 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/vmware/govmomi/ovf"
+
+	ctxgen "github.com/vmware-tanzu/vm-operator/pkg/context/generic"
+	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
+)
+
+type contextKeyType uint8
+
+type contextValueType struct {
+	cache *pkgutil.Cache[VersionedOVFEnvelope]
+	locks *pkgutil.LockPool[string, *sync.RWMutex]
+	getFn GetterFn
+}
+
+type VersionedOVFEnvelope struct {
+	OvfEnvelope    *ovf.Envelope
+	ContentVersion string
+}
+
+type GetterFn func(ctx context.Context, itemID string) (*ovf.Envelope, error)
+
+const contextKeyValue contextKeyType = 0
+
+// ErrNoGetter is returned from GetOVFEnvelope if there is no getter function.
+var ErrNoGetter = errors.New("ovfcache getter fn is nil")
+
+// WithContext returns a new context with an OVF cache.
+func WithContext(
+	parent context.Context,
+	maxCachedItems int,
+	expireAfter, expireCheckInterval time.Duration) context.Context {
+
+	return ctxgen.WithContext(
+		parent,
+		contextKeyValue,
+		func() contextValueType {
+			cache := pkgutil.NewCache[VersionedOVFEnvelope](
+				expireAfter,
+				expireCheckInterval,
+				maxCachedItems)
+			locks := &pkgutil.LockPool[string, *sync.RWMutex]{}
+
+			// Clean up the lock pool when the ovf cache item expires.
+			go func() {
+				for k := range cache.ExpiredChan() {
+					l := locks.Get(k)
+					// This could still delete an in-use lock if it's retrieved
+					// from the pool but not locked yet. If it's already locked,
+					// this will wait until it's unlocked to delete it from the
+					// pool.
+					l.Lock()
+					locks.Delete(k)
+					l.Unlock()
+				}
+			}()
+
+			return contextValueType{
+				cache: cache,
+				locks: locks,
+			}
+		})
+}
+
+func Put(
+	ctx context.Context,
+	itemID string,
+	env VersionedOVFEnvelope) pkgutil.CachePutResult {
+
+	return ctxgen.FromContext(
+		ctx,
+		contextKeyValue,
+		func(curVal contextValueType) pkgutil.CachePutResult {
+			return curVal.cache.Put(itemID, env)
+		})
+}
+
+func GetLock(
+	ctx context.Context,
+	itemID string) sync.Locker {
+
+	return ctxgen.FromContext(
+		ctx,
+		contextKeyValue,
+		func(curVal contextValueType) sync.Locker {
+			return curVal.locks.Get(itemID)
+		})
+}
+
+func SetGetter(parent context.Context, getter GetterFn) {
+	ctxgen.SetContext(
+		parent,
+		contextKeyValue,
+		func(curVal contextValueType) contextValueType {
+			curVal.getFn = getter
+			return curVal
+		})
+}
+
+func GetOVFEnvelope(
+	ctx context.Context,
+	itemID, contentVersion string) (env *ovf.Envelope, err error) {
+
+	ctxgen.ExecWithContext(
+		ctx,
+		contextKeyValue,
+		func(val contextValueType) {
+			logger := logr.FromContextOrDiscard(ctx).
+				WithValues(
+					"itemID", itemID,
+					"contentVersion", contentVersion,
+				).V(4)
+
+			// Lock the current item to prevent concurrent downloads of the same
+			// OVF. This is done before the get from cache below to prevent
+			// stale result.
+			curItemLock := val.locks.Get(itemID)
+			curItemLock.Lock()
+			defer curItemLock.Unlock()
+
+			isHitFn := func(e VersionedOVFEnvelope) bool {
+				return contentVersion == e.ContentVersion
+			}
+
+			cacheItem, found := val.cache.Get(itemID, isHitFn)
+			if found {
+				logger.Info("Cache item hit, using cached OVF")
+				env = cacheItem.OvfEnvelope
+				return
+			}
+
+			if val.getFn == nil {
+				err = ErrNoGetter
+				return
+			}
+
+			logger.Info("Cache item miss, downloading OVF from vCenter")
+			env, err = val.getFn(ctx, itemID)
+			if err != nil || env == nil {
+				env = nil
+				return
+			}
+
+			cacheItem = VersionedOVFEnvelope{
+				ContentVersion: contentVersion,
+				OvfEnvelope:    env,
+			}
+
+			putResult := val.cache.Put(itemID, cacheItem)
+			logger.Info("Cache item put",
+				"itemID", itemID,
+				"putResult", putResult)
+		})
+	return env, err
+
+}

--- a/pkg/util/ovfcache/internal/ovfcache_internal_suite_test.go
+++ b/pkg/util/ovfcache/internal/ovfcache_internal_suite_test.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package internal_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestOVFCacheInternal(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "OVF Cache Internal Test Suite")
+}

--- a/pkg/util/ovfcache/internal/ovfcache_internal_test.go
+++ b/pkg/util/ovfcache/internal/ovfcache_internal_test.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package internal_test
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/vmware/govmomi/ovf"
+
+	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache/internal"
+)
+
+const fakeString = "fake"
+
+var _ = Describe("WithContext", func() {
+	const (
+		maxItems            = 3
+		expireAfter         = 3 * time.Second
+		expireCheckInterval = 1 * time.Second
+	)
+
+	var (
+		ctx context.Context
+	)
+
+	BeforeEach(func() {
+		ctx = internal.WithContext(
+			context.Background(),
+			maxItems,
+			expireAfter,
+			expireCheckInterval)
+	})
+
+	AfterEach(func() {
+		ctx = nil
+	})
+
+	It("should succeed", func() {
+		Expect(ctx).ToNot(BeNil())
+	})
+
+	It("Should delete lock for expired item", func() {
+		Expect(ctx).ToNot(BeNil())
+
+		const itemID = fakeString
+
+		r := internal.Put(ctx, itemID, internal.VersionedOVFEnvelope{})
+		Expect(r).To(Equal(pkgutil.CachePutResultCreate))
+
+		curItemLock := internal.GetLock(ctx, itemID)
+		Expect(curItemLock).ToNot(BeNil())
+
+		Eventually(func() bool {
+			// A new lock is returned if the item is not found, thus the lock
+			// should be different after the item is expired and deleted from
+			// the pool.
+			return internal.GetLock(ctx, itemID) != curItemLock
+		}, 5*time.Second, 1*time.Second).Should(BeTrue())
+	})
+})
+
+var _ = Describe("GetOVFEnvelope", func() {
+
+	const (
+		maxItems            = 100
+		expireAfter         = 30 * time.Minute
+		expireCheckInterval = 5 * time.Minute
+	)
+
+	var (
+		ctx context.Context
+	)
+
+	BeforeEach(func() {
+		ctx = internal.WithContext(
+			context.Background(),
+			maxItems,
+			expireAfter,
+			expireCheckInterval)
+	})
+
+	AfterEach(func() {
+		ctx = nil
+	})
+
+	When("there is no getter", func() {
+
+		It("should return an error", func() {
+			env, err := internal.GetOVFEnvelope(ctx, fakeString, "v1")
+			Expect(err).To(MatchError(internal.ErrNoGetter))
+			Expect(env).To(BeNil())
+		})
+	})
+
+	When("there is a getter that returns an error", func() {
+		BeforeEach(func() {
+			internal.SetGetter(
+				ctx,
+				func(ctx context.Context, itemID string) (*ovf.Envelope, error) {
+					return &ovf.Envelope{}, errors.New(fakeString)
+				})
+		})
+		It("should return the error", func() {
+			env, err := internal.GetOVFEnvelope(ctx, fakeString, "v1")
+			Expect(err).To(MatchError(fakeString))
+			Expect(env).To(BeNil())
+
+		})
+	})
+
+	When("there is a getter that returns an item", func() {
+		BeforeEach(func() {
+			internal.SetGetter(
+				ctx,
+				func(ctx context.Context, itemID string) (*ovf.Envelope, error) {
+					return &ovf.Envelope{
+						Product: &ovf.ProductSection{},
+					}, nil
+				})
+		})
+		It("should return env", func() {
+			env, err := internal.GetOVFEnvelope(ctx, fakeString, "v1")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(env).To(Equal(&ovf.Envelope{
+				Product: &ovf.ProductSection{},
+			}))
+
+			// Change what the getter returns.
+			internal.SetGetter(
+				ctx,
+				func(ctx context.Context, itemID string) (*ovf.Envelope, error) {
+					return &ovf.Envelope{
+						Network: &ovf.NetworkSection{},
+					}, nil
+				})
+
+			// Assert the original, cached item is still returned.
+			env, err = internal.GetOVFEnvelope(ctx, fakeString, "v1")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(env).To(Equal(&ovf.Envelope{
+				Product: &ovf.ProductSection{},
+			}))
+		})
+	})
+
+})

--- a/pkg/util/ovfcache/ovfcache.go
+++ b/pkg/util/ovfcache/ovfcache.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ovfcache
+
+import (
+	"context"
+	"time"
+
+	"github.com/vmware/govmomi/ovf"
+
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache/internal"
+)
+
+// GetterFn returns an OVF envelope for a provided library item ID.
+type GetterFn = internal.GetterFn
+
+const (
+	maxItems            = 100
+	expireAfter         = 30 * time.Minute
+	expireCheckInterval = 5 * time.Minute
+)
+
+// ErrNoGetter is returned from GetOVFEnvelope if there is no getter function.
+var ErrNoGetter = internal.ErrNoGetter
+
+// WithContext returns a new context with an OVF cache.
+func WithContext(parent context.Context) context.Context {
+	return internal.WithContext(
+		parent,
+		maxItems,
+		expireAfter,
+		expireCheckInterval)
+
+}
+
+// SetGetter assigns to the context the function used to retrieve an OVF
+// envelope when it is not in the cache.
+func SetGetter(parent context.Context, getter GetterFn) {
+	internal.SetGetter(parent, getter)
+}
+
+// GetOVFEnvelope returns the OVF envelope for the provided item ID, either from
+// the cache or from vSphere. If the item is not in the cache, it will be cached
+// prior to being returned.
+func GetOVFEnvelope(
+	ctx context.Context,
+	itemID, contentVersion string) (env *ovf.Envelope, err error) {
+
+	return internal.GetOVFEnvelope(ctx, itemID, contentVersion)
+}

--- a/pkg/util/ovfcache/ovfcache_suite_test.go
+++ b/pkg/util/ovfcache/ovfcache_suite_test.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ovfcache_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestOVFCache(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "OVF Cache Test Suite")
+}

--- a/pkg/util/ovfcache/ovfcache_test.go
+++ b/pkg/util/ovfcache/ovfcache_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ovfcache_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/vmware/govmomi/ovf"
+
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
+)
+
+var _ = Describe("WithContext", func() {
+	It("should succeed", func() {
+		Expect(ovfcache.WithContext(context.Background())).ToNot(BeNil())
+	})
+
+})
+
+var _ = Describe("GetOVFEnvelope", func() {
+
+	var (
+		ctx context.Context
+	)
+
+	BeforeEach(func() {
+		ctx = ovfcache.WithContext(context.Background())
+		ovfcache.SetGetter(
+			ctx,
+			func(ctx context.Context, itemID string) (*ovf.Envelope, error) {
+				return &ovf.Envelope{}, nil
+			})
+	})
+
+	AfterEach(func() {
+		ctx = nil
+	})
+
+	It("should succeed", func() {
+		env, err := ovfcache.GetOVFEnvelope(ctx, "fake", "v1")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(env).To(Equal(&ovf.Envelope{}))
+	})
+
+})

--- a/test/builder/unit_test_context.go
+++ b/test/builder/unit_test_context.go
@@ -17,6 +17,7 @@ import (
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/context/fake"
 	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 )
 
 // UnitTestContext is used for general purpose unit testing.
@@ -28,8 +29,12 @@ type UnitTestContext struct {
 
 // NewUnitTestContext returns a new UnitTestContext.
 func NewUnitTestContext(initObjects ...client.Object) *UnitTestContext {
-	return NewUnitTestContextWithParentContext(
-		ctxop.WithContext(pkgcfg.NewContext()), initObjects...)
+
+	ctx := pkgcfg.NewContext()
+	ctx = ctxop.WithContext(ctx)
+	ctx = ovfcache.WithContext(ctx)
+
+	return NewUnitTestContextWithParentContext(ctx, initObjects...)
 }
 
 func NewUnitTestContextWithParentContext(ctx context.Context, initObjects ...client.Object) *UnitTestContext {

--- a/test/builder/vcsim_test_context.go
+++ b/test/builder/vcsim_test_context.go
@@ -64,6 +64,7 @@ import (
 	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 	pkgmgr "github.com/vmware-tanzu/vm-operator/pkg/manager"
 	"github.com/vmware-tanzu/vm-operator/pkg/record"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	pkgclient "github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/client"
 	"github.com/vmware-tanzu/vm-operator/test/testutil"
 )
@@ -281,7 +282,10 @@ func (s *TestSuite) NewTestContextForVCSim(
 	config VCSimTestConfig,
 	initObjects ...ctrlclient.Object) *TestContextForVCSim {
 
-	return NewTestContextForVCSim(ctxop.WithContext(pkgcfg.NewContext()), config, initObjects...)
+	ctx := pkgcfg.NewContext()
+	ctx = ctxop.WithContext(ctx)
+	ctx = ovfcache.WithContext(ctx)
+	return NewTestContextForVCSim(ctx, config, initObjects...)
 }
 
 func (s *TestSuite) NewTestContextForVCSimWithParentContext(


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch refactors the OVF cache into an context-based package so the cache may be shared across the project and not limited to the vSphere provider. This also simplifies a future refactor to transition the cache to using Secret/ ConfigMap resources in Kube for caching the OVF envelopes as opposed to an in-memory store.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

This is required for the Fast Deploy work in order to efficiently retrieve the OVF envelope for parsing its controllers/disks.


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Context-based OVF cache
```