### PR TITLE
✨ Annotations-to-ExtraConfig Support

### DIFF
--- a/pkg/vmconfig/anno2extraconfig/anno2extraconfig_reconciler.go
+++ b/pkg/vmconfig/anno2extraconfig/anno2extraconfig_reconciler.go
@@ -1,0 +1,143 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package anno2extraconfig
+
+import (
+	"context"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/mo"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	"github.com/vmware-tanzu/vm-operator/pkg/vmconfig"
+)
+
+const (
+	ManagementProxyAllowListExtraConfig = "guestinfo.com.vmware.mgmt.proxy.allowlist/"
+	ManagementProxyAllowListAnnotation  = "mgmt.proxy.vmware.com/allowlist"
+
+	ManagementProxyWatermarkExtraConfig = "com.vmware.mgmt.proxy.watermark"
+	ManagementProxyWatermarkAnnotation  = "mgmt.proxy.vmware.com/watermark"
+)
+
+// AnnotationsToExtraConfigKeys is a map whose keys represent
+// annotations on VirtualMachine objects for which ExtraConfig key/values should
+// be added/removed to/from a vSphere VM.
+//
+// If a VM has one of these annotations, a key/value should be present on the
+// vSphere VM where the key is the value from this map and the value is the
+// value of the annotation.
+//
+// If a vSphere VM's ExtraConfig's keys includes a value from this map but the
+// VM does not have the corresponding annotation, then the ExtraConfig key
+// should be removed from the vSphere VM.
+var AnnotationsToExtraConfigKeys = map[string]string{
+	ManagementProxyWatermarkAnnotation: ManagementProxyWatermarkExtraConfig,
+	ManagementProxyAllowListAnnotation: ManagementProxyAllowListExtraConfig,
+}
+
+// Reconcile configures the VM's annotations that should be ExtraConfig.
+func Reconcile(
+	ctx context.Context,
+	k8sClient ctrlclient.Client,
+	vimClient *vim25.Client,
+	vm *vmopv1.VirtualMachine,
+	moVM mo.VirtualMachine,
+	configSpec *vimtypes.VirtualMachineConfigSpec) error {
+
+	return New().Reconcile(ctx, k8sClient, vimClient, vm, moVM, configSpec)
+}
+
+type reconciler struct{}
+
+var _ vmconfig.Reconciler = reconciler{}
+
+func New() vmconfig.Reconciler {
+	return reconciler{}
+}
+
+func (r reconciler) Name() string {
+	return "anno2extraconfig"
+}
+
+func (r reconciler) OnResult(
+	_ context.Context,
+	_ *vmopv1.VirtualMachine,
+	_ mo.VirtualMachine,
+	_ error) error {
+
+	return nil
+}
+
+func (r reconciler) Reconcile(
+	ctx context.Context,
+	k8sClient ctrlclient.Client,
+	vimClient *vim25.Client,
+	vm *vmopv1.VirtualMachine,
+	moVM mo.VirtualMachine,
+	configSpec *vimtypes.VirtualMachineConfigSpec) error {
+
+	if ctx == nil {
+		panic("context is nil")
+	}
+	if k8sClient == nil {
+		panic("k8sClient is nil")
+	}
+	if vimClient == nil {
+		panic("vimClient is nil")
+	}
+	if vm == nil {
+		panic("vm is nil")
+	}
+	if configSpec == nil {
+		panic("configSpec is nil")
+	}
+
+	if moVM.Config == nil {
+		return nil
+	}
+
+	var newEC object.OptionValueList
+	outEC := object.OptionValueList(configSpec.ExtraConfig)
+	curEC := object.OptionValueList(moVM.Config.ExtraConfig)
+
+	for annotationKey, extraConfigKey := range AnnotationsToExtraConfigKeys {
+		// Get the annotation's value.
+		curAnnoVal := vm.Annotations[annotationKey]
+
+		if curAnnoVal != "" {
+			// The VM *does* have the annotation, so ensure it is added/updated
+			// in the ExtraConfig.
+			curECVal, _ := curEC.GetString(extraConfigKey)
+			if curAnnoVal != curECVal {
+				newEC = append(newEC, &vimtypes.OptionValue{
+					Key:   extraConfigKey,
+					Value: curAnnoVal,
+				})
+			}
+		} else if _, ok := curEC.Get(extraConfigKey); ok {
+			// The VM does not have the annotation, but the vSphere VM has the
+			// ExtraConfig, so ensure it is removed.
+			newEC = append(newEC, &vimtypes.OptionValue{
+				Key:   extraConfigKey,
+				Value: "",
+			})
+		} else if _, ok := outEC.Get(extraConfigKey); ok {
+			// The VM does not have the annotation, but the existing ConfigSpec
+			// has the ExtraConfig, so ensure it is removed.
+			newEC = append(newEC, &vimtypes.OptionValue{
+				Key:   extraConfigKey,
+				Value: "",
+			})
+		}
+	}
+
+	configSpec.ExtraConfig = curEC.Diff(newEC.Join(outEC...)...)
+
+	return nil
+}

