### PR TITLE
✨ Nuke the old session based class VM updating

### DIFF
--- a/pkg/providers/vsphere/vmprovider_vm_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_test.go
@@ -2147,6 +2147,8 @@ func vmTests() {
 
 			Context("VM Class with PCI passthrough devices", func() {
 				BeforeEach(func() {
+					// For old behavior, we'll fallback to these standalone fields when the class
+					// does not have a ConfigSpec.
 					vmClass.Spec.Hardware.Devices = vmopv1.VirtualDevices{
 						VGPUDevices: []vmopv1.VGPUDevice{
 							{
@@ -2163,7 +2165,7 @@ func vmTests() {
 					}
 				})
 
-				It("VM should not have PCI devices from VM Class", func() {
+				It("VM should have PCI devices from VM Class", func() {
 					vcVM, err := createOrUpdateAndGetVcVM(ctx, vmProvider, vm)
 					Expect(err).ToNot(HaveOccurred())
 
@@ -2172,7 +2174,7 @@ func vmTests() {
 
 					devList := object.VirtualDeviceList(o.Config.Hardware.Device)
 					p := devList.SelectByType(&vimtypes.VirtualPCIPassthrough{})
-					Expect(p).To(BeEmpty())
+					Expect(p).To(HaveLen(2))
 				})
 			})
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

We should be creating the VM with its desired configuration in the first place nowadays so this not needed.
Just comment out the network interface related stuff since it will be reused very soon for network mutability. 

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

**Please add a release note if necessary**:

```release-note
Remove remaining remnants of old post-create VM reconfigure.
```