### PR TITLE
🌱 Do not CBLO if VM watcher service fails

### DIFF
--- a/services/vm-watcher/vm_watcher_service.go
+++ b/services/vm-watcher/vm_watcher_service.go
@@ -84,10 +84,18 @@ func (s Service) Start(ctx context.Context) error {
 			// error, then do not treat the error as fatal. This allows the
 			// loop to run again, kicking off another watcher with what should
 			// be updated credentials.
-			if !vsphereclient.IsInvalidLogin(err) &&
-				!vsphereclient.IsNotAuthenticatedError(err) {
+			if vsphereclient.IsInvalidLogin(err) ||
+				vsphereclient.IsNotAuthenticatedError(err) {
 
-				return err
+				logger.V(4).Error(
+					err,
+					"Authn/authz issue trying start vm watcher service")
+
+			} else {
+				// Log unexpected error.
+				logger.Error(
+					err,
+					"Unexpected error trying to start vm watcher service")
 			}
 		}
 	}


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch updates the behavior of the VM watcher service to no longer return an error if there is an issue starting. While this is the correct behavior, it also results in CBLO for the VM Op pod if the reason for the error is external and not resolved.

For example, if a user configures the host name of vCenter to be invalid, the VM Op pod will be in CBLO until this is resolved. Again, this is technically correct, and resolves itself once the user fixes the misconfigured setting.

However, the VM Op pod becoming unavailable on a single-node Supervisor also means no webhooks are running, and this would be bad.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Do not exit pod if VM watcher service fails to start
```