### PR TITLE
🌱 Add spec.groupName to VM API

### DIFF
--- a/api/v1alpha1/virtualmachine_conversion.go
+++ b/api/v1alpha1/virtualmachine_conversion.go
@@ -837,6 +837,10 @@ func Convert_v1alpha4_VirtualMachineStatus_To_v1alpha1_VirtualMachineStatus(
 	return nil
 }
 
+func restore_v1alpha4_VirtualMachineGroupName(dst, src *vmopv1.VirtualMachine) {
+	dst.Spec.GroupName = src.Spec.GroupName
+}
+
 func restore_v1alpha4_VirtualMachineCryptoSpec(dst, src *vmopv1.VirtualMachine) {
 	dst.Spec.Crypto = src.Spec.Crypto
 }
@@ -1279,6 +1283,7 @@ func (src *VirtualMachine) ConvertTo(dstRaw ctrlconversion.Hub) error {
 	restore_v1alpha4_VirtualMachinePromoteDisksMode(dst, restored)
 	restore_v1alpha4_VirtualMachineBootOptions(dst, restored)
 	restore_v1alpha4_VirtualMachineAffinitySpec(dst, restored)
+	restore_v1alpha4_VirtualMachineGroupName(dst, restored)
 
 	// END RESTORE
 

--- a/api/v1alpha1/zz_generated.conversion.go
+++ b/api/v1alpha1/zz_generated.conversion.go
@@ -2101,6 +2101,7 @@ func autoConvert_v1alpha4_VirtualMachineSpec_To_v1alpha1_VirtualMachineSpec(in *
 	// WARNING: in.PromoteDisksMode requires manual conversion: does not exist in peer-type
 	// WARNING: in.BootOptions requires manual conversion: does not exist in peer-type
 	// WARNING: in.CurrentSnapshot requires manual conversion: does not exist in peer-type
+	// WARNING: in.GroupName requires manual conversion: does not exist in peer-type
 	return nil
 }
 

--- a/api/v1alpha2/virtualmachine_conversion.go
+++ b/api/v1alpha2/virtualmachine_conversion.go
@@ -151,6 +151,10 @@ func Convert_v1alpha4_VirtualMachine_To_v1alpha2_VirtualMachine(
 	return nil
 }
 
+func restore_v1alpha4_VirtualMachineGroupName(dst, src *vmopv1.VirtualMachine) {
+	dst.Spec.GroupName = src.Spec.GroupName
+}
+
 func restore_v1alpha4_VirtualMachineCryptoSpec(dst, src *vmopv1.VirtualMachine) {
 	dst.Spec.Crypto = src.Spec.Crypto
 }
@@ -338,6 +342,7 @@ func (src *VirtualMachine) ConvertTo(dstRaw ctrlconversion.Hub) error {
 	restore_v1alpha4_VirtualMachinePromoteDisksMode(dst, restored)
 	restore_v1alpha4_VirtualMachineBootOptions(dst, restored)
 	restore_v1alpha4_VirtualMachineAffinitySpec(dst, restored)
+	restore_v1alpha4_VirtualMachineGroupName(dst, restored)
 
 	// END RESTORE
 

--- a/api/v1alpha2/zz_generated.conversion.go
+++ b/api/v1alpha2/zz_generated.conversion.go
@@ -3225,6 +3225,7 @@ func autoConvert_v1alpha4_VirtualMachineSpec_To_v1alpha2_VirtualMachineSpec(in *
 	// WARNING: in.PromoteDisksMode requires manual conversion: does not exist in peer-type
 	// WARNING: in.BootOptions requires manual conversion: does not exist in peer-type
 	// WARNING: in.CurrentSnapshot requires manual conversion: does not exist in peer-type
+	// WARNING: in.GroupName requires manual conversion: does not exist in peer-type
 	return nil
 }
 

--- a/api/v1alpha3/virtualmachine_conversion.go
+++ b/api/v1alpha3/virtualmachine_conversion.go
@@ -113,6 +113,10 @@ func Convert_v1alpha3_VirtualMachineStatus_To_v1alpha4_VirtualMachineStatus(
 	return nil
 }
 
+func restore_v1alpha4_VirtualMachineGroupName(dst, src *vmopv1.VirtualMachine) {
+	dst.Spec.GroupName = src.Spec.GroupName
+}
+
 func restore_v1alpha4_VirtualMachinePromoteDisksMode(dst, src *vmopv1.VirtualMachine) {
 	dst.Spec.PromoteDisksMode = src.Spec.PromoteDisksMode
 }
@@ -144,6 +148,7 @@ func (src *VirtualMachine) ConvertTo(dstRaw ctrlconversion.Hub) error {
 	restore_v1alpha4_VirtualMachinePromoteDisksMode(dst, restored)
 	restore_v1alpha4_VirtualMachineBootOptions(dst, restored)
 	restore_v1alpha4_VirtualMachineAffinitySpec(dst, restored)
+	restore_v1alpha4_VirtualMachineGroupName(dst, restored)
 
 	// END RESTORE
 

--- a/api/v1alpha3/zz_generated.conversion.go
+++ b/api/v1alpha3/zz_generated.conversion.go
@@ -3802,6 +3802,7 @@ func autoConvert_v1alpha4_VirtualMachineSpec_To_v1alpha3_VirtualMachineSpec(in *
 	// WARNING: in.PromoteDisksMode requires manual conversion: does not exist in peer-type
 	// WARNING: in.BootOptions requires manual conversion: does not exist in peer-type
 	// WARNING: in.CurrentSnapshot requires manual conversion: does not exist in peer-type
+	// WARNING: in.GroupName requires manual conversion: does not exist in peer-type
 	return nil
 }
 

--- a/api/v1alpha4/virtualmachine_types.go
+++ b/api/v1alpha4/virtualmachine_types.go
@@ -932,6 +932,15 @@ type VirtualMachineSpec struct {
 	// be overridden by specifying the PowerState to PoweredOff in the
 	// VirtualMachineSpec.
 	CurrentSnapshot *vmopv1common.LocalObjectRef `json:"currentSnapshot,omitempty"`
+
+	// +optional
+
+	// GroupName indicates the name of the VirtualMachineGroup to which this
+	// VM belongs.
+	//
+	// VMs that belong to a group do not drive their own placement, rather that
+	// is handled by the group.
+	GroupName string `json:"groupName,omitempty"`
 }
 
 // VirtualMachineReservedSpec describes a set of VM configuration options

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachinereplicasets.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachinereplicasets.yaml
@@ -4103,6 +4103,14 @@ spec:
                         - kind
                         - name
                         type: object
+                      groupName:
+                        description: |-
+                          GroupName indicates the name of the VirtualMachineGroup to which this
+                          VM belongs.
+
+                          VMs that belong to a group do not drive their own placement, rather that
+                          is handled by the group.
+                        type: string
                       guestID:
                         description: |-
                           GuestID describes the desired guest operating system identifier for a VM.

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -7641,6 +7641,14 @@ spec:
                 - kind
                 - name
                 type: object
+              groupName:
+                description: |-
+                  GroupName indicates the name of the VirtualMachineGroup to which this
+                  VM belongs.
+
+                  VMs that belong to a group do not drive their own placement, rather that
+                  is handled by the group.
+                type: string
               guestID:
                 description: |-
                   GuestID describes the desired guest operating system identifier for a VM.

--- a/docs/ref/api/v1alpha4.md
+++ b/docs/ref/api/v1alpha4.md
@@ -3104,6 +3104,11 @@ Additionally, the VirtualMachineSpec will be updated to match
 the power state from the snapshot (i.e., powered on). This can
 be overridden by specifying the PowerState to PoweredOff in the
 VirtualMachineSpec. |
+| `groupName` _string_ | GroupName indicates the name of the VirtualMachineGroup to which this
+VM belongs.
+
+VMs that belong to a group do not drive their own placement, rather that
+is handled by the group. |
 
 ### VirtualMachineStatus
 

--- a/pkg/providers/vsphere/vmlifecycle/update_status.go
+++ b/pkg/providers/vsphere/vmlifecycle/update_status.go
@@ -81,6 +81,8 @@ func ReconcileStatus(
 		summary     = vmCtx.MoVM.Summary
 	)
 
+	reconcileGroup(vmCtx)
+
 	if config := vmCtx.MoVM.Config; config != nil {
 		extraConfig = object.OptionValueList(config.ExtraConfig).StringMap()
 	}
@@ -142,6 +144,12 @@ func ReconcileStatus(
 	}
 
 	return apierrorsutil.NewAggregate(errs)
+}
+
+func reconcileGroup(vmCtx pkgctx.VirtualMachineContext) {
+	if vmCtx.VM.Spec.GroupName == "" {
+		conditions.Delete(vmCtx.VM, vmopv1.VirtualMachineGroupMemberConditionGroupLinked)
+	}
 }
 
 func getRuntimeHostHostname(


### PR DESCRIPTION
This patch introduces the field spec.groupName to the VirtualMachine API.

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch introduces the field spec.groupName to the VirtualMachine API.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Introduce spec.groupName to VM API.
```

<!-- readthedocs-preview vm-operator start -->
----
📚 Documentation preview 📚: https://vm-operator--1004.org.readthedocs.build/en/1004/

<!-- readthedocs-preview vm-operator end -->