### PR TITLE
🌱 Verify unfocus

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,29 @@ jobs:
     - name: Verify codegen
       run: make verify-codegen
 
+  verify-unfocus:
+    needs:
+    - verify-go-modules
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+    - name: Install node
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'npm'
+        cache-dependency-path: 'hack/quicktype/package-lock.json'
+    - name: Install Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ env.GO_VERSION }}
+        go-version-file: 'go.mod'
+        cache: true
+        cache-dependency-path: '**/go.sum'
+    - name: Verify unfocus
+      run: make verify-unfocus
+
   verify-manifests:
     needs:
     - verify-go-modules

--- a/Makefile
+++ b/Makefile
@@ -315,6 +315,10 @@ lint-shell: ## Lint the project's shell scripts
 fix: GOLANGCI_LINT_FLAGS = --fast=false --fix
 fix: lint-go ## Tries to fix errors reported by lint-go-full target
 
+.PHONY: unfocus
+unfocus: | $(GINKGO) ## Unfocuses all tests
+	$(GINKGO) unfocus .
+
 ## --------------------------------------
 ## Generate
 ## --------------------------------------
@@ -839,6 +843,10 @@ verify: prereqs ## Run static code analysis
 .PHONY: verify-codegen
 verify-codegen: ## Verify generated code
 	hack/verify-codegen.sh
+
+.PHONY: verify-unfocus
+verify-unfocus: ## Verify no tests have focus
+	hack/verify-unfocus.sh
 
 .PHONY: verify-local-manifests
 verify-local-manifests: ## Verify the local manifests

--- a/hack/verify-unfocus.sh
+++ b/hack/verify-unfocus.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# Check if any tests have a focus.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Change directories to the parent directory of the one in which this
+# script is located.
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+
+make unfocus || exit_code="${?}"
+if [ "${exit_code:-0}" -ne 0 ]; then
+
+  # Please note the following heredoc uses leading tabs to allow
+  # the contents to be indented with the if/fi statement. For
+  # more information on indenting heredocs, please see the section
+  # entitled "Mutli-line message, with tabs suppressed" from The
+  # Linux Documentation Project (TLDP) at
+  # https://tldp.org/LDP/abs/html/here-docs.html.
+  cat <<-EOF
+	Please investigate why the target is failing by running the
+	following command locally from the root of the project:
+
+	    make unfocus
+
+	Thank you!
+	EOF
+
+  exit "${exit_code}"
+fi
+
+if git diff --exit-code './**/*_test.go'; then
+  printf '\nCongratulations! No tests have a focus!\n'
+else
+  exit_code="${?}"
+
+  # Please note the following heredoc uses leading tabs to allow
+  # the contents to be indented with the if/fi statement. For
+  # more information on indenting heredocs, please see the section
+  # entitled "Mutli-line message, with tabs suppressed" from The
+  # Linux Documentation Project (TLDP) at
+  # https://tldp.org/LDP/abs/html/here-docs.html.
+  cat <<-EOF
+	Please run the following command locally to remove all focuses from
+	tests:
+
+	    make unfocus
+
+	Thank you!
+	EOF
+
+  exit "${exit_code}"
+fi
+


### PR DESCRIPTION
This patch adds a GitHub action that fails fast if any test in the pull request has a programattic test focus.

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch adds a GitHub action that fails fast if any test in the pull request has a programattic test focus.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
GitHub action fails fast if there is a test with a programmatic focus.
```