### PR TITLE
:bug: Allow non-class changes to VM spec for classless VMs

### DIFF
--- a/webhooks/virtualmachine/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator.go
@@ -470,6 +470,10 @@ func (v validator) validateClassOnCreate(ctx *pkgctx.WebhookRequestContext, vm *
 func (v validator) validateClassOnUpdate(ctx *pkgctx.WebhookRequestContext, vm, oldVM *vmopv1.VirtualMachine) field.ErrorList {
 	var allErrs field.ErrorList
 
+	if oldVM.Spec.ClassName == vm.Spec.ClassName {
+		return allErrs
+	}
+
 	if f := pkgcfg.FromContext(ctx).Features; !f.VMResize && !f.VMResizeCPUMemory {
 		return append(allErrs,
 			validation.ValidateImmutableField(vm.Spec.ClassName, oldVM.Spec.ClassName, field.NewPath("spec", "className"))...)

--- a/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
@@ -3902,6 +3902,25 @@ func unitTestsValidateUpdate() {
 		//
 		// RESIZE_CPU is disabled, FSS_WCP_MOBILITY_VM_IMPORT_NEW_NET is disabled
 		//
+
+		Entry("always allow changes to non-class fields for classless VMs",
+			testParams{
+				setup: func(ctx *unitValidatingWebhookContext) {
+					ctx.oldVM.Spec.ClassName = ""
+					ctx.oldVM.Spec.PowerState = vmopv1.VirtualMachinePowerStateOff
+
+					ctx.vm.Spec.PowerState = vmopv1.VirtualMachinePowerStateOn
+					ctx.vm.Spec.ClassName = ""
+
+					pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+						config.Features.VMImportNewNet = false
+						config.Features.VMResizeCPUMemory = false
+					})
+				},
+				expectAllowed: true,
+			},
+		),
+
 		Entry("require spec.className for privileged user when FSS_RESIZE_CPU & FSS_WCP_MOBILITY_VM_IMPORT_NEW_NET are disabled",
 			testParams{
 				setup: func(ctx *unitValidatingWebhookContext) {


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

For classless VMs the validation webhook rejects changes to any fields.  This basically prevents users from making any changes to imported VMs.


**Please add a release note if necessary**:

```release-note
Allow non-class changes to VM spec for classless VMs
```