### PR TITLE
🌱 Increase timeout in VM group finalizer test

### DIFF
--- a/controllers/virtualmachine/virtualmachinegroup/virtualmachinegroup_controller_test.go
+++ b/controllers/virtualmachine/virtualmachinegroup/virtualmachinegroup_controller_test.go
@@ -153,7 +153,8 @@ var _ = Describe(
 					vmGroup3 := &vmopv1.VirtualMachineGroup{}
 					g.Expect(ctx.Client.Get(ctx, vmGroup3Key, vmGroup3)).To(Succeed())
 					g.Expect(vmGroup3.GetFinalizers()).To(ContainElement(finalizer))
-				}).Should(Succeed(), "waiting for VirtualMachineGroup finalizer")
+					// Using a longer timeout to ensure all VM Groups above are reconciled.
+				}, "5s", "100ms").Should(Succeed(), "waiting for VirtualMachineGroup finalizer")
 			})
 		})
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR increases the timeout in VM Group finalizer tests from the default 1s to 5s to ensure all VM Group objects have enough time to reconcile. There've been some CI failures reported intermittently due to the short timeout: https://github.com/vmware-tanzu/vm-operator/actions/runs/15542882768/job/43757629172?pr=987.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes N/A.


**Are there any special notes for your reviewer**:

None.


**Please add a release note if necessary**:

```release-note
NONE
```