### PR TITLE
deps: Bump govmomi to include CreateSCSIController fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/vmware-tanzu/vm-operator/external/tanzu-topology v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/vm-operator/pkg/backup/api v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels v0.0.0-00010101000000-000000000000
-	github.com/vmware/govmomi v0.52.0-alpha.0.0.20250528190340-70c5ca6d1de6
+	github.com/vmware/govmomi v0.52.0-alpha.0.0.20250530184040-db3efb71ccd0
 	golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc
 	// * https://github.com/vmware-tanzu/vm-operator/security/dependabot/24
 	golang.org/x/text v0.25.0

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,8 @@ github.com/vmware-tanzu/net-operator-api v0.0.0-20240523152550-862e2c4eb0e0 h1:y
 github.com/vmware-tanzu/net-operator-api v0.0.0-20240523152550-862e2c4eb0e0/go.mod h1:w6QJGm3crIA16ZIz1FVQXD2NVeJhOgGXxW05RbVTSTo=
 github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20241112044858-9da8637c1b0d h1:z9lrzKVtNlujduv9BilzPxuge/LE2F0N1ms3TP4JZvw=
 github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20241112044858-9da8637c1b0d/go.mod h1:Q4JzNkNMvjo7pXtlB5/R3oME4Nhah7fAObWgghVmtxk=
-github.com/vmware/govmomi v0.52.0-alpha.0.0.20250528190340-70c5ca6d1de6 h1:bN8pTz2iE5FKfygrNb503EryTKX3MFyqgTURiW88VdA=
-github.com/vmware/govmomi v0.52.0-alpha.0.0.20250528190340-70c5ca6d1de6/go.mod h1:3ywivawGRfMP2SDCeyKqxTl2xNIHTXF0ilvp72dot5A=
+github.com/vmware/govmomi v0.52.0-alpha.0.0.20250530184040-db3efb71ccd0 h1:6ZGICBefKU4Hvm+bDBYorUY7LeNqmRKnTxDEDwOPDuA=
+github.com/vmware/govmomi v0.52.0-alpha.0.0.20250530184040-db3efb71ccd0/go.mod h1:3ywivawGRfMP2SDCeyKqxTl2xNIHTXF0ilvp72dot5A=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
When vmop has FastDeploy enabled, it can fail transforming ovf to config spec due to govmomi's naming of "lsilogic-sas", rather than "lsilogicsas".

Pulling in this [govmomi fix](https://github.com/vmware/govmomi/pull/3796) supports both names.
