### PR TITLE
🌱 Handle network interface changes when VM is in powered off state

### DIFF
--- a/pkg/providers/vsphere/session/session_vm_update.go
+++ b/pkg/providers/vsphere/session/session_vm_update.go
@@ -821,6 +821,16 @@ func (s *Session) resizeVMWhenPoweredStateOff(
 		}
 	}
 
+	if pkgcfg.FromContext(vmCtx).Features.MutableNetworks {
+		virtualDevices := object.VirtualDeviceList(moVM.Config.Hardware.Device)
+		currentEthCards := virtualDevices.SelectByType((*vimtypes.VirtualEthernetCard)(nil))
+		ethCardDeviceChanges, err := UpdateEthCardDeviceChanges(vmCtx, &resizeArgs.NetworkResults, currentEthCards)
+		if err != nil {
+			return err
+		}
+		configSpec.DeviceChange = append(configSpec.DeviceChange, ethCardDeviceChanges...)
+	}
+
 	if pkgcfg.FromContext(vmCtx).Features.VMResize {
 		if err := vmopv1util.OverwriteResizeConfigSpec(
 			vmCtx,


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

The VM's network interfaces can be modified when the VM is in the off steady state, so reconcile any differences during that state as well. This isn't strictly required since we will also do this when the VM is in the transitioning to on state, but it is nice to reflect changes before that.

Improve the checks the VM e2e tests to better assert that the Ethernet device is that of what we expect by asserting the External ID and MAC address.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:



**Please add a release note if necessary**:


```release-note
NONE
```