### PR TITLE
🌱 Ensure network interface provider ref is set even with no default annotation

### DIFF
--- a/webhooks/virtualmachine/mutation/virtualmachine_mutator.go
+++ b/webhooks/virtualmachine/mutation/virtualmachine_mutator.go
@@ -312,7 +312,9 @@ func AddDefaultNetworkInterface(
 	// they do mean slightly different things, and kind of complicated to know what to do like if the annotation
 	// is removed.
 	if _, ok := vm.Annotations[v1alpha1.NoDefaultNicAnnotation]; ok {
-		return false
+		if vm.Spec.Network == nil || len(vm.Spec.Network.Interfaces) == 0 {
+			return false
+		}
 	}
 
 	if vm.Spec.Network != nil && vm.Spec.Network.Disabled {


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

With the annotation, we should not add a default interface, but if there are interfaces present, we should still be setting any missing network provider refs.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

**Please add a release note if necessary**:

```release-note
NONE
```