### PR TITLE
🌱 Override disk promo mode

### DIFF
--- a/config/local/vmoperator/local_env_var_patch.yaml
+++ b/config/local/vmoperator/local_env_var_patch.yaml
@@ -17,6 +17,10 @@ spec:
           value: "true"
         - name: MEM_STATS_PERIOD
           value: "10m"
+        - name: FAST_DEPLOY_MODE
+          value: ""
+        - name: PROMOTE_DISKS_MODE
+          value: ""
         - name: VSPHERE_NETWORKING
           value: "false"
         - name: FSS_WCP_INSTANCE_STORAGE

--- a/config/wcp/vmoperator/manager_env_var_patch.yaml
+++ b/config/wcp/vmoperator/manager_env_var_patch.yaml
@@ -61,6 +61,18 @@
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
+    name: FAST_DEPLOY_MODE
+    value: ""
+
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: PROMOTE_DISKS_MODE
+    value: ""
+
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
     name: FSS_PODVMONSTRETCHEDSUPERVISOR
     value: "<FSS_PODVMONSTRETCHEDSUPERVISOR>"
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -149,6 +149,9 @@ type Config struct {
 	// Defaults to "direct".
 	FastDeployMode string
 
+	// PromoteDisksMode determines the default mode for disk promotion.
+	PromoteDisksMode string
+
 	// VCCredsSecretName is the name of the secret in the pod namespace that
 	// contains the VC credentials.
 	//

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -41,6 +41,7 @@ func Default() Config {
 		AsyncCreateEnabled:           true,
 		MemStatsPeriod:               10 * time.Minute,
 		FastDeployMode:               pkgconst.FastDeployModeLinked,
+		PromoteDisksMode:             "",
 		VCCredsSecretName:            pkgconst.VCCredsSecretName,
 		CreateVMRequeueDelay:         10 * time.Second,
 		PoweredOnVMHasIPRequeueDelay: 10 * time.Second,

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -32,6 +32,7 @@ func FromEnv() Config {
 	setBool(env.AsyncCreateEnabled, &config.AsyncCreateEnabled)
 	setDuration(env.MemStatsPeriod, &config.MemStatsPeriod)
 	setString(env.FastDeployMode, &config.FastDeployMode)
+	setString(env.PromoteDisksMode, &config.PromoteDisksMode)
 	setString(env.VCCredsSecretName, &config.VCCredsSecretName)
 
 	setDuration(env.InstanceStoragePVPlacementFailedTTL, &config.InstanceStorage.PVPlacementFailedTTL)

--- a/pkg/config/env/env.go
+++ b/pkg/config/env/env.go
@@ -28,6 +28,7 @@ const (
 	AsyncSignalEnabled
 	AsyncCreateEnabled
 	FastDeployMode
+	PromoteDisksMode
 	VCCredsSecretName
 	InstanceStoragePVPlacementFailedTTL
 	InstanceStorageJitterMaxFactor
@@ -117,6 +118,8 @@ func (n VarName) String() string {
 		return "ASYNC_CREATE_ENABLED"
 	case FastDeployMode:
 		return "FAST_DEPLOY_MODE"
+	case PromoteDisksMode:
+		return "PROMOTE_DISKS_MODE"
 	case VCCredsSecretName:
 		return "VC_CREDS_SECRET_NAME"
 	case InstanceStoragePVPlacementFailedTTL:

--- a/pkg/config/env_test.go
+++ b/pkg/config/env_test.go
@@ -109,6 +109,7 @@ var _ = Describe(
 					Expect(os.Setenv("SYNC_IMAGE_REQUEUE_DELAY", "128h")).To(Succeed())
 					Expect(os.Setenv("DEPLOYMENT_NAME", "129")).To(Succeed())
 					Expect(os.Setenv("SIGUSR2_RESTART_ENABLED", "true")).To(Succeed())
+					Expect(os.Setenv("PROMOTE_DISKS_MODE", "130")).To(Succeed())
 				})
 				It("Should return a default config overridden by the environment", func() {
 					Expect(config).To(BeComparableTo(pkgcfg.Config{
@@ -163,6 +164,7 @@ var _ = Describe(
 						SyncImageRequeueDelay:        128 * time.Hour,
 						DeploymentName:               "129",
 						SIGUSR2RestartEnabled:        true,
+						PromoteDisksMode:             "130",
 					}))
 				})
 			})


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch allows the value of a VM's spec.promoDisksMode to be globally overriden via the env var PROMOTE_DISKS_MODE.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```