### PR TITLE
:seedling: Prevent snapshot of VKS nodes

### DIFF
--- a/pkg/providers/vsphere/vmprovider_vm.go
+++ b/pkg/providers/vsphere/vmprovider_vm.go
@@ -1262,6 +1262,13 @@ func (vs *vSphereVMProvider) reconcileSnapshotRevert(
 		vmCtx.Logger.V(5).Info("No current snapshot specified, skipping revert")
 		return false, nil
 	}
+
+	// Skip snapshot revert processing for VKS/TKG nodes
+	if kubeutil.HasCAPILabels(vmCtx.VM.Labels) {
+		vmCtx.Logger.V(4).Info("Skipping snapshot revert for VKS/TKG node",
+			"vmName", vmCtx.VM.Name, "snapshotName", vmCtx.VM.Spec.CurrentSnapshot.Name)
+		return false, nil
+	}
 	desiredSnapshotName := vmCtx.VM.Spec.CurrentSnapshot.Name
 
 	// Check if the snapshot CR exists.
@@ -1524,6 +1531,13 @@ func (vs *vSphereVMProvider) reconcileSnapshot(
 
 	// If no snapshots found, nothing to do
 	if len(vmSnapshots) == 0 {
+		return nil
+	}
+
+	// Skip snapshot processing for VKS/TKG nodes
+	if kubeutil.HasCAPILabels(vmCtx.VM.Labels) {
+		vmCtx.Logger.V(4).Info("Skipping snapshot processing for VKS/TKG node",
+			"vmName", vmCtx.VM.Name)
 		return nil
 	}
 

--- a/webhooks/virtualmachine/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator.go
@@ -1927,6 +1927,11 @@ func (v validator) validateSnapshot(
 		allErrs = append(allErrs, field.Required(snapshotPath.Child("name"), ""))
 	}
 
+	// Check if the VM is a VKS node and prevent snapshot revert
+	if kubeutil.HasCAPILabels(vm.Labels) {
+		allErrs = append(allErrs, field.Forbidden(snapshotPath, "snapshot revert is not allowed for VKS nodes"))
+	}
+
 	return allErrs
 }
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This change modifies the VM snapshot webhook to reject snapshot requests on VKS nodes.  This is done by checking for CAPI added labels on the VKS nodes which is already a contract / pattern that is followed in VM operator for other workflows (e.g., backup).

Since webhook validation based on labels is always race-y, this change also modifies the snapshot reconciliation workflow in the provider to skip taking snapshot of VKS nodes.


**Please add a release note if necessary**:

```release-note
Prevent snapshot of VKS nodes
```