### PR TITLE
🌱 Include child ResourcePools in VMSetResourcePolicy Status

### DIFF
--- a/api/v1alpha4/virtualmachinesetresourcepolicy_types.go
+++ b/api/v1alpha4/virtualmachinesetresourcepolicy_types.go
@@ -39,6 +39,7 @@ type VirtualMachineSetResourcePolicySpec struct {
 // VirtualMachineSetResourcePolicyStatus defines the observed state of
 // VirtualMachineSetResourcePolicy.
 type VirtualMachineSetResourcePolicyStatus struct {
+	ResourcePools  []ResourcePoolStatus         `json:"resourcePools,omitempty"`
 	ClusterModules []VSphereClusterModuleStatus `json:"clustermodules,omitempty"`
 }
 
@@ -48,6 +49,13 @@ type VSphereClusterModuleStatus struct {
 	GroupName   string `json:"groupName"`
 	ModuleUuid  string `json:"moduleUUID"` //nolint:revive
 	ClusterMoID string `json:"clusterMoID"`
+}
+
+// ResourcePoolStatus describes the observed state of a vSphere child
+// resource pool created for the Spec.ResourcePool.Name.
+type ResourcePoolStatus struct {
+	ClusterMoID           string `json:"clusterMoID"`
+	ChildResourcePoolMoID string `json:"childResourcePoolMoID"`
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachinesetresourcepolicies.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachinesetresourcepolicies.yaml
@@ -449,6 +449,21 @@ spec:
                   - moduleUUID
                   type: object
                 type: array
+              resourcepools:
+                items:
+                  description: |-
+                    ResourcePoolStatus describes the observed state of a vSphere child
+                    resource pool created for the Spec.ResourcePool.Name.
+                  properties:
+                    childResourcePoolMoID:
+                      type: string
+                    clusterMoID:
+                      type: string
+                  required:
+                  - childResourcePoolMoID
+                  - clusterMoID
+                  type: object
+                type: array
             type: object
         type: object
     served: true


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

This is needed for operators that are waiting for the child RP to be created in the expected Zone/CCR.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

This is an internal CRD and reorganizing the Status to have the CCR at more of a top level isn't worth the version conversion effort for this. I can go back and update the older versions status to have the new fields if needed.

**Please add a release note if necessary**:

```release-note

```