### PR TITLE
🐛 Do not promote disks twice

### DIFF
--- a/api/v1alpha1/zz_generated.conversion.go
+++ b/api/v1alpha1/zz_generated.conversion.go
@@ -2215,7 +2215,6 @@ func autoConvert_v1alpha4_VirtualMachineStatus_To_v1alpha1_VirtualMachineStatus(
 	out.LastRestartTime = (*v1.Time)(unsafe.Pointer(in.LastRestartTime))
 	out.HardwareVersion = in.HardwareVersion
 	// WARNING: in.Storage requires manual conversion: does not exist in peer-type
-	// WARNING: in.TaskID requires manual conversion: does not exist in peer-type
 	// WARNING: in.CurrentSnapshot requires manual conversion: does not exist in peer-type
 	// WARNING: in.RootSnapshots requires manual conversion: does not exist in peer-type
 	return nil

--- a/api/v1alpha2/zz_generated.conversion.go
+++ b/api/v1alpha2/zz_generated.conversion.go
@@ -3334,7 +3334,6 @@ func autoConvert_v1alpha4_VirtualMachineStatus_To_v1alpha2_VirtualMachineStatus(
 	out.LastRestartTime = (*v1.Time)(unsafe.Pointer(in.LastRestartTime))
 	out.HardwareVersion = in.HardwareVersion
 	// WARNING: in.Storage requires manual conversion: does not exist in peer-type
-	// WARNING: in.TaskID requires manual conversion: does not exist in peer-type
 	// WARNING: in.CurrentSnapshot requires manual conversion: does not exist in peer-type
 	// WARNING: in.RootSnapshots requires manual conversion: does not exist in peer-type
 	return nil

--- a/api/v1alpha3/zz_generated.conversion.go
+++ b/api/v1alpha3/zz_generated.conversion.go
@@ -3916,7 +3916,6 @@ func autoConvert_v1alpha4_VirtualMachineStatus_To_v1alpha3_VirtualMachineStatus(
 	} else {
 		out.Storage = nil
 	}
-	// WARNING: in.TaskID requires manual conversion: does not exist in peer-type
 	// WARNING: in.CurrentSnapshot requires manual conversion: does not exist in peer-type
 	// WARNING: in.RootSnapshots requires manual conversion: does not exist in peer-type
 	return nil

--- a/api/v1alpha4/virtualmachine_types.go
+++ b/api/v1alpha4/virtualmachine_types.go
@@ -1236,12 +1236,6 @@ type VirtualMachineStatus struct {
 
 	// +optional
 
-	// TaskID describes the observed ID of the task created by VM Operator to
-	// perform some long-running operation on the VM.
-	TaskID string `json:"taskID,omitempty"`
-
-	// +optional
-
 	// CurrentSnapshot describes the observed working snapshot of the VirtualMachine.
 	CurrentSnapshot *vmopv1common.LocalObjectRef `json:"currentSnapshot,omitempty"`
 

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -9403,11 +9403,6 @@ spec:
                         x-kubernetes-int-or-string: true
                     type: object
                 type: object
-              taskID:
-                description: |-
-                  TaskID describes the observed ID of the task created by VM Operator to
-                  perform some long-running operation on the VM.
-                type: string
               uniqueID:
                 description: |-
                   UniqueID describes a unique identifier that is provided by the underlying

--- a/pkg/providers/vsphere/session/session_vm_update.go
+++ b/pkg/providers/vsphere/session/session_vm_update.go
@@ -84,8 +84,8 @@ func (s *Session) UpdateVirtualMachine(
 		vmCtx.Logger.Info("Reconciling config for suspended vm")
 		updateErr = reconcileSuspendedVM(vmCtx, s.K8sClient, vcVM)
 
-	case vmCtx.VM.Status.TaskID != "":
-		vmCtx.Logger.Info("Reconciling config for VM with task")
+	case pkgctx.HasVMRunningTask(vmCtx):
+		vmCtx.Logger.Info("Reconciling config for VM with running task")
 		updateErr = reconcileVMWithTask(vmCtx, s.K8sClient, vcVM)
 
 	case isVMPaused(vmCtx):

--- a/pkg/providers/vsphere/vmprovider_vm_group_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_group_test.go
@@ -101,7 +101,7 @@ func vmGroupTests() {
 				},
 				Conditions: []metav1.Condition{
 					{
-						Type:   vmopv1.VirtualMachineImageCacheConditionOVFReady,
+						Type:   vmopv1.VirtualMachineImageCacheConditionHardwareReady,
 						Status: metav1.ConditionTrue,
 					},
 				},

--- a/pkg/providers/vsphere/vmprovider_vm_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_test.go
@@ -3671,15 +3671,49 @@ func vmTests() {
 								Expect(vm.Status.PowerState).To(Equal(expectedPowerState))
 							})
 						})
-						When("vm has task", func() {
+
+						When("vm has running task", func() {
+							var (
+								reg     *simulator.Registry
+								simCtx  *simulator.Context
+								taskRef vimtypes.ManagedObjectReference
+							)
+
 							JustBeforeEach(func() {
-								vm.Status.TaskID = "123"
+								simCtx = ctx.SimulatorContext()
+								reg = simCtx.Map
+								taskRef = reg.Put(&mo.Task{
+									Info: vimtypes.TaskInfo{
+										State:         vimtypes.TaskInfoStateRunning,
+										DescriptionId: "fake.task.1",
+									},
+								}).Reference()
+
+								vmRef := vimtypes.ManagedObjectReference{
+									Type:  string(vimtypes.ManagedObjectTypesVirtualMachine),
+									Value: vm.Status.UniqueID,
+								}
+
+								reg.WithLock(
+									simCtx,
+									vmRef,
+									func() {
+										vm := reg.Get(vmRef).(*simulator.VirtualMachine)
+										vm.RecentTask = append(vm.RecentTask, taskRef)
+									})
+
 							})
+
+							AfterEach(func() {
+								reg.Remove(simCtx, taskRef)
+							})
+
 							It("should not change the power state", func() {
 								Expect(errors.Is(createOrUpdateVM(ctx, vmProvider, vm), vsphere.ErrHasTask)).To(BeTrue())
 								Expect(vm.Status.PowerState).To(Equal(expectedPowerState))
 							})
 						})
+
 					})
 
 					DescribeTable("powerOffModes",
@@ -3801,16 +3835,50 @@ func vmTests() {
 								Expect(vm.Status.PowerState).To(Equal(expectedPowerState))
 							})
 						})
