### PR TITLE
🐛 Fix empty VMI Status.Disks[] after upgrade

### DIFF
--- a/controllers/contentlibrary/clustercontentlibraryitem/clustercontentlibraryitem_controller.go
+++ b/controllers/contentlibrary/clustercontentlibraryitem/clustercontentlibraryitem_controller.go
@@ -318,7 +318,7 @@ func (r *Reconciler) syncImageContent(ctx *pkgctx.ClusterContentLibraryItemConte
 	cclItem := ctx.CCLItem
 	cvmi := ctx.CVMI
 	latestVersion := cclItem.Status.ContentVersion
-	if cvmi.Status.ProviderContentVersion == latestVersion {
+	if cvmi.Status.ProviderContentVersion == latestVersion && len(cvmi.Status.Disks) != 0 {
 		return nil
 	}
 

--- a/controllers/contentlibrary/clustercontentlibraryitem/clustercontentlibraryitem_controller_unit_test.go
+++ b/controllers/contentlibrary/clustercontentlibraryitem/clustercontentlibraryitem_controller_unit_test.go
@@ -264,6 +264,7 @@ func unitTestsReconcile() {
 						},
 						Status: vmopv1.VirtualMachineImageStatus{
 							ProviderContentVersion: cclItemCtx.CCLItem.Status.ContentVersion,
+							Disks:                  make([]vmopv1.VirtualMachineImageDiskInfo, 1),
 							Firmware:               "should-not-be-updated",
 						},
 					}

--- a/controllers/contentlibrary/contentlibraryitem/contentlibraryitem_controller.go
+++ b/controllers/contentlibrary/contentlibraryitem/contentlibraryitem_controller.go
@@ -286,7 +286,7 @@ func (r *Reconciler) syncImageContent(ctx *pkgctx.ContentLibraryItemContext) err
 	clItem := ctx.CLItem
 	vmi := ctx.VMI
 	latestVersion := clItem.Status.ContentVersion
-	if vmi.Status.ProviderContentVersion == latestVersion {
+	if vmi.Status.ProviderContentVersion == latestVersion && len(vmi.Status.Disks) != 0 {
 		return nil
 	}
 

--- a/controllers/contentlibrary/contentlibraryitem/contentlibraryitem_controller_unit_test.go
+++ b/controllers/contentlibrary/contentlibraryitem/contentlibraryitem_controller_unit_test.go
@@ -243,6 +243,7 @@ func unitTestsReconcile() {
 						Status: vmopv1.VirtualMachineImageStatus{
 							ProviderContentVersion: clItemCtx.CLItem.Status.ContentVersion,
 							Firmware:               "should-not-be-updated",
+							Disks:                  make([]vmopv1.VirtualMachineImageDiskInfo, 1),
 						},
 					}
 					Expect(ctx.Client.Create(ctx, vmi)).To(Succeed())


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

The VMI Status.Disks[] field was added in v1a3 but since the cached content version will be the same, that field won't be populated.

Just a quick fix of checking for the present of disks. There is a WIP branch in this area that will fix it in a better way.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #

**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:


```release-note
NONE
```