### PR TITLE
✨ Conditions helper & refactor

### DIFF
--- a/pkg/conditions/conditions.go
+++ b/pkg/conditions/conditions.go
@@ -1,0 +1,229 @@
+// Copyright (c) 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package conditions
+
+import (
+	"sort"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// ReadyConditionType indicates a resource is ready.
+	ReadyConditionType = "Ready"
+)
+
+// Conditions is an alias for a slice of metav1.Condition objects and provides
+// helpful functions.
+type Conditions []metav1.Condition
+
+// c4g returns a Conditions type from a Getter. This is used throughout this
+// package to reduce the need to write "Conditions(obj.GetConditions())".
+func c4g(g Getter) Conditions {
+	return g.GetConditions()
+}
+
+// GetConditions allows the Conditions type to implement the Getter interface.
+func (l Conditions) GetConditions() []metav1.Condition {
+	return l
+}
+
+// Get returns the condition with the given type, otherwise nil is returned.
+func (l Conditions) Get(t string) *metav1.Condition {
+	for _, c := range l {
+		if c.Type == t {
+			return &c
+		}
+	}
+	return nil
+}
+
+// Has returns true if a condition with the given type exists.
+func (l Conditions) Has(t string) bool {
+	return l.Get(t) != nil
+}
+
+// IsTrue returns true if the condition with the given type exists and is
+// True, otherwise false is returned.
+func (l Conditions) IsTrue(t string) bool {
+	if c := l.Get(t); c != nil {
+		return c.Status == metav1.ConditionTrue
+	}
+	return false
+}
+
+// IsFalse returns true if the condition with the given type exists and is
+// False, otherwise false is returned.
+func (l Conditions) IsFalse(t string) bool {
+	if c := l.Get(t); c != nil {
+		return c.Status == metav1.ConditionFalse
+	}
+	return false
+}
+
+// IsUnknown returns true if the condition with the given type exists and is
+// Unknown, otherwise false is returned.
+func (l Conditions) IsUnknown(t string) bool {
+	if c := l.Get(t); c != nil {
+		return c.Status == metav1.ConditionUnknown
+	}
+	return true
+}
+
+// GetReason returns the condition's reason or an empty string if the condition
+// does not exist.
+func (l Conditions) GetReason(t string) string {
+	if c := l.Get(t); c != nil {
+		return c.Reason
+	}
+	return ""
+}
+
+// GetMessage returns the condition's message or an empty string if the
+// condition does not exist.
+func (l Conditions) GetMessage(t string) string {
+	if c := l.Get(t); c != nil {
+		return c.Message
+	}
+	return ""
+}
+
+// GetLastTransitionTime returns the condition's last transition time or a nil
+// value if the condition does not exist.
+func (l Conditions) GetLastTransitionTime(t string) *metav1.Time {
+	if c := l.Get(t); c != nil {
+		return &c.LastTransitionTime
+	}
+	return nil
+}
+
+// Set sets the given condition.
+// If a condition with the same type already exists, its LastTransitionTime is
+// only updated if a change is detected in one of the following fields:
+// Status, Reason, or Message.
+func (l Conditions) Set(c *metav1.Condition) Conditions {
+	if c == nil {
+		return l
+	}
+
+	// Check if the new conditions already exists, and change it only if there
+	// is a status transition (otherwise preserve the current last transition
+	// time).
+	exists := false
+	for i := range l {
+		existingCondition := l[i]
+		if existingCondition.Type == c.Type {
+			exists = true
+			if !hasSameState(&existingCondition, c) {
+				c.LastTransitionTime = metav1.NewTime(
+					time.Now().UTC().Truncate(time.Second))
+				l[i] = *c
+				break
+			}
+			c.LastTransitionTime = existingCondition.LastTransitionTime
+			break
+		}
+	}
+
+	// If the condition does not exist, add it, setting the transition time only
+	// if it is not already set
+	if !exists {
+		if c.LastTransitionTime.IsZero() {
+			c.LastTransitionTime = metav1.NewTime(
+				time.Now().UTC().Truncate(time.Second))
+		}
+		l = append(l, *c)
+	}
+
+	// Sorts conditions for convenience of the consumer, i.e. kubectl.
+	sort.Slice(l, func(i, j int) bool {
+		return lexicographicLess(&l[i], &l[j])
+	})
+
+	return l
+}
+
+// MarkTrue sets Status=True for the condition with the given type.
+func (l Conditions) MarkTrue(t string) Conditions {
+	return l.Set(TrueCondition(t))
+}
+
+// MarkUnknown sets Status=Unknown for the condition with the given type.
+func (l Conditions) MarkUnknown(
+	t, reason, messageFormat string, messageArgs ...any) Conditions {
+
+	return l.Set(UnknownCondition(t, reason, messageFormat, messageArgs...))
+}
+
+// MarkFalse sets Status=False for the condition with the given type.
+func (l Conditions) MarkFalse(
+	t, reason, messageFormat string, messageArgs ...any) Conditions {
+
+	return l.Set(FalseCondition(t, reason, messageFormat, messageArgs...))
+}
+
+// SetSummary sets a Ready condition with a summary of all the existing
+// conditions. If there are no existing conditions, no summary condition is
+// generated.
+func (l Conditions) SetSummary(options ...MergeOption) Conditions {
+
+	return l.Set(summary(l, options...))
+}
+
+// SetMirror creates a new condition by mirroring the Ready condition from a
+// source object. If the source object does not have a Ready condition, the
+// target is not modified.
+func (l Conditions) SetMirror(
+	targetCondition string,
+	from Getter,
+	options ...MirrorOptions) Conditions {
+
+	return l.Set(mirror(from, targetCondition, options...))
+}
+
+// SetAggregate creates a new condition by aggregating all of the Ready
+// conditions from a list of source objects. If a source object is missing the
+// Ready condition, that object is excluded from aggregation. If none of the
+// source objects have a Ready condition, the target is not modified.
+func (l Conditions) SetAggregate(
+	targetCondition string,
+	from []Getter,
+	options ...MergeOption) Conditions {
+
+	return l.Set(aggregate(from, targetCondition, options...))
+}
+
+// Delete removes the condition with the given type.
+func (l Conditions) Delete(t string) Conditions {
+	if len(l) == 0 {
+		return l
+	}
+	newConditions := make([]metav1.Condition, 0, len(l))
+	for _, c := range l {
+		if c.Type != t {
+			newConditions = append(newConditions, c)
+		}
+	}
+	return newConditions
+}
+
+// hasSameState returns true if a condition has the same state of another; state
+// is defined by the union of following fields: Type, Status, Reason, and
+// Message. The field LastTransitionTime is excluded.
+func hasSameState(a, b *metav1.Condition) bool {
+	return a.Type == b.Type &&
+		a.Status == b.Status &&
+		a.Reason == b.Reason &&
+		a.Message == b.Message
+}
+
+// lexicographicLess returns true if a condition is less than another with
+// regards to the to order of conditions designed for convenience of the
+// consumer, i.e. kubectl. According to this order the Ready condition always
+// goes first, followed by all the other conditions sorted by Type.
+func lexicographicLess(a, b *metav1.Condition) bool {
+	return (a.Type == ReadyConditionType || a.Type < b.Type) &&
+		b.Type != ReadyConditionType
+}

