### PR TITLE
🌱 Fix expected error message in VM network validation

### DIFF
--- a/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
@@ -2190,10 +2190,9 @@ func unitTestsValidateCreate() {
 					},
 					validate: doValidateWithMsg(
 						fmt.Sprintf(`spec.network.interfaces[0].name: Invalid value: "dummy-vm-dummy-nw-%x": is the resulting network interface name: must be no more than 253 characters`, make([]byte, validation.DNS1123SubdomainMaxLength)),
-						`spec.network.interfaces[1].name: Invalid value: "dummy-vm-dummy-nw-dummy_If": is the resulting network interface name: a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters`,
-						`'-' or '.'`,
-						`and must start and end with an alphanumeric character (e.g. 'example.com'`,
-						"regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')"),
+						`spec.network.interfaces[1].name: Invalid value: "dummy-vm-dummy-nw-dummy_If": is the resulting network interface name: a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', `+
+							`and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')`,
+					),
 				},
 			),
 		)


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This message was split over multiple lines. This might have been a left over from when doValidateWithMsg() was splitting the validation response by "," (since that is what is used to join the individual failure reasons) but that falls apart for messages that have "," in them so we just match by substring instead.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note
NONE
```