### PR TITLE
:seedling: Allow imported and registered VMs to skip image validation checks on Create/Update

### DIFF
--- a/api/v1alpha3/virtualmachine_types.go
+++ b/api/v1alpha3/virtualmachine_types.go
@@ -197,6 +197,18 @@ const (
 	// ManagerID on a VirtualMachine contains the UUID of the
 	// VMware vCenter (VC) that is managing this virtual machine.
 	ManagerID = GroupName + "/manager-id"
+
+	// RegisteredVMAnnotation on a VirtualMachine represents that a virtual machine has
+	// been registered using the RegisterVM API after a restore, or a fail-over operation by
+	// a vendor. The presence of this annotation is used to bypass some validation checks
+	// that are otherwise applicable to all VirtualMachine create/update requests.
+	RegisteredVMAnnotation = GroupName + "/registered-vm"
+
+	// ImportedVMAnnotation on a VirtualMachine represents that a traditional virtual
+	// machine has been imported into Supervisor using the ImportVM API. The presence of this
+	// annotation is used to bypass some validation checks that are otherwise applicable
+	// to all VirtualMachine create/update requests.
+	ImportedVMAnnotation = GroupName + "/imported-vm"
 )
 
 const (

--- a/pkg/util/annotations/helpers.go
+++ b/pkg/util/annotations/helpers.go
@@ -9,6 +9,14 @@ import (
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 )
 
+func HasRegisterVM(o metav1.Object) bool {
+	return hasAnnotation(o, vmopv1.RegisteredVMAnnotation)
+}
+
+func HasImportVM(o metav1.Object) bool {
+	return hasAnnotation(o, vmopv1.ImportedVMAnnotation)
+}
+
 func HasForceEnableBackup(o metav1.Object) bool {
 	return hasAnnotation(o, vmopv1.ForceEnableBackupAnnotation)
 }

--- a/pkg/util/annotations/helpers_test.go
+++ b/pkg/util/annotations/helpers_test.go
@@ -46,3 +46,37 @@ var _ = DescribeTable(
 	Entry("present but empty ", map[string]string{vmopv1.ForceEnableBackupAnnotation: ""}, true),
 	Entry("present and not empty ", map[string]string{vmopv1.ForceEnableBackupAnnotation: "true"}, true),
 )
+
+var _ = DescribeTable(
+	"HasRegisterVM",
+	func(in map[string]string, out bool) {
+		vm := &vmopv1.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: in,
+			},
+		}
+		actual := annotations.HasRegisterVM(vm)
+		Expect(actual).To(Equal(out))
+	},
+	Entry("nil", nil, false),
+	Entry("not present", map[string]string{"foo": "bar"}, false),
+	Entry("present but empty ", map[string]string{vmopv1.RegisteredVMAnnotation: ""}, true),
+	Entry("present and not empty ", map[string]string{vmopv1.RegisteredVMAnnotation: "true"}, true),
+)
+
+var _ = DescribeTable(
+	"HasImportVM",
+	func(in map[string]string, out bool) {
+		vm := &vmopv1.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: in,
+			},
+		}
+		actual := annotations.HasImportVM(vm)
+		Expect(actual).To(Equal(out))
+	},
+	Entry("nil", nil, false),
+	Entry("not present", map[string]string{"foo": "bar"}, false),
+	Entry("present but empty ", map[string]string{vmopv1.ImportedVMAnnotation: ""}, true),
+	Entry("present and not empty ", map[string]string{vmopv1.ImportedVMAnnotation: "true"}, true),
+)

--- a/pkg/util/vmopv1/vm.go
+++ b/pkg/util/vmopv1/vm.go
@@ -233,6 +233,19 @@ func IsImagelessVM(vm vmopv1.VirtualMachine) bool {
 	return vm.Spec.Image == nil && vm.Spec.ImageName == ""
 }
 
+// ImageRefsEqual returns true if the two image refs match.
+func ImageRefsEqual(ref1, ref2 *vmopv1.VirtualMachineImageRef) bool {
+	if ref1 == nil && ref2 == nil {
+		return true
+	}
+
+	if ref1 != nil && ref2 != nil {
+		return *ref1 == *ref2
+	}
+
+	return false
+}
+
 // SyncStorageUsageForNamespace updates the StoragePolicyUsage resource for
 // the given namespace and storage class with the reported usage information
 // for VMs in that namespace that use the specified storage class.

--- a/pkg/util/vmopv1/vm_test.go
+++ b/pkg/util/vmopv1/vm_test.go
@@ -522,6 +522,59 @@ var _ = DescribeTable("IsImageLessVM",
 	),
 )
 
+var _ = DescribeTable("ImageRefsEqual",
+	func(
+		ref1 *vmopv1.VirtualMachineImageRef,
+		ref2 *vmopv1.VirtualMachineImageRef,
+		expected bool,
+	) {
+		Ω(vmopv1util.ImageRefsEqual(ref1, ref2)).Should(Equal(expected))
+	},
+	Entry(
+		"both refs nil",
+		nil,
+		nil,
+		true,
+	),
+	Entry(
+		"ref1 is nil, ref2 is not",
+		nil,
+		&vmopv1.VirtualMachineImageRef{
+			Name: "dummy",
+		},
+		false,
+	),
+	Entry(
+		"ref1 is not nil, ref2 is nil",
+		&vmopv1.VirtualMachineImageRef{
+			Name: "dummy",
+		},
+		nil,
+		false,
+	),
+	Entry(
+		"both not nil, one containing an extra field",
+		&vmopv1.VirtualMachineImageRef{
+			Name: "dummy",
+		},
+		&vmopv1.VirtualMachineImageRef{
+			Name: "dummy",
+			Kind: "ClusterVirtualMachineImage",
+		},
+		false,
+	),
+	Entry(
+		"both not nil, same values",
+		&vmopv1.VirtualMachineImageRef{
+			Name: "dummy",
+		},
+		&vmopv1.VirtualMachineImageRef{
+			Name: "dummy",
+		},
+		true,
+	),
+)
+
 var _ = Describe("SyncStorageUsageForNamespace", func() {
 	var (
 		ctx          context.Context


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

VMs that are imported, or registered already have the virtual machine created on the infrastructure.  As such, we don't need to apply the same strict validations for them such as making sure the image is not null / valid.  To that end, this change introduces an annotation that will be applied on the Imported, or Registered VMs.  This will allow our webhooks to skip these checks if the annotation is present.

For now, maintain the existing mechanism which allows _all_ VM creations to be imageless if the import or the incremental restore feature is enabled.  Once this change is merged, we will yank out that code to make that check stricter (only annotation based).


**Are there any special notes for your reviewer**:

There;s also a change to the UT method that validates messages.  Instead of splitting that into a string array and matching elements, we are now comparing substrings.  This is because the comma delimiter used to split the reasons results in false splits when a reason contains an object.


**Please add a release note if necessary**:

```release-note
Allow imported and registered VMs to skip image validation checks on Create/Update
```