### PR TITLE
✨ VirtualMachineGroup Power State Reconciliation

### DIFF
--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -32,6 +32,27 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /default-mutate-vmoperator-vmware-com-v1alpha4-virtualmachinegroup
+  failurePolicy: Fail
+  name: default.mutating.virtualmachinegroup.v1alpha4.vmoperator.vmware.com
+  rules:
+  - apiGroups:
+    - vmoperator.vmware.com
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - virtualmachinegroups
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /default-mutate-vmoperator-vmware-com-v1alpha4-virtualmachinereplicaset
   failurePolicy: Fail
   name: default.mutating.virtualmachinereplicaset.v1alpha4.vmoperator.vmware.com
@@ -114,6 +135,27 @@ webhooks:
     - UPDATE
     resources:
     - virtualmachineclasses
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /default-validate-vmoperator-vmware-com-v1alpha4-virtualmachinegroup
+  failurePolicy: Fail
+  name: default.validating.virtualmachinegroup.v1alpha4.vmoperator.vmware.com
+  rules:
+  - apiGroups:
+    - vmoperator.vmware.com
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - virtualmachinegroups
   sideEffects: None
 - admissionReviewVersions:
   - v1

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -113,4 +113,13 @@ const (
 	// resource. For example, when applied to a VM, deleting the VirtualMachine
 	// object in Kubernetes will not result in the deletion of the vSphere VM.
 	SkipDeletePlatformResourceKey string = "vmoperator.vmware.com.protected/skip-delete-platform-resource"
+
+	// LastUpdatedPowerStateTimeAnnotation is the annotation key for the last
+	// updated time of the power state.
+	LastUpdatedPowerStateTimeAnnotation = "vmoperator.vmware.com.protected/last-updated-power-state-time"
+
+	// ApplyPowerStateTimeAnnotation is the annotation key for the time to apply
+	// a power state change to a VirtualMachine or a VirtualMachineGroup object
+	// scheduled from its parent group.
+	ApplyPowerStateTimeAnnotation = "vmoperator.vmware.com.protected/apply-power-state-time"
 )

--- a/webhooks/virtualmachine/mutation/virtualmachine_mutator_suite_test.go
+++ b/webhooks/virtualmachine/mutation/virtualmachine_mutator_suite_test.go
@@ -21,6 +21,7 @@ var suite = builder.NewTestSuiteForMutatingWebhookWithContext(
 			BuildVersion: "v1",
 			Features: pkgcfg.FeatureStates{
 				BringYourOwnEncryptionKey: true,
+				VMGroups:                  true,
 			},
 			PodNamespace: "default",
 		}),

--- a/webhooks/virtualmachinegroup/mutation/virtualmachinegroup_mutator.go
+++ b/webhooks/virtualmachinegroup/mutation/virtualmachinegroup_mutator.go
@@ -1,0 +1,165 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package mutation
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"time"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	"github.com/vmware-tanzu/vm-operator/pkg/builder"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants"
+	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+)
+
+const (
+	webHookName = "default"
+)
+
+// +kubebuilder:webhook:path=/default-mutate-vmoperator-vmware-com-v1alpha4-virtualmachinegroup,mutating=true,failurePolicy=fail,groups=vmoperator.vmware.com,resources=virtualmachinegroups,verbs=create;update,versions=v1alpha4,name=default.mutating.virtualmachinegroup.v1alpha4.vmoperator.vmware.com,sideEffects=None,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachinegroups,verbs=get;list;update
+
+// AddToManager adds the webhook to the provided manager.
+func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) error {
+	hook, err := builder.NewMutatingWebhook(ctx, mgr, webHookName, NewMutator(mgr.GetClient()))
+	if err != nil {
+		return fmt.Errorf("failed to create mutation webhook: %w", err)
+	}
+	mgr.GetWebhookServer().Register(hook.Path, hook)
+
+	return nil
+}
+
+// NewMutator returns the package's Mutator.
+func NewMutator(client ctrlclient.Client) builder.Mutator {
+	return mutator{
+		client:    client,
+		converter: runtime.DefaultUnstructuredConverter,
+	}
+}
+
+type mutator struct {
+	client    ctrlclient.Client
+	converter runtime.UnstructuredConverter
+}
+
+func (m mutator) Mutate(ctx *pkgctx.WebhookRequestContext) admission.Response {
+	if ctx.Op == admissionv1.Delete {
+		return admission.Allowed("")
+	}
+
+	modified, err := m.vmGroupFromUnstructured(ctx.Obj)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	var wasMutated bool
+
+	switch ctx.Op {
+	case admissionv1.Create:
+		if ok := ProcessPowerState(ctx, modified, nil); ok {
+			wasMutated = true
+		}
+	case admissionv1.Update:
+		oldVMGroup, err := m.vmGroupFromUnstructured(ctx.OldObj)
+		if err != nil {
+			return admission.Errored(http.StatusInternalServerError, err)
+		}
+
+		if ok := ProcessPowerState(ctx, modified, oldVMGroup); ok {
+			wasMutated = true
+		}
+	}
+
+	if !wasMutated {
+		return admission.Allowed("")
+	}
+
+	rawModified, err := json.Marshal(modified)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	return admission.PatchResponseFromRaw(ctx.RawObj, rawModified)
+}
+
+func (m mutator) For() schema.GroupVersionKind {
+	return vmopv1.GroupVersion.WithKind(reflect.TypeOf(vmopv1.VirtualMachineGroup{}).Name())
+}
+
+func (m mutator) vmGroupFromUnstructured(obj runtime.Unstructured) (*vmopv1.VirtualMachineGroup, error) {
+	vmGroup := &vmopv1.VirtualMachineGroup{}
+	if err := m.converter.FromUnstructured(obj.UnstructuredContent(), vmGroup); err != nil {
+		return nil, err
+	}
+	return vmGroup, nil
+}
+
+// ProcessPowerState updates the last updated power state time annotation to the
+// current UTC time in RFC3339Nano format for the following cases:
+// 1. The group is created with non-empty power state.
+// 2. The power state has changed.
+// 3. The group members are updated with different order or delay.
+// It also removes the apply power state change time annotation if the group
+// is being updated directly (not inherited from a parent).
+func ProcessPowerState(
+	ctx *pkgctx.WebhookRequestContext,
+	vmGroup, oldVMGroup *vmopv1.VirtualMachineGroup) bool {
+	// If the old VMGroup is nil, this is a creation request.
+	if oldVMGroup == nil {
+		oldVMGroup = &vmopv1.VirtualMachineGroup{
+			Spec: vmopv1.VirtualMachineGroupSpec{
+				PowerState: "",
+				Members:    []vmopv1.GroupMember{},
+			},
+		}
+	}
+
+	var wasMutated bool
+
+	// Set the last updated power state time annotation.
+	if vmGroup.Spec.PowerState != oldVMGroup.Spec.PowerState ||
+		!reflect.DeepEqual(vmGroup.Spec.Members, oldVMGroup.Spec.Members) {
+		if vmGroup.Annotations == nil {
+			vmGroup.Annotations = make(map[string]string)
+		}
+		now := time.Now().UTC().Format(time.RFC3339Nano)
+		vmGroup.Annotations[constants.LastUpdatedPowerStateTimeAnnotation] = now
+		wasMutated = true
+	}
+
+	// Check if we should remove the apply-power-state time annotation.
+	var (
+		oldAnnoTime = oldVMGroup.Annotations[constants.ApplyPowerStateTimeAnnotation]
+		newAnnoTime = vmGroup.Annotations[constants.ApplyPowerStateTimeAnnotation]
+	)
+
+	if oldAnnoTime != newAnnoTime {
+		// VM Group is being updated from its parent group, no op.
+		return wasMutated
+	}
+
+	if oldVMGroup.Spec.PowerState != vmGroup.Spec.PowerState ||
+		!reflect.DeepEqual(vmGroup.Spec.Members, oldVMGroup.Spec.Members) {
+		// VM Group's power state is being updated directly, remove the stale
+		// annotation to apply the power state immediately.
+		if newAnnoTime != "" {
+			delete(vmGroup.Annotations, constants.ApplyPowerStateTimeAnnotation)
+			wasMutated = true
+		}
+	}
+
+	return wasMutated
+}

