### PR TITLE
Graceful VM dir cleanup / crypto+linked

### DIFF
--- a/api/v1alpha4/virtualmachine_types.go
+++ b/api/v1alpha4/virtualmachine_types.go
@@ -891,6 +891,9 @@ type VirtualMachineSpec struct {
 	//               snapshots do not support online promotion.
 	// - Offline  -- Promote disks while the VM is powered off.
 	//
+	// Please note, this field is ignored for encrypted VMs since they do not
+	// use delta disks.
+	//
 	// Defaults to Online.
 	PromoteDisksMode VirtualMachinePromoteDisksMode `json:"promoteDisksMode,omitempty"`
 

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachinereplicasets.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachinereplicasets.yaml
@@ -4612,6 +4612,9 @@ spec:
                                         snapshots do not support online promotion.
                           - Offline  -- Promote disks while the VM is powered off.
 
+                          Please note, this field is ignored for encrypted VMs since they do not
+                          use delta disks.
+
                           Defaults to Online.
                         enum:
                         - Online

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -8150,6 +8150,9 @@ spec:
                                 snapshots do not support online promotion.
                   - Offline  -- Promote disks while the VM is powered off.
 
+                  Please note, this field is ignored for encrypted VMs since they do not
+                  use delta disks.
+
                   Defaults to Online.
                 enum:
                 - Online

--- a/pkg/providers/vsphere/vmlifecycle/create.go
+++ b/pkg/providers/vsphere/vmlifecycle/create.go
@@ -19,18 +19,19 @@ type CreateArgs struct {
 	UseContentLibrary bool
 	ProviderItemID    string
 
-	ConfigSpec          vimtypes.VirtualMachineConfigSpec
-	StorageProvisioning string
-	DatacenterMoID      string
-	FolderMoID          string
-	ResourcePoolMoID    string
-	HostMoID            string
-	StorageProfileID    string
-	DatastoreMoID       string // gce2e only: used only if StorageProfileID is unset
-	Datastores          []DatastoreRef
-	DiskPaths           []string
-	FilePaths           []string
-	ZoneName            string
+	ConfigSpec                vimtypes.VirtualMachineConfigSpec
+	StorageProvisioning       string
+	DatacenterMoID            string
+	FolderMoID                string
+	ResourcePoolMoID          string
+	HostMoID                  string
+	StorageProfileID          string
+	IsEncryptedStorageProfile bool
+	DatastoreMoID             string // gce2e only: used only if StorageProfileID is unset
+	Datastores                []DatastoreRef
+	DiskPaths                 []string
+	FilePaths                 []string
+	ZoneName                  string
 }
 
 type DatastoreRef struct {

--- a/pkg/providers/vsphere/vmprovider_vm.go
+++ b/pkg/providers/vsphere/vmprovider_vm.go
@@ -1673,8 +1673,15 @@ func (vs *vSphereVMProvider) vmCreateGetStoragePrereqs(
 		return err
 	}
 
-	vmStorageProfileID := vmStorage.StorageClassToPolicyID[vmStorageClass]
-	provisioningType, err := virtualmachine.GetDefaultDiskProvisioningType(vmCtx, vcClient, vmStorageProfileID)
+	storageProfileID := vmStorage.StorageClassToPolicyID[vmStorageClass]
+	isEnc, _, err := kubeutil.IsEncryptedStorageClass(
+		vmCtx, vs.k8sClient, vmCtx.VM.Spec.StorageClass)
+	if err != nil {
+		return err
+	}
+
+	provisioningType, err := virtualmachine.GetDefaultDiskProvisioningType(
+		vmCtx, vcClient, storageProfileID)
 	if err != nil {
 		reason, msg := errToConditionReasonAndMessage(err)
 		pkgcnd.MarkFalse(vmCtx.VM, vmopv1.VirtualMachineConditionStorageReady, reason, "%s", msg)
@@ -1683,7 +1690,8 @@ func (vs *vSphereVMProvider) vmCreateGetStoragePrereqs(
 
 	createArgs.Storage = vmStorage
 	createArgs.StorageProvisioning = provisioningType
-	createArgs.StorageProfileID = vmStorageProfileID
+	createArgs.StorageProfileID = storageProfileID
+	createArgs.IsEncryptedStorageProfile = isEnc
 	pkgcnd.MarkTrue(vmCtx.VM, vmopv1.VirtualMachineConditionStorageReady)
 
 	return nil


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch fixes an issue with how the VM home dir is cleaned up upon a failed fast deploy of a VM. If the VM home dir is already gone, the old code failed with a FileNotFound fault. Now that fault is ignored.

This patch also defaults VMs to use direct mode with Fast Deploy if the VM is using an encrypted storage policy.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```