### PR TITLE
✨ Add option to not configure gateway on interfaces

### DIFF
--- a/api/v1alpha2/virtualmachine_network_types.go
+++ b/api/v1alpha2/virtualmachine_network_types.go
@@ -98,12 +98,11 @@ type VirtualMachineNetworkInterfaceSpec struct {
 
 	// Gateway4 is the default, IP4 gateway for this interface.
 	//
+	// If unset, the gateway from the network provider will be used. However,
+	// if set to "None", the network provider gateway will be ignored.
+	//
 	// Please note this field is only supported if the network connection
 	// supports manual IP allocation.
-	//
-	// If the network connection supports manual IP allocation and the
-	// Addresses field includes at least one IP4 address, then this field
-	// is required.
 	//
 	// Please note the IP address must include the network prefix length, ex.
 	// 192.168.0.1/24.
@@ -115,12 +114,11 @@ type VirtualMachineNetworkInterfaceSpec struct {
 
 	// Gateway6 is the primary IP6 gateway for this interface.
 	//
+	// If unset, the gateway from the network provider will be used. However,
+	// if set to "None", the network provider gateway will be ignored.
+	//
 	// Please note this field is only supported if the network connection
 	// supports manual IP allocation.
-	//
-	// If the network connection supports manual IP allocation and the
-	// Addresses field includes at least one IP6 address, then this field
-	// is required.
 	//
 	// Please note the IP address must include the network prefix length, ex.
 	// 2001:db8:101::1/64.

--- a/api/v1alpha3/virtualmachine_network_types.go
+++ b/api/v1alpha3/virtualmachine_network_types.go
@@ -100,12 +100,11 @@ type VirtualMachineNetworkInterfaceSpec struct {
 
 	// Gateway4 is the default, IP4 gateway for this interface.
 	//
+	// If unset, the gateway from the network provider will be used. However,
+	// if set to "None", the network provider gateway will be ignored.
+	//
 	// Please note this field is only supported if the network connection
 	// supports manual IP allocation.
-	//
-	// If the network connection supports manual IP allocation and the
-	// Addresses field includes at least one IP4 address, then this field
-	// is required.
 	//
 	// Please note the IP address must include the network prefix length, ex.
 	// 192.168.0.1/24.
@@ -117,12 +116,11 @@ type VirtualMachineNetworkInterfaceSpec struct {
 
 	// Gateway6 is the primary IP6 gateway for this interface.
 	//
+	// If unset, the gateway from the network provider will be used. However,
+	// if set to "None", the network provider gateway will be ignored.
+	//
 	// Please note this field is only supported if the network connection
 	// supports manual IP allocation.
-	//
-	// If the network connection supports manual IP allocation and the
-	// Addresses field includes at least one IP6 address, then this field
-	// is required.
 	//
 	// Please note the IP address must include the network prefix length, ex.
 	// 2001:db8:101::1/64.

--- a/api/v1alpha4/virtualmachine_network_types.go
+++ b/api/v1alpha4/virtualmachine_network_types.go
@@ -100,12 +100,11 @@ type VirtualMachineNetworkInterfaceSpec struct {
 
 	// Gateway4 is the default, IP4 gateway for this interface.
 	//
+	// If unset, the gateway from the network provider will be used. However,
+	// if set to "None", the network provider gateway will be ignored.
+	//
 	// Please note this field is only supported if the network connection
 	// supports manual IP allocation.
-	//
-	// If the network connection supports manual IP allocation and the
-	// Addresses field includes at least one IP4 address, then this field
-	// is required.
 	//
 	// Please note the IP address must include the network prefix length, ex.
 	// 192.168.0.1/24.
@@ -117,12 +116,11 @@ type VirtualMachineNetworkInterfaceSpec struct {
 
 	// Gateway6 is the primary IP6 gateway for this interface.
 	//
+	// If unset, the gateway from the network provider will be used. However,
+	// if set to "None", the network provider gateway will be ignored.
+	//
 	// Please note this field is only supported if the network connection
 	// supports manual IP allocation.
-	//
-	// If the network connection supports manual IP allocation and the
-	// Addresses field includes at least one IP6 address, then this field
-	// is required.
 	//
 	// Please note the IP address must include the network prefix length, ex.
 	// 2001:db8:101::1/64.

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachinereplicasets.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachinereplicasets.yaml
@@ -1368,12 +1368,11 @@ spec:
                                   description: |-
                                     Gateway4 is the default, IP4 gateway for this interface.
 
+                                    If unset, the gateway from the network provider will be used. However,
+                                    if set to "None", the network provider gateway will be ignored.
+
                                     Please note this field is only supported if the network connection
                                     supports manual IP allocation.
-
-                                    If the network connection supports manual IP allocation and the
-                                    Addresses field includes at least one IP4 address, then this field
-                                    is required.
 
                                     Please note the IP address must include the network prefix length, ex.
                                     192.168.0.1/24.
@@ -1384,12 +1383,11 @@ spec:
                                   description: |-
                                     Gateway6 is the primary IP6 gateway for this interface.
 
+                                    If unset, the gateway from the network provider will be used. However,
+                                    if set to "None", the network provider gateway will be ignored.
+
                                     Please note this field is only supported if the network connection
                                     supports manual IP allocation.
-
-                                    If the network connection supports manual IP allocation and the
-                                    Addresses field includes at least one IP6 address, then this field
-                                    is required.
 
                                     Please note the IP address must include the network prefix length, ex.
                                     2001:db8:101::1/64.
@@ -3298,12 +3296,11 @@ spec:
                                   description: |-
                                     Gateway4 is the default, IP4 gateway for this interface.
 
+                                    If unset, the gateway from the network provider will be used. However,
+                                    if set to "None", the network provider gateway will be ignored.
+
                                     Please note this field is only supported if the network connection
                                     supports manual IP allocation.
-
-                                    If the network connection supports manual IP allocation and the
-                                    Addresses field includes at least one IP4 address, then this field
-                                    is required.
 
                                     Please note the IP address must include the network prefix length, ex.
                                     192.168.0.1/24.
@@ -3314,12 +3311,11 @@ spec:
                                   description: |-
                                     Gateway6 is the primary IP6 gateway for this interface.
 
+                                    If unset, the gateway from the network provider will be used. However,
+                                    if set to "None", the network provider gateway will be ignored.
+
                                     Please note this field is only supported if the network connection
                                     supports manual IP allocation.
-
-                                    If the network connection supports manual IP allocation and the
-                                    Addresses field includes at least one IP6 address, then this field
-                                    is required.
 
                                     Please note the IP address must include the network prefix length, ex.
                                     2001:db8:101::1/64.

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -1645,12 +1645,11 @@ spec:
                           description: |-
                             Gateway4 is the default, IP4 gateway for this interface.
 
+                            If unset, the gateway from the network provider will be used. However,
+                            if set to "None", the network provider gateway will be ignored.
+
                             Please note this field is only supported if the network connection
                             supports manual IP allocation.
-
-                            If the network connection supports manual IP allocation and the
-                            Addresses field includes at least one IP4 address, then this field
-                            is required.
 
                             Please note the IP address must include the network prefix length, ex.
                             192.168.0.1/24.
@@ -1661,12 +1660,11 @@ spec:
                           description: |-
                             Gateway6 is the primary IP6 gateway for this interface.
 
+                            If unset, the gateway from the network provider will be used. However,
+                            if set to "None", the network provider gateway will be ignored.
+
                             Please note this field is only supported if the network connection
                             supports manual IP allocation.
-
-                            If the network connection supports manual IP allocation and the
-                            Addresses field includes at least one IP6 address, then this field
-                            is required.
 
                             Please note the IP address must include the network prefix length, ex.
                             2001:db8:101::1/64.
@@ -4187,12 +4185,11 @@ spec:
                           description: |-
                             Gateway4 is the default, IP4 gateway for this interface.
 
+                            If unset, the gateway from the network provider will be used. However,
+                            if set to "None", the network provider gateway will be ignored.
+
                             Please note this field is only supported if the network connection
                             supports manual IP allocation.
-
-                            If the network connection supports manual IP allocation and the
-                            Addresses field includes at least one IP4 address, then this field
-                            is required.
 
                             Please note the IP address must include the network prefix length, ex.
                             192.168.0.1/24.
@@ -4203,12 +4200,11 @@ spec:
                           description: |-
                             Gateway6 is the primary IP6 gateway for this interface.
 
+                            If unset, the gateway from the network provider will be used. However,
+                            if set to "None", the network provider gateway will be ignored.
+
                             Please note this field is only supported if the network connection
                             supports manual IP allocation.
-
-                            If the network connection supports manual IP allocation and the
-                            Addresses field includes at least one IP6 address, then this field
-                            is required.
 
                             Please note the IP address must include the network prefix length, ex.
                             2001:db8:101::1/64.
@@ -6827,12 +6823,11 @@ spec:
                           description: |-
                             Gateway4 is the default, IP4 gateway for this interface.
 
+                            If unset, the gateway from the network provider will be used. However,
+                            if set to "None", the network provider gateway will be ignored.
+
                             Please note this field is only supported if the network connection
                             supports manual IP allocation.
-
-                            If the network connection supports manual IP allocation and the
-                            Addresses field includes at least one IP4 address, then this field
-                            is required.
 
                             Please note the IP address must include the network prefix length, ex.
                             192.168.0.1/24.
@@ -6843,12 +6838,11 @@ spec:
                           description: |-
                             Gateway6 is the primary IP6 gateway for this interface.
 
+                            If unset, the gateway from the network provider will be used. However,
+                            if set to "None", the network provider gateway will be ignored.
+
                             Please note this field is only supported if the network connection
                             supports manual IP allocation.
-
-                            If the network connection supports manual IP allocation and the
-                            Addresses field includes at least one IP6 address, then this field
-                            is required.
 
                             Please note the IP address must include the network prefix length, ex.
                             2001:db8:101::1/64.

--- a/pkg/providers/vsphere/network/gosc.go
+++ b/pkg/providers/vsphere/network/gosc.go
@@ -37,7 +37,9 @@ func GuestOSCustomization(results NetworkInterfaceResults) ([]vimtypes.Customiza
 
 				adapter.Ip = &vimtypes.CustomizationFixedIp{IpAddress: ip.String()}
 				adapter.SubnetMask = net.IP(subnetMask).String()
-				adapter.Gateway = []string{ipConfig.Gateway}
+				if ipConfig.Gateway != "" {
+					adapter.Gateway = []string{ipConfig.Gateway}
+				}
 				break
 			}
 		}
@@ -67,7 +69,9 @@ func GuestOSCustomization(results NetworkInterfaceResults) ([]vimtypes.Customiza
 					IpAddress:  ip.String(),
 					SubnetMask: int32(ones), //nolint:gosec // disable G115
 				})
-				adapter.IpV6Spec.Gateway = append(adapter.IpV6Spec.Gateway, ipConfig.Gateway)
+				if ipConfig.Gateway != "" {
+					adapter.IpV6Spec.Gateway = append(adapter.IpV6Spec.Gateway, ipConfig.Gateway)
+				}
 			}
 		}
 

--- a/pkg/providers/vsphere/network/gosc_test.go
+++ b/pkg/providers/vsphere/network/gosc_test.go
@@ -95,6 +95,36 @@ var _ = Describe("GOSC", func() {
 				Expect(addressSpec.IpAddress).To(Equal(ipv6))
 				Expect(addressSpec.SubnetMask).To(BeEquivalentTo(ipv6Subnet))
 			})
+
+			Context("Gateway4/6 are disabled", func() {
+				BeforeEach(func() {
+					results.Results[0].IPConfigs[0].Gateway = ""
+					results.Results[0].IPConfigs[1].Gateway = ""
+				})
+
+				It("returns success", func() {
+					Expect(err).ToNot(HaveOccurred())
+					Expect(adapterMappings).To(HaveLen(1))
+					mapping := adapterMappings[0]
+
+					adapter := mapping.Adapter
+					Expect(adapter.Gateway).To(BeNil())
+					Expect(adapter.SubnetMask).To(Equal("255.255.255.0"))
+					Expect(adapter.DnsServerList).To(Equal([]string{dnsServer1}))
+					Expect(adapter.Ip).To(BeAssignableToTypeOf(&vimtypes.CustomizationFixedIp{}))
+					fixedIP := adapter.Ip.(*vimtypes.CustomizationFixedIp)
+					Expect(fixedIP.IpAddress).To(Equal(ipv4))
+
+					ipv6Spec := adapter.IpV6Spec
+					Expect(ipv6Spec).ToNot(BeNil())
+					Expect(ipv6Spec.Gateway).To(BeNil())
+					Expect(ipv6Spec.Ip).To(HaveLen(1))
+					Expect(ipv6Spec.Ip[0]).To(BeAssignableToTypeOf(&vimtypes.CustomizationFixedIpV6{}))
+					addressSpec := ipv6Spec.Ip[0].(*vimtypes.CustomizationFixedIpV6)
+					Expect(addressSpec.IpAddress).To(Equal(ipv6))
+					Expect(addressSpec.SubnetMask).To(BeEquivalentTo(ipv6Subnet))
+				})
+			})
 		})
 
 		Context("IPv4/6 DHCP", func() {

--- a/pkg/providers/vsphere/network/netplan.go
+++ b/pkg/providers/vsphere/network/netplan.go
@@ -41,8 +41,10 @@ func NetPlanCustomization(result NetworkInterfaceResults) (*netplan.Network, err
 			for i := range r.IPConfigs {
 				ipConfig := r.IPConfigs[i]
 				if ipConfig.IsIPv4 {
-					if npEth.Gateway4 == nil || *npEth.Gateway4 == "" {
-						npEth.Gateway4 = &ipConfig.Gateway
+					if ipConfig.Gateway != "" {
+						if npEth.Gateway4 == nil || *npEth.Gateway4 == "" {
+							npEth.Gateway4 = &ipConfig.Gateway
+						}
 					}
 					npEth.Addresses = append(
 						npEth.Addresses,
@@ -57,8 +59,10 @@ func NetPlanCustomization(result NetworkInterfaceResults) (*netplan.Network, err
 			for i := range r.IPConfigs {
 				ipConfig := r.IPConfigs[i]
 				if !ipConfig.IsIPv4 {
-					if npEth.Gateway6 == nil || *npEth.Gateway6 == "" {
-						npEth.Gateway6 = &ipConfig.Gateway
+					if ipConfig.Gateway != "" {
+						if npEth.Gateway6 == nil || *npEth.Gateway6 == "" {
+							npEth.Gateway6 = &ipConfig.Gateway
+						}
 					}
 					npEth.Addresses = append(
 						npEth.Addresses,

--- a/pkg/providers/vsphere/network/netplan_test.go
+++ b/pkg/providers/vsphere/network/netplan_test.go
@@ -112,6 +112,26 @@ var _ = Describe("Netplan", func() {
 				Expect(*route.Via).To(Equal("10.1.1.1"))
 				Expect(*route.Metric).To(BeEquivalentTo(42))
 			})
+
+			Context("Gateway4/6 are disabled", func() {
+				BeforeEach(func() {
+					results.Results[0].IPConfigs[0].Gateway = ""
+					results.Results[0].IPConfigs[1].Gateway = ""
+				})
+
+				It("gateways are nil", func() {
+					Expect(err).ToNot(HaveOccurred())
+					Expect(config).ToNot(BeNil())
+					Expect(config.Version).To(Equal(constants.NetPlanVersion))
+
+					Expect(config.Ethernets).To(HaveLen(1))
+					Expect(config.Ethernets).To(HaveKey(ifName))
+
+					np := config.Ethernets[ifName]
+					Expect(np.Gateway4).To(BeNil())
+					Expect(np.Gateway6).To(BeNil())
+				})
+			})
 		})
 
 		Context("IPv4/6 DHCP", func() {

--- a/pkg/providers/vsphere/network/network_test.go
+++ b/pkg/providers/vsphere/network/network_test.go
@@ -190,6 +190,32 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 					Expect(result.Routes[0].Metric).To(BeEquivalentTo(42))
 				})
 
+				Context("Gateway4/6 are disabled", func() {
+					BeforeEach(func() {
+						networkSpec.Interfaces[0].Gateway4 = "None"
+						networkSpec.Interfaces[0].Gateway6 = "None"
+					})
+
+					It("returns success", func() {
+						Expect(err).ToNot(HaveOccurred())
+						Expect(results.Results).To(HaveLen(1))
+
+						result := results.Results[0]
+
+						By("has no gateways", func() {
+							Expect(result.IPConfigs).To(HaveLen(2))
+							ipConfig := result.IPConfigs[0]
+							Expect(ipConfig.IPCIDR).To(Equal("172.42.1.100/24"))
+							Expect(ipConfig.IsIPv4).To(BeTrue())
+							Expect(ipConfig.Gateway).To(BeEmpty())
+							ipConfig = result.IPConfigs[1]
+							Expect(ipConfig.IPCIDR).To(Equal("fd1a:6c85:79fe:7c98:0000:0000:0000:000f/56"))
+							Expect(ipConfig.IsIPv4).To(BeFalse())
+							Expect(ipConfig.Gateway).To(BeEmpty())
+						})
+					})
+				})
+
 				Context("Bootstrap has use globals as defaults", func() {
 					BeforeEach(func() {
 						vm.Spec.Bootstrap = &vmopv1.VirtualMachineBootstrapSpec{

--- a/webhooks/virtualmachine/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator.go
@@ -622,6 +622,7 @@ func (v validator) validateNetwork(
 	return allErrs
 }
 
+//nolint:gocyclo
 func (v validator) validateNetworkInterfaceSpec(
 	interfacePath *field.Path,
 	interfaceSpec vmopv1.VirtualMachineNetworkInterfaceSpec,
@@ -662,7 +663,7 @@ func (v validator) validateNetworkInterfaceSpec(
 		}
 	}
 
-	if ipv4 := interfaceSpec.Gateway4; ipv4 != "" {
+	if ipv4 := interfaceSpec.Gateway4; ipv4 != "" && ipv4 != "None" {
 		p := interfacePath.Child("gateway4")
 
 		if len(ipv4Addrs) == 0 {
@@ -674,7 +675,7 @@ func (v validator) validateNetworkInterfaceSpec(
 		}
 	}
 
-	if ipv6 := interfaceSpec.Gateway6; ipv6 != "" {
+	if ipv6 := interfaceSpec.Gateway6; ipv6 != "" && ipv6 != "None" {
 		p := interfacePath.Child("gateway6")
 
 		if len(ipv6Addrs) == 0 {

--- a/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
@@ -1794,6 +1794,30 @@ func unitTestsValidateCreate() {
 				},
 			),
 
+			Entry("allow static with disabled gateways",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						ctx.vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{
+							HostName: "my-vm",
+							Interfaces: []vmopv1.VirtualMachineNetworkInterfaceSpec{
+								{
+									Name: "eth0",
+									Addresses: []string{
+										"192.168.1.100/24",
+										"2605:a601:a0ba:720:2ce6:776d:8be4:2496/48",
+									},
+									DHCP4:    false,
+									DHCP6:    false,
+									Gateway4: "None",
+									Gateway6: "None",
+								},
+							},
+						}
+					},
+					expectAllowed: true,
+				},
+			),
+
 			Entry("allow guestDeviceName, static address, mtu, nameservers, routes and searchDomains when bootstrap is CloudInit",
 				testParams{
 					setup: func(ctx *unitValidatingWebhookContext) {


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Allow setting the Interface Gateway{4,6} to "None" to indicate to not set the gateway that is provided from the underlying network provider in the network configuration. This can be useful when a VM is configured with multiple interfaces.

Remove an incorrect documentation note about the gateway: it is allowed to manually provide IP addresses without a gateway.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note
VM.Spec.Network.Interfaces[].Gateway4 and Gateway6 can be set to "None" to not set the gateway that is provided from the underlying network provider.
```