### PR TITLE
🌱 Enqueue reconcile between groups and linked members

### DIFF
--- a/controllers/virtualmachine/virtualmachine/virtualmachine_controller.go
+++ b/controllers/virtualmachine/virtualmachine/virtualmachine_controller.go
@@ -1,5 +1,5 @@
 // © Broadcom. All Rights Reserved.
-// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: Apache-2.0
 
 package virtualmachine
@@ -134,6 +134,17 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 					ctx,
 					r.Logger.WithName("SnapshotToVMMapper"),
 				),
+			),
+		)
+	}
+
+	// Watch VirtualMachineGroup resources to trigger VMs reconciliation when
+	// their groups are created or updated (e.g. placement results).
+	if pkgcfg.FromContext(ctx).Features.VMGroups {
+		builder = builder.Watches(
+			&vmopv1.VirtualMachineGroup{},
+			handler.EnqueueRequestsFromMapFunc(
+				vmopv1util.GroupToVMsMapperFn(ctx, r.Client),
 			),
 		)
 	}

--- a/pkg/util/vmopv1/vm_test.go
+++ b/pkg/util/vmopv1/vm_test.go
@@ -995,6 +995,23 @@ var _ = Describe("GroupToVMsMapperFn", func() {
 				},
 			}
 		})
+		When("the VM has a different group name", func() {
+			BeforeEach(func() {
+				vmObj := &vmopv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespaceName,
+						Name:      vmName,
+					},
+					Spec: vmopv1.VirtualMachineSpec{
+						GroupName: "different-group",
+					},
+				}
+				withObjs = append(withObjs, vmObj)
+			})
+			Specify("no reconcile requests should be returned", func() {
+				Expect(reqs).To(BeEmpty())
+			})
+		})
 		When("the VM has neither linked nor placement ready conditions", func() {
 			BeforeEach(func() {
 				vmObj := &vmopv1.VirtualMachine{

--- a/pkg/util/vmopv1/vm_test.go
+++ b/pkg/util/vmopv1/vm_test.go
@@ -1019,6 +1019,9 @@ var _ = Describe("GroupToVMsMapperFn", func() {
 						Namespace: namespaceName,
 						Name:      vmName,
 					},
+					Spec: vmopv1.VirtualMachineSpec{
+						GroupName: groupName,
+					},
 					Status: vmopv1.VirtualMachineStatus{
 						Conditions: []metav1.Condition{},
 					},
@@ -1042,6 +1045,9 @@ var _ = Describe("GroupToVMsMapperFn", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: namespaceName,
 						Name:      vmName,
+					},
+					Spec: vmopv1.VirtualMachineSpec{
+						GroupName: groupName,
 					},
 					Status: vmopv1.VirtualMachineStatus{
 						Conditions: []metav1.Condition{
@@ -1072,6 +1078,9 @@ var _ = Describe("GroupToVMsMapperFn", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: namespaceName,
 						Name:      vmName,
+					},
+					Spec: vmopv1.VirtualMachineSpec{
+						GroupName: groupName,
 					},
 					Status: vmopv1.VirtualMachineStatus{
 						Conditions: []metav1.Condition{

--- a/pkg/util/vmopv1/vm_test.go
+++ b/pkg/util/vmopv1/vm_test.go
@@ -1,5 +1,5 @@
 // © Broadcom. All Rights Reserved.
-// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: Apache-2.0
 
 package vmopv1_test
@@ -906,6 +906,170 @@ var _ = Describe("EncryptionClassToVirtualMachineMapper", func() {
 						},
 					},
 				))
+			})
+		})
+	})
+})
+
+var _ = Describe("GroupToVMsMapperFn", func() {
+	const (
+		namespaceName  = "fake-namespace"
+		groupName      = "group-name"
+		childGroupName = "child-group-name"
+		vmName         = "vm-name"
+		vmKind         = "VirtualMachine"
+		groupKind      = "VirtualMachineGroup"
+	)
+	var (
+		ctx                 context.Context
+		k8sClient           ctrlclient.Client
+		groupObj            *vmopv1.VirtualMachineGroup
+		withObjs            []ctrlclient.Object
+		reqs                []reconcile.Request
+		linkedTrueCondition = metav1.Condition{
+			Type:   vmopv1.VirtualMachineGroupMemberConditionGroupLinked,
+			Status: metav1.ConditionTrue,
+		}
+	)
+	BeforeEach(func() {
+		ctx = context.Background()
+		withObjs = nil
+		groupObj = &vmopv1.VirtualMachineGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespaceName,
+				Name:      groupName,
+			},
+		}
+	})
+	JustBeforeEach(func() {
+		k8sClient = builder.NewFakeClient(withObjs...)
+		reqs = vmopv1util.GroupToVMsMapperFn(ctx, k8sClient)(ctx, groupObj)
+	})
+
+	When("the group has no linked VM kind members", func() {
+		Specify("no reconcile requests should be returned", func() {
+			Expect(reqs).To(BeEmpty())
+		})
+	})
+	When("the group has linked VMGroup kind members", func() {
+		BeforeEach(func() {
+			groupObj.Spec.BootOrder = []vmopv1.VirtualMachineGroupBootOrderGroup{
+				{
+					Members: []vmopv1.GroupMember{
+						{
+							Kind: groupKind,
+							Name: childGroupName,
+						},
+					},
+				},
+			}
+			groupObj.Status.Members = []vmopv1.VirtualMachineGroupMemberStatus{
+				{
+					Kind:       groupKind,
+					Name:       childGroupName,
+					Conditions: []metav1.Condition{linkedTrueCondition},
+				},
+			}
+		})
+		Specify("no reconcile requests should be returned", func() {
+			Expect(reqs).To(BeEmpty())
+		})
+	})
+	When("the group has linked VM kind members", func() {
+		BeforeEach(func() {
+			groupObj.Spec.BootOrder = []vmopv1.VirtualMachineGroupBootOrderGroup{
+				{
+					Members: []vmopv1.GroupMember{
+						{
+							Kind: vmKind,
+							Name: vmName,
+						},
+					},
+				},
+			}
+			groupObj.Status.Members = []vmopv1.VirtualMachineGroupMemberStatus{
+				{
+					Kind:       vmKind,
+					Name:       vmName,
+					Conditions: []metav1.Condition{linkedTrueCondition},
+				},
+			}
+		})
+		When("the VM has neither linked nor placement ready conditions", func() {
+			BeforeEach(func() {
+				vmObj := &vmopv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespaceName,
+						Name:      vmName,
+					},
+					Status: vmopv1.VirtualMachineStatus{
+						Conditions: []metav1.Condition{},
+					},
+				}
+				withObjs = append(withObjs, vmObj)
+			})
+			Specify("one reconcile request should be returned", func() {
+				Expect(reqs).To(ConsistOf(
+					reconcile.Request{
+						NamespacedName: types.NamespacedName{
+							Namespace: namespaceName,
+							Name:      vmName,
+						},
+					},
+				))
+			})
+		})
+		When("the VM has linked condition true and placement ready condition false", func() {
+			BeforeEach(func() {
+				vmObj := &vmopv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespaceName,
+						Name:      vmName,
+					},
+					Status: vmopv1.VirtualMachineStatus{
+						Conditions: []metav1.Condition{
+							linkedTrueCondition,
+							metav1.Condition{
+								Type:   vmopv1.VirtualMachineConditionPlacementReady,
+								Status: metav1.ConditionFalse,
+							},
+						},
+					},
+				}
+				withObjs = append(withObjs, vmObj)
+			})
+			Specify("one reconcile request should be returned", func() {
+				Expect(reqs).To(ConsistOf(
+					reconcile.Request{
+						NamespacedName: types.NamespacedName{
+							Namespace: namespaceName,
+							Name:      vmName,
+						},
+					},
+				))
+			})
+		})
+		When("the VM status has both linked and placement ready conditions true", func() {
+			BeforeEach(func() {
+				vmObj := &vmopv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespaceName,
+						Name:      vmName,
+					},
+					Status: vmopv1.VirtualMachineStatus{
+						Conditions: []metav1.Condition{
+							linkedTrueCondition,
+							metav1.Condition{
+								Type:   vmopv1.VirtualMachineConditionPlacementReady,
+								Status: metav1.ConditionTrue,
+							},
+						},
+					},
+				}
+				withObjs = append(withObjs, vmObj)
+			})
+			Specify("no reconcile requests should be returned", func() {
+				Expect(reqs).To(BeEmpty())
 			})
 		})
 	})


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR has the following two changes:

1. Add a new mapper func to trigger reconciliation of VMs when their group changes
   - ensuring VM status is updated with the group's linked condition as soon as it is adopted by a group
   - allowing immediate placement of the VM when the group has placement result ready

2. Updated the existing mapper func to trigger reconciliation of VM Groups when a linked member is updated
   - ensuring VM Group's member status reflects the latest state of its members

**Which issue(s) is/are addressed by this PR?**

Fixes N/A.

**Are there any special notes for your reviewer**:

None.

**Please add a release note if necessary**:

```release-note
Enqueue reconcile between group to linked VM members.
```