### PR TITLE
📖 Fix broken link in the deploy VM doc

### DIFF
--- a/docs/tutorials/deploy-vm/README.md
+++ b/docs/tutorials/deploy-vm/README.md
@@ -75,7 +75,7 @@ spec:
 
 8.  :wave: The field `spec.bootstrap`, and the fields inside of it, are used to configure the VM's [bootstrap provider](#bootstrap-provider).
 
-9.  :wave: The field `spec.cdrom` is used to configure the VM's [CD-ROM](../concepts/workloads/vm/#cd-rom) devices to mount ISO images.
+9.  :wave: The field `spec.cdrom` is used to configure the VM's [CD-ROM](../../concepts/workloads/vm/#cd-rom) devices to mount ISO images.
 
 ## Bootstrap Provider
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

The current redirect doesn't work as it points to https://vm-operator.readthedocs.io/en/latest/tutorials/concepts/workloads/vm/#cd-rom.

This PR fixes it by redirecting to https://vm-operator.readthedocs.io/en/latest/concepts/workloads/vm/#cd-rom.


**Which issue(s) is/are addressed by this PR?**

Fixes N/A.


**Are there any special notes for your reviewer**:

None.

**Please add a release note if necessary**:

```release-note
NONE
```

<!-- readthedocs-preview vm-operator start -->
----
📚 Documentation preview 📚: https://vm-operator--845.org.readthedocs.build/en/845/

<!-- readthedocs-preview vm-operator end -->