### PR TITLE
🐛 Avoid needlessly VC client logout when creds haven't changed

### DIFF
--- a/controllers/contentlibrary/utils/controller_builder_test.go
+++ b/controllers/contentlibrary/utils/controller_builder_test.go
@@ -48,7 +48,7 @@ var _ = Describe("AddToManager",
 		)
 
 		BeforeEach(func() {
-			parentCtx = pkgcfg.NewContext()
+			parentCtx = pkgcfg.NewContextWithDefaultConfig()
 		})
 
 		JustBeforeEach(func() {

--- a/controllers/infra/secret/infra_secret_controller.go
+++ b/controllers/infra/secret/infra_secret_controller.go
@@ -10,15 +10,14 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
@@ -27,13 +26,8 @@ import (
 	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 )
 
-const (
-	// VcCredsSecretName is the credential secret that stores the VM operator service provider user credentials.
-	VcCredsSecretName = "wcp-vmop-sa-vc-auth" //nolint:gosec
-)
-
 type provider interface {
-	ResetVcClient(ctx context.Context)
+	UpdateVcCreds(ctx context.Context, data map[string][]byte) error
 }
 
 // AddToManager adds this package's controller to the provided manager.
@@ -45,25 +39,34 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
 	)
 
-	r := NewReconciler(
-		ctx,
-		mgr.GetClient(),
-		ctrl.Log.WithName("controllers").WithName(controllerName),
-		record.New(mgr.GetEventRecorderFor(controllerNameLong)),
-		ctx.Namespace,
-		ctx.VMProvider,
-	)
-
-	c, err := controller.New(controllerName, mgr, controller.Options{Reconciler: r})
-	if err != nil {
-		return err
+	vcCredsKey := ctrlclient.ObjectKey{
+		Name:      pkgcfg.FromContext(ctx).VCCredsSecretName,
+		Namespace: ctx.Namespace,
 	}
 
+	// This controller only watches Secrets in the pod namespace.
 	cache, err := pkgmgr.NewNamespacedCacheForObject(
 		mgr,
 		&ctx.SyncPeriod,
 		controlledType,
-		r.vmOpNamespace)
+		vcCredsKey.Namespace)
+	if err != nil {
+		return err
+	}
+
+	r := NewReconciler(
+		ctx,
+		cache,
+		ctrl.Log.WithName("controllers").WithName(controllerName),
+		record.New(mgr.GetEventRecorderFor(controllerNameLong)),
+		ctx.VMProvider,
+		vcCredsKey,
+	)
+
+	c, err := controller.New(controllerName, mgr, controller.Options{
+		Reconciler:              r,
+		MaxConcurrentReconciles: 1,
+	})
 	if err != nil {
 		return err
 	}
@@ -74,10 +77,10 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		&handler.TypedEnqueueRequestForObject[*corev1.Secret]{},
 		predicate.TypedFuncs[*corev1.Secret]{
 			CreateFunc: func(e event.TypedCreateEvent[*corev1.Secret]) bool {
-				return e.Object.GetName() == VcCredsSecretName
+				return e.Object.GetName() == vcCredsKey.Name
 			},
 			UpdateFunc: func(e event.TypedUpdateEvent[*corev1.Secret]) bool {
-				return e.ObjectOld.GetName() == VcCredsSecretName
+				return e.ObjectOld.GetName() == vcCredsKey.Name
 			},
 			DeleteFunc: func(e event.TypedDeleteEvent[*corev1.Secret]) bool {
 				return false
@@ -88,33 +91,33 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		},
 		kubeutil.TypedResourceVersionChangedPredicate[*corev1.Secret]{},
 	))
-
 }
 
 func NewReconciler(
 	ctx context.Context,
-	client client.Client,
+	secretReader ctrlclient.Reader,
 	logger logr.Logger,
 	recorder record.Recorder,
-	vmOpNamespace string,
-	provider provider) *Reconciler {
+	provider provider,
+	vcCredsKey ctrlclient.ObjectKey) *Reconciler {
+
 	return &Reconciler{
-		Context:       ctx,
-		Client:        client,
-		Logger:        logger,
-		Recorder:      recorder,
-		vmOpNamespace: vmOpNamespace,
-		provider:      provider,
+		Context:      ctx,
+		SecretReader: secretReader,
+		Logger:       logger,
+		Recorder:     recorder,
+		provider:     provider,
+		vcCredsKey:   vcCredsKey,
 	}
 }
 
 type Reconciler struct {
-	client.Client
-	Context       context.Context
-	Logger        logr.Logger
-	Recorder      record.Recorder
-	vmOpNamespace string
-	provider      provider
+	Context      context.Context
+	SecretReader ctrlclient.Reader
+	Logger       logr.Logger
+	Recorder     record.Recorder
+	provider     provider
+	vcCredsKey   ctrlclient.ObjectKey
 }
 
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
@@ -122,16 +125,20 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	ctx = pkgcfg.JoinContext(ctx, r.Context)
 
