### PR TITLE
🌱 (x-port vc-9.0.0) Go 1.23.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,12 @@
 name: ci
 
 env:
-  GO_VERSION: 1.23
+  # This value is usually commented out, allowing the go-version-file
+  # directive to pull the Go version from the go.mod file. However,
+  # sometimes we need to explicitly override the Go version, ex. CVEs,
+  # when it is not possible to update the go.mod version yet, ex. the
+  # internal builds do not yet support that version of Go.
+  GO_VERSION: 1.23.6
 
 on:
   pull_request:
@@ -59,6 +64,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GO_VERSION }}
+        go-version-file: 'go.mod'
         cache: true
         cache-dependency-path: '**/go.sum'
     - name: Run go mod tidy
@@ -85,6 +91,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GO_VERSION }}
+        go-version-file: 'go.mod'
         cache: true
         cache-dependency-path: '**/go.sum'
     - name: Verify codegen
@@ -101,6 +108,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GO_VERSION }}
+        go-version-file: 'go.mod'
         cache: true
         cache-dependency-path: '**/go.sum'
     - name: Create kind cluster
@@ -125,6 +133,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GO_VERSION }}
+        go-version-file: 'go.mod'
         cache: true
         cache-dependency-path: '**/go.sum'
     - name: Setup the cache for golangci-lint
@@ -148,6 +157,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GO_VERSION }}
+        go-version-file: 'go.mod'
         cache: true
         cache-dependency-path: '**/go.sum'
     - name: Setup the cache for govulncheck
@@ -170,6 +180,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GO_VERSION }}
+        go-version-file: 'go.mod'
         cache: true
         cache-dependency-path: '**/go.sum'
     - name: Build Image
@@ -186,6 +197,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GO_VERSION }}
+        go-version-file: 'go.mod'
         cache: true
         cache-dependency-path: '**/go.sum'
     - name: Test


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

Cross-port of #887 to release/vc-9.0.0.

This patch updates go.mod to use Go 1.23.6 to account for https://pkg.go.dev/vuln/GO-2025-3447.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Go 1.23.6
```