### PR TITLE
🐛 (x-port vc-9.0.0) Always load the infra/zone controller

### DIFF
--- a/controllers/infra/controllers.go
+++ b/controllers/infra/controllers.go
@@ -38,10 +38,8 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 			return fmt.Errorf("failed to initialize validatingwebhookconfiguration webhook controller: %w", err)
 		}
 	}
-	if pkgcfg.FromContext(ctx).Features.WorkloadDomainIsolation {
-		if err := zone.AddToManager(ctx, mgr); err != nil {
-			return fmt.Errorf("failed to initialize infra zone controller: %w", err)
-		}
+	if err := zone.AddToManager(ctx, mgr); err != nil {
+		return fmt.Errorf("failed to initialize infra zone controller: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

Cross-port of https://github.com/vmware-tanzu/vm-operator/pull/886 to release/vc-9.0.0.

This patch fixes a bug where the zone controller was not loaded unless the Workload Domain Isolation capability was enabled. That logic is old and was supposed to be removed, but was missed.


<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Always load the zone controller
```