### PR TITLE
✨ Zone placement group and org

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -91,4 +91,25 @@ const (
 	// VCCredsSecretName is the name of the secret in the pod namespace
 	// that contains the VC credentials.
 	VCCredsSecretName = "wcp-vmop-sa-vc-auth" //nolint:gosec
+
+	// ZonePlacementOrgLabelKey is the name of a label that may be used with
+	// a shared value across a group of Zone Placement Groups (ZPG), also
+	// known as a Zone Placement Org (ZPO). This is to ensure all ZPGs within
+	// a ZPO are best-effort spread across available zones.
+	//
+	// When the number of ZPGs in a ZPO exceed the number of available zones,
+	// the ZPGs that are placed after the number of zones are exceeded can end
+	// up in any zone.
+	ZonePlacementOrgLabelKey = "vmoperator.vmware.com/zone-placement-org"
+
+	// ZonePlacementGroupLabelKey is the name of a label that may be used with
+	// a shared value across a group of VMs to ensure all the VMs honor the
+	// zone placement result of the first VM from the group to receive a
+	// placement recommendation.
+	//
+	// This label should only be used for concepts like a pool of VMs that
+	// otherwise use the same VM class, image and storage class, as placement
+	// will only consider these requirements for the first VM that requests
+	// placement out of the entire group.
+	ZonePlacementGroupLabelKey = "vmoperator.vmware.com/zone-placement-group"
 )


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch introduces the concepts of a Zone Placement Group (ZPG) and Zone Placement Org (ZPO). VM workloads in a ZPG are affined to a single zone with the zone discovered by using DRS to do placement for a single member of the ZPG. ZPGs in a ZPO are automatically spread across available zones. If the number of ZPGs in a ZPO exceeds the number of available zones then the remaining ZPGs are placed non-deterministically.

The label "vmoperator.vmware.com/zone-placement-group" is used to define a ZPG. The label "vmoperator.vmware.com/zone-placement-org" is used to define a ZPO.
    
VMs may be members of ZPGs without also being members of ZPOs. However, VMs MUST be members of ZPGs in order to participate in a ZPO.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

Please note this is effectively affinity, which is not yet available for VM workloads on Supervisor to due DRS. However, this is required as part of a VKS use case. The provided label may eventually be removed and replaced with actual affinity.

Please see the coverage to prove the new test handles the new code:

<img width="997" alt="image" src="https://github.com/user-attachments/assets/e71d122a-2800-4d1d-b578-ce3be443e631" />

<img width="997" alt="image" src="https://github.com/user-attachments/assets/55a39a21-0976-40af-96e8-b08b9adc9d0f" />

<img width="997" alt="image" src="https://github.com/user-attachments/assets/191831d2-1e22-4adb-bee7-e68d854e679f" />

<img width="997" alt="image" src="https://github.com/user-attachments/assets/735a7243-819c-4b9e-99cf-852d1f4ba74b" />

<img width="997" alt="image" src="https://github.com/user-attachments/assets/3661bbac-26c7-4490-866e-91e5c228393f" />

<img width="997" alt="image" src="https://github.com/user-attachments/assets/5569d7f4-72bf-49a0-8e96-1fc889a5ba43" />



**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Support for zone placement groups to ensure all VMs in a group are placed in the same zone based on a DRS recommendation for one member of the group and zone placement orgs to ensure the groups in an org are best-effort spread across zones.
```