### PR TITLE
🐛 Fix use of old condition constant

### DIFF
--- a/pkg/providers/vsphere/vmprovider_vm_group_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_group_test.go
@@ -101,7 +101,7 @@ func vmGroupTests() {
 				},
 				Conditions: []metav1.Condition{
 					{
-						Type:   vmopv1.VirtualMachineImageCacheConditionOVFReady,
+						Type:   vmopv1.VirtualMachineImageCacheConditionHardwareReady,
 						Status: metav1.ConditionTrue,
 					},
 				},


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch fixes an issue where the old OVFReady condition was used in the VM group placement test instead of the new HardwareReady condition. This only occurred because the PR that made the constant change (#1069) was merged without any conflicts, even though it probably should have failed due to the PR merged ahead of it (#1066) that used this condition constant that had been changed.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```