### PR TITLE
✨ Refactor VM reconcile logic order

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ replace (
 )
 
 require (
+	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/go-logr/logr v1.4.2
 	github.com/google/go-cmp v0.7.0
@@ -52,7 +53,6 @@ require (
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
-	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -99,4 +99,12 @@ const (
 	// SkipValidationAnnotationKey is a privileged annotation that may be used
 	// to skip the validation webhooks for a given object.
 	SkipValidationAnnotationKey string = "vmoperator.vmware.com.protected/skip-validation"
+
+	// BootstrapHashConfigSpecAnnotationKey is the annotation used to track the
+	// config spec used to bootstrap a VM's guest information.
+	BootstrapHashConfigSpecAnnotationKey = "vmoperator.vmware.com/bootstrap-hash-configspec"
+
+	// BootstrapHashCustomSpecAnnotationKey is the annotation used to track the
+	// customization spec used to bootstrap a VM's guest information.
+	BootstrapHashCustomSpecAnnotationKey = "vmoperator.vmware.com/bootstrap-hash-customspec"
 )

--- a/pkg/context/virtualmachine_context.go
+++ b/pkg/context/virtualmachine_context.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/vmware/govmomi/vim25/mo"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
 )
@@ -22,6 +23,17 @@ type VirtualMachineContext struct {
 	MoVM   mo.VirtualMachine
 }
 
-func (v *VirtualMachineContext) String() string {
+func (v VirtualMachineContext) String() string {
+	if v.VM == nil {
+		return ""
+	}
 	return fmt.Sprintf("%s %s/%s", v.VM.GroupVersionKind(), v.VM.Namespace, v.VM.Name)
+}
+
+func (v VirtualMachineContext) IsPoweringOn() bool {
+	if v.VM == nil {
+		return false
+	}
+	return v.VM.Spec.PowerState == vmopv1.VirtualMachinePowerStateOn &&
+		v.MoVM.Runtime.PowerState != vimtypes.VirtualMachinePowerStatePoweredOn
 }

--- a/pkg/providers/vsphere/session/session.go
+++ b/pkg/providers/vsphere/session/session.go
@@ -13,7 +13,6 @@ import (
 
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/internal"
-	res "github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/resources"
 	pkgclient "github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/client"
 )
 
@@ -24,10 +23,10 @@ type Session struct {
 	ClusterMoRef types.ManagedObjectReference
 }
 
-func (s *Session) invokeFsrVirtualMachine(vmCtx pkgctx.VirtualMachineContext, resVM *res.VirtualMachine) error {
+func (s *Session) invokeFsrVirtualMachine(vmCtx pkgctx.VirtualMachineContext) error {
 	vmCtx.Logger.Info("Invoking FSR on VM")
 
-	task, err := internal.VirtualMachineFSR(vmCtx, resVM.MoRef(), s.Client.VimClient())
+	task, err := internal.VirtualMachineFSR(vmCtx, vmCtx.MoVM.Self, s.Client.VimClient())
 	if err != nil {
 		return fmt.Errorf("failed to invoke FSR: %w", err)
 	}

--- a/pkg/providers/vsphere/virtualmachine/backup_test.go
+++ b/pkg/providers/vsphere/virtualmachine/backup_test.go
@@ -128,7 +128,7 @@ func backupTests() {
 							backupOpts.BackupVersion = vT1
 						}
 
-						Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
+						Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(MatchError(virtualmachine.ErrBackingUp))
 						expectedVMYAML := getExpectedBackupObjectYAML(vmCtx.VM.DeepCopy())
 						verifyBackupDataInExtraConfig(ctx, vcVM, backupapi.VMResourceYAMLExtraConfigKey, expectedVMYAML, true)
 
@@ -188,7 +188,7 @@ func backupTests() {
 							backupOpts.BackupVersion = vT3
 						}
 
-						Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
+						Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(MatchError(virtualmachine.ErrBackingUp))
 						expectedVMYAML := getExpectedBackupObjectYAML(vmCtx.VM.DeepCopy())
 						verifyBackupDataInExtraConfig(ctx, vcVM, backupapi.VMResourceYAMLExtraConfigKey, expectedVMYAML, true)
 
@@ -251,7 +251,7 @@ func backupTests() {
 							backupOpts.BackupVersion = vT3
 						}
 
-						Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
+						Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(MatchError(virtualmachine.ErrBackingUp))
 						// getExpectedBackupObjectYaml empties the expected VM yaml's status
 						expectedVMYAML := getExpectedBackupObjectYAML(vmCtx.VM.DeepCopy())
 						verifyBackupDataInExtraConfig(ctx, vcVM, backupapi.VMResourceYAMLExtraConfigKey, expectedVMYAML, true)
@@ -312,7 +312,7 @@ func backupTests() {
 							backupOpts.BackupVersion = vT3
 						}
 
-						Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
+						Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(MatchError(virtualmachine.ErrBackingUp))
 						expectedVMYAML := getExpectedBackupObjectYAML(vmCtx.VM.DeepCopy())
 						verifyBackupDataInExtraConfig(ctx, vcVM, backupapi.VMResourceYAMLExtraConfigKey, expectedVMYAML, true)
 
@@ -452,7 +452,7 @@ func backupTests() {
 							backupOpts.BackupVersion = vT3
 						}
 
-						Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
+						Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(MatchError(virtualmachine.ErrBackingUp))
 						resYAML := getExpectedBackupObjectYAML(secretRes)
 						verifyBackupDataInExtraConfig(ctx, vcVM, backupapi.AdditionalResourcesYAMLExtraConfigKey, resYAML, true)
 
@@ -515,7 +515,7 @@ func backupTests() {
 							backupOpts.BackupVersion = vT3
 						}
 
-						Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
+						Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(MatchError(virtualmachine.ErrBackingUp))
 						newResYAML := getExpectedBackupObjectYAML(secretRes.DeepCopy())
 						verifyBackupDataInExtraConfig(ctx, vcVM, backupapi.AdditionalResourcesYAMLExtraConfigKey, newResYAML, true)
 
@@ -619,7 +619,7 @@ func backupTests() {
 							backupOpts.BackupVersion = vT1
 						}
 
-						Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
+						Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(MatchError(virtualmachine.ErrBackingUp))
 						secretResYAML := getExpectedBackupObjectYAML(secretRes.DeepCopy())
 						cmResYAML := getExpectedBackupObjectYAML(cmRes.DeepCopy())
 						expectedYAML := secretResYAML + "\n---\n" + cmResYAML
@@ -643,7 +643,7 @@ func backupTests() {
 							VcVM:          vcVM,
 							DiskUUIDToPVC: nil,
 						}
-						Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
+						Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(MatchError(virtualmachine.ErrBackingUp))
 						verifyBackupDataInExtraConfig(ctx, vcVM, backupapi.PVCDiskDataExtraConfigKey, "", true)
 					})
 				})