--- a/pkg/conditions/conditions_suite_test.go
+++ b/pkg/conditions/conditions_suite_test.go
@@ -1,10 +1,45 @@
-// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2022-2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package conditions
 
 import (
 	_ "github.com/onsi/ginkgo/v2"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
-// This is required so the Gingko flags are added (specifically gingko.noColor)
+type nonKubeObj struct {
+	c []metav1.Condition
+}
+
+func (o nonKubeObj) GetConditions() []metav1.Condition {
+	return o.c
+}
+
+func (o *nonKubeObj) SetConditions(c []metav1.Condition) {
+	o.c = c
+}
+
+type kubeObj corev1.Service
+
+func (o kubeObj) GetConditions() []metav1.Condition {
+	return o.Status.Conditions
+}
+
+func (o *kubeObj) SetConditions(c []metav1.Condition) {
+	if o == nil {
+		return
+	}
+	o.Status.Conditions = c
+}
+
+func (o *kubeObj) DeepCopyObject() runtime.Object {
+	if o == nil {
+		return nil
+	}
+	c := kubeObj(*((*corev1.Service)(o)).DeepCopy())
+	return &c
+}

--- a/pkg/conditions/conditions_test.go
+++ b/pkg/conditions/conditions_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conditions
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestDelete(t *testing.T) {
+	testCases := []struct {
+		name string
+		in   Conditions
+		out  Conditions
+	}{
+		{
+			name: "nil input",
+			in:   nil,
+			out:  nil,
+		},
+		{
+			name: "type to delete does not exist",
+			in: Conditions{
+				{
+					Type: "Hello",
+				},
+			},
+			out: Conditions{
+				{
+					Type: "Hello",
+				},
+			},
+		},
+		{
+			name: "type to delete does exist",
+			in: Conditions{
+				{
+					Type: "Hello",
+				},
+				{
+					Type: ReadyConditionType,
+				},
+			},
+			out: Conditions{
+				{
+					Type: "Hello",
+				},
+			},
+		},
+	}
+
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(tc.in.Delete(ReadyConditionType)).To(Equal(tc.out))
+		})
+	}
+}

