### PR TITLE
🌱 Add sub-modules in go lint and fix reported issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -226,14 +226,17 @@ issues:
     - staticcheck
     text: "^SA1019: [^.]+.WaitForResult is deprecated: Please use WaitForResultEx instead."
   - linters:
+    - staticcheck
+    text: "^SA1019: .*TCPSocket is deprecated"
+  - linters:
     - revive
     text: ".*should have (a package )?comment.*"
   - linters:
     - revive
     text: "^exported: comment on exported const"
   - linters:
-    - staticcheck
-    text: "^SA1019: .*TCPSocket is deprecated"
+    - revive
+    text: "unused-parameter: parameter"
   - linters:
     - govet
     text: "printf: non-constant format string in call"
@@ -254,6 +257,12 @@ issues:
     linters:
     - gosec
     - depguard
-  - linters:
-    - revive
-    text: "unused-parameter: parameter"
+  # Ignore underscores in conversion function names as required by K8s API.
+  - path: "_conversion.go"
+    text: ".*use underscores in Go names"
+  # Ignore unsafe.Pointer() calls used in conversion functions.
+  - path: "_conversion.go"
+    text: "G103: Use of unsafe calls should be audited"
+  # Ignore different receiver names in conversion functions (e.g. src vs dst).
+  - path: "_conversion.go"
+    text: ".*receiver name"

