### PR TITLE
🌱 Consolidate reconcile member and add tests in VM Group controller

### DIFF
--- a/api/v1alpha4/virtualmachine_types.go
+++ b/api/v1alpha4/virtualmachine_types.go
@@ -1286,6 +1286,22 @@ func (vm *VirtualMachine) SetConditions(conditions []metav1.Condition) {
 	vm.Status.Conditions = conditions
 }
 
+func (vm *VirtualMachine) GetGroupName() string {
+	return vm.Spec.GroupName
+}
+
+func (vm *VirtualMachine) SetGroupName(value string) {
+	vm.Spec.GroupName = value
+}
+
+func (vm *VirtualMachine) GetPowerState() VirtualMachinePowerState {
+	return vm.Status.PowerState
+}
+
+func (vm *VirtualMachine) SetPowerState(value VirtualMachinePowerState) {
+	vm.Spec.PowerState = value
+}
+
 // +kubebuilder:object:root=true
 
 // VirtualMachineList contains a list of VirtualMachine.

--- a/api/v1alpha4/virtualmachinegroup_types.go
+++ b/api/v1alpha4/virtualmachinegroup_types.go
@@ -24,6 +24,9 @@ const (
 )
 
 // +kubebuilder:object:generate=false
+
+// VirtualMachineOrGroup is an internal interface that represents a
+// VirtualMachine or VirtualMachineGroup object.
 type VirtualMachineOrGroup interface {
 	metav1.Object
 	runtime.Object
@@ -285,7 +288,7 @@ func (vmg *VirtualMachineGroup) SetGroupName(value string) {
 }
 
 func (vmg *VirtualMachineGroup) GetPowerState() VirtualMachinePowerState {
-	// VirtualMachineGroup does not have a power state in its status.
+	// VirtualMachineGroup does not have a power state recorded in its status.
 	return ""
 }
 

--- a/api/v1alpha4/virtualmachinegroup_types.go
+++ b/api/v1alpha4/virtualmachinegroup_types.go
@@ -6,6 +6,7 @@ package v1alpha4
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 const (
@@ -21,6 +22,18 @@ const (
 	// member has a placement decision ready.
 	VirtualMachineGroupMemberConditionPlacementReady = "PlacementReady"
 )
+
+// +kubebuilder:object:generate=false
+type VirtualMachineOrGroup interface {
+	metav1.Object
+	runtime.Object
+	DeepCopyObject() runtime.Object
+	GetGroupName() string
+	SetGroupName(value string)
+	GetPowerState() VirtualMachinePowerState
+	SetPowerState(value VirtualMachinePowerState)
+	GetConditions() []metav1.Condition
+}
 
 // GroupMember describes a member of a VirtualMachineGroup.
 type GroupMember struct {
@@ -261,6 +274,23 @@ type VirtualMachineGroup struct {
 
 	Spec   VirtualMachineGroupSpec   `json:"spec,omitempty"`
 	Status VirtualMachineGroupStatus `json:"status,omitempty"`
+}
+
+func (vmg *VirtualMachineGroup) GetGroupName() string {
+	return vmg.Spec.GroupName
+}
+
+func (vmg *VirtualMachineGroup) SetGroupName(value string) {
+	vmg.Spec.GroupName = value
+}
+
+func (vmg *VirtualMachineGroup) GetPowerState() VirtualMachinePowerState {
+	// VirtualMachineGroup does not have a power state in its status.
+	return ""
+}
+
+func (vmg *VirtualMachineGroup) SetPowerState(value VirtualMachinePowerState) {
+	vmg.Spec.PowerState = value
 }
 
 func (vmg *VirtualMachineGroup) GetConditions() []metav1.Condition {


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR combines the `reconcileVMMember` and `reconcileVMGMember` functions into a single `reconcileMember` in the VM Group controller, by introducing `VirtualMachineOrGroup` interface. This simplifies the reconciliation logic and reduces duplication, ensuring future updates to member reconciliation are consistent.

This PR also adds the tests in VM Group controller for member and power state reconciliation to improve test coverage.

**Which issue(s) is/are addressed by this PR?**

Fixes N/A.


**Are there any special notes for your reviewer**:

None.


**Please add a release note if necessary**:

```release-note
NONE
```