### PR TITLE
🐛 Always set ConfigSpec CpuAllocation.Shares field

### DIFF
--- a/pkg/providers/vsphere/virtualmachine/configspec_test.go
+++ b/pkg/providers/vsphere/virtualmachine/configspec_test.go
@@ -115,11 +115,11 @@ var _ = Describe("CreateConfigSpec", func() {
 					Expect(configSpec.CpuAllocation.Shares).ToNot(BeNil())
 					Expect(configSpec.CpuAllocation.Shares.Level).To(Equal(vimtypes.SharesLevelNormal))
 					Expect(configSpec.CpuAllocation.Limit).To(HaveValue(BeEquivalentTo(-1)))
-					Expect(configSpec.CpuAllocation.Reservation).To(HaveValue(BeEquivalentTo(0)))
+					Expect(configSpec.CpuAllocation.Reservation).To(HaveValue(BeZero()))
 					Expect(configSpec.MemoryAllocation.Shares).ToNot(BeNil())
 					Expect(configSpec.MemoryAllocation.Shares.Level).To(Equal(vimtypes.SharesLevelNormal))
 					Expect(configSpec.MemoryAllocation.Limit).To(HaveValue(BeEquivalentTo(-1)))
-					Expect(configSpec.MemoryAllocation.Reservation).To(HaveValue(BeEquivalentTo(0)))
+					Expect(configSpec.MemoryAllocation.Reservation).To(HaveValue(BeZero()))
 				})
 			})
 
@@ -199,6 +199,12 @@ var _ = Describe("CreateConfigSpec", func() {
 			classConfigSpec = vimtypes.VirtualMachineConfigSpec{
 				Name:       "dont-use-this-dummy-VM",
 				Annotation: "test-annotation",
+				CpuAllocation: &vimtypes.ResourceAllocationInfo{
+					Reservation: ptr.To[int64](42),
+				},
+				MemoryAllocation: &vimtypes.ResourceAllocationInfo{
+					Reservation: ptr.To[int64](42),
+				},
 				DeviceChange: []vimtypes.BaseVirtualDeviceConfigSpec{
 					&vimtypes.VirtualDeviceConfigSpec{
 						Operation: vimtypes.VirtualDeviceConfigSpecOperationAdd,
@@ -222,7 +228,15 @@ var _ = Describe("CreateConfigSpec", func() {
 			Expect(configSpec.NumCPUs).To(BeEquivalentTo(vmClassSpec.Hardware.Cpus))
 			Expect(configSpec.MemoryMB).To(BeEquivalentTo(4 * 1024))
 			Expect(configSpec.CpuAllocation).ToNot(BeNil())
+			Expect(configSpec.CpuAllocation.Shares).ToNot(BeNil())
+			Expect(configSpec.CpuAllocation.Shares.Level).To(Equal(vimtypes.SharesLevelNormal))
+			Expect(configSpec.CpuAllocation.Reservation).To(HaveValue(BeEquivalentTo(2684354560000)))
+			Expect(configSpec.CpuAllocation.Limit).To(HaveValue(BeEquivalentTo(5368709120000)))
 			Expect(configSpec.MemoryAllocation).ToNot(BeNil())
+			Expect(configSpec.MemoryAllocation.Shares).ToNot(BeNil())
+			Expect(configSpec.MemoryAllocation.Shares.Level).To(Equal(vimtypes.SharesLevelNormal))
+			Expect(configSpec.MemoryAllocation.Reservation).To(HaveValue(BeEquivalentTo(2048)))
+			Expect(configSpec.MemoryAllocation.Limit).To(HaveValue(BeEquivalentTo(4096)))
 			Expect(configSpec.Firmware).To(Equal(vmImageStatus.Firmware))
 			Expect(configSpec.DeviceChange).To(HaveLen(1))
 			dSpec := configSpec.DeviceChange[0].GetVirtualDeviceConfigSpec()


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Just like the MemoryAllocation.Shares, some changes in PlaceVmsXCluster now requires the Shares to always be set. Simplify some duplicated defaulting code for the CPU and Memory ResourceAllocationInfos.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

**Please add a release note if necessary**:

```release-note
Default ConfigSpec CPU and Memory resource allocation to best-effort, to satisfy PlaceVmsXCluster requirement
```