### PR TITLE
🌱 Support skip-validation annotation

### DIFF
--- a/pkg/builder/constants.go
+++ b/pkg/builder/constants.go
@@ -7,6 +7,9 @@ package builder
 const (
 	AdmitMesgUpdateOnDeleting = "Update is allowed during deletion in order to remove the finalizers."
 
+	SkipValidationAllowed = "Allowed due to skipping validation"
+	SkipValidationDenied  = "Denied due to skipping validation"
+
 	// kubeAdminUser is the username of the kube admin account.
 	kubeAdminUser = "kubernetes-admin"
 )

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -95,4 +95,8 @@ const (
 	// ClusterModuleNameAnnotationKey is the annotation key for cluster module group name for
 	// the VM. The VM must have a VirtualMachineSetResourcePolicy assigned.
 	ClusterModuleNameAnnotationKey string = "vsphere-cluster-module-group"
+
+	// SkipValidationAnnotationKey is a privileged annotation that may be used
+	// to skip the validation webhooks for a given object.
+	SkipValidationAnnotationKey string = "vmoperator.vmware.com.protected/skip-validation"
 )


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch adds support for an annotation, `vmoperator.vmware.com.protected/skip-validation`, that works across all VM Operator objects and allows a privileged user to indicate that the validation webhooks should be skipped for the object to which said annotation is applied.

Please note, this annotation also results in bypassing the quota check for an object.

This is a useful, break-glass feature for fixing up objects in etcd that have gone screwy and need to be updated in ways that would violate the registered, validation webhooks.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Support annotation "vmoperator.vmware.com.protected/skip-validation" that allows privileged users to skip VM Operator managed validation webhooks as well as quota checks.
```