### PR TITLE
🐛 Propagate the config context into the prober

### DIFF
--- a/controllers/virtualmachine/virtualmachine/virtualmachine_controller.go
+++ b/controllers/virtualmachine/virtualmachine/virtualmachine_controller.go
@@ -69,7 +69,7 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
 	)
 
-	proberManager, err := prober.AddToManager(mgr, ctx.VMProvider)
+	proberManager, err := prober.AddToManager(ctx, mgr, ctx.VMProvider)
 	if err != nil {
 		return err
 	}

--- a/pkg/prober/fake/worker/fake_prober_worker.go
+++ b/pkg/prober/fake/worker/fake_prober_worker.go
@@ -5,13 +5,13 @@
 package worker
 
 import (
-	"context"
 	"fmt"
 	"sync"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 
 	proberctx "github.com/vmware-tanzu/vm-operator/pkg/prober/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/prober/probe"
@@ -52,7 +52,7 @@ func (w *FakeWorker) CreateProbeContext(vm *vmopv1.VirtualMachine) (*proberctx.P
 	}
 
 	return &proberctx.ProbeContext{
-		Context:       context.Background(),
+		Context:       pkgcfg.NewContext(),
 		Logger:        ctrl.Log.WithName("fake-probe").WithValues("vmName", vm.NamespacedName()),
 		VM:            vm,
 		ProbeType:     "fake-probe",
@@ -61,6 +61,8 @@ func (w *FakeWorker) CreateProbeContext(vm *vmopv1.VirtualMachine) (*proberctx.P
 }
 
 func (w *FakeWorker) DoProbe(ctx *proberctx.ProbeContext) error {
+	_ = pkgcfg.FromContext(ctx)
+
 	w.Lock()
 	defer w.Unlock()
 

--- a/pkg/prober/prober_manager_test.go
+++ b/pkg/prober/prober_manager_test.go
@@ -21,7 +21,7 @@ import (
 	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
-
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgmgr "github.com/vmware-tanzu/vm-operator/pkg/manager"
 	proberctx "github.com/vmware-tanzu/vm-operator/pkg/prober/context"
 	fakeworker "github.com/vmware-tanzu/vm-operator/pkg/prober/fake/worker"
@@ -52,7 +52,7 @@ var _ = Describe("VirtualMachine probes", func() {
 	)
 
 	BeforeEach(func() {
-		ctx = context.Background()
+		ctx = pkgcfg.NewContextWithDefaultConfig()
 		periodSeconds = 1
 
 		vm = &vmopv1.VirtualMachine{
@@ -81,7 +81,7 @@ var _ = Describe("VirtualMachine probes", func() {
 		fakeRecorder = record.New(eventRecorder)
 		fakeVMProvider = &fake.VMProvider{}
 		fakeCtrlManager = &fakeManager{client: fakeClient}
-		testManagerIf := NewManager(fakeClient, fakeRecorder, fakeVMProvider)
+		testManagerIf := NewManager(ctx, fakeClient, fakeRecorder, fakeVMProvider)
 		testManager = testManagerIf.(*manager)
 		fakeWorkerIf = fakeworker.NewFakeWorker(testManager.readinessQueue)
 		fakeWorker = fakeWorkerIf.(*fakeworker.FakeWorker)
@@ -111,13 +111,13 @@ var _ = Describe("VirtualMachine probes", func() {
 	}
 
 	Specify("Adding prober to controller manager should succeed", func() {
-		m, err := AddToManager(fakeCtrlManager, fakeVMProvider)
+		m, err := AddToManager(ctx, fakeCtrlManager, fakeVMProvider)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(m).ToNot(BeNil())
 	})
 
 	Specify("Starting probe manager should succeed", func() {
-		m, err := AddToManager(fakeCtrlManager, fakeVMProvider)
+		m, err := AddToManager(ctx, fakeCtrlManager, fakeVMProvider)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(m).ToNot(BeNil())
 

--- a/pkg/prober/worker/readiness_worker_test.go
+++ b/pkg/prober/worker/readiness_worker_test.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	proberctx "github.com/vmware-tanzu/vm-operator/pkg/prober/context"
@@ -68,7 +69,7 @@ var _ = Describe("VirtualMachine readiness probes", func() {
 			TCPProbe:       fakeTCPProbe,
 			GuestHeartbeat: fakeHeartbeatProbe,
 		}
-		testWorker = NewReadinessWorker(queue, prober, fakeClient, fakeRecorder)
+		testWorker = NewReadinessWorker(pkgcfg.NewContext(), queue, prober, fakeClient, fakeRecorder)
 	})
 
 	checkReadyCondition := func(c client.Client, objKey client.ObjectKey, expectedCondition metav1.ConditionStatus) {


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

If after a VC creds rotation - which will close the existing VC client - the prober is the first to try to create a new VC client, it will panic without the Config in the context so pass down that context into the probe context.



**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note
NONE
```