### PR TITLE
🐛 Reconcile VM SetResourcePolicy because of Zone change

### DIFF
--- a/controllers/virtualmachinesetresourcepolicy/virtualmachinesetresourcepolicy_controller_intg_test.go
+++ b/controllers/virtualmachinesetresourcepolicy/virtualmachinesetresourcepolicy_controller_intg_test.go
@@ -15,8 +15,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	topologyv1 "github.com/vmware-tanzu/vm-operator/external/tanzu-topology/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
-
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
@@ -100,6 +100,19 @@ func intgTestsReconcile() {
 
 			By("Create policy should be called", func() {
 				Eventually(called.Load).Should(BeTrue())
+			})
+
+			By("Reconcile when Zone is added", func() {
+				called.Store(false)
+
+				zone := &topologyv1.Zone{}
+				zone.Name = "my-new-zone"
+				zone.Namespace = ctx.Namespace
+				Expect(ctx.Client.Create(ctx, zone)).To(Succeed())
+
+				By("Reconcile again because of Zone create", func() {
+					Eventually(called.Load).Should(BeTrue())
+				})
 			})
 
 			By("Deleting the VirtualMachineSetResourcePolicy", func() {

--- a/controllers/virtualmachinesetresourcepolicy/virtualmachinesetresourcepolicy_controller_suite_test.go
+++ b/controllers/virtualmachinesetresourcepolicy/virtualmachinesetresourcepolicy_controller_suite_test.go
@@ -21,7 +21,12 @@ import (
 var intgFakeVMProvider = providerfake.NewVMProvider()
 
 var suite = builder.NewTestSuiteForControllerWithContext(
-	pkgcfg.NewContextWithDefaultConfig(),
+	pkgcfg.UpdateContext(
+		pkgcfg.NewContextWithDefaultConfig(),
+		func(config *pkgcfg.Config) {
+			config.Features.WorkloadDomainIsolation = true
+		},
+	),
 	virtualmachinesetresourcepolicy.AddToManager,
 	func(ctx *pkgctx.ControllerManagerContext, _ ctrlmgr.Manager) error {
 		ctx.VMProvider = intgFakeVMProvider


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

When a Zone is added, the VirtualMachineSetResourcePolicies in the namespace need to be reconciled because we need to create the child ResourcePool and ClusterModules for that new CCR.

While at the moment we only care when a Zone is added just watch for all events since we eventually will need to handle Zone removal.

Without this, the Zone won't be ready to use until the next resync time.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #

**Are there any special notes for your reviewer**:

**Please add a release note if necessary**:

```release-note
NONE
```