### PR TITLE
✨ Handle network interfaces changes during VM power on

### DIFF
--- a/pkg/providers/vsphere/network/gosc_test.go
+++ b/pkg/providers/vsphere/network/gosc_test.go
@@ -38,7 +38,7 @@ var _ = Describe("GOSC", func() {
 		)
 
 		BeforeEach(func() {
-			results.Results = nil
+			results = network.NetworkInterfaceResults{}
 		})
 
 		JustBeforeEach(func() {

--- a/pkg/providers/vsphere/network/list_interfaces.go
+++ b/pkg/providers/vsphere/network/list_interfaces.go
@@ -1,0 +1,102 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package network
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	netopv1alpha1 "github.com/vmware-tanzu/net-operator-api/api/v1alpha1"
+	vpcv1alpha1 "github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
+	ncpv1alpha1 "github.com/vmware-tanzu/vm-operator/external/ncp/api/v1alpha1"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
+	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+)
+
+func ListOrphanedNetworkInterfaces(
+	vmCtx pkgctx.VirtualMachineContext,
+	client ctrlclient.Client,
+	results *NetworkInterfaceResults,
+) error {
+
+	networkType := pkgcfg.FromContext(vmCtx).NetworkProviderType
+	if networkType == "" {
+		return fmt.Errorf("no network provider set")
+	}
+
+	// TODO: Anything v1a2 or later will have the label. Maybe check the created at annotation
+	// value and do a more exhaustive list if this is an old VM.
+	listOpts := []ctrlclient.ListOption{
+		ctrlclient.InNamespace(vmCtx.VM.Namespace),
+		ctrlclient.MatchingLabels{VMNameLabel: vmCtx.VM.Name},
+	}
+
+	expectedInterfaceNames := sets.Set[string]{}
+	for idx := range results.Results {
+		expectedInterfaceNames.Insert(results.Results[idx].ObjectName)
+	}
+
+	var objList []ctrlclient.Object
+
+	switch networkType {
+	case pkgcfg.NetworkProviderTypeVDS:
+		var list netopv1alpha1.NetworkInterfaceList
+		if err := client.List(vmCtx, &list, listOpts...); err != nil {
+			return err
+		}
+
+		for i := range list.Items {
+			if !expectedInterfaceNames.Has(list.Items[i].Name) && isOwnedBy(vmCtx.VM, &list.Items[i]) {
+				objList = append(objList, &list.Items[i])
+			}
+		}
+
+	case pkgcfg.NetworkProviderTypeNSXT:
+		var list ncpv1alpha1.VirtualNetworkInterfaceList
+		if err := client.List(vmCtx, &list, listOpts...); err != nil {
+			return err
+		}
+
+		for i := range list.Items {
+			if !expectedInterfaceNames.Has(list.Items[i].Name) && isOwnedBy(vmCtx.VM, &list.Items[i]) {
+				objList = append(objList, &list.Items[i])
+			}
+		}
+
+	case pkgcfg.NetworkProviderTypeVPC:
+		var list vpcv1alpha1.SubnetPortList
+		if err := client.List(vmCtx, &list, listOpts...); err != nil {
+			return err
+		}
+
+		for i := range list.Items {
+			if !expectedInterfaceNames.Has(list.Items[i].Name) && isOwnedBy(vmCtx.VM, &list.Items[i]) {
+				objList = append(objList, &list.Items[i])
+			}
+		}
+
+	case pkgcfg.NetworkProviderTypeNamed:
+		// No objects.
+
+	default:
+		return fmt.Errorf("unsupported network provider envvar value: %q", networkType)
+	}
+
+	results.OrphanedNetworkInterfaces = objList
+	return nil
+}
+
+func isOwnedBy(vm *vmopv1.VirtualMachine, object ctrlclient.Object) bool {
+	for _, ref := range object.GetOwnerReferences() {
+		if ref.UID == vm.UID {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/providers/vsphere/network/list_interfaces_test.go
+++ b/pkg/providers/vsphere/network/list_interfaces_test.go
@@ -1,0 +1,149 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package network_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/google/uuid"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	netopv1alpha1 "github.com/vmware-tanzu/net-operator-api/api/v1alpha1"
+	vpcv1alpha1 "github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
+	ncpv1alpha1 "github.com/vmware-tanzu/vm-operator/external/ncp/api/v1alpha1"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/network"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+var _ = Describe("ListOrphanedNetworkInterfaces", func() {
+
+	var (
+		testConfig builder.VCSimTestConfig
+		ctx        *builder.TestContextForVCSim
+
+		vmCtx pkgctx.VirtualMachineContext
+		vm    *vmopv1.VirtualMachine
+
+		results     network.NetworkInterfaceResults
+		initObjects []ctrlclient.Object
+	)
+
+	BeforeEach(func() {
+		testConfig = builder.VCSimTestConfig{}
+		results = network.NetworkInterfaceResults{}
+
+		vm = &vmopv1.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "list-interfaces-test-vm",
+				Namespace: "list-interfaces-test-ns",
+				UID:       types.UID(uuid.NewString()),
+			},
+		}
+	})
+
+	JustBeforeEach(func() {
+		ctx = suite.NewTestContextForVCSim(testConfig, initObjects...)
+
+		vmCtx = pkgctx.VirtualMachineContext{
+			Context: ctx,
+			Logger:  suite.GetLogger().WithName("list_interfaces_test"),
+			VM:      vm,
+		}
+	})
+
+	AfterEach(func() {
+		initObjects = nil
+	})
+
+	DescribeTableSubtree("Network Env",
+		func(networkEnv builder.NetworkEnv) {
+			var obj ctrlclient.Object
+
+			createInterfaceCr := func(name string, vm *vmopv1.VirtualMachine, makeOwner bool) ctrlclient.Object {
+				switch networkEnv {
+				case builder.NetworkEnvVDS:
+					obj = &netopv1alpha1.NetworkInterface{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      name,
+							Namespace: vm.Namespace,
+						},
+					}
+				case builder.NetworkEnvNSXT:
+					obj = &ncpv1alpha1.VirtualNetworkInterface{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      name,
+							Namespace: vm.Namespace,
+						},
+					}
+				case builder.NetworkEnvVPC:
+					obj = &vpcv1alpha1.SubnetPort{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      name,
+							Namespace: vm.Namespace,
+						},
+					}
+				default:
+					Expect(false).To(BeTrue())
+				}
+
+				obj.SetLabels(map[string]string{network.VMNameLabel: vm.Name})
+				if makeOwner {
+					Expect(ctrlutil.SetOwnerReference(vm, obj, ctx.Client.Scheme())).To(Succeed())
+				}
+
+				return obj
+			}
+
+			BeforeEach(func() {
+				testConfig.WithNetworkEnv = networkEnv
+			})
+
+			It("Returns orphaned owned interface CR", func() {
+				ownedNetIf := createInterfaceCr(vm.Name+"-owned", vm, true)
+				Expect(ctx.Client.Create(ctx, ownedNetIf)).To(Succeed())
+				unownedNetIf := createInterfaceCr(vm.Name+"-unowned", vm, false)
+				Expect(ctx.Client.Create(ctx, unownedNetIf)).To(Succeed())
+
+				err := network.ListOrphanedNetworkInterfaces(vmCtx, ctx.Client, &results)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(results.OrphanedNetworkInterfaces).To(HaveLen(1))
+				Expect(results.OrphanedNetworkInterfaces[0].GetName()).To(Equal(ownedNetIf.GetName()))
+			})
+
+			Context("Multiple owned interfaces", func() {
+
+				It("Returns just orphaned interface", func() {
+					ownedNetIf1 := createInterfaceCr(vm.Name+"-owned1", vm, true)
+					Expect(ctx.Client.Create(ctx, ownedNetIf1)).To(Succeed())
+					ownedNetIf2 := createInterfaceCr(vm.Name+"-owned2", vm, true)
+					Expect(ctx.Client.Create(ctx, ownedNetIf2)).To(Succeed())
+					unownedNetIf := createInterfaceCr(vm.Name+"-unowned", vm, false)
+					Expect(ctx.Client.Create(ctx, unownedNetIf)).To(Succeed())
+
+					results.Results = []network.NetworkInterfaceResult{
+						{
+							ObjectName: ownedNetIf2.GetName(),
+						},
+					}
+
+					err := network.ListOrphanedNetworkInterfaces(vmCtx, ctx.Client, &results)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(results.OrphanedNetworkInterfaces).To(HaveLen(1))
+					Expect(results.OrphanedNetworkInterfaces[0].GetName()).To(Equal(ownedNetIf1.GetName()))
+				})
+			})
+		},
+		Entry("VDS", builder.NetworkEnvVDS),
+		Entry("NSX-T", builder.NetworkEnvNSXT),
+		Entry("VPC", builder.NetworkEnvVPC),
+	)
+})

