### PR TITLE
✨ Dynamic CRDs from feature/capabilities

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -163,6 +163,8 @@ linters:
         - alias: proxyaddr
           pkg: github.com/vmware-tanzu/vm-operator/pkg/util/kube/proxyaddr
 
+        - alias: pkgcrd
+          pkg: github.com/vmware-tanzu/vm-operator/pkg/crd
         - alias: pkgcfg
           pkg: github.com/vmware-tanzu/vm-operator/pkg/config
         - alias: pkgctx

--- a/config/crd/crd.go
+++ b/config/crd/crd.go
@@ -1,0 +1,12 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package crd
+
+import "embed"
+
+// Bases is an embedded filesystem containing the VM Operator base CRDs.
+//
+//go:embed bases/*.yaml
+var Bases embed.FS

--- a/config/local/vmoperator/local_env_var_patch.yaml
+++ b/config/local/vmoperator/local_env_var_patch.yaml
@@ -17,6 +17,8 @@ spec:
           value: "true"
         - name: MEM_STATS_PERIOD
           value: "10m"
+        - name: CRD_CLEANUP_ENABLED
+          value: "false"
         - name: VSPHERE_NETWORKING
           value: "false"
         - name: FSS_WCP_INSTANCE_STORAGE

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -48,6 +48,26 @@ rules:
   - list
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - appplatform.vmware.com
   resources:
   - supervisorproperties

