### PR TITLE
🐛 Background reconcile awareness support

### DIFF
--- a/controllers/virtualmachine/virtualmachine/virtualmachine_controller.go
+++ b/controllers/virtualmachine/virtualmachine/virtualmachine_controller.go
@@ -334,8 +334,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 	}()
 
 	if !vm.DeletionTimestamp.IsZero() {
-		err = r.ReconcileDelete(vmCtx)
-		return ctrl.Result{}, err
+		return ctrl.Result{}, r.ReconcileDelete(vmCtx)
 	}
 
 	if err = r.ReconcileNormal(vmCtx); err != nil && !ignoredCreateErr(err) {
@@ -574,7 +573,7 @@ func getIsDefaultVMClassController(ctx context.Context) bool {
 // ignoredCreateErr is written this way in order to illustrate coverage more
 // accurately.
 func ignoredCreateErr(err error) bool {
-	if errors.Is(err, providers.ErrDuplicateCreate) {
+	if errors.Is(err, providers.ErrReconcileInProgress) {
 		return true
 	}
 	if errors.Is(err, providers.ErrTooManyCreates) {

--- a/controllers/virtualmachine/virtualmachine/virtualmachine_controller_intg_test.go
+++ b/controllers/virtualmachine/virtualmachine/virtualmachine_controller_intg_test.go
@@ -168,7 +168,7 @@ func intgTestsReconcile() {
 					intgFakeVMProvider,
 					func(ctx context.Context, vm *vmopv1.VirtualMachine) error {
 						atomic.AddInt32(&createAttempts, 1)
-						return providers.ErrDuplicateCreate
+						return providers.ErrReconcileInProgress
 					},
 				)
 			})

--- a/pkg/providers/vm_provider_interface.go
+++ b/pkg/providers/vm_provider_interface.go
@@ -24,10 +24,10 @@ var (
 	// threads/goroutines have reached the allowed limit.
 	ErrTooManyCreates = errors.New("too many creates")
 
-	// ErrDuplicateCreate is returned from the CreateOrUpdateVirtualMachineAsync
-	// function if it is called for a VM while a create goroutine for that VM is
-	// already executing.
-	ErrDuplicateCreate = errors.New("duplicate create")
+	// ErrReconcileInProgress is returned from the
+	// CreateOrUpdateVirtualMachine and DeleteVirtualMachine functions when
+	// the VM is still being reconciled in a background thread.
+	ErrReconcileInProgress = errors.New("reconcile already in progress")
 )
 
 // VirtualMachineProviderInterface is a pluggable interface for VM Providers.


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch adds support to the VirtualMachine controller for background reconciliation awareness. Rather, the controller is now aware if a VM is already being reconciled in a background thread due to an async operation and will not allow the VM to be reconciled again until the async operation is complete.

This is necessary due to someone rapidly applying VM yaml then deleting it. When this occurs it is possible that the vSphere VM is not deleted since its creation is occurring on a background thread. 


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:




**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Do not reconcile VMs being processed in the background.
```