### PR TITLE
🐛  Fix potential VM validation webhook NPE for Spec.Network

### DIFF
--- a/webhooks/virtualmachine/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator.go
@@ -1230,8 +1230,13 @@ func (v validator) validateImmutableNetwork(ctx *pkgctx.WebhookRequestContext, v
 
 	p := field.NewPath("spec", "network")
 
-	oldInterfaces := oldVM.Spec.Network.Interfaces
-	newInterfaces := vm.Spec.Network.Interfaces
+	var oldInterfaces, newInterfaces []vmopv1.VirtualMachineNetworkInterfaceSpec
+	if oldNetwork != nil {
+		oldInterfaces = oldNetwork.Interfaces
+	}
+	if newNetwork != nil {
+		newInterfaces = newNetwork.Interfaces
+	}
 
 	if len(oldInterfaces) != len(newInterfaces) {
 		return append(allErrs, field.Forbidden(p.Child("interfaces"), "network interfaces cannot be added or removed"))


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

If the VM Spec.Network was changed to/from nil, the validation webhook would NPE. 

Add a few basic update tests for VM Spec.Network.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #

**Are there any special notes for your reviewer**:

I think the stems from late in v1a2 we decided to make most of the top level Spec/Status fields pointers and this was just missed.

**Please add a release note if necessary**:

```release-note
NONE
```