### PR TITLE
🐛 Use sentinel not found error in GetVirtualMachine()

### DIFF
--- a/pkg/providers/vsphere/vcenter/getvm.go
+++ b/pkg/providers/vsphere/vcenter/getvm.go
@@ -18,11 +18,7 @@ import (
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 )
 
-type getVMNotFoundError struct{}
-
-func (n getVMNotFoundError) Error() string {
-	return "vm not found"
-}
+var errVMNotFound = errors.New("vm not found")
 
 // GetVirtualMachine gets the VM from VC, either by the Instance UUID, BIOS UUID, or MoID.
 func GetVirtualMachine(
@@ -34,7 +30,7 @@ func GetVirtualMachine(
 	if id := vmCtx.VM.UID; id != "" {
 		if vm, err := findVMByUUID(vmCtx, vimClient, datacenter, string(id), true); err == nil {
 			return vm, nil
-		} else if !errors.Is(err, getVMNotFoundError{}) {
+		} else if !errors.Is(err, errVMNotFound) {
 			return nil, err
 		}
 	}
@@ -43,7 +39,7 @@ func GetVirtualMachine(
 	if id := vmCtx.VM.Spec.BiosUUID; id != "" {
 		if vm, err := findVMByUUID(vmCtx, vimClient, datacenter, id, false); err == nil {
 			return vm, nil
-		} else if !errors.Is(err, getVMNotFoundError{}) {
+		} else if !errors.Is(err, errVMNotFound) {
 			return nil, err
 		}
 	}
@@ -52,7 +48,7 @@ func GetVirtualMachine(
 	if id := vmCtx.VM.Status.UniqueID; id != "" {
 		if vm, err := findVMByMoID(vmCtx, vimClient, id); err == nil {
 			return vm, nil
-		} else if !errors.Is(err, getVMNotFoundError{}) {
+		} else if !errors.Is(err, errVMNotFound) {
 			return nil, err
 		}
 	}
@@ -74,7 +70,7 @@ func findVMByMoID(
 	if err := property.DefaultCollector(vimClient).RetrieveOne(vmCtx, moRef, []string{"name"}, &vm); err != nil {
 		var f *vimtypes.ManagedObjectNotFound
 		if _, ok := fault.As(err, &f); ok {
-			return nil, getVMNotFoundError{}
+			return nil, errVMNotFound
 		}
 		return nil, fmt.Errorf("error retreiving VM via MoID: %w", err)
 	}
@@ -94,7 +90,7 @@ func findVMByUUID(
 	if err != nil {
 		return nil, fmt.Errorf("error finding VM by UUID %q: %w", uuid, err)
 	} else if ref == nil {
-		return nil, getVMNotFoundError{}
+		return nil, errVMNotFound
 	}
 
 	vm, ok := ref.(*object.VirtualMachine)


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

Properly use errors.Is() instead of As(), as Is() is not just a type comparison (ie, IsA[]()). I knew that but too easy to forget this. The errors.As() usage still worked correct because getVMNotFoundError did not contain any fields, so the underlying == still would match.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:


```release-note
NONE
```