### PR TITLE
🌱 Update vm.status.currentSnapshot in snapshot controller

### DIFF
--- a/controllers/virtualmachinesnapshot/virtualmachinesnapshot_controller.go
+++ b/controllers/virtualmachinesnapshot/virtualmachinesnapshot_controller.go
@@ -171,23 +171,23 @@ func (r *Reconciler) ReconcileNormal(ctx *pkgctx.VirtualMachineSnapshotContext) 
 	}
 
 	// vm object already set with snapshot reference
-	if vm.Spec.CurrentSnapshot != nil && vm.Spec.CurrentSnapshot.Name == ctx.VirtualMachineSnapshot.Name {
-		ctx.Logger.Info("VirtualMachine current snapshot already up to date", "spec.currentSnapshot", vm.Spec.CurrentSnapshot.Name)
+	if vm.Status.CurrentSnapshot != nil && vm.Status.CurrentSnapshot.Name == ctx.VirtualMachineSnapshot.Name {
+		ctx.Logger.Info("VirtualMachine current snapshot already up to date", "status.currentSnapshot", vm.Status.CurrentSnapshot.Name)
 		return nil
 	}
 
 	objRef := vmSnapshotCRToLocalObjectRef(ctx.VirtualMachineSnapshot)
 
-	// patch vm resource with the spec.currentSnapshot
+	// patch vm resource with the status.currentSnapshot
 	vmPatch := client.MergeFrom(vm.DeepCopy())
-	vm.Spec.CurrentSnapshot = objRef
-	if err := r.Patch(ctx, vm, vmPatch); err != nil {
+	vm.Status.CurrentSnapshot = objRef
+	if err := r.Status().Patch(ctx, vm, vmPatch); err != nil {
 		return fmt.Errorf(
 			"failed to patch VM resource %s with current snapshot %s: %w", objKey,
 			ctx.VirtualMachineSnapshot.Name, err)
 	}
 
-	ctx.Logger.Info("Successfully patched VirtualMachine's current snapshot reference", "vm.Name", vm.Name, "spec.currentSnapshot", vm.Spec.CurrentSnapshot.Name)
+	ctx.Logger.Info("Successfully patched VirtualMachine's current snapshot reference", "vm.Name", vm.Name, "status.currentSnapshot", vm.Status.CurrentSnapshot.Name)
 	return nil
 }
 
@@ -355,40 +355,7 @@ func (r *Reconciler) updateVMStatus(ctx *pkgctx.VirtualMachineSnapshotContext, p
 	return nil
 }
 
-// Set current snapshot of VM to the parent snapshot or to nil.
 func (r *Reconciler) updateVMCurrentSnapshot(ctx *pkgctx.VirtualMachineSnapshotContext, parentVMSnapshot *vmopv1.VirtualMachineSnapshot) error {
-	ctx.Logger.Info("Updating VM current snapshot")
-	if err := r.updateVMSpecCurrentSnapshot(ctx, parentVMSnapshot); err != nil {
-		return err
-	}
-	if err := r.updateVMStatusCurrentSnapshot(ctx, parentVMSnapshot); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (r *Reconciler) updateVMSpecCurrentSnapshot(ctx *pkgctx.VirtualMachineSnapshotContext, parentVMSnapshot *vmopv1.VirtualMachineSnapshot) error {
-	vm := ctx.VM
-	if vm.Spec.CurrentSnapshot != nil && vm.Spec.CurrentSnapshot.Name != ctx.VirtualMachineSnapshot.Name {
-		ctx.Logger.Info("VM spec current snapshot is not the same as the snapshot being deleted, skipping update")
-		return nil
-	}
-	vmPatch := client.MergeFrom(vm.DeepCopy())
-	if parentVMSnapshot != nil {
-		ctx.Logger.V(5).Info("Updating VM spec current snapshot", "vm", vm.Name, "new current snapshot", parentVMSnapshot.Name)
-		vm.Spec.CurrentSnapshot = vmSnapshotCRToLocalObjectRef(parentVMSnapshot)
-	} else {
-		ctx.Logger.V(5).Info("Updating VM spec current snapshot", "vm", vm.Name, "new current snapshot", "nil")
-		vm.Spec.CurrentSnapshot = nil
-	}
-	if err := r.Patch(ctx, vm, vmPatch); err != nil {
-		return fmt.Errorf("failed to patch VM %s spec with current snapshot: %w", vm.Name, err)
-	}
-	return nil
-}
-
-func (r *Reconciler) updateVMStatusCurrentSnapshot(ctx *pkgctx.VirtualMachineSnapshotContext, parentVMSnapshot *vmopv1.VirtualMachineSnapshot) error {
 	vm := ctx.VM
 	if vm.Status.CurrentSnapshot != nil && vm.Status.CurrentSnapshot.Name != ctx.VirtualMachineSnapshot.Name {
 		ctx.Logger.V(5).Info("VM status current snapshot is not the same as the snapshot being deleted, skipping update")

--- a/controllers/virtualmachinesnapshot/virtualmachinesnapshot_controller.go
+++ b/controllers/virtualmachinesnapshot/virtualmachinesnapshot_controller.go
@@ -187,7 +187,7 @@ func (r *Reconciler) ReconcileNormal(ctx *pkgctx.VirtualMachineSnapshotContext) 
 			ctx.VirtualMachineSnapshot.Name, err)
 	}
 
-	ctx.Logger.Info("Successfully patched VirtualMachine's current snapshot reference", "vm.Name", vm.Name, "status.currentSnapshot", vm.Status.CurrentSnapshot.Name)
+	ctx.Logger.Info("Successfully patched VirtualMachine status with current snapshot reference", "vm.Name", vm.Name, "status.currentSnapshot", vm.Status.CurrentSnapshot.Name)
 	return nil
 }
 

--- a/controllers/virtualmachinesnapshot/virtualmachinesnapshot_controller_intg_test.go
+++ b/controllers/virtualmachinesnapshot/virtualmachinesnapshot_controller_intg_test.go
@@ -178,6 +178,8 @@ func intgTestsReconcileDelete() {
 					Expect(vcSimCtx.Client.Status().Update(ctx, vm)).To(Succeed())
 					vm.Spec.CurrentSnapshot = newLocalObjectRefWithSnapshotName(vmSnapshot.Name)
 					Expect(vcSimCtx.Client.Update(ctx, vm)).To(Succeed())
+					vm.Status.CurrentSnapshot = newLocalObjectRefWithSnapshotName(vmSnapshot.Name)
+					Expect(vcSimCtx.Client.Status().Update(ctx, vm)).To(Succeed())
 					vmObjKey := types.NamespacedName{Name: vm.Name, Namespace: vm.Namespace}
 
 					Eventually(func(g Gomega) {
@@ -205,6 +207,7 @@ func intgTestsReconcileDelete() {
 					vmObj := getVirtualMachine(vcSimCtx, vmObjKey)
 					g.Expect(vmObj).ToNot(BeNil())
 					g.Expect(vmObj.Spec.CurrentSnapshot).To(BeNil())
+					g.Expect(vmObj.Status.CurrentSnapshot).To(BeNil())
 					tmpVMSSnapshot := getVirtualMachineSnapshot(vcSimCtx, vmObjKey)
 					g.Expect(tmpVMSSnapshot).To(BeNil())
 				}).Should(Succeed(), "waiting current snapshot to be deleted")
@@ -382,12 +385,16 @@ func intgTestsReconcileDelete() {
 				By("update vm current snapshot")
 				vm.Spec.CurrentSnapshot = newLocalObjectRefWithSnapshotName(currentSnapshotName)
 				Expect(vcSimCtx.Client.Update(ctx, vm)).To(Succeed())
+				vm.Status.CurrentSnapshot = newLocalObjectRefWithSnapshotName(currentSnapshotName)
+				Expect(vcSimCtx.Client.Status().Update(ctx, vm)).To(Succeed())
 				vmObjKey := types.NamespacedName{Name: vm.Name, Namespace: vm.Namespace}
 				Eventually(func(g Gomega) {
 					vmObj := getVirtualMachine(vcSimCtx, vmObjKey)
 					g.Expect(vmObj).ToNot(BeNil())
 					g.Expect(vmObj.Spec.CurrentSnapshot).ToNot(BeNil())
 					g.Expect(vmObj.Spec.CurrentSnapshot.Name).To(Equal(currentSnapshotName))
+					g.Expect(vmObj.Status.CurrentSnapshot).ToNot(BeNil())
+					g.Expect(vmObj.Status.CurrentSnapshot.Name).To(Equal(currentSnapshotName))
 				}).Should(Succeed(), "waiting current snapshot to be set on virtualmachine")
 			})
 
@@ -433,6 +440,8 @@ func intgTestsReconcileDelete() {
 							g.Expect(vmObj).ToNot(BeNil())
 							g.Expect(vmObj.Spec.CurrentSnapshot).ToNot(BeNil())
 							g.Expect(vmObj.Spec.CurrentSnapshot.Name).To(Equal(vmSnapshotL1.Name))
+							g.Expect(vmObj.Status.CurrentSnapshot).ToNot(BeNil())
+							g.Expect(vmObj.Status.CurrentSnapshot.Name).To(Equal(vmSnapshotL1.Name))
 						}).Should(Succeed(), "waiting for current snapshot to be updated to root")
 
 						By("check parent snapshot's children should be updated")
@@ -468,6 +477,8 @@ func intgTestsReconcileDelete() {
 							vmObj := getVirtualMachine(vcSimCtx, vmObjKey)
 							g.Expect(vmObj).ToNot(BeNil())
 							g.Expect(vmObj.Spec.CurrentSnapshot.Name).To(Equal(vmSnapshotL1Name))
+							g.Expect(vmObj.Status.CurrentSnapshot).ToNot(BeNil())
+							g.Expect(vmObj.Status.CurrentSnapshot.Name).To(Equal(vmSnapshotL1Name))
 						}).Should(Succeed())
 					})
 				})
