### PR TITLE
:seedling: Introduce a new annotation to identify failed over VMs

### DIFF
--- a/api/v1alpha3/virtualmachine_types.go
+++ b/api/v1alpha3/virtualmachine_types.go
@@ -198,17 +198,25 @@ const (
 	// VMware vCenter (VC) that is managing this virtual machine.
 	ManagerID = GroupName + "/manager-id"
 
-	// RegisteredVMAnnotation on a VirtualMachine represents that a virtual machine has
-	// been registered using the RegisterVM API after a restore, or a fail-over operation by
-	// a vendor. The presence of this annotation is used to bypass some validation checks
-	// that are otherwise applicable to all VirtualMachine create/update requests.
-	RegisteredVMAnnotation = GroupName + "/registered-vm"
+	// RestoredVMAnnotation on a VirtualMachine represents that a virtual
+	// machine has been restored using the RegisterVM API, typically by a
+	// VADP based data protection vendor. The presence of this annotation is
+	// used to bypass some validation checks that are otherwise
+	// applicable to all VirtualMachine create/update requests.
+	RestoredVMAnnotation = GroupName + "/restored-vm"
 
 	// ImportedVMAnnotation on a VirtualMachine represents that a traditional virtual
 	// machine has been imported into Supervisor using the ImportVM API. The presence of this
 	// annotation is used to bypass some validation checks that are otherwise applicable
 	// to all VirtualMachine create/update requests.
 	ImportedVMAnnotation = GroupName + "/imported-vm"
+
+	// FailedOverVMAnnotation on a VirtualMachine resource represents that a virtual
+	// machine has been failed over from one site to the other, typically as part of a
+	// disaster recovery workflow.  The presence of this annotation is used to bypass
+	// some validation checks that are otherwise applicable to all VirtualMachine
+	// create/update requests.
+	FailedOverVMAnnotation = GroupName + "/failed-over-vm"
 )
 
 const (

--- a/pkg/backup/api/backup_types.go
+++ b/pkg/backup/api/backup_types.go
@@ -108,20 +108,4 @@ const (
 	// specifying this key, backup/restore and/or disaster recovery solutions are
 	// responsible to register the VM with Supervisor.
 	DisableAutoRegistrationExtraConfigKey = "vmservice.virtualmachine.disableAutomaticRegistration"
-
-	// TestFailoverLabelKey label signifies that a VirtualMachine is going through
-	// a test recovery plan scenario. Typically, this involves failing over a VM
-	// to a dedicated temporary network so as to not exhaust, and cause IP address
-	// collisions with the production network. This label on a VirtualMachine
-	// custom resource allows vendors to change the VM's network interface to
-	// connect to the test network after the VM is registered post a failover.
-	//
-	// VM operator does not support mutable networks, so this label allows only
-	// select vendors (e.g., SRM) to support recovery plan test workflows while we
-	// build support for true network mutability.
-	//
-	// The value of this label does not matter. Its presence is considered a
-	// sufficient evidence to indicate that the virtual machine is going through
-	// test fail-over.
-	TestFailoverLabelKey = "virtualmachine." + GroupName + "/test-failover"
 )

--- a/pkg/util/annotations/helpers.go
+++ b/pkg/util/annotations/helpers.go
@@ -9,8 +9,12 @@ import (
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 )
 
-func HasRegisterVM(o metav1.Object) bool {
-	return hasAnnotation(o, vmopv1.RegisteredVMAnnotation)
+func HasRestoredVM(o metav1.Object) bool {
+	return hasAnnotation(o, vmopv1.RestoredVMAnnotation)
+}
+
+func HasFailOverVM(o metav1.Object) bool {
+	return hasAnnotation(o, vmopv1.FailedOverVMAnnotation)
 }
 
 func HasImportVM(o metav1.Object) bool {

--- a/pkg/util/annotations/helpers_test.go
+++ b/pkg/util/annotations/helpers_test.go
@@ -48,20 +48,20 @@ var _ = DescribeTable(
 )
 
 var _ = DescribeTable(
-	"HasRegisterVM",
+	"HasRestoredVM",
 	func(in map[string]string, out bool) {
 		vm := &vmopv1.VirtualMachine{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: in,
 			},
 		}
-		actual := annotations.HasRegisterVM(vm)
+		actual := annotations.HasRestoredVM(vm)
 		Expect(actual).To(Equal(out))
 	},
 	Entry("nil", nil, false),
 	Entry("not present", map[string]string{"foo": "bar"}, false),
-	Entry("present but empty ", map[string]string{vmopv1.RegisteredVMAnnotation: ""}, true),
-	Entry("present and not empty ", map[string]string{vmopv1.RegisteredVMAnnotation: "true"}, true),
+	Entry("present but empty ", map[string]string{vmopv1.RestoredVMAnnotation: ""}, true),
+	Entry("present and not empty ", map[string]string{vmopv1.RestoredVMAnnotation: "true"}, true),
 )
 
 var _ = DescribeTable(
@@ -79,4 +79,21 @@ var _ = DescribeTable(
 	Entry("not present", map[string]string{"foo": "bar"}, false),
 	Entry("present but empty ", map[string]string{vmopv1.ImportedVMAnnotation: ""}, true),
 	Entry("present and not empty ", map[string]string{vmopv1.ImportedVMAnnotation: "true"}, true),
+)
+
+var _ = DescribeTable(
+	"HasFailOverVM",
+	func(in map[string]string, out bool) {
+		vm := &vmopv1.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: in,
+			},
+		}
+		actual := annotations.HasFailOverVM(vm)
+		Expect(actual).To(Equal(out))
+	},
+	Entry("nil", nil, false),
+	Entry("not present", map[string]string{"foo": "bar"}, false),
+	Entry("present but empty ", map[string]string{vmopv1.FailedOverVMAnnotation: ""}, true),
+	Entry("present and not empty ", map[string]string{vmopv1.FailedOverVMAnnotation: "true"}, true),
 )


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

We need a new annotation for failed over VMs so we can skip some webhook checks.  This is different from imported, or registered VMs since we will need to relax additional webhook checks such as allowing for network manipulation.

Remove the test failover annotation since that is no longer needed.

**Are there any special notes for your reviewer**:

This annotation can be considered a replacement of the test failover annotation except it will be used by production failover workflows as well.

**Please add a release note if necessary**:

```release-note
Introduce a new annotation to identify failed over VMs
```