### PR TITLE
✨ Introduce VirtualMachineGroupPublishRequest controller

### DIFF
--- a/api/v1alpha4/virtualmachinegroup_publishrequest_types.go
+++ b/api/v1alpha4/virtualmachinegroup_publishrequest_types.go
@@ -15,6 +15,10 @@ const (
 	// The condition's status is set to true only when all other conditions
 	// present on the resource have a truthy status.
 	VirtualMachineGroupPublishRequestConditionComplete = "Complete"
+
+	// VirtualMachineGroupPublishRequestConditionReasonPending indicates there are still pending
+	// VirtualMachinePublishRequest to be completed.
+	VirtualMachineGroupPublishRequestConditionReasonPending = "VirtualMachinePublishRequestsPending"
 )
 
 // VirtualMachineGroupPublishRequestSpec defines the desired state of a

--- a/api/v1alpha4/virtualmachinepublishrequest_types.go
+++ b/api/v1alpha4/virtualmachinepublishrequest_types.go
@@ -108,6 +108,12 @@ const (
 	ImageUnavailableReason = "ImageUnavailable"
 )
 
+const (
+	// VirtualMachinePublishRequestManagedByLabelKey is the label key to identify VirtualMachinePublishRequest that
+	// is created as a part of the VirtualMachineGroupPublishRequest.
+	VirtualMachinePublishRequestManagedByLabelKey = GroupName + "/virtualmachinepublishrequest-managed-by"
+)
+
 // VirtualMachinePublishRequestSource is the source of a publication request,
 // typically a VirtualMachine resource.
 type VirtualMachinePublishRequestSource struct {

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachine"
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachineclass"
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachinegroup"
+	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachinegrouppublishrequest"
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachineimagecache"
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachinepublishrequest"
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachinereplicaset"
@@ -84,6 +85,9 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 	if pkgcfg.FromContext(ctx).Features.VMGroups {
 		if err := virtualmachinegroup.AddToManager(ctx, mgr); err != nil {
 			return fmt.Errorf("failed to initialize VMG controller: %w", err)
+		}
+		if err := virtualmachinegrouppublishrequest.AddToManager(ctx, mgr); err != nil {
+			return fmt.Errorf("failed to initialize VirtualMachineGroupPublishRequest controller: %w", err)
 		}
 	}
 

--- a/controllers/virtualmachinegrouppublishrequest/virtualmachinegrouppublishrequest_controller.go
+++ b/controllers/virtualmachinegrouppublishrequest/virtualmachinegrouppublishrequest_controller.go
@@ -6,20 +6,29 @@ package virtualmachinegrouppublishrequest
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
+	"time"
 
+	"github.com/go-logr/logr"
+	imgregv1a1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	"github.com/go-logr/logr"
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+	pkgerr "github.com/vmware-tanzu/vm-operator/pkg/errors"
 	"github.com/vmware-tanzu/vm-operator/pkg/patch"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
 	"github.com/vmware-tanzu/vm-operator/pkg/record"
@@ -27,7 +36,10 @@ import (
 )
 
 const (
-	finalizerName = "vmoperator.vmware.com/virtualmachinegrouppublishrequest"
+	finalizerName         = "vmoperator.vmware.com/virtualmachinegrouppublishrequest"
+	undefinedSpecErrorMsg = "spec.%s is undefined"
+	invalidSpecErrorMsg   = "webhooks failed to mutate/validate spec. please delete and create again."
+	delTTLMsg             = "%s vm group publish request due to TTL expired"
 )
 
 // AddToManager adds this package's controller to the provided manager.
@@ -49,6 +61,7 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 	)
 	return ctrl.NewControllerManagedBy(mgr).
 		For(controlledType).
+		Owns(&vmopv1.VirtualMachinePublishRequest{}).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: ctx.MaxConcurrentReconciles,
 			LogConstructor: pkgutil.ControllerLogConstructor(
@@ -59,7 +72,7 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		Complete(r)
 }
 
