### PR TITLE
📖 docs: specify 'volumeMode: Block' in PVC YAML examples

### DIFF
--- a/docs/concepts/workloads/vm.md
+++ b/docs/concepts/workloads/vm.md
@@ -637,7 +637,7 @@ The following steps describe how to provide additional storage with [PersistentV
     spec:
       accessModes:
       - ReadWriteOnce
-      volumeMode: Filesystem
+      volumeMode: Block
       resources:
         requests:
           storage: 8Gi

--- a/docs/tutorials/deploy-vm/iso.md
+++ b/docs/tutorials/deploy-vm/iso.md
@@ -86,7 +86,8 @@ metadata:
   namespace: my-namespace
 spec:
   accessModes:
-    - ReadWriteOnce
+  - ReadWriteOnce
+  volumeMode: Block
   resources:
     requests:
       storage: 20Gi # (1)


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR updates all PVC YAML examples in the docs to explicitly set `volumeMode: Block`, which better reflects typical VM volume use cases.

**Which issue(s) is/are addressed by this PR?**

Fixes N/A.


**Are there any special notes for your reviewer**:

None.


**Please add a release note if necessary**:

```release-note
Docs: specify 'volumeMode: Block' in PVC YAML examples.
```