### PR TITLE
🌱 Remove enabled FSS STORAGE_QUOTA_M2 from vmoperator code

### DIFF
--- a/config/local/vmoperator/local_env_var_patch.yaml
+++ b/config/local/vmoperator/local_env_var_patch.yaml
@@ -33,8 +33,6 @@ spec:
           value: "false"
         - name: FSS_WCP_VMSERVICE_INCREMENTAL_RESTORE
           value: "false"
-        - name: FSS_STORAGE_QUOTA_M2
-          value: "false"
         - name: FSS_WCP_VMSERVICE_BYOK
           value: "false"
         - name: FSS_WCP_SUPERVISOR_ASYNC_UPGRADE
@@ -68,4 +66,6 @@ spec:
         - name: FSS_WCP_WORKLOAD_DOMAIN_ISOLATION
           value: "true"
         - name: FSS_WCP_VMSERVICE_ISO_SUPPORT
+          value: "true"
+        - name: FSS_STORAGE_QUOTA_M2
           value: "true"

--- a/config/wcp/vmoperator/manager_env_var_patch.yaml
+++ b/config/wcp/vmoperator/manager_env_var_patch.yaml
@@ -97,12 +97,6 @@
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
-    name: FSS_STORAGE_QUOTA_M2
-    value: "<FSS_STORAGE_QUOTA_M2>"
-
-- op: add
-  path: /spec/template/spec/containers/0/env/-
-  value:
     name: FSS_WCP_VMSERVICE_BYOK
     value: "<FSS_WCP_VMSERVICE_BYOK>"
 
@@ -184,4 +178,10 @@
   path: /spec/template/spec/containers/0/env/-
   value:
     name: FSS_WCP_VMSERVICE_ISO_SUPPORT
+    value: "true"
+
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: FSS_STORAGE_QUOTA_M2
     value: "true"

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -33,10 +33,8 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 	if err := infra.AddToManager(ctx, mgr); err != nil {
 		return fmt.Errorf("failed to initialize Infra controllers: %w", err)
 	}
