### PR TITLE
🐛 Skip ISO images in unified storage quota validator

### DIFF
--- a/webhooks/unifiedstoragequota/validation/unifiedstoragequota_validator.go
+++ b/webhooks/unifiedstoragequota/validation/unifiedstoragequota_validator.go
@@ -178,6 +178,11 @@ func (h *RequestedCapacityHandler) HandleCreate(ctx *pkgctx.WebhookRequestContex
 		return CapacityResponse{Response: webhook.Errored(http.StatusBadRequest, fmt.Errorf("unsupported image kind %s", vm.Spec.Image.Kind))}
 	}
 
+	// Skip ISO images as they don't have boot disks.
+	if imageStatus.Type == "ISO" {
+		return CapacityResponse{Response: webhook.Allowed("")}
+	}
+
 	if len(imageStatus.Disks) < 1 || imageStatus.Disks[0].Capacity == nil {
 		return CapacityResponse{Response: webhook.Errored(http.StatusNotFound, errors.New("boot disk not found in image status"))}
 	}

--- a/webhooks/unifiedstoragequota/validation/unifiedstoragequota_validator_unit_test.go
+++ b/webhooks/unifiedstoragequota/validation/unifiedstoragequota_validator_unit_test.go
@@ -682,6 +682,17 @@ func testRequestedCapacityHandlerHandleCreate() {
 					})
 				})
 
+				When("image type is ISO", func() {
+					BeforeEach(func() {
+						vmi.Status.Type = "ISO"
+					})
+
+					It("should write StatusOK code and an empty RequestedCapacity to the response", func() {
+						Expect(resp.Allowed).To(BeTrue())
+						Expect(int(resp.Result.Code)).To(Equal(http.StatusOK))
+					})
+				})
+
 				When("disks section is empty in image status", func() {
 					It("should write StatusNotFound code and an empty RequestedCapacity to the response", func() {
 						Expect(resp.Allowed).To(BeFalse())


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR updates the unified storage quota validating webhook to skip ISO-type images, as these VMIs don't have any disks listed under the status field.

Given the following VM YAML:

```console
$ cat vm-iso.yaml
apiVersion: vmoperator.vmware.com/v1alpha3
kind: VirtualMachine
metadata:
  name: test-vm-iso
  namespace: sdiliyaer-test
spec:
  className: best-effort-small
  storageClass: wcpglobal-storage-profile
  cdrom:
  - name: cdrom1
    image:
      kind: VirtualMachineImage
      name: vmi-da1c2e296c431a6eb
  guestID: otherGuest
```

Current webhook denies the VM creation request:

```console
$ kubectl apply -f vm-iso.yaml
Error from server (Forbidden): error when creating "vm-iso.yaml": admission webhook "quota-create.validating.virtualmachine.v1alpha3.vmoperator.vmware.com" denied the request: Operation denied, Error returned from extension service for resource VirtualMachine in namespace sdiliyaer-test, err = {"capacity":"0","storageClassName":"","storagePolicyId":"","reason":"boot disk not found in image status"}
```

With the change from this PR applied, VM can be created successfully:

```console
$ kubectl apply -f vm-iso.yaml
virtualmachine.vmoperator.vmware.com/test-vm-iso created

$ kubectl get vm -n sdiliyaer-test
NAME          POWER-STATE   AGE
test-vm-iso   PoweredOn     7m43s
```

**Which issue(s) is/are addressed by this PR?**

Fixes N/A.

**Are there any special notes for your reviewer**:

N/A.

**Please add a release note if necessary**:

```release-note
Skip ISO images in unified storage quota validator.
```