@@ -695,7 +695,7 @@ func backupTests() {
 							backupOpts.BackupVersion = vT2
 						}
 
-						Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
+						Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(MatchError(virtualmachine.ErrBackingUp))
 
 						diskData := []backupapi.PVCDiskData{
 							{
@@ -731,7 +731,7 @@ func backupTests() {
 							backupOpts.BackupVersion = vT2
 						}
 
-						Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
+						Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(MatchError(virtualmachine.ErrBackingUp))
 
 						err := vcVM.Properties(vmCtx, vcVM.Reference(), vsphere.VMUpdatePropertiesSelector, &backupOpts.VMCtx.MoVM)
 						Expect(err).NotTo(HaveOccurred())
@@ -742,7 +742,7 @@ func backupTests() {
 							backupOpts.BackupVersion = vT3
 						}
 
-						Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
+						Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(MatchError(virtualmachine.ErrBackingUp))
 
 						verifyBackupDataInExtraConfig(ctx, vcVM, backupapi.PVCDiskDataExtraConfigKey, "", true)
 
@@ -795,8 +795,7 @@ func backupTests() {
 								BackupVersion: "1004",
 							}
 
-							err := virtualmachine.BackupVirtualMachine(backupOpts)
-							Expect(err).ToNot(HaveOccurred())
+							Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
 
 							// verify key doesn't get updated to "t4" and stays at "t1"
 							verifyBackupDataInExtraConfig(ctx, vcVM, backupapi.BackupVersionExtraConfigKey, vT2, false)
@@ -818,8 +817,7 @@ func backupTests() {
 								BackupVersion: "1004",
 							}
 
-							err := virtualmachine.BackupVirtualMachine(backupOpts)
-							Expect(err).ToNot(HaveOccurred())
+							Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(MatchError(virtualmachine.ErrBackingUp))
 
 							// verify key gets updated to "1004"
 							verifyBackupDataInExtraConfig(ctx, vcVM, backupapi.BackupVersionExtraConfigKey, "1004", false)
@@ -874,7 +872,7 @@ func backupTests() {
 
 							// Update the generation to simulate a new spec update of the VM.
 							backupOpts.VMCtx.VM.ObjectMeta.Generation = 11
-							Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
+							Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(MatchError(virtualmachine.ErrBackingUp))
 							verifyBackupDataInExtraConfig(ctx, vcVM, backupapi.BackupVersionExtraConfigKey, vT3, false)
 							Expect(vmCtx.VM.Annotations[vmopv1.VirtualMachineBackupVersionAnnotation]).To(Equal(vT3))
 							c := conditions.Get(vmCtx.VM, vmopv1.VirtualMachineBackupUpToDateCondition)
@@ -910,7 +908,7 @@ func backupTests() {
 								BackupVersion: vT2,
 							}
 
-							Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
+							Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(MatchError(virtualmachine.ErrBackingUp))
 							verifyBackupDataInExtraConfig(ctx, vcVM, backupapi.BackupVersionExtraConfigKey, vT2, false)
 							Expect(vmCtx.VM.Annotations[vmopv1.VirtualMachineBackupVersionAnnotation]).To(Equal(vT2))
 							c := conditions.Get(vmCtx.VM, vmopv1.VirtualMachineBackupUpToDateCondition)
@@ -1019,7 +1017,7 @@ func backupTests() {
 								VcVM:             vcVM,
 								ClassicDiskUUIDs: nil,
 							}
-							Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
+							Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(MatchError(virtualmachine.ErrBackingUp))
 							verifyBackupDataInExtraConfig(ctx, vcVM, backupapi.ClassicDiskDataExtraConfigKey, "", false)
 						})
 					})
