### PR TITLE
🐛 Require VM ResourcePolicyName when specifying a cluster module

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -91,4 +91,8 @@ const (
 	// VCCredsSecretName is the name of the secret in the pod namespace
 	// that contains the VC credentials.
 	VCCredsSecretName = "wcp-vmop-sa-vc-auth" //nolint:gosec
+
+	// ClusterModuleNameAnnotationKey is the annotation key for cluster module group name for
+	// the VM. The VM must have a VirtualMachineSetResourcePolicy assigned.
+	ClusterModuleNameAnnotationKey string = "vsphere-cluster-module-group"
 )

--- a/pkg/providers/vsphere/session/session_vm_update.go
+++ b/pkg/providers/vsphere/session/session_vm_update.go
@@ -21,9 +21,9 @@ import (
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
 	vmopv1common "github.com/vmware-tanzu/vm-operator/api/v1alpha4/common"
-	"github.com/vmware-tanzu/vm-operator/pkg"
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
+	pkgconst "github.com/vmware-tanzu/vm-operator/pkg/constants"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/clustermodules"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/constants"
@@ -824,7 +824,7 @@ func (s *Session) attachClusterModule(
 	resourcePolicy *vmopv1.VirtualMachineSetResourcePolicy) error {
 
 	// The clusterModule is required be able to enforce the vm-vm anti-affinity policy.
-	clusterModuleName := vmCtx.VM.Annotations[pkg.ClusterModuleNameKey]
+	clusterModuleName := vmCtx.VM.Annotations[pkgconst.ClusterModuleNameAnnotationKey]
 	if clusterModuleName == "" {
 		return nil
 	}

--- a/pkg/providers/vsphere/vmprovider_vm_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_test.go
@@ -2824,6 +2824,18 @@ func vmTests() {
 				resourcePolicy = nil
 			})
 
+			When("a cluster module is specified without resource policy", func() {
+				JustBeforeEach(func() {
+					vm.Spec.Reserved.ResourcePolicyName = ""
+				})
+
+				It("returns error", func() {
+					_, err := createOrUpdateAndGetVcVM(ctx, vmProvider, vm)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("cannot set cluster module without resource policy"))
+				})
+			})
+
 			It("VM is created in child Folder and ResourcePool", func() {
 				vcVM, err := createOrUpdateAndGetVcVM(ctx, vmProvider, vm)
 				Expect(err).ToNot(HaveOccurred())

--- a/pkg/vmoperator.go
+++ b/pkg/vmoperator.go
@@ -7,7 +7,4 @@ package pkg
 const (
 	// VMOperatorKey is the base FQDN for VM operator.
 	VMOperatorKey string = "vmoperator.vmware.com"
-
-	// ClusterModuleNameKey is the annotation key for clusterModule group name information at VM operator.
-	ClusterModuleNameKey string = "vsphere-cluster-module-group"
 )


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

The VM SetResourcePolicy contains the cluster module info, so if the VM has the special cluster module annotation, enforce that the resource policy is set.  Post create, we only need the VM's resource policy to set the VM cluster module. We really only need if it is not already set but that is not easy to check as this point.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

The only user of this is well behaved but otherwise this would have caused a panic.

**Please add a release note if necessary**:

```release-note
NONE
```