### PR TITLE
:seedling: Include UUID of disk backing in disk backup

### DIFF
--- a/pkg/backup/api/backup_types.go
+++ b/pkg/backup/api/backup_types.go
@@ -37,6 +37,10 @@ type PVCDiskData struct {
 	PVCName string
 	// AccessMode is the access modes of the PVC backed by the virtual disk.
 	AccessModes []string
+
+	// UUID is the UUID of the virtual disk device backing. This
+	// is only used in fail-over workflows.
+	UUID string
 }
 
 // ClassicDiskData contains the backup data of a classic (static) disk attached
@@ -44,6 +48,10 @@ type PVCDiskData struct {
 type ClassicDiskData struct {
 	// Filename is the datastore path to the virtual disk.
 	FileName string
+
+	// UUID is the UUID of the virtual disk device backing. This
+	// is only used in fail-over workflows.
+	UUID string
 }
 
 const (

--- a/pkg/providers/vsphere/virtualmachine/backup.go
+++ b/pkg/providers/vsphere/virtualmachine/backup.go
@@ -424,10 +424,12 @@ func getDesiredDiskDataForBackup(opts BackupVirtualMachineOptions) (string, stri
 						FileName:    b.FileName,
 						PVCName:     pvc.Name,
 						AccessModes: backupapi.ToPersistentVolumeAccessModes(pvc.Spec.AccessModes),
+						UUID:        b.Uuid,
 					})
 				} else if _, ok := opts.ClassicDiskUUIDs[b.Uuid]; ok {
 					classicDiskData = append(classicDiskData, backupapi.ClassicDiskData{
 						FileName: b.FileName,
+						UUID:     b.Uuid,
 					})
 				}
 			}

--- a/pkg/providers/vsphere/virtualmachine/backup_test.go
+++ b/pkg/providers/vsphere/virtualmachine/backup_test.go
@@ -692,6 +692,7 @@ func backupTests() {
 								FileName:    vcSimDiskFileName,
 								PVCName:     dummyPVC.Name,
 								AccessModes: backupapi.ToPersistentVolumeAccessModes(dummyPVC.Spec.AccessModes),
+								UUID:        vcSimDiskUUID,
 							},
 						}
 						diskDataJSON, err := json.Marshal(diskData)
@@ -1011,6 +1012,7 @@ func backupTests() {
 							diskData := []backupapi.ClassicDiskData{
 								{
 									FileName: vcSimDiskFileName,
+									UUID:     vcSimDiskUUID,
 								},
 							}
 							diskDataJSON, err := json.Marshal(diskData)


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This change modifies the disk backup to also include disk UUIDs.  This allows us to look up and identify disks using UUIDs to differentiate classic disks from disks that should be FCDs.

For now, the disk UUIDs are only used in failover workflows since vSphere Replication guarantees that the disks will be restored with the same UUID as the primary/source.


**Are there any special notes for your reviewer**:

This change is specific for failover of VMs.


**Please add a release note if necessary**:

```release-note
Include UUID of disk backing in disk backup
```