### PR TITLE
🌱 (x-port vc-9.0.0) Increase CPU and mem limit for controller-manager pod

### DIFF
--- a/config/wcp/vmoperator/cpu_resources_patch.yaml
+++ b/config/wcp/vmoperator/cpu_resources_patch.yaml
@@ -12,8 +12,8 @@ spec:
       - name: manager
         resources:
           limits:
-            cpu: 750m
-            memory: 550Mi
+            cpu: 1500m
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 75Mi


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Cross-port of https://github.com/vmware-tanzu/vm-operator/pull/869 to release/vc-9.0.0.

This change increases the CPU and memory limits for the controller manager pod in VM operator deployment to support the desired scale for VCF 9.0.

Testing Done:
- Generated the manifest and verified that the CPU and memory limits were updated:
```
          limits:
            cpu: 1500m
            memory: 1Gi
          requests:
            cpu: 100m
            memory: 75Mi
```


**Please add a release note if necessary**:

```release-note
Increase CPU and memory limits for the controller manager pod
```