### PR TITLE
✨ Add VirtualMachineClassInstance reconciliation

### DIFF
--- a/api/v1alpha4/virtualmachineclassinstance_types.go
+++ b/api/v1alpha4/virtualmachineclassinstance_types.go
@@ -24,6 +24,7 @@ type VirtualMachineClassInstanceStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="CPU",type="string",JSONPath=".spec.hardware.cpus"
 // +kubebuilder:printcolumn:name="Memory",type="string",JSONPath=".spec.hardware.memory"
+// +kubebuilder:printcolumn:name="State",type="string",JSONPath=".metadata.labels.vmoperator\\.vmware\\.com/vmclass-state"
 
 // VirtualMachineClassInstance is the schema for the virtualmachineclassinstances API and
 // represents the desired state and observed status of a virtualmachineclassinstance

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachineclassinstances.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachineclassinstances.yaml
@@ -23,6 +23,9 @@ spec:
     - jsonPath: .spec.hardware.memory
       name: Memory
       type: string
+    - jsonPath: .metadata.labels.vmoperator\.vmware\.com/vmclass-state
+      name: State
+      type: string
     name: v1alpha4
     schema:
       openAPIV3Schema:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -217,6 +217,7 @@ rules:
   resources:
   - clustervirtualmachineimages
   - virtualmachineclasses
+  - virtualmachineclassinstances
   - virtualmachinegroups
   - virtualmachineimagecaches
   - virtualmachineimages
@@ -249,6 +250,7 @@ rules:
   - vmoperator.vmware.com
   resources:
   - virtualmachineclasses/status
+  - virtualmachineclassinstances/status
   - virtualmachinegroups/status
   - virtualmachineimagecaches/status
   - virtualmachinepublishrequests/status

--- a/controllers/virtualmachineclass/virtualmachineclass_controller.go
+++ b/controllers/virtualmachineclass/virtualmachineclass_controller.go
@@ -6,20 +6,27 @@ package virtualmachineclass
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
 
+	xxhash "github.com/cespare/xxhash/v2"
 	"github.com/go-logr/logr"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
+	pkgconst "github.com/vmware-tanzu/vm-operator/pkg/constants"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/patch"
+	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
 	"github.com/vmware-tanzu/vm-operator/pkg/record"
 )
 
