### PR TITLE
X-Port 9.0.1 -- 🐛 Disable ExternalID for NetOP interfaces

### DIFF
--- a/pkg/providers/vsphere/network/network.go
+++ b/pkg/providers/vsphere/network/network.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25"
@@ -371,10 +370,12 @@ func createNetOPNetworkInterface(
 			return err
 		}
 
+		/* We can only set this once we know all the hosts have been upgraded.
 		if netIf.ResourceVersion == "" {
 			// For new interfaces, set the ExternalID so we can better uniquely identify them.
 			netIf.Spec.ExternalID = uuid.NewString()
 		}
+		*/
 
 		if netIf.Labels == nil {
 			netIf.Labels = map[string]string{}

--- a/pkg/providers/vsphere/network/network_test.go
+++ b/pkg/providers/vsphere/network/network_test.go
@@ -316,7 +316,8 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 					Expect(netInterface.Spec.NetworkName).To(Equal(networkName))
 
 					externalID = netInterface.Spec.ExternalID
-					Expect(externalID).ToNot(BeEmpty())
+					// Expect(externalID).ToNot(BeEmpty())
+					Expect(externalID).To(BeEmpty())
 
 					netInterface.Status.ExternalID = externalID
 					netInterface.Status.NetworkID = ctx.NetworkRef.Reference().Value


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

The fix to enable setting the EthCard ExternalID on non-NSXT DVPDs (NetOP in our case) is partially dependent on ESX host changes, and for upgrades the host version may very much lag of VC/VMOP versions.

The fallout from this is that like before we cannot easily uniquely identify NetOP interfaces so we'll fallback to the old best-effort matching by backing.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Disable externalID for NICs on VDS.
```