### PR TITLE
:seedling: Cleanup image check from storage quota validator create

### DIFF
--- a/webhooks/unifiedstoragequota/validation/unifiedstoragequota_validator.go
+++ b/webhooks/unifiedstoragequota/validation/unifiedstoragequota_validator.go
@@ -150,9 +150,11 @@ func (h *RequestedCapacityHandler) HandleCreate(ctx *pkgctx.WebhookRequestContex
 		return CapacityResponse{Response: webhook.Errored(http.StatusInternalServerError, err)}
 	}
 
-	if vm.Spec.Image == nil {
-		return CapacityResponse{Response: webhook.Errored(http.StatusBadRequest, errors.New("vm.Spec.Image is required"))}
-	}
+	// This webhook will not be called if vm.Spec.Image is not set. This is done in order to ensure that imageless VMs
+	// do not participate in quota validation. The VirtualMachine ValidatingWebhook still performs image validation.
+	//
+	// Please see https://github.com/vmware-tanzu/vm-operator/pull/822 and
+	// https://github.com/vmware-tanzu/vm-operator/blob/main/config/webhook/storage_quota_webhook_configuration.yaml#L30-L31
 	vmiName := vm.Spec.Image.Name
 	var imageStatus vmopv1.VirtualMachineImageStatus
 

--- a/webhooks/unifiedstoragequota/validation/unifiedstoragequota_validator_unit_test.go
+++ b/webhooks/unifiedstoragequota/validation/unifiedstoragequota_validator_unit_test.go
@@ -611,21 +611,6 @@ func testRequestedCapacityHandlerHandleCreate() {
 				})
 			})
 
-			When("vm image is nil", func() {
-				BeforeEach(func() {
-					vm = &vmopv1.VirtualMachine{}
-				})
-
-				It("should write StatusBadRequest code and an empty RequestedCapacity to the response", func() {
-					Expect(resp.Allowed).To(BeFalse())
-					Expect(int(resp.Result.Code)).To(Equal(http.StatusBadRequest))
-
-					Expect(resp.Capacity.String()).To(Equal(expected.Capacity.String()))
-					Expect(resp.StoragePolicyID).To(Equal(expected.StoragePolicyID))
-					Expect(resp.StorageClassName).To(Equal(expected.StorageClassName))
-				})
-			})
-
 			Context("vmi is specified as vm image kind", func() {
 				var vmi *vmopv1.VirtualMachineImage
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->

Remove the `vm.Spec.Image` check from the storage quota validator. [PR 822](https://github.com/vmware-tanzu/vm-operator/pull/822) introduced a change to the storage quota validating webhook configuration to skip quota validation for imageless VMs. So, this check is not needed as the validator will not be called if the value is not set.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```