### PR TITLE
🌱 Defaults for ConfigSpec CPU/mem alloc

### DIFF
--- a/pkg/providers/vsphere/virtualmachine/configspec_test.go
+++ b/pkg/providers/vsphere/virtualmachine/configspec_test.go
@@ -416,6 +416,33 @@ var _ = Describe("CreateConfigSpec", func() {
 				Expect(namespacedName).To(Equal(vm.NamespacedName()))
 			})
 		})
+
+		When("VM Class has reservations", func() {
+			BeforeEach(func() {
+				vmClassSpec.Policies = vmopv1.VirtualMachineClassPolicies{}
+				classConfigSpec.CpuAllocation = &vimtypes.ResourceAllocationInfo{
+					Reservation: ptr.To[int64](200),
+				}
+				classConfigSpec.MemoryAllocation = &vimtypes.ResourceAllocationInfo{
+					Reservation: ptr.To[int64](200),
+				}
+			})
+			Specify("configSpec should have the allocation defaults", func() {
+				Expect(configSpec.CpuAllocation).ToNot(BeNil())
+				Expect(configSpec.CpuAllocation.Reservation).ToNot(BeNil())
+				Expect(configSpec.CpuAllocation.Limit).ToNot(BeNil())
+				Expect(*configSpec.CpuAllocation.Reservation).To(Equal(int64(200)))
+				Expect(*configSpec.CpuAllocation.Limit).To(Equal(int64(-1)))
+
+				Expect(configSpec.MemoryAllocation).ToNot(BeNil())
+				Expect(configSpec.MemoryAllocation.Reservation).ToNot(BeNil())
+				Expect(configSpec.MemoryAllocation.Limit).ToNot(BeNil())
+				Expect(*configSpec.MemoryAllocation.Reservation).To(Equal(int64(200)))
+				Expect(*configSpec.MemoryAllocation.Limit).To(Equal(int64(-1)))
+				Expect(configSpec.MemoryAllocation.Shares).ToNot(BeNil())
+				Expect(configSpec.MemoryAllocation.Shares.Level).To(Equal(vimtypes.SharesLevelNormal))
+			})
+		})
 	})
 })
 


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch ensures there are defaults for the ConfigSpec CPU/mem allocation fields for limits and shares.

The documentation for a ResourceAllocation object states that all (VM) fields must be set for certain APIs, including ImportVApp. A part of that API is used by the vpxd placement engine to construct fake VMs in order to support assignable hardware. Therefore:

CPU allocation:
- Ensure limit is set to -1 if there is a reservation.

Memory allocation:
- Ensure shares is not nil.
- Ensure limit is set to -1 if there is a reservation.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Defaults for CPU/memory allocations in ConfigSpec to fix bug in placement engine
```