--- a/api/utilconversion/conversion_fuzz.go
+++ b/api/utilconversion/conversion_fuzz.go
@@ -16,6 +16,7 @@ package utilconversion
 import (
 	"math/rand"
 
+	//nolint:depguard
 	"github.com/onsi/gomega"
 
 	"github.com/google/go-cmp/cmp"

--- a/api/v1alpha1/conversion_test.go
+++ b/api/v1alpha1/conversion_test.go
@@ -289,7 +289,6 @@ func overrideVirtualMachineImageFieldsFuncs(codecs runtimeserializer.CodecFactor
 			overrideConditionsSeverity(imageStatus.Conditions)
 
 			// Do not exist in nextver.
-			//imageStatus.ContentLibraryRef = nil
 			imageStatus.ImageSupported = nil
 
 			// These are deprecated.

--- a/api/v1alpha1/virtualmachineimage_conversion.go
+++ b/api/v1alpha1/virtualmachineimage_conversion.go
@@ -28,7 +28,7 @@ func Convert_v1alpha4_VirtualMachineImageOSInfo_To_v1alpha1_VirtualMachineImageO
 }
 
 func convert_v1alpha1_VirtualMachineImageOSInfo_To_v1alpha4_VirtualMachineImageOSInfo(
-	in *VirtualMachineImageOSInfo, out *vmopv1.VirtualMachineImageOSInfo, s apiconversion.Scope) error {
+	in *VirtualMachineImageOSInfo, out *vmopv1.VirtualMachineImageOSInfo, _ apiconversion.Scope) error {
 
 	out.Type = in.Type
 	out.Version = in.Version
@@ -37,7 +37,7 @@ func convert_v1alpha1_VirtualMachineImageOSInfo_To_v1alpha4_VirtualMachineImageO
 }
 
 func convert_v1alpha4_VirtualMachineImage_OVFProperties_To_v1alpha1_VirtualMachineImage_OVFEnv(
-	in []vmopv1.OVFProperty, out *map[string]OvfProperty, s apiconversion.Scope) error {
+	in []vmopv1.OVFProperty, out *map[string]OvfProperty, _ apiconversion.Scope) error {
 
 	if in != nil {
 		*out = map[string]OvfProperty{}
@@ -56,7 +56,7 @@ func convert_v1alpha4_VirtualMachineImage_OVFProperties_To_v1alpha1_VirtualMachi
 }
 
 func convert_v1alpha1_VirtualMachineImage_OVFEnv_To_v1alpha4_VirtualMachineImage_OVFProperties(
-	in map[string]OvfProperty, out *[]vmopv1.OVFProperty, s apiconversion.Scope) error {
+	in map[string]OvfProperty, out *[]vmopv1.OVFProperty, _ apiconversion.Scope) error {
 
 	if in != nil {
 		*out = make([]vmopv1.OVFProperty, 0, len(in))
@@ -365,7 +365,7 @@ func convert_v1alpha1_VirtualMachineImageAnnotations_To_v1alpha4_VirtualMachineI
 
 	// remove any system annotations in nextver object
 	if *dstAnnotations != nil {
-		for k, _ := range *dstAnnotations {
+		for k := range *dstAnnotations {
 			if strings.HasPrefix(k, "vmware-system") {
 				delete(*dstAnnotations, k)
 			}

--- a/api/v1alpha2/doc.go
+++ b/api/v1alpha2/doc.go
@@ -6,4 +6,5 @@
 // +kubebuilder:object:generate=true
 // +groupName=vmoperator.vmware.com
 // +k8s:conversion-gen=github.com/vmware-tanzu/vm-operator/api/v1alpha4
+
 package v1alpha2

--- a/api/v1alpha2/sysprep/conversion/v1alpha2/sysprep_conversion.go
+++ b/api/v1alpha2/sysprep/conversion/v1alpha2/sysprep_conversion.go
@@ -14,6 +14,8 @@ import (
 	vmopv1sysprep "github.com/vmware-tanzu/vm-operator/api/v1alpha4/sysprep"
 )
 
+// Convert_sysprep_Sysprep_To_sysprep_Sysprep converts the Sysprep from v1alpha2
+// to v1alpha4.
 // Please see https://github.com/kubernetes/code-generator/issues/172 for why
 // this function exists in this directory structure.
 func Convert_sysprep_Sysprep_To_sysprep_Sysprep(

--- a/api/v1alpha2/sysprep/conversion/v1alpha4/sysprep_conversion.go
+++ b/api/v1alpha2/sysprep/conversion/v1alpha4/sysprep_conversion.go
@@ -13,6 +13,8 @@ import (
 	vmopv1sysprep "github.com/vmware-tanzu/vm-operator/api/v1alpha4/sysprep"
 )
 
+// Convert_sysprep_Sysprep_To_sysprep_Sysprep converts the Sysprep from v1alpha4
+// to v1alpha2.
 // Please see https://github.com/kubernetes/code-generator/issues/172 for why
 // this function exists in this directory structure.
 func Convert_sysprep_Sysprep_To_sysprep_Sysprep(

--- a/api/v1alpha2/sysprep/sysprep.go
+++ b/api/v1alpha2/sysprep/sysprep.go
@@ -102,7 +102,7 @@ type GUIUnattended struct {
 	TimeZone int32 `json:"timeZone,omitempty"`
 }
 
-// PasswordSecretKeySelector references the password value from a Secret resource
+// PasswordSecretKeySelector references the password value from a Secret resource.
 type PasswordSecretKeySelector struct {
 	// Name is the name of the secret.
 	Name string `json:"name"`
@@ -148,7 +148,7 @@ type Identification struct {
 	JoinWorkgroup string `json:"joinWorkgroup,omitempty"`
 }
 
-// DomainPasswordSecretKeySelector references the password value from a Secret resource
+// DomainPasswordSecretKeySelector references the password value from a Secret resource.
 type DomainPasswordSecretKeySelector struct {
 	// Name is the name of the secret.
 	Name string `json:"name"`
@@ -214,7 +214,7 @@ type UserData struct {
 	ProductID *ProductIDSecretKeySelector `json:"productID,omitempty"`
 }
 
-// ProductIDSecretKeySelector references the ProductID value from a Secret resource
+// ProductIDSecretKeySelector references the ProductID value from a Secret resource.
 type ProductIDSecretKeySelector struct {
 	// Name is the name of the secret.
 	Name string `json:"name"`

--- a/api/v1alpha2/virtualmachine_readiness_types.go
+++ b/api/v1alpha2/virtualmachine_readiness_types.go
@@ -79,7 +79,7 @@ type TCPSocketAction struct {
 // GuestHeartbeatStatus is the guest heartbeat status.
 type GuestHeartbeatStatus string
 
-// See govmomi.vim25.types.ManagedEntityStatus
+// See govmomi.vim25.types.ManagedEntityStatus.
 const (
 	// GrayHeartbeatStatus means VMware Tools are not installed or not running.
 	GrayHeartbeatStatus GuestHeartbeatStatus = "gray"

--- a/api/v1alpha3/cloudinit/cloudconfig.go
+++ b/api/v1alpha3/cloudinit/cloudconfig.go
@@ -9,7 +9,7 @@ package cloudinit
 import (
 	"encoding/json"
 
-	vmopv1common "github.com/vmware-tanzu/vm-operator/api/v1alpha3/common"
+	vmopv1a3common "github.com/vmware-tanzu/vm-operator/api/v1alpha3/common"
 )
 
 // CloudConfig is the VM Operator API subset of a Cloud-Init CloudConfig and
@@ -101,7 +101,7 @@ type User struct {
 
 	// HashedPasswd is a hash of the user's password that will be applied even
 	// if the specified user already exists.
-	HashedPasswd *vmopv1common.SecretKeySelector `json:"hashed_passwd,omitempty"`
+	HashedPasswd *vmopv1a3common.SecretKeySelector `json:"hashed_passwd,omitempty"`
 
 	// +optional
 
@@ -157,7 +157,7 @@ type User struct {
 	// Passwd is a hash of the user's password that will be applied only to
 	// a newly created user. To apply a new, hashed password to an existing user
 	// please use HashedPasswd instead.
-	Passwd *vmopv1common.SecretKeySelector `json:"passwd,omitempty"`
+	Passwd *vmopv1a3common.SecretKeySelector `json:"passwd,omitempty"`
 
 	// +optional
 

--- a/api/v1alpha3/common/conversion/v1alpha3/common_conversion.go
+++ b/api/v1alpha3/common/conversion/v1alpha3/common_conversion.go
@@ -2,7 +2,7 @@
 // The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: Apache-2.0
 
-package v1alpha2
+package v1alpha3
 
 import (
 	"maps"
@@ -13,6 +13,8 @@ import (
 	vmopv1common "github.com/vmware-tanzu/vm-operator/api/v1alpha4/common"
 )
 
+// Convert_common_ObjectMeta_To_common_ObjectMeta converts the ObjectMeta from
+// v1alpha3 to v1alpha4.
 // Please see https://github.com/kubernetes/code-generator/issues/172 for why
 // this function exists in this directory structure.
 func Convert_common_ObjectMeta_To_common_ObjectMeta(

--- a/api/v1alpha3/common/conversion/v1alpha4/common_conversion.go
+++ b/api/v1alpha3/common/conversion/v1alpha4/common_conversion.go
@@ -2,7 +2,7 @@
 // The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: Apache-2.0
 
-package v1alpha2
+package v1alpha4
 
 import (
 	"maps"
@@ -13,6 +13,8 @@ import (
 	vmopv1common "github.com/vmware-tanzu/vm-operator/api/v1alpha4/common"
 )
 
+// Convert_common_ObjectMeta_To_common_ObjectMeta converts the ObjectMeta from
+// v1alpha4 to v1alpha3.
 // Please see https://github.com/kubernetes/code-generator/issues/172 for why
 // this function exists in this directory structure.
 func Convert_common_ObjectMeta_To_common_ObjectMeta(

--- a/api/v1alpha3/conversion_test.go
+++ b/api/v1alpha3/conversion_test.go
@@ -280,7 +280,3 @@ func overrideVirtualMachineImageFieldsFuncs(codecs runtimeserializer.CodecFactor
 		},
 	}
 }
-
-func ptrOf[T any](v T) *T {
-	return &v
-}

--- a/api/v1alpha3/sysprep/sysprep.go
+++ b/api/v1alpha3/sysprep/sysprep.go
@@ -109,7 +109,7 @@ type GUIUnattended struct {
 	TimeZone int32 `json:"timeZone"`
 }
 
-// PasswordSecretKeySelector references the password value from a Secret resource
+// PasswordSecretKeySelector references the password value from a Secret resource.
 type PasswordSecretKeySelector struct {
 	// Name is the name of the secret.
 	Name string `json:"name"`
@@ -150,7 +150,7 @@ type Identification struct {
 	JoinWorkgroup string `json:"joinWorkgroup,omitempty"`
 }
 
-// DomainPasswordSecretKeySelector references the password value from a Secret resource
+// DomainPasswordSecretKeySelector references the password value from a Secret resource.
 type DomainPasswordSecretKeySelector struct {
 	// Name is the name of the secret.
 	Name string `json:"name"`
@@ -217,7 +217,7 @@ type UserData struct {
 	ProductID *ProductIDSecretKeySelector `json:"productID,omitempty"`
 }
 
-// ProductIDSecretKeySelector references the ProductID value from a Secret resource
+// ProductIDSecretKeySelector references the ProductID value from a Secret resource.
 type ProductIDSecretKeySelector struct {
 	// Name is the name of the secret.
 	Name string `json:"name"`

--- a/api/v1alpha3/virtualmachine_bootstrap_types.go
+++ b/api/v1alpha3/virtualmachine_bootstrap_types.go
@@ -5,9 +5,9 @@
 package v1alpha3
 
 import (
-	vmopv1cloudinit "github.com/vmware-tanzu/vm-operator/api/v1alpha3/cloudinit"
-	vmopv1common "github.com/vmware-tanzu/vm-operator/api/v1alpha3/common"
-	vmopv1sysprep "github.com/vmware-tanzu/vm-operator/api/v1alpha3/sysprep"
+	vmopv1a3cloudinit "github.com/vmware-tanzu/vm-operator/api/v1alpha3/cloudinit"
+	vmopv1a3common "github.com/vmware-tanzu/vm-operator/api/v1alpha3/common"
+	vmopv1a3sysprep "github.com/vmware-tanzu/vm-operator/api/v1alpha3/sysprep"
 )
 
 // VirtualMachineBootstrapSpec defines the desired state of a VM's bootstrap
@@ -98,7 +98,7 @@ type VirtualMachineBootstrapCloudInitSpec struct {
 	// bootstrap the VM.
 	//
 	// Please note this field and RawCloudConfig are mutually exclusive.
-	CloudConfig *vmopv1cloudinit.CloudConfig `json:"cloudConfig,omitempty"`
+	CloudConfig *vmopv1a3cloudinit.CloudConfig `json:"cloudConfig,omitempty"`
 
 	// +optional
 
@@ -109,7 +109,7 @@ type VirtualMachineBootstrapCloudInitSpec struct {
 	// base64-encoded, or gzipped and base64-encoded.
 	//
 	// Please note this field and CloudConfig are mutually exclusive.
-	RawCloudConfig *vmopv1common.SecretKeySelector `json:"rawCloudConfig,omitempty"`
+	RawCloudConfig *vmopv1a3common.SecretKeySelector `json:"rawCloudConfig,omitempty"`
 
 	// +optional
 
@@ -174,7 +174,7 @@ type VirtualMachineBootstrapSysprepSpec struct {
 	// https://technet.microsoft.com/en-us/library/cc771830(v=ws.10).aspx.
 	//
 	// Please note this field and RawSysprep are mutually exclusive.
-	Sysprep *vmopv1sysprep.Sysprep `json:"sysprep,omitempty"`
+	Sysprep *vmopv1a3sysprep.Sysprep `json:"sysprep,omitempty"`
 
 	// +optional
 
@@ -185,7 +185,7 @@ type VirtualMachineBootstrapSysprepSpec struct {
 	// or gzipped and base64-encoded.
 	//
 	// Please note this field and Sysprep are mutually exclusive.
-	RawSysprep *vmopv1common.SecretKeySelector `json:"rawSysprep,omitempty"`
+	RawSysprep *vmopv1a3common.SecretKeySelector `json:"rawSysprep,omitempty"`
 }
 
 // VirtualMachineBootstrapVAppConfigSpec describes the vApp configuration
@@ -198,7 +198,7 @@ type VirtualMachineBootstrapVAppConfigSpec struct {
 	// Properties is a list of vApp/OVF property key/value pairs.
 	//
 	// Please note this field and RawProperties are mutually exclusive.
-	Properties []vmopv1common.KeyValueOrSecretKeySelectorPair `json:"properties,omitempty"`
+	Properties []vmopv1a3common.KeyValueOrSecretKeySelectorPair `json:"properties,omitempty"`
 
 	// +optional
 

--- a/api/v1alpha3/virtualmachine_network_types.go
+++ b/api/v1alpha3/virtualmachine_network_types.go
@@ -7,7 +7,7 @@ package v1alpha3
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	vmopv1common "github.com/vmware-tanzu/vm-operator/api/v1alpha3/common"
+	vmopv1a3common "github.com/vmware-tanzu/vm-operator/api/v1alpha3/common"
 )
 
 // VirtualMachineNetworkRouteSpec defines a static route for a guest.
@@ -43,7 +43,7 @@ type VirtualMachineNetworkInterfaceSpec struct {
 	//
 	// If no network is provided, then this interface will be connected to the
 	// Namespace's default network.
-	Network *vmopv1common.PartialObjectRef `json:"network,omitempty"`
+	Network *vmopv1a3common.PartialObjectRef `json:"network,omitempty"`
 
 	// +optional
 	// +kubebuilder:validation:Pattern=^\w\w+$
@@ -383,7 +383,7 @@ type VirtualMachineNetworkDHCPOptionsStatus struct {
 	// reported per interface would be:
 	// key='1', value='prepend domain-name-servers 192.0.2.1;'
 	// key='2', value='require subnet-mask, domain-name-servers;'.
-	Config []vmopv1common.KeyValuePair `json:"config,omitempty"`
+	Config []vmopv1a3common.KeyValuePair `json:"config,omitempty"`
 
 	// +optional
 
@@ -655,7 +655,7 @@ type VirtualMachineNetworkIPStackStatus struct {
 	// 'key=value' as provided by the underlying provider. For example, on
 	// Linux and/or BSD, the systcl -a output would be reported as:
 	// key='5', value='net.ipv4.tcp_keepalive_time = 7200'.
-	KernelConfig []vmopv1common.KeyValuePair `json:"kernelConfig,omitempty"`
+	KernelConfig []vmopv1a3common.KeyValuePair `json:"kernelConfig,omitempty"`
 }
 
 // VirtualMachineNetworkStatus defines the observed state of a VM's

--- a/api/v1alpha3/virtualmachine_readiness_types.go
+++ b/api/v1alpha3/virtualmachine_readiness_types.go
@@ -84,7 +84,7 @@ type TCPSocketAction struct {
 // GuestHeartbeatStatus is the guest heartbeat status.
 type GuestHeartbeatStatus string
 
-// See govmomi.vim25.types.ManagedEntityStatus
+// See govmomi.vim25.types.ManagedEntityStatus.
 const (
 	// GrayHeartbeatStatus means VMware Tools are not installed or not running.
 	GrayHeartbeatStatus GuestHeartbeatStatus = "gray"

--- a/api/v1alpha3/virtualmachine_types.go
+++ b/api/v1alpha3/virtualmachine_types.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	vmopv1common "github.com/vmware-tanzu/vm-operator/api/v1alpha3/common"
+	vmopv1a3common "github.com/vmware-tanzu/vm-operator/api/v1alpha3/common"
 )
 
 const (
@@ -792,7 +792,7 @@ type VirtualMachineStatus struct {
 
 	// Class is a reference to the VirtualMachineClass resource used to deploy
 	// this VM.
-	Class *vmopv1common.LocalObjectRef `json:"class,omitempty"`
+	Class *vmopv1a3common.LocalObjectRef `json:"class,omitempty"`
 
 	// +optional
 

--- a/api/v1alpha3/virtualmachineimage_types.go
+++ b/api/v1alpha3/virtualmachineimage_types.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	vmopv1common "github.com/vmware-tanzu/vm-operator/api/v1alpha3/common"
+	vmopv1a3common "github.com/vmware-tanzu/vm-operator/api/v1alpha3/common"
 )
 
 const (
@@ -152,7 +152,7 @@ type VirtualMachineImageSpec struct {
 
 	// ProviderRef is a reference to the resource that contains the source of
 	// this image's information.
-	ProviderRef *vmopv1common.LocalObjectRef `json:"providerRef,omitempty"`
+	ProviderRef *vmopv1a3common.LocalObjectRef `json:"providerRef,omitempty"`
 }
 
 // VirtualMachineImageStatus defines the observed state of VirtualMachineImage.
@@ -213,7 +213,7 @@ type VirtualMachineImageStatus struct {
 
 	// VMwareSystemProperties describes the observed VMware system properties defined for
 	// this image.
-	VMwareSystemProperties []vmopv1common.KeyValuePair `json:"vmwareSystemProperties,omitempty"`
+	VMwareSystemProperties []vmopv1a3common.KeyValuePair `json:"vmwareSystemProperties,omitempty"`
 
 	// +optional
 

--- a/api/v1alpha3/virtualmachineimagecache_conversion.go
+++ b/api/v1alpha3/virtualmachineimagecache_conversion.go
@@ -11,15 +11,15 @@ import (
 )
 
 // ConvertTo converts this VirtualMachineImageCache to the Hub version.
-func (src *VirtualMachineImageCache) ConvertTo(dstRaw ctrlconversion.Hub) error {
+func (i *VirtualMachineImageCache) ConvertTo(dstRaw ctrlconversion.Hub) error {
 	dst := dstRaw.(*vmopv1.VirtualMachineImageCache)
-	return Convert_v1alpha3_VirtualMachineImageCache_To_v1alpha4_VirtualMachineImageCache(src, dst, nil)
+	return Convert_v1alpha3_VirtualMachineImageCache_To_v1alpha4_VirtualMachineImageCache(i, dst, nil)
 }
 
 // ConvertFrom converts the hub version to this VirtualMachineImageCache.
-func (dst *VirtualMachineImageCache) ConvertFrom(srcRaw ctrlconversion.Hub) error {
+func (i *VirtualMachineImageCache) ConvertFrom(srcRaw ctrlconversion.Hub) error {
 	src := srcRaw.(*vmopv1.VirtualMachineImageCache)
-	return Convert_v1alpha4_VirtualMachineImageCache_To_v1alpha3_VirtualMachineImageCache(src, dst, nil)
+	return Convert_v1alpha4_VirtualMachineImageCache_To_v1alpha3_VirtualMachineImageCache(src, i, nil)
 }
 
 // ConvertTo converts this VirtualMachineImageCacheList to the Hub version.

--- a/api/v1alpha3/virtualmachineimagecache_types.go
+++ b/api/v1alpha3/virtualmachineimagecache_types.go
@@ -59,18 +59,18 @@ type VirtualMachineImageCacheSpec struct {
 // cache object's spec.locations list if such a location does not already exist.
 // Calling this function for a pair of datacenterID and datastoreID values that
 // already exist in the object's spec.locations list has no effect.
-func (o *VirtualMachineImageCache) AddLocation(
+func (i *VirtualMachineImageCache) AddLocation(
 	datacenterID,
 	datastoreID string) {
 
-	for i := range o.Spec.Locations {
-		l := o.Spec.Locations[i]
+	for idx := range i.Spec.Locations {
+		l := i.Spec.Locations[idx]
 		if l.DatacenterID == datacenterID && l.DatastoreID == datastoreID {
 			return
 		}
 	}
-	o.Spec.Locations = append(
-		o.Spec.Locations,
+	i.Spec.Locations = append(
+		i.Spec.Locations,
 		VirtualMachineImageCacheLocationSpec{
 			DatacenterID: datacenterID,
 			DatastoreID:  datastoreID,

--- a/api/v1alpha3/virtualmachinereplicaset_types.go
+++ b/api/v1alpha3/virtualmachinereplicaset_types.go
@@ -5,8 +5,9 @@
 package v1alpha3
 
 import (
-	vmopv1common "github.com/vmware-tanzu/vm-operator/api/v1alpha3/common"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	vmopv1a3common "github.com/vmware-tanzu/vm-operator/api/v1alpha3/common"
 )
 
 const (
@@ -55,7 +56,7 @@ type VirtualMachineTemplateSpec struct {
 	//
 	// ObjectMeta contains the desired Labels and Annotations that must be
 	// applied to each replica virtual machine.
-	vmopv1common.ObjectMeta `json:"metadata,omitempty"`
+	vmopv1a3common.ObjectMeta `json:"metadata,omitempty"`
 
 	// +optional
 	//
@@ -147,7 +148,7 @@ func (rs *VirtualMachineReplicaSet) SetConditions(conditions []metav1.Condition)
 // +kubebuilder:printcolumn:name="Ready",type="integer",JSONPath=".status.readyReplicas",description="Total number of ready virtual machines targeted by this VirtualMachineReplicaSet"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of VirtualMachineReplicaSet"
 
-// VirtualMachineReplicaSet is the schema for the virtualmachinereplicasets API
+// VirtualMachineReplicaSet is the schema for the virtualmachinereplicasets API.
 type VirtualMachineReplicaSet struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -158,7 +159,7 @@ type VirtualMachineReplicaSet struct {
 
 // +kubebuilder:object:root=true
 
-// VirtualMachineList contains a list of VirtualMachine.
+// VirtualMachineReplicaSetList contains a list of VirtualMachine.
 type VirtualMachineReplicaSetList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/v1alpha4/groupversion_info.go
+++ b/api/v1alpha4/groupversion_info.go
@@ -24,9 +24,6 @@ var (
 	AddToScheme = schemeBuilder.AddToScheme
 
 	objectTypes = []runtime.Object{}
-
-	// localSchemeBuilder is used for type conversions.
-	localSchemeBuilder = schemeBuilder
 )
 
 func addKnownTypes(scheme *runtime.Scheme) error {

--- a/api/v1alpha4/sysprep/sysprep.go
+++ b/api/v1alpha4/sysprep/sysprep.go
@@ -109,7 +109,7 @@ type GUIUnattended struct {
 	TimeZone int32 `json:"timeZone"`
 }
 
-// PasswordSecretKeySelector references the password value from a Secret resource
+// PasswordSecretKeySelector references the password value from a Secret resource.
 type PasswordSecretKeySelector struct {
 	// Name is the name of the secret.
 	Name string `json:"name"`
@@ -150,7 +150,7 @@ type Identification struct {
 	JoinWorkgroup string `json:"joinWorkgroup,omitempty"`
 }
 
-// DomainPasswordSecretKeySelector references the password value from a Secret resource
+// DomainPasswordSecretKeySelector references the password value from a Secret resource.
 type DomainPasswordSecretKeySelector struct {
 	// Name is the name of the secret.
 	Name string `json:"name"`
@@ -217,7 +217,7 @@ type UserData struct {
 	ProductID *ProductIDSecretKeySelector `json:"productID,omitempty"`
 }
 
-// ProductIDSecretKeySelector references the ProductID value from a Secret resource
+// ProductIDSecretKeySelector references the ProductID value from a Secret resource.
 type ProductIDSecretKeySelector struct {
 	// Name is the name of the secret.
 	Name string `json:"name"`

--- a/api/v1alpha4/virtualmachine_readiness_types.go
+++ b/api/v1alpha4/virtualmachine_readiness_types.go
@@ -84,7 +84,7 @@ type TCPSocketAction struct {
 // GuestHeartbeatStatus is the guest heartbeat status.
 type GuestHeartbeatStatus string
 
-// See govmomi.vim25.types.ManagedEntityStatus
+// See govmomi.vim25.types.ManagedEntityStatus.
 const (
 	// GrayHeartbeatStatus means VMware Tools are not installed or not running.
 	GrayHeartbeatStatus GuestHeartbeatStatus = "gray"

--- a/api/v1alpha4/virtualmachineimagecache_types.go
+++ b/api/v1alpha4/virtualmachineimagecache_types.go
@@ -59,18 +59,18 @@ type VirtualMachineImageCacheSpec struct {
 // cache object's spec.locations list if such a location does not already exist.
 // Calling this function for a pair of datacenterID and datastoreID values that
 // already exist in the object's spec.locations list has no effect.
-func (o *VirtualMachineImageCache) AddLocation(
+func (i *VirtualMachineImageCache) AddLocation(
 	datacenterID,
 	datastoreID string) {
 
-	for i := range o.Spec.Locations {
-		l := o.Spec.Locations[i]
+	for idx := range i.Spec.Locations {
+		l := i.Spec.Locations[idx]
 		if l.DatacenterID == datacenterID && l.DatastoreID == datastoreID {
 			return
 		}
 	}
-	o.Spec.Locations = append(
-		o.Spec.Locations,
+	i.Spec.Locations = append(
+		i.Spec.Locations,
 		VirtualMachineImageCacheLocationSpec{
 			DatacenterID: datacenterID,
 			DatastoreID:  datastoreID,

--- a/api/v1alpha4/virtualmachinereplicaset_types.go
+++ b/api/v1alpha4/virtualmachinereplicaset_types.go
@@ -5,8 +5,9 @@
 package v1alpha4
 
 import (
-	vmopv1common "github.com/vmware-tanzu/vm-operator/api/v1alpha4/common"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	vmopv1common "github.com/vmware-tanzu/vm-operator/api/v1alpha4/common"
 )
 
 const (
@@ -148,7 +149,7 @@ func (rs *VirtualMachineReplicaSet) SetConditions(conditions []metav1.Condition)
 // +kubebuilder:printcolumn:name="Ready",type="integer",JSONPath=".status.readyReplicas",description="Total number of ready virtual machines targeted by this VirtualMachineReplicaSet"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of VirtualMachineReplicaSet"
 
-// VirtualMachineReplicaSet is the schema for the virtualmachinereplicasets API
+// VirtualMachineReplicaSet is the schema for the virtualmachinereplicasets API.
 type VirtualMachineReplicaSet struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -159,7 +160,7 @@ type VirtualMachineReplicaSet struct {
 
 // +kubebuilder:object:root=true
 
-// VirtualMachineList contains a list of VirtualMachine.
+// VirtualMachineReplicaSetList contains a list of VirtualMachineReplicaSet.
 type VirtualMachineReplicaSetList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachinereplicasets.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachinereplicasets.yaml
@@ -35,7 +35,7 @@ spec:
     schema:
       openAPIV3Schema:
         description: VirtualMachineReplicaSet is the schema for the virtualmachinereplicasets
-          API
+          API.
         properties:
           apiVersion:
             description: |-
@@ -1944,7 +1944,7 @@ spec:
     schema:
       openAPIV3Schema:
         description: VirtualMachineReplicaSet is the schema for the virtualmachinereplicasets
-          API
+          API.
         properties:
           apiVersion:
             description: |-

--- a/docs/ref/api/v1alpha3.md
+++ b/docs/ref/api/v1alpha3.md
@@ -115,7 +115,7 @@ VirtualMachine as a VirtualMachineImage to an image registry.
 
 
 
-VirtualMachineReplicaSet is the schema for the virtualmachinereplicasets API
+VirtualMachineReplicaSet is the schema for the virtualmachinereplicasets API.
 
 
 

--- a/docs/ref/api/v1alpha4.md
+++ b/docs/ref/api/v1alpha4.md
@@ -115,7 +115,7 @@ VirtualMachine as a VirtualMachineImage to an image registry.
 
 
 
-VirtualMachineReplicaSet is the schema for the virtualmachinereplicasets API
+VirtualMachineReplicaSet is the schema for the virtualmachinereplicasets API.
 
 
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Currently `golangci-lint` doesn't support multiple modules as reported in https://github.com/golangci/golangci-lint/issues/828, so our `api/` and other submodules are never being linted.

This PR addresses this by updating the `lint-go` Makefile target to run the `golangci-lint` command in each module.

The `.golangci.yml` is updated to ignore some of the rules specific to `_conversion.go` files by using the `path:` param.

**Which issue(s) is/are addressed by this PR?**

Fixes N/A.

**Are there any special notes for your reviewer**:

- Ran `make lint-go-full` command locally and passed:

```console
sdiliyaer in ~/vm-operator on git:fix/go-lint ✔  998dd804e "Add sub-modules in go lint and fix reported issues"
16:10:38 $ make lint-go
Running golangci-lint in ./
INFO golangci-lint has version v1.60.0 built with go1.23.2 from (unknown, modified: ?, mod sum: "h1:MgoGnQcKdStp+lOhqQM79cQpI29j0ZQugNBC9sDg6h8=") on (unknown)
INFO [config_reader] Config search paths: [./ /Users/sdiliyaer/vm-operator /Users/sdiliyaer /Users /]
INFO [config_reader] Used config file .golangci.yml
INFO [lintersdb] Active 31 linters: [asciicheck bodyclose depguard dogsled errcheck errorlint exportloopref goconst gocritic gocyclo godot gofmt goimports goprintffuncname gosec gosimple govet importas ineffassign misspell nakedret nilerr nolintlint prealloc revive rowserrcheck staticcheck stylecheck unconvert unparam unused]
INFO [loader] Go packages loading at mode 575 (compiled_files|exports_file|imports|name|deps|files|types_sizes) took 2.73593653s
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 62.476091ms
INFO [linters_context/goanalysis] analyzers took 0s with no stages
INFO [runner/skip_dirs] Skipped 13 issues from dir external/vsphere-csi-driver/pkg/syncer/cnsoperator/apis/cnsnodevmattachment/v1alpha1 by pattern external
INFO [runner/skip_dirs] Skipped 4 issues from dir external/vsphere-csi-driver/pkg/syncer/cnsoperator/apis by pattern external
INFO [runner/skip_dirs] Skipped 354 issues from dir pkg/util/cloudinit/schema by pattern pkg/util/cloudinit/schema
INFO [runner/skip_dirs] Skipped 163 issues from dir pkg/util/netplan/schema by pattern pkg/util/netplan/schema
INFO [runner] Issues before processing: 2484, after processing: 0
INFO [runner] Processors filtering stat (in/out): skip_files: 2484/2478, filename_unadjuster: 2484/2484, identifier_marker: 1944/1944, exclude-rules: 1670/170, invalid_issue: 2484/2484, autogenerated_exclude: 1944/1944, nolint: 170/0, cgo: 2484/2484, path_prettifier: 2484/2484, skip_dirs: 2478/1944, exclude: 1944/1670
INFO [runner] processing took 216.941639ms with stages: autogenerated_exclude: 96.135517ms, nolint: 55.383599ms, identifier_marker: 28.900799ms, path_prettifier: 15.040751ms, exclude-rules: 12.436514ms, skip_files: 4.191141ms, exclude: 2.533083ms, skip_dirs: 1.856633ms, cgo: 217.19µs, filename_unadjuster: 128.795µs, invalid_issue: 114.685µs, max_same_issues: 996ns, uniq_by_line: 364ns, fixer: 258ns, diff: 210ns, sort_results: 206ns, path_shortener: 178ns, source_code: 178ns, max_from_linter: 175ns, max_per_file_from_linter: 138ns, path_prefixer: 120ns, severity-rules: 109ns
INFO [runner] linters took 3.223497475s with stages: goanalysis_metalinter: 3.006450016s
INFO File cache stats: 0 entries of total size 0B
INFO Memory: 62 samples, avg is 57.9MB, max is 89.7MB
INFO Execution took 6.056932206s
Running golangci-lint in ./api/
INFO golangci-lint has version v1.60.0 built with go1.23.2 from (unknown, modified: ?, mod sum: "h1:MgoGnQcKdStp+lOhqQM79cQpI29j0ZQugNBC9sDg6h8=") on (unknown)
INFO [config_reader] Config search paths: [./ /Users/sdiliyaer/vm-operator/api /Users/sdiliyaer/vm-operator /Users/sdiliyaer /Users /]
INFO [config_reader] Used config file ../.golangci.yml
INFO [lintersdb] Active 31 linters: [asciicheck bodyclose depguard dogsled errcheck errorlint exportloopref goconst gocritic gocyclo godot gofmt goimports goprintffuncname gosec gosimple govet importas ineffassign misspell nakedret nilerr nolintlint prealloc revive rowserrcheck staticcheck stylecheck unconvert unparam unused]
INFO [loader] Go packages loading at mode 575 (compiled_files|files|name|types_sizes|deps|exports_file|imports) took 823.356523ms
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 41.440549ms
INFO [linters_context/goanalysis] analyzers took 0s with no stages
INFO [runner] Issues before processing: 1424, after processing: 0
INFO [runner] Processors filtering stat (in/out): filename_unadjuster: 1424/1424, skip_files: 1424/562, skip_dirs: 562/562, cgo: 1424/1424, identifier_marker: 562/562, invalid_issue: 1424/1424, path_prettifier: 1424/1424, autogenerated_exclude: 562/562, exclude: 562/525, nolint: 64/0, exclude-rules: 525/64
INFO [runner] processing took 94.510053ms with stages: identifier_marker: 38.58432ms, nolint: 19.288558ms, exclude-rules: 14.909651ms, autogenerated_exclude: 14.444723ms, path_prettifier: 2.820535ms, exclude: 2.400888ms, skip_files: 1.489761ms, skip_dirs: 258.252µs, invalid_issue: 162.149µs, cgo: 107.019µs, filename_unadjuster: 41.043µs, max_same_issues: 878ns, uniq_by_line: 435ns, diff: 315ns, fixer: 290ns, source_code: 263ns, sort_results: 221ns, max_from_linter: 217ns, path_shortener: 150ns, max_per_file_from_linter: 142ns, path_prefixer: 124ns, severity-rules: 119ns
INFO [runner] linters took 2.132635791s with stages: goanalysis_metalinter: 2.038002467s
INFO File cache stats: 0 entries of total size 0B
INFO Memory: 32 samples, avg is 55.2MB, max is 77.7MB
INFO Execution took 3.029506703s
Skipping ./external/appplatform/
Skipping ./external/byok/
Skipping ./external/capabilities/
Skipping ./external/ncp/
Skipping ./external/storage-policy-quota/
Skipping ./external/tanzu-topology/
Skipping ./hack/tools/
Running golangci-lint in ./pkg/backup/api/
INFO golangci-lint has version v1.60.0 built with go1.23.2 from (unknown, modified: ?, mod sum: "h1:MgoGnQcKdStp+lOhqQM79cQpI29j0ZQugNBC9sDg6h8=") on (unknown)
INFO [config_reader] Config search paths: [./ /Users/sdiliyaer/vm-operator/pkg/backup/api /Users/sdiliyaer/vm-operator/pkg/backup /Users/sdiliyaer/vm-operator/pkg /Users/sdiliyaer/vm-operator /Users/sdiliyaer /Users /]
INFO [config_reader] Used config file ../../../.golangci.yml
INFO [lintersdb] Active 31 linters: [asciicheck bodyclose depguard dogsled errcheck errorlint exportloopref goconst gocritic gocyclo godot gofmt goimports goprintffuncname gosec gosimple govet importas ineffassign misspell nakedret nilerr nolintlint prealloc revive rowserrcheck staticcheck stylecheck unconvert unparam unused]
INFO [loader] Go packages loading at mode 575 (compiled_files|deps|files|imports|exports_file|name|types_sizes) took 70.164443ms
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 449.05µs
INFO [linters_context/goanalysis] analyzers took 0s with no stages
INFO [runner] Issues before processing: 2, after processing: 0
INFO [runner] Processors filtering stat (in/out): path_prettifier: 2/2, skip_dirs: 2/2, autogenerated_exclude: 2/2, identifier_marker: 2/2, exclude-rules: 1/0, invalid_issue: 2/2, filename_unadjuster: 2/2, skip_files: 2/2, exclude: 2/1, cgo: 2/2
INFO [runner] processing took 330.854µs with stages: autogenerated_exclude: 202.466µs, identifier_marker: 48.023µs, path_prettifier: 43.649µs, skip_dirs: 10.41µs, skip_files: 9.039µs, exclude-rules: 4.531µs, cgo: 2.885µs, invalid_issue: 2.644µs, exclude: 1.933µs, filename_unadjuster: 989ns, max_same_issues: 981ns, nolint: 895ns, diff: 517ns, max_from_linter: 330ns, uniq_by_line: 287ns, fixer: 284ns, sort_results: 220ns, severity-rules: 179ns, source_code: 168ns, path_shortener: 150ns, max_per_file_from_linter: 143ns, path_prefixer: 131ns
INFO [runner] linters took 1.774342742s with stages: goanalysis_metalinter: 1.773919743s
INFO File cache stats: 0 entries of total size 0B
INFO Memory: 20 samples, avg is 52.9MB, max is 61.3MB
INFO Execution took 1.880377356s
Running golangci-lint in ./pkg/constants/testlabels/
INFO golangci-lint has version v1.60.0 built with go1.23.2 from (unknown, modified: ?, mod sum: "h1:MgoGnQcKdStp+lOhqQM79cQpI29j0ZQugNBC9sDg6h8=") on (unknown)
INFO [config_reader] Config search paths: [./ /Users/sdiliyaer/vm-operator/pkg/constants/testlabels /Users/sdiliyaer/vm-operator/pkg/constants /Users/sdiliyaer/vm-operator/pkg /Users/sdiliyaer/vm-operator /Users/sdiliyaer /Users /]
INFO [config_reader] Used config file ../../../.golangci.yml
INFO [lintersdb] Active 31 linters: [asciicheck bodyclose depguard dogsled errcheck errorlint exportloopref goconst gocritic gocyclo godot gofmt goimports goprintffuncname gosec gosimple govet importas ineffassign misspell nakedret nilerr nolintlint prealloc revive rowserrcheck staticcheck stylecheck unconvert unparam unused]
INFO [loader] Go packages loading at mode 575 (exports_file|files|compiled_files|deps|imports|name|types_sizes) took 74.130595ms
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 342.397µs
INFO [linters_context/goanalysis] analyzers took 0s with no stages
INFO [runner] Issues before processing: 2, after processing: 0
INFO [runner] Processors filtering stat (in/out): filename_unadjuster: 2/2, identifier_marker: 2/2, skip_dirs: 2/2, autogenerated_exclude: 2/2, exclude: 2/1, exclude-rules: 1/0, cgo: 2/2, invalid_issue: 2/2, skip_files: 2/2, path_prettifier: 2/2
INFO [runner] processing took 454.972µs with stages: autogenerated_exclude: 292.201µs, path_prettifier: 62.696µs, identifier_marker: 58.899µs, skip_dirs: 14.574µs, skip_files: 6.121µs, exclude-rules: 4.602µs, cgo: 4.094µs, invalid_issue: 3.919µs, exclude: 2.512µs, max_same_issues: 1.251µs, nolint: 882ns, filename_unadjuster: 715ns, uniq_by_line: 454ns, fixer: 372ns, sort_results: 281ns, max_from_linter: 266ns, path_shortener: 240ns, diff: 197ns, max_per_file_from_linter: 194ns, source_code: 190ns, path_prefixer: 159ns, severity-rules: 153ns
INFO [runner] linters took 1.621550513s with stages: goanalysis_metalinter: 1.620987818s
INFO File cache stats: 0 entries of total size 0B
INFO Memory: 19 samples, avg is 56.2MB, max is 65.3MB
INFO Execution took 1.726803056s
```

- Verified `make fix` didn't fix issues that were explicitly excluded.

**Please add a release note if necessary**:

```release-note
Add sub-modules in lint-go Makefile target and fix reported issues.
```

<!-- readthedocs-preview vm-operator start -->
----
📚 Documentation preview 📚: https://vm-operator--897.org.readthedocs.build/en/897/

<!-- readthedocs-preview vm-operator end -->