### PR TITLE
✨ Add support for publishing a VM to non-CLS backed libraries

### DIFF
--- a/pkg/providers/fake/fake_vm_provider.go
+++ b/pkg/providers/fake/fake_vm_provider.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vapi/library"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 
@@ -41,9 +42,10 @@ type funcs struct {
 	GetVirtualMachineHardwareVersionFn func(ctx context.Context, vm *vmopv1.VirtualMachine) (vimtypes.HardwareVersion, error)
 	PlaceVirtualMachineGroupFn         func(ctx context.Context, group *vmopv1.VirtualMachineGroup, groupPlacement []providers.VMGroupPlacement) error
 
-	GetItemFromLibraryByNameFn func(ctx context.Context, contentLibrary, itemName string) (*library.Item, error)
-	UpdateContentLibraryItemFn func(ctx context.Context, itemID, newName string, newDescription *string) error
-	SyncVirtualMachineImageFn  func(ctx context.Context, cli, vmi client.Object) error
+	GetItemFromLibraryByNameFn   func(ctx context.Context, contentLibrary, itemName string) (*library.Item, error)
+	GetItemFromInventoryByNameFn func(ctx context.Context, contentLibrary, itemName string) (object.Reference, error)
+	UpdateContentLibraryItemFn   func(ctx context.Context, itemID, newName string, newDescription *string) error
+	SyncVirtualMachineImageFn    func(ctx context.Context, cli, vmi client.Object) error
 
 	UpdateVcPNIDFn           func(ctx context.Context, vcPNID, vcPort string) error
 	UpdateVcCredsFn          func(ctx context.Context, data map[string][]byte) error
@@ -272,6 +274,18 @@ func (s *VMProvider) GetItemFromLibraryByName(ctx context.Context,
 	defer s.Unlock()
 	if s.GetItemFromLibraryByNameFn != nil {
 		return s.GetItemFromLibraryByNameFn(ctx, contentLibrary, itemName)
+	}
+
+	return nil, nil
+}
+
+func (s *VMProvider) GetItemFromInventoryByName(ctx context.Context, contentLibrary, itemName string) (object.Reference, error) {
+	_ = pkgcfg.FromContext(ctx)
+
+	s.Lock()
+	defer s.Unlock()
+	if s.GetItemFromInventoryByNameFn != nil {
+		return s.GetItemFromInventoryByNameFn(ctx, contentLibrary, itemName)
 	}
 
 	return nil, nil

--- a/pkg/providers/vm_provider_interface.go
+++ b/pkg/providers/vm_provider_interface.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vapi/library"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -57,6 +58,7 @@ type VirtualMachineProviderInterface interface {
 	ComputeCPUMinFrequency(ctx context.Context) error
 
 	GetItemFromLibraryByName(ctx context.Context, contentLibrary, itemName string) (*library.Item, error)
+	GetItemFromInventoryByName(ctx context.Context, contentLibrary, itemName string) (object.Reference, error)
 	UpdateContentLibraryItem(ctx context.Context, itemID, newName string, newDescription *string) error
 	SyncVirtualMachineImage(ctx context.Context, cli, vmi ctrlclient.Object) error
 

--- a/pkg/providers/vsphere/virtualmachine/publish.go
+++ b/pkg/providers/vsphere/virtualmachine/publish.go
@@ -7,10 +7,14 @@ package virtualmachine
 import (
 	"fmt"
 
+	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vapi/rest"
 	"github.com/vmware/govmomi/vapi/vcenter"
+	"github.com/vmware/govmomi/vim25"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
 
 	imgregv1a1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha1"
+	imgregv1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha2"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
@@ -60,4 +64,72 @@ func CreateOVF(
 	return vcenter.NewManager(client).CreateOVF(
 		pkgutil.WithVAPIActivationID(vmCtx, client, actID),
 		ovf)
+}
+
+// CloneVM clones a source virtual machine, as a VM template, into an inventory-backed
+// content library as defined by the VirtualMachinePublishRequest object.
+func CloneVM(
+	vmCtx pkgctx.VirtualMachineContext,
+	vimClient *vim25.Client,
+	vmPubReq *vmopv1.VirtualMachinePublishRequest,
+	cl *imgregv1.ContentLibrary,
+	storagePolicyID, actID string) (string, error) {
+
+	descriptionPrefix := fmt.Sprintf(itemDescriptionFormat, string(vmPubReq.UID))
+
+	targetName := vmPubReq.Status.TargetRef.Item.Name
+
+	folderRef := vimtypes.ManagedObjectReference{
+		Type:  string(vimtypes.ManagedObjectTypesFolder),
+		Value: cl.Spec.ID,
+	}
+
+	cloneSpec := vimtypes.VirtualMachineCloneSpec{
+		Location: vimtypes.VirtualMachineRelocateSpec{
+			Folder: &folderRef,
+			// Causes a linked clone to be unlinked and consolidated
+			DiskMoveType: string(vimtypes.VirtualMachineRelocateDiskMoveOptionsMoveAllDiskBackingsAndDisallowSharing),
+			Profile: []vimtypes.BaseVirtualMachineProfileSpec{
+				&vimtypes.VirtualMachineDefinedProfileSpec{ProfileId: storagePolicyID},
+			},
+		},
+		Template: true,
+		Config: &vimtypes.VirtualMachineConfigSpec{
+			Annotation: descriptionPrefix + vmPubReq.Status.TargetRef.Item.Description,
+		},
+	}
+
+	vmCtx.Logger.Info("Publishing VM as template",
+		"actId", actID,
+		"targetName", targetName,
+		"cloneSpec", cloneSpec,
+		"cloneSource", vmCtx.VM.Status.UniqueID,
+		"cloneTarget", cl.Spec.ID)
+
+	vm := object.NewVirtualMachine(
+		vimClient,
+		vimtypes.ManagedObjectReference{
+			Type:  string(vimtypes.ManagedObjectTypesVirtualMachine),
+			Value: vmCtx.VM.Status.UniqueID,
+		})
+
+	cloneTask, err := vm.Clone(
+		vmCtx,
+		object.NewFolder(vimClient, folderRef),
+		targetName,
+		cloneSpec)
+
+	if err != nil {
+		return "", fmt.Errorf("failed to call clone api: %w", err)
+	}
+
+	cloneTaskInfo, err := cloneTask.WaitForResult(vmCtx)
+	if err != nil {
+		return "", fmt.Errorf("failed to clone VM to template: %w", err)
+	}
+	vmCtx.Logger.V(4).Info("cloned VM", "taskInfo", cloneTaskInfo)
+
+	cloneMoRef := cloneTaskInfo.Result.(vimtypes.ManagedObjectReference)
+
+	return cloneMoRef.Value, nil
 }

--- a/pkg/providers/vsphere/vmprovider.go
+++ b/pkg/providers/vsphere/vmprovider.go
@@ -425,6 +425,32 @@ func (vs *vSphereVMProvider) GetItemFromLibraryByName(ctx context.Context,
 	return contentLibraryProvider.GetLibraryItem(ctx, contentLibrary, itemName, false)
 }
 
+func (vs *vSphereVMProvider) GetItemFromInventoryByName(
+	ctx context.Context,
+	contentLibrary, itemName string) (object.Reference, error) {
+
+	client, err := vs.getVcClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	c := client.VimClient()
+
+	searchIndex := object.NewSearchIndex(c)
+
+	folderRef := vimtypes.ManagedObjectReference{
+		Type:  string(vimtypes.ManagedObjectTypesFolder),
+		Value: contentLibrary,
+	}
+
+	vm, err := searchIndex.FindChild(ctx, folderRef, itemName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find child vm %s: %w", itemName, err)
+	}
+
+	return vm, nil
+}
+
 func (vs *vSphereVMProvider) UpdateContentLibraryItem(ctx context.Context, itemID, newName string, newDescription *string) error {
 	pkgutil.FromContextOrDefault(ctx).V(4).Info("Update Content Library Item", "itemID", itemID)
 

--- a/test/builder/dummies.go
+++ b/test/builder/dummies.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/google/uuid"
 	imgregv1a1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha1"
+	imgregv1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha2"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -156,6 +157,32 @@ func DummyContentLibrary(name, namespace, uuid string) *imgregv1a1.ContentLibrar
 				{
 					Type:               imgregv1a1.ReadyCondition,
 					Status:             corev1.ConditionTrue,
+					LastTransitionTime: metav1.Now(),
+				},
+			},
+		},
+	}
+}
+
+func DummyContentLibraryV1A2(name, namespace, id string) *imgregv1.ContentLibrary {
+	return &imgregv1.ContentLibrary{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: imgregv1.ContentLibrarySpec{
+			BaseContentLibrarySpec: imgregv1.BaseContentLibrarySpec{
+				ID:   id,
+				Type: imgregv1.LibraryTypeInventory,
+			},
+			AllowPublish: true,
+		},
+		Status: imgregv1.ContentLibraryStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:               imgregv1.ReadyCondition,
+					Status:             metav1.ConditionTrue,
+					Reason:             string(metav1.ConditionTrue),
 					LastTransitionTime: metav1.Now(),
 				},
 			},


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->

This PR refactors the VirtualMachinePublishRequest flow to allow for publishing a vm as a template to a non-CLS backed library.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Add support for publishing a VM to non-CLS backed libraries.
```