### PR TITLE
📖 Fix doc about VM power state transitions

### DIFF
--- a/docs/concepts/workloads/vm.md
+++ b/docs/concepts/workloads/vm.md
@@ -801,13 +801,13 @@ Please note that there are supported power state transitions, and if a power sta
             <th style="text-align:center;"><code>PoweredOff</code></th>
             <td style="text-align:center;">✓</td>
             <td style="text-align:center;"><code>NA</code></td>
-            <td style="text-align:center;">✓<br /><em>if <code>spec.powerOffMode: Hard</code></em></td>
+            <td style="text-align:center;">❌</td>
             <td style="text-align:center;">❌</td>
         </tr>
         <tr>
             <th style="text-align:center;"><code>Suspended</code></th>
             <td style="text-align:center;">✓</td>
-            <td style="text-align:center;">❌</td>
+            <td style="text-align:center;">✓<br /><em>if <code>spec.powerOffMode: Hard</code></em></td>
             <td style="text-align:center;"><code>NA</code></td>
             <td style="text-align:center;">❌</td>
         </tr>


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

The doc on VM power state transitions indicated it was possible to suspend a powered off VM. That is incorrect and was transposed with hard powering off a suspended VM.



**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Fix documented VM power state transitions to correct poweredOff-->suspended transition.
```

<!-- readthedocs-preview vm-operator start -->
----
📚 Documentation preview 📚: https://vm-operator--993.org.readthedocs.build/en/993/

<!-- readthedocs-preview vm-operator end -->