### PR TITLE
🌱 Remove stale owner ref when group name changes

### DIFF
--- a/api/v1alpha4/virtualmachine_types.go
+++ b/api/v1alpha4/virtualmachine_types.go
@@ -1053,6 +1053,12 @@ type VirtualMachineSpec struct {
 	//
 	// VMs that belong to a group do not drive their own placement, rather that
 	// is handled by the group.
+	//
+	// When this field is set to a valid group that contains this VM as a
+	// member, an owner reference to that group is added to this VM.
+	//
+	// When this field is deleted or changed, any existing owner reference to
+	// the previous group will be removed from this VM.
 	GroupName string `json:"groupName,omitempty"`
 }
 

--- a/api/v1alpha4/virtualmachinegroup_types.go
+++ b/api/v1alpha4/virtualmachinegroup_types.go
@@ -83,7 +83,11 @@ type VirtualMachineGroupSpec struct {
 
 	// GroupName describes the name of the group that this group belongs to.
 	//
-	// If omitted, this group is not a member of any other group.
+	// When this field is set to a valid group that contains this VM Group as a
+	// member, an owner reference to that group is added to this VM Group.
+	//
+	// When this field is deleted or changed, any existing owner reference to
+	// the previous group will be removed from this VM Group.
 	GroupName string `json:"groupName,omitempty"`
 
 	// +optional

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachinegroups.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachinegroups.yaml
@@ -102,7 +102,11 @@ spec:
                 description: |-
                   GroupName describes the name of the group that this group belongs to.
 
-                  If omitted, this group is not a member of any other group.
+                  When this field is set to a valid group that contains this VM Group as a
+                  member, an owner reference to that group is added to this VM Group.
+
+                  When this field is deleted or changed, any existing owner reference to
+                  the previous group will be removed from this VM Group.
                 type: string
               nextForcePowerStateSyncTime:
                 description: |-

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachinereplicasets.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachinereplicasets.yaml
@@ -4210,6 +4210,12 @@ spec:
 
                           VMs that belong to a group do not drive their own placement, rather that
                           is handled by the group.
+
+                          When this field is set to a valid group that contains this VM as a
+                          member, an owner reference to that group is added to this VM.
+
+                          When this field is deleted or changed, any existing owner reference to
+                          the previous group will be removed from this VM.
                         type: string
                       guestID:
                         description: |-

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -7748,6 +7748,12 @@ spec:
 
                   VMs that belong to a group do not drive their own placement, rather that
                   is handled by the group.
+
+                  When this field is set to a valid group that contains this VM as a
+                  member, an owner reference to that group is added to this VM.
+
+                  When this field is deleted or changed, any existing owner reference to
+                  the previous group will be removed from this VM.
                 type: string
               guestID:
                 description: |-

--- a/controllers/virtualmachinegroup/virtualmachinegroup_controller.go
+++ b/controllers/virtualmachinegroup/virtualmachinegroup_controller.go
@@ -399,7 +399,7 @@ func (r *Reconciler) reconcileMember(
 
 	patch := client.MergeFrom(obj.DeepCopyObject().(vmopv1.VirtualMachineOrGroup))
 
-	if err := controllerutil.SetControllerReference(
+	if err := controllerutil.SetOwnerReference(
 		ctx.VMGroup,
 		obj,
 		r.Scheme(),

--- a/pkg/util/vmopv1/owner_refs.go
+++ b/pkg/util/vmopv1/owner_refs.go
@@ -1,0 +1,49 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package vmopv1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+)
+
+// RemoveStaleGroupOwnerRef removes an object's owner reference to the previous
+// group if the object's group name is deleted or changed to a different group.
+// Returns true if any owner references were modified, false otherwise.
+func RemoveStaleGroupOwnerRef(newObj, oldObj vmopv1.VirtualMachineOrGroup) bool {
+
+	var (
+		oldGroupName = oldObj.GetGroupName()
+		newGroupName = newObj.GetGroupName()
+	)
+
+	if oldGroupName == "" || oldGroupName == newGroupName {
+		return false
+	}
+
+	// Object's group name is deleted or changed to a different group name.
+	// Remove the owner reference to the old group if it exists in new object.
+
+	var (
+		filteredRefs      []metav1.OwnerReference
+		oldGroupRefExists bool
+	)
+
+	for _, ref := range newObj.GetOwnerReferences() {
+		if ref.Kind == "VirtualMachineGroup" && ref.Name == oldGroupName {
+			oldGroupRefExists = true
+			continue
+		}
+		filteredRefs = append(filteredRefs, ref)
+	}
+
+	if oldGroupRefExists {
+		newObj.SetOwnerReferences(filteredRefs)
+		return true
+	}
+
+	return false
+}

--- a/pkg/util/vmopv1/owner_refs.go
+++ b/pkg/util/vmopv1/owner_refs.go
@@ -27,10 +27,12 @@ func RemoveStaleGroupOwnerRef(newObj, oldObj vmopv1.VirtualMachineOrGroup) bool 
 	// Object's group name is deleted or changed to a different group name.
 	// Remove the owner reference to the old group if it exists in new object.
 
-	var (
-		filteredRefs      []metav1.OwnerReference
-		oldGroupRefExists bool
+	filteredRefs := make(
+		[]metav1.OwnerReference,
+		0,
+		len(newObj.GetOwnerReferences()),
 	)
+	oldGroupRefExists := false
 
 	for _, ref := range newObj.GetOwnerReferences() {
 		if ref.Kind == "VirtualMachineGroup" && ref.Name == oldGroupName {

--- a/pkg/util/vmopv1/owner_refs_test.go
+++ b/pkg/util/vmopv1/owner_refs_test.go
@@ -1,0 +1,195 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package vmopv1_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	vmopv1util "github.com/vmware-tanzu/vm-operator/pkg/util/vmopv1"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+const (
+	apiVersion = "vmoperator.vmware.com/v1alpha4"
+	groupKind  = "VirtualMachineGroup"
+)
+
+var _ = Describe("RemoveStaleGroupOwnerRef", func() {
+
+	var (
+		oldGroupName = "old-group"
+		newGroupName = "new-group"
+		oldGroupUID  = types.UID("old-group-owner-uid")
+		newGroupUID  = types.UID("new-group-owner-uid")
+	)
+
+	Context("VirtualMachine", func() {
+		var (
+			oldVM *vmopv1.VirtualMachine
+			newVM *vmopv1.VirtualMachine
+		)
+
+		BeforeEach(func() {
+			oldVM = builder.DummyVirtualMachine()
+			newVM = builder.DummyVirtualMachine()
+		})
+
+		When("old group name is empty", func() {
+			BeforeEach(func() {
+				oldVM.Spec.GroupName = ""
+				newVM.Spec.GroupName = newGroupName
+			})
+
+			It("should return false without modifying owner references", func() {
+				originalRefs := newVM.OwnerReferences
+				result := vmopv1util.RemoveStaleGroupOwnerRef(newVM, oldVM)
+				Expect(result).To(BeFalse())
+				Expect(newVM.OwnerReferences).To(Equal(originalRefs))
+			})
+		})
+
+		When("group name hasn't changed", func() {
+			BeforeEach(func() {
+				oldVM.Spec.GroupName = oldGroupName
+				newVM.Spec.GroupName = oldGroupName
+			})
+
+			It("should return false without modifying owner references", func() {
+				originalRefs := newVM.OwnerReferences
+				result := vmopv1util.RemoveStaleGroupOwnerRef(newVM, oldVM)
+				Expect(result).To(BeFalse())
+				Expect(newVM.OwnerReferences).To(Equal(originalRefs))
+			})
+		})
+
+		When("group name changed but no stale group owner reference exists", func() {
+			BeforeEach(func() {
+				oldVM.Spec.GroupName = oldGroupName
+				newVM.Spec.GroupName = newGroupName
+				newVM.OwnerReferences = []metav1.OwnerReference{
+					{
+						APIVersion: apiVersion,
+						Kind:       groupKind,
+						Name:       newGroupName,
+						UID:        newGroupUID,
+					},
+				}
+			})
+
+			It("should return false without modifying owner references", func() {
+				originalRefs := newVM.OwnerReferences
+				result := vmopv1util.RemoveStaleGroupOwnerRef(newVM, oldVM)
+				Expect(result).To(BeFalse())
+				Expect(newVM.OwnerReferences).To(Equal(originalRefs))
+			})
+		})
+
+		When("group name changed and stale owner reference exists", func() {
+			BeforeEach(func() {
+				oldVM.Spec.GroupName = oldGroupName
+				newVM.Spec.GroupName = newGroupName
+				newVM.OwnerReferences = []metav1.OwnerReference{
+					{
+						APIVersion: apiVersion,
+						Kind:       groupKind,
+						Name:       oldGroupName,
+						UID:        oldGroupUID,
+					},
+				}
+			})
+
+			It("should return true and remove the stale owner reference", func() {
+				result := vmopv1util.RemoveStaleGroupOwnerRef(newVM, oldVM)
+				Expect(result).To(BeTrue())
+				Expect(newVM.OwnerReferences).To(BeEmpty())
+			})
+		})
+
+		When("group name removed and stale owner reference exists", func() {
+			BeforeEach(func() {
+				oldVM.Spec.GroupName = oldGroupName
+				newVM.Spec.GroupName = ""
+				newVM.OwnerReferences = []metav1.OwnerReference{
+					{
+						APIVersion: apiVersion,
+						Kind:       groupKind,
+						Name:       oldGroupName,
+						UID:        newGroupUID,
+					},
+				}
+			})
+
+			It("should return true and remove the stale owner reference", func() {
+				result := vmopv1util.RemoveStaleGroupOwnerRef(newVM, oldVM)
+				Expect(result).To(BeTrue())
+				Expect(newVM.OwnerReferences).To(BeEmpty())
+			})
+		})
+
+		When("multiple VirtualMachineGroup owner references exist", func() {
+			BeforeEach(func() {
+				oldVM.Spec.GroupName = oldGroupName
+				newVM.Spec.GroupName = newGroupName
+				newVM.OwnerReferences = []metav1.OwnerReference{
+					{
+						APIVersion: apiVersion,
+						Kind:       groupKind,
+						Name:       oldGroupName,
+						UID:        oldGroupUID,
+					},
+					{
+						APIVersion: apiVersion,
+						Kind:       groupKind,
+						Name:       newGroupName,
+						UID:        newGroupUID,
+					},
+				}
+			})
+
+			It("should only remove the stale owner reference", func() {
+				result := vmopv1util.RemoveStaleGroupOwnerRef(newVM, oldVM)
+				Expect(result).To(BeTrue())
+				Expect(newVM.OwnerReferences).To(HaveLen(1))
+				Expect(newVM.OwnerReferences[0].APIVersion).To(Equal(apiVersion))
+				Expect(newVM.OwnerReferences[0].Kind).To(Equal(groupKind))
+				Expect(newVM.OwnerReferences[0].Name).To(Equal(newGroupName))
+				Expect(newVM.OwnerReferences[0].UID).To(Equal(newGroupUID))
+			})
+		})
+	})
+
+	Context("VirtualMachineGroup", func() {
+		var (
+			oldVMG = &vmopv1.VirtualMachineGroup{}
+			newVMG = &vmopv1.VirtualMachineGroup{}
+		)
+
+		When("group name changed and stale owner reference exists", func() {
+			BeforeEach(func() {
+				oldVMG.Spec.GroupName = oldGroupName
+				newVMG.Spec.GroupName = newGroupName
+				newVMG.OwnerReferences = []metav1.OwnerReference{
+					{
+						APIVersion: apiVersion,
+						Kind:       groupKind,
+						Name:       oldGroupName,
+						UID:        oldGroupUID,
+					},
+				}
+			})
+
+			It("should return true and remove the stale owner reference", func() {
+				result := vmopv1util.RemoveStaleGroupOwnerRef(newVMG, oldVMG)
+				Expect(result).To(BeTrue())
+				Expect(newVMG.OwnerReferences).To(BeEmpty())
+			})
+		})
+	})
+})

--- a/webhooks/virtualmachine/mutation/virtualmachine_mutator.go
+++ b/webhooks/virtualmachine/mutation/virtualmachine_mutator.go
@@ -1,5 +1,5 @@
 // © Broadcom. All Rights Reserved.
-// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: Apache-2.0
 
 package mutation
@@ -284,6 +284,9 @@ func (m mutator) Mutate(ctx *pkgctx.WebhookRequestContext) admission.Response {
 		}
 
 		if pkgcfg.FromContext(ctx).Features.VMGroups {
+			if ok := vmopv1util.RemoveStaleGroupOwnerRef(modified, oldVM); ok {
+				wasMutated = true
+			}
 			if ok := CleanupApplyPowerStateChangeTimeAnno(ctx, modified, oldVM); ok {
 				wasMutated = true
 			}

--- a/webhooks/virtualmachinegroup/mutation/virtualmachinegroup_mutator.go
+++ b/webhooks/virtualmachinegroup/mutation/virtualmachinegroup_mutator.go
@@ -24,6 +24,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/builder"
 	"github.com/vmware-tanzu/vm-operator/pkg/constants"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+	vmopv1util "github.com/vmware-tanzu/vm-operator/pkg/util/vmopv1"
 )
 
 const (
@@ -89,6 +90,10 @@ func (m mutator) Mutate(ctx *pkgctx.WebhookRequestContext) admission.Response {
 			return admission.Denied(err.Error())
 		}
 		if ok {
+			wasMutated = true
+		}
+
+		if ok := vmopv1util.RemoveStaleGroupOwnerRef(modified, oldVMGroup); ok {
 			wasMutated = true
 		}
 	}


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR updates VM & VMG mutating webhook to remove stale group owner reference when `spec.GroupName` is changed. It also updates the VM Group controller to set owner reference (instead of controller reference) to its members.


**Which issue(s) is/are addressed by this PR?**

Fixes N/A.


**Are there any special notes for your reviewer**:

Deployed this change to an internal testbed and verified the VM's owner reference to group was added/removed as expected:

- Create a VM in group-1

```console
$ kubectl get vm -n sdiliyaer-test vm-1 -o json | jq '.spec.groupName,.metadata.ownerReferences'
"vmg-1"
[
  {
    "apiVersion": "vmoperator.vmware.com/v1alpha4",
    "kind": "VirtualMachineGroup",
    "name": "vmg-1",
    "uid": "be2ae38d-539e-4db2-8d36-1519a68b9409"
  }
]
```

- Update the VM to group-2

```console
$ kubectl get vm -n sdiliyaer-test vm-1 -o json | jq '.spec.groupName,.metadata.ownerReferences'
"vmg-2"
[
  {
    "apiVersion": "vmoperator.vmware.com/v1alpha4",
    "kind": "VirtualMachineGroup",
    "name": "vmg-2",
    "uid": "c3d27181-91ac-4ec1-83e2-5ffd6f737802"
  }
]
```

- Remove group name from the VM

```console
$ kubectl get vm -n sdiliyaer-test vm-1 -o json | jq '.spec.groupName,.metadata.ownerReferences'
null
null
```

**Please add a release note if necessary**:

```release-note
Remove stale owner ref when group name changes via mutating webhook and switch to owner reference in VM Group controller.
```