--- a/pkg/vmconfig/anno2extraconfig/anno2extraconfig_reconciler_suite_test.go
+++ b/pkg/vmconfig/anno2extraconfig/anno2extraconfig_reconciler_suite_test.go
@@ -1,0 +1,25 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package anno2extraconfig_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/klog/v2"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func init() {
+	klog.SetOutput(GinkgoWriter)
+	logf.SetLogger(klog.Background())
+}
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "AnnotationsToExtraConfig Reconciler Test Suite")
+}

--- a/pkg/vmconfig/anno2extraconfig/anno2extraconfig_reconciler_test.go
+++ b/pkg/vmconfig/anno2extraconfig/anno2extraconfig_reconciler_test.go
@@ -1,0 +1,426 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package anno2extraconfig_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/mo"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
+	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
+	"github.com/vmware-tanzu/vm-operator/pkg/vmconfig"
+	"github.com/vmware-tanzu/vm-operator/pkg/vmconfig/anno2extraconfig"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+var _ = Describe("New", func() {
+	It("should return a reconciler", func() {
+		Expect(anno2extraconfig.New()).ToNot(BeNil())
+	})
+})
+
+var _ = Describe("Name", func() {
+	It("should return 'anno2extraconfig'", func() {
+		Expect(anno2extraconfig.New().Name()).To(Equal("anno2extraconfig"))
+	})
+})
+
+var _ = Describe("OnResult", func() {
+	It("should return nil", func() {
+		var ctx context.Context
+		Expect(anno2extraconfig.New().OnResult(ctx, nil, mo.VirtualMachine{}, nil)).To(Succeed())
+	})
+})
+
+var _ = Describe("Reconcile", func() {
+
+	var (
+		r          vmconfig.Reconciler
+		ctx        context.Context
+		k8sClient  ctrlclient.Client
+		vimClient  *vim25.Client
+		moVM       mo.VirtualMachine
+		vm         *vmopv1.VirtualMachine
+		withObjs   []ctrlclient.Object
+		withFuncs  interceptor.Funcs
+		configSpec *vimtypes.VirtualMachineConfigSpec
+	)
+
+	BeforeEach(func() {
+		r = anno2extraconfig.New()
+
+		vcsimCtx := builder.NewTestContextForVCSim(
+			ctxop.WithContext(pkgcfg.NewContextWithDefaultConfig()), builder.VCSimTestConfig{})
+		ctx = vcsimCtx
+		ctx = vmconfig.WithContext(ctx)
+
+		vimClient = vcsimCtx.VCClient.Client
+
+		moVM = mo.VirtualMachine{
+			Config: &vimtypes.VirtualMachineConfigInfo{},
+		}
+
+		configSpec = &vimtypes.VirtualMachineConfigSpec{}
+
+		vm = &vmopv1.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:   "my-namespace",
+				Name:        "my-vm",
+				Annotations: map[string]string{},
+			},
+			Spec: vmopv1.VirtualMachineSpec{},
+		}
+
+		withFuncs = interceptor.Funcs{}
+		withObjs = []ctrlclient.Object{}
+	})
+
+	JustBeforeEach(func() {
+		k8sClient = builder.NewFakeClientWithInterceptors(withFuncs, withObjs...)
+	})
+
+	Context("a panic is expected", func() {
+		When("ctx is nil", func() {
+			JustBeforeEach(func() {
+				ctx = nil
+			})
+			It("should panic", func() {
+				fn := func() {
+					_ = r.Reconcile(ctx, k8sClient, vimClient, vm, moVM, configSpec)
+				}
+				Expect(fn).To(PanicWith("context is nil"))
+			})
+		})
+		When("k8sClient is nil", func() {
+			JustBeforeEach(func() {
+				k8sClient = nil
+			})
+			It("should panic", func() {
+				fn := func() {
+					_ = r.Reconcile(ctx, k8sClient, vimClient, vm, moVM, configSpec)
+				}
+				Expect(fn).To(PanicWith("k8sClient is nil"))
+			})
+		})
+		When("vimClient is nil", func() {
+			JustBeforeEach(func() {
+				vimClient = nil
+			})
+			It("should panic", func() {
+				fn := func() {
+					_ = r.Reconcile(ctx, k8sClient, vimClient, vm, moVM, configSpec)
+				}
+				Expect(fn).To(PanicWith("vimClient is nil"))
+			})
+		})
+		When("vm is nil", func() {
+			JustBeforeEach(func() {
+				vm = nil
+			})
+			It("should panic", func() {
+				fn := func() {
+					_ = r.Reconcile(ctx, k8sClient, vimClient, vm, moVM, configSpec)
+				}
+				Expect(fn).To(PanicWith("vm is nil"))
+			})
+		})
+		When("configSpec is nil", func() {
+			JustBeforeEach(func() {
+				configSpec = nil
+			})
+			It("should panic", func() {
+				fn := func() {
+					_ = r.Reconcile(ctx, k8sClient, vimClient, vm, moVM, configSpec)
+				}
+				Expect(fn).To(PanicWith("configSpec is nil"))
+			})
+		})
+	})
+
+	When("no panic is expected", func() {
+
+		const (
+			annotationKey1  = anno2extraconfig.ManagementProxyAllowListAnnotation
+			extraConfigKey1 = anno2extraconfig.ManagementProxyAllowListExtraConfig
+			annotationKey2  = anno2extraconfig.ManagementProxyWatermarkAnnotation
+			extraConfigKey2 = anno2extraconfig.ManagementProxyWatermarkExtraConfig
+
+			value1 = "1234"
+			value2 = "5678"
+		)
+
+		var (
+			err error
+		)
+
+		JustBeforeEach(func() {
+			err = anno2extraconfig.Reconcile(
+				ctx,
+				k8sClient,
+				vimClient,
+				vm,
+				moVM,
+				configSpec)
+		})
+
+		assertEmptyExtraConfig := func() {
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			ExpectWithOffset(1, configSpec.ExtraConfig).To(HaveLen(0))
+		}
+
+		assertExtraConfig := func(expectedKey, expectedValue string) {
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			outEC := object.OptionValueList(configSpec.ExtraConfig)
+			v, ok := outEC.GetString(expectedKey)
+			ExpectWithOffset(1, ok).To(BeTrue())
+			ExpectWithOffset(1, v).To(Equal(expectedValue))
+		}
+
+		assertNotExtraConfig := func(notExpectedKey string) {
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			outEC := object.OptionValueList(configSpec.ExtraConfig)
+			_, ok := outEC.GetString(notExpectedKey)
+			ExpectWithOffset(1, ok).To(BeFalse())
+		}
+
+		When("moVM config is nil", func() {
+			BeforeEach(func() {
+				moVM.Config = nil
+			})
+			It("should not return an error", func() {
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		When("Annotation is present on VM", func() {
+
+			BeforeEach(func() {
+				vm.Annotations[annotationKey1] = value1
+			})
+			When("ExtraConfig key is missing from ConfigInfo", func() {
+				BeforeEach(func() {
+					moVM.Config.ExtraConfig = nil
+				})
+				It("should update the ConfigSpec", func() {
+					assertExtraConfig(extraConfigKey1, value1)
+				})
+
+				When("ExtraConfig key is different in ConfigSpec", func() {
+					BeforeEach(func() {
+						configSpec.ExtraConfig = []vimtypes.BaseOptionValue{
+							&vimtypes.OptionValue{
+								Key:   extraConfigKey1,
+								Value: value2,
+							},
+						}
+					})
+					It("should update the ConfigSpec", func() {
+						Expect(configSpec.ExtraConfig).To(HaveLen(1))
+						assertExtraConfig(extraConfigKey1, value1)
+					})
+				})
+			})
+			When("ExtraConfig key is different in ConfigInfo", func() {
+				BeforeEach(func() {
+					moVM.Config.ExtraConfig = []vimtypes.BaseOptionValue{
+						&vimtypes.OptionValue{
+							Key:   extraConfigKey1,
+							Value: value2,
+						},
+					}
+				})
+				It("should update the ConfigSpec", func() {
+					Expect(configSpec.ExtraConfig).To(HaveLen(1))
+					assertExtraConfig(extraConfigKey1, value1)
+				})
+
+				When("ExtraConfig key is different in ConfigSpec", func() {
+					BeforeEach(func() {
+						configSpec.ExtraConfig = []vimtypes.BaseOptionValue{
+							&vimtypes.OptionValue{
+								Key:   extraConfigKey1,
+								Value: value2,
+							},
+						}
+					})
+					It("should update the ConfigSpec", func() {
+						Expect(configSpec.ExtraConfig).To(HaveLen(1))
+						assertExtraConfig(extraConfigKey1, value1)
+					})
+				})
+			})
+		})
+
+		When("Multiple annotations are present on VM", func() {
+
+			BeforeEach(func() {
+				vm.Annotations[annotationKey1] = value1
+				vm.Annotations[annotationKey2] = value1
+			})
+			When("ExtraConfig key 2 is missing from ConfigInfo", func() {
+				BeforeEach(func() {
+					moVM.Config.ExtraConfig = []vimtypes.BaseOptionValue{
+						&vimtypes.OptionValue{
+							Key:   extraConfigKey1,
+							Value: value1,
+						},
+					}
+				})
+				It("should update the ConfigSpec", func() {
+					Expect(configSpec.ExtraConfig).To(HaveLen(1))
+					assertExtraConfig(extraConfigKey2, value1)
+				})
+
+				When("ExtraConfig key is different in ConfigSpec", func() {
+					BeforeEach(func() {
+						configSpec.ExtraConfig = []vimtypes.BaseOptionValue{
+							&vimtypes.OptionValue{
+								Key:   extraConfigKey2,
+								Value: value2,
+							},
+						}
+					})
+					It("should update the ConfigSpec", func() {
+						Expect(configSpec.ExtraConfig).To(HaveLen(1))
+						assertNotExtraConfig(extraConfigKey1)
+						assertExtraConfig(extraConfigKey2, value1)
+					})
+				})
+			})
+		})
+
+		When("Annotation is missing from VM", func() {
+
+			BeforeEach(func() {
+				vm.Annotations = nil
+			})
+			When("ExtraConfig key is missing from ConfigInfo", func() {
+				BeforeEach(func() {
+					moVM.Config.ExtraConfig = nil
+				})
+				It("should not update the ConfigSpec", func() {
+					assertEmptyExtraConfig()
+				})
+
+				When("ExtraConfig key is present in ConfigSpec", func() {
+					BeforeEach(func() {
+						configSpec.ExtraConfig = []vimtypes.BaseOptionValue{
+							&vimtypes.OptionValue{
+								Key:   extraConfigKey1,
+								Value: value2,
+							},
+						}
+					})
+					It("should update the ConfigSpec", func() {
+						Expect(configSpec.ExtraConfig).To(HaveLen(1))
+						assertExtraConfig(extraConfigKey1, "")
+					})
+				})
+			})
+			When("ExtraConfig key is present in ConfigInfo", func() {
+				BeforeEach(func() {
+					moVM.Config.ExtraConfig = []vimtypes.BaseOptionValue{
+						&vimtypes.OptionValue{
+							Key:   extraConfigKey1,
+							Value: value1,
+						},
+					}
+				})
+				It("should update the ConfigSpec", func() {
+					Expect(configSpec.ExtraConfig).To(HaveLen(1))
+					assertExtraConfig(extraConfigKey1, "")
+				})
+
+				When("ExtraConfig key is different in ConfigSpec", func() {
+					BeforeEach(func() {
+						configSpec.ExtraConfig = []vimtypes.BaseOptionValue{
+							&vimtypes.OptionValue{
+								Key:   extraConfigKey1,
+								Value: value2,
+							},
+						}
+					})
+					It("should update the ConfigSpec", func() {
+						Expect(configSpec.ExtraConfig).To(HaveLen(1))
+						assertExtraConfig(extraConfigKey1, "")
+					})
+				})
+			})
+
+			When("ExtraConfig keys are present in ConfigInfo", func() {
+				BeforeEach(func() {
+					moVM.Config.ExtraConfig = []vimtypes.BaseOptionValue{
+						&vimtypes.OptionValue{
+							Key:   extraConfigKey1,
+							Value: value1,
+						},
+						&vimtypes.OptionValue{
+							Key:   extraConfigKey2,
+							Value: value1,
+						},
+					}
+				})
+				It("should update the ConfigSpec", func() {
+					Expect(configSpec.ExtraConfig).To(HaveLen(2))
+					assertExtraConfig(extraConfigKey1, "")
+					assertExtraConfig(extraConfigKey2, "")
+				})
+
+				When("ExtraConfig keys are different in ConfigSpec", func() {
+					BeforeEach(func() {
+						configSpec.ExtraConfig = []vimtypes.BaseOptionValue{
+							&vimtypes.OptionValue{
+								Key:   extraConfigKey1,
+								Value: value2,
+							},
+							&vimtypes.OptionValue{
+								Key:   extraConfigKey2,
+								Value: value2,
+							},
+						}
+					})
+					It("should update the ConfigSpec", func() {
+						Expect(configSpec.ExtraConfig).To(HaveLen(2))
+						assertExtraConfig(extraConfigKey1, "")
+						assertExtraConfig(extraConfigKey2, "")
+					})
+
+					When("ConfigSpec.ExtraConfig already has other keys", func() {
+						BeforeEach(func() {
+							configSpec.ExtraConfig = append(
+								configSpec.ExtraConfig,
+								&vimtypes.OptionValue{
+									Key:   "fu",
+									Value: value2,
+								},
+								&vimtypes.OptionValue{
+									Key:   "bar",
+									Value: value2,
+								})
+						})
+						It("should update the ConfigSpec", func() {
+							Expect(configSpec.ExtraConfig).To(HaveLen(4))
+							assertExtraConfig(extraConfigKey1, "")
+							assertExtraConfig(extraConfigKey2, "")
+							assertExtraConfig("fu", value2)
+							assertExtraConfig("bar", value2)
+						})
+					})
+				})
+			})
+		})
+	})
+})

--- a/webhooks/virtualmachine/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator.go
@@ -44,6 +44,7 @@ import (
 	spqutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube/spq"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	vmopv1util "github.com/vmware-tanzu/vm-operator/pkg/util/vmopv1"
+	"github.com/vmware-tanzu/vm-operator/pkg/vmconfig/anno2extraconfig"
 	"github.com/vmware-tanzu/vm-operator/webhooks/common"
 )
 
@@ -1554,6 +1555,12 @@ func (v validator) validateAnnotation(ctx *pkgctx.WebhookRequestContext, vm, old
 
 	if vm.Annotations[pkgconst.ApplyPowerStateTimeAnnotation] != oldVM.Annotations[pkgconst.ApplyPowerStateTimeAnnotation] {
 		allErrs = append(allErrs, field.Forbidden(annotationPath.Key(pkgconst.ApplyPowerStateTimeAnnotation), modifyAnnotationNotAllowedForNonAdmin))
+	}
+
+	for k := range anno2extraconfig.AnnotationsToExtraConfigKeys {
+		if vm.Annotations[k] != oldVM.Annotations[k] {
+			allErrs = append(allErrs, field.Forbidden(annotationPath.Key(k), modifyAnnotationNotAllowedForNonAdmin))
+		}
 	}
 
 	// The following annotations will be added by the mutation webhook upon VM creation.

--- a/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
@@ -38,6 +38,7 @@ import (
 	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	vmopv1util "github.com/vmware-tanzu/vm-operator/pkg/util/vmopv1"
+	"github.com/vmware-tanzu/vm-operator/pkg/vmconfig/anno2extraconfig"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
@@ -1191,6 +1192,8 @@ func unitTestsValidateCreate() {
 						ctx.vm.Annotations[vmopv1.FailedOverVMAnnotation] = dummyFailedOverAnnVal
 						ctx.vm.Annotations[pkgconst.SkipDeletePlatformResourceKey] = dummyFailedOverAnnVal
 						ctx.vm.Annotations[pkgconst.ApplyPowerStateTimeAnnotation] = time.Now().Format(time.RFC3339Nano)
+						ctx.vm.Annotations[anno2extraconfig.ManagementProxyAllowListAnnotation] = dummyVmiName
+						ctx.vm.Annotations[anno2extraconfig.ManagementProxyWatermarkAnnotation] = dummyVmiName
 					},
 					validate: doValidateWithMsg(
 						field.Forbidden(annotationPath.Key(vmopv1.RestoredVMAnnotation), "modifying this annotation is not allowed for non-admin users").Error(),
@@ -1200,6 +1203,8 @@ func unitTestsValidateCreate() {
 						field.Forbidden(annotationPath.Key(vmopv1.FirstBootDoneAnnotation), "modifying this annotation is not allowed for non-admin users").Error(),
 						field.Forbidden(annotationPath.Key(pkgconst.SkipDeletePlatformResourceKey), "modifying this annotation is not allowed for non-admin users").Error(),
 						field.Forbidden(annotationPath.Key(pkgconst.ApplyPowerStateTimeAnnotation), "modifying this annotation is not allowed for non-admin users").Error(),
+						field.Forbidden(annotationPath.Key(anno2extraconfig.ManagementProxyAllowListAnnotation), "modifying this annotation is not allowed for non-admin users").Error(),
+						field.Forbidden(annotationPath.Key(anno2extraconfig.ManagementProxyWatermarkAnnotation), "modifying this annotation is not allowed for non-admin users").Error(),
 					),
 				},
 			),
@@ -1215,6 +1220,8 @@ func unitTestsValidateCreate() {
 						ctx.vm.Annotations[vmopv1.FailedOverVMAnnotation] = dummyFailedOverAnnVal
 						ctx.vm.Annotations[pkgconst.SkipDeletePlatformResourceKey] = dummyFailedOverAnnVal
 						ctx.vm.Annotations[pkgconst.ApplyPowerStateTimeAnnotation] = time.Now().Format(time.RFC3339Nano)
+						ctx.vm.Annotations[anno2extraconfig.ManagementProxyAllowListAnnotation] = dummyVmiName
+						ctx.vm.Annotations[anno2extraconfig.ManagementProxyWatermarkAnnotation] = dummyVmiName
 					},
 					expectAllowed: true,
 				},
@@ -1237,6 +1244,8 @@ func unitTestsValidateCreate() {
 						ctx.vm.Annotations[vmopv1.FailedOverVMAnnotation] = dummyFailedOverAnnVal
 						ctx.vm.Annotations[pkgconst.SkipDeletePlatformResourceKey] = dummyFailedOverAnnVal
 						ctx.vm.Annotations[pkgconst.ApplyPowerStateTimeAnnotation] = time.Now().Format(time.RFC3339Nano)
+						ctx.vm.Annotations[anno2extraconfig.ManagementProxyAllowListAnnotation] = dummyVmiName
+						ctx.vm.Annotations[anno2extraconfig.ManagementProxyWatermarkAnnotation] = dummyVmiName
 					},
 					expectAllowed: true,
 				},
@@ -3477,6 +3486,8 @@ func unitTestsValidateUpdate() {
 						ctx.oldVM.Annotations[vmopv1.ImportedVMAnnotation] = dummyImportedAnnVal
 						ctx.oldVM.Annotations[vmopv1.FailedOverVMAnnotation] = dummyFailedOverAnnVal
 						ctx.oldVM.Annotations[pkgconst.ApplyPowerStateTimeAnnotation] = time.Now().Format(time.RFC3339Nano)
+						ctx.oldVM.Annotations[anno2extraconfig.ManagementProxyAllowListAnnotation] = dummyVmiName
+						ctx.oldVM.Annotations[anno2extraconfig.ManagementProxyWatermarkAnnotation] = dummyVmiName
 
 						ctx.vm.Annotations[vmopv1.InstanceIDAnnotation] = dummyInstanceIDVal + updateSuffix
 						ctx.vm.Annotations[vmopv1.FirstBootDoneAnnotation] = dummyFirstBootDoneVal + updateSuffix
@@ -3486,6 +3497,9 @@ func unitTestsValidateUpdate() {
 						ctx.vm.Annotations[vmopv1.ImportedVMAnnotation] = dummyImportedAnnVal + updateSuffix
 						ctx.vm.Annotations[vmopv1.FailedOverVMAnnotation] = dummyFailedOverAnnVal + updateSuffix
 						ctx.vm.Annotations[pkgconst.ApplyPowerStateTimeAnnotation] = time.Now().Add(time.Minute).Format(time.RFC3339Nano)
+						ctx.vm.Annotations[anno2extraconfig.ManagementProxyAllowListAnnotation] = dummyVmiName + updateSuffix
+						ctx.vm.Annotations[anno2extraconfig.ManagementProxyWatermarkAnnotation] = dummyVmiName + updateSuffix
+
 					},
 					validate: doValidateWithMsg(
 						field.Forbidden(annotationPath.Key(vmopv1.InstanceIDAnnotation), "modifying this annotation is not allowed for non-admin users").Error(),
@@ -3496,6 +3510,8 @@ func unitTestsValidateUpdate() {
 						field.Forbidden(annotationPath.Key(vmopv1.ImportedVMAnnotation), "modifying this annotation is not allowed for non-admin users").Error(),
 						field.Forbidden(annotationPath.Key(vmopv1.FailedOverVMAnnotation), "modifying this annotation is not allowed for non-admin users").Error(),
 						field.Forbidden(annotationPath.Key(pkgconst.ApplyPowerStateTimeAnnotation), "modifying this annotation is not allowed for non-admin users").Error(),
+						field.Forbidden(annotationPath.Key(anno2extraconfig.ManagementProxyAllowListAnnotation), "modifying this annotation is not allowed for non-admin users").Error(),
+						field.Forbidden(annotationPath.Key(anno2extraconfig.ManagementProxyWatermarkAnnotation), "modifying this annotation is not allowed for non-admin users").Error(),
 					),
 				},
 			),
@@ -3510,6 +3526,8 @@ func unitTestsValidateUpdate() {
 						ctx.oldVM.Annotations[vmopv1.ImportedVMAnnotation] = dummyImportedAnnVal
 						ctx.oldVM.Annotations[vmopv1.FailedOverVMAnnotation] = dummyFailedOverAnnVal
 						ctx.oldVM.Annotations[pkgconst.ApplyPowerStateTimeAnnotation] = time.Now().Format(time.RFC3339Nano)
+						ctx.oldVM.Annotations[anno2extraconfig.ManagementProxyAllowListAnnotation] = dummyVmiName
+						ctx.oldVM.Annotations[anno2extraconfig.ManagementProxyWatermarkAnnotation] = dummyVmiName
 					},
 					validate: doValidateWithMsg(
 						field.Forbidden(annotationPath.Key(vmopv1.InstanceIDAnnotation), "modifying this annotation is not allowed for non-admin users").Error(),
@@ -3520,6 +3538,8 @@ func unitTestsValidateUpdate() {
 						field.Forbidden(annotationPath.Key(vmopv1.ImportedVMAnnotation), "modifying this annotation is not allowed for non-admin users").Error(),
 						field.Forbidden(annotationPath.Key(vmopv1.FailedOverVMAnnotation), "modifying this annotation is not allowed for non-admin users").Error(),
 						field.Forbidden(annotationPath.Key(pkgconst.ApplyPowerStateTimeAnnotation), "modifying this annotation is not allowed for non-admin users").Error(),
+						field.Forbidden(annotationPath.Key(anno2extraconfig.ManagementProxyAllowListAnnotation), "modifying this annotation is not allowed for non-admin users").Error(),
+						field.Forbidden(annotationPath.Key(anno2extraconfig.ManagementProxyWatermarkAnnotation), "modifying this annotation is not allowed for non-admin users").Error(),
 					),
 				},
 			),
