### PR TITLE
🌱 Do not delete non-connected VMs

### DIFF
--- a/controllers/virtualmachine/virtualmachine/virtualmachine_controller.go
+++ b/controllers/virtualmachine/virtualmachine/virtualmachine_controller.go
@@ -38,7 +38,6 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/patch"
 	"github.com/vmware-tanzu/vm-operator/pkg/prober"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
-	vspherevm "github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/virtualmachine"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/vmlifecycle"
 	"github.com/vmware-tanzu/vm-operator/pkg/record"
 	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
@@ -448,12 +447,6 @@ func (r *Reconciler) ReconcileDelete(ctx *pkgctx.VirtualMachineContext) (reterr 
 		}()
 
 		if err := r.VMProvider.DeleteVirtualMachine(ctx, ctx.VM); err != nil {
-			// If VM can not be deleted due to reconciliation being paused, ignore that.
-			if errors.Is(err, vspherevm.ErrorVMPausedByAdmin()) {
-				ctx.Logger.Info("VM could not be deleted since it contains the pause reconcile ExtraConfig key")
-				return nil
-			}
-			ctx.Logger.Error(err, "Failed to delete VirtualMachine")
 			return err
 		}
 

--- a/pkg/providers/vsphere/virtualmachine/delete.go
+++ b/pkg/providers/vsphere/virtualmachine/delete.go
@@ -5,7 +5,6 @@
 package virtualmachine
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/go-logr/logr"
@@ -14,18 +13,11 @@ import (
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+	pkgerr "github.com/vmware-tanzu/vm-operator/pkg/errors"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/constants"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/paused"
 	vmutil "github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/vm"
 )
