### PR TITLE
🐛 Decrement concurrent creates if getCreateArgs fails

### DIFF
--- a/pkg/providers/vsphere/vmprovider_vm.go
+++ b/pkg/providers/vsphere/vmprovider_vm.go
@@ -182,15 +182,13 @@ func (vs *vSphereVMProvider) createOrUpdateVirtualMachine(
 			return nil, err
 		}
 
-		if newVM != nil {
-			// If the create actually occurred, fall-through to an update
-			// post-reconfigure.
-			return nil, vs.createdVirtualMachineFallthroughUpdate(
-				vmCtx,
-				newVM,
-				client,
-				createArgs)
-		}
+		// If the create actually occurred, fall-through to an update
+		// post-reconfigure.
+		return nil, vs.createdVirtualMachineFallthroughUpdate(
+			vmCtx,
+			newVM,
+			client,
+			createArgs)
 	}
 
 	vmNamespacedName := vm.NamespacedName()
@@ -216,6 +214,9 @@ func (vs *vSphereVMProvider) createOrUpdateVirtualMachine(
 
 	createArgs, err := vs.getCreateArgs(vmCtx, client)
 	if err != nil {
+		// If getting the create args failed, the concurrent counter needs to be
+		// decremented before returning.
+		cleanupFn()
 		return nil, err
 	}
 


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch ensures the counter that tracks the number of concurrent creates is properly decremented if the getCreateArgs function fails when doing a non-blocking create.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Decrement concurrent creates counter if getCreateArgs fails
```