### PR TITLE
🌱 Only reconcile connected VMs

### DIFF
--- a/pkg/util/vsphere/watcher/watcher.go
+++ b/pkg/util/vsphere/watcher/watcher.go
@@ -34,6 +34,7 @@ func DefaultWatchedPropertyPaths() []string {
 		"summary.config.name",
 		"summary.guest",
 		"summary.overallStatus",
+		"summary.runtime.connectionState",
 		"summary.runtime.host",
 		"summary.runtime.powerState",
 		"summary.storage.timestamp",


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch ensures only connected VMs are reconciled. If a VM is not in a connected state, it will not be requeued for reconciliation. Instead the watcher service will enqueue the VM for reconciliation once the VM's connection state has changed.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Reconcile VMs with connectionState == connected or reconcile when it changes to connected
```