### PR TITLE
:seedling: Introduce a capability for VM Snapshots

### DIFF
--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -75,9 +75,10 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		}
 	}
 
-	// TODO: guard with a capability
-	if err := virtualmachinesnapshot.AddToManager(ctx, mgr); err != nil {
-		return fmt.Errorf("failed to initialize VirtualMachineSnapshot controller: %w", err)
+	if pkgcfg.FromContext(ctx).Features.VMSnapshots {
+		if err := virtualmachinesnapshot.AddToManager(ctx, mgr); err != nil {
+			return fmt.Errorf("failed to initialize VirtualMachineSnapshot controller: %w", err)
+		}
 	}
 
 	if pkgcfg.FromContext(ctx).Features.VMGroups {

--- a/pkg/config/capabilities/capabilities_test.go
+++ b/pkg/config/capabilities/capabilities_test.go
@@ -150,6 +150,9 @@ var _ = Describe("UpdateCapabilities", func() {
 						capabilities.CapabilityKeyImmutableClasses: {
 							Activated: true,
 						},
+						capabilities.CapabilityKeyVMSnapshots: {
+							Activated: true,
+						},
 					}
 					Expect(client.Status().Patch(ctx, &obj, objPatch)).To(Succeed())
 				})
@@ -162,6 +165,7 @@ var _ = Describe("UpdateCapabilities", func() {
 							config.Features.MutableNetworks = true
 							config.Features.VMGroups = true
 							config.Features.ImmutableClasses = true
+							config.Features.VMSnapshots = true
 						})
 					})
 					Specify("capabilities did not change", func() {
@@ -184,6 +188,9 @@ var _ = Describe("UpdateCapabilities", func() {
 					})
 					Specify(capabilities.CapabilityKeyImmutableClasses, func() {
 						Expect(pkgcfg.FromContext(ctx).Features.ImmutableClasses).To(BeTrue())
+					})
+					Specify(capabilities.CapabilityKeyVMSnapshots, func() {
+						Expect(pkgcfg.FromContext(ctx).Features.VMSnapshots).To(BeTrue())
 					})
 				})
 
@@ -208,6 +215,9 @@ var _ = Describe("UpdateCapabilities", func() {
 					})
 					Specify(capabilities.CapabilityKeyImmutableClasses, func() {
 						Expect(pkgcfg.FromContext(ctx).Features.ImmutableClasses).To(BeTrue())
+					})
+					Specify(capabilities.CapabilityKeyVMSnapshots, func() {
+						Expect(pkgcfg.FromContext(ctx).Features.VMSnapshots).To(BeTrue())
 					})
 				})
 			})
@@ -241,6 +251,9 @@ var _ = Describe("UpdateCapabilities", func() {
 						capabilities.CapabilityKeyImmutableClasses: {
 							Activated: false,
 						},
+						capabilities.CapabilityKeyVMSnapshots: {
+							Activated: false,
+						},
 					}
 					Expect(client.Status().Patch(ctx, &obj, objPatch)).To(Succeed())
 				})
@@ -265,6 +278,9 @@ var _ = Describe("UpdateCapabilities", func() {
 					})
 					Specify(capabilities.CapabilityKeyImmutableClasses, func() {
 						Expect(pkgcfg.FromContext(ctx).Features.ImmutableClasses).To(BeFalse())
+					})
+					Specify(capabilities.CapabilityKeyVMSnapshots, func() {
+						Expect(pkgcfg.FromContext(ctx).Features.VMSnapshots).To(BeFalse())
 					})
 				})
 
@@ -298,6 +314,9 @@ var _ = Describe("UpdateCapabilities", func() {
 					})
 					Specify(capabilities.CapabilityKeyImmutableClasses, func() {
 						Expect(pkgcfg.FromContext(ctx).Features.ImmutableClasses).To(BeFalse())
+					})
+					Specify(capabilities.CapabilityKeyVMSnapshots, func() {
+						Expect(pkgcfg.FromContext(ctx).Features.VMSnapshots).To(BeFalse())
 					})
 				})
 			})
@@ -489,6 +508,19 @@ var _ = Describe("UpdateCapabilitiesFeatures", func() {
 				Expect(pkgcfg.FromContext(ctx).Features.ImmutableClasses).To(BeTrue())
 			})
 		})
