### PR TITLE
✨ update the CM's membership when the VM is in the steady-state

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -120,6 +120,10 @@ const (
 	// the VM. The VM must have a VirtualMachineSetResourcePolicy assigned.
 	ClusterModuleNameAnnotationKey string = "vsphere-cluster-module-group"
 
+	// ClusterModuleUUIDAnnotationKey is the annotation key for cluster module UUID for
+	// the VM. The VM must have a VirtualMachineSetResourcePolicy assigned.
+	ClusterModuleUUIDAnnotationKey string = "vsphere-cluster-module-group-uuid"
+
 	// SkipValidationAnnotationKey is a privileged annotation that may be used
 	// to skip the validation webhooks for a given object.
 	SkipValidationAnnotationKey string = "vmoperator.vmware.com.protected/skip-validation"

--- a/pkg/providers/vsphere/vmprovider_vm_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_test.go
@@ -3380,10 +3380,11 @@ func vmTests() {
 			})
 
 			It("Returns error with non-existence cluster module", func() {
-				vm.Annotations["vsphere-cluster-module-group"] = "bogusClusterMod"
+				clusterModName := "bogusClusterMod"
+				vm.Annotations["vsphere-cluster-module-group"] = clusterModName
 				err := createOrUpdateVM(ctx, vmProvider, vm)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("ClusterModule bogusClusterMod not found"))
+				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("ClusterModule %q not found", clusterModName)))
 			})
 		})
 

--- a/test/builder/dummies.go
+++ b/test/builder/dummies.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	imgregv1a1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha1"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -21,14 +22,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	imgregv1a1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha1"
-
-	spqv1 "github.com/vmware-tanzu/vm-operator/external/storage-policy-quota/api/v1alpha2"
-	topologyv1 "github.com/vmware-tanzu/vm-operator/external/tanzu-topology/api/v1alpha1"
-
 	vmopv1a1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
 	vmopv1common "github.com/vmware-tanzu/vm-operator/api/v1alpha4/common"
+	spqv1 "github.com/vmware-tanzu/vm-operator/external/storage-policy-quota/api/v1alpha2"
+	topologyv1 "github.com/vmware-tanzu/vm-operator/external/tanzu-topology/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 )
 
@@ -44,15 +42,13 @@ const (
 	DummyStorageClassName          = "dummy-storage-class"
 	DummyResourceQuotaName         = "dummy-resource-quota"
 	DummyZoneName                  = "dummy-zone"
-	DummyDeletedZoneName           = "dummy-zone-deleted"
 	DummyNamespaceName             = "dummy-ns"
 	DummyVMGroupName               = "dummy-vm-group"
 	DummyVMGroupPublishRequestName = "dummy-vm-group-publish-request"
 	DummyContentLibraryName        = "dummy-cl"
-	DummyImageVM0Name              = "dummy-image-vm0-name"
-	DummyImageVM1Name              = "dummy-image-vm1-name"
 	DummyVirtualMachine0Name       = "dummy-vm0"
 	DummyVirtualMachine1Name       = "dummy-vm1"
+	DummyClusterModule             = "dummy-cluster-module"
 )
 
 const (
@@ -468,7 +464,7 @@ func DummyVirtualMachineSetResourcePolicy() *vmopv1.VirtualMachineSetResourcePol
 				},
 			},
 			Folder:              "dummy-folder",
-			ClusterModuleGroups: []string{"dummy-cluster-modules"},
+			ClusterModuleGroups: []string{DummyClusterModule},
 		},
 	}
 }


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
A VM's cluster module membership is updated when the VM is switched from off to on. This change adds a new annotation to store the VM's cluster module UUID and updates the membership whenever there is a cluster module change. 

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # N/A


**Are there any special notes for your reviewer**:

N/A


**Please add a release note if necessary**:

```release-note
N/A
```