@@ -1033,7 +1031,7 @@ func backupTests() {
 								BackupVersion:    vT1,
 							}
 
-							Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
+							Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(MatchError(virtualmachine.ErrBackingUp))
 							diskData := []backupapi.ClassicDiskData{
 								{
 									FileName: vcSimDiskFileName,
@@ -1056,7 +1054,7 @@ func backupTests() {
 								ClassicDiskUUIDs: map[string]struct{}{vcSimDiskUUID: {}},
 								BackupVersion:    vT1,
 							}
-							Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
+							Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(MatchError(virtualmachine.ErrBackingUp))
 
 							err := vcVM.Properties(vmCtx, vcVM.Reference(), vsphere.VMUpdatePropertiesSelector, &vmCtx.MoVM)
 							Expect(err).NotTo(HaveOccurred())
@@ -1085,7 +1083,7 @@ func backupTests() {
 								ClassicDiskUUIDs: map[string]struct{}{vcSimDiskUUID: {}},
 								BackupVersion:    vT1,
 							}
-							Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
+							Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(MatchError(virtualmachine.ErrBackingUp))
 
 							err := vcVM.Properties(vmCtx, vcVM.Reference(), vsphere.VMUpdatePropertiesSelector, &vmCtx.MoVM)
 							Expect(err).NotTo(HaveOccurred())
@@ -1098,7 +1096,7 @@ func backupTests() {
 								ClassicDiskUUIDs: nil,
 								BackupVersion:    vT2,
 							}
-							Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(Succeed())
+							Expect(virtualmachine.BackupVirtualMachine(backupOpts)).To(MatchError(virtualmachine.ErrBackingUp))
 
 							verifyBackupDataInExtraConfig(ctx, vcVM, backupapi.ClassicDiskDataExtraConfigKey, "", true)
 

--- a/pkg/providers/vsphere/virtualmachine/delete.go
+++ b/pkg/providers/vsphere/virtualmachine/delete.go
@@ -49,7 +49,7 @@ func DeleteVirtualMachine(
 		//             that indicates this state.
 
 		return fmt.Errorf("failed to delete vm: %w", pkgerr.NoRequeueError{
-			Message: fmt.Sprintf("unsupported VM connection state: %s", cs),
+			Message: fmt.Sprintf("unsupported connection state: %s", cs),
 		})
 	}
 

--- a/pkg/providers/vsphere/virtualmachine/delete_test.go
+++ b/pkg/providers/vsphere/virtualmachine/delete_test.go
@@ -129,7 +129,7 @@ func deleteTests() {
 				var noRequeueErr pkgerr.NoRequeueError
 				Expect(errors.As(err, &noRequeueErr)).To(BeTrue())
 				Expect(noRequeueErr.Message).To(Equal(
-					fmt.Sprintf("unsupported VM connection state: %s", state)))
+					fmt.Sprintf("unsupported connection state: %s", state)))
 				Expect(ctx.GetVMFromMoID(moVM.Reference().Value)).ToNot(BeNil())
 			}
 		},

