### PR TITLE
🌱 Prevent duplicate and self referenced members in VM Group

### DIFF
--- a/webhooks/virtualmachinegroup/validation/virtualmachinegroup_validator_intg_test.go
+++ b/webhooks/virtualmachinegroup/validation/virtualmachinegroup_validator_intg_test.go
@@ -5,6 +5,7 @@
 package validation_test
 
 import (
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -25,6 +26,7 @@ const (
 	invalidTimeFormatMsg                     = "time must be in RFC3339Nano format"
 	modifyAnnotationNotAllowedForNonAdminMsg = "modifying this annotation is not allowed for non-admin users"
 	emptyPowerStateNotAllowedAfterSetMsg     = "cannot set powerState to empty once it's been set"
+	selfReferenceMemberNotAllowedMsg         = "group cannot have itself as a member"
 )
 
 func intgTests() {
@@ -75,8 +77,8 @@ func newIntgValidatingWebhookContext() *intgValidatingWebhookContext {
 
 	ctx.vmGroup = &vmopv1.VirtualMachineGroup{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "vmgroup-",
-			Namespace:    ctx.Namespace,
+			Name:      "vmgroup-root",
+			Namespace: ctx.Namespace,
 		},
 		Spec: vmopv1.VirtualMachineGroupSpec{
 			BootOrder: []vmopv1.VirtualMachineGroupBootOrderGroup{
@@ -109,7 +111,9 @@ func intgTestsValidateCreate() {
 	)
 
 	type createArgs struct {
-		invalidTimeFormat bool
+		invalidTimeFormat   bool
+		duplicateMember     bool
+		selfReferenceMember bool
 	}
 
 	validateCreate := func(args createArgs, expectedAllowed bool, expectedReason string) {
@@ -120,6 +124,21 @@ func intgTestsValidateCreate() {
 			ctx.vmGroup.Annotations[constants.LastUpdatedPowerStateTimeAnnotation] = invalidTime
 		} else {
 			ctx.vmGroup.Annotations[constants.LastUpdatedPowerStateTimeAnnotation] = time.Now().Format(time.RFC3339Nano)
+		}
+
+		if args.duplicateMember {
+			ctx.vmGroup.Spec.BootOrder = append(ctx.vmGroup.Spec.BootOrder, ctx.vmGroup.Spec.BootOrder...)
+		}
+
+		if args.selfReferenceMember {
+			ctx.vmGroup.Spec.BootOrder = append(ctx.vmGroup.Spec.BootOrder, vmopv1.VirtualMachineGroupBootOrderGroup{
+				Members: []vmopv1.GroupMember{
+					{
+						Kind: "VirtualMachineGroup",
+						Name: ctx.vmGroup.Name,
+					},
+				},
+			})
 		}
 
 		err := ctx.Client.Create(ctx, ctx.vmGroup)
@@ -146,6 +165,10 @@ func intgTestsValidateCreate() {
 		Entry("should work", createArgs{}, true, ""),
 		Entry("should not work with invalid last-updated-power-state annotation",
 			createArgs{invalidTimeFormat: true}, false, invalidTimeFormatMsg),
+		Entry("should not work with duplicate members",
+			createArgs{duplicateMember: true}, false, "spec.bootOrder[1].members[0]: Duplicate value: \"VirtualMachine/vm-1\", spec.bootOrder[1].members[1]: Duplicate value: \"VirtualMachine/vm-2\", spec.bootOrder[1].members[2]: Duplicate value: \"VirtualMachineGroup/vmgroup-1\""),
+		Entry("should not work with self reference member",
+			createArgs{selfReferenceMember: true}, false, selfReferenceMemberNotAllowedMsg),
 	)
 }
 
@@ -215,6 +238,43 @@ func intgTestsValidateUpdate() {
 
 		It("should allow the request", func() {
 			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	When("update is performed with duplicate members among different boot orders", func() {
+		BeforeEach(func() {
+			ctx.vmGroup.Spec.BootOrder = append(ctx.vmGroup.Spec.BootOrder, ctx.vmGroup.Spec.BootOrder...)
+		})
+
+		It("should deny the request", func() {
+			Expect(err).To(HaveOccurred())
+			bootOrderPath := field.NewPath("spec", "bootOrder")
+			for i := 1; i < len(ctx.vmGroup.Spec.BootOrder); i++ {
+				for j, member := range ctx.vmGroup.Spec.BootOrder[i].Members {
+					curPath := bootOrderPath.Index(i).Child("members").Index(j)
+					Expect(err.Error()).To(ContainSubstring(curPath.String()))
+					dupVal := fmt.Sprintf("Duplicate value: \"%s/%s\"", member.Kind, member.Name)
+					Expect(err.Error()).To(ContainSubstring(dupVal))
+				}
+			}
+		})
+	})
+
+	When("update is performed with self reference member", func() {
+		BeforeEach(func() {
+			ctx.vmGroup.Spec.BootOrder = append(ctx.vmGroup.Spec.BootOrder, vmopv1.VirtualMachineGroupBootOrderGroup{
+				Members: []vmopv1.GroupMember{
+					{
+						Kind: "VirtualMachineGroup",
+						Name: ctx.vmGroup.Name,
+					},
+				},
+			})
+		})
+
+		It("should deny the request", func() {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(selfReferenceMemberNotAllowedMsg))
 		})
 	})
 }

--- a/webhooks/virtualmachinegroup/validation/virtualmachinegroup_validator_unit_test.go
+++ b/webhooks/virtualmachinegroup/validation/virtualmachinegroup_validator_unit_test.go
@@ -118,7 +118,7 @@ func unitTestsValidateCreate() {
 		lastUpdatedPowerState string
 		nextForceSyncTime     string
 		duplicateMember       bool
-		selfReferenceMember   bool
+		selfReferenced        bool
 	}
 
 	validateCreate := func(args createArgs, expectedAllowed bool, expectedReason string) {
@@ -162,7 +162,7 @@ func unitTestsValidateCreate() {
 			}
 		}
 
-		if args.selfReferenceMember {
+		if args.selfReferenced {
 			ctx.vmGroup.Spec.BootOrder = []vmopv1.VirtualMachineGroupBootOrderGroup{
 				{
 					Members: []vmopv1.GroupMember{
@@ -173,6 +173,7 @@ func unitTestsValidateCreate() {
 					},
 				},
 			}
+			ctx.vmGroup.Spec.GroupName = ctx.vmGroup.Name
 		}
 
 		var err error
@@ -202,8 +203,8 @@ func unitTestsValidateCreate() {
 			createArgs{isServiceUser: false, nextForceSyncTime: time.Now().Format(time.RFC3339Nano), lastUpdatedPowerState: time.Now().Format(time.RFC3339Nano)}, true, ""),
 		Entry("should not work with duplicate members",
 			createArgs{duplicateMember: true}, false, "spec.bootOrder[1].members[0]: Duplicate value: \"VirtualMachine/vm-dup\""),
-		Entry("should not work with self reference member",
-			createArgs{selfReferenceMember: true}, false, selfReferenceMemberNotAllowedMsg),
+		Entry("should not work with self reference member or group name",
+			createArgs{selfReferenced: true}, false, selfRefMemberOrGroupMsg),
 	)
 }
 
@@ -220,7 +221,7 @@ func unitTestsValidateUpdate() {
 		invalidLastUpdatedPowerState bool
 		nextForceSyncTime            string
 		duplicateMember              bool
-		selfReferenceMember          bool
+		selfReferenced               bool
 	}
 
 	validateUpdate := func(args updateArgs, expectedAllowed bool, expectedReason string) {
@@ -278,7 +279,7 @@ func unitTestsValidateUpdate() {
 			}
 		}
 
-		if args.selfReferenceMember {
+		if args.selfReferenced {
 			ctx.vmGroup.Spec.BootOrder = []vmopv1.VirtualMachineGroupBootOrderGroup{
 				{
 					Members: []vmopv1.GroupMember{
@@ -289,6 +290,7 @@ func unitTestsValidateUpdate() {
 					},
 				},
 			}
+			ctx.vmGroup.Spec.GroupName = ctx.vmGroup.Name
 		}
 
 		var err error
@@ -324,8 +326,8 @@ func unitTestsValidateUpdate() {
 			updateArgs{modifyLastUpdatedPowerState: true, isServiceUser: false, oldPowerState: vmopv1.VirtualMachinePowerStateOn, newPowerState: vmopv1.VirtualMachinePowerStateOff, nextForceSyncTime: time.Now().Format(time.RFC3339Nano)}, true, ""),
 		Entry("should not work with duplicate members",
 			updateArgs{duplicateMember: true}, false, "spec.bootOrder[1].members[0]: Duplicate value: \"VirtualMachineGroup/vmg-dup\""),
-		Entry("should not work with self reference member",
-			updateArgs{selfReferenceMember: true}, false, selfReferenceMemberNotAllowedMsg),
+		Entry("should not work with self reference member or group name",
+			updateArgs{selfReferenced: true}, false, selfRefMemberOrGroupMsg),
 	)
 }
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR updates the VirtualMachineGroup validating webhook to verify the `spec.bootOrder` field doesn't contain duplicate members or the group itself. This ensures all group members have determined boot order delay.

The webhook also verifies a group's `spec.groupName` to not reference itself either.


**Which issue(s) is/are addressed by this PR?**

Fixes N/A.


**Are there any special notes for your reviewer**:

Deployed this change to an internal testbed and verified the expected workflow:

- VMG creation with duplicate/self-referenced members:

```console
$ cat vmg-duplicate-members.yaml
apiVersion: vmoperator.vmware.com/v1alpha5
kind: VirtualMachineGroup
metadata:
  name: vmg-root
  namespace: sdiliyaer-test
spec:
  bootOrder:
  - members:
    - name: vm-1
      kind: VirtualMachine
    - name: vmg-1
      kind: VirtualMachineGroup
  - members:
    - name: vm-1
      kind: VirtualMachine
    - name: vmg-1
      kind: VirtualMachineGroup
    - name: vmg-root
      kind: VirtualMachineGroup

$ kubectl create -f vmg-duplicate-members.yaml
... error when creating "vmg-duplicate-members.yaml": admission webhook "default.validating.virtualmachinegroup.v1alpha5.vmoperator.vmware.com" denied the request: spec.bootOrder[1].members[0]: Duplicate value: "VirtualMachine/vm-1", spec.bootOrder[1].members[1]: Duplicate value: "VirtualMachineGroup/vmg-1", spec.bootOrder[1].members[2]: Invalid value: "VirtualMachineGroup/vmg-root": group cannot have itself as a member
```

- VMG update with duplicate/self-referenced members:

```console
$ cat vmg-valid-members.yaml
apiVersion: vmoperator.vmware.com/v1alpha5
kind: VirtualMachineGroup
metadata:
  name: vmg-root
  namespace: sdiliyaer-test
spec:
  bootOrder:
  - members:
    - name: vm-1
      kind: VirtualMachine
    - name: vmg-1
      kind: VirtualMachineGroup

$ kubectl create -f vmg-valid-members.yaml
virtualmachinegroup.vmoperator.vmware.com/vmg-root created

$ cat vmg-duplicate-members.yaml
apiVersion: vmoperator.vmware.com/v1alpha5
kind: VirtualMachineGroup
metadata:
  name: vmg-root
  namespace: sdiliyaer-test
spec:
  bootOrder:
  - members:
    - name: vm-1
      kind: VirtualMachine
    - name: vmg-1
      kind: VirtualMachineGroup
  - members:
    - name: vm-1
      kind: VirtualMachine
    - name: vmg-1
      kind: VirtualMachineGroup
    - name: vmg-root
      kind: VirtualMachineGroup

$ kubectl apply -f vmg-duplicate-members.yaml
... error when patching "vmg-duplicate-members.yaml": admission webhook "default.validating.virtualmachinegroup.v1alpha5.vmoperator.vmware.com" denied the request: spec.bootOrder[1].members[0]: Duplicate value: "VirtualMachine/vm-1", spec.bootOrder[1].members[1]: Duplicate value: "VirtualMachineGroup/vmg-1", spec.bootOrder[1].members[2]: Invalid value: "VirtualMachineGroup/vmg-root": group cannot have itself as a member
```

**Please add a release note if necessary**:

```release-note
 Prevent duplicate and self referenced members in VM Group.
```
