### PR TITLE
:sapling: Drive create snapshot workflow only through the custom resource

### DIFF
--- a/api/v1alpha4/virtualmachine_types.go
+++ b/api/v1alpha4/virtualmachine_types.go
@@ -1016,20 +1016,15 @@ type VirtualMachineSpec struct {
 
 	// +optional
 
-	// CurrentSnapshot represents the desired snapshot that the
-	// virtual machine should point to. This field can have three
-	// possible values:
+	// CurrentSnapshot represents the desired snapshot that the VM
+	// should point to. This field can be specified to revert the VM
+	// to a given snapshot. Once the virtual machine has been
+	// successfully reverted to the desired snapshot, the value of
+	// this field is cleared.
 	//
-	// - The value of this field is nil when the working snapshot is at
-	//   the root of the snapshot tree.
-	//
-	// - When a new snapshot is requested by creating a new
-	//   VirtualMachineSnapshot, the value of this field is set to the
-	//   new snapshot resource's name.
-	//
-	// - If the value of this field is set to an existing snapshot that
-	//   is different from the status.currentSnapshot, the virtual machine is
-	//   reverted to the requested snapshot.
+	// The value of this field must be an existing object of
+	// VirtualMachineSnapshot kind that exists on the API server. All
+	// other values are invalid.
 	//
 	// Reverting a virtual machine to a snapshot rolls back the data
 	// and the configuration of the virtual machine to that of the

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachinereplicasets.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachinereplicasets.yaml
@@ -4150,20 +4150,15 @@ spec:
                         type: object
                       currentSnapshot:
                         description: |-
-                          CurrentSnapshot represents the desired snapshot that the
-                          virtual machine should point to. This field can have three
-                          possible values:
+                          CurrentSnapshot represents the desired snapshot that the VM
+                          should point to. This field can be specified to revert the VM
+                          to a given snapshot. Once the virtual machine has been
+                          successfully reverted to the desired snapshot, the value of
+                          this field is cleared.
 
-                          - The value of this field is nil when the working snapshot is at
-                            the root of the snapshot tree.
-
-                          - When a new snapshot is requested by creating a new
-                            VirtualMachineSnapshot, the value of this field is set to the
-                            new snapshot resource's name.
-
-                          - If the value of this field is set to an existing snapshot that
-                            is different from the status.currentSnapshot, the virtual machine is
-                            reverted to the requested snapshot.
+                          The value of this field must be an existing object of
+                          VirtualMachineSnapshot kind that exists on the API server. All
+                          other values are invalid.
 
                           Reverting a virtual machine to a snapshot rolls back the data
                           and the configuration of the virtual machine to that of the

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -7688,20 +7688,15 @@ spec:
                 type: object
               currentSnapshot:
                 description: |-
-                  CurrentSnapshot represents the desired snapshot that the
-                  virtual machine should point to. This field can have three
-                  possible values:
+                  CurrentSnapshot represents the desired snapshot that the VM
+                  should point to. This field can be specified to revert the VM
+                  to a given snapshot. Once the virtual machine has been
+                  successfully reverted to the desired snapshot, the value of
+                  this field is cleared.
 
-                  - The value of this field is nil when the working snapshot is at
-                    the root of the snapshot tree.
-
-                  - When a new snapshot is requested by creating a new
-                    VirtualMachineSnapshot, the value of this field is set to the
-                    new snapshot resource's name.
-
-                  - If the value of this field is set to an existing snapshot that
-                    is different from the status.currentSnapshot, the virtual machine is
-                    reverted to the requested snapshot.
+                  The value of this field must be an existing object of
+                  VirtualMachineSnapshot kind that exists on the API server. All
+                  other values are invalid.
 
                   Reverting a virtual machine to a snapshot rolls back the data
                   and the configuration of the virtual machine to that of the

--- a/controllers/virtualmachine/virtualmachine/virtualmachine_controller.go
+++ b/controllers/virtualmachine/virtualmachine/virtualmachine_controller.go
@@ -149,6 +149,22 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		)
 	}
 
+	// Watch VirtualMachineSnapshot resources to trigger VM reconciliation
+	// when snapshots are created or updated.
+	// We could also use the owner reference to queue the request, but on
+	// the off chance that the owner ref has not been set, use a custom mapper.
+	if pkgcfg.FromContext(ctx).Features.VMSnapshots {
+		builder = builder.Watches(
+			&vmopv1.VirtualMachineSnapshot{},
+			handler.EnqueueRequestsFromMapFunc(
+				vmopv1util.SnapshotToVMMapperFn(
+					ctx,
+					r.Logger.WithName("SnapshotToVMMapper"),
+				),
+			),
+		)
+	}
+
 	return builder.Complete(r)
 }
 

--- a/controllers/virtualmachinesnapshot/virtualmachinesnapshot_controller.go
+++ b/controllers/virtualmachinesnapshot/virtualmachinesnapshot_controller.go
@@ -132,63 +132,50 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 		return ctrl.Result{}, nil
 	}
 
-	if err := r.ReconcileNormal(vmSnapshotCtx); err != nil {
-		vmSnapshotCtx.Logger.Error(err, "Failed to reconcile VirtualMachineSnapShot")
-		return ctrl.Result{}, err
-	}
-
-	return ctrl.Result{}, nil
+	return r.ReconcileNormal(vmSnapshotCtx)
 }
 
