### PR TITLE
🌱 Support for "make tools-install"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -273,6 +273,16 @@ tools: $(TOOLING_BINARIES) ## Build tooling binaries
 $(TOOLING_BINARIES):
 	make -C $(TOOLS_DIR) $(@F)
 
+ifneq (,$(strip $(wildcard $(GOPATH))))
+.PHONY: tools-install
+tools-install: $(TOOLING_BINARIES)
+tools-install: ## Install the tooling binaries to $GOPATH/bin
+ifeq (,$(strip $(wildcard $(GOPATH)/bin)))
+	mkdir -p "$(GOPATH)/bin"
+endif # (,$(strip $(wildcard $(GOPATH)/bin)))
+	cp -f $(TOOLS_BIN_DIR)/* "$(GOPATH)/bin"
+endif # (,$(strip $(wildcard $(GOPATH))))
+
 ## --------------------------------------
 ## Linting and fixing linter errors
 ## --------------------------------------


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch provides a helpful make target that installs all the tooling used by VM Operator to $GOPATH/bin. This is not required to use the tooling, but as some folks like to manually run tests by calling "ginkgo" directly, this ensures the same versions used by VM Op are also the default versions in $GOPATH/bin. This, of course, assumes the user has added $GOPATH/bin to their $PATH environment variable.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Support "make tools-install" to copy all tool binaries to "$GOPATH/bin".
```