### PR TITLE
(x-port vc-9.0.0) 🐛 Handle invalid VC Session in GetVirtualMachine()

### DIFF
--- a/pkg/providers/vsphere/vmprovider.go
+++ b/pkg/providers/vsphere/vmprovider.go
@@ -243,7 +243,7 @@ func (vs *vSphereVMProvider) getVM(
 	client *vcclient.Client,
 	notFoundReturnErr bool) (*object.VirtualMachine, error) {
 
-	vcVM, err := vcenter.GetVirtualMachine(vmCtx, client.VimClient(), client.Datacenter(), client.Finder())
+	vcVM, err := vcenter.GetVirtualMachine(vmCtx, client.VimClient(), client.Datacenter())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

Cross-port of main https://github.com/vmware-tanzu/vm-operator/pull/866 to release/vc-9.0.0

If the VC session is invalid - like because the VC creds had rotated - GetVirtualMachine() could incorrectly return that the VM does not exist. If the lookup is being done to in response to the k8s VM being deleted, we would not actually delete the VC VM.

While here, improve how looking up by the MoID was done: we don't need to use the Finder instead just use the PropertyCollector. The old Finder lookup would always return an error if the MoID doesn't exist, which means that we could get stuck if the VM actually didn't exist. This would really only be an issue of we removed the VC VM but failed to remove our finalizer.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #

**Are there any special notes for your reviewer**:

**Please add a release note if necessary**:


```release-note
Fix an issue that when a VC session is invalid - like because it is logged out - a VM may not be actually deleted on VC.
```