--- a/pkg/conditions/merge.go
+++ b/pkg/conditions/merge.go
@@ -106,7 +106,18 @@ func getConditionGroups(conditions []localizedCondition) conditionGroups {
 			if a.Type != b.Type {
 				return lexicographicLess(a.Condition, b.Condition)
 			}
-			return a.GetName() < b.GetName()
+
+			ta, aok := a.Getter.(metav1.Object)
+			tb, bok := b.Getter.(metav1.Object)
+
+			switch {
+			case aok && bok:
+				return ta.GetName() < tb.GetName()
+			case bok:
+				return true
+			default:
+				return false
+			}
 		})
 	}
 

--- a/pkg/conditions/merge_strategies.go
+++ b/pkg/conditions/merge_strategies.go
@@ -19,6 +19,9 @@ package conditions
 import (
 	"fmt"
 	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // mergeOptions allows to set strategies for merging a set of conditions into a single condition,
@@ -110,7 +113,18 @@ func localizeReason(reason string, from Getter) string {
 	if strings.Contains(reason, "@") {
 		return reason
 	}
-	return fmt.Sprintf("%s @ %s/%s", reason, from.GetObjectKind().GroupVersionKind().Kind, from.GetName())
+
+	tf1, ok1 := from.(runtime.Object)
+	tf2, ok2 := from.(metav1.Object)
+
+	if !ok1 || !ok2 {
+		return reason
+	}
+
+	return fmt.Sprintf("%s @ %s/%s",
+		reason,
+		tf1.GetObjectKind().GroupVersionKind().Kind,
+		tf2.GetName())
 }
 
 // getMessage returns the message to be applied to the condition resulting by merging a set of condition groups.

--- a/pkg/conditions/merge_strategies_test.go
+++ b/pkg/conditions/merge_strategies_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Kubernetes Authors.
+Copyright 2020-2024 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -21,91 +21,150 @@ import (
 
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 )
 
 func TestGetStepCounterMessage(t *testing.T) {
-	g := NewWithT(t)
+	testCases := []struct {
+		name string
+		obj  Setter
+	}{
+		{
+			name: "Kube object",
+			obj:  &kubeObj{},
+		},
+		{
+			name: "Non-kube object",
+			obj:  &nonKubeObj{},
+		},
+	}
 
-	groups := getConditionGroups(conditionsWithSource(&vmopv1.VirtualMachine{},
-		nil1,
-		true1, true1,
-		falseInfo1,
-		falseWarning1, falseWarning1,
-		falseError1,
-		unknown1,
-	))
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
 
-	got := getStepCounterMessage(groups, 8)
+			groups := getConditionGroups(conditionsWithSource(tc.obj,
+				nil1,
+				true1, true1,
+				falseInfo1,
+				falseWarning1, falseWarning1,
+				falseError1,
+				unknown1,
+			))
 
-	// step count message should report n° if true conditions over to number
-	g.Expect(got).To(Equal("2 of 8 completed"))
+			got := getStepCounterMessage(groups, 8)
+
+			// step count message should report n° if true conditions over to number
+			g.Expect(got).To(Equal("2 of 8 completed"))
+		})
+	}
+
 }
 
 func TestLocalizeReason(t *testing.T) {
-	g := NewWithT(t)
-
-	getter := &vmopv1.VirtualMachine{
-		TypeMeta: metav1.TypeMeta{
-			Kind: "VirtualMachine",
+	testCases := []struct {
+		name string
+		obj  Setter
+		exp  string
+	}{
+		{
+			name: "Kube object",
+			obj: &kubeObj{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "Service",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-service",
+				},
+			},
+			exp: "foo @ Service/my-service",
 		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-vm",
+		{
+			name: "Non-kube object",
+			obj:  &nonKubeObj{},
+			exp:  "foo",
 		},
 	}
 
-	// localize should reason location
-	got := localizeReason("foo", getter)
-	g.Expect(got).To(Equal("foo @ VirtualMachine/test-vm"))
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
 
-	// localize should not alter existing location
-	got = localizeReason("foo @ SomeKind/some-name", getter)
-	g.Expect(got).To(Equal("foo @ SomeKind/some-name"))
+			// localize should reason location
+			got := localizeReason("foo", tc.obj)
+			g.Expect(got).To(Equal(tc.exp))
+
+			// localize should not alter existing location
+			got = localizeReason("foo @ SomeKind/some-name", tc.obj)
+			g.Expect(got).To(Equal("foo @ SomeKind/some-name"))
+		})
+	}
 }
 
 func TestGetFirstReasonAndMessage(t *testing.T) {
-	g := NewWithT(t)
 
-	foo := FalseCondition("foo", "falseFoo", "message falseFoo")
-	bar := FalseCondition("bar", "falseBar", "message falseBar")
-
-	getter := &vmopv1.VirtualMachine{
-		TypeMeta: metav1.TypeMeta{
-			Kind: "VirtualMachine",
+	testCases := []struct {
+		name string
+		obj  Setter
+		exp  string
+	}{
+		{
+			name: "Kube object",
+			obj: &kubeObj{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "Service",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-service",
+				},
+			},
+			exp: "falseBar @ Service/my-service",
 		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-vm",
+		{
+			name: "Non-kube object",
+			obj:  &nonKubeObj{},
+			exp:  "falseBar",
 		},
 	}
 
-	groups := getConditionGroups(conditionsWithSource(getter, foo, bar))
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
 
-	// getFirst should report first condition in lexicografical order if no order is specified
-	gotReason := getFirstReason(groups, nil, false)
-	g.Expect(gotReason).To(Equal("falseBar"))
-	gotMessage := getFirstMessage(groups, nil)
-	g.Expect(gotMessage).To(Equal("message falseBar"))
+			foo := FalseCondition("foo", "falseFoo", "message falseFoo")
+			bar := FalseCondition("bar", "falseBar", "message falseBar")
 
-	// getFirst should report should respect order
-	gotReason = getFirstReason(groups, []string{"foo", "bar"}, false)
-	g.Expect(gotReason).To(Equal("falseFoo"))
-	gotMessage = getFirstMessage(groups, []string{"foo", "bar"})
-	g.Expect(gotMessage).To(Equal("message falseFoo"))
+			groups := getConditionGroups(conditionsWithSource(tc.obj, foo, bar))
 
-	// getFirst should report should respect order in case of missing conditions
-	gotReason = getFirstReason(groups, []string{"missingBaz", "foo", "bar"}, false)
-	g.Expect(gotReason).To(Equal("falseFoo"))
-	gotMessage = getFirstMessage(groups, []string{"missingBaz", "foo", "bar"})
-	g.Expect(gotMessage).To(Equal("message falseFoo"))
+			// getFirst should report first condition in lexicografical order if no order is specified
+			gotReason := getFirstReason(groups, nil, false)
+			g.Expect(gotReason).To(Equal("falseBar"))
+			gotMessage := getFirstMessage(groups, nil)
+			g.Expect(gotMessage).To(Equal("message falseBar"))
 
-	// getFirst should fallback to first condition if none of the conditions in the list exists
-	gotReason = getFirstReason(groups, []string{"missingBaz"}, false)
-	g.Expect(gotReason).To(Equal("falseBar"))
-	gotMessage = getFirstMessage(groups, []string{"missingBaz"})
-	g.Expect(gotMessage).To(Equal("message falseBar"))
+			// getFirst should report should respect order
+			gotReason = getFirstReason(groups, []string{"foo", "bar"}, false)
+			g.Expect(gotReason).To(Equal("falseFoo"))
+			gotMessage = getFirstMessage(groups, []string{"foo", "bar"})
+			g.Expect(gotMessage).To(Equal("message falseFoo"))
 
-	// getFirstReason should localize reason if required
-	gotReason = getFirstReason(groups, nil, true)
-	g.Expect(gotReason).To(Equal("falseBar @ VirtualMachine/test-vm"))
+			// getFirst should report should respect order in case of missing conditions
+			gotReason = getFirstReason(groups, []string{"missingBaz", "foo", "bar"}, false)
+			g.Expect(gotReason).To(Equal("falseFoo"))
+			gotMessage = getFirstMessage(groups, []string{"missingBaz", "foo", "bar"})
+			g.Expect(gotMessage).To(Equal("message falseFoo"))
+
+			// getFirst should fallback to first condition if none of the conditions in the list exists
+			gotReason = getFirstReason(groups, []string{"missingBaz"}, false)
+			g.Expect(gotReason).To(Equal("falseBar"))
+			gotMessage = getFirstMessage(groups, []string{"missingBaz"})
+			g.Expect(gotMessage).To(Equal("message falseBar"))
+
+			// getFirstReason should localize reason if required
+			gotReason = getFirstReason(groups, nil, true)
+			g.Expect(gotReason).To(Equal(tc.exp))
+		})
+	}
 }

