### PR TITLE
🌱 Require UserData.FullName and OrgName for inlined Sysprep

### DIFF
--- a/pkg/providers/vsphere/vmlifecycle/bootstrap_sysprep.go
+++ b/pkg/providers/vsphere/vmlifecycle/bootstrap_sysprep.go
@@ -122,13 +122,13 @@ func convertTo(from *vmopv1sysprep.Sysprep, bsArgs *BootstrapArgs) *vimtypes.Cus
 	}
 
 	sysprepCustomization.UserData = vimtypes.CustomizationUserData{
-		// This is a mandatory field
+		// These are mandatory fields.
+		FullName: from.UserData.FullName,
+		OrgName:  from.UserData.OrgName,
 		ComputerName: &vimtypes.CustomizationFixedName{
 			Name: bsArgs.HostName,
 		},
 	}
-	sysprepCustomization.UserData.FullName = from.UserData.FullName
-	sysprepCustomization.UserData.OrgName = from.UserData.OrgName
 	// In the case of a VMI with volume license key, this might not be set.
 	// Hence, add a check to see if the productID is set to empty.
 	if bootstrapData.Sysprep != nil && bootstrapData.Sysprep.ProductID != "" {

--- a/webhooks/virtualmachine/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator.go
@@ -414,6 +414,15 @@ func (v validator) validateInlineSysprep(
 		}
 	}
 
+	if sysprep.UserData.FullName == "" {
+		p := s.Child("userData", "fullName")
+		allErrs = append(allErrs, field.Required(p, ""))
+	}
+	if sysprep.UserData.OrgName == "" {
+		p := s.Child("userData", "orgName")
+		allErrs = append(allErrs, field.Required(p, ""))
+	}
+
 	return allErrs
 }
 

--- a/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
@@ -1579,6 +1579,26 @@ func unitTestsValidateCreate() {
 					),
 				},
 			),
+			Entry("disallow inline Sysprep without FullName or OrgName",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						ctx.vm.Spec.Bootstrap = &vmopv1.VirtualMachineBootstrapSpec{
+							Sysprep: &vmopv1.VirtualMachineBootstrapSysprepSpec{
+								Sysprep: &sysprep.Sysprep{
+									UserData: sysprep.UserData{
+										FullName: "",
+										OrgName:  "",
+									},
+								},
+							},
+						}
+					},
+					validate: doValidateWithMsg(
+						`spec.bootstrap.sysprep.sysprep.userData.fullName: Required value`,
+						`spec.bootstrap.sysprep.sysprep.userData.orgName: Required value`,
+					),
+				},
+			),
 			Entry("disallow vAppConfig mixing inline Properties and RawProperties",
 				testParams{
 					setup: func(ctx *unitValidatingWebhookContext) {
@@ -3704,7 +3724,12 @@ func unitTestsValidateUpdate() {
 						ctx.vm.Spec.Network.HostName = strings.Repeat("a", 16)
 						ctx.vm.Spec.Bootstrap = &vmopv1.VirtualMachineBootstrapSpec{
 							Sysprep: &vmopv1.VirtualMachineBootstrapSysprepSpec{
-								Sysprep: &sysprep.Sysprep{},
+								Sysprep: &sysprep.Sysprep{
+									UserData: sysprep.UserData{
+										FullName: "Foo",
+										OrgName:  "Bar",
+									},
+								},
 							},
 						}
 					},
@@ -3727,7 +3752,12 @@ func unitTestsValidateUpdate() {
 						ctx.vm.Spec.Network.HostName = strings.Repeat("a", 16)
 						ctx.vm.Spec.Bootstrap = &vmopv1.VirtualMachineBootstrapSpec{
 							Sysprep: &vmopv1.VirtualMachineBootstrapSysprepSpec{
-								Sysprep: &sysprep.Sysprep{},
+								Sysprep: &sysprep.Sysprep{
+									UserData: sysprep.UserData{
+										FullName: "Foo",
+										OrgName:  "Bar",
+									},
+								},
 							},
 						}
 					},


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Since we're filling in the ComputerName for inlined GOSC Sysprep, the FullName and OrgName are required.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note
Due to the requirements of Sysprep GOSC customization, when using inlined Sysprep bootstrapping, the UserData.FullName and UserData.OrgName are required fields.
```