### PR TITLE
✨ Fast Deploy (Experimental)

### DIFF
--- a/config/wcp/vmoperator/manager_env_var_patch.yaml
+++ b/config/wcp/vmoperator/manager_env_var_patch.yaml
@@ -112,6 +112,12 @@
     name: FSS_WCP_SUPERVISOR_ASYNC_UPGRADE
     value: "<FSS_WCP_SUPERVISOR_ASYNC_UPGRADE_VALUE>"
 
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: FSS_WCP_VMSERVICE_FAST_DEPLOY
+    value: "<FSS_WCP_VMSERVICE_FAST_DEPLOY_VALUE>"
+
 #
 # Feature state switch flags beneath this line are enabled on main and only
 # retained in this file because it is used by internal testing to determine the

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/vmware-tanzu/vm-operator/external/tanzu-topology v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/vm-operator/pkg/backup/api v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels v0.0.0-00010101000000-000000000000
-	github.com/vmware/govmomi v0.47.0-alpha.0.0.20241217002132-3def2df5dfb3
+	github.com/vmware/govmomi v0.47.0-alpha.0.0.20241219162111-46d5d8739f1e
 	golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc
 	// * https://github.com/vmware-tanzu/vm-operator/security/dependabot/24
 	golang.org/x/text v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,8 @@ github.com/vmware-tanzu/net-operator-api v0.0.0-20240523152550-862e2c4eb0e0 h1:y
 github.com/vmware-tanzu/net-operator-api v0.0.0-20240523152550-862e2c4eb0e0/go.mod h1:w6QJGm3crIA16ZIz1FVQXD2NVeJhOgGXxW05RbVTSTo=
 github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20241112044858-9da8637c1b0d h1:z9lrzKVtNlujduv9BilzPxuge/LE2F0N1ms3TP4JZvw=
 github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20241112044858-9da8637c1b0d/go.mod h1:Q4JzNkNMvjo7pXtlB5/R3oME4Nhah7fAObWgghVmtxk=
