### PR TITLE
🐛 Disable schema not yet upgrade VM validation checks

### DIFF
--- a/webhooks/virtualmachine/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator.go
@@ -1253,12 +1253,14 @@ func (v validator) validateSchemaUpgrade(
 		ctx.Logger.V(4).Info("Deleted annotation",
 			"key", pkgconst.UpgradedToBuildVersionAnnotationKey)
 
-	case oldUpBuildVer == "" || oldUpBuildVer != pkgcfg.FromContext(ctx).BuildVersion:
-		// If the annotations' values do not match the expected values, then the
-		// VM may not be modified.
-		allErrs = append(allErrs, field.Forbidden(
-			fieldPath.Key(pkgconst.UpgradedToBuildVersionAnnotationKey),
-			notUpgraded))
+		/*
+			case oldUpBuildVer == "" || oldUpBuildVer != pkgcfg.FromContext(ctx).BuildVersion:
+				// If the annotations' values do not match the expected values, then the
+				// VM may not be modified.
+				allErrs = append(allErrs, field.Forbidden(
+					fieldPath.Key(pkgconst.UpgradedToBuildVersionAnnotationKey),
+					notUpgraded))
+		*/
 	}
 
 	switch {
@@ -1273,12 +1275,15 @@ func (v validator) validateSchemaUpgrade(
 		ctx.Logger.V(4).Info("Deleted annotation",
 			"key", pkgconst.UpgradedToSchemaVersionAnnotationKey)
 
-	case oldUpSchemVer == "" || oldUpSchemVer != vmopv1.GroupVersion.Version:
-		// If the annotations' values do not match the expected values, then the
-		// VM may not be modified.
-		allErrs = append(allErrs, field.Forbidden(
-			fieldPath.Key(pkgconst.UpgradedToSchemaVersionAnnotationKey),
-			notUpgraded))
+		/*
+			case oldUpSchemVer == "" || oldUpSchemVer != vmopv1.GroupVersion.Version:
+				// If the annotations' values do not match the expected values, then the
+				// VM may not be modified.
+				allErrs = append(allErrs, field.Forbidden(
+					fieldPath.Key(pkgconst.UpgradedToSchemaVersionAnnotationKey),
+					notUpgraded))
+
+		*/
 	}
 
 	return allErrs

--- a/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
@@ -4966,7 +4966,7 @@ func unitTestsValidateUpdate() {
 			},
 		),
 
-		Entry("disallow change when upgradedToBuildVersion is missing",
+		XEntry("disallow change when upgradedToBuildVersion is missing",
 			testParams{
 				setup: func(ctx *unitValidatingWebhookContext) {
 					ctx.IsPrivilegedAccount = false
@@ -4983,7 +4983,7 @@ func unitTestsValidateUpdate() {
 			},
 		),
 
-		Entry("disallow change when upgradedToSchemaVersion is missing",
+		XEntry("disallow change when upgradedToSchemaVersion is missing",
 			testParams{
 				setup: func(ctx *unitValidatingWebhookContext) {
 					ctx.IsPrivilegedAccount = false


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This has broken some E2E tests so temporarily disable those validation checks until this can all be sorted out.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note
NONE
```