### PR TITLE
🌱 Do not requeue VMIC for empty Spec fields

### DIFF
--- a/controllers/virtualmachineimagecache/virtualmachineimagecache_controller.go
+++ b/controllers/virtualmachineimagecache/virtualmachineimagecache_controller.go
@@ -6,7 +6,6 @@ package virtualmachineimagecache
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"path"
 	"reflect"
@@ -156,15 +155,15 @@ func (r *reconciler) ReconcileNormal(
 
 	// Verify the item's ID.
 	if obj.Spec.ProviderID == "" {
-		return errors.New("spec.providerID is empty")
+		return pkgerr.NoRequeueError{Message: "spec.providerID is empty"}
 	}
 
 	// Verify the item's version.
 	if obj.Spec.ProviderVersion == "" {
-		return errors.New("spec.providerVersion is empty")
+		return pkgerr.NoRequeueError{Message: "spec.providerVersion is empty"}
 	}
 
-	logger := r.Logger.WithValues(
+	logger := logr.FromContextOrDiscard(ctx).WithValues(
 		"providerID", obj.Spec.ProviderID,
 		"providerVersion", obj.Spec.ProviderVersion)
 	ctx = logr.NewContext(ctx, logger)

--- a/pkg/errors/requeue_error.go
+++ b/pkg/errors/requeue_error.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 // RequeueError may be returned from any part of a reconcile call stack and the
@@ -27,16 +28,46 @@ func (e RequeueError) Error() string {
 	return fmt.Sprintf("requeue after %s", e.After)
 }
 
+// NoRequeueError may be returned from any part of a reconcile call stack and the
+// controller will not requeue the request. This can be used to return an error
+// but not cause the back-off retry to occur.
+type NoRequeueError struct {
+	Message string
+}
+
+func (e NoRequeueError) Error() string {
+	if e.Message == "" {
+		return "no requeue"
+	}
+	return e.Message
+}
+
 // ResultFromError returns a ReconcileResult based on the provided error. If
-// the error contains an embedded RequeueError, then it is used to influence
-// the result.
+// the error contains an embedded RequeueError or NoRequeueError, then it is
+// used to influence the result. An embedded RequeueError is favored in an
+// error that also contains a NoRequeueError.
+// An embedded NoRequeueError will return a controller-runtime TerminalError
+// that will be logged and counted as an error but does not retry.
 func ResultFromError(err error) (ctrl.Result, error) {
-	var dst RequeueError
-	if err != nil && errors.As(err, &dst) {
-		if dst.After == 0 {
+	if err == nil {
+		return ctrl.Result{}, nil
+	}
+
+	var requeue RequeueError
+	if errors.As(err, &requeue) {
+		if requeue.After == 0 {
 			return ctrl.Result{Requeue: true}, nil
 		}
-		return ctrl.Result{RequeueAfter: dst.After}, nil
+		return ctrl.Result{RequeueAfter: requeue.After}, nil
 	}
+
+	var noRequeue NoRequeueError
+	if errors.As(err, &noRequeue) {
+		// TerminalError is confusingly named: it won't cause an error retry to
+		// be enqueued but later events from like a watch will still be queued.
+		// Wrap the original error so any other wrapped errors are still there.
+		return ctrl.Result{}, reconcile.TerminalError(err)
+	}
+
 	return ctrl.Result{}, err
 }


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

If these empty Spec fields are updated, the Watch() will cause the controller to reconcile the object so we don't need to do a requeue.

Add NoRequeueError that returns the controller-runtime TerminalError that does not do a requeue but is logged and counted as an error.

While here, update the VMIC ReconcileNormal() to use the logger from the context instead of parent reconciler so the object name is still there.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

There are a few other ways to do this:
 - Just have the controller return the TerminalError directly but this would cause "terminal error: " to be prepended to the condition message when I'd prefer to keep it as-is (and not complicate the defer())
 - Have the existing RequeueError with a negative After denote this instead but but I'd rather have a different name so the intention is explicit.  If we wanted to later, we could use a negative After to have ResultFromError() return a ctrl.Result{}, nil for an error that doesn't need to be logged or counted as an error.

Also TerminalError has a confusing name: [it just causes](https://github.com/kubernetes-sigs/controller-runtime/blob/990f2eddd615fa4f8cbee1e176b2b6096f112ac8/pkg/internal/controller/controller.go#L331-L332) the object to not be requeued, but can be later queue due to an event from like a watch.

**Please add a release note if necessary**:

```release-note
NONE
```