### PR TITLE
🐛 Support non-friendly name for FastDeploy+vSAN

### DIFF
--- a/api/v1alpha4/virtualmachinegroup_types.go
+++ b/api/v1alpha4/virtualmachinegroup_types.go
@@ -172,6 +172,10 @@ type VirtualMachineGroupPlacementDatastoreStatus struct {
 	// DiskKey describes the device key to which this recommendation applies.
 	// When omitted, this recommendation is for the VM's home directory.
 	DiskKey *int32 `json:"diskKey,omitempty"`
+
+	// TopLevelDirectoryCreateSupported indicates whether or not the datastore
+	// uses the DatastoreNamespaceManager.
+	TopLevelDirectoryCreateSupported bool `json:"topLevelDirectoryCreateSupported,omitempty"`
 }
 
 type VirtualMachinePlacementStatus struct {

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachinegroups.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachinegroups.yaml
@@ -352,6 +352,11 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                              topLevelDirectoryCreateSupported:
+                                description: |-
+                                  TopLevelDirectoryCreateSupported indicates whether or not the datastore
+                                  uses the DatastoreNamespaceManager.
+                                type: boolean
                               url:
                                 description: URL describes the datastore URL.
                                 type: string

--- a/pkg/providers/vsphere/placement/zone_placement.go
+++ b/pkg/providers/vsphere/placement/zone_placement.go
@@ -64,6 +64,8 @@ type DatastoreResult struct {
 	// true if for a disk. DiskKey is only valid if ForDisk is true.
 	ForDisk bool
 	DiskKey int32
+
+	Capabilities vimtypes.DatastoreCapability
 }
 
 func doesVMNeedPlacement(vmCtx pkgctx.VirtualMachineContext) (res Result) {
@@ -489,6 +491,7 @@ func getDatastoreProperties(
 		ctx,
 		dsRefs,
 		[]string{
+			"capability",
 			"info.supportedVDiskFormats",
 			"info.url",
 			"name",
@@ -507,6 +510,7 @@ func getDatastoreProperties(
 				dsInfo := moDS.Info.GetDatastoreInfo()
 				ds.DiskFormats = dsInfo.SupportedVDiskFormats
 				ds.URL = dsInfo.Url
+				ds.Capabilities = moDS.Capability
 			}
 		}
 	}

--- a/pkg/providers/vsphere/vmprovider_vm.go
+++ b/pkg/providers/vsphere/vmprovider_vm.go
@@ -63,6 +63,7 @@ import (
 	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
 	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	vmopv1util "github.com/vmware-tanzu/vm-operator/pkg/util/vmopv1"
 	vmutil "github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/vm"
 	vmconfcrypto "github.com/vmware-tanzu/vm-operator/pkg/vmconfig/crypto"
@@ -1814,6 +1815,7 @@ func (vs *vSphereVMProvider) vmCreateDoPlacementByGroup(
 		result.Datastores[i].Name = ds.Name
 		result.Datastores[i].URL = ds.URL
 		result.Datastores[i].DiskFormats = ds.SupportedDiskFormats
+		result.Datastores[i].Capabilities.TopLevelDirectoryCreateSupported = ptr.To(ds.TopLevelDirectoryCreateSupported)
 	}
 
 	// InstanceStoragePlacement flag is needed to update the VM's annotations
@@ -1855,6 +1857,7 @@ func processPlacementResult(
 			createArgs.Datastores[i].Name = result.Datastores[i].Name
 			createArgs.Datastores[i].URL = result.Datastores[i].URL
 			createArgs.Datastores[i].DiskFormats = result.Datastores[i].DiskFormats
+			createArgs.Datastores[i].Capabilities = result.Datastores[i].Capabilities
 		}
 	}
 


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch updates the way VMs are provisioned on vSAN using Fast Deploy. Instead of using the VM folder's friendly name, it is first converted to the UUID path. Otherwise there is a bug in vpxd that ignores the friendly path during VM create and decides the folder does not exist, creating yet another new folder.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```