### PR TITLE
🐛 Log the VM's recent tasks on reconcile / ignore certain tasks

### DIFF
--- a/pkg/providers/vsphere/session/session_vm_update.go
+++ b/pkg/providers/vsphere/session/session_vm_update.go
@@ -85,7 +85,7 @@ func (s *Session) UpdateVirtualMachine(
 		vmCtx.Logger.Info("Reconciling config for suspended vm")
 		updateErr = reconcileSuspendedVM(vmCtx, s.K8sClient, vcVM)
 
-	case pkgctx.HasVMRunningTask(vmCtx):
+	case pkgctx.HasVMRunningTask(vmCtx, false):
 		vmCtx.Logger.Info("Reconciling config for VM with running task")
 		updateErr = reconcileVMWithTask(vmCtx, s.K8sClient, vcVM)
 

--- a/pkg/vmconfig/crypto/crypto_reconciler_pre.go
+++ b/pkg/vmconfig/crypto/crypto_reconciler_pre.go
@@ -143,7 +143,7 @@ func (r reconciler) Reconcile(
 
 	if paused.ByAdmin(moVM) ||
 		paused.ByDevOps(vm) ||
-		pkgctx.HasVMRunningTask(ctx) {
+		pkgctx.HasVMRunningTask(ctx, false) {
 
 		// If the VM is paused or has a task, just update the status.
 		return updateStatus(ctx, args, false)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch adds logging to record the VM's recent tasks when a VM is reconciled. The log level depends on the task's state. If running or in error, the standard level, 2, is used. Otherwise the task is logged at level 4.

This patch also updates `HasVMRunningTask` to ignore certain, well-known tasks that should not prevent VM Op from reconciling desired state.



**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```