@@ -498,6 +509,7 @@ func intgTestsReconcileDelete() {
 							vmObj := getVirtualMachine(vcSimCtx, vmObjKey)
 							g.Expect(vmObj).ToNot(BeNil())
 							g.Expect(vmObj.Spec.CurrentSnapshot).To(BeNil())
+							g.Expect(vmObj.Status.CurrentSnapshot).To(BeNil())
 						}).Should(Succeed())
 						By("vm root snapshots should be updated")
 						Eventually(func(g Gomega) {
@@ -518,6 +530,8 @@ func intgTestsReconcileDelete() {
 							vmObj := getVirtualMachine(vcSimCtx, vmObjKey)
 							g.Expect(vmObj).ToNot(BeNil())
 							g.Expect(vmObj.Spec.CurrentSnapshot.Name).To(Equal(vmSnapshotL2Name))
+							g.Expect(vmObj.Status.CurrentSnapshot).ToNot(BeNil())
+							g.Expect(vmObj.Status.CurrentSnapshot.Name).To(Equal(vmSnapshotL2Name))
 						}).Should(Succeed())
 					})
 				})
@@ -551,6 +565,8 @@ func intgTestsReconcileDelete() {
 							vmObj := getVirtualMachine(vcSimCtx, vmObjKey)
 							g.Expect(vmObj).ToNot(BeNil())
 							g.Expect(vmObj.Spec.CurrentSnapshot.Name).To(Equal(vmSnapshotL2Name))
+							g.Expect(vmObj.Status.CurrentSnapshot).ToNot(BeNil())
+							g.Expect(vmObj.Status.CurrentSnapshot.Name).To(Equal(vmSnapshotL2Name))
 						}).Should(Succeed())
 						By("check parent snapshot's children should be updated")
 						parent := vmSnapshotL2
