### PR TITLE
🐛 Defer content version check when Fast Deploy

### DIFF
--- a/controllers/contentlibrary/utils/controller_builder.go
+++ b/controllers/contentlibrary/utils/controller_builder.go
@@ -462,10 +462,20 @@ func (r *Reconciler) syncImageContent(
 	vmiStatus *vmopv1.VirtualMachineImageStatus) error {
 
 	latestVersion := cliStatus.ContentVersion
-	if vmiStatus.ProviderContentVersion == latestVersion {
-		// Hack: populate Disks fields during version upgrade.
-		if len(vmiStatus.Disks) != 0 {
-			return nil
+
+	if !pkgcfg.FromContext(ctx).Features.FastDeploy {
+		// This same check is performed in the VMI Cache controller, which is
+		// what actually retrieves the OVF when syncing a VMI when Fast Deploy
+		// is enabled. Therefore this check does not need to be performed here.
+		//
+		// Additionally, if the Fast Deploy FSS is enabled *after* a VMI is
+		// created, the following content version check would prevent the VMI
+		// Cache object from being created.
+		if vmiStatus.ProviderContentVersion == latestVersion {
+			// Hack: populate Disks fields during version upgrade.
+			if len(vmiStatus.Disks) != 0 {
+				return nil
+			}
 		}
 	}
 


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch defers the content version check of a VMI to the VMI Cache controller when Fast Deploy is enabled.

This change also allows the Fast Deploy FSS to be enabled after VMIs are already created without having to delete the VMIs and bounce the VM Op controller.



**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```