### PR TITLE
🌱 Return taskInfo from successful VM Reconfigure task

### DIFF
--- a/pkg/providers/vsphere/resources/vm.go
+++ b/pkg/providers/vsphere/resources/vm.go
@@ -98,7 +98,7 @@ func (vm *VirtualMachine) Reconfigure(
 		return taskInfo, fmt.Errorf("reconfigure VM task failed: %w", err)
 	}
 
-	return nil, nil
+	return taskInfo, nil
 }
 
 func (vm *VirtualMachine) GetProperties(ctx context.Context, properties []string) (*mo.VirtualMachine, error) {


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This can contain useful info even when the task succeeds. We currently only ever care about the taskInfo when we also care if the task fails, so this was otherwise working.

This resource VirtualMachine package is super old, and only ever tested indirectly, and my eventual plan is to either remove it entirely or move it functionality into the virtualmachine package so just quick fix this now so it doesn't trip up anybody else later.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

**Please add a release note if necessary**:


```release-note
NONE
```