### PR TITLE
Make VM Route Metric field optional

### DIFF
--- a/api/v1alpha2/virtualmachine_network_types.go
+++ b/api/v1alpha2/virtualmachine_network_types.go
@@ -19,7 +19,10 @@ type VirtualMachineNetworkRouteSpec struct {
 	Via string `json:"via"`
 
 	// Metric is the weight/priority of the route.
-	Metric int32 `json:"metric"`
+	//
+	// +optional
+	// +kubebuilder:validation:Minimum=1
+	Metric int32 `json:"metric,omitempty"`
 }
 
 // VirtualMachineNetworkInterfaceSpec describes the desired state of a VM's

--- a/api/v1alpha3/virtualmachine_network_types.go
+++ b/api/v1alpha3/virtualmachine_network_types.go
@@ -18,8 +18,11 @@ type VirtualMachineNetworkRouteSpec struct {
 	// Via is an IP4 or IP6 address.
 	Via string `json:"via"`
 
+	// +optional
+	// +kubebuilder:validation:Minimum=1
+
 	// Metric is the weight/priority of the route.
-	Metric int32 `json:"metric"`
+	Metric int32 `json:"metric,omitempty"`
 }
 
 // VirtualMachineNetworkInterfaceSpec describes the desired state of a VM's

--- a/api/v1alpha4/virtualmachine_network_types.go
+++ b/api/v1alpha4/virtualmachine_network_types.go
@@ -18,8 +18,11 @@ type VirtualMachineNetworkRouteSpec struct {
 	// Via is an IP4 or IP6 address.
 	Via string `json:"via"`
 
+	// +optional
+	// +kubebuilder:validation:Minimum=1
+
 	// Metric is the weight/priority of the route.
-	Metric int32 `json:"metric"`
+	Metric int32 `json:"metric,omitempty"`
 }
 
 // VirtualMachineNetworkInterfaceSpec describes the desired state of a VM's

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachinereplicasets.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachinereplicasets.yaml
@@ -1483,6 +1483,7 @@ spec:
                                         description: Metric is the weight/priority
                                           of the route.
                                         format: int32
+                                        minimum: 1
                                         type: integer
                                       to:
                                         description: To is an IP4 or IP6 address.
@@ -1491,7 +1492,6 @@ spec:
                                         description: Via is an IP4 or IP6 address.
                                         type: string
                                     required:
-                                    - metric
                                     - to
                                     - via
                                     type: object
@@ -3411,6 +3411,7 @@ spec:
                                         description: Metric is the weight/priority
                                           of the route.
                                         format: int32
+                                        minimum: 1
                                         type: integer
                                       to:
                                         description: To is an IP4 or IP6 address.
@@ -3419,7 +3420,6 @@ spec:
                                         description: Via is an IP4 or IP6 address.
                                         type: string
                                     required:
-                                    - metric
                                     - to
                                     - via
                                     type: object

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -1769,6 +1769,7 @@ spec:
                                 description: Metric is the weight/priority of the
                                   route.
                                 format: int32
+                                minimum: 1
                                 type: integer
                               to:
                                 description: To is an IP4 or IP6 address.
@@ -1777,7 +1778,6 @@ spec:
                                 description: Via is an IP4 or IP6 address.
                                 type: string
                             required:
-                            - metric
                             - to
                             - via
                             type: object
@@ -4318,6 +4318,7 @@ spec:
                                 description: Metric is the weight/priority of the
                                   route.
                                 format: int32
+                                minimum: 1
                                 type: integer
                               to:
                                 description: To is an IP4 or IP6 address.
@@ -4326,7 +4327,6 @@ spec:
                                 description: Via is an IP4 or IP6 address.
                                 type: string
                             required:
-                            - metric
                             - to
                             - via
                             type: object
@@ -6965,6 +6965,7 @@ spec:
                                 description: Metric is the weight/priority of the
                                   route.
                                 format: int32
+                                minimum: 1
                                 type: integer
                               to:
                                 description: To is an IP4 or IP6 address.
@@ -6973,7 +6974,6 @@ spec:
                                 description: Via is an IP4 or IP6 address.
                                 type: string
                             required:
-                            - metric
                             - to
                             - via
                             type: object