@@ -582,6 +598,8 @@ func intgTestsReconcileDelete() {
 							vmObj := getVirtualMachine(vcSimCtx, vmObjKey)
 							g.Expect(vmObj).ToNot(BeNil())
 							g.Expect(vmObj.Spec.CurrentSnapshot.Name).To(Equal(vmSnapshotL2Name))
+							g.Expect(vmObj.Status.CurrentSnapshot).ToNot(BeNil())
+							g.Expect(vmObj.Status.CurrentSnapshot.Name).To(Equal(vmSnapshotL2Name))
 						}).Should(Succeed())
 					})
 				})

--- a/controllers/virtualmachinesnapshot/virtualmachinesnapshot_controller_intg_test.go
+++ b/controllers/virtualmachinesnapshot/virtualmachinesnapshot_controller_intg_test.go
@@ -102,7 +102,7 @@ func intgTestsReconcile() {
 			Eventually(func(g Gomega) {
 				vmObj := getVirtualMachine(ctx, vmObjKey)
 				g.Expect(vmObj).ToNot(BeNil())
-				g.Expect(vmObj.Spec.CurrentSnapshot).To(Equal(&vmopv1common.LocalObjectRef{
+				g.Expect(vmObj.Status.CurrentSnapshot).To(Equal(&vmopv1common.LocalObjectRef{
 					APIVersion: "vmoperator.vmware.com/v1alpha4",
 					Kind:       "VirtualMachineSnapshot",
 					Name:       vmSnapshot.Name,
@@ -176,8 +176,6 @@ func intgTestsReconcileDelete() {
 					Expect(vcSimCtx.Client.Create(ctx, vm)).To(Succeed())
 					vm.Status.UniqueID = uniqueVMID
 					Expect(vcSimCtx.Client.Status().Update(ctx, vm)).To(Succeed())
-					vm.Spec.CurrentSnapshot = newLocalObjectRefWithSnapshotName(vmSnapshot.Name)
-					Expect(vcSimCtx.Client.Update(ctx, vm)).To(Succeed())
 					vm.Status.CurrentSnapshot = newLocalObjectRefWithSnapshotName(vmSnapshot.Name)
 					Expect(vcSimCtx.Client.Status().Update(ctx, vm)).To(Succeed())
 					vmObjKey := types.NamespacedName{Name: vm.Name, Namespace: vm.Namespace}
@@ -206,7 +204,6 @@ func intgTestsReconcileDelete() {
 				Eventually(func(g Gomega) {
 					vmObj := getVirtualMachine(vcSimCtx, vmObjKey)
 					g.Expect(vmObj).ToNot(BeNil())
-					g.Expect(vmObj.Spec.CurrentSnapshot).To(BeNil())
 					g.Expect(vmObj.Status.CurrentSnapshot).To(BeNil())
 					tmpVMSSnapshot := getVirtualMachineSnapshot(vcSimCtx, vmObjKey)
 					g.Expect(tmpVMSSnapshot).To(BeNil())
@@ -248,8 +245,8 @@ func intgTestsReconcileDelete() {
 						Consistently(func(g Gomega) {
 							vmObj := getVirtualMachine(vcSimCtx, vmObjKey)
 							g.Expect(vmObj).ToNot(BeNil())
-							g.Expect(vmObj.Spec.CurrentSnapshot).To(Not(BeNil()))
-							g.Expect(*vmObj.Spec.CurrentSnapshot).To(Equal(*newLocalObjectRefWithSnapshotName(vmSnapshot.Name)))
+							g.Expect(vmObj.Status.CurrentSnapshot).To(Not(BeNil()))
+							g.Expect(*vmObj.Status.CurrentSnapshot).To(Equal(*newLocalObjectRefWithSnapshotName(vmSnapshot.Name)))
 						}).Should(Succeed())
 					})
 				})
@@ -292,8 +289,8 @@ func intgTestsReconcileDelete() {
 						Expect(vcSimCtx.Client.Create(ctx, vm)).To(Succeed())
 						vm.Status.UniqueID = uniqueVMID
 						Expect(vcSimCtx.Client.Status().Update(ctx, vm)).To(Succeed())
-						vm.Spec.CurrentSnapshot = newLocalObjectRefWithSnapshotName(vmSnapshot.Name)
-						Expect(vcSimCtx.Client.Update(ctx, vm)).To(Succeed())
+						vm.Status.CurrentSnapshot = newLocalObjectRefWithSnapshotName(vmSnapshot.Name)
+						Expect(vcSimCtx.Client.Status().Update(ctx, vm)).To(Succeed())
 						vmObjKey := types.NamespacedName{Name: vm.Name, Namespace: vm.Namespace}
 
 						Eventually(func(g Gomega) {
@@ -383,16 +380,12 @@ func intgTestsReconcileDelete() {
 
 			JustBeforeEach(func() {
 				By("update vm current snapshot")
-				vm.Spec.CurrentSnapshot = newLocalObjectRefWithSnapshotName(currentSnapshotName)
-				Expect(vcSimCtx.Client.Update(ctx, vm)).To(Succeed())
 				vm.Status.CurrentSnapshot = newLocalObjectRefWithSnapshotName(currentSnapshotName)
 				Expect(vcSimCtx.Client.Status().Update(ctx, vm)).To(Succeed())
 				vmObjKey := types.NamespacedName{Name: vm.Name, Namespace: vm.Namespace}
 				Eventually(func(g Gomega) {
 					vmObj := getVirtualMachine(vcSimCtx, vmObjKey)
 					g.Expect(vmObj).ToNot(BeNil())
-					g.Expect(vmObj.Spec.CurrentSnapshot).ToNot(BeNil())
-					g.Expect(vmObj.Spec.CurrentSnapshot.Name).To(Equal(currentSnapshotName))
 					g.Expect(vmObj.Status.CurrentSnapshot).ToNot(BeNil())
 					g.Expect(vmObj.Status.CurrentSnapshot.Name).To(Equal(currentSnapshotName))
 				}).Should(Succeed(), "waiting current snapshot to be set on virtualmachine")
@@ -438,8 +431,6 @@ func intgTestsReconcileDelete() {
 						Eventually(func(g Gomega) {
 							vmObj := getVirtualMachine(vcSimCtx, vmObjKey)
 							g.Expect(vmObj).ToNot(BeNil())
-							g.Expect(vmObj.Spec.CurrentSnapshot).ToNot(BeNil())
-							g.Expect(vmObj.Spec.CurrentSnapshot.Name).To(Equal(vmSnapshotL1.Name))
 							g.Expect(vmObj.Status.CurrentSnapshot).ToNot(BeNil())
 							g.Expect(vmObj.Status.CurrentSnapshot.Name).To(Equal(vmSnapshotL1.Name))
 						}).Should(Succeed(), "waiting for current snapshot to be updated to root")
@@ -476,7 +467,6 @@ func intgTestsReconcileDelete() {
 						Eventually(func(g Gomega) {
 							vmObj := getVirtualMachine(vcSimCtx, vmObjKey)
 							g.Expect(vmObj).ToNot(BeNil())
-							g.Expect(vmObj.Spec.CurrentSnapshot.Name).To(Equal(vmSnapshotL1Name))
 							g.Expect(vmObj.Status.CurrentSnapshot).ToNot(BeNil())
 							g.Expect(vmObj.Status.CurrentSnapshot.Name).To(Equal(vmSnapshotL1Name))
 						}).Should(Succeed())
@@ -508,7 +498,6 @@ func intgTestsReconcileDelete() {
 						Eventually(func(g Gomega) {
 							vmObj := getVirtualMachine(vcSimCtx, vmObjKey)
 							g.Expect(vmObj).ToNot(BeNil())
-							g.Expect(vmObj.Spec.CurrentSnapshot).To(BeNil())
 							g.Expect(vmObj.Status.CurrentSnapshot).To(BeNil())
 						}).Should(Succeed())
 						By("vm root snapshots should be updated")
@@ -529,7 +518,6 @@ func intgTestsReconcileDelete() {
 						Eventually(func(g Gomega) {
 							vmObj := getVirtualMachine(vcSimCtx, vmObjKey)
 							g.Expect(vmObj).ToNot(BeNil())
-							g.Expect(vmObj.Spec.CurrentSnapshot.Name).To(Equal(vmSnapshotL2Name))
 							g.Expect(vmObj.Status.CurrentSnapshot).ToNot(BeNil())
 							g.Expect(vmObj.Status.CurrentSnapshot.Name).To(Equal(vmSnapshotL2Name))
 						}).Should(Succeed())
@@ -564,7 +552,6 @@ func intgTestsReconcileDelete() {
 						Eventually(func(g Gomega) {
 							vmObj := getVirtualMachine(vcSimCtx, vmObjKey)
 							g.Expect(vmObj).ToNot(BeNil())
-							g.Expect(vmObj.Spec.CurrentSnapshot.Name).To(Equal(vmSnapshotL2Name))
 							g.Expect(vmObj.Status.CurrentSnapshot).ToNot(BeNil())
 							g.Expect(vmObj.Status.CurrentSnapshot.Name).To(Equal(vmSnapshotL2Name))
 						}).Should(Succeed())
@@ -597,7 +584,6 @@ func intgTestsReconcileDelete() {
 						Eventually(func(g Gomega) {
 							vmObj := getVirtualMachine(vcSimCtx, vmObjKey)
 							g.Expect(vmObj).ToNot(BeNil())
-							g.Expect(vmObj.Spec.CurrentSnapshot.Name).To(Equal(vmSnapshotL2Name))
 							g.Expect(vmObj.Status.CurrentSnapshot).ToNot(BeNil())
 							g.Expect(vmObj.Status.CurrentSnapshot.Name).To(Equal(vmSnapshotL2Name))
 						}).Should(Succeed())

--- a/controllers/virtualmachinesnapshot/virtualmachinesnapshot_controller_unit_test.go
+++ b/controllers/virtualmachinesnapshot/virtualmachinesnapshot_controller_unit_test.go
@@ -203,6 +203,9 @@ func unitTestsReconcile() {
 			It("returns success", func() {
 				_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: vmSnapshotNamespacedKey})
 				Expect(err).ToNot(HaveOccurred())
+				Expect(vm.Spec.CurrentSnapshot).To(BeNil())
+				Expect(vm.Status.CurrentSnapshot).To(BeNil())
+				Expect(vm.Status.RootSnapshots).To(HaveLen(0))
 			})
 
 			When("Calling DeleteSnapshot to VC", func() {
@@ -316,6 +319,7 @@ func unitTestsReconcile() {
 				BeforeEach(func() {
 					vmSnapshotL2.DeletionTimestamp = &now
 					vm.Spec.CurrentSnapshot = vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL2)
+					vm.Status.CurrentSnapshot = vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL2)
 					vm.Status.RootSnapshots = []vmopv1common.LocalObjectRef{*vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL1)}
 					// assign before the reconcile
 					vmSnapshotToReconcile = vmSnapshotL2
@@ -326,6 +330,7 @@ func unitTestsReconcile() {
 					It("returns success, vm current snapshot is updated to root", func() {
 						Expect(err).ToNot(HaveOccurred())
 						Expect(vm.Spec.CurrentSnapshot).To(Equal(vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL1)))
+						Expect(vm.Status.CurrentSnapshot).To(Equal(vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL1)))
 						Expect(vm.Status.RootSnapshots).To(HaveLen(1))
 						Expect(vm.Status.RootSnapshots).To(ContainElement(*vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL1)))
 						By("check parent snapshot's children should be updated")
@@ -339,10 +344,12 @@ func unitTestsReconcile() {
 				When("it's not the current snapshot", func() {
 					BeforeEach(func() {
 						vm.Spec.CurrentSnapshot = vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL1)
+						vm.Status.CurrentSnapshot = vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL1)
 					})
 					It("returns success, vm current snapshot is not changed", func() {
 						Expect(err).ToNot(HaveOccurred())
 						Expect(vm.Spec.CurrentSnapshot).To(Equal(vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL1)))
+						Expect(vm.Status.CurrentSnapshot).To(Equal(vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL1)))
 					})
 				})
 			})
@@ -360,6 +367,7 @@ func unitTestsReconcile() {
 				BeforeEach(func() {
 					vmSnapshotL1.DeletionTimestamp = &now
 					vm.Spec.CurrentSnapshot = vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL1)
+					vm.Status.CurrentSnapshot = vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL1)
 					vm.Status.RootSnapshots = []vmopv1common.LocalObjectRef{*vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL1)}
 					vmSnapshotToReconcile = vmSnapshotL1
 					parent = nil
@@ -369,6 +377,7 @@ func unitTestsReconcile() {
 					It("returns success, vm current snapshot is updated to nil", func() {
 						Expect(err).ToNot(HaveOccurred())
 						Expect(vm.Spec.CurrentSnapshot).To(BeNil())
+						Expect(vm.Status.CurrentSnapshot).To(BeNil())
 						Expect(vm.Status.RootSnapshots).To(HaveLen(1))
 						Expect(vm.Status.RootSnapshots).To(ContainElement(*vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL2)))
 					})
@@ -376,10 +385,12 @@ func unitTestsReconcile() {
 				When("it's not the current snapshot", func() {
 					BeforeEach(func() {
 						vm.Spec.CurrentSnapshot = vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL2)
+						vm.Status.CurrentSnapshot = vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL2)
 					})
 					It("returns success, vm current snapshot is not changed", func() {
 						Expect(err).ToNot(HaveOccurred())
 						Expect(vm.Spec.CurrentSnapshot).To(Equal(vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL2)))
+						Expect(vm.Status.CurrentSnapshot).To(Equal(vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL2)))
 					})
 				})
 			})
@@ -399,6 +410,7 @@ func unitTestsReconcile() {
 				BeforeEach(func() {
 					vmSnapshotL3Node1.DeletionTimestamp = &now
 					vm.Spec.CurrentSnapshot = vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL3Node1)
+					vm.Status.CurrentSnapshot = vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL3Node1)
 					vm.Status.RootSnapshots = []vmopv1common.LocalObjectRef{*vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL1)}
 					vmSnapshotToReconcile = vmSnapshotL3Node1
 					parent = vmSnapshotL2
@@ -408,6 +420,7 @@ func unitTestsReconcile() {
 					It("returns success, vm current snapshot is updated to parent", func() {
 						Expect(err).ToNot(HaveOccurred())
 						Expect(vm.Spec.CurrentSnapshot).To(Equal(vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL2)))
+						Expect(vm.Status.CurrentSnapshot).To(Equal(vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL2)))
 						By("check parent snapshot's children should be updated")
 						Expect(parent).To(Not(BeNil()))
 						Expect(parent.Status.Children).To(HaveLen(1))
@@ -420,10 +433,12 @@ func unitTestsReconcile() {
 				When("it's not the current snapshot", func() {
 					BeforeEach(func() {
 						vm.Spec.CurrentSnapshot = vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL2)
+						vm.Status.CurrentSnapshot = vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL2)
 					})
 					It("returns success, vm current snapshot is not changed", func() {
 						Expect(err).ToNot(HaveOccurred())
 						Expect(vm.Spec.CurrentSnapshot).To(Equal(vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL2)))
+						Expect(vm.Status.CurrentSnapshot).To(Equal(vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL2)))
 					})
 				})
 			})

--- a/controllers/virtualmachinesnapshot/virtualmachinesnapshot_controller_unit_test.go
+++ b/controllers/virtualmachinesnapshot/virtualmachinesnapshot_controller_unit_test.go
@@ -123,13 +123,13 @@ func unitTestsReconcile() {
 				vmObj := &vmopv1.VirtualMachine{}
 				Expect(ctx.Client.Get(ctx, objKey, vmObj)).To(Succeed())
 
-				Expect(vmObj.Spec.CurrentSnapshot).To(Equal(vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshot)))
+				Expect(vmObj.Status.CurrentSnapshot).To(Equal(vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshot)))
 			})
 		})
 
 		When("vm ready with different current snapshot", func() {
 			BeforeEach(func() {
-				vm.Spec.CurrentSnapshot = &vmopv1common.LocalObjectRef{
+				vm.Status.CurrentSnapshot = &vmopv1common.LocalObjectRef{
 					APIVersion: vmSnapshot.APIVersion,
 					Kind:       vmSnapshot.Kind,
 					Name:       "dummy-diff-snapshot",
@@ -144,14 +144,14 @@ func unitTestsReconcile() {
 				vmObj := &vmopv1.VirtualMachine{}
 				Expect(ctx.Client.Get(ctx, objKey, vmObj)).To(Succeed())
 
-				Expect(vmObj.Spec.CurrentSnapshot).To(Equal(vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshot)))
+				Expect(vmObj.Status.CurrentSnapshot).To(Equal(vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshot)))
 			})
 		})
 
 		When("vm ready with matching current snapshot name", func() {
 			BeforeEach(func() {
 				vm.Status.UniqueID = dummyVMUUID
-				vm.Spec.CurrentSnapshot = &vmopv1common.LocalObjectRef{
+				vm.Status.CurrentSnapshot = &vmopv1common.LocalObjectRef{
 					APIVersion: vmSnapshot.APIVersion,
 					Kind:       vmSnapshot.Kind,
 					Name:       vmSnapshot.Name,
@@ -203,7 +203,6 @@ func unitTestsReconcile() {
 			It("returns success", func() {
 				_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: vmSnapshotNamespacedKey})
 				Expect(err).ToNot(HaveOccurred())
-				Expect(vm.Spec.CurrentSnapshot).To(BeNil())
 				Expect(vm.Status.CurrentSnapshot).To(BeNil())
 				Expect(vm.Status.RootSnapshots).To(HaveLen(0))
 			})
@@ -318,7 +317,6 @@ func unitTestsReconcile() {
 				//   L3-n1    L3-n2
 				BeforeEach(func() {
 					vmSnapshotL2.DeletionTimestamp = &now
-					vm.Spec.CurrentSnapshot = vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL2)
 					vm.Status.CurrentSnapshot = vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL2)
 					vm.Status.RootSnapshots = []vmopv1common.LocalObjectRef{*vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL1)}
 					// assign before the reconcile
@@ -329,7 +327,6 @@ func unitTestsReconcile() {
 				When("it's the current snapshot", func() {
 					It("returns success, vm current snapshot is updated to root", func() {
 						Expect(err).ToNot(HaveOccurred())
-						Expect(vm.Spec.CurrentSnapshot).To(Equal(vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL1)))
 						Expect(vm.Status.CurrentSnapshot).To(Equal(vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL1)))
 						Expect(vm.Status.RootSnapshots).To(HaveLen(1))
 						Expect(vm.Status.RootSnapshots).To(ContainElement(*vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL1)))
@@ -343,12 +340,10 @@ func unitTestsReconcile() {
 				})
 				When("it's not the current snapshot", func() {
 					BeforeEach(func() {
-						vm.Spec.CurrentSnapshot = vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL1)
 						vm.Status.CurrentSnapshot = vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL1)
 					})
 					It("returns success, vm current snapshot is not changed", func() {
 						Expect(err).ToNot(HaveOccurred())
-						Expect(vm.Spec.CurrentSnapshot).To(Equal(vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL1)))
 						Expect(vm.Status.CurrentSnapshot).To(Equal(vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL1)))
 					})
 				})
@@ -366,7 +361,6 @@ func unitTestsReconcile() {
 				//   L3-n1    L3-n2
 				BeforeEach(func() {
 					vmSnapshotL1.DeletionTimestamp = &now
-					vm.Spec.CurrentSnapshot = vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL1)
 					vm.Status.CurrentSnapshot = vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL1)
 					vm.Status.RootSnapshots = []vmopv1common.LocalObjectRef{*vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL1)}
 					vmSnapshotToReconcile = vmSnapshotL1
@@ -376,7 +370,6 @@ func unitTestsReconcile() {
 				When("it's the current snapshot", func() {
 					It("returns success, vm current snapshot is updated to nil", func() {
 						Expect(err).ToNot(HaveOccurred())
-						Expect(vm.Spec.CurrentSnapshot).To(BeNil())
 						Expect(vm.Status.CurrentSnapshot).To(BeNil())
 						Expect(vm.Status.RootSnapshots).To(HaveLen(1))
 						Expect(vm.Status.RootSnapshots).To(ContainElement(*vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL2)))
@@ -384,12 +377,10 @@ func unitTestsReconcile() {
 				})
 				When("it's not the current snapshot", func() {
 					BeforeEach(func() {
-						vm.Spec.CurrentSnapshot = vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL2)
 						vm.Status.CurrentSnapshot = vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL2)
 					})
 					It("returns success, vm current snapshot is not changed", func() {
 						Expect(err).ToNot(HaveOccurred())
-						Expect(vm.Spec.CurrentSnapshot).To(Equal(vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL2)))
 						Expect(vm.Status.CurrentSnapshot).To(Equal(vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL2)))
 					})
 				})
@@ -409,7 +400,6 @@ func unitTestsReconcile() {
 				//       L3-n2
 				BeforeEach(func() {
 					vmSnapshotL3Node1.DeletionTimestamp = &now
-					vm.Spec.CurrentSnapshot = vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL3Node1)
 					vm.Status.CurrentSnapshot = vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL3Node1)
 					vm.Status.RootSnapshots = []vmopv1common.LocalObjectRef{*vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL1)}
 					vmSnapshotToReconcile = vmSnapshotL3Node1
@@ -419,7 +409,6 @@ func unitTestsReconcile() {
 				When("it's the current snapshot", func() {
 					It("returns success, vm current snapshot is updated to parent", func() {
 						Expect(err).ToNot(HaveOccurred())
-						Expect(vm.Spec.CurrentSnapshot).To(Equal(vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL2)))
 						Expect(vm.Status.CurrentSnapshot).To(Equal(vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL2)))
 						By("check parent snapshot's children should be updated")
 						Expect(parent).To(Not(BeNil()))
@@ -432,12 +421,10 @@ func unitTestsReconcile() {
 				})
 				When("it's not the current snapshot", func() {
 					BeforeEach(func() {
-						vm.Spec.CurrentSnapshot = vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL2)
 						vm.Status.CurrentSnapshot = vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL2)
 					})
 					It("returns success, vm current snapshot is not changed", func() {
 						Expect(err).ToNot(HaveOccurred())
-						Expect(vm.Spec.CurrentSnapshot).To(Equal(vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL2)))
 						Expect(vm.Status.CurrentSnapshot).To(Equal(vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL2)))
 					})
 				})

--- a/pkg/providers/vsphere/virtualmachine/snapshot.go
+++ b/pkg/providers/vsphere/virtualmachine/snapshot.go
@@ -87,6 +87,7 @@ func CreateSnapshot(args SnapshotArgs) (*types.ManagedObjectReference, error) {
 	return &snapMoRef, nil
 }
 
+// DeleteSnapshot deletes a snapshot from vCenter.
 func DeleteSnapshot(args SnapshotArgs) error {
 	t, err := args.VcVM.RemoveSnapshot(args.VMCtx, args.VMSnapshot.Name, args.RemoveChildren, args.Consolidate)
 	if err != nil {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->
- Adding the logic to update the vm.status.currentSnapshot. Follow up of https://github.com/vmware-tanzu/vm-operator/pull/1032.
- Previously it updates the vm.spec.currentSnapshot as well. Remove that logic from vmSnapshot controller. 


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Update vm.status.currentSnapshot in snapshot controller
```