-						When("vm has task", func() {
+
+						When("vm has running task", func() {
+							var (
+								reg     *simulator.Registry
+								simCtx  *simulator.Context
+								taskRef vimtypes.ManagedObjectReference
+							)
+
 							JustBeforeEach(func() {
-								vm.Status.TaskID = "123"
+								simCtx = ctx.SimulatorContext()
+								reg = simCtx.Map
+								taskRef = reg.Put(&mo.Task{
+									Info: vimtypes.TaskInfo{
+										State:         vimtypes.TaskInfoStateRunning,
+										DescriptionId: "fake.task.2",
+									},
+								}).Reference()
+
+								vmRef := vimtypes.ManagedObjectReference{
+									Type:  string(vimtypes.ManagedObjectTypesVirtualMachine),
+									Value: vm.Status.UniqueID,
+								}
+
+								reg.WithLock(
+									simCtx,
+									vmRef,
+									func() {
+										vm := reg.Get(vmRef).(*simulator.VirtualMachine)
+										vm.RecentTask = append(vm.RecentTask, taskRef)
+									})
+
 							})
+
+							AfterEach(func() {
+								reg.Remove(simCtx, taskRef)
+							})
+
 							It("should not change the power state", func() {
 								Expect(errors.Is(createOrUpdateVM(ctx, vmProvider, vm), vsphere.ErrHasTask)).To(BeTrue())
 								Expect(vm.Status.PowerState).To(Equal(expectedPowerState))
 							})
 						})
 					})
+
 					When("suspendMode is hard", func() {
 						JustBeforeEach(func() {
 							vm.Spec.SuspendMode = vmopv1.VirtualMachinePowerOpModeHard
@@ -3895,15 +3963,49 @@ func vmTests() {
 								Expect(vm.Status.PowerState).To(Equal(expectedPowerState))
 							})
 						})
-						When("vm has task", func() {
+
+						When("vm has running task", func() {
+							var (
+								reg     *simulator.Registry
+								simCtx  *simulator.Context
+								taskRef vimtypes.ManagedObjectReference
+							)
+
 							JustBeforeEach(func() {
-								vm.Status.TaskID = "123"
+								simCtx = ctx.SimulatorContext()
+								reg = simCtx.Map
+								taskRef = reg.Put(&mo.Task{
+									Info: vimtypes.TaskInfo{
+										State:         vimtypes.TaskInfoStateRunning,
+										DescriptionId: "fake.task.3",
+									},
+								}).Reference()
+
+								vmRef := vimtypes.ManagedObjectReference{
+									Type:  string(vimtypes.ManagedObjectTypesVirtualMachine),
+									Value: vm.Status.UniqueID,
+								}
+
+								reg.WithLock(
+									simCtx,
+									vmRef,
+									func() {
+										vm := reg.Get(vmRef).(*simulator.VirtualMachine)
+										vm.RecentTask = append(vm.RecentTask, taskRef)
+									})
+
 							})
+
+							AfterEach(func() {
+								reg.Remove(simCtx, taskRef)
+							})
+
 							It("should not change the power state", func() {
 								Expect(errors.Is(createOrUpdateVM(ctx, vmProvider, vm), vsphere.ErrHasTask)).To(BeTrue())
 								Expect(vm.Status.PowerState).To(Equal(expectedPowerState))
 							})
 						})
+
 					})
 
 					When("there is a power on check annotation", func() {

--- a/pkg/vmconfig/crypto/crypto_reconciler_pre.go
+++ b/pkg/vmconfig/crypto/crypto_reconciler_pre.go
@@ -18,6 +18,7 @@ import (
 	byokv1 "github.com/vmware-tanzu/vm-operator/external/byok/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
+	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
 	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/paused"
@@ -140,7 +141,10 @@ func (r reconciler) Reconcile(
 		return err
 	}
 
-	if paused.ByAdmin(moVM) || paused.ByDevOps(vm) || vm.Status.TaskID != "" {
+	if paused.ByAdmin(moVM) ||
+		paused.ByDevOps(vm) ||
+		pkgctx.HasVMRunningTask(ctx) {
+
 		// If the VM is paused or has a task, just update the status.
 		return updateStatus(ctx, args, false)
 	}


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch fixes an issue where disks were being promoted twice due to a stale controller cache on systems with heavy load. The disk promotion reconciler depended upon the promo task reference to be written to the VM status, but upon re-entering reconcile, the status.taskRef field may be empty if the cache is not updated.

This fix removes status.taskRef and instead fetches all of a VM's recent tasks at the beginning of each reconcile.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```