### PR TITLE
🐛 Preserve crypto status in managed vols (PVC)

### DIFF
--- a/controllers/virtualmachine/volume/volume_controller_unit_test.go
+++ b/controllers/virtualmachine/volume/volume_controller_unit_test.go
@@ -1149,6 +1149,35 @@ FaultMessage: ([]vimtypes.LocalizableMessage) \u003cnil\u003e\\n }\\n },\\n Type
 							})
 						})
 					})
+
+					When("Existing status has crypto info for a PVC", func() {
+
+						newCryptoStatus := func() *vmopv1.VirtualMachineVolumeCryptoStatus {
+							return &vmopv1.VirtualMachineVolumeCryptoStatus{
+								ProviderID: "my-provider-id",
+								KeyID:      "my-key-id",
+							}
+						}
+
+						assertPVCHasCrypto := func() {
+							ExpectWithOffset(1, vm.Status.Volumes[3].Crypto).To(Equal(newCryptoStatus()))
+						}
+
+						BeforeEach(func() {
+							vm.Status.Volumes = append(vm.Status.Volumes,
+								vmopv1.VirtualMachineVolumeStatus{
+									Name:   vmVol1.Name,
+									Type:   vmopv1.VirtualMachineStorageDiskTypeManaged,
+									Crypto: newCryptoStatus(),
+								},
+							)
+						})
+						It("includes the PVC crypto in the result", func() {
+							assertBaselineVolStatus()
+							assertPVCHasCrypto()
+						})
+
+					})
 				})
 			})
 		})


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch ensures the crypto information in status.volumes is preserved for PVCs.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

Depends on #842


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Preserve the crypto info in a managed volume's status.
```