### PR TITLE
🌱 Remove FSS ISO Support

### DIFF
--- a/config/local/vmoperator/local_env_var_patch.yaml
+++ b/config/local/vmoperator/local_env_var_patch.yaml
@@ -23,8 +23,6 @@ spec:
           value: "true"
         - name: NETWORK_PROVIDER
           value: "NAMED"
-        - name: FSS_WCP_VMSERVICE_ISO_SUPPORT
-          value: "false"
         - name: FSS_WCP_VMSERVICE_RESIZE
           value: "false"
         - name: FSS_WCP_VMSERVICE_RESIZE_CPU_MEMORY
@@ -69,4 +67,5 @@ spec:
           value: "true"
         - name: FSS_WCP_WORKLOAD_DOMAIN_ISOLATION
           value: "true"
-
+        - name: FSS_WCP_VMSERVICE_ISO_SUPPORT
+          value: "true"

--- a/config/wcp/vmoperator/manager_env_var_patch.yaml
+++ b/config/wcp/vmoperator/manager_env_var_patch.yaml
@@ -37,12 +37,6 @@
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
-    name: FSS_WCP_VMSERVICE_ISO_SUPPORT
-    value: "<FSS_WCP_VMSERVICE_ISO_SUPPORT_VALUE>"
-
-- op: add
-  path: /spec/template/spec/containers/0/env/-
-  value:
     name: PRIVILEGED_USERS
     value: "<COMMA_SEPARATED_LIST_OF_USERS>"
 
@@ -184,4 +178,10 @@
   path: /spec/template/spec/containers/0/env/-
   value:
     name: FSS_WCP_WORKLOAD_DOMAIN_ISOLATION
