### PR TITLE
🐛 Fix CRD capability controller numExit races

### DIFF
--- a/controllers/infra/capability/crd/crd_capability_controller_test.go
+++ b/controllers/infra/capability/crd/crd_capability_controller_test.go
@@ -37,6 +37,7 @@ var _ = Describe(
 		)
 
 		BeforeEach(func() {
+			atomic.StoreInt32(&numExits, 0)
 			ctx = suite.NewIntegrationTestContext()
 			status = capv1.CapabilitiesStatus{}
 			obj = &capv1.Capabilities{
@@ -53,7 +54,6 @@ var _ = Describe(
 		})
 
 		AfterEach(func() {
-			atomic.StoreInt32(&numExits, 0)
 			Expect(ctx.Client.Delete(ctx, obj)).To(Succeed())
 			Eventually(apierrors.IsNotFound(
 				ctx.Client.Get(ctx, capabilities.ConfigMapKey, obj),


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

I get occasional test failures in the CRD capability controller where numExits is one more than expected. Moving the reset to the BeforeEach() seems to fix it, or at least make it much less likely, and this is the ConfigMap controller already has it.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note
NONE
```