### PR TITLE
🐛 Set VM group linked condition during status update

### DIFF
--- a/pkg/providers/vsphere/vmlifecycle/update_status.go
+++ b/pkg/providers/vsphere/vmlifecycle/update_status.go
@@ -81,7 +81,9 @@ func ReconcileStatus(
 		summary     = vmCtx.MoVM.Summary
 	)
 
-	reconcileGroup(vmCtx)
+	if err := UpdateGroupLinkedCondition(vmCtx, k8sClient); err != nil {
+		errs = append(errs, err)
+	}
 
 	if config := vmCtx.MoVM.Config; config != nil {
 		extraConfig = object.OptionValueList(config.ExtraConfig).StringMap()
@@ -146,10 +148,66 @@ func ReconcileStatus(
 	return apierrorsutil.NewAggregate(errs)
 }
 
-func reconcileGroup(vmCtx pkgctx.VirtualMachineContext) {
+// UpdateGroupLinkedCondition updates the GroupLinked condition for the VM if
+// the VM is a member of a group.
+func UpdateGroupLinkedCondition(
+	vmCtx pkgctx.VirtualMachineContext,
+	k8sClient ctrlclient.Client) error {
 	if vmCtx.VM.Spec.GroupName == "" {
-		conditions.Delete(vmCtx.VM, vmopv1.VirtualMachineGroupMemberConditionGroupLinked)
+		conditions.Delete(
+			vmCtx.VM,
+			vmopv1.VirtualMachineGroupMemberConditionGroupLinked)
+
+		return nil
 	}
+
+	var (
+		obj vmopv1.VirtualMachineGroup
+		key = ctrlclient.ObjectKey{
+			Name:      vmCtx.VM.Spec.GroupName,
+			Namespace: vmCtx.VM.Namespace,
+		}
+	)
+
+	if err := k8sClient.Get(vmCtx, key, &obj); err != nil {
+		if !apierrors.IsNotFound(err) {
+			conditions.MarkError(
+				vmCtx.VM,
+				vmopv1.VirtualMachineGroupMemberConditionGroupLinked,
+				"Error",
+				err)
+
+			return err
+		}
+
+		conditions.MarkFalse(
+			vmCtx.VM,
+			vmopv1.VirtualMachineGroupMemberConditionGroupLinked,
+			"NotFound",
+			"")
+
+		return nil
+	}
+
+	for _, m := range obj.Spec.Members {
+		if m.Kind == "VirtualMachine" {
+			if m.Name == vmCtx.VM.Name {
+				conditions.MarkTrue(
+					vmCtx.VM,
+					vmopv1.VirtualMachineGroupMemberConditionGroupLinked)
+
+				return nil
+			}
+		}
+	}
+
+	conditions.MarkFalse(
+		vmCtx.VM,
+		vmopv1.VirtualMachineGroupMemberConditionGroupLinked,
+		"NotMember",
+		"")
+
+	return nil
 }
 
 func getRuntimeHostHostname(


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR sets VM's GroupLinked condition during status updates. It ensures the condition accurately reflects the current state (e.g. when VM switches to a different group or when the existing group's member is changed/deleted).

**Which issue(s) is/are addressed by this PR?**

Fixes N/A.

**Are there any special notes for your reviewer**:

None.

**Please add a release note if necessary**:

```release-note
Set VM group linked condition during VM status update.
```