+		Context(capabilities.CapabilityKeyVMSnapshots, func() {
+			BeforeEach(func() {
+				Expect(pkgcfg.FromContext(ctx).Features.VMSnapshots).To(BeFalse())
+				obj.Status.Supervisor[capabilities.CapabilityKeyVMSnapshots] = capv1.CapabilityStatus{
+					Activated: true,
+				}
+			})
+			Specify("Enabled", func() {
+				Expect(ok).To(BeTrue())
+				Expect(diff).To(Equal("VMSnapshots=true"))
+				Expect(pkgcfg.FromContext(ctx).Features.VMSnapshots).To(BeTrue())
+			})
+		})
 	})
 })
 
@@ -523,6 +555,9 @@ var _ = Describe("WouldUpdateCapabilitiesFeatures", func() {
 			capabilities.CapabilityKeyImmutableClasses: {
 				Activated: true,
 			},
+			capabilities.CapabilityKeyVMSnapshots: {
+				Activated: true,
+			},
 		}
 
 		ok, diff = false, ""
@@ -542,6 +577,7 @@ var _ = Describe("WouldUpdateCapabilitiesFeatures", func() {
 					config.Features.MutableNetworks = true
 					config.Features.VMGroups = true
 					config.Features.ImmutableClasses = true
+					config.Features.VMSnapshots = true
 				})
 			})
 			Specify("capabilities did not change", func() {
@@ -566,6 +602,9 @@ var _ = Describe("WouldUpdateCapabilitiesFeatures", func() {
 			Specify(capabilities.CapabilityKeyImmutableClasses, func() {
 				Expect(pkgcfg.FromContext(ctx).Features.ImmutableClasses).To(BeTrue())
 			})
+			Specify(capabilities.CapabilityKeyVMSnapshots, func() {
+				Expect(pkgcfg.FromContext(ctx).Features.VMSnapshots).To(BeTrue())
+			})
 		})
 
 		When("the capabilities are different", func() {
@@ -580,7 +619,7 @@ var _ = Describe("WouldUpdateCapabilitiesFeatures", func() {
 			})
 			Specify("capabilities changed", func() {
 				Expect(ok).To(BeTrue())
-				Expect(diff).To(Equal("BringYourOwnEncryptionKey=true,ImmutableClasses=true,MutableNetworks=true,TKGMultipleCL=true,VMGroups=true,WorkloadDomainIsolation=true"))
+				Expect(diff).To(Equal("BringYourOwnEncryptionKey=true,ImmutableClasses=true,MutableNetworks=true,TKGMultipleCL=true,VMGroups=true,VMSnapshots=true,WorkloadDomainIsolation=true"))
 			})
 			Specify(capabilities.CapabilityKeyBringYourOwnKeyProvider, func() {
 				Expect(pkgcfg.FromContext(ctx).Features.BringYourOwnEncryptionKey).To(BeFalse())
@@ -599,6 +638,9 @@ var _ = Describe("WouldUpdateCapabilitiesFeatures", func() {
 			})
 			Specify(capabilities.CapabilityKeyImmutableClasses, func() {
 				Expect(pkgcfg.FromContext(ctx).Features.ImmutableClasses).To(BeFalse())
+			})
+			Specify(capabilities.CapabilityKeyVMSnapshots, func() {
+				Expect(pkgcfg.FromContext(ctx).Features.VMSnapshots).To(BeFalse())
 			})
 		})
 	})

--- a/pkg/config/capabilities/capabilties.go
+++ b/pkg/config/capabilities/capabilties.go
@@ -54,6 +54,11 @@ const (
 	// CapabilityKeyImmutableClasses is the name of capability key defined in the
 	// Supervisor capabilities CRD.
 	CapabilityKeyImmutableClasses = "supports_VM_service_immutable_VM_classes"
+
+	// CapabilityKeyVMSnapshots is the name of the capability key
+	// defined in the Supervisor capabilities CRD for the VM snapshots
+	// capability.
+	CapabilityKeyVMSnapshots = "supports_VM_service_VM_snapshots"
 )
 
 var (
@@ -198,7 +203,10 @@ func updateCapabilitiesFeaturesFromCRD(
 			fs.VMGroups = capStatus.Activated
 		case CapabilityKeyImmutableClasses:
 			fs.ImmutableClasses = capStatus.Activated
+		case CapabilityKeyVMSnapshots:
+			fs.VMSnapshots = capStatus.Activated
 		}
+
 	}
 	return fs
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -183,6 +183,7 @@ type FeatureStates struct {
 	MutableNetworks            bool
 	VMGroups                   bool
 	ImmutableClasses           bool
+	VMSnapshots                bool
 }
 
 type InstanceStorage struct {


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This change introduces a new capability for VM snapshots.  This will be leveraged by CCI to determine whether or not snapshot operation on a virtual machine is supported for a given VM.


**Please add a release note if necessary**:


```release-note
Introduce a capability for VM Snapshots
```