--- a/pkg/providers/vsphere/network/netplan.go
+++ b/pkg/providers/vsphere/network/netplan.go
@@ -76,11 +76,17 @@ func NetPlanCustomization(result NetworkInterfaceResults) (*netplan.Network, err
 
 		for i := range r.Routes {
 			route := r.Routes[i]
+
+			var metric *int64
+			if route.Metric != 0 {
+				metric = ptr.To(int64(route.Metric))
+			}
+
 			npEth.Routes = append(
 				npEth.Routes,
 				netplan.Route{
 					To:     &route.To,
-					Metric: ptr.To(int64(route.Metric)),
+					Metric: metric,
 					Via:    &route.Via,
 				},
 			)

--- a/pkg/providers/vsphere/network/netplan_test.go
+++ b/pkg/providers/vsphere/network/netplan_test.go
@@ -75,9 +75,13 @@ var _ = Describe("Netplan", func() {
 						SearchDomains:   []string{searchDomain1},
 						Routes: []network.NetworkInterfaceRoute{
 							{
-								To:     "185.107.56.59",
+								To:     "185.107.56.0/24",
 								Via:    "10.1.1.1",
 								Metric: 42,
+							},
+							{
+								To:  "134.23.5.3.0/24",
+								Via: "20.2.2.2",
 							},
 						},
 					},
@@ -93,24 +97,29 @@ var _ = Describe("Netplan", func() {
 				Expect(config.Ethernets).To(HaveKey(ifName))
 
 				np := config.Ethernets[ifName]
-				Expect(*np.Match.Macaddress).To(Equal(macAddr1Norm))
-				Expect(*np.SetName).To(Equal(guestDevName))
-				Expect(*np.Dhcp4).To(BeFalse())
-				Expect(*np.Dhcp6).To(BeFalse())
-				Expect(*np.AcceptRa).To(BeFalse())
+				Expect(np.Match.Macaddress).To(HaveValue(Equal(macAddr1Norm)))
+				Expect(np.SetName).To(HaveValue(Equal(guestDevName)))
+				Expect(np.Dhcp4).To(HaveValue(BeFalse()))
+				Expect(np.Dhcp6).To(HaveValue(BeFalse()))
+				Expect(np.AcceptRa).To(HaveValue(BeFalse()))
 				Expect(np.Addresses).To(HaveLen(2))
 				Expect(np.Addresses[0]).To(Equal(netplan.Address{String: ptr.To(ipv4CIDR)}))
 				Expect(np.Addresses[1]).To(Equal(netplan.Address{String: ptr.To(ipv6 + fmt.Sprintf("/%d", ipv6Subnet))}))
-				Expect(*np.Gateway4).To(Equal(ipv4Gateway))
-				Expect(*np.Gateway6).To(Equal(ipv6Gateway))
-				Expect(*np.MTU).To(BeEquivalentTo(1500))
+				Expect(np.Gateway4).To(HaveValue(Equal(ipv4Gateway)))
+				Expect(np.Gateway6).To(HaveValue(Equal(ipv6Gateway)))
+				Expect(np.MTU).To(HaveValue(BeEquivalentTo(1500)))
 				Expect(np.Nameservers.Addresses).To(Equal([]string{dnsServer1}))
 				Expect(np.Nameservers.Search).To(Equal([]string{searchDomain1}))
-				Expect(np.Routes).To(HaveLen(1))
-				route := np.Routes[0]
-				Expect(*route.To).To(Equal("185.107.56.59"))
-				Expect(*route.Via).To(Equal("10.1.1.1"))
-				Expect(*route.Metric).To(BeEquivalentTo(42))
+
+				Expect(np.Routes).To(HaveLen(2))
+				route0 := np.Routes[0]
+				Expect(route0.To).To(HaveValue(Equal("185.107.56.0/24")))
+				Expect(route0.Via).To(HaveValue(Equal("10.1.1.1")))
+				Expect(route0.Metric).To(HaveValue(BeEquivalentTo(42)))
+				route1 := np.Routes[1]
+				Expect(route1.To).To(HaveValue(Equal("134.23.5.3.0/24")))
+				Expect(route1.Via).To(HaveValue(Equal("20.2.2.2")))
+				Expect(route1.Metric).To(BeNil())
 			})
 
 			Context("Gateway4/6 are disabled", func() {
@@ -159,12 +168,12 @@ var _ = Describe("Netplan", func() {
 				Expect(config.Ethernets).To(HaveKey(ifName))
 
 				np := config.Ethernets[ifName]
-				Expect(*np.Match.Macaddress).To(Equal(macAddr1Norm))
-				Expect(*np.SetName).To(Equal(guestDevName))
-				Expect(*np.Dhcp4).To(BeTrue())
-				Expect(*np.Dhcp6).To(BeTrue())
-				Expect(*np.AcceptRa).To(BeTrue())
-				Expect(*np.MTU).To(BeEquivalentTo(9000))
+				Expect(np.Match.Macaddress).To(HaveValue(Equal(macAddr1Norm)))
+				Expect(np.SetName).To(HaveValue(Equal(guestDevName)))
+				Expect(np.Dhcp4).To(HaveValue(BeTrue()))
+				Expect(np.Dhcp6).To(HaveValue(BeTrue()))
+				Expect(np.AcceptRa).To(HaveValue(BeTrue()))
+				Expect(np.MTU).To(HaveValue(BeEquivalentTo(9000)))
 				Expect(np.Nameservers.Addresses).To(Equal([]string{dnsServer1}))
 				Expect(np.Nameservers.Search).To(Equal([]string{searchDomain1}))
 				Expect(np.Routes).To(BeEmpty())


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This field is not required in the Netplan so also only set it in the generated Netplan if non-zero.

Use Gomega's HaveValue matcher to better assert Netplan fields that are pointers.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #

**Are there any special notes for your reviewer**:

**Please add a release note if necessary**:

```release-note
The Metric field in the VirtualMachineNetworkRouteSpec is optional. Add a validation that if set, the metric must be greater than zero.
```