### PR TITLE
:seedling: Remove FSS_WCP_TKG_Multiple_CL

### DIFF
--- a/config/local/vmoperator/local_env_var_patch.yaml
+++ b/config/local/vmoperator/local_env_var_patch.yaml
@@ -25,8 +25,6 @@ spec:
           value: "false"
         - name: FSS_PODVMONSTRETCHEDSUPERVISOR
           value: "false"
-        - name: FSS_WCP_TKG_Multiple_CL
-          value: "false"
         - name: FSS_WCP_MOBILITY_VM_IMPORT_NEW_NET
           value: "false"
         - name: FSS_WCP_WORKLOAD_DOMAIN_ISOLATION
@@ -65,3 +63,4 @@ spec:
           value: "true"
         - name: FSS_WCP_VMSERVICE_K8S_WORKLOAD_MGMT_API
           value: "true"
+

--- a/config/wcp/vmoperator/manager_env_var_patch.yaml
+++ b/config/wcp/vmoperator/manager_env_var_patch.yaml
@@ -55,12 +55,6 @@
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
-    name: FSS_WCP_TKG_Multiple_CL
-    value: "<FSS_WCP_TKG_Multiple_CL_VALUE>"
-
-- op: add
-  path: /spec/template/spec/containers/0/env/-
-  value:
     name: FSS_WCP_VMSERVICE_K8S_WORKLOAD_MGMT_API
     value: "<FSS_WCP_VMSERVICE_K8S_WORKLOAD_MGMT_API_VALUE>"
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -137,7 +137,7 @@ type FeatureStates struct {
 	InstanceStorage            bool // FSS_WCP_INSTANCE_STORAGE
 	K8sWorkloadMgmtAPI         bool // FSS_WCP_VMSERVICE_K8S_WORKLOAD_MGMT_API
 	PodVMOnStretchedSupervisor bool // FSS_PODVMONSTRETCHEDSUPERVISOR
-	TKGMultipleCL              bool // FSS_WCP_TKG_Multiple_CL
+	TKGMultipleCL              bool // to be fetched dynamically from capability
 	// TODO(akutz) This FSS is a placeholder until leadership can figure out the
 	//             plan for FSSs going forward.
 	UnifiedStorageQuota       bool // FSS_PLACEHOLDER_WCP_UNIFIED_STORAGE_QUOTA

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -57,7 +57,6 @@ func FromEnv() Config {
 	setBool(env.FSSIsoSupport, &config.Features.IsoSupport)
 	setBool(env.FSSK8sWorkloadMgmtAPI, &config.Features.K8sWorkloadMgmtAPI)
 	setBool(env.FSSPodVMOnStretchedSupervisor, &config.Features.PodVMOnStretchedSupervisor)
-	setBool(env.FSSTKGMultipleCL, &config.Features.TKGMultipleCL)
 	setBool(env.FSSUnifiedStorageQuota, &config.Features.UnifiedStorageQuota)
 	setBool(env.FSSVMResize, &config.Features.VMResize)
 	setBool(env.FSSVMResizeCPUMemory, &config.Features.VMResizeCPUMemory)

--- a/pkg/config/env/env.go
+++ b/pkg/config/env/env.go
@@ -50,7 +50,6 @@ const (
 	FSSIsoSupport
 	FSSK8sWorkloadMgmtAPI
 	FSSPodVMOnStretchedSupervisor
-	FSSTKGMultipleCL
 	FSSUnifiedStorageQuota
 	FSSVMResize
 	FSSVMResizeCPUMemory
@@ -159,8 +158,6 @@ func (n VarName) String() string {
 		return "FSS_WCP_VMSERVICE_K8S_WORKLOAD_MGMT_API"
 	case FSSPodVMOnStretchedSupervisor:
 		return "FSS_PODVMONSTRETCHEDSUPERVISOR"
-	case FSSTKGMultipleCL:
-		return "FSS_WCP_TKG_Multiple_CL"
 	case FSSUnifiedStorageQuota:
 		return "FSS_STORAGE_QUOTA_M2"
 	case FSSVMResize:

--- a/pkg/config/env_test.go
+++ b/pkg/config/env_test.go
@@ -93,7 +93,6 @@ var _ = Describe(
 					Expect(os.Setenv("FSS_WCP_NAMESPACED_VM_CLASS", "false")).To(Succeed())
 					Expect(os.Setenv("FSS_WCP_VMSERVICE_K8S_WORKLOAD_MGMT_API", "true")).To(Succeed())
 					Expect(os.Setenv("FSS_WCP_VMSERVICE_ISO_SUPPORT", "true")).To(Succeed())
-					Expect(os.Setenv("FSS_WCP_TKG_Multiple_CL", "false")).To(Succeed())
 					Expect(os.Setenv("FSS_STORAGE_QUOTA_M2", "true")).To(Succeed())
 					Expect(os.Setenv("FSS_WCP_VMSERVICE_RESIZE", "true")).To(Succeed())
 					Expect(os.Setenv("FSS_WCP_VMSERVICE_RESIZE_CPU_MEMORY", "true")).To(Succeed())


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Since the WCP_TKG_Multiple_CL FSS has been enabled on main, and will be released with VCF 9.0
Removing all the occurrences of FSS_WCP_TKG_Multiple_CL.
Will keep the capabilities which are being set dynamically.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #848 


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

```release-note
Removed the WCP_TKG_Multiple_CL feature state switch as it has been enabled
```