### PR TITLE
Revert "🌱 Update vm.status.currentSnapshot in snapshot controller"

### DIFF
--- a/controllers/virtualmachinesnapshot/virtualmachinesnapshot_controller.go
+++ b/controllers/virtualmachinesnapshot/virtualmachinesnapshot_controller.go
@@ -174,23 +174,23 @@ func (r *Reconciler) ReconcileNormal(ctx *pkgctx.VirtualMachineSnapshotContext) 
 	}
 
 	// vm object already set with snapshot reference
-	if vm.Status.CurrentSnapshot != nil && vm.Status.CurrentSnapshot.Name == ctx.VirtualMachineSnapshot.Name {
-		ctx.Logger.Info("VirtualMachine current snapshot already up to date", "status.currentSnapshot", vm.Status.CurrentSnapshot.Name)
+	if vm.Spec.CurrentSnapshot != nil && vm.Spec.CurrentSnapshot.Name == ctx.VirtualMachineSnapshot.Name {
+		ctx.Logger.Info("VirtualMachine current snapshot already up to date", "spec.currentSnapshot", vm.Spec.CurrentSnapshot.Name)
 		return nil
 	}
 
 	objRef := vmSnapshotCRToLocalObjectRef(ctx.VirtualMachineSnapshot)
 
-	// patch vm resource with the status.currentSnapshot
+	// patch vm resource with the spec.currentSnapshot
 	vmPatch := client.MergeFrom(vm.DeepCopy())
-	vm.Status.CurrentSnapshot = objRef
-	if err := r.Status().Patch(ctx, vm, vmPatch); err != nil {
+	vm.Spec.CurrentSnapshot = objRef
+	if err := r.Patch(ctx, vm, vmPatch); err != nil {
 		return fmt.Errorf(
 			"failed to patch VM resource %s with current snapshot %s: %w", objKey,
 			ctx.VirtualMachineSnapshot.Name, err)
 	}
 
-	ctx.Logger.Info("Successfully patched VirtualMachine status with current snapshot reference", "vm.Name", vm.Name, "status.currentSnapshot", vm.Status.CurrentSnapshot.Name)
+	ctx.Logger.Info("Successfully patched VirtualMachine's current snapshot reference", "vm.Name", vm.Name, "spec.currentSnapshot", vm.Spec.CurrentSnapshot.Name)
 	return nil
 }
 
@@ -358,23 +358,26 @@ func (r *Reconciler) updateVMStatus(ctx *pkgctx.VirtualMachineSnapshotContext, p
 	return nil
 }
 
+// Set current snapshot of VM to the parent snapshot or to nil.
 func (r *Reconciler) updateVMCurrentSnapshot(ctx *pkgctx.VirtualMachineSnapshotContext, parentVMSnapshot *vmopv1.VirtualMachineSnapshot) error {
+	ctx.Logger.Info("Updating VM current snapshot")
 	vm := ctx.VM
-	if vm.Status.CurrentSnapshot != nil && vm.Status.CurrentSnapshot.Name != ctx.VirtualMachineSnapshot.Name {
-		ctx.Logger.V(5).Info("VM status current snapshot is not the same as the snapshot being deleted, skipping update")
+	if vm.Spec.CurrentSnapshot != nil && vm.Spec.CurrentSnapshot.Name != ctx.VirtualMachineSnapshot.Name {
+		ctx.Logger.Info("VM current snapshot is not the same as the snapshot being deleted, skipping update")
 		return nil
 	}
 	vmPatch := client.MergeFrom(vm.DeepCopy())
 	if parentVMSnapshot != nil {
-		vm.Status.CurrentSnapshot = vmSnapshotCRToLocalObjectRef(parentVMSnapshot)
-		ctx.Logger.V(5).Info("Updating VM status current snapshot", "vm", vm.Name, "new current snapshot", parentVMSnapshot.Name)
+		ctx.Logger.V(5).Info("Updating VM current snapshot", "vm", vm.Name, "new current snapshot", parentVMSnapshot.Name)
+		vm.Spec.CurrentSnapshot = vmSnapshotCRToLocalObjectRef(parentVMSnapshot)
 	} else {
-		ctx.Logger.V(5).Info("Updating VM status current snapshot", "vm", vm.Name, "new current snapshot", "nil")
-		vm.Status.CurrentSnapshot = nil
+		ctx.Logger.V(5).Info("Updating VM current snapshot", "vm", vm.Name, "new current snapshot", "nil")
+		vm.Spec.CurrentSnapshot = nil
 	}
-	if err := r.Status().Patch(ctx, vm, vmPatch); err != nil {
-		return fmt.Errorf("failed to patch VM %s status with current snapshot: %w", vm.Name, err)
+	if err := r.Patch(ctx, vm, vmPatch); err != nil {
+		return fmt.Errorf("failed to patch VM %s with current snapshot: %w", vm.Name, err)
 	}
+
 	return nil
 }
 

--- a/controllers/virtualmachinesnapshot/virtualmachinesnapshot_controller_intg_test.go
+++ b/controllers/virtualmachinesnapshot/virtualmachinesnapshot_controller_intg_test.go
@@ -102,7 +102,7 @@ func intgTestsReconcile() {
 			Eventually(func(g Gomega) {
 				vmObj := getVirtualMachine(ctx, vmObjKey)
 				g.Expect(vmObj).ToNot(BeNil())
-				g.Expect(vmObj.Status.CurrentSnapshot).To(Equal(&vmopv1common.LocalObjectRef{
+				g.Expect(vmObj.Spec.CurrentSnapshot).To(Equal(&vmopv1common.LocalObjectRef{
 					APIVersion: "vmoperator.vmware.com/v1alpha4",
 					Kind:       "VirtualMachineSnapshot",
 					Name:       vmSnapshot.Name,
@@ -176,8 +176,8 @@ func intgTestsReconcileDelete() {
 					Expect(vcSimCtx.Client.Create(ctx, vm)).To(Succeed())
 					vm.Status.UniqueID = uniqueVMID
 					Expect(vcSimCtx.Client.Status().Update(ctx, vm)).To(Succeed())
-					vm.Status.CurrentSnapshot = newLocalObjectRefWithSnapshotName(vmSnapshot.Name)
-					Expect(vcSimCtx.Client.Status().Update(ctx, vm)).To(Succeed())
+					vm.Spec.CurrentSnapshot = newLocalObjectRefWithSnapshotName(vmSnapshot.Name)
+					Expect(vcSimCtx.Client.Update(ctx, vm)).To(Succeed())
 					vmObjKey := types.NamespacedName{Name: vm.Name, Namespace: vm.Namespace}
 
 					Eventually(func(g Gomega) {
@@ -204,7 +204,7 @@ func intgTestsReconcileDelete() {
 				Eventually(func(g Gomega) {
 					vmObj := getVirtualMachine(vcSimCtx, vmObjKey)
 					g.Expect(vmObj).ToNot(BeNil())
-					g.Expect(vmObj.Status.CurrentSnapshot).To(BeNil())
+					g.Expect(vmObj.Spec.CurrentSnapshot).To(BeNil())
 					tmpVMSSnapshot := getVirtualMachineSnapshot(vcSimCtx, vmObjKey)
 					g.Expect(tmpVMSSnapshot).To(BeNil())
 				}).Should(Succeed(), "waiting current snapshot to be deleted")
@@ -245,8 +245,8 @@ func intgTestsReconcileDelete() {
 						Consistently(func(g Gomega) {
 							vmObj := getVirtualMachine(vcSimCtx, vmObjKey)
 							g.Expect(vmObj).ToNot(BeNil())
-							g.Expect(vmObj.Status.CurrentSnapshot).To(Not(BeNil()))
-							g.Expect(*vmObj.Status.CurrentSnapshot).To(Equal(*newLocalObjectRefWithSnapshotName(vmSnapshot.Name)))
+							g.Expect(vmObj.Spec.CurrentSnapshot).To(Not(BeNil()))
+							g.Expect(*vmObj.Spec.CurrentSnapshot).To(Equal(*newLocalObjectRefWithSnapshotName(vmSnapshot.Name)))
 						}).Should(Succeed())
 					})
 				})
@@ -289,8 +289,8 @@ func intgTestsReconcileDelete() {
 						Expect(vcSimCtx.Client.Create(ctx, vm)).To(Succeed())
 						vm.Status.UniqueID = uniqueVMID
 						Expect(vcSimCtx.Client.Status().Update(ctx, vm)).To(Succeed())
-						vm.Status.CurrentSnapshot = newLocalObjectRefWithSnapshotName(vmSnapshot.Name)
-						Expect(vcSimCtx.Client.Status().Update(ctx, vm)).To(Succeed())
+						vm.Spec.CurrentSnapshot = newLocalObjectRefWithSnapshotName(vmSnapshot.Name)
+						Expect(vcSimCtx.Client.Update(ctx, vm)).To(Succeed())
 						vmObjKey := types.NamespacedName{Name: vm.Name, Namespace: vm.Namespace}
 
 						Eventually(func(g Gomega) {
@@ -380,14 +380,14 @@ func intgTestsReconcileDelete() {
 
 			JustBeforeEach(func() {
 				By("update vm current snapshot")
-				vm.Status.CurrentSnapshot = newLocalObjectRefWithSnapshotName(currentSnapshotName)
-				Expect(vcSimCtx.Client.Status().Update(ctx, vm)).To(Succeed())
+				vm.Spec.CurrentSnapshot = newLocalObjectRefWithSnapshotName(currentSnapshotName)
+				Expect(vcSimCtx.Client.Update(ctx, vm)).To(Succeed())
 				vmObjKey := types.NamespacedName{Name: vm.Name, Namespace: vm.Namespace}
 				Eventually(func(g Gomega) {
 					vmObj := getVirtualMachine(vcSimCtx, vmObjKey)
 					g.Expect(vmObj).ToNot(BeNil())
-					g.Expect(vmObj.Status.CurrentSnapshot).ToNot(BeNil())
-					g.Expect(vmObj.Status.CurrentSnapshot.Name).To(Equal(currentSnapshotName))
+					g.Expect(vmObj.Spec.CurrentSnapshot).ToNot(BeNil())
+					g.Expect(vmObj.Spec.CurrentSnapshot.Name).To(Equal(currentSnapshotName))
 				}).Should(Succeed(), "waiting current snapshot to be set on virtualmachine")
 			})
 
@@ -431,8 +431,8 @@ func intgTestsReconcileDelete() {
 						Eventually(func(g Gomega) {
 							vmObj := getVirtualMachine(vcSimCtx, vmObjKey)
 							g.Expect(vmObj).ToNot(BeNil())
-							g.Expect(vmObj.Status.CurrentSnapshot).ToNot(BeNil())
-							g.Expect(vmObj.Status.CurrentSnapshot.Name).To(Equal(vmSnapshotL1.Name))
+							g.Expect(vmObj.Spec.CurrentSnapshot).ToNot(BeNil())
+							g.Expect(vmObj.Spec.CurrentSnapshot.Name).To(Equal(vmSnapshotL1.Name))
 						}).Should(Succeed(), "waiting for current snapshot to be updated to root")
 
 						By("check parent snapshot's children should be updated")
@@ -467,8 +467,7 @@ func intgTestsReconcileDelete() {
 						Eventually(func(g Gomega) {
 							vmObj := getVirtualMachine(vcSimCtx, vmObjKey)
 							g.Expect(vmObj).ToNot(BeNil())
-							g.Expect(vmObj.Status.CurrentSnapshot).ToNot(BeNil())
-							g.Expect(vmObj.Status.CurrentSnapshot.Name).To(Equal(vmSnapshotL1Name))
+							g.Expect(vmObj.Spec.CurrentSnapshot.Name).To(Equal(vmSnapshotL1Name))
 						}).Should(Succeed())
 					})
 				})
@@ -498,7 +497,7 @@ func intgTestsReconcileDelete() {
 						Eventually(func(g Gomega) {
 							vmObj := getVirtualMachine(vcSimCtx, vmObjKey)
 							g.Expect(vmObj).ToNot(BeNil())
-							g.Expect(vmObj.Status.CurrentSnapshot).To(BeNil())
+							g.Expect(vmObj.Spec.CurrentSnapshot).To(BeNil())
 						}).Should(Succeed())
 						By("vm root snapshots should be updated")
 						Eventually(func(g Gomega) {
@@ -518,8 +517,7 @@ func intgTestsReconcileDelete() {
 						Eventually(func(g Gomega) {
 							vmObj := getVirtualMachine(vcSimCtx, vmObjKey)
 							g.Expect(vmObj).ToNot(BeNil())
-							g.Expect(vmObj.Status.CurrentSnapshot).ToNot(BeNil())
-							g.Expect(vmObj.Status.CurrentSnapshot.Name).To(Equal(vmSnapshotL2Name))
+							g.Expect(vmObj.Spec.CurrentSnapshot.Name).To(Equal(vmSnapshotL2Name))
 						}).Should(Succeed())
 					})
 				})
@@ -552,8 +550,7 @@ func intgTestsReconcileDelete() {
 						Eventually(func(g Gomega) {
 							vmObj := getVirtualMachine(vcSimCtx, vmObjKey)
 							g.Expect(vmObj).ToNot(BeNil())
-							g.Expect(vmObj.Status.CurrentSnapshot).ToNot(BeNil())
-							g.Expect(vmObj.Status.CurrentSnapshot.Name).To(Equal(vmSnapshotL2Name))
+							g.Expect(vmObj.Spec.CurrentSnapshot.Name).To(Equal(vmSnapshotL2Name))
 						}).Should(Succeed())
 						By("check parent snapshot's children should be updated")
 						parent := vmSnapshotL2
@@ -584,8 +581,7 @@ func intgTestsReconcileDelete() {
 						Eventually(func(g Gomega) {
 							vmObj := getVirtualMachine(vcSimCtx, vmObjKey)
 							g.Expect(vmObj).ToNot(BeNil())
-							g.Expect(vmObj.Status.CurrentSnapshot).ToNot(BeNil())
-							g.Expect(vmObj.Status.CurrentSnapshot.Name).To(Equal(vmSnapshotL2Name))
+							g.Expect(vmObj.Spec.CurrentSnapshot.Name).To(Equal(vmSnapshotL2Name))
 						}).Should(Succeed())
 					})
 				})

--- a/controllers/virtualmachinesnapshot/virtualmachinesnapshot_controller_unit_test.go
+++ b/controllers/virtualmachinesnapshot/virtualmachinesnapshot_controller_unit_test.go
@@ -123,13 +123,13 @@ func unitTestsReconcile() {
 				vmObj := &vmopv1.VirtualMachine{}
 				Expect(ctx.Client.Get(ctx, objKey, vmObj)).To(Succeed())
 
-				Expect(vmObj.Status.CurrentSnapshot).To(Equal(vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshot)))
+				Expect(vmObj.Spec.CurrentSnapshot).To(Equal(vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshot)))
 			})
 		})
 
 		When("vm ready with different current snapshot", func() {
 			BeforeEach(func() {
-				vm.Status.CurrentSnapshot = &vmopv1common.LocalObjectRef{
+				vm.Spec.CurrentSnapshot = &vmopv1common.LocalObjectRef{
 					APIVersion: vmSnapshot.APIVersion,
 					Kind:       vmSnapshot.Kind,
 					Name:       "dummy-diff-snapshot",
@@ -144,14 +144,14 @@ func unitTestsReconcile() {
 				vmObj := &vmopv1.VirtualMachine{}
 				Expect(ctx.Client.Get(ctx, objKey, vmObj)).To(Succeed())
 
-				Expect(vmObj.Status.CurrentSnapshot).To(Equal(vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshot)))
+				Expect(vmObj.Spec.CurrentSnapshot).To(Equal(vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshot)))
 			})
 		})
 
 		When("vm ready with matching current snapshot name", func() {
 			BeforeEach(func() {
 				vm.Status.UniqueID = dummyVMUUID
-				vm.Status.CurrentSnapshot = &vmopv1common.LocalObjectRef{
+				vm.Spec.CurrentSnapshot = &vmopv1common.LocalObjectRef{
 					APIVersion: vmSnapshot.APIVersion,
 					Kind:       vmSnapshot.Kind,
 					Name:       vmSnapshot.Name,
@@ -203,8 +203,6 @@ func unitTestsReconcile() {
 			It("returns success", func() {
 				_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: vmSnapshotNamespacedKey})
 				Expect(err).ToNot(HaveOccurred())
-				Expect(vm.Status.CurrentSnapshot).To(BeNil())
-				Expect(vm.Status.RootSnapshots).To(HaveLen(0))
 			})
 
 			When("Calling DeleteSnapshot to VC", func() {
@@ -317,7 +315,7 @@ func unitTestsReconcile() {
 				//   L3-n1    L3-n2
 				BeforeEach(func() {
 					vmSnapshotL2.DeletionTimestamp = &now
-					vm.Status.CurrentSnapshot = vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL2)
+					vm.Spec.CurrentSnapshot = vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL2)
 					vm.Status.RootSnapshots = []vmopv1common.LocalObjectRef{*vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL1)}
 					// assign before the reconcile
 					vmSnapshotToReconcile = vmSnapshotL2
@@ -327,7 +325,7 @@ func unitTestsReconcile() {
 				When("it's the current snapshot", func() {
 					It("returns success, vm current snapshot is updated to root", func() {
 						Expect(err).ToNot(HaveOccurred())
-						Expect(vm.Status.CurrentSnapshot).To(Equal(vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL1)))
+						Expect(vm.Spec.CurrentSnapshot).To(Equal(vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL1)))
 						Expect(vm.Status.RootSnapshots).To(HaveLen(1))
 						Expect(vm.Status.RootSnapshots).To(ContainElement(*vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL1)))
 						By("check parent snapshot's children should be updated")
@@ -340,11 +338,11 @@ func unitTestsReconcile() {
 				})
 				When("it's not the current snapshot", func() {
 					BeforeEach(func() {
-						vm.Status.CurrentSnapshot = vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL1)
+						vm.Spec.CurrentSnapshot = vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL1)
 					})
 					It("returns success, vm current snapshot is not changed", func() {
 						Expect(err).ToNot(HaveOccurred())
-						Expect(vm.Status.CurrentSnapshot).To(Equal(vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL1)))
+						Expect(vm.Spec.CurrentSnapshot).To(Equal(vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL1)))
 					})
 				})
 			})
@@ -361,7 +359,7 @@ func unitTestsReconcile() {
 				//   L3-n1    L3-n2
 				BeforeEach(func() {
 					vmSnapshotL1.DeletionTimestamp = &now
-					vm.Status.CurrentSnapshot = vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL1)
+					vm.Spec.CurrentSnapshot = vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL1)
 					vm.Status.RootSnapshots = []vmopv1common.LocalObjectRef{*vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL1)}
 					vmSnapshotToReconcile = vmSnapshotL1
 					parent = nil
@@ -370,18 +368,18 @@ func unitTestsReconcile() {
 				When("it's the current snapshot", func() {
 					It("returns success, vm current snapshot is updated to nil", func() {
 						Expect(err).ToNot(HaveOccurred())
-						Expect(vm.Status.CurrentSnapshot).To(BeNil())
+						Expect(vm.Spec.CurrentSnapshot).To(BeNil())
 						Expect(vm.Status.RootSnapshots).To(HaveLen(1))
 						Expect(vm.Status.RootSnapshots).To(ContainElement(*vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL2)))
 					})
 				})
 				When("it's not the current snapshot", func() {
 					BeforeEach(func() {
-						vm.Status.CurrentSnapshot = vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL2)
+						vm.Spec.CurrentSnapshot = vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL2)
 					})
 					It("returns success, vm current snapshot is not changed", func() {
 						Expect(err).ToNot(HaveOccurred())
-						Expect(vm.Status.CurrentSnapshot).To(Equal(vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL2)))
+						Expect(vm.Spec.CurrentSnapshot).To(Equal(vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL2)))
 					})
 				})
 			})
@@ -400,7 +398,7 @@ func unitTestsReconcile() {
 				//       L3-n2
 				BeforeEach(func() {
 					vmSnapshotL3Node1.DeletionTimestamp = &now
-					vm.Status.CurrentSnapshot = vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL3Node1)
+					vm.Spec.CurrentSnapshot = vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL3Node1)
 					vm.Status.RootSnapshots = []vmopv1common.LocalObjectRef{*vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL1)}
 					vmSnapshotToReconcile = vmSnapshotL3Node1
 					parent = vmSnapshotL2
@@ -409,7 +407,7 @@ func unitTestsReconcile() {
 				When("it's the current snapshot", func() {
 					It("returns success, vm current snapshot is updated to parent", func() {
 						Expect(err).ToNot(HaveOccurred())
-						Expect(vm.Status.CurrentSnapshot).To(Equal(vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL2)))
+						Expect(vm.Spec.CurrentSnapshot).To(Equal(vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL2)))
 						By("check parent snapshot's children should be updated")
 						Expect(parent).To(Not(BeNil()))
 						Expect(parent.Status.Children).To(HaveLen(1))
@@ -421,11 +419,11 @@ func unitTestsReconcile() {
 				})
 				When("it's not the current snapshot", func() {
 					BeforeEach(func() {
-						vm.Status.CurrentSnapshot = vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL2)
+						vm.Spec.CurrentSnapshot = vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL2)
 					})
 					It("returns success, vm current snapshot is not changed", func() {
 						Expect(err).ToNot(HaveOccurred())
-						Expect(vm.Status.CurrentSnapshot).To(Equal(vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL2)))
+						Expect(vm.Spec.CurrentSnapshot).To(Equal(vmSnapshotCRToLocalObjectRefWithDefaultVersion(vmSnapshotL2)))
 					})
 				})
 			})

--- a/pkg/providers/vsphere/virtualmachine/snapshot.go
+++ b/pkg/providers/vsphere/virtualmachine/snapshot.go
@@ -93,7 +93,6 @@ func CreateSnapshot(args SnapshotArgs) (*types.ManagedObjectReference, error) {
 	return &snapMoRef, nil
 }
 
-// DeleteSnapshot deletes a snapshot from vCenter.
 func DeleteSnapshot(args SnapshotArgs) error {
 	t, err := args.VcVM.RemoveSnapshot(args.VMCtx, args.VMSnapshot.Name, args.RemoveChildren, args.Consolidate)
 	if err != nil {


### PR DESCRIPTION
Reverts vmware-tanzu/vm-operator#1043

This change removed the code which modifies the spec.currentSnapshot in the create snapshot workflow.  This was because we were going to drive the snapshot creation through the VMSnapshot custom resource.  That work is tracked by #1049.  Once that is merged, we can re-introduce parts of this change. 