--- a/pkg/providers/vsphere/network/netplan_test.go
+++ b/pkg/providers/vsphere/network/netplan_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Netplan", func() {
 		)
 
 		BeforeEach(func() {
-			results.Results = nil
+			results = network.NetworkInterfaceResults{}
 			config = nil
 		})
 

--- a/pkg/providers/vsphere/network/network_test.go
+++ b/pkg/providers/vsphere/network/network_test.go
@@ -503,7 +503,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 					netInterface.Status.InterfaceID = interfaceID
 					netInterface.Status.MacAddress = macAddress
 					netInterface.Status.ProviderStatus = &ncpv1alpha1.VirtualNetworkInterfaceProviderStatus{
-						NsxLogicalSwitchID: builder.NsxTLogicalSwitchUUID,
+						NsxLogicalSwitchID: builder.GetNsxTLogicalSwitchUUID(0),
 					}
 					netInterface.Status.IPAddresses = []ncpv1alpha1.VirtualNetworkInterfaceIP{
 						{
@@ -539,7 +539,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 				result := results.Results[0]
 				Expect(result.MacAddress).To(Equal(macAddress))
 				Expect(result.ExternalID).To(Equal(interfaceID))
-				Expect(result.NetworkID).To(Equal(builder.NsxTLogicalSwitchUUID))
+				Expect(result.NetworkID).To(Equal(builder.GetNsxTLogicalSwitchUUID(0)))
 				Expect(result.Name).To(Equal(interfaceName))
 
 				Expect(result.IPConfigs).To(HaveLen(2))
@@ -606,7 +606,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 						netInterface.Status.InterfaceID = interfaceID
 						netInterface.Status.MacAddress = macAddress
 						netInterface.Status.ProviderStatus = &ncpv1alpha1.VirtualNetworkInterfaceProviderStatus{
-							NsxLogicalSwitchID: builder.NsxTLogicalSwitchUUID,
+							NsxLogicalSwitchID: builder.GetNsxTLogicalSwitchUUID(0),
 						}
 						netInterface.Status.IPAddresses = []ncpv1alpha1.VirtualNetworkInterfaceIP{
 							{
@@ -642,7 +642,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 					result := results.Results[0]
 					Expect(result.MacAddress).To(Equal(macAddress))
 					Expect(result.ExternalID).To(Equal(interfaceID))
-					Expect(result.NetworkID).To(Equal(builder.NsxTLogicalSwitchUUID))
+					Expect(result.NetworkID).To(Equal(builder.GetNsxTLogicalSwitchUUID(0)))
 					Expect(result.Name).To(Equal(interfaceName))
 
 					Expect(result.IPConfigs).To(HaveLen(2))
@@ -709,7 +709,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 				Expect(ctx.NetworkRef.Reference().Type).To(Equal("DistributedVirtualPortgroup"))
 
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("subnetPort is not ready yet"))
+				Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
 				Expect(results.Results).To(BeEmpty())
 
 				By("simulate successful NSX Operator reconcile", func() {
@@ -727,7 +727,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 
 					subnetPort.Status.Attachment.ID = interfaceID
 					subnetPort.Status.NetworkInterfaceConfig.MACAddress = macAddress
-					subnetPort.Status.NetworkInterfaceConfig.LogicalSwitchUUID = builder.VPCLogicalSwitchUUID
+					subnetPort.Status.NetworkInterfaceConfig.LogicalSwitchUUID = builder.GetVPCTLogicalSwitchUUID(0)
 					subnetPort.Status.NetworkInterfaceConfig.IPAddresses = []vpcv1alpha1.NetworkInterfaceIPAddress{
 						{
 							IPAddress: "192.168.1.110/24",
@@ -760,7 +760,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 				result := results.Results[0]
 				Expect(result.MacAddress).To(Equal(macAddress))
 				Expect(result.ExternalID).To(Equal(interfaceID))
-				Expect(result.NetworkID).To(Equal(builder.VPCLogicalSwitchUUID))
+				Expect(result.NetworkID).To(Equal(builder.GetVPCTLogicalSwitchUUID(0)))
 				Expect(result.Name).To(Equal(interfaceName))
 
 				Expect(result.IPConfigs).To(HaveLen(2))

--- a/pkg/providers/vsphere/vmprovider_vm_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_test.go
@@ -61,6 +61,8 @@ import (
 const (
 	// Hardcoded vcsim CPU frequency.
 	vcsimCPUFreq = 2294
+
+	cvmiKind = "ClusterVirtualMachineImage"
 )
 
 //nolint:gocyclo // allowed is 30, this function is 32

--- a/pkg/util/resize/backings.go
+++ b/pkg/util/resize/backings.go
@@ -218,3 +218,46 @@ func MatchVirtualSCSIPassthroughDeviceBackingInfo(
 		expectedBacking.GetVirtualDeviceDeviceBackingInfo(),
 		curBacking.GetVirtualDeviceDeviceBackingInfo())
 }
+
+func MatchVirtualEthernetCardNetworkBackingInfo(
+	expectedBacking *vimtypes.VirtualEthernetCardNetworkBackingInfo,
+	baseBacking vimtypes.BaseVirtualDeviceBackingInfo) bool {
+
+	curBacking, ok := baseBacking.(*vimtypes.VirtualEthernetCardNetworkBackingInfo)
+	if !ok {
+		return false
+	}
+
+	// Ignore Network field since this is just used for testing.
+	// InPassthroughMode is deprecated.
+
+	return MatchVirtualDeviceDeviceBackingInfo(
+		expectedBacking.GetVirtualDeviceDeviceBackingInfo(),
+		curBacking.GetVirtualDeviceDeviceBackingInfo())
+}
+
+func MatchVirtualEthernetCardDistributedVirtualPortBackingInfo(
+	expectedBacking *vimtypes.VirtualEthernetCardDistributedVirtualPortBackingInfo,
+	baseBacking vimtypes.BaseVirtualDeviceBackingInfo) bool {
+
+	curBacking, ok := baseBacking.(*vimtypes.VirtualEthernetCardDistributedVirtualPortBackingInfo)
+	if !ok {
+		return false
+	}
+
+	return expectedBacking.Port.SwitchUuid == curBacking.Port.SwitchUuid &&
+		expectedBacking.Port.PortgroupKey == curBacking.Port.PortgroupKey
+}
+
+func MatchVirtualEthernetCardOpaqueNetworkBackingInfo(
+	expectedBacking *vimtypes.VirtualEthernetCardOpaqueNetworkBackingInfo,
+	baseBacking vimtypes.BaseVirtualDeviceBackingInfo) bool {
+
+	curBacking, ok := baseBacking.(*vimtypes.VirtualEthernetCardOpaqueNetworkBackingInfo)
+	if !ok {
+		return false
+	}
+
+	return expectedBacking.OpaqueNetworkId == curBacking.OpaqueNetworkId &&
+		expectedBacking.OpaqueNetworkType == curBacking.OpaqueNetworkType
+}

--- a/pkg/util/resize/backings_test.go
+++ b/pkg/util/resize/backings_test.go
@@ -567,4 +567,114 @@ var _ = Describe("Backings", func() {
 		),
 	)
 
+	DescribeTable("MatchVirtualEthernetCardNetworkBackingInfo",
+		func(expected *vimtypes.VirtualEthernetCardNetworkBackingInfo, current vimtypes.BaseVirtualDeviceBackingInfo, match bool) {
+			m := resize.MatchVirtualEthernetCardNetworkBackingInfo(expected, current)
+			Expect(m).To(Equal(match), cmp.Diff(current, expected))
+		},
+
+		Entry("#1",
+			&vimtypes.VirtualEthernetCardNetworkBackingInfo{},
+			&vimtypes.VirtualNVDIMMBackingInfo{},
+			false,
+		),
+		Entry("#2",
+			&vimtypes.VirtualEthernetCardNetworkBackingInfo{},
+			&vimtypes.VirtualEthernetCardNetworkBackingInfo{},
+			true,
+		),
+		Entry("#3",
+			&vimtypes.VirtualEthernetCardNetworkBackingInfo{
+				VirtualDeviceDeviceBackingInfo: vimtypes.VirtualDeviceDeviceBackingInfo{DeviceName: "bar"},
+			},
+			&vimtypes.VirtualEthernetCardNetworkBackingInfo{
+				VirtualDeviceDeviceBackingInfo: vimtypes.VirtualDeviceDeviceBackingInfo{DeviceName: "bar"},
+			},
+			true,
+		),
+	)
+
+	DescribeTable("MatchVirtualEthernetCardDistributedVirtualPortBackingInfo",
+		func(expected *vimtypes.VirtualEthernetCardDistributedVirtualPortBackingInfo, current vimtypes.BaseVirtualDeviceBackingInfo, match bool) {
+			m := resize.MatchVirtualEthernetCardDistributedVirtualPortBackingInfo(expected, current)
+			Expect(m).To(Equal(match), cmp.Diff(current, expected))
+		},
+
+		Entry("#1",
+			&vimtypes.VirtualEthernetCardDistributedVirtualPortBackingInfo{},
+			&vimtypes.VirtualNVDIMMBackingInfo{},
+			false,
+		),
+		Entry("#2",
+			&vimtypes.VirtualEthernetCardDistributedVirtualPortBackingInfo{},
+			&vimtypes.VirtualEthernetCardDistributedVirtualPortBackingInfo{},
+			true,
+		),
+		Entry("#3",
+			&vimtypes.VirtualEthernetCardDistributedVirtualPortBackingInfo{
+				Port: vimtypes.DistributedVirtualSwitchPortConnection{
+					SwitchUuid:   "foo",
+					PortgroupKey: "bar",
+				},
+			},
+			&vimtypes.VirtualEthernetCardDistributedVirtualPortBackingInfo{
+				Port: vimtypes.DistributedVirtualSwitchPortConnection{
+					SwitchUuid:   "foo",
+					PortgroupKey: "bar",
+				},
+			},
+			true,
+		),
+		Entry("#4",
+			&vimtypes.VirtualEthernetCardDistributedVirtualPortBackingInfo{
+				Port: vimtypes.DistributedVirtualSwitchPortConnection{
+					SwitchUuid:   "foo",
+					PortgroupKey: "foo",
+				},
+			},
+			&vimtypes.VirtualEthernetCardDistributedVirtualPortBackingInfo{
+				Port: vimtypes.DistributedVirtualSwitchPortConnection{
+					SwitchUuid:   "bar",
+					PortgroupKey: "bar",
+				},
+			},
+			false,
+		),
+	)
+
+	DescribeTable("MatchVirtualEthernetCardOpaqueNetworkBackingInfo",
+		func(expected *vimtypes.VirtualEthernetCardOpaqueNetworkBackingInfo, current vimtypes.BaseVirtualDeviceBackingInfo, match bool) {
+			m := resize.MatchVirtualEthernetCardOpaqueNetworkBackingInfo(expected, current)
+			Expect(m).To(Equal(match), cmp.Diff(current, expected))
+		},
+
+		Entry("#1",
+			&vimtypes.VirtualEthernetCardOpaqueNetworkBackingInfo{},
+			&vimtypes.VirtualNVDIMMBackingInfo{},
+			false,
+		),
+		Entry("#2",
+			&vimtypes.VirtualEthernetCardOpaqueNetworkBackingInfo{
+				OpaqueNetworkId:   "foo",
+				OpaqueNetworkType: "bar",
+			},
+			&vimtypes.VirtualEthernetCardOpaqueNetworkBackingInfo{
+				OpaqueNetworkId:   "foo",
+				OpaqueNetworkType: "bar",
+			},
+			true,
+		),
+		Entry("#3",
+			&vimtypes.VirtualEthernetCardOpaqueNetworkBackingInfo{
+				OpaqueNetworkId:   "foo",
+				OpaqueNetworkType: "foo",
+			},
+			&vimtypes.VirtualEthernetCardOpaqueNetworkBackingInfo{
+				OpaqueNetworkId:   "bar",
+				OpaqueNetworkType: "bar",
+			},
+			false,
+		),
+	)
+
 })


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

During power on, determine if any existing network interface need to added and/or removed from the VM, and delete the now orphaned network interface CRs after the VM has been reconfigured.

New interfaces will always get added as vmxnet3 devices.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

**Please add a release note if necessary**:

```release-note
NONE
```