### PR TITLE
🌱 Allow changes to VM Spec.Networks.Interfaces

### DIFF
--- a/pkg/config/capabilities/capabilities_test.go
+++ b/pkg/config/capabilities/capabilities_test.go
@@ -141,6 +141,9 @@ var _ = Describe("UpdateCapabilities", func() {
 						capabilities.CapabilityKeyWorkloadIsolation: {
 							Activated: true,
 						},
+						capabilities.CapabilityKeyMutableNetworks: {
+							Activated: true,
+						},
 					}
 					Expect(client.Status().Patch(ctx, &obj, objPatch)).To(Succeed())
 				})
@@ -150,6 +153,7 @@ var _ = Describe("UpdateCapabilities", func() {
 							config.Features.BringYourOwnEncryptionKey = true
 							config.Features.TKGMultipleCL = true
 							config.Features.WorkloadDomainIsolation = true
+							config.Features.MutableNetworks = true
 						})
 					})
 					Specify("capabilities did not change", func() {
@@ -163,6 +167,9 @@ var _ = Describe("UpdateCapabilities", func() {
 					})
 					Specify(capabilities.CapabilityKeyWorkloadIsolation, func() {
 						Expect(pkgcfg.FromContext(ctx).Features.WorkloadDomainIsolation).To(BeTrue())
+					})
+					Specify(capabilities.CapabilityKeyMutableNetworks, func() {
+						Expect(pkgcfg.FromContext(ctx).Features.MutableNetworks).To(BeTrue())
 					})
 				})
 
@@ -178,6 +185,9 @@ var _ = Describe("UpdateCapabilities", func() {
 					})
 					Specify(capabilities.CapabilityKeyWorkloadIsolation, func() {
 						Expect(pkgcfg.FromContext(ctx).Features.WorkloadDomainIsolation).To(BeTrue())
+					})
+					Specify(capabilities.CapabilityKeyMutableNetworks, func() {
+						Expect(pkgcfg.FromContext(ctx).Features.MutableNetworks).To(BeTrue())
 					})
 				})
 			})
@@ -202,6 +212,9 @@ var _ = Describe("UpdateCapabilities", func() {
 						capabilities.CapabilityKeyWorkloadIsolation: {
 							Activated: false,
 						},
+						capabilities.CapabilityKeyMutableNetworks: {
+							Activated: false,
+						},
 					}
 					Expect(client.Status().Patch(ctx, &obj, objPatch)).To(Succeed())
 				})
@@ -218,6 +231,9 @@ var _ = Describe("UpdateCapabilities", func() {
 					Specify(capabilities.CapabilityKeyWorkloadIsolation, func() {
 						Expect(pkgcfg.FromContext(ctx).Features.WorkloadDomainIsolation).To(BeFalse())
 					})
+					Specify(capabilities.CapabilityKeyMutableNetworks, func() {
+						Expect(pkgcfg.FromContext(ctx).Features.MutableNetworks).To(BeFalse())
+					})
 				})
 
 				When("the capabilities are different", func() {
@@ -226,6 +242,7 @@ var _ = Describe("UpdateCapabilities", func() {
 							config.Features.BringYourOwnEncryptionKey = true
 							config.Features.TKGMultipleCL = true
 							config.Features.WorkloadDomainIsolation = true
+							config.Features.MutableNetworks = true
 						})
 					})
 					Specify("capabilities changed", func() {
@@ -239,6 +256,9 @@ var _ = Describe("UpdateCapabilities", func() {
 					})
 					Specify(capabilities.CapabilityKeyWorkloadIsolation, func() {
 						Expect(pkgcfg.FromContext(ctx).Features.WorkloadDomainIsolation).To(BeFalse())
+					})
+					Specify(capabilities.CapabilityKeyMutableNetworks, func() {
+						Expect(pkgcfg.FromContext(ctx).Features.MutableNetworks).To(BeFalse())
 					})
 				})
 			})
