### PR TITLE
[x-port 9.0] 🐛 Fix StorageClass usage for VMs

### DIFF
--- a/controllers/virtualmachine/storagepolicyusage/storagepolicyusage_controller.go
+++ b/controllers/virtualmachine/storagepolicyusage/storagepolicyusage_controller.go
@@ -36,6 +36,19 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
 	)
 
+	// Index the VM's spec.storageClass field to make it easy to list VMs in a
+	// namespace by the field.
+	if err := mgr.GetFieldIndexer().IndexField(
+		ctx,
+		&vmopv1.VirtualMachine{},
+		"spec.storageClass",
+		func(rawObj client.Object) []string {
+			vm := rawObj.(*vmopv1.VirtualMachine)
+			return []string{vm.Spec.StorageClass}
+		}); err != nil {
+		return err
+	}
+
 	r := NewReconciler(
 		ctx,
 		mgr.GetClient(),
@@ -117,7 +130,19 @@ func (r *Reconciler) ReconcileNormal(
 	if err := r.Client.List(
 		ctx,
 		&list,
-		client.InNamespace(namespace)); err != nil {
+		client.InNamespace(namespace),
+		client.MatchingFields{"spec.storageClass": obj.Spec.StorageClassName},
+		//
+		// !!! WARNING !!!
+		//
+		// The use of the UnsafeDisableDeepCopy option improves
+		// performance by skipping a CPU-intensive operation.
+		// However, it also means any writes to the returned
+		// objects will directly impact the cache. Therefore,
+		// please be aware of this when doing anything with the
+		// object(s) that are the result of this operation.
+		//
+		client.UnsafeDisableDeepCopy); err != nil {
 
 		return fmt.Errorf(
 			"failed to list VMs in namespace %s: %w", namespace, err)


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch fixes the way VM usage is reported for StoragePolicyUsage documents. Previously all VMs in a namespace would be summed to find a StoragePolicyUsage document's total usage. In fact only the VMs that use the same StorageClass as the StoragePolicyUsage should be included.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Do not over-count for when determining StorageClass usage.
```