### PR TITLE
:bug: Storage Quota validator should return the sum of all disk capacities in image status

### DIFF
--- a/webhooks/unifiedstoragequota/validation/unifiedstoragequota_validator_unit_test.go
+++ b/webhooks/unifiedstoragequota/validation/unifiedstoragequota_validator_unit_test.go
@@ -697,11 +697,19 @@ func testRequestedCapacityHandlerHandleCreate() {
 								Capacity: nil,
 							},
 						}
+
+						expected = validation.CapacityResponse{
+							RequestedCapacity: validation.RequestedCapacity{
+								Capacity:         *resource.NewQuantity(0, resource.BinarySI),
+								StoragePolicyID:  "id42",
+								StorageClassName: "dummy-storage-class",
+							},
+						}
 					})
 
-					It("should write StatusNotFound code and an empty RequestedCapacity to the response", func() {
-						Expect(resp.Allowed).To(BeFalse())
-						Expect(int(resp.Result.Code)).To(Equal(http.StatusNotFound))
+					It("should write StatusOK code and the correct RequestedCapacity to the response", func() {
+						Expect(resp.Allowed).To(BeTrue())
+						Expect(int(resp.Result.Code)).To(Equal(http.StatusOK))
 
 						Expect(resp.Capacity.String()).To(Equal(expected.Capacity.String()))
 						Expect(resp.StoragePolicyID).To(Equal(expected.StoragePolicyID))
@@ -727,6 +735,42 @@ func testRequestedCapacityHandlerHandleCreate() {
 					})
 
 					It("should write StatusOK code and the correct RequestedCapacity to the response", func() {
+						Expect(resp.Allowed).To(BeTrue())
+						Expect(int(resp.Result.Code)).To(Equal(http.StatusOK))
+
+						Expect(resp.Capacity.String()).To(Equal(expected.Capacity.String()))
+						Expect(resp.StoragePolicyID).To(Equal(expected.StoragePolicyID))
+						Expect(resp.StorageClassName).To(Equal(expected.StorageClassName))
+					})
+				})
+
+				When("there are multiple disks listed", func() {
+					BeforeEach(func() {
+						vmi.Status.Disks = []vmopv1.VirtualMachineImageDiskInfo{
+							{
+								Capacity: resource.NewQuantity(10*1024*1024*1024, resource.BinarySI),
+							},
+							{
+								Capacity: resource.NewQuantity(10*1024*1024*1024, resource.BinarySI),
+							},
+							{
+								Capacity: resource.NewQuantity(10*1024*1024*1024, resource.BinarySI),
+							},
+							{
+								Capacity: nil,
+							},
+						}
+
+						expected = validation.CapacityResponse{
+							RequestedCapacity: validation.RequestedCapacity{
+								Capacity:         *resource.NewQuantity(3*10*1024*1024*1024, resource.BinarySI),
+								StoragePolicyID:  "id42",
+								StorageClassName: "dummy-storage-class",
+							},
+						}
+					})
+
+					It("should return the sum of all disks in the response", func() {
 						Expect(resp.Allowed).To(BeTrue())
 						Expect(int(resp.Result.Code)).To(Equal(http.StatusOK))
 
@@ -817,11 +861,19 @@ func testRequestedCapacityHandlerHandleCreate() {
 							},
 						}
 						withObjects = append([]ctrlclient.Object{withObjects[0]}, cvmi)
+
+						expected = validation.CapacityResponse{
+							RequestedCapacity: validation.RequestedCapacity{
+								Capacity:         *resource.NewQuantity(0, resource.BinarySI),
+								StoragePolicyID:  "id42",
+								StorageClassName: "dummy-storage-class",
+							},
+						}
 					})
 
-					It("should write StatusNotFound code and an empty RequestedCapacity to the response", func() {
-						Expect(resp.Allowed).To(BeFalse())
-						Expect(int(resp.Result.Code)).To(Equal(http.StatusNotFound))
+					It("should write StatusOK code and the correct RequestedCapacity to the response", func() {
+						Expect(resp.Allowed).To(BeTrue())
+						Expect(int(resp.Result.Code)).To(Equal(http.StatusOK))
 
 						Expect(resp.Capacity.String()).To(Equal(expected.Capacity.String()))
 						Expect(resp.StoragePolicyID).To(Equal(expected.StoragePolicyID))
@@ -848,6 +900,40 @@ func testRequestedCapacityHandlerHandleCreate() {
 					})
 
 					It("should write StatusOK code and the correct RequestedCapacity to the response", func() {
+						Expect(resp.Allowed).To(BeTrue())
+						Expect(int(resp.Result.Code)).To(Equal(http.StatusOK))
+
+						Expect(resp.Capacity.String()).To(Equal(expected.Capacity.String()))
+						Expect(resp.StoragePolicyID).To(Equal(expected.StoragePolicyID))
+						Expect(resp.StorageClassName).To(Equal(expected.StorageClassName))
+					})
+				})
+
+				When("there are multiple disks listed", func() {
+					BeforeEach(func() {
+						cvmi.Status.Disks = []vmopv1.VirtualMachineImageDiskInfo{
+							{
+								Capacity: resource.NewQuantity(10*1024*1024*1024, resource.BinarySI),
+							},
+							{
+								Capacity: resource.NewQuantity(10*1024*1024*1024, resource.BinarySI),
+							},
+							{
+								Capacity: resource.NewQuantity(10*1024*1024*1024, resource.BinarySI),
+							},
+						}
+						withObjects = append([]ctrlclient.Object{withObjects[0]}, cvmi)
+
+						expected = validation.CapacityResponse{
+							RequestedCapacity: validation.RequestedCapacity{
+								Capacity:         *resource.NewQuantity(3*10*1024*1024*1024, resource.BinarySI),
+								StoragePolicyID:  "id42",
+								StorageClassName: "dummy-storage-class",
+							},
+						}
+					})
+
+					It("should return the sum of all disks in the response", func() {
 						Expect(resp.Allowed).To(BeTrue())
 						Expect(int(resp.Result.Code)).To(Equal(http.StatusOK))
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->

Currently, the Storage Quota validator only returns the capacity of the first disk in the (c)vmi status, whereas it should be returning the sum of the capacities of all disks listed in the image status. This PR fixes this.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Return the total capacity of all disks in an image during Storage Quota validation.
```