### PR TITLE
🌱 Restore prior placement request/response log levels

### DIFF
--- a/pkg/providers/vsphere/placement/cluster_placement.go
+++ b/pkg/providers/vsphere/placement/cluster_placement.go
@@ -241,14 +241,14 @@ func ClusterPlaceVMForCreate(
 		placementSpec.VmPlacementSpecs[i].ConfigSpec = cs
 	}
 
-	logger.Info("PlaceVmsXCluster request", "spec", vimtypes.ToString(placementSpec))
+	logger.V(4).Info("PlaceVmsXCluster request", "spec", vimtypes.ToString(placementSpec))
 
 	results, err := object.NewRootFolder(vcClient).PlaceVmsXCluster(ctx, placementSpec)
 	if err != nil {
 		return nil, err
 	}
 
-	logger.Info("PlaceVmsXCluster response", "results", vimtypes.ToString(results))
+	logger.V(6).Info("PlaceVmsXCluster response", "results", vimtypes.ToString(results))
 
 	if len(results.Faults) != 0 {
 		var faultMgs []string


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

VKS VMs have a very big ExtraConfig payload which causes a ton of logging output. Until we sanitize the EC for placement, bump the log levels to their prior value.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note
NONE
```