### PR TITLE
🌱 Move utilconversion test helpers into pkg

### DIFF
--- a/api/utilconversion/fuzztests/conversion_fuzz.go
+++ b/api/utilconversion/fuzztests/conversion_fuzz.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package utilconversion
+package fuzztests
 
 import (
 	"math/rand"
@@ -28,6 +28,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	ctrlconversion "sigs.k8s.io/controller-runtime/pkg/conversion"
+
+	"github.com/vmware-tanzu/vm-operator/api/utilconversion"
 )
 
 // GetFuzzer returns a new fuzzer to be used for testing.
@@ -94,7 +96,7 @@ func SpokeHubSpoke(input FuzzTestFuncInput) {
 		// NOTE: There are use case when we want to skip this operation, e.g. if the spoke object does not have ObjectMeta (e.g. kubeadm types).
 		if !input.SkipSpokeAnnotationCleanup {
 			metaAfter := spokeAfter.(metav1.Object)
-			delete(metaAfter.GetAnnotations(), AnnotationKey)
+			delete(metaAfter.GetAnnotations(), utilconversion.AnnotationKey)
 		}
 
 		if input.SpokeAfterMutation != nil {

--- a/api/v1alpha1/conversion_test.go
+++ b/api/v1alpha1/conversion_test.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 
-	"github.com/vmware-tanzu/vm-operator/api/utilconversion"
+	"github.com/vmware-tanzu/vm-operator/api/utilconversion/fuzztests"
 	vmopv1a1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
 )
@@ -23,7 +23,7 @@ var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 
 	var (
 		scheme *runtime.Scheme
-		input  utilconversion.FuzzTestFuncInput
+		input  fuzztests.FuzzTestFuncInput
 	)
 
 	BeforeEach(func() {
@@ -33,12 +33,12 @@ var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 	})
 
 	AfterEach(func() {
-		input = utilconversion.FuzzTestFuncInput{}
+		input = fuzztests.FuzzTestFuncInput{}
 	})
 
 	Context("VirtualMachine", func() {
 		BeforeEach(func() {
-			input = utilconversion.FuzzTestFuncInput{
+			input = fuzztests.FuzzTestFuncInput{
 				Scheme: scheme,
 				Hub:    &vmopv1.VirtualMachine{},
 				Spoke:  &vmopv1a1.VirtualMachine{},
@@ -49,19 +49,19 @@ var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 		})
 		Context("Spoke-Hub-Spoke", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.SpokeHubSpoke(input)
+				fuzztests.SpokeHubSpoke(input)
 			})
 		})
 		Context("Hub-Spoke-Hub", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.HubSpokeHub(input)
+				fuzztests.HubSpokeHub(input)
 			})
 		})
 	})
 
 	Context("VirtualMachineClass", func() {
 		BeforeEach(func() {
-			input = utilconversion.FuzzTestFuncInput{
+			input = fuzztests.FuzzTestFuncInput{
 				Scheme: scheme,
 				Hub:    &vmopv1.VirtualMachineClass{},
 				Spoke:  &vmopv1a1.VirtualMachineClass{},
@@ -72,19 +72,19 @@ var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 		})
 		Context("Spoke-Hub-Spoke", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.SpokeHubSpoke(input)
+				fuzztests.SpokeHubSpoke(input)
 			})
 		})
 		Context("Hub-Spoke-Hub", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.HubSpokeHub(input)
+				fuzztests.HubSpokeHub(input)
 			})
 		})
 	})
 
 	Context("VirtualMachineImage", func() {
 		BeforeEach(func() {
-			input = utilconversion.FuzzTestFuncInput{
+			input = fuzztests.FuzzTestFuncInput{
 				Scheme: scheme,
 				Hub:    &vmopv1.VirtualMachineImage{},
 				Spoke:  &vmopv1a1.VirtualMachineImage{},
@@ -95,19 +95,19 @@ var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 		})
 		Context("Spoke-Hub-Spoke", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.SpokeHubSpoke(input)
+				fuzztests.SpokeHubSpoke(input)
 			})
 		})
 		Context("Hub-Spoke-Hub", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.HubSpokeHub(input)
+				fuzztests.HubSpokeHub(input)
 			})
 		})
 	})
 
 	Context("ClusterVirtualMachineImage", func() {
 		BeforeEach(func() {
-			input = utilconversion.FuzzTestFuncInput{
+			input = fuzztests.FuzzTestFuncInput{
 				Scheme: scheme,
 				Hub:    &vmopv1.ClusterVirtualMachineImage{},
 				Spoke:  &vmopv1a1.ClusterVirtualMachineImage{},
@@ -118,19 +118,19 @@ var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 		})
 		Context("Spoke-Hub-Spoke", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.SpokeHubSpoke(input)
+				fuzztests.SpokeHubSpoke(input)
 			})
 		})
 		Context("Hub-Spoke-Hub", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.HubSpokeHub(input)
+				fuzztests.HubSpokeHub(input)
 			})
 		})
 	})
 
 	Context("VirtualMachinePublishRequest", func() {
 		BeforeEach(func() {
-			input = utilconversion.FuzzTestFuncInput{
+			input = fuzztests.FuzzTestFuncInput{
 				Scheme: scheme,
 				Hub:    &vmopv1.VirtualMachinePublishRequest{},
 				Spoke:  &vmopv1a1.VirtualMachinePublishRequest{},
@@ -141,19 +141,19 @@ var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 		})
 		Context("Spoke-Hub-Spoke", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.SpokeHubSpoke(input)
+				fuzztests.SpokeHubSpoke(input)
 			})
 		})
 		Context("Hub-Spoke-Hub", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.HubSpokeHub(input)
+				fuzztests.HubSpokeHub(input)
 			})
 		})
 	})
 
 	Context("VirtualMachineService", func() {
 		BeforeEach(func() {
-			input = utilconversion.FuzzTestFuncInput{
+			input = fuzztests.FuzzTestFuncInput{
 				Scheme: scheme,
 				Hub:    &vmopv1.VirtualMachineService{},
 				Spoke:  &vmopv1a1.VirtualMachineService{},
@@ -161,18 +161,18 @@ var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 		})
 		Context("Spoke-Hub-Spoke", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.SpokeHubSpoke(input)
+				fuzztests.SpokeHubSpoke(input)
 			})
 		})
 		Context("Hub-Spoke-Hub", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.HubSpokeHub(input)
+				fuzztests.HubSpokeHub(input)
 			})
 		})
 	})
 	Context("VirtualMachineSetResourcePolicy", func() {
 		BeforeEach(func() {
-			input = utilconversion.FuzzTestFuncInput{
+			input = fuzztests.FuzzTestFuncInput{
 				Scheme: scheme,
 				Hub:    &vmopv1.VirtualMachineSetResourcePolicy{},
 				Spoke:  &vmopv1a1.VirtualMachineSetResourcePolicy{},
@@ -180,12 +180,12 @@ var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 		})
 		Context("Spoke-Hub-Spoke", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.SpokeHubSpoke(input)
+				fuzztests.SpokeHubSpoke(input)
 			})
 		})
 		Context("Hub-Spoke-Hub", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.HubSpokeHub(input)
+				fuzztests.HubSpokeHub(input)
 			})
 		})
 	})

