### PR TITLE
FastDeploy: Use Datastore method to check if cache files exist

### DIFF
--- a/controllers/virtualmachineimagecache/virtualmachineimagecache_controller_test.go
+++ b/controllers/virtualmachineimagecache/virtualmachineimagecache_controller_test.go
@@ -421,12 +421,12 @@ var _ = Describe(
 					func() vmopv1.VirtualMachineImageCache {
 
 						faker.fakeSRIClient = true
-						faker.queryVirtualDiskUuidFn = func(
+						faker.datastoreFileExistsFn = func(
 							context.Context,
 							string,
-							*object.Datacenter) (string, error) {
+							*object.Datacenter) error {
 
-							return "", errors.New("query disk error")
+							return errors.New("query disk error")
 						}
 
 						return getVMICacheObj(
@@ -440,7 +440,7 @@ var _ = Describe(
 					},
 					true, "", // OVFReady
 					true, "", // ProviderReady
-					false, "0 of 1 completed", "failed to cache storage items: failed to query disk uuid: query disk error", // DisksReady
+					false, "0 of 1 completed", "failed to cache storage items: failed to query disk: query disk error", // DisksReady
 					false, "2 of 3 completed", // Ready
 				),
 			)
@@ -485,10 +485,10 @@ type fakeClient struct {
 	fakeCLSProvdr bool
 	fakeSRIClient bool
 
-	queryVirtualDiskUuidFn func( //nolint:revive,stylecheck
+	datastoreFileExistsFn func(
 		ctx context.Context,
 		name string,
-		datacenter *object.Datacenter) (string, error)
+		datacenter *object.Datacenter) error
 
 	copyVirtualDiskFn func(
 		ctx context.Context,
@@ -561,7 +561,7 @@ func (m *fakeClient) reset() {
 	m.fakeCLSProvdr = false
 	m.fakeSRIClient = false
 
-	m.queryVirtualDiskUuidFn = nil
+	m.datastoreFileExistsFn = nil
 	m.copyVirtualDiskFn = nil
 	m.makeDirectoryFn = nil
 	m.waitForTaskFn = nil
@@ -597,15 +597,15 @@ func (m *fakeClient) newCacheStorageURIsClientFn(
 	return nil
 }
 
-func (m *fakeClient) QueryVirtualDiskUuid( //nolint:revive,stylecheck
+func (m *fakeClient) DatastoreFileExists(
 	ctx context.Context,
 	name string,
-	datacenter *object.Datacenter) (string, error) {
+	datacenter *object.Datacenter) error {
 
-	if fn := m.queryVirtualDiskUuidFn; fn != nil {
+	if fn := m.datastoreFileExistsFn; fn != nil {
 		return fn(ctx, name, datacenter)
 	}
-	return "", nil
+	return nil
 }
 
 func (m *fakeClient) CopyVirtualDisk(

--- a/pkg/util/vsphere/library/item_cache_test.go
+++ b/pkg/util/vsphere/library/item_cache_test.go
@@ -6,6 +6,7 @@ package library_test
 
 import (
 	"context"
+	"os"
 	"sync/atomic"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -23,9 +24,8 @@ type nilContextKey uint8
 var nilContext = context.WithValue(context.Background(), nilContextKey(0), "nil")
 
 type fakeCacheStorageURIsClient struct {
-	queryErr    error
-	queryResult string
-	queryCalls  int32
+	queryErr   error
+	queryCalls int32
 
 	copyErr    error
 	copyResult *object.Task
@@ -38,13 +38,13 @@ type fakeCacheStorageURIsClient struct {
 	waitCalls int32
 }
 
-func (m *fakeCacheStorageURIsClient) QueryVirtualDiskUuid( //nolint:revive,stylecheck
+func (m *fakeCacheStorageURIsClient) DatastoreFileExists(
 	ctx context.Context,
 	name string,
-	datacenter *object.Datacenter) (string, error) {
+	datacenter *object.Datacenter) error {
 
 	_ = atomic.AddInt32(&m.queryCalls, 1)
-	return m.queryResult, m.queryErr
+	return m.queryErr
 }
 
 func (m *fakeCacheStorageURIsClient) CopyVirtualDisk(
@@ -252,7 +252,7 @@ var _ = Describe("CacheStorageURIs", func() {
 			When("querying the virtual disk fails with FileNotFound", func() {
 
 				BeforeEach(func() {
-					client.queryErr = soap.WrapVimFault(&vimtypes.FileNotFound{})
+					client.queryErr = os.ErrNotExist
 				})
 
 				When("creating the path where the disk is cached fails", func() {


### PR DESCRIPTION
QueryVirtualDiskUuid only works for .vmdk, we need to check if other types exist, such as .nvram

Originally planned to use HostDatastoreBrowser.SearchDatastore via govmomi's [object.Datastore.Stat](https://github.com/vmware/govmomi/blob/a77f0207e1b0281252f37c2f40210b036fe3e7ea/object/datastore.go#L444) method, however:
- Would need to refactor so object.Datastore is plumbed through, instead of string DatastorePath:
 `"[DatastoreName] dir/file.ext"`
- Considered using govmomi [object.DatastoreFile.Stat](https://github.com/vmware/govmomi/blob/a77f0207e1b0281252f37c2f40210b036fe3e7ea/object/datastore_file.go#L156), but has the same plumbing issue
- The Datastore HEAD method can use DatastorePath and avoids creating a Task / WaitForUpdates
- Both methods require the same Datastore.Browse permission

The getDatacenters helper method was collecting Datacenter.Name, which validated the moid, but Name property was not used. Changed to get the InventoryPath which also validates the moid and is used to construct the Datastore HEAD request URL. Note that while setting: `object.Datastore.InventoryPath = Datacenter.Name`
would work is most environments, the full path is needed if Datacenter is in a sub Folder with the RootFolder.
