### PR TITLE
🌱 Remove VirtualMachineGroupPublishRequestStatus source and target fields

### DIFF
--- a/api/v1alpha4/virtualmachinegroup_publishrequest_types.go
+++ b/api/v1alpha4/virtualmachinegroup_publishrequest_types.go
@@ -83,16 +83,6 @@ type VirtualMachineGroupPublishRequestSpec struct {
 type VirtualMachineGroupPublishRequestStatus struct {
 	// +optional
 
-	// Source is the name of the published VirtualMachineGroup.
-	Source string `json:"source,omitempty"`
-
-	// +optional
-
-	// Target is the name of the ContentLibrary to which the group is published.
-	Target string `json:"target,omitempty"`
-
-	// +optional
-
 	// CompletionTime represents when the request was completed. It is not
 	// guaranteed to be set in happens-before order across separate operations.
 	// It is represented in RFC3339 form and is in UTC.

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachinegrouppublishrequests.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachinegrouppublishrequests.yaml
@@ -263,9 +263,6 @@ spec:
                 x-kubernetes-list-map-keys:
                 - source
                 x-kubernetes-list-type: map
-              source:
-                description: Source is the name of the published VirtualMachineGroup.
-                type: string
               startTime:
                 description: |-
                   StartTime represents when the request was acknowledged by the
@@ -276,10 +273,6 @@ spec:
                   Please note that the group will not be published until the group's Ready
                   condition is true.
                 format: date-time
-                type: string
-              target:
-                description: Target is the name of the ContentLibrary to which the
-                  group is published.
                 type: string
             type: object
         type: object


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This PR removes VirtualMachineGroupPublishRequestStatus source and target fields. Those fields are no longer needed once #1091 is merged. spec.source and spec.target will be the source of truth for which source VM group and target content library is used for a VM group publish request. 


Fixes # N/A


**Are there any special notes for your reviewer**:

N/A


**Please add a release note if necessary**:

```release-note
None
```