### PR TITLE
🌱 Add Capability for VM Groups

### DIFF
--- a/pkg/config/capabilities/capabilities_test.go
+++ b/pkg/config/capabilities/capabilities_test.go
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 Broadcom. All Rights Reserved.
-// Broadcom Confidential. The term "Broadcom" refers to Broadcom Inc.
-// and/or its subsidiaries.
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package capabilities_test
 
@@ -144,6 +144,9 @@ var _ = Describe("UpdateCapabilities", func() {
 						capabilities.CapabilityKeyMutableNetworks: {
 							Activated: true,
 						},
+						capabilities.CapabilityKeyVMGroups: {
+							Activated: true,
+						},
 					}
 					Expect(client.Status().Patch(ctx, &obj, objPatch)).To(Succeed())
 				})
@@ -154,6 +157,7 @@ var _ = Describe("UpdateCapabilities", func() {
 							config.Features.TKGMultipleCL = true
 							config.Features.WorkloadDomainIsolation = true
 							config.Features.MutableNetworks = true
+							config.Features.VMGroups = true
 						})
 					})
 					Specify("capabilities did not change", func() {
@@ -170,6 +174,9 @@ var _ = Describe("UpdateCapabilities", func() {
 					})
 					Specify(capabilities.CapabilityKeyMutableNetworks, func() {
 						Expect(pkgcfg.FromContext(ctx).Features.MutableNetworks).To(BeTrue())
+					})
+					Specify(capabilities.CapabilityKeyVMGroups, func() {
+						Expect(pkgcfg.FromContext(ctx).Features.VMGroups).To(BeTrue())
 					})
 				})
 
@@ -188,6 +195,9 @@ var _ = Describe("UpdateCapabilities", func() {
 					})
 					Specify(capabilities.CapabilityKeyMutableNetworks, func() {
 						Expect(pkgcfg.FromContext(ctx).Features.MutableNetworks).To(BeTrue())
+					})
+					Specify(capabilities.CapabilityKeyVMGroups, func() {
+						Expect(pkgcfg.FromContext(ctx).Features.VMGroups).To(BeTrue())
 					})
 				})
 			})
@@ -215,6 +225,9 @@ var _ = Describe("UpdateCapabilities", func() {
 						capabilities.CapabilityKeyMutableNetworks: {
 							Activated: false,
 						},
+						capabilities.CapabilityKeyVMGroups: {
+							Activated: false,
+						},
 					}
 					Expect(client.Status().Patch(ctx, &obj, objPatch)).To(Succeed())
 				})
@@ -234,6 +247,9 @@ var _ = Describe("UpdateCapabilities", func() {
 					Specify(capabilities.CapabilityKeyMutableNetworks, func() {
 						Expect(pkgcfg.FromContext(ctx).Features.MutableNetworks).To(BeFalse())
 					})
+					Specify(capabilities.CapabilityKeyVMGroups, func() {
+						Expect(pkgcfg.FromContext(ctx).Features.VMGroups).To(BeFalse())
+					})
 				})
 
 				When("the capabilities are different", func() {
@@ -243,6 +259,7 @@ var _ = Describe("UpdateCapabilities", func() {
 							config.Features.TKGMultipleCL = true
 							config.Features.WorkloadDomainIsolation = true
 							config.Features.MutableNetworks = true
+							config.Features.VMGroups = true
 						})
 					})
 					Specify("capabilities changed", func() {
@@ -259,6 +276,9 @@ var _ = Describe("UpdateCapabilities", func() {
 					})
 					Specify(capabilities.CapabilityKeyMutableNetworks, func() {
 						Expect(pkgcfg.FromContext(ctx).Features.MutableNetworks).To(BeFalse())
+					})
+					Specify(capabilities.CapabilityKeyVMGroups, func() {
+						Expect(pkgcfg.FromContext(ctx).Features.VMGroups).To(BeFalse())
 					})
 				})
 			})
@@ -411,6 +431,32 @@ var _ = Describe("UpdateCapabilitiesFeatures", func() {
 				Expect(pkgcfg.FromContext(ctx).Features.WorkloadDomainIsolation).To(BeTrue())
 			})
 		})
+		Context(capabilities.CapabilityKeyMutableNetworks, func() {
+			BeforeEach(func() {
+				Expect(pkgcfg.FromContext(ctx).Features.MutableNetworks).To(BeFalse())
+				obj.Status.Supervisor[capabilities.CapabilityKeyMutableNetworks] = capv1.CapabilityStatus{
+					Activated: true,
+				}
+			})
+			Specify("Enabled", func() {
+				Expect(ok).To(BeTrue())
+				Expect(diff).To(Equal("MutableNetworks=true"))
+				Expect(pkgcfg.FromContext(ctx).Features.MutableNetworks).To(BeTrue())
+			})
+		})
+		Context(capabilities.CapabilityKeyVMGroups, func() {
+			BeforeEach(func() {
+				Expect(pkgcfg.FromContext(ctx).Features.VMGroups).To(BeFalse())
+				obj.Status.Supervisor[capabilities.CapabilityKeyVMGroups] = capv1.CapabilityStatus{
+					Activated: true,
+				}
+			})
+			Specify("Enabled", func() {
+				Expect(ok).To(BeTrue())
+				Expect(diff).To(Equal("VMGroups=true"))
+				Expect(pkgcfg.FromContext(ctx).Features.VMGroups).To(BeTrue())
+			})
+		})
 	})
 })
 
