### PR TITLE
🌱 Consistently use the default config for controller integration tests

### DIFF
--- a/controllers/infra/capability/configmap/configmap_capability_controller_suite_test.go
+++ b/controllers/infra/capability/configmap/configmap_capability_controller_suite_test.go
@@ -27,9 +27,9 @@ func init() {
 
 var suite = builder.NewTestSuiteForControllerWithContext(
 	pkgcfg.UpdateContext(
-		pkgcfg.NewContext(),
+		pkgcfg.NewContextWithDefaultConfig(),
 		func(config *pkgcfg.Config) {
-			config.Features.SVAsyncUpgrade = true
+			config.Features.SVAsyncUpgrade = false
 		},
 	),
 	capability.AddToManager,

--- a/controllers/infra/capability/configmap/configmap_capability_controller_test.go
+++ b/controllers/infra/capability/configmap/configmap_capability_controller_test.go
@@ -67,13 +67,11 @@ var _ = Describe(
 						suite.Context,
 						func(config *pkgcfg.Config) {
 							config.Features.TKGMultipleCL = false
-							config.Features.WorkloadDomainIsolation = false
 						},
 					)
 
 					obj.Data = map[string]string{
 						capabilities.CapabilityKeyTKGMultipleContentLibraries: "true",
-						capabilities.CapabilityKeyWorkloadIsolation:           "true",
 					}
 				})
 				Specify("the pod was exited", func() {
@@ -84,7 +82,6 @@ var _ = Describe(
 				Specify("feature states should be updated", func() {
 					Eventually(func(g Gomega) {
 						g.Expect(pkgcfg.FromContext(suite.Context).Features.TKGMultipleCL).To(BeTrue())
-						g.Expect(pkgcfg.FromContext(suite.Context).Features.WorkloadDomainIsolation).To(BeTrue())
 					}, time.Second*5).Should(Succeed())
 				})
 			})
@@ -95,13 +92,11 @@ var _ = Describe(
 						suite.Context,
 						func(config *pkgcfg.Config) {
 							config.Features.TKGMultipleCL = true
-							config.Features.WorkloadDomainIsolation = true
 						},
 					)
 
 					obj.Data = map[string]string{
 						capabilities.CapabilityKeyTKGMultipleContentLibraries: "false",
-						capabilities.CapabilityKeyWorkloadIsolation:           "false",
 					}
 				})
 				Specify("the pod was exited", func() {
@@ -112,7 +107,6 @@ var _ = Describe(
 				Specify("feature states should be updated", func() {
 					Eventually(func(g Gomega) {
 						g.Expect(pkgcfg.FromContext(suite.Context).Features.TKGMultipleCL).To(BeFalse())
-						g.Expect(pkgcfg.FromContext(suite.Context).Features.WorkloadDomainIsolation).To(BeFalse())
 					}, time.Second*5).Should(Succeed())
 				})
 			})
@@ -124,20 +118,17 @@ var _ = Describe(
 					suite.Context,
 					func(config *pkgcfg.Config) {
 						config.Features.TKGMultipleCL = false
-						config.Features.WorkloadDomainIsolation = false
 					},
 				)
 
 				obj.Data = map[string]string{
 					capabilities.CapabilityKeyTKGMultipleContentLibraries: "true",
-					capabilities.CapabilityKeyWorkloadIsolation:           "true",
 				}
 			})
 
 			JustBeforeEach(func() {
 				Eventually(func(g Gomega) {
 					g.Expect(pkgcfg.FromContext(suite.Context).Features.TKGMultipleCL).To(BeTrue())
-					g.Expect(pkgcfg.FromContext(suite.Context).Features.WorkloadDomainIsolation).To(BeTrue())
 				}, time.Second*5).Should(Succeed())
 
 				obj.Data[capabilities.CapabilityKeyTKGMultipleContentLibraries] = "false"
@@ -153,7 +144,6 @@ var _ = Describe(
 			Specify("feature states should be updated", func() {
 				Eventually(func(g Gomega) {
 					g.Expect(pkgcfg.FromContext(suite.Context).Features.TKGMultipleCL).To(BeFalse())
-					g.Expect(pkgcfg.FromContext(suite.Context).Features.WorkloadDomainIsolation).To(BeTrue())
 				}, time.Second*5).Should(Succeed())
 			})
 		})
@@ -164,7 +154,6 @@ var _ = Describe(
 					suite.Context,
 					func(config *pkgcfg.Config) {
 						config.Features.TKGMultipleCL = false
-						config.Features.WorkloadDomainIsolation = false
 					},
 				)
 
@@ -177,7 +166,6 @@ var _ = Describe(
 				Consistently(func(g Gomega) {
 					g.Expect(atomic.LoadInt32(&numExits)).To(Equal(int32(0)))
 					g.Expect(pkgcfg.FromContext(suite.Context).Features.TKGMultipleCL).To(BeFalse())
-					g.Expect(pkgcfg.FromContext(suite.Context).Features.WorkloadDomainIsolation).To(BeFalse())
 				}, time.Second*3).Should(Succeed())
 			})
 		})