--- a/config/wcp/vmoperator/manager_env_var_patch.yaml
+++ b/config/wcp/vmoperator/manager_env_var_patch.yaml
@@ -61,6 +61,12 @@
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
+    name: CRD_CLEANUP_ENABLED
+    value: "false"
+
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
     name: FSS_PODVMONSTRETCHEDSUPERVISOR
     value: "<FSS_PODVMONSTRETCHEDSUPERVISOR>"
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -154,6 +154,13 @@ type Config struct {
 	//
 	// Defaults to "wcp-vmop-sa-vc-auth".
 	VCCredsSecretName string
+
+	// CRDCleanupEnabled indicates to delete CRDs or remove their fields when a
+	// feature/capability is disabled.
+	//
+	// Please note, this field has no effect if a CRD is being installed for the
+	// first time.
+	CRDCleanupEnabled bool
 }
 
 // GetMaxDeployThreadsOnProvider returns MaxDeployThreadsOnProvider if it is >0

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -62,5 +62,6 @@ func Default() Config {
 		WebhookSecretName:            defaultPrefix + "webhook-server-cert",
 		WebhookSecretNamespace:       defaultPrefix + "system",
 		WebhookSecretVolumeMountPath: "/tmp/k8s-webhook-server/serving-certs",
+		CRDCleanupEnabled:            false,
 	}
 }

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -33,6 +33,7 @@ func FromEnv() Config {
 	setDuration(env.MemStatsPeriod, &config.MemStatsPeriod)
 	setString(env.FastDeployMode, &config.FastDeployMode)
 	setString(env.VCCredsSecretName, &config.VCCredsSecretName)
+	setBool(env.CRDCleanupEnabled, &config.CRDCleanupEnabled)
 
 	setDuration(env.InstanceStoragePVPlacementFailedTTL, &config.InstanceStorage.PVPlacementFailedTTL)
 	setFloat64(env.InstanceStorageJitterMaxFactor, &config.InstanceStorage.JitterMaxFactor)

--- a/pkg/config/env/env.go
+++ b/pkg/config/env/env.go
@@ -13,7 +13,6 @@ type VarName uint8
 
 const (
 	_varNameBegin VarName = iota
-
 	MaxCreateVMsOnProvider
 	CreateVMRequeueDelay
 	PoweredOnVMHasIPRequeueDelay
@@ -51,6 +50,7 @@ const (
 	WebhookServiceNamespace
 	WebhookSecretName
 	WebhookSecretNamespace
+	CRDCleanupEnabled
 	FSSInstanceStorage
 	FSSK8sWorkloadMgmtAPI
 	FSSPodVMOnStretchedSupervisor
@@ -89,6 +89,10 @@ func All() []VarName {
 //nolint:gocyclo
 func (n VarName) String() string {
 	switch n {
+
+	//
+	// Config
+	//
 	case MaxCreateVMsOnProvider:
 		return "MAX_CREATE_VMS_ON_PROVIDER"
 	case CreateVMRequeueDelay:
@@ -163,6 +167,12 @@ func (n VarName) String() string {
 		return "WEBHOOK_SECRET_NAME"
 	case WebhookSecretNamespace:
 		return "WEBHOOK_SECRET_NAMESPACE"
+	case CRDCleanupEnabled:
+		return "CRD_CLEANUP_ENABLED"
+
+	//
+	// Features/Capabilities
+	//
 	case FSSInstanceStorage:
 		return "FSS_WCP_INSTANCE_STORAGE"
 	case FSSK8sWorkloadMgmtAPI:

--- a/pkg/config/env_test.go
+++ b/pkg/config/env_test.go
@@ -109,6 +109,7 @@ var _ = Describe(
 					Expect(os.Setenv("SYNC_IMAGE_REQUEUE_DELAY", "128h")).To(Succeed())
 					Expect(os.Setenv("DEPLOYMENT_NAME", "129")).To(Succeed())
 					Expect(os.Setenv("SIGUSR2_RESTART_ENABLED", "true")).To(Succeed())
+					Expect(os.Setenv("CRD_CLEANUP_ENABLED", "true")).To(Succeed())
 				})
 				It("Should return a default config overridden by the environment", func() {
 					Expect(config).To(BeComparableTo(pkgcfg.Config{
@@ -145,6 +146,7 @@ var _ = Describe(
 						WebhookSecretName:            "123",
 						WebhookSecretNamespace:       "124",
 						WebhookSecretVolumeMountPath: pkgcfg.Default().WebhookSecretVolumeMountPath,
+						CRDCleanupEnabled:            true,
 						Features: pkgcfg.FeatureStates{
 							InstanceStorage:           false,
 							K8sWorkloadMgmtAPI:        true,

--- a/pkg/crd/crd_suite_test.go
+++ b/pkg/crd/crd_suite_test.go
@@ -1,0 +1,26 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package crd_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/klog/v2"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func init() {
+	klog.InitFlags(nil)
+	klog.SetOutput(GinkgoWriter)
+	logf.SetLogger(klog.Background())
+}
+
+func TestCRD(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CRD Test Suite")
+}

--- a/pkg/crd/crd_test.go
+++ b/pkg/crd/crd_test.go
@@ -1,0 +1,520 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package crd_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
+	pkgcrd "github.com/vmware-tanzu/vm-operator/pkg/crd"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
+)
+
+var _ = Describe("UnstructuredBases", func() {
+	It("should get the expected crds", func() {
+		crds, err := pkgcrd.UnstructuredBases()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(crds).To(HaveLen(19))
+	})
+})
+
+var _ = Describe("Install", func() {
+	var (
+		ctx    context.Context
+		client ctrlclient.Client
+	)
+
+	BeforeEach(func() {
+		ctx = pkgcfg.WithConfig(pkgcfg.Config{
+			CRDCleanupEnabled: false,
+			Features: pkgcfg.FeatureStates{
+				FastDeploy:       false,
+				ImmutableClasses: false,
+				VMGroups:         false,
+				VMSnapshots:      false,
+			},
+		})
+
+		scheme := runtime.NewScheme()
+		Expect(apiextensionsv1.AddToScheme(scheme)).To(Succeed())
+		client = fake.NewClientBuilder().
+			WithScheme(scheme).
+			Build()
+	})
+
+	JustBeforeEach(func() {
+		Expect(pkgcrd.Install(ctx, client, nil)).To(Succeed())
+	})
+
+	assertField := func(expected bool, fields ...string) {
+		obj := unstructured.Unstructured{
+			Object: map[string]any{},
+		}
+		obj.SetAPIVersion("apiextensions.k8s.io/v1")
+		obj.SetKind("CustomResourceDefinition")
+		obj.SetName("virtualmachines.vmoperator.vmware.com")
+
+		ExpectWithOffset(1, client.Get(
+			ctx,
+			ctrlclient.ObjectKeyFromObject(&obj),
+			&obj)).To(Succeed())
+
+		versions, _, err := unstructured.NestedSlice(
+			obj.Object, "spec", "versions")
+		ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+		hasField := false
+		for j := range versions {
+			v := versions[j].(map[string]any)
+			_, okay, err := unstructured.NestedFieldNoCopy(
+				v,
+				fields...)
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			if okay {
+				hasField = okay
+				break
+			}
+		}
+		ExpectWithOffset(1, hasField).To(Equal(expected))
+	}
+
+	When("no crds are installed", func() {
+		When("no capabilities are enabled", func() {
+			It("should get the expected crds", func() {
+				var obj apiextensionsv1.CustomResourceDefinitionList
+				Expect(client.List(ctx, &obj)).To(Succeed())
+				Expect(obj.Items).To(HaveLen(14))
+			})
+
+			DescribeTable("vm api should not have spec fields",
+				func(field string) {
+					fields := []string{
+						"schema",
+						"openAPIV3Schema",
+						"properties",
+						"spec",
+						"properties",
+						field,
+					}
+					assertField(false, fields...)
+				},
+				Entry("spec.bootOptions", "bootOptions"),
+				Entry("spec.class", "class"),
+				Entry("spec.currentSnapshot", "currentSnapshot"),
+				Entry("spec.groupName", "groupName"),
+			)
+
+			DescribeTable("vm api should not have status fields",
+				func(field string) {
+					fields := []string{
+						"schema",
+						"openAPIV3Schema",
+						"properties",
+						"status",
+						"properties",
+						field,
+					}
+					assertField(false, fields...)
+				},
+				Entry("status.currentSnapshot", "currentSnapshot"),
+				Entry("status.rootSnapshots", "rootSnapshots"),
+			)
+		})
+
+		When("groups are enabled", func() {
+			BeforeEach(func() {
+				pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+					config.Features.VMGroups = true
+				})
+			})
+			It("should get the expected crds", func() {
+				var obj apiextensionsv1.CustomResourceDefinitionList
+				Expect(client.List(ctx, &obj)).To(Succeed())
+				Expect(obj.Items).To(HaveLen(16))
+			})
+
+			DescribeTable("vm api should have spec fields",
+				func(field string) {
+					fields := []string{
+						"schema",
+						"openAPIV3Schema",
+						"properties",
+						"spec",
+						"properties",
+						field,
+					}
+					assertField(true, fields...)
+				},
+				Entry("spec.bootOptions", "bootOptions"),
+				Entry("spec.groupName", "groupName"),
+			)
+		})
+
+		When("snapshots are enabled", func() {
+			BeforeEach(func() {
+				pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+					config.Features.VMSnapshots = true
+				})
+			})
+			It("should get the expected crds", func() {
+				var obj apiextensionsv1.CustomResourceDefinitionList
+				Expect(client.List(ctx, &obj)).To(Succeed())
+				Expect(obj.Items).To(HaveLen(15))
+			})
+
+			DescribeTable("vm api should have spec fields",
+				func(field string) {
+					fields := []string{
+						"schema",
+						"openAPIV3Schema",
+						"properties",
+						"spec",
+						"properties",
+						field,
+					}
+					assertField(true, fields...)
+				},
+				Entry("spec.currentSnapshot", "currentSnapshot"),
+			)
+
+			DescribeTable("vm api should have status fields",
+				func(field string) {
+					fields := []string{
+						"schema",
+						"openAPIV3Schema",
+						"properties",
+						"status",
+						"properties",
+						field,
+					}
+					assertField(true, fields...)
+				},
+				Entry("status.currentSnapshot", "currentSnapshot"),
+				Entry("status.rootSnapshots", "rootSnapshots"),
+			)
+		})
+
+		When("immutable classes are enabled", func() {
+			BeforeEach(func() {
+				pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+					config.Features.ImmutableClasses = true
+				})
+			})
+			It("should get the expected crds", func() {
+				var obj apiextensionsv1.CustomResourceDefinitionList
+				Expect(client.List(ctx, &obj)).To(Succeed())
+				Expect(obj.Items).To(HaveLen(15))
+			})
+			DescribeTable("vm api should have spec fields",
+				func(field string) {
+					fields := []string{
+						"schema",
+						"openAPIV3Schema",
+						"properties",
+						"spec",
+						"properties",
+						field,
+					}
+					assertField(true, fields...)
+				},
+				Entry("spec.class", "class"),
+			)
+		})
+
+		When("fast deploy is enabled", func() {
+			BeforeEach(func() {
+				pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+					config.Features.FastDeploy = true
+				})
+			})
+			It("should get the expected crds", func() {
+				var obj apiextensionsv1.CustomResourceDefinitionList
+				Expect(client.List(ctx, &obj)).To(Succeed())
+				Expect(obj.Items).To(HaveLen(15))
+			})
+		})
+
+		When("all features are enabled", func() {
+			BeforeEach(func() {
+				pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+					config.Features.FastDeploy = true
+					config.Features.ImmutableClasses = true
+					config.Features.VMGroups = true
+					config.Features.VMSnapshots = true
+				})
+			})
+			It("should get the expected crds", func() {
+				var obj apiextensionsv1.CustomResourceDefinitionList
+				Expect(client.List(ctx, &obj)).To(Succeed())
+				Expect(obj.Items).To(HaveLen(19))
+			})
+		})
+	})
+
+	When("crds were already installed with caps enabled and with conversion info", func() {
+		var (
+			crc apiextensionsv1.CustomResourceConversion
+		)
+
+		BeforeEach(func() {
+
+			crc = apiextensionsv1.CustomResourceConversion{
+				Strategy: apiextensionsv1.WebhookConverter,
+				Webhook: &apiextensionsv1.WebhookConversion{
+					ConversionReviewVersions: []string{"v1"},
+					ClientConfig: &apiextensionsv1.WebhookClientConfig{
+						URL: ptr.To("http://127.0.0.1"),
+						Service: &apiextensionsv1.ServiceReference{
+							Namespace: "default",
+							Name:      "webhook",
+							Path:      ptr.To("/convert"),
+							Port:      ptr.To(int32(443)),
+						},
+					},
+				},
+			}
+
+			Expect(pkgcrd.Install(
+				pkgcfg.WithConfig(pkgcfg.Config{
+					Features: pkgcfg.FeatureStates{
+						FastDeploy:       true,
+						ImmutableClasses: true,
+						VMGroups:         true,
+						VMSnapshots:      true,
+					},
+				}),
+				client,
+				func(kind string, obj *unstructured.Unstructured) error {
+					if err := unstructured.SetNestedMap(
+						obj.Object,
+						map[string]any{
+							"strategy": string(crc.Strategy),
+							"webhook": map[string]any{
+								"clientConfig": map[string]any{
+									"url": *crc.Webhook.ClientConfig.URL,
+									"service": map[string]any{
+										"namespace": crc.Webhook.ClientConfig.Service.Namespace,
+										"name":      crc.Webhook.ClientConfig.Service.Name,
+										"path":      *crc.Webhook.ClientConfig.Service.Path,
+									},
+								},
+							},
+						},
+						"spec",
+						"conversion"); err != nil {
+						return err
+					}
+
+					if err := unstructured.SetNestedStringSlice(
+						obj.Object,
+						crc.Webhook.ConversionReviewVersions,
+						"spec",
+						"conversion",
+						"webhook",
+						"conversionReviewVersions"); err != nil {
+						return err
+					}
+
+					if err := unstructured.SetNestedField(
+						obj.Object,
+						int64(*crc.Webhook.ClientConfig.Service.Port),
+						"spec",
+						"conversion",
+						"webhook",
+						"clientConfig",
+						"service",
+						"port"); err != nil {
+						return err
+					}
+
+					return nil
+
+				})).To(Succeed())
+
+			// Verify the CRDs were installed.
+			var obj apiextensionsv1.CustomResourceDefinitionList
+			Expect(client.List(ctx, &obj)).To(Succeed())
+			Expect(obj.Items).To(HaveLen(19))
+			for i := range obj.Items {
+				ExpectWithOffset(1, obj.Items[i].Spec.Conversion).ToNot(BeNil())
+				ExpectWithOffset(1, *obj.Items[i].Spec.Conversion).To(Equal(crc))
+			}
+		})
+
+		When("CRD cleanup is disabled", func() {
+			BeforeEach(func() {
+				pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+					config.CRDCleanupEnabled = false
+				})
+			})
+
+			When("no capabilities are enabled", func() {
+				It("should get the expected crds", func() {
+					var obj apiextensionsv1.CustomResourceDefinitionList
+					Expect(client.List(ctx, &obj)).To(Succeed())
+					Expect(obj.Items).To(HaveLen(19))
+					for i := range obj.Items {
+						ExpectWithOffset(1, obj.Items[i].Spec.Conversion).ToNot(BeNil())
+						ExpectWithOffset(1, *obj.Items[i].Spec.Conversion).To(Equal(crc))
+					}
+				})
+
+				DescribeTable("vm api should not have removed spec fields",
+					func(field string) {
+						fields := []string{
+							"schema",
+							"openAPIV3Schema",
+							"properties",
+							"spec",
+							"properties",
+							field,
+						}
+						assertField(true, fields...)
+					},
+					Entry("spec.bootOptions", "bootOptions"),
+					Entry("spec.class", "class"),
+					Entry("spec.currentSnapshot", "currentSnapshot"),
+					Entry("spec.groupName", "groupName"),
+				)
+
+				DescribeTable("vm api should not have removed status fields",
+					func(field string) {
+						fields := []string{
+							"schema",
+							"openAPIV3Schema",
+							"properties",
+							"status",
+							"properties",
+							field,
+						}
+						assertField(true, fields...)
+					},
+					Entry("status.currentSnapshot", "currentSnapshot"),
+					Entry("status.rootSnapshots", "rootSnapshots"),
+				)
+			})
+
+		})
+
+		When("CRD cleanup is enabled", func() {
+			BeforeEach(func() {
+				pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+					config.CRDCleanupEnabled = true
+				})
+			})
+			When("no capabilities are enabled", func() {
+				It("should get the expected crds", func() {
+					var obj apiextensionsv1.CustomResourceDefinitionList
+					Expect(client.List(ctx, &obj)).To(Succeed())
+					Expect(obj.Items).To(HaveLen(14))
+					for i := range obj.Items {
+						ExpectWithOffset(1, obj.Items[i].Spec.Conversion).ToNot(BeNil())
+						ExpectWithOffset(1, *obj.Items[i].Spec.Conversion).To(Equal(crc))
+					}
+				})
+
+				DescribeTable("vm api should have removed spec fields",
+					func(field string) {
+						fields := []string{
+							"schema",
+							"openAPIV3Schema",
+							"properties",
+							"spec",
+							"properties",
+							field,
+						}
+						assertField(false, fields...)
+					},
+					Entry("spec.bootOptions", "bootOptions"),
+					Entry("spec.class", "class"),
+					Entry("spec.currentSnapshot", "currentSnapshot"),
+					Entry("spec.groupName", "groupName"),
+				)
+
+				DescribeTable("vm api should have removed status fields",
+					func(field string) {
+						fields := []string{
+							"schema",
+							"openAPIV3Schema",
+							"properties",
+							"status",
+							"properties",
+							field,
+						}
+						assertField(false, fields...)
+					},
+					Entry("status.currentSnapshot", "currentSnapshot"),
+					Entry("status.rootSnapshots", "rootSnapshots"),
+				)
+
+				When("one of the crds is already deleted", func() {
+					BeforeEach(func() {
+						obj := apiextensionsv1.CustomResourceDefinition{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "virtualmachinegroups.vmoperator.vmware.com",
+							},
+						}
+						Expect(client.Delete(ctx, &obj)).To(Succeed())
+					})
+
+					It("should get the expected crds", func() {
+						var obj apiextensionsv1.CustomResourceDefinitionList
+						Expect(client.List(ctx, &obj)).To(Succeed())
+						Expect(obj.Items).To(HaveLen(14))
+						for i := range obj.Items {
+							ExpectWithOffset(1, obj.Items[i].Spec.Conversion).ToNot(BeNil())
+							ExpectWithOffset(1, *obj.Items[i].Spec.Conversion).To(Equal(crc))
+						}
+					})
+
+					DescribeTable("vm api should have removed spec fields",
+						func(field string) {
+							fields := []string{
+								"schema",
+								"openAPIV3Schema",
+								"properties",
+								"spec",
+								"properties",
+								field,
+							}
+							assertField(false, fields...)
+						},
+						Entry("spec.bootOptions", "bootOptions"),
+						Entry("spec.class", "class"),
+						Entry("spec.currentSnapshot", "currentSnapshot"),
+						Entry("spec.groupName", "groupName"),
+					)
+
+					DescribeTable("vm api should have removed status fields",
+						func(field string) {
+							fields := []string{
+								"schema",
+								"openAPIV3Schema",
+								"properties",
+								"status",
+								"properties",
+								field,
+							}
+							assertField(false, fields...)
+						},
+						Entry("status.currentSnapshot", "currentSnapshot"),
+						Entry("status.rootSnapshots", "rootSnapshots"),
+					)
+				})
+			})
+		})
+
+	})
+
+})


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch updates VM Operator to dynamically install/update its CRDs based on the detected feature/capability state. For example, if the FastDeploy feature is disabled then the VirtualMachineMachineImageCache CRD will not be installed. If the feature is enabled while VM Operator is running, then VM Operator will stop, install the CRD, and start again. Additionally, disabling the feature will cause VM Operator to stop, remove the CRD, and start again.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