--- a/pkg/conditions/patch_test.go
+++ b/pkg/conditions/patch_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Kubernetes Authors.
+Copyright 2020-2024 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -23,8 +23,6 @@ import (
 
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 )
 
 func TestNewPatch(t *testing.T) {
@@ -261,25 +259,24 @@ func TestApply(t *testing.T) {
 func TestApplyDoesNotAlterLastTransitionTime(t *testing.T) {
 	g := NewWithT(t)
 
-	before := &vmopv1.VirtualMachine{}
-	after := &vmopv1.VirtualMachine{
-		Status: vmopv1.VirtualMachineStatus{
-			Conditions: []metav1.Condition{
-				{
-					Type:               "foo",
-					Status:             metav1.ConditionTrue,
-					LastTransitionTime: metav1.NewTime(time.Now().UTC().Truncate(time.Second)),
-				},
+	var before nonKubeObj
+	after := nonKubeObj{
+		c: []metav1.Condition{
+			{
+				Type:               "foo",
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: metav1.NewTime(time.Now().UTC().Truncate(time.Second)),
 			},
 		},
 	}
-	latest := &vmopv1.VirtualMachine{}
+	var latest nonKubeObj
 
-	// latest has no conditions, so we are actually adding the condition but in this case we should not set the LastTransition Time
-	// but we should preserve the LastTransition set in after
+	// latest has no conditions, so we are actually adding the condition but in
+	// this case we should not set the lastTransitionTime, but we should
+	// preserve the LastTransition set in after
 
 	diff := NewPatch(before, after)
-	err := diff.Apply(latest)
+	err := diff.Apply(&latest)
 
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(latest.GetConditions()).To(Equal(after.GetConditions()))

--- a/pkg/conditions/unstructured_test.go
+++ b/pkg/conditions/unstructured_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Kubernetes Authors.
+Copyright 2020-2024 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -24,8 +24,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-
-	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 )
 
 func TestUnstructuredGetConditions(t *testing.T) {
@@ -33,10 +31,10 @@ func TestUnstructuredGetConditions(t *testing.T) {
 
 	scheme := runtime.NewScheme()
 	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
-	g.Expect(vmopv1.AddToScheme(scheme)).To(Succeed())
+	scheme.AddKnownTypes(corev1.SchemeGroupVersion, &kubeObj{})
 
 	// GetConditions should return conditions from an unstructured object
-	c := &vmopv1.VirtualMachine{}
+	c := &kubeObj{}
 	c.SetConditions(conditionList(true1))
 	u := &unstructured.Unstructured{}
 	g.Expect(scheme.Convert(c, u, nil)).To(Succeed())
@@ -44,7 +42,7 @@ func TestUnstructuredGetConditions(t *testing.T) {
 	g.Expect(UnstructuredGetter(u).GetConditions()).To(haveSameConditionsOf(conditionList(true1)))
 
 	// GetConditions should return nil for an unstructured object with empty conditions
-	c = &vmopv1.VirtualMachine{}
+	c = &kubeObj{}
 	u = &unstructured.Unstructured{}
 	g.Expect(scheme.Convert(c, u, nil)).To(Succeed())
 
@@ -82,9 +80,9 @@ func TestUnstructuredSetConditions(t *testing.T) {
 	// gets an unstructured with empty conditions
 	scheme := runtime.NewScheme()
 	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
-	g.Expect(vmopv1.AddToScheme(scheme)).To(Succeed())
+	scheme.AddKnownTypes(corev1.SchemeGroupVersion, &kubeObj{})
 
-	c := &vmopv1.VirtualMachine{}
+	c := &kubeObj{}
 	u := &unstructured.Unstructured{}
 	g.Expect(scheme.Convert(c, u, nil)).To(Succeed())
 

--- a/pkg/providers/vsphere/vmprovider_vm_utils.go
+++ b/pkg/providers/vsphere/vmprovider_vm_utils.go
@@ -149,7 +149,7 @@ func GetVirtualMachineImageSpecAndStatus(
 	}
 
 	var (
-		obj    conditions.Getter
+		obj    ctrlclient.Object
 		objErr error
 		spec   vmopv1.VirtualMachineImageSpec
 		status vmopv1.VirtualMachineImageStatus
@@ -245,7 +245,7 @@ func GetVirtualMachineImageSpecAndStatus(
 	conditions.SetMirror(
 		vmCtx.VM,
 		vmopv1.VirtualMachineConditionImageReady,
-		obj,
+		obj.(conditions.Getter),
 		conditions.WithFallbackValue(false, "NotReady", vmiNotReadyMessage))
 	if conditions.IsFalse(vmCtx.VM, vmopv1.VirtualMachineConditionImageReady) {
 		return nil,


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch introduces the new type `Conditions` from `pkg/conditions`. This new type provides all of the same helper functions the package provides, but now for any slice of `metav1.Condition` objects. The previous helpers have been rewritten to use the new type.

Perhaps more importantly, the package has been updated to no longer require that the `Getter` and `Setter` interfaces refer to Kubernetes objects. Now the interfaces are valid for *any* Golang type that implements the get/set functions.

Finally, the `pkg/patch` package has also been updated to account for the changes to the `pkg/conditions` interfaces `Getter` and `Setter`.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
The `pkg/conditions` package now works with non-Kubernetes objects.
```