### PR TITLE
✨ Add Snapshot quota webhoook extension

### DIFF
--- a/config/webhook/storage_quota_webhook_configuration.yaml
+++ b/config/webhook/storage_quota_webhook_configuration.yaml
@@ -56,3 +56,23 @@ webhooks:
       || (has(oldObject.spec.advanced) && has(oldObject.spec.advanced.bootDiskCapacity)
       && object.spec.advanced.bootDiskCapacity != oldObject.spec.advanced.bootDiskCapacity))
     name: boot-disk-change
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: storage-quota-webhook-service
+      namespace: kube-system
+      path: /validate-storage-quota
+  failurePolicy: Fail
+  name: quota-create.validating.virtualmachinesnapshot.v1alpha5.vmoperator.vmware.com
+  rules:
+  - apiGroups:
+    - vmoperator.vmware.com
+    apiVersions:
+    - v1alpha5
+    operations:
+    - CREATE
+    resources:
+    - virtualmachinesnapshots
+  sideEffects: None

--- a/controllers/infra/capability/configmap/configmap_capability_controller.go
+++ b/controllers/infra/capability/configmap/configmap_capability_controller.go
@@ -132,7 +132,7 @@ func (r *Reconciler) Reconcile(
 			r.Client,
 			fmt.Sprintf("capabilities have changed: %s", diff)); err != nil {
 
-			r.Logger.Error(err, "Failed to exit due to capability change")
+			logger.Error(err, "Failed to exit due to capability change")
 			return ctrl.Result{}, err
 		}
 	}

--- a/controllers/infra/capability/crd/crd_capability_controller.go
+++ b/controllers/infra/capability/crd/crd_capability_controller.go
@@ -106,7 +106,7 @@ func (r *Reconciler) Reconcile(
 			r.Client,
 			fmt.Sprintf("capabilities have changed: %s", diff)); err != nil {
 
-			r.Logger.Error(err, "Failed to exit due to capability change")
+			logger.Error(err, "Failed to exit due to capability change")
 			return ctrl.Result{}, err
 		}
 	}

--- a/controllers/storagepolicyquota/storagepolicyquota_controller.go
+++ b/controllers/storagepolicyquota/storagepolicyquota_controller.go
@@ -140,19 +140,22 @@ func (r *Reconciler) ReconcileNormal(
 	// - VirtualMachine
 	// - VirtualMachineSnapshot
 	resourceKinds := []struct {
-		kind     string
-		nameFunc func(string) string
-		enabled  bool // Only create StoragePolicyUsage for enabled resource kinds
+		kind               string
+		nameFunc           func(string) string
+		quotaExtensionName string
+		enabled            bool // Only create StoragePolicyUsage for enabled resource kinds
 	}{
 		{
-			kind:     spqutil.VirtualMachineKind,
-			nameFunc: spqutil.StoragePolicyUsageNameForVM,
-			enabled:  true,
+			kind:               spqutil.VirtualMachineKind,
+			nameFunc:           spqutil.StoragePolicyUsageNameForVM,
+			quotaExtensionName: spqutil.StoragePolicyQuotaVMExtensionName,
+			enabled:            true,
 		},
 		{
-			kind:     spqutil.VirtualMachineSnapshotKind,
-			nameFunc: spqutil.StoragePolicyUsageNameForVMSnapshot,
-			enabled:  pkgcfg.FromContext(ctx).Features.VMSnapshots,
+			kind:               spqutil.VirtualMachineSnapshotKind,
+			nameFunc:           spqutil.StoragePolicyUsageNameForVMSnapshot,
+			quotaExtensionName: spqutil.StoragePolicyQuotaVMSnapshotExtensionName,
+			enabled:            pkgcfg.FromContext(ctx).Features.VMSnapshots,
 		},
 	}
 
@@ -183,7 +186,7 @@ func (r *Reconciler) ReconcileNormal(
 				spu.Spec.StoragePolicyId = spq.Spec.StoragePolicyId
 				spu.Spec.ResourceAPIgroup = ptr.To(vmopv1.GroupVersion.Group)
 				spu.Spec.ResourceKind = resourceKind.kind
-				spu.Spec.ResourceExtensionName = spqutil.StoragePolicyQuotaExtensionName
+				spu.Spec.ResourceExtensionName = resourceKind.quotaExtensionName
 				spu.Spec.ResourceExtensionNamespace = r.PodNamespace
 				spu.Spec.CABundle = caBundle
 

--- a/controllers/storagepolicyquota/storagepolicyquota_controller_intg_test.go
+++ b/controllers/storagepolicyquota/storagepolicyquota_controller_intg_test.go
@@ -135,7 +135,7 @@ func intgTestsReconcile() {
 				g.Expect(obj.Spec.StorageClassName).To(Equal(storageClassName))
 				g.Expect(obj.Spec.ResourceAPIgroup).To(Equal(ptr.To(vmopv1.GroupVersion.Group)))
 				g.Expect(obj.Spec.ResourceKind).To(Equal(spqutil.VirtualMachineKind))
-				g.Expect(obj.Spec.ResourceExtensionName).To(Equal(spqutil.StoragePolicyQuotaExtensionName))
+				g.Expect(obj.Spec.ResourceExtensionName).To(Equal(spqutil.StoragePolicyQuotaVMExtensionName))
 				g.Expect(obj.Spec.ResourceExtensionNamespace).To(Equal(ctx.PodNamespace))
 				g.Expect(obj.Spec.CABundle).To(Equal([]byte("fake-ca-bundle")))
 			}).Should(Succeed())

--- a/controllers/virtualmachine/storagepolicyusage/storagepolicyusage_controller_intg_test.go
+++ b/controllers/virtualmachine/storagepolicyusage/storagepolicyusage_controller_intg_test.go
@@ -99,7 +99,7 @@ func intgTestsReconcile() {
 			Expect(ctx.Client.Status().Update(ctx, &obj)).To(Succeed())
 		})
 
