### PR TITLE
🐛 Wait on vAppConfig during async create

### DIFF
--- a/pkg/providers/vsphere/vmlifecycle/bootstrap_linuxprep.go
+++ b/pkg/providers/vsphere/vmlifecycle/bootstrap_linuxprep.go
@@ -44,7 +44,7 @@ func BootStrapLinuxPrep(
 	var configSpec *vimtypes.VirtualMachineConfigSpec
 	if vAppConfigSpec != nil {
 		configSpec = &vimtypes.VirtualMachineConfigSpec{}
-		configSpec.VAppConfig = GetOVFVAppConfigForConfigSpec(
+		configSpec.VAppConfig, err = GetOVFVAppConfigForConfigSpec(
 			config,
 			vAppConfigSpec,
 			bsArgs.BootstrapData.VAppData,
@@ -52,5 +52,5 @@ func BootStrapLinuxPrep(
 			bsArgs.TemplateRenderFn)
 	}
 
-	return configSpec, customSpec, nil
+	return configSpec, customSpec, err
 }

--- a/pkg/providers/vsphere/vmlifecycle/bootstrap_sysprep.go
+++ b/pkg/providers/vsphere/vmlifecycle/bootstrap_sysprep.go
@@ -76,7 +76,7 @@ func BootstrapSysPrep(
 	var configSpec *vimtypes.VirtualMachineConfigSpec
 	if vAppConfigSpec != nil {
 		configSpec = &vimtypes.VirtualMachineConfigSpec{}
-		configSpec.VAppConfig = GetOVFVAppConfigForConfigSpec(
+		configSpec.VAppConfig, err = GetOVFVAppConfigForConfigSpec(
 			config,
 			vAppConfigSpec,
 			bsArgs.BootstrapData.VAppData,
@@ -84,7 +84,7 @@ func BootstrapSysPrep(
 			bsArgs.TemplateRenderFn)
 	}
 
-	return configSpec, customSpec, nil
+	return configSpec, customSpec, err
 }
 
 func convertTo(from *vmopv1sysprep.Sysprep, bsArgs *BootstrapArgs) *vimtypes.CustomizationSysprep {

--- a/pkg/providers/vsphere/vmlifecycle/bootstrap_vappconfig_test.go
+++ b/pkg/providers/vsphere/vmlifecycle/bootstrap_vappconfig_test.go
@@ -21,6 +21,7 @@ var _ = Describe("VAppConfig Bootstrap", func() {
 	const key, value = "fooKey", "fooValue"
 
 	var (
+		err              error
 		configInfo       *vimtypes.VirtualMachineConfigInfo
 		vAppConfigSpec   *vmopv1.VirtualMachineBootstrapVAppConfigSpec
 		bsArgs           vmlifecycle.BootstrapArgs
@@ -53,12 +54,22 @@ var _ = Describe("VAppConfig Bootstrap", func() {
 	Context("GetOVFVAppConfigForConfigSpec", func() {
 
 		JustBeforeEach(func() {
-			baseVMConfigSpec = vmlifecycle.GetOVFVAppConfigForConfigSpec(
+			baseVMConfigSpec, err = vmlifecycle.GetOVFVAppConfigForConfigSpec(
 				configInfo,
 				vAppConfigSpec,
 				bsArgs.VAppData,
 				bsArgs.VAppExData,
 				bsArgs.TemplateRenderFn)
+		})
+
+		When("config.vAppConfig is nil", func() {
+			BeforeEach(func() {
+				configInfo.VAppConfig = nil
+			})
+			It("Should return an error", func() {
+				Expect(err).To(MatchError("vAppConfig is not yet available"))
+				Expect(baseVMConfigSpec).To(BeNil())
+			})
 		})
 
 		Context("Empty input", func() {


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch updates the behavior of the vAppConfig, LinuxPrep, and Sysprep bootstrap providers to wait on the VM to have a non-nil config.vAppConfig property when it is expected to exist.

Async create means we are no longer falling through to the update logic directly after create, instead, relying on the reconciler to be reentrant. That all works fine, but the problem is vpxd is sending signal on the property collector that the VM is ready prior to its config.vAppConfig property being set.

VM Op receives this signal and proceeds to reconcile the VM. Since previously we did not wait on an expected vAppConfig, we proceeded to configure and power on the VM. Once it is powered on, any customization that dependended upon the vAppConfig properties being set prior to first boot will no longer work.

This patch returns an error from GetOVFVAppConfigForConfigSpec if the VM has a nil config.vAppConfig.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

The following steps were taken to verify the fix:

1. Replace VM Op on Supervisor with an image built from this change.
2. Apply the following VM:
    ```yaml
    apiVersion: vmoperator.vmware.com/v1alpha3
    kind: VirtualMachine
    metadata:
      name: my-vm-1
      namespace: my-namespace-1
    spec:
      className: best-effort-small
      imageName: vmi-5119c3e3493b3cfe9 # ubuntu-server 24.10
      storageClass: wcpglobal-storage-profile
      bootstrap:
        linuxPrep: {}
        vAppConfig:
          properties:
          - key: password
            value:
              value: 'And another one bites the dust.'
    ```
3. Look for key indicators from the VM Op [log](https://gist.github.com/akutz/d720013817ea2b1d0f13dc5728e1c411):
    1. Non-blocking create:
        ```shell
        I1209 16:01:56.384947       1 vmprovider_vm.go:208] "Doing a non-blocking create" logger="vsphere" vmName="my-namespace-1/my-vm-1"
        ```
    2. The reconciler backing off due to the vAppConfig not being available yet on the newly created VM:
        ```shell
        E1209 16:02:04.715968       1 virtualmachine_controller.go:323] "Failed to reconcile VirtualMachine" err="updating state failed with failed to create bootstrap data: vAppConfig is not yet available" logger="VirtualMachine" name="my-namespace-1/my-vm-1"
        I1209 16:02:04.721253       1 recorder.go:104] "updating state failed with failed to create bootstrap data: vAppConfig is not yet available" logger="events" type="Warning" object={"kind":"VirtualMachine","namespace":"my-namespace-1","name":"my-vm-1","uid":"7289b06a-11e7-44de-b2b3-fa3aed4c34df","apiVersion":"vmoperator.vmware.com/v1alpha3","resourceVersion":"3060028"} reason="UpdateFailure"

        ```
    3. The VM being created successfully with an IP and its vAppConfig property set as expected:
        1. It has an IP address:
            <img width="2104" alt="image" src="https://github.com/user-attachments/assets/3dfc93cf-fa9a-4c36-a1d5-f5003b56cab9">
        1. It has the expected vAppConfig property:
            <img width="2104" alt="image" src="https://github.com/user-attachments/assets/dae94450-c3c0-4241-a3c0-d1ce3d20b9d3">




**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    5. If a release note is not required, please write "NONE".
-->

```release-note
The VM controller now enter exponential backoff with an error until a VM that is expected to have a vAppConfig does so
```