### PR TITLE
:bug: Do not invoke StoragePolicyQuota Validating Webhook for imageless VMs

### DIFF
--- a/config/webhook/storage_quota_webhook_configuration.yaml
+++ b/config/webhook/storage_quota_webhook_configuration.yaml
@@ -27,6 +27,9 @@ webhooks:
     resources:
     - virtualmachines
   sideEffects: None
+  matchConditions:
+  - expression: has(object.spec.image)
+    name: has-image
 - admissionReviewVersions:
   - v1
   - v1beta1


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

As part of StoragePolicyQuota Validating Webhook that runs inside VM Operator there is a check to ensure that the VM image is provided since this is where we obtain the image capacity from. This has the unintended side-effect of blocking vm creation for imageless VMs.

This patch modifies the ValidatingWebhookConfiguration used in the StoragePolicyQuota validation flow to ignore VM creation request where the image is not provided. This will prevent this webhook from blocking imageless VM creations, while allowing the VirtualMachine ValidatingWebhook to continue to perform image validation. 


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Do not invoke StoragePolicyQuota Validating Webhook for imageless VMs
```