### PR TITLE
🐛 x-port 8.0.3: Fix PCI DVX devs on update

### DIFF
--- a/pkg/vmprovider/providers/vsphere2/session/session_vm_update.go
+++ b/pkg/vmprovider/providers/vsphere2/session/session_vm_update.go
@@ -192,6 +192,22 @@ func UpdatePCIDeviceChanges(
 							expectedAllowedDev.VendorId == currAllowedDevs[i].VendorId
 					}
 				}
+
+			case *vimTypes.VirtualPCIPassthroughDvxBackingInfo:
+				b := expectedBacking.(*vimTypes.VirtualPCIPassthroughDvxBackingInfo)
+				if a.DeviceClass == b.DeviceClass {
+					if len(a.ConfigParams) == len(b.ConfigParams) {
+						am := make(map[string]any, len(a.ConfigParams))
+						bm := make(map[string]any, len(b.ConfigParams))
+						for i := 0; i < len(a.ConfigParams); i++ {
+							aov := a.ConfigParams[i].GetOptionValue()
+							bov := b.ConfigParams[i].GetOptionValue()
+							am[aov.Key] = aov.Value
+							bm[bov.Key] = bov.Value
+						}
+						backingMatch = apiEquality.Semantic.DeepEqual(am, bm)
+					}
+				}
 			}
 
 			if backingMatch {


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch fixes how PCI Passthrough devices are handled when their backing is VirtualPCIPassthroughDvxBackingInfo. Previously they would be removed/added during a pre-poweron reconfigure due to the lack of proper device matching. This patch ensures if nothing has changed, the existing devices are not removed/added.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Do not remove/add PCI DVX devices on update if nothing has changed.
```