@@ -439,6 +485,9 @@ var _ = Describe("WouldUpdateCapabilitiesFeatures", func() {
 			capabilities.CapabilityKeyMutableNetworks: {
 				Activated: true,
 			},
+			capabilities.CapabilityKeyVMGroups: {
+				Activated: true,
+			},
 		}
 
 		ok, diff = false, ""
@@ -456,6 +505,7 @@ var _ = Describe("WouldUpdateCapabilitiesFeatures", func() {
 					config.Features.TKGMultipleCL = true
 					config.Features.WorkloadDomainIsolation = true
 					config.Features.MutableNetworks = true
+					config.Features.VMGroups = true
 				})
 			})
 			Specify("capabilities did not change", func() {
@@ -474,6 +524,9 @@ var _ = Describe("WouldUpdateCapabilitiesFeatures", func() {
 			Specify(capabilities.CapabilityKeyMutableNetworks, func() {
 				Expect(pkgcfg.FromContext(ctx).Features.MutableNetworks).To(BeTrue())
 			})
+			Specify(capabilities.CapabilityKeyVMGroups, func() {
+				Expect(pkgcfg.FromContext(ctx).Features.VMGroups).To(BeTrue())
+			})
 		})
 
 		When("the capabilities are different", func() {
@@ -483,11 +536,12 @@ var _ = Describe("WouldUpdateCapabilitiesFeatures", func() {
 					config.Features.TKGMultipleCL = false
 					config.Features.WorkloadDomainIsolation = false
 					config.Features.MutableNetworks = false
+					config.Features.VMGroups = false
 				})
 			})
 			Specify("capabilities changed", func() {
 				Expect(ok).To(BeTrue())
-				Expect(diff).To(Equal("BringYourOwnEncryptionKey=true,MutableNetworks=true,TKGMultipleCL=true,WorkloadDomainIsolation=true"))
+				Expect(diff).To(Equal("BringYourOwnEncryptionKey=true,MutableNetworks=true,TKGMultipleCL=true,VMGroups=true,WorkloadDomainIsolation=true"))
 			})
 			Specify(capabilities.CapabilityKeyBringYourOwnKeyProvider, func() {
 				Expect(pkgcfg.FromContext(ctx).Features.BringYourOwnEncryptionKey).To(BeFalse())
@@ -500,6 +554,9 @@ var _ = Describe("WouldUpdateCapabilitiesFeatures", func() {
 			})
 			Specify(capabilities.CapabilityKeyMutableNetworks, func() {
 				Expect(pkgcfg.FromContext(ctx).Features.MutableNetworks).To(BeFalse())
+			})
+			Specify(capabilities.CapabilityKeyVMGroups, func() {
+				Expect(pkgcfg.FromContext(ctx).Features.VMGroups).To(BeFalse())
 			})
 		})
 	})

--- a/pkg/config/capabilities/capabilties.go
+++ b/pkg/config/capabilities/capabilties.go
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 Broadcom. All Rights Reserved.
-// Broadcom Confidential. The term "Broadcom" refers to Broadcom Inc.
-// and/or its subsidiaries.
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
 
 package capabilities
 
@@ -46,6 +46,10 @@ const (
 	// CapabilityKeyMutableNetworks is the name of capability key
 	// defined in the capabilities ConfigMap and/or CRD.
 	CapabilityKeyMutableNetworks = "supports_VM_service_mutable_networks"
+
+	// CapabilityKeyVMGroups is the name of capability key defined in the
+	// Supervisor capabilities CRD.
+	CapabilityKeyVMGroups = "supports_VM_service_VM_groups"
 )
 
 var (
@@ -186,6 +190,8 @@ func updateCapabilitiesFeaturesFromCRD(
 			fs.WorkloadDomainIsolation = capStatus.Activated
 		case CapabilityKeyMutableNetworks:
 			fs.MutableNetworks = capStatus.Activated
+		case CapabilityKeyVMGroups:
+			fs.VMGroups = capStatus.Activated
 		}
 	}
 	return fs

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -181,6 +181,7 @@ type FeatureStates struct {
 	SVAsyncUpgrade             bool // FSS_WCP_SUPERVISOR_ASYNC_UPGRADE
 	FastDeploy                 bool // FSS_WCP_VMSERVICE_FAST_DEPLOY
 	MutableNetworks            bool
+	VMGroups                   bool
 }
 
 type InstanceStorage struct {


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR introduces a new `VMGroups` feature which is set by the Supervisor Capability CRD entry `supports_VM_service_VM_groups`. This will be used to guard the VM Group feature related code.

Verified by deploying this change to an internal testbed with this Supervisor Capability set to true. VMOP logs:

```
I0516 18:14:36.331572       1 main.go:110] "Initial features from environment" logger="setup" features={"InstanceStorage":false,"K8sWorkloadMgmtAPI":false,"PodVMOnStretchedSupervisor":true,"TKGMultipleCL":false,"VMResize":false,"VMResizeCPUMemory":true,"VMImportNewNet":true,"WorkloadDomainIsolation":false,"VMIncrementalRestore":true,"BringYourOwnEncryptionKey":false,"SVAsyncUpgrade":true,"FastDeploy":false,"MutableNetworks":false,"VMGroups":false}
...
I0516 18:14:36.362261       1 main.go:124] "Initial features from capabilities" logger="setup" features={"InstanceStorage":false,"K8sWorkloadMgmtAPI":false,"PodVMOnStretchedSupervisor":true,"TKGMultipleCL":true,"VMResize":false,"VMResizeCPUMemory":true,"VMImportNewNet":true,"WorkloadDomainIsolation":true,"VMIncrementalRestore":true,"BringYourOwnEncryptionKey":false,"SVAsyncUpgrade":true,"FastDeploy":false,"MutableNetworks":false,"VMGroups":true}
```



**Which issue(s) is/are addressed by this PR?**

Fixes none.


**Are there any special notes for your reviewer**:

A corresponding PR has been created internally to add the Supervisor Capability with this name.


**Please add a release note if necessary**:

```release-note
Add Capability for VM Groups.
```