### PR TITLE
🌱 Do not hardcode PVC UUID in backup test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/vmware-tanzu/vm-operator/external/tanzu-topology v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/vm-operator/pkg/backup/api v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels v0.0.0-00010101000000-000000000000
-	github.com/vmware/govmomi v0.47.0-alpha.0.0.20241212200752-b1027ba34d97
+	github.com/vmware/govmomi v0.47.0-alpha.0.0.20241213132711-bde6f8c8ae04
 	golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc
 	// * https://github.com/vmware-tanzu/vm-operator/security/dependabot/24
 	golang.org/x/text v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,8 @@ github.com/vmware-tanzu/net-operator-api v0.0.0-20240523152550-862e2c4eb0e0 h1:y
 github.com/vmware-tanzu/net-operator-api v0.0.0-20240523152550-862e2c4eb0e0/go.mod h1:w6QJGm3crIA16ZIz1FVQXD2NVeJhOgGXxW05RbVTSTo=
 github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20241112044858-9da8637c1b0d h1:z9lrzKVtNlujduv9BilzPxuge/LE2F0N1ms3TP4JZvw=
 github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20241112044858-9da8637c1b0d/go.mod h1:Q4JzNkNMvjo7pXtlB5/R3oME4Nhah7fAObWgghVmtxk=
-github.com/vmware/govmomi v0.47.0-alpha.0.0.20241212200752-b1027ba34d97 h1:cU+/GAgXM2PvaynD0SE/SmQrATKoH1BHYr8aLif0fC4=
-github.com/vmware/govmomi v0.47.0-alpha.0.0.20241212200752-b1027ba34d97/go.mod h1:bYwUHpGpisE4AOlDl5eph90T+cjJMIcKx/kaa5v5rQM=
+github.com/vmware/govmomi v0.47.0-alpha.0.0.20241213132711-bde6f8c8ae04 h1:f0q34TEWkqjtsENWOEUqp3snpxZtbs0qiBhH5FSgoyU=
+github.com/vmware/govmomi v0.47.0-alpha.0.0.20241213132711-bde6f8c8ae04/go.mod h1:bYwUHpGpisE4AOlDl5eph90T+cjJMIcKx/kaa5v5rQM=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/providers/vsphere/virtualmachine/backup_test.go
+++ b/pkg/providers/vsphere/virtualmachine/backup_test.go
@@ -38,11 +38,6 @@ func backupTests() {
 		vcSimVMPath       = "DC0_C0_RP0_VM0"
 		vcSimDiskFileName = "[LocalDS_0] DC0_C0_RP0_VM0/disk1.vmdk"
 
-		// TODO(akutz) Do not hard-code this value. Instead use
-		//             QueryVirtualDiskUuid to find it from the file name.
-		//             However, there is a bug in vC Sim's implementation of
-		//             this function, so hard-code for now.
-		vcSimDiskUUID = "60c03576-c448-58e1-a47a-1165dd2c4120"
 		// dummy backup versions at timestamp t1, t2, t3.
 		vT1 = "1001"
 		vT2 = "1002"
@@ -52,10 +47,11 @@ func backupTests() {
 	)
 
 	var (
-		ctx        *builder.TestContextForVCSim
-		vcVM       *object.VirtualMachine
-		vmCtx      pkgctx.VirtualMachineContext
-		testConfig builder.VCSimTestConfig
+		ctx           *builder.TestContextForVCSim
+		vcVM          *object.VirtualMachine
+		vmCtx         pkgctx.VirtualMachineContext
+		testConfig    builder.VCSimTestConfig
+		vcSimDiskUUID string
 	)
 
 	BeforeEach(func() {
@@ -64,6 +60,12 @@ func backupTests() {
 
 	JustBeforeEach(func() {
 		ctx = suite.NewTestContextForVCSim(testConfig)
+
+		dskMgr := object.NewVirtualDiskManager(ctx.VCClient.Client)
+		var err error
+		vcSimDiskUUID, err = dskMgr.QueryVirtualDiskUuid(ctx, vcSimDiskFileName, ctx.Datacenter)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(vcSimDiskUUID).ToNot(BeZero())
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch updates the GoVmomi dependency to https://github.com/vmware/govmomi/commit/bde6f8c8ae045fea4a6fa3fac5c6da55620906b4 to support no longer encoding an unstable disk UUID in the PVC backup tests.

Please see https://github.com/vmware-tanzu/vm-operator/pull/824 for more information.



**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Do not hardcode PVC UUID in backup tests.
```