### PR TITLE
:sparkles: Handle VM Class instances during VM class reconcile

### DIFF
--- a/api/v1alpha4/virtualmachineclassinstance_types.go
+++ b/api/v1alpha4/virtualmachineclassinstance_types.go
@@ -8,6 +8,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	// VMClassInstanceActiveLabelKey represents if a
+	// VirtualMachineClassInstance can be used to deploy a new virtual
+	// machine, or resize an existing one. The presence of this label
+	// on a VirtualMachineClassInstance marks the instance as active.
+	// The value of this key does not matter.
+	VMClassInstanceActiveLabelKey = GroupName + "/active"
+)
+
 // VirtualMachineClassInstanceSpec defines the desired state of VirtualMachineClassInstance.
 // It is a composite of VirtualMachineClassSpec.
 type VirtualMachineClassInstanceSpec struct {
@@ -24,6 +33,7 @@ type VirtualMachineClassInstanceStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="CPU",type="string",JSONPath=".spec.hardware.cpus"
 // +kubebuilder:printcolumn:name="Memory",type="string",JSONPath=".spec.hardware.memory"
+// +kubebuilder:printcolumn:name="Active",type="string",JSONPath=".metadata.labels['vmoperator\\.vmware\\.com/active']"
 
 // VirtualMachineClassInstance is the schema for the virtualmachineclassinstances API and
 // represents the desired state and observed status of a virtualmachineclassinstance

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachineclassinstances.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachineclassinstances.yaml
@@ -23,6 +23,9 @@ spec:
     - jsonPath: .spec.hardware.memory
       name: Memory
       type: string
+    - jsonPath: .metadata.labels['vmoperator\.vmware\.com/active']
+      name: Active
+      type: string
     name: v1alpha4
     schema:
       openAPIV3Schema:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -217,6 +217,7 @@ rules:
   resources:
   - clustervirtualmachineimages
   - virtualmachineclasses
+  - virtualmachineclassinstances
   - virtualmachinegroups
   - virtualmachineimagecaches
   - virtualmachineimages
@@ -250,6 +251,7 @@ rules:
   - vmoperator.vmware.com
   resources:
   - virtualmachineclasses/status
+  - virtualmachineclassinstances/status
   - virtualmachinegroups/status
   - virtualmachineimagecaches/status
   - virtualmachinepublishrequests/status

--- a/controllers/storagepolicyquota/storagepolicyquota_controller_unit_test.go
+++ b/controllers/storagepolicyquota/storagepolicyquota_controller_unit_test.go
@@ -107,12 +107,7 @@ func unitTestsReconcile() {
 		ctx = suite.NewUnitTestContextForController(withObjects...)
 
 		reconciler = storagepolicyquota.NewReconciler(
-			pkgcfg.UpdateContext(
-				ctx,
-				func(config *pkgcfg.Config) {
-					config.Features.PodVMOnStretchedSupervisor = true
-				},
-			),
+			pkgcfg.NewContextWithDefaultConfig(),
 			ctx.Client,
 			ctx.Logger,
 			ctx.Recorder,

--- a/controllers/virtualmachineclass/virtualmachineclass_controller.go
+++ b/controllers/virtualmachineclass/virtualmachineclass_controller.go
@@ -6,20 +6,27 @@ package virtualmachineclass
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
 
+	xxhash "github.com/cespare/xxhash/v2"
 	"github.com/go-logr/logr"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
+	pkgconst "github.com/vmware-tanzu/vm-operator/pkg/constants"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/patch"
+	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
 	"github.com/vmware-tanzu/vm-operator/pkg/record"
 )
 
@@ -69,6 +76,8 @@ type Reconciler struct {
 
 // +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachineclasses,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachineclasses/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachineclassinstances,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachineclassinstances/status,verbs=get;update;patch
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
 	ctx = pkgcfg.JoinContext(ctx, r.Context)
@@ -111,5 +120,165 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 }
 
 func (r *Reconciler) ReconcileNormal(vmClassCtx *pkgctx.VirtualMachineClassContext) error {
+	// Reconcile VM class instances if the Supervisor supports it.
+	if pkgcfg.FromContext(vmClassCtx).Features.ImmutableClasses {
+		vmClassCtx.Logger.Info("Reconciling VirtualMachineClassInstances for VM class")
+		if err := r.reconcileInstance(vmClassCtx); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// TODO: copied from pkg/providers/vsphere/vmlifecycle/bootstrap.go.
+func getVimTypeHash(obj vimtypes.AnyType) (string, error) {
+	data, err := json.Marshal(obj)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal vim type to json: %w", err)
+	}
+	h := xxhash.New()
+	if _, err := h.Write(data); err != nil {
+		return "", fmt.Errorf("failed to write vim type to hash: %w", err)
+	}
+	out := h.Sum(nil)
+	return fmt.Sprintf("%x", out), nil
+}
+
+// vmClassHash returns a hash of the VM Class Reserved + VirtualMachineConfigSpec.
+func vmClassHash(ctx *pkgctx.VirtualMachineClassContext, class *vmopv1.VirtualMachineClass) (string, error) {
+	if len(class.Spec.ConfigSpec) == 0 {
+		// wcpsvc is expected to always set configSpec when creating a VM class.
+		return "", fmt.Errorf("%s configSpec is nil", class.Name)
+	}
+
+	spec, err := vsphere.GetVMClassConfigSpec(ctx, class.Spec.ConfigSpec)
+	if err != nil {
+		return "", err
+	}
+
+	data := struct {
+		Reserved bool                              `json:"reserved"`
+		Spec     vimtypes.VirtualMachineConfigSpec `json:"spec"`
+	}{
+		class.Spec.ReservedProfileID != "",
+		spec,
+	}
+
+	return getVimTypeHash(data)
+}
+
+// reconcileInstance creates a VirtualMachineClassInstance for the
+// given VirtualMachineClass. The name of the instance object contains
+// the a hash of ConfigSpec (and other relevant fields) to uniquely
+// identify a configuration. The hash is generated using a 64-bit
+// xxHash algorithm. The instance also contains:
+//   - An annotation containing the same hash
+//   - A label with the corresponding VM class name to allow for
+//     efficient server side queries to list instances for a given VM
+//     class.
+//   - A label to indicate if an instance is active. An instance is
+//     marked inactive if the configuration of the VM class is modified,
+//     or the class is removed from the namespace or deleted.  There
+//     can only be one active instance of a VM class. So, all other
+//     instances are marked inactive.
+//   - Owner reference to the owning class.
+func (r *Reconciler) reconcileInstance(ctx *pkgctx.VirtualMachineClassContext) error {
+	hash, err := vmClassHash(ctx, ctx.VMClass)
+	if err != nil {
+		ctx.Logger.Error(err, "Failed to calculate the hash value required to create VM class instance")
+		return err
+	}
+
+	vmClassInstance := &vmopv1.VirtualMachineClassInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ctx.VMClass.Namespace,
+			Name:      ctx.VMClass.Name + "-" + hash,
+		},
+	}
+
+	// Note that there's a window where users will be able to specify
+	// a stale VM class instance to create a VM if the call comes in
+	// after we create a new instance but before we mark the existing
+	// active one as "inactive". The alternative is to flip the order
+	// but that will lead to rejection of VM creations even though
+	// there's a valid class associated with the namespace. So we
+	// choose former.
+	_, err = ctrlutil.CreateOrPatch(ctx, r.Client, vmClassInstance, func() error {
+		if err := ctrlutil.SetControllerReference(
+			ctx.VMClass, vmClassInstance, r.Scheme()); err != nil {
+
+			return err
+		}
+
+		vmClassInstance.Spec.VirtualMachineClassSpec = ctx.VMClass.Spec
+
+		// Set the hash as an annotation on the instance.
+		if vmClassInstance.Annotations == nil {
+			vmClassInstance.Annotations = make(map[string]string)
+		}
+		vmClassInstance.Annotations[pkgconst.VirtualMachineClassHashAnnotationKey] = hash
+
+		// Set a label to mark the instance as active.
+		if vmClassInstance.Labels == nil {
+			vmClassInstance.Labels = make(map[string]string)
+		}
+		vmClassInstance.Labels[vmopv1.VMClassInstanceActiveLabelKey] = ""
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	var list vmopv1.VirtualMachineClassInstanceList
+
+	if err := r.Client.List(ctx, &list,
+		client.InNamespace(ctx.VMClass.Namespace)); err != nil {
+
+		ctx.Logger.Error(err, "Error listing instances for VM class")
+		return err
+	}
+
+	for _, instance := range list.Items {
+		// Only process instances owned by this VM class
+		owned, err := ctrlutil.HasOwnerReference(instance.OwnerReferences, ctx.VMClass, r.Scheme())
+		if err != nil {
+			return fmt.Errorf("failed to check if VM class instance is owned by the class. err: %w", err)
+		}
+
+		if !owned {
+			ctx.Logger.Info("Skipping this instance since it is not owned by VM class")
+			continue
+		}
+
+		// Create a deepcopy of the object for patching.
+		patch := client.MergeFrom(instance.DeepCopy())
+
+		if val, ok := instance.Annotations[pkgconst.VirtualMachineClassHashAnnotationKey]; ok && val == hash {
+			// Hash value on the VM class instance matches with the
+			// hash we just calculated. Mark this class as active.
+			if _, ok := instance.Labels[vmopv1.VMClassInstanceActiveLabelKey]; !ok {
+				ctx.Logger.Info("Marking instance as active")
+				if instance.Labels == nil {
+					instance.Labels = make(map[string]string)
+				}
+				instance.Labels[vmopv1.VMClassInstanceActiveLabelKey] = ""
+			}
+		} else {
+			// Mark the instance as inactive since its hash does not
+			// match the hash of the current version of VM class.
+			ctx.Logger.Info("Marking instance as inactive")
+			delete(instance.Labels, vmopv1.VMClassInstanceActiveLabelKey)
+			// If this was the last label, set labels to nil so the
+			// field gets removed from the object.
+		}
+
+		if err := r.Client.Patch(ctx, &instance, patch); err != nil {
+			ctx.Logger.Error(err, "patch failed")
+			return err
+		}
+	}
+
 	return nil
 }

--- a/controllers/virtualmachineclass/virtualmachineclass_controller_suite_test.go
+++ b/controllers/virtualmachineclass/virtualmachineclass_controller_suite_test.go
@@ -8,10 +8,13 @@ import (
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
+	"github.com/vmware/govmomi/vim25/types"
 
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachineclass"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	"github.com/vmware-tanzu/vm-operator/pkg/manager"
+	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
@@ -27,3 +30,17 @@ func TestVirtualMachineClass(t *testing.T) {
 var _ = BeforeSuite(suite.BeforeSuite)
 
 var _ = AfterSuite(suite.AfterSuite)
+
+// setConfigSpec populates the spec.configSpec field as wcpsvc would when creating a VM Class.
+func setConfigSpec(vmClass *vmopv1.VirtualMachineClass) {
+	spec := types.VirtualMachineConfigSpec{
+		NumCPUs:  int32(vmClass.Spec.Hardware.Cpus),
+		MemoryMB: vmClass.Spec.Hardware.Memory.Value(),
+	}
+
+	var err error
+	vmClass.Spec.ConfigSpec, err = pkgutil.MarshalConfigSpecToJSON(spec)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -122,4 +122,8 @@ const (
 	// a power state change to a VirtualMachine or a VirtualMachineGroup object
 	// scheduled from its parent group.
 	ApplyPowerStateTimeAnnotation = "vmoperator.vmware.com.protected/apply-power-state-time"
+
+	// VirtualMachineClassHashAnnotationKey is the annotation key for the VM Class hash
+	// used to generate VirtualMachineClassInstances.
+	VirtualMachineClassHashAnnotationKey = "vmoperator.vmware.com/vmclass-hash"
 )

--- a/test/builder/fake.go
+++ b/test/builder/fake.go
@@ -58,6 +58,7 @@ func KnownObjectTypes() []client.Object {
 		&vmopv1.VirtualMachineGroup{},
 		&vmopv1.VirtualMachineService{},
 		&vmopv1.VirtualMachineClass{},
+		&vmopv1.VirtualMachineClassInstance{},
 		&vmopv1.VirtualMachinePublishRequest{},
 		&vmopv1.ClusterVirtualMachineImage{},
 		&vmopv1.VirtualMachineImage{},


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Reconcile VM classes to create VM class instance.  An instance is created with an annotation containing the hash of the ConfigSpec.  Additionally, the instance object also has an OwnerReference to the corresponding class.  The controller ensures that at a time, only the instance mapping to the latest ConfigSpec hash is marked as active.  The active / inactive property is represented by a label to allow clients to query efficiently.

**Please add a release note if necessary**:
```release-note
Handle VM Class instances during VM class reconcile
```