-func (r *Reconciler) ReconcileNormal(ctx *pkgctx.VirtualMachineSnapshotContext) error {
+func (r *Reconciler) ReconcileNormal(ctx *pkgctx.VirtualMachineSnapshotContext) (ctrl.Result, error) {
 	ctx.Logger.Info("Reconciling VirtualMachineSnapshot")
 
-	if !controllerutil.ContainsFinalizer(ctx.VirtualMachineSnapshot, Finalizer) {
-		// Set the finalizer and return so the object is patched immediately.
-		controllerutil.AddFinalizer(ctx.VirtualMachineSnapshot, Finalizer)
-		return nil
-	}
-	// return early if snapshot is ready; nothing to do
-	if conditions.IsTrue(ctx.VirtualMachineSnapshot, vmopv1.VirtualMachineSnapshotReadyCondition) {
-		return nil
+	// If the finalizer is not present, add it.  Return so the object is patched immediately.
+	if controllerutil.AddFinalizer(ctx.VirtualMachineSnapshot, Finalizer) {
+		ctx.Logger.Info("Added finalizer to snapshot", "snapshot", ctx.VirtualMachineSnapshot.Name)
+		return ctrl.Result{}, nil
 	}
 
 	vmSnapshot := ctx.VirtualMachineSnapshot
 	ctx.Logger.Info("Fetching VirtualMachine from snapshot object", "vmSnapshot", vmSnapshot.Name)
+
+	// TODO: AKP: These validations must be removed once they are added in the validation webhook.
 	if vmSnapshot.Spec.VMRef == nil {
-		return errVMRefNil
+		return ctrl.Result{}, errVMRefNil
 	}
+
 	vm := &vmopv1.VirtualMachine{}
 	objKey := client.ObjectKey{Name: vmSnapshot.Spec.VMRef.Name, Namespace: vmSnapshot.Namespace}
 	if err := r.Get(ctx, objKey, vm); err != nil {
 		ctx.Logger.Error(err, "failed to get VirtualMachine", "vm", objKey)
-		return err
+		return ctrl.Result{}, err
 	}
 
 	ctx.VM = vm
-	if vm.Status.UniqueID == "" {
-		return errors.New("VM hasn't been created and has no uniqueID")
+
+	// The snapshot must be owned by a VM.  Set an owner reference to the VM.
+	if err := controllerutil.SetControllerReference(ctx.VM, ctx.VirtualMachineSnapshot, r.Scheme()); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to set owner reference to snapshot: %w", err)
 	}
 
-	// vm object already set with snapshot reference
-	if vm.Status.CurrentSnapshot != nil && vm.Status.CurrentSnapshot.Name == ctx.VirtualMachineSnapshot.Name {
-		ctx.Logger.Info("VirtualMachine current snapshot already up to date", "status.currentSnapshot", vm.Status.CurrentSnapshot.Name)
-		return nil
+	// Return early if snapshot is ready; nothing to do
+	if conditions.IsTrue(ctx.VirtualMachineSnapshot, vmopv1.VirtualMachineSnapshotReadyCondition) {
+		// TODO: Patch the status of the snapshot to populate any other fields such as storage used.
+		return ctrl.Result{}, nil
 	}
 
-	objRef := vmSnapshotCRToLocalObjectRef(ctx.VirtualMachineSnapshot)
-
-	// patch vm resource with the status.currentSnapshot
-	vmPatch := client.MergeFrom(vm.DeepCopy())
-	vm.Status.CurrentSnapshot = objRef
-	if err := r.Status().Patch(ctx, vm, vmPatch); err != nil {
-		return fmt.Errorf(
-			"failed to patch VM resource %s with current snapshot %s: %w", objKey,
-			ctx.VirtualMachineSnapshot.Name, err)
-	}
-
-	ctx.Logger.Info("Successfully patched VirtualMachine status with current snapshot reference", "vm.Name", vm.Name, "status.currentSnapshot", vm.Status.CurrentSnapshot.Name)
-	return nil
+	// The snapshot is not ready yet. The VM controller will handle the actual snapshot creation
+	// when it detects this snapshot resource. We just need to requeue to check again later.
+	ctx.Logger.V(5).Info("snapshot not yet complete. Requeuing reconcile request")
+	return ctrl.Result{RequeueAfter: pkgcfg.FromContext(ctx).SnapshotInProgressRequeueDelay}, nil
 }
 
 func (r *Reconciler) ReconcileDelete(ctx *pkgctx.VirtualMachineSnapshotContext) error {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -73,6 +73,13 @@ type Config struct {
 	// Defaults to 10 seconds.
 	SyncImageRequeueDelay time.Duration
 
+	// SnapshotInProgressRequeueDelay is the requeue delay that is
+	// used to requeue when a snapshot is in progress. This is used so
+	// we can come back and update the status of the snapshot of the
+	// snapshot.
+	// Defaults to 10 seconds.
+	SnapshotInProgressRequeueDelay time.Duration
+
 	NetworkProviderType  NetworkProviderType
 	VSphereNetworking    bool
 	LoadBalancerProvider string

--- a/pkg/providers/vsphere/vmprovider_vm.go
+++ b/pkg/providers/vsphere/vmprovider_vm.go
@@ -11,6 +11,7 @@ import (
 	"maps"
 	"math/rand"
 	"path"
+	"sort"
 	"strings"
 	"sync"
 	"text/template"
@@ -1169,17 +1170,35 @@ func (vs *vSphereVMProvider) reconcileSnapshotRevert(
 		vmCtx.Logger.V(5).Info("No current snapshot specified, skipping revert")
 		return false, nil
 	}
-
-	// Check if the VM has a snapshot by the desired name.
 	desiredSnapshotName := vmCtx.VM.Spec.CurrentSnapshot.Name
-	snapObj, err := vs.findDesiredSnapshot(vmCtx, desiredSnapshotName)
-	if err != nil {
-		vmCtx.Logger.Error(err, "Error finding desired snapshot to revert to")
+
+	// Check if the snapshot CR exists.
+	snopCR := &vmopv1.VirtualMachineSnapshot{}
+	if err := vs.k8sClient.Get(
+		vmCtx,
+		ctrlclient.ObjectKey{Name: desiredSnapshotName, Namespace: vmCtx.VM.Namespace},
+		snopCR); err != nil {
+		vmCtx.Logger.Error(err, "Error getting snapshot CR", "snapshotName", desiredSnapshotName)
 		return false, err
 	}
 
-	// Govmomi ensures that if FindSnapshot doesn't return an error, a
-	// snapshot managed object is returned. Handle it anyway.
+	// Check if the snapshot CR is ready.  This is to ensure that the snapshot
+	//  as reconciled via our snapshot controller and is not an out-of-band snapshot.
+	if !pkgcnd.IsTrue(snopCR, vmopv1.VirtualMachineSnapshotReadyCondition) {
+		vmCtx.Logger.V(5).Info("Snapshot CR is not ready, skipping revert", "snapshotName", desiredSnapshotName)
+		return false, fmt.Errorf("snapshot CR is not ready, skipping revert")
+	}
+
+	// Check if the VM has a snapshot by the desired name.
+	snapObj, err := virtualmachine.FindSnapshot(vmCtx, desiredSnapshotName)
+	if err != nil {
+		vmCtx.Logger.Error(err, "Error finding snapshot", "snapshotName", desiredSnapshotName)
+
+		return false, err
+	}
+
+	// If FindSnapshot doesn't return an error, a snapshot managed object is returned.
+	// But handle a scenario where the object is nil anyway.
 	if snapObj == nil {
 		vmCtx.Logger.V(4).Info("Snapshot not found, treating as new snapshot request",
 			"snapshotName", desiredSnapshotName)
@@ -1239,47 +1258,6 @@ func (vs *vSphereVMProvider) reconcileSnapshotRevert(
 	// the updated VM spec, labels, and annotations. The VM status
 	// will be updated in the subsequent reconcile loop.
 	return true, nil
-}
-
-// findDesiredSnapshot finds the snapshot object by name, returns nil if not found.
-func (vs *vSphereVMProvider) findDesiredSnapshot(
-	vmCtx pkgctx.VirtualMachineContext,
-	snapshotName string) (*vimtypes.ManagedObjectReference, error) {
-
-	snapObj, err := virtualmachine.FindSnapshot(vmCtx, snapshotName)
-	if err != nil {
-		// Only skip (return nil) for expected cases where we should not fail:
-		// 1. VM has no snapshots at all
-		// 2. Snapshot by name doesn't exist (this would be a different error message)
-		if errors.Is(err, virtualmachine.ErrNoSnapshots) {
-			vmCtx.Logger.V(4).Info("VM has no snapshots, skipping",
-				"snapshotName", snapshotName)
-			return nil, nil
-		}
-
-		// Check if snapshot by name doesn't exist
-		if errors.Is(err, virtualmachine.ErrSnapshotNotFound) {
-			vmCtx.Logger.V(4).Info("Snapshot not found on the VM (snapshot doesn't exist)",
-				"snapshotName", snapshotName)
-			return nil, nil
-		}
-
-		// For all other errors (property collector error, multiple snapshots, etc.),
-		// return the actual error and requeue the reconcile request.
-		vmCtx.Logger.Error(err, "Error finding snapshot",
-			"snapshotName", snapshotName)
-		return nil, err
-	}
-
-	// snapObj is nil when VM has snapshots but the specific snapshot doesn't exist
-	// This is the normal case when FindSnapshot succeeds but doesn't find the named snapshot.
-	if snapObj == nil {
-		vmCtx.Logger.V(4).Info("Snapshot not found on the VM (snapshot doesn't exist)",
-			"snapshotName", snapshotName)
-		return nil, nil
-	}
-
-	return snapObj, nil
 }
 
 // needsSnapshotRevert checks if the VM's current snapshot differs
@@ -1367,6 +1345,16 @@ func (vs *vSphereVMProvider) restoreVMSpecFromSnapshot(
 	// about pruning fields here since the backup process already
 	// handles that.
 	vmCtx.VM.Spec = *(&vm.Spec).DeepCopy()
+
+	// VM spec should never have spec.currentSnapshot set because the
+	// currentSnapshot is only set during a revert operation. However,
+	// in the off-chance that a snapshot was taken _during_ a revert,
+	// clear it out.
+	vmCtx.VM.Spec.CurrentSnapshot = nil
+
+	// TODO: AKP: We need to merge (and skip) some labels so that we
+	// are not simply reverting to the previous labels. Otherwise, we
+	// risk the VM being impacted after a snapshot revert.
 	vmCtx.VM.Labels = maps.Clone(vm.Labels)
 	vmCtx.VM.Annotations = maps.Clone(vm.Annotations)
 	// Empty out the status.
@@ -1379,7 +1367,7 @@ func (vs *vSphereVMProvider) restoreVMSpecFromSnapshot(
 	revertProgressKey := pkgconst.VirtualMachineSnapshotRevertInProgressAnnotationKey
 	delete(vmCtx.VM.Annotations, revertProgressKey)
 
-	vmCtx.Logger.Info("VM custom resource has been restored from snapshot",
+	vmCtx.Logger.V(4).Info("VM custom resource has been restored from snapshot",
 		"restoredAnnotations", vmCtx.VM.Annotations,
 		"restoredLabels", vmCtx.VM.Labels)
 
@@ -1434,39 +1422,111 @@ func (vs *vSphereVMProvider) getVMYamlFromSnapshot(
 func (vs *vSphereVMProvider) reconcileSnapshot(
 	vmCtx pkgctx.VirtualMachineContext,
 	vcVM *object.VirtualMachine) error {
-	// Skip creating a new snapshot if the VM doesn't specify a desired snapshot.
-	if vmCtx.VM.Spec.CurrentSnapshot == nil {
-		return nil
-	}
 
-	// Fetch the VirtualMachineSnapshot object.
-	vmSnapshot, err := getVirtualMachineSnapShotObject(vmCtx, vs.k8sClient)
+	// Find all VirtualMachineSnapshot objects that reference this VM
+	vmSnapshots, err := vs.getVirtualMachineSnapshotsForVM(vmCtx)
 	if err != nil {
 		return err
 	}
 
-	// If it's being deleted, skip snapshot creation.
-	if !vmSnapshot.DeletionTimestamp.IsZero() {
-		vmCtx.Logger.Info("Skipping snapshot creation because the VirtualMachineSnapshot is being deleted")
+	vmCtx.Logger.Info("Found snapshots for VM", "snapshotCount", len(vmSnapshots), "snapshots", vmSnapshots)
+
+	// If no snapshots found, nothing to do
+	if len(vmSnapshots) == 0 {
 		return nil
+	}
+
+	// Sort snapshots by creation timestamp to ensure consistent ordering
+	sort.Slice(vmSnapshots, func(i, j int) bool {
+		return vmSnapshots[i].CreationTimestamp.Before(&vmSnapshots[j].CreationTimestamp)
+	})
+
+	// Find the first (oldest) snapshot that is not ready
+	// We process snapshots in chronological order, one at a time
+	// Also calculate the total pending snapshots so we can requeue the
+	// request to continue processing other snapshots.
+	var snapshotToProcess *vmopv1.VirtualMachineSnapshot
+	totalPendingSnapshots := 0
+	for _, snapshot := range vmSnapshots {
+		// Skip snapshots that are already ready
+		if pkgcnd.IsTrue(&snapshot, vmopv1.VirtualMachineSnapshotReadyCondition) {
+			vmCtx.Logger.V(4).Info("Skipping snapshot that is already ready",
+				"snapshotName", snapshot.Name)
+			continue
+		}
+
+		if snapshot.DeletionTimestamp.IsZero() {
+			totalPendingSnapshots++
+		}
+
+		// Found the first snapshot that needs processing
+		if snapshotToProcess == nil {
+			snapshotToProcess = &snapshot
+		}
+	}
+
+	// If no snapshot needs processing, we're done
+	if snapshotToProcess == nil {
+		vmCtx.Logger.V(4).Info("All snapshots are ready or being deleted, nothing to process")
+		return nil
+	}
+
+	// If the oldest snapshot is being deleted, wait for it to finish.
+	if !snapshotToProcess.DeletionTimestamp.IsZero() {
+		vmCtx.Logger.V(4).Info("Snapshot is being deleted, waiting for completion",
+			"snapshotName", snapshotToProcess.Name)
+		return nil
+	}
+
+	// If the oldest snapshot is in progress, wait for it to complete
+	if pkgcnd.IsTrue(snapshotToProcess, "VirtualMachineSnapshotInProgress") {
+		vmCtx.Logger.V(4).Info("Snapshot is in progress, waiting for completion",
+			"snapshotName", snapshotToProcess.Name)
+		return nil
+	}
+
+	// Mark the snapshot as in progress before starting the operation to
+	// prevent concurrent snapshots.
+	if err := vs.markSnapshotInProgress(vmCtx, snapshotToProcess); err != nil {
+		vmCtx.Logger.Error(err, "Failed to mark snapshot as in progress", "snapshotName", snapshotToProcess.Name)
+		return err
 	}
 
 	snapArgs := virtualmachine.SnapshotArgs{
 		VMCtx:      vmCtx,
 		VcVM:       vcVM,
-		VMSnapshot: vmSnapshot,
+		VMSnapshot: *snapshotToProcess,
 	}
 
-	vmCtx.Logger.Info("Creating a new snapshot of the virtual machine")
+	vmCtx.Logger.Info("Creating snapshot on vSphere",
+		"snapshotName", snapshotToProcess.Name)
 	snapMoRef, err := virtualmachine.SnapshotVirtualMachine(snapArgs)
 	if err != nil {
-		vmCtx.Logger.Error(err, "failed to snapshot virtual machine")
+		// Mark the snapshot as failed and clear in-progress status
+		vs.markSnapshotFailed(vmCtx, snapshotToProcess, err)
+		vmCtx.Logger.Error(err, "Failed to create snapshot", "snapshotName", snapshotToProcess.Name)
 		return err
 	}
 
-	if err = PatchSnapshotStatus(vmCtx, vs.k8sClient,
-		&vmSnapshot, snapMoRef); err != nil {
+	// Update the snapshot status with the successful result
+	if err = PatchSnapshotStatus(vmCtx, vs.k8sClient, snapshotToProcess, snapMoRef); err != nil {
+		vmCtx.Logger.Error(err, "Failed to update snapshot status", "snapshotName", snapshotToProcess.Name)
 		return err
+	}
+
+	// Successfully processed one snapshot
+	// Check if there are more snapshots to process after this one
+	totalPendingSnapshots--
+	vmCtx.Logger.Info("Successfully completed snapshot operation",
+		"snapshotName", snapshotToProcess.Name,
+		"remainingSnapshots", totalPendingSnapshots)
+
+	// If there are more pending snapshots, requeue to process the next one
+	if totalPendingSnapshots > 0 {
+		vmCtx.Logger.Info("Requeuing to process remaining snapshots",
+			"snapshotName", snapshotToProcess.Name,
+			"remainingSnapshots", totalPendingSnapshots)
+		return fmt.Errorf("requeuing to process %d remaining snapshots: %w", totalPendingSnapshots, pkgerr.RequeueError{})
 	}
 
 	/* TODO:
@@ -2587,4 +2647,64 @@ func (vs *vSphereVMProvider) vmResizeGetArgs(
 	}
 
 	return resizeArgs, nil
+}
+
+// getVirtualMachineSnapshotsForVM finds all VirtualMachineSnapshot objects that reference this VM.
+func (vs *vSphereVMProvider) getVirtualMachineSnapshotsForVM(
+	vmCtx pkgctx.VirtualMachineContext) ([]vmopv1.VirtualMachineSnapshot, error) {
+
+	// List all VirtualMachineSnapshot objects in the VM's namespace
+	var snapshotList vmopv1.VirtualMachineSnapshotList
+	if err := vs.k8sClient.List(vmCtx, &snapshotList, ctrlclient.InNamespace(vmCtx.VM.Namespace)); err != nil {
+		return nil, fmt.Errorf("failed to list VirtualMachineSnapshot objects: %w", err)
+	}
+
+	// Filter snapshots that reference this VM
+	var vmSnapshots []vmopv1.VirtualMachineSnapshot
+	for _, snapshot := range snapshotList.Items {
+		if snapshot.Spec.VMRef != nil && snapshot.Spec.VMRef.Name == vmCtx.VM.Name {
+			vmSnapshots = append(vmSnapshots, snapshot)
+		}
+	}
+
+	vmCtx.Logger.V(4).Info("Found VirtualMachineSnapshot objects for VM",
+		"count", len(vmSnapshots))
+
+	return vmSnapshots, nil
+}
+
+// markSnapshotInProgress marks a snapshot as currently being processed.
+func (vs *vSphereVMProvider) markSnapshotInProgress(vmCtx pkgctx.VirtualMachineContext, vmSnapshot *vmopv1.VirtualMachineSnapshot) error {
+	// Create a patch to set the InProgress condition
+	patch := ctrlclient.MergeFrom(vmSnapshot.DeepCopy())
+
+	// Set the InProgress condition to prevent concurrent operations
+	pkgcnd.MarkTrue(vmSnapshot, "VirtualMachineSnapshotInProgress")
+
+	// Use Patch instead of Update to avoid conflicts with snapshot controller
+	if err := vs.k8sClient.Status().Patch(vmCtx, vmSnapshot, patch); err != nil {
+		return fmt.Errorf("failed to mark snapshot as in progress: %w", err)
+	}
+
+	vmCtx.Logger.V(4).Info("Marked snapshot as in progress", "snapshotName", vmSnapshot.Name)
+	return nil
+}
+
+// markSnapshotFailed marks a snapshot as failed and clears the in-progress status.
+func (vs *vSphereVMProvider) markSnapshotFailed(vmCtx pkgctx.VirtualMachineContext, vmSnapshot *vmopv1.VirtualMachineSnapshot, err error) {
+	// Create a patch to update the snapshot status
+	patch := ctrlclient.MergeFrom(vmSnapshot.DeepCopy())
+
+	// Clear the InProgress condition
+	pkgcnd.Delete(vmSnapshot, "VirtualMachineSnapshotInProgress")
+
+	// Mark the snapshot as failed
+	pkgcnd.MarkFalse(vmSnapshot, vmopv1.VirtualMachineSnapshotReadyCondition, "SnapshotFailed", "%s", err.Error())
+
+	// Use Patch instead of Update to avoid conflicts with snapshot controller (best effort)
+	if updateErr := vs.k8sClient.Status().Patch(vmCtx, vmSnapshot, patch); updateErr != nil {
+		vmCtx.Logger.Error(updateErr, "Failed to update snapshot status after failure", "snapshotName", vmSnapshot.Name)
+	}
+
+	vmCtx.Logger.V(4).Info("Marked snapshot as failed", "snapshotName", vmSnapshot.Name, "error", err.Error())
 }

--- a/pkg/providers/vsphere/vmprovider_vm_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_test.go
@@ -2855,14 +2855,16 @@ func vmTests() {
 						Expect(err).ToNot(HaveOccurred())
 						Expect(task.Wait(ctx)).To(Succeed())
 
+						// Mark the snapshot as ready.
+						conditions.MarkTrue(vmSnapshot, vmopv1.VirtualMachineSnapshotReadyCondition)
+						// Create the snapshot CR to which the VM should revert
+						Expect(ctx.Client.Create(ctx, vmSnapshot)).To(Succeed())
+
 						vm.Spec.CurrentSnapshot = &vmopv1common.LocalObjectRef{
 							APIVersion: vmSnapshot.APIVersion,
 							Kind:       vmSnapshot.Kind,
 							Name:       vmSnapshot.Name,
 						}
-
-						// Create the snapshot CR
-						Expect(ctx.Client.Create(ctx, vmSnapshot)).To(Succeed())
 
 						// This should return an error because findDesiredSnapshot should return an error
 						// when there are multiple snapshots with the same name
@@ -2872,37 +2874,6 @@ func vmTests() {
 
 						// Verify that the error causes a requeue (not a NoRequeueError)
 						Expect(pkgerr.IsNoRequeueError(err)).To(BeFalse(), "Multiple snapshots error should cause requeue")
-					})
-				})
-
-				Context("create multiple snapshots with the same name", func() {
-					It("should return an error and requeue a reconcile)", func() {
-						// Create VM first to get vcVM reference
-						vcVM, err := createOrUpdateAndGetVcVM(ctx, vmProvider, vm)
-						Expect(err).ToNot(HaveOccurred())
-
-						// Create snapshot in vCenter
-						task, err := vcVM.CreateSnapshot(ctx, vmSnapshot.Name, "test snapshot for revert", false, false)
-						Expect(err).ToNot(HaveOccurred())
-						Expect(task.Wait(ctx)).To(Succeed())
-
-						// Create another snapshot with the same name
-						task, err = vcVM.CreateSnapshot(ctx, vmSnapshot.Name, "test snapshot for revert", false, false)
-						Expect(err).ToNot(HaveOccurred())
-						Expect(task.Wait(ctx)).To(Succeed())
-
-						vm.Spec.CurrentSnapshot = &vmopv1common.LocalObjectRef{
-							APIVersion: vmSnapshot.APIVersion,
-							Kind:       vmSnapshot.Kind,
-							Name:       vmSnapshot.Name,
-						}
-
-						// Create the snapshot CR
-						Expect(ctx.Client.Create(ctx, vmSnapshot)).To(Succeed())
-
-						err = createOrUpdateVM(ctx, vmProvider, vm)
-						Expect(err).To(HaveOccurred())
-						Expect(err.Error()).To(ContainSubstring("resolves to 2 snapshots"))
 					})
 				})
 
@@ -2917,38 +2888,12 @@ func vmTests() {
 
 					It("should not trigger a revert (new snapshot workflow)", func() {
 						// Create the snapshot CR but don't create actual vCenter snapshot
+						conditions.MarkTrue(vmSnapshot, vmopv1.VirtualMachineSnapshotReadyCondition)
 						Expect(ctx.Client.Create(ctx, vmSnapshot)).To(Succeed())
 
 						err := createOrUpdateVM(ctx, vmProvider, vm)
-						Expect(err).NotTo(HaveOccurred())
-
-						// Verify VM status reflects current snapshot
-						Expect(vm.Status.CurrentSnapshot).ToNot(BeNil())
-						Expect(vm.Status.CurrentSnapshot.Name).To(Equal(vmSnapshot.Name))
-					})
-				})
-
-				Context("when desired snapshot doesn't exist in vCenter", func() {
-					BeforeEach(func() {
-						vm.Spec.CurrentSnapshot = &vmopv1common.LocalObjectRef{
-							APIVersion: vmSnapshot.APIVersion,
-							Kind:       vmSnapshot.Kind,
-							Name:       "non-existent-snapshot",
-						}
-					})
-
-					It("should not trigger a revert (create snapshot workflow)", func() {
-						// Create a different snapshot CR
-						nonExistentSnapshot := builder.DummyVirtualMachineSnapshot("", "non-existent-snapshot", vm.Name)
-						nonExistentSnapshot.Namespace = nsInfo.Namespace
-						Expect(ctx.Client.Create(ctx, nonExistentSnapshot)).To(Succeed())
-
-						err := createOrUpdateVM(ctx, vmProvider, vm)
-						Expect(err).ToNot(HaveOccurred())
-
-						// Verify VM status reflects current snapshot
-						Expect(vm.Status.CurrentSnapshot).ToNot(BeNil())
-						Expect(vm.Status.CurrentSnapshot.Name).To(Equal(vm.Spec.CurrentSnapshot.Name))
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).To(ContainSubstring("no snapshots for this VM"))
 					})
 				})
 
@@ -2968,19 +2913,33 @@ func vmTests() {
 					})
 				})
 
-				Context("when VM is already at desired snapshot", func() {
-					It("should succeed without performing revert", func() {
-						// Create VM first to get vcVM reference
-						vcVM, err := createOrUpdateAndGetVcVM(ctx, vmProvider, vm)
-						Expect(err).ToNot(HaveOccurred())
+				Context("when desired snapshot CR is not ready", func() {
+					BeforeEach(func() {
+						vm.Spec.CurrentSnapshot = &vmopv1common.LocalObjectRef{
+							APIVersion: vmSnapshot.APIVersion,
+							Kind:       vmSnapshot.Kind,
+							Name:       vmSnapshot.Name,
+						}
+					})
 
-						// Create snapshot in vCenter
-						task, err := vcVM.CreateSnapshot(ctx, vmSnapshot.Name, "test snapshot for revert", false, false)
-						Expect(err).ToNot(HaveOccurred())
-						Expect(task.Wait(ctx)).To(Succeed())
-
-						// Create snapshot CR for the above snapshot
+					It("should fail with snapshot CR not found error", func() {
+						// Create snapshot CR but don't mark it as ready.
 						Expect(ctx.Client.Create(ctx, vmSnapshot)).To(Succeed())
+
+						err := createOrUpdateVM(ctx, vmProvider, vm)
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).To(ContainSubstring("snapshot CR is not ready, skipping revert"))
+					})
+				})
+
+				Context("revert to current snapshot", func() {
+					It("should succeed", func() {
+						// Create snapshot CR to trigger a snapshot workflow
+						Expect(ctx.Client.Create(ctx, vmSnapshot)).To(Succeed())
+
+						// Create VM so the snapshot reconciliation can run
+						_, err := createOrUpdateAndGetVcVM(ctx, vmProvider, vm)
+						Expect(err).ToNot(HaveOccurred())
 
 						// Set desired snapshot to point to the above snapshot
 						vm.Spec.CurrentSnapshot = &vmopv1common.LocalObjectRef{
@@ -3012,6 +2971,9 @@ func vmTests() {
 						Expect(task.Wait(ctx)).To(Succeed())
 
 						// Create first snapshot CR
+						// Mark the snapshot as ready so that the snapshot workflow doesn't try to create it.
+						conditions.MarkTrue(vmSnapshot, vmopv1.VirtualMachineSnapshotReadyCondition)
+
 						Expect(ctx.Client.Create(ctx, vmSnapshot)).To(Succeed())
 
 						// Create second snapshot
@@ -3023,6 +2985,8 @@ func vmTests() {
 						Expect(task.Wait(ctx)).To(Succeed())
 
 						// Create second snapshot CR
+						// Mark the snapshot as ready so that the snapshot workflow doesn't try to create it.
+						conditions.MarkTrue(secondSnapshot, vmopv1.VirtualMachineSnapshotReadyCondition)
 						Expect(ctx.Client.Create(ctx, secondSnapshot)).To(Succeed())
 
 						// Set desired snapshot to first snapshot (revert from second to first)
@@ -4176,96 +4140,262 @@ func vmTests() {
 			})
 		})
 
-		Context("VM Snapshots", func() {
+		Context("new snapshot workflow driven by VirtualMachineSnapshot CRs", func() {
 			var (
-				vmSnapshot *vmopv1.VirtualMachineSnapshot
+				snapshot1 *vmopv1.VirtualMachineSnapshot
+				snapshot2 *vmopv1.VirtualMachineSnapshot
 			)
 
 			BeforeEach(func() {
 				testConfig.WithVMSnapshots = true
-				vmSnapshot = builder.DummyVirtualMachineSnapshot("", "test-snap", vm.Name)
 			})
 
-			JustBeforeEach(func() {
-				vmSnapshot.Namespace = nsInfo.Namespace
-			})
-
-			Context("snapshot capability is not enabled", func() {
-				BeforeEach(func() {
-					vm.Spec.CurrentSnapshot = &vmopv1common.LocalObjectRef{
-						APIVersion: vmSnapshot.APIVersion,
-						Kind:       vmSnapshot.Kind,
-						Name:       vmSnapshot.Name,
-					}
-
-					testConfig.WithVMSnapshots = false
-				})
-
-				It("does not take a new snapshot, and the status is not updated", func() {
-					// create the snapshot obj
-					Expect(ctx.Client.Create(ctx, vmSnapshot)).To(Succeed())
-
-					vcVM, err := createOrUpdateAndGetVcVM(ctx, vmProvider, vm)
-					Expect(err).To(BeNil())
-					Expect(vcVM).ToNot(BeNil())
-					snap, err := vcVM.FindSnapshot(ctx, vmSnapshot.Name)
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(Equal("no snapshots for this VM"))
-					Expect(snap).To(BeNil())
-					Expect(vm.Status.CurrentSnapshot).To(BeNil())
-				})
-			})
-
-			Context("vm snapshot object doesn't exist", func() {
-				BeforeEach(func() {
-					vm.Spec.CurrentSnapshot = &vmopv1common.LocalObjectRef{
-						APIVersion: vmSnapshot.APIVersion,
-						Kind:       vmSnapshot.Kind,
-						Name:       vmSnapshot.Name,
-					}
-				})
-
-				It("return obj not found err", func() {
+			Context("when no snapshots exist", func() {
+				It("should complete without error", func() {
 					err := createOrUpdateVM(ctx, vmProvider, vm)
-					Expect(err).ToNot(BeNil())
-					Expect(err.Error()).To(ContainSubstring("virtualmachinesnapshots.vmoperator.vmware.com \"test-snap\" not found"))
+					Expect(err).ToNot(HaveOccurred())
 				})
 			})
 
-			Context("create new vm snapshot and patch status", func() {
-				BeforeEach(func() {
-					vm.Spec.CurrentSnapshot = &vmopv1common.LocalObjectRef{
-						APIVersion: vmSnapshot.APIVersion,
-						Kind:       vmSnapshot.Kind,
-						Name:       vmSnapshot.Name,
-					}
+			Context("when one snapshot exists and is not ready", func() {
+				JustBeforeEach(func() {
+					snapshot1 = builder.DummyVirtualMachineSnapshot(vm.Namespace, "snapshot-1", vm.Name)
+					Expect(ctx.Client.Create(ctx, snapshot1)).To(Succeed())
 				})
 
-				It("success", func() {
-					// create the snapshot obj
-					Expect(ctx.Client.Create(ctx, vmSnapshot)).To(Succeed())
+				It("should process the snapshot", func() {
+					err := createOrUpdateVM(ctx, vmProvider, vm)
+					Expect(err).ToNot(HaveOccurred())
 
-					vcVM, err := createOrUpdateAndGetVcVM(ctx, vmProvider, vm)
-					Expect(err).To(BeNil())
-					Expect(vcVM).ToNot(BeNil())
-					snap, err := vcVM.FindSnapshot(ctx, vmSnapshot.Name)
-					Expect(err).To(BeNil())
-					Expect(snap).ToNot(BeNil())
+					// Verify snapshot was processed
+					updatedSnapshot := &vmopv1.VirtualMachineSnapshot{}
+					err = ctx.Client.Get(ctx, client.ObjectKey{
+						Name:      snapshot1.Name,
+						Namespace: snapshot1.Namespace,
+					}, updatedSnapshot)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(conditions.IsTrue(updatedSnapshot, vmopv1.VirtualMachineSnapshotReadyCondition)).To(BeTrue())
+					Expect(updatedSnapshot.Status.Quiesced).To(BeTrue())
+				})
+			})
 
-					Expect(vm.Status.CurrentSnapshot).To(Equal(&vmopv1common.LocalObjectRef{
-						APIVersion: vmSnapshot.APIVersion,
-						Kind:       vmSnapshot.Kind,
-						Name:       vmSnapshot.Name,
-					}))
+			Context("when multiple snapshots exist", func() {
+				It("should process snapshots in order (oldest first)", func() {
+					snapshot1 = builder.DummyVirtualMachineSnapshot(vm.Namespace, "snapshot-1", vm.Name)
+					creationTimeStamp := metav1.NewTime(time.Now())
+					snapshot1.CreationTimestamp = creationTimeStamp
+					Expect(ctx.Client.Create(ctx, snapshot1)).To(Succeed())
 
-					snapObj := &vmopv1.VirtualMachineSnapshot{}
-					err = ctx.Client.Get(ctx, client.ObjectKey{Name: vmSnapshot.Name, Namespace: vmSnapshot.Namespace}, snapObj)
-					Expect(err).To(BeNil())
+					later := metav1.NewTime(time.Now().Add(1 * time.Second))
+					snapshot2 = builder.DummyVirtualMachineSnapshot(vm.Namespace, "snapshot-2", vm.Name)
+					snapshot2.CreationTimestamp = later
+					Expect(ctx.Client.Create(ctx, snapshot2)).To(Succeed())
 
-					Expect(snapObj.Status.Quiesced).To(BeFalse())
-					Expect(snapObj.Status.Conditions).To(HaveLen(1))
-					Expect(snapObj.Status.Conditions[0].Type).To(Equal(vmopv1.VirtualMachineSnapshotReadyCondition))
-					Expect(snapObj.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
+					// First reconcile should process snapshot1, and requeue to process snapshot2.
+					err := createOrUpdateVM(ctx, vmProvider, vm)
+					Expect(err).To(HaveOccurred())
+					Expect(errors.Is(err, pkgerr.RequeueError{})).To(BeTrue())
+					Expect(err.Error()).To(ContainSubstring("requeuing to process 1 remaining snapshots"))
+
+					// Check that snapshot1 is ready
+					updatedSnapshot1 := &vmopv1.VirtualMachineSnapshot{}
+					err = ctx.Client.Get(ctx, client.ObjectKey{
+						Name:      snapshot1.Name,
+						Namespace: snapshot1.Namespace,
+					}, updatedSnapshot1)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(conditions.IsTrue(updatedSnapshot1, vmopv1.VirtualMachineSnapshotReadyCondition)).To(BeTrue())
+
+					// Check that snapshot2 is not ready yet
+					updatedSnapshot2 := &vmopv1.VirtualMachineSnapshot{}
+					err = ctx.Client.Get(ctx, client.ObjectKey{
+						Name:      snapshot2.Name,
+						Namespace: snapshot2.Namespace,
+					}, updatedSnapshot2)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(conditions.IsTrue(updatedSnapshot2, vmopv1.VirtualMachineSnapshotReadyCondition)).To(BeFalse())
+
+					// Second reconcile should process snapshot2
+					err = createOrUpdateVM(ctx, vmProvider, vm)
+					Expect(err).ToNot(HaveOccurred())
+
+					// Now snapshot2 should be ready
+					err = ctx.Client.Get(ctx, client.ObjectKey{
+						Name:      snapshot2.Name,
+						Namespace: snapshot2.Namespace,
+					}, updatedSnapshot2)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(conditions.IsTrue(updatedSnapshot2, vmopv1.VirtualMachineSnapshotReadyCondition)).To(BeTrue())
+				})
+			})
+
+			Context("when one snapshot is already in progress", func() {
+				It("should not process any snapshots", func() {
+					snapshot1 = builder.DummyVirtualMachineSnapshot(vm.Namespace, "snapshot-1", vm.Name)
+					snapshot2 = builder.DummyVirtualMachineSnapshot(vm.Namespace, "snapshot-2", vm.Name)
+
+					// Mark snapshot1 as in progress
+					conditions.MarkTrue(snapshot1, "VirtualMachineSnapshotInProgress")
+					Expect(ctx.Client.Create(ctx, snapshot1)).To(Succeed())
+					Expect(ctx.Client.Create(ctx, snapshot2)).To(Succeed())
+
+					err := createOrUpdateVM(ctx, vmProvider, vm)
+					Expect(err).ToNot(HaveOccurred())
+
+					// Neither snapshot should be ready
+					updatedSnapshot1 := &vmopv1.VirtualMachineSnapshot{}
+					err = ctx.Client.Get(ctx, client.ObjectKey{
+						Name:      snapshot1.Name,
+						Namespace: snapshot1.Namespace,
+					}, updatedSnapshot1)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(conditions.IsTrue(updatedSnapshot1, vmopv1.VirtualMachineSnapshotReadyCondition)).To(BeFalse())
+
+					updatedSnapshot2 := &vmopv1.VirtualMachineSnapshot{}
+					err = ctx.Client.Get(ctx, client.ObjectKey{
+						Name:      snapshot2.Name,
+						Namespace: snapshot2.Namespace,
+					}, updatedSnapshot2)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(conditions.IsTrue(updatedSnapshot2, vmopv1.VirtualMachineSnapshotReadyCondition)).To(BeFalse())
+				})
+			})
+
+			Context("when snapshot is being deleted", func() {
+				It("should skip all snapshot creation due to vSphere constraint", func() {
+					// Mark snapshot1 as being deleted
+					snapshot1 = builder.DummyVirtualMachineSnapshot(vm.Namespace, "snapshot-1", vm.Name)
+					// Set a finalizer so we can mark the object for deletion.
+					snapshot1.ObjectMeta.Finalizers = []string{"dummy-finalizer"}
+
+					// Mark snapshot1 as being deleted
+					snapshot2 = builder.DummyVirtualMachineSnapshot(vm.Namespace, "snapshot-2", vm.Name)
+
+					Expect(ctx.Client.Create(ctx, snapshot1)).To(Succeed())
+					Expect(ctx.Client.Create(ctx, snapshot2)).To(Succeed())
+
+					// Delete the snapshot
+					Expect(ctx.Client.Delete(ctx, snapshot1)).To(Succeed())
+
+					err := createOrUpdateVM(ctx, vmProvider, vm)
+					Expect(err).ToNot(HaveOccurred())
+
+					// snapshot1 should not be processed (being deleted)
+					updatedSnapshot1 := &vmopv1.VirtualMachineSnapshot{}
+					err = ctx.Client.Get(ctx, client.ObjectKey{
+						Name:      snapshot1.Name,
+						Namespace: snapshot1.Namespace,
+					}, updatedSnapshot1)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(conditions.IsTrue(updatedSnapshot1, vmopv1.VirtualMachineSnapshotReadyCondition)).To(BeFalse())
+
+					// snapshot2 should also not be processed due to the deletion constraint
+					updatedSnapshot2 := &vmopv1.VirtualMachineSnapshot{}
+					err = ctx.Client.Get(ctx, client.ObjectKey{
+						Name:      snapshot2.Name,
+						Namespace: snapshot2.Namespace,
+					}, updatedSnapshot2)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(conditions.IsTrue(updatedSnapshot2, vmopv1.VirtualMachineSnapshotReadyCondition)).To(BeFalse())
+				})
+			})
+
+			Context("when snapshot already exists and is ready", func() {
+				It("should skip ready snapshot and process the next one", func() {
+					snapshot1 = builder.DummyVirtualMachineSnapshot(vm.Namespace, "snapshot-1", vm.Name)
+					snapshot2 = builder.DummyVirtualMachineSnapshot(vm.Namespace, "snapshot-2", vm.Name)
+
+					// Mark snapshot1 as ready
+					conditions.MarkTrue(snapshot1, vmopv1.VirtualMachineSnapshotReadyCondition)
+					Expect(ctx.Client.Create(ctx, snapshot1)).To(Succeed())
+					Expect(ctx.Client.Create(ctx, snapshot2)).To(Succeed())
+
+					err := createOrUpdateVM(ctx, vmProvider, vm)
+					Expect(err).ToNot(HaveOccurred())
+
+					// snapshot1 should remain ready and not be processed again
+					updatedSnapshot1 := &vmopv1.VirtualMachineSnapshot{}
+					err = ctx.Client.Get(ctx, client.ObjectKey{
+						Name:      snapshot1.Name,
+						Namespace: snapshot1.Namespace,
+					}, updatedSnapshot1)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(conditions.IsTrue(updatedSnapshot1, vmopv1.VirtualMachineSnapshotReadyCondition)).To(BeTrue())
+
+					// snapshot2 should be processed
+					updatedSnapshot2 := &vmopv1.VirtualMachineSnapshot{}
+					err = ctx.Client.Get(ctx, client.ObjectKey{
+						Name:      snapshot2.Name,
+						Namespace: snapshot2.Namespace,
+					}, updatedSnapshot2)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(conditions.IsTrue(updatedSnapshot2, vmopv1.VirtualMachineSnapshotReadyCondition)).To(BeTrue())
+				})
+			})
+
+			Context("when snapshot has nil VMRef", func() {
+				It("should skip snapshot with nil VMRef and process the next one", func() {
+					snapshot1 = builder.DummyVirtualMachineSnapshot(vm.Namespace, "snapshot-1", vm.Name)
+					snapshot2 = builder.DummyVirtualMachineSnapshot(vm.Namespace, "snapshot-2", vm.Name)
+
+					// Set snapshot1 VMRef to nil
+					snapshot1.Spec.VMRef = nil
+					Expect(ctx.Client.Create(ctx, snapshot1)).To(Succeed())
+					Expect(ctx.Client.Create(ctx, snapshot2)).To(Succeed())
+
+					err := createOrUpdateVM(ctx, vmProvider, vm)
+					Expect(err).ToNot(HaveOccurred())
+
+					// snapshot1 should not be processed (nil VMRef)
+					updatedSnapshot1 := &vmopv1.VirtualMachineSnapshot{}
+					err = ctx.Client.Get(ctx, client.ObjectKey{
+						Name:      snapshot1.Name,
+						Namespace: snapshot1.Namespace,
+					}, updatedSnapshot1)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(conditions.IsTrue(updatedSnapshot1, vmopv1.VirtualMachineSnapshotReadyCondition)).To(BeFalse())
+
+					// snapshot2 should be processed
+					updatedSnapshot2 := &vmopv1.VirtualMachineSnapshot{}
+					err = ctx.Client.Get(ctx, client.ObjectKey{
+						Name:      snapshot2.Name,
+						Namespace: snapshot2.Namespace,
+					}, updatedSnapshot2)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(conditions.IsTrue(updatedSnapshot2, vmopv1.VirtualMachineSnapshotReadyCondition)).To(BeTrue())
+				})
+			})
+
+			Context("when snapshot references different VM", func() {
+				It("should skip snapshot for different VM and process the next one", func() {
+					snapshot1 = builder.DummyVirtualMachineSnapshot(vm.Namespace, "snapshot-1", vm.Name)
+					snapshot2 = builder.DummyVirtualMachineSnapshot(vm.Namespace, "snapshot-2", vm.Name)
+
+					// Set snapshot1 to reference a different VM
+					snapshot1.Spec.VMRef.Name = "different-vm"
+					Expect(ctx.Client.Create(ctx, snapshot1)).To(Succeed())
+					Expect(ctx.Client.Create(ctx, snapshot2)).To(Succeed())
+
+					err := createOrUpdateVM(ctx, vmProvider, vm)
+					Expect(err).ToNot(HaveOccurred())
+
+					// snapshot1 should not be processed (different VM)
+					updatedSnapshot1 := &vmopv1.VirtualMachineSnapshot{}
+					err = ctx.Client.Get(ctx, client.ObjectKey{
+						Name:      snapshot1.Name,
+						Namespace: snapshot1.Namespace,
+					}, updatedSnapshot1)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(conditions.IsTrue(updatedSnapshot1, vmopv1.VirtualMachineSnapshotReadyCondition)).To(BeFalse())
+
+					// snapshot2 should be processed
+					updatedSnapshot2 := &vmopv1.VirtualMachineSnapshot{}
+					err = ctx.Client.Get(ctx, client.ObjectKey{
+						Name:      snapshot2.Name,
+						Namespace: snapshot2.Namespace,
+					}, updatedSnapshot2)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(conditions.IsTrue(updatedSnapshot2, vmopv1.VirtualMachineSnapshotReadyCondition)).To(BeTrue())
 				})
 			})
 		})

--- a/pkg/providers/vsphere/vmprovider_vm_utils.go
+++ b/pkg/providers/vsphere/vmprovider_vm_utils.go
@@ -492,25 +492,6 @@ func GetVMSetResourcePolicy(
 	return resourcePolicy, nil
 }
 
-func getVirtualMachineSnapShotObject(
-	vmCtx pkgctx.VirtualMachineContext,
-	k8sClient ctrlclient.Client) (vmopv1.VirtualMachineSnapshot, error) {
-
-	var (
-		obj vmopv1.VirtualMachineSnapshot
-		key = ctrlclient.ObjectKey{
-			Name:      vmCtx.VM.Spec.CurrentSnapshot.Name,
-			Namespace: vmCtx.VM.Namespace,
-		}
-	)
-
-	if err := k8sClient.Get(vmCtx, key, &obj); err != nil {
-		return vmopv1.VirtualMachineSnapshot{}, err
-	}
-
-	return obj, nil
-}
-
 // AddInstanceStorageVolumes checks if VM class is configured with instance storage volumes and appends the
 // volumes to the VM's Spec if not already done. Return true if the VM had or now has instance storage volumes.
 func AddInstanceStorageVolumes(

--- a/pkg/util/vmopv1/vm.go
+++ b/pkg/util/vmopv1/vm.go
@@ -22,6 +22,7 @@ import (
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
 	byokv1 "github.com/vmware-tanzu/vm-operator/external/byok/api/v1alpha1"
+	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	"github.com/vmware-tanzu/vm-operator/pkg/constants"
 	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
@@ -270,6 +271,44 @@ func SyncStorageUsageForNamespace(
 			},
 		}
 	}()
+}
+
+// SnapshotToVMMapperFn returns a mapper function that can be used to
+// queue reconcile requests for the VirtualMachines in response to an
+// event on the VirtualMachineSnapshot resource.
+func SnapshotToVMMapperFn(
+	ctx context.Context,
+	logger logr.Logger,
+) func(_ context.Context, o client.Object) []reconcile.Request {
+
+	return func(_ context.Context, o client.Object) []reconcile.Request {
+		snapshot := o.(*vmopv1.VirtualMachineSnapshot)
+		logger := logger.WithValues("snapshotName", snapshot.Name, "namespace", snapshot.Namespace)
+
+		// Only process snapshots that reference a VM
+		if snapshot.Spec.VMRef == nil {
+			logger.V(4).Info("Skipping snapshot with no VM reference")
+			return nil
+		}
+
+		// Only process snapshots that are not ready.
+		if conditions.IsTrue(snapshot, vmopv1.VirtualMachineSnapshotReadyCondition) {
+			logger.V(4).Info("Skipping snapshot that is already ready")
+			return nil
+		}
+
+		logger.V(4).Info("Queuing VM reconciliation due to snapshot event", "vmName", snapshot.Spec.VMRef.Name)
+
+		// Queue reconciliation for the referenced VM
+		return []reconcile.Request{
+			{
+				NamespacedName: client.ObjectKey{
+					Namespace: snapshot.Namespace,
+					Name:      snapshot.Spec.VMRef.Name,
+				},
+			},
+		}
+	}
 }
 
 // EncryptionClassToVirtualMachineMapper returns a mapper function used to

--- a/test/builder/dummies.go
+++ b/test/builder/dummies.go
@@ -10,6 +10,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
@@ -549,22 +550,20 @@ func DummyVirtualMachineWebConsoleRequest(namespace, wcrName, vmName, pubKey str
 
 func DummyVirtualMachineSnapshot(namespace, name, vmName string) *vmopv1.VirtualMachineSnapshot {
 	return &vmopv1.VirtualMachineSnapshot{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "VirtualMachineSnapshot",
-			APIVersion: "vmoperator.vmware.com/v1alpha4",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
-			Finalizers: []string{
-				"vmoperator.vmware.com/virtualmachinesnapshot",
-			},
 		},
 		Spec: vmopv1.VirtualMachineSnapshotSpec{
 			VMRef: &vmopv1common.LocalObjectRef{
 				APIVersion: "vmoperator.vmware.com/v1alpha4",
 				Kind:       "VirtualMachine",
 				Name:       vmName,
+			},
+			Quiesce: &vmopv1.QuiesceSpec{
+				Timeout: &metav1.Duration{
+					Duration: 10 * time.Minute,
+				},
 			},
 		},
 	}


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Initially, we were driving the snapshot workflow through the snapshot custom resource modifying the VM's spec.currentSnapshot field -- which will then be reconciled by the VM controller to take a snapshot.

This presents a problem that we can not revert a VM to the current snapshot -- which is one of the most common workflows.  To address that, we will not watch the VirtualMachineSnapshot type custom resources that are not in ready state and reconcile those from the VM controller.  Even though this is not ideal (a controller reconciling a resources for which there's a dedicated controller already exists), this is necessary to keep all the VM configuration changes in a single controller so we don't have to use distributed locking between controllers.

This change:
- Updates the APIs with correct commentary
- Modifies the snapshot controller to always set OwnerRef on the snapshot pointing to the VM.
- Modifies the snapshot controller to not patch the spec.currentSnapshot on the VM.
- Modifies the VM controller to enqueue reconcile requests to VMs for any events on a snapshot resource that is not ready.
- Implement an ordering in the snapshot workflow so that the oldest snapshot request is processed.
- Modifies the revert workflow to clear out the spec.currentStatus (if set) so that users can revert the VM to the current snapshot.


**Are there any special notes for your reviewer**:

I would appreciate a closer look on the snapshot ordering and the requeue semantics in case of both snapshot, and revert operations.


**Please add a release note if necessary**:

```release-note
Drive create snapshot workflow only through the custom resource
```