--- a/api/v1alpha2/conversion_test.go
+++ b/api/v1alpha2/conversion_test.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 
-	"github.com/vmware-tanzu/vm-operator/api/utilconversion"
+	"github.com/vmware-tanzu/vm-operator/api/utilconversion/fuzztests"
 	vmopv1a2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
 	vmopv1sysprep "github.com/vmware-tanzu/vm-operator/api/v1alpha4/sysprep"
@@ -26,7 +26,7 @@ var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 
 	var (
 		scheme *runtime.Scheme
-		input  utilconversion.FuzzTestFuncInput
+		input  fuzztests.FuzzTestFuncInput
 	)
 
 	BeforeEach(func() {
@@ -36,12 +36,12 @@ var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 	})
 
 	AfterEach(func() {
-		input = utilconversion.FuzzTestFuncInput{}
+		input = fuzztests.FuzzTestFuncInput{}
 	})
 
 	Context("VirtualMachine", func() {
 		BeforeEach(func() {
-			input = utilconversion.FuzzTestFuncInput{
+			input = fuzztests.FuzzTestFuncInput{
 				Scheme: scheme,
 				Hub:    &vmopv1.VirtualMachine{},
 				Spoke:  &vmopv1a2.VirtualMachine{},
@@ -52,19 +52,19 @@ var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 		})
 		Context("Spoke-Hub-Spoke", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.SpokeHubSpoke(input)
+				fuzztests.SpokeHubSpoke(input)
 			})
 		})
 		Context("Hub-Spoke-Hub", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.HubSpokeHub(input)
+				fuzztests.HubSpokeHub(input)
 			})
 		})
 	})
 
 	Context("VirtualMachineClass", func() {
 		BeforeEach(func() {
-			input = utilconversion.FuzzTestFuncInput{
+			input = fuzztests.FuzzTestFuncInput{
 				Scheme: scheme,
 				Hub:    &vmopv1.VirtualMachineClass{},
 				Spoke:  &vmopv1a2.VirtualMachineClass{},
@@ -72,19 +72,19 @@ var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 		})
 		Context("Spoke-Hub-Spoke", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.SpokeHubSpoke(input)
+				fuzztests.SpokeHubSpoke(input)
 			})
 		})
 		Context("Hub-Spoke-Hub", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.HubSpokeHub(input)
+				fuzztests.HubSpokeHub(input)
 			})
 		})
 	})
 
 	Context("VirtualMachineImage", func() {
 		BeforeEach(func() {
-			input = utilconversion.FuzzTestFuncInput{
+			input = fuzztests.FuzzTestFuncInput{
 				Scheme: scheme,
 				Hub:    &vmopv1.VirtualMachineImage{},
 				Spoke:  &vmopv1a2.VirtualMachineImage{},
@@ -95,19 +95,19 @@ var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 		})
 		Context("Spoke-Hub-Spoke", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.SpokeHubSpoke(input)
+				fuzztests.SpokeHubSpoke(input)
 			})
 		})
 		Context("Hub-Spoke-Hub", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.HubSpokeHub(input)
+				fuzztests.HubSpokeHub(input)
 			})
 		})
 	})
 
 	Context("ClusterVirtualMachineImage", func() {
 		BeforeEach(func() {
-			input = utilconversion.FuzzTestFuncInput{
+			input = fuzztests.FuzzTestFuncInput{
 				Scheme: scheme,
 				Hub:    &vmopv1.ClusterVirtualMachineImage{},
 				Spoke:  &vmopv1a2.ClusterVirtualMachineImage{},
@@ -118,19 +118,19 @@ var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 		})
 		Context("Spoke-Hub-Spoke", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.SpokeHubSpoke(input)
+				fuzztests.SpokeHubSpoke(input)
 			})
 		})
 		Context("Hub-Spoke-Hub", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.HubSpokeHub(input)
+				fuzztests.HubSpokeHub(input)
 			})
 		})
 	})
 
 	Context("VirtualMachinePublishRequest", func() {
 		BeforeEach(func() {
-			input = utilconversion.FuzzTestFuncInput{
+			input = fuzztests.FuzzTestFuncInput{
 				Scheme: scheme,
 				Hub:    &vmopv1.VirtualMachinePublishRequest{},
 				Spoke:  &vmopv1a2.VirtualMachinePublishRequest{},
@@ -138,19 +138,19 @@ var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 		})
 		Context("Spoke-Hub-Spoke", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.SpokeHubSpoke(input)
+				fuzztests.SpokeHubSpoke(input)
 			})
 		})
 		Context("Hub-Spoke-Hub", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.HubSpokeHub(input)
+				fuzztests.HubSpokeHub(input)
 			})
 		})
 	})
 
 	Context("VirtualMachineService", func() {
 		BeforeEach(func() {
-			input = utilconversion.FuzzTestFuncInput{
+			input = fuzztests.FuzzTestFuncInput{
 				Scheme: scheme,
 				Hub:    &vmopv1.VirtualMachineService{},
 				Spoke:  &vmopv1a2.VirtualMachineService{},
@@ -158,19 +158,19 @@ var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 		})
 		Context("Spoke-Hub-Spoke", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.SpokeHubSpoke(input)
+				fuzztests.SpokeHubSpoke(input)
 			})
 		})
 		Context("Hub-Spoke-Hub", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.HubSpokeHub(input)
+				fuzztests.HubSpokeHub(input)
 			})
 		})
 	})
 
 	Context("VirtualMachineSetResourcePolicy", func() {
 		BeforeEach(func() {
-			input = utilconversion.FuzzTestFuncInput{
+			input = fuzztests.FuzzTestFuncInput{
 				Scheme: scheme,
 				Hub:    &vmopv1.VirtualMachineSetResourcePolicy{},
 				Spoke:  &vmopv1a2.VirtualMachineSetResourcePolicy{},
@@ -178,19 +178,19 @@ var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 		})
 		Context("Spoke-Hub-Spoke", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.SpokeHubSpoke(input)
+				fuzztests.SpokeHubSpoke(input)
 			})
 		})
 		Context("Hub-Spoke-Hub", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.HubSpokeHub(input)
+				fuzztests.HubSpokeHub(input)
 			})
 		})
 	})
 
 	Context("VirtualMachineWebConsoleRequest", func() {
 		BeforeEach(func() {
-			input = utilconversion.FuzzTestFuncInput{
+			input = fuzztests.FuzzTestFuncInput{
 				Scheme: scheme,
 				Hub:    &vmopv1.VirtualMachineWebConsoleRequest{},
 				Spoke:  &vmopv1a2.VirtualMachineWebConsoleRequest{},
@@ -198,12 +198,12 @@ var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 		})
 		Context("Spoke-Hub-Spoke", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.SpokeHubSpoke(input)
+				fuzztests.SpokeHubSpoke(input)
 			})
 		})
 		Context("Hub-Spoke-Hub", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.HubSpokeHub(input)
+				fuzztests.HubSpokeHub(input)
 			})
 		})
 	})

