### PR TITLE
🐛 Handle resize for VMs that were classless

### DIFF
--- a/pkg/util/vmopv1/resize.go
+++ b/pkg/util/vmopv1/resize.go
@@ -58,6 +58,9 @@ func MustSetLastResizedAnnotation(
 }
 
 // SetLastResizedAnnotationClassName sets the resize annotation to just of the class name.
+// This is called from the VM mutation wehbook to record the prior class name of a VM
+// that does not already have the annotation (so that ResizeNeeded() will return true).
+// Note className may be empty if the VM was classless.
 func SetLastResizedAnnotationClassName(
 	vm *vmopv1.VirtualMachine,
 	className string) error {
@@ -107,7 +110,7 @@ func ResizeNeeded(
 	vmClass vmopv1.VirtualMachineClass) bool {
 
 	lra, exists := getLastResizeAnnotation(vm)
-	if !exists || lra.Name == "" {
+	if !exists {
 		// The VM does not have the last resized annotation. Most likely this is an existing VM
 		// and the VM Spec.ClassName hasn't been changed (because the mutation webhook sets the
 		// annotation when it changes). However, if the same class opt-in annotation is set, do

--- a/webhooks/virtualmachine/mutation/virtualmachine_mutator_unit_test.go
+++ b/webhooks/virtualmachine/mutation/virtualmachine_mutator_unit_test.go
@@ -1148,6 +1148,23 @@ func unitTestsMutating() {
 					})
 				})
 
+				When("existing vm is classless", func() {
+					It("set last-resize annotation", func() {
+						oldVM.Spec.ClassName = ""
+						ctx.vm.Spec.ClassName = newClassName
+
+						updated, err := mutation.SetLastResizeAnnotation(&ctx.WebhookRequestContext, ctx.vm, oldVM)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(updated).To(BeTrue())
+
+						className, uid, gen, exists := vmopv1util.GetLastResizedAnnotation(*ctx.vm)
+						Expect(exists).To(BeTrue())
+						Expect(className).To(Equal(oldVM.Spec.ClassName))
+						Expect(uid).To(BeEmpty())
+						Expect(gen).To(BeZero())
+					})
+				})
+
 				When("vm already has last-resize annotation", func() {
 					It("annotation is not changed", func() {
 						vmClass := builder.DummyVirtualMachineClass("my-class")


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

For a classless VM, we'll store an empty class name in the LastResizedAnnotation value. Update ResizeNeeded() to instead compare that empty class name with the existing - now not empty class name - so it will now return that the VM needs a resize.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note
Handle resize of VMs that were originally classless.
```