-// Reconciler reconciles a VirtualMachineGroupePublishRequest object.
+// Reconciler reconciles a VirtualMachineGroupPublishRequest object.
 type Reconciler struct {
 	client.Client
 	Context    context.Context
@@ -95,63 +108,308 @@ func NewReconciler(
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
 	ctx = pkgcfg.JoinContext(ctx, r.Context)
 
-	obj := &vmopv1.VirtualMachineGroupPublishRequest{}
-	if err := r.apiReader.Get(ctx, req.NamespacedName, obj); err != nil {
+	vmGroupPublishRequest := &vmopv1.VirtualMachineGroupPublishRequest{}
+	if err := r.Get(ctx, req.NamespacedName, vmGroupPublishRequest); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	objCtx := &pkgctx.VirtualMachineGroupPublishRequestContext{
-		Context: ctx,
-		Logger:  pkgutil.FromContextOrDefault(ctx),
-		Obj:     obj,
+	vmGroupPublishRequestCtx := &pkgctx.VirtualMachineGroupPublishRequestContext{
+		Context:               ctx,
+		Logger:                pkgutil.FromContextOrDefault(ctx),
+		VMGroupPublishRequest: vmGroupPublishRequest,
 	}
-	patchHelper, err := patch.NewHelper(obj, r.Client)
+	patchHelper, err := patch.NewHelper(vmGroupPublishRequest, r.Client)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf(
 			"failed to init patch helper for %s/%s: %w",
-			obj.Namespace,
-			obj.Name, err)
+			vmGroupPublishRequest.Namespace,
+			vmGroupPublishRequest.Name,
+			err)
 	}
 
 	defer func() {
-		if err := patchHelper.Patch(ctx, obj); err != nil {
+		if err := patchHelper.Patch(ctx, vmGroupPublishRequest); err != nil {
 			if reterr == nil {
 				reterr = err
 			}
-			objCtx.Logger.Error(err, "patch failed")
+			vmGroupPublishRequestCtx.Logger.Error(err, "patch failed")
 		}
 	}()
 
-	if !obj.DeletionTimestamp.IsZero() {
-		return r.ReconcileDelete(objCtx)
+	if !vmGroupPublishRequest.DeletionTimestamp.IsZero() {
+		return r.ReconcileDelete(vmGroupPublishRequestCtx)
 	}
 
-	return r.ReconcileNormal(objCtx)
+	return pkgerr.ResultFromError(r.ReconcileNormal(vmGroupPublishRequestCtx))
 }
 
 func (r *Reconciler) ReconcileDelete(
 	ctx *pkgctx.VirtualMachineGroupPublishRequestContext) (ctrl.Result, error) {
-
 	ctx.Logger.Info("Reconciling VirtualMachineGroupPublishRequest Deletion")
 
-	if controllerutil.ContainsFinalizer(ctx.Obj, finalizerName) {
-		controllerutil.RemoveFinalizer(ctx.Obj, finalizerName)
+	if controllerutil.ContainsFinalizer(ctx.VMGroupPublishRequest, finalizerName) {
+		ctx.Logger.Info("Removing owned VirtualMachinePublishRequests")
+		if err := r.deleteVMPublishRequests(ctx); err != nil {
+			return ctrl.Result{}, err
+		}
+
+		controllerutil.RemoveFinalizer(ctx.VMGroupPublishRequest, finalizerName)
 		ctx.Logger.Info("Removed finalizer for VirtualMachineGroupPublishRequest")
 	}
 	ctx.Logger.V(4).Info("Finished Reconciling VirtualMachineGroupPublishRequest Deletion")
 	return ctrl.Result{}, nil
 }
 
-func (r *Reconciler) ReconcileNormal(
-	ctx *pkgctx.VirtualMachineGroupPublishRequestContext) (_ ctrl.Result, reterr error) {
+func (r *Reconciler) ReconcileNormal(ctx *pkgctx.VirtualMachineGroupPublishRequestContext) error {
+	ctx.Logger.Info("Reconciling VirtualMachineGroupPublishRequest")
+	vmGroupPublishReq := ctx.VMGroupPublishRequest
 
-	ctx.Logger.Info("Reconciling VirtualMachinePublishRequest")
-	vmGroupPublishReq := ctx.Obj
-
-	if !controllerutil.ContainsFinalizer(vmGroupPublishReq, finalizerName) {
-		controllerutil.AddFinalizer(vmGroupPublishReq, finalizerName)
-		return ctrl.Result{}, reterr
+	if controllerutil.AddFinalizer(vmGroupPublishReq, finalizerName) {
+		ctx.Logger.Info("Added finalizer for VirtualMachineGroupPublishRequest")
+		return nil
 	}
 
-	return ctrl.Result{}, nil
+	if conditions.IsTrue(vmGroupPublishReq, vmopv1.VirtualMachineGroupPublishRequestConditionComplete) {
+		return r.reconcileSpecTTL(ctx)
+	}
+
+	if err := r.verifySpec(vmGroupPublishReq); err != nil {
+		return err
+	}
+
+	return r.reconcileStatus(ctx)
+}
+
+func (r *Reconciler) reconcileStatus(ctx *pkgctx.VirtualMachineGroupPublishRequestContext) error {
+	if ctx.VMGroupPublishRequest.Status.StartTime.IsZero() {
+		ctx.VMGroupPublishRequest.Status.StartTime = metav1.NewTime(time.Now())
+	}
+
+	existReqsMap, pendingReqsSet, completedReqsSet, err := r.getVMPublishRequests(ctx)
+	if err != nil {
+		return err
+	}
+
+	r.reconcileStatusImages(ctx, existReqsMap)
+
+	desiredReqsSet := sets.New(ctx.VMGroupPublishRequest.Spec.VirtualMachines...)
+	if err := r.reconcileNewPublishRequests(ctx, sets.KeySet(existReqsMap), desiredReqsSet); err != nil {
+		return err
+	}
+	return r.reconcileStatusCompletedCondition(ctx, pendingReqsSet, completedReqsSet, desiredReqsSet)
+}
+
+// getVMPublishRequests returns a map of VMGroupPublishRequests own by the VirtualMachineGroupPublishRequest
+// along with a set of pending VMGroupPublishRequest and a set of completed VMGroupPublishRequest.
+// The key for those objects is the source VirtualMachine name.
+func (r *Reconciler) getVMPublishRequests(
+	ctx *pkgctx.VirtualMachineGroupPublishRequestContext) (
+	map[string]vmopv1.VirtualMachinePublishRequest,
+	sets.Set[string],
+	sets.Set[string],
+	error) {
+
+	reqs := &vmopv1.VirtualMachinePublishRequestList{}
+	// retrieve from API server directly to avoid duplicate resource creation in case that the newly
+	// created vm publish request has not made it back into the client's cache
+	if err := r.apiReader.List(ctx,
+		reqs,
+		client.InNamespace(ctx.VMGroupPublishRequest.Namespace),
+		client.MatchingLabels{
+			vmopv1.VirtualMachinePublishRequestManagedByLabelKey: ctx.VMGroupPublishRequest.Name,
+		}); err != nil {
+		ctx.Logger.Error(err, "failed to list VirtualMachinePublishRequest")
+		return nil, nil, nil, err
+	}
+
+	existReqsMap := make(map[string]vmopv1.VirtualMachinePublishRequest)
+	pendingReqsSet := sets.Set[string]{}
+	completedReqsSet := sets.Set[string]{}
+	for _, req := range reqs.Items {
+		if metav1.IsControlledBy(&req, ctx.VMGroupPublishRequest) {
+			existReqsMap[req.Spec.Source.Name] = req
+			if req.Status.Ready {
+				completedReqsSet.Insert(req.Spec.Source.Name)
+			} else {
+				pendingReqsSet.Insert(req.Spec.Source.Name)
+			}
+		}
+	}
+
+	return existReqsMap, pendingReqsSet, completedReqsSet, nil
+}
+
+// reconcileStatusImages updates status's image status by taking a map of VMGroupPublishRequests
+// own by the VirtualMachineGroupPublishRequest and converting them into a sorted list of
+// VirtualMachineGroupPublishRequestImageStatus. Sorting prevents reconciling when list is unchanged.
+func (r *Reconciler) reconcileStatusImages(
+	ctx *pkgctx.VirtualMachineGroupPublishRequestContext,
+	existReqsMap map[string]vmopv1.VirtualMachinePublishRequest) {
+
+	imageStatuses := make([]vmopv1.VirtualMachineGroupPublishRequestImageStatus, 0, len(existReqsMap))
+	for _, req := range existReqsMap {
+		imageStatuses = append(imageStatuses, vmopv1.VirtualMachineGroupPublishRequestImageStatus{
+			Source:             req.Spec.Source.Name,
+			PublishRequestName: req.Name,
+			ImageName:          req.Status.ImageName,
+			Conditions:         req.Status.Conditions,
+		})
+	}
+
+	ctx.VMGroupPublishRequest.Status.Images = slices.SortedFunc(slices.Values(imageStatuses),
+		func(a, b vmopv1.VirtualMachineGroupPublishRequestImageStatus) int {
+			return strings.Compare(a.Source, b.Source)
+		})
+}
+
+// reconcileNewPublishRequests compares a set of exist requests and a set of expected requests and
+// creates new requests if they are missing in the exist requests set.
+// It returns nil ONLY when no new publish requests were created, in other words, the set of exist requests
+// and the set of expected requests are the same.
+func (r *Reconciler) reconcileNewPublishRequests(
+	ctx *pkgctx.VirtualMachineGroupPublishRequestContext,
+	existReqsSet, desiredReqsSet sets.Set[string]) error {
+
+	newReqsSet := desiredReqsSet.Difference(existReqsSet)
+	if newReqsSet.Len() == 0 {
+		return nil
+	}
+
+	vmGroupPubReqGvk, err := apiutil.GVKForObject(ctx.VMGroupPublishRequest, r.Scheme())
+	if err != nil {
+		return err
+	}
+
+	vmAPIVersion := vmopv1.GroupVersion.String()
+	clAPIVersion := imgregv1a1.GroupVersion.String()
+	for sourceVM := range newReqsSet {
+		// TTLSecondsAfterFinished is intentionally unset to avoid vm publish request to be
+		// deleted after completion.
+		if err := r.Create(ctx, &vmopv1.VirtualMachinePublishRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ctx.VMGroupPublishRequest.Namespace,
+				GenerateName: ctx.VMGroupPublishRequest.Name + "-",
+				OwnerReferences: []metav1.OwnerReference{
+					*metav1.NewControllerRef(ctx.VMGroupPublishRequest, vmGroupPubReqGvk),
+				},
+				Labels: map[string]string{
+					vmopv1.VirtualMachinePublishRequestManagedByLabelKey: ctx.VMGroupPublishRequest.Name,
+				},
+			},
+			Spec: vmopv1.VirtualMachinePublishRequestSpec{
+				Source: vmopv1.VirtualMachinePublishRequestSource{
+					Name:       sourceVM,
+					Kind:       "VirtualMachine",
+					APIVersion: vmAPIVersion,
+				},
+				Target: vmopv1.VirtualMachinePublishRequestTarget{
+					Location: vmopv1.VirtualMachinePublishRequestTargetLocation{
+						Name:       ctx.VMGroupPublishRequest.Spec.Target,
+						Kind:       "ContentLibrary",
+						APIVersion: clAPIVersion,
+					},
+				},
+			},
+		}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// reconcileStatusCompletedCondition sets vm group publish request's completed condition and completion time
+// once all desired vm publish requests are completed.
+func (r *Reconciler) reconcileStatusCompletedCondition(
+	ctx *pkgctx.VirtualMachineGroupPublishRequestContext,
+	pendingReqsSet, completedReqsSet, desiredReqsSet sets.Set[string]) error {
+
+	if completedReqsSet.Equal(desiredReqsSet) {
+		conditions.MarkTrue(ctx.VMGroupPublishRequest, vmopv1.VirtualMachineGroupPublishRequestConditionComplete)
+		ctx.VMGroupPublishRequest.Status.CompletionTime = metav1.Now()
+		ctx.Logger.Info("VirtualMachineGroupPublishRequest completed successfully")
+		// update to condition will trigger a reconcile to process TTL value
+		return nil
+	}
+
+	conditions.MarkFalse(
+		ctx.VMGroupPublishRequest,
+		vmopv1.VirtualMachinePublishRequestConditionComplete,
+		vmopv1.VirtualMachineGroupPublishRequestConditionReasonPending,
+		"waiting %d more vm publish requests to be completed",
+		pendingReqsSet.Len())
+
+	return nil
+}
+
+// verifySpec ensures spec's source, target, and virtualMachines are set up and validated properly by the webhooks.
+// It sets the completed condition to false with message asking user to re-create the group request.
+func (r *Reconciler) verifySpec(vmGroupPublishReq *vmopv1.VirtualMachineGroupPublishRequest) error {
+	var errs []error
+	if vmGroupPublishReq.Spec.Source == "" {
+		errs = append(errs, fmt.Errorf(undefinedSpecErrorMsg, "source"))
+	}
+	if vmGroupPublishReq.Spec.Target == "" {
+		errs = append(errs, fmt.Errorf(undefinedSpecErrorMsg, "target"))
+	}
+	if len(vmGroupPublishReq.Spec.VirtualMachines) == 0 {
+		errs = append(errs, fmt.Errorf(undefinedSpecErrorMsg, "virtualMachines"))
+	}
+
+	if len(errs) > 0 {
+		// in the rare case that webhooks were down when request was created
+		// set condition to failure
+		conditions.MarkError(vmGroupPublishReq,
+			vmopv1.VirtualMachineGroupPublishRequestConditionComplete,
+			invalidSpecErrorMsg,
+			errors.Join(errs...))
+
+		return pkgerr.NoRequeueError{Message: invalidSpecErrorMsg}
+	}
+
+	return nil
+}
+
+// reconcileSpecTTL deletes the group publish request and its child vm publish requests once the TTL expires.
+func (r *Reconciler) reconcileSpecTTL(ctx *pkgctx.VirtualMachineGroupPublishRequestContext) error {
+	vmGroupPubReq := ctx.VMGroupPublishRequest
+
+	// skip deletions when ttl is nil
+	if vmGroupPubReq.Spec.TTLSecondsAfterFinished == nil {
+		return nil
+	}
+
+	// calculate expiration time based on the completion time and the expected ttl.
+	// when ttl is zero, the expiration completion time is same as completion time which triggers immediate deletion.
+	expirationTime := vmGroupPubReq.Status.CompletionTime.Time.Add(time.Duration(*vmGroupPubReq.Spec.TTLSecondsAfterFinished) * time.Second)
+	if time.Now().Before(expirationTime) {
+		return pkgerr.RequeueError{After: time.Until(expirationTime)}
+	}
+
+	ctx.Logger.Info(fmt.Sprintf(delTTLMsg, "deleting"))
+	if err := r.Delete(ctx, vmGroupPubReq); client.IgnoreNotFound(err) != nil {
+		ctx.Logger.Error(err, fmt.Sprintf(delTTLMsg, "failed to delete"))
+		return err
+	}
+	ctx.Logger.Info(fmt.Sprintf(delTTLMsg, "deleted"))
+	return nil
+}
+
+// deleteVMPublishRequests deletes vm publish requests owned by this group publish request.
+// It is called in ReconcileDelete() but not strictly necessarily since it's owned VirtualMachinePublishRequests have
+// OwnerReference set to it and the k8s GC will clean up them as well if VirtualMachineGroupPublishRequest is deleted.
+// The explicit delete helps speeding up the cleanup process.
+func (r *Reconciler) deleteVMPublishRequests(ctx *pkgctx.VirtualMachineGroupPublishRequestContext) error {
+	reqs, _, _, err := r.getVMPublishRequests(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, req := range reqs {
+		if err := r.Delete(ctx, &req); client.IgnoreNotFound(err) != nil {
+			ctx.Logger.Error(err, "failed to delete vm publish request", "name", req.Name)
+			return err
+		}
+	}
+	return nil
 }

--- a/controllers/virtualmachinegrouppublishrequest/virtualmachinegrouppublishrequest_controller_intg_test.go
+++ b/controllers/virtualmachinegrouppublishrequest/virtualmachinegrouppublishrequest_controller_intg_test.go
@@ -1,0 +1,248 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package virtualmachinegrouppublishrequest_test
+
+import (
+	"fmt"
+	"math/rand"
+	"reflect"
+	"slices"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+func intgTests() {
+	Describe(
+		"Reconcile",
+		Label(
+			testlabels.Controller,
+			testlabels.EnvTest,
+			testlabels.API,
+		),
+		intgTestsReconcile,
+	)
+}
+
+func intgTestsReconcile() {
+	var (
+		ctx           *builder.IntegrationTestContext
+		vmGroupPubReq *vmopv1.VirtualMachineGroupPublishRequest
+	)
+
+	getVMGroupPubReq := func(ctx *builder.IntegrationTestContext, objKey client.ObjectKey) *vmopv1.VirtualMachineGroupPublishRequest {
+		req := &vmopv1.VirtualMachineGroupPublishRequest{}
+		if err := ctx.Client.Get(ctx, objKey, req); err != nil {
+			return nil
+		}
+		return req
+	}
+
+	getVMPubReqs := func(ctx *builder.IntegrationTestContext, ns string) []vmopv1.VirtualMachinePublishRequest {
+		reqs := &vmopv1.VirtualMachinePublishRequestList{}
+		Expect(ctx.Client.List(ctx, reqs, client.InNamespace(ns), client.MatchingLabels{
+			vmopv1.VirtualMachinePublishRequestManagedByLabelKey: vmGroupPubReq.Name,
+		})).NotTo(HaveOccurred())
+		return reqs.Items
+	}
+
+	setVMPubReqRandomCondition := func(vmPubReq *vmopv1.VirtualMachinePublishRequest) {
+		_, err := controllerutil.CreateOrPatch(ctx, ctx.Client, vmPubReq, func() error {
+			vmPubReqConditions := []string{
+				vmopv1.VirtualMachinePublishRequestConditionSourceValid,
+				vmopv1.VirtualMachinePublishRequestConditionTargetValid,
+				vmopv1.VirtualMachinePublishRequestConditionUploaded,
+				vmopv1.VirtualMachinePublishRequestConditionImageAvailable,
+				vmopv1.VirtualMachinePublishRequestConditionComplete,
+			}
+			vmPubReqReasons := []string{
+				vmopv1.SourceVirtualMachineNotExistReason,
+				vmopv1.SourceVirtualMachineNotCreatedReason,
+				vmopv1.TargetContentLibraryNotExistReason,
+				vmopv1.TargetContentLibraryNotReadyReason,
+				vmopv1.TargetContentLibraryNotWritableReason,
+			}
+			// mark condition to true does not impact reconciliation since the controller checks for status.ready
+			updatedCondition := vmPubReqConditions[rand.Intn(len(vmPubReqConditions))]
+			updatedReason := vmPubReqReasons[rand.Intn(len(vmPubReqReasons))]
+			if rand.Int()%2 == 0 {
+				conditions.MarkFalse(vmPubReq, updatedCondition, updatedReason, "")
+			} else {
+				conditions.MarkTrue(vmPubReq, updatedCondition)
+			}
+
+			return nil
+		})
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	setVMPubReqCompleted := func(vmPubReq *vmopv1.VirtualMachinePublishRequest) {
+		_, err := controllerutil.CreateOrPatch(ctx, ctx.Client, vmPubReq, func() error {
+			vmPubReq.Status.Ready = true
+			return nil
+		})
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	verifyDeletionEventually := func() {
+		Eventually(func() []string {
+			if req := getVMGroupPubReq(ctx, client.ObjectKeyFromObject(vmGroupPubReq)); req != nil {
+				return req.GetFinalizers()
+			}
+			return nil
+		}).ShouldNot(ContainElement(finalizerName), "deletes finalizer")
+
+		Eventually(func(g Gomega) {
+			reqs := getVMPubReqs(ctx, vmGroupPubReq.Namespace)
+			g.Expect(len(reqs)).To(Equal(0))
+			req := &vmopv1.VirtualMachineGroupPublishRequest{}
+			err := ctx.Client.Get(ctx, client.ObjectKeyFromObject(vmGroupPubReq), req)
+			g.Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
+		}).Should(Succeed(), "deletes vm group publish request and its child vm publish requests")
+	}
+
+	verifyFalseConditionEventually := func(expectedPendingCnt int) {
+		Eventually(func(g Gomega) {
+			req := getVMGroupPubReq(ctx, client.ObjectKeyFromObject(vmGroupPubReq))
+			g.Expect(req).ToNot(BeNil())
+			verifyFalseCondition(g, req, expectedPendingCnt)
+		}).Should(Succeed(), fmt.Sprintf("sets completed condition to false with %d pending", expectedPendingCnt))
+	}
+
+	verifyImageStatusEventually := func(expectedImages []vmopv1.VirtualMachineGroupPublishRequestImageStatus) {
+		Eventually(func(g Gomega) {
+			req := getVMGroupPubReq(ctx, client.ObjectKeyFromObject(vmGroupPubReq))
+			g.Expect(req).ToNot(BeNil())
+			g.Expect(reflect.DeepEqual(req.Status.Images, expectedImages)).To(BeTrue())
+		}).Should(Succeed(), "reflects owned vm publish requests' conditions to group request status.images")
+	}
+
+	BeforeEach(func() {
+		ctx = suite.NewIntegrationTestContext()
+		vmGroupPubReq = builder.VirtualMachineGroupPublishRequest(builder.DummyVMGroupPublishRequestName,
+			ctx.Namespace, []string{builder.DummyVirtualMachine0Name, builder.DummyVirtualMachine1Name})
+		Expect(ctx.Client.Create(ctx, vmGroupPubReq)).To(Succeed())
+
+		Eventually(func() []string {
+			if req := getVMGroupPubReq(ctx, client.ObjectKeyFromObject(vmGroupPubReq)); req != nil {
+				return req.GetFinalizers()
+			}
+			return nil
+		}).Should(ContainElement(finalizerName), "adds finalizer")
+	})
+	AfterEach(func() {
+		ctx.AfterEach()
+		ctx = nil
+		vmGroupPubReq = nil
+	})
+
+	Context("ReconcileNormal", func() {
+		It("simulates VirtualMachineGroupPublishRequest completion workflow", func() {
+
+			Eventually(func(g Gomega) {
+				req := getVMGroupPubReq(ctx, client.ObjectKeyFromObject(vmGroupPubReq))
+				Expect(req).ToNot(BeNil())
+				g.Expect(req.Status.StartTime).ToNot(Equal(metav1.Time{}))
+			}).Should(Succeed(), "sets start time")
+
+			Eventually(func(g Gomega) {
+				reqs := getVMPubReqs(ctx, vmGroupPubReq.Namespace)
+				Expect(reqs).To(HaveLen(len(vmGroupPubReq.Spec.VirtualMachines)))
+			}).Should(Succeed(), "creates vm publish requests for each of the vms")
+
+			// reconcile re-queued since last vm publish requests creations returns requeue error
+			verifyFalseConditionEventually(len(vmGroupPubReq.Spec.VirtualMachines))
+
+			reqs := getVMPubReqs(ctx, vmGroupPubReq.Namespace)
+			Expect(reqs).To(HaveLen(len(vmGroupPubReq.Spec.VirtualMachines)))
+
+			// update vm publish request condition should reflect changes to vm group publish request status images[]
+			setVMPubReqRandomCondition(&reqs[0])
+			setVMPubReqRandomCondition(&reqs[1])
+			Eventually(func(g Gomega) {
+				reqs := getVMPubReqs(ctx, vmGroupPubReq.Namespace)
+				Expect(reqs).To(HaveLen(len(vmGroupPubReq.Spec.VirtualMachines)))
+				verifyImageStatusEventually(constructStatusImages(reqs))
+			}).Should(Succeed(), "sets completed condition to true")
+
+			// mark one of the vm publish requests to be true
+			setVMPubReqCompleted(&reqs[0])
+			verifyFalseConditionEventually(len(vmGroupPubReq.Spec.VirtualMachines) - 1)
+
+			// mark last of the vm publish requests to be true
+			setVMPubReqCompleted(&reqs[1])
+			Eventually(func(g Gomega) {
+				req := getVMGroupPubReq(ctx, client.ObjectKeyFromObject(vmGroupPubReq))
+				Expect(req).ToNot(BeNil())
+				verifyTrueCondition(g, req)
+			}).Should(Succeed(), "sets completed condition to true")
+
+			// sets ttl to a future time
+			req := getVMGroupPubReq(ctx, client.ObjectKeyFromObject(vmGroupPubReq))
+			Expect(req).ToNot(BeNil())
+			Expect(req.Spec.TTLSecondsAfterFinished).To(BeNil())
+			_, err := controllerutil.CreateOrPatch(ctx, ctx.Client, req, func() error {
+				newTTL := int64(time.Since(req.Status.CompletionTime.Time) + 10*time.Second)
+				req.Spec.TTLSecondsAfterFinished = &newTTL
+				return nil
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			verifyDeletionEventually()
+		})
+	})
+
+	Context("ReconcileDelete", func() {
+		It("simulates VirtualMachineGroupPublishRequest deletion workflow", func() {
+			// ensure there are still pending vm publish requests
+			verifyFalseConditionEventually(len(vmGroupPubReq.Spec.VirtualMachines))
+			Expect(ctx.Client.Delete(ctx, vmGroupPubReq)).To(Succeed())
+			verifyDeletionEventually()
+		})
+	})
+}
+
+func verifyFalseCondition(g Gomega, req *vmopv1.VirtualMachineGroupPublishRequest, expectedPendingCnt int) {
+	g.Expect(req.Status.Conditions).To(HaveLen(1))
+	g.Expect(req.Status.Conditions[0].Type).To(Equal(vmopv1.VirtualMachinePublishRequestConditionComplete))
+	g.Expect(req.Status.Conditions[0].Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(req.Status.Conditions[0].Reason).To(Equal(vmopv1.VirtualMachineGroupPublishRequestConditionReasonPending))
+	g.Expect(req.Status.Conditions[0].Message).To(
+		Equal(fmt.Sprintf("waiting %d more vm publish requests to be completed", expectedPendingCnt)))
+}
+
+func verifyTrueCondition(g Gomega, req *vmopv1.VirtualMachineGroupPublishRequest) {
+	g.Expect(req.Status.Conditions).To(HaveLen(1))
+	g.Expect(req.Status.Conditions[0].Type).To(Equal(vmopv1.VirtualMachinePublishRequestConditionComplete))
+	g.Expect(req.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(req.Status.CompletionTime).ToNot(Equal(metav1.Time{}))
+}
+
+func constructStatusImages(
+	vmPubReqs []vmopv1.VirtualMachinePublishRequest) []vmopv1.VirtualMachineGroupPublishRequestImageStatus {
+	imageStatuses := make([]vmopv1.VirtualMachineGroupPublishRequestImageStatus, 0, len(vmPubReqs))
+	for _, req := range vmPubReqs {
+		imageStatuses = append(imageStatuses, vmopv1.VirtualMachineGroupPublishRequestImageStatus{
+			Source:             req.Spec.Source.Name,
+			PublishRequestName: req.Name,
+			ImageName:          req.Status.ImageName,
+			Conditions:         req.Status.Conditions,
+		})
+	}
+	return slices.SortedFunc(slices.Values(imageStatuses),
+		func(a, b vmopv1.VirtualMachineGroupPublishRequestImageStatus) int {
+			return strings.Compare(a.Source, b.Source)
+		})
+}

--- a/controllers/virtualmachinegrouppublishrequest/virtualmachinegrouppublishrequest_controller_suite_test.go
+++ b/controllers/virtualmachinegrouppublishrequest/virtualmachinegrouppublishrequest_controller_suite_test.go
@@ -29,8 +29,7 @@ var suite = builder.NewTestSuiteForControllerWithContext(
 	})
 
 func TestVirtualMachineGroupPublishRequest(t *testing.T) {
-	// TODO: Add intg tests and unit tests
-	// suite.Register(t, "VirtualMachineGroupPublishRequest controller suite", intgTests, unitTests)
+	suite.Register(t, "VirtualMachineGroupPublishRequest controller suite", intgTests, unitTests)
 }
 
 var _ = BeforeSuite(suite.BeforeSuite)

--- a/controllers/virtualmachinegrouppublishrequest/virtualmachinegrouppublishrequest_controller_unit_test.go
+++ b/controllers/virtualmachinegrouppublishrequest/virtualmachinegrouppublishrequest_controller_unit_test.go
@@ -1,0 +1,215 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package virtualmachinegrouppublishrequest_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachinegrouppublishrequest"
+	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
+	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+	pkgerr "github.com/vmware-tanzu/vm-operator/pkg/errors"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+const (
+	finalizerName = "vmoperator.vmware.com/virtualmachinegrouppublishrequest"
+)
+
+func unitTests() {
+	Describe(
+		"Reconcile",
+		Label(
+			testlabels.Controller,
+			testlabels.API,
+		), unitTestsReconcile,
+	)
+}
+
+func unitTestsReconcile() {
+	var (
+		initObjects       []client.Object
+		ctx               *builder.UnitTestContextForController
+		reconciler        *virtualmachinegrouppublishrequest.Reconciler
+		vmGroupPubReq     *vmopv1.VirtualMachineGroupPublishRequest
+		vmpGroupPubReqCtx *pkgctx.VirtualMachineGroupPublishRequestContext
+	)
+
+	BeforeEach(func() {
+		vmGroupPubReq = builder.VirtualMachineGroupPublishRequest(
+			builder.DummyVMGroupPublishRequestName,
+			builder.DummyNamespaceName,
+			[]string{builder.DummyVirtualMachine0Name, builder.DummyVirtualMachine1Name})
+		controllerutil.AddFinalizer(vmGroupPubReq, finalizerName)
+	})
+
+	JustBeforeEach(func() {
+		ctx = suite.NewUnitTestContextForController(initObjects...)
+		reconciler = virtualmachinegrouppublishrequest.NewReconciler(
+			ctx,
+			ctx.Client,
+			ctx.Client,
+			ctx.Logger,
+			ctx.Recorder,
+			ctx.VMProvider,
+		)
+		vmpGroupPubReqCtx = &pkgctx.VirtualMachineGroupPublishRequestContext{
+			Context:               ctx,
+			Logger:                ctx.Logger.WithName(vmGroupPubReq.Name),
+			VMGroupPublishRequest: vmGroupPubReq,
+		}
+	})
+
+	AfterEach(func() {
+		ctx.AfterEach()
+		ctx = nil
+		initObjects = nil
+		reconciler = nil
+		vmGroupPubReq = nil
+		vmpGroupPubReqCtx = nil
+	})
+
+	Context("ReconcileDelete", func() {
+		When("object does have finalizer set", func() {
+			It("should delete finalizer", func() {
+				_, err := reconciler.ReconcileDelete(vmpGroupPubReqCtx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(vmGroupPubReq.GetFinalizers()).ToNot(ContainElement(finalizerName))
+				getVMPublishRequests(vmGroupPubReq, reconciler, 0)
+			})
+		})
+	})
+
+	Context("ReconcileNormal", func() {
+
+		When("object does not have finalizer set", func() {
+			It("should set finalizer", func() {
+				controllerutil.RemoveFinalizer(vmGroupPubReq, finalizerName)
+				Expect(reconciler.ReconcileNormal(vmpGroupPubReqCtx)).NotTo(HaveOccurred())
+				Expect(vmGroupPubReq.GetFinalizers()).To(ContainElement(finalizerName))
+			})
+		})
+
+		When("object does not have spec optional fields with default values set properly", func() {
+			var (
+				specErr error
+			)
+			AfterEach(func() {
+				Expect(vmGroupPubReq.Status.Conditions).To(HaveLen(1))
+				Expect(vmGroupPubReq.Status.Conditions[0].Status).To(Equal(metav1.ConditionFalse))
+				Expect(specErr).To(Equal(pkgerr.NoRequeueError{
+					Message: "webhooks failed to mutate/validate spec. please delete and create again.",
+				}))
+			})
+			BeforeEach(func() {
+				specErr = nil
+			})
+
+			It("should set complete condition false when spec source is missing", func() {
+				vmGroupPubReq.Spec.Source = ""
+				specErr = reconciler.ReconcileNormal(vmpGroupPubReqCtx)
+				Expect(vmGroupPubReq.Status.Conditions[0].Message).To(ContainSubstring("spec.source is undefined"))
+			})
+
+			It("should set complete condition false when spec target is missing", func() {
+				vmGroupPubReq.Spec.Target = ""
+				specErr = reconciler.ReconcileNormal(vmpGroupPubReqCtx)
+				Expect(vmGroupPubReq.Status.Conditions[0].Message).To(ContainSubstring("spec.target is undefined"))
+			})
+
+			It("should set complete condition false when spec virtualMachines is missing", func() {
+				vmGroupPubReq.Spec.VirtualMachines = nil
+				specErr = reconciler.ReconcileNormal(vmpGroupPubReqCtx)
+				Expect(vmGroupPubReq.Status.Conditions[0].Message).To(ContainSubstring("spec.virtualMachines is undefined"))
+			})
+
+			It("should set complete condition false when spec source and spec target is missing", func() {
+				vmGroupPubReq.Spec.Source = ""
+				vmGroupPubReq.Spec.Target = ""
+				specErr = reconciler.ReconcileNormal(vmpGroupPubReqCtx)
+				Expect(vmGroupPubReq.Status.Conditions[0].Message).To(ContainSubstring("spec.source is undefined"))
+				Expect(vmGroupPubReq.Status.Conditions[0].Message).To(ContainSubstring("spec.target is undefined"))
+			})
+		})
+
+		When("there is no vm publish requests exist", func() {
+			It("should create two dummy vm publish requests", func() {
+				Expect(reconciler.ReconcileNormal(vmpGroupPubReqCtx)).To(Succeed())
+				Expect(vmGroupPubReq.Status.StartTime).ToNot(Equal(metav1.Time{}))
+				reqs := getVMPublishRequests(vmGroupPubReq, reconciler, len(vmGroupPubReq.Spec.VirtualMachines))
+				verifyRequest(reqs[0], vmGroupPubReq)
+				verifyRequest(reqs[1], vmGroupPubReq)
+			})
+		})
+
+		When("there is a pending vm publish request", func() {
+			It("should create other vm publish requests", func() {
+				// first reconcile normal creates the vm requests
+				Expect(reconciler.ReconcileNormal(vmpGroupPubReqCtx)).To(Succeed())
+				reqs := getVMPublishRequests(vmGroupPubReq, reconciler, len(vmGroupPubReq.Spec.VirtualMachines))
+				Expect(reconciler.Delete(vmpGroupPubReqCtx, &reqs[0])).To(Succeed())
+				getVMPublishRequests(vmGroupPubReq, reconciler, len(vmGroupPubReq.Spec.VirtualMachines)-1)
+				Expect(reconciler.ReconcileNormal(vmpGroupPubReqCtx)).To(Succeed())
+				getVMPublishRequests(vmGroupPubReq, reconciler, len(vmGroupPubReq.Spec.VirtualMachines))
+			})
+		})
+
+		When("all vm publish requests are created", func() {
+			It("should update the completed condition to False with waiting for completion message", func() {
+				// first reconcile normal creates the vm requests
+				// second reconcile enters reconcileStatusCompletedCondition()
+				Expect(reconciler.ReconcileNormal(vmpGroupPubReqCtx)).To(Succeed())
+				Expect(reconciler.ReconcileNormal(vmpGroupPubReqCtx)).To(Succeed())
+				Eventually(func(g Gomega) {
+					verifyFalseCondition(g, vmGroupPubReq, len(vmGroupPubReq.Spec.VirtualMachines))
+				}).Should(Succeed(), fmt.Sprintf("sets completed condition to false with %d pending",
+					len(vmGroupPubReq.Spec.VirtualMachines)))
+			})
+		})
+
+		When("vm group publish request is completed", func() {
+			BeforeEach(func() {
+				conditions.MarkTrue(vmGroupPubReq, vmopv1.VirtualMachineGroupPublishRequestConditionComplete)
+			})
+			It("should return nil when ttl is nil", func() {
+				Expect(reconciler.ReconcileNormal(vmpGroupPubReqCtx)).To(BeNil())
+			})
+		})
+	})
+}
+
+func getVMPublishRequests(
+	vmGroupPubReq *vmopv1.VirtualMachineGroupPublishRequest,
+	reconciler *virtualmachinegrouppublishrequest.Reconciler,
+	expectedPendingCnt int) []vmopv1.VirtualMachinePublishRequest {
+	reqs := &vmopv1.VirtualMachinePublishRequestList{}
+	Expect(reconciler.List(reconciler.Context,
+		reqs,
+		client.InNamespace(vmGroupPubReq.Namespace),
+		client.MatchingLabels{
+			vmopv1.VirtualMachinePublishRequestManagedByLabelKey: vmGroupPubReq.Name,
+		})).NotTo(HaveOccurred())
+	Expect(reqs.Items).To(HaveLen(expectedPendingCnt))
+	return reqs.Items
+}
+
+func verifyRequest(req vmopv1.VirtualMachinePublishRequest, vmGroupPub *vmopv1.VirtualMachineGroupPublishRequest) {
+	Expect(req.Name).To(ContainSubstring(vmGroupPub.Name))
+	Expect(metav1.HasLabel(req.ObjectMeta, vmopv1.VirtualMachinePublishRequestManagedByLabelKey)).To(BeTrue())
+	Expect(req.Labels).To(HaveKeyWithValue(vmopv1.VirtualMachinePublishRequestManagedByLabelKey, vmGroupPub.Name))
+	Expect(metav1.IsControlledBy(&req, vmGroupPub)).To(BeTrue())
+	Expect(req.Spec.Source.Kind).To(Equal("VirtualMachine"))
+	Expect(req.Spec.Source.Name).To(ContainSubstring("dummy-vm"))
+	Expect(req.Spec.Target.Location.Name).To(Equal(vmGroupPub.Spec.Target))
+	Expect(req.Spec.Target.Location.Kind).To(Equal("ContentLibrary"))
+}

--- a/pkg/context/virtualmachinegrouppublishrequest_context.go
+++ b/pkg/context/virtualmachinegrouppublishrequest_context.go
@@ -17,13 +17,13 @@ import (
 // VirtualMachineGroupPublishRequest controller.
 type VirtualMachineGroupPublishRequestContext struct {
 	context.Context
-	Logger logr.Logger
-	Obj    *vmopv1.VirtualMachineGroupPublishRequest
+	Logger                logr.Logger
+	VMGroupPublishRequest *vmopv1.VirtualMachineGroupPublishRequest
 }
 
 func (v VirtualMachineGroupPublishRequestContext) String() string {
 	return fmt.Sprintf("%s %s/%s",
-		v.Obj.GroupVersionKind(),
-		v.Obj.Namespace,
-		v.Obj.Name)
+		v.VMGroupPublishRequest.GroupVersionKind(),
+		v.VMGroupPublishRequest.Namespace,
+		v.VMGroupPublishRequest.Name)
 }

--- a/test/builder/dummies.go
+++ b/test/builder/dummies.go
@@ -21,6 +21,7 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	imgregv1a1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha1"
+
 	spqv1 "github.com/vmware-tanzu/vm-operator/external/storage-policy-quota/api/v1alpha2"
 	topologyv1 "github.com/vmware-tanzu/vm-operator/external/tanzu-topology/api/v1alpha1"
 
@@ -31,18 +32,26 @@ import (
 )
 
 const (
-	DummyVMIName           = "vmi-0123456789"
-	DummyCVMIName          = "vmi-9876543210"
-	DummyImageName         = "dummy-image-name"
-	DummyClassName         = "dummyClassName"
-	DummyVolumeName        = "dummy-volume-name"
-	DummyPVCName           = "dummyPVCName"
-	DummyDistroVersion     = "dummyDistroVersion"
-	DummyOSType            = "centosGuest"
-	DummyStorageClassName  = "dummy-storage-class"
-	DummyResourceQuotaName = "dummy-resource-quota"
-	DummyZoneName          = "dummy-zone"
-	DummyDeletedZoneName   = "dummy-zone-deleted"
+	DummyVMIName                   = "vmi-0123456789"
+	DummyCVMIName                  = "vmi-9876543210"
+	DummyImageName                 = "dummy-image-name"
+	DummyClassName                 = "dummyClassName"
+	DummyVolumeName                = "dummy-volume-name"
+	DummyPVCName                   = "dummyPVCName"
+	DummyDistroVersion             = "dummyDistroVersion"
+	DummyOSType                    = "centosGuest"
+	DummyStorageClassName          = "dummy-storage-class"
+	DummyResourceQuotaName         = "dummy-resource-quota"
+	DummyZoneName                  = "dummy-zone"
+	DummyDeletedZoneName           = "dummy-zone-deleted"
+	DummyNamespaceName             = "dummy-ns"
+	DummyVMGroupName               = "dummy-vm-group"
+	DummyVMGroupPublishRequestName = "dummy-vm-group-publish-request"
+	DummyContentLibraryName        = "dummy-cl"
+	DummyImageVM0Name              = "dummy-image-vm0-name"
+	DummyImageVM1Name              = "dummy-image-vm1-name"
+	DummyVirtualMachine0Name       = "dummy-vm0"
+	DummyVirtualMachine1Name       = "dummy-vm1"
 )
 
 const (
@@ -500,6 +509,20 @@ func DummyVirtualMachinePublishRequest(name, namespace, sourceName, itemName, cl
 					Kind:       "ContentLibrary",
 				},
 			},
+		},
+	}
+}
+
+func VirtualMachineGroupPublishRequest(name, namespace string, vms []string) *vmopv1.VirtualMachineGroupPublishRequest {
+	return &vmopv1.VirtualMachineGroupPublishRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: vmopv1.VirtualMachineGroupPublishRequestSpec{
+			Source:          DummyVMGroupName,
+			Target:          DummyContentLibraryName,
+			VirtualMachines: vms,
 		},
 	}
 }


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR implements the VirtualMachineGroupPublishRequest API that was introduced on https://github.com/vmware-tanzu/vm-operator/pull/1050. 

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes NA

**Are there any special notes for your reviewer**:
Manual Testing:

- created VMs 
<img width="537" height="108" alt="Screenshot 2025-07-28 at 8 34 29 PM" src="https://github.com/user-attachments/assets/ec4a3da4-476e-4d71-bd9a-560701da72d2" />

- created  the VM group publish request
<img width="853" height="1472" alt="Screenshot 2025-07-28 at 8 34 51 PM" src="https://github.com/user-attachments/assets/521cead7-3e4b-4b27-b069-29dec5b0f0ee" />

- completed the VM group publish request
<img width="855" height="1742" alt="Screenshot 2025-07-28 at 8 35 22 PM" src="https://github.com/user-attachments/assets/0e914858-9bf0-467a-bce7-0be3d62a90d2" />

Webhook changes will be in a separate PR.  The mutating webhook is responsible for generating spec.virtualMachines list from the VM group. 
**Please add a release note if necessary**:

```release-note
Implement the VirutalMachineGroupPublishRequest API
```