--- a/api/v1alpha3/conversion_test.go
+++ b/api/v1alpha3/conversion_test.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 
-	"github.com/vmware-tanzu/vm-operator/api/utilconversion"
+	"github.com/vmware-tanzu/vm-operator/api/utilconversion/fuzztests"
 	vmopv1a3 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
 	vmopv1sysprep "github.com/vmware-tanzu/vm-operator/api/v1alpha4/sysprep"
@@ -26,7 +26,7 @@ var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 
 	var (
 		scheme *runtime.Scheme
-		input  utilconversion.FuzzTestFuncInput
+		input  fuzztests.FuzzTestFuncInput
 	)
 
 	BeforeEach(func() {
@@ -36,12 +36,12 @@ var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 	})
 
 	AfterEach(func() {
-		input = utilconversion.FuzzTestFuncInput{}
+		input = fuzztests.FuzzTestFuncInput{}
 	})
 
 	Context("VirtualMachine", func() {
 		BeforeEach(func() {
-			input = utilconversion.FuzzTestFuncInput{
+			input = fuzztests.FuzzTestFuncInput{
 				Scheme: scheme,
 				Hub:    &vmopv1.VirtualMachine{},
 				Spoke:  &vmopv1a3.VirtualMachine{},
@@ -52,19 +52,19 @@ var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 		})
 		Context("Spoke-Hub-Spoke", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.SpokeHubSpoke(input)
+				fuzztests.SpokeHubSpoke(input)
 			})
 		})
 		Context("Hub-Spoke-Hub", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.HubSpokeHub(input)
+				fuzztests.HubSpokeHub(input)
 			})
 		})
 	})
 
 	Context("VirtualMachineClass", func() {
 		BeforeEach(func() {
-			input = utilconversion.FuzzTestFuncInput{
+			input = fuzztests.FuzzTestFuncInput{
 				Scheme: scheme,
 				Hub:    &vmopv1.VirtualMachineClass{},
 				Spoke:  &vmopv1a3.VirtualMachineClass{},
@@ -72,19 +72,19 @@ var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 		})
 		Context("Spoke-Hub-Spoke", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.SpokeHubSpoke(input)
+				fuzztests.SpokeHubSpoke(input)
 			})
 		})
 		Context("Hub-Spoke-Hub", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.HubSpokeHub(input)
+				fuzztests.HubSpokeHub(input)
 			})
 		})
 	})
 
 	Context("VirtualMachineImage", func() {
 		BeforeEach(func() {
-			input = utilconversion.FuzzTestFuncInput{
+			input = fuzztests.FuzzTestFuncInput{
 				Scheme: scheme,
 				Hub:    &vmopv1.VirtualMachineImage{},
 				Spoke:  &vmopv1a3.VirtualMachineImage{},
@@ -95,19 +95,19 @@ var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 		})
 		Context("Spoke-Hub-Spoke", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.SpokeHubSpoke(input)
+				fuzztests.SpokeHubSpoke(input)
 			})
 		})
 		Context("Hub-Spoke-Hub", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.HubSpokeHub(input)
+				fuzztests.HubSpokeHub(input)
 			})
 		})
 	})
 
 	Context("ClusterVirtualMachineImage", func() {
 		BeforeEach(func() {
-			input = utilconversion.FuzzTestFuncInput{
+			input = fuzztests.FuzzTestFuncInput{
 				Scheme: scheme,
 				Hub:    &vmopv1.ClusterVirtualMachineImage{},
 				Spoke:  &vmopv1a3.ClusterVirtualMachineImage{},
@@ -118,19 +118,19 @@ var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 		})
 		Context("Spoke-Hub-Spoke", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.SpokeHubSpoke(input)
+				fuzztests.SpokeHubSpoke(input)
 			})
 		})
 		Context("Hub-Spoke-Hub", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.HubSpokeHub(input)
+				fuzztests.HubSpokeHub(input)
 			})
 		})
 	})
 
 	Context("VirtualMachineImageCache", func() {
 		BeforeEach(func() {
-			input = utilconversion.FuzzTestFuncInput{
+			input = fuzztests.FuzzTestFuncInput{
 				Scheme: scheme,
 				Hub:    &vmopv1.VirtualMachineImageCache{},
 				Spoke:  &vmopv1a3.VirtualMachineImageCache{},
@@ -138,19 +138,19 @@ var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 		})
 		Context("Spoke-Hub-Spoke", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.SpokeHubSpoke(input)
+				fuzztests.SpokeHubSpoke(input)
 			})
 		})
 		Context("Hub-Spoke-Hub", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.HubSpokeHub(input)
+				fuzztests.HubSpokeHub(input)
 			})
 		})
 	})
 
 	Context("VirtualMachinePublishRequest", func() {
 		BeforeEach(func() {
-			input = utilconversion.FuzzTestFuncInput{
+			input = fuzztests.FuzzTestFuncInput{
 				Scheme: scheme,
 				Hub:    &vmopv1.VirtualMachinePublishRequest{},
 				Spoke:  &vmopv1a3.VirtualMachinePublishRequest{},
@@ -158,19 +158,19 @@ var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 		})
 		Context("Spoke-Hub-Spoke", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.SpokeHubSpoke(input)
+				fuzztests.SpokeHubSpoke(input)
 			})
 		})
 		Context("Hub-Spoke-Hub", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.HubSpokeHub(input)
+				fuzztests.HubSpokeHub(input)
 			})
 		})
 	})
 
 	Context("VirtualMachineService", func() {
 		BeforeEach(func() {
-			input = utilconversion.FuzzTestFuncInput{
+			input = fuzztests.FuzzTestFuncInput{
 				Scheme: scheme,
 				Hub:    &vmopv1.VirtualMachineService{},
 				Spoke:  &vmopv1a3.VirtualMachineService{},
@@ -178,19 +178,19 @@ var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 		})
 		Context("Spoke-Hub-Spoke", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.SpokeHubSpoke(input)
+				fuzztests.SpokeHubSpoke(input)
 			})
 		})
 		Context("Hub-Spoke-Hub", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.HubSpokeHub(input)
+				fuzztests.HubSpokeHub(input)
 			})
 		})
 	})
 
 	Context("VirtualMachineSetResourcePolicy", func() {
 		BeforeEach(func() {
-			input = utilconversion.FuzzTestFuncInput{
+			input = fuzztests.FuzzTestFuncInput{
 				Scheme: scheme,
 				Hub:    &vmopv1.VirtualMachineSetResourcePolicy{},
 				Spoke:  &vmopv1a3.VirtualMachineSetResourcePolicy{},
@@ -198,19 +198,19 @@ var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 		})
 		Context("Spoke-Hub-Spoke", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.SpokeHubSpoke(input)
+				fuzztests.SpokeHubSpoke(input)
 			})
 		})
 		Context("Hub-Spoke-Hub", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.HubSpokeHub(input)
+				fuzztests.HubSpokeHub(input)
 			})
 		})
 	})
 
 	Context("VirtualMachineWebConsoleRequest", func() {
 		BeforeEach(func() {
-			input = utilconversion.FuzzTestFuncInput{
+			input = fuzztests.FuzzTestFuncInput{
 				Scheme: scheme,
 				Hub:    &vmopv1.VirtualMachineWebConsoleRequest{},
 				Spoke:  &vmopv1a3.VirtualMachineWebConsoleRequest{},
@@ -218,12 +218,12 @@ var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 		})
 		Context("Spoke-Hub-Spoke", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.SpokeHubSpoke(input)
+				fuzztests.SpokeHubSpoke(input)
 			})
 		})
 		Context("Hub-Spoke-Hub", func() {
 			It("should get fuzzy with it", func() {
-				utilconversion.HubSpokeHub(input)
+				fuzztests.HubSpokeHub(input)
 			})
 		})
 	})


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch moves the utilconversion fuzz helpers into a sub-package in order to prevent those helpers from being imported into the dependency graph when building non-test packages.

This helps downstream projects like CSI that import our API module from being impacted by any versioning issues that occur out of the fuzz helper logic.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Move API fuzz helpers into sub-package.
```