### PR TITLE
🐛 Determine NS associated StorageClass only with Policy ID

### DIFF
--- a/controllers/storagepolicyquota/storagepolicyquota_controller.go
+++ b/controllers/storagepolicyquota/storagepolicyquota_controller.go
@@ -126,12 +126,11 @@ func (r *Reconciler) ReconcileNormal(
 		return err
 	}
 
-	// Get the list of storage classes for the provided policy ID.
-	objs, err := spqutil.GetStorageClassesForPolicy(
+	// Get the list of storage classes for the provided policy quota.
+	objs, err := spqutil.GetStorageClassesForPolicyQuota(
 		ctx,
 		r.Client,
-		src.Namespace,
-		src.Spec.StoragePolicyId)
+		src)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/kube/spq/spq_suite_test.go
+++ b/pkg/util/kube/spq/spq_suite_test.go
@@ -28,4 +28,6 @@ const (
 	defaultNamespace = "default"
 	myStorageClass   = "my-storage-class"
 	fakeString       = "fake"
+	sc1PolicyID      = "my-storage-policy-id-1"
+	sc2PolicyID      = "my-storage-policy-id-2"
 )

--- a/test/builder/dummies.go
+++ b/test/builder/dummies.go
@@ -50,13 +50,17 @@ const (
 )
 
 func DummyStorageClass() *storagev1.StorageClass {
+	return DummyStorageClassWithID("id42")
+}
+
+func DummyStorageClassWithID(policyID string) *storagev1.StorageClass {
 	return &storagev1.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: DummyStorageClassName,
 		},
 		Provisioner: "foo",
 		Parameters: map[string]string{
-			"storagePolicyID": "id42",
+			"storagePolicyID": policyID,
 		},
 	}
 }
@@ -156,33 +160,14 @@ func DummyClusterContentLibrary(name, uuid string) *imgregv1a1.ClusterContentLib
 	}
 }
 
-func DummyStoragePolicyQuota(quotaName, quotaNs, className string) *spqv1.StoragePolicyQuota {
+func DummyStoragePolicyQuota(name, namespace, policyID string) *spqv1.StoragePolicyQuota {
 	return &spqv1.StoragePolicyQuota{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      quotaName,
-			Namespace: quotaNs,
+			Name:      name,
+			Namespace: namespace,
 		},
-		Spec: spqv1.StoragePolicyQuotaSpec{StoragePolicyId: "uuid-abcd-1234"},
-		Status: spqv1.StoragePolicyQuotaStatus{
-			SCLevelQuotaStatuses: []spqv1.SCLevelQuotaStatus{
-				{
-					StorageClassName: className,
-				},
-			},
-			ResourceTypeLevelQuotaStatuses: []spqv1.ResourceTypeLevelQuotaStatus{
-				{
-					ResourceExtensionName: "volume.cns.vsphere.vmware.com",
-					ResourceTypeSCLevelQuotaStatuses: []spqv1.SCLevelQuotaStatus{{
-						StorageClassName: className,
-					}},
-				},
-				{
-					ResourceExtensionName: "volume.cns.vsphere.vmware.com",
-					ResourceTypeSCLevelQuotaStatuses: []spqv1.SCLevelQuotaStatus{{
-						StorageClassName: className + "-abcde",
-					}},
-				},
-			},
+		Spec: spqv1.StoragePolicyQuotaSpec{
+			StoragePolicyId: policyID,
 		},
 	}
 }

--- a/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
@@ -1265,12 +1265,12 @@ func unitTestsValidateCreate() {
 				Entry("storage class associated with namespace",
 					testParams{
 						setup: func(ctx *unitValidatingWebhookContext) {
-							storageClass := builder.DummyStorageClass()
+							storageClass := builder.DummyStorageClassWithID("my-policy-id")
 							Expect(ctx.Client.Create(ctx, storageClass)).To(Succeed())
 							ctx.vm.Spec.StorageClass = storageClass.Name
 
 							storagePolicyQuota := builder.DummyStoragePolicyQuota(
-								storageClass.Name+"-storagepolicyquota", ctx.vm.Namespace, storageClass.Name)
+								storageClass.Name+"-storagepolicyquota", ctx.vm.Namespace, "my-policy-id")
 							Expect(ctx.Client.Create(ctx, storagePolicyQuota)).To(Succeed())
 						},
 						expectAllowed: true,
@@ -1279,12 +1279,12 @@ func unitTestsValidateCreate() {
 				Entry("storage class not associated with namespace",
 					testParams{
 						setup: func(ctx *unitValidatingWebhookContext) {
-							storageClass := builder.DummyStorageClass()
+							storageClass := builder.DummyStorageClassWithID("my-policy-id")
 							Expect(ctx.Client.Create(ctx, storageClass)).To(Succeed())
 							ctx.vm.Spec.StorageClass = storageClass.Name
 
 							storagePolicyQuota := builder.DummyStoragePolicyQuota(
-								storageClass.Name+"-storagepolicyquota", ctx.vm.Namespace, storageClass.Name+"foo")
+								storageClass.Name+"-storagepolicyquota", ctx.vm.Namespace, "some-other-id")
 							Expect(ctx.Client.Create(ctx, storagePolicyQuota)).To(Succeed())
 						},
 						validate: doValidateWithMsg(
@@ -1294,14 +1294,14 @@ func unitTestsValidateCreate() {
 				Entry("WFFC storage class associated with namespace",
 					testParams{
 						setup: func(ctx *unitValidatingWebhookContext) {
-							storageClass := builder.DummyStorageClass()
+							storageClass := builder.DummyStorageClassWithID("my-policy-id")
 							baseSCName := storageClass.Name
 							storageClass.Name += "wffc"
 							Expect(ctx.Client.Create(ctx, storageClass)).To(Succeed())
 							ctx.vm.Spec.StorageClass = storageClass.Name
 
 							storagePolicyQuota := builder.DummyStoragePolicyQuota(
-								baseSCName+"-storagepolicyquota", ctx.vm.Namespace, storageClass.Name)
+								baseSCName+"-storagepolicyquota", ctx.vm.Namespace, "my-policy-id")
 							Expect(ctx.Client.Create(ctx, storagePolicyQuota)).To(Succeed())
 						},
 						expectAllowed: true,


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Stop also checking the StoragePolicyQuota Status for the StorageClass name since that is only populated by CSI when a StoragePolicyUsage is created. Previously we would not create our VM SPU until the SPQ Status was populated by the pod SPU. This can lead to delays before we would determine that the StorageClass has been associated with the namespace.

Also, do not list all StoragePolicyQuotas during SPQ reconcile.  When reconciling a SQP, we would later end up listing all the SQP in the namespace to determine what storage classes are associated with the policy quota. We don't need to list all the SQPs since each one will be reconciled.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #

**Are there any special notes for your reviewer**:

CSI says that both the Immediate and WFFC variants of the SC are always suppose to be made available to an NS together.

**Please add a release note if necessary**:

```release-note
Stop referring to the StoragePolicyQuota Status for StorageClass namespace association.
```