@@ -69,6 +76,8 @@ type Reconciler struct {
 
 // +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachineclasses,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachineclasses/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachineclassinstances,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachineclassinstances/status,verbs=get;update;patch
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
 	ctx = pkgcfg.JoinContext(ctx, r.Context)
@@ -111,5 +120,124 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 }
 
 func (r *Reconciler) ReconcileNormal(vmClassCtx *pkgctx.VirtualMachineClassContext) error {
+	if pkgcfg.FromContext(vmClassCtx).Features.ImmutableClasses {
+		if err := r.reconcileInstance(vmClassCtx); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// TODO: copied from pkg/providers/vsphere/vmlifecycle/bootstrap.go.
+func getVimTypeHash(obj vimtypes.AnyType) (string, error) {
+	data, err := json.Marshal(obj)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal vim type to json: %w", err)
+	}
+	h := xxhash.New()
+	if _, err := h.Write(data); err != nil {
+		return "", fmt.Errorf("failed to write vim type to hash: %w", err)
+	}
+	out := h.Sum(nil)
+	return fmt.Sprintf("%x", out), nil
+}
+
+// vmClassHash returns a hash of the VM Class Reserved + VirtualMachineConfigSpec.
+func vmClassHash(ctx *pkgctx.VirtualMachineClassContext, class *vmopv1.VirtualMachineClass) (string, error) {
+	if len(class.Spec.ConfigSpec) == 0 {
+		// wcpsvc is expected to always set configSpec when creating a VM class.
+		return "", fmt.Errorf("%s configSpec is nil", class.Name)
+	}
+
+	spec, err := vsphere.GetVMClassConfigSpec(ctx, class.Spec.ConfigSpec)
+	if err != nil {
+		return "", err
+	}
+
+	data := struct {
+		Reserved bool                              `json:"reserved"`
+		Spec     vimtypes.VirtualMachineConfigSpec `json:"spec"`
+	}{
+		class.Spec.ReservedProfileID != "",
+		spec,
+	}
+
+	return getVimTypeHash(data)
+}
+
+// reconcileInstance creates a VirtualMachineClassInstance of the given VirtualMachineClass.
+// The Instance is named VMClass Name + VMClass Hash and is:
+// - Annotated with the VMClass Hash
+// - Labeled with VMClass Name
+// - Labeled with VMClass State "active"
+// - Owner ref set to the VMClass
+// All other Instances of this VM class are labeled "inactive".
+func (r *Reconciler) reconcileInstance(ctx *pkgctx.VirtualMachineClassContext) error {
+	hash, err := vmClassHash(ctx, ctx.VMClass)
+	if err != nil {
+		return err
+	}
+
+	vmClassInstance := &vmopv1.VirtualMachineClassInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ctx.VMClass.Namespace,
+			Name:      ctx.VMClass.Name + "-" + hash,
+		},
+	}
+
+	_, err = ctrlutil.CreateOrPatch(ctx, r.Client, vmClassInstance, func() error {
+		if err := ctrlutil.SetControllerReference(
+			ctx.VMClass, vmClassInstance, r.Scheme()); err != nil {
+
+			return err
+		}
+
+		vmClassInstance.Spec.VirtualMachineClassSpec = ctx.VMClass.Spec
+
+		vmClassInstance.Annotations = map[string]string{
+			pkgconst.VirtualMachineClassHashAnnotationKey: hash,
+		}
+
+		vmClassInstance.Labels = map[string]string{
+			pkgconst.VirtualMachineClassNameLabelKey:  ctx.VMClass.Name,
+			pkgconst.VirtualMachineClassStateLabelKey: pkgconst.VirtualMachineClassStateActive,
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	var list vmopv1.VirtualMachineClassInstanceList
+
+	err = r.Client.List(ctx, &list,
+		client.InNamespace(ctx.VMClass.Namespace),
+		client.MatchingLabels(vmClassInstance.Labels))
+	if err != nil {
+		return err
+	}
+
+	for i := range list.Items {
+		instance := &list.Items[i]
+
+		if instance.Name == vmClassInstance.Name {
+			continue
+		}
+
+		patchHelper, err := patch.NewHelper(instance, r.Client)
+		if err != nil {
+			return fmt.Errorf("failed to init patch helper for %s: %w", instance.Name, err)
+		}
+
+		instance.Labels[pkgconst.VirtualMachineClassStateLabelKey] = pkgconst.VirtualMachineClassStateInactive
+
+		if err := patchHelper.Patch(ctx, instance); err != nil {
+			ctx.Logger.Error(err, "patch failed")
+			return err
+		}
+	}
+
 	return nil
 }

--- a/controllers/virtualmachineclass/virtualmachineclass_controller_intg_test.go
+++ b/controllers/virtualmachineclass/virtualmachineclass_controller_intg_test.go
@@ -7,12 +7,15 @@ package virtualmachineclass_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
+	pkgconst "github.com/vmware-tanzu/vm-operator/pkg/constants"
 	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
@@ -62,6 +65,12 @@ func intgTestsReconcile() {
 				},
 			},
 		}
+
+		setConfigSpec(vmClass)
+
+		pkgcfg.SetContext(suite, func(config *pkgcfg.Config) {
+			config.Features.ImmutableClasses = true
+		})
 	})
 
 	AfterEach(func() {
@@ -78,7 +87,70 @@ func intgTestsReconcile() {
 			Expect(err == nil || apierrors.IsNotFound(err)).To(BeTrue())
 		})
 
-		It("noop", func() {
+		It("Should create VirtualMachineClassInstance", func() {
+			Eventually(func(g Gomega) {
+				var list vmopv1.VirtualMachineClassInstanceList
+				err := ctx.Client.List(ctx, &list, client.InNamespace(vmClass.Namespace))
+				g.Expect(err).ToNot(HaveOccurred())
+
+				g.Expect(list.Items).To(HaveLen(1))
+
+				instance := list.Items[0]
+
+				g.Expect(instance.Annotations).ToNot(BeEmpty())
+				g.Expect(instance.Annotations[pkgconst.VirtualMachineClassHashAnnotationKey]).ToNot(BeEmpty())
+
+				g.Expect(instance.Labels).ToNot(BeEmpty())
+				g.Expect(instance.Labels[pkgconst.VirtualMachineClassNameLabelKey]).To(Equal(vmClass.Name))
+				g.Expect(instance.Labels[pkgconst.VirtualMachineClassStateLabelKey]).To(Equal(pkgconst.VirtualMachineClassStateActive))
+			}).Should(Succeed())
+		})
+
+		It("Should create new VirtualMachineClassInstance when config changes", func() {
+			vmClass.Spec.Hardware.Cpus++
+			setConfigSpec(vmClass)
+
+			err := ctx.Client.Update(ctx, vmClass)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func(g Gomega) {
+				var list vmopv1.VirtualMachineClassInstanceList
+				err := ctx.Client.List(ctx, &list, client.InNamespace(vmClass.Namespace))
+				g.Expect(err).ToNot(HaveOccurred())
+
+				g.Expect(list.Items).To(HaveLen(2))
+			}).Should(Succeed())
+
+			vmClass.Spec.Hardware.Cpus++
+			setConfigSpec(vmClass)
+
+			err = ctx.Client.Update(ctx, vmClass)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func(g Gomega) {
+				var list vmopv1.VirtualMachineClassInstanceList
+				err := ctx.Client.List(ctx, &list, client.InNamespace(vmClass.Namespace))
+				g.Expect(err).ToNot(HaveOccurred())
+
+				g.Expect(list.Items).To(HaveLen(3))
+
+				state := map[string]int{
+					pkgconst.VirtualMachineClassStateActive:   0,
+					pkgconst.VirtualMachineClassStateInactive: 0,
+				}
+
+				for _, item := range list.Items {
+					val := item.Labels[pkgconst.VirtualMachineClassStateLabelKey]
+
+					g.Expect(val).ToNot(BeEmpty())
+
+					state[val]++
+				}
+
+				g.Expect(state).To(HaveLen(2))
+				g.Expect(state[pkgconst.VirtualMachineClassStateActive]).To(Equal(1))
+				g.Expect(state[pkgconst.VirtualMachineClassStateInactive]).To(Equal(2))
+			}).Should(Succeed())
 		})
 	})
 }

