### PR TITLE
🌱 Delete dir created during VM deploy

### DIFF
--- a/api/v1alpha4/virtualmachine_types.go
+++ b/api/v1alpha4/virtualmachine_types.go
@@ -1269,6 +1269,24 @@ type VirtualMachine struct {
 	Status VirtualMachineStatus `json:"status,omitempty"`
 }
 
+// SetAnnotation adds or sets an annotation on this object.
+// Please note, this function is not thread-safe.
+func (vm *VirtualMachine) SetAnnotation(k, v string) {
+	if vm.Annotations == nil {
+		vm.Annotations = map[string]string{}
+	}
+	vm.Annotations[k] = v
+}
+
+// SetLabel adds or sets a label on this object.
+// Please note, this function is not thread-safe.
+func (vm *VirtualMachine) SetLabel(k, v string) {
+	if vm.Labels == nil {
+		vm.Labels = map[string]string{}
+	}
+	vm.Labels[k] = v
+}
+
 func (vm *VirtualMachine) NamespacedName() string {
 	return vm.Namespace + "/" + vm.Name
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -146,7 +146,7 @@ type Config struct {
 	//   - the value is anything else, then fast deploy is not used to deploy
 	//     VMs.
 	//
-	// Defaults to "direct".
+	// Defaults to "linked".
 	FastDeployMode string
 
 	// VCCredsSecretName is the name of the secret in the pod namespace that

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -75,6 +75,11 @@ const (
 	// the datacenter ID and datastore ID, ex. datacenter-50,datastore-42.
 	VMICacheLocationAnnotationKey = "vmicache.vmoperator.vmware.com/location"
 
+	// VMHomeDatacenterAndDatastoreIDExtraConfigKey is applied to VMs to track
+	// the managed object IDs of the datacenter and datastore when the VM's home
+	// folder is created.
+	VMHomeDatacenterAndDatastoreIDExtraConfigKey = "vmservice.vmHomeDatacenterAndDatastoreID"
+
 	// FastDeployAnnotationKey is applied to VirtualMachine resources that want
 	// to control the mode of FastDeploy used to create the underlying VM.
 	// Please note, this annotation only has any effect if the FastDeploy FSS is

--- a/pkg/providers/vsphere/vmprovider_vm_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_test.go
@@ -1742,6 +1742,7 @@ func vmTests() {
 							Expect(enc.Encode(configSpec)).To(Succeed())
 
 							vmClass.Spec.ConfigSpec = w.Bytes()
+							vm.Spec.PowerState = vmopv1.VirtualMachinePowerStateOff
 						})
 
 						JustBeforeEach(func() {
@@ -1779,24 +1780,59 @@ func vmTests() {
 								true)).To(Succeed())
 						})
 
-						It("should succeed", func() {
-							vcVM, err := createOrUpdateAndGetVcVM(ctx, vmProvider, vm)
-							Expect(err).ToNot(HaveOccurred())
+						assertSuccess := func(
+							expectedToHaveNVRAM bool,
+							expectKeepDisksKey bool) {
 
+							vcVM, err := createOrUpdateAndGetVcVM(ctx, vmProvider, vm)
+							ExpectWithOffset(1, err).ToNot(HaveOccurred())
 							var moVM mo.VirtualMachine
-							Expect(vcVM.Properties(
+							ExpectWithOffset(1, vcVM.Properties(
 								ctx,
 								vcVM.Reference(),
 								[]string{"config.extraConfig"},
 								&moVM)).To(Succeed())
 							ec := object.OptionValueList(moVM.Config.ExtraConfig)
 							v1, _ := ec.GetString("hello")
-							Expect(v1).To(Equal("world"))
+							ExpectWithOffset(1, v1).To(Equal("world"))
 							v2, _ := ec.GetString("fu")
-							Expect(v2).To(Equal("bar"))
-							v3, _ := ec.GetString(pkgconst.VMProvKeepDisksExtraConfigKey)
-							Expect(v3).To(Equal(path.Base(ctx.ContentLibraryItemDiskPath)))
+							ExpectWithOffset(1, v2).To(Equal("bar"))
+
+							if expectKeepDisksKey {
+								v, _ := ec.GetString(pkgconst.VMProvKeepDisksExtraConfigKey)
+								ExpectWithOffset(1, v).To(Equal(path.Base(ctx.ContentLibraryItemDiskPath)))
+							} else {
+								v, ok := ec.GetString(pkgconst.VMProvKeepDisksExtraConfigKey)
+								ExpectWithOffset(1, ok).To(BeFalse(), v)
+							}
+
+							nvramFile, hasNVRAM := ec.GetString("nvram")
+							ExpectWithOffset(1, hasNVRAM).To(Equal(expectedToHaveNVRAM), nvramFile)
+						}
+
+						When("mode is direct", func() {
+							JustBeforeEach(func() {
+								vm.SetAnnotation(
+									pkgconst.FastDeployAnnotationKey,
+									pkgconst.FastDeployModeDirect)
+							})
+
+							It("should succeed", func() {
+								assertSuccess(true, false)
+							})
 						})
+
+						When("mode is linked", func() {
+							JustBeforeEach(func() {
+								vm.SetAnnotation(
+									pkgconst.FastDeployAnnotationKey,
+									pkgconst.FastDeployModeLinked)
+							})
+							It("should succeed", func() {
+								assertSuccess(true, true)
+							})
+						})
+
 					})
 				})
 

--- a/pkg/vmconfig/diskpromo/diskpromo_reconciler.go
+++ b/pkg/vmconfig/diskpromo/diskpromo_reconciler.go
@@ -141,11 +141,15 @@ func (r reconciler) Reconcile(
 		}
 	}
 
-	logger = logger.WithValues("mode", vm.Spec.PromoteDisksMode)
+	promoMode := vm.Spec.PromoteDisksMode
+	if promoMode == "" {
+		promoMode = vmopv1.VirtualMachinePromoteDisksModeOnline
+	}
+	logger = logger.WithValues("mode", promoMode)
 
 	logger.V(4).Info("Finding candidates for disk promotion")
 
-	if vm.Spec.PromoteDisksMode == vmopv1.VirtualMachinePromoteDisksModeDisabled {
+	if promoMode == vmopv1.VirtualMachinePromoteDisksModeDisabled {
 		// Skip VMs that do not request promotion.
 		pkgcond.Delete(vm, vmopv1.VirtualMachineDiskPromotionSynced)
 		return nil
@@ -221,7 +225,7 @@ func (r reconciler) Reconcile(
 		return nil
 	}
 
-	switch vm.Spec.PromoteDisksMode {
+	switch promoMode {
 	case vmopv1.VirtualMachinePromoteDisksModeOnline:
 		if moVM.Snapshot != nil && moVM.Snapshot.CurrentSnapshot != nil {
 			// Skip VMs that have snapshots.


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch updates the Fast Deploy workflow to track the path of the directory created during VM provisioning and to delete that directory when a VM is being deleted. If the directory no longer exists, then no error will occur.

This patch is required to mitigate a bug in vpxd on main related to vSAN datastores. Currently they do not support creating VMs using an explicit path.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

Replaces #1081.


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```