--- a/pkg/providers/vsphere/vmlifecycle/bootstrap_cloudinit_test.go
+++ b/pkg/providers/vsphere/vmlifecycle/bootstrap_cloudinit_test.go
@@ -385,7 +385,8 @@ var _ = Describe("CloudInit Bootstrap", func() {
 		)
 
 		JustBeforeEach(func() {
-			configSpec, err = vmlifecycle.GetCloudInitGuestInfoCustSpec(configInfo, metaData, userData)
+			configSpec, err = vmlifecycle.GetCloudInitGuestInfoCustSpec(
+				context.Background(), configInfo, metaData, userData)
 		})
 
 		Context("vAppConfig", func() {
@@ -494,7 +495,8 @@ var _ = Describe("CloudInit Bootstrap", func() {
 
 		JustBeforeEach(func() {
 			var err error
-			configSpec, custSpec, err = vmlifecycle.GetCloudInitPrepCustSpec(configInfo, metaData, userData)
+			configSpec, custSpec, err = vmlifecycle.GetCloudInitPrepCustSpec(
+				context.Background(), configInfo, metaData, userData)
 			Expect(err).ToNot(HaveOccurred())
 		})
 

--- a/pkg/providers/vsphere/vmlifecycle/bootstrap_linuxprep_test.go
+++ b/pkg/providers/vsphere/vmlifecycle/bootstrap_linuxprep_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/vmware/govmomi/vim25/mo"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -77,12 +78,20 @@ var _ = Describe("LinuxPrep Bootstrap", func() {
 					Name:      "linux-prep-bootstrap-test",
 					Namespace: "test-ns",
 				},
+				Spec: vmopv1.VirtualMachineSpec{
+					PowerState: vmopv1.VirtualMachinePowerStateOn,
+				},
 			}
 
 			vmCtx = pkgctx.VirtualMachineContext{
 				Context: context.Background(),
 				Logger:  suite.GetLogger(),
 				VM:      vm,
+				MoVM: mo.VirtualMachine{
+					Runtime: vimtypes.VirtualMachineRuntimeInfo{
+						PowerState: vimtypes.VirtualMachinePowerStatePoweredOff,
+					},
+				},
 			}
 		})
 

--- a/pkg/providers/vsphere/vmlifecycle/bootstrap_sysprep.go
+++ b/pkg/providers/vsphere/vmlifecycle/bootstrap_sysprep.go
@@ -5,23 +5,32 @@
 package vmlifecycle
 
 import (
-	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
 	vmopv1sysprep "github.com/vmware-tanzu/vm-operator/api/v1alpha4/sysprep"
+	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/network"
 	"github.com/vmware-tanzu/vm-operator/pkg/util"
 )
 
 func BootstrapSysPrep(
-	_ context.Context,
+	vmCtx pkgctx.VirtualMachineContext,
 	config *vimtypes.VirtualMachineConfigInfo,
 	sysPrepSpec *vmopv1.VirtualMachineBootstrapSysprepSpec,
 	vAppConfigSpec *vmopv1.VirtualMachineBootstrapVAppConfigSpec,
 	bsArgs *BootstrapArgs) (*vimtypes.VirtualMachineConfigSpec, *vimtypes.CustomizationSpec, error) {
+
+	logger := logr.FromContextOrDiscard(vmCtx)
+	logger.V(4).Info("Reconciling Sysprep bootstrap state")
+
+	if !vmCtx.IsPoweringOn() {
+		vmCtx.Logger.V(4).Info("Skipping Sysprep since VM is not powering on")
+		return nil, nil, nil
+	}
 
 	var (
 		data     string

--- a/pkg/providers/vsphere/vmlifecycle/bootstrap_sysprep_test.go
+++ b/pkg/providers/vsphere/vmlifecycle/bootstrap_sysprep_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/vmware/govmomi/vim25/mo"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -80,12 +81,20 @@ var _ = Describe("SysPrep Bootstrap", func() {
 					Name:      "sys-prep-bootstrap-test",
 					Namespace: "test-ns",
 				},
+				Spec: vmopv1.VirtualMachineSpec{
+					PowerState: vmopv1.VirtualMachinePowerStateOn,
+				},
 			}
 
 			vmCtx = pkgctx.VirtualMachineContext{
 				Context: context.Background(),
 				Logger:  suite.GetLogger(),
 				VM:      vm,
+				MoVM: mo.VirtualMachine{
+					Runtime: vimtypes.VirtualMachineRuntimeInfo{
+						PowerState: vimtypes.VirtualMachinePowerStatePoweredOff,
+					},
+				},
 			}
 		})
 