-github.com/vmware/govmomi v0.47.0-alpha.0.0.20241217002132-3def2df5dfb3 h1:yAJRiepA8WT+tizYK9TRxCoYTlp3h0t3CP9RL5jNZ3Q=
-github.com/vmware/govmomi v0.47.0-alpha.0.0.20241217002132-3def2df5dfb3/go.mod h1:bYwUHpGpisE4AOlDl5eph90T+cjJMIcKx/kaa5v5rQM=
+github.com/vmware/govmomi v0.47.0-alpha.0.0.20241219162111-46d5d8739f1e h1:xWk68LmieEMkyArGnvKLSn6APFUVbm/I5swqHX+3WGs=
+github.com/vmware/govmomi v0.47.0-alpha.0.0.20241219162111-46d5d8739f1e/go.mod h1:bYwUHpGpisE4AOlDl5eph90T+cjJMIcKx/kaa5v5rQM=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -147,6 +147,8 @@ type FeatureStates struct {
 	VMIncrementalRestore      bool // FSS_WCP_VMSERVICE_INCREMENTAL_RESTORE
 	BringYourOwnEncryptionKey bool // FSS_WCP_VMSERVICE_BYOK
 	SVAsyncUpgrade            bool // FSS_WCP_SUPERVISOR_ASYNC_UPGRADE
+	// TODO(akutz) This FSS is placeholder.
+	FastDeploy bool // FSS_WCP_VMSERVICE_FAST_DEPLOY
 }
 
 type InstanceStorage struct {

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -63,7 +63,7 @@ func FromEnv() Config {
 	setBool(env.FSSVMImportNewNet, &config.Features.VMImportNewNet)
 	setBool(env.FSSVMIncrementalRestore, &config.Features.VMIncrementalRestore)
 	setBool(env.FSSBringYourOwnEncryptionKey, &config.Features.BringYourOwnEncryptionKey)
-
+	setBool(env.FSSFastDeploy, &config.Features.FastDeploy)
 	setBool(env.FSSSVAsyncUpgrade, &config.Features.SVAsyncUpgrade)
 	if !config.Features.SVAsyncUpgrade {
 		// When SVAsyncUpgrade is enabled, we'll later use the capability CM to determine if

--- a/pkg/config/env/env.go
+++ b/pkg/config/env/env.go
@@ -58,7 +58,7 @@ const (
 	FSSVMIncrementalRestore
 	FSSBringYourOwnEncryptionKey
 	FSSSVAsyncUpgrade
-
+	FSSFastDeploy
 	_varNameEnd
 )
 
@@ -176,6 +176,8 @@ func (n VarName) String() string {
 		return "FSS_WCP_VMSERVICE_BYOK"
 	case FSSSVAsyncUpgrade:
 		return "FSS_WCP_SUPERVISOR_ASYNC_UPGRADE"
+	case FSSFastDeploy:
+		return "FSS_WCP_VMSERVICE_FAST_DEPLOY"
 	}
 	panic("unknown environment variable")
 }

--- a/pkg/config/env_test.go
+++ b/pkg/config/env_test.go
@@ -101,6 +101,7 @@ var _ = Describe(
 					Expect(os.Setenv("FSS_WCP_VMSERVICE_INCREMENTAL_RESTORE", "true")).To(Succeed())
 					Expect(os.Setenv("FSS_WCP_VMSERVICE_BYOK", "true")).To(Succeed())
 					Expect(os.Setenv("FSS_WCP_SUPERVISOR_ASYNC_UPGRADE", "false")).To(Succeed())
+					Expect(os.Setenv("FSS_WCP_VMSERVICE_FAST_DEPLOY", "true")).To(Succeed())
 					Expect(os.Setenv("CREATE_VM_REQUEUE_DELAY", "125h")).To(Succeed())
 					Expect(os.Setenv("POWERED_ON_VM_HAS_IP_REQUEUE_DELAY", "126h")).To(Succeed())
 				})
@@ -150,6 +151,7 @@ var _ = Describe(
 							BringYourOwnEncryptionKey: true,
 							SVAsyncUpgrade:            false, // Capability gate so tested below
 							WorkloadDomainIsolation:   true,
+							FastDeploy:                true,
 						},
 						CreateVMRequeueDelay:         125 * time.Hour,
 						PoweredOnVMHasIPRequeueDelay: 126 * time.Hour,

--- a/pkg/providers/vsphere/client/client_test.go
+++ b/pkg/providers/vsphere/client/client_test.go
@@ -89,6 +89,8 @@ var _ = Describe("Client", Label(testlabels.VCSim), Ordered /* Avoided race for 
 				serverCertFile = f
 			}
 
+			datacenter := simulator.Map.Any("Datacenter")
+
 			cfg = &config.VSphereVMProviderConfig{
 				VcPNID: server.URL.Hostname(),
 				VcPort: server.URL.Port(),
@@ -98,7 +100,7 @@ var _ = Describe("Client", Label(testlabels.VCSim), Ordered /* Avoided race for 
 				},
 				CAFilePath:            serverCertFile,
 				InsecureSkipTLSVerify: false,
-				Datacenter:            simulator.Map.Any("Datacenter").Reference().Value,
+				Datacenter:            datacenter.Reference().Value,
 			}
 		})
 

--- a/pkg/providers/vsphere/contentlibrary/content_library_utils.go
+++ b/pkg/providers/vsphere/contentlibrary/content_library_utils.go
@@ -84,15 +84,13 @@ func initImageStatusFromOVFVirtualSystem(
 
 	// Use operating system info from the first os section in the VM image, if one exists.
 	if os := ovfVirtualSystem.OperatingSystem; os != nil {
-		o := os
-
 		osInfo := &imageStatus.OSInfo
-		osInfo.ID = strconv.Itoa(int(o.ID))
-		if o.Version != nil {
-			osInfo.Version = *o.Version
+		osInfo.ID = strconv.Itoa(int(os.ID))
+		if os.Version != nil {
+			osInfo.Version = *os.Version
 		}
-		if o.OSType != nil {
-			osInfo.Type = *o.OSType
+		if os.OSType != nil {
+			osInfo.Type = *os.OSType
 		}
 	}
 

--- a/pkg/providers/vsphere/vmlifecycle/create.go
+++ b/pkg/providers/vsphere/vmlifecycle/create.go
@@ -5,9 +5,11 @@ package vmlifecycle
 
 import (
 	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vapi/rest"
 	"github.com/vmware/govmomi/vim25"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 )
@@ -24,17 +26,39 @@ type CreateArgs struct {
 	HostMoID            string
 	StorageProfileID    string
 	DatastoreMoID       string // gce2e only: used only if StorageProfileID is unset
+	Datastores          []DatastoreRef
+	ZoneName            string
+}
+
+type DatastoreRef struct {
+	Name                             string
+	MoRef                            vimtypes.ManagedObjectReference
+	URL                              string
+	TopLevelDirectoryCreateSupported bool
+
+	// ForDisk is false if the recommendation is for the VM's home directory and
+	// true if for a disk. DiskKey is only valid if ForDisk is true.
+	ForDisk bool
+	DiskKey int32
 }
 
 func CreateVirtualMachine(
 	vmCtx pkgctx.VirtualMachineContext,
+	k8sClient ctrlclient.Client,
 	restClient *rest.Client,
 	vimClient *vim25.Client,
 	finder *find.Finder,
+	datacenter *object.Datacenter,
 	createArgs *CreateArgs) (*vimtypes.ManagedObjectReference, error) {
 
 	if createArgs.UseContentLibrary {
-		return deployFromContentLibrary(vmCtx, restClient, vimClient, createArgs)
+		return deployFromContentLibrary(
+			vmCtx,
+			k8sClient,
+			restClient,
+			vimClient,
+			datacenter,
+			createArgs)
 	}
 
 	return cloneVMFromInventory(vmCtx, finder, createArgs)

--- a/pkg/providers/vsphere/vmlifecycle/create_contentlibrary_linked_clone.go
+++ b/pkg/providers/vsphere/vmlifecycle/create_contentlibrary_linked_clone.go
@@ -1,0 +1,225 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package vmlifecycle
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vapi/library"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vim25"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
+	vmopv1util "github.com/vmware-tanzu/vm-operator/pkg/util/vmopv1"
+	clsutil "github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/library"
+)
+
+func linkedCloneOVF(
+	vmCtx pkgctx.VirtualMachineContext,
+	k8sClient ctrlclient.Client,
+	vimClient *vim25.Client,
+	restClient *rest.Client,
+	datacenter *object.Datacenter,
+	item *library.Item,
+	createArgs *CreateArgs) (*vimtypes.ManagedObjectReference, error) {
+
+	logger := vmCtx.Logger.WithName("linkedCloneOVF")
+
+	if len(createArgs.Datastores) == 0 {
+		return nil, errors.New("no compatible datastores")
+	}
+
+	// Get the information required to do the linked clone.
+	imgInfo, err := getImageLinkedCloneInfo(
+		vmCtx,
+		k8sClient,
+		restClient,
+		item)
+	if err != nil {
+		return nil, err
+	}
+
+	topLevelCacheDir, err := clsutil.GetTopLevelCacheDir(
+		vmCtx,
+		object.NewDatastoreNamespaceManager(vimClient),
+		datacenter,
+		object.NewDatastore(vimClient, createArgs.Datastores[0].MoRef),
+		createArgs.Datastores[0].Name,
+		createArgs.Datastores[0].URL,
+		createArgs.Datastores[0].TopLevelDirectoryCreateSupported)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create top-level cache dir: %w", err)
+	}
+	logger.Info("Got top-level cache dir", "topLevelCacheDir", topLevelCacheDir)
+
+	dstDir := clsutil.GetCacheDirForLibraryItem(
+		topLevelCacheDir,
+		imgInfo.ItemID,
+		imgInfo.ItemContentVersion)
+	logger.Info("Got item cache dir", "dstDir", dstDir)
+
+	dstURIs, err := clsutil.CacheStorageURIs(
+		vmCtx,
+		newCacheStorageURIsClient(vimClient),
+		datacenter,
+		datacenter,
+		dstDir,
+		imgInfo.DiskURIs...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to cache library item disks: %w", err)
+	}
+	logger.Info("Got parent disks", "dstURIs", dstURIs)
+
+	vmDir := path.Dir(createArgs.ConfigSpec.Files.VmPathName)
+	logger.Info("Got vm dir", "vmDir", vmDir)
+
+	// Update the ConfigSpec with the disk chains.
+	var disks []*vimtypes.VirtualDisk
+	for i := range createArgs.ConfigSpec.DeviceChange {
+		dc := createArgs.ConfigSpec.DeviceChange[i].GetVirtualDeviceConfigSpec()
+		if d, ok := dc.Device.(*vimtypes.VirtualDisk); ok {
+			disks = append(disks, d)
+
+			// The profile is no longer needed since we have placement.
+			dc.Profile = nil
+		}
+	}
+	logger.Info("Got disks", "disks", disks)
+
+	if a, b := len(dstURIs), len(disks); a != b {
+		return nil, fmt.Errorf(
+			"invalid disk count: len(uris)=%d, len(disks)=%d", a, b)
+	}
+
+	for i := range disks {
+		d := disks[i]
+		if bfb, ok := d.Backing.(vimtypes.BaseVirtualDeviceFileBackingInfo); ok {
+			fb := bfb.GetVirtualDeviceFileBackingInfo()
+			fb.Datastore = &createArgs.Datastores[0].MoRef
+			fb.FileName = fmt.Sprintf("%s/%s-%d.vmdk", vmDir, vmCtx.VM.Name, i)
+		}
+		if fb, ok := d.Backing.(*vimtypes.VirtualDiskFlatVer2BackingInfo); ok {
+			fb.Parent = &vimtypes.VirtualDiskFlatVer2BackingInfo{
+				VirtualDeviceFileBackingInfo: vimtypes.VirtualDeviceFileBackingInfo{
+					Datastore: &createArgs.Datastores[0].MoRef,
+					FileName:  dstURIs[i],
+				},
+				DiskMode:        string(vimtypes.VirtualDiskModePersistent),
+				ThinProvisioned: ptr.To(true),
+			}
+		}
+	}
+
+	// The profile is no longer needed since we have placement.
+	createArgs.ConfigSpec.VmProfile = nil
+
+	vmCtx.Logger.Info(
+		"Deploying OVF Library Item as linked clone",
+		"itemID", item.ID,
+		"itemName", item.Name,
+		"configSpec", createArgs.ConfigSpec)
+
+	folder := object.NewFolder(
+		vimClient,
+		vimtypes.ManagedObjectReference{
+			Type:  "Folder",
+			Value: createArgs.FolderMoID,
+		})
+	pool := object.NewResourcePool(
+		vimClient,
+		vimtypes.ManagedObjectReference{
+			Type:  "ResourcePool",
+			Value: createArgs.ResourcePoolMoID,
+		})
+
+	createTask, err := folder.CreateVM(
+		vmCtx,
+		createArgs.ConfigSpec,
+		pool,
+		nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call create task: %w", err)
+	}
+
+	createTaskInfo, err := createTask.WaitForResult(vmCtx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to wait for create task: %w", err)
+	}
+
+	vmRef, ok := createTaskInfo.Result.(vimtypes.ManagedObjectReference)
+	if !ok {
+		return nil, fmt.Errorf(
+			"failed to assert create task result is ref: %[1]T %+[1]v",
+			createTaskInfo.Result)
+	}
+
+	return &vmRef, nil
+}
+
+func getImageLinkedCloneInfo(
+	vmCtx pkgctx.VirtualMachineContext,
+	k8sClient ctrlclient.Client,
+	restClient *rest.Client,
+	item *library.Item) (vmopv1util.ImageDiskInfo, error) {
+
+	imgInfo, err := vmopv1util.GetImageDiskInfo(
+		vmCtx,
+		k8sClient,
+		*vmCtx.VM.Spec.Image,
+		vmCtx.VM.Namespace)
+
+	if err == nil {
+		return imgInfo, nil
+	}
+
+	if err != vmopv1util.ErrImageNotSynced {
+		return vmopv1util.ImageDiskInfo{},
+			fmt.Errorf("failed to get image info before syncing: %w", err)
+	}
+
+	if err := clsutil.SyncLibraryItem(
+		vmCtx,
+		library.NewManager(restClient),
+		item.ID); err != nil {
+
+		return vmopv1util.ImageDiskInfo{}, fmt.Errorf("failed to sync: %w", err)
+	}
+
+	if imgInfo, err = vmopv1util.GetImageDiskInfo(
+		vmCtx,
+		k8sClient,
+		*vmCtx.VM.Spec.Image,
+		vmCtx.VM.Namespace); err != nil {
+
+		return vmopv1util.ImageDiskInfo{},
+			fmt.Errorf("failed to get image info after syncing: %w", err)
+	}
+
+	return imgInfo, nil
+}
+
+func newCacheStorageURIsClient(c *vim25.Client) clsutil.CacheStorageURIsClient {
+	return &cacheStorageURIsClient{
+		FileManager:        object.NewFileManager(c),
+		VirtualDiskManager: object.NewVirtualDiskManager(c),
+	}
+}
+
+type cacheStorageURIsClient struct {
+	*object.FileManager
+	*object.VirtualDiskManager
+}
+
+func (c *cacheStorageURIsClient) WaitForTask(
+	ctx context.Context, task *object.Task) error {
+
+	return task.Wait(ctx)
+}

--- a/pkg/providers/vsphere/vmprovider_vm.go
+++ b/pkg/providers/vsphere/vmprovider_vm.go
@@ -5,6 +5,7 @@ package vsphere
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"math/rand"
@@ -47,6 +48,7 @@ import (
 	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/annotations"
 	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	vmopv1util "github.com/vmware-tanzu/vm-operator/pkg/util/vmopv1"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmconfig"
 )
@@ -199,7 +201,7 @@ func (vs *vSphereVMProvider) createOrUpdateVirtualMachine(
 		//
 		// However, we need to make sure we decrement the number of concurrent
 		// creates before returning.
-		decrementConcurrentCreatesFn()
+		cleanupFn()
 		return nil, providers.ErrDuplicateCreate
 	}
 
@@ -446,6 +448,7 @@ func (vs *vSphereVMProvider) vmCreatePathName(
 	if len(vmCtx.VM.Spec.Cdrom) == 0 {
 		return nil // only needed when deploying ISO library items
 	}
+
 	if createArgs.StorageProfileID == "" {
 		return nil
 	}
@@ -495,6 +498,33 @@ func (vs *vSphereVMProvider) vmCreatePathName(
 	return nil
 }
 
+func (vs *vSphereVMProvider) vmCreatePathNameFromDatastoreRecommendation(
+	vmCtx pkgctx.VirtualMachineContext,
+	createArgs *VMCreateArgs) error {
+
+	if createArgs.ConfigSpec.Files == nil {
+		createArgs.ConfigSpec.Files = &vimtypes.VirtualMachineFileInfo{}
+	}
+	if createArgs.ConfigSpec.Files.VmPathName != "" {
+		return nil
+	}
+	if len(createArgs.Datastores) == 0 {
+		return errors.New("no compatible datastores")
+	}
+
+	createArgs.ConfigSpec.Files.VmPathName = fmt.Sprintf(
+		"[%s] %s/%s.vmx",
+		createArgs.Datastores[0].Name,
+		vmCtx.VM.UID,
+		vmCtx.VM.Name)
+
+	vmCtx.Logger.Info(
+		"vmCreatePathName",
+		"VmPathName", createArgs.ConfigSpec.Files.VmPathName)
+
+	return nil
+}
+
 func (vs *vSphereVMProvider) getCreateArgs(
 	vmCtx pkgctx.VirtualMachineContext,
 	vcClient *vcclient.Client) (*VMCreateArgs, error) {
@@ -512,8 +542,14 @@ func (vs *vSphereVMProvider) getCreateArgs(
 		return nil, err
 	}
 
-	if err := vs.vmCreatePathName(vmCtx, vcClient, createArgs); err != nil {
-		return nil, err
+	if pkgcfg.FromContext(vmCtx).Features.FastDeploy {
+		if err := vs.vmCreatePathNameFromDatastoreRecommendation(vmCtx, createArgs); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := vs.vmCreatePathName(vmCtx, vcClient, createArgs); err != nil {
+			return nil, err
+		}
 	}
 
 	if err := vs.vmCreateFixupConfigSpec(vmCtx, vcClient, createArgs); err != nil {
@@ -534,9 +570,11 @@ func (vs *vSphereVMProvider) createVirtualMachine(
 
 	moRef, err := vmlifecycle.CreateVirtualMachine(
 		ctx,
+		vs.k8sClient,
 		vcClient.RestClient(),
 		vcClient.VimClient(),
 		vcClient.Finder(),
+		vcClient.Datacenter(),
 		&args.CreateArgs)
 
 	if err != nil {
@@ -546,11 +584,29 @@ func (vs *vSphereVMProvider) createVirtualMachine(
 			vmopv1.VirtualMachineConditionCreated,
 			"Error",
 			err.Error())
+
+		if pkgcfg.FromContext(ctx).Features.FastDeploy {
+			conditions.MarkFalse(
+				ctx.VM,
+				vmopv1.VirtualMachineConditionPlacementReady,
+				"Error",
+				err.Error())
+		}
+
 		return nil, err
 	}
 
 	ctx.VM.Status.UniqueID = moRef.Reference().Value
 	conditions.MarkTrue(ctx.VM, vmopv1.VirtualMachineConditionCreated)
+
+	if pkgcfg.FromContext(ctx).Features.FastDeploy {
+		if zoneName := args.ZoneName; zoneName != "" {
+			if ctx.VM.Labels == nil {
+				ctx.VM.Labels = map[string]string{}
+			}
+			ctx.VM.Labels[topology.KubernetesTopologyZoneLabelKey] = zoneName
+		}
+	}
 
 	return object.NewVirtualMachine(vcClient.VimClient(), *moRef), nil
 }
@@ -569,9 +625,11 @@ func (vs *vSphereVMProvider) createVirtualMachineAsync(
 
 	moRef, vimErr := vmlifecycle.CreateVirtualMachine(
 		ctx,
+		vs.k8sClient,
 		vcClient.RestClient(),
 		vcClient.VimClient(),
 		vcClient.Finder(),
+		vcClient.Datacenter(),
 		&args.CreateArgs)
 
 	if vimErr != nil {
@@ -591,7 +649,25 @@ func (vs *vSphereVMProvider) createVirtualMachineAsync(
 					vmopv1.VirtualMachineConditionCreated,
 					"Error",
 					vimErr.Error())
-				return nil //nolint:nilerr
+
+				if pkgcfg.FromContext(ctx).Features.FastDeploy {
+					conditions.MarkFalse(
+						ctx.VM,
+						vmopv1.VirtualMachineConditionPlacementReady,
+						"Error",
+						vimErr.Error())
+				}
+
+				return nil
+			}
+
+			if pkgcfg.FromContext(ctx).Features.FastDeploy {
+				if zoneName := args.ZoneName; zoneName != "" {
+					if ctx.VM.Labels == nil {
+						ctx.VM.Labels = map[string]string{}
+					}
+					ctx.VM.Labels[topology.KubernetesTopologyZoneLabelKey] = zoneName
+				}
 			}
 
 			ctx.VM.Status.UniqueID = moRef.Reference().Value
@@ -765,6 +841,7 @@ func (vs *vSphereVMProvider) vmCreateDoPlacement(
 		vmCtx,
 		vs.k8sClient,
 		vcClient.VimClient(),
+		vcClient.Finder(),
 		placementConfigSpec,
 		constraints)
 	if err != nil {
@@ -777,6 +854,18 @@ func (vs *vSphereVMProvider) vmCreateDoPlacement(
 
 	if result.HostMoRef != nil {
 		createArgs.HostMoID = result.HostMoRef.Value
+	}
+
+	if pkgcfg.FromContext(vmCtx).Features.FastDeploy {
+		createArgs.Datastores = make([]vmlifecycle.DatastoreRef, len(result.Datastores))
+		for i := range result.Datastores {
+			createArgs.Datastores[i].DiskKey = result.Datastores[i].DiskKey
+			createArgs.Datastores[i].ForDisk = result.Datastores[i].ForDisk
+			createArgs.Datastores[i].MoRef = result.Datastores[i].MoRef
+			createArgs.Datastores[i].Name = result.Datastores[i].Name
+			createArgs.Datastores[i].URL = result.Datastores[i].URL
+			createArgs.Datastores[i].TopLevelDirectoryCreateSupported = result.Datastores[i].TopLevelDirectoryCreateSupported
+		}
 	}
 
 	if result.InstanceStoragePlacement {
@@ -799,12 +888,16 @@ func (vs *vSphereVMProvider) vmCreateDoPlacement(
 	}
 
 	if result.ZonePlacement {
-		if vmCtx.VM.Labels == nil {
-			vmCtx.VM.Labels = map[string]string{}
+		if pkgcfg.FromContext(vmCtx).Features.FastDeploy {
+			createArgs.ZoneName = result.ZoneName
+		} else {
+			if vmCtx.VM.Labels == nil {
+				vmCtx.VM.Labels = map[string]string{}
+			}
+			// Note if the VM create fails for some reason, but this label gets updated on the k8s VM,
+			// then this is the pre-assigned zone on later create attempts.
+			vmCtx.VM.Labels[topology.KubernetesTopologyZoneLabelKey] = result.ZoneName
 		}
-		// Note if the VM create fails for some reason, but this label gets updated on the k8s VM,
-		// then this is the pre-assigned zone on later create attempts.
-		vmCtx.VM.Labels[topology.KubernetesTopologyZoneLabelKey] = result.ZoneName
 	}
 
 	conditions.MarkTrue(vmCtx.VM, vmopv1.VirtualMachineConditionPlacementReady)
@@ -1243,6 +1336,17 @@ func (vs *vSphereVMProvider) vmCreateGenConfigSpec(
 		createArgs.ImageStatus,
 		minCPUFreq)
 
+	if pkgcfg.FromContext(vmCtx).Features.FastDeploy {
+		if err := vs.vmCreateGenConfigSpecImage(vmCtx, createArgs); err != nil {
+			return err
+		}
+		createArgs.ConfigSpec.VmProfile = []vimtypes.BaseVirtualMachineProfileSpec{
+			&vimtypes.VirtualMachineDefinedProfileSpec{
+				ProfileId: createArgs.StorageProfileID,
+			},
+		}
+	}
+
 	// Get the encryption class details for the VM.
 	if pkgcfg.FromContext(vmCtx).Features.BringYourOwnEncryptionKey {
 		for _, r := range vmconfig.FromContext(vmCtx) {
@@ -1259,20 +1363,61 @@ func (vs *vSphereVMProvider) vmCreateGenConfigSpec(
 		}
 	}
 
-	err := vs.vmCreateGenConfigSpecExtraConfig(vmCtx, createArgs)
-	if err != nil {
+	if err := vs.vmCreateGenConfigSpecExtraConfig(vmCtx, createArgs); err != nil {
 		return err
 	}
 
-	err = vs.vmCreateGenConfigSpecChangeBootDiskSize(vmCtx, createArgs)
-	if err != nil {
+	if err := vs.vmCreateGenConfigSpecChangeBootDiskSize(vmCtx, createArgs); err != nil {
 		return err
 	}
 
-	err = vs.vmCreateGenConfigSpecZipNetworkInterfaces(vmCtx, createArgs)
-	if err != nil {
+	if err := vs.vmCreateGenConfigSpecZipNetworkInterfaces(vmCtx, createArgs); err != nil {
 		return err
 	}
+
+	return nil
+}
+
+func (vs *vSphereVMProvider) vmCreateGenConfigSpecImage(
+	vmCtx pkgctx.VirtualMachineContext,
+	createArgs *VMCreateArgs) error {
+
+	if createArgs.ImageStatus.Type != "OVF" {
+		return nil
+	}
+
+	if createArgs.ImageStatus.ProviderItemID == "" {
+		return errors.New("empty image provider item id")
+	}
+	if createArgs.ImageStatus.ProviderContentVersion == "" {
+		return errors.New("empty image provider content version")
+	}
+
+	ovf, err := ovfcache.GetOVFEnvelope(
+		vmCtx,
+		createArgs.ImageStatus.ProviderItemID,
+		createArgs.ImageStatus.ProviderContentVersion)
+	if err != nil {
+		return fmt.Errorf("failed to get ovf from cache: %w", err)
+	}
+
+	ovfConfigSpec, err := ovf.ToConfigSpec()
+	if err != nil {
+		return fmt.Errorf("failed to transform ovf to config spec: %w", err)
+	}
+
+	if createArgs.ConfigSpec.GuestId == "" {
+		createArgs.ConfigSpec.GuestId = ovfConfigSpec.GuestId
+	}
+
+	// Inherit the image's vAppConfig.
+	createArgs.ConfigSpec.VAppConfig = ovfConfigSpec.VAppConfig
+
+	// Inherit the image's disks and their controllers.
+	pkgutil.CopyStorageControllersAndDisks(
+		&createArgs.ConfigSpec,
+		ovfConfigSpec,
+		createArgs.StorageProfileID)
 
 	return nil
 }
@@ -1507,6 +1652,7 @@ func (vs *vSphereVMProvider) vmResizeGetArgs(
 			resizeArgs.VMClass.Spec,
 			vmopv1.VirtualMachineImageStatus{},
 			minCPUFreq)
+
 	}
 
 	return resizeArgs, nil

--- a/pkg/util/nil.go
+++ b/pkg/util/nil.go
@@ -1,0 +1,15 @@
+package util
+
+import "reflect"
+
+// IsNil returns true if v is nil, including a nil check against possible
+// interface data.
+func IsNil(v any) bool {
+	if v == nil {
+		return true
+	}
+	if vv := reflect.ValueOf(v); vv.Kind() == reflect.Ptr {
+		return vv.IsNil()
+	}
+	return false
+}

--- a/pkg/util/nil_test.go
+++ b/pkg/util/nil_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package util_test
+
+import (
+	"bytes"
+	"io"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/vmware-tanzu/vm-operator/pkg/util"
+)
+
+var _ = Describe("IsNil", func() {
+
+	DescribeTable("value type is not concrete",
+		func(f func() any, expected bool) {
+			Ω(util.IsNil(f())).Should(Equal(expected))
+		},
+		Entry("nil", func() any { return nil }, true),
+		Entry("a string", func() any { return "hello" }, false),
+		Entry("a uint8", func() any { return uint8(1) }, false),
+		Entry("a nil *bool", func() any { return (*bool)(nil) }, true),
+
+		Entry("a nil *bytes.Buffer", func() any { return (*bytes.Buffer)(nil) }, true),
+		Entry("a nil io.Reader", func() any { return (io.Reader)(nil) }, true),
+	)
+
+	When("value type is concrete", func() {
+		When("value type is *bytes.Buffer", func() {
+			When("nil", func() {
+				It("should return false", func() {
+					var v *bytes.Buffer = nil
+					Ω(util.IsNil(v)).Should(BeTrue())
+				})
+			})
+			When("not-nil", func() {
+				It("should return false", func() {
+					v := &bytes.Buffer{}
+					Ω(util.IsNil(v)).Should(BeFalse())
+				})
+			})
+		})
+		When("value type is io.Reader", func() {
+			When("nil", func() {
+				It("should return false", func() {
+					var v io.Reader = nil
+					Ω(util.IsNil(v)).Should(BeTrue())
+				})
+			})
+			When("not-nil", func() {
+				It("should return false", func() {
+					var v io.Reader = &bytes.Buffer{}
+					Ω(util.IsNil(v)).Should(BeFalse())
+				})
+			})
+		})
+	})
+})

--- a/pkg/util/vmopv1/image.go
+++ b/pkg/util/vmopv1/image.go
@@ -1,0 +1,232 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package vmopv1
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path"
+	"strings"
+
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	imgregv1a1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
+	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
+)
+
+// ErrImageNotSynced is returned from GetImageInfo when the underlying content
+// library item is not synced.
+var ErrImageNotSynced = errors.New("image not synced")
+
+// ImageDiskInfo contains information about a VM image that is used to create a VM.
+type ImageDiskInfo struct {
+	ItemID             string
+	ItemContentVersion string
+	DiskURIs           []string
+}
+
+// GetImageDiskInfo returns the information about a VM image's disks, used to
+// create a VM.
+// This method returns an error for images that are not OVFs.
+func GetImageDiskInfo(
+	ctx context.Context,
+	k8sClient ctrlclient.Client,
+	imgRef vmopv1.VirtualMachineImageRef,
+	namespace string) (ImageDiskInfo, error) {
+
+	if pkgutil.IsNil(ctx) {
+		panic("context is nil")
+	}
+	if pkgutil.IsNil(k8sClient) {
+		panic("k8sClient is nil")
+	}
+
+	img, err := GetImage(ctx, k8sClient, imgRef, namespace)
+	if err != nil {
+		return ImageDiskInfo{}, err
+	}
+
+	if err := IsImageOVF(img); err != nil {
+		return ImageDiskInfo{}, err
+	}
+	if err := IsImageReady(img); err != nil {
+		return ImageDiskInfo{}, err
+	}
+	if err := IsImageProviderReady(img); err != nil {
+		return ImageDiskInfo{}, err
+	}
+
+	item, err := GetContentLibraryItemForImage(ctx, k8sClient, img)
+	if err != nil {
+		return ImageDiskInfo{}, err
+	}
+	if err := IsLibraryItemSynced(item); err != nil {
+		return ImageDiskInfo{}, err
+	}
+
+	diskURIs, err := GetStorageURIsForLibraryItemDisks(item)
+	if err != nil {
+		return ImageDiskInfo{}, err
+	}
+
+	return ImageDiskInfo{
+		DiskURIs:           diskURIs,
+		ItemID:             string(item.Spec.UUID),
+		ItemContentVersion: item.Status.ContentVersion,
+	}, nil
+}
+
+// GetImage returns the VirtualMachineImage or ClusterVirtualMachineImage for
+// the provided image reference.
+func GetImage(
+	ctx context.Context,
+	k8sClient ctrlclient.Client,
+	imgRef vmopv1.VirtualMachineImageRef,
+	namespace string) (vmopv1.VirtualMachineImage, error) {
+
+	if pkgutil.IsNil(ctx) {
+		panic("context is nil")
+	}
+	if pkgutil.IsNil(k8sClient) {
+		panic("k8sClient is nil")
+	}
+
+	var obj vmopv1.VirtualMachineImage
+
+	switch imgRef.Kind {
+	case vmiKind:
+		// Namespace scope image.
+		if err := k8sClient.Get(
+			ctx,
+			ctrlclient.ObjectKey{
+				Name:      imgRef.Name,
+				Namespace: namespace,
+			},
+			&obj); err != nil {
+
+			return vmopv1.VirtualMachineImage{}, err
+		}
+	case cvmiKind:
+		// Cluster scope image.
+		var obj2 vmopv1.ClusterVirtualMachineImage
+		if err := k8sClient.Get(
+			ctx,
+			ctrlclient.ObjectKey{
+				Name: imgRef.Name,
+			}, &obj2); err != nil {
+
+			return vmopv1.VirtualMachineImage{}, err
+		}
+		obj = vmopv1.VirtualMachineImage(obj2)
+	default:
+		return vmopv1.VirtualMachineImage{},
+			fmt.Errorf("unsupported image kind: %q", imgRef.Kind)
+	}
+
+	return obj, nil
+}
+
+func IsImageReady(img vmopv1.VirtualMachineImage) error {
+	if !conditions.IsTrue(&img, vmopv1.ReadyConditionType) {
+		return fmt.Errorf(
+			"image condition is not ready: %v",
+			conditions.Get(&img, vmopv1.ReadyConditionType))
+	}
+	if img.Spec.ProviderRef == nil || img.Spec.ProviderRef.Name == "" {
+		return errors.New("image provider ref is empty")
+	}
+	return nil
+}
+
+func IsImageOVF(img vmopv1.VirtualMachineImage) error {
+	if img.Status.Type != string(imgregv1a1.ContentLibraryItemTypeOvf) {
+		return fmt.Errorf(
+			"image type %q is not OVF", img.Status.Type)
+	}
+	return nil
+}
+
+func IsImageProviderReady(img vmopv1.VirtualMachineImage) error {
+	if img.Spec.ProviderRef == nil {
+		return errors.New("image provider ref is nil")
+	}
+	if img.Spec.ProviderRef.Name == "" {
+		return errors.New("image provider ref name is empty")
+	}
+	return nil
+}
+
+func IsLibraryItemSynced(item imgregv1a1.ContentLibraryItem) error {
+	if !item.Status.Cached || item.Status.SizeInBytes.IsZero() {
+		return ErrImageNotSynced
+	}
+	return nil
+}
+
+func GetContentLibraryItemForImage(
+	ctx context.Context,
+	k8sClient ctrlclient.Client,
+	img vmopv1.VirtualMachineImage) (imgregv1a1.ContentLibraryItem, error) {
+
+	if pkgutil.IsNil(ctx) {
+		panic("context is nil")
+	}
+	if pkgutil.IsNil(k8sClient) {
+		panic("k8sClient is nil")
+	}
+
+	var obj imgregv1a1.ContentLibraryItem
+
+	if img.Namespace != "" {
+		// Namespace scope ContentLibraryItem.
+		if err := k8sClient.Get(
+			ctx,
+			ctrlclient.ObjectKey{
+				Name:      img.Spec.ProviderRef.Name,
+				Namespace: img.Namespace,
+			},
+			&obj); err != nil {
+
+			return imgregv1a1.ContentLibraryItem{}, err
+		}
+	} else {
+		// Cluster scope ClusterContentLibraryItem.
+		var obj2 imgregv1a1.ClusterContentLibraryItem
+		if err := k8sClient.Get(
+			ctx,
+			ctrlclient.ObjectKey{Name: img.Spec.ProviderRef.Name},
+			&obj2); err != nil {
+
+			return imgregv1a1.ContentLibraryItem{}, err
+		}
+		obj = imgregv1a1.ContentLibraryItem(obj2)
+	}
+
+	return obj, nil
+}
+
+// GetStorageURIsForLibraryItemDisks returns the paths to the VMDK files from
+// the provided library item.
+func GetStorageURIsForLibraryItemDisks(
+	item imgregv1a1.ContentLibraryItem) ([]string, error) {
+
+	var storageURIs []string
+	for i := range item.Status.FileInfo {
+		fi := item.Status.FileInfo[i]
+		if fi.StorageURI != "" {
+			if strings.EqualFold(path.Ext(fi.StorageURI), ".vmdk") {
+				storageURIs = append(storageURIs, fi.StorageURI)
+			}
+		}
+	}
+	if len(storageURIs) == 0 {
+		return nil, fmt.Errorf(
+			"no vmdk files found in the content library item status: %v",
+			item.Status)
+	}
+	return storageURIs, nil
+}

--- a/pkg/util/vmopv1/image_test.go
+++ b/pkg/util/vmopv1/image_test.go
@@ -1,0 +1,306 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package vmopv1_test
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	imgregv1a1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	vmopv1common "github.com/vmware-tanzu/vm-operator/api/v1alpha3/common"
+	vmopv1util "github.com/vmware-tanzu/vm-operator/pkg/util/vmopv1"
+)
+
+var _ = DescribeTable("IsImageReady",
+	func(obj vmopv1.VirtualMachineImage, expErr string) {
+		err := vmopv1util.IsImageReady(obj)
+		if expErr != "" {
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(expErr))
+		} else {
+			Expect(err).ToNot(HaveOccurred())
+		}
+	},
+	Entry(
+		"condition is missing",
+		vmopv1.VirtualMachineImage{},
+		"image condition is not ready: nil",
+	),
+	Entry(
+		"condition is not ready",
+		vmopv1.VirtualMachineImage{
+			Status: vmopv1.VirtualMachineImageStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   vmopv1.ReadyConditionType,
+						Status: metav1.ConditionFalse,
+					},
+				},
+			},
+		},
+		fmt.Sprintf("image condition is not ready: %v", &metav1.Condition{
+			Type:   vmopv1.ReadyConditionType,
+			Status: metav1.ConditionFalse,
+		}),
+	),
+	Entry(
+		"provider ref is nil",
+		vmopv1.VirtualMachineImage{
+			Status: vmopv1.VirtualMachineImageStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   vmopv1.ReadyConditionType,
+						Status: metav1.ConditionTrue,
+					},
+				},
+			},
+		},
+		"image provider ref is empty",
+	),
+	Entry(
+		"provider ref name is empty",
+		vmopv1.VirtualMachineImage{
+			Spec: vmopv1.VirtualMachineImageSpec{
+				ProviderRef: &vmopv1common.LocalObjectRef{},
+			},
+			Status: vmopv1.VirtualMachineImageStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   vmopv1.ReadyConditionType,
+						Status: metav1.ConditionTrue,
+					},
+				},
+			},
+		},
+		"image provider ref is empty",
+	),
+	Entry(
+		"ready",
+		vmopv1.VirtualMachineImage{
+			Spec: vmopv1.VirtualMachineImageSpec{
+				ProviderRef: &vmopv1common.LocalObjectRef{
+					Name: "my-provider-ref-name",
+				},
+			},
+			Status: vmopv1.VirtualMachineImageStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   vmopv1.ReadyConditionType,
+						Status: metav1.ConditionTrue,
+					},
+				},
+			},
+		},
+		"",
+	),
+)
+
+var _ = DescribeTable("IsImageOVF",
+	func(obj vmopv1.VirtualMachineImage, expErr string) {
+		err := vmopv1util.IsImageOVF(obj)
+		if expErr != "" {
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(expErr))
+		} else {
+			Expect(err).ToNot(HaveOccurred())
+		}
+	},
+	Entry(
+		"no type",
+		vmopv1.VirtualMachineImage{},
+		"image type \"\" is not OVF",
+	),
+	Entry(
+		"ISO",
+		vmopv1.VirtualMachineImage{
+			Status: vmopv1.VirtualMachineImageStatus{
+				Type: "ISO",
+			},
+		},
+		"image type \"ISO\" is not OVF",
+	),
+	Entry(
+		"OVF",
+		vmopv1.VirtualMachineImage{
+			Status: vmopv1.VirtualMachineImageStatus{
+				Type: "OVF",
+			},
+		},
+		"",
+	),
+)
+
+var _ = DescribeTable("IsImageProviderReady",
+	func(obj vmopv1.VirtualMachineImage, expErr string) {
+		err := vmopv1util.IsImageProviderReady(obj)
+		if expErr != "" {
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(expErr))
+		} else {
+			Expect(err).ToNot(HaveOccurred())
+		}
+	},
+	Entry(
+		"ref is nil",
+		vmopv1.VirtualMachineImage{},
+		"image provider ref is nil",
+	),
+	Entry(
+		"name is empty",
+		vmopv1.VirtualMachineImage{
+			Spec: vmopv1.VirtualMachineImageSpec{
+				ProviderRef: &vmopv1common.LocalObjectRef{},
+			},
+		},
+		"image provider ref name is empty",
+	),
+	Entry(
+		"ready",
+		vmopv1.VirtualMachineImage{
+			Spec: vmopv1.VirtualMachineImageSpec{
+				ProviderRef: &vmopv1common.LocalObjectRef{
+					Name: "my-provider-ref",
+				},
+			},
+		},
+		"",
+	),
+)
+
+var _ = DescribeTable("IsLibraryItemSynced",
+	func(obj imgregv1a1.ContentLibraryItem, expErr string) {
+		err := vmopv1util.IsLibraryItemSynced(obj)
+		if expErr != "" {
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(expErr))
+		} else {
+			Expect(err).ToNot(HaveOccurred())
+		}
+	},
+	Entry(
+		"not cached",
+		imgregv1a1.ContentLibraryItem{},
+		vmopv1util.ErrImageNotSynced.Error(),
+	),
+	Entry(
+		"zero size",
+		imgregv1a1.ContentLibraryItem{
+			Status: imgregv1a1.ContentLibraryItemStatus{
+				Cached: true,
+			},
+		},
+		vmopv1util.ErrImageNotSynced.Error(),
+	),
+	Entry(
+		"synced",
+		imgregv1a1.ContentLibraryItem{
+			Status: imgregv1a1.ContentLibraryItemStatus{
+				Cached:      true,
+				SizeInBytes: resource.MustParse("10Gi"),
+			},
+		},
+		"",
+	),
+)
+
+var _ = DescribeTable("GetStorageURIsForLibraryItemDisks",
+	func(obj imgregv1a1.ContentLibraryItem, expOut []string, expErr string) {
+		out, err := vmopv1util.GetStorageURIsForLibraryItemDisks(obj)
+		if expErr != "" {
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(expErr))
+		} else {
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(Equal(expOut))
+		}
+	},
+	Entry(
+		"no disks",
+		imgregv1a1.ContentLibraryItem{},
+		nil,
+		fmt.Sprintf(
+			"no vmdk files found in the content library item status: %v",
+			imgregv1a1.ContentLibraryItemStatus{}),
+	),
+
+	Entry(
+		"has disks and other files",
+		imgregv1a1.ContentLibraryItem{
+			Status: imgregv1a1.ContentLibraryItemStatus{
+				FileInfo: []imgregv1a1.FileInfo{
+					{
+						StorageURI: "ds://vmfs/volumes/123/my-image.ovf",
+					},
+					{
+						StorageURI: "ds://vmfs/volumes/123/my-image-disk-1.vmdk",
+					},
+					{
+						StorageURI: "ds://vmfs/volumes/123/my-image-disk-2.VMDK",
+					},
+					{
+						StorageURI: "ds://vmfs/volumes/123/my-image.mf",
+					},
+				},
+			},
+		},
+		[]string{
+			"ds://vmfs/volumes/123/my-image-disk-1.vmdk",
+			"ds://vmfs/volumes/123/my-image-disk-2.VMDK",
+		},
+		"",
+	),
+)
+
+var _ = XDescribe("GetContentLibraryItemForImage", func() {
+
+	var (
+		ctx       context.Context
+		k8sClient ctrlclient.Client
+		img       vmopv1.VirtualMachineImage
+		expOut    imgregv1a1.ContentLibraryItem
+		expErr    error
+	)
+
+	_, _, _, _, _ = ctx, k8sClient, img, expOut, expErr
+
+	// TODO(akutz) Implement test
+})
+
+var _ = XDescribe("GetImageDiskInfo", func() {
+	var (
+		ctx       context.Context
+		k8sClient ctrlclient.Client
+		imgRef    vmopv1.VirtualMachineImageRef
+		namespace string
+		expOut    vmopv1util.ImageDiskInfo
+		expErr    error
+	)
+
+	_, _, _, _, _, _ = ctx, k8sClient, imgRef, namespace, expOut, expErr
+
+	// TODO(akutz) Implement test
+})
+
+var _ = XDescribe("GetImage", func() {
+	var (
+		ctx       context.Context
+		k8sClient ctrlclient.Client
+		imgRef    vmopv1.VirtualMachineImageRef
+		namespace string
+		expOut    vmopv1.VirtualMachineImage
+		expErr    error
+	)
+
+	_, _, _, _, _, _ = ctx, k8sClient, imgRef, namespace, expOut, expErr
+
+	// TODO(akutz) Implement test
+})

--- a/pkg/util/vsphere/client/client_test.go
+++ b/pkg/util/vsphere/client/client_test.go
@@ -72,6 +72,8 @@ var _ = Describe("Client", Label(testlabels.VCSim), Ordered /* Avoided race for 
 				User: url.UserPassword(expectedUsername, expectedPassword),
 			}
 
+			datacenter := simulator.Map.Any("Datacenter")
+
 			// Configure TLS.
 			model.Service.TLS = tlsConfig
 
@@ -92,7 +94,7 @@ var _ = Describe("Client", Label(testlabels.VCSim), Ordered /* Avoided race for 
 				Password:   expectedPassword,
 				CAFilePath: serverCertFile,
 				Insecure:   false,
-				Datacenter: simulator.Map.Any("Datacenter").Reference().Value,
+				Datacenter: datacenter.Reference().Value,
 			}
 		})
 

--- a/pkg/util/vsphere/library/item_cache.go
+++ b/pkg/util/vsphere/library/item_cache.go
@@ -1,0 +1,284 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package library
+
+import (
+	"context"
+	"crypto/sha1" //nolint:gosec // used for creating directory name
+	"fmt"
+	"io"
+	"path"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"github.com/vmware/govmomi/fault"
+	"github.com/vmware/govmomi/object"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+
+	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
+)
+
+// CacheStorageURIsClient implements the client methods used by the
+// CacheStorageURIs method.
+type CacheStorageURIsClient interface {
+	QueryVirtualDiskUuid(
+		ctx context.Context,
+		name string,
+		datacenter *object.Datacenter) (string, error)
+
+	CopyVirtualDisk(
+		ctx context.Context,
+		srcName string, srcDatacenter *object.Datacenter,
+		dstName string, dstDatacenter *object.Datacenter,
+		dstSpec vimtypes.BaseVirtualDiskSpec, force bool) (*object.Task, error)
+
+	MakeDirectory(
+		ctx context.Context,
+		name string,
+		datacenter *object.Datacenter,
+		createParentDirectories bool) error
+
+	WaitForTask(ctx context.Context, task *object.Task) error
+}
+
+// CacheStorageURIs copies the disk(s) from srcDiskURIs to dstDir and returns
+// the path(s) to the copied disk(s).
+func CacheStorageURIs(
+	ctx context.Context,
+	client CacheStorageURIsClient,
+	dstDatacenter, srcDatacenter *object.Datacenter,
+	dstDir string,
+	srcDiskURIs ...string) ([]string, error) {
+
+	if pkgutil.IsNil(ctx) {
+		panic("context is nil")
+	}
+	if pkgutil.IsNil(client) {
+		panic("client is nil")
+	}
+	if dstDatacenter == nil {
+		panic("dstDatacenter is nil")
+	}
+	if srcDatacenter == nil {
+		panic("srcDatacenter is nil")
+	}
+	if dstDir == "" {
+		panic("dstDir is empty")
+	}
+
+	var dstStorageURIs = make([]string, len(srcDiskURIs))
+
+	for i := range srcDiskURIs {
+		dstFilePath, err := copyDisk(
+			ctx,
+			client,
+			dstDir,
+			srcDiskURIs[i],
+			dstDatacenter,
+			srcDatacenter)
+		if err != nil {
+			return nil, err
+		}
+		dstStorageURIs[i] = dstFilePath
+	}
+
+	return dstStorageURIs, nil
+}
+
+func copyDisk(
+	ctx context.Context,
+	client CacheStorageURIsClient,
+	dstDir, srcFilePath string,
+	dstDatacenter, srcDatacenter *object.Datacenter) (string, error) {
+
+	var (
+		srcFileName = path.Base(srcFilePath)
+		dstFileName = GetCachedFileNameForVMDK(srcFileName) + ".vmdk"
+		dstFilePath = path.Join(dstDir, dstFileName)
+	)
+
+	// Check to see if the disk is already cached.
+	_, queryDiskErr := client.QueryVirtualDiskUuid(
+		ctx,
+		dstFilePath,
+		dstDatacenter)
+	if queryDiskErr == nil {
+		// Disk exists, return the path to it.
+		return dstFilePath, nil
+	}
+	if !fault.Is(queryDiskErr, &vimtypes.FileNotFound{}) {
+		return "", fmt.Errorf("failed to query disk uuid: %w", queryDiskErr)
+	}
+
+	// Create the VM folder.
+	if err := client.MakeDirectory(
+		ctx,
+		dstDir,
+		dstDatacenter,
+		true); err != nil {
+
+		return "", fmt.Errorf("failed to create folder %q: %w", dstDir, err)
+	}
+
+	// The base disk does not exist, create it.
+	copyDiskTask, err := client.CopyVirtualDisk(
+		ctx,
+		srcFilePath,
+		srcDatacenter,
+		dstFilePath,
+		dstDatacenter,
+		&vimtypes.FileBackedVirtualDiskSpec{
+			VirtualDiskSpec: vimtypes.VirtualDiskSpec{
+				AdapterType: string(vimtypes.VirtualDiskAdapterTypeLsiLogic),
+				DiskType:    string(vimtypes.VirtualDiskTypeThin),
+			},
+		},
+		false)
+	if err != nil {
+		return "", fmt.Errorf("failed to call copy disk: %w", err)
+	}
+	if err := client.WaitForTask(ctx, copyDiskTask); err != nil {
+		return "", fmt.Errorf("failed to wait for copy disk: %w", err)
+	}
+
+	return dstFilePath, nil
+}
+
+const topLevelCacheDirName = ".contentlib-cache"
+
+// GetTopLevelCacheDirClient implements the client methods used by the
+// GetTopLevelCacheDir method.
+type GetTopLevelCacheDirClient interface {
+	CreateDirectory(
+		ctx context.Context,
+		datastore *object.Datastore,
+		displayName, policy string) (string, error)
+
+	ConvertNamespacePathToUuidPath(
+		ctx context.Context,
+		datacenter *object.Datacenter,
+		datastoreURL string) (string, error)
+}
+
+// GetTopLevelCacheDir returns the top-level cache directory at the root of the
+// datastore.
+// If the datastore uses vSAN, this function also ensures the top-level
+// directory exists.
+func GetTopLevelCacheDir(
+	ctx context.Context,
+	client GetTopLevelCacheDirClient,
+	dstDatacenter *object.Datacenter,
+	dstDatastore *object.Datastore,
+	dstDatastoreName, dstDatastoreURL string,
+	topLevelDirectoryCreateSupported bool) (string, error) {
+
+	if pkgutil.IsNil(ctx) {
+		panic("context is nil")
+	}
+	if pkgutil.IsNil(client) {
+		panic("client is nil")
+	}
+	if dstDatacenter == nil {
+		panic("dstDatacenter is nil")
+	}
+	if dstDatastore == nil {
+		panic("dstDatastore is nil")
+	}
+	if dstDatastoreName == "" {
+		panic("dstDatastoreName is empty")
+	}
+	if dstDatastoreURL == "" {
+		panic("dstDatastoreURL is empty")
+	}
+
+	logger := logr.FromContextOrDiscard(ctx).WithName("GetTopLevelCacheDir")
+
+	logger.V(4).Info(
+		"Args",
+		"dstDatastoreName", dstDatastoreName,
+		"dstDatastoreURL", dstDatastoreURL,
+		"topLevelDirectoryCreateSupported", topLevelDirectoryCreateSupported)
+
+	if topLevelDirectoryCreateSupported {
+		return fmt.Sprintf(
+			"[%s] %s", dstDatastoreName, topLevelCacheDirName), nil
+	}
+
+	// TODO(akutz) Figure out a way to test if the directory already exists
+	//             instead of trying to just create it again and using the
+	//             FileAlreadyExists error as signal.
+
+	dstDatastorePath, _ := strings.CutPrefix(dstDatastoreURL, "ds://")
+	topLevelCacheDirPath := path.Join(dstDatastorePath, topLevelCacheDirName)
+
+	logger.V(4).Info(
+		"CreateDirectory",
+		"dstDatastorePath", dstDatastorePath,
+		"topLevelCacheDirPath", topLevelCacheDirPath)
+
+	uuidTopLevelCacheDirPath, err := client.CreateDirectory(
+		ctx,
+		dstDatastore,
+		topLevelCacheDirPath,
+		"")
+	if err != nil {
+		if !fault.Is(err, &vimtypes.FileAlreadyExists{}) {
+			return "", fmt.Errorf("failed to create directory: %w", err)
+		}
+
+		logger.V(4).Info(
+			"ConvertNamespacePathToUuidPath",
+			"dstDatacenter", dstDatacenter.Reference().Value,
+			"topLevelCacheDirPath", topLevelCacheDirPath)
+
+		uuidTopLevelCacheDirPath, err = client.ConvertNamespacePathToUuidPath(
+			ctx,
+			dstDatacenter,
+			topLevelCacheDirPath)
+		if err != nil {
+			return "", fmt.Errorf(
+				"failed to convert namespace path=%q: %w",
+				topLevelCacheDirPath, err)
+		}
+	}
+
+	logger.V(4).Info(
+		"Got absolute top level cache dir path",
+		"uuidTopLevelCacheDirPath", uuidTopLevelCacheDirPath)
+
+	topLevelCacheDirName := path.Base(uuidTopLevelCacheDirPath)
+
+	return fmt.Sprintf("[%s] %s", dstDatastoreName, topLevelCacheDirName), nil
+}
+
+// GetCacheDirForLibraryItem returns the cache directory for a library item
+// beneath a top-level cache directory.
+func GetCacheDirForLibraryItem(
+	topLevelCacheDir, itemUUID, contentVersion string) string {
+
+	if topLevelCacheDir == "" {
+		panic("topLevelCacheDir is empty")
+	}
+	if itemUUID == "" {
+		panic("itemUUID is empty")
+	}
+	if contentVersion == "" {
+		panic("contentVersion is empty")
+	}
+	return path.Join(topLevelCacheDir, itemUUID, contentVersion)
+}
+
+// GetCachedFileNameForVMDK returns the first 17 characters of a SHA-1 sum of
+// a VMDK file name and extension, ex. my-disk.vmdk.
+func GetCachedFileNameForVMDK(vmdkFileName string) string {
+	if vmdkFileName == "" {
+		panic("vmdkFileName is empty")
+	}
+	if ext := path.Ext(vmdkFileName); ext != "" {
+		vmdkFileName, _ = strings.CutSuffix(vmdkFileName, ext)
+	}
+	h := sha1.New() //nolint:gosec // used for creating directory name
+	_, _ = io.WriteString(h, vmdkFileName)
+	return fmt.Sprintf("%x", h.Sum(nil))[0:17]
+}

--- a/pkg/util/vsphere/library/item_cache_test.go
+++ b/pkg/util/vsphere/library/item_cache_test.go
@@ -1,0 +1,647 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package library_test
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/soap"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+
+	clsutil "github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/library"
+)
+
+type nilContextKey uint8
+
+var nilContext = context.WithValue(context.Background(), nilContextKey(0), "nil")
+
+type fakeCacheStorageURIsClient struct {
+	queryErr    error
+	queryResult string
+	queryCalls  int32
+
+	copyErr    error
+	copyResult *object.Task
+	copyCalls  int32
+
+	makeErr   error
+	makeCalls int32
+
+	waitErr   error
+	waitCalls int32
+}
+
+func (m *fakeCacheStorageURIsClient) QueryVirtualDiskUuid( //nolint:revive,stylecheck
+	ctx context.Context,
+	name string,
+	datacenter *object.Datacenter) (string, error) {
+
+	_ = atomic.AddInt32(&m.queryCalls, 1)
+	return m.queryResult, m.queryErr
+}
+
+func (m *fakeCacheStorageURIsClient) CopyVirtualDisk(
+	ctx context.Context,
+	srcName string, srcDatacenter *object.Datacenter,
+	dstName string, dstDatacenter *object.Datacenter,
+	dstSpec vimtypes.BaseVirtualDiskSpec, force bool) (*object.Task, error) {
+
+	_ = atomic.AddInt32(&m.copyCalls, 1)
+	return m.copyResult, m.copyErr
+}
+
+func (m *fakeCacheStorageURIsClient) MakeDirectory(
+	ctx context.Context,
+	name string,
+	datacenter *object.Datacenter,
+	createParentDirectories bool) error {
+
+	_ = atomic.AddInt32(&m.makeCalls, 1)
+	return m.makeErr
+}
+
+func (m *fakeCacheStorageURIsClient) WaitForTask(
+	ctx context.Context, task *object.Task) error {
+
+	_ = atomic.AddInt32(&m.waitCalls, 1)
+	return m.waitErr
+}
+
+var _ = Describe("CacheStorageURIs", func() {
+
+	var (
+		ctx    context.Context
+		client *fakeCacheStorageURIsClient
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		client = &fakeCacheStorageURIsClient{}
+
+		Expect(ctx).ToNot(BeNil())
+		Expect(client).ToNot(BeNil())
+	})
+
+	var _ = DescribeTable("it should panic",
+		func(
+			ctx context.Context,
+			client clsutil.CacheStorageURIsClient,
+			dstDatacenter, srcDatacenter *object.Datacenter,
+			dstDir string,
+			expPanic string) {
+
+			if ctx == nilContext {
+				ctx = nil
+			}
+
+			f := func() {
+				_, _ = clsutil.CacheStorageURIs(
+					ctx,
+					client,
+					dstDatacenter,
+					srcDatacenter,
+					dstDir)
+			}
+
+			Expect(f).To(PanicWith(expPanic))
+		},
+
+		Entry(
+			"nil ctx",
+			nilContext,
+			&fakeCacheStorageURIsClient{},
+			&object.Datacenter{},
+			&object.Datacenter{},
+			"[my-datastore] .contentlib-cache/123/v1",
+			"context is nil",
+		),
+		Entry(
+			"nil client",
+			context.Background(),
+			nil,
+			&object.Datacenter{},
+			&object.Datacenter{},
+			"[my-datastore] .contentlib-cache/123/v1",
+			"client is nil",
+		),
+		Entry(
+			"nil dstDatacenter",
+			context.Background(),
+			&fakeCacheStorageURIsClient{},
+			nil,
+			&object.Datacenter{},
+			"[my-datastore] .contentlib-cache/123/v1",
+			"dstDatacenter is nil",
+		),
+		Entry(
+			"nil srcDatacenter",
+			context.Background(),
+			&fakeCacheStorageURIsClient{},
+			&object.Datacenter{},
+			nil,
+			"[my-datastore] .contentlib-cache/123/v1",
+			"srcDatacenter is nil",
+		),
+		Entry(
+			"empty dstDir",
+			context.Background(),
+			&fakeCacheStorageURIsClient{},
+			&object.Datacenter{},
+			&object.Datacenter{},
+			"",
+			"dstDir is empty",
+		),
+	)
+
+	When("it should not panic", func() {
+
+		const (
+			srcDatastoreName                = "my-datastore-2"
+			srcContentLibID                 = "4c502fa7-7ac6-45b9-bd31-15918a193026"
+			srcContentLibItemID             = "d9c5e5fa-5f41-4c80-bd11-a70716f860ac"
+			srcContentLibItemContentVersion = "v1"
+			srcContentLibItemPath           = "[" + srcDatastoreName + "] contentlib/" +
+				srcContentLibID + "/" + srcContentLibItemID
+
+			dstDatastoreName = "my-datastore-1"
+			dstDir           = "[" + dstDatastoreName + "] .contentlib-cache/" +
+				srcContentLibItemID + "/" + srcContentLibItemContentVersion
+		)
+
+		var (
+			ctx           context.Context
+			client        *fakeCacheStorageURIsClient
+			dstDatacenter *object.Datacenter
+			srcDatacenter *object.Datacenter
+			srcDiskURIs   []string
+
+			err error
+			out []string
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			client = &fakeCacheStorageURIsClient{}
+			dstDatacenter = object.NewDatacenter(
+				nil, vimtypes.ManagedObjectReference{
+					Type:  "Datacenter",
+					Value: "datacenter-1",
+				})
+			srcDatacenter = dstDatacenter
+			srcDiskURIs = []string{
+				srcContentLibItemPath + "/photon5-disk1.vmdk",
+				srcContentLibItemPath + "/photon5-disk2.vmdk",
+			}
+		})
+
+		JustBeforeEach(func() {
+			out, err = clsutil.CacheStorageURIs(
+				ctx,
+				client,
+				dstDatacenter,
+				srcDatacenter,
+				dstDir,
+				srcDiskURIs...)
+		})
+
+		When("the disks are already cached", func() {
+			It("should return the paths to the cached disks", func() {
+				Expect(client.queryCalls).To(Equal(int32(2)))
+				Expect(client.makeCalls).To(BeZero())
+				Expect(client.copyCalls).To(BeZero())
+				Expect(client.waitCalls).To(BeZero())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(out).To(Equal([]string{
+					dstDir + "/" + "e66e8b0765f8ff917.vmdk",
+					dstDir + "/" + "b020a5eae7f68a91d.vmdk",
+				}))
+			})
+		})
+
+		When("the disks are not already cached", func() {
+
+			When("querying the virtual disk fails with a RuntimeFault", func() {
+
+				BeforeEach(func() {
+					client.queryErr = soap.WrapVimFault(&vimtypes.RuntimeFault{})
+				})
+
+				It("should return the error", func() {
+					Expect(client.queryCalls).To(Equal(int32(1)))
+					Expect(client.makeCalls).To(BeZero())
+					Expect(client.copyCalls).To(BeZero())
+					Expect(client.waitCalls).To(BeZero())
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(MatchError(soap.WrapVimFault(&vimtypes.RuntimeFault{})))
+				})
+
+			})
+
+			When("querying the virtual disk fails with FileNotFound", func() {
+
+				BeforeEach(func() {
+					client.queryErr = soap.WrapVimFault(&vimtypes.FileNotFound{})
+				})
+
+				When("creating the path where the disk is cached fails", func() {
+					BeforeEach(func() {
+						client.makeErr = soap.WrapVimFault(&vimtypes.RuntimeFault{})
+					})
+					It("should return the error", func() {
+						Expect(client.queryCalls).To(Equal(int32(1)))
+						Expect(client.makeCalls).To(Equal(int32(1)))
+						Expect(client.copyCalls).To(BeZero())
+						Expect(client.waitCalls).To(BeZero())
+						Expect(err).To(HaveOccurred())
+						Expect(err).To(MatchError(soap.WrapVimFault(&vimtypes.RuntimeFault{})))
+					})
+				})
+
+				When("creating the path where the disk is cached succeeds", func() {
+
+					When("calling the copy disk api fails", func() {
+						BeforeEach(func() {
+							client.copyErr = soap.WrapVimFault(&vimtypes.RuntimeFault{})
+						})
+						It("should return the error", func() {
+							Expect(client.queryCalls).To(Equal(int32(1)))
+							Expect(client.makeCalls).To(Equal(int32(1)))
+							Expect(client.copyCalls).To(Equal(int32(1)))
+							Expect(client.waitCalls).To(BeZero())
+							Expect(err).To(HaveOccurred())
+							Expect(err).To(MatchError(soap.WrapVimFault(&vimtypes.RuntimeFault{})))
+						})
+					})
+
+					When("calling the copy disk api succeeds", func() {
+
+						When("copying the disk fails", func() {
+							BeforeEach(func() {
+								client.waitErr = soap.WrapVimFault(&vimtypes.RuntimeFault{})
+							})
+							It("should return the error", func() {
+								Expect(client.queryCalls).To(Equal(int32(1)))
+								Expect(client.makeCalls).To(Equal(int32(1)))
+								Expect(client.copyCalls).To(Equal(int32(1)))
+								Expect(client.waitCalls).To(Equal(int32(1)))
+								Expect(err).To(HaveOccurred())
+								Expect(err).To(MatchError(soap.WrapVimFault(&vimtypes.RuntimeFault{})))
+							})
+						})
+
+						When("copying the disk succeeds", func() {
+							It("should return the paths to the cached disks", func() {
+								Expect(client.queryCalls).To(Equal(int32(2)))
+								Expect(client.makeCalls).To(Equal(int32(2)))
+								Expect(client.copyCalls).To(Equal(int32(2)))
+								Expect(client.waitCalls).To(Equal(int32(2)))
+								Expect(err).ToNot(HaveOccurred())
+								Expect(out).To(Equal([]string{
+									dstDir + "/" + "e66e8b0765f8ff917.vmdk",
+									dstDir + "/" + "b020a5eae7f68a91d.vmdk",
+								}))
+							})
+						})
+					})
+				})
+			})
+
+		})
+	})
+})
+
+type fakeGetTopLevelCacheDirClient struct {
+	createErr    error
+	createResult string
+	createCalls  int32
+
+	convertErr    error
+	convertResult string
+	convertCalls  int32
+}
+
+func (m *fakeGetTopLevelCacheDirClient) CreateDirectory(
+	ctx context.Context,
+	datastore *object.Datastore,
+	displayName, policy string) (string, error) {
+
+	_ = atomic.AddInt32(&m.createCalls, 1)
+	return m.createResult, m.createErr
+}
+
+func (m *fakeGetTopLevelCacheDirClient) ConvertNamespacePathToUuidPath( //nolint:revive,stylecheck
+	ctx context.Context,
+	datacenter *object.Datacenter,
+	datastoreURL string) (string, error) {
+
+	_ = atomic.AddInt32(&m.convertCalls, 1)
+	return m.convertResult, m.convertErr
+}
+
+var _ = Describe("GetTopLevelCacheDir", func() {
+
+	var _ = DescribeTable("it should panic",
+		func(
+			ctx context.Context,
+			client clsutil.GetTopLevelCacheDirClient,
+			dstDatacenter *object.Datacenter,
+			dstDatastore *object.Datastore,
+			dstDatastoreName,
+			dstDatastoreURL string,
+			topLevelDirectoryCreateSupported bool,
+			expPanic string) {
+
+			if ctx == nilContext {
+				ctx = nil
+			}
+
+			f := func() {
+				_, _ = clsutil.GetTopLevelCacheDir(
+					ctx,
+					client,
+					dstDatacenter,
+					dstDatastore,
+					dstDatastoreName,
+					dstDatastoreURL,
+					topLevelDirectoryCreateSupported)
+			}
+
+			Expect(f).To(PanicWith(expPanic))
+		},
+
+		Entry(
+			"nil ctx",
+			nilContext,
+			&fakeGetTopLevelCacheDirClient{},
+			&object.Datacenter{},
+			&object.Datastore{},
+			"my-datastore",
+			"ds://my-datastore",
+			false,
+			"context is nil",
+		),
+		Entry(
+			"nil client",
+			context.Background(),
+			nil,
+			&object.Datacenter{},
+			&object.Datastore{},
+			"my-datastore",
+			"ds://my-datastore",
+			false,
+			"client is nil",
+		),
+		Entry(
+			"nil dstDatacenter",
+			context.Background(),
+			&fakeGetTopLevelCacheDirClient{},
+			nil,
+			&object.Datastore{},
+			"my-datastore",
+			"ds://my-datastore",
+			false,
+			"dstDatacenter is nil",
+		),
+		Entry(
+			"nil dstDatastore",
+			context.Background(),
+			&fakeGetTopLevelCacheDirClient{},
+			&object.Datacenter{},
+			nil,
+			"my-datastore",
+			"ds://my-datastore",
+			false,
+			"dstDatastore is nil",
+		),
+		Entry(
+			"empty dstDatastoreName",
+			context.Background(),
+			&fakeGetTopLevelCacheDirClient{},
+			&object.Datacenter{},
+			&object.Datastore{},
+			"",
+			"ds://my-datastore",
+			false,
+			"dstDatastoreName is empty",
+		),
+		Entry(
+			"empty dstDatastoreURL",
+			context.Background(),
+			&fakeGetTopLevelCacheDirClient{},
+			&object.Datacenter{},
+			&object.Datastore{},
+			"my-datastore",
+			"",
+			false,
+			"dstDatastoreURL is empty",
+		),
+	)
+
+	var _ = When("it should not panic", func() {
+
+		var (
+			ctx                              context.Context
+			client                           *fakeGetTopLevelCacheDirClient
+			dstDatacenter                    *object.Datacenter
+			dstDatastore                     *object.Datastore
+			dstDatastoreName                 string
+			dstDatastoreURL                  string
+			topLevelDirectoryCreateSupported bool
+
+			err error
+			out string
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			client = &fakeGetTopLevelCacheDirClient{}
+			dstDatacenter = object.NewDatacenter(
+				nil, vimtypes.ManagedObjectReference{
+					Type:  "Datacenter",
+					Value: "datacenter-1",
+				})
+			dstDatastore = object.NewDatastore(
+				nil, vimtypes.ManagedObjectReference{
+					Type:  "Datastore",
+					Value: "datastore-1",
+				})
+			dstDatastoreName = "my-datastore"
+			dstDatastoreURL = "ds://my-datastore"
+			topLevelDirectoryCreateSupported = true
+		})
+
+		JustBeforeEach(func() {
+			out, err = clsutil.GetTopLevelCacheDir(
+				ctx,
+				client,
+				dstDatacenter,
+				dstDatastore,
+				dstDatastoreName,
+				dstDatastoreURL,
+				topLevelDirectoryCreateSupported)
+		})
+
+		When("datastore supports top-level directories", func() {
+			It("should return the expected path", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(out).To(Equal("[my-datastore] .contentlib-cache"))
+			})
+		})
+
+		When("datastore does not support top-level directories", func() {
+			BeforeEach(func() {
+				topLevelDirectoryCreateSupported = false
+				client.createResult = "ds://vmfs/volumes/123/abc"
+			})
+			It("should return the expected path", func() {
+				Expect(client.createCalls).To(Equal(int32(1)))
+				Expect(client.convertCalls).To(BeZero())
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(out).To(Equal("[my-datastore] abc"))
+			})
+
+			When("create directory returns an error", func() {
+				When("error is not FileAlreadyExists", func() {
+					BeforeEach(func() {
+						client.createErr = fmt.Errorf(
+							"nested %w",
+							soap.WrapVimFault(&vimtypes.RuntimeFault{}))
+					})
+
+					It("should return the error", func() {
+						Expect(client.createCalls).To(Equal(int32(1)))
+						Expect(client.convertCalls).To(BeZero())
+
+						Expect(err).To(HaveOccurred())
+						Expect(err).To(MatchError(soap.WrapVimFault(
+							&vimtypes.RuntimeFault{})))
+					})
+				})
+				When("error is FileAlreadyExists", func() {
+					BeforeEach(func() {
+						client.createErr = fmt.Errorf(
+							"nested %w",
+							soap.WrapVimFault(&vimtypes.FileAlreadyExists{}))
+
+						client.convertResult = "abc"
+					})
+
+					It("should return the expected path", func() {
+						Expect(client.createCalls).To(Equal(int32(1)))
+						Expect(client.convertCalls).To(Equal(int32(1)))
+
+						Expect(err).ToNot(HaveOccurred())
+						Expect(out).To(Equal("[my-datastore] abc"))
+					})
+
+					When("convert path returns an error", func() {
+						BeforeEach(func() {
+							client.convertErr = fmt.Errorf(
+								"nested %w",
+								soap.WrapVimFault(&vimtypes.RuntimeFault{}))
+						})
+
+						It("should return the error", func() {
+							Expect(client.createCalls).To(Equal(int32(1)))
+							Expect(client.convertCalls).To(Equal(int32(1)))
+
+							Expect(err).To(HaveOccurred())
+							Expect(err).To(MatchError(soap.WrapVimFault(
+								&vimtypes.RuntimeFault{})))
+						})
+					})
+				})
+			})
+
+		})
+	})
+})
+
+var _ = DescribeTable("GetCacheDirForLibraryItem",
+	func(topLevelCacheDir, itemUUID, contentVersion, expOut, expPanic string) {
+		var out string
+		f := func() {
+			out = clsutil.GetCacheDirForLibraryItem(
+				topLevelCacheDir,
+				itemUUID,
+				contentVersion)
+		}
+		if expPanic != "" {
+			Expect(f).To(PanicWith(expPanic))
+		} else {
+			Expect(f).ToNot(Panic())
+			Expect(out).To(Equal(expOut))
+		}
+	},
+	Entry(
+		"empty topLevelCacheDir should panic",
+		"", "b", "c",
+		"",
+		"topLevelCacheDir is empty",
+	),
+	Entry(
+		"empty itemUUID should panic",
+		"a", "", "c",
+		"",
+		"itemUUID is empty",
+	),
+	Entry(
+		"empty contentVersion should panic",
+		"a", "b", "",
+		"",
+		"contentVersion is empty",
+	),
+	Entry(
+		"absolute topLevelCacheDir",
+		"/a", "b", "c",
+		"/a/b/c",
+		"",
+	),
+	Entry(
+		"relative topLevelCacheDir",
+		"a", "b", "c",
+		"a/b/c",
+		"",
+	),
+)
+
+var _ = DescribeTable("GetCachedFileNameForVMDK",
+	func(vmdkFileName, expOut, expPanic string) {
+		var out string
+		f := func() {
+			out = clsutil.GetCachedFileNameForVMDK(vmdkFileName)
+		}
+		if expPanic != "" {
+			Expect(f).To(PanicWith(expPanic))
+		} else {
+			Expect(f).ToNot(Panic())
+			Expect(out).To(Equal(expOut))
+		}
+	},
+	Entry(
+		"empty vmdkFileName should panic",
+		"",
+		"",
+		"vmdkFileName is empty",
+	),
+	Entry(
+		"file name sans extension",
+		"disk",
+		"a07bdcbcbb025d146",
+		"",
+	),
+	Entry(
+		"file name with extension",
+		"disk.vmdk",
+		"a07bdcbcbb025d146",
+		"",
+	),
+)

--- a/pkg/util/vsphere/library/item_sync.go
+++ b/pkg/util/vsphere/library/item_sync.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package library
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/vmware/govmomi/vapi/library"
+
+	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
+)
+
+// SyncLibraryItemClient implements the client methods used by the
+// SyncLibraryItem method.
+type SyncLibraryItemClient interface {
+	GetLibraryItem(ctx context.Context, id string) (*library.Item, error)
+	SyncLibraryItem(ctx context.Context, item *library.Item, force bool) error
+}
+
+// SyncLibraryItem issues a sync call to the provided library item.
+func SyncLibraryItem(
+	ctx context.Context,
+	client SyncLibraryItemClient,
+	itemID string) error {
+
+	if pkgutil.IsNil(ctx) {
+		panic("context is nil")
+	}
+	if pkgutil.IsNil(client) {
+		panic("client is nil")
+	}
+	if itemID == "" {
+		panic("itemID is empty")
+	}
+
+	logger := logr.FromContextOrDiscard(ctx)
+
+	// A file from a library item that belongs to a subscribed library may not
+	// be fully available. Sync the file to ensure it is present.
+	logger.Info("Syncing content library item", "libraryItemID", itemID)
+	libItem, err := client.GetLibraryItem(ctx, itemID)
+	if err != nil {
+		return fmt.Errorf(
+			"error getting library item %s: %w", itemID, err)
+	}
+	if libItem.Type == "LOCAL" {
+		return nil
+	}
+	if err := client.SyncLibraryItem(ctx, libItem, true); err != nil {
+		return fmt.Errorf(
+			"error syncing library item %s: %w", itemID, err)
+	}
+	return nil
+}

--- a/pkg/util/vsphere/library/item_sync_test.go
+++ b/pkg/util/vsphere/library/item_sync_test.go
@@ -1,0 +1,170 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package library_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/go-logr/logr"
+	"github.com/vmware/govmomi/vapi/library"
+
+	clsutil "github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/library"
+)
+
+type fakeSyncLibraryItemClient struct {
+	getLibItemItem   *library.Item
+	getLibItemErr    error
+	getLibItemCalls  int32
+	syncLibItemErr   error
+	syncLibItemCalls int32
+}
+
+func (m *fakeSyncLibraryItemClient) GetLibraryItem(
+	ctx context.Context,
+	id string) (*library.Item, error) {
+
+	_ = atomic.AddInt32(&m.getLibItemCalls, 1)
+	return m.getLibItemItem, m.getLibItemErr
+}
+
+func (m *fakeSyncLibraryItemClient) SyncLibraryItem(
+	ctx context.Context,
+	item *library.Item, force bool) error {
+
+	_ = atomic.AddInt32(&m.syncLibItemCalls, 1)
+	return m.syncLibItemErr
+}
+
+var _ = Describe("SyncLibraryItem", func() {
+
+	var (
+		ctx    context.Context
+		client *fakeSyncLibraryItemClient
+		itemID string
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		client = &fakeSyncLibraryItemClient{}
+		itemID = "fake"
+	})
+
+	When("it should panic", func() {
+		When("context is nil", func() {
+			BeforeEach(func() {
+				ctx = nil
+			})
+			It("should panic", func() {
+				Expect(func() {
+					_ = clsutil.SyncLibraryItem(ctx, client, itemID)
+				}).To(PanicWith("context is nil"))
+			})
+		})
+		When("client is nil", func() {
+			BeforeEach(func() {
+				client = nil
+			})
+			It("should panic", func() {
+				client = nil
+				Expect(func() {
+					_ = clsutil.SyncLibraryItem(ctx, client, itemID)
+				}).To(PanicWith("client is nil"))
+			})
+		})
+		When("library item ID is empty", func() {
+			BeforeEach(func() {
+				itemID = ""
+			})
+			It("should panic", func() {
+				Expect(func() {
+					_ = clsutil.SyncLibraryItem(ctx, client, itemID)
+				}).To(PanicWith("itemID is empty"))
+			})
+		})
+	})
+
+	When("it should not panic", func() {
+
+		var (
+			syncErr error
+		)
+
+		BeforeEach(func() {
+			ctx = logr.NewContext(context.Background(), GinkgoLogr)
+		})
+
+		JustBeforeEach(func() {
+			syncErr = clsutil.SyncLibraryItem(ctx, client, itemID)
+		})
+
+		When("item does not exist", func() {
+			BeforeEach(func() {
+				client.getLibItemErr = errors.New("404 Not Found")
+			})
+			It("should 404", func() {
+				Expect(syncErr).To(HaveOccurred())
+				Expect(syncErr).To(MatchError(fmt.Errorf(
+					"error getting library item %s: %w", itemID,
+					client.getLibItemErr)))
+				Expect(atomic.LoadInt32(&client.getLibItemCalls)).To(Equal(int32(1)))
+
+			})
+		})
+
+		When("item does exist", func() {
+			BeforeEach(func() {
+				client.getLibItemItem = &library.Item{
+					ID:   itemID,
+					Type: "LOCAL",
+				}
+			})
+			When("the item is local", func() {
+				BeforeEach(func() {
+					client.getLibItemItem.Type = "LOCAL"
+				})
+				It("should succeed without calling sync", func() {
+					Expect(syncErr).ToNot(HaveOccurred())
+					Expect(atomic.LoadInt32(&client.getLibItemCalls)).To(Equal(int32(1)))
+					Expect(atomic.LoadInt32(&client.syncLibItemCalls)).To(Equal(int32(0)))
+				})
+			})
+			When("the item is subscribed", func() {
+				BeforeEach(func() {
+					client.getLibItemItem.Type = "SUBSCRIBED"
+				})
+				When("there is an issue with syncing", func() {
+					BeforeEach(func() {
+						client.syncLibItemErr = errors.New("timed out")
+					})
+					It("should return an error", func() {
+						Expect(syncErr).To(HaveOccurred())
+						Expect(syncErr).To(MatchError(fmt.Errorf(
+							"error syncing library item %s: %w", itemID,
+							client.syncLibItemErr)))
+						Expect(atomic.LoadInt32(&client.getLibItemCalls)).To(Equal(int32(1)))
+						Expect(atomic.LoadInt32(&client.syncLibItemCalls)).To(Equal(int32(1)))
+					})
+				})
+				When("there is no issue with syncing", func() {
+					BeforeEach(func() {
+						client.getLibItemItem = &library.Item{
+							ID: itemID,
+						}
+					})
+					It("should succeed", func() {
+						Expect(syncErr).ToNot(HaveOccurred())
+						Expect(atomic.LoadInt32(&client.getLibItemCalls)).To(Equal(int32(1)))
+						Expect(atomic.LoadInt32(&client.syncLibItemCalls)).To(Equal(int32(1)))
+					})
+				})
+			})
+		})
+	})
+})

--- a/pkg/util/vsphere/library/library_suite_test.go
+++ b/pkg/util/vsphere/library/library_suite_test.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package library_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestContentLibrary(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ContentLibrary Test Suite")
+}


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This patch adds support for the Fast Deploy feature, i.e. the ability to quickly provision a VM as a linked clone, as an experimental feature that must be enabled manually. There are many things about this feature that may change prior to it being ready for production.

The patch notes below are broken down into several sections:

* **Goals** -- What is currently supported
* **Non-goals** -- What is not on the table right now 
* **Architecture**
    * **Activation** -- How to enable this experimental feature
    * **Placement** --  Request datastore recommendations
    * **Disk cache** -- Per-datastore cache for Content Library item disk(s)
    * **Create VM** --  Create linked clone directly from cached disk


## Goals

The following goals are what is considered in-scope for this experimental feature at this time. Just because something is not listed, it does not mean it will not be added before the feature is made generally available:

* Support all VM images that are OVFs
* Support multiple zones
* Support workload-domain isolation
* Support all datastore types, including host-local and vSAN


## Non-goals

The following is a list of non-goals that are not in scope at this time, although most of them should be revisited prior to this feature graduating to production:

* Support VM encryption

    Child disks can only be encrypted if their parent disks are encrypted. Users *could* deploy an encrypted VM without using Fast Deploy, and then publish that VM as an image to then be used as the source for provisioning encrypted VMs using Fast Deploy.

    However, child disks must also use the same encryption key as their parent disks. This limitation flies in the face of the upcoming Bring Your Own Key (BYOK) provider feature.

    To accommodate this feature, online disk promotion will be an option once the VM is deployed. This means VMs will be deployed linked clones, privy to the deploy speed a linked clone affords. However, once the VM is created, even if it is powered on, its disks will be promoted so they no longer point back to their parents. While the VM will no longer be save the storage space a linked clone offers, the VM will also be able to support encryption.

* Support VM images that are VM templates (VMTX)

    The architecture behind Fast Deploy makes it trivial to support deploying VM images that point to VM templates. While not in scope at this time, it is likely this becomes part of the feature prior to it graduating to production-ready.

* Support for backup/restore

    The qualified backup/restore workflows for VM Service VMs have never been validated with linked clones as they have not been supported by VM Service up until this point.

    Due to how the linked clones are created in this feature, users should not expect existing backup/restore software to work with VMs provisioned with Fast Deploy at this time.

    To accommodate this feature, online disk promotion will be an option once the VM is deployed. This means VMs will be deployed linked clones, privy to the deploy speed a linked clone affords. However, once the VM is created, even if it is powered on, its disks will be promoted so they no longer point back to their parents. While the VM will no longer be save the storage space a linked clone offers, the VM will also be able to support backup/restore.

* Support for site replication

    Similar to backup/restore, site replication workflows may not work with linked clones from bare disks either.

    To accommodate this feature, online disk promotion will be an option once the VM is deployed. This means VMs will be deployed linked clones, privy to the deploy speed a linked clone affords. However, once the VM is created, even if it is powered on, its disks will be promoted so they no longer point back to their parents. While the VM will no longer be save the storage space a linked clone offers, the VM will also be able to support site replication.

* Support for datastore maintenance/migration

    Existing datastore maintenance/migration workflows may not be aware of or know how to handle the top-level `.contentlib-cache` directories created to cache disks from Content Library items on recommended datastores.

    To accommodate this feature, the goal is to transition the cached disks to be First Class Disks (FCD), but that requires some features not yet available to FCDs, such as the ability to query for the existence of an FCD based on its metadata.


## Architecture

The architecture is broken down into the following sections:

* **Activation** -- How to enable this experimental feature
* **Placement**  -- Request datastore recommendations
* **Disk cache** -- Per-datastore cache for Content Library item disk(s)
* **Create VM**  -- Create linked clone directly from cached disk

### Activation

Enabling the experimental Fast Deploy feature requires setting the environment variable `FSS_WCP_VMSERVICE_FAST_DEPLOY` to `true` in the VM Operator deployment.

Please note, even when the feature is activated, it is possible to bypass the feature altogether by specifying the following annotation on a VM: `vmoperator.vmware.com/fast-deploy: "false"`. This annotation is completely ignored unless the feature is already activated via environment variable as described above.


### Placement

The following steps provide a broad overview of how placement works:

1. The ConfigSpec used to create/place the VM now includes:

    1. The disks and controllers used by the disks from the image.

       The disks also specify the VM spec's storage class's underlying storage policy ID.

    1. The image's guest ID if none was specified by the VM class or VM spec.

    1. The root `VMProfile` now specifies the VM spec's storage class's underlying storage policy ID

1. A placement recommendation for datastores is always required, which uses the storage policies specified in the ConfigSpec to recommend a compatible datastore.

1. A path is constructed that points to where the VM will be created on the recommended datastore, ex.: `[<DATASTORE>] <KUBE_VM_OBJ_UUID>/<KUBE_VM_NAME>.vmx`


### Disk cache

The disk(s) from a Content Library item are cached on-demand on the
recommended datastore:

1. The path(s) to the image's VMDK file(s) from the underlying Content Library Item are retrieved.

1. A special, top-level directory named `.contentlib-cache` is created, if it does not exist, at the root of the recommended datastore.

   Please note, this does support vSAN and thus the top-level directory may actually be a UUID that is resolved to `.contentlib-cache`.

1. A path is constructed that points to where the disk(s) for the library item are expected to be cached on the recommended datastore, ex.: `[<DATASTORE>] .contentlib-cache/<LIB_ITEM_ID>/<LIB_ITEM_CONTENT_VERSION>`

   If this path does not exist, it is created.

1. The following occurs for each of the library item's VMDK files:

    1. The first 17 characters of a SHA-1 sum of the VMDK file name are used to build the expected path to the VMDK file's cached location on the recommended datastore, ex.: `[<DATASTORE>] .contentlib-cache/<LIB_ITEM_ID>/<LIB_ITEM_CONTENT_VERSION>/<17_CHAR_SHA1_SUM>.vmdk`

    1. If there is no VMDK at the above path, the VMDK file is copied to the above path.

The cached disks and entire cache folder structure are automatically removed once there are no longer any VMs deployed as linked clones using a cached disk.

This will likely change in the future to prevent the need to re-cache a disk just because the VMs deployed from it are no longer using it. Otherwise disks may need to be continuously cached, which reduces the value this feature provides.


### Create VM

1. The `VirtualDisk` devices in the ConfigSpec used to create the VM are updated with `VirtualDiskFlatVer2BackingInfo` backings that specify a parent backing which refers to the cached, base disk from above.

    The path to each of the VM's disks is constructed based on the index of the disk, ex.: `[<DATASTORE>] <KUBE_VM_OBJ_UUID>/<KUBE_VM_NAME>-<DISK_INDEX>.vmdk`.

1. The `CreateVM_Task` VMODL1 API is used to create the VM. Because the the VM's disks have parent backings, this new VM is effectively a linked clone.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    4. If a release note is not required, please write "NONE".
-->

```release-note
Experimental support for Fast Deploy (linked clones)
```