### PR TITLE
🌱(xport 9.0.1) Only create SPU for snapshot when its feature gate is enabled (#1086)

### DIFF
--- a/controllers/storagepolicyquota/storagepolicyquota_controller_unit_test.go
+++ b/controllers/storagepolicyquota/storagepolicyquota_controller_unit_test.go
@@ -160,18 +160,31 @@ func unitTestsReconcile() {
 				resourceKinds := []struct {
 					Kind     string
 					NameFunc func(string) string
+					Enabled  bool
 				}{
 					{
 						Kind:     "VirtualMachine",
 						NameFunc: spqutil.StoragePolicyUsageNameForVM,
+						Enabled:  true,
 					},
 					{
 						Kind:     "VirtualMachineSnapshot",
 						NameFunc: spqutil.StoragePolicyUsageNameForVMSnapshot,
+						Enabled:  pkgcfg.FromContext(ctx).Features.VMSnapshots,
 					},
 				}
 				for _, resourceKind := range resourceKinds {
 					var obj spqv1.StoragePolicyUsage
+					if !resourceKind.Enabled {
+						ExpectWithOffset(1, ctx.Client.Get(
+							ctx,
+							types.NamespacedName{
+								Namespace: namespace,
+								Name:      resourceKind.NameFunc(storageClassName),
+							},
+							&obj)).NotTo(Succeed())
+						continue
+					}
 					ExpectWithOffset(1, ctx.Client.Get(
 						ctx,
 						types.NamespacedName{
@@ -189,11 +202,22 @@ func unitTestsReconcile() {
 				}
 			}
 
-			When("a StoragePolicyUsage resource does not exist", func() {
-				It("creates the resource", func() {
+			When("StoragePolicyUsage resources do not exist", func() {
+				It("creates resource for VirtualMachine by default", func() {
 					assertStoragePolicyUsage(err)
 				})
+				When("VMSnapshot feature flag is enabled", func() {
+					BeforeEach(func() {
+						pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+							config.Features.VMSnapshots = true
+						})
+					})
+					It("creates resources for VirtualMachine and VirtualMachineSnapshot", func() {
+						assertStoragePolicyUsage(err)
+					})
+				})
 			})
+
 			When("a StoragePolicyUsage resource does exist", func() {
 				var dst *spqv1.StoragePolicyUsage
 
@@ -291,5 +315,4 @@ func unitTestsReconcile() {
 			})
 		})
 	})
-
 }


### PR DESCRIPTION
…#1086)

Any resource related to VMSnapshot should be created only if its feature gate is enabled.

**What does this PR do, and why is it needed?**

Cross port to 9.0.1 since this commit is already in https://github.com/vmware-tanzu/vm-operator/pull/1046

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
None
```