### PR TITLE
🌱 Use UnsafeDisableDeepCopy when possible

### DIFF
--- a/controllers/virtualmachine/storagepolicyusage/storagepolicyusage_controller.go
+++ b/controllers/virtualmachine/storagepolicyusage/storagepolicyusage_controller.go
@@ -117,7 +117,18 @@ func (r *Reconciler) ReconcileNormal(
 	if err := r.Client.List(
 		ctx,
 		&list,
-		client.InNamespace(namespace)); err != nil {
+		client.InNamespace(namespace),
+		//
+		// !!! WARNING !!!
+		//
+		// The use of the UnsafeDisableDeepCopy option improves
+		// performance by skipping a CPU-intensive operation.
+		// However, it also means any writes to the returned
+		// objects will directly impact the cache. Therefore,
+		// please be aware of this when doing anything with the
+		// object(s) that are the result of this operation.
+		//
+		client.UnsafeDisableDeepCopy); err != nil {
 
 		return fmt.Errorf(
 			"failed to list VMs in namespace %s: %w", namespace, err)


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch updates many K8s client.List calls to use the UnsafeDisableDeepCopy option where it is possible to do so. This is done with caution, and only in places where the result is self-contained and there is little chance of mutating the objects from the cache. There is also a warning placed on every location where this option is used.

This patch improves performance.

Credit to @bryanv for thinking of this.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Use UnsafeDisableDeepCopy when listing objects to improve performance where safe to do so.
```