### PR TITLE
📖 Update link to GuestOS IDs

### DIFF
--- a/api/v1alpha3/virtualmachine_types.go
+++ b/api/v1alpha3/virtualmachine_types.go
@@ -692,12 +692,14 @@ type VirtualMachineSpec struct {
 	// guest ID, then that value is used.
 	// The guest ID from VirtualMachineClass used to deploy the VM is ignored.
 	//
-	// For a complete list of supported values, refer to https://bit.ly/3TiZX3G.
-	// Note that some guest ID values may require a minimal hardware version,
-	// which can be set using the `spec.minHardwareVersion` field.
+	// For a complete list of supported values, please refer to
+	// https://developer.broadcom.com/xapis/vsphere-web-services-api/latest/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html.
+	//
+	// Please note that some guest ID values may require a minimal hardware
+	// version, which can be set using the `spec.minHardwareVersion` field.
 	// To see the mapping between virtual hardware versions and the product
-	// versions that support a specific guest ID, visit the following link:
-	// https://knowledge.broadcom.com/external/article/315655/virtual-machine-hardware-versions.html
+	// versions that support a specific guest ID, please refer to
+	// https://knowledge.broadcom.com/external/article/315655/virtual-machine-hardware-versions.html.
 	//
 	// Please note that this field is immutable after the VM is powered on.
 	// To change the guest ID after the VM is powered on, the VM must be powered

--- a/api/v1alpha4/virtualmachine_types.go
+++ b/api/v1alpha4/virtualmachine_types.go
@@ -859,12 +859,14 @@ type VirtualMachineSpec struct {
 	// guest ID, then that value is used.
 	// The guest ID from VirtualMachineClass used to deploy the VM is ignored.
 	//
-	// For a complete list of supported values, refer to https://bit.ly/3TiZX3G.
-	// Note that some guest ID values may require a minimal hardware version,
-	// which can be set using the `spec.minHardwareVersion` field.
+	// For a complete list of supported values, please refer to
+	// https://developer.broadcom.com/xapis/vsphere-web-services-api/latest/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html.
+	//
+	// Please note that some guest ID values may require a minimal hardware
+	// version, which can be set using the `spec.minHardwareVersion` field.
 	// To see the mapping between virtual hardware versions and the product
-	// versions that support a specific guest ID, visit the following link:
-	// https://knowledge.broadcom.com/external/article/315655/virtual-machine-hardware-versions.html
+	// versions that support a specific guest ID, please refer to
+	// https://knowledge.broadcom.com/external/article/315655/virtual-machine-hardware-versions.html.
 	//
 	// Please note that this field is immutable after the VM is powered on.
 	// To change the guest ID after the VM is powered on, the VM must be powered

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachinereplicasets.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachinereplicasets.yaml
@@ -1113,12 +1113,14 @@ spec:
                           guest ID, then that value is used.
                           The guest ID from VirtualMachineClass used to deploy the VM is ignored.
 
-                          For a complete list of supported values, refer to https://bit.ly/3TiZX3G.
-                          Note that some guest ID values may require a minimal hardware version,
-                          which can be set using the `spec.minHardwareVersion` field.
+                          For a complete list of supported values, please refer to
+                          https://developer.broadcom.com/xapis/vsphere-web-services-api/latest/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html.
+
+                          Please note that some guest ID values may require a minimal hardware
+                          version, which can be set using the `spec.minHardwareVersion` field.
                           To see the mapping between virtual hardware versions and the product
-                          versions that support a specific guest ID, visit the following link:
-                          https://knowledge.broadcom.com/external/article/315655/virtual-machine-hardware-versions.html
+                          versions that support a specific guest ID, please refer to
+                          https://knowledge.broadcom.com/external/article/315655/virtual-machine-hardware-versions.html.
 
                           Please note that this field is immutable after the VM is powered on.
                           To change the guest ID after the VM is powered on, the VM must be powered
@@ -3117,12 +3119,14 @@ spec:
                           guest ID, then that value is used.
                           The guest ID from VirtualMachineClass used to deploy the VM is ignored.
 
-                          For a complete list of supported values, refer to https://bit.ly/3TiZX3G.
-                          Note that some guest ID values may require a minimal hardware version,
-                          which can be set using the `spec.minHardwareVersion` field.
+                          For a complete list of supported values, please refer to
+                          https://developer.broadcom.com/xapis/vsphere-web-services-api/latest/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html.
+
+                          Please note that some guest ID values may require a minimal hardware
+                          version, which can be set using the `spec.minHardwareVersion` field.
                           To see the mapping between virtual hardware versions and the product
-                          versions that support a specific guest ID, visit the following link:
-                          https://knowledge.broadcom.com/external/article/315655/virtual-machine-hardware-versions.html
+                          versions that support a specific guest ID, please refer to
+                          https://knowledge.broadcom.com/external/article/315655/virtual-machine-hardware-versions.html.
 
                           Please note that this field is immutable after the VM is powered on.
                           To change the guest ID after the VM is powered on, the VM must be powered

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -3945,12 +3945,14 @@ spec:
                   guest ID, then that value is used.
                   The guest ID from VirtualMachineClass used to deploy the VM is ignored.
 
-                  For a complete list of supported values, refer to https://bit.ly/3TiZX3G.
-                  Note that some guest ID values may require a minimal hardware version,
-                  which can be set using the `spec.minHardwareVersion` field.
+                  For a complete list of supported values, please refer to
+                  https://developer.broadcom.com/xapis/vsphere-web-services-api/latest/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html.
+
+                  Please note that some guest ID values may require a minimal hardware
+                  version, which can be set using the `spec.minHardwareVersion` field.
                   To see the mapping between virtual hardware versions and the product
-                  versions that support a specific guest ID, visit the following link:
-                  https://knowledge.broadcom.com/external/article/315655/virtual-machine-hardware-versions.html
+                  versions that support a specific guest ID, please refer to
+                  https://knowledge.broadcom.com/external/article/315655/virtual-machine-hardware-versions.html.
 
                   Please note that this field is immutable after the VM is powered on.
                   To change the guest ID after the VM is powered on, the VM must be powered
@@ -6668,12 +6670,14 @@ spec:
                   guest ID, then that value is used.
                   The guest ID from VirtualMachineClass used to deploy the VM is ignored.
 
-                  For a complete list of supported values, refer to https://bit.ly/3TiZX3G.
-                  Note that some guest ID values may require a minimal hardware version,
-                  which can be set using the `spec.minHardwareVersion` field.
+                  For a complete list of supported values, please refer to
+                  https://developer.broadcom.com/xapis/vsphere-web-services-api/latest/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html.
+
+                  Please note that some guest ID values may require a minimal hardware
+                  version, which can be set using the `spec.minHardwareVersion` field.
                   To see the mapping between virtual hardware versions and the product
-                  versions that support a specific guest ID, visit the following link:
-                  https://knowledge.broadcom.com/external/article/315655/virtual-machine-hardware-versions.html
+                  versions that support a specific guest ID, please refer to
+                  https://knowledge.broadcom.com/external/article/315655/virtual-machine-hardware-versions.html.
 
                   Please note that this field is immutable after the VM is powered on.
                   To change the guest ID after the VM is powered on, the VM must be powered

--- a/docs/concepts/workloads/vm.md
+++ b/docs/concepts/workloads/vm.md
@@ -869,7 +869,7 @@ govc vm.info -vm.uuid $(k get vm -o jsonpath='{.spec.instanceUUID}' -n $ns $name
 
 ### Guest ID
 
-The optional field `spec.guestID` that may be used when deploying a VM to specify its guest operating system identifier. This field may also be updated when a VM is powered off. The value of this field is derived from the list of [supported guest identifiers](https://dp-downloads.broadcom.com/api-content/apis/API_VWSA_001/8.0U2/html/SDK/vsphere-ws/docs/ReferenceGuide/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html). The following command may be used to query the currently supported guest identifiers for a given vSphere environment:
+The optional field `spec.guestID` that may be used when deploying a VM to specify its guest operating system identifier. This field may also be updated when a VM is powered off. The value of this field is derived from the list of [supported guest identifiers](https://developer.broadcom.com/xapis/vsphere-web-services-api/latest/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html). The following command may be used to query the currently supported guest identifiers for a given vSphere environment:
 
 ```shell
 govc vm.option.info -cluster CLUSTER_NAME

--- a/docs/ref/api/v1alpha1.md
+++ b/docs/ref/api/v1alpha1.md
@@ -1497,6 +1497,12 @@ _Appears in:_
 | Field | Description |
 | --- | --- |
 | `host` _string_ | Host describes the hostname or IP address of the infrastructure host that the VirtualMachine is executing on. |
+| `hostName` _string_ | HostName describes the observed hostname reported by the VirtualMachine's
+guest operating system.
+
+Please note, this value is only reported if VMware Tools is installed in
+the guest, and the value may or may not be a fully qualified domain name
+(FQDN), it simply depends on what is reported by the guest. |
 | `powerState` _[VirtualMachinePowerState](#virtualmachinepowerstate)_ | PowerState describes the current power state of the VirtualMachine. |
 | `phase` _[VMStatusPhase](#vmstatusphase)_ | Phase describes the current phase information of the VirtualMachine. |
 | `conditions` _[Condition](#condition) array_ | Conditions describes the current condition information of the VirtualMachine. |

--- a/docs/ref/api/v1alpha2.md
+++ b/docs/ref/api/v1alpha2.md
@@ -1186,10 +1186,7 @@ Please note IP4 and IP6 addresses must include the network prefix length,
 ex. 192.168.0.10/24 or 2001:db8:101::a/64.
 
 Please note this field may not contain IP4 addresses if DHCP4 is set
-to true or IP6 addresses if DHCP6 is set to true.
-
-Please note if the Interfaces field is non-empty then this field is
-ignored and should be specified on the elements in the Interfaces list. |
+to true or IP6 addresses if DHCP6 is set to true. |
 | `dhcp4` _boolean_ | DHCP4 indicates whether or not this interface uses DHCP for IP4
 networking.
 
@@ -1208,12 +1205,11 @@ Please note this field is mutually exclusive with IP6 addresses in the
 Addresses field and the Gateway6 field. |
 | `gateway4` _string_ | Gateway4 is the default, IP4 gateway for this interface.
 
+If unset, the gateway from the network provider will be used. However,
+if set to "None", the network provider gateway will be ignored.
+
 Please note this field is only supported if the network connection
 supports manual IP allocation.
-
-If the network connection supports manual IP allocation and the
-Addresses field includes at least one IP4 address, then this field
-is required.
 
 Please note the IP address must include the network prefix length, ex.
 192.168.0.1/24.
@@ -1221,12 +1217,11 @@ Please note the IP address must include the network prefix length, ex.
 Please note this field is mutually exclusive with DHCP4. |
 | `gateway6` _string_ | Gateway6 is the primary IP6 gateway for this interface.
 
+If unset, the gateway from the network provider will be used. However,
+if set to "None", the network provider gateway will be ignored.
+
 Please note this field is only supported if the network connection
 supports manual IP allocation.
-
-If the network connection supports manual IP allocation and the
-Addresses field includes at least one IP6 address, then this field
-is required.
 
 Please note the IP address must include the network prefix length, ex.
 2001:db8:101::1/64.
@@ -1373,6 +1368,12 @@ Please note this information does *not* represent the *observed* network
 state of the VM, but is intended for situations where someone boots a VM
 with no appropriate bootstrap engine and needs to know the network config
 valid for the deployed VM. |
+| `hostName` _string_ | HostName describes the observed hostname reported by the VirtualMachine's
+guest operating system.
+
+Please note, this value is only reported if VMware Tools is installed in
+the guest, and the value may or may not be a fully qualified domain name
+(FQDN), it simply depends on what is reported by the guest. |
 | `interfaces` _[VirtualMachineNetworkInterfaceStatus](#virtualmachinenetworkinterfacestatus) array_ | Interfaces describes the status of the VM's network interfaces. |
 | `ipStacks` _[VirtualMachineNetworkIPStackStatus](#virtualmachinenetworkipstackstatus) array_ | IPStacks describes information about the guest's configured IP networking
 stacks. |

--- a/docs/ref/api/v1alpha3.md
+++ b/docs/ref/api/v1alpha3.md
@@ -936,8 +936,8 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `id` _string_ | ID describes the value used to locate the disk.
-The value of this field depends on the type of disk.
+| `id` _string_ | ID describes the value used to locate the file.
+The value of this field depends on the type of file.
 For Type=Classic, the ID value describes a datastore path, ex.
 "[my-datastore-1] .contentlib-cache/1234/5678/my-disk-1.vmdk".
 For Type=Managed, the ID value describes a First Class Disk (FCD). |
@@ -974,7 +974,7 @@ _Appears in:_
 be cached. |
 | `datastoreID` _string_ | DatastoreID describes the ID of the datastore to which the image should
 be cached. |
-| `files` _[VirtualMachineImageCacheFileStatus](#virtualmachineimagecachediskstatus) array_ | Disks describes the image's disks cached on this datastore. |
+| `files` _[VirtualMachineImageCacheFileStatus](#virtualmachineimagecachefilestatus) array_ | Files describes the image's files cached on this datastore. |
 | `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#condition-v1-meta) array_ | Conditions describes any conditions associated with this cache location.
 
 Generally this should just include the ReadyType condition. |
@@ -1517,10 +1517,7 @@ Please note IP4 and IP6 addresses must include the network prefix length,
 ex. 192.168.0.10/24 or 2001:db8:101::a/64.
 
 Please note this field may not contain IP4 addresses if DHCP4 is set
-to true or IP6 addresses if DHCP6 is set to true.
-
-Please note if the Interfaces field is non-empty then this field is
-ignored and should be specified on the elements in the Interfaces list. |
+to true or IP6 addresses if DHCP6 is set to true. |
 | `dhcp4` _boolean_ | DHCP4 indicates whether or not this interface uses DHCP for IP4
 networking.
 
@@ -1539,12 +1536,11 @@ Please note this field is mutually exclusive with IP6 addresses in the
 Addresses field and the Gateway6 field. |
 | `gateway4` _string_ | Gateway4 is the default, IP4 gateway for this interface.
 
+If unset, the gateway from the network provider will be used. However,
+if set to "None", the network provider gateway will be ignored.
+
 Please note this field is only supported if the network connection
 supports manual IP allocation.
-
-If the network connection supports manual IP allocation and the
-Addresses field includes at least one IP4 address, then this field
-is required.
 
 Please note the IP address must include the network prefix length, ex.
 192.168.0.1/24.
@@ -1552,12 +1548,11 @@ Please note the IP address must include the network prefix length, ex.
 Please note this field is mutually exclusive with DHCP4. |
 | `gateway6` _string_ | Gateway6 is the primary IP6 gateway for this interface.
 
+If unset, the gateway from the network provider will be used. However,
+if set to "None", the network provider gateway will be ignored.
+
 Please note this field is only supported if the network connection
 supports manual IP allocation.
-
-If the network connection supports manual IP allocation and the
-Addresses field includes at least one IP6 address, then this field
-is required.
 
 Please note the IP address must include the network prefix length, ex.
 2001:db8:101::1/64.
@@ -1659,7 +1654,7 @@ for DNS labels:
   * Underscores are not allowed.
   * Dashes are permitted, but not at the start or end of the value.
   * Symbol unicode points, such as emoji, are permitted, ex. ✓. However,
-    please notes that the use of emoji, even where allowed, may not
+    please note that the use of emoji, even where allowed, may not
     compatible with the guest operating system, so it recommended to
     stick with more common characters for this value.
   * The value may be a valid IP4 or IP6 address. Please note, the use of
@@ -1747,6 +1742,12 @@ Please note this information does *not* represent the *observed* network
 state of the VM, but is intended for situations where someone boots a VM
 with no appropriate bootstrap engine and needs to know the network config
 valid for the deployed VM. |
+| `hostName` _string_ | HostName describes the observed hostname reported by the VirtualMachine's
+guest operating system.
+
+Please note, this value is only reported if VMware Tools is installed in
+the guest, and the value may or may not be a fully qualified domain name
+(FQDN), it simply depends on what is reported by the guest. |
 | `interfaces` _[VirtualMachineNetworkInterfaceStatus](#virtualmachinenetworkinterfacestatus) array_ | Interfaces describes the status of the VM's network interfaces. |
 | `ipStacks` _[VirtualMachineNetworkIPStackStatus](#virtualmachinenetworkipstackstatus) array_ | IPStacks describes information about the guest's configured IP networking
 stacks. |
@@ -2432,12 +2433,14 @@ Otherwise, if the VM is deployed from an OVF template that defines a
 guest ID, then that value is used.
 The guest ID from VirtualMachineClass used to deploy the VM is ignored.
 
-For a complete list of supported values, refer to https://bit.ly/3TiZX3G.
-Note that some guest ID values may require a minimal hardware version,
-which can be set using the `spec.minHardwareVersion` field.
+For a complete list of supported values, please refer to
+https://developer.broadcom.com/xapis/vsphere-web-services-api/latest/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html.
+
+Please note that some guest ID values may require a minimal hardware
+version, which can be set using the `spec.minHardwareVersion` field.
 To see the mapping between virtual hardware versions and the product
-versions that support a specific guest ID, visit the following link:
-https://knowledge.broadcom.com/external/article/315655/virtual-machine-hardware-versions.html
+versions that support a specific guest ID, please refer to
+https://knowledge.broadcom.com/external/article/315655/virtual-machine-hardware-versions.html.
 
 Please note that this field is immutable after the VM is powered on.
 To change the guest ID after the VM is powered on, the VM must be powered
@@ -2638,7 +2641,7 @@ _Underlying type:_ `string`
 VirtualMachineVolumeType describes the type of a VirtualMachine volume.
 
 _Appears in:_
-- [VirtualMachineImageCacheFileStatus](#virtualmachineimagecachediskstatus)
+- [VirtualMachineImageCacheFileStatus](#virtualmachineimagecachefilestatus)
 - [VirtualMachineVolumeStatus](#virtualmachinevolumestatus)
 
 

--- a/docs/ref/api/v1alpha4.md
+++ b/docs/ref/api/v1alpha4.md
@@ -506,6 +506,79 @@ persistent volumes managed by this VM. |
 for this VM, a feature utilized by external backup systems such as
 VMware Data Recovery. |
 
+### VirtualMachineBootOptions
+
+
+
+VirtualMachineBootOptions defines the boot-time behavior of a virtual machine.
+
+_Appears in:_
+- [VirtualMachineSpec](#virtualmachinespec)
+
+| Field | Description |
+| --- | --- |
+| `bootDelay` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#duration-v1-meta)_ | BootDelay is the delay before starting the boot sequence. The boot delay
+specifies a time interval between virtual machine power on or restart and
+the beginning of the boot sequence. |
+| `bootOrder` _[VirtualMachineBootOptionsBootableDevice](#virtualmachinebootoptionsbootabledevice) array_ | BootOrder represents the boot order of the virtual machine. After list is exhausted,
+default BIOS boot device algorithm is used for booting. Note that order of the entries
+in the list is important: device listed first is used for boot first, if that one
+fails second entry is used, and so on. Platform may have some internal limit on the
+number of devices it supports. If bootable device is not reached before platform's limit
+is hit, boot will fail. At least single entry is supported by all products supporting
+boot order settings.
+
+The available devices are:
+
+- Disk    -- If there are classic and managed disks, the first classic disk is selected.
+             If there are only managed disks, the first disk is selected.
+- Network -- The first interface listed in spec.network.interfaces.
+- CDRom   -- The first bootable CD-ROM device. |
+| `bootRetryEnabled` _boolean_ | BootRetryEnabled specifies whether a virtual machine that fails to boot
+will try again. If set to true, a virtual machine that fails to boot will
+try again after BootRetryDelay time period has expired. If set to false, the
+virtual machine waits indefinitely for you to initiate boot retry. |
+| `bootRetryDelay` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#duration-v1-meta)_ | BootRetryDelay specifies a time interval between virtual machine boot failure
+and the subsequent attempt to boot again. The virtual machine uses this value
+only if BootRetryEnabled is true. |
+| `enterBIOSSetup` _boolean_ | EnterBIOSSetup specifies whether to automatically enter BIOS setup the next
+time the virtual machine boots. The virtual machine resets this flag to false
+so that subsequent boots proceed normally. |
+| `efiSecureBootEnabled` _boolean_ | EFISecureBootEnabled specifies whether the virtual machine's firmware will
+perform signature checks of any EFI images loaded during startup. If set to
+true, signature checks will be performed and the virtual machine's firmware
+will refuse to start any images which do not pass those signature checks.
+
+Please note, this field will not be honored unless the value of spec.firmware
+is "EFI". |
+| `networkBootProtocol` _[VirtualMachineBootOptionsNetworkBootProtocol](#virtualmachinebootoptionsnetworkbootprotocol)_ | NetworkBootProtocol is the protocol to attempt during PXE network boot or NetBoot.
+The available protocols are:
+
+- IP4 -- PXE (or Apple NetBoot) over IPv4. The default.
+- IP6 -- PXE over IPv6. Only meaningful for EFI virtual machines. |
+
+### VirtualMachineBootOptionsBootableDevice
+
+_Underlying type:_ `string`
+
+VirtualMachineBootOptionsBootableDevice represents the type of bootable device
+that a VM may be booted from.
+
+_Appears in:_
+- [VirtualMachineBootOptions](#virtualmachinebootoptions)
+
+
+### VirtualMachineBootOptionsNetworkBootProtocol
+
+_Underlying type:_ `string`
+
+VirtualMachineBootOptionsNetworkBootProtocol represents the protocol to
+use during PXE network boot or NetBoot.
+
+_Appears in:_
+- [VirtualMachineBootOptions](#virtualmachinebootoptions)
+
+
 ### VirtualMachineBootstrapCloudInitSpec
 
 
@@ -924,6 +997,7 @@ encrypted. |
 Please note, this field will be empty if the VirtualMachine is not
 encrypted. |
 
+
 ### VirtualMachineEncryptionType
 
 _Underlying type:_ `string`
@@ -946,8 +1020,8 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `id` _string_ | ID describes the value used to locate the disk.
-The value of this field depends on the type of disk.
+| `id` _string_ | ID describes the value used to locate the file.
+The value of this field depends on the type of file.
 For Type=Classic, the ID value describes a datastore path, ex.
 "[my-datastore-1] .contentlib-cache/1234/5678/my-disk-1.vmdk".
 For Type=Managed, the ID value describes a First Class Disk (FCD). |
@@ -984,7 +1058,7 @@ _Appears in:_
 be cached. |
 | `datastoreID` _string_ | DatastoreID describes the ID of the datastore to which the image should
 be cached. |
-| `files` _[VirtualMachineImageCacheFileStatus](#virtualmachineimagecachediskstatus) array_ | Disks describes the image's disks cached on this datastore. |
+| `files` _[VirtualMachineImageCacheFileStatus](#virtualmachineimagecachefilestatus) array_ | Files describes the image's files cached on this datastore. |
 | `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#condition-v1-meta) array_ | Conditions describes any conditions associated with this cache location.
 
 Generally this should just include the ReadyType condition. |
@@ -1527,10 +1601,7 @@ Please note IP4 and IP6 addresses must include the network prefix length,
 ex. 192.168.0.10/24 or 2001:db8:101::a/64.
 
 Please note this field may not contain IP4 addresses if DHCP4 is set
-to true or IP6 addresses if DHCP6 is set to true.
-
-Please note if the Interfaces field is non-empty then this field is
-ignored and should be specified on the elements in the Interfaces list. |
+to true or IP6 addresses if DHCP6 is set to true. |
 | `dhcp4` _boolean_ | DHCP4 indicates whether or not this interface uses DHCP for IP4
 networking.
 
@@ -1549,12 +1620,11 @@ Please note this field is mutually exclusive with IP6 addresses in the
 Addresses field and the Gateway6 field. |
 | `gateway4` _string_ | Gateway4 is the default, IP4 gateway for this interface.
 
+If unset, the gateway from the network provider will be used. However,
+if set to "None", the network provider gateway will be ignored.
+
 Please note this field is only supported if the network connection
 supports manual IP allocation.
-
-If the network connection supports manual IP allocation and the
-Addresses field includes at least one IP4 address, then this field
-is required.
 
 Please note the IP address must include the network prefix length, ex.
 192.168.0.1/24.
@@ -1562,12 +1632,11 @@ Please note the IP address must include the network prefix length, ex.
 Please note this field is mutually exclusive with DHCP4. |
 | `gateway6` _string_ | Gateway6 is the primary IP6 gateway for this interface.
 
+If unset, the gateway from the network provider will be used. However,
+if set to "None", the network provider gateway will be ignored.
+
 Please note this field is only supported if the network connection
 supports manual IP allocation.
-
-If the network connection supports manual IP allocation and the
-Addresses field includes at least one IP6 address, then this field
-is required.
 
 Please note the IP address must include the network prefix length, ex.
 2001:db8:101::1/64.
@@ -1669,7 +1738,7 @@ for DNS labels:
   * Underscores are not allowed.
   * Dashes are permitted, but not at the start or end of the value.
   * Symbol unicode points, such as emoji, are permitted, ex. ✓. However,
-    please notes that the use of emoji, even where allowed, may not
+    please note that the use of emoji, even where allowed, may not
     compatible with the guest operating system, so it recommended to
     stick with more common characters for this value.
   * The value may be a valid IP4 or IP6 address. Please note, the use of
@@ -1757,6 +1826,12 @@ Please note this information does *not* represent the *observed* network
 state of the VM, but is intended for situations where someone boots a VM
 with no appropriate bootstrap engine and needs to know the network config
 valid for the deployed VM. |
+| `hostName` _string_ | HostName describes the observed hostname reported by the VirtualMachine's
+guest operating system.
+
+Please note, this value is only reported if VMware Tools is installed in
+the guest, and the value may or may not be a fully qualified domain name
+(FQDN), it simply depends on what is reported by the guest. |
 | `interfaces` _[VirtualMachineNetworkInterfaceStatus](#virtualmachinenetworkinterfacestatus) array_ | Interfaces describes the status of the VM's network interfaces. |
 | `ipStacks` _[VirtualMachineNetworkIPStackStatus](#virtualmachinenetworkipstackstatus) array_ | IPStacks describes information about the guest's configured IP networking
 stacks. |
@@ -1801,6 +1876,17 @@ VirtualMachinePowerState defines a VM's desired and observed power states.
 _Appears in:_
 - [VirtualMachineSpec](#virtualmachinespec)
 - [VirtualMachineStatus](#virtualmachinestatus)
+
+
+### VirtualMachinePromoteDisksMode
+
+_Underlying type:_ `string`
+
+VirtualMachinePromoteDisksMode represents the available modes for promoting
+child disks to full clones.
+
+_Appears in:_
+- [VirtualMachineSpec](#virtualmachinespec)
 
 
 ### VirtualMachinePublishRequestSource
@@ -2442,18 +2528,32 @@ Otherwise, if the VM is deployed from an OVF template that defines a
 guest ID, then that value is used.
 The guest ID from VirtualMachineClass used to deploy the VM is ignored.
 
-For a complete list of supported values, refer to https://bit.ly/3TiZX3G.
-Note that some guest ID values may require a minimal hardware version,
-which can be set using the `spec.minHardwareVersion` field.
+For a complete list of supported values, please refer to
+https://developer.broadcom.com/xapis/vsphere-web-services-api/latest/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html.
+
+Please note that some guest ID values may require a minimal hardware
+version, which can be set using the `spec.minHardwareVersion` field.
 To see the mapping between virtual hardware versions and the product
-versions that support a specific guest ID, visit the following link:
-https://knowledge.broadcom.com/external/article/315655/virtual-machine-hardware-versions.html
+versions that support a specific guest ID, please refer to
+https://knowledge.broadcom.com/external/article/315655/virtual-machine-hardware-versions.html.
 
 Please note that this field is immutable after the VM is powered on.
 To change the guest ID after the VM is powered on, the VM must be powered
 off and then powered on again with the updated guest ID spec.
 
 This field is required when the VM has any CD-ROM devices attached. |
+| `promoteDisksMode` _[VirtualMachinePromoteDisksMode](#virtualmachinepromotedisksmode)_ | PromoteDisksMode describes the mode used to promote a VM's delta disks to
+full disks. The available modes are:
+
+- Disabled -- Do not promote disks.
+- Online   -- Promote disks while the VM is powered on. VMs with
+              snapshots do not support online promotion.
+- Offline  -- Promote disks while the VM is powered off.
+
+Defaults to Online. |
+| `bootOptions` _[VirtualMachineBootOptions](#virtualmachinebootoptions)_ | BootOptions describes the settings that control the boot behavior of the
+virtual machine. These settings take effect during the next power-on of the
+virtual machine. |
 
 ### VirtualMachineStatus
 
@@ -2468,8 +2568,8 @@ _Appears in:_
 | --- | --- |
 | `class` _[LocalObjectRef](#localobjectref)_ | Class is a reference to the VirtualMachineClass resource used to deploy
 this VM. |
-| `host` _string_ | Host describes the hostname or IP address of the infrastructure host
-where the VM is executed. |
+| `nodeName` _string_ | NodeName describes the observed name of the node where the VirtualMachine
+is scheduled. |
 | `powerState` _[VirtualMachinePowerState](#virtualmachinepowerstate)_ | PowerState describes the observed power state of the VirtualMachine. |
 | `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#condition-v1-meta) array_ | Conditions describes the observed conditions of the VirtualMachine. |
 | `crypto` _[VirtualMachineCryptoStatus](#virtualmachinecryptostatus)_ | Crypto describes the observed state of the VirtualMachine's encryption
@@ -2499,6 +2599,8 @@ hardware version.
 Please refer to VirtualMachineSpec.MinHardwareVersion for more
 information on the topic of a VM's hardware version. |
 | `storage` _[VirtualMachineStorageStatus](#virtualmachinestoragestatus)_ | Storage describes the observed state of the VirtualMachine's storage. |
+| `taskID` _string_ | TaskID describes the observed ID of the task created by VM Operator to
+perform some long-running operation on the VM. |
 
 ### VirtualMachineStorageStatus
 
@@ -2648,7 +2750,7 @@ _Underlying type:_ `string`
 VirtualMachineVolumeType describes the type of a VirtualMachine volume.
 
 _Appears in:_
-- [VirtualMachineImageCacheFileStatus](#virtualmachineimagecachediskstatus)
+- [VirtualMachineImageCacheFileStatus](#virtualmachineimagecachefilestatus)
 - [VirtualMachineVolumeStatus](#virtualmachinevolumestatus)
 
 

--- a/docs/tutorials/deploy-vm/iso.md
+++ b/docs/tutorials/deploy-vm/iso.md
@@ -115,7 +115,7 @@ spec:
 ```
 
 1.  :wave: The `storage` field specifies the size of the VM's boot disk.
-2.  :wave: The `guestID` field is required to specify the [guest operating system identifier](https://dp-downloads.broadcom.com/api-content/apis/API_VWSA_001/8.0U3/html/ReferenceGuides/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html) when deploying a VM from an ISO image.
+2.  :wave: The `guestID` field is required to specify the [guest operating system identifier](https://developer.broadcom.com/xapis/vsphere-web-services-api/latest/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html) when deploying a VM from an ISO image.
 3.  :wave: The `name` field must consist of at least two lowercase letters or digits and be unique among all CD-ROM devices attached to the VM.
 4.  :wave: The `image.kind` field specifies the type of the ISO image (either `VirtualMachineImage` or `ClusterVirtualMachineImage`).
 5.  :wave: The `image.name` field specifies the Kubernetes object name of the ISO type `VirtualMachineImage` or `ClusterVirtualMachineImage` resource.


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch updates the link to the official VMware docs for supported guest IDs.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Update link to guest OS identifiers.
```

<!-- readthedocs-preview vm-operator start -->
----
📚 Documentation preview 📚: https://vm-operator--981.org.readthedocs.build/en/981/

<!-- readthedocs-preview vm-operator end -->