### PR TITLE
🐛 Fix duplicate append of Image.Status fields

### DIFF
--- a/pkg/providers/vsphere/contentlibrary/content_library_utils.go
+++ b/pkg/providers/vsphere/contentlibrary/content_library_utils.go
@@ -65,6 +65,8 @@ func UpdateVmiWithOvfEnvelope(obj client.Object, ovfEnvelope ovf.Envelope) {
 
 	if ovfEnvelope.Disk != nil && len(ovfEnvelope.Disk.Disks) > 0 {
 		populateImageStatusFromOVFDiskSection(status, ovfEnvelope.Disk)
+	} else {
+		status.Disks = nil
 	}
 }
 
@@ -107,6 +109,7 @@ func initImageStatusFromOVFVirtualSystem(
 		}
 	}
 
+	imageStatus.OVFProperties = nil
 	for _, product := range ovfVirtualSystem.Product {
 		for _, prop := range product.Property {
 			// Only show user configurable properties
@@ -121,6 +124,7 @@ func initImageStatusFromOVFVirtualSystem(
 		}
 	}
 
+	imageStatus.VMwareSystemProperties = nil
 	ovfSystemProps := getVmwareSystemPropertiesFromOvf(ovfVirtualSystem)
 	if len(ovfSystemProps) > 0 {
 		for k, v := range ovfSystemProps {

--- a/pkg/providers/vsphere/contentlibrary/content_library_utils_test.go
+++ b/pkg/providers/vsphere/contentlibrary/content_library_utils_test.go
@@ -177,6 +177,16 @@ var _ = Describe("UpdateVmiWithOvfEnvelope", func() {
 		Expect(image.Status.Disks[1].Capacity.String()).To(Equal("10Gi"))
 	})
 
+	It("Repeated UpdateVmiWithOvfEnvelope should not duplicated items", func() {
+		Expect(image.Status.Disks).ToNot(BeEmpty())
+		Expect(image.Status.OVFProperties).ToNot(BeEmpty())
+		Expect(image.Status.VMwareSystemProperties).ToNot(BeEmpty())
+
+		savedImage := image.DeepCopy()
+		contentlibrary.UpdateVmiWithOvfEnvelope(image, ovfEnvelope)
+		Expect(image).To(Equal(savedImage))
+	})
+
 	Context("Image is V1Alpha1Compatible", func() {
 		BeforeEach(func() {
 			ovfEnvelope.VirtualSystem.VirtualHardware[0].ExtraConfig = append(ovfEnvelope.VirtualSystem.VirtualHardware[0].ExtraConfig,


### PR DESCRIPTION


**What does this PR do, and why is it needed?**

Clear arrays in the Image Status before updating them. This bug had been mostly masked by the short circuit check above but without clearing it the duplicate appends would eventually cause the object to exceed the allowed limit.

Partial cherry-pick of bb1c8810 since this branch still has the content version check.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #

**Are there any special notes for your reviewer**:

Sigh right branch this time.

**Please add a release note if necessary**:

```release-note
Prevent duplicate entries from appearing in the CVMI/VMI Status.
```