### PR TITLE
🌱 Golang 1.24.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/vm-operator
 
-go 1.24.1
+go 1.24.2
 
 replace (
 	github.com/vmware-tanzu/vm-operator/api => ./api

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/vmware-tanzu/vm-operator/hack/tools
 
 go 1.23.0
 
-toolchain go1.24.1
+toolchain go1.24.2
 
 require (
 	github.com/AlekSi/gocov-xml v1.1.0


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR updates VM Operator to use Golang 1.24.2 to fix vulncheck-go reported in CI: https://github.com/vmware-tanzu/vm-operator/actions/runs/14384515971/job/40336445216?pr=933


**Which issue(s) is/are addressed by this PR?**
Fixes N/A.


**Are there any special notes for your reviewer**:

Another PR will be submitted to the internal cayman_vm-operator repo to upgrade the cayman_go version as well.

**Please add a release note if necessary**:

```release-note
Golang 1.24.2
```