### PR TITLE
✨ Support poweron.check and delete.check annotations

### DIFF
--- a/api/v1alpha4/virtualmachine_types.go
+++ b/api/v1alpha4/virtualmachine_types.go
@@ -152,6 +152,53 @@ const (
 )
 
 const (
+	// checkAnnotationSubDomain is the sub-domain to be used for all check-style
+	// annotations that enable external components to participate in a VM's
+	// lifecycle events.
+	checkAnnotationSubDomain = "check.vmoperator.vmware.com"
+
+	// CheckAnnotationPowerOn is an annotation that may be used to prevent a
+	// VM from being powered on. A user can still set a VM's spec.powerState to
+	// PoweredOn, but the VM will not be powered on until the check annotation
+	// is removed.
+	//
+	// Please note, there may be multiple check annotations, ex.:
+	//
+	// - poweron.check.vmoperator.vmware.com/component1: "reason"
+	// - poweron.check.vmoperator.vmware.com/component2: "reason"
+	// - poweron.check.vmoperator.vmware.com/component3: "reason"
+	//
+	// All check annotations must be removed before a VM can be powered on.
+	//
+	// This annotation may only be applied when creating a new VM by any user.
+	//
+	// Only privileged users may apply this annotation to existing VMs.
+	//
+	// Only privileged users may remove this annotation from a VM. If a
+	// non-privileged user accidentally adds this annotation when creating a VM,
+	// the recourse is to delete the VM and recreate it without the annotation.
+	CheckAnnotationPowerOn = "poweron." + checkAnnotationSubDomain
+
+	// CheckAnnotationDelete is an annotation that may be used to prevent a
+	// VM from being deleted. A user can still delete the VM, but the VM will
+	// not *actually* be removed until the annotation is removed.
+	//
+	// Unlike a finalizer, this annotation *also* prevents the underlying
+	// vSphere VM from being deleted as well.
+	//
+	// Please note, there may be multiple check annotations, ex.:
+	//
+	// - delete.check.vmoperator.vmware.com/component1: "reason"
+	// - delete.check.vmoperator.vmware.com/component2: "reason"
+	// - delete.check.vmoperator.vmware.com/component3: "reason"
+	//
+	// All check annotations must be removed before a VM can be deleted.
+	//
+	// Only privileged users may add or remove this annotation.
+	CheckAnnotationDelete = "delete." + checkAnnotationSubDomain
+)
+
+const (
 	// ManagedByExtensionKey and ManagedByExtensionType represent the ManagedBy
 	// field on the VM. They are used to differentiate VM Service managed VMs
 	// from traditional vSphere VMs.

--- a/controllers/virtualmachine/virtualmachine/virtualmachine_controller_unit_test.go
+++ b/controllers/virtualmachine/virtualmachine/virtualmachine_controller_unit_test.go
@@ -323,8 +323,15 @@ func unitTestsReconcile() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("will not delete the created VM when VM is paused by devops ", func() {
+		It("will not delete the created VM when VM is paused by devops", func() {
 			vm.Annotations[vmopv1.PauseAnnotation] = "enabled"
+			err := reconciler.ReconcileDelete(vmCtx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(vm.GetFinalizers()).To(ContainElement(finalizer))
+		})
+
+		It("will not delete the created VM when VM has delete.check annotation", func() {
+			vm.Annotations[vmopv1.CheckAnnotationDelete+"/app1"] = "reason"
 			err := reconciler.ReconcileDelete(vmCtx)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(vm.GetFinalizers()).To(ContainElement(finalizer))

--- a/pkg/providers/vsphere/session/session_vm_update_test.go
+++ b/pkg/providers/vsphere/session/session_vm_update_test.go
@@ -1365,6 +1365,20 @@ var _ = Describe("UpdateVirtualMachine", func() {
 				vm.Spec.PowerState = vmopv1.VirtualMachinePowerStateOn
 			})
 
+			When("there is a power on check annotation", func() {
+				BeforeEach(func() {
+					vm.Annotations = map[string]string{
+						vmopv1.CheckAnnotationPowerOn + "/app": "reason",
+					}
+				})
+				It("should not power on the VM", func() {
+					Expect(sess.UpdateVirtualMachine(vmCtx, vcVM, getUpdateArgs, getResizeArgs)).To(Succeed())
+					Expect(vcVM.Properties(ctx, vcVM.Reference(), vmProps, &vmCtx.MoVM)).To(Succeed())
+					Expect(vmCtx.MoVM.Summary.Runtime.PowerState).To(Equal(vimtypes.VirtualMachinePowerStatePoweredOff))
+					assertUpdate()
+				})
+			})
+
 			const (
 				oldDiskSizeBytes = int64(10 * 1024 * 1024 * 1024)
 				newDiskSizeGi    = 20
@@ -1715,6 +1729,20 @@ var _ = Describe("UpdateVirtualMachine", func() {
 				Expect(vcVM.Properties(ctx, vcVM.Reference(), vmProps, &vmCtx.MoVM)).To(Succeed())
 				Expect(vmCtx.MoVM.Summary.Runtime.PowerState).To(Equal(vimtypes.VirtualMachinePowerStatePoweredOn))
 				assertUpdate()
+			})
+
+			When("there is a power on check annotation", func() {
+				BeforeEach(func() {
+					vm.Annotations = map[string]string{
+						vmopv1.CheckAnnotationPowerOn + "/app": "reason",
+					}
+				})
+				It("should not power on the VM", func() {
+					Expect(sess.UpdateVirtualMachine(vmCtx, vcVM, getUpdateArgs, getResizeArgs)).To(Succeed())
+					Expect(vcVM.Properties(ctx, vcVM.Reference(), vmProps, &vmCtx.MoVM)).To(Succeed())
+					Expect(vmCtx.MoVM.Summary.Runtime.PowerState).To(Equal(vimtypes.VirtualMachinePowerStateSuspended))
+					assertUpdate()
+				})
 			})
 		})
 


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

This patch adds support for the following annotations:

* `poweron.check.vmoperator.vmware.com`

    This annotation prevents a VM from being powered on until the annotation is removed. Unlike the generic pause annotation, this annotation:

    * Does not prevent the VM from being reconciled.
    * Can exist multiple times in the format `poweron.check.vmoperator.vmware.com/<COMPONENT>: <REASON>`

    This annotation can be applied to new VMs by non-privileged or privileged users. Only privileged users can modify or remove this annotation.

*  `delete.check.vmoperator.vmware.com`

    This annotation prevents a VM from being deleted until the annotation is removed. Unlike the generic pause annotation, this annotation:

    * Does not prevent the VM from being reconciled.
    * Can exist multiple times in the format `delete.check.vmoperator.vmware.com/<COMPONENT>: <REASON>`

    This annotation can only be added, modified, or removed on new/existing VMs by privileged users.

The purpose of both annotations is to enable external components to participate in the lifecycle of a VM.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Support annotations poweron.check and delete.check to allow external components to participate in VM lifecycle events.
```

<!-- readthedocs-preview vm-operator start -->
----
📚 Documentation preview 📚: https://vm-operator--946.org.readthedocs.build/en/946/

<!-- readthedocs-preview vm-operator end -->