### PR TITLE
🐛 Remove Inventory path fallback for GetVM

### DIFF
--- a/pkg/providers/vsphere/vcenter/getvm_test.go
+++ b/pkg/providers/vsphere/vcenter/getvm_test.go
@@ -8,10 +8,8 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/vmware/govmomi/vim25/mo"
-	vimtypes "github.com/vmware/govmomi/vim25/types"
 	"k8s.io/apimachinery/pkg/types"
 
-	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/vcenter"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
@@ -52,54 +50,6 @@ func getVM() {
 		}
 	})
 
-	Context("Gets VM by inventory", func() {
-		BeforeEach(func() {
-			vm, err := ctx.Finder.VirtualMachine(ctx, vcVMName)
-			Expect(err).ToNot(HaveOccurred())
-
-			task, err := vm.Clone(ctx, nsInfo.Folder, vmCtx.VM.Name, vimtypes.VirtualMachineCloneSpec{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(task.Wait(ctx)).To(Succeed())
-		})
-
-		It("returns success", func() {
-			vm, err := vcenter.GetVirtualMachine(vmCtx, ctx.Client, ctx.VCClient.Client, ctx.Datacenter, ctx.Finder)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(vm).ToNot(BeNil())
-		})
-
-		It("returns nil if VM does not exist", func() {
-			vmCtx.VM.Name = "bogus"
-			vm, err := vcenter.GetVirtualMachine(vmCtx, ctx.Client, ctx.VCClient.Client, ctx.Datacenter, ctx.Finder)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(vm).To(BeNil())
-		})
-
-		Context("Namespace Folder does not exist", func() {
-			BeforeEach(func() {
-				task, err := nsInfo.Folder.Destroy(vmCtx)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(task.Wait(vmCtx)).To(Succeed())
-			})
-
-			It("returns error", func() {
-				vm, err := vcenter.GetVirtualMachine(vmCtx, ctx.Client, ctx.VCClient.Client, ctx.Datacenter, ctx.Finder)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(HavePrefix("failed to get namespace Folder"))
-				Expect(vm).To(BeNil())
-			})
-		})
-
-		It("returns success when MoID is invalid", func() {
-			// Expect fallback to inventory.
-			vmCtx.VM.Status.UniqueID = "vm-bogus"
-
-			vm, err := vcenter.GetVirtualMachine(vmCtx, ctx.Client, ctx.VCClient.Client, ctx.Datacenter, ctx.Finder)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(vm).ToNot(BeNil())
-		})
-	})
-
 	Context("Gets VM when MoID is set", func() {
 		BeforeEach(func() {
 			vm, err := ctx.Finder.VirtualMachine(ctx, vcVMName)
@@ -108,7 +58,7 @@ func getVM() {
 		})
 
 		It("returns success", func() {
-			vm, err := vcenter.GetVirtualMachine(vmCtx, ctx.Client, ctx.VCClient.Client, ctx.Datacenter, ctx.Finder)
+			vm, err := vcenter.GetVirtualMachine(vmCtx, ctx.VCClient.Client, ctx.Datacenter, ctx.Finder)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(vm).ToNot(BeNil())
 			Expect(vm.Reference().Value).To(Equal(vmCtx.VM.Status.UniqueID))
@@ -126,44 +76,9 @@ func getVM() {
 		})
 
 		It("returns success", func() {
-			vm, err := vcenter.GetVirtualMachine(vmCtx, ctx.Client, ctx.VCClient.Client, ctx.Datacenter, ctx.Finder)
+			vm, err := vcenter.GetVirtualMachine(vmCtx, ctx.VCClient.Client, ctx.Datacenter, ctx.Finder)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(vm).ToNot(BeNil())
-		})
-	})
-
-	Context("Gets VM with ResourcePolicy by inventory", func() {
-		BeforeEach(func() {
-			resourcePolicy, folder := ctx.CreateVirtualMachineSetResourcePolicy("getvm-test", nsInfo)
-			if vmCtx.VM.Spec.Reserved == nil {
-				vmCtx.VM.Spec.Reserved = &vmopv1.VirtualMachineReservedSpec{}
-			}
-			vmCtx.VM.Spec.Reserved.ResourcePolicyName = resourcePolicy.Name
-
-			vm, err := ctx.Finder.VirtualMachine(ctx, vcVMName)
-			Expect(err).ToNot(HaveOccurred())
-
-			task, err := vm.Clone(ctx, folder, vmCtx.VM.Name, vimtypes.VirtualMachineCloneSpec{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(task.Wait(ctx)).To(Succeed())
-		})
-
-		It("returns success", func() {
-			vm, err := vcenter.GetVirtualMachine(vmCtx, ctx.Client, ctx.VCClient.Client, ctx.Datacenter, ctx.Finder)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(vm).ToNot(BeNil())
-		})
-
-		It("returns error when ResourcePolicy does not exist", func() {
-			if vmCtx.VM.Spec.Reserved == nil {
-				vmCtx.VM.Spec.Reserved = &vmopv1.VirtualMachineReservedSpec{}
-			}
-			vmCtx.VM.Spec.Reserved.ResourcePolicyName = "bogus"
-
-			vm, err := vcenter.GetVirtualMachine(vmCtx, ctx.Client, ctx.VCClient.Client, ctx.Datacenter, ctx.Finder)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(HavePrefix("failed to get VirtualMachineSetResourcePolicy"))
-			Expect(vm).To(BeNil())
 		})
 	})
 }

--- a/pkg/providers/vsphere/vmprovider.go
+++ b/pkg/providers/vsphere/vmprovider.go
@@ -242,7 +242,7 @@ func (vs *vSphereVMProvider) getVM(
 	client *vcclient.Client,
 	notFoundReturnErr bool) (*object.VirtualMachine, error) {
 
-	vcVM, err := vcenter.GetVirtualMachine(vmCtx, vs.k8sClient, client.VimClient(), client.Datacenter(), client.Finder())
+	vcVM, err := vcenter.GetVirtualMachine(vmCtx, client.VimClient(), client.Datacenter(), client.Finder())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Originally, we'd try to find a VM via its MoID, with a fallback to the Inventory by path. Since then, we've added the Instance and Bios UUIDs as preferred ways to find a VM. VMs are now created with a known Instance ID - that of the k8s VM UID - that we can use for lookup.

This removes lookup depending on k8s objects to determine if the VM exists that have a separate lifecycle than the VM.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note
The lookup VM by the Inventory path final fallback is removed. VM lookup will be via the Instance UUID, BiosUUID, or the MoID.
```