### PR TITLE
🐛 Fix lint error about err checking

### DIFF
--- a/pkg/providers/vsphere/vmlifecycle/create_contentlibrary_linked_clone.go
+++ b/pkg/providers/vsphere/vmlifecycle/create_contentlibrary_linked_clone.go
@@ -180,7 +180,7 @@ func getImageLinkedCloneInfo(
 		return imgInfo, nil
 	}
 
-	if err != vmopv1util.ErrImageNotSynced {
+	if !errors.Is(err, vmopv1util.ErrImageNotSynced) {
 		return vmopv1util.ImageDiskInfo{},
 			fmt.Errorf("failed to get image info before syncing: %w", err)
 	}


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch fixes a linter error that occurs in GitHub actions due to a feature enabled prior to the Fast Deploy PoC PR being merged. That slipped in an issue the linter checks. This fixes that.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

This was handled in https://github.com/vmware-tanzu/vm-operator/pull/834, but #823 was merged after the linter came into effect, and this issue was not caught in that PR. However, this is why there was a [failure on `main`](https://github.com/vmware-tanzu/vm-operator/actions/runs/12505711663/job/34889502628)  after the PR was merged 


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Use "errors.Is" in the Fast Deploy code when checking errors
```