### PR TITLE
🐛 Add image ExtraConfig to VM when FastDeploy

### DIFF
--- a/pkg/providers/vsphere/vmprovider_test.go
+++ b/pkg/providers/vsphere/vmprovider_test.go
@@ -473,6 +473,13 @@ virtualSystem:
     - key: tools.toolsUpgradePolicy
       required: false
       value: upgradeAtPowerCycle
+    extraConfig:
+    - key: hello
+      required: false
+      value: world
+    - key: fu
+      required: false
+      value: barred
     id: null
     info: Virtual hardware requirements
     item:

--- a/pkg/providers/vsphere/vmprovider_vm.go
+++ b/pkg/providers/vsphere/vmprovider_vm.go
@@ -1644,6 +1644,21 @@ func (vs *vSphereVMProvider) vmCreateGenConfigSpecImage(
 	// Inherit the image's vAppConfig.
 	createArgs.ConfigSpec.VAppConfig = ovfConfigSpec.VAppConfig
 
+	// Merge the image's extra config.
+	if srcEC := ovfConfigSpec.ExtraConfig; len(srcEC) > 0 {
+		if dstEC := createArgs.ConfigSpec.ExtraConfig; len(dstEC) == 0 {
+			// The current config spec doesn't have any extra config, so just
+			// set it to use the extra config from the image.
+			createArgs.ConfigSpec.ExtraConfig = srcEC
+		} else {
+			// The current config spec already has extra config, so merge the
+			// extra config from the image, but do not overwrite any keys that
+			// already exist in the current config spec.
+			createArgs.ConfigSpec.ExtraConfig = object.OptionValueList(dstEC).
+				Join(srcEC...)
+		}
+	}
+
 	// Inherit the image's disks and their controllers.
 	pkgutil.CopyStorageControllersAndDisks(
 		&createArgs.ConfigSpec,


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch ensures an image's ExtraConfig is added to a VM provisioned with Fast Deploy.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Add image's ExtraConfig to VM during create with fast deploy
```