### PR TITLE
:sparkles: Introduce spec.class for VirtualMachines

### DIFF
--- a/api/v1alpha1/zz_generated.conversion.go
+++ b/api/v1alpha1/zz_generated.conversion.go
@@ -2062,6 +2062,7 @@ func autoConvert_v1alpha4_VirtualMachineSpec_To_v1alpha1_VirtualMachineSpec(in *
 	// WARNING: in.Image requires manual conversion: does not exist in peer-type
 	out.ImageName = in.ImageName
 	out.ClassName = in.ClassName
+	// WARNING: in.Class requires manual conversion: does not exist in peer-type
 	// WARNING: in.Affinity requires manual conversion: does not exist in peer-type
 	// WARNING: in.Crypto requires manual conversion: does not exist in peer-type
 	out.StorageClass = in.StorageClass

--- a/api/v1alpha2/zz_generated.conversion.go
+++ b/api/v1alpha2/zz_generated.conversion.go
@@ -3188,6 +3188,7 @@ func autoConvert_v1alpha4_VirtualMachineSpec_To_v1alpha2_VirtualMachineSpec(in *
 	// WARNING: in.Image requires manual conversion: does not exist in peer-type
 	out.ImageName = in.ImageName
 	out.ClassName = in.ClassName
+	// WARNING: in.Class requires manual conversion: does not exist in peer-type
 	// WARNING: in.Affinity requires manual conversion: does not exist in peer-type
 	// WARNING: in.Crypto requires manual conversion: does not exist in peer-type
 	out.StorageClass = in.StorageClass

--- a/api/v1alpha3/zz_generated.conversion.go
+++ b/api/v1alpha3/zz_generated.conversion.go
@@ -3773,6 +3773,7 @@ func autoConvert_v1alpha4_VirtualMachineSpec_To_v1alpha3_VirtualMachineSpec(in *
 	out.Image = (*VirtualMachineImageRef)(unsafe.Pointer(in.Image))
 	out.ImageName = in.ImageName
 	out.ClassName = in.ClassName
+	// WARNING: in.Class requires manual conversion: does not exist in peer-type
 	// WARNING: in.Affinity requires manual conversion: does not exist in peer-type
 	out.Crypto = (*VirtualMachineCryptoSpec)(unsafe.Pointer(in.Crypto))
 	out.StorageClass = in.StorageClass

--- a/api/v1alpha4/virtualmachine_types.go
+++ b/api/v1alpha4/virtualmachine_types.go
@@ -647,11 +647,45 @@ type VirtualMachineSpec struct {
 	// ClassName describes the name of the VirtualMachineClass resource used to
 	// deploy this VM.
 	//
+	// When creating a virtual machine, if this field is empty and a
+	// VirtualMachineClassInstance is specified in spec.class, then
+	// this field is populated with the VirtualMachineClass object's
+	// name.
+	//
+	// Please also note, when creating a new VirtualMachine, if this field and
+	// spec.class are both non-empty, then they must refer to the same
+	// VirtualMachineClass or an error is returned.
+	//
 	// Please note, this field *may* be empty if the VM was imported instead of
 	// deployed by VM Operator. An imported VirtualMachine resource references
 	// an existing VM on the underlying platform that was not deployed from a
 	// VM class.
+	//
+	// If a VM is using a class, a different value in spec.className
+	// leads to the VM being resized.
 	ClassName string `json:"className,omitempty"`
+
+	// +optional
+
+	// Class describes the VirtualMachineClassInsance resource that is
+	// referenced by this virtual machine. This can be the
+	// VirtualMachineClassInstance that the virtual machine was
+	// created, or later resized with.
+	//
+	// The value of spec.class.Name must be the Kubernetes object name
+	// of a valid VirtualMachineClassInstance resource.
+	//
+	// Please also note, if this field and spec.className are both
+	// non-empty, then they must refer to the same VirtualMachineClass
+	// or an error is returned.
+	//
+	// If a className is specified, but this field is omitted, VM operator
+	// picks the latest instance for the VM class to create the VM.
+	//
+	// If a VM class has been modified and thus, the newly available
+	// VirtualMachineClassInstance can be specified in spec.class to
+	// trigger a resize operation.
+	Class *vmopv1common.LocalObjectRef `json:"class,omitempty"`
 
 	// +optional
 

--- a/api/v1alpha4/zz_generated.deepcopy.go
+++ b/api/v1alpha4/zz_generated.deepcopy.go
@@ -2944,6 +2944,11 @@ func (in *VirtualMachineSpec) DeepCopyInto(out *VirtualMachineSpec) {
 		*out = new(VirtualMachineImageRef)
 		**out = **in
 	}
+	if in.Class != nil {
+		in, out := &in.Class, &out.Class
+		*out = new(common.LocalObjectRef)
+		**out = **in
+	}
 	if in.Affinity != nil {
 		in, out := &in.Affinity, &out.Affinity
 		*out = new(VirtualMachineAffinitySpec)

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachinereplicasets.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachinereplicasets.yaml
@@ -3975,15 +3975,72 @@ spec:
                         x-kubernetes-list-map-keys:
                         - name
                         x-kubernetes-list-type: map
+                      class:
+                        description: |-
+                          Class describes the VirtualMachineClassInsance resource that is
+                          referenced by this virtual machine. This can be the
+                          VirtualMachineClassInstance that the virtual machine was
+                          created, or later resized with.
+
+                          The value of spec.class.Name must be the Kubernetes object name
+                          of a valid VirtualMachineClassInstance resource.
+
+                          Please also note, if this field and spec.className are both
+                          non-empty, then they must refer to the same VirtualMachineClass
+                          or an error is returned.
+
+                          If a className is specified, but this field is omitted, VM operator
+                          picks the latest instance for the VM class to create the VM.
+
+                          If a VM class has been modified and thus, the newly available
+                          VirtualMachineClassInstance can be specified in spec.class to
+                          trigger a resize operation.
+                        properties:
+                          apiVersion:
+                            description: |-
+                              APIVersion defines the versioned schema of this representation of an
+                              object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                            type: string
+                          kind:
+                            description: |-
+                              Kind is a string value representing the REST resource this object
+                              represents.
+                              Servers may infer this from the endpoint the client submits requests to.
+                              Cannot be updated.
+                              In CamelCase.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          name:
+                            description: |-
+                              Name refers to a unique resource in the current namespace.
+                              More info: http://kubernetes.io/docs/user-guide/identifiers#names
+                            type: string
+                        required:
+                        - apiVersion
+                        - kind
+                        - name
+                        type: object
                       className:
                         description: |-
                           ClassName describes the name of the VirtualMachineClass resource used to
                           deploy this VM.
 
+                          When creating a virtual machine, if this field is empty and a
+                          VirtualMachineClassInstance is specified in spec.class, then
+                          this field is populated with the VirtualMachineClass object's
+                          name.
+
+                          Please also note, when creating a new VirtualMachine, if this field and
+                          spec.class are both non-empty, then they must refer to the same
+                          VirtualMachineClass or an error is returned.
+
                           Please note, this field *may* be empty if the VM was imported instead of
                           deployed by VM Operator. An imported VirtualMachine resource references
                           an existing VM on the underlying platform that was not deployed from a
                           VM class.
+
+                          If a VM is using a class, a different value in spec.className
+                          leads to the VM being resized.
                         type: string
                       crypto:
                         description: Crypto describes the desired encryption state

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -7513,15 +7513,72 @@ spec:
                 x-kubernetes-list-map-keys:
                 - name
                 x-kubernetes-list-type: map
+              class:
+                description: |-
+                  Class describes the VirtualMachineClassInsance resource that is
+                  referenced by this virtual machine. This can be the
+                  VirtualMachineClassInstance that the virtual machine was
+                  created, or later resized with.
+
+                  The value of spec.class.Name must be the Kubernetes object name
+                  of a valid VirtualMachineClassInstance resource.
+
+                  Please also note, if this field and spec.className are both
+                  non-empty, then they must refer to the same VirtualMachineClass
+                  or an error is returned.
+
+                  If a className is specified, but this field is omitted, VM operator
+                  picks the latest instance for the VM class to create the VM.
+
+                  If a VM class has been modified and thus, the newly available
+                  VirtualMachineClassInstance can be specified in spec.class to
+                  trigger a resize operation.
+                properties:
+                  apiVersion:
+                    description: |-
+                      APIVersion defines the versioned schema of this representation of an
+                      object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                    type: string
+                  kind:
+                    description: |-
+                      Kind is a string value representing the REST resource this object
+                      represents.
+                      Servers may infer this from the endpoint the client submits requests to.
+                      Cannot be updated.
+                      In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name refers to a unique resource in the current namespace.
+                      More info: http://kubernetes.io/docs/user-guide/identifiers#names
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
               className:
                 description: |-
                   ClassName describes the name of the VirtualMachineClass resource used to
                   deploy this VM.
 
+                  When creating a virtual machine, if this field is empty and a
+                  VirtualMachineClassInstance is specified in spec.class, then
+                  this field is populated with the VirtualMachineClass object's
+                  name.
+
+                  Please also note, when creating a new VirtualMachine, if this field and
+                  spec.class are both non-empty, then they must refer to the same
+                  VirtualMachineClass or an error is returned.
+
                   Please note, this field *may* be empty if the VM was imported instead of
                   deployed by VM Operator. An imported VirtualMachine resource references
                   an existing VM on the underlying platform that was not deployed from a
                   VM class.
+
+                  If a VM is using a class, a different value in spec.className
+                  leads to the VM being resized.
                 type: string
               crypto:
                 description: Crypto describes the desired encryption state of the


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This change introduces spec.class for VirtualMachine resources.  This reference points to a VirtualMachineClassInstance resource.  This field, together with spec.className uniquely represent the hardware configuration of a VM.

The spec.className and spec.class fields always point to the same underlying VM class.

If only one of these fields is specified, VM mutation webhook populates the other.  If both are specified, the VM validation webhook ensures that the references are valid.

A resize operation can be triggered by any of the following methods:
- Specifying a different class in spec.className field
- Specifying a new instance of the same class

**Are there any special notes for your reviewer**:

A follow up PR will introduce the mutation and validation webhook changes.

**Please add a release note if necessary**:

```release-note
Introduce spec.class for VirtualMachines
```