### PR TITLE
🌱  Misc network mutability updates

### DIFF
--- a/pkg/providers/vsphere/network/devices.go
+++ b/pkg/providers/vsphere/network/devices.go
@@ -5,6 +5,8 @@
 package network
 
 import (
+	"slices"
+
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/mo"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
@@ -50,7 +52,7 @@ func MapEthernetDevicesToSpecIdx(
 		matchingIdx := findMatchingEthCardForInterfaceSpec(vmCtx, client, interfaceSpec, ethCards)
 		if matchingIdx >= 0 {
 			devKeyToSpecIdx[ethCards[matchingIdx].GetVirtualDevice().Key] = i
-			ethCards = append(ethCards[:matchingIdx], ethCards[matchingIdx+1:]...)
+			ethCards = slices.Delete(ethCards, matchingIdx, matchingIdx+1)
 		}
 	}
 
@@ -214,7 +216,7 @@ func findMatchingEthCardNCPNetIf(
 		}
 
 		ethCard := bEthCard.GetVirtualEthernetCard()
-		if ethCard.ExternalId == netIf.Status.InterfaceID || ethCard.MacAddress == netIf.Status.MacAddress {
+		if ethCard.ExternalId == netIf.Status.InterfaceID && ethCard.MacAddress == netIf.Status.MacAddress {
 			return i
 		}
 	}
@@ -257,8 +259,9 @@ func findMatchingEthCardVPCSubnetPort(
 			continue
 		}
 
+		// TODO: Relax this to check for just MacAddress during VPC backup/restore.
 		ethCard := bEthCard.GetVirtualEthernetCard()
-		if ethCard.ExternalId == subnetPort.Status.Attachment.ID || ethCard.MacAddress == subnetPort.Status.NetworkInterfaceConfig.MACAddress {
+		if ethCard.ExternalId == subnetPort.Status.Attachment.ID && ethCard.MacAddress == subnetPort.Status.NetworkInterfaceConfig.MACAddress {
 			return i
 		}
 	}

--- a/pkg/providers/vsphere/network/reconcile.go
+++ b/pkg/providers/vsphere/network/reconcile.go
@@ -40,7 +40,7 @@ func ReconcileNetworkInterfaces(
 			existingIdx := findExistingEthCardForOrphanedCR(ctx, r.Name, results.OrphanedNetworkInterfaces, currentEthCards)
 			if existingIdx >= 0 {
 				// As best we can, we determined that one of the VM's current ethernet card corresponds to a now
-				// unreferenced (orphaned) network interface CR for the same interface name. To keep the device
+				// unreferenced (orphaned) network interface CR with the same interface name. To keep the device
 				// type the same, do an edit on the existing device.
 				editDev := currentEthCards[existingIdx]
 
@@ -107,7 +107,7 @@ func findExistingEthCardForOrphanedCR(
 	for idx, obj := range orphanedObjects {
 		if v, ok := obj.GetLabels()[VMInterfaceNameLabel]; !ok {
 			// Favor interfaces that we had labeled with the interface spec name first. Otherwise,
-			// fallback to just trying to match by the name suffix which isn't perfect.
+			// fallback to just trying to match by the suffix which isn't perfect.
 			if strings.HasSuffix(obj.GetName(), suffix) {
 				objIdxWithoutLabel = append(objIdxWithoutLabel, idx)
 			}

--- a/pkg/providers/vsphere/session/session_vm_update.go
+++ b/pkg/providers/vsphere/session/session_vm_update.go
@@ -659,9 +659,14 @@ func (s *Session) reconcileNetworkInterfaces(
 	}
 
 	if pkgcfg.FromContext(vmCtx).Features.MutableNetworks {
-		if err := network.ListOrphanedNetworkInterfaces(vmCtx, s.K8sClient, &results); err != nil {
-			return network.NetworkInterfaceResults{},
-				fmt.Errorf("failed to list orphaned network interfaces: %w", err)
+		// TODO: Until we are reconfiguring (hot-plug) a powered on VM for network device
+		// changes, don't list orphan interfaces because they need to hang around until
+		// the device is actually removed from the VM.
+		if vmCtx.MoVM.Runtime.PowerState == vimtypes.VirtualMachinePowerStatePoweredOff {
+			if err := network.ListOrphanedNetworkInterfaces(vmCtx, s.K8sClient, &results); err != nil {
+				return network.NetworkInterfaceResults{},
+					fmt.Errorf("failed to list orphaned network interfaces: %w", err)
+			}
 		}
 	}
 
@@ -710,13 +715,8 @@ func (s *Session) fixupMacAddresses(
 	vcVM *object.VirtualMachine,
 	networkResults network.NetworkInterfaceResults) error {
 
-	networkDevices, err := res.NewVMFromObject(vcVM).GetNetworkDevices(vmCtx)
-	if err != nil {
-		return err
-	}
-
 	if pkgcfg.FromContext(vmCtx).Features.MutableNetworks {
-		return s.fixupMacAddressMutableNetworks(networkDevices, networkResults)
+		return s.fixupMacAddressMutableNetworks(vmCtx, vcVM, networkResults)
 	}
 
 	missingMAC := false
@@ -729,6 +729,11 @@ func (s *Session) fixupMacAddresses(
 	if !missingMAC {
 		// Expected path in NSX-T since it always provides the MAC address.
 		return nil
+	}
+
+	networkDevices, err := res.NewVMFromObject(vcVM).GetNetworkDevices(vmCtx)
+	if err != nil {
+		return err
 	}
 
 	// Just zip these together until we can do interface identification.
@@ -745,19 +750,26 @@ func (s *Session) fixupMacAddresses(
 }
 
 func (s *Session) fixupMacAddressMutableNetworks(
-	networkDevices object.VirtualDeviceList,
+	ctx context.Context,
+	vcVM *object.VirtualMachine,
 	networkResults network.NetworkInterfaceResults) error {
 
 	if !networkResults.UpdatedEthCards {
 		return nil
 	}
 
+	networkDevices, err := res.NewVMFromObject(vcVM).GetNetworkDevices(ctx)
+	if err != nil {
+		return err
+	}
+
 	for idx, r := range networkResults.Results {
 		if r.DeviceKey != 0 {
+			//
 			matchingIdx := slices.IndexFunc(networkDevices,
 				func(d vimtypes.BaseVirtualDevice) bool { return d.GetVirtualDevice().Key == r.DeviceKey })
 			if matchingIdx >= 0 {
-				networkDevices = append(networkDevices[:matchingIdx], networkDevices[matchingIdx+1:]...)
+				networkDevices = slices.Delete(networkDevices, matchingIdx, matchingIdx+1)
 			}
 			continue
 		}
@@ -768,7 +780,7 @@ func (s *Session) fixupMacAddressMutableNetworks(
 			networkResults.Results[idx].DeviceKey = matchDev.Key
 			networkResults.Results[idx].MacAddress = matchDev.MacAddress
 
-			networkDevices = append(networkDevices[:matchingIdx], networkDevices[matchingIdx+1:]...)
+			networkDevices = slices.Delete(networkDevices, matchingIdx, matchingIdx+1)
 		}
 	}
 
@@ -962,9 +974,8 @@ func (s *Session) reconcileNetworkAndGuestCustomizationState(
 		if err := s.K8sClient.Delete(
 			vmCtx,
 			networkResults.OrphanedNetworkInterfaces[i],
-		); err != nil {
-
-			return err
+		); ctrlclient.IgnoreNotFound(err) != nil {
+			vmCtx.Logger.Error(err, "failed to delete orphaned network interface")
 		}
 	}
 

--- a/pkg/providers/vsphere/vmlifecycle/bootstrap_cloudinit.go
+++ b/pkg/providers/vsphere/vmlifecycle/bootstrap_cloudinit.go
@@ -112,6 +112,15 @@ func BootStrapCloudInit(
 	logger := logr.FromContextOrDiscard(vmCtx)
 	logger.V(4).Info("Reconciling Cloud-Init bootstrap state")
 
+	if bsArgs.NetworkResults.UpdatedEthCards {
+		// We're not yet doing hot-plug of ethernet devices for a powered on VM. Therefore, if this
+		// VM is on and there were network device related changes, don't apply a new cloud-config
+		// since the VM does not have the expected ethernet devices.
+		if vmCtx.MoVM.Runtime.PowerState == vimtypes.VirtualMachinePowerStatePoweredOn {
+			return nil, nil, nil
+		}
+	}
+
 	netPlan, err := network.NetPlanCustomization(bsArgs.NetworkResults)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create NetPlan customization: %w", err)


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

When fixing up the Ethernet MAC addresses, only fetch the VM's current devices if there is something that actually needs fixing. In practice, the fixup is only needed adding a NIC in VDS.

Until we support hot-plug, better handle pending network changes. Skip trying to update the cloud-init data with a pending network change since the VM hardware state does not match its desired state and we don't have the prior interface spec.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note

```