### PR TITLE
✨ Support Supervisor+VPC DNS lookups in guests

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -82,6 +82,12 @@ type Config struct {
 	PodServiceAccountName string
 	DeploymentName        string
 
+	KubeadmConfigMapName    string
+	KubeDNSLBServiceName    string
+	KubeSystemNamespace     string
+	KubeadmClusterConfigKey string
+	DefaultClusterDomain    string
+
 	// SIGUSR2RestartEnabled allows SIGUSR2 to cause the pod to restart.
 	SIGUSR2RestartEnabled bool
 

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -63,5 +63,10 @@ func Default() Config {
 		WebhookSecretName:            defaultPrefix + "webhook-server-cert",
 		WebhookSecretNamespace:       defaultPrefix + "system",
 		WebhookSecretVolumeMountPath: "/tmp/k8s-webhook-server/serving-certs",
+		KubeadmConfigMapName:         "kubeadm-config",
+		KubeDNSLBServiceName:         "kube-dns-lb",
+		KubeSystemNamespace:          "kube-system",
+		KubeadmClusterConfigKey:      "ClusterConfiguration",
+		DefaultClusterDomain:         "cluster.local",
 	}
 }

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -59,6 +59,12 @@ func FromEnv() Config {
 	setString(env.WebhookSecretName, &config.WebhookSecretName)
 	setString(env.WebhookSecretNamespace, &config.WebhookSecretNamespace)
 
+	setString(env.KubeadmConfigMapName, &config.KubeadmConfigMapName)
+	setString(env.KubeDNSLBServiceName, &config.KubeDNSLBServiceName)
+	setString(env.KubeSystemNamespace, &config.KubeSystemNamespace)
+	setString(env.KubeadmClusterConfigKey, &config.KubeadmClusterConfigKey)
+	setString(env.DefaultClusterDomain, &config.DefaultClusterDomain)
+
 	setBool(env.FSSInstanceStorage, &config.Features.InstanceStorage)
 	setBool(env.FSSK8sWorkloadMgmtAPI, &config.Features.K8sWorkloadMgmtAPI)
 	setBool(env.FSSPodVMOnStretchedSupervisor, &config.Features.PodVMOnStretchedSupervisor)

--- a/pkg/config/env/env.go
+++ b/pkg/config/env/env.go
@@ -52,6 +52,11 @@ const (
 	WebhookServiceNamespace
 	WebhookSecretName
 	WebhookSecretNamespace
+	KubeadmConfigMapName
+	KubeDNSLBServiceName
+	KubeSystemNamespace
+	KubeadmClusterConfigKey
+	DefaultClusterDomain
 	FSSInstanceStorage
 	FSSK8sWorkloadMgmtAPI
 	FSSPodVMOnStretchedSupervisor
@@ -166,6 +171,16 @@ func (n VarName) String() string {
 		return "WEBHOOK_SECRET_NAME"
 	case WebhookSecretNamespace:
 		return "WEBHOOK_SECRET_NAMESPACE"
+	case KubeadmConfigMapName:
+		return "KUBEADM_CONFIGMAP_NAME"
+	case KubeDNSLBServiceName:
+		return "KUBE_DNS_LB_SERVICE_NAME"
+	case KubeSystemNamespace:
+		return "KUBE_SYSTEM_NAMESPACE"
+	case KubeadmClusterConfigKey:
+		return "KUBEADM_CLUSTER_CONFIG_KEY"
+	case DefaultClusterDomain:
+		return "DEFAULT_CLUSTER_DOMAIN"
 	case FSSInstanceStorage:
 		return "FSS_WCP_INSTANCE_STORAGE"
 	case FSSK8sWorkloadMgmtAPI:

--- a/pkg/config/env_test.go
+++ b/pkg/config/env_test.go
@@ -109,6 +109,12 @@ var _ = Describe(
 					Expect(os.Setenv("SYNC_IMAGE_REQUEUE_DELAY", "128h")).To(Succeed())
 					Expect(os.Setenv("DEPLOYMENT_NAME", "129")).To(Succeed())
 					Expect(os.Setenv("SIGUSR2_RESTART_ENABLED", "true")).To(Succeed())
+					Expect(os.Setenv("KUBEADM_CONFIGMAP_NAME", "130")).To(Succeed())
+					Expect(os.Setenv("KUBE_DNS_LB_SERVICE_NAME", "131")).To(Succeed())
+					Expect(os.Setenv("KUBE_SYSTEM_NAMESPACE", "132")).To(Succeed())
+					Expect(os.Setenv("KUBEADM_CLUSTER_CONFIG_KEY", "133")).To(Succeed())
+					Expect(os.Setenv("DEFAULT_CLUSTER_DOMAIN", "134")).To(Succeed())
+
 				})
 				It("Should return a default config overridden by the environment", func() {
 					Expect(config).To(BeComparableTo(pkgcfg.Config{
@@ -164,6 +170,11 @@ var _ = Describe(
 						SyncImageRequeueDelay:        128 * time.Hour,
 						DeploymentName:               "129",
 						SIGUSR2RestartEnabled:        true,
+						KubeadmConfigMapName:         "130",
+						KubeDNSLBServiceName:         "131",
+						KubeSystemNamespace:          "132",
+						KubeadmClusterConfigKey:      "133",
+						DefaultClusterDomain:         "134",
 					}))
 				})
 			})


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch adds support for propagating the Supervisor's DNS into guests via the Supervisor kube-system/kube-dns-lb service, which exposes the Supervisor DNS over an IP address visible to workload networks.

Please note this currently only works on the VPC Supervisor network topology. This is because only that topology creates the service kube-system/kube-dns-lb to surface the Supervisor's DNS to workload networks.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Support for Supervisor DNS in guests running on VPC networking.
```