### PR TITLE
⚠️ Remove UpdateConfigSpecFirmware()

### DIFF
--- a/pkg/providers/vsphere/session/session_vm_update.go
+++ b/pkg/providers/vsphere/session/session_vm_update.go
@@ -438,18 +438,6 @@ func UpdateConfigSpecGuestID(
 	}
 }
 
-func UpdateConfigSpecFirmware(
-	config *vimtypes.VirtualMachineConfigInfo,
-	configSpec *vimtypes.VirtualMachineConfigSpec,
-	vm *vmopv1.VirtualMachine) {
-
-	if val, ok := vm.Annotations[constants.FirmwareOverrideAnnotation]; ok {
-		if (val == "efi" || val == "bios") && config.Firmware != val {
-			configSpec.Firmware = val
-		}
-	}
-}
-
 // updateConfigSpec overlays the VM Class spec with the provided ConfigSpec to
 // form a desired ConfigSpec that will be used to reconfigure the VM.
 func updateConfigSpec(
@@ -475,7 +463,6 @@ func updateConfigSpec(
 	UpdateConfigSpecAnnotation(config, configSpec)
 	UpdateConfigSpecChangeBlockTracking(
 		vmCtx, config, configSpec, &updateArgs.ConfigSpec, vmCtx.VM.Spec)
-	UpdateConfigSpecFirmware(config, configSpec, vmCtx.VM)
 	UpdateConfigSpecGuestID(config, configSpec, vmCtx.VM.Spec.GuestID)
 
 	needsResize := false

--- a/pkg/providers/vsphere/session/session_vm_update_test.go
+++ b/pkg/providers/vsphere/session/session_vm_update_test.go
@@ -483,42 +483,6 @@ var _ = Describe("Update ConfigSpec", func() {
 		})
 	})
 
-	Context("Firmware", func() {
-		var vm *vmopv1.VirtualMachine
-
-		BeforeEach(func() {
-			vm = &vmopv1.VirtualMachine{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: make(map[string]string),
-				},
-			}
-			config.Firmware = "bios"
-		})
-
-		It("No firmware annotation", func() {
-			session.UpdateConfigSpecFirmware(config, configSpec, vm)
-			Expect(configSpec.Firmware).To(BeEmpty())
-		})
-
-		It("Set firmware annotation equal to current vm firmware", func() {
-			vm.Annotations[constants.FirmwareOverrideAnnotation] = config.Firmware
-			session.UpdateConfigSpecFirmware(config, configSpec, vm)
-			Expect(configSpec.Firmware).To(BeEmpty())
-		})
-
-		It("Set firmware annotation differing to current vm firmware", func() {
-			vm.Annotations[constants.FirmwareOverrideAnnotation] = "efi"
-			session.UpdateConfigSpecFirmware(config, configSpec, vm)
-			Expect(configSpec.Firmware).To(Equal("efi"))
-		})
-
-		It("Set firmware annotation to an invalid value", func() {
-			vm.Annotations[constants.FirmwareOverrideAnnotation] = "invalidfirmware"
-			session.UpdateConfigSpecFirmware(config, configSpec, vm)
-			Expect(configSpec.Firmware).To(BeEmpty())
-		})
-	})
-
 	Context("Ethernet Card Changes", func() {
 		var expectedList object.VirtualDeviceList
 		var currentList object.VirtualDeviceList

--- a/pkg/providers/vsphere/virtualmachine/configspec.go
+++ b/pkg/providers/vsphere/virtualmachine/configspec.go
@@ -78,8 +78,8 @@ func CreateConfigSpec(
 		configSpec.Version = hardwareVersion.String()
 	}
 
-	if val, ok := vmCtx.VM.Annotations[constants.FirmwareOverrideAnnotation]; ok && (val == "efi" || val == "bios") {
-		configSpec.Firmware = val
+	if firmware := vmCtx.VM.Annotations[constants.FirmwareOverrideAnnotation]; firmware == "efi" || firmware == "bios" {
+		configSpec.Firmware = firmware
 	} else if vmImageStatus.Firmware != "" {
 		// Use the image's firmware type if present.
 		// This is necessary until the vSphere UI can support creating VM Classes with


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

This is from the early days when we could only update the VM's Firmware - and most things for that matter - after the VM was created since Content Library did not support creating from a ConfigSpec. Since now CL supports that, and some time back I added support in CreateConfigSpec() for the firmware annotation, so the VM is just created with the specified firmware.

Changing the firmware of existing VM is generally not going to result in a booting VM, so at the moment I didn't implement similar support in resize. My preference would be to remove this.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #

**Are there any special notes for your reviewer**:

I want to start to reworking the entire VM create/update unit tests so they can be run with resize enabled and disabled. This is one the deltas. It is easy enough to add this as a dev ops resize overwrite if we want to keep things the same instead.

**Please add a release note if necessary**:

```release-note
If set, the VM vmoperator.vmware.com/firmware annotation is only used to create the VM.
```