### PR TITLE
✨ Build approximate VM spec when reverting to imported snapshots

### DIFF
--- a/api/v1alpha5/virtualmachinesnapshot_types.go
+++ b/api/v1alpha5/virtualmachinesnapshot_types.go
@@ -11,6 +11,14 @@ import (
 	vmopv1common "github.com/vmware-tanzu/vm-operator/api/v1alpha5/common"
 )
 
+const (
+	// ImportedSnapshotAnnotation on a VirtualMachineSnapshot represents that a snapshot
+	// has been imported by the Mobility Service. Mobility service uses this annotation to
+	// differentiate such snapshots from external snapshots. This annotation is used to
+	// determine whether to approximate a VM spec for revert operations to such snapshots.
+	ImportedSnapshotAnnotation = GroupName + "/imported-snapshot"
+)
+
 // VirtualMachineSnapshotSpec defines the desired state of VirtualMachineSnapshot.
 type VirtualMachineSnapshotSpec struct {
 	// +optional

--- a/pkg/providers/vsphere/vmprovider_vm.go
+++ b/pkg/providers/vsphere/vmprovider_vm.go
@@ -12,6 +12,7 @@ import (
 	"math/rand"
 	"path"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"text/template"
@@ -1337,7 +1338,7 @@ func (vs *vSphereVMProvider) reconcileSnapshotRevert(
 	// Restore VM spec and metadata from the snapshot.
 	vmCtx.Logger.Info("Starting VM spec and metadata restoration from snapshot")
 
-	if err := vs.restoreVMSpecFromSnapshot(vmCtx, vcVM, snapObj); err != nil {
+	if err := vs.restoreVMSpecFromSnapshot(vmCtx, vcVM, snapCR, snapObj); err != nil {
 		vmCtx.Logger.Error(err, "Restoring VM spec and metadata from snapshot failed")
 		return true, err
 	}
@@ -1395,9 +1396,10 @@ func (vs *vSphereVMProvider) performSnapshotRevert(
 func (vs *vSphereVMProvider) restoreVMSpecFromSnapshot(
 	vmCtx pkgctx.VirtualMachineContext,
 	vcVM *object.VirtualMachine,
+	snapCR *vmopv1.VirtualMachineSnapshot,
 	snapObj *vimtypes.ManagedObjectReference) error {
 
-	vmYAML, err := vs.getVMYamlFromSnapshot(vmCtx, vcVM, snapObj)
+	vmYAML, err := vs.getVMYamlFromSnapshot(vmCtx, vcVM, snapCR, snapObj)
 	if err != nil {
 		vmCtx.Logger.Error(err, "failed to parse VM spec from snapshot")
 		return err
@@ -1451,6 +1453,7 @@ func (vs *vSphereVMProvider) restoreVMSpecFromSnapshot(
 func (vs *vSphereVMProvider) getVMYamlFromSnapshot(
 	vmCtx pkgctx.VirtualMachineContext,
 	vcVM *object.VirtualMachine,
+	snapCR *vmopv1.VirtualMachineSnapshot,
 	snap *vimtypes.ManagedObjectReference) (string, error) {
 
 	var moSnap mo.VirtualMachineSnapshot
@@ -1466,16 +1469,141 @@ func (vs *vSphereVMProvider) getVMYamlFromSnapshot(
 	ecList := object.OptionValueList(moSnap.Config.ExtraConfig)
 	raw, exists := ecList.GetString(backupapi.VMResourceYAMLExtraConfigKey)
 	if !exists {
-		vmCtx.Logger.V(4).Info("VM does not have the necessary ExtraConfig in the Snapshot",
+		// if the Snapshot has ImportedSnapshotAnnotation, then only perform an approximation of the VM spec
+		_, found := snapCR.GetAnnotations()[vmopv1.ImportedSnapshotAnnotation]
+		if !found {
+			vmCtx.Logger.Info(fmt.Sprintf("Revert is being attempted to a Snapshot which neither has ExtraConfig nor the %s annotation. This is an unsupported functionality.", vmopv1.ImportedSnapshotAnnotation))
+			return "", nil
+		}
+
+		vmCtx.Logger.Info(
+			"VM does not have the necessary ExtraConfig in the Snapshot. The snapshot is imported, approximating the spec from the VirtualMachineConfigInfo.",
 			"expectedKey", backupapi.VMResourceYAMLExtraConfigKey)
-		// TODO: VMSVC-2709
-		// Note that an imported VM could have snapshots that do not
-		// have this backup key set. In this case, we need to
-		// approximately generate the spec from the ConfigInfo.
-		// We also set the ExtraConfig so we do not have to do this
-		// when this VM is reverted to the same snapshot in future
-		// again.
-		return "", nil
+
+		// For VMs that are imported, we do not have the
+		// ExtraConfig set in the snapshot. In this case, we
+		// will approximate the spec from the VirtualMachineConfigInfo.
+		// This is a best-effort attempt to restore the VM spec
+		// and metadata from the snapshot.
+
+		vm := vmopv1.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      vmCtx.VM.Name,
+				Namespace: vmCtx.VM.Namespace,
+			},
+		}
+
+		vcClient, err := vs.getVcClient(vmCtx)
+		if err != nil {
+			vmCtx.Logger.Error(err, "error fetching vcClient")
+			return "", err
+		}
+
+		vm.Spec = vmopv1.VirtualMachineSpec{
+			InstanceUUID: moSnap.Config.InstanceUuid,
+			BiosUUID:     moSnap.Config.Uuid,
+			GuestID:      vcClient.VimClient().ServiceContent.About.InstanceUuid,
+
+			// Classless and Imageless VMs
+			ClassName: "",
+			ImageName: "",
+			Image:     nil,
+
+			// We only support VM snapshots and affinity policies are not part of VMs.
+			Affinity: nil,
+
+			// It's not possible to construct the crypto spec looking at the VM.
+			Crypto: nil,
+
+			// No PVCs for imported VMs. For day 2, users can convert disks in PVCs using just-in-time PVCs.
+			Volumes: []vmopv1.VirtualMachineVolume{},
+
+			// This is used for slot reservation starting VCF 9.0.  The reverted VM will continue to use the reserved
+			// profile but it won't be part of the spec since the plumbing from VM class to VCFA won't exist (VCFA
+			// expects slots of a class to be reserved if this is set).
+			Reserved: nil,
+
+			// The VM will continue to have the same boot options from the snapshot state.
+			// If user wants to change that, they can specify a custom boot option (boot order).
+			BootOptions: nil,
+
+			// currentSnapshot is only used to trigger a revert, so this must be empty.
+			CurrentSnapshot: nil,
+
+			// Group name is overridden to the VM's current group.
+			// We can't know (or guess) what the group the VM was when the snapshot was taken.
+			GroupName: vmCtx.VM.Spec.GroupName,
+
+			// When Snapshot is taken with Policy A and then VM is updated to use Policy B,
+			// after a revert to Snapshot with Policy A is performed, VM continues to have Policy A.
+			StorageClass: vmCtx.VM.Spec.StorageClass,
+
+			Advanced: &vmopv1.VirtualMachineAdvancedSpec{
+				ChangeBlockTracking: moSnap.Config.ChangeTrackingEnabled,
+			},
+
+			Network: &vmopv1.VirtualMachineNetworkSpec{
+				HostName: vmCtx.MoVM.Guest.HostName,
+			},
+		}
+
+		// Inferred from the power state of the snapshot
+		// It doesn't matter what the power state of the VM is at the time of revert.
+		// The VM is always reverted in the same power state as the snapshot.
+		snapshot := vmlifecycle.FindSnapshotInTree(vmCtx.MoVM.Snapshot.RootSnapshotList, snap.Value)
+		if snapshot == nil {
+			// weird situation here
+			// the snapshot being processed doesn't exist in the snapshot tree
+			// this shouldn't be happening
+			err := fmt.Errorf("snapshot %s not found in VM Snapshot Tree", snap.Value)
+			vmCtx.Logger.Error(err, "")
+			return "", err
+		}
+		// convert from vimtypes.VirtualMachinePowerState to vmopv1.VirtualMachinePowerState
+		poweredOn := snapshot.State == vimtypes.VirtualMachinePowerStatePoweredOn
+		if poweredOn {
+			vm.Spec.PowerState = vmopv1.VirtualMachinePowerStateOn
+		} else {
+			vm.Spec.PowerState = vmopv1.VirtualMachinePowerStateOff
+		}
+
+		// Number of elements in the spec.network.interfaces list must be same as number of VM's NICs from ConfigInfo
+		// Details of each interface (which network does it connect to) is ignored
+		// Networking can be fixed after revert and it is not possible to map the vSphere network to Supervisor networks.
+		devices := object.VirtualDeviceList(moSnap.Config.Hardware.Device)
+		vNICs := devices.SelectByType((*vimtypes.VirtualEthernetCard)(nil))
+		if len(vNICs) == 0 {
+			// If no vNICs are defined, then disable network
+			vm.Spec.Network.Disabled = true
+		} else {
+			interfaces := make([]vmopv1.VirtualMachineNetworkInterfaceSpec, len(vNICs))
+			for i := range vNICs {
+				interfaces[i] = vmopv1.VirtualMachineNetworkInterfaceSpec{
+					Name: fmt.Sprintf("eth%d", i),
+				}
+			}
+			vm.Spec.Network.Interfaces = interfaces
+		}
+
+		// MinHardwareVersion is set to the Current Hardware Version of the VM
+		chv, err := strconv.ParseInt(moSnap.Config.Version, 10, 32)
+		if err != nil {
+			vmCtx.Logger.V(5).Info("unable to approximate minimum hardware version", "hwVersionFromSnapshot", moSnap.Config.Version)
+		} else {
+			vm.Spec.MinHardwareVersion = int32(chv)
+		}
+
+		// TODO(future): Labels and Annotations are skipped for now as design discussions are
+		// on storing Labels and Annotations in VC are in progress
+		vm.Labels = map[string]string{}
+		vm.Annotations = map[string]string{}
+
+		vmYAML, err := yaml.Marshal(vm)
+		if err != nil {
+			return "", fmt.Errorf("failed to marshal VM into YAML %+v: %w", vm, err)
+		}
+
+		return string(vmYAML), nil
 	}
 
 	vmCtx.Logger.V(5).Info("Found backup data in snapshot config",

--- a/pkg/providers/vsphere/vmprovider_vm_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_test.go
@@ -3210,8 +3210,103 @@ func vmTests() {
 						Expect(moVM.Snapshot.CurrentSnapshot).ToNot(BeNil())
 
 						// Find the snapshot name in the tree to verify it matches
-						currentSnapName := vmlifecycle.FindSnapshotNameInTree(moVM.Snapshot.RootSnapshotList, moVM.Snapshot.CurrentSnapshot.Value)
-						Expect(currentSnapName).To(Equal(vmSnapshot.Name))
+						currentSnap := vmlifecycle.FindSnapshotInTree(moVM.Snapshot.RootSnapshotList, moVM.Snapshot.CurrentSnapshot.Value)
+						Expect(currentSnap).ToNot(BeNil())
+						Expect(currentSnap.Name).To(Equal(vmSnapshot.Name))
+					})
+				})
+
+				// Simulate an Imported Snapshot scenario by
+				//	- creating the VC VM and VM while ensuring the backup is not taken.
+				//	- creating a snapshot on VC AND THEN only creating the VMSnapshot CR so that the ExtraConfig is
+				// 	  not stamped by the controller.
+				// 	- change some bits in the VM CR and take a second snapshot. This snapshot can be taken through a
+				//	  VMSnapshot. This is needed to make sure that we are not reverting to a snapshot that the VM is
+				//    running off at the same time.
+				//	- Now, revert the VM to the first snapshot. It is expected that the spec fields would now be approximated.
+				Context("when reverting to imported snapshot", func() {
+					var secondSnapshot *vmopv1.VirtualMachineSnapshot
+
+					BeforeEach(func() {
+						pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
+							config.Features.VMImportNewNet = true
+						})
+					})
+
+					It("should successfully revert to desired snapshot and approximate the VM Spec", func() {
+						if vm.Labels == nil {
+							vm.Labels = make(map[string]string)
+						}
+						
+						vm.Labels[kubeutil.CAPVClusterRoleLabelKey] = ""
+
+						// Create VM first
+						vcVM, err := createOrUpdateAndGetVcVM(ctx, vmProvider, vm)
+						Expect(err).ToNot(HaveOccurred())
+
+						// make sure the VM doesn't have the ExtraConfig stamped
+						var moVM mo.VirtualMachine
+						Expect(vcVM.Properties(ctx, vcVM.Reference(), nil, &moVM)).To(Succeed())
+						Expect(moVM.Config.ExtraConfig).ToNot(BeNil())
+						ecMap := pkgutil.OptionValues(moVM.Config.ExtraConfig).StringMap()
+						Expect(ecMap).ToNot(HaveKey(backupapi.VMResourceYAMLExtraConfigKey))
+
+						// Create first snapshot in vCenter
+						task, err := vcVM.CreateSnapshot(ctx, vmSnapshot.Name, "first snapshot", false, false)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(task.Wait(ctx)).To(Succeed())
+
+						// Create first snapshot CR
+						// Mark the snapshot as ready so that the snapshot workflow doesn't try to create it.
+						conditions.MarkTrue(vmSnapshot, vmopv1.VirtualMachineSnapshotReadyCondition)
+						vmSnapshot.Annotations[vmopv1.ImportedSnapshotAnnotation] = ""
+						Expect(ctx.Client.Create(ctx, vmSnapshot)).To(Succeed())
+
+						// Snapshot should be owned by the VM resource.
+						o := vmopv1.VirtualMachine{}
+						Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(vm), &o)).To(Succeed())
+						Expect(controllerutil.SetOwnerReference(&o, vmSnapshot, ctx.Scheme)).To(Succeed())
+						Expect(ctx.Client.Update(ctx, vmSnapshot)).To(Succeed())
+
+						// modify the VM Spec
+						Expect(vm.Spec.PowerOffMode).To(Equal(vmopv1.VirtualMachinePowerOpModeHard))
+						vm.Spec.PowerOffMode = vmopv1.VirtualMachinePowerOpModeSoft
+						Expect(ctx.Client.Update(ctx, vm)).To(Succeed())
+
+						// Create second snapshot
+						secondSnapshot = builder.DummyVirtualMachineSnapshot("", "test-second-snap", vm.Name)
+						secondSnapshot.Namespace = nsInfo.Namespace
+
+						task, err = vcVM.CreateSnapshot(ctx, secondSnapshot.Name, "second snapshot", false, false)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(task.Wait(ctx)).To(Succeed())
+
+						// Create second snapshot CR
+						// Mark the snapshot as ready so that the snapshot workflow doesn't try to create it.
+						conditions.MarkTrue(secondSnapshot, vmopv1.VirtualMachineSnapshotReadyCondition)
+						// Snapshot should be owned by the VM resource.
+						Expect(controllerutil.SetOwnerReference(&o, vmSnapshot, ctx.Scheme)).To(Succeed())
+						Expect(controllerutil.SetOwnerReference(&o, secondSnapshot, ctx.Scheme)).To(Succeed())
+						Expect(ctx.Client.Update(ctx, vmSnapshot)).To(Succeed())
+						Expect(ctx.Client.Create(ctx, secondSnapshot)).To(Succeed())
+
+						// Set desired snapshot to first snapshot (revert from second to first)
+						vm.Spec.CurrentSnapshot = &vmopv1common.LocalObjectRef{
+							APIVersion: vmSnapshot.APIVersion,
+							Kind:       vmSnapshot.Kind,
+							Name:       vmSnapshot.Name,
+						}
+
+						err = createOrUpdateVM(ctx, vmProvider, vm)
+						Expect(err).ToNot(HaveOccurred())
+
+						// Verify VM status reflects the reverted snapshot
+						Expect(vm.Status.CurrentSnapshot).ToNot(BeNil())
+						Expect(vm.Status.CurrentSnapshot.Name).To(Equal(vmSnapshot.Name))
+
+						// Verify the revert operation reverted to the expected values
+						Expect(vm.Spec.PowerOffMode).To(Equal(vmopv1.VirtualMachinePowerOpMode("")))
+						Expect(vm.Spec.Volumes).To(BeEmpty())
 					})
 				})
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This commit introduces the ability to build an approximate VM spec when
reverting to imported snapshots. The spec is constructed based on the
snapshot's metadata and some fields from the state of the VM in VC,
allowing for a more accurate representation of the VM's state at the
time of the snapshot.

This is done so that the VM spec can reach to a state that likely defines
how the VM was configured when the Snapshot was taken.

**Which issue(s) is/are addressed by this PR?** 

NA


**Are there any special notes for your reviewer**:

## Simulated Test scenario

1. Create a VM using `VirtualMachine` CR.
2. Take a snapshot of the VM from VC.
3. Create a `VirtualMachineSnapshot` CR pointing to the snapshot created in (2)
4. Made some changes to `VirtualMachine` CR.
5. Revert to the snapshot by setting `spec.currentSnapshot` in `VirtualMachine` CR.

The `VirtualMachine` CR should now have spec fields approximated from the workflow introduced in this PR.

**Please add a release note if necessary**:

```release-note
✨ Build approximate VM spec when reverting to imported snapshots
```





