### PR TITLE
🌱 Golang 1.24.4

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -2,7 +2,7 @@ module github.com/vmware-tanzu/vm-operator/api
 
 go 1.23.0
 
-toolchain go1.24.2
+toolchain go1.24.4
 
 require (
 	github.com/google/go-cmp v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/vm-operator
 
-go 1.24.2
+go 1.24.4
 
 replace (
 	github.com/vmware-tanzu/vm-operator/api => ./api

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/vmware-tanzu/vm-operator/hack/tools
 
 go 1.23.0
 
-toolchain go1.24.2
+toolchain go1.24.4
 
 require (
 	github.com/AlekSi/gocov-xml v1.1.0


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR updates VM Operator to use Golang 1.24.4 to fix vulncheck-go errors reported in CI, e.g.: https://github.com/vmware-tanzu/vm-operator/actions/runs/15593530772/job/43918314191?pr=1011


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes N/A.


**Are there any special notes for your reviewer**:

Another PR will be submitted to the internal `cayman_vm-operator` repo to upgrade the cayman_go version to match this.


**Please add a release note if necessary**:

```release-note
Golang 1.24.4
```