### PR TITLE
:bug: Use NSX-T LB for VPC networking when lb unspecified

### DIFF
--- a/controllers/virtualmachineservice/virtualmachineservice_controller.go
+++ b/controllers/virtualmachineservice/virtualmachineservice_controller.go
@@ -54,7 +54,7 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 
 	lbProviderType := pkgcfg.FromContext(ctx).LoadBalancerProvider
 	if lbProviderType == "" {
-		if pkgcfg.FromContext(ctx).NetworkProviderType == pkgcfg.NetworkProviderTypeNSXT {
+		if pkgcfg.FromContext(ctx).NetworkProviderType == pkgcfg.NetworkProviderTypeNSXT || pkgcfg.FromContext(ctx).NetworkProviderType == pkgcfg.NetworkProviderTypeVPC {
 			lbProviderType = providers.NSXTLoadBalancer
 		}
 	}


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This patch adds choosing NSXT lb when lb type unspecified during VPC networking. VPC started with only AVI lb and with design changes, this got overlooked. 
When the VirtualMachineService created in VPC networking includes annotations for `externalTrafficPolicy` and `healthCheckNodePort`, it's expected for VirtualMachineService to have annotation `ncp/healthCheckNodePort`.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # N/A


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:


```release-note
NONE
```