### PR TITLE
📖 Update docs to use V1alpha4 template functions

### DIFF
--- a/docs/concepts/workloads/guest.md
+++ b/docs/concepts/workloads/guest.md
@@ -92,7 +92,7 @@ The data in the above `Secret` is referenced by portions of the `VirtualMachine`
 
 #### Schema Differences
 
-Please note, there are a few differences between the inline Cloud Config and the official format. Please refer to [`./api/v1alpha2/cloudinit/cloudconfig.go`](https://github.com/vmware-tanzu/vm-operator/blob/main/api/v1alpha2/cloudinit/cloudconfig.go) for up-to-date information on how the inline Cloud Config compares to the official format.
+Please note, there are a few differences between the inline Cloud Config and the official format. Please refer to [`./api/v1alpha4/cloudinit/cloudconfig.go`](https://github.com/vmware-tanzu/vm-operator/blob/main/api/v1alpha4/cloudinit/cloudconfig.go) for up-to-date information on how the inline Cloud Config compares to the official format.
 
 ##### Default User
 
@@ -380,16 +380,16 @@ The following YAML may be used to bootstrap a Windows image with minimal informa
                   <Ipv6Settings>
                     <DhcpEnabled>false</DhcpEnabled>
                   </Ipv6Settings>
-                  <Identifier>{{ V1alpha1_FirstNicMacAddr }}</Identifier>
+                  <Identifier>{{ V1alpha4_FirstNicMacAddr }}</Identifier>
                   <UnicastIpAddresses>
-                    <IpAddress wcm:action="add" wcm:keyValue="1">{{ V1alpha1_FirstIP }}</IpAddress>
+                    <IpAddress wcm:action="add" wcm:keyValue="1">{{ V1alpha4_FirstIP }}</IpAddress>
                   </UnicastIpAddresses>
                   <Routes>
                     <Route wcm:action="add">
                       <Identifier>0</Identifier>
                       <Metric>10</Metric>
-                      <NextHopAddress>{{ (index .V1alpha1.Net.Devices 0).Gateway4 }}</NextHopAddress>
-                      <Prefix>{{ V1alpha1_SubnetMask V1alpha1_FirstIP }}</Prefix>
+                      <NextHopAddress>{{ (index .V1alpha4.Net.Devices 0).Gateway4 }}</NextHopAddress>
+                      <Prefix>{{ V1alpha4_SubnetMask V1alpha4_FirstIP }}</Prefix>
                     </Route>
                   </Routes>
                 </Interface>
@@ -401,8 +401,8 @@ The following YAML may be used to bootstrap a Windows image with minimal informa
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
               <Interfaces>
                 <Interface wcm:action="add">
-                  <Identifier>{{ V1alpha1_FirstNicMacAddr }}</Identifier>
-                  <DNSServerSearchOrder> {{ range .V1alpha1.Net.Nameservers }} <IpAddress
+                  <Identifier>{{ V1alpha4_FirstNicMacAddr }}</Identifier>
+                  <DNSServerSearchOrder> {{ range .V1alpha4.Net.Nameservers }} <IpAddress
                       wcm:action="add"
                       wcm:keyValue="{{.}}"></IpAddress> {{ end }} </DNSServerSearchOrder>
                 </Interface>

--- a/docs/tutorials/deploy-vm/README.md
+++ b/docs/tutorials/deploy-vm/README.md
@@ -26,7 +26,7 @@ spec:
       allowGuestControl: true
 ```
 
-1.  :wave: The field `apiVersion` indicates the resource's schema, ex. `vmoperator.vmware.com`, and version, ex.`v1alpha2`.
+1.  :wave: The field `apiVersion` indicates the resource's schema, ex. `vmoperator.vmware.com`, and version, ex.`v1alpha4`.
 
 2.  :wave: The field `kind` specifies the kind of resource, ex. `VirtualMachine`.
 

--- a/docs/tutorials/deploy-vm/vappconfig.md
+++ b/docs/tutorials/deploy-vm/vappconfig.md
@@ -21,16 +21,16 @@ spec:
       properties:
       - key: nameservers
         value:
-          value: "{{ (index .V1alpha2.Net.Nameservers 0) }}"
+          value: "{{ (index .V1alpha4.Net.Nameservers 0) }}"
       - key: management_ip
         value:
-          value: "{{ (index (index .V1alpha2.Net.Devices 0).IPAddresses 0) }}"
+          value: "{{ (index (index .V1alpha4.Net.Devices 0).IPAddresses 0) }}"
       - key: hostname
         value:
-          value: "{{ .V1alpha2.VM.Name }}"
+          value: "{{ .V1alpha4.VM.Name }}"
       - key: management_gateway
         value:
-          value: "{{ (index .V1alpha2.Net.Devices 0).Gateway4 }}"
+          value: "{{ (index .V1alpha4.Net.Devices 0).Gateway4 }}"
 ```
 
 For more information on the templating used, please refer to the [documentation](./../../concepts/workloads/guest.md#vappconfig) for the vAppConfig bootstrap provider.

--- a/docs/tutorials/troubleshooting/ip-assignment.md
+++ b/docs/tutorials/troubleshooting/ip-assignment.md
@@ -63,7 +63,7 @@ For VMs deployed with Sysprep, a powered on VM sans IP usually indicates that gu
 
 2. Inspect the GOSC results by logging into the VM using the web console and examining the log files located at `C:\Windows\TEMP\vmware-imc\guestcust`.
 
-3. Validate the sysprep answers file by logging into the VM using the web console and examining `C:\sysprep1001\sysprep.xml`. For example, there should be evidence that `<Identifier>{{ V1alpha2_FirstNicMacAddr }}</Identifier>` was converted to the actual MAC addresses, ex. `<Identifier>00-11-22-33-aa-bb-cc</Identifier>`.
+3. Validate the sysprep answers file by logging into the VM using the web console and examining `C:\sysprep1001\sysprep.xml`. For example, there should be evidence that `<Identifier>{{ V1alpha4_FirstNicMacAddr }}</Identifier>` was converted to the actual MAC addresses, ex. `<Identifier>00-11-22-33-aa-bb-cc</Identifier>`.
 
 4. Inspect the sysprep logs by logging into the VM using the web console and examining the log files located in `C:\Windows\Panther\setuperr`, `C:\Windows\Panther\Unattendgc\setuperr`, and `C:\Windows\System32\Sysprep\Panther\setuperr`.
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR updates template functions and other places in docs to use `v1alpha4` since it's the latest supported API version.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes N/A.


**Are there any special notes for your reviewer**:

None.


**Please add a release note if necessary**:

```release-note
Update docs to use V1alpha4 template functions.
```