-		By("create StoragePolicyUsage", func() {
+		By("create StoragePolicyUsage for VM", func() {
 			Expect(ctx.Client.Create(ctx, &spqv1.StoragePolicyUsage{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: ctx.Namespace,
@@ -109,8 +109,8 @@ func intgTestsReconcile() {
 					StoragePolicyId:       storagePolicyID,
 					StorageClassName:      storageClassName,
 					ResourceAPIgroup:      ptr.To(vmopv1.GroupVersion.Group),
-					ResourceKind:          spqutil.VirtualMachineSnapshotKind,
-					ResourceExtensionName: spqutil.StoragePolicyQuotaExtensionName,
+					ResourceKind:          spqutil.VirtualMachineKind,
+					ResourceExtensionName: spqutil.StoragePolicyQuotaVMExtensionName,
 				},
 			})).To(Succeed())
 		})
@@ -126,7 +126,7 @@ func intgTestsReconcile() {
 					StorageClassName:      storageClassName,
 					ResourceAPIgroup:      ptr.To(vmopv1.GroupVersion.Group),
 					ResourceKind:          spqutil.VirtualMachineSnapshotKind,
-					ResourceExtensionName: spqutil.StoragePolicyQuotaExtensionName,
+					ResourceExtensionName: spqutil.StoragePolicyQuotaVMSnapshotExtensionName,
 				},
 			})).To(Succeed())
 		})

--- a/controllers/virtualmachinesnapshot/virtualmachinesnapshot_controller.go
+++ b/controllers/virtualmachinesnapshot/virtualmachinesnapshot_controller.go
@@ -204,14 +204,15 @@ func (r *Reconciler) ReconcileNormal(ctx *pkgctx.VirtualMachineSnapshotContext) 
 			return ctrl.Result{}, fmt.Errorf("failed to calculate requested capacity for snapshot: %w", err)
 		}
 		vmSnapshot.Status.Storage.Requested = requested
-		ctx.Logger.V(5).Info("Updated vmSnapshot requested capacity", "requested", vmSnapshot.Status.Storage.Requested)
+		ctx.Logger.V(5).Info("Updated vmSnapshot requested capacity",
+			"requested", vmSnapshot.Status.Storage.Requested)
 		// Enqueue the storage classes to sync corresponding SPU.
 		for _, requested := range vmSnapshot.Status.Storage.Requested {
 			ctx.StorageClassesToSync.Insert(requested.StorageClass)
 		}
 	}
 
-	ctx.Logger.V(4).Info("Updating snapshot's status used capacity")
+	ctx.Logger.V(5).Info("Updating snapshot's status used capacity")
 	size, err := r.VMProvider.GetSnapshotSize(ctx, vmSnapshot.Name, vm)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get snapshot size: %w", err)
