### PR TITLE
🌱 Go 1.23.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,13 @@
 name: ci
 
+env:
+  # This value is usually commented out, allowing the go-version-file
+  # directive to pull the Go version from the go.mod file. However,
+  # sometimes we need to explicitly override the Go version, ex. CVEs,
+  # when it is not possible to update the go.mod version yet, ex. the
+  # internal builds do not yet support that version of Go.
+  GO_VERSION: 1.23.6
+
 on:
   pull_request:
     branches:
@@ -55,7 +63,8 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version-file: go.mod
+        go-version: ${{ env.GO_VERSION }}
+        go-version-file: 'go.mod'
         cache: true
         cache-dependency-path: '**/go.sum'
     - name: Run go mod tidy
@@ -81,7 +90,8 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version-file: go.mod
+        go-version: ${{ env.GO_VERSION }}
+        go-version-file: 'go.mod'
         cache: true
         cache-dependency-path: '**/go.sum'
     - name: Verify codegen
@@ -97,7 +107,8 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version-file: go.mod
+        go-version: ${{ env.GO_VERSION }}
+        go-version-file: 'go.mod'
         cache: true
         cache-dependency-path: '**/go.sum'
     - name: Create kind cluster
@@ -121,7 +132,8 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version-file: go.mod
+        go-version: ${{ env.GO_VERSION }}
+        go-version-file: 'go.mod'
         cache: true
         cache-dependency-path: '**/go.sum'
     - name: Setup the cache for golangci-lint
@@ -144,7 +156,8 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version-file: go.mod
+        go-version: ${{ env.GO_VERSION }}
+        go-version-file: 'go.mod'
         cache: true
         cache-dependency-path: '**/go.sum'
     - name: Setup the cache for govulncheck
@@ -166,7 +179,8 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version-file: go.mod
+        go-version: ${{ env.GO_VERSION }}
+        go-version-file: 'go.mod'
         cache: true
         cache-dependency-path: '**/go.sum'
     - name: Build Image
@@ -182,7 +196,8 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version-file: go.mod
+        go-version: ${{ env.GO_VERSION }}
+        go-version-file: 'go.mod'
         cache: true
         cache-dependency-path: '**/go.sum'
     - name: Test


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch updates go.mod to use Go 1.23.6 to account for https://pkg.go.dev/vuln/GO-2025-3447.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Go 1.23.6
```