### PR TITLE
🐛 Fix CD-ROM backing ISO library item size check

### DIFF
--- a/pkg/providers/vsphere/virtualmachine/cdrom.go
+++ b/pkg/providers/vsphere/virtualmachine/cdrom.go
@@ -203,7 +203,7 @@ func getBackingFileNameByImageRef(
 
 	// Subscribed content library item file may not always be stored in VC.
 	// Sync the item to ensure the file is available for CD-ROM connection.
-	if syncFile && (!itemStatus.Cached || itemStatus.SizeInBytes.Size() == 0) {
+	if syncFile && (!itemStatus.Cached || itemStatus.SizeInBytes.IsZero()) {
 		vmCtx.Logger.Info("Syncing content library item", "libItemUUID", libItemUUID)
 		libItem, err := libManager.GetLibraryItem(vmCtx, libItemUUID)
 		if err != nil {


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR uses `apimachinery.resource.Quantity`'s `IsZero()` function to correctly check if the CD-ROM's backing ISO library library item is empty. The originally used `Size ()` function returns the number of bytes required to marshal the value to protobuf (i.e. the statement would always be false as that function returns 3 for zero-size quantity).

**Which issue(s) is/are addressed by this PR?**

Fixes N/A.

**Are there any special notes for your reviewer**:

None.

**Please add a release note if necessary**:

```release-note
Fix CD-ROM backing ISO library item size check to use resource.IsZero() function.
```