### PR TITLE
🌱 VMICache location / disk promotion ignores snapshots & waits on guest customization

### DIFF
--- a/api/v1alpha3/virtualmachineimagecache_types.go
+++ b/api/v1alpha3/virtualmachineimagecache_types.go
@@ -27,6 +27,12 @@ type VirtualMachineImageCacheLocationSpec struct {
 	// be cached.
 	DatacenterID string `json:"datacenterID"`
 
+	// ProfileID describes the ID of the storage profile used to cache the
+	// image.
+	// Please note, this profile *must* include the datastore specified by the
+	// datastoreID field.
+	ProfileID string `json:"profileID"`
+
 	// DatastoreID describes the ID of the datastore to which the image should
 	// be cached.
 	DatastoreID string `json:"datastoreID"`
@@ -50,22 +56,28 @@ type VirtualMachineImageCacheSpec struct {
 	// +listType=map
 	// +listMapKey=datacenterID
 	// +listMapKey=datastoreID
+	// +listMapKey=profileID
 
 	// Locations describes the locations where the image should be cached.
 	Locations []VirtualMachineImageCacheLocationSpec `json:"locations,omitempty"`
 }
 
-// AddLocation adds the provided datacenterID and datastoreID to the the image
-// cache object's spec.locations list if such a location does not already exist.
-// Calling this function for a pair of datacenterID and datastoreID values that
-// already exist in the object's spec.locations list has no effect.
+// AddLocation adds the provided datacenterID, datastoreID, and profileID to the
+// the image cache object's spec.locations list if such a location does not
+// already exist. Calling this function for a set of datacenterID, datastoreID,
+// and profileID values that already exist in the object's spec.locations list
+// has no effect.
 func (i *VirtualMachineImageCache) AddLocation(
 	datacenterID,
-	datastoreID string) {
+	datastoreID,
+	profileID string) {
 
 	for idx := range i.Spec.Locations {
 		l := i.Spec.Locations[idx]
-		if l.DatacenterID == datacenterID && l.DatastoreID == datastoreID {
+		if l.DatacenterID == datacenterID &&
+			l.DatastoreID == datastoreID &&
+			l.ProfileID == profileID {
+
 			return
 		}
 	}
@@ -74,6 +86,7 @@ func (i *VirtualMachineImageCache) AddLocation(
 		VirtualMachineImageCacheLocationSpec{
 			DatacenterID: datacenterID,
 			DatastoreID:  datastoreID,
+			ProfileID:    profileID,
 		})
 }
 
@@ -96,13 +109,16 @@ type VirtualMachineImageCacheFileStatus struct {
 
 type VirtualMachineImageCacheLocationStatus struct {
 
-	// DatacenterID describes the ID of the datacenter to which the image should
-	// be cached.
+	// DatacenterID describes the ID of the datacenter where the image is
+	// cached.
 	DatacenterID string `json:"datacenterID"`
 
-	// DatastoreID describes the ID of the datastore to which the image should
-	// be cached.
+	// DatastoreID describes the ID of the datastore where the image is cached.
 	DatastoreID string `json:"datastoreID"`
+
+	// ProfileID describes the ID of the storage profile used to cache the
+	// image.
+	ProfileID string `json:"profileID"`
 
 	// +optional
 	// +listType=map
@@ -153,6 +169,7 @@ type VirtualMachineImageCacheStatus struct {
 	// +listType=map
 	// +listMapKey=datacenterID
 	// +listMapKey=datastoreID
+	// +listMapKey=profileID
 
 	// Locations describe the observed locations where the image is cached.
 	Locations []VirtualMachineImageCacheLocationStatus `json:"locations,omitempty"`

--- a/api/v1alpha3/zz_generated.conversion.go
+++ b/api/v1alpha3/zz_generated.conversion.go
@@ -2196,6 +2196,7 @@ func Convert_v1alpha4_VirtualMachineImageCacheList_To_v1alpha3_VirtualMachineIma
 
 func autoConvert_v1alpha3_VirtualMachineImageCacheLocationSpec_To_v1alpha4_VirtualMachineImageCacheLocationSpec(in *VirtualMachineImageCacheLocationSpec, out *v1alpha4.VirtualMachineImageCacheLocationSpec, s conversion.Scope) error {
 	out.DatacenterID = in.DatacenterID
+	out.ProfileID = in.ProfileID
 	out.DatastoreID = in.DatastoreID
 	return nil
 }
@@ -2207,6 +2208,7 @@ func Convert_v1alpha3_VirtualMachineImageCacheLocationSpec_To_v1alpha4_VirtualMa
 
 func autoConvert_v1alpha4_VirtualMachineImageCacheLocationSpec_To_v1alpha3_VirtualMachineImageCacheLocationSpec(in *v1alpha4.VirtualMachineImageCacheLocationSpec, out *VirtualMachineImageCacheLocationSpec, s conversion.Scope) error {
 	out.DatacenterID = in.DatacenterID
+	out.ProfileID = in.ProfileID
 	out.DatastoreID = in.DatastoreID
 	return nil
 }
@@ -2219,6 +2221,7 @@ func Convert_v1alpha4_VirtualMachineImageCacheLocationSpec_To_v1alpha3_VirtualMa
 func autoConvert_v1alpha3_VirtualMachineImageCacheLocationStatus_To_v1alpha4_VirtualMachineImageCacheLocationStatus(in *VirtualMachineImageCacheLocationStatus, out *v1alpha4.VirtualMachineImageCacheLocationStatus, s conversion.Scope) error {
 	out.DatacenterID = in.DatacenterID
 	out.DatastoreID = in.DatastoreID
+	out.ProfileID = in.ProfileID
 	if in.Files != nil {
 		in, out := &in.Files, &out.Files
 		*out = make([]v1alpha4.VirtualMachineImageCacheFileStatus, len(*in))
@@ -2242,6 +2245,7 @@ func Convert_v1alpha3_VirtualMachineImageCacheLocationStatus_To_v1alpha4_Virtual
 func autoConvert_v1alpha4_VirtualMachineImageCacheLocationStatus_To_v1alpha3_VirtualMachineImageCacheLocationStatus(in *v1alpha4.VirtualMachineImageCacheLocationStatus, out *VirtualMachineImageCacheLocationStatus, s conversion.Scope) error {
 	out.DatacenterID = in.DatacenterID
 	out.DatastoreID = in.DatastoreID
+	out.ProfileID = in.ProfileID
 	if in.Files != nil {
 		in, out := &in.Files, &out.Files
 		*out = make([]VirtualMachineImageCacheFileStatus, len(*in))

--- a/api/v1alpha4/virtualmachineimagecache_types.go
+++ b/api/v1alpha4/virtualmachineimagecache_types.go
@@ -27,6 +27,12 @@ type VirtualMachineImageCacheLocationSpec struct {
 	// be cached.
 	DatacenterID string `json:"datacenterID"`
 
+	// ProfileID describes the ID of the storage profile used to cache the
+	// image.
+	// Please note, this profile *must* include the datastore specified by the
+	// datastoreID field.
+	ProfileID string `json:"profileID"`
+
 	// DatastoreID describes the ID of the datastore to which the image should
 	// be cached.
 	DatastoreID string `json:"datastoreID"`
@@ -50,22 +56,28 @@ type VirtualMachineImageCacheSpec struct {
 	// +listType=map
 	// +listMapKey=datacenterID
 	// +listMapKey=datastoreID
+	// +listMapKey=profileID
 
 	// Locations describes the locations where the image should be cached.
 	Locations []VirtualMachineImageCacheLocationSpec `json:"locations,omitempty"`
 }
 
-// AddLocation adds the provided datacenterID and datastoreID to the the image
-// cache object's spec.locations list if such a location does not already exist.
-// Calling this function for a pair of datacenterID and datastoreID values that
-// already exist in the object's spec.locations list has no effect.
+// AddLocation adds the provided datacenterID, datastoreID, and profileID to the
+// the image cache object's spec.locations list if such a location does not
+// already exist. Calling this function for a set of datacenterID, datastoreID,
+// and profileID values that already exist in the object's spec.locations list
+// has no effect.
 func (i *VirtualMachineImageCache) AddLocation(
 	datacenterID,
-	datastoreID string) {
+	datastoreID,
+	profileID string) {
 
 	for idx := range i.Spec.Locations {
 		l := i.Spec.Locations[idx]
-		if l.DatacenterID == datacenterID && l.DatastoreID == datastoreID {
+		if l.DatacenterID == datacenterID &&
+			l.DatastoreID == datastoreID &&
+			l.ProfileID == profileID {
+
 			return
 		}
 	}
@@ -74,6 +86,7 @@ func (i *VirtualMachineImageCache) AddLocation(
 		VirtualMachineImageCacheLocationSpec{
 			DatacenterID: datacenterID,
 			DatastoreID:  datastoreID,
+			ProfileID:    profileID,
 		})
 }
 
@@ -117,13 +130,16 @@ type VirtualMachineImageCacheFileStatus struct {
 
 type VirtualMachineImageCacheLocationStatus struct {
 
-	// DatacenterID describes the ID of the datacenter to which the image should
-	// be cached.
+	// DatacenterID describes the ID of the datacenter where the image is
+	// cached.
 	DatacenterID string `json:"datacenterID"`
 
-	// DatastoreID describes the ID of the datastore to which the image should
-	// be cached.
+	// DatastoreID describes the ID of the datastore where the image is cached.
 	DatastoreID string `json:"datastoreID"`
+
+	// ProfileID describes the ID of the storage profile used to cache the
+	// image.
+	ProfileID string `json:"profileID"`
 
 	// +optional
 	// +listType=map
@@ -174,6 +190,7 @@ type VirtualMachineImageCacheStatus struct {
 	// +listType=map
 	// +listMapKey=datacenterID
 	// +listMapKey=datastoreID
+	// +listMapKey=profileID
 
 	// Locations describe the observed locations where the image is cached.
 	Locations []VirtualMachineImageCacheLocationStatus `json:"locations,omitempty"`

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachineimagecaches.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachineimagecaches.yaml
@@ -62,14 +62,23 @@ spec:
                         DatastoreID describes the ID of the datastore to which the image should
                         be cached.
                       type: string
+                    profileID:
+                      description: |-
+                        ProfileID describes the ID of the storage profile used to cache the
+                        image.
+                        Please note, this profile *must* include the datastore specified by the
+                        datastoreID field.
+                      type: string
                   required:
                   - datacenterID
                   - datastoreID
+                  - profileID
                   type: object
                 type: array
                 x-kubernetes-list-map-keys:
                 - datacenterID
                 - datastoreID
+                - profileID
                 x-kubernetes-list-type: map
               providerID:
                 description: |-
@@ -223,13 +232,12 @@ spec:
                       type: array
                     datacenterID:
                       description: |-
-                        DatacenterID describes the ID of the datacenter to which the image should
-                        be cached.
+                        DatacenterID describes the ID of the datacenter where the image is
+                        cached.
                       type: string
                     datastoreID:
-                      description: |-
-                        DatastoreID describes the ID of the datastore to which the image should
-                        be cached.
+                      description: DatastoreID describes the ID of the datastore where
+                        the image is cached.
                       type: string
                     files:
                       description: Files describes the image's files cached on this
@@ -259,14 +267,21 @@ spec:
                       - id
                       - type
                       x-kubernetes-list-type: map
+                    profileID:
+                      description: |-
+                        ProfileID describes the ID of the storage profile used to cache the
+                        image.
+                      type: string
                   required:
                   - datacenterID
                   - datastoreID
+                  - profileID
                   type: object
                 type: array
                 x-kubernetes-list-map-keys:
                 - datacenterID
                 - datastoreID
+                - profileID
                 x-kubernetes-list-type: map
               ovf:
                 description: OVF describes the observed status of the cached OVF content.
@@ -334,14 +349,23 @@ spec:
                         DatastoreID describes the ID of the datastore to which the image should
                         be cached.
                       type: string
+                    profileID:
+                      description: |-
+                        ProfileID describes the ID of the storage profile used to cache the
+                        image.
+                        Please note, this profile *must* include the datastore specified by the
+                        datastoreID field.
+                      type: string
                   required:
                   - datacenterID
                   - datastoreID
+                  - profileID
                   type: object
                 type: array
                 x-kubernetes-list-map-keys:
                 - datacenterID
                 - datastoreID
+                - profileID
                 x-kubernetes-list-type: map
               providerID:
                 description: |-
@@ -495,13 +519,12 @@ spec:
                       type: array
                     datacenterID:
                       description: |-
-                        DatacenterID describes the ID of the datacenter to which the image should
-                        be cached.
+                        DatacenterID describes the ID of the datacenter where the image is
+                        cached.
                       type: string
                     datastoreID:
-                      description: |-
-                        DatastoreID describes the ID of the datastore to which the image should
-                        be cached.
+                      description: DatastoreID describes the ID of the datastore where
+                        the image is cached.
                       type: string
                     files:
                       description: Files describes the image's files cached on this
@@ -543,14 +566,21 @@ spec:
                       - id
                       - type
                       x-kubernetes-list-type: map
+                    profileID:
+                      description: |-
+                        ProfileID describes the ID of the storage profile used to cache the
+                        image.
+                      type: string
                   required:
                   - datacenterID
                   - datastoreID
+                  - profileID
                   type: object
                 type: array
                 x-kubernetes-list-map-keys:
                 - datacenterID
                 - datastoreID
+                - profileID
                 x-kubernetes-list-type: map
               ovf:
                 description: OVF describes the observed status of the cached OVF content.

--- a/controllers/virtualmachineimagecache/virtualmachineimagecache_controller_test.go
+++ b/controllers/virtualmachineimagecache/virtualmachineimagecache_controller_test.go
@@ -7,7 +7,6 @@ package virtualmachineimagecache_test
 import (
 	"context"
 	"errors"
-	"fmt"
 	"path"
 	"time"
 
@@ -139,21 +138,17 @@ var _ = Describe(
 			dsName, err := ds.ObjectName(ctx)
 			g.ExpectWithOffset(1, err).ToNot(HaveOccurred())
 
-			topLevelCacheDir := fmt.Sprintf(
-				"[%s] %s",
-				dsName,
-				clsutil.TopLevelCacheDirName)
-
 			itemCacheDir := clsutil.GetCacheDirForLibraryItem(
-				topLevelCacheDir,
-				obj.Spec.ProviderID,
+				dsName,
+				obj.Name,
+				spec.ProfileID,
 				obj.Spec.ProviderVersion)
 
-			vmdkFileName := clsutil.GetCachedFileNameForVMDK(
+			vmdkFileName := clsutil.GetCachedFileName(
 				"ttylinux-pc_i486-16.1-disk1.vmdk") + ".vmdk"
 			vmdkFilePath := path.Join(itemCacheDir, vmdkFileName)
 
-			nvramFileName := clsutil.GetCachedFileNameForVMDK(
+			nvramFileName := clsutil.GetCachedFileName(
 				"ttylinux-pc_i486-16.1-2.nvram") + ".nvram"
 			nvramFilePath := path.Join(itemCacheDir, nvramFileName)
 
@@ -398,6 +393,7 @@ var _ = Describe(
 							vmopv1.VirtualMachineImageCacheLocationSpec{
 								DatacenterID: fakeString,
 								DatastoreID:  vcSimCtx.Datastore.Reference().Value,
+								ProfileID:    vcSimCtx.StorageProfileID,
 							})
 					},
 					true, "", // OVFReady
@@ -416,6 +412,7 @@ var _ = Describe(
 							vmopv1.VirtualMachineImageCacheLocationSpec{
 								DatacenterID: vcSimCtx.Datacenter.Reference().Value,
 								DatastoreID:  fakeString,
+								ProfileID:    vcSimCtx.StorageProfileID,
 							})
 					},
 					true, "", // OVFReady
@@ -444,6 +441,7 @@ var _ = Describe(
 							vmopv1.VirtualMachineImageCacheLocationSpec{
 								DatacenterID: vcSimCtx.Datacenter.Reference().Value,
 								DatastoreID:  vcSimCtx.Datastore.Reference().Value,
+								ProfileID:    vcSimCtx.StorageProfileID,
 							})
 					},
 					true, "", // OVFReady
@@ -477,6 +475,7 @@ var _ = Describe(
 							vmopv1.VirtualMachineImageCacheLocationSpec{
 								DatacenterID: vcSimCtx.Datacenter.Reference().Value,
 								DatastoreID:  vcSimCtx.Datastore.Reference().Value,
+								ProfileID:    vcSimCtx.StorageProfileID,
 							})
 					},
 					true, "", // OVFReady

--- a/pkg/providers/vsphere/vmprovider_vm.go
+++ b/pkg/providers/vsphere/vmprovider_vm.go
@@ -1736,7 +1736,10 @@ func (vs *vSphereVMProvider) vmCreateGetSourceFilePaths(
 		func() error {
 			obj.Spec.ProviderID = itemID
 			obj.Spec.ProviderVersion = itemVersion
-			obj.AddLocation(datacenterID, datastoreID)
+			obj.AddLocation(
+				datacenterID,
+				datastoreID,
+				createArgs.StorageProfileID)
 			return nil
 		}); err != nil {
 		return fmt.Errorf(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch updates the VMICache controller to create a top-level directory per cached item. This ensures there is no single, top-level directory per datastore for all cached disks/files. On VSAN, a top-level datastore directory is a volume, and having multiple, concurrent threads read/write to this volume can lead to read/write lock errors.

This patch also updates the disk promotion reconciler to ignore any disks that participate in snapshots. This prevents a VM from constantly being tagged as out-of-sync for disk promotion if the VM has a snapshot.
    
Finally, this patch causes disk promotion to wait until there is not a pending or running guest customization.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

This fix has been manually verified on a VSAN-enabled testbed, and it is about to be put through gce2e.


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```