### PR TITLE
🐛 Disable fast-deploy for instance storage VMs

### DIFF
--- a/controllers/virtualmachine/virtualmachine/virtualmachine_controller.go
+++ b/controllers/virtualmachine/virtualmachine/virtualmachine_controller.go
@@ -276,6 +276,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 			}
 		}
 
+		if mode != "" {
+			if pkgcfg.FromContext(ctx).Features.InstanceStorage && vmopv1util.IsInstanceStoragePresent(vm) {
+				mode = ""
+				reason = "instance storage present"
+			}
+		}
+
 		switch strings.ToLower(mode) {
 		case pkgconst.FastDeployModeDirect, pkgconst.FastDeployModeLinked:
 			logger.V(4).Info("Using fast-deploy for this VM", "mode", mode)


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

This is just a quick temp fix to disable fast-deploy when a VM has instance storage. This depends on a implementation detail in that the "first" reconcile will add the class's instance storage volume to the VM Spec so later reconciles can detect that and once the instance storage PVCs are bound, create the VM without fast-deploy.

This will be fixed for real once we can adjust placement to support a specific, already selected host for later placements where we just need the datastores.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:



**Please add a release note if necessary**:

```release-note
Disable fast-deploy for VMs with instance storage volumes
```