### PR TITLE
🐛 Fix panic in controllers missing ovfcache

### DIFF
--- a/controllers/contentlibrary/clustercontentlibraryitem/clustercontentlibraryitem_controller.go
+++ b/controllers/contentlibrary/clustercontentlibraryitem/clustercontentlibraryitem_controller.go
@@ -30,6 +30,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
 	"github.com/vmware-tanzu/vm-operator/pkg/record"
 	imgutil "github.com/vmware-tanzu/vm-operator/pkg/util/image"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 )
 
 // AddToManager adds this package's controller to the provided manager.
@@ -93,6 +94,7 @@ type Reconciler struct {
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
 	ctx = pkgcfg.JoinContext(ctx, r.Context)
+	ctx = ovfcache.JoinContext(ctx, r.Context)
 
 	logger := r.Logger.WithValues("cclItemName", req.Name)
 	logger.Info("Reconciling ClusterContentLibraryItem")

--- a/controllers/contentlibrary/clustercontentlibraryitem/clustercontentlibraryitem_controller_suite_test.go
+++ b/controllers/contentlibrary/clustercontentlibraryitem/clustercontentlibraryitem_controller_suite_test.go
@@ -14,13 +14,14 @@ import (
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	providerfake "github.com/vmware-tanzu/vm-operator/pkg/providers/fake"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 var intgFakeVMProvider = providerfake.NewVMProvider()
 
 var suite = builder.NewTestSuiteForControllerWithContext(
-	pkgcfg.NewContextWithDefaultConfig(),
+	ovfcache.WithContext(pkgcfg.NewContextWithDefaultConfig()),
 	clustercontentlibraryitem.AddToManager,
 	func(ctx *pkgctx.ControllerManagerContext, _ ctrlmgr.Manager) error {
 		ctx.VMProvider = intgFakeVMProvider

--- a/controllers/contentlibrary/contentlibraryitem/contentlibraryitem_controller.go
+++ b/controllers/contentlibrary/contentlibraryitem/contentlibraryitem_controller.go
@@ -30,6 +30,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
 	"github.com/vmware-tanzu/vm-operator/pkg/record"
 	imgutil "github.com/vmware-tanzu/vm-operator/pkg/util/image"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 )
 
 // AddToManager adds this package's controller to the provided manager.
@@ -93,6 +94,7 @@ type Reconciler struct {
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
 	ctx = pkgcfg.JoinContext(ctx, r.Context)
+	ctx = ovfcache.JoinContext(ctx, r.Context)
 
 	logger := r.Logger.WithValues("clItemName", req.Name, "namespace", req.Namespace)
 	logger.Info("Reconciling ContentLibraryItem")

--- a/controllers/contentlibrary/contentlibraryitem/contentlibraryitem_controller_suite_test.go
+++ b/controllers/contentlibrary/contentlibraryitem/contentlibraryitem_controller_suite_test.go
@@ -13,13 +13,14 @@ import (
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	providerfake "github.com/vmware-tanzu/vm-operator/pkg/providers/fake"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 var intgFakeVMProvider = providerfake.NewVMProvider()
 
 var suite = builder.NewTestSuiteForControllerWithContext(
-	pkgcfg.NewContextWithDefaultConfig(),
+	ovfcache.WithContext(pkgcfg.NewContextWithDefaultConfig()),
 	contentlibraryitem.AddToManager,
 	func(ctx *pkgctx.ControllerManagerContext, _ ctrlmgr.Manager) error {
 		ctx.VMProvider = intgFakeVMProvider

--- a/controllers/virtualmachine/virtualmachine/virtualmachine_controller.go
+++ b/controllers/virtualmachine/virtualmachine/virtualmachine_controller.go
@@ -40,6 +40,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/util/annotations"
 	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	vmopv1util "github.com/vmware-tanzu/vm-operator/pkg/util/vmopv1"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmconfig"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmconfig/crypto"
@@ -279,7 +280,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 	}
 
 	ctx = ctxop.WithContext(ctx)
-
+	ctx = ovfcache.JoinContext(ctx, r.Context)
 	ctx = record.WithContext(ctx, r.Recorder)
 
 	vm := &vmopv1.VirtualMachine{}

--- a/controllers/virtualmachine/virtualmachine/virtualmachine_controller_intg_test.go
+++ b/controllers/virtualmachine/virtualmachine/virtualmachine_controller_intg_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
 	providerfake "github.com/vmware-tanzu/vm-operator/pkg/providers/fake"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	vsclient "github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/client"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/watcher"
@@ -452,6 +453,7 @@ var _ = Describe(
 			)
 			ctx = cource.WithContext(ctx)
 			ctx = watcher.WithContext(ctx)
+			ctx = ovfcache.WithContext(ctx)
 
 			provider = providerfake.NewVMProvider()
 			provider.VSphereClientFn = func(ctx context.Context) (*vsclient.Client, error) {

--- a/controllers/virtualmachine/virtualmachine/virtualmachine_controller_suite_test.go
+++ b/controllers/virtualmachine/virtualmachine/virtualmachine_controller_suite_test.go
@@ -16,6 +16,7 @@ import (
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	providerfake "github.com/vmware-tanzu/vm-operator/pkg/providers/fake"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
@@ -23,14 +24,15 @@ import (
 var intgFakeVMProvider = providerfake.NewVMProvider()
 
 var suite = builder.NewTestSuiteForControllerWithContext(
-	cource.WithContext(
-		pkgcfg.UpdateContext(pkgcfg.NewContextWithDefaultConfig(), func(config *pkgcfg.Config) {
-			config.SyncPeriod = 60 * time.Minute
-			config.CreateVMRequeueDelay = 1 * time.Second
-			config.PoweredOnVMHasIPRequeueDelay = 1 * time.Second
-			config.AsyncSignalDisabled = true
-			config.AsyncCreateDisabled = true
-		})),
+	ovfcache.WithContext(
+		cource.WithContext(
+			pkgcfg.UpdateContext(pkgcfg.NewContextWithDefaultConfig(), func(config *pkgcfg.Config) {
+				config.SyncPeriod = 60 * time.Minute
+				config.CreateVMRequeueDelay = 1 * time.Second
+				config.PoweredOnVMHasIPRequeueDelay = 1 * time.Second
+				config.AsyncSignalDisabled = true
+				config.AsyncCreateDisabled = true
+			}))),
 	virtualmachine.AddToManager,
 	func(ctx *pkgctx.ControllerManagerContext, _ ctrlmgr.Manager) error {
 		ctx.VMProvider = intgFakeVMProvider

--- a/pkg/util/ovfcache/internal/ovfcache_internal_test.go
+++ b/pkg/util/ovfcache/internal/ovfcache_internal_test.go
@@ -65,6 +65,62 @@ var _ = Describe("WithContext", func() {
 	})
 })
 
+var _ = Describe("JoinContext", func() {
+
+	const (
+		maxItems            = 3
+		expireAfter         = 3 * time.Second
+		expireCheckInterval = 1 * time.Second
+	)
+
+	var (
+		left  context.Context
+		right context.Context
+	)
+
+	BeforeEach(func() {
+		left = internal.WithContext(
+			context.Background(),
+			maxItems,
+			expireAfter,
+			expireCheckInterval)
+
+		right = internal.WithContext(
+			context.Background(),
+			maxItems,
+			expireAfter,
+			expireCheckInterval)
+	})
+
+	AfterEach(func() {
+		left, right = nil, nil
+	})
+
+	When("left has the cache", func() {
+		BeforeEach(func() {
+			right = context.Background()
+		})
+		It("should have the cache", func() {
+			Expect(internal.Cache(internal.JoinContext(left, right))).To(Equal(internal.Cache(left)))
+		})
+	})
+
+	When("right has the cache", func() {
+		BeforeEach(func() {
+			left = context.Background()
+		})
+		It("should have the cache", func() {
+			Expect(internal.Cache(internal.JoinContext(left, right))).To(Equal(internal.Cache(right)))
+		})
+	})
+
+	When("both have the cache", func() {
+		It("should have the right cache", func() {
+			Expect(internal.Cache(internal.JoinContext(left, right))).To(Equal(internal.Cache(right)))
+		})
+	})
+})
+
 var _ = Describe("GetOVFEnvelope", func() {
 
 	const (

--- a/pkg/util/ovfcache/ovfcache.go
+++ b/pkg/util/ovfcache/ovfcache.go
@@ -31,7 +31,12 @@ func WithContext(parent context.Context) context.Context {
 		maxItems,
 		expireAfter,
 		expireCheckInterval)
+}
 
+// JoinContext returns a context with the OVF cache from the right or left, in
+// that order.
+func JoinContext(left, right context.Context) context.Context {
+	return internal.JoinContext(left, right)
 }
 
 // SetGetter assigns to the context the function used to retrieve an OVF


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch fixes the issue where controllers getting the OVF cache from the context would panic because the original commit did not include the JoinContext call for the OVF cache in the controllers.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Fix panic when OVF cache is missing from context
```