### PR TITLE
🌱 Only create SPU for snapshot when its feature gate is enabled

### DIFF
--- a/controllers/storagepolicyquota/storagepolicyquota_controller.go
+++ b/controllers/storagepolicyquota/storagepolicyquota_controller.go
@@ -107,8 +107,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 		return ctrl.Result{}, nil
 	}
 
-	if err := r.ReconcileNormal(ctx, &obj); err != nil {
-		pkgutil.FromContextOrDefault(ctx).Error(err, "Failed to ReconcileNormal StoragePolicyQuota")
+	logger := pkgutil.FromContextOrDefault(ctx)
+
+	if err := r.ReconcileNormal(ctx, logger, &obj); err != nil {
+		logger.Error(err, "Failed to ReconcileNormal StoragePolicyQuota")
 		return ctrl.Result{}, err
 	}
 
@@ -117,6 +119,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 
 func (r *Reconciler) ReconcileNormal(
 	ctx context.Context,
+	logger logr.Logger,
 	spq *spqv1.StoragePolicyQuota) error {
 
 	caBundle, err := spqutil.GetWebhookCABundle(ctx, r.Client)
@@ -137,26 +140,35 @@ func (r *Reconciler) ReconcileNormal(
 	// - VirtualMachine
 	// - VirtualMachineSnapshot
 	resourceKinds := []struct {
-		Kind     string
-		NameFunc func(string) string
+		kind     string
+		nameFunc func(string) string
+		enabled  bool // Only create StoragePolicyUsage for enabled resource kinds
 	}{
 		{
-			Kind:     spqutil.VirtualMachineKind,
-			NameFunc: spqutil.StoragePolicyUsageNameForVM,
+			kind:     spqutil.VirtualMachineKind,
+			nameFunc: spqutil.StoragePolicyUsageNameForVM,
+			enabled:  true,
 		},
 		{
-			Kind:     spqutil.VirtualMachineSnapshotKind,
-			NameFunc: spqutil.StoragePolicyUsageNameForVMSnapshot,
+			kind:     spqutil.VirtualMachineSnapshotKind,
+			nameFunc: spqutil.StoragePolicyUsageNameForVMSnapshot,
+			enabled:  pkgcfg.FromContext(ctx).Features.VMSnapshots,
 		},
 	}
 
 	var errs []error
 	for i := range objs {
 		for _, resourceKind := range resourceKinds {
+			if !resourceKind.enabled {
+				logger.V(4).Info("Skip creating storage policy usage for resource kind",
+					"kind", resourceKind.kind)
+				continue
+			}
+
 			spu := spqv1.StoragePolicyUsage{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: spq.Namespace,
-					Name:      resourceKind.NameFunc(objs[i].Name),
+					Name:      resourceKind.nameFunc(objs[i].Name),
 				},
 			}
 
@@ -170,7 +182,7 @@ func (r *Reconciler) ReconcileNormal(
 				spu.Spec.StorageClassName = objs[i].Name
 				spu.Spec.StoragePolicyId = spq.Spec.StoragePolicyId
 				spu.Spec.ResourceAPIgroup = ptr.To(vmopv1.GroupVersion.Group)
-				spu.Spec.ResourceKind = resourceKind.Kind
+				spu.Spec.ResourceKind = resourceKind.kind
 				spu.Spec.ResourceExtensionName = spqutil.StoragePolicyQuotaExtensionName
 				spu.Spec.ResourceExtensionNamespace = r.PodNamespace
 				spu.Spec.CABundle = caBundle

--- a/controllers/storagepolicyquota/storagepolicyquota_controller_intg_test.go
+++ b/controllers/storagepolicyquota/storagepolicyquota_controller_intg_test.go
@@ -112,48 +112,40 @@ func intgTestsReconcile() {
 				})).To(Succeed())
 		})
 
-		It("should result in the creation of StoragePolicyUsage resources for VirtualMachine and VirtualMachineSnapshot", func() {
-			resourceKinds := []struct {
-				Kind     string
-				NameFunc func(string) string
-			}{
-				{
-					Kind:     "VirtualMachine",
-					NameFunc: spqutil.StoragePolicyUsageNameForVM,
-				},
-				{
-					Kind:     "VirtualMachineSnapshot",
-					NameFunc: spqutil.StoragePolicyUsageNameForVMSnapshot,
-				},
-			}
+		It("should only create StoragePolicyUsage resources for VirtualMachine", func() {
 			Eventually(func(g Gomega) {
-				for _, resourceKind := range resourceKinds {
-					var obj spqv1.StoragePolicyUsage
-					dstKey := client.ObjectKey{
-						Namespace: ctx.Namespace,
-						Name:      resourceKind.NameFunc(storageClassName),
-					}
-					g.Expect(ctx.Client.Get(ctx, dstKey, &obj)).To(Succeed())
-
-					g.Expect(obj.OwnerReferences).To(Equal([]metav1.OwnerReference{
-						{
-							APIVersion:         spqv1.GroupVersion.String(),
-							Kind:               spqutil.StoragePolicyQuotaKind,
-							Name:               storageQuotaName,
-							UID:                storageQuotaUID,
-							Controller:         ptr.To(true),
-							BlockOwnerDeletion: ptr.To(true),
-						},
-					}))
-					g.Expect(obj.Spec.StoragePolicyId).To(Equal(storagePolicyID))
-					g.Expect(obj.Spec.StorageClassName).To(Equal(storageClassName))
-					g.Expect(obj.Spec.ResourceAPIgroup).To(Equal(ptr.To(vmopv1.GroupVersion.Group)))
-					g.Expect(obj.Spec.ResourceKind).To(Equal(resourceKind.Kind))
-					g.Expect(obj.Spec.ResourceExtensionName).To(Equal(spqutil.StoragePolicyQuotaExtensionName))
-					g.Expect(obj.Spec.ResourceExtensionNamespace).To(Equal(ctx.PodNamespace))
-					g.Expect(obj.Spec.CABundle).To(Equal([]byte("fake-ca-bundle")))
+				var obj spqv1.StoragePolicyUsage
+				dstKey := client.ObjectKey{
+					Namespace: ctx.Namespace,
+					Name:      spqutil.StoragePolicyUsageNameForVM(storageClassName),
 				}
+				g.Expect(ctx.Client.Get(ctx, dstKey, &obj)).To(Succeed())
+
+				g.Expect(obj.OwnerReferences).To(Equal([]metav1.OwnerReference{
+					{
+						APIVersion:         spqv1.GroupVersion.String(),
+						Kind:               spqutil.StoragePolicyQuotaKind,
+						Name:               storageQuotaName,
+						UID:                storageQuotaUID,
+						Controller:         ptr.To(true),
+						BlockOwnerDeletion: ptr.To(true),
+					},
+				}))
+				g.Expect(obj.Spec.StoragePolicyId).To(Equal(storagePolicyID))
+				g.Expect(obj.Spec.StorageClassName).To(Equal(storageClassName))
+				g.Expect(obj.Spec.ResourceAPIgroup).To(Equal(ptr.To(vmopv1.GroupVersion.Group)))
+				g.Expect(obj.Spec.ResourceKind).To(Equal(spqutil.VirtualMachineKind))
+				g.Expect(obj.Spec.ResourceExtensionName).To(Equal(spqutil.StoragePolicyQuotaExtensionName))
+				g.Expect(obj.Spec.ResourceExtensionNamespace).To(Equal(ctx.PodNamespace))
+				g.Expect(obj.Spec.CABundle).To(Equal([]byte("fake-ca-bundle")))
 			}).Should(Succeed())
+
+			var obj spqv1.StoragePolicyUsage
+			dstKey := client.ObjectKey{
+				Namespace: ctx.Namespace,
+				Name:      spqutil.StoragePolicyUsageNameForVMSnapshot(storageClassName),
+			}
+			Expect(ctx.Client.Get(ctx, dstKey, &obj)).NotTo(Succeed())
 		})
 	})
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**
Any resource related to VMSnapshot should be created only if its feature gate is enabled.

**Are there any special notes for your reviewer**:

Verified in real env, by default
```
I0808 05:26:24.886316       1 storagepolicyquota_controller.go:160] "Skip creating storage policy usage for resource kind" logger="controllers.StoragePolicyQuota" kind="VirtualMachineSnapshot"
```
Once the feature gate is enabled, SPU is created
```
I0808 05:49:30.072534       1 capabilties.go:172] "Updated features from capabilities" logger="setup" dryRun=false diff="TKGMultipleCL=true,VMSnapshots=true,WorkloadDomainIsolation=true"

 k get storagepolicyusage -n lubron-test wcpglobal-storage-profile-vmsnapshot-usage
NAME                                         AGE
wcpglobal-storage-profile-vmsnapshot-usage   25m
```


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
None
```