+    value: "true"
+
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: FSS_WCP_VMSERVICE_ISO_SUPPORT
     value: "true"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -168,7 +168,6 @@ func (c Config) GetMaxDeployThreadsOnProvider() int {
 }
 
 type FeatureStates struct {
-	IsoSupport                 bool // FSS_WCP_VMSERVICE_ISO_SUPPORT
 	InstanceStorage            bool // FSS_WCP_INSTANCE_STORAGE
 	K8sWorkloadMgmtAPI         bool // FSS_WCP_VMSERVICE_K8S_WORKLOAD_MGMT_API
 	PodVMOnStretchedSupervisor bool // FSS_PODVMONSTRETCHEDSUPERVISOR

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -60,7 +60,6 @@ func FromEnv() Config {
 	setString(env.WebhookSecretNamespace, &config.WebhookSecretNamespace)
 
 	setBool(env.FSSInstanceStorage, &config.Features.InstanceStorage)
-	setBool(env.FSSIsoSupport, &config.Features.IsoSupport)
 	setBool(env.FSSK8sWorkloadMgmtAPI, &config.Features.K8sWorkloadMgmtAPI)
 	setBool(env.FSSPodVMOnStretchedSupervisor, &config.Features.PodVMOnStretchedSupervisor)
 	setBool(env.FSSUnifiedStorageQuota, &config.Features.UnifiedStorageQuota)

--- a/pkg/config/env/env.go
+++ b/pkg/config/env/env.go
@@ -53,7 +53,6 @@ const (
 	WebhookSecretName
 	WebhookSecretNamespace
 	FSSInstanceStorage
-	FSSIsoSupport
 	FSSK8sWorkloadMgmtAPI
 	FSSPodVMOnStretchedSupervisor
 	FSSUnifiedStorageQuota
@@ -170,8 +169,6 @@ func (n VarName) String() string {
 		return "WEBHOOK_SECRET_NAMESPACE"
 	case FSSInstanceStorage:
 		return "FSS_WCP_INSTANCE_STORAGE"
-	case FSSIsoSupport:
-		return "FSS_WCP_VMSERVICE_ISO_SUPPORT"
 	case FSSK8sWorkloadMgmtAPI:
 		return "FSS_WCP_VMSERVICE_K8S_WORKLOAD_MGMT_API"
 	case FSSPodVMOnStretchedSupervisor:

--- a/pkg/config/env_test.go
+++ b/pkg/config/env_test.go
@@ -95,7 +95,6 @@ var _ = Describe(
 					Expect(os.Setenv("FSS_WCP_INSTANCE_STORAGE", "false")).To(Succeed())
 					Expect(os.Setenv("FSS_WCP_NAMESPACED_VM_CLASS", "false")).To(Succeed())
 					Expect(os.Setenv("FSS_WCP_VMSERVICE_K8S_WORKLOAD_MGMT_API", "true")).To(Succeed())
-					Expect(os.Setenv("FSS_WCP_VMSERVICE_ISO_SUPPORT", "true")).To(Succeed())
 					Expect(os.Setenv("FSS_STORAGE_QUOTA_M2", "true")).To(Succeed())
 					Expect(os.Setenv("FSS_WCP_VMSERVICE_RESIZE", "true")).To(Succeed())
 					Expect(os.Setenv("FSS_WCP_VMSERVICE_RESIZE_CPU_MEMORY", "true")).To(Succeed())
@@ -150,7 +149,6 @@ var _ = Describe(
 						WebhookSecretVolumeMountPath: pkgcfg.Default().WebhookSecretVolumeMountPath,
 						Features: pkgcfg.FeatureStates{
 							InstanceStorage:           false,
-							IsoSupport:                true,
 							K8sWorkloadMgmtAPI:        true,
 							UnifiedStorageQuota:       true,
 							VMResize:                  true,

--- a/pkg/providers/vsphere/session/session_vm_update.go
+++ b/pkg/providers/vsphere/session/session_vm_update.go
@@ -533,13 +533,11 @@ func (s *Session) prePowerOnVMConfigSpec(
 	}
 	configSpec.DeviceChange = append(configSpec.DeviceChange, pciDeviceChanges...)
 
-	if pkgcfg.FromContext(vmCtx).Features.IsoSupport {
-		cdromDeviceChanges, err := virtualmachine.UpdateCdromDeviceChanges(vmCtx, s.Client.RestClient(), s.K8sClient, virtualDevices)
-		if err != nil {
-			return nil, false, fmt.Errorf("update CD-ROM device changes error: %w", err)
-		}
-		configSpec.DeviceChange = append(configSpec.DeviceChange, cdromDeviceChanges...)
+	cdromDeviceChanges, err := virtualmachine.UpdateCdromDeviceChanges(vmCtx, s.Client.RestClient(), s.K8sClient, virtualDevices)
+	if err != nil {
+		return nil, false, fmt.Errorf("update CD-ROM device changes error: %w", err)
 	}
+	configSpec.DeviceChange = append(configSpec.DeviceChange, cdromDeviceChanges...)
 
 	return configSpec, needsResize, nil
 }
@@ -802,10 +800,8 @@ func (s *Session) poweredOnVMReconfigure(
 	UpdateConfigSpecExtraConfig(vmCtx, config, configSpec, nil, nil, vmCtx.VM, nil)
 	UpdateConfigSpecChangeBlockTracking(vmCtx, config, configSpec, nil, vmCtx.VM.Spec)
 
-	if pkgcfg.FromContext(vmCtx).Features.IsoSupport {
-		if err := virtualmachine.UpdateConfigSpecCdromDeviceConnection(vmCtx, s.Client.RestClient(), s.K8sClient, config, configSpec); err != nil {
-			return false, fmt.Errorf("update CD-ROM device connection error: %w", err)
-		}
+	if err := virtualmachine.UpdateConfigSpecCdromDeviceConnection(vmCtx, s.Client.RestClient(), s.K8sClient, config, configSpec); err != nil {
+		return false, fmt.Errorf("update CD-ROM device connection error: %w", err)
 	}
 
 	refetchProps, err := doReconfigure(

--- a/pkg/providers/vsphere/vmprovider_vm_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_test.go
@@ -3035,20 +3035,24 @@ func vmTests() {
 				vmClass.Namespace = nsInfo.Namespace
 				Expect(ctx.Client.Create(ctx, vmClass)).To(Succeed())
 
-				clusterVMImage := &vmopv1.ClusterVirtualMachineImage{}
-				Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: ctx.ContentLibraryIsoImageName}, clusterVMImage)).To(Succeed())
+				// Add required objects to get CD-ROM backing file name.
+				cvmiName := "vmi-iso"
+				objs := builder.DummyImageAndItemObjectsForCdromBacking(cvmiName, "", cvmiKind, "test-file.iso", ctx.ContentLibraryIsoItemID, true, true, true, "ISO")
+				for _, obj := range objs {
+					Expect(ctx.Client.Create(ctx, obj)).To(Succeed())
+				}
 
 				vm.Namespace = nsInfo.Namespace
 				vm.Spec.ClassName = vmClass.Name
-				vm.Spec.ImageName = clusterVMImage.Name
+				vm.Spec.ImageName = cvmiName
 				vm.Spec.Image.Kind = cvmiKind
-				vm.Spec.Image.Name = clusterVMImage.Name
+				vm.Spec.Image.Name = cvmiName
 				vm.Spec.StorageClass = ctx.StorageClassName
 				vm.Spec.Cdrom = []vmopv1.VirtualMachineCdromSpec{{
 					Name: "cdrom0",
 					Image: vmopv1.VirtualMachineImageRef{
-						Name: cvmiKind,
-						Kind: clusterVMImage.Name,
+						Name: cvmiName,
+						Kind: cvmiKind,
 					},
 				}}
 			})

--- a/test/builder/dummies.go
+++ b/test/builder/dummies.go
@@ -577,7 +577,8 @@ func DummyImageAndItemObjectsForCdromBacking(
 	}
 
 	imgStatus := vmopv1.VirtualMachineImageStatus{
-		Type: string(itemType),
+		Type:           string(itemType),
+		ProviderItemID: libItemUUID,
 	}
 	if imgReady {
 		imgStatus.Conditions = []metav1.Condition{
@@ -602,6 +603,10 @@ func DummyImageAndItemObjectsForCdromBacking(
 	}
 
 	if kind == vmiKind {
+		if imgSpec.ProviderRef != nil {
+			imgSpec.ProviderRef.Kind = "ContentLibraryItem"
+		}
+
 		imageObj = &vmopv1.VirtualMachineImage{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
@@ -620,6 +625,11 @@ func DummyImageAndItemObjectsForCdromBacking(
 			Status: itemStatus,
 		}
 	} else {
+
+		if imgSpec.ProviderRef != nil {
+			imgSpec.ProviderRef.Kind = "ClusterContentLibraryItem"
+		}
+
 		imageObj = &vmopv1.ClusterVirtualMachineImage{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,

--- a/test/builder/vcsim_test_context.go
+++ b/test/builder/vcsim_test_context.go
@@ -127,9 +127,6 @@ type VCSimTestConfig struct {
 	// WithNetworkEnv is the network environment type.
 	WithNetworkEnv NetworkEnv
 
-	// WithISOSupport enables the FSS_WCP_VMSERVICE_ISO_SUPPORT FSS.
-	WithISOSupport bool
-
 	// WithoutEncryptionClass disables the creation of the EncryptionClass
 	// resource in each workload namespace.
 	WithoutEncryptionClass bool
@@ -529,7 +526,6 @@ func (c *TestContextForVCSim) setupEnv(config VCSimTestConfig) {
 		cc.Features.VMResize = config.WithVMResize
 		cc.Features.VMResizeCPUMemory = config.WithVMResizeCPUMemory
 		cc.Features.WorkloadDomainIsolation = !config.WithoutWorkloadDomainIsolation
-		cc.Features.IsoSupport = config.WithISOSupport
 		cc.Features.VMIncrementalRestore = config.WithVMIncrementalRestore
 	})
 }

--- a/webhooks/virtualmachine/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator.go
@@ -1507,9 +1507,6 @@ func (v validator) validateCdrom(
 	}
 
 	f := field.NewPath("spec", "cdrom")
-	if !pkgcfg.FromContext(ctx).Features.IsoSupport {
-		return append(allErrs, field.Forbidden(f, fmt.Sprintf(featureNotEnabled, "CD-ROM (ISO) support")))
-	}
 
 	// GuestID must be set when deploying an ISO VM with CD-ROMs.
 	if vm.Spec.GuestID == "" {

--- a/webhooks/virtualmachine/validation/virtualmachine_validator_intg_test.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator_intg_test.go
@@ -13,7 +13,6 @@ import (
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
 	"github.com/vmware-tanzu/vm-operator/api/v1alpha4/common"
-	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
@@ -63,9 +62,6 @@ func newIntgValidatingWebhookContext() *intgValidatingWebhookContext {
 	ctx := &intgValidatingWebhookContext{
 		IntegrationTestContext: *suite.NewIntegrationTestContext(),
 	}
-	pkgcfg.SetContext(suite, func(config *pkgcfg.Config) {
-		config.Features.IsoSupport = true
-	})
 
 	ctx.vm = builder.DummyVirtualMachine()
 	ctx.vm.Namespace = ctx.Namespace

--- a/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
@@ -209,9 +209,6 @@ func unitTestsValidateCreate() {
 	BeforeEach(func() {
 		ctx = newUnitTestContextForValidatingWebhook(false)
 		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-			config.Features.IsoSupport = true
-		})
-		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
 			config.Features.WorkloadDomainIsolation = true
 		})
 	})
@@ -2522,25 +2519,6 @@ func unitTestsValidateCreate() {
 				},
 			),
 
-			Entry("disallow creating a VM with CD-ROM when FSS is not enabled",
-				testParams{
-					setup: func(ctx *unitValidatingWebhookContext) {
-						pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-							config.Features.IsoSupport = false
-						})
-						ctx.vm.Spec.Cdrom = []vmopv1.VirtualMachineCdromSpec{
-							{
-								Name: "cdrom",
-							},
-						}
-					},
-					validate: doValidateWithMsg(
-						`spec.cdrom: Forbidden: the CD-ROM (ISO) support feature is not enabled`,
-					),
-					expectAllowed: false,
-				},
-			),
-
 			Entry("disallow creating a VM with CD-ROM and empty guest ID",
 				testParams{
 					setup: func(ctx *unitValidatingWebhookContext) {
@@ -2766,9 +2744,6 @@ func unitTestsValidateUpdate() {
 
 	BeforeEach(func() {
 		ctx = newUnitTestContextForValidatingWebhook(true)
-		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-			config.Features.IsoSupport = true
-		})
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR removes the `ISO Support` FSS related code since it's been enabled on main for a while. The env var for the FSS is retained in the deployment YAML as "true" to avoid breaking internal tests that rely on reading this value.


**Which issue(s) is/are addressed by this PR?** 

Fixes N/A.


**Are there any special notes for your reviewer**:

Ran `gobuild` internally and verified VMOP deployment from that build.


**Please add a release note if necessary**:

```release-note
Remove enabled feature state switch for ISO support.
```