### PR TITLE
🌱 Exclude snapshot related disks/files when calculating VM status storage usage

### DIFF
--- a/api/v1alpha4/virtualmachine_storage_types.go
+++ b/api/v1alpha4/virtualmachine_storage_types.go
@@ -202,14 +202,16 @@ type VirtualMachineStorageStatusUsed struct {
 	// +optional
 
 	// Disks describes the total storage space used by a VirtualMachine's
-	// non-PVC disks.
+	// non-PVC disks. This does not include the any child / delta disks
+	// created for snapshots.
 	Disks *resource.Quantity `json:"disks,omitempty"`
 
 	// +optional
 
 	// Other describes the total storage space used by the VirtualMachine's
-	// non disk files, ex. the configuration file, swap space, logs, snapshots,
-	// etc.
+	// non-disk files, ex. the configuration file, swap space, logs, etc.
+	// This does not include the non-disk files created for snapshots,
+	// ex. snapshot data, list, and memory files.
 	Other *resource.Quantity `json:"other,omitempty"`
 }
 

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -9388,7 +9388,8 @@ spec:
                         - type: string
                         description: |-
                           Disks describes the total storage space used by a VirtualMachine's
-                          non-PVC disks.
+                          non-PVC disks. This does not include the any child / delta disks
+                          created for snapshots.
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       other:
@@ -9397,8 +9398,9 @@ spec:
                         - type: string
                         description: |-
                           Other describes the total storage space used by the VirtualMachine's
-                          non disk files, ex. the configuration file, swap space, logs, snapshots,
-                          etc.
+                          non-disk files, ex. the configuration file, swap space, logs, etc.
+                          This does not include the non-disk files created for snapshots,
+                          ex. snapshot data, list, and memory files.
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                     type: object

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/vmware-tanzu/vm-operator/external/tanzu-topology v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/vm-operator/pkg/backup/api v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels v0.0.0-00010101000000-000000000000
-	github.com/vmware/govmomi v0.52.0-alpha.0.0.20250722192943-7d0426427f42
+	github.com/vmware/govmomi v0.52.0-alpha.0.0.20250807230438-0eee109f1f2c
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/net v0.40.0 // indirect
 	// * https://github.com/vmware-tanzu/vm-operator/security/dependabot/24

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,8 @@ github.com/vmware-tanzu/net-operator-api v0.0.0-20240523152550-862e2c4eb0e0 h1:y
 github.com/vmware-tanzu/net-operator-api v0.0.0-20240523152550-862e2c4eb0e0/go.mod h1:w6QJGm3crIA16ZIz1FVQXD2NVeJhOgGXxW05RbVTSTo=
 github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20241112044858-9da8637c1b0d h1:z9lrzKVtNlujduv9BilzPxuge/LE2F0N1ms3TP4JZvw=
 github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20241112044858-9da8637c1b0d/go.mod h1:Q4JzNkNMvjo7pXtlB5/R3oME4Nhah7fAObWgghVmtxk=
-github.com/vmware/govmomi v0.52.0-alpha.0.0.20250722192943-7d0426427f42 h1:ogNnbx5af4hn8kRmG/n/3341Tzz0PfC+qdxXeQ0fOiw=
-github.com/vmware/govmomi v0.52.0-alpha.0.0.20250722192943-7d0426427f42/go.mod h1:ZJ5Zd2wDGRzsTRBqA1jpqtbyoe8mRok1rWiPsrL8c7k=
+github.com/vmware/govmomi v0.52.0-alpha.0.0.20250807230438-0eee109f1f2c h1:1nMVFr1CBMSNLLjsfx3QPfZ5k0R1/O29QX/A2X0w3RQ=
+github.com/vmware/govmomi v0.52.0-alpha.0.0.20250807230438-0eee109f1f2c/go.mod h1:ZJ5Zd2wDGRzsTRBqA1jpqtbyoe8mRok1rWiPsrL8c7k=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/providers/vsphere/contentlibrary/content_library_utils.go
+++ b/pkg/providers/vsphere/contentlibrary/content_library_utils.go
@@ -185,7 +185,12 @@ func UpdateVmiWithVirtualMachine(
 
 			if uuid != "" {
 				di, _ := vmdk.GetVirtualDiskInfoByUUID(
-					ctx, nil, vm, false, uuid)
+					ctx,
+					nil,   /* the client is not needed since props aren't refetched */
+					vm,    /* use props from this object */
+					false, /* do not refetch props */
+					false, /* include disks related to snapshots */
+					uuid)
 				capacity = kubeutil.BytesToResource(di.CapacityInBytes)
 				size = kubeutil.BytesToResource(di.Size)
 			}

--- a/pkg/providers/vsphere/virtualmachine/cdrom_test.go
+++ b/pkg/providers/vsphere/virtualmachine/cdrom_test.go
@@ -281,10 +281,11 @@ func cdromTests() {
 					for _, r := range result {
 						if d, ok := r.GetVirtualDeviceConfigSpec().Device.(*vimtypes.VirtualCdrom); ok {
 							if b, ok := d.Backing.(*vimtypes.VirtualCdromIsoBackingInfo); ok {
-								if b.FileName == vmiFileName {
+								switch b.FileName {
+								case vmiFileName:
 									cdromChangeVmi = r
 									unitNumVmi = d.UnitNumber
-								} else if b.FileName == cvmiFileName {
+								case cvmiFileName:
 									cdromChangeCvmi = r
 									unitNumCvmi = d.UnitNumber
 								}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**
Consume new `GetVirtualDiskInfoByUUID` in govmomi introduced by https://github.com/vmware/govmomi/pull/3832 

Now when calculating the usage for VM, it exclude those snapshot related delta disks. Since we will calculate snapshot related usage in VMSnapshot CR instead of VirtualMachine CR.

And for VMI's usage, we still include all chains. Related detail can be found here https://github.com/vmware-tanzu/vm-operator/pull/1083#discussion_r2261235151


**More Info**
Updated VM status when the VM has two snapshots
```
    volumes:
    - attached: true
      diskUUID: 6000C292-3c7a-7cbc-c945-0fb35c5a494b
      limit: 10Gi
      name: lubron-vm
      requested: 10Gi
      type: Classic
      used: "24117592"
    - attached: true
      diskUUID: 6000C299-85a3-b188-e22e-3b6c3c3993d6
      limit: 5Gi
      name: lubron-vol
      requested: 5Gi
      type: Managed
      used: "1049058"
```

VM's disk chain
<img width="981" height="856" alt="image" src="https://github.com/user-attachments/assets/77aeb354-9fec-4611-94a0-e298464b7553" />
1. The disk 2000 is the Classic disk
2. The disk 2001 is the Managed disk

Disk 2000's size correspond to size of (file15 + file16)
<img width="644" height="416" alt="image" src="https://github.com/user-attachments/assets/9b3adcb4-b876-4c8c-bb73-454d08034a02" />
24117248 + 344 == 24117592

Disk 2001's size corresponds to size of (file17 + file18)
<img width="728" height="436" alt="image" src="https://github.com/user-attachments/assets/53f90f6a-5bbe-4b41-8b23-4465c49f89e3" />
482 + 1048576 == 1049058


<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Exclude snapshot related disks/files when calculating VM status storage usage
```