### PR TITLE
✨ Move network interface matching into network

### DIFF
--- a/pkg/providers/vsphere/network/network.go
+++ b/pkg/providers/vsphere/network/network.go
@@ -59,7 +59,9 @@ type NetworkInterfaceResult struct {
 	// Fields from the InterfaceSpec used later during customization.
 	Name            string
 	GuestDeviceName string
+	NoIPv4          bool
 	DHCP4           bool
+	NoIPv6          bool
 	DHCP6           bool
 	MTU             int64
 	Nameservers     []string

--- a/pkg/providers/vsphere/network/reconcile.go
+++ b/pkg/providers/vsphere/network/reconcile.go
@@ -1,0 +1,151 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package network
+
+import (
+	"context"
+	"strings"
+
+	"github.com/vmware/govmomi/object"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	netopv1alpha1 "github.com/vmware-tanzu/net-operator-api/api/v1alpha1"
+	vpcv1alpha1 "github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
+	ncpv1alpha1 "github.com/vmware-tanzu/vm-operator/external/ncp/api/v1alpha1"
+
+	"github.com/vmware-tanzu/vm-operator/pkg/util/resize"
+)
+
+func ReconcileNetworkInterfaces(
+	ctx context.Context,
+	results *NetworkInterfaceResults,
+	currentEthCards object.VirtualDeviceList,
+) ([]vimtypes.BaseVirtualDeviceConfigSpec, error) {
+
+	var deviceChanges []vimtypes.BaseVirtualDeviceConfigSpec
+
+	for idx, r := range results.Results {
+		matchingIdx := FindMatchingEthCard(currentEthCards, r.Device.(vimtypes.BaseVirtualEthernetCard))
+		if matchingIdx >= 0 {
+			// Exact match. Claim it by removing the device from the current ethernet cards.
+			matchDev := currentEthCards[matchingIdx].(vimtypes.BaseVirtualEthernetCard).GetVirtualEthernetCard()
+			results.Results[idx].DeviceKey = matchDev.Key
+			results.Results[idx].MacAddress = matchDev.MacAddress
+			currentEthCards = append(currentEthCards[:matchingIdx], currentEthCards[matchingIdx+1:]...)
+		} else {
+			existingIdx := findExistingEthCardForOrphanedCR(ctx, r.Name, results.OrphanedNetworkInterfaces, currentEthCards)
+			if existingIdx >= 0 {
+				editDev := currentEthCards[existingIdx]
+
+				ethDev := editDev.(vimtypes.BaseVirtualEthernetCard).GetVirtualEthernetCard()
+				ethDev.Backing = r.Device.GetVirtualDevice().Backing
+				ethDev.AddressType = r.Device.(vimtypes.BaseVirtualEthernetCard).GetVirtualEthernetCard().AddressType
+				ethDev.MacAddress = r.Device.(vimtypes.BaseVirtualEthernetCard).GetVirtualEthernetCard().MacAddress
+				ethDev.ExternalId = r.Device.(vimtypes.BaseVirtualEthernetCard).GetVirtualEthernetCard().ExternalId
+
+				deviceChanges = append(deviceChanges, &vimtypes.VirtualDeviceConfigSpec{
+					Device:    editDev,
+					Operation: vimtypes.VirtualDeviceConfigSpecOperationEdit,
+				})
+
+				currentEthCards = append(currentEthCards[:existingIdx], currentEthCards[existingIdx+1:]...)
+			} else {
+				deviceChanges = append(deviceChanges, &vimtypes.VirtualDeviceConfigSpec{
+					Device:    r.Device,
+					Operation: vimtypes.VirtualDeviceConfigSpecOperationAdd,
+				})
+			}
+
+			results.AddedEthernetCard = true
+		}
+	}
+
+	// Remove any unmatched existing interfaces.
+	removeDeviceChanges := make([]vimtypes.BaseVirtualDeviceConfigSpec, 0, len(currentEthCards))
+	for _, dev := range currentEthCards {
+		removeDeviceChanges = append(removeDeviceChanges, &vimtypes.VirtualDeviceConfigSpec{
+			Device:    dev,
+			Operation: vimtypes.VirtualDeviceConfigSpecOperationRemove,
+		})
+	}
+
+	// Process any removes first.
+	return append(removeDeviceChanges, deviceChanges...), nil
+}
+
+// findExistingEthCardForOrphanedCR trys to an orphaned interface and if it has
+// a matching current ethernet card, so the current card can be edited.
+func findExistingEthCardForOrphanedCR(
+	_ context.Context,
+	interfaceName string,
+	orphanedObjects []ctrlclient.Object,
+	currentEthCards object.VirtualDeviceList) int {
+
+	// TODO: Not perfect but until we annotate the interface CR with its interface spec name.
+	suffix := "-" + interfaceName
+
+	for _, obj := range orphanedObjects {
+		if !strings.HasSuffix(obj.GetName(), suffix) {
+			continue
+		}
+
+		switch netIf := obj.(type) {
+		case *netopv1alpha1.NetworkInterface:
+			return findMatchingEthCardNetOpNetIf(netIf, currentEthCards)
+		case *ncpv1alpha1.VirtualNetworkInterface:
+			return findMatchingEthCardNCPNetIf(netIf, currentEthCards)
+		case *vpcv1alpha1.SubnetPort:
+			return findMatchingEthCardVPCSubnetPort(netIf, currentEthCards)
+		}
+	}
+
+	return -1
+}
+
+func FindMatchingEthCard(
+	currentEthCards object.VirtualDeviceList,
+	ethCard vimtypes.BaseVirtualEthernetCard) int {
+
+	ethDev := ethCard.GetVirtualEthernetCard()
+	matchingIdx := -1
+
+	for idx := range currentEthCards {
+		curDev := currentEthCards[idx].(vimtypes.BaseVirtualEthernetCard).GetVirtualEthernetCard()
+
+		if ethDev.AddressType == string(vimtypes.VirtualEthernetCardMacTypeManual) {
+			if ethDev.MacAddress != curDev.MacAddress {
+				continue
+			}
+		}
+
+		if ethDev.ExternalId != "" {
+			if ethDev.ExternalId != curDev.ExternalId {
+				continue
+			}
+		}
+
+		if curDev.Backing == nil {
+			continue
+		}
+
+		var backingMatch bool
+		switch a := ethDev.Backing.(type) {
+		case *vimtypes.VirtualEthernetCardNetworkBackingInfo:
+			backingMatch = resize.MatchVirtualEthernetCardNetworkBackingInfo(a, curDev.Backing)
+		case *vimtypes.VirtualEthernetCardDistributedVirtualPortBackingInfo:
+			backingMatch = resize.MatchVirtualEthernetCardDistributedVirtualPortBackingInfo(a, curDev.Backing)
+		case *vimtypes.VirtualEthernetCardOpaqueNetworkBackingInfo:
+			backingMatch = resize.MatchVirtualEthernetCardOpaqueNetworkBackingInfo(a, curDev.Backing)
+		}
+
+		if backingMatch {
+			matchingIdx = idx
+			break
+		}
+	}
+
+	return matchingIdx
+}

--- a/pkg/providers/vsphere/session/session_vm_update.go
+++ b/pkg/providers/vsphere/session/session_vm_update.go
@@ -58,87 +58,12 @@ type VMResizeArgs struct {
 	ConfigSpec vimtypes.VirtualMachineConfigSpec
 }
 
-func findMatchingEthCard(
-	currentEthCards object.VirtualDeviceList,
-	ethCard vimtypes.BaseVirtualEthernetCard) int {
-
-	ethDev := ethCard.GetVirtualEthernetCard()
-	matchingIdx := -1
-
-	for idx := range currentEthCards {
-		curDev := currentEthCards[idx].(vimtypes.BaseVirtualEthernetCard).GetVirtualEthernetCard()
-
-		if ethDev.AddressType == string(vimtypes.VirtualEthernetCardMacTypeManual) {
-			if ethDev.MacAddress != curDev.MacAddress {
-				continue
-			}
-		}
-
-		if ethDev.ExternalId != "" {
-			if ethDev.ExternalId != curDev.ExternalId {
-				continue
-			}
-		}
-
-		if curDev.Backing == nil {
-			continue
-		}
-
-		var backingMatch bool
-		switch a := ethDev.Backing.(type) {
-		case *vimtypes.VirtualEthernetCardNetworkBackingInfo:
-			backingMatch = resize.MatchVirtualEthernetCardNetworkBackingInfo(a, curDev.Backing)
-		case *vimtypes.VirtualEthernetCardDistributedVirtualPortBackingInfo:
-			backingMatch = resize.MatchVirtualEthernetCardDistributedVirtualPortBackingInfo(a, curDev.Backing)
-		case *vimtypes.VirtualEthernetCardOpaqueNetworkBackingInfo:
-			backingMatch = resize.MatchVirtualEthernetCardOpaqueNetworkBackingInfo(a, curDev.Backing)
-		}
-
-		if backingMatch {
-			matchingIdx = idx
-			break
-		}
-	}
-
-	return matchingIdx
-}
-
 func UpdateEthCardDeviceChanges(
-	_ context.Context,
+	ctx context.Context,
 	results *network.NetworkInterfaceResults,
 	currentEthCards object.VirtualDeviceList) ([]vimtypes.BaseVirtualDeviceConfigSpec, error) {
 
-	var deviceChanges []vimtypes.BaseVirtualDeviceConfigSpec
-
-	for idx, r := range results.Results {
-		matchingIdx := findMatchingEthCard(currentEthCards, r.Device.(vimtypes.BaseVirtualEthernetCard))
-		if matchingIdx == -1 {
-			results.AddedEthernetCard = true
-			deviceChanges = append(deviceChanges, &vimtypes.VirtualDeviceConfigSpec{
-				Device:    r.Device,
-				Operation: vimtypes.VirtualDeviceConfigSpecOperationAdd,
-			})
-		} else {
-			matchDev := currentEthCards[matchingIdx].(vimtypes.BaseVirtualEthernetCard).GetVirtualEthernetCard()
-			results.Results[idx].DeviceKey = matchDev.Key
-			results.Results[idx].MacAddress = matchDev.MacAddress
-
-			// This expected ethernet card from the results matched with a current one so claim it.
-			currentEthCards = append(currentEthCards[:matchingIdx], currentEthCards[matchingIdx+1:]...)
-		}
-	}
-
-	// Remove any unmatched existing interfaces.
-	removeDeviceChanges := make([]vimtypes.BaseVirtualDeviceConfigSpec, 0, len(currentEthCards))
-	for _, dev := range currentEthCards {
-		removeDeviceChanges = append(removeDeviceChanges, &vimtypes.VirtualDeviceConfigSpec{
-			Device:    dev,
-			Operation: vimtypes.VirtualDeviceConfigSpecOperationRemove,
-		})
-	}
-
-	// Process any removes first.
-	return append(removeDeviceChanges, deviceChanges...), nil
+	return network.ReconcileNetworkInterfaces(ctx, results, currentEthCards)
 }
 
 // UpdateConfigSpecExtraConfig updates the ExtraConfig of the given ConfigSpec.
@@ -504,7 +429,7 @@ func (s *Session) fixupMacAddressMutableNetworks(
 			continue
 		}
 
-		matchingIdx := findMatchingEthCard(networkDevices, r.Device.(vimtypes.BaseVirtualEthernetCard))
+		matchingIdx := network.FindMatchingEthCard(networkDevices, r.Device.(vimtypes.BaseVirtualEthernetCard))
 		if matchingIdx >= 0 {
 			matchDev := networkDevices[matchingIdx].(vimtypes.BaseVirtualEthernetCard).GetVirtualEthernetCard()
 			updateArgs.NetworkResults.Results[idx].DeviceKey = matchDev.Key

--- a/pkg/providers/vsphere/vmprovider_vm2_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm2_test.go
@@ -28,13 +28,14 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/network"
+	"github.com/vmware-tanzu/vm-operator/pkg/util"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 type fakeNetworkProvider interface {
 	simulateInterfaceReconcile(ctx *builder.TestContextForVCSim, vm *vmopv1.VirtualMachine, networkName, interfaceName string, idx int)
-	assertEthCardBacking(ctx *builder.TestContextForVCSim, dev vimtypes.BaseVirtualDevice, idx int)
+	assertEthernetCard(ctx *builder.TestContextForVCSim, dev vimtypes.BaseVirtualDevice, idx int)
 	assertNetworkInterfacesDNE(ctx *builder.TestContextForVCSim, vm *vmopv1.VirtualMachine, networkName, interfaceName string)
 }
 
@@ -59,7 +60,7 @@ func (v vdsNetworkProvider) simulateInterfaceReconcile(
 	netInterface.Status.MacAddress = "" // NetOP doesn't set this.
 	netInterface.Status.IPConfigs = []netopv1alpha1.IPConfig{
 		{
-			IP:         fmt.Sprintf("192.168.1.11%d", idx),
+			IP:         fmt.Sprintf("192.168.1.2%d", idx),
 			IPFamily:   corev1.IPv4Protocol,
 			Gateway:    "192.168.1.1",
 			SubnetMask: "255.255.255.0",
@@ -74,7 +75,7 @@ func (v vdsNetworkProvider) simulateInterfaceReconcile(
 	Expect(ctx.Client.Status().Update(ctx, netInterface)).To(Succeed())
 }
 
-func (v vdsNetworkProvider) assertEthCardBacking(
+func (v vdsNetworkProvider) assertEthernetCard(
 	ctx *builder.TestContextForVCSim,
 	dev vimtypes.BaseVirtualDevice,
 	idx int) {
@@ -118,13 +119,14 @@ func (n nsxtNetworkProvider) simulateInterfaceReconcile(
 	Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(netInterface), netInterface)).To(Succeed())
 	Expect(netInterface.Spec.VirtualNetwork).To(Equal(networkName))
 
+	netInterface.Status.InterfaceID = netInterface.Name
 	netInterface.Status.MacAddress = fmt.Sprintf("01-23-45-67-89-AB-CD-%X", idx)
 	netInterface.Status.ProviderStatus = &ncpv1alpha1.VirtualNetworkInterfaceProviderStatus{
 		NsxLogicalSwitchID: builder.GetNsxTLogicalSwitchUUID(idx),
 	}
 	netInterface.Status.IPAddresses = []ncpv1alpha1.VirtualNetworkInterfaceIP{
 		{
-			IP:         fmt.Sprintf("192.168.1.11%d", idx),
+			IP:         fmt.Sprintf("192.168.1.2%d", idx),
 			Gateway:    "192.168.1.1",
 			SubnetMask: "255.255.255.0",
 		},
@@ -138,7 +140,7 @@ func (n nsxtNetworkProvider) simulateInterfaceReconcile(
 	Expect(ctx.Client.Status().Update(ctx, netInterface)).To(Succeed())
 }
 
-func (n nsxtNetworkProvider) assertEthCardBacking(
+func (n nsxtNetworkProvider) assertEthernetCard(
 	ctx *builder.TestContextForVCSim,
 	dev vimtypes.BaseVirtualDevice,
 	idx int) {
@@ -147,6 +149,9 @@ func (n nsxtNetworkProvider) assertEthCardBacking(
 	backingInfo, ok := backing.(*vimtypes.VirtualEthernetCardDistributedVirtualPortBackingInfo)
 	Expect(ok).Should(BeTrue())
 	Expect(backingInfo.Port.PortgroupKey).To(Equal(ctx.NetworkRefs[idx].Reference().Value))
+
+	ethCard := dev.(vimtypes.BaseVirtualEthernetCard).GetVirtualEthernetCard()
+	Expect(ethCard.MacAddress).To(Equal(fmt.Sprintf("01-23-45-67-89-AB-CD-%X", idx)))
 }
 
 func (n nsxtNetworkProvider) assertNetworkInterfacesDNE(
@@ -182,7 +187,8 @@ func (v vpcNetworkProvider) simulateInterfaceReconcile(
 	Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(subnetPort), subnetPort)).To(Succeed())
 	Expect(subnetPort.Spec.Subnet).To(Equal(networkName))
 
-	subnetPort.Status.NetworkInterfaceConfig.MACAddress = "01-23-45-67-89-AB-CD-EF"
+	subnetPort.Status.Attachment.ID = subnetPort.Name
+	subnetPort.Status.NetworkInterfaceConfig.MACAddress = fmt.Sprintf("01-23-45-67-89-AB-CD-%X", idx)
 	subnetPort.Status.NetworkInterfaceConfig.LogicalSwitchUUID = builder.GetVPCTLogicalSwitchUUID(idx)
 	subnetPort.Status.NetworkInterfaceConfig.IPAddresses = []vpcv1alpha1.NetworkInterfaceIPAddress{
 		{
@@ -199,7 +205,7 @@ func (v vpcNetworkProvider) simulateInterfaceReconcile(
 	Expect(ctx.Client.Status().Update(ctx, subnetPort)).To(Succeed())
 }
 
-func (v vpcNetworkProvider) assertEthCardBacking(
+func (v vpcNetworkProvider) assertEthernetCard(
 	ctx *builder.TestContextForVCSim,
 	dev vimtypes.BaseVirtualDevice,
 	idx int) {
@@ -208,6 +214,9 @@ func (v vpcNetworkProvider) assertEthCardBacking(
 	backingInfo, ok := backing.(*vimtypes.VirtualEthernetCardDistributedVirtualPortBackingInfo)
 	Expect(ok).Should(BeTrue())
 	Expect(backingInfo.Port.PortgroupKey).To(Equal(ctx.NetworkRefs[idx].Reference().Value))
+
+	ethCard := dev.(vimtypes.BaseVirtualEthernetCard).GetVirtualEthernetCard()
+	Expect(ethCard.MacAddress).To(Equal(fmt.Sprintf("01-23-45-67-89-AB-CD-%X", idx)))
 }
 
 func (v vpcNetworkProvider) assertNetworkInterfacesDNE(
@@ -234,6 +243,18 @@ func (v vpcNetworkProvider) assertNetworkInterfacesDNE(
 // and we'll see how these need to evolve.
 func vmE2ETests() {
 
+	const (
+		networkName0   = "my-network-0"
+		interfaceName0 = "eth0"
+		networkName1   = "my-network-1"
+		interfaceName1 = "eth1"
+		networkName2   = "my-network-2"
+
+		bsCloudInit = "cloudInit"
+		bsSysprep   = "sysPrep"
+		bsLinuxPrep = "linuxPrep"
+	)
+
 	var (
 		initObjects []client.Object
 		testConfig  builder.VCSimTestConfig
@@ -252,7 +273,7 @@ func vmE2ETests() {
 		network.RetryTimeout = 1 * time.Millisecond
 
 		testConfig = builder.VCSimTestConfig{
-			NumNetworks:        2,
+			NumNetworks:        3,
 			WithContentLibrary: true,
 		}
 
@@ -345,17 +366,7 @@ func vmE2ETests() {
 
 	Context("VM E2E", func() {
 
-		const (
-			networkName0   = "my-network-0"
-			interfaceName0 = "eth0"
-			networkName1   = "my-network-1"
-			interfaceName1 = "eth1"
-
-			bsCloudInit = "cloudInit"
-			bsSysprep   = "sysPrep"
-		)
-
-		DescribeTableSubtree("Simulate VM operations",
+		DescribeTableSubtree("Simulate VM power on/off with adding/removing network interfaces ",
 			func(networkEnv builder.NetworkEnv, bootstrap string) {
 				var np fakeNetworkProvider
 
@@ -392,6 +403,10 @@ func vmE2ETests() {
 									Key:  "unattend",
 								},
 							},
+						}
+					case bsLinuxPrep:
+						vm.Spec.Bootstrap = &vmopv1.VirtualMachineBootstrapSpec{
+							LinuxPrep: &vmopv1.VirtualMachineBootstrapLinuxPrepSpec{},
 						}
 					}
 
@@ -441,14 +456,14 @@ func vmE2ETests() {
 					Expect(vm.Status.UniqueID).ToNot(BeEmpty())
 					vcVM := ctx.GetVMFromMoID(vm.Status.UniqueID)
 
-					By("Has expected NIC backing", func() {
+					By("has expected NIC backing", func() {
 						devList, err := vcVM.Device(ctx)
 						Expect(err).ToNot(HaveOccurred())
 						l := devList.SelectByType(&vimtypes.VirtualEthernetCard{})
 						Expect(l).To(HaveLen(1))
 
-						dev0 := l[0].GetVirtualDevice()
-						np.assertEthCardBacking(ctx, dev0, 0)
+						dev0 := l[0]
+						np.assertEthernetCard(ctx, dev0, 0)
 					})
 
 					By("add network interface", func() {
@@ -458,7 +473,7 @@ func vmE2ETests() {
 						vm.Spec.Network.Interfaces[1].Network.Name = networkName1
 					})
 
-					// NOTE: network changes only checked during power on
+					// NOTE: network changes only checked during powering on
 					By("power off and on VM", func() {
 						vm.Spec.PowerState = vmopv1.VirtualMachinePowerStateOff
 						Expect(createOrUpdateVM(ctx, vmProvider, vm)).To(Succeed())
@@ -481,8 +496,8 @@ func vmE2ETests() {
 						l := devList.SelectByType(&vimtypes.VirtualEthernetCard{})
 						Expect(l).To(HaveLen(2))
 
-						dev1 := l[1].GetVirtualDevice()
-						np.assertEthCardBacking(ctx, dev1, 1)
+						dev1 := l[1]
+						np.assertEthernetCard(ctx, dev1, 1)
 					})
 
 					By("remove just added network interface", func() {
@@ -503,8 +518,8 @@ func vmE2ETests() {
 						l := devList.SelectByType(&vimtypes.VirtualEthernetCard{})
 						Expect(l).To(HaveLen(1))
 
-						dev0 := l[0].GetVirtualDevice()
-						np.assertEthCardBacking(ctx, dev0, 0)
+						dev0 := l[0]
+						np.assertEthernetCard(ctx, dev0, 0)
 
 						By("network interface has been deleted", func() {
 							np.assertNetworkInterfacesDNE(ctx, vm, networkName1, interfaceName1)
@@ -515,6 +530,199 @@ func vmE2ETests() {
 			Entry("VDS with CloudInit", builder.NetworkEnvVDS, bsCloudInit),
 			Entry("NSX-T with CloudInit", builder.NetworkEnvNSXT, bsCloudInit),
 			Entry("VPC with Sysprep", builder.NetworkEnvVPC, bsSysprep),
+		)
+
+		DescribeTableSubtree("Simulate VM power off/on with network interface edits",
+			func(networkEnv builder.NetworkEnv, bootstrap string) {
+				var np fakeNetworkProvider
+
+				BeforeEach(func() {
+					testConfig.WithNetworkEnv = networkEnv
+
+					switch networkEnv {
+					case builder.NetworkEnvVDS:
+						np = vdsNetworkProvider{}
+					case builder.NetworkEnvNSXT:
+						np = nsxtNetworkProvider{}
+					case builder.NetworkEnvVPC:
+						np = vpcNetworkProvider{}
+					}
+
+					// We assert the device type is preserved when editing an interface spec.
+					configSpec := vimtypes.VirtualMachineConfigSpec{
+						DeviceChange: []vimtypes.BaseVirtualDeviceConfigSpec{
+							&vimtypes.VirtualDeviceConfigSpec{
+								Operation: vimtypes.VirtualDeviceConfigSpecOperationAdd,
+								Device:    &vimtypes.VirtualE1000e{},
+							},
+							&vimtypes.VirtualDeviceConfigSpec{
+								Operation: vimtypes.VirtualDeviceConfigSpecOperationAdd,
+								Device:    &vimtypes.VirtualVmxnet2{},
+							},
+						},
+					}
+
+					jsonConfigSpec, err := util.MarshalConfigSpecToJSON(configSpec)
+					Expect(err).ToNot(HaveOccurred())
+					vmClass.Spec.ConfigSpec = jsonConfigSpec
+				})
+
+				JustBeforeEach(func() {
+					switch bootstrap {
+					case bsCloudInit:
+						Expect(ctx.Client.Create(ctx, cloudInitSecret)).To(Succeed())
+						vm.Spec.Bootstrap = &vmopv1.VirtualMachineBootstrapSpec{
+							CloudInit: &vmopv1.VirtualMachineBootstrapCloudInitSpec{
+								RawCloudConfig: &common.SecretKeySelector{
+									Name: cloudInitSecret.Name,
+								},
+							},
+						}
+					case bsSysprep:
+						Expect(ctx.Client.Create(ctx, sysprepSecret)).To(Succeed())
+						vm.Spec.Bootstrap = &vmopv1.VirtualMachineBootstrapSpec{
+							Sysprep: &vmopv1.VirtualMachineBootstrapSysprepSpec{
+								RawSysprep: &common.SecretKeySelector{
+									Name: sysprepSecret.Name,
+									Key:  "unattend",
+								},
+							},
+						}
+					case bsLinuxPrep:
+						vm.Spec.Bootstrap = &vmopv1.VirtualMachineBootstrapSpec{
+							LinuxPrep: &vmopv1.VirtualMachineBootstrapLinuxPrepSpec{},
+						}
+					}
+
+					vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{
+						Interfaces: []vmopv1.VirtualMachineNetworkInterfaceSpec{
+							{
+								Name: interfaceName0,
+								Network: &common.PartialObjectRef{
+									Name: networkName0,
+								},
+							},
+							{
+								Name: interfaceName1,
+								Network: &common.PartialObjectRef{
+									Name: networkName1,
+								},
+							},
+						},
+					}
+
+					if networkEnv == builder.NetworkEnvVPC {
+						for i := range vm.Spec.Network.Interfaces {
+							vm.Spec.Network.Interfaces[i].Network.Kind = "Subnet"
+							vm.Spec.Network.Interfaces[i].Network.APIVersion = "crd.nsx.vmware.com/v1alpha1"
+						}
+					}
+				})
+
+				It("DoIt", func() {
+					err := createOrUpdateVM(ctx, vmProvider, vm)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
+					Expect(conditions.IsFalse(vm, vmopv1.VirtualMachineConditionNetworkReady)).To(BeTrue())
+
+					By("simulate successful network provider reconcile", func() {
+						np.simulateInterfaceReconcile(ctx, vm, networkName0, interfaceName0, 0)
+					})
+
+					{
+						// TODO: We should create all the interface CRs up front.
+						err := createOrUpdateVM(ctx, vmProvider, vm)
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
+						Expect(conditions.IsFalse(vm, vmopv1.VirtualMachineConditionNetworkReady)).To(BeTrue())
+					}
+
+					By("simulate successful network provider reconcile", func() {
+						np.simulateInterfaceReconcile(ctx, vm, networkName1, interfaceName1, 1)
+					})
+
+					Expect(createOrUpdateVM(ctx, vmProvider, vm)).To(Succeed())
+
+					By("has expected conditions", func() {
+						Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionClassReady)).To(BeTrue())
+						Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionImageReady)).To(BeTrue())
+						Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionStorageReady)).To(BeTrue())
+						if bootstrap != "" {
+							Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionBootstrapReady)).To(BeTrue())
+						} else {
+							Expect(conditions.Get(vm, vmopv1.VirtualMachineConditionBootstrapReady)).To(BeNil())
+						}
+						Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionNetworkReady)).To(BeTrue())
+						Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionPlacementReady)).To(BeTrue())
+						Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionCreated)).To(BeTrue())
+					})
+
+					Expect(vm.Status.UniqueID).ToNot(BeEmpty())
+					vcVM := ctx.GetVMFromMoID(vm.Status.UniqueID)
+
+					By("has expected NIC device types and backings", func() {
+						devList, err := vcVM.Device(ctx)
+						Expect(err).ToNot(HaveOccurred())
+						l := devList.SelectByType(&vimtypes.VirtualEthernetCard{})
+						Expect(l).To(HaveLen(2))
+
+						dev0 := l[0]
+						_, ok := dev0.(*vimtypes.VirtualE1000e)
+						Expect(ok).To(BeTrue())
+						np.assertEthernetCard(ctx, dev0, 0)
+
+						dev1 := l[1]
+						_, ok = dev1.(*vimtypes.VirtualVmxnet2)
+						Expect(ok).To(BeTrue())
+						np.assertEthernetCard(ctx, dev1, 1)
+					})
+
+					By("update network interface", func() {
+						vm.Spec.Network.Interfaces[1].Network.Name = networkName2
+					})
+
+					By("power off and on VM", func() {
+						vm.Spec.PowerState = vmopv1.VirtualMachinePowerStateOff
+						Expect(createOrUpdateVM(ctx, vmProvider, vm)).To(Succeed())
+
+						vm.Spec.PowerState = vmopv1.VirtualMachinePowerStateOn
+						err = createOrUpdateVM(ctx, vmProvider, vm)
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
+					})
+
+					By("simulate successful network provider reconcile on added interface", func() {
+						np.simulateInterfaceReconcile(ctx, vm, networkName2, interfaceName1, 2)
+					})
+
+					Expect(createOrUpdateVM(ctx, vmProvider, vm)).To(Succeed())
+
+					By("network interface has been deleted", func() {
+						np.assertNetworkInterfacesDNE(ctx, vm, networkName1, interfaceName1)
+					})
+
+					By("has expected NIC device types and backings", func() {
+						devList, err := vcVM.Device(ctx)
+						Expect(err).ToNot(HaveOccurred())
+						l := devList.SelectByType(&vimtypes.VirtualEthernetCard{})
+						Expect(l).To(HaveLen(2))
+
+						dev0 := l[0]
+						_, ok := dev0.(*vimtypes.VirtualE1000e)
+						Expect(ok).To(BeTrue())
+						np.assertEthernetCard(ctx, dev0, 0)
+
+						dev1 := l[1]
+						_, ok = dev1.(*vimtypes.VirtualVmxnet2)
+						Expect(ok).To(BeTrue())
+						np.assertEthernetCard(ctx, dev1, 2)
+					})
+				})
+			},
+			Entry("VDS with CloudInit", builder.NetworkEnvVDS, bsCloudInit),
+			Entry("VPC with CloudInit", builder.NetworkEnvVPC, bsCloudInit),
+			Entry("VDS with LinuxPrep", builder.NetworkEnvVDS, bsLinuxPrep),
+			Entry("NSX-T with Sysprep", builder.NetworkEnvNSXT, bsSysprep),
 		)
 	})
 }


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

Also try to preserve ethernet card device type when an interface spec is updated to just point to a new network.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:



**Please add a release note if necessary**:

```release-note
NONE
```