@@ -3536,6 +3556,9 @@ func unitTestsValidateUpdate() {
 						ctx.oldVM.Annotations[vmopv1.ImportedVMAnnotation] = dummyImportedAnnVal
 						ctx.oldVM.Annotations[vmopv1.FailedOverVMAnnotation] = dummyFailedOverAnnVal
 						ctx.oldVM.Annotations[pkgconst.ApplyPowerStateTimeAnnotation] = time.Now().Format(time.RFC3339Nano)
+						ctx.oldVM.Annotations[anno2extraconfig.ManagementProxyAllowListAnnotation] = dummyVmiName
+						ctx.oldVM.Annotations[anno2extraconfig.ManagementProxyWatermarkAnnotation] = dummyVmiName
+
 						ctx.vm.Annotations[vmopv1.InstanceIDAnnotation] = dummyInstanceIDVal + updateSuffix
 						ctx.vm.Annotations[vmopv1.FirstBootDoneAnnotation] = dummyFirstBootDoneVal + updateSuffix
 						ctx.vm.Annotations[pkgconst.CreatedAtBuildVersionAnnotationKey] = dummyCreatedAtBuildVersionVal + updateSuffix
@@ -3544,6 +3567,8 @@ func unitTestsValidateUpdate() {
 						ctx.vm.Annotations[vmopv1.ImportedVMAnnotation] = dummyImportedAnnVal + updateSuffix
 						ctx.vm.Annotations[vmopv1.FailedOverVMAnnotation] = dummyFailedOverAnnVal + updateSuffix
 						ctx.vm.Annotations[pkgconst.ApplyPowerStateTimeAnnotation] = time.Now().Add(time.Minute).Format(time.RFC3339Nano)
+						ctx.vm.Annotations[anno2extraconfig.ManagementProxyAllowListAnnotation] = dummyVmiName + updateSuffix
+						ctx.vm.Annotations[anno2extraconfig.ManagementProxyWatermarkAnnotation] = dummyVmiName + updateSuffix
 					},
 					expectAllowed: true,
 				},
