### PR TITLE
🌱  Reduce prober log spam

### DIFF
--- a/pkg/prober/prober_manager.go
+++ b/pkg/prober/prober_manager.go
@@ -121,11 +121,13 @@ func (m *manager) AddToProberManager(vm *vmopv1.VirtualMachine) {
 // RemoveFromProberManager removes a VM from the prober manager.
 func (m *manager) RemoveFromProberManager(vm *vmopv1.VirtualMachine) {
 	vmName := vm.NamespacedName()
-	m.log.V(4).Info("Remove from prober manager", "vm", vmName)
 
 	m.readinessMutex.Lock()
 	defer m.readinessMutex.Unlock()
-	delete(m.vmReadinessProbeList, vmName)
+	if _, ok := m.vmReadinessProbeList[vmName]; ok {
+		m.log.V(4).Info("Remove from prober manager", "vm", vmName)
+		delete(m.vmReadinessProbeList, vmName)
+	}
 }
 
 // Start starts the probe manager.


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

Only log if the VM had a readiness probe that we're now removing (not very common)

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:


```release-note
NONE
```