### PR TITLE
:sparkles: Add support for reverting a VM to a given snapshot

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -150,4 +150,9 @@ const (
 	// VirtualMachineClassHashAnnotationKey is the annotation key for the VM Class hash
 	// used to generate VirtualMachineClassInstances.
 	VirtualMachineClassHashAnnotationKey = "vmoperator.vmware.com/vmclass-hash"
+
+	// VirtualMachineSnapshotRevertInProgressAnnotationKey is the
+	// annotation key to indicate that a VM snapshot revert is in
+	// progress.
+	VirtualMachineSnapshotRevertInProgressAnnotationKey = "vmoperator.vmware.com/snapshot-revert-in-progress"
 )

--- a/pkg/providers/vsphere/virtualmachine/snapshot_test.go
+++ b/pkg/providers/vsphere/virtualmachine/snapshot_test.go
@@ -210,7 +210,7 @@ func snapShotTests() {
 					VMSnapshot: vmSnapshot,
 					VcVM:       vcVM,
 				}
-				Expect(virtualmachine.DeleteSnapshot(deleteArgs)).To(MatchError(virtualmachine.ErrVMSnapshotNotFound))
+				Expect(virtualmachine.DeleteSnapshot(deleteArgs)).To(MatchError(virtualmachine.ErrSnapshotNotFound))
 			})
 		})
 
@@ -251,7 +251,7 @@ func snapShotTests() {
 					VMSnapshot: vmSnapshot,
 					VcVM:       vcVM,
 				}
-				Expect(virtualmachine.DeleteSnapshot(deleteArgs)).To(MatchError(virtualmachine.ErrVMSnapshotNotFound))
+				Expect(virtualmachine.DeleteSnapshot(deleteArgs)).To(MatchError(virtualmachine.ErrSnapshotNotFound))
 			})
 		})
 	})

--- a/pkg/providers/vsphere/vmprovider.go
+++ b/pkg/providers/vsphere/vmprovider.go
@@ -563,7 +563,7 @@ func (vs *vSphereVMProvider) DeleteSnapshot(
 		RemoveChildren: removeChildren,
 		Consolidate:    consolidate,
 	}); err != nil {
-		if errors.Is(err, virtualmachine.ErrVMSnapshotNotFound) {
+		if errors.Is(err, virtualmachine.ErrSnapshotNotFound) {
 			log.V(5).Info("snapshot not found")
 			return false, nil
 		}

--- a/test/builder/vcsim_test_context.go
+++ b/test/builder/vcsim_test_context.go
@@ -111,6 +111,9 @@ type VCSimTestConfig struct {
 	// WithVMIncrementalRestore enables the FSS_WCP_VMSERVICE_INCREMENTAL_RESTORE FSS.
 	WithVMIncrementalRestore bool
 
+	// WithVMSnapshots enables the FSS_WCP_VMSERVICE_VM_SNAPSHOTS FSS.
+	WithVMSnapshots bool
+
 	// WithoutStorageClass disables the storage class required, meaning that the
 	// Datastore will be used instead. In WCP production the storage class is
 	// always required; the Datastore is only needed for gce2e.
@@ -564,6 +567,7 @@ func (c *TestContextForVCSim) setupEnv(config VCSimTestConfig) {
 		cc.Features.VMResizeCPUMemory = config.WithVMResizeCPUMemory
 		cc.Features.WorkloadDomainIsolation = !config.WithoutWorkloadDomainIsolation
 		cc.Features.VMIncrementalRestore = config.WithVMIncrementalRestore
+		cc.Features.VMSnapshots = config.WithVMSnapshots
 	})
 }
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This change adds the capability to revert a VM from a given snapshot. This can be done by the user by modifying the currentSnapshot field of the VM's spec to point to the desired snapshot.

Along with reverting the VM to the given snapshot, we also roll back the VM's Kubernetes state (Spec, Labels, Annotations) to the state that was recorded in the Snapshot.  This is done by leveraging the state recorded for backup / restore.

Other changes include:
- Update the create snapshot workflow to be conditioned on the VM snapshot capability.  Also move the tests to be conditioned on the capability.  Added a test to ensure that if the capability is not enabled, no snapshots are created on the VM.
- A new annotation is added on the VM to indicate when a VM is being reverted from a snapshot.  It is possible that the VC VM is successfully reverted, but the VM's spec/metadata reverting fails.  In that case, we would want to indicate to the user that this VM is _in_ restore from snapshot phase.  In a followup change, we will modify the VM reconcile workflow to bail out if the VM is being reverted.
- Add a method to update the status of the VM with the current snapshot details.
- A couple of helper methods to find the snapshot from the snapshot tree of the VM.


**Are there any special notes for your reviewer**:

NA

**Please add a release note if necessary**:

```release-note
Add support for reverting a VM to a given snapshot
```