### PR TITLE
✨ Mark v1alpha1 as deprecated

### DIFF
--- a/api/v1alpha1/contentlibraryprovider_types.go
+++ b/api/v1alpha1/contentlibraryprovider_types.go
@@ -22,6 +22,7 @@ type ContentLibraryProviderStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:printcolumn:name="Content-Library-UUID",type="string",JSONPath=".spec.uuid",description="UUID of the vSphere content library"
+// +kubebuilder:deprecatedversion:warning="This API has been deprecated and is unsupported in future versions"
 
 // ContentLibraryProvider is the Schema for the contentlibraryproviders API.
 type ContentLibraryProvider struct {
@@ -33,6 +34,7 @@ type ContentLibraryProvider struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion:warning="This API has been deprecated and is unsupported in future versions"
 
 // ContentLibraryProviderList contains a list of ContentLibraryProvider.
 type ContentLibraryProviderList struct {

--- a/api/v1alpha1/contentsource_types.go
+++ b/api/v1alpha1/contentsource_types.go
@@ -31,6 +31,7 @@ type ContentSourceStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Cluster
+// +kubebuilder:deprecatedversion:warning="This API has been deprecated and is unsupported in future versions"
 
 // ContentSource is the Schema for the contentsources API.
 // A ContentSource represents the desired specification and the observed status of a ContentSource instance.
@@ -43,6 +44,7 @@ type ContentSource struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion:warning="This API has been deprecated and is unsupported in future versions"
 
 // ContentSourceList contains a list of ContentSource.
 type ContentSourceList struct {

--- a/api/v1alpha1/virtualmachine_types.go
+++ b/api/v1alpha1/virtualmachine_types.go
@@ -698,6 +698,7 @@ func (vm *VirtualMachine) SetConditions(conditions Conditions) {
 // +kubebuilder:printcolumn:name="Image",type="string",priority=1,JSONPath=".spec.imageName"
 // +kubebuilder:printcolumn:name="Primary-IP",type="string",priority=1,JSONPath=".status.vmIp"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:deprecatedversion
 
 // VirtualMachine is the Schema for the virtualmachines API.
 // A VirtualMachine represents the desired specification and the observed status of a VirtualMachine instance.  A
@@ -715,9 +716,10 @@ func (vm VirtualMachine) NamespacedName() string {
 	return vm.Namespace + "/" + vm.Name
 }
 
-// VirtualMachineList contains a list of VirtualMachine.
-//
 // +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion
+
+// VirtualMachineList contains a list of VirtualMachine.
 type VirtualMachineList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/v1alpha1/virtualmachineclass_types.go
+++ b/api/v1alpha1/virtualmachineclass_types.go
@@ -154,6 +154,7 @@ type VirtualMachineClassStatus struct {
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="VGPU-Devices-Profile-Names",type="string",priority=1,JSONPath=".spec.hardware.devices.vgpuDevices[*].profileName"
 // +kubebuilder:printcolumn:name="Passthrough-DeviceIDs",type="string",priority=1,JSONPath=".spec.hardware.devices.dynamicDirectPathIODevices[*].deviceID"
+// +kubebuilder:deprecatedversion
 
 // VirtualMachineClass is the Schema for the virtualmachineclasses API.
 // A VirtualMachineClass represents the desired specification and the observed status of a VirtualMachineClass
@@ -169,6 +170,7 @@ type VirtualMachineClass struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion
 
 // VirtualMachineClassList contains a list of VirtualMachineClass.
 type VirtualMachineClassList struct {

--- a/api/v1alpha1/virtualmachineclassbinding_types.go
+++ b/api/v1alpha1/virtualmachineclassbinding_types.go
@@ -20,6 +20,7 @@ type ClassReference struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Namespaced,shortName=vmclassbinding
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:deprecatedversion:warning="This API has been deprecated and is unsupported in future versions"
 
 // VirtualMachineClassBinding is a binding object responsible for
 // defining a VirtualMachineClass and a Namespace associated with it.

--- a/api/v1alpha1/virtualmachineimage_types.go
+++ b/api/v1alpha1/virtualmachineimage_types.go
@@ -167,6 +167,7 @@ func (vmImage *VirtualMachineImage) SetConditions(conditions Conditions) {
 // +kubebuilder:printcolumn:name="Format",type="string",JSONPath=".spec.type"
 // +kubebuilder:printcolumn:name="Image-Supported",type="boolean",priority=1,JSONPath=".status.imageSupported"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:deprecatedversion
 
 // VirtualMachineImage is the Schema for the virtualmachineimages API
 // A VirtualMachineImage represents a VirtualMachine image (e.g. VM template) that can be used as the base image
@@ -181,6 +182,7 @@ type VirtualMachineImage struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion
 
 // VirtualMachineImageList contains a list of VirtualMachineImage.
 type VirtualMachineImageList struct {
@@ -207,6 +209,7 @@ func (clusterVirtualMachineImage *ClusterVirtualMachineImage) SetConditions(cond
 // +kubebuilder:printcolumn:name="Format",type="string",JSONPath=".spec.type"
 // +kubebuilder:printcolumn:name="Image-Supported",type="boolean",priority=1,JSONPath=".status.imageSupported"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:deprecatedversion
 
 // ClusterVirtualMachineImage is the schema for the clustervirtualmachineimage API
 // A ClusterVirtualMachineImage represents the desired specification and the observed status of a
@@ -220,6 +223,7 @@ type ClusterVirtualMachineImage struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion
 
 // ClusterVirtualMachineImageList contains a list of ClusterVirtualMachineImage.
 type ClusterVirtualMachineImageList struct {

--- a/api/v1alpha1/virtualmachinepublishrequest_types.go
+++ b/api/v1alpha1/virtualmachinepublishrequest_types.go
@@ -344,6 +344,7 @@ func (vmpr *VirtualMachinePublishRequest) SetConditions(conditions Conditions) {
 // +kubebuilder:resource:scope=Namespaced,shortName=vmpub
 // +kubebuilder:storageversion:false
 // +kubebuilder:subresource:status
+// +kubebuilder:deprecatedversion
 
 // VirtualMachinePublishRequest defines the information necessary to publish a
 // VirtualMachine as a VirtualMachineImage to an image registry.
@@ -356,6 +357,7 @@ type VirtualMachinePublishRequest struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion
 
 // VirtualMachinePublishRequestList contains a list of
 // VirtualMachinePublishRequest resources.

--- a/api/v1alpha1/virtualmachineservice_types.go
+++ b/api/v1alpha1/virtualmachineservice_types.go
@@ -139,6 +139,7 @@ type VirtualMachineServiceStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Type",type="string",JSONPath=".spec.type"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:deprecatedversion
 
 // VirtualMachineService is the Schema for the virtualmachineservices API.
 // A VirtualMachineService represents the desired specification and the observed status of a VirtualMachineService
@@ -157,6 +158,7 @@ func (s *VirtualMachineService) NamespacedName() string {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion
 
 // VirtualMachineServiceList contains a list of VirtualMachineService.
 type VirtualMachineServiceList struct {

--- a/api/v1alpha1/virtualmachinesetresourcepolicy_types.go
+++ b/api/v1alpha1/virtualmachinesetresourcepolicy_types.go
@@ -57,6 +57,7 @@ type ClusterModuleStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion:false
 // +kubebuilder:subresource:status
+// +kubebuilder:deprecatedversion
 
 // VirtualMachineSetResourcePolicy is the Schema for the virtualmachinesetresourcepolicies API.
 type VirtualMachineSetResourcePolicy struct {
@@ -72,6 +73,7 @@ func (res VirtualMachineSetResourcePolicy) NamespacedName() string {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion
 
 // VirtualMachineSetResourcePolicyList contains a list of VirtualMachineSetResourcePolicy.
 type VirtualMachineSetResourcePolicyList struct {

--- a/api/v1alpha1/webconsolerequest_types.go
+++ b/api/v1alpha1/webconsolerequest_types.go
@@ -51,6 +51,7 @@ type WebConsoleRequestStatus struct {
 // +kubebuilder:resource:scope=Namespaced
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
+// +kubebuilder:deprecatedversion:warning="This API has been deprecated and is unsupported in future versions"
 
 // WebConsoleRequest allows the creation of a one-time web console ticket that can be used to interact with the VM.
 type WebConsoleRequest struct {
@@ -66,6 +67,7 @@ func (s *WebConsoleRequest) NamespacedName() string {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion:warning="This API has been deprecated and is unsupported in future versions"
 
 // WebConsoleRequestList contains a list of WebConsoleRequests.
 type WebConsoleRequestList struct {

--- a/config/crd/bases/vmoperator.vmware.com_clustervirtualmachineimages.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_clustervirtualmachineimages.yaml
@@ -39,6 +39,7 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/vmoperator.vmware.com_contentlibraryproviders.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_contentlibraryproviders.yaml
@@ -19,6 +19,9 @@ spec:
       jsonPath: .spec.uuid
       name: Content-Library-UUID
       type: string
+    deprecated: true
+    deprecationWarning: This API has been deprecated and is unsupported in future
+      versions
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/vmoperator.vmware.com_contentsources.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_contentsources.yaml
@@ -14,7 +14,10 @@ spec:
     singular: contentsource
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - deprecated: true
+    deprecationWarning: This API has been deprecated and is unsupported in future
+      versions
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachineclassbindings.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachineclassbindings.yaml
@@ -20,6 +20,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: This API has been deprecated and is unsupported in future
+      versions
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachineclasses.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachineclasses.yaml
@@ -34,6 +34,7 @@ spec:
       name: Passthrough-DeviceIDs
       priority: 1
       type: string
+    deprecated: true
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachineimages.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachineimages.yaml
@@ -37,6 +37,7 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachinepublishrequests.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachinepublishrequests.yaml
@@ -16,7 +16,8 @@ spec:
     singular: virtualmachinepublishrequest
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - deprecated: true
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -35,6 +35,7 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachineservices.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachineservices.yaml
@@ -23,6 +23,7 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachinesetresourcepolicies.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachinesetresourcepolicies.yaml
@@ -14,7 +14,8 @@ spec:
     singular: virtualmachinesetresourcepolicy
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - deprecated: true
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: VirtualMachineSetResourcePolicy is the Schema for the virtualmachinesetresourcepolicies

--- a/config/crd/bases/vmoperator.vmware.com_webconsolerequests.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_webconsolerequests.yaml
@@ -14,7 +14,10 @@ spec:
     singular: webconsolerequest
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - deprecated: true
+    deprecationWarning: This API has been deprecated and is unsupported in future
+      versions
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: WebConsoleRequest allows the creation of a one-time web console


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch marks v1alpha1 as deprecated. The APIs ContentLibraryProvider, ContentSource, and VirtualMachineClassBinding, and WebConsoleRequest, along with their List variants, also indicate they are no longer supported in future versions.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Deprecate the v1alpha1 APIs 
```