@@ -416,6 +436,9 @@ var _ = Describe("WouldUpdateCapabilitiesFeatures", func() {
 			capabilities.CapabilityKeyWorkloadIsolation: {
 				Activated: true,
 			},
+			capabilities.CapabilityKeyMutableNetworks: {
+				Activated: true,
+			},
 		}
 
 		ok, diff = false, ""
@@ -432,6 +455,7 @@ var _ = Describe("WouldUpdateCapabilitiesFeatures", func() {
 					config.Features.BringYourOwnEncryptionKey = true
 					config.Features.TKGMultipleCL = true
 					config.Features.WorkloadDomainIsolation = true
+					config.Features.MutableNetworks = true
 				})
 			})
 			Specify("capabilities did not change", func() {
@@ -447,6 +471,9 @@ var _ = Describe("WouldUpdateCapabilitiesFeatures", func() {
 			Specify(capabilities.CapabilityKeyWorkloadIsolation, func() {
 				Expect(pkgcfg.FromContext(ctx).Features.WorkloadDomainIsolation).To(BeTrue())
 			})
+			Specify(capabilities.CapabilityKeyMutableNetworks, func() {
+				Expect(pkgcfg.FromContext(ctx).Features.MutableNetworks).To(BeTrue())
+			})
 		})
 
 		When("the capabilities are different", func() {
@@ -455,11 +482,12 @@ var _ = Describe("WouldUpdateCapabilitiesFeatures", func() {
 					config.Features.BringYourOwnEncryptionKey = false
 					config.Features.TKGMultipleCL = false
 					config.Features.WorkloadDomainIsolation = false
+					config.Features.MutableNetworks = false
 				})
 			})
 			Specify("capabilities changed", func() {
 				Expect(ok).To(BeTrue())
-				Expect(diff).To(Equal("BringYourOwnEncryptionKey=true,TKGMultipleCL=true,WorkloadDomainIsolation=true"))
+				Expect(diff).To(Equal("BringYourOwnEncryptionKey=true,MutableNetworks=true,TKGMultipleCL=true,WorkloadDomainIsolation=true"))
 			})
 			Specify(capabilities.CapabilityKeyBringYourOwnKeyProvider, func() {
 				Expect(pkgcfg.FromContext(ctx).Features.BringYourOwnEncryptionKey).To(BeFalse())
@@ -469,6 +497,9 @@ var _ = Describe("WouldUpdateCapabilitiesFeatures", func() {
 			})
 			Specify(capabilities.CapabilityKeyWorkloadIsolation, func() {
 				Expect(pkgcfg.FromContext(ctx).Features.WorkloadDomainIsolation).To(BeFalse())
+			})
+			Specify(capabilities.CapabilityKeyMutableNetworks, func() {
+				Expect(pkgcfg.FromContext(ctx).Features.MutableNetworks).To(BeFalse())
 			})
 		})
 	})

--- a/pkg/config/capabilities/capabilties.go
+++ b/pkg/config/capabilities/capabilties.go
@@ -42,6 +42,10 @@ const (
 	// CapabilityKeyWorkloadIsolation is the name of capability key
 	// defined in the capabilities ConfigMap and/or CRD.
 	CapabilityKeyWorkloadIsolation = "Workload_Domain_Isolation_Supported"
+
+	// CapabilityKeyMutableNetworks is the name of capability key
+	// defined in the capabilities ConfigMap and/or CRD.
+	CapabilityKeyMutableNetworks = "supports_VM_service_mutable_networks"
 )
 
 var (
@@ -180,6 +184,8 @@ func updateCapabilitiesFeaturesFromCRD(
 			fs.TKGMultipleCL = capStatus.Activated
 		case CapabilityKeyWorkloadIsolation:
 			fs.WorkloadDomainIsolation = capStatus.Activated
+		case CapabilityKeyMutableNetworks:
+			fs.MutableNetworks = capStatus.Activated
 		}
 	}
 	return fs

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -183,6 +183,7 @@ type FeatureStates struct {
 	BringYourOwnEncryptionKey bool // FSS_WCP_VMSERVICE_BYOK
 	SVAsyncUpgrade            bool // FSS_WCP_SUPERVISOR_ASYNC_UPGRADE
 	FastDeploy                bool // FSS_WCP_VMSERVICE_FAST_DEPLOY
+	MutableNetworks           bool
 }
 
 type InstanceStorage struct {

--- a/webhooks/virtualmachine/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator.go
@@ -1241,7 +1241,7 @@ func (v validator) validateImmutableReserved(
 }
 
 func (v validator) validateImmutableNetwork(
-	_ *pkgctx.WebhookRequestContext,
+	ctx *pkgctx.WebhookRequestContext,
 	vm, oldVM *vmopv1.VirtualMachine) field.ErrorList {
 
 	var allErrs field.ErrorList
@@ -1250,6 +1250,10 @@ func (v validator) validateImmutableNetwork(
 	newNetwork := vm.Spec.Network
 
 	if oldNetwork == nil && newNetwork == nil {
+		return allErrs
+	}
+
+	if pkgcfg.FromContext(ctx).Features.MutableNetworks {
 		return allErrs
 	}
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Relax the VM validation webhook so this is not longer treated as immutable with the capability is enabled. Still a lot of work remaining to allow network mutability end to end.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #

**Are there any special notes for your reviewer**:

**Please add a release note if necessary**:

```release-note
NONE
```