### PR TITLE
🌱 Refactor bootstrap templates

### DIFF
--- a/pkg/providers/vsphere/vmlifecycle/bootstrap.go
+++ b/pkg/providers/vsphere/vmlifecycle/bootstrap.go
@@ -50,7 +50,7 @@ type BootstrapData struct {
 	Sysprep     *sysprep.SecretData
 }
 
-type TemplateRenderFunc func(string, string) string
+type TemplateRenderFunc func(string, string) (string, error)
 
 type BootstrapArgs struct {
 	BootstrapData

--- a/pkg/providers/vsphere/vmlifecycle/bootstrap_sysprep.go
+++ b/pkg/providers/vsphere/vmlifecycle/bootstrap_sysprep.go
@@ -56,7 +56,11 @@ func BootstrapSysPrep(
 		}
 
 		if bsArgs.TemplateRenderFn != nil {
-			data = bsArgs.TemplateRenderFn(key, data)
+			var err error
+			data, err = bsArgs.TemplateRenderFn(key, data)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to render template for key %q: %w", key, err)
+			}
 		}
 
 		identity = &vimtypes.CustomizationSysprepText{

--- a/pkg/providers/vsphere/vmlifecycle/bootstrap_templatedata_test.go
+++ b/pkg/providers/vsphere/vmlifecycle/bootstrap_templatedata_test.go
@@ -85,7 +85,8 @@ var _ = Describe("TemplateVMMetadata", func() {
 		DescribeTable("v1alpha1 template functions",
 			func(str, expected string) {
 				fn := vmlifecycle.GetTemplateRenderFunc(vmCtx, bsArgs)
-				out := fn("", str)
+				out, err := fn("", str)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(out).To(Equal(expected))
 			},
 			Entry("first_cidrIp", "{{ (index (index .V1alpha1.Net.Devices 0).IPAddresses 0) }}", ip1Cidr),
@@ -101,7 +102,8 @@ var _ = Describe("TemplateVMMetadata", func() {
 		DescribeTable("v1alpha2 template functions",
 			func(str, expected string) {
 				fn := vmlifecycle.GetTemplateRenderFunc(vmCtx, bsArgs)
-				out := fn("", str)
+				out, err := fn("", str)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(out).To(Equal(expected))
 			},
 			Entry("first_cidrIp", "{{ (index (index .V1alpha2.Net.Devices 0).IPAddresses 0) }}", ip1Cidr),
@@ -117,7 +119,8 @@ var _ = Describe("TemplateVMMetadata", func() {
 		DescribeTable("v1alpha3 template functions",
 			func(str, expected string) {
 				fn := vmlifecycle.GetTemplateRenderFunc(vmCtx, bsArgs)
-				out := fn("", str)
+				out, err := fn("", str)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(out).To(Equal(expected))
 			},
 			Entry("first_cidrIp", "{{ (index (index .V1alpha3.Net.Devices 0).IPAddresses 0) }}", ip1Cidr),
@@ -133,7 +136,8 @@ var _ = Describe("TemplateVMMetadata", func() {
 		DescribeTable("v1alpha4 template functions",
 			func(str, expected string) {
 				fn := vmlifecycle.GetTemplateRenderFunc(vmCtx, bsArgs)
-				out := fn("", str)
+				out, err := fn("", str)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(out).To(Equal(expected))
 			},
 			Entry("first_cidrIp", "{{ (index (index .V1alpha4.Net.Devices 0).IPAddresses 0) }}", ip1Cidr),
@@ -149,7 +153,8 @@ var _ = Describe("TemplateVMMetadata", func() {
 		DescribeTable("v1alpha5 template functions",
 			func(str, expected string) {
 				fn := vmlifecycle.GetTemplateRenderFunc(vmCtx, bsArgs)
-				out := fn("", str)
+				out, err := fn("", str)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(out).To(Equal(expected))
 			},
 			Entry("first_cidrIp", "{{ (index (index .V1alpha5.Net.Devices 0).IPAddresses 0) }}", ip1Cidr),
@@ -167,7 +172,8 @@ var _ = Describe("TemplateVMMetadata", func() {
 		DescribeTable("v1alpha1 constant names",
 			func(str, expected string) {
 				fn := vmlifecycle.GetTemplateRenderFunc(vmCtx, bsArgs)
-				out := fn("", str)
+				out, err := fn("", str)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(out).To(Equal(expected))
 			},
 			Entry("cidr_ip1", "{{ "+constants.V1alpha1FirstIP+" }}", ip1Cidr),
@@ -189,7 +195,8 @@ var _ = Describe("TemplateVMMetadata", func() {
 		DescribeTable("v1alpha2 constant names",
 			func(str, expected string) {
 				fn := vmlifecycle.GetTemplateRenderFunc(vmCtx, bsArgs)
-				out := fn("", str)
+				out, err := fn("", str)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(out).To(Equal(expected))
 			},
 			Entry("cidr_ip1", "{{ "+constants.V1alpha2FirstIP+" }}", ip1Cidr),
@@ -211,7 +218,8 @@ var _ = Describe("TemplateVMMetadata", func() {
 		DescribeTable("v1alpha3 constant names",
 			func(str, expected string) {
 				fn := vmlifecycle.GetTemplateRenderFunc(vmCtx, bsArgs)
-				out := fn("", str)
+				out, err := fn("", str)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(out).To(Equal(expected))
 			},
 			Entry("cidr_ip1", "{{ "+constants.V1alpha3FirstIP+" }}", ip1Cidr),
@@ -233,7 +241,8 @@ var _ = Describe("TemplateVMMetadata", func() {
 		DescribeTable("v1alpha4 constant names",
 			func(str, expected string) {
 				fn := vmlifecycle.GetTemplateRenderFunc(vmCtx, bsArgs)
-				out := fn("", str)
+				out, err := fn("", str)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(out).To(Equal(expected))
 			},
 			Entry("cidr_ip1", "{{ "+constants.V1alpha4FirstIP+" }}", ip1Cidr),
@@ -255,7 +264,8 @@ var _ = Describe("TemplateVMMetadata", func() {
 		DescribeTable("v1alpha5 constant names",
 			func(str, expected string) {
 				fn := vmlifecycle.GetTemplateRenderFunc(vmCtx, bsArgs)
-				out := fn("", str)
+				out, err := fn("", str)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(out).To(Equal(expected))
 			},
 			Entry("cidr_ip1", "{{ "+constants.V1alpha5FirstIP+" }}", ip1Cidr),
@@ -277,11 +287,11 @@ var _ = Describe("TemplateVMMetadata", func() {
 	})
 
 	Context("Invalid template names", func() {
-		DescribeTable("returns the original text",
+		DescribeTable("returns error for invalid templates",
 			func(str string) {
 				fn := vmlifecycle.GetTemplateRenderFunc(vmCtx, bsArgs)
-				out := fn("", str)
-				Expect(out).To(Equal(str))
+				_, err := fn("", str)
+				Expect(err).To(HaveOccurred())
 			},
 			Entry("ip1", "{{ "+constants.V1alpha1IP+" \"192.1.0\" }}"),
 			Entry("ip2", "{{ "+constants.V1alpha1FirstIPFromNIC+" 5 }}"),
@@ -292,11 +302,11 @@ var _ = Describe("TemplateVMMetadata", func() {
 			Entry("nameserver", "{{ (index .V1alpha1.Net.NameServers 0) }}"),
 		)
 
-		DescribeTable("returns the original text, v1a2 style",
+		DescribeTable("returns error for invalid templates, v1a2 style",
 			func(str string) {
 				fn := vmlifecycle.GetTemplateRenderFunc(vmCtx, bsArgs)
-				out := fn("", str)
-				Expect(out).To(Equal(str))
+				_, err := fn("", str)
+				Expect(err).To(HaveOccurred())
 			},
 			Entry("ip1", "{{ "+constants.V1alpha2IP+" \"192.1.0\" }}"),
 			Entry("ip2", "{{ "+constants.V1alpha2FirstIPFromNIC+" 5 }}"),
@@ -307,11 +317,11 @@ var _ = Describe("TemplateVMMetadata", func() {
 			Entry("nameserver", "{{ (index .V1alpha2.Net.NameServers 0) }}"),
 		)
 
-		DescribeTable("returns the original text, v1a3 style",
+		DescribeTable("returns error for invalid templates, v1a3 style",
 			func(str string) {
 				fn := vmlifecycle.GetTemplateRenderFunc(vmCtx, bsArgs)
-				out := fn("", str)
-				Expect(out).To(Equal(str))
+				_, err := fn("", str)
+				Expect(err).To(HaveOccurred())
 			},
 			Entry("ip1", "{{ "+constants.V1alpha3IP+" \"192.1.0\" }}"),
 			Entry("ip2", "{{ "+constants.V1alpha3FirstIPFromNIC+" 5 }}"),
@@ -322,11 +332,11 @@ var _ = Describe("TemplateVMMetadata", func() {
 			Entry("nameserver", "{{ (index .V1alpha3.Net.NameServers 0) }}"),
 		)
 
-		DescribeTable("returns the original text, v1a4 style",
+		DescribeTable("returns error for invalid templates, v1a4 style",
 			func(str string) {
 				fn := vmlifecycle.GetTemplateRenderFunc(vmCtx, bsArgs)
-				out := fn("", str)
-				Expect(out).To(Equal(str))
+				_, err := fn("", str)
+				Expect(err).To(HaveOccurred())
 			},
 			Entry("ip1", "{{ "+constants.V1alpha4IP+" \"192.1.0\" }}"),
 			Entry("ip2", "{{ "+constants.V1alpha4FirstIPFromNIC+" 5 }}"),
@@ -337,11 +347,11 @@ var _ = Describe("TemplateVMMetadata", func() {
 			Entry("nameserver", "{{ (index .V1alpha4.Net.NameServers 0) }}"),
 		)
 
-		DescribeTable("returns the original text, v1a5 style",
+		DescribeTable("returns error for invalid templates, v1a5 style",
 			func(str string) {
 				fn := vmlifecycle.GetTemplateRenderFunc(vmCtx, bsArgs)
-				out := fn("", str)
-				Expect(out).To(Equal(str))
+				_, err := fn("", str)
+				Expect(err).To(HaveOccurred())
 			},
 			Entry("ip1", "{{ "+constants.V1alpha5IP+" \"192.1.0\" }}"),
 			Entry("ip2", "{{ "+constants.V1alpha5FirstIPFromNIC+" 5 }}"),
@@ -357,7 +367,8 @@ var _ = Describe("TemplateVMMetadata", func() {
 		DescribeTable("return one level of escaped removed",
 			func(str, expected string) {
 				fn := vmlifecycle.GetTemplateRenderFunc(vmCtx, bsArgs)
-				out := fn("", str)
+				out, err := fn("", str)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(out).To(Equal(expected))
 			},
 			Entry("skip_data1", "\\{\\{ (index (index .V1alpha1.Net.Devices 0).IPAddresses 0) \\}\\}", "{{ (index (index .V1alpha1.Net.Devices 0).IPAddresses 0) }}"),
@@ -369,7 +380,8 @@ var _ = Describe("TemplateVMMetadata", func() {
 		DescribeTable("return one level of escaped removed, v1a2 style",
 			func(str, expected string) {
 				fn := vmlifecycle.GetTemplateRenderFunc(vmCtx, bsArgs)
-				out := fn("", str)
+				out, err := fn("", str)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(out).To(Equal(expected))
 			},
 			Entry("skip_data1", "\\{\\{ (index (index .V1alpha2.Net.Devices 0).IPAddresses 0) \\}\\}", "{{ (index (index .V1alpha2.Net.Devices 0).IPAddresses 0) }}"),
@@ -381,7 +393,8 @@ var _ = Describe("TemplateVMMetadata", func() {
 		DescribeTable("return one level of escaped removed, v1a3 style",
 			func(str, expected string) {
 				fn := vmlifecycle.GetTemplateRenderFunc(vmCtx, bsArgs)
-				out := fn("", str)
+				out, err := fn("", str)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(out).To(Equal(expected))
 			},
 			Entry("skip_data1", "\\{\\{ (index (index .V1alpha3.Net.Devices 0).IPAddresses 0) \\}\\}", "{{ (index (index .V1alpha3.Net.Devices 0).IPAddresses 0) }}"),
@@ -393,7 +406,8 @@ var _ = Describe("TemplateVMMetadata", func() {
 		DescribeTable("return one level of escaped removed, v1a4 style",
 			func(str, expected string) {
 				fn := vmlifecycle.GetTemplateRenderFunc(vmCtx, bsArgs)
-				out := fn("", str)
+				out, err := fn("", str)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(out).To(Equal(expected))
 			},
 			Entry("skip_data1", "\\{\\{ (index (index .V1alpha4.Net.Devices 0).IPAddresses 0) \\}\\}", "{{ (index (index .V1alpha4.Net.Devices 0).IPAddresses 0) }}"),
@@ -405,7 +419,8 @@ var _ = Describe("TemplateVMMetadata", func() {
 		DescribeTable("return one level of escaped removed, v1a5 style",
 			func(str, expected string) {
 				fn := vmlifecycle.GetTemplateRenderFunc(vmCtx, bsArgs)
-				out := fn("", str)
+				out, err := fn("", str)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(out).To(Equal(expected))
 			},
 			Entry("skip_data1", "\\{\\{ (index (index .V1alpha5.Net.Devices 0).IPAddresses 0) \\}\\}", "{{ (index (index .V1alpha5.Net.Devices 0).IPAddresses 0) }}"),

--- a/pkg/providers/vsphere/vmlifecycle/bootstrap_vappconfig.go
+++ b/pkg/providers/vsphere/vmlifecycle/bootstrap_vappconfig.go
@@ -6,6 +6,7 @@ package vmlifecycle
 
 import (
 	"errors"
+	"fmt"
 
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 
@@ -70,7 +71,11 @@ func GetOVFVAppConfigForConfigSpec(
 	if templateRenderFn != nil {
 		// If we have a templating func, apply it to whatever data we have, regardless of the source.
 		for k, v := range vAppData {
-			vAppData[k] = templateRenderFn(k, v)
+			rendered, err := templateRenderFn(k, v)
+			if err != nil {
+				return nil, fmt.Errorf("failed to render template for key %q: %w", k, err)
+			}
+			vAppData[k] = rendered
 		}
 	}
 

--- a/pkg/providers/vsphere/vmlifecycle/bootstrap_vappconfig_test.go
+++ b/pkg/providers/vsphere/vmlifecycle/bootstrap_vappconfig_test.go
@@ -97,8 +97,8 @@ var _ = Describe("VAppConfig Bootstrap", func() {
 
 			Context("Applies TemplateRenderFn when specified", func() {
 				BeforeEach(func() {
-					bsArgs.TemplateRenderFn = func(_, v string) string {
-						return strings.ToUpper(v)
+					bsArgs.TemplateRenderFn = func(_, v string) (string, error) {
+						return strings.ToUpper(v), nil
 					}
 				})
 
@@ -140,8 +140,8 @@ var _ = Describe("VAppConfig Bootstrap", func() {
 
 			Context("Applies TemplateRenderFn when specified", func() {
 				BeforeEach(func() {
-					bsArgs.TemplateRenderFn = func(_, v string) string {
-						return strings.ToUpper(v)
+					bsArgs.TemplateRenderFn = func(_, v string) (string, error) {
+						return strings.ToUpper(v), nil
 					}
 				})
 
@@ -192,8 +192,8 @@ var _ = Describe("VAppConfig Bootstrap", func() {
 
 			Context("Applies TemplateRenderFn when specified", func() {
 				BeforeEach(func() {
-					bsArgs.TemplateRenderFn = func(_, v string) string {
-						return strings.ToUpper(v)
+					bsArgs.TemplateRenderFn = func(_, v string) (string, error) {
+						return strings.ToUpper(v), nil
 					}
 				})
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch dramatically simplifies the repetitive nature of bootstrap_template.go by adopting Golang generics.

This patch also refactors the bootstrap template function to return an error instead of just logging it.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Refactor bootstrap templates to use Go generics and return errors.
```