### PR TITLE
🌱 Emit memory statistics to log file / prometheus

### DIFF
--- a/config/local/vmoperator/local_env_var_patch.yaml
+++ b/config/local/vmoperator/local_env_var_patch.yaml
@@ -11,6 +11,8 @@ spec:
         env:
         - name: ASYNC_SIGNAL_DISABLED
           value: "false"
+        - name: MEM_STATS_PERIOD
+          value: "10m"
         - name: VSPHERE_NETWORKING
           value: "false"
         - name: FSS_WCP_INSTANCE_STORAGE

--- a/config/wcp/vmoperator/manager_env_var_patch.yaml
+++ b/config/wcp/vmoperator/manager_env_var_patch.yaml
@@ -49,6 +49,12 @@
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
+    name: MEM_STATS_PERIOD
+    value: "10m"
+
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
     name: FSS_PODVMONSTRETCHEDSUPERVISOR
     value: "<FSS_PODVMONSTRETCHEDSUPERVISOR>"
 

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
 	ctrlsig "sigs.k8s.io/controller-runtime/pkg/manager/signals"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	capv1 "github.com/vmware-tanzu/vm-operator/external/capabilities/api/v1alpha1"
@@ -35,6 +36,7 @@ import (
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	pkgmgr "github.com/vmware-tanzu/vm-operator/pkg/manager"
 	pkgmgrinit "github.com/vmware-tanzu/vm-operator/pkg/manager/init"
+	"github.com/vmware-tanzu/vm-operator/pkg/mem"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/watcher"
@@ -76,6 +78,8 @@ func main() {
 
 	initLogging()
 
+	initMemStats()
+
 	initFeatures()
 
 	initRateLimiting()
@@ -115,6 +119,13 @@ func initFeatures() {
 
 	setupLog.Info("Initial features from capabilities",
 		"features", pkgcfg.FromContext(ctx).Features)
+}
+
+func initMemStats() {
+	mem.Start(
+		ctrl.Log,
+		defaultConfig.MemStatsPeriod,
+		metrics.Registry.MustRegister)
 }
 
 func initContext() {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -118,6 +118,12 @@ type Config struct {
 	//
 	// Defaults to false.
 	AsyncCreateDisabled bool
+
+	// MemStatsPeriod describes the interval at which memory statistics are
+	// emitted to the log file.
+	//
+	// Defaults to 10m.
+	MemStatsPeriod time.Duration
 }
 
 // GetMaxDeployThreadsOnProvider returns MaxDeployThreadsOnProvider if it is >0

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -40,6 +40,7 @@ func Default() Config {
 		MaxConcurrentReconciles:      1,
 		AsyncSignalDisabled:          false,
 		AsyncCreateDisabled:          false,
+		MemStatsPeriod:               10 * time.Minute,
 		CreateVMRequeueDelay:         10 * time.Second,
 		PoweredOnVMHasIPRequeueDelay: 10 * time.Second,
 		NetworkProviderType:          NetworkProviderTypeNamed,

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -30,6 +30,7 @@ func FromEnv() Config {
 	setBool(env.LogSensitiveData, &config.LogSensitiveData)
 	setBool(env.AsyncSignalDisabled, &config.AsyncSignalDisabled)
 	setBool(env.AsyncCreateDisabled, &config.AsyncCreateDisabled)
+	setDuration(env.MemStatsPeriod, &config.MemStatsPeriod)
 
 	setDuration(env.InstanceStoragePVPlacementFailedTTL, &config.InstanceStorage.PVPlacementFailedTTL)
 	setFloat64(env.InstanceStorageJitterMaxFactor, &config.InstanceStorage.JitterMaxFactor)

--- a/pkg/config/env/env.go
+++ b/pkg/config/env/env.go
@@ -36,6 +36,7 @@ const (
 	RateLimitBurst
 	SyncPeriod
 	MaxConcurrentReconciles
+	MemStatsPeriod
 	LeaderElectionID
 	PodName
 	PodNamespace
@@ -130,6 +131,8 @@ func (n VarName) String() string {
 		return "SYNC_PERIOD"
 	case MaxConcurrentReconciles:
 		return "MAX_CONCURRENT_RECONCILES"
+	case MemStatsPeriod:
+		return "MEM_STATS_PERIOD"
 	case LeaderElectionID:
 		return "LEADER_ELECTION_ID"
 	case PodName:

--- a/pkg/config/env_test.go
+++ b/pkg/config/env_test.go
@@ -104,6 +104,8 @@ var _ = Describe(
 					Expect(os.Setenv("FSS_WCP_VMSERVICE_FAST_DEPLOY", "true")).To(Succeed())
 					Expect(os.Setenv("CREATE_VM_REQUEUE_DELAY", "125h")).To(Succeed())
 					Expect(os.Setenv("POWERED_ON_VM_HAS_IP_REQUEUE_DELAY", "126h")).To(Succeed())
+					Expect(os.Setenv("MEM_STATS_PERIOD", "127h")).To(Succeed())
+
 				})
 				It("Should return a default config overridden by the environment", func() {
 					Expect(config).To(BeComparableTo(pkgcfg.Config{
@@ -155,6 +157,7 @@ var _ = Describe(
 						},
 						CreateVMRequeueDelay:         125 * time.Hour,
 						PoweredOnVMHasIPRequeueDelay: 126 * time.Hour,
+						MemStatsPeriod:               127 * time.Hour,
 					}))
 				})
 			})

--- a/pkg/mem/mem.go
+++ b/pkg/mem/mem.go
@@ -1,0 +1,324 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package mem
+
+import (
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var startOnce sync.Once
+
+const (
+	namespace = "vmservice"
+	subsystem = "memory"
+
+	keyNow           = "now"
+	keyBuckHashSys   = "buckHashSys"
+	keyDebugGC       = "debugGC"
+	keyEnableGC      = "enableGC"
+	keyFrees         = "frees"
+	keyGcCPUFraction = "gcCPUFraction"
+	keyGcSys         = "gcSys"
+	keyHeapAlloc     = "heapAlloc"
+	keyHeapIdle      = "heapIdle"
+	keyHeapInUse     = "heapInUse"
+	keyHeapObjects   = "heapObjects"
+	keyHeapReleased  = "heapReleased"
+	keyHeapSys       = "heapSys"
+	keyLastGC        = "lastGC"
+	keyLive          = "live"
+	keyLookups       = "lookups"
+	keyMCacheInUse   = "mCacheInUse"
+	keyMCacheSys     = "mCacheSys"
+	keyMSpanInUse    = "mSpanInUse"
+	keyMSpanSys      = "mSpanSys"
+	keyMallocs       = "mallocs"
+	keyNextGC        = "nextGC"
+	keyNumForcedGC   = "numForcedGC"
+	keyNumGC         = "numGC"
+	keyOtherSys      = "otherSys"
+	keyPauseTotalNs  = "pauseTotalNs"
+	keyStackInUse    = "stackInUse"
+	keyStackSys      = "stackSys"
+	keySys           = "sys"
+	keyTotalAlloc    = "totalAlloc"
+)
+
+var gauges struct {
+	buckHashSys   prometheus.Gauge
+	frees         prometheus.Gauge
+	gcCPUFraction prometheus.Gauge
+	gcSys         prometheus.Gauge
+	heapAlloc     prometheus.Gauge
+	heapIdle      prometheus.Gauge
+	heapInUse     prometheus.Gauge
+	heapObjects   prometheus.Gauge
+	heapReleased  prometheus.Gauge
+	heapSys       prometheus.Gauge
+	live          prometheus.Gauge
+	lookups       prometheus.Gauge
+	mCacheInUse   prometheus.Gauge
+	mCacheSys     prometheus.Gauge
+	mSpanInUse    prometheus.Gauge
+	mSpanSys      prometheus.Gauge
+	mallocs       prometheus.Gauge
+	nextGC        prometheus.Gauge
+	numForcedGC   prometheus.Gauge
+	numGC         prometheus.Gauge
+	otherSys      prometheus.Gauge
+	pauseTotalNs  prometheus.Gauge
+	stackInUse    prometheus.Gauge
+	stackSys      prometheus.Gauge
+	sys           prometheus.Gauge
+	totalAlloc    prometheus.Gauge
+}
+
+func ng(name, help string) prometheus.Gauge {
+	return prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Subsystem: subsystem,
+		Name:      name,
+		Help:      help,
+	})
+}
+
+// Start begins the goroutine that periodically logs the results of
+// runtime.ReadMemStats(*runtime.MemStats).
+func Start(
+	logger logr.Logger,
+	interval time.Duration,
+	mustRegisterMetricsFn func(c ...prometheus.Collector)) {
+
+	startOnce.Do(func() {
+		if mustRegisterMetricsFn != nil {
+			initMetrics(mustRegisterMetricsFn)
+		}
+		go start(logger, interval, mustRegisterMetricsFn != nil)
+	})
+}
+
+func initMetrics(fn func(c ...prometheus.Collector)) {
+	gauges.buckHashSys = ng(
+		keyBuckHashSys,
+		"Bytes of memory in profiling bucket hash tables",
+	)
+	gauges.frees = ng(
+		keyFrees,
+		"Cumulative count of heap objects freed",
+	)
+	gauges.gcCPUFraction = ng(
+		keyGcCPUFraction,
+		"Fraction of this program's available CPU time used by the GC since the program started",
+	)
+	gauges.gcSys = ng(
+		keyGcSys,
+		"Bytes of memory in garbage collection metadata",
+	)
+	gauges.heapAlloc = ng(
+		keyHeapAlloc,
+		"Bytes of allocated heap objects",
+	)
+	gauges.heapIdle = ng(
+		keyHeapIdle,
+		"Bytes in idle (unused) spans",
+	)
+	gauges.heapInUse = ng(
+		keyHeapInUse,
+		"Bytes in in-use spans",
+	)
+	gauges.heapObjects = ng(
+		keyHeapObjects,
+		"Number of allocated heap objects",
+	)
+	gauges.heapReleased = ng(
+		"heapReleased",
+		"Bytes of physical memory returned to the OS",
+	)
+	gauges.heapSys = ng(
+		keyHeapSys,
+		"Bytes of heap memory obtained from the OS",
+	)
+	gauges.live = ng(
+		keyLive,
+		"Number of live objects, i.e. mallocs - frees",
+	)
+	gauges.lookups = ng(
+		keyLookups,
+		"Number of pointer lookups performed by the runtime",
+	)
+	gauges.mCacheInUse = ng(
+		keyMCacheInUse,
+		"Bytes of allocated mcache structures",
+	)
+	gauges.mCacheSys = ng(
+		keyMCacheSys,
+		"Bytes of memory obtained from the OS for mcache structures",
+	)
+	gauges.mSpanInUse = ng(
+		keyMSpanInUse,
+		"Bytes of allocated mspan structures",
+	)
+	gauges.mSpanSys = ng(
+		keyMSpanSys,
+		"Bytes of memory obtained from the OS for mspan structures",
+	)
+	gauges.mallocs = ng(
+		keyMallocs,
+		"Cumulative count of heap objects allocated",
+	)
+	gauges.nextGC = ng(
+		keyNextGC,
+		"Target heap size of the next GC cycle",
+	)
+	gauges.numForcedGC = ng(
+		keyNumForcedGC,
+		"Number of GC cycles that were forced by the application calling the GC function",
+	)
+	gauges.numGC = ng(
+		keyNumGC,
+		"Number of completed GC cycles",
+	)
+	gauges.otherSys = ng(
+		keyOtherSys,
+		"Bytes of memory in miscellaneous off-heap runtime allocations.",
+	)
+	gauges.pauseTotalNs = ng(
+		keyPauseTotalNs,
+		"Cumulative nanoseconds in GC stop-the-world pauses since the program started",
+	)
+	gauges.stackInUse = ng(
+		keyStackInUse,
+		"Bytes in stack spans",
+	)
+	gauges.stackSys = ng(
+		keyStackSys,
+		"Bytes of stack memory obtained from the OS",
+	)
+	gauges.sys = ng(
+		keySys,
+		"Total bytes of memory obtained from the OS",
+	)
+	gauges.totalAlloc = ng(
+		keyTotalAlloc,
+		"Cumulative bytes allocated for heap objects",
+	)
+
+	// Register the metrics.
+	fn(
+		gauges.buckHashSys,
+		gauges.frees,
+		gauges.gcCPUFraction,
+		gauges.gcSys,
+		gauges.heapAlloc,
+		gauges.heapIdle,
+		gauges.heapInUse,
+		gauges.heapObjects,
+		gauges.heapReleased,
+		gauges.heapSys,
+		gauges.live,
+		gauges.lookups,
+		gauges.mCacheInUse,
+		gauges.mCacheSys,
+		gauges.mSpanInUse,
+		gauges.mSpanSys,
+		gauges.mallocs,
+		gauges.nextGC,
+		gauges.numForcedGC,
+		gauges.numGC,
+		gauges.otherSys,
+		gauges.pauseTotalNs,
+		gauges.stackInUse,
+		gauges.stackSys,
+		gauges.sys,
+		gauges.totalAlloc,
+	)
+}
+
+func start(
+	logger logr.Logger,
+	interval time.Duration,
+	metricsEnabled bool) {
+
+	t := time.NewTicker(interval)
+
+	for {
+		var m runtime.MemStats
+		runtime.ReadMemStats(&m)
+
+		liveObjs := m.Mallocs - m.Frees
+
+		logger.Info(
+			"MemStats",
+			"now", time.Now().UnixNano(), // use same scale as lastGC
+			keyBuckHashSys, m.BuckHashSys,
+			keyDebugGC, m.DebugGC,
+			keyEnableGC, m.EnableGC,
+			keyFrees, m.Frees,
+			keyGcCPUFraction, m.GCCPUFraction,
+			keyGcSys, m.GCSys,
+			keyHeapAlloc, m.HeapAlloc,
+			keyHeapIdle, m.HeapIdle,
+			keyHeapInUse, m.HeapInuse,
+			keyHeapObjects, m.HeapObjects,
+			keyHeapReleased, m.HeapReleased,
+			keyHeapSys, m.HeapSys,
+			keyLastGC, m.LastGC,
+			keyLive, liveObjs,
+			keyLookups, m.Lookups,
+			keyMCacheInUse, m.MCacheInuse,
+			keyMCacheSys, m.MCacheSys,
+			keyMSpanInUse, m.MSpanInuse,
+			keyMSpanSys, m.MSpanSys,
+			keyMallocs, m.Mallocs,
+			keyNextGC, m.NextGC,
+			keyNumForcedGC, m.NumForcedGC,
+			keyNumGC, m.NumGC,
+			keyOtherSys, m.OtherSys,
+			keyPauseTotalNs, m.PauseTotalNs,
+			keyStackInUse, m.StackInuse,
+			keyStackSys, m.StackSys,
+			keySys, m.Sys,
+			keyTotalAlloc, m.TotalAlloc,
+		)
+
+		if metricsEnabled {
+			gauges.buckHashSys.Set(float64(m.BuckHashSys))
+			gauges.frees.Set(float64(m.Frees))
+			gauges.gcCPUFraction.Set(m.GCCPUFraction)
+			gauges.gcSys.Set(float64(m.GCSys))
+			gauges.heapAlloc.Set(float64(m.HeapAlloc))
+			gauges.heapIdle.Set(float64(m.HeapIdle))
+			gauges.heapInUse.Set(float64(m.HeapInuse))
+			gauges.heapObjects.Set(float64(m.HeapObjects))
+			gauges.heapReleased.Set(float64(m.HeapReleased))
+			gauges.heapSys.Set(float64(m.HeapSys))
+			gauges.live.Set(float64(liveObjs))
+			gauges.lookups.Set(float64(m.Lookups))
+			gauges.mCacheInUse.Set(float64(m.MCacheInuse))
+			gauges.mCacheSys.Set(float64(m.MCacheSys))
+			gauges.mSpanInUse.Set(float64(m.MSpanInuse))
+			gauges.mSpanSys.Set(float64(m.MSpanSys))
+			gauges.mallocs.Set(float64(m.Mallocs))
+			gauges.nextGC.Set(float64(m.NextGC))
+			gauges.numForcedGC.Set(float64(m.NumForcedGC))
+			gauges.numGC.Set(float64(m.NumGC))
+			gauges.otherSys.Set(float64(m.OtherSys))
+			gauges.pauseTotalNs.Set(float64(m.PauseTotalNs))
+			gauges.stackInUse.Set(float64(m.StackInuse))
+			gauges.stackSys.Set(float64(m.StackSys))
+			gauges.sys.Set(float64(m.Sys))
+			gauges.totalAlloc.Set(float64(m.TotalAlloc))
+		}
+
+		// Wait for the next tick.
+		<-t.C
+	}
+}

--- a/pkg/mem/mem_suite_test.go
+++ b/pkg/mem/mem_suite_test.go
@@ -1,0 +1,17 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package mem_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMem(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Mem Suite")
+}

--- a/pkg/mem/mem_test.go
+++ b/pkg/mem/mem_test.go
@@ -1,0 +1,65 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package mem_test
+
+import (
+	"sync/atomic"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"github.com/vmware-tanzu/vm-operator/pkg/mem"
+)
+
+var _ = Describe("Start", func() {
+	var (
+		s      sinkr
+		logger logr.Logger
+	)
+	BeforeEach(func() {
+		s = sinkr{}
+		logger = logr.New(&s)
+	})
+	JustBeforeEach(func() {
+		mem.Start(logger, time.Millisecond*500, metrics.Registry.MustRegister)
+	})
+	It("Should log the memory at least twice", func() {
+		Eventually(func(g Gomega) {
+			g.Expect(atomic.LoadInt32(&s.infoCalls)).To(BeNumerically(">=", int32(2)))
+			mf, err := metrics.Registry.Gather()
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(mf).To(HaveLen(26))
+		}, time.Second*20).Should(Succeed())
+	})
+})
+
+type sinkr struct {
+	infoCalls int32
+}
+
+func (s sinkr) Init(info logr.RuntimeInfo) {
+}
+
+func (s sinkr) Enabled(level int) bool {
+	return true
+}
+
+func (s *sinkr) Info(level int, msg string, keysAndValues ...any) {
+	atomic.AddInt32(&s.infoCalls, 1)
+}
+
+func (s sinkr) Error(err error, msg string, keysAndValues ...any) {
+}
+
+func (s sinkr) WithValues(keysAndValues ...any) logr.LogSink {
+	return &s
+}
+
+func (s sinkr) WithName(name string) logr.LogSink {
+	return &s
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This package adds support for emitting the results of a periodic call to `runtime.ReadMemStats`, enabling easily discovering the memory usage of the containers from the perspective of the Go runtime.

The environment variable `MEM_STATS_PERIOD` may be set to a valid time.Duration string to configure the interval, and it defaults to 10m.

The memory usage is emitted as soon as `main.go` begins, ex.:

```shell
I0121 09:38:11.853666   91609 mem.go:30] "MemStats" now=1737473891853622000 buckHashSys=1449862 debugGC=false enableGC=true frees=9602 gcCPUFraction=0.013948351398451445 gcSys=3138792 heapAlloc=4623544 heapIdle=1736704 heapInUse=6127616 heapObjects=18663 heapReleased=1703936 heapSys=7864320 lastGC=1737473891832972000 lookups=0 mCacheInUse=12000 mSpanInUse=126560 mSpanSys=130560 mallocs=28265 nextGC=6347392 numForcedGC=0 numGC=2 otherSys=1181098 pauseTotalNs=77666 stackInUse=524288 stackSys=524288 sys=14304520 totalAlloc=6120904
```

Please refer to [`runtime.MemStats`](https://pkg.go.dev/runtime#MemStats) for more information on the keys/values.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

~~A future enhancement would be to emit these values as prometheus metrics as well.~~ This has been implemented as part of this PR.


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Periodically gather process memory usage and print to log file and emit as Prometheus metrics
```