### PR TITLE
📖 Update VM crypto docs on rekey

### DIFF
--- a/docs/concepts/workloads/vm.md
+++ b/docs/concepts/workloads/vm.md
@@ -227,8 +227,49 @@ spec:
 
 Users can rekey VMs and their [classic disks](#volume-type) by:
 
-* Switching to a different `EncryptionClass` by changing the value of `spec.crypto.encryptionClassName`.
 * Using the default key provider, if one exists, by removing `spec.crypto.encryptionClassName`.
+* Switching to a different `EncryptionClass` by changing the value of `spec.crypto.encryptionClassName`.
+
+!!! note "Rekeying with a different `EncryptionClass`"
+
+    Please note that picking a different `EncryptionClass` to rekey a VM requires the new `EncryptionClass` resource to either:
+
+    * Have a different provider ID than the one currently used by the VM
+    * Have a different key ID than the one currently used by the VM
+
+    For example, imagine the following, two `EncryptionClass` resources:
+
+
+    === "`EncryptionClass 1`"
+
+        ```yaml
+        apiVersion: encryption.vmware.com/v1alpha1
+        kind: EncryptionClass
+        metadata:
+          name: my-encryption-class-1
+          namespace: my-namespace-1
+        spec:
+          keyProvider: local
+        ```
+
+    === "EncryptionClass 2"
+
+        ```yaml
+        apiVersion: encryption.vmware.com/v1alpha1
+        kind: EncryptionClass
+        metadata:
+          name: my-encryption-class-2
+          namespace: my-namespace-1
+        spec:
+          keyProvider: local
+        ```
+
+    Switching a VM from `my-encryption-class-1` to `my-encryption-class-2` will have no effect since both `EncryptionClass` resources:
+
+    * Reference the same, underlying key provider
+    * Do not specify the key ID, thus rely on key generation
+
+    Even though the lack of an explicit key ID means one will be generated, the logic to rekey a VM depends on comparing the key ID from the `EncryptionClass` with the one currently used by the VM. If the one from the `EncryptionClass` is empty, i.e. use a generated key, then it does not cause a rekey to occur since the VM already has a key.
 
 Either change results in the VM and its [classic disks](#volume-type) being rekeyed using the new key provider.
 


### PR DESCRIPTION
This patch adds more documentation around rekeying an encrypted VM to explain that rekeying requires the encryption classes to have different provider and/or key IDs.

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch adds more documentation around rekeying an encrypted VM to explain that rekeying requires the encryption classes to have different provider and/or key IDs.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Update docs for rekeying encrypted VM
```

<!-- readthedocs-preview vm-operator start -->
----
📚 Documentation preview 📚: https://vm-operator--857.org.readthedocs.build/en/857/

<!-- readthedocs-preview vm-operator end -->