### PR TITLE
🐛 Remove CL Item ContentVersion short circuit

### DIFF
--- a/controllers/contentlibrary/clustercontentlibraryitem/clustercontentlibraryitem_controller.go
+++ b/controllers/contentlibrary/clustercontentlibraryitem/clustercontentlibraryitem_controller.go
@@ -317,10 +317,6 @@ func (r *Reconciler) setUpCVMIFromCCLItem(ctx *pkgctx.ClusterContentLibraryItemC
 func (r *Reconciler) syncImageContent(ctx *pkgctx.ClusterContentLibraryItemContext) error {
 	cclItem := ctx.CCLItem
 	cvmi := ctx.CVMI
-	latestVersion := cclItem.Status.ContentVersion
-	if cvmi.Status.ProviderContentVersion == latestVersion {
-		return nil
-	}
 
 	err := r.VMProvider.SyncVirtualMachineImage(ctx, cclItem, cvmi)
 	if err != nil {
@@ -329,7 +325,7 @@ func (r *Reconciler) syncImageContent(ctx *pkgctx.ClusterContentLibraryItemConte
 			vmopv1.VirtualMachineImageNotSyncedReason,
 			"Failed to sync to the latest content version from provider")
 	} else {
-		cvmi.Status.ProviderContentVersion = latestVersion
+		cvmi.Status.ProviderContentVersion = cclItem.Status.ContentVersion
 	}
 
 	// Sync the image's type, OS information and capabilities to the resource's

--- a/controllers/contentlibrary/clustercontentlibraryitem/clustercontentlibraryitem_controller_unit_test.go
+++ b/controllers/contentlibrary/clustercontentlibraryitem/clustercontentlibraryitem_controller_unit_test.go
@@ -255,7 +255,7 @@ func unitTestsReconcile() {
 				})
 			})
 
-			When("ClusterVirtualMachineImage resource is created and already up-to-date", func() {
+			XWhen("ClusterVirtualMachineImage resource is created and already up-to-date", func() {
 
 				JustBeforeEach(func() {
 					cvmi := &vmopv1.ClusterVirtualMachineImage{

--- a/controllers/contentlibrary/contentlibraryitem/contentlibraryitem_controller.go
+++ b/controllers/contentlibrary/contentlibraryitem/contentlibraryitem_controller.go
@@ -285,10 +285,6 @@ func (r *Reconciler) setUpVMIFromCLItem(ctx *pkgctx.ContentLibraryItemContext) e
 func (r *Reconciler) syncImageContent(ctx *pkgctx.ContentLibraryItemContext) error {
 	clItem := ctx.CLItem
 	vmi := ctx.VMI
-	latestVersion := clItem.Status.ContentVersion
-	if vmi.Status.ProviderContentVersion == latestVersion {
-		return nil
-	}
 
 	err := r.VMProvider.SyncVirtualMachineImage(ctx, clItem, vmi)
 	if err != nil {
@@ -297,7 +293,7 @@ func (r *Reconciler) syncImageContent(ctx *pkgctx.ContentLibraryItemContext) err
 			vmopv1.VirtualMachineImageNotSyncedReason,
 			"Failed to sync to the latest content version from provider")
 	} else {
-		vmi.Status.ProviderContentVersion = latestVersion
+		vmi.Status.ProviderContentVersion = clItem.Status.ContentVersion
 	}
 
 	// Sync the image's type, OS information and capabilities to the resource's

--- a/controllers/contentlibrary/contentlibraryitem/contentlibraryitem_controller_unit_test.go
+++ b/controllers/contentlibrary/contentlibraryitem/contentlibraryitem_controller_unit_test.go
@@ -232,7 +232,7 @@ func unitTestsReconcile() {
 				})
 			})
 
-			When("VirtualMachineImage resource is created and already up-to-date", func() {
+			XWhen("VirtualMachineImage resource is created and already up-to-date", func() {
 
 				JustBeforeEach(func() {
 					vmi := &vmopv1.VirtualMachineImage{


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

To avoid repeated CL Item sync tasks, we'll compare the item and image cached content versions, and skip fetching the OVF envelope if they match. But since we've added fields to the image Status (like Disks[]) in v1a3, those new fields won't be updated until the item changes.

The big hammer for this is to just remove the check instead of including another internal version in the cached version. Short term, this will cause an increase in the number of sync tasks, but the existing OVF cache will reduce that somewhat. There is a larger WIP in this area that will fix this bug without the increase in sync tasks.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #

**Are there any special notes for your reviewer**:

If the WIP takes longer to land than expected we can revise this by like appending "-v1a3" to our versions.

**Please add a release note if necessary**:

This is just a temp, quick fix.

```release-note
NONE
```