--- a/controllers/virtualmachineclass/virtualmachineclass_controller_suite_test.go
+++ b/controllers/virtualmachineclass/virtualmachineclass_controller_suite_test.go
@@ -8,10 +8,13 @@ import (
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
+	"github.com/vmware/govmomi/vim25/types"
 
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachineclass"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	"github.com/vmware-tanzu/vm-operator/pkg/manager"
+	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
@@ -27,3 +30,17 @@ func TestVirtualMachineClass(t *testing.T) {
 var _ = BeforeSuite(suite.BeforeSuite)
 
 var _ = AfterSuite(suite.AfterSuite)
+
+// setConfigSpec populates the spec.configSpec field as wcpsvc would when creating a VM Class.
+func setConfigSpec(vmClass *vmopv1.VirtualMachineClass) {
+	spec := types.VirtualMachineConfigSpec{
+		NumCPUs:  int32(vmClass.Spec.Hardware.Cpus),
+		MemoryMB: vmClass.Spec.Hardware.Memory.Value(),
+	}
+
+	var err error
+	vmClass.Spec.ConfigSpec, err = pkgutil.MarshalConfigSpecToJSON(spec)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/controllers/virtualmachineclass/virtualmachineclass_controller_unit_test.go
+++ b/controllers/virtualmachineclass/virtualmachineclass_controller_unit_test.go
@@ -49,6 +49,7 @@ func unitTestsReconcile() {
 				Name: "dummy-vmclass",
 			},
 		}
+		setConfigSpec(vmClass)
 	})
 
 	JustBeforeEach(func() {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -122,4 +122,23 @@ const (
 	// a power state change to a VirtualMachine or a VirtualMachineGroup object
 	// scheduled from its parent group.
 	ApplyPowerStateTimeAnnotation = "vmoperator.vmware.com.protected/apply-power-state-time"
+
+	// VirtualMachineClassHashAnnotationKey is the annotation key for the VM Class hash
+	// used to generate VirtualMachineClassInstances.
+	VirtualMachineClassHashAnnotationKey = "vmoperator.vmware.com/vmclass-hash"
+
+	// VirtualMachineClassNameLabelKey is the VM Class name of a Class Instance.
+	VirtualMachineClassNameLabelKey = "vmoperator.vmware.com/vmclass-name"
+
+	// VirtualMachineClassStateLabelKey is the VM Class Instance State,
+	// where value is "active" or "inactive".
+	VirtualMachineClassStateLabelKey = "vmoperator.vmware.com/vmclass-state"
+
+	// VirtualMachineClassStateActive is a VirtualMachineClassStateLabelKey value
+	// indicating the Class Instance corresponds to the current VM Class configuration.
+	VirtualMachineClassStateActive = "active"
+
+	// VirtualMachineClassStateInactive is a VirtualMachineClassStateLabelKey value
+	// indicating the Class Instance corresponds to a previous VM Class configuration.
+	VirtualMachineClassStateInactive = "inactive"
 )


### PR DESCRIPTION
When a VirtualMachineClass is created, or updated, we create a VirtualMachineClassInstance with:
- Name: VirtualMachineClass.Name + VirtualMachineClass hash
- Annotations: VirtualMachineClass hash
- Labels: State - "active" or "inactive"

Only 1 VirtualMachineClassInstance corresponding to a VirtualMachineClass is "active". Other instances are labeled "inactive", to later be removed when no VirtualMachines are using the Instance.