@@ -253,7 +254,8 @@ func (r *Reconciler) ReconcileDelete(ctx *pkgctx.VirtualMachineSnapshotContext) 
 	objKey := client.ObjectKey{Name: vmSnapshot.Spec.VMRef.Name, Namespace: vmSnapshot.Namespace}
 	if err := r.Get(ctx, objKey, vm); err != nil {
 		if apierrors.IsNotFound(err) {
-			ctx.Logger.V(4).Info("VirtualMachine not found, assuming the snapshot is deleted along with moVM, remove finalizer")
+			ctx.Logger.V(5).Info("VirtualMachine not found, assuming the " +
+				"snapshot is deleted along with moVM, remove finalizer")
 			controllerutil.RemoveFinalizer(vmSnapshot, Finalizer)
 			// We don't sync SPU since we don't know which StorageClass of the VM.
 			return nil
@@ -279,7 +281,8 @@ func (r *Reconciler) ReconcileDelete(ctx *pkgctx.VirtualMachineSnapshotContext) 
 		return fmt.Errorf("failed to delete snapshot: %w", err)
 	}
 	if vmNotFound {
-		ctx.Logger.V(4).Info("VirtualMachine not found, assuming the snapshot is deleted along with moVM, remove finalizer")
+		ctx.Logger.V(5).Info("VirtualMachine not found, assuming the" +
+			" snapshot is deleted along with moVM, remove finalizer")
 		controllerutil.RemoveFinalizer(vmSnapshot, Finalizer)
 		return nil
 	}

--- a/pkg/util/kube/spq/spq.go
+++ b/pkg/util/kube/spq/spq.go
@@ -28,9 +28,22 @@ const (
 	// StoragePolicyUsageKind is the name of the StoragePolicyUsage kind.
 	StoragePolicyUsageKind = "StoragePolicyUsage"
 
-	// StoragePolicyQuotaExtensionName is the name of the storage policy
-	// extension service provided by VM Service.
-	StoragePolicyQuotaExtensionName = "vmware-system-vmop-webhook-service"
+	// StoragePolicyQuotaVMExtensionName is the name of the storage policy
+	// extension service provided by VM Service for VirtualMachines.
+	// *Note*:
+	// This is immutable for backward compatibility, so we can't add
+	// the vm prefix.
+	StoragePolicyQuotaVMExtensionName = "vmware-system-vmop-webhook-service"
+
+	// StoragePolicyQuotaVMSnapshotExtensionName is the name of the storage policy
+	// extension service provided by VM Service for VMSnapshots.
+	// *Note*:
+	// We need to use distinct name for each SPU even though their resourceKind differ.
+	// This is due to the limitation of quota webhook.
+	// Storage quota framework uses the extension name from the webhook service
+	// (and not resource kind) to consolidate all the SPUs for the StoragePolicyQuota
+	// for a namespace.  Therefore, each extension must have a different name.
+	StoragePolicyQuotaVMSnapshotExtensionName = "snapshot-vmware-system-vmop-webhook-service"
 
 	// ValidatingWebhookConfigName is the name of the ValidatingWebhookConfiguration
 	// containing correct CA Bundle used by StoragePolicyUsage.

--- a/pkg/util/kube/vmsnapshot.go
+++ b/pkg/util/kube/vmsnapshot.go
@@ -51,7 +51,7 @@ func CalculateReservedForSnapshotPerStorageClass(
 			requestedMap[vm.Spec.StorageClass] = resource.NewQuantity(0, resource.BinarySI)
 		}
 
-		logger.V(5).Info("adding memory size to the total reserved capacity", "memory", vmClass.Spec.Hardware.Memory, "storageClass", vm.Spec.StorageClass)
+		logger.V(4).Info("adding memory size to the total reserved capacity", "memory", vmClass.Spec.Hardware.Memory, "storageClass", vm.Spec.StorageClass)
 		requestedMap[vm.Spec.StorageClass].Add(vmClass.Spec.Hardware.Memory)
 	}
 
@@ -75,7 +75,7 @@ func CalculateReservedForSnapshotPerStorageClass(
 				requestedMap[vm.Spec.StorageClass] = resource.NewQuantity(0, resource.BinarySI)
 			}
 
-			logger.V(5).Info("adding disk size to the total reserved capacity", "disk", volume.Name,
+			logger.V(4).Info("adding disk size to the total reserved capacity", "disk", volume.Name,
 				"storageClass", vm.Spec.StorageClass, "requested", volume.Requested)
 			requestedMap[vm.Spec.StorageClass].Add(*volume.Requested)
 		case vmopv1.VirtualMachineStorageDiskTypeManaged:
@@ -86,7 +86,7 @@ func CalculateReservedForSnapshotPerStorageClass(
 			pvcSpec, ok := volumePVCMap[volume.Name]
 			if !ok {
 				// TODO (lubron): If if this case possible?
-				logger.V(5).Info("skipping disk because corresponding pvc is not found in the vm.spec.volumes", "volume", volume.Name)
+				logger.V(4).Info("skipping disk because corresponding pvc is not found in the vm.spec.volumes", "volume", volume.Name)
 				continue
 			}
 
@@ -98,7 +98,7 @@ func CalculateReservedForSnapshotPerStorageClass(
 					requestedMap[pvcSpec.InstanceVolumeClaim.StorageClass] = resource.NewQuantity(0, resource.BinarySI)
 				}
 
-				logger.V(5).Info("adding disk size to the total reserved capacity", "disk", volume.Name,
+				logger.V(4).Info("adding disk size to the total reserved capacity", "disk", volume.Name,
 					"storageClass", pvcSpec.InstanceVolumeClaim.StorageClass, "requested", pvcSpec.InstanceVolumeClaim.Size)
 				requestedMap[pvcSpec.InstanceVolumeClaim.StorageClass].Add(pvcSpec.InstanceVolumeClaim.Size)
 				continue
@@ -123,7 +123,7 @@ func CalculateReservedForSnapshotPerStorageClass(
 
 			volumeRequested := pvc.Spec.Resources.Requests.Storage()
 
-			logger.V(5).Info("adding disk size to the total reserved capacity", "disk", volume.Name,
+			logger.V(4).Info("adding disk size to the total reserved capacity", "disk", volume.Name,
 				"storageClass", *pvc.Spec.StorageClassName, "requested", volumeRequested)
 			requestedMap[*pvc.Spec.StorageClassName].Add(*volumeRequested)
 		default:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**
When a snapshot is created, storage quota webhook queries snapshot quota webhook extension for reserved capacity.
1. Add and register handler for vmsnapshot extension webhook endpoint when the feature is enabled
      1. for vm extension webhook, use new resourceRequest object which contains an array of requestedCapacity if snapshot feature gate is enabled. Return legacy requestedCapacity if feature gate is not enabled.
1. Add the webhook config in validation webhook config
1. Make sure `validatingwebhookconfiguration_controller` updates the SPU for VMSnapshot when the feature is enabled.

This PR also 
1. Refactors some of the loggers to make sure it's the one from context.
1. Use a different quotaExtensionName for VMSnapshot's SPU. Since quota webhook has limitation that SPU for different resource kind must have different different extensionName.


**Are there any special notes for your reviewer**:
In VMOP log, snapshot is enabled
```
I0819 17:49:56.907828       1 capabilties.go:146] "Checking if capabilities would update features" logger="capability-crd-controller" Capabilities="supervisor-capabilities" reconcileID="4bf01c67-a056-4317-aa3c-dd1136aeedd3" dryRun=true oldFeat={"InstanceStorage":false,"K8sWorkloadMgmtAPI":false,"PodVMOnStretchedSupervisor":true,"TKGMultipleCL":true,"VMResize":false,"VMResizeCPUMemory":true,"VMImportNewNet":true,"WorkloadDomainIsolation":true,"VMIncrementalRestore":true,"BringYourOwnEncryptionKey":true,"SVAsyncUpgrade":true,"FastDeploy":false,"MutableNetworks":false,"VMGroups":false,"ImmutableClasses":false,"VMSnapshots":true,"InventoryContentLibrary":false,"VMPlacementPolicies":false}
```

When created a VM, I could see log in `storage-quota-webhook` that it handles the VM quota admission without error.
```
I0819 21:41:38.152489       1 quota_webhook.go:725] "Sufficient namespace quota to reserve" logger="storage-quota-admission-webhook" Namespace="lubron-test" Capacity="10Gi" QuotaNeeded="15Gi" QuotaLimit="9223372036854775807"
I0819 21:41:38.152596       1 quota_webhook.go:855] "Operation allowed for Resource" logger="storage-quota-admission-webhook" lubron-vm="Namespace" lubron-test="Kind" VirtualMachine="due to sufficient storage policy quota to reserve with StorageQuota" total-quota="(MISSING)"
I0819 21:41:38.152619       1 quota_webhook.go:915] "Updated StorageQuota->StoragePolicyLevelQuotaStatus for" logger="storage-quota-admission-webhook" Kind="VirtualMachine" Name="lubron-vm" StorageQuota="total-quota" Namespace="lubron-test" OldReserved="0" Reserved="10Gi" PolicylevelLimit="9223372036854775807"
I0819 21:41:38.176459       1 storagequota_controller.go:87] "StorageQuota Reconcile Started" logger="controllers.StorageQuota.StorageQuota" name="lubron-test/total-quota" trace="32800f2e-6790-4c56-93a5-02235917b5c8"
I0819 21:41:38.176790       1 quota_webhook.go:870] "validateQuotaForResource: Successfully Patched StorageQuota to reflect new reservations" logger="storage-quota-admission-webhook" StorageQuota="total-quota" Namespace="lubron-test" StoragePolicy="ab97ff81-b969-473d-9dd0-cf6f3bef8981" Request Capacity="10Gi"
I0819 21:41:38.176851       1 quota_webhook.go:1065] "Finished handling request for object in storage quota admission webhook!!!" logger="storage-quota-admission-webhook" Kind="VirtualMachine" Name="lubron-vm" Namespace="lubron-test" Time Taken="365.313661ms"
```
SPU for VM got updated
```
root@421378ce001ca7985825fc798e4a7d91 [ ~ ]# k get storagepolicyusage -n lubron-test wcpglobal-storage-profile-vm-usage -oyaml
apiVersion: cns.vmware.com/v1alpha2
kind: StoragePolicyUsage
metadata:
  creationTimestamp: "2025-08-19T18:54:36Z"
  generation: 1
  name: wcpglobal-storage-profile-vm-usage
  namespace: lubron-test
  ownerReferences:
  - apiVersion: cns.vmware.com/v1alpha2
    blockOwnerDeletion: true
    controller: true
    kind: StoragePolicyQuota
    name: wcpglobal-storage-profile-storagepolicyquota
    uid: 4dbb23a6-c609-4663-bd06-430e8d268efb
  resourceVersion: "1078524"
  uid: 7cba1523-b727-46af-a4e7-bc4356dca40f
spec:
  caBundle: LS...g==
  resourceApiGroup: vmoperator.vmware.com
  resourceExtensionName: vmware-system-vmop-webhook-service
  resourceExtensionNamespace: vmware-system-vmop
  resourceKind: VirtualMachine
  storageClassName: wcpglobal-storage-profile
  storagePolicyId: ab97ff81-b969-473d-9dd0-cf6f3bef8981
status:
  quotaUsage:
    reserved: "0"
    used: "10737420196"
```
Try created a snapshot, and quota webhook works as expected
```
I0819 21:47:09.639613       1 quota_webhook.go:725] "Sufficient namespace quota to reserve" logger="storage-quota-admission-webhook" Namespace="lubron-test" Capacity="10Gi" QuotaNeeded="69793220516" QuotaLimit="9223372036854775807"
I0819 21:47:09.640226       1 quota_webhook.go:855] "Operation allowed for Resource" logger="storage-quota-admission-webhook" sn-1="Namespace" lubron-test="Kind" VirtualMachineSnapshot="due to sufficient storage policy quota to reserve with StorageQuota" total-quota="(MISSING)"
I0819 21:47:09.641241       1 quota_webhook.go:915] "Updated StorageQuota->StoragePolicyLevelQuotaStatus for" logger="storage-quota-admission-webhook" Kind="VirtualMachineSnapshot" Name="sn-1" StorageQuota="total-quota" Namespace="lubron-test" OldReserved="40Gi" Reserved="50Gi" PolicylevelLimit="9223372036854775807"
I0819 21:47:09.672281       1 storagequota_controller.go:87] "StorageQuota Reconcile Started" logger="controllers.StorageQuota.StorageQuota" name="lubron-test/total-quota" trace="3b0df9e6-d224-4616-822b-6c129ade4496"
I0819 21:47:09.678219       1 quota_webhook.go:870] "validateQuotaForResource: Successfully Patched StorageQuota to reflect new reservations" logger="storage-quota-admission-webhook" StorageQuota="total-quota" Namespace="lubron-test" StoragePolicy="ab97ff81-b969-473d-9dd0-cf6f3bef8981" Request Capacity="10Gi"
I0819 21:47:09.678274       1 quota_webhook.go:1065] "Finished handling request for object in storage quota admission webhook!!!" logger="storage-quota-admission-webhook" Kind="VirtualMachineSnapshot" Name="sn-1" Namespace="lubron-test" Time Taken="67.748543ms"
```


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    5. If a release note is not required, please write "NONE".
-->

```release-note
None
```