-
-// errorVMPausedByAdmin is an error thrown during VM deletion.
-// Indicating because admin paused VM, deletion operation is paused.
-var errorVMPausedByAdmin = errors.New(constants.VMPausedByAdminError)
-
-func ErrorVMPausedByAdmin() error {
-	return errorVMPausedByAdmin
-}
 
 func DeleteVirtualMachine(
 	vmCtx pkgctx.VirtualMachineContext,
@@ -34,19 +26,45 @@ func DeleteVirtualMachine(
 	if err := vcVM.Properties(
 		vmCtx,
 		vcVM.Reference(),
-		[]string{"config.extraConfig"}, &vmCtx.MoVM); err != nil {
+		[]string{
+			"config.extraConfig",
+			"summary.runtime.connectionState",
+		}, &vmCtx.MoVM); err != nil {
 
-		vmCtx.Logger.Error(err, "failed to fetch config.extraConfig properties of VM for DeleteVirtualMachine")
-		return err
+		return fmt.Errorf("failed to fetch props when deleting VM: %w", err)
 	}
+
+	// Only process connected VMs or if the connection state is empty.
+	if cs := vmCtx.MoVM.Summary.Runtime.ConnectionState; cs != "" && cs !=
+		vimtypes.VirtualMachineConnectionStateConnected {
+
+		// Return a NoRequeueError so the VM is not requeued for
+		// reconciliation.
+		//
+		// The watcher service ensures that VMs will be reconciled
+		// immediately upon their summary.runtime.connectionState value
+		// changing.
+		//
+		// TODO(akutz) Determine if we should surface some type of condition
+		//             that indicates this state.
+
+		return fmt.Errorf("failed to delete vm: %w", pkgerr.NoRequeueError{
+			Message: fmt.Sprintf("unsupported VM connection state: %s", cs),
+		})
+	}
+
 	// Throw an error to distinguish from successful deletion.
 	if paused := paused.ByAdmin(vmCtx.MoVM); paused {
 		if vmCtx.VM.Labels == nil {
 			vmCtx.VM.Labels = make(map[string]string)
 		}
 		vmCtx.VM.Labels[vmopv1.PausedVMLabelKey] = "admin"
-		return ErrorVMPausedByAdmin()
+
+		return fmt.Errorf("failed to delete vm: %w", pkgerr.NoRequeueError{
+			Message: constants.VMPausedByAdminError,
+		})
 	}
+
 	if _, err := vmutil.SetAndWaitOnPowerState(
 		logr.NewContext(vmCtx, vmCtx.Logger),
 		vcVM.Client(),

--- a/pkg/providers/vsphere/virtualmachine/delete_test.go
+++ b/pkg/providers/vsphere/virtualmachine/delete_test.go
@@ -5,12 +5,20 @@
 package virtualmachine_test
 
 import (
+	"errors"
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vim25/mo"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+	pkgerr "github.com/vmware-tanzu/vm-operator/pkg/errors"
+	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/constants"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/virtualmachine"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
@@ -69,4 +77,66 @@ func deleteTests() {
 
 		Expect(ctx.GetVMFromMoID(moID)).To(BeNil())
 	})
+
+	Specify("VM is paused by admin", func() {
+		var moVM mo.VirtualMachine
+		Expect(vcVM.Properties(ctx, vcVM.Reference(), nil, &moVM)).To(Succeed())
+
+		simulator.Map.WithLock(
+			simulator.SpoofContext(),
+			vcVM.Reference(),
+			func() {
+				vm := simulator.Map.Get(vcVM.Reference()).(*simulator.VirtualMachine)
+				vm.Config = &vimtypes.VirtualMachineConfigInfo{
+					ExtraConfig: []vimtypes.BaseOptionValue{
+						&vimtypes.OptionValue{
+							Key:   vmopv1.PauseVMExtraConfigKey,
+							Value: "True",
+						},
+					},
+				}
+			})
+
+		err := virtualmachine.DeleteVirtualMachine(vmCtx, vcVM)
+
+		Expect(err).To(HaveOccurred())
+		var noRequeueErr pkgerr.NoRequeueError
+		Expect(errors.As(err, &noRequeueErr)).To(BeTrue())
+		Expect(noRequeueErr.Message).To(Equal(constants.VMPausedByAdminError))
+		Expect(ctx.GetVMFromMoID(moVM.Reference().Value)).ToNot(BeNil())
+	})
+
+	DescribeTable("VM is not connected",
+		func(state vimtypes.VirtualMachineConnectionState) {
+			var moVM mo.VirtualMachine
+			Expect(vcVM.Properties(ctx, vcVM.Reference(), nil, &moVM)).To(Succeed())
+
+			simulator.Map.WithLock(
+				simulator.SpoofContext(),
+				vcVM.Reference(),
+				func() {
+					vm := simulator.Map.Get(vcVM.Reference()).(*simulator.VirtualMachine)
+					vm.Summary.Runtime.ConnectionState = state
+				})
+
+			err := virtualmachine.DeleteVirtualMachine(vmCtx, vcVM)
+
+			if state == "" {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ctx.GetVMFromMoID(moVM.Reference().Value)).To(BeNil())
+			} else {
+				Expect(err).To(HaveOccurred())
+				var noRequeueErr pkgerr.NoRequeueError
+				Expect(errors.As(err, &noRequeueErr)).To(BeTrue())
+				Expect(noRequeueErr.Message).To(Equal(
+					fmt.Sprintf("unsupported VM connection state: %s", state)))
+				Expect(ctx.GetVMFromMoID(moVM.Reference().Value)).ToNot(BeNil())
+			}
+		},
+		Entry("empty", vimtypes.VirtualMachineConnectionState("")),
+		Entry("disconnected", vimtypes.VirtualMachineConnectionStateDisconnected),
+		Entry("inaccessible", vimtypes.VirtualMachineConnectionStateInaccessible),
+		Entry("invalid", vimtypes.VirtualMachineConnectionStateInvalid),
+		Entry("orphaned", vimtypes.VirtualMachineConnectionStateOrphaned),
+	)
 }

--- a/pkg/providers/vsphere/vmprovider_vm.go
+++ b/pkg/providers/vsphere/vmprovider_vm.go
@@ -764,9 +764,9 @@ func (vs *vSphereVMProvider) updateVirtualMachine(
 			//
 			// TODO(akutz) Determine if we should surface some type of condition
 			//             that indicates this state.
-			return pkgerr.NoRequeueError{
+			return fmt.Errorf("failed to update VM: %w", pkgerr.NoRequeueError{
 				Message: fmt.Sprintf("unsupported VM connection state: %s", cs),
-			}
+			})
 		}
 
 		if vmCtx.MoVM.ResourcePool == nil {


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch prevents VM Op from spawning DestroyVM_Task calls when a VM is not in a connected state. This is an addendum to https://github.com/vmware-tanzu/vm-operator/pull/896.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Do not delete non-connected VMs.
```