### PR TITLE
🐛 Fix StorageClass usage for VMs

### DIFF
--- a/controllers/virtualmachine/storagepolicyusage/storagepolicyusage_controller_unit_test.go
+++ b/controllers/virtualmachine/storagepolicyusage/storagepolicyusage_controller_unit_test.go
@@ -17,6 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -80,8 +81,22 @@ func unitTestsReconcile() {
 			withObjects = append(withObjects, vm2)
 		}
 
-		ctx = suite.NewUnitTestContextForControllerWithFuncs(
-			withFuncs, withObjects...)
+		ctx = suite.NewUnitTestContextForController()
+
+		// Replace the client with one that has the indexed field.
+		ctx.Client = ctrlfake.NewClientBuilder().
+			WithScheme(builder.NewScheme()).
+			WithIndex(
+				&vmopv1.VirtualMachine{},
+				"spec.storageClass",
+				func(rawObj ctrlclient.Object) []string {
+					vm := rawObj.(*vmopv1.VirtualMachine)
+					return []string{vm.Spec.StorageClass}
+				}).
+			WithObjects(withObjects...).
+			WithInterceptorFuncs(withFuncs).
+			WithStatusSubresource(builder.KnownObjectTypes()...).
+			Build()
 
 		reconciler = storagepolicyusage.NewReconciler(
 			pkgcfg.UpdateContext(
@@ -287,6 +302,7 @@ func unitTestsReconcile() {
 							Kind: "VirtualMachineImage",
 							Name: "my-vmi",
 						},
+						StorageClass: name,
 					},
 					Status: vmopv1.VirtualMachineStatus{
 						Conditions: []metav1.Condition{
@@ -313,6 +329,7 @@ func unitTestsReconcile() {
 							Kind: "VirtualMachineImage",
 							Name: "my-vmi",
 						},
+						StorageClass: name,
 					},
 					Status: vmopv1.VirtualMachineStatus{
 						Conditions: []metav1.Condition{
@@ -388,6 +405,14 @@ func unitTestsReconcile() {
 					vm1.Finalizers = []string{"fake.com/finalizer"}
 				})
 				Specify("the reported information should only include non-deleted VMs", func() {
+					assertReportedTotals(spu, err, nil, zeroQuantity, resource.MustParse("10Gi"))
+				})
+			})
+			Context("that have different storage classes", func() {
+				BeforeEach(func() {
+					vm1.Spec.StorageClass = name + "1"
+				})
+				Specify("the reported information should only include VMs that use the same storage class", func() {
 					assertReportedTotals(spu, err, nil, zeroQuantity, resource.MustParse("10Gi"))
 				})
 			})


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch fixes the way VM usage is reported for StoragePolicyUsage documents. Previously all VMs in a namespace would be summed to find a StoragePolicyUsage document's total usage. In fact only the VMs that use the same StorageClass as the StoragePolicyUsage should be included.



**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

Cross-porting this to 9.0 is going to be manual because of changes to the VM storage status on main. See https://github.com/vmware-tanzu/vm-operator/pull/865 for those changes.


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Do not over-count for when determining StorageClass usage.
```