### PR TITLE
🌱  Only include GuestBootstrap condition when present in ExtraConfig

### DIFF
--- a/pkg/providers/vsphere/vmlifecycle/update_status.go
+++ b/pkg/providers/vsphere/vmlifecycle/update_status.go
@@ -464,18 +464,12 @@ func MarkBootstrapCondition(
 	vm *vmopv1.VirtualMachine,
 	extraConfig map[string]string) {
 
-	if len(extraConfig) == 0 {
-		conditions.MarkUnknown(
-			vm, vmopv1.GuestBootstrapCondition, "NoExtraConfig", "")
+	status, reason, msg, ok := util.GetBootstrapConditionValues(extraConfig)
+	if !ok {
+		conditions.Delete(vm, vmopv1.GuestBootstrapCondition)
 		return
 	}
 
-	status, reason, msg, ok := util.GetBootstrapConditionValues(extraConfig)
-	if !ok {
-		conditions.MarkUnknown(
-			vm, vmopv1.GuestBootstrapCondition, "NoBootstrapStatus", "")
-		return
-	}
 	if status {
 		c := conditions.TrueCondition(vmopv1.GuestBootstrapCondition)
 		if reason != "" {

--- a/pkg/providers/vsphere/vmlifecycle/update_status_test.go
+++ b/pkg/providers/vsphere/vmlifecycle/update_status_test.go
@@ -1784,16 +1784,14 @@ var _ = Describe("VSphere Bootstrap Status to VM Status Condition", func() {
 			extraConfig = nil
 		})
 
-		Context("unknown condition", func() {
+		Context("no bootstrap condition in extra config", func() {
 			When("extraConfig unset", func() {
 				BeforeEach(func() {
 					extraConfig = nil
+					conditions.MarkTrue(vm, vmopv1.GuestBootstrapCondition)
 				})
-				It("sets condition unknown", func() {
-					expectedConditions := []metav1.Condition{
-						*conditions.UnknownCondition(vmopv1.GuestBootstrapCondition, "NoExtraConfig", ""),
-					}
-					Expect(vm.Status.Conditions).To(conditions.MatchConditions(expectedConditions))
+				It("removes condition", func() {
+					Expect(conditions.Get(vm, vmopv1.GuestBootstrapCondition)).To(BeNil())
 				})
 			})
 			When("no bootstrap status", func() {
@@ -1801,12 +1799,10 @@ var _ = Describe("VSphere Bootstrap Status to VM Status Condition", func() {
 					extraConfig = map[string]string{
 						"key1": "val1",
 					}
+					conditions.MarkTrue(vm, vmopv1.GuestBootstrapCondition)
 				})
-				It("sets condition unknown", func() {
-					expectedConditions := []metav1.Condition{
-						*conditions.UnknownCondition(vmopv1.GuestBootstrapCondition, "NoBootstrapStatus", ""),
-					}
-					Expect(vm.Status.Conditions).To(conditions.MatchConditions(expectedConditions))
+				It("removes condition", func() {
+					Expect(conditions.Get(vm, vmopv1.GuestBootstrapCondition)).To(BeNil())
 				})
 			})
 		})


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

The GuestBootstrap condition reflects the VM's ExtraConfig 'guestinfo.vmservice.bootstrap.condition' field. Only include the condition when field is present instead of reporting the condition with an unknown status. The EC field is not typically set, and the presence of an unknown condition lead users to believe something was wrong.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:



**Please add a release note if necessary**:

```release-note
Only report the VM GuestBootstrap condition when the corresponding ExtraConfig field is present.
```