### PR TITLE
✨ Support PVCs with WFFC StorageClass

### DIFF
--- a/controllers/virtualmachine/volume/volume_controller_suite_test.go
+++ b/controllers/virtualmachine/volume/volume_controller_suite_test.go
@@ -29,7 +29,6 @@ var suite = builder.NewTestSuiteForControllerWithContext(
 	})
 
 func TestVolume(t *testing.T) {
-
 	suite.Register(t, "Volume controller suite", intgTests, unitTests)
 }
 

--- a/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
@@ -1311,64 +1311,6 @@ func unitTestsValidateCreate() {
 		})
 	})
 
-	Context("Volumes", func() {
-		DescribeTable("PVC with StorageClass",
-			doTest,
-			Entry("Immediate",
-				testParams{
-					setup: func(ctx *unitValidatingWebhookContext) {
-						sc := builder.DummyStorageClass()
-						sc.VolumeBindingMode = ptr.To(storagev1.VolumeBindingImmediate)
-						Expect(ctx.Client.Create(ctx, sc)).To(Succeed())
-						pvc := builder.DummyPersistentVolumeClaim()
-						pvc.Namespace = ctx.vm.Namespace
-						pvc.Spec.StorageClassName = &sc.Name
-						Expect(ctx.Client.Create(ctx, pvc)).To(Succeed())
-
-						ctx.vm.Spec.Volumes = append(ctx.vm.Spec.Volumes, vmopv1.VirtualMachineVolume{
-							Name: "test-vol",
-							VirtualMachineVolumeSource: vmopv1.VirtualMachineVolumeSource{
-								PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
-									PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
-										ClaimName: pvc.Name,
-									},
-								},
-							},
-						})
-					},
-					expectAllowed: true,
-				},
-			),
-
-			Entry("WaitForFirstConsumer",
-				testParams{
-					setup: func(ctx *unitValidatingWebhookContext) {
-						sc := builder.DummyStorageClass()
-						sc.VolumeBindingMode = ptr.To(storagev1.VolumeBindingWaitForFirstConsumer)
-						Expect(ctx.Client.Create(ctx, sc)).To(Succeed())
-						pvc := builder.DummyPersistentVolumeClaim()
-						pvc.Namespace = ctx.vm.Namespace
-						pvc.Spec.StorageClassName = &sc.Name
-						Expect(ctx.Client.Create(ctx, pvc)).To(Succeed())
-
-						ctx.vm.Spec.Volumes = append(ctx.vm.Spec.Volumes, vmopv1.VirtualMachineVolume{
-							Name: "test-vol",
-							VirtualMachineVolumeSource: vmopv1.VirtualMachineVolumeSource{
-								PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
-									PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
-										ClaimName: pvc.Name,
-									},
-								},
-							},
-						})
-					},
-					validate: doValidateWithMsg(
-						`spec.volumes[1].persistentVolumeClaim: Forbidden: PVC with WaitForFirstConsumer StorageClass is not supported for VirtualMachines`),
-				},
-			),
-		)
-	})
-
 	Context("Bootstrap", func() {
 
 		DescribeTable("bootstrap create", doTest,
@@ -4026,64 +3968,6 @@ func unitTestsValidateUpdate() {
 			},
 		),
 	)
-
-	Context("Volumes", func() {
-		DescribeTable("PVC with StorageClass",
-			doTest,
-			Entry("Immediate",
-				testParams{
-					setup: func(ctx *unitValidatingWebhookContext) {
-						sc := builder.DummyStorageClass()
-						sc.VolumeBindingMode = ptr.To(storagev1.VolumeBindingImmediate)
-						Expect(ctx.Client.Create(ctx, sc)).To(Succeed())
-						pvc := builder.DummyPersistentVolumeClaim()
-						pvc.Namespace = ctx.vm.Namespace
-						pvc.Spec.StorageClassName = &sc.Name
-						Expect(ctx.Client.Create(ctx, pvc)).To(Succeed())
-
-						ctx.vm.Spec.Volumes = append(ctx.vm.Spec.Volumes, vmopv1.VirtualMachineVolume{
-							Name: "test-vol",
-							VirtualMachineVolumeSource: vmopv1.VirtualMachineVolumeSource{
-								PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
-									PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
-										ClaimName: pvc.Name,
-									},
-								},
-							},
-						})
-					},
-					expectAllowed: true,
-				},
-			),
-
-			Entry("WaitForFirstConsumer",
-				testParams{
-					setup: func(ctx *unitValidatingWebhookContext) {
-						sc := builder.DummyStorageClass()
-						sc.VolumeBindingMode = ptr.To(storagev1.VolumeBindingWaitForFirstConsumer)
-						Expect(ctx.Client.Create(ctx, sc)).To(Succeed())
-						pvc := builder.DummyPersistentVolumeClaim()
-						pvc.Namespace = ctx.vm.Namespace
-						pvc.Spec.StorageClassName = &sc.Name
-						Expect(ctx.Client.Create(ctx, pvc)).To(Succeed())
-
-						ctx.vm.Spec.Volumes = append(ctx.vm.Spec.Volumes, vmopv1.VirtualMachineVolume{
-							Name: "test-vol",
-							VirtualMachineVolumeSource: vmopv1.VirtualMachineVolumeSource{
-								PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
-									PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
-										ClaimName: pvc.Name,
-									},
-								},
-							},
-						})
-					},
-					validate: doValidateWithMsg(
-						`spec.volumes[1].persistentVolumeClaim: Forbidden: PVC with WaitForFirstConsumer StorageClass is not supported for VirtualMachines`),
-				},
-			),
-		)
-	})
 
 	Context("Network", func() {
 


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

For PVCs that are using a WaitForFirstConsumer StorageClass, set the PVC selected-node annotation to one of the Node names that is in the same Zone as the VM (any Node is sufficient).

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note
For VM Volumes that reference a PVC with a WaitForFirstConsumer StorageClass, set the volume.kubernetes.io/selected-node annotation to that of a Node in the VM's Zone.
```