This has been validated on a real testbed:

**With `CRD_CLEANUPE_ENABLED=true`**

```shell
I0819 14:24:08.363984       1 main.go:73] "Starting VM Operator controller" logger="setup" version="1.8.6+f6b6d2eb" buildnumber="00000000" buildtype="dev" commit="f6b6d2eb"
I0819 14:24:08.365700       1 main.go:114] "Initial features from environment" logger="setup" features={"InstanceStorage":false,"K8sWorkloadMgmtAPI":false,"PodVMOnStretchedSupervisor":true,"TKGMultipleCL":false,"VMResize":false,"VMResizeCPUMemory":true,"VMImportNewNet":true,"WorkloadDomainIsolation":false,"VMIncrementalRestore":true,"BringYourOwnEncryptionKey":true,"SVAsyncUpgrade":true,"FastDeploy":true,"MutableNetworks":false,"VMGroups":false,"ImmutableClasses":false,"VMSnapshots":false,"InventoryContentLibrary":false,"VMPlacementPolicies":false}
I0819 14:24:08.366043       1 mem.go:258] "MemStats" now=1755613448365922930 buckHashSys=1451515 debugGC=false enableGC=true frees=17071 gcCPUFraction=0.05856558034000202 gcSys=3101968 heapAlloc=3217136 heapIdle=2596864 heapInUse=5332992 heapObjects=12907 heapReleased=2129920 heapSys=7929856 lastGC=1755613448362672541 live=12907 lookups=0 mCacheInUse=4832 mCacheSys=15704 mSpanInUse=85760 mSpanSys=97920 mallocs=29978 nextGC=6739106 numForcedGC=0 numGC=3 otherSys=663077 pauseTotalNs=3957967 stackInUse=458752 stackSys=458752 sys=13718792 totalAlloc=5916696
I0819 14:24:08.369839       1 envvar.go:172] "Feature gate default state" feature="ClientsAllowCBOR" enabled=false
I0819 14:24:08.369866       1 envvar.go:172] "Feature gate default state" feature="ClientsPreferCBOR" enabled=false
I0819 14:24:08.369870       1 envvar.go:172] "Feature gate default state" feature="InformerResourceVersion" enabled=false
I0819 14:24:08.369906       1 envvar.go:172] "Feature gate default state" feature="InOrderInformers" enabled=true
I0819 14:24:08.369908       1 envvar.go:172] "Feature gate default state" feature="WatchListClient" enabled=false
I0819 14:24:08.411666       1 capabilties.go:146] "Checking if capabilities would update features" logger="setup" dryRun=false oldFeat={"InstanceStorage":false,"K8sWorkloadMgmtAPI":false,"PodVMOnStretchedSupervisor":true,"TKGMultipleCL":false,"VMResize":false,"VMResizeCPUMemory":true,"VMImportNewNet":true,"WorkloadDomainIsolation":false,"VMIncrementalRestore":true,"BringYourOwnEncryptionKey":true,"SVAsyncUpgrade":true,"FastDeploy":true,"MutableNetworks":false,"VMGroups":false,"ImmutableClasses":false,"VMSnapshots":false,"InventoryContentLibrary":false,"VMPlacementPolicies":false}
I0819 14:24:08.412218       1 capabilties.go:172] "Updated features from capabilities" logger="setup" dryRun=false diff="InventoryContentLibrary=true,TKGMultipleCL=true,WorkloadDomainIsolation=true"
I0819 14:24:08.412251       1 main.go:128] "Initial features from capabilities" logger="setup" features={"InstanceStorage":false,"K8sWorkloadMgmtAPI":false,"PodVMOnStretchedSupervisor":true,"TKGMultipleCL":true,"VMResize":false,"VMResizeCPUMemory":true,"VMImportNewNet":true,"WorkloadDomainIsolation":true,"VMIncrementalRestore":true,"BringYourOwnEncryptionKey":true,"SVAsyncUpgrade":true,"FastDeploy":true,"MutableNetworks":false,"VMGroups":false,"ImmutableClasses":false,"VMSnapshots":false,"InventoryContentLibrary":true,"VMPlacementPolicies":false}
I0819 14:24:08.412446       1 main.go:133] "Installing/updating CRDs" logger="setup" features={"InstanceStorage":false,"K8sWorkloadMgmtAPI":false,"PodVMOnStretchedSupervisor":true,"TKGMultipleCL":true,"VMResize":false,"VMResizeCPUMemory":true,"VMImportNewNet":true,"WorkloadDomainIsolation":true,"VMIncrementalRestore":true,"BringYourOwnEncryptionKey":true,"SVAsyncUpgrade":true,"FastDeploy":true,"MutableNetworks":false,"VMGroups":false,"ImmutableClasses":false,"VMSnapshots":false,"InventoryContentLibrary":true,"VMPlacementPolicies":false}
I0819 14:24:08.534709       1 crd.go:67] "Processing CRD" logger="DEFAULT" kind="ClusterVirtualMachineImage"
I0819 14:24:08.600938       1 crd.go:67] "Processing CRD" logger="DEFAULT" kind="ContentLibraryProvider"
I0819 14:24:08.611209       1 crd.go:67] "Processing CRD" logger="DEFAULT" kind="ContentSourceBinding"
I0819 14:24:08.619002       1 crd.go:67] "Processing CRD" logger="DEFAULT" kind="ContentSource"
I0819 14:24:08.628945       1 crd.go:67] "Processing CRD" logger="DEFAULT" kind="VirtualMachineClassBinding"
I0819 14:24:08.639325       1 crd.go:67] "Processing CRD" logger="DEFAULT" kind="VirtualMachineClass"
I0819 14:24:08.678403       1 crd.go:67] "Processing CRD" logger="DEFAULT" kind="VirtualMachineClassInstance"
I0819 14:24:08.685108       1 crd.go:315] "Deleting CRD" logger="DEFAULT" kind="VirtualMachineClassInstance"
I0819 14:24:08.694539       1 crd.go:67] "Processing CRD" logger="DEFAULT" kind="VirtualMachineGroupPublishRequest"
I0819 14:24:08.707400       1 crd.go:303] "Skipped creation of CRD" logger="DEFAULT" kind="VirtualMachineGroupPublishRequest"
I0819 14:24:08.707461       1 crd.go:67] "Processing CRD" logger="DEFAULT" kind="VirtualMachineGroup"
I0819 14:24:08.713100       1 crd.go:303] "Skipped creation of CRD" logger="DEFAULT" kind="VirtualMachineGroup"
I0819 14:24:08.713127       1 crd.go:67] "Processing CRD" logger="DEFAULT" kind="VirtualMachineImageCache"
I0819 14:24:08.761186       1 crd.go:67] "Processing CRD" logger="DEFAULT" kind="VirtualMachineImage"
I0819 14:24:08.803926       1 crd.go:67] "Processing CRD" logger="DEFAULT" kind="VirtualMachinePublishRequest"
I0819 14:24:08.845866       1 crd.go:67] "Processing CRD" logger="DEFAULT" kind="VirtualMachineReplicaSet"
I0819 14:24:09.067653       1 crd.go:67] "Processing CRD" logger="DEFAULT" kind="VirtualMachine"
I0819 14:24:09.244037       1 crd.go:369] "Mutating CRD on update" logger="DEFAULT" kind="VirtualMachine"
I0819 14:24:09.244097       1 crd.go:219] "Removing CRD field" logger="DEFAULT" kind="VirtualMachine" field="schema.openAPIV3Schema.properties.spec.properties.bootOptions"
I0819 14:24:09.253331       1 crd.go:219] "Removing CRD field" logger="DEFAULT" kind="VirtualMachine" field="schema.openAPIV3Schema.properties.spec.properties.groupName"
I0819 14:24:09.272227       1 crd.go:219] "Removing CRD field" logger="DEFAULT" kind="VirtualMachine" field="schema.openAPIV3Schema.properties.spec.properties.currentSnapshot"
I0819 14:24:09.273845       1 crd.go:219] "Removing CRD field" logger="DEFAULT" kind="VirtualMachine" field="schema.openAPIV3Schema.properties.status.properties.currentSnapshot"
I0819 14:24:09.280044       1 crd.go:219] "Removing CRD field" logger="DEFAULT" kind="VirtualMachine" field="schema.openAPIV3Schema.properties.status.properties.rootSnapshots"
I0819 14:24:09.743881       1 crd.go:67] "Processing CRD" logger="DEFAULT" kind="VirtualMachineService"
I0819 14:24:09.773690       1 crd.go:67] "Processing CRD" logger="DEFAULT" kind="VirtualMachineSetResourcePolicy"
I0819 14:24:09.799840       1 crd.go:67] "Processing CRD" logger="DEFAULT" kind="VirtualMachineSnapshot"
I0819 14:24:09.805212       1 crd.go:303] "Skipped creation of CRD" logger="DEFAULT" kind="VirtualMachineSnapshot"
I0819 14:24:09.805288       1 crd.go:67] "Processing CRD" logger="DEFAULT" kind="VirtualMachineWebConsoleRequest"
I0819 14:24:09.817572       1 crd.go:67] "Processing CRD" logger="DEFAULT" kind="WebConsoleRequest"
```

From `I0819 14:24:08.685108       1 crd.go:315] "Deleting CRD" logger="DEFAULT" kind="VirtualMachineClassInstance"`, it is clear that if `CRD_CLEANUP_ENABLED=true`, the CRDs are removed as intended. Other log lines verify the fields are removed. We can also verify that by running:

```shell
kubectl get crd virtualmachines.vmoperator.vmware.com -oyaml | \
  grep 'bootOptions\|groupName\|currentSnapshot\|rootSnapshots'
```

The above command emits nothing, because those fields were removed.

**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Install/update/remove CRDs dynamically based on feature states.
```