### PR TITLE
✨ Reconcile VM schema upgrade

### DIFF
--- a/controllers/virtualmachine/virtualmachine/virtualmachine_controller_intg_test.go
+++ b/controllers/virtualmachine/virtualmachine/virtualmachine_controller_intg_test.go
@@ -441,60 +441,6 @@ func intgTestsReconcile() {
 
 		})
 
-		When("VM schema needs upgrade", func() {
-			instanceUUID := uuid.NewString()
-			biosUUID := uuid.NewString()
-
-			BeforeEach(func() {
-				providerfake.SetCreateOrUpdateFunction(
-					ctx,
-					intgFakeVMProvider,
-					func(ctx context.Context, vm *vmopv1.VirtualMachine) error {
-						vm.Status.InstanceUUID = instanceUUID
-						vm.Status.BiosUUID = biosUUID
-						return nil
-					},
-				)
-			})
-
-			// NOTE: mutating webhook sets the default spec.instanceUUID, but is not run in this test -
-			// leaving spec.instanceUUID empty as it would be for a pre-v1alpha3 VM
-			It("will set spec.instanceUUID", func() {
-				Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
-
-				Eventually(func(g Gomega) {
-					vm := getVirtualMachine(ctx, vmKey)
-					g.Expect(vm).ToNot(BeNil())
-					g.Expect(vm.Spec.InstanceUUID).To(Equal(instanceUUID))
-				}).Should(Succeed(), "waiting for expected instanceUUID")
-			})
-
-			// NOTE: mutating webhook sets the default spec.biosUUID, but is not run in this test -
-			// leaving spec.biosUUID empty as it would be for a pre-v1alpha3 VM
-			It("will set spec.biosUUID", func() {
-				Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
-
-				Eventually(func(g Gomega) {
-					vm := getVirtualMachine(ctx, vmKey)
-					g.Expect(vm).ToNot(BeNil())
-					g.Expect(vm.Spec.BiosUUID).To(Equal(biosUUID))
-				}).Should(Succeed(), "waiting for expected biosUUID")
-			})
-
-			It("will set cloudInit.instanceID", func() {
-				vm.Spec.Bootstrap = &vmopv1.VirtualMachineBootstrapSpec{
-					CloudInit: &vmopv1.VirtualMachineBootstrapCloudInitSpec{},
-				}
-				Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
-
-				Eventually(func(g Gomega) {
-					vm := getVirtualMachine(ctx, vmKey)
-					g.Expect(vm).ToNot(BeNil())
-					g.Expect(vm.Spec.Bootstrap.CloudInit.InstanceID).To(BeEquivalentTo(vm.UID))
-				}).Should(Succeed(), "waiting for expected instanceID")
-			})
-		})
-
 		It("Reconciles after VirtualMachineClass change", func() {
 			providerfake.SetCreateOrUpdateFunction(
 				ctx,

--- a/pkg/builder/auth_test.go
+++ b/pkg/builder/auth_test.go
@@ -21,6 +21,12 @@ var _ = DescribeTable("IsPrivilegedAccount",
 		Ω(builder.IsPrivilegedAccount(ctx, userInfo)).To(Equal(expected))
 	},
 	Entry(
+		"nil context",
+		(*pkgctx.WebhookContext)(nil),
+		authv1.UserInfo{},
+		false,
+	),
+	Entry(
 		"empty inputs",
 		&pkgctx.WebhookContext{Context: pkgcfg.NewContext()},
 		authv1.UserInfo{},
@@ -55,7 +61,7 @@ var _ = DescribeTable("IsPrivilegedAccount",
 		true,
 	),
 	Entry(
-		"is service account",
+		"is vm op service account",
 		&pkgctx.WebhookContext{
 			Context:            pkgcfg.NewContext(),
 			Namespace:          "my-ns",

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -27,6 +27,30 @@ const (
 	// at which an object was first created.
 	CreatedAtSchemaVersionAnnotationKey = createdAtPrefix + "schema-version"
 
+	upgradedToPrefix = "vmoperator.vmware.com/upgraded-to-"
+
+	// UpgradedToBuildVersionAnnotationKey is set on VirtualMachine
+	// objects when the function "ReconcileSchemaUpgrade" from
+	// pkg/providers/vsphere/upgrade/virtualmachine/vm_schema_upgrade.go is
+	// executed.
+	//
+	// Please note, a validation webhook will deny any patch/update operations
+	// on VirtualMachine objects from unprivileged users until such time the
+	// object has this annotation with a value that matches the current build
+	// version.
+	UpgradedToBuildVersionAnnotationKey = upgradedToPrefix + "build-version"
+
+	// UpgradedToSchemaVersionAnnotationKey is set on VirtualMachine
+	// objects when the function "ReconcileSchemaUpgrade" from
+	// pkg/providers/vsphere/upgrade/virtualmachine/vm_schema_upgrade.go is
+	// executed.
+	//
+	// Please note, a validation webhook will deny any patch/update operations
+	// on VirtualMachine objects from unprivileged users until such time the
+	// object has this annotation with a value that matches the current build
+	// version.
+	UpgradedToSchemaVersionAnnotationKey = upgradedToPrefix + "schema-version"
+
 	// MinSupportedHWVersionForPVC is the supported virtual hardware version for
 	// persistent volumes.
 	MinSupportedHWVersionForPVC = vimtypes.VMX15

--- a/pkg/context/webhook_request_context.go
+++ b/pkg/context/webhook_request_context.go
@@ -31,8 +31,11 @@ type WebhookRequestContext struct {
 	// Operation is the operation.
 	Op admissionv1.Operation
 
-	// IsPrivilegedAccount is if this request is from a privileged account (currently
-	// that's either kube-admin or the pod's system account).
+	// IsPrivilegedAccount is if this request is from a privileged account, ex.
+	// - kube-admin
+	// - system:masters
+	// - VM Op service account
+	// - in the privileged account env var
 	IsPrivilegedAccount bool
 
 	// UserInfo is the user information associated with the webhook request.

--- a/pkg/providers/vsphere/upgrade/virtualmachine/vm_schema_upgrade.go
+++ b/pkg/providers/vsphere/upgrade/virtualmachine/vm_schema_upgrade.go
@@ -1,0 +1,173 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package virtualmachine
+
+import (
+	"context"
+
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-logr/logr"
+	"github.com/vmware/govmomi/vim25/mo"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
+	pkgconst "github.com/vmware-tanzu/vm-operator/pkg/constants"
+	pkgerr "github.com/vmware-tanzu/vm-operator/pkg/errors"
+	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/vmlifecycle"
+)
+
+var ErrUpgradeSchema = pkgerr.NoRequeueNoErr("upgraded vm schema")
+
+// ReconcileSchemaUpgrade ensures the VM's spec is upgraded to match the current
+// expectations for the data that should be present on a VirtualMachine object.
+// This may include back-filling data from the underlying vSphere VM into the
+// API object's spec.
+//
+// Please note, each time VM Operator is upgraded, patch/update operations
+// against VirtualMachine objects by unprivileged users will be denied until
+// ReconcileSchemaUpgrade is executed. This ensures the objects are not changing
+// while the object is being back-filled.
+func ReconcileSchemaUpgrade(
+	ctx context.Context,
+	k8sClient ctrlclient.Client,
+	vm *vmopv1.VirtualMachine,
+	moVM mo.VirtualMachine) error {
+
+	if ctx == nil {
+		panic("context is nil")
+	}
+	if k8sClient == nil {
+		panic("k8sClient is nil")
+	}
+	if vm == nil {
+		panic("vm is nil")
+	}
+	if moVM.Config == nil {
+		panic("moVM.config is nil")
+	}
+
+	logger := logr.FromContextOrDiscard(ctx)
+	logger.V(4).Info("Reconciling schema upgrade for VM")
+
+	var (
+		curBuildVersion  = pkgcfg.FromContext(ctx).BuildVersion
+		curSchemaVersion = vmopv1.GroupVersion.Version
+
+		vmBuildVersion  = vm.Annotations[pkgconst.UpgradedToBuildVersionAnnotationKey]
+		vmSchemaVersion = vm.Annotations[pkgconst.UpgradedToSchemaVersionAnnotationKey]
+	)
+
+	if vmBuildVersion == curBuildVersion &&
+		vmSchemaVersion == curSchemaVersion {
+
+		logger.V(4).Info("Skipping reconciliation of schema upgrade for VM" +
+			" that is already upgraded")
+		return nil
+	}
+
+	reconcileBIOSUUID(ctx, vm, moVM)
+	reconcileInstanceUUID(ctx, vm, moVM)
+	reconcileCloudInitInstanceUUID(ctx, vm, moVM)
+
+	// Indicate the VM has been upgraded.
+	if vm.Annotations == nil {
+		vm.Annotations = map[string]string{}
+	}
+	vm.Annotations[pkgconst.UpgradedToBuildVersionAnnotationKey] = curBuildVersion
+	vm.Annotations[pkgconst.UpgradedToSchemaVersionAnnotationKey] = curSchemaVersion
+
+	logger.V(4).Info("Upgraded VM schema version",
+		"buildVersion", curBuildVersion,
+		"schemaVersion", curSchemaVersion)
+
+	return ErrUpgradeSchema
+}
+
+func reconcileBIOSUUID(
+	ctx context.Context,
+	vm *vmopv1.VirtualMachine,
+	moVM mo.VirtualMachine) {
+
+	logger := logr.FromContextOrDiscard(ctx)
+	logger.V(4).Info("Reconciling schema upgrade for VM BIOS UUID")
+
+	if vm.Spec.BiosUUID != "" {
+		logger.V(4).Info("Skipping reconciliation of schema upgrade for VM " +
+			"instance BIOS that is already upgraded")
+		return
+	}
+
+	if moVM.Config.Uuid == "" {
+		logger.V(4).Info("Skipping reconciliation of schema upgrade for VM " +
+			"BIOS UUID with empty config.uuid")
+		return
+	}
+
+	vm.Spec.BiosUUID = moVM.Config.Uuid
+	logger.V(4).Info("Reconciled schema upgrade for VM BIOS UUID")
+}
+
+func reconcileInstanceUUID(
+	ctx context.Context,
+	vm *vmopv1.VirtualMachine,
+	moVM mo.VirtualMachine) {
+
+	logger := logr.FromContextOrDiscard(ctx)
+	logger.V(4).Info("Reconciling schema upgrade for VM instance UUID")
+
+	if vm.Spec.InstanceUUID != "" {
+		logger.V(4).Info("Skipping reconciliation of schema upgrade for VM " +
+			"instance UUID that is already upgraded")
+		return
+	}
+
+	if moVM.Config.InstanceUuid == "" {
+		logger.V(4).Info("Skipping reconciliation of schema upgrade for VM " +
+			"instance UUID with empty config.instanceUuid")
+		return
+	}
+
+	vm.Spec.InstanceUUID = moVM.Config.InstanceUuid
+	logger.V(4).Info("Reconciled schema upgrade for VM instance UUID")
+}
+
+func reconcileCloudInitInstanceUUID(
+	ctx context.Context,
+	vm *vmopv1.VirtualMachine,
+	_ mo.VirtualMachine) {
+
+	logger := logr.FromContextOrDiscard(ctx)
+	logger.V(4).Info(
+		"Reconciling schema upgrade for VM cloud-init instance UUID")
+
+	if vm.Spec.Bootstrap == nil {
+		logger.V(4).Info(
+			"Skipping reconciliation of schema upgrade for VM cloud-init " +
+				"instance UUID with nil spec.bootstrap")
+		return
+	}
+
+	if vm.Spec.Bootstrap.CloudInit == nil {
+		logger.V(4).Info(
+			"Skipping reconciliation of schema upgrade for VM cloud-init " +
+				"instance UUID with nil spec.bootstrap.cloudInit")
+		return
+	}
+
+	if vm.Spec.Bootstrap.CloudInit.InstanceID != "" {
+		logger.V(4).Info(
+			"Skipping reconciliation of schema upgrade for VM cloud-init" +
+				"instance UUID that is already upgraded")
+		return
+	}
+
+	_ = vmlifecycle.BootStrapCloudInitInstanceID(
+		vm,
+		vm.Spec.Bootstrap.CloudInit)
+
+	logger.V(4).Info(
+		"Reconciled schema upgrade for VM cloud-init instance UUID")
+}

--- a/pkg/providers/vsphere/upgrade/virtualmachine/vm_schema_upgrade_suite_test.go
+++ b/pkg/providers/vsphere/upgrade/virtualmachine/vm_schema_upgrade_suite_test.go
@@ -1,0 +1,23 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package virtualmachine_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/klog/v2"
+)
+
+func init() {
+	klog.InitFlags(nil)
+	klog.SetOutput(GinkgoWriter)
+}
+
+func TestVMSchemaUpgrade(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "VM Schema Upgrade Suite")
+}

--- a/pkg/providers/vsphere/upgrade/virtualmachine/vm_schema_upgrade_test.go
+++ b/pkg/providers/vsphere/upgrade/virtualmachine/vm_schema_upgrade_test.go
@@ -1,0 +1,261 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package virtualmachine_test
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/vmware/govmomi/vim25/mo"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	"github.com/vmware-tanzu/vm-operator/pkg"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
+	pkgconst "github.com/vmware-tanzu/vm-operator/pkg/constants"
+	upgradevm "github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/upgrade/virtualmachine"
+)
+
+var _ = Describe("ReconcileSchemaUpgrade", func() {
+
+	var (
+		ctx       context.Context
+		k8sClient ctrlclient.Client
+		vm        *vmopv1.VirtualMachine
+		moVM      mo.VirtualMachine
+	)
+
+	BeforeEach(func() {
+		pkg.BuildVersion = "v1.2.3"
+		ctx = pkgcfg.NewContextWithDefaultConfig()
+		ctx = logr.NewContext(ctx, klog.Background())
+		k8sClient = fake.NewFakeClient()
+		vm = &vmopv1.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				UID: types.UID("abc-123"),
+			},
+		}
+		moVM = mo.VirtualMachine{
+			Config: &vimtypes.VirtualMachineConfigInfo{},
+		}
+	})
+
+	When("it should panic", func() {
+		When("ctx is nil", func() {
+			BeforeEach(func() {
+				ctx = nil
+			})
+			It("should panic", func() {
+				fn := func() {
+					_ = upgradevm.ReconcileSchemaUpgrade(ctx, k8sClient, vm, moVM)
+				}
+				Expect(fn).To(PanicWith("context is nil"))
+			})
+		})
+
+		When("k8sClient is nil", func() {
+			JustBeforeEach(func() {
+				k8sClient = nil
+			})
+			It("should panic", func() {
+				fn := func() {
+					_ = upgradevm.ReconcileSchemaUpgrade(ctx, k8sClient, vm, moVM)
+				}
+				Expect(fn).To(PanicWith("k8sClient is nil"))
+			})
+		})
+
+		When("vm is nil", func() {
+			JustBeforeEach(func() {
+				vm = nil
+			})
+			It("should panic", func() {
+				fn := func() {
+					_ = upgradevm.ReconcileSchemaUpgrade(ctx, k8sClient, vm, moVM)
+				}
+				Expect(fn).To(PanicWith("vm is nil"))
+			})
+		})
+
+		When("moVM.config is nil", func() {
+			BeforeEach(func() {
+				moVM.Config = nil
+			})
+			It("should panic", func() {
+				fn := func() {
+					_ = upgradevm.ReconcileSchemaUpgrade(ctx, k8sClient, vm, moVM)
+				}
+				Expect(fn).To(PanicWith("moVM.config is nil"))
+			})
+		})
+	})
+
+	When("it should not panic", func() {
+		var expectedErr error
+
+		BeforeEach(func() {
+			expectedErr = upgradevm.ErrUpgradeSchema
+		})
+		JustBeforeEach(func() {
+			err := upgradevm.ReconcileSchemaUpgrade(
+				ctx,
+				k8sClient,
+				vm,
+				moVM)
+			if expectedErr == nil {
+				Expect(err).ToNot(HaveOccurred())
+			} else {
+				Expect(err).To(MatchError(expectedErr))
+			}
+		})
+
+		When("the object is already upgraded", func() {
+			BeforeEach(func() {
+				expectedErr = nil
+
+				vm.Annotations = map[string]string{
+					pkgconst.UpgradedToBuildVersionAnnotationKey:  pkgcfg.FromContext(ctx).BuildVersion,
+					pkgconst.UpgradedToSchemaVersionAnnotationKey: vmopv1.GroupVersion.Version,
+				}
+				vm.Spec.InstanceUUID = ""
+				vm.Spec.BiosUUID = ""
+				vm.Spec.Bootstrap = &vmopv1.VirtualMachineBootstrapSpec{
+					CloudInit: &vmopv1.VirtualMachineBootstrapCloudInitSpec{
+						InstanceID: "",
+					},
+				}
+				moVM.Config = &vimtypes.VirtualMachineConfigInfo{
+					InstanceUuid: "123",
+					Uuid:         "123",
+				}
+			})
+			It("should not modify any of the fields it would otherwise upgrade", func() {
+				Expect(vm.Spec.InstanceUUID).To(BeEmpty())
+				Expect(vm.Spec.BiosUUID).To(BeEmpty())
+				Expect(vm.Spec.Bootstrap.CloudInit.InstanceID).To(BeEmpty())
+			})
+		})
+
+		When("the object needs to be upgraded", func() {
+			BeforeEach(func() {
+				moVM.Config = &vimtypes.VirtualMachineConfigInfo{
+					Uuid:         "test-bios-uuid",
+					InstanceUuid: "test-instance-uuid",
+				}
+			})
+
+			assertUpgraded := func() {
+				ExpectWithOffset(1, vm.Annotations).To(HaveKeyWithValue(
+					pkgconst.UpgradedToBuildVersionAnnotationKey,
+					pkgcfg.FromContext(ctx).BuildVersion))
+				ExpectWithOffset(1, vm.Annotations).To(HaveKeyWithValue(
+					pkgconst.UpgradedToSchemaVersionAnnotationKey,
+					vmopv1.GroupVersion.Version))
+			}
+
+			Context("BIOS UUID reconciliation", func() {
+				When("BIOS UUID is empty in VM spec", func() {
+					It("should set BIOS UUID from moVM", func() {
+						assertUpgraded()
+						Expect(vm.Spec.BiosUUID).To(Equal("test-bios-uuid"))
+					})
+				})
+
+				When("BIOS UUID is already set in VM spec", func() {
+					BeforeEach(func() {
+						vm.Spec.BiosUUID = "existing-bios-uuid"
+					})
+					It("should not modify existing BIOS UUID", func() {
+						Expect(vm.Spec.BiosUUID).To(Equal("existing-bios-uuid"))
+					})
+				})
+
+				When("moVM config UUID is empty", func() {
+					BeforeEach(func() {
+						moVM.Config.Uuid = ""
+					})
+					It("should not set BIOS UUID", func() {
+						Expect(vm.Spec.BiosUUID).To(BeEmpty())
+					})
+				})
+			})
+
+			Context("Instance UUID reconciliation", func() {
+				When("Instance UUID is empty in VM spec", func() {
+					It("should set Instance UUID from moVM", func() {
+						assertUpgraded()
+						Expect(vm.Spec.InstanceUUID).To(Equal("test-instance-uuid"))
+					})
+				})
+
+				When("Instance UUID is already set in VM spec", func() {
+					BeforeEach(func() {
+						vm.Spec.InstanceUUID = "existing-instance-uuid"
+					})
+					It("should not modify existing Instance UUID", func() {
+						Expect(vm.Spec.InstanceUUID).To(Equal("existing-instance-uuid"))
+					})
+				})
+
+				When("moVM config InstanceUuid is empty", func() {
+					BeforeEach(func() {
+						moVM.Config.InstanceUuid = ""
+					})
+					It("should not set Instance UUID", func() {
+						Expect(vm.Spec.InstanceUUID).To(BeEmpty())
+					})
+				})
+			})
+
+			Context("CloudInit instance UUID reconciliation", func() {
+				When("VM has CloudInit bootstrap configuration", func() {
+					BeforeEach(func() {
+						vm.Spec.Bootstrap = &vmopv1.VirtualMachineBootstrapSpec{
+							CloudInit: &vmopv1.VirtualMachineBootstrapCloudInitSpec{},
+						}
+					})
+
+					When("CloudInit InstanceID is empty", func() {
+						It("should generate CloudInit InstanceID", func() {
+							assertUpgraded()
+							Expect(vm.Spec.Bootstrap.CloudInit.InstanceID).ToNot(BeEmpty())
+						})
+					})
+
+					When("CloudInit InstanceID is already set", func() {
+						BeforeEach(func() {
+							vm.Spec.Bootstrap.CloudInit.InstanceID = "existing-cloud-init-id"
+						})
+						It("should not modify existing CloudInit InstanceID", func() {
+							Expect(vm.Spec.Bootstrap.CloudInit.InstanceID).To(Equal("existing-cloud-init-id"))
+						})
+					})
+				})
+
+				When("VM has no bootstrap configuration", func() {
+					It("should not set CloudInit InstanceID", func() {
+						Expect(vm.Spec.Bootstrap).To(BeNil())
+					})
+				})
+
+				When("VM has bootstrap but no CloudInit configuration", func() {
+					BeforeEach(func() {
+						vm.Spec.Bootstrap = &vmopv1.VirtualMachineBootstrapSpec{}
+					})
+					It("should not set CloudInit InstanceID", func() {
+						Expect(vm.Spec.Bootstrap.CloudInit).To(BeNil())
+					})
+				})
+			})
+		})
+	})
+})

--- a/pkg/providers/vsphere/vmlifecycle/bootstrap_cloudinit.go
+++ b/pkg/providers/vsphere/vmlifecycle/bootstrap_cloudinit.go
@@ -44,7 +44,7 @@ type WaitOnNetwork struct {
 var CloudInitUserDataSecretKeys = []string{"user-data", "value"}
 
 func BootStrapCloudInitInstanceID(
-	vmCtx pkgctx.VirtualMachineContext,
+	vm *vmopv1.VirtualMachine,
 	cloudInitSpec *vmopv1.VirtualMachineBootstrapCloudInitSpec) string {
 
 	// The Cloud-Init instance ID is from spec.bootstrap.cloudInit.instanceID.
@@ -61,10 +61,10 @@ func BootStrapCloudInitInstanceID(
 		// spec.bootstrap.cloudInit.instanceID, use the VM resource's object
 		// UID as the Cloud-Init instance ID if the value of
 		// spec.bootstrap.cloudInit.instanceID is empty.
-		iid = string(vmCtx.VM.UID)
+		iid = string(vm.UID)
 	}
 
-	if v := vmCtx.VM.Annotations[vmopv1.InstanceIDAnnotation]; v != "" && v != iid {
+	if v := vm.Annotations[vmopv1.InstanceIDAnnotation]; v != "" && v != iid {
 		// Before the introduction of spec.bootstrap.cloudInit.instanceID,
 		// the Cloud-Init instance ID was set to the value of the VM object's
 		// metadata.uid field.
@@ -90,7 +90,7 @@ func BootStrapCloudInitInstanceID(
 		// spec.bootstrap.cloudInit.instanceID or metadata.uid), go ahead and
 		// use the value from the annotation.
 		iid = v
-		delete(vmCtx.VM.Annotations, vmopv1.InstanceIDAnnotation)
+		delete(vm.Annotations, vmopv1.InstanceIDAnnotation)
 	}
 
 	// If the value of the Cloud-Init instance ID is different than the
@@ -122,7 +122,7 @@ func BootStrapCloudInit(
 		sshPublicKeys = strings.Join(cloudInitSpec.SSHAuthorizedKeys, "\n")
 	}
 
-	iid := BootStrapCloudInitInstanceID(vmCtx, cloudInitSpec)
+	iid := BootStrapCloudInitInstanceID(vmCtx.VM, cloudInitSpec)
 
 	metadata, err := GetCloudInitMetadata(
 		iid, bsArgs.HostName, bsArgs.DomainName, netPlan, sshPublicKeys,

--- a/pkg/providers/vsphere/vsphere_suite_test.go
+++ b/pkg/providers/vsphere/vsphere_suite_test.go
@@ -96,7 +96,8 @@ func createOrUpdateVM(
 				errors.Is(err, vsphere.ErrRestart),
 				errors.Is(err, vsphere.ErrSetPowerState),
 				errors.Is(err, vsphere.ErrUpgradeHardwareVersion),
-				errors.Is(err, vsphere.ErrPromoteDisks):
+				errors.Is(err, vsphere.ErrPromoteDisks),
+				errors.Is(err, vsphere.ErrUpgradeSchema):
 
 				repeat = true
 			default:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch provides an officially supported path for upgrading a VM Op VM's schema to match the latest version supported by VM Op.

Importantly, this change also disallows all updates to the VM Op VM object until such time the VM object is updated. This is critical as it prevents any changes that might interrupt or be in conflict with the changes occurring as part of the upgrade.



**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

I ran this by @zjs for VKS consideration as well as Brandon Nelson, and they both agree this change makes sense and are good with it.


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Do not allow modifying VM objects that are not upgraded.
```