--- a/webhooks/virtualmachinegroup/mutation/virtualmachinegroup_mutator_intg_test.go
+++ b/webhooks/virtualmachinegroup/mutation/virtualmachinegroup_mutator_intg_test.go
@@ -1,0 +1,199 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package mutation_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+func intgTests() {
+	Describe(
+		"Mutate",
+		Label(
+			testlabels.Create,
+			testlabels.Update,
+			testlabels.Delete,
+			testlabels.EnvTest,
+			testlabels.API,
+			testlabels.Mutation,
+			testlabels.Webhook,
+		),
+		intgTestsMutating,
+	)
+}
+
+type intgMutatingWebhookContext struct {
+	builder.IntegrationTestContext
+	vmGroup *vmopv1.VirtualMachineGroup
+}
+
+func newIntgMutatingWebhookContext() *intgMutatingWebhookContext {
+	ctx := &intgMutatingWebhookContext{
+		IntegrationTestContext: *suite.NewIntegrationTestContext(),
+	}
+
+	ctx.vmGroup = &vmopv1.VirtualMachineGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dummy-vm-group",
+			Namespace: ctx.Namespace,
+		},
+	}
+
+	return ctx
+}
+
+func intgTestsMutating() {
+	var (
+		ctx *intgMutatingWebhookContext
+	)
+
+	BeforeEach(func() {
+		ctx = newIntgMutatingWebhookContext()
+	})
+
+	AfterEach(func() {
+		ctx = nil
+	})
+
+	Describe("mutate", func() {
+		Context("placeholder", func() {
+			AfterEach(func() {
+				Expect(ctx.Client.Delete(ctx, ctx.vmGroup)).To(Succeed())
+			})
+
+			It("should work", func() {
+				err := ctx.Client.Create(ctx, ctx.vmGroup)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+	})
+
+	Context("PowerState Mutation", func() {
+		AfterEach(func() {
+			if ctx.vmGroup.ResourceVersion != "" {
+				Expect(ctx.Client.Delete(ctx, ctx.vmGroup)).To(Succeed())
+			}
+		})
+
+		When("Creating VirtualMachineGroup with non-empty power state", func() {
+			BeforeEach(func() {
+				ctx.vmGroup.Spec.PowerState = vmopv1.VirtualMachinePowerStateOn
+			})
+
+			It("Should set last-updated-power-state annotation", func() {
+				Expect(ctx.Client.Create(ctx, ctx.vmGroup)).To(Succeed())
+
+				modified := &vmopv1.VirtualMachineGroup{}
+				Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(ctx.vmGroup), modified)).To(Succeed())
+				Expect(modified.Annotations).To(HaveKey(constants.LastUpdatedPowerStateTimeAnnotation))
+				timestamp := modified.Annotations[constants.LastUpdatedPowerStateTimeAnnotation]
+				_, err := time.Parse(time.RFC3339, timestamp)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		When("Updating VirtualMachineGroup with power state change", func() {
+			BeforeEach(func() {
+				ctx.vmGroup.Spec.PowerState = vmopv1.VirtualMachinePowerStateOff
+				Expect(ctx.Client.Create(ctx, ctx.vmGroup)).To(Succeed())
+			})
+
+			It("Should update last-updated-power-state annotation", func() {
+				modified := &vmopv1.VirtualMachineGroup{}
+				Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(ctx.vmGroup), modified)).To(Succeed())
+
+				// Record the original timestamp
+				originalTimestamp := modified.Annotations[constants.LastUpdatedPowerStateTimeAnnotation]
+				Expect(originalTimestamp).ToNot(BeEmpty())
+
+				// Change power state
+				modified.Spec.PowerState = vmopv1.VirtualMachinePowerStateOn
+				Expect(ctx.Client.Update(ctx, modified)).To(Succeed())
+
+				// Get the updated object
+				updated := &vmopv1.VirtualMachineGroup{}
+				Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(ctx.vmGroup), updated)).To(Succeed())
+
+				// Check that the annotation was updated
+				Expect(updated.Annotations).To(HaveKey(constants.LastUpdatedPowerStateTimeAnnotation))
+				newTimestamp := updated.Annotations[constants.LastUpdatedPowerStateTimeAnnotation]
+				Expect(newTimestamp).NotTo(Equal(originalTimestamp))
+				_, err := time.Parse(time.RFC3339Nano, newTimestamp)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		When("Updating VirtualMachineGroup with power state change and pre-existing apply power state change time annotation", func() {
+			BeforeEach(func() {
+				ctx.vmGroup.Spec.PowerState = vmopv1.VirtualMachinePowerStateOn
+				if ctx.vmGroup.Annotations == nil {
+					ctx.vmGroup.Annotations = make(map[string]string)
+				}
+				ctx.vmGroup.Annotations[constants.ApplyPowerStateTimeAnnotation] = time.Now().UTC().Format(time.RFC3339Nano)
+				Expect(ctx.Client.Create(ctx, ctx.vmGroup)).To(Succeed())
+			})
+
+			It("Should remove the apply power state change time annotation", func() {
+				modified := &vmopv1.VirtualMachineGroup{}
+				Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(ctx.vmGroup), modified)).To(Succeed())
+
+				// Verify all the expected annotations are present
+				Expect(modified.Annotations).To(HaveKey(constants.LastUpdatedPowerStateTimeAnnotation))
+				Expect(modified.Annotations).To(HaveKey(constants.ApplyPowerStateTimeAnnotation))
+
+				// Change power state
+				modified.Spec.PowerState = vmopv1.VirtualMachinePowerStateOff
+				Expect(ctx.Client.Update(ctx, modified)).To(Succeed())
+
+				// Get the updated object
+				updated := &vmopv1.VirtualMachineGroup{}
+				Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(ctx.vmGroup), updated)).To(Succeed())
+
+				// Verify the apply power state change time annotation is removed.
+				Expect(updated.Annotations).ToNot(HaveKey(constants.ApplyPowerStateTimeAnnotation))
+				Expect(updated.Annotations).To(HaveKey(constants.LastUpdatedPowerStateTimeAnnotation))
+			})
+		})
+
+		When("Updating VirtualMachineGroup without power state change", func() {
+			BeforeEach(func() {
+				ctx.vmGroup.Spec.PowerState = vmopv1.VirtualMachinePowerStateOn
+				Expect(ctx.Client.Create(ctx, ctx.vmGroup)).To(Succeed())
+			})
+
+			It("Should not update last-updated-power-state annotation", func() {
+				modified := &vmopv1.VirtualMachineGroup{}
+				Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(ctx.vmGroup), modified)).To(Succeed())
+
+				// Record the original timestamp
+				originalTimestamp := modified.Annotations[constants.LastUpdatedPowerStateTimeAnnotation]
+
+				// Update without changing power state
+				modified.Labels = map[string]string{"new-label": "value"}
+				Expect(ctx.Client.Update(ctx, modified)).To(Succeed())
+
+				// Get the updated object
+				updated := &vmopv1.VirtualMachineGroup{}
+				Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(ctx.vmGroup), updated)).To(Succeed())
+
+				// Check that the annotation was not updated
+				Expect(updated.Annotations).To(HaveKey(constants.LastUpdatedPowerStateTimeAnnotation))
+				newTimestamp := updated.Annotations[constants.LastUpdatedPowerStateTimeAnnotation]
+				Expect(newTimestamp).To(Equal(originalTimestamp))
+			})
+		})
+	})
+}

