### PR TITLE
🌱 Misc VirtualMachineSetResourcePolicy clean ups

### DIFF
--- a/pkg/providers/vsphere/vmprovider_resourcepolicy_test.go
+++ b/pkg/providers/vsphere/vmprovider_resourcepolicy_test.go
@@ -16,7 +16,7 @@ import (
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
-	vsphere "github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
+	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
@@ -67,6 +67,24 @@ func resourcePolicyTests() {
 			ctx.AfterEach()
 			ctx = nil
 			initObjects = nil
+		})
+
+		Context("Empty VirtualMachineSetResourcePolicy", func() {
+			It("Creates and Deletes successfully", func() {
+				resourcePolicy := &vmopv1.VirtualMachineSetResourcePolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "empty-policy",
+						Namespace: nsInfo.Namespace,
+					},
+				}
+
+				By("Create", func() {
+					Expect(vmProvider.CreateOrUpdateVirtualMachineSetResourcePolicy(ctx, resourcePolicy)).To(Succeed())
+				})
+				By("Delete", func() {
+					Expect(vmProvider.DeleteVirtualMachineSetResourcePolicy(ctx, resourcePolicy)).To(Succeed())
+				})
+			})
 		})
 
 		Context("VirtualMachineSetResourcePolicy", func() {

--- a/pkg/topology/availability_zones.go
+++ b/pkg/topology/availability_zones.go
@@ -109,10 +109,14 @@ func GetNamespaceFolderAndRPMoIDs(
 		if err != nil && !errors.Is(err, ErrNoZones) {
 			return "", nil, err
 		}
+
 		for _, zone := range zones {
-			folderMoID = zone.Spec.ManagedVMs.FolderMoID
+			if folderMoID == "" {
+				folderMoID = zone.Spec.ManagedVMs.FolderMoID
+			}
 			rpMoIDs = append(rpMoIDs, zone.Spec.ManagedVMs.PoolMoIDs...)
 		}
+
 		return folderMoID, rpMoIDs, nil
 	}
 
@@ -123,7 +127,9 @@ func GetNamespaceFolderAndRPMoIDs(
 
 	for _, az := range availabilityZones {
 		if nsInfo, ok := az.Spec.Namespaces[namespace]; ok {
-			folderMoID = nsInfo.FolderMoId
+			if folderMoID == "" {
+				folderMoID = nsInfo.FolderMoId
+			}
 			if len(nsInfo.PoolMoIDs) != 0 {
 				rpMoIDs = append(rpMoIDs, nsInfo.PoolMoIDs...)
 			} else {

--- a/webhooks/virtualmachinesetresourcepolicy/validation/virtualmachinesetresourcepolicy_validator.go
+++ b/webhooks/virtualmachinesetresourcepolicy/validation/virtualmachinesetresourcepolicy_validator.go
@@ -107,9 +107,9 @@ func (v validator) validateSpec(ctx *pkgctx.WebhookRequestContext, vmRP *vmopv1.
 	var fieldErrs field.ErrorList
 	specPath := field.NewPath("spec")
 
-	fieldErrs = append(fieldErrs, v.validateResourcePool(ctx, specPath.Child("resourcepool"), vmRP.Spec.ResourcePool)...)
+	fieldErrs = append(fieldErrs, v.validateResourcePool(ctx, specPath.Child("resourcePool"), vmRP.Spec.ResourcePool)...)
 	fieldErrs = append(fieldErrs, v.validateFolder(ctx, specPath.Child("folder"), vmRP.Spec.Folder)...)
-	fieldErrs = append(fieldErrs, v.validateClusterModules(ctx, specPath.Child("clustermodules"), vmRP.Spec.ClusterModuleGroups)...)
+	fieldErrs = append(fieldErrs, v.validateClusterModules(ctx, specPath.Child("clusterModuleGroups"), vmRP.Spec.ClusterModuleGroups)...)
 
 	return fieldErrs
 }
@@ -152,9 +152,9 @@ func (v validator) validateAllowedChanges(ctx *pkgctx.WebhookRequestContext, vmR
 	specPath := field.NewPath("spec")
 
 	// Validate all fields under spec which are not allowed to change.
-	allErrs = append(allErrs, validation.ValidateImmutableField(vmRP.Spec.ResourcePool, oldVMRP.Spec.ResourcePool, specPath.Child("resourcepool"))...)
+	allErrs = append(allErrs, validation.ValidateImmutableField(vmRP.Spec.ResourcePool, oldVMRP.Spec.ResourcePool, specPath.Child("resourcePool"))...)
 	allErrs = append(allErrs, validation.ValidateImmutableField(vmRP.Spec.Folder, oldVMRP.Spec.Folder, specPath.Child("folder"))...)
-	allErrs = append(allErrs, validation.ValidateImmutableField(vmRP.Spec.ClusterModuleGroups, oldVMRP.Spec.ClusterModuleGroups, specPath.Child("clustermodules"))...)
+	allErrs = append(allErrs, validation.ValidateImmutableField(vmRP.Spec.ClusterModuleGroups, oldVMRP.Spec.ClusterModuleGroups, specPath.Child("clusterModuleGroups"))...)
 
 	return allErrs
 }

--- a/webhooks/virtualmachinesetresourcepolicy/validation/virtualmachinesetresourcepolicy_validator_intg_test.go
+++ b/webhooks/virtualmachinesetresourcepolicy/validation/virtualmachinesetresourcepolicy_validator_intg_test.go
@@ -4,15 +4,14 @@
 package validation_test
 
 import (
-	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/util/validation/field"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
-
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
@@ -99,7 +98,7 @@ func intgTestsValidateCreate() {
 		ctx = nil
 	})
 
-	fieldPath := field.NewPath("spec", "resourcepool", "reservations", "memory")
+	fieldPath := field.NewPath("spec", "resourcePool", "reservations", "memory")
 	DescribeTable("create table", validateCreate,
 		Entry("should work", true, "", nil),
 		Entry("should not work for invalid", false,

--- a/webhooks/virtualmachinesetresourcepolicy/validation/virtualmachinesetresourcepolicy_validator_unit_test.go
+++ b/webhooks/virtualmachinesetresourcepolicy/validation/virtualmachinesetresourcepolicy_validator_unit_test.go
@@ -128,7 +128,7 @@ func unitTestsValidateCreate() {
 		ctx = nil
 	})
 
-	reservationsPath := field.NewPath("spec", "resourcepool", "reservations")
+	reservationsPath := field.NewPath("spec", "resourcePool", "reservations")
 	detailMsg := "reservation value cannot exceed the limit value"
 	DescribeTable("create table", validateCreate,
 		Entry("should allow valid", createArgs{}, true, nil, nil),


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

The child Folder and ResourcePool name can be empty but we weren't checking for this.

When getting both the Resource Pool and Folder MoIDs of a namespace, don't necessarily always return the last FolderMoID on the Zone or AZ. The Folder is VC scoped and we should not ever have a Zone or AZ without it, return the value if at least one of the Zone/AZ has it set.

Use the v1a2+ field names in the validation webhook error messages

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #

**Are there any special notes for your reviewer**:

**Please add a release note if necessary**:


```release-note
NONE
```