--- a/controllers/infra/capability/crd/crd_capability_controller_suite_test.go
+++ b/controllers/infra/capability/crd/crd_capability_controller_suite_test.go
@@ -27,7 +27,7 @@ func init() {
 
 var suite = builder.NewTestSuiteForControllerWithContext(
 	pkgcfg.UpdateContext(
-		pkgcfg.NewContext(),
+		pkgcfg.NewContextWithDefaultConfig(),
 		func(config *pkgcfg.Config) {
 			config.Features.SVAsyncUpgrade = true
 		},

--- a/controllers/infra/validatingwebhookconfiguration/validatingwebhookconfiguration_controller_suite_test.go
+++ b/controllers/infra/validatingwebhookconfiguration/validatingwebhookconfiguration_controller_suite_test.go
@@ -19,7 +19,7 @@ import (
 var suite = builder.NewTestSuiteForControllerWithContext(
 	cource.WithContext(
 		pkgcfg.UpdateContext(
-			pkgcfg.NewContext(),
+			pkgcfg.NewContextWithDefaultConfig(),
 			func(config *pkgcfg.Config) {
 				config.Features.PodVMOnStretchedSupervisor = true
 			},

--- a/controllers/storageclass/storageclass_controller_suite_test.go
+++ b/controllers/storageclass/storageclass_controller_suite_test.go
@@ -33,7 +33,7 @@ func init() {
 
 var suite = builder.NewTestSuiteForControllerWithContext(
 	pkgcfg.UpdateContext(
-		pkgcfg.NewContext(),
+		pkgcfg.NewContextWithDefaultConfig(),
 		func(config *pkgcfg.Config) {
 			config.Features.BringYourOwnEncryptionKey = true
 		},

--- a/controllers/storagepolicyquota/storagepolicyquota_controller_suite_test.go
+++ b/controllers/storagepolicyquota/storagepolicyquota_controller_suite_test.go
@@ -19,7 +19,7 @@ import (
 var suite = builder.NewTestSuiteForControllerWithContext(
 	cource.WithContext(
 		pkgcfg.UpdateContext(
-			pkgcfg.NewContext(),
+			pkgcfg.NewContextWithDefaultConfig(),
 			func(config *pkgcfg.Config) {
 				config.Features.PodVMOnStretchedSupervisor = true
 			},

--- a/controllers/virtualmachine/storagepolicyusage/storagepolicyusage_controller_suite_test.go
+++ b/controllers/virtualmachine/storagepolicyusage/storagepolicyusage_controller_suite_test.go
@@ -19,7 +19,7 @@ import (
 var suite = builder.NewTestSuiteForControllerWithContext(
 	cource.WithContext(
 		pkgcfg.UpdateContext(
-			pkgcfg.NewContext(),
+			pkgcfg.NewContextWithDefaultConfig(),
 			func(config *pkgcfg.Config) {
 				config.Features.PodVMOnStretchedSupervisor = true
 			},

--- a/test/builder/test_suite.go
+++ b/test/builder/test_suite.go
@@ -313,7 +313,7 @@ func (s *TestSuite) init() {
 			CRDDirectoryPaths: []string{
 				filepath.Join(rootDir, "config", "crd", "external-crds"),
 			},
-			BinaryAssetsDirectory: filepath.Join(testutil.GetRootDirOrDie(), "hack", "tools", "bin", goruntime.GOOS+"_"+goruntime.GOARCH),
+			BinaryAssetsDirectory: filepath.Join(rootDir, "hack", "tools", "bin", goruntime.GOOS+"_"+goruntime.GOARCH),
 		}
 	}
 }


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

Also fix the feature state for the ConfigMap capabilities controller. It is only used when SVAsyncUpgrade is false but the setup was setting it to true. The fallout from this is that the WorkloadDomainIsolation feature is not via the capability when async upgrade is false so remove that from the integration tests.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #

**Are there any special notes for your reviewer**:

The CM capability controller is mostly moot at this point, and it may be time to update the Default().

**Please add a release note if necessary**:

```release-note
NONE
```