### PR TITLE
🐛 Only set Netplan MTU if a positive value

### DIFF
--- a/pkg/providers/vsphere/network/netplan.go
+++ b/pkg/providers/vsphere/network/netplan.go
@@ -24,11 +24,14 @@ func NetPlanCustomization(result NetworkInterfaceResults) (*netplan.Network, err
 				Macaddress: ptr.To(NormalizeNetplanMac(r.MacAddress)),
 			},
 			SetName: &r.GuestDeviceName,
-			MTU:     &r.MTU,
 			Nameservers: &netplan.Nameserver{
 				Addresses: r.Nameservers,
 				Search:    r.SearchDomains,
 			},
+		}
+
+		if r.MTU > 0 {
+			npEth.MTU = &r.MTU
 		}
 
 		npEth.Dhcp4 = &r.DHCP4

--- a/pkg/providers/vsphere/network/netplan_test.go
+++ b/pkg/providers/vsphere/network/netplan_test.go
@@ -141,6 +141,24 @@ var _ = Describe("Netplan", func() {
 					Expect(np.Gateway6).To(BeNil())
 				})
 			})
+
+			Context("MTU is zero", func() {
+				BeforeEach(func() {
+					results.Results[0].MTU = 0
+				})
+
+				It("MTU is nil", func() {
+					Expect(err).ToNot(HaveOccurred())
+					Expect(config).ToNot(BeNil())
+					Expect(config.Version).To(Equal(constants.NetPlanVersion))
+
+					Expect(config.Ethernets).To(HaveLen(1))
+					Expect(config.Ethernets).To(HaveKey(ifName))
+
+					np := config.Ethernets[ifName]
+					Expect(np.MTU).To(BeNil())
+				})
+			})
 		})
 
 		Context("IPv4/6 DHCP", func() {


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

It appears there was an upstream change that started to render an MTU of zero as "null" in the netplan configuration which is not valid.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

First noticed in Ubuntu 24.04

**Please add a release note if necessary**:

```release-note
When using cloudinit bootstrap, only set the netplan MTU when greater than zero.
```