### PR TITLE
🐛 Do not panic in CLS controllers

### DIFF
--- a/controllers/contentlibrary/contentlibraryitem/contentlibraryitem_controller_intg_test.go
+++ b/controllers/contentlibrary/contentlibraryitem/contentlibraryitem_controller_intg_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/controllers/contentlibrary/utils"
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
@@ -76,7 +77,10 @@ func intgTestsReconcile() {
 		ctx = suite.NewIntegrationTestContext()
 
 		intgFakeVMProvider.Lock()
-		intgFakeVMProvider.SyncVirtualMachineImageFn = func(_ context.Context, _, vmiObj client.Object) error {
+		intgFakeVMProvider.SyncVirtualMachineImageFn = func(ctx context.Context, _, vmiObj client.Object) error {
+			// Verify ovfcache is in context and does not panic.
+			_, _ = ovfcache.GetOVFEnvelope(ctx, "", "")
+
 			vmi := vmiObj.(*vmopv1.VirtualMachineImage)
 			// Use Firmware field to verify the provider function is called.
 			vmi.Status.Firmware = firmwareValue

--- a/controllers/contentlibrary/utils/controller_builder.go
+++ b/controllers/contentlibrary/utils/controller_builder.go
@@ -33,6 +33,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
 	"github.com/vmware-tanzu/vm-operator/pkg/record"
 	imgutil "github.com/vmware-tanzu/vm-operator/pkg/util/image"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	vmopv1util "github.com/vmware-tanzu/vm-operator/pkg/util/vmopv1"
 )
 
@@ -123,6 +124,7 @@ func (r *Reconciler) Reconcile(
 	req ctrl.Request) (_ ctrl.Result, reterr error) {
 
 	ctx = pkgcfg.JoinContext(ctx, r.Context)
+	ctx = ovfcache.JoinContext(ctx, r.Context)
 
 	logger := ctrl.Log.WithName(r.Kind).WithValues("name", req.String())
 


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch fixes a panic in the ContentLibrary controllers that occurs due to a missing JoinContext for ovfcache in the Reconcile function.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```