-	if pkgcfg.FromContext(ctx).Features.UnifiedStorageQuota {
-		if err := spq.AddToManager(ctx, mgr); err != nil {
-			return fmt.Errorf("failed to initialize StoragePolicyQuota controller: %w", err)
-		}
+	if err := spq.AddToManager(ctx, mgr); err != nil {
+		return fmt.Errorf("failed to initialize StoragePolicyQuota controller: %w", err)
 	}
 	if err := virtualmachine.AddToManager(ctx, mgr); err != nil {
 		return fmt.Errorf("failed to initialize VirtualMachine controller: %w", err)

--- a/controllers/infra/controllers.go
+++ b/controllers/infra/controllers.go
@@ -15,7 +15,6 @@ import (
 	"github.com/vmware-tanzu/vm-operator/controllers/infra/secret"
 	"github.com/vmware-tanzu/vm-operator/controllers/infra/validatingwebhookconfiguration"
 	"github.com/vmware-tanzu/vm-operator/controllers/infra/zone"
-	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 )
 
@@ -33,10 +32,8 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 	if err := secret.AddToManager(ctx, mgr); err != nil {
 		return fmt.Errorf("failed to initialize infra secret controller: %w", err)
 	}
-	if pkgcfg.FromContext(ctx).Features.UnifiedStorageQuota {
-		if err := validatingwebhookconfiguration.AddToManager(ctx, mgr); err != nil {
-			return fmt.Errorf("failed to initialize validatingwebhookconfiguration webhook controller: %w", err)
-		}
+	if err := validatingwebhookconfiguration.AddToManager(ctx, mgr); err != nil {
+		return fmt.Errorf("failed to initialize validatingwebhookconfiguration webhook controller: %w", err)
 	}
 	if err := zone.AddToManager(ctx, mgr); err != nil {
 		return fmt.Errorf("failed to initialize infra zone controller: %w", err)

--- a/controllers/virtualmachine/controllers.go
+++ b/controllers/virtualmachine/controllers.go
@@ -12,7 +12,6 @@ import (
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachine/storagepolicyusage"
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachine/virtualmachine"
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachine/volume"
-	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 )
 
@@ -21,10 +20,8 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 	if err := virtualmachine.AddToManager(ctx, mgr); err != nil {
 		return fmt.Errorf("failed to initialize virtualmachine controller: %w", err)
 	}
-	if pkgcfg.FromContext(ctx).Features.UnifiedStorageQuota {
-		if err := storagepolicyusage.AddToManager(ctx, mgr); err != nil {
-			return fmt.Errorf("failed to initialize virtualmachine storagepolicyusage controller: %w", err)
-		}
+	if err := storagepolicyusage.AddToManager(ctx, mgr); err != nil {
+		return fmt.Errorf("failed to initialize virtualmachine storagepolicyusage controller: %w", err)
 	}
 	if err := volume.AddToManager(ctx, mgr); err != nil {
 		return fmt.Errorf("failed to initialize virtualmachine volume controller: %w", err)

--- a/controllers/virtualmachine/virtualmachine/virtualmachine_controller.go
+++ b/controllers/virtualmachine/virtualmachine/virtualmachine_controller.go
@@ -349,12 +349,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 	}
 
 	defer func() {
-		if pkgcfg.FromContext(ctx).Features.UnifiedStorageQuota {
-			vmopv1util.SyncStorageUsageForNamespace(
-				ctx,
-				vm.Namespace,
-				vm.Spec.StorageClass)
-		}
+		vmopv1util.SyncStorageUsageForNamespace(
+			ctx,
+			vm.Namespace,
+			vm.Spec.StorageClass)
 		if err := patchHelper.Patch(ctx, vm); err != nil {
 			if reterr == nil {
 				reterr = err

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -172,18 +172,15 @@ type FeatureStates struct {
 	K8sWorkloadMgmtAPI         bool // FSS_WCP_VMSERVICE_K8S_WORKLOAD_MGMT_API
 	PodVMOnStretchedSupervisor bool // FSS_PODVMONSTRETCHEDSUPERVISOR
 	TKGMultipleCL              bool // to be fetched dynamically from capability
-	// TODO(akutz) This FSS is a placeholder until leadership can figure out the
-	//             plan for FSSs going forward.
-	UnifiedStorageQuota       bool // FSS_PLACEHOLDER_WCP_UNIFIED_STORAGE_QUOTA
-	VMResize                  bool // FSS_WCP_VMSERVICE_RESIZE
-	VMResizeCPUMemory         bool // FSS_WCP_VMSERVICE_RESIZE_CPU_MEMORY
-	VMImportNewNet            bool // FSS_WCP_MOBILITY_VM_IMPORT_NEW_NET
-	WorkloadDomainIsolation   bool // FSS_WCP_WORKLOAD_DOMAIN_ISOLATION
-	VMIncrementalRestore      bool // FSS_WCP_VMSERVICE_INCREMENTAL_RESTORE
-	BringYourOwnEncryptionKey bool // FSS_WCP_VMSERVICE_BYOK
-	SVAsyncUpgrade            bool // FSS_WCP_SUPERVISOR_ASYNC_UPGRADE
-	FastDeploy                bool // FSS_WCP_VMSERVICE_FAST_DEPLOY
-	MutableNetworks           bool
+	VMResize                   bool // FSS_WCP_VMSERVICE_RESIZE
+	VMResizeCPUMemory          bool // FSS_WCP_VMSERVICE_RESIZE_CPU_MEMORY
+	VMImportNewNet             bool // FSS_WCP_MOBILITY_VM_IMPORT_NEW_NET
+	WorkloadDomainIsolation    bool // FSS_WCP_WORKLOAD_DOMAIN_ISOLATION
+	VMIncrementalRestore       bool // FSS_WCP_VMSERVICE_INCREMENTAL_RESTORE
+	BringYourOwnEncryptionKey  bool // FSS_WCP_VMSERVICE_BYOK
+	SVAsyncUpgrade             bool // FSS_WCP_SUPERVISOR_ASYNC_UPGRADE
+	FastDeploy                 bool // FSS_WCP_VMSERVICE_FAST_DEPLOY
+	MutableNetworks            bool
 }
 
 type InstanceStorage struct {

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -28,7 +28,6 @@ func Default() Config {
 			InstanceStorage:            true,
 			PodVMOnStretchedSupervisor: false,
 			TKGMultipleCL:              false,
-			UnifiedStorageQuota:        false,
 			WorkloadDomainIsolation:    false,
 		},
 		InstanceStorage: InstanceStorage{

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -62,7 +62,6 @@ func FromEnv() Config {
 	setBool(env.FSSInstanceStorage, &config.Features.InstanceStorage)
 	setBool(env.FSSK8sWorkloadMgmtAPI, &config.Features.K8sWorkloadMgmtAPI)
 	setBool(env.FSSPodVMOnStretchedSupervisor, &config.Features.PodVMOnStretchedSupervisor)
-	setBool(env.FSSUnifiedStorageQuota, &config.Features.UnifiedStorageQuota)
 	setBool(env.FSSVMResize, &config.Features.VMResize)
 	setBool(env.FSSVMResizeCPUMemory, &config.Features.VMResizeCPUMemory)
 	setBool(env.FSSVMImportNewNet, &config.Features.VMImportNewNet)

--- a/pkg/config/env/env.go
+++ b/pkg/config/env/env.go
@@ -55,7 +55,6 @@ const (
 	FSSInstanceStorage
 	FSSK8sWorkloadMgmtAPI
 	FSSPodVMOnStretchedSupervisor
-	FSSUnifiedStorageQuota
 	FSSVMResize
 	FSSVMResizeCPUMemory
 	FSSVMImportNewNet
@@ -173,8 +172,6 @@ func (n VarName) String() string {
 		return "FSS_WCP_VMSERVICE_K8S_WORKLOAD_MGMT_API"
 	case FSSPodVMOnStretchedSupervisor:
 		return "FSS_PODVMONSTRETCHEDSUPERVISOR"
-	case FSSUnifiedStorageQuota:
-		return "FSS_STORAGE_QUOTA_M2"
 	case FSSVMResize:
 		return "FSS_WCP_VMSERVICE_RESIZE"
 	case FSSVMResizeCPUMemory:

--- a/pkg/config/env_test.go
+++ b/pkg/config/env_test.go
@@ -95,7 +95,6 @@ var _ = Describe(
 					Expect(os.Setenv("FSS_WCP_INSTANCE_STORAGE", "false")).To(Succeed())
 					Expect(os.Setenv("FSS_WCP_NAMESPACED_VM_CLASS", "false")).To(Succeed())
 					Expect(os.Setenv("FSS_WCP_VMSERVICE_K8S_WORKLOAD_MGMT_API", "true")).To(Succeed())
-					Expect(os.Setenv("FSS_STORAGE_QUOTA_M2", "true")).To(Succeed())
 					Expect(os.Setenv("FSS_WCP_VMSERVICE_RESIZE", "true")).To(Succeed())
 					Expect(os.Setenv("FSS_WCP_VMSERVICE_RESIZE_CPU_MEMORY", "true")).To(Succeed())
 					Expect(os.Setenv("FSS_WCP_MOBILITY_VM_IMPORT_NEW_NET", "true")).To(Succeed())
@@ -150,7 +149,6 @@ var _ = Describe(
 						Features: pkgcfg.FeatureStates{
 							InstanceStorage:           false,
 							K8sWorkloadMgmtAPI:        true,
-							UnifiedStorageQuota:       true,
 							VMResize:                  true,
 							VMResizeCPUMemory:         true,
 							VMImportNewNet:            true,

--- a/webhooks/webhooks.go
+++ b/webhooks/webhooks.go
@@ -56,10 +56,8 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) err
 		}
 	}
 
-	if pkgcfg.FromContext(ctx).Features.UnifiedStorageQuota {
-		if err := unifiedstoragequota.AddToManager(ctx, mgr); err != nil {
-			return fmt.Errorf("failed to initialize UnifiedStorageQuota webhooks: %w", err)
-		}
+	if err := unifiedstoragequota.AddToManager(ctx, mgr); err != nil {
+		return fmt.Errorf("failed to initialize UnifiedStorageQuota webhooks: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR removes the STORAGE_QUOTA_M2 FSS related code since it's been enabled on main for a while. The env var for the FSS is retained in the deployment YAML as "true" to avoid breaking internal tests that rely on reading this value.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note
 Remove enabled FSS STORAGE_QUOTA_M2 from vmoperator code
```