@@ -3562,6 +3587,8 @@ func unitTestsValidateUpdate() {
 						ctx.oldVM.Annotations[vmopv1.FailedOverVMAnnotation] = dummyFailedOverAnnVal
 						ctx.oldVM.Annotations[pkgconst.ClusterModuleNameAnnotationKey] = dummyClusterModuleAnnVal
 						ctx.oldVM.Annotations[pkgconst.ApplyPowerStateTimeAnnotation] = time.Now().Format(time.RFC3339Nano)
+						ctx.oldVM.Annotations[anno2extraconfig.ManagementProxyAllowListAnnotation] = dummyVmiName
+						ctx.oldVM.Annotations[anno2extraconfig.ManagementProxyWatermarkAnnotation] = dummyVmiName
 					},
 					expectAllowed: true,
 				},
@@ -3587,6 +3614,9 @@ func unitTestsValidateUpdate() {
 						ctx.oldVM.Annotations[vmopv1.ImportedVMAnnotation] = dummyImportedAnnVal
 						ctx.oldVM.Annotations[vmopv1.FailedOverVMAnnotation] = dummyFailedOverAnnVal
 						ctx.oldVM.Annotations[pkgconst.ApplyPowerStateTimeAnnotation] = time.Now().Format(time.RFC3339Nano)
+						ctx.oldVM.Annotations[anno2extraconfig.ManagementProxyAllowListAnnotation] = dummyVmiName
+						ctx.oldVM.Annotations[anno2extraconfig.ManagementProxyWatermarkAnnotation] = dummyVmiName
+
 						ctx.vm.Annotations[vmopv1.InstanceIDAnnotation] = dummyInstanceIDVal + updateSuffix
 						ctx.vm.Annotations[vmopv1.FirstBootDoneAnnotation] = dummyFirstBootDoneVal + updateSuffix
 						ctx.vm.Annotations[pkgconst.CreatedAtBuildVersionAnnotationKey] = dummyCreatedAtBuildVersionVal + updateSuffix
@@ -3595,6 +3625,8 @@ func unitTestsValidateUpdate() {
 						ctx.vm.Annotations[vmopv1.ImportedVMAnnotation] = dummyImportedAnnVal + updateSuffix
 						ctx.vm.Annotations[vmopv1.FailedOverVMAnnotation] = dummyFailedOverAnnVal + updateSuffix
 						ctx.vm.Annotations[pkgconst.ApplyPowerStateTimeAnnotation] = time.Now().Add(time.Minute).Format(time.RFC3339Nano)
+						ctx.vm.Annotations[anno2extraconfig.ManagementProxyAllowListAnnotation] = dummyVmiName + updateSuffix
+						ctx.vm.Annotations[anno2extraconfig.ManagementProxyWatermarkAnnotation] = dummyVmiName + updateSuffix
 					},
 					expectAllowed: true,
 				},
@@ -3620,6 +3652,8 @@ func unitTestsValidateUpdate() {
 						ctx.oldVM.Annotations[vmopv1.ImportedVMAnnotation] = dummyImportedAnnVal
 						ctx.oldVM.Annotations[vmopv1.FailedOverVMAnnotation] = dummyFailedOverAnnVal
 						ctx.oldVM.Annotations[pkgconst.ApplyPowerStateTimeAnnotation] = time.Now().Format(time.RFC3339Nano)
+						ctx.oldVM.Annotations[anno2extraconfig.ManagementProxyAllowListAnnotation] = dummyVmiName
+						ctx.oldVM.Annotations[anno2extraconfig.ManagementProxyWatermarkAnnotation] = dummyVmiName
 					},
 					expectAllowed: true,
 				},


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch supports updating a VM's ExtraConfig from a set of approved annotation keys. If the VM does not have the annotation, its corresponding ExtraConfig value will be removed.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Certain, protected annotations are translated to ExtraConfig values on a VM.
```