### PR TITLE
🌱 Go 1.23.5 / GH Action uses go.mod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,5 @@
 name: ci
 
-env:
-  GO_VERSION: 1.23
-
 on:
   pull_request:
     branches:
@@ -58,7 +55,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: go.mod
         cache: true
         cache-dependency-path: '**/go.sum'
     - name: Run go mod tidy
@@ -84,7 +81,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: go.mod
         cache: true
         cache-dependency-path: '**/go.sum'
     - name: Verify codegen
@@ -100,7 +97,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: go.mod
         cache: true
         cache-dependency-path: '**/go.sum'
     - name: Create kind cluster
@@ -124,7 +121,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: go.mod
         cache: true
         cache-dependency-path: '**/go.sum'
     - name: Setup the cache for golangci-lint
@@ -147,7 +144,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: go.mod
         cache: true
         cache-dependency-path: '**/go.sum'
     - name: Setup the cache for govulncheck
@@ -169,7 +166,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: go.mod
         cache: true
         cache-dependency-path: '**/go.sum'
     - name: Build Image
@@ -185,7 +182,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: go.mod
         cache: true
         cache-dependency-path: '**/go.sum'
     - name: Test

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/vm-operator
 
-go 1.23
+go 1.23.5
 
 replace (
 	github.com/vmware-tanzu/vm-operator/api => ./api


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch updates go.mod to specify Go 1.23.5 and updates the GitHub actions to use the Go version from go.mod.

This patch also addresses https://pkg.go.dev/vuln/GO-2025-3420 and https://pkg.go.dev/vuln/GO-2025-3373, both fixed by updating from Go 1.23.4 to 1.23.5.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Use Go 1.23.5
```