--- a/pkg/providers/vsphere/vmlifecycle/bootstrap_vappconfig.go
+++ b/pkg/providers/vsphere/vmlifecycle/bootstrap_vappconfig.go
@@ -5,19 +5,23 @@
 package vmlifecycle
 
 import (
-	"context"
 	"errors"
 
+	"github.com/go-logr/logr"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 )
 
 func BootstrapVAppConfig(
-	_ context.Context,
+	vmCtx pkgctx.VirtualMachineContext,
 	config *vimtypes.VirtualMachineConfigInfo,
 	vAppConfigSpec *vmopv1.VirtualMachineBootstrapVAppConfigSpec,
 	bsArgs *BootstrapArgs) (*vimtypes.VirtualMachineConfigSpec, *vimtypes.CustomizationSpec, error) {
+
+	logger := logr.FromContextOrDiscard(vmCtx)
+	logger.V(4).Info("Reconciling vApp bootstrap state")
 
 	var (
 		err        error

--- a/pkg/providers/vsphere/vmlifecycle/update_status.go
+++ b/pkg/providers/vsphere/vmlifecycle/update_status.go
@@ -40,34 +40,17 @@ import (
 	vmopv1util "github.com/vmware-tanzu/vm-operator/pkg/util/vmopv1"
 )
 
-var (
-	// VMStatusPropertiesSelector is the minimum properties needed to be
-	// retrieved in order to populate the Status. Callers may provide a MO with
-	// more. This often saves us a second round trip in the common steady state.
-	VMStatusPropertiesSelector = []string{
-		"config.changeTrackingEnabled",
-		"config.extraConfig",
-		"config.hardware.device",
-		"config.keyId",
-		"layoutEx",
-		"guest",
-		"resourcePool",
-		"runtime",
-		"summary",
-	}
-)
-
-type UpdateStatusData struct {
+type ReconcileStatusData struct {
 	// NetworkDeviceKeysToSpecIdx maps the network device's DeviceKey to its
 	// corresponding index in the VM's Spec.Network.Interfaces[].
 	NetworkDeviceKeysToSpecIdx map[int32]int
 }
 
-func UpdateStatus(
+func ReconcileStatus(
 	vmCtx pkgctx.VirtualMachineContext,
 	k8sClient ctrlclient.Client,
 	vcVM *object.VirtualMachine,
-	data UpdateStatusData) error {
+	data ReconcileStatusData) error {
 
 	vm := vmCtx.VM
 

--- a/pkg/util/vsphere/vm/hardware_version.go
+++ b/pkg/util/vsphere/vm/hardware_version.go
@@ -99,7 +99,6 @@ func ReconcileMinHardwareVersion(
 
 	// If the VM is not powered off, then there is nothing to do.
 	if mo.Runtime.PowerState != vimtypes.VirtualMachinePowerStatePoweredOff {
-		log.Info("Skipping upgrade because VM is not powered off")
 		return ReconcileMinHardwareVersionResultNotPoweredOff, nil
 	}
 

--- a/pkg/vmconfig/crypto/crypto_reconciler.go
+++ b/pkg/vmconfig/crypto/crypto_reconciler.go
@@ -9,6 +9,10 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/mo"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
 	"github.com/vmware-tanzu/vm-operator/pkg/bitmask"
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
@@ -20,6 +24,18 @@ import (
 type reconciler struct{}
 
 var _ vmconfig.Reconciler = reconciler{}
+
+// Reconcile configures the VM's crypto settings.
+func Reconcile(
+	ctx context.Context,
+	k8sClient ctrlclient.Client,
+	vimClient *vim25.Client,
+	vm *vmopv1.VirtualMachine,
+	moVM mo.VirtualMachine,
+	configSpec ptrCfgSpec) error {
+
+	return New().Reconcile(ctx, k8sClient, vimClient, vm, moVM, configSpec)
+}
 
 // New returns a new Reconciler for a VM's crypto state.
 func New() vmconfig.ReconcilerWithContext {

--- a/pkg/vmconfig/crypto/crypto_reconciler_pre.go
+++ b/pkg/vmconfig/crypto/crypto_reconciler_pre.go
@@ -140,8 +140,8 @@ func (r reconciler) Reconcile(
 		return err
 	}
 
-	if paused.ByAdmin(moVM) || paused.ByDevOps(vm) {
-		// If the VM is paused, just update the status.
+	if paused.ByAdmin(moVM) || paused.ByDevOps(vm) || vm.Status.TaskID != "" {
+		// If the VM is paused or has a task, just update the status.
 		return updateStatus(ctx, args, false)
 	}
 

--- a/pkg/vmconfig/crypto/crypto_reconciler_pre_test.go
+++ b/pkg/vmconfig/crypto/crypto_reconciler_pre_test.go
@@ -670,6 +670,33 @@ var _ = Describe("Reconcile", Label(testlabels.Crypto), func() {
 							Expect(c.Reason).To(Equal(pkgcrypto.ReasonNoDefaultKeyProvider.String()))
 						})
 
+						When("vm has task", func() {
+							BeforeEach(func() {
+								moVM.Config.Hardware.Device = []vimtypes.BaseVirtualDevice{
+									&vimtypes.VirtualDisk{
+										VirtualDevice: vimtypes.VirtualDevice{
+											Backing: &vimtypes.VirtualDiskFlatVer2BackingInfo{
+												KeyId: &vimtypes.CryptoKeyId{},
+											},
+										},
+									},
+								}
+								vm.Status.TaskID = "123"
+							})
+							It("should update the status without returning an error", func() {
+								Expect(err).ToNot(HaveOccurred())
+								Expect(vm.Status.Crypto).ToNot(BeNil())
+								Expect(vm.Status.Crypto).To(Equal(&vmopv1.VirtualMachineCryptoStatus{
+									Encrypted: []vmopv1.VirtualMachineEncryptionType{
+										vmopv1.VirtualMachineEncryptionTypeConfig,
+										vmopv1.VirtualMachineEncryptionTypeDisks,
+									},
+									ProviderID: provider1ID,
+									KeyID:      provider1Key1ID,
+								}))
+							})
+						})
+
 						When("vm is paused", func() {
 							Context("by admin", func() {
 								BeforeEach(func() {

--- a/pkg/vmconfig/diskpromo/diskpromo_reconciler_test.go
+++ b/pkg/vmconfig/diskpromo/diskpromo_reconciler_test.go
@@ -24,7 +24,6 @@ import (
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
-	pkgerr "github.com/vmware-tanzu/vm-operator/pkg/errors"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmconfig"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmconfig/diskpromo"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
@@ -54,7 +53,6 @@ var _ = Describe("Reconcile", Label(testlabels.V1Alpha4), func() {
 		withObjs   []ctrlclient.Object
 		withFuncs  interceptor.Funcs
 		configSpec *vimtypes.VirtualMachineConfigSpec
-		noRequeue  = pkgerr.NoRequeueError{Message: "doing online disk promotion"}
 
 		// Used for testing that only tasks with promoteDisksTaskKey are reconciled
 		createDiskTask string
@@ -238,7 +236,7 @@ var _ = Describe("Reconcile", Label(testlabels.V1Alpha4), func() {
 
 					It("should promote disks", func() {
 						Expect(err).To(HaveOccurred())
-						Expect(err).To(Equal(noRequeue))
+						Expect(err).To(Equal(diskpromo.ErrPromoteDisks))
 						Expect(vm.Status.TaskID).ToNot(BeEmpty())
 
 						// simulator promoteDisks will delay the task based on disk capacity,
@@ -335,7 +333,7 @@ var _ = Describe("Reconcile", Label(testlabels.V1Alpha4), func() {
 
 					It("should fail the task", func() {
 						Expect(err).To(HaveOccurred())
-						Expect(err).To(Equal(noRequeue))
+						Expect(err).To(Equal(diskpromo.ErrPromoteDisks))
 						Expect(vm.Status.TaskID).ToNot(BeEmpty())
 
 						err = r.Reconcile(ctx, k8sClient, vimClient, vm, moVM, configSpec)

--- a/test/builder/dummies.go
+++ b/test/builder/dummies.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -361,7 +362,7 @@ func DummyVirtualMachine() *vmopv1.VirtualMachine {
 					AllowGuestControl: ptr.To(true),
 				},
 			},
-			GuestID: DummyOSType,
+			GuestID: string(vimtypes.VirtualMachineGuestOsIdentifierCentosGuest),
 		},
 	}
 }
@@ -548,7 +549,7 @@ func DummyVirtualMachineWebConsoleRequest(namespace, wcrName, vmName, pubKey str
 
 func DummyImageAndItemObjectsForCdromBacking(
 	name, ns, kind, storageURI, libItemUUID string,
-	imgReady, imgHasProviderRef, itemObjExists bool,
+	imgReady, imgCached bool, imgSize resource.Quantity, imgHasProviderRef, itemObjExists bool,
 	itemType imgregv1a1.ContentLibraryItemType) []ctrlclient.Object {
 	var imageObj, itemObj ctrlclient.Object
 
@@ -579,10 +580,14 @@ func DummyImageAndItemObjectsForCdromBacking(
 	}
 
 	itemStatus := imgregv1a1.ContentLibraryItemStatus{
-		Type: itemType,
+		Type:        itemType,
+		Cached:      imgCached,
+		SizeInBytes: imgSize,
 		FileInfo: []imgregv1a1.FileInfo{
 			{
-				StorageURI: storageURI,
+				StorageURI:  storageURI,
+				Cached:      imgCached,
+				SizeInBytes: imgSize,
 			},
 		},
 	}

--- a/test/builder/test_suite.go
+++ b/test/builder/test_suite.go
@@ -69,6 +69,10 @@ func init() {
 	klog.InitFlags(nil)
 	klog.SetOutput(GinkgoWriter)
 	logf.SetLogger(klog.Background())
+
+	// TODO(akutz) This is kind of handy, but ultimately it makes discerning
+	//             test-specific logs from regular log non-trivial.
+	// GinkgoLogr = klog.Background()
 }
 
 // TestSuite is used for unit and integration testing builder. Each TestSuite
@@ -142,7 +146,11 @@ func (s *TestSuite) GetEnvTestConfig() *rest.Config {
 }
 
 func (s *TestSuite) GetLogger() logr.Logger {
-	return logf.Log
+	logger, err := logr.FromContext(s.Context)
+	if err != nil {
+		return s.manager.GetLogger()
+	}
+	return logger
 }
 
 // NewTestSuite returns a new test suite used for unit and/or integration test.


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch refactors the VM reconcile logic order to be:

1. Reconcile backup state and end reconcile if any changes (ex. reconfigure)
2. Reconcile status
3. Reconcile config and end reconcile if any changes (ex. reconfigure, upgrade hardware version)
4. Reconcile power state

This patch also ensures that a powered off VM is reconfigured if there are any requested changes as opposed to waiting for the VM to be powered on.

This makes the logic much easier to follow as it is now completely reentrant. VM Op will reconcile the entire desired state of a VM every time, which is what _should_ happen. There is also an additional performance improvement since we do not need to always fetch VIM properties twice in a single reconcile loop.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Refactor VM reconcile logic order
```