-	if req.Name == VcCredsSecretName && req.Namespace == r.vmOpNamespace {
-		r.reconcileVcCreds(ctx, req)
-		return ctrl.Result{}, nil
+	if req.NamespacedName == r.vcCredsKey {
+		return ctrl.Result{}, r.reconcileVcCreds(ctx)
 	}
 
 	r.Logger.Error(nil, "Reconciling unexpected object", "req", req.NamespacedName)
 	return ctrl.Result{}, nil
 }
 
-func (r *Reconciler) reconcileVcCreds(ctx context.Context, req ctrl.Request) {
-	r.Logger.Info("Reconciling updated VM Operator credentials", "secret", req.NamespacedName)
-	r.provider.ResetVcClient(ctx)
+func (r *Reconciler) reconcileVcCreds(ctx context.Context) error {
+	secret := corev1.Secret{}
+	if err := r.SecretReader.Get(ctx, r.vcCredsKey, &secret); err != nil {
+		return ctrlclient.IgnoreNotFound(err)
+	}
+
+	r.Logger.Info("Reconciling updated VM Operator credentials", "secret", r.vcCredsKey)
+	return r.provider.UpdateVcCreds(ctx, secret.Data)
 }

--- a/controllers/infra/secret/infra_secret_controller_suite_test.go
+++ b/controllers/infra/secret/infra_secret_controller_suite_test.go
@@ -12,6 +12,7 @@ import (
 	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/vmware-tanzu/vm-operator/controllers/infra/secret"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	providerfake "github.com/vmware-tanzu/vm-operator/pkg/providers/fake"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
@@ -19,7 +20,8 @@ import (
 
 var provider = providerfake.NewVMProvider()
 
-var suite = builder.NewTestSuiteForController(
+var suite = builder.NewTestSuiteForControllerWithContext(
+	pkgcfg.NewContextWithDefaultConfig(),
 	secret.AddToManager,
 	func(ctx *pkgctx.ControllerManagerContext, _ ctrlmgr.Manager) error {
 		ctx.VMProvider = provider

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -147,6 +147,12 @@ type Config struct {
 	//
 	// Defaults to "direct".
 	FastDeployMode string
+
+	// VCCredsSecretName is the name of the secret in the pod namespace that
+	// contains the VC credentials.
+	//
+	// Defaults to "wcp-vmop-sa-vc-auth".
+	VCCredsSecretName string
 }
 
 // GetMaxDeployThreadsOnProvider returns MaxDeployThreadsOnProvider if it is >0

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -43,6 +43,7 @@ func Default() Config {
 		AsyncCreateEnabled:           true,
 		MemStatsPeriod:               10 * time.Minute,
 		FastDeployMode:               pkgconst.FastDeployModeDirect,
+		VCCredsSecretName:            pkgconst.VCCredsSecretName,
 		CreateVMRequeueDelay:         10 * time.Second,
 		PoweredOnVMHasIPRequeueDelay: 10 * time.Second,
 		SyncImageRequeueDelay:        10 * time.Second,

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -33,6 +33,7 @@ func FromEnv() Config {
 	setBool(env.AsyncCreateEnabled, &config.AsyncCreateEnabled)
 	setDuration(env.MemStatsPeriod, &config.MemStatsPeriod)
 	setString(env.FastDeployMode, &config.FastDeployMode)
+	setString(env.VCCredsSecretName, &config.VCCredsSecretName)
 
 	setDuration(env.InstanceStoragePVPlacementFailedTTL, &config.InstanceStorage.PVPlacementFailedTTL)
 	setFloat64(env.InstanceStorageJitterMaxFactor, &config.InstanceStorage.JitterMaxFactor)

--- a/pkg/config/env/env.go
+++ b/pkg/config/env/env.go
@@ -29,6 +29,7 @@ const (
 	AsyncSignalEnabled
 	AsyncCreateEnabled
 	FastDeployMode
+	VCCredsSecretName
 	InstanceStoragePVPlacementFailedTTL
 	InstanceStorageJitterMaxFactor
 	InstanceStorageSeedRequeueDuration
@@ -121,6 +122,8 @@ func (n VarName) String() string {
 		return "ASYNC_CREATE_ENABLED"
 	case FastDeployMode:
 		return "FAST_DEPLOY_MODE"
+	case VCCredsSecretName:
+		return "VC_CREDS_SECRET_NAME"
 	case InstanceStoragePVPlacementFailedTTL:
 		return "INSTANCE_STORAGE_PV_PLACEMENT_FAILED_TTL"
 	case InstanceStorageJitterMaxFactor:

--- a/pkg/config/env_test.go
+++ b/pkg/config/env_test.go
@@ -81,6 +81,7 @@ var _ = Describe(
 					Expect(os.Setenv("ASYNC_SIGNAL_ENABLED", "false")).To(Succeed())
 					Expect(os.Setenv("ASYNC_CREATE_ENABLED", "false")).To(Succeed())
 					Expect(os.Setenv("FAST_DEPLOY_MODE", pkgconst.FastDeployModeLinked)).To(Succeed())
+					Expect(os.Setenv("VC_CREDS_SECRET_NAME", pkgconst.VCCredsSecretName)).To(Succeed())
 					Expect(os.Setenv("LEADER_ELECTION_ID", "115")).To(Succeed())
 					Expect(os.Setenv("POD_NAME", "116")).To(Succeed())
 					Expect(os.Setenv("POD_NAMESPACE", "117")).To(Succeed())
@@ -135,6 +136,7 @@ var _ = Describe(
 						AsyncSignalEnabled:           false,
 						AsyncCreateEnabled:           false,
 						FastDeployMode:               pkgconst.FastDeployModeLinked,
+						VCCredsSecretName:            pkgconst.VCCredsSecretName,
 						LeaderElectionID:             "115",
 						PodName:                      "116",
 						PodNamespace:                 "117",

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -87,4 +87,8 @@ const (
 	// of new pods, ensuring at least one pod is online at all times.
 	// The value is the reason for the restart.
 	LastRestartReasonAnnotationKey = "vmoperator.vmware.com/last-restart-reason"
+
+	// VCCredsSecretName is the name of the secret in the pod namespace
+	// that contains the VC credentials.
+	VCCredsSecretName = "wcp-vmop-sa-vc-auth" //nolint:gosec
 )

--- a/pkg/providers/fake/fake_vm_provider.go
+++ b/pkg/providers/fake/fake_vm_provider.go
@@ -40,20 +40,16 @@ type funcs struct {
 	GetVirtualMachineWebMKSTicketFn    func(ctx context.Context, vm *vmopv1.VirtualMachine, pubKey string) (string, error)
 	GetVirtualMachineHardwareVersionFn func(ctx context.Context, vm *vmopv1.VirtualMachine) (vimtypes.HardwareVersion, error)
 
-	// ListItemsFromContentLibraryFn              func(ctx context.Context, contentLibrary *vmopv1.ContentLibraryProvider) ([]string, error)
-	// GetVirtualMachineImageFromContentLibraryFn func(ctx context.Context, contentLibrary *vmopv1.ContentLibraryProvider, itemID string,
-	//	currentCLImages map[string]vmopv1.VirtualMachineImage) (*vmopv1.VirtualMachineImage, error)
-
 	GetItemFromLibraryByNameFn func(ctx context.Context, contentLibrary, itemName string) (*library.Item, error)
 	UpdateContentLibraryItemFn func(ctx context.Context, itemID, newName string, newDescription *string) error
 	SyncVirtualMachineImageFn  func(ctx context.Context, cli, vmi client.Object) error
 
-	UpdateVcPNIDFn  func(ctx context.Context, vcPNID, vcPort string) error
-	ResetVcClientFn func(ctx context.Context)
+	UpdateVcPNIDFn           func(ctx context.Context, vcPNID, vcPort string) error
+	UpdateVcCredsFn          func(ctx context.Context, data map[string][]byte) error
+	ComputeCPUMinFrequencyFn func(ctx context.Context) error
 
 	CreateOrUpdateVirtualMachineSetResourcePolicyFn func(ctx context.Context, rp *vmopv1.VirtualMachineSetResourcePolicy) error
 	DeleteVirtualMachineSetResourcePolicyFn         func(ctx context.Context, rp *vmopv1.VirtualMachineSetResourcePolicy) error
-	ComputeCPUMinFrequencyFn                        func(ctx context.Context) error
 
 	GetTasksByActIDFn func(ctx context.Context, actID string) (tasksInfo []vimtypes.TaskInfo, retErr error)
 
@@ -83,6 +79,8 @@ func (s *VMProvider) Reset() {
 }
 
 func (s *VMProvider) CreateOrUpdateVirtualMachine(ctx context.Context, vm *vmopv1.VirtualMachine) error {
+	_ = pkgcfg.FromContext(ctx)
+
 	s.Lock()
 	defer s.Unlock()
 	if s.CreateOrUpdateVirtualMachineFn != nil {
@@ -93,6 +91,8 @@ func (s *VMProvider) CreateOrUpdateVirtualMachine(ctx context.Context, vm *vmopv
 }
 
 func (s *VMProvider) CreateOrUpdateVirtualMachineAsync(ctx context.Context, vm *vmopv1.VirtualMachine) (<-chan error, error) {
+	_ = pkgcfg.FromContext(ctx)
+
 	s.Lock()
 	defer s.Unlock()
 	if s.CreateOrUpdateVirtualMachineAsyncFn != nil {
@@ -103,6 +103,8 @@ func (s *VMProvider) CreateOrUpdateVirtualMachineAsync(ctx context.Context, vm *
 }
 
 func (s *VMProvider) DeleteVirtualMachine(ctx context.Context, vm *vmopv1.VirtualMachine) error {
+	_ = pkgcfg.FromContext(ctx)
+
 	s.Lock()
 	defer s.Unlock()
 	if s.DeleteVirtualMachineFn != nil {
@@ -112,22 +114,27 @@ func (s *VMProvider) DeleteVirtualMachine(ctx context.Context, vm *vmopv1.Virtua
 	return nil
 }
 
-func (s *VMProvider) PublishVirtualMachine(ctx context.Context, vm *vmopv1.VirtualMachine,
-	vmPub *vmopv1.VirtualMachinePublishRequest, cl *imgregv1a1.ContentLibrary, actID string) (string, error) {
+func (s *VMProvider) PublishVirtualMachine(
+	ctx context.Context,
+	vm *vmopv1.VirtualMachine,
+	vmPub *vmopv1.VirtualMachinePublishRequest,
+	cl *imgregv1a1.ContentLibrary, actID string) (string, error) {
+
+	_ = pkgcfg.FromContext(ctx)
+
 	s.Lock()
 	defer s.Unlock()
-
 	s.isPublishVMCalled = true
-
 	if s.PublishVirtualMachineFn != nil {
 		return s.PublishVirtualMachineFn(ctx, vm, vmPub, cl, actID)
 	}
-
 	s.AddToVMPublishMap(actID, vimtypes.TaskInfoStateSuccess)
 	return "dummy-id", nil
 }
 
 func (s *VMProvider) GetVirtualMachineGuestHeartbeat(ctx context.Context, vm *vmopv1.VirtualMachine) (vmopv1.GuestHeartbeatStatus, error) {
+	_ = pkgcfg.FromContext(ctx)
+
 	s.Lock()
 	defer s.Unlock()
 	if s.GetVirtualMachineGuestHeartbeatFn != nil {
@@ -141,6 +148,8 @@ func (s *VMProvider) GetVirtualMachineProperties(
 	vm *vmopv1.VirtualMachine,
 	propertyPaths []string) (map[string]any, error) {
 
+	_ = pkgcfg.FromContext(ctx)
+
 	s.Lock()
 	defer s.Unlock()
 	if s.GetVirtualMachinePropertiesFn != nil {
@@ -150,6 +159,8 @@ func (s *VMProvider) GetVirtualMachineProperties(
 }
 
 func (s *VMProvider) GetVirtualMachineWebMKSTicket(ctx context.Context, vm *vmopv1.VirtualMachine, pubKey string) (string, error) {
+	_ = pkgcfg.FromContext(ctx)
+
 	s.Lock()
 	defer s.Unlock()
 	if s.GetVirtualMachineWebMKSTicketFn != nil {
@@ -159,6 +170,8 @@ func (s *VMProvider) GetVirtualMachineWebMKSTicket(ctx context.Context, vm *vmop
 }
 
 func (s *VMProvider) GetVirtualMachineHardwareVersion(ctx context.Context, vm *vmopv1.VirtualMachine) (vimtypes.HardwareVersion, error) {
+	_ = pkgcfg.FromContext(ctx)
+
 	s.Lock()
 	defer s.Unlock()
 	if s.GetVirtualMachineHardwareVersionFn != nil {
@@ -168,9 +181,10 @@ func (s *VMProvider) GetVirtualMachineHardwareVersion(ctx context.Context, vm *v
 }
 
 func (s *VMProvider) CreateOrUpdateVirtualMachineSetResourcePolicy(ctx context.Context, resourcePolicy *vmopv1.VirtualMachineSetResourcePolicy) error {
+	_ = pkgcfg.FromContext(ctx)
+
 	s.Lock()
 	defer s.Unlock()
-
 	if s.CreateOrUpdateVirtualMachineSetResourcePolicyFn != nil {
 		return s.CreateOrUpdateVirtualMachineSetResourcePolicyFn(ctx, resourcePolicy)
 	}
@@ -178,9 +192,10 @@ func (s *VMProvider) CreateOrUpdateVirtualMachineSetResourcePolicy(ctx context.C
 }
 
 func (s *VMProvider) DeleteVirtualMachineSetResourcePolicy(ctx context.Context, resourcePolicy *vmopv1.VirtualMachineSetResourcePolicy) error {
+	_ = pkgcfg.FromContext(ctx)
+
 	s.Lock()
 	defer s.Unlock()
-
 	if s.DeleteVirtualMachineSetResourcePolicyFn != nil {
 		return s.DeleteVirtualMachineSetResourcePolicyFn(ctx, resourcePolicy)
 	}
@@ -188,6 +203,8 @@ func (s *VMProvider) DeleteVirtualMachineSetResourcePolicy(ctx context.Context, 
 }
 
 func (s *VMProvider) ComputeCPUMinFrequency(ctx context.Context) error {
+	_ = pkgcfg.FromContext(ctx)
+
 	s.Lock()
 	defer s.Unlock()
 	if s.ComputeCPUMinFrequencyFn != nil {
@@ -198,6 +215,8 @@ func (s *VMProvider) ComputeCPUMinFrequency(ctx context.Context) error {
 }
 
 func (s *VMProvider) UpdateVcPNID(ctx context.Context, vcPNID, vcPort string) error {
+	_ = pkgcfg.FromContext(ctx)
+
 	s.Lock()
 	defer s.Unlock()
 	if s.UpdateVcPNIDFn != nil {
@@ -206,46 +225,22 @@ func (s *VMProvider) UpdateVcPNID(ctx context.Context, vcPNID, vcPort string) er
 	return nil
 }
 
-func (s *VMProvider) ResetVcClient(ctx context.Context) {
+func (s *VMProvider) UpdateVcCreds(ctx context.Context, data map[string][]byte) error {
+	_ = pkgcfg.FromContext(ctx)
+
 	s.Lock()
 	defer s.Unlock()
-
-	if s.ResetVcClientFn != nil {
-		s.ResetVcClientFn(ctx)
+	if s.UpdateVcCredsFn != nil {
+		return s.UpdateVcCredsFn(ctx, data)
 	}
+	return nil
 }
-
-/*
-func (s *VMProvider) ListItemsFromContentLibrary(ctx context.Context, contentLibrary *vmopv1.ContentLibraryProvider) ([]string, error) {
-	s.Lock()
-	defer s.Unlock()
-
-	if s.ListItemsFromContentLibraryFn != nil {
-		return s.ListItemsFromContentLibraryFn(ctx, contentLibrary)
-	}
-
-	// No-op for now.
-	return []string{}, nil
-}
-
-func (s *VMProvider) GetVirtualMachineImageFromContentLibrary(ctx context.Context, contentLibrary *vmopv1.ContentLibraryProvider, itemID string,
-	currentCLImages map[string]vmopv1.VirtualMachineImage) (*vmopv1.VirtualMachineImage, error) {
-	s.Lock()
-	defer s.Unlock()
-
-	if s.GetVirtualMachineImageFromContentLibraryFn != nil {
-		return s.GetVirtualMachineImageFromContentLibraryFn(ctx, contentLibrary, itemID, currentCLImages)
-	}
-
-	// No-op for now.
-	return nil, nil
-}
-*/
 
 func (s *VMProvider) SyncVirtualMachineImage(ctx context.Context, cli, vmi client.Object) error {
+	_ = pkgcfg.FromContext(ctx)
+
 	s.Lock()
 	defer s.Unlock()
-
 	if s.SyncVirtualMachineImageFn != nil {
 		return s.SyncVirtualMachineImageFn(ctx, cli, vmi)
 	}
@@ -255,9 +250,11 @@ func (s *VMProvider) SyncVirtualMachineImage(ctx context.Context, cli, vmi clien
 
 func (s *VMProvider) GetItemFromLibraryByName(ctx context.Context,
 	contentLibrary, itemName string) (*library.Item, error) {
+
+	_ = pkgcfg.FromContext(ctx)
+
 	s.Lock()
 	defer s.Unlock()
-
 	if s.GetItemFromLibraryByNameFn != nil {
 		return s.GetItemFromLibraryByNameFn(ctx, contentLibrary, itemName)
 	}
@@ -266,9 +263,10 @@ func (s *VMProvider) GetItemFromLibraryByName(ctx context.Context,
 }
 
 func (s *VMProvider) UpdateContentLibraryItem(ctx context.Context, itemID, newName string, newDescription *string) error {
+	_ = pkgcfg.FromContext(ctx)
+
 	s.Lock()
 	defer s.Unlock()
-
 	if s.UpdateContentLibraryItemFn != nil {
 		return s.UpdateContentLibraryItemFn(ctx, itemID, newName, newDescription)
 	}
@@ -276,9 +274,10 @@ func (s *VMProvider) UpdateContentLibraryItem(ctx context.Context, itemID, newNa
 }
 
 func (s *VMProvider) GetTasksByActID(ctx context.Context, actID string) (tasksInfo []vimtypes.TaskInfo, retErr error) {
+	_ = pkgcfg.FromContext(ctx)
+
 	s.Lock()
 	defer s.Unlock()
-
 	if s.GetTasksByActIDFn != nil {
 		return s.GetTasksByActIDFn(ctx, actID)
 	}
@@ -340,9 +339,10 @@ func (s *VMProvider) DoesProfileSupportEncryption(
 	ctx context.Context,
 	profileID string) (bool, error) {
 
+	_ = pkgcfg.FromContext(ctx)
+
 	s.Lock()
 	defer s.Unlock()
-
 	if fn := s.DoesProfileSupportEncryptionFn; fn != nil {
 		return fn(ctx, profileID)
 	}
@@ -350,9 +350,10 @@ func (s *VMProvider) DoesProfileSupportEncryption(
 }
 
 func (s *VMProvider) VSphereClient(ctx context.Context) (*vsclient.Client, error) {
+	_ = pkgcfg.FromContext(ctx)
+
 	s.Lock()
 	defer s.Unlock()
-
 	if fn := s.VSphereClientFn; fn != nil {
 		return fn(ctx)
 	}

--- a/pkg/providers/vm_provider_interface.go
+++ b/pkg/providers/vm_provider_interface.go
@@ -47,7 +47,7 @@ type VirtualMachineProviderInterface interface {
 
 	// "Infra" related
 	UpdateVcPNID(ctx context.Context, vcPNID, vcPort string) error
-	ResetVcClient(ctx context.Context)
+	UpdateVcCreds(ctx context.Context, data map[string][]byte) error
 	ComputeCPUMinFrequency(ctx context.Context) error
 
 	GetItemFromLibraryByName(ctx context.Context, contentLibrary, itemName string) (*library.Item, error)

--- a/pkg/providers/vsphere/client/client.go
+++ b/pkg/providers/vsphere/client/client.go
@@ -13,7 +13,7 @@ import (
 
 type Client struct {
 	*client.Client
-	config *config.VSphereVMProviderConfig
+	config config.VSphereVMProviderConfig
 }
 
 // NewClient creates a new Client. As a side effect, it creates a vim25 client
@@ -38,10 +38,10 @@ func NewClient(
 
 	return &Client{
 		Client: c,
-		config: config,
+		config: *config,
 	}, nil
 }
 
-func (c *Client) Config() *config.VSphereVMProviderConfig {
+func (c *Client) Config() config.VSphereVMProviderConfig {
 	return c.config
 }

--- a/pkg/providers/vsphere/client/client_test.go
+++ b/pkg/providers/vsphere/client/client_test.go
@@ -95,7 +95,7 @@ var _ = Describe("Client", Label(testlabels.VCSim), Ordered /* Avoided race for 
 			cfg = &config.VSphereVMProviderConfig{
 				VcPNID: server.URL.Hostname(),
 				VcPort: server.URL.Port(),
-				VcCreds: &credentials.VSphereVMProviderCredentials{
+				VcCreds: credentials.VSphereVMProviderCredentials{
 					Username: expectedPassword,
 					Password: expectedPassword,
 				},

--- a/pkg/providers/vsphere/config/config_test.go
+++ b/pkg/providers/vsphere/config/config_test.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/config"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/credentials"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
@@ -44,9 +45,10 @@ func configTests() {
 
 			Context("when a secret doesn't exist", func() {
 				It("returns no provider config and an error", func() {
+					// Note that NewTestContextForVCSim() creates this Secret.
 					secret := &corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "vmop-vcsim-dummy-creds",
+							Name:      pkgcfg.FromContext(ctx).VCCredsSecretName,
 							Namespace: ctx.PodNamespace,
 						},
 					}
@@ -164,13 +166,13 @@ func configTests() {
 var _ = Describe("ConfigMapToProviderConfig", func() {
 
 	var (
-		providerCreds    *credentials.VSphereVMProviderCredentials
+		providerCreds    credentials.VSphereVMProviderCredentials
 		providerConfigIn *config.VSphereVMProviderConfig
 		configMap        *corev1.ConfigMap
 	)
 
 	BeforeEach(func() {
-		providerCreds = &credentials.VSphereVMProviderCredentials{Username: "username", Password: "password"}
+		providerCreds = credentials.VSphereVMProviderCredentials{Username: "username", Password: "password"}
 		providerConfigIn = &config.VSphereVMProviderConfig{
 			VcPNID:                      "my-vc.vmware.com",
 			VcPort:                      "433",
@@ -187,7 +189,7 @@ var _ = Describe("ConfigMapToProviderConfig", func() {
 	})
 
 	JustBeforeEach(func() {
-		configMap = config.ProviderConfigToConfigMap("dummy-ns", providerConfigIn, "dummy-secrets")
+		configMap = config.ProviderConfigToConfigMap("dummy-ns", providerConfigIn)
 	})
 
 	It("provider config is correctly extracted from the ConfigMap", func() {

--- a/pkg/providers/vsphere/credentials/credentials.go
+++ b/pkg/providers/vsphere/credentials/credentials.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -21,44 +20,29 @@ type VSphereVMProviderCredentials struct {
 	Password string
 }
 
-func GetProviderCredentials(client ctrlclient.Client, namespace, secretName string) (*VSphereVMProviderCredentials, error) {
+func GetProviderCredentials(
+	ctx context.Context,
+	client ctrlclient.Client,
+	namespace, secretName string) (VSphereVMProviderCredentials, error) {
+
 	secret := &corev1.Secret{}
 	secretKey := types.NamespacedName{Namespace: namespace, Name: secretName}
-	if err := client.Get(context.Background(), secretKey, secret); err != nil {
-		// Log message used by VMC LINT. Refer to before making changes
-		return nil, fmt.Errorf("cannot find secret for provider credentials: %s: %w", secretKey, err)
+	if err := client.Get(ctx, secretKey, secret); err != nil {
+		return VSphereVMProviderCredentials{}, fmt.Errorf("cannot find secret for provider credentials: %s: %w", secretKey, err)
 	}
 
-	var credentials VSphereVMProviderCredentials
-	credentials.Username = string(secret.Data["username"])
-	credentials.Password = string(secret.Data["password"])
+	return ExtractVCCredentials(secret.Data)
+}
+
+func ExtractVCCredentials(data map[string][]byte) (VSphereVMProviderCredentials, error) {
+	credentials := VSphereVMProviderCredentials{
+		Username: string(data["username"]),
+		Password: string(data["password"]),
+	}
 
 	if credentials.Username == "" || credentials.Password == "" {
-		return nil, errors.New("vCenter username and password are missing")
+		return VSphereVMProviderCredentials{}, errors.New("vCenter username and password are missing")
 	}
 
-	return &credentials, nil
-}
-
-func setSecretData(secret *corev1.Secret, credentials *VSphereVMProviderCredentials) {
-	if secret.Data == nil {
-		secret.Data = map[string][]byte{}
-	}
-
-	secret.Data["username"] = []byte(credentials.Username)
-	secret.Data["password"] = []byte(credentials.Password)
-}
-
-// ProviderCredentialsToSecret returns the Secret for the credentials.
-// Testing only.
-func ProviderCredentialsToSecret(namespace string, credentials *VSphereVMProviderCredentials, vcCredsSecretName string) *corev1.Secret {
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      vcCredsSecretName,
-			Namespace: namespace,
-		},
-	}
-	setSecretData(secret, credentials)
-
-	return secret
+	return credentials, nil
 }

--- a/pkg/providers/vsphere/credentials/credentials_test.go
+++ b/pkg/providers/vsphere/credentials/credentials_test.go
@@ -5,31 +5,50 @@
 package credentials_test
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	. "github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/credentials"
+	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/credentials"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
-func newSecret(name string, ns string, user string, pass string) (*corev1.Secret, *VSphereVMProviderCredentials) {
-	creds := &VSphereVMProviderCredentials{
+func newSecret(name, namespace, user, pass string) (*corev1.Secret, credentials.VSphereVMProviderCredentials) {
+	creds := credentials.VSphereVMProviderCredentials{
 		Username: user,
 		Password: pass,
 	}
-	secret := ProviderCredentialsToSecret(ns, creds, name)
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			"username": []byte(creds.Username),
+			"password": []byte(creds.Password),
+		},
+	}
+
 	return secret, creds
 }
 
 var _ = Describe("GetProviderCredentials", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
 
 	Context("when a good secret exists", func() {
 		Specify("returns good credentials with no error", func() {
 			secretIn, credsIn := newSecret("some-name", "some-namespace", "some-user", "some-pass")
 			client := builder.NewFakeClient(secretIn)
-			credsOut, err := GetProviderCredentials(client, secretIn.Namespace, secretIn.Name)
+			credsOut, err := credentials.GetProviderCredentials(ctx, client, secretIn.Namespace, secretIn.Name)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(credsOut).To(Equal(credsIn))
 		})
@@ -41,9 +60,9 @@ var _ = Describe("GetProviderCredentials", func() {
 			Specify("returns no credentials with error", func() {
 				secretIn, _ := newSecret("some-name", "some-namespace", "", "some-pass")
 				client := builder.NewFakeClient(secretIn)
-				credsOut, err := GetProviderCredentials(client, secretIn.Namespace, secretIn.Name)
+				credsOut, err := credentials.GetProviderCredentials(ctx, client, secretIn.Namespace, secretIn.Name)
 				Expect(err).To(HaveOccurred())
-				Expect(credsOut).To(BeNil())
+				Expect(credsOut).To(BeZero())
 			})
 		})
 
@@ -51,9 +70,9 @@ var _ = Describe("GetProviderCredentials", func() {
 			Specify("returns no credentials with error", func() {
 				secretIn, _ := newSecret("some-name", "some-namespace", "some-user", "")
 				client := builder.NewFakeClient(secretIn)
-				credsOut, err := GetProviderCredentials(client, secretIn.Namespace, secretIn.Name)
+				credsOut, err := credentials.GetProviderCredentials(ctx, client, secretIn.Namespace, secretIn.Name)
 				Expect(err).To(HaveOccurred())
-				Expect(credsOut).To(BeNil())
+				Expect(credsOut).To(BeZero())
 			})
 		})
 	})
@@ -61,9 +80,9 @@ var _ = Describe("GetProviderCredentials", func() {
 	Context("when no secret exists", func() {
 		Specify("returns no credentials with error", func() {
 			client := builder.NewFakeClient()
-			credsOut, err := GetProviderCredentials(client, "none-namespace", "none-name")
+			credsOut, err := credentials.GetProviderCredentials(ctx, client, "none-namespace", "none-name")
 			Expect(err).To(HaveOccurred())
-			Expect(credsOut).To(BeNil())
+			Expect(credsOut).To(BeZero())
 		})
 	})
 })

--- a/pkg/providers/vsphere/placement/zone_placement_test.go
+++ b/pkg/providers/vsphere/placement/zone_placement_test.go
@@ -87,7 +87,7 @@ func vcSimPlacement() {
 	)
 
 	BeforeEach(func() {
-		parentCtx = pkgcfg.NewContext()
+		parentCtx = pkgcfg.NewContextWithDefaultConfig()
 		testConfig = builder.VCSimTestConfig{}
 
 		vm = builder.DummyVirtualMachine()

--- a/pkg/providers/vsphere/vmprovider_vm2_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm2_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
-	vsphere "github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
+	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/network"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )

--- a/pkg/providers/vsphere/vmprovider_vm_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_test.go
@@ -13,7 +13,6 @@ import (
 	"math/rand"
 	"sync"
 
-	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
@@ -25,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/google/uuid"
 	vimcrypto "github.com/vmware/govmomi/crypto"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/simulator"
@@ -81,7 +81,8 @@ func vmTests() {
 	)
 
 	BeforeEach(func() {
-		parentCtx = ctxop.WithContext(pkgcfg.NewContext())
+		parentCtx = pkgcfg.NewContextWithDefaultConfig()
+		parentCtx = ctxop.WithContext(parentCtx)
 		parentCtx = ovfcache.WithContext(parentCtx)
 		parentCtx = cource.WithContext(parentCtx)
 		pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {

--- a/pkg/vmconfig/crypto/crypto_reconciler_pre_test.go
+++ b/pkg/vmconfig/crypto/crypto_reconciler_pre_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Reconcile", Label(testlabels.Crypto), func() {
 		r = pkgcrypto.New()
 
 		vcsimCtx := builder.NewTestContextForVCSim(
-			ctxop.WithContext(pkgcfg.NewContext()), builder.VCSimTestConfig{})
+			ctxop.WithContext(pkgcfg.NewContextWithDefaultConfig()), builder.VCSimTestConfig{})
 		ctx = vcsimCtx
 		ctx = r.WithContext(ctx)
 		ctx = vmconfig.WithContext(ctx)


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

Only logout an existing VC client when the creds have actually changed. Previously, when the Infra Secret controller first starts it would have always logged the VC client if present. While this race has been present for a long time, the addition of the VM Watcher Service made this more likely now since that will usually create a VC client before the Infra secret has started.

Move the VC creds secret into a config param. Previously, the Infra Secret controller was hardcoding the secret name, while we'd otherwise obtain the name from the VMOP ConfigMap. This secret name hasn't changed since day 1 so just move it into our config.

In the fake VM provider, add gets of the config from the context since we now expect and require the config to be there.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

Effectively deprecating the VcCredsSecretName is what @akutz and I settled on for this

**Please add a release note if necessary**:

```release-note
VcCredsSecretName item in the VMOP ConfigMap is no longer referenced
```