### PR TITLE
:bug: Do not patch a zone with finalizer if it is being deleted

### DIFF
--- a/pkg/util/vsphere/watcher/watcher_context.go
+++ b/pkg/util/vsphere/watcher/watcher_context.go
@@ -113,3 +113,21 @@ func Remove(ctx context.Context, ref moRef, id string) (err error) {
 		})
 	return
 }
+
+// Close closes the watcher associated with the context.
+func Close(ctx context.Context) (err error) {
+	if !pkgcfg.FromContext(ctx).AsyncSignalEnabled {
+		return ErrAsyncSignalDisabled
+	}
+	ctxgen.ExecWithContext(
+		ctx,
+		contextKeyValue,
+		func(w contextValueType) {
+			if w == nil {
+				err = ErrNoWatcher
+			} else {
+				w.close()
+			}
+		})
+	return
+}

--- a/services/vm-watcher/vm_watcher_service.go
+++ b/services/vm-watcher/vm_watcher_service.go
@@ -132,6 +132,17 @@ func (s Service) vmFolderMoRefWithIDs(
 		z := zones.Items[i]
 
 		if v := z.Spec.ManagedVMs.FolderMoID; v != "" {
+
+			// If a zone is being deleted and it does not have any
+			// finalizer, the zone controller has already stopped the
+			// watcher and removed the finalizer. Or, a zone is being
+			// deleted even before a watcher could start. In either
+			// case, no need to watch this folder.
+			if !z.DeletionTimestamp.IsZero() &&
+				!controllerutil.ContainsFinalizer(&z, zonectrl.Finalizer) {
+				continue
+			}
+
 			if _, ok := moids[v]; !ok {
 				moids[v] = make([]string, 0, 1)
 
@@ -144,6 +155,7 @@ func (s Service) vmFolderMoRefWithIDs(
 			}
 			moids[v] = append(moids[v], fmt.Sprintf("%s/%s", z.Namespace, z.Name))
 
+			// Ensure we add a finalizer to zones that the watcher is watching.
 			if !controllerutil.ContainsFinalizer(&z, zonectrl.Finalizer) {
 				zonesWithoutFinalizer = append(zonesWithoutFinalizer, z)
 			}


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

API server rejects Patch requests when the zone controller is attempting to add a finalizer to the zone, causing the watcher to never start.  And since the watcher is the entity removing the finalizer, the zone stays stuck in deletion forever.  This change skips a zone from being patched if the zone is being deleted.

Additionally, do not watch folders backing a zone if the zone is marked for deletion and the zone does not contain the finalizer.  This can happen in situations where the zone controller has already removed the finalizer after stopping the watcher, but the zone is somehow not removed.

**Please add a release note if necessary**:

```release-note
Do not patch a zone with finalizer if it is being deleted
```