### PR TITLE
🐛 Relax VM Group webhook to allow power state changes

### DIFF
--- a/webhooks/virtualmachinegroup/validation/virtualmachinegroup_validator.go
+++ b/webhooks/virtualmachinegroup/validation/virtualmachinegroup_validator.go
@@ -36,11 +36,20 @@ const (
 // +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachinegroups,verbs=get;list
 
 // AddToManager adds the webhook to the provided manager.
-func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) error {
-	hook, err := builder.NewValidatingWebhook(ctx, mgr, webHookName, NewValidator(mgr.GetClient()))
+func AddToManager(
+	ctx *pkgctx.ControllerManagerContext,
+	mgr ctrlmgr.Manager) error {
+	hook, err := builder.NewValidatingWebhook(
+		ctx,
+		mgr,
+		webHookName,
+		NewValidator(mgr.GetClient()),
+	)
 	if err != nil {
-		return fmt.Errorf("failed to create VirtualMachineGroup validation webhook: %w", err)
+		return fmt.Errorf(
+			"failed to create VirtualMachineGroup validation webhook: %w", err)
 	}
+
 	mgr.GetWebhookServer().Register(hook.Path, hook)
 
 	return nil
@@ -59,20 +68,28 @@ type validator struct {
 	converter runtime.UnstructuredConverter
 }
 
-// vmGroupFromUnstructured returns the VirtualMachineGroup from the unstructured object.
-func (v validator) vmGroupFromUnstructured(obj runtime.Unstructured) (*vmopv1.VirtualMachineGroup, error) {
+// vmGroupFromUnstructured returns the VirtualMachineGroup from the unstructured
+// object.
+func (v validator) vmGroupFromUnstructured(
+	obj runtime.Unstructured) (*vmopv1.VirtualMachineGroup, error) {
 	vmGroup := &vmopv1.VirtualMachineGroup{}
-	if err := v.converter.FromUnstructured(obj.UnstructuredContent(), vmGroup); err != nil {
+	if err := v.converter.FromUnstructured(
+		obj.UnstructuredContent(),
+		vmGroup); err != nil {
 		return nil, err
 	}
+
 	return vmGroup, nil
 }
 
 func (v validator) For() schema.GroupVersionKind {
-	return vmopv1.GroupVersion.WithKind(reflect.TypeOf(vmopv1.VirtualMachineGroup{}).Name())
+	return vmopv1.GroupVersion.WithKind(
+		reflect.TypeOf(vmopv1.VirtualMachineGroup{}).Name(),
+	)
 }
 
-func (v validator) ValidateCreate(ctx *pkgctx.WebhookRequestContext) admission.Response {
+func (v validator) ValidateCreate(
+	ctx *pkgctx.WebhookRequestContext) admission.Response {
 	vmGroup, err := v.vmGroupFromUnstructured(ctx.Obj)
 	if err != nil {
 		return webhook.Errored(http.StatusBadRequest, err)
@@ -80,7 +97,7 @@ func (v validator) ValidateCreate(ctx *pkgctx.WebhookRequestContext) admission.R
 
 	var fieldErrs field.ErrorList
 
-	fieldErrs = append(fieldErrs, v.validateAnnotation(ctx, vmGroup, nil)...)
+	fieldErrs = append(fieldErrs, v.validatePowerState(ctx, vmGroup, nil)...)
 
 	validationErrs := make([]string, 0, len(fieldErrs))
 	for _, fieldErr := range fieldErrs {
@@ -90,11 +107,13 @@ func (v validator) ValidateCreate(ctx *pkgctx.WebhookRequestContext) admission.R
 	return common.BuildValidationResponse(ctx, nil, validationErrs, nil)
 }
 
-func (v validator) ValidateDelete(*pkgctx.WebhookRequestContext) admission.Response {
+func (v validator) ValidateDelete(
+	_ *pkgctx.WebhookRequestContext) admission.Response {
 	return admission.Allowed("")
 }
 
-func (v validator) ValidateUpdate(ctx *pkgctx.WebhookRequestContext) admission.Response {
+func (v validator) ValidateUpdate(
+	ctx *pkgctx.WebhookRequestContext) admission.Response {
 	vmGroup, err := v.vmGroupFromUnstructured(ctx.Obj)
 	if err != nil {
 		return webhook.Errored(http.StatusBadRequest, err)
@@ -107,8 +126,10 @@ func (v validator) ValidateUpdate(ctx *pkgctx.WebhookRequestContext) admission.R
 
 	var fieldErrs field.ErrorList
 
-	fieldErrs = append(fieldErrs, v.validateAnnotation(ctx, vmGroup, oldVMGroup)...)
-	fieldErrs = append(fieldErrs, v.validatePowerState(ctx, vmGroup, oldVMGroup)...)
+	fieldErrs = append(fieldErrs,
+		v.validatePowerState(ctx, vmGroup, oldVMGroup)...,
+	)
+
 	validationErrs := make([]string, 0, len(fieldErrs))
 	for _, fieldErr := range fieldErrs {
 		validationErrs = append(validationErrs, fieldErr.Error())
@@ -117,46 +138,55 @@ func (v validator) ValidateUpdate(ctx *pkgctx.WebhookRequestContext) admission.R
 	return common.BuildValidationResponse(ctx, nil, validationErrs, nil)
 }
 
-func (v validator) validateAnnotation(ctx *pkgctx.WebhookRequestContext, vmGroup, oldVMGroup *vmopv1.VirtualMachineGroup) field.ErrorList {
-	var allErrs field.ErrorList
-
-	// Use an empty VMGroup to validate annotation on creation requests.
+func (v validator) validatePowerState(
+	ctx *pkgctx.WebhookRequestContext,
+	newVMGroup, oldVMGroup *vmopv1.VirtualMachineGroup) field.ErrorList {
+	// Use an empty VMGroup to validate creation requests.
 	if oldVMGroup == nil {
 		oldVMGroup = &vmopv1.VirtualMachineGroup{}
 	}
 
-	annotationPath := field.NewPath("metadata", "annotations")
+	var (
+		allErrs           field.ErrorList
+		annotationPath    = field.NewPath("metadata", "annotations")
+		oldAnnotationTime = oldVMGroup.Annotations[constants.LastUpdatedPowerStateTimeAnnotation]
+		newAnnotationTime = newVMGroup.Annotations[constants.LastUpdatedPowerStateTimeAnnotation]
+	)
 
-	// Disallow if last-updated-power-state annotation was modified by a non-admin user.
-	oldVal := oldVMGroup.Annotations[constants.LastUpdatedPowerStateTimeAnnotation]
-	newVal := vmGroup.Annotations[constants.LastUpdatedPowerStateTimeAnnotation]
-	if !ctx.IsPrivilegedAccount && oldVal != newVal {
-		allErrs = append(allErrs, field.Forbidden(
-			annotationPath.Key(constants.LastUpdatedPowerStateTimeAnnotation),
-			modifyAnnotationNotAllowedForNonAdmin))
+	// Disallow if last-updated-power-state annotation was modified directly by
+	// non-admin users. It should be updated only by the mutating webhook when
+	// the group's power state or next force sync time changes.
+	if !ctx.IsPrivilegedAccount {
+		powerStateChanged := oldVMGroup.Spec.PowerState !=
+			newVMGroup.Spec.PowerState
+		syncTimeChanged := oldVMGroup.Spec.NextForcePowerStateSyncTime !=
+			newVMGroup.Spec.NextForcePowerStateSyncTime
+		annotationChanged := oldAnnotationTime != newAnnotationTime
+
+		if annotationChanged && !powerStateChanged && !syncTimeChanged {
+			allErrs = append(allErrs, field.Forbidden(
+				annotationPath.Key(constants.LastUpdatedPowerStateTimeAnnotation),
+				modifyAnnotationNotAllowedForNonAdmin))
+		}
 	}
 
-	// Disallow if the last-updated-power-state annotation value is not in RFC3339Nano format.
-	if newVal != "" {
-		if _, err := time.Parse(time.RFC3339Nano, newVal); err != nil {
+	// Disallow if the last-updated-power-state annotation value is not in the
+	// RFC3339Nano format.
+	if newAnnotationTime != "" {
+		if _, err := time.Parse(time.RFC3339Nano, newAnnotationTime); err != nil {
 			allErrs = append(allErrs, field.Invalid(
 				annotationPath.Key(constants.LastUpdatedPowerStateTimeAnnotation),
-				newVal,
+				newAnnotationTime,
 				invalidTimeFormat))
 		}
 	}
 
-	return allErrs
-}
-
-func (v validator) validatePowerState(_ *pkgctx.WebhookRequestContext, vmGroup, oldVMGroup *vmopv1.VirtualMachineGroup) field.ErrorList {
-	var allErrs field.ErrorList
-
-	powerStatePath := field.NewPath("spec", "powerState")
-
 	// Disallow setting powerState to empty after it's been set.
-	if oldVMGroup.Spec.PowerState != "" && vmGroup.Spec.PowerState == "" {
-		allErrs = append(allErrs, field.Forbidden(powerStatePath, emptyPowerStateNotAllowedAfterSet))
+	if oldVMGroup.Spec.PowerState != "" && newVMGroup.Spec.PowerState == "" {
+		allErrs = append(allErrs, field.Forbidden(
+			field.NewPath("spec", "powerState"),
+			emptyPowerStateNotAllowedAfterSet,
+		))
 	}
 
 	return allErrs


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR updates the VM Group validating webhook to only disallow `lastUpdatedPowerStateTime` annotation change if it's set directly by non-admin users. This ensures the non-admins can still update the VM Group's power state (which triggers the annotation change by mutating webhook) while preventing them from modifying the annotation directly.

While here, also formatted the code to keep line length under 80 chars where possible.


**Which issue(s) is/are addressed by this PR?**:

Fixes N/A.


**Are there any special notes for your reviewer**:

- Updated tests to cover 100% of the validating webhook functionality: 
<img width="614" alt="image" src="https://github.com/user-attachments/assets/6308fcb2-4970-49c1-8558-cb4f568dc985" />

- Deployed this change to a testbed and verified that non-admin users cannot update the annotation directly, but can update the group's power state and next sync time as expected:

```console
$ kubectl get vmg -n sdiliyaer-test vmg-test -o json | jq .spec.powerState
"PoweredOff"
$ kubectl apply -f vmg.yaml
virtualmachinegroup.vmoperator.vmware.com/vmg-test configured
$ kubectl get vmg -n sdiliyaer-test vmg-test -o json | jq .spec.powerState
"PoweredOn"

$ kubectl get vmg -n sdiliyaer-test vmg-test -o json | jq .spec.nextForcePowerStateSyncTime
null
$ kubectl apply -f vmg.yaml
virtualmachinegroup.vmoperator.vmware.com/vmg-test configured
$ kubectl get vmg -n sdiliyaer-test vmg-test -o json | jq .spec.nextForcePowerStateSyncTime
"2025-06-13T16:53:12.565068607Z"

$ kubectl annotate vmg -n sdiliyaer-test vmg-test vmoperator.vmware.com.protected/last-updated-power-state-time=2025-06-13T16:03:31.831806331Z --overwrite
Error from server (metadata.annotations[vmoperator.vmware.com.protected/last-updated-power-state-time]: Forbidden: modifying this annotation is not allowed for non-admin users): admission webhook "default.validating.virtualmachinegroup.v1alpha4.vmoperator.vmware.com" denied the request: metadata.annotations[vmoperator.vmware.com.protected/last-updated-power-state-time]: Forbidden: modifying this annotation is not allowed for non-admin users
```

**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Relax VM Group webhook to allow power state changes from non-admin users.
```