--- a/webhooks/virtualmachinegroup/mutation/virtualmachinegroup_mutator_suite_test.go
+++ b/webhooks/virtualmachinegroup/mutation/virtualmachinegroup_mutator_suite_test.go
@@ -1,0 +1,36 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package mutation_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachinegroup/mutation"
+)
+
+// suite is used for unit and integration testing this webhook.
+var suite = builder.NewTestSuiteForMutatingWebhookWithContext(
+	pkgcfg.WithConfig(
+		pkgcfg.Config{
+			Features: pkgcfg.FeatureStates{
+				VMGroups: true,
+			},
+		}),
+	mutation.AddToManager,
+	mutation.NewMutator,
+	"default.mutating.virtualmachinegroup.v1alpha4.vmoperator.vmware.com",
+)
+
+func TestWebhook(t *testing.T) {
+	suite.Register(t, "Mutating webhook suite", intgTests, uniTests)
+}
+
+var _ = BeforeSuite(suite.BeforeSuite)
+
+var _ = AfterSuite(suite.AfterSuite)

--- a/webhooks/virtualmachinegroup/mutation/virtualmachinegroup_mutator_unit_test.go
+++ b/webhooks/virtualmachinegroup/mutation/virtualmachinegroup_mutator_unit_test.go
@@ -1,0 +1,174 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package mutation_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachinegroup/mutation"
+)
+
+func uniTests() {
+	Describe(
+		"Mutate",
+		Label(
+			testlabels.Create,
+			testlabels.Update,
+			testlabels.Delete,
+			testlabels.API,
+			testlabels.Mutation,
+			testlabels.Webhook,
+		),
+		unitTestsMutating,
+	)
+}
+
+type unitMutationWebhookContext struct {
+	builder.UnitTestContextForMutatingWebhook
+	vmGroup *vmopv1.VirtualMachineGroup
+}
+
+func newUnitTestContextForMutatingWebhook() *unitMutationWebhookContext {
+	vmGroup := &vmopv1.VirtualMachineGroup{}
+	obj, err := builder.ToUnstructured(vmGroup)
+	Expect(err).ToNot(HaveOccurred())
+
+	return &unitMutationWebhookContext{
+		UnitTestContextForMutatingWebhook: *suite.NewUnitTestContextForMutatingWebhook(obj),
+		vmGroup:                           vmGroup,
+	}
+}
+
+func unitTestsMutating() {
+	var (
+		ctx *unitMutationWebhookContext
+	)
+
+	BeforeEach(func() {
+		ctx = newUnitTestContextForMutatingWebhook()
+	})
+
+	Describe("VirtualMachineGroupMutator should admit updates when object is under deletion", func() {
+		Context("when update request comes in while deletion in progress ", func() {
+			It("should admit update operation", func() {
+				t := metav1.Now()
+				ctx.WebhookRequestContext.Obj.SetDeletionTimestamp(&t)
+				response := ctx.Mutate(&ctx.WebhookRequestContext)
+				Expect(response.Allowed).To(BeTrue())
+			})
+		})
+	})
+
+	Describe("ProcessPowerState", func() {
+		Context("Creation", func() {
+			When("PowerState is set", func() {
+				It("Should add the last-updated-power-state annotation", func() {
+					ctx.vmGroup.Spec.PowerState = vmopv1.VirtualMachinePowerStateOn
+
+					result := mutation.ProcessPowerState(&ctx.WebhookRequestContext, ctx.vmGroup, nil)
+					Expect(result).To(BeTrue())
+					Expect(ctx.vmGroup.Annotations).To(HaveKey(constants.LastUpdatedPowerStateTimeAnnotation))
+					timestamp := ctx.vmGroup.Annotations[constants.LastUpdatedPowerStateTimeAnnotation]
+					_, err := time.Parse(time.RFC3339, timestamp)
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+
+			When("PowerState is not set and no members are present", func() {
+				It("Should not add the last-updated-power-state annotation", func() {
+					ctx.vmGroup.Spec.Members = []vmopv1.GroupMember{}
+					result := mutation.ProcessPowerState(&ctx.WebhookRequestContext, ctx.vmGroup, nil)
+					Expect(result).To(BeFalse())
+				})
+			})
+		})
+
+		Context("Update", func() {
+			When("PowerState changes", func() {
+				It("Should add the last-updated-power-state annotation", func() {
+					oldVMGroup := ctx.vmGroup.DeepCopy()
+					oldVMGroup.Spec.PowerState = vmopv1.VirtualMachinePowerStateOff
+					ctx.vmGroup.Spec.PowerState = vmopv1.VirtualMachinePowerStateOn
+
+					result := mutation.ProcessPowerState(&ctx.WebhookRequestContext, ctx.vmGroup, oldVMGroup)
+					Expect(result).To(BeTrue())
+					Expect(ctx.vmGroup.Annotations).To(HaveKey(constants.LastUpdatedPowerStateTimeAnnotation))
+					timestamp := ctx.vmGroup.Annotations[constants.LastUpdatedPowerStateTimeAnnotation]
+					_, err := time.Parse(time.RFC3339Nano, timestamp)
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+
+			When("PowerState is not changed but members are updated", func() {
+				It("Should add the last-updated-power-state annotation", func() {
+					oldVMGroup := ctx.vmGroup.DeepCopy()
+					oldVMGroup.Spec.Members = []vmopv1.GroupMember{}
+					ctx.vmGroup.Spec.Members = []vmopv1.GroupMember{
+						{
+							Kind: "VirtualMachine",
+							Name: "vm1",
+						},
+					}
+
+					result := mutation.ProcessPowerState(&ctx.WebhookRequestContext, ctx.vmGroup, oldVMGroup)
+					Expect(result).To(BeTrue())
+					Expect(ctx.vmGroup.Annotations).To(HaveKey(constants.LastUpdatedPowerStateTimeAnnotation))
+					timestamp := ctx.vmGroup.Annotations[constants.LastUpdatedPowerStateTimeAnnotation]
+					_, err := time.Parse(time.RFC3339Nano, timestamp)
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+
+			When("PowerState changes with a pre-existing apply-power-state time annotation", func() {
+				It("Should remove the apply-power-state time annotation", func() {
+					oldVMGroup := ctx.vmGroup.DeepCopy()
+					oldVMGroup.Spec.PowerState = vmopv1.VirtualMachinePowerStateOn
+					if oldVMGroup.Annotations == nil {
+						oldVMGroup.Annotations = make(map[string]string)
+					}
+					oldVMGroup.Annotations[constants.ApplyPowerStateTimeAnnotation] = time.Now().UTC().Format(time.RFC3339Nano)
+					ctx.vmGroup.Spec.PowerState = vmopv1.VirtualMachinePowerStateOff
+
+					result := mutation.ProcessPowerState(&ctx.WebhookRequestContext, ctx.vmGroup, oldVMGroup)
+					Expect(result).To(BeTrue())
+					Expect(ctx.vmGroup.Annotations).ToNot(HaveKey(constants.ApplyPowerStateTimeAnnotation))
+				})
+			})
+
+			When("Neither PowerState nor members change", func() {
+				It("Should not modify annotations", func() {
+					oldVMGroup := ctx.vmGroup.DeepCopy()
+					oldVMGroup.Spec.PowerState = vmopv1.VirtualMachinePowerStateOn
+					oldVMGroup.Spec.Members = []vmopv1.GroupMember{
+						{
+							Kind: "VirtualMachine",
+							Name: "vm1",
+						},
+					}
+					ctx.vmGroup.Spec.PowerState = vmopv1.VirtualMachinePowerStateOn
+					ctx.vmGroup.Spec.Members = []vmopv1.GroupMember{
+						{
+							Kind: "VirtualMachine",
+							Name: "vm1",
+						},
+					}
+
+					result := mutation.ProcessPowerState(&ctx.WebhookRequestContext, ctx.vmGroup, oldVMGroup)
+					Expect(result).To(BeFalse())
+					Expect(ctx.vmGroup.Annotations).To(Equal(oldVMGroup.Annotations))
+				})
+			})
+		})
+	})
+}

--- a/webhooks/virtualmachinegroup/validation/virtualmachinegroup_validator.go
+++ b/webhooks/virtualmachinegroup/validation/virtualmachinegroup_validator.go
@@ -1,0 +1,163 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package validation
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	"github.com/vmware-tanzu/vm-operator/pkg/builder"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants"
+	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/webhooks/common"
+)
+
+const (
+	webHookName                           = "default"
+	modifyAnnotationNotAllowedForNonAdmin = "modifying this annotation is not allowed for non-admin users"
+	emptyPowerStateNotAllowedAfterSet     = "cannot set powerState to empty once it's been set"
+	invalidTimeFormat                     = "time must be in RFC3339Nano format"
+)
+
+// +kubebuilder:webhook:verbs=create;update,path=/default-validate-vmoperator-vmware-com-v1alpha4-virtualmachinegroup,mutating=false,failurePolicy=fail,groups=vmoperator.vmware.com,resources=virtualmachinegroups,versions=v1alpha4,name=default.validating.virtualmachinegroup.v1alpha4.vmoperator.vmware.com,sideEffects=None,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachinegroups,verbs=get;list
+
+// AddToManager adds the webhook to the provided manager.
+func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) error {
+	hook, err := builder.NewValidatingWebhook(ctx, mgr, webHookName, NewValidator(mgr.GetClient()))
+	if err != nil {
+		return fmt.Errorf("failed to create VirtualMachineGroup validation webhook: %w", err)
+	}
+	mgr.GetWebhookServer().Register(hook.Path, hook)
+
+	return nil
+}
+
+// NewValidator returns the package's Validator.
+func NewValidator(client client.Client) builder.Validator {
+	return validator{
+		client:    client,
+		converter: runtime.DefaultUnstructuredConverter,
+	}
+}
+
+type validator struct {
+	client    client.Client
+	converter runtime.UnstructuredConverter
+}
+
+// vmGroupFromUnstructured returns the VirtualMachineGroup from the unstructured object.
+func (v validator) vmGroupFromUnstructured(obj runtime.Unstructured) (*vmopv1.VirtualMachineGroup, error) {
+	vmGroup := &vmopv1.VirtualMachineGroup{}
+	if err := v.converter.FromUnstructured(obj.UnstructuredContent(), vmGroup); err != nil {
+		return nil, err
+	}
+	return vmGroup, nil
+}
+
+func (v validator) For() schema.GroupVersionKind {
+	return vmopv1.GroupVersion.WithKind(reflect.TypeOf(vmopv1.VirtualMachineGroup{}).Name())
+}
+
+func (v validator) ValidateCreate(ctx *pkgctx.WebhookRequestContext) admission.Response {
+	vmGroup, err := v.vmGroupFromUnstructured(ctx.Obj)
+	if err != nil {
+		return webhook.Errored(http.StatusBadRequest, err)
+	}
+
+	var fieldErrs field.ErrorList
+
+	fieldErrs = append(fieldErrs, v.validateAnnotation(ctx, vmGroup, nil)...)
+
+	validationErrs := make([]string, 0, len(fieldErrs))
+	for _, fieldErr := range fieldErrs {
+		validationErrs = append(validationErrs, fieldErr.Error())
+	}
+
+	return common.BuildValidationResponse(ctx, nil, validationErrs, nil)
+}
+
+func (v validator) ValidateDelete(*pkgctx.WebhookRequestContext) admission.Response {
+	return admission.Allowed("")
+}
+
+func (v validator) ValidateUpdate(ctx *pkgctx.WebhookRequestContext) admission.Response {
+	vmGroup, err := v.vmGroupFromUnstructured(ctx.Obj)
+	if err != nil {
+		return webhook.Errored(http.StatusBadRequest, err)
+	}
+
+	oldVMGroup, err := v.vmGroupFromUnstructured(ctx.OldObj)
+	if err != nil {
+		return webhook.Errored(http.StatusBadRequest, err)
+	}
+
+	var fieldErrs field.ErrorList
+
+	fieldErrs = append(fieldErrs, v.validateAnnotation(ctx, vmGroup, oldVMGroup)...)
+	fieldErrs = append(fieldErrs, v.validatePowerState(ctx, vmGroup, oldVMGroup)...)
+	validationErrs := make([]string, 0, len(fieldErrs))
+	for _, fieldErr := range fieldErrs {
+		validationErrs = append(validationErrs, fieldErr.Error())
+	}
+
+	return common.BuildValidationResponse(ctx, nil, validationErrs, nil)
+}
+
+func (v validator) validateAnnotation(ctx *pkgctx.WebhookRequestContext, vmGroup, oldVMGroup *vmopv1.VirtualMachineGroup) field.ErrorList {
+	var allErrs field.ErrorList
+
+	// Use an empty VMGroup to validate annotation on creation requests.
+	if oldVMGroup == nil {
+		oldVMGroup = &vmopv1.VirtualMachineGroup{}
+	}
+
+	annotationPath := field.NewPath("metadata", "annotations")
+
+	// Disallow if last-updated-power-state annotation was modified by a non-admin user.
+	oldVal := oldVMGroup.Annotations[constants.LastUpdatedPowerStateTimeAnnotation]
+	newVal := vmGroup.Annotations[constants.LastUpdatedPowerStateTimeAnnotation]
+	if !ctx.IsPrivilegedAccount && oldVal != newVal {
+		allErrs = append(allErrs, field.Forbidden(
+			annotationPath.Key(constants.LastUpdatedPowerStateTimeAnnotation),
+			modifyAnnotationNotAllowedForNonAdmin))
+	}
+
+	// Disallow if the last-updated-power-state annotation value is not in RFC3339Nano format.
+	if newVal != "" {
+		if _, err := time.Parse(time.RFC3339Nano, newVal); err != nil {
+			allErrs = append(allErrs, field.Invalid(
+				annotationPath.Key(constants.LastUpdatedPowerStateTimeAnnotation),
+				newVal,
+				invalidTimeFormat))
+		}
+	}
+
+	return allErrs
+}
+
+func (v validator) validatePowerState(_ *pkgctx.WebhookRequestContext, vmGroup, oldVMGroup *vmopv1.VirtualMachineGroup) field.ErrorList {
+	var allErrs field.ErrorList
+
+	powerStatePath := field.NewPath("spec", "powerState")
+
+	// Disallow setting powerState to empty after it's been set.
+	if oldVMGroup.Spec.PowerState != "" && vmGroup.Spec.PowerState == "" {
+		allErrs = append(allErrs, field.Forbidden(powerStatePath, emptyPowerStateNotAllowedAfterSet))
+	}
+
+	return allErrs
+}

--- a/webhooks/virtualmachinegroup/validation/virtualmachinegroup_validator_intg_test.go
+++ b/webhooks/virtualmachinegroup/validation/virtualmachinegroup_validator_intg_test.go
@@ -1,0 +1,236 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package validation_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+const (
+	dummyNamespaceName                       = "dummy-namespace"
+	invalidTime                              = "invalid-time"
+	invalidTimeFormatMsg                     = "time must be in RFC3339Nano format"
+	modifyAnnotationNotAllowedForNonAdminMsg = "modifying this annotation is not allowed for non-admin users"
+	emptyPowerStateNotAllowedAfterSetMsg     = "cannot set powerState to empty once it's been set"
+)
+
+func intgTests() {
+	Describe(
+		"Create",
+		Label(
+			testlabels.Create,
+			testlabels.EnvTest,
+			testlabels.API,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		intgTestsValidateCreate,
+	)
+	Describe(
+		"Update",
+		Label(
+			testlabels.Update,
+			testlabels.EnvTest,
+			testlabels.API,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		intgTestsValidateUpdate,
+	)
+	Describe(
+		"Delete",
+		Label(
+			testlabels.Delete,
+			testlabels.EnvTest,
+			testlabels.API,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		intgTestsValidateDelete,
+	)
+}
+
+type intgValidatingWebhookContext struct {
+	builder.IntegrationTestContext
+	vmGroup *vmopv1.VirtualMachineGroup
+}
+
+func newIntgValidatingWebhookContext() *intgValidatingWebhookContext {
+	ctx := &intgValidatingWebhookContext{
+		IntegrationTestContext: *suite.NewIntegrationTestContext(),
+	}
+
+	ctx.vmGroup = &vmopv1.VirtualMachineGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "vmgroup-",
+			Namespace:    ctx.Namespace,
+		},
+		Spec: vmopv1.VirtualMachineGroupSpec{
+			Members: []vmopv1.GroupMember{
+				{
+					Kind: "VirtualMachine",
+					Name: "vm-1",
+				},
+				{
+					Kind: "VirtualMachine",
+					Name: "vm-2",
+				},
+				{
+					Kind: "VirtualMachineGroup",
+					Name: "vmgroup-1",
+				},
+			},
+		},
+	}
+
+	return ctx
+}
+
+func intgTestsValidateCreate() {
+	var (
+		ctx *intgValidatingWebhookContext
+	)
+
+	type createArgs struct {
+		invalidTimeFormat bool
+	}
+
+	validateCreate := func(args createArgs, expectedAllowed bool, expectedReason string) {
+		if ctx.vmGroup.Annotations == nil {
+			ctx.vmGroup.Annotations = make(map[string]string)
+		}
+		if args.invalidTimeFormat {
+			ctx.vmGroup.Annotations[constants.LastUpdatedPowerStateTimeAnnotation] = invalidTime
+		} else {
+			ctx.vmGroup.Annotations[constants.LastUpdatedPowerStateTimeAnnotation] = time.Now().Format(time.RFC3339Nano)
+		}
+
+		err := ctx.Client.Create(ctx, ctx.vmGroup)
+		if expectedAllowed {
+			Expect(err).ToNot(HaveOccurred())
+		} else {
+			Expect(err).To(HaveOccurred())
+			if expectedReason != "" {
+				Expect(err.Error()).To(ContainSubstring(expectedReason))
+			}
+		}
+	}
+
+	BeforeEach(func() {
+		ctx = newIntgValidatingWebhookContext()
+	})
+
+	AfterEach(func() {
+		ctx.AfterEach()
+		ctx = nil
+	})
+
+	DescribeTable("create table", validateCreate,
+		Entry("should work", createArgs{}, true, ""),
+		Entry("should not work with invalid last-updated-power-state annotation",
+			createArgs{invalidTimeFormat: true}, false, invalidTimeFormatMsg),
+	)
+}
+
+func intgTestsValidateUpdate() {
+	var (
+		ctx *intgValidatingWebhookContext
+		err error
+	)
+
+	BeforeEach(func() {
+		ctx = newIntgValidatingWebhookContext()
+		Expect(ctx.Client.Create(ctx, ctx.vmGroup)).To(Succeed())
+	})
+
+	JustBeforeEach(func() {
+		err = ctx.Client.Update(suite, ctx.vmGroup)
+	})
+
+	AfterEach(func() {
+		ctx.AfterEach()
+		ctx = nil
+	})
+
+	When("update is performed with empty power state after it's been set", func() {
+		BeforeEach(func() {
+			// First set a power state
+			ctx.vmGroup.Spec.PowerState = vmopv1.VirtualMachinePowerStateOn
+			Expect(ctx.Client.Update(suite, ctx.vmGroup)).To(Succeed())
+
+			// Then try to set it to empty
+			ctx.vmGroup.Spec.PowerState = ""
+		})
+
+		It("should deny the request", func() {
+			Expect(err).To(HaveOccurred())
+			expectedPath := field.NewPath("spec", "powerState")
+			Expect(err.Error()).To(ContainSubstring(expectedPath.String()))
+			Expect(err.Error()).To(ContainSubstring(emptyPowerStateNotAllowedAfterSetMsg))
+		})
+	})
+
+	When("update is performed with invalid time format in last-updated-power-state annotation", func() {
+		BeforeEach(func() {
+			if ctx.vmGroup.Annotations == nil {
+				ctx.vmGroup.Annotations = make(map[string]string)
+			}
+			ctx.vmGroup.Annotations[constants.LastUpdatedPowerStateTimeAnnotation] = invalidTime
+		})
+
+		It("should deny the request", func() {
+			Expect(err).To(HaveOccurred())
+			expectedPath := field.NewPath("metadata", "annotations").Key(constants.LastUpdatedPowerStateTimeAnnotation)
+			Expect(err.Error()).To(ContainSubstring(expectedPath.String()))
+			Expect(err.Error()).To(ContainSubstring(invalidTimeFormatMsg))
+		})
+	})
+
+	When("update is performed with valid time format in last-updated-power-state annotation", func() {
+		BeforeEach(func() {
+			// This would be rejected for non-admin users in a real environment,
+			// but the integration test context doesn't fully simulate user permissions
+			if ctx.vmGroup.Annotations == nil {
+				ctx.vmGroup.Annotations = make(map[string]string)
+			}
+			ctx.vmGroup.Annotations[constants.LastUpdatedPowerStateTimeAnnotation] = time.Now().Format(time.RFC3339Nano)
+		})
+
+		It("should allow the request", func() {
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+}
+
+func intgTestsValidateDelete() {
+	var (
+		ctx *intgValidatingWebhookContext
+	)
+
+	BeforeEach(func() {
+		ctx = newIntgValidatingWebhookContext()
+		Expect(ctx.Client.Create(ctx, ctx.vmGroup)).To(Succeed())
+	})
+
+	It("should allow delete", func() {
+		Expect(ctx.Client.Delete(ctx, ctx.vmGroup)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		ctx.AfterEach()
+		ctx = nil
+	})
+}

--- a/webhooks/virtualmachinegroup/validation/virtualmachinegroup_validator_suite_test.go
+++ b/webhooks/virtualmachinegroup/validation/virtualmachinegroup_validator_suite_test.go
@@ -1,0 +1,35 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package validation_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachinegroup/validation"
+)
+
+// suite is used for unit and integration testing this webhook.
+var suite = builder.NewTestSuiteForValidatingWebhookWithContext(
+	pkgcfg.WithConfig(
+		pkgcfg.Config{
+			Features: pkgcfg.FeatureStates{
+				VMGroups: true,
+			},
+		}),
+	validation.AddToManager,
+	validation.NewValidator,
+	"default.validating.virtualmachinegroup.v1alpha4.vmoperator.vmware.com")
+
+func TestWebhook(t *testing.T) {
+	suite.Register(t, "Validation webhook suite", intgTests, unitTests)
+}
+
+var _ = BeforeSuite(suite.BeforeSuite)
+
+var _ = AfterSuite(suite.AfterSuite)

--- a/webhooks/virtualmachinegroup/validation/virtualmachinegroup_validator_unit_test.go
+++ b/webhooks/virtualmachinegroup/validation/virtualmachinegroup_validator_unit_test.go
@@ -1,0 +1,243 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package validation_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+func unitTests() {
+	Describe(
+		"Create",
+		Label(
+			testlabels.Create,
+			testlabels.API,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		unitTestsValidateCreate,
+	)
+	Describe(
+		"Update",
+		Label(
+			testlabels.Update,
+			testlabels.API,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		unitTestsValidateUpdate,
+	)
+	Describe(
+		"Delete",
+		Label(
+			testlabels.Delete,
+			testlabels.API,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		unitTestsValidateDelete,
+	)
+}
+
+type unitValidatingWebhookContext struct {
+	builder.UnitTestContextForValidatingWebhook
+	vmGroup, oldVMGroup *vmopv1.VirtualMachineGroup
+}
+
+func newUnitTestContextForValidatingWebhook(isUpdate bool) *unitValidatingWebhookContext {
+	vmGroup := &vmopv1.VirtualMachineGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dummy-vmgroup",
+			Namespace: dummyNamespaceName,
+		},
+		Spec: vmopv1.VirtualMachineGroupSpec{
+			Members: []vmopv1.GroupMember{
+				{
+					Kind: "VirtualMachine",
+					Name: "vm-1",
+				},
+				{
+					Kind: "VirtualMachine",
+					Name: "vm-2",
+				},
+				{
+					Kind: "VirtualMachineGroup",
+					Name: "vmgroup-1",
+				},
+			},
+		},
+	}
+
+	obj, err := builder.ToUnstructured(vmGroup)
+	Expect(err).ToNot(HaveOccurred())
+
+	var oldVMGroup *vmopv1.VirtualMachineGroup
+	var oldObj *unstructured.Unstructured
+
+	if isUpdate {
+		oldVMGroup = vmGroup.DeepCopy()
+		oldObj, err = builder.ToUnstructured(oldVMGroup)
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	initObjects := []client.Object{}
+
+	return &unitValidatingWebhookContext{
+		UnitTestContextForValidatingWebhook: *suite.NewUnitTestContextForValidatingWebhook(obj, oldObj, initObjects...),
+		vmGroup:                             vmGroup,
+		oldVMGroup:                          oldVMGroup,
+	}
+}
+
+func unitTestsValidateCreate() {
+	var (
+		ctx *unitValidatingWebhookContext
+	)
+
+	type createArgs struct {
+		isServiceUser         bool
+		powerState            vmopv1.VirtualMachinePowerState
+		lastUpdatedPowerState string
+	}
+
+	validateCreate := func(args createArgs, expectedAllowed bool, expectedReason string) {
+		ctx = newUnitTestContextForValidatingWebhook(false)
+
+		if args.isServiceUser {
+			ctx.IsPrivilegedAccount = true
+		}
+
+		ctx.vmGroup.Spec.PowerState = args.powerState
+
+		if args.lastUpdatedPowerState != "" {
+			if ctx.vmGroup.Annotations == nil {
+				ctx.vmGroup.Annotations = make(map[string]string)
+			}
+			ctx.vmGroup.Annotations[constants.LastUpdatedPowerStateTimeAnnotation] = args.lastUpdatedPowerState
+		}
+
+		var err error
+		ctx.WebhookRequestContext.Obj, err = builder.ToUnstructured(ctx.vmGroup)
+		Expect(err).ToNot(HaveOccurred())
+
+		response := ctx.ValidateCreate(&ctx.WebhookRequestContext)
+		Expect(response.Allowed).To(Equal(expectedAllowed))
+		if !expectedAllowed && expectedReason != "" {
+			Expect(string(response.Result.Reason)).To(ContainSubstring(expectedReason))
+		}
+	}
+
+	DescribeTable("create table", validateCreate,
+		Entry("should work with no power state", createArgs{}, true, ""),
+		Entry("should work with power state on", createArgs{powerState: vmopv1.VirtualMachinePowerStateOn}, true, ""),
+		Entry("should work with power state off", createArgs{powerState: vmopv1.VirtualMachinePowerStateOff}, true, ""),
+		Entry("should not work with invalid time format in last-updated-power-state annotation",
+			createArgs{isServiceUser: true, lastUpdatedPowerState: invalidTime}, false, invalidTimeFormatMsg),
+		Entry("should work with valid time format in last-updated-power-state annotation",
+			createArgs{isServiceUser: true, lastUpdatedPowerState: time.Now().Format(time.RFC3339Nano)}, true, ""),
+		Entry("should not work with non-admin modifying last-updated-power-state annotation",
+			createArgs{isServiceUser: false, lastUpdatedPowerState: time.Now().Format(time.RFC3339Nano)}, false, modifyAnnotationNotAllowedForNonAdminMsg),
+	)
+}
+
+func unitTestsValidateUpdate() {
+	var (
+		ctx *unitValidatingWebhookContext
+	)
+
+	type updateArgs struct {
+		isServiceUser                bool
+		oldPowerState                vmopv1.VirtualMachinePowerState
+		newPowerState                vmopv1.VirtualMachinePowerState
+		modifyLastUpdatedPowerState  bool
+		invalidLastUpdatedPowerState bool
+	}
+
+	validateUpdate := func(args updateArgs, expectedAllowed bool, expectedReason string) {
+		ctx = newUnitTestContextForValidatingWebhook(true)
+
+		if args.isServiceUser {
+			ctx.IsPrivilegedAccount = true
+		}
+
+		// Setup old VMGroup
+		ctx.oldVMGroup.Spec.PowerState = args.oldPowerState
+
+		// Setup new VMGroup
+		ctx.vmGroup.Spec.PowerState = args.newPowerState
+
+		if args.modifyLastUpdatedPowerState {
+			if ctx.vmGroup.Annotations == nil {
+				ctx.vmGroup.Annotations = make(map[string]string)
+			}
+			if ctx.oldVMGroup.Annotations == nil {
+				ctx.oldVMGroup.Annotations = make(map[string]string)
+			}
+
+			ctx.oldVMGroup.Annotations[constants.LastUpdatedPowerStateTimeAnnotation] = "2023-01-01T00:00:00Z"
+
+			if args.invalidLastUpdatedPowerState {
+				ctx.vmGroup.Annotations[constants.LastUpdatedPowerStateTimeAnnotation] = invalidTime
+			} else {
+				ctx.vmGroup.Annotations[constants.LastUpdatedPowerStateTimeAnnotation] = time.Now().Format(time.RFC3339Nano)
+			}
+		}
+
+		var err error
+		ctx.WebhookRequestContext.Obj, err = builder.ToUnstructured(ctx.vmGroup)
+		Expect(err).ToNot(HaveOccurred())
+
+		ctx.WebhookRequestContext.OldObj, err = builder.ToUnstructured(ctx.oldVMGroup)
+		Expect(err).ToNot(HaveOccurred())
+
+		response := ctx.ValidateUpdate(&ctx.WebhookRequestContext)
+		Expect(response.Allowed).To(Equal(expectedAllowed))
+		if !expectedAllowed && expectedReason != "" {
+			Expect(string(response.Result.Reason)).To(ContainSubstring(expectedReason))
+		}
+	}
+
+	DescribeTable("update table", validateUpdate,
+		Entry("should work with no power state change",
+			updateArgs{oldPowerState: vmopv1.VirtualMachinePowerStateOn, newPowerState: vmopv1.VirtualMachinePowerStateOn}, true, ""),
+		Entry("should work with power state change",
+			updateArgs{oldPowerState: vmopv1.VirtualMachinePowerStateOn, newPowerState: vmopv1.VirtualMachinePowerStateOff}, true, ""),
+		Entry("should not work with empty power state after it's been set",
+			updateArgs{oldPowerState: vmopv1.VirtualMachinePowerStateOn, newPowerState: ""}, false, emptyPowerStateNotAllowedAfterSetMsg),
+		Entry("should not work with non-admin modifying last-updated-power-state annotation",
+			updateArgs{modifyLastUpdatedPowerState: true, isServiceUser: false}, false, modifyAnnotationNotAllowedForNonAdminMsg),
+		Entry("should work with admin modifying last-updated-power-state annotation",
+			updateArgs{modifyLastUpdatedPowerState: true, isServiceUser: true}, true, ""),
+		Entry("should not work with invalid time format in last-updated-power-state annotation",
+			updateArgs{modifyLastUpdatedPowerState: true, isServiceUser: true, invalidLastUpdatedPowerState: true}, false, invalidTimeFormatMsg),
+	)
+}
+
+func unitTestsValidateDelete() {
+	var (
+		ctx *unitValidatingWebhookContext
+	)
+
+	BeforeEach(func() {
+		ctx = newUnitTestContextForValidatingWebhook(false)
+	})
+
+	It("should allow delete", func() {
+		response := ctx.ValidateDelete(&ctx.WebhookRequestContext)
+		Expect(response.Allowed).To(BeTrue())
+	})
+}

--- a/webhooks/virtualmachinegroup/webhooks.go
+++ b/webhooks/virtualmachinegroup/webhooks.go
@@ -1,0 +1,28 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package virtualmachinegroup
+
+import (
+	"fmt"
+
+	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
+
+	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachinegroup/mutation"
+	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachinegroup/validation"
+)
+
+// AddToManager adds the webhook to the provided manager.
+func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) error {
+	if err := mutation.AddToManager(ctx, mgr); err != nil {
+		return fmt.Errorf("failed to initialize mutation webhook: %w", err)
+	}
+
+	if err := validation.AddToManager(ctx, mgr); err != nil {
+		return fmt.Errorf("failed to initialize validation webhook: %w", err)
+	}
+
+	return nil
+}

--- a/webhooks/webhooks.go
+++ b/webhooks/webhooks.go
@@ -16,6 +16,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/webhooks/unifiedstoragequota"
 	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachine"
 	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachineclass"
+	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachinegroup"
 	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachinepublishrequest"
 	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachinereplicaset"
 	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachineservice"
@@ -58,6 +59,12 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) err
 
 	if err := unifiedstoragequota.AddToManager(ctx, mgr); err != nil {
 		return fmt.Errorf("failed to initialize UnifiedStorageQuota webhooks: %w", err)
+	}
+
+	if pkgcfg.FromContext(ctx).Features.VMGroups {
+		if err := virtualmachinegroup.AddToManager(ctx, mgr); err != nil {
+			return fmt.Errorf("failed to initialize VirtualMachineGroup webhooks: %w", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR updates the VM Group's controller to reconcile changes to `Spec.PowerState`, applying each member's `powerOnDelay` in order. It also adds mutation and validation webhooks for required operations.

In a nutshell, given the following VM Group YAML example:

```yaml
apiVersion: vmoperator.vmware.com/v1alpha4
kind: VirtualMachineGroup
metadata:
  name: vmgroup-1
  namespace: default
spec:
  powerState: PoweredOn
  members:   
  - kind: VirtualMachine      
    name: vm1
    powerOnDelay: 1s
  - kind: VirtualMachineGroup 
    name: vmgroup-2
    powerOnDelay: 2s
  - kind: VirtualMachineGroup 
    name: vmgroup-3
    powerOnDelay: 3s
```

The power on sequence will be:
- Power on `vm1` after 1s
- Power on all VMs in `vmgroup-2` after 3s (1s + 2s)
- Power on all VMs in `vmgroup-3` after 6s (1s + 2s + 3s)


**Which issue(s) is/are addressed by this PR?**

Fixes N/A.

**Are there any special notes for your reviewer**:

Controller tests are not included in this PR, as there is an upcoming API change that will modify the structure of VM Group members. A follow-up PR will address that change and complete the remaining test TODOs.


**Please add a release note if necessary**:

```release-note
Initial VirtualMachineGroup Power State Reconciliation.
```

<!-- readthedocs-preview vm-operator start -->
----
📚 Documentation preview 📚: https://vm-operator--995.org.readthedocs.build/en/995/

<!-- readthedocs-preview vm-operator end -->