### PR TITLE
🌱 Set group linked condition for nested child groups

### DIFF
--- a/api/v1alpha2/virtualmachine_types.go
+++ b/api/v1alpha2/virtualmachine_types.go
@@ -582,6 +582,10 @@ func (vm *VirtualMachine) SetConditions(conditions []metav1.Condition) {
 	vm.Status.Conditions = conditions
 }
 
+func (vm *VirtualMachine) GetMemberKind() string {
+	return vm.Kind
+}
+
 func (vm *VirtualMachine) GetGroupName() string {
 	return vm.Spec.GroupName
 }

--- a/api/v1alpha2/virtualmachinegroup_types.go
+++ b/api/v1alpha2/virtualmachinegroup_types.go
@@ -31,11 +31,13 @@ type VirtualMachineOrGroup interface {
 	metav1.Object
 	runtime.Object
 	DeepCopyObject() runtime.Object
+	GetMemberKind() string
 	GetGroupName() string
 	SetGroupName(value string)
 	GetPowerState() VirtualMachinePowerState
 	SetPowerState(value VirtualMachinePowerState)
 	GetConditions() []metav1.Condition
+	SetConditions([]metav1.Condition)
 }
 
 // GroupMember describes a member of a VirtualMachineGroup.
@@ -280,6 +282,10 @@ type VirtualMachineGroup struct {
 
 	Spec   VirtualMachineGroupSpec   `json:"spec,omitempty"`
 	Status VirtualMachineGroupStatus `json:"status,omitempty"`
+}
+
+func (vmg *VirtualMachineGroup) GetMemberKind() string {
+	return vmg.Kind
 }
 
 func (vmg *VirtualMachineGroup) GetGroupName() string {

--- a/api/v1alpha3/virtualmachine_types.go
+++ b/api/v1alpha3/virtualmachine_types.go
@@ -938,6 +938,10 @@ func (vm *VirtualMachine) SetConditions(conditions []metav1.Condition) {
 	vm.Status.Conditions = conditions
 }
 
+func (vm *VirtualMachine) GetMemberKind() string {
+	return vm.Kind
+}
+
 func (vm *VirtualMachine) GetGroupName() string {
 	return vm.Spec.GroupName
 }

--- a/api/v1alpha3/virtualmachinegroup_types.go
+++ b/api/v1alpha3/virtualmachinegroup_types.go
@@ -31,11 +31,13 @@ type VirtualMachineOrGroup interface {
 	metav1.Object
 	runtime.Object
 	DeepCopyObject() runtime.Object
+	GetMemberKind() string
 	GetGroupName() string
 	SetGroupName(value string)
 	GetPowerState() VirtualMachinePowerState
 	SetPowerState(value VirtualMachinePowerState)
 	GetConditions() []metav1.Condition
+	SetConditions([]metav1.Condition)
 }
 
 // GroupMember describes a member of a VirtualMachineGroup.
@@ -280,6 +282,10 @@ type VirtualMachineGroup struct {
 
 	Spec   VirtualMachineGroupSpec   `json:"spec,omitempty"`
 	Status VirtualMachineGroupStatus `json:"status,omitempty"`
+}
+
+func (vmg *VirtualMachineGroup) GetMemberKind() string {
+	return vmg.Kind
 }
 
 func (vmg *VirtualMachineGroup) GetGroupName() string {

--- a/api/v1alpha4/virtualmachine_types.go
+++ b/api/v1alpha4/virtualmachine_types.go
@@ -1280,6 +1280,10 @@ func (vm *VirtualMachine) SetConditions(conditions []metav1.Condition) {
 	vm.Status.Conditions = conditions
 }
 
+func (vm *VirtualMachine) GetMemberKind() string {
+	return vm.Kind
+}
+
 func (vm *VirtualMachine) GetGroupName() string {
 	return vm.Spec.GroupName
 }

--- a/api/v1alpha4/virtualmachinegroup_types.go
+++ b/api/v1alpha4/virtualmachinegroup_types.go
@@ -31,11 +31,13 @@ type VirtualMachineOrGroup interface {
 	metav1.Object
 	runtime.Object
 	DeepCopyObject() runtime.Object
+	GetMemberKind() string
 	GetGroupName() string
 	SetGroupName(value string)
 	GetPowerState() VirtualMachinePowerState
 	SetPowerState(value VirtualMachinePowerState)
 	GetConditions() []metav1.Condition
+	SetConditions([]metav1.Condition)
 }
 
 // GroupMember describes a member of a VirtualMachineGroup.
@@ -280,6 +282,10 @@ type VirtualMachineGroup struct {
 
 	Spec   VirtualMachineGroupSpec   `json:"spec,omitempty"`
 	Status VirtualMachineGroupStatus `json:"status,omitempty"`
+}
+
+func (vmg *VirtualMachineGroup) GetMemberKind() string {
+	return vmg.Kind
 }
 
 func (vmg *VirtualMachineGroup) GetGroupName() string {

--- a/api/v1alpha5/virtualmachine_types.go
+++ b/api/v1alpha5/virtualmachine_types.go
@@ -1378,6 +1378,10 @@ func (vm *VirtualMachine) SetConditions(conditions []metav1.Condition) {
 	vm.Status.Conditions = conditions
 }
 
+func (vm *VirtualMachine) GetMemberKind() string {
+	return vm.Kind
+}
+
 func (vm *VirtualMachine) GetGroupName() string {
 	return vm.Spec.GroupName
 }

--- a/api/v1alpha5/virtualmachinegroup_types.go
+++ b/api/v1alpha5/virtualmachinegroup_types.go
@@ -31,11 +31,13 @@ type VirtualMachineOrGroup interface {
 	metav1.Object
 	runtime.Object
 	DeepCopyObject() runtime.Object
+	GetMemberKind() string
 	GetGroupName() string
 	SetGroupName(value string)
 	GetPowerState() VirtualMachinePowerState
 	SetPowerState(value VirtualMachinePowerState)
 	GetConditions() []metav1.Condition
+	SetConditions([]metav1.Condition)
 }
 
 // GroupMember describes a member of a VirtualMachineGroup.
@@ -281,6 +283,10 @@ type VirtualMachineGroup struct {
 
 	Spec   VirtualMachineGroupSpec   `json:"spec,omitempty"`
 	Status VirtualMachineGroupStatus `json:"status,omitempty"`
+}
+
+func (vmg *VirtualMachineGroup) GetMemberKind() string {
+	return vmg.Kind
 }
 
 func (vmg *VirtualMachineGroup) GetGroupName() string {

--- a/pkg/providers/vsphere/vmprovider_vm_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_test.go
@@ -1314,7 +1314,7 @@ func vmTests() {
 						Specify("it should return an error creating VM", func() {
 							err := createOrUpdateVM(ctx, vmProvider, vm)
 							Expect(err).To(HaveOccurred())
-							Expect(err.Error()).To(ContainSubstring("failed to get VM Group object"))
+							Expect(err.Error()).To(ContainSubstring("VM is not linked to its group"))
 						})
 					})
 
@@ -1352,10 +1352,6 @@ func vmTests() {
 										Name: vm.Name,
 										Kind: "VirtualMachine",
 										Conditions: []metav1.Condition{
-											{
-												Type:   vmopv1.VirtualMachineGroupMemberConditionGroupLinked,
-												Status: metav1.ConditionTrue,
-											},
 											{
 												Type:   vmopv1.VirtualMachineGroupMemberConditionPlacementReady,
 												Status: metav1.ConditionFalse,
@@ -1403,10 +1399,6 @@ func vmTests() {
 										Name: vm.Name,
 										Kind: "VirtualMachine",
 										Conditions: []metav1.Condition{
-											{
-												Type:   vmopv1.VirtualMachineGroupMemberConditionGroupLinked,
-												Status: metav1.ConditionTrue,
-											},
 											{
 												Type:   vmopv1.VirtualMachineGroupMemberConditionPlacementReady,
 												Status: metav1.ConditionTrue,


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR updates the VirtualMachineGroup controller to set the group linked condition if a group belongs to another group (i.e. `VMG.Spec.GroupName` is not empty).

This PR also refactors the existing logic for updating the VM's group linked condition by using a single `UpdateGroupLinkedCondition()` function for both VM and VMG kind members via the `VirtualMachineOrGroup` type.


**Which issue(s) is/are addressed by this PR?**

Fixes N/A.


**Are there any special notes for your reviewer**:

Deployed this change to an internal testbed and verified both VM & VMG group linked condition as follows:

- Created a group with empty `Spec.GroupName` (no group linked condition)

```yaml
status:
  conditions:
  - lastTransitionTime: "2025-08-22T14:18:54Z"
    message: ""
    reason: "True"
    status: "True"
    type: Ready
```

- Set `Spec.GroupName` to a non-existing parent group (`NotFound`)

```yaml
spec:
  groupName: vmg-root
status:
  conditions:
  - lastTransitionTime: "2025-08-22T14:19:58Z"
    message: group is not linked to its parent group
    reason: Error
    status: "False"
    type: Ready
  - lastTransitionTime: "2025-08-22T14:19:58Z"
    message: ""
    reason: NotFound
    status: "False"
    type: GroupLinked
```

- Set `Spec.GroupName` to a parent group whose member doesn't contain this child group (`NotMember`)

```yaml
spec:
  groupName: vmg-root
status:
  conditions:
  - lastTransitionTime: "2025-08-22T14:19:58Z"
    message: group is not linked to its parent group
    reason: Error
    status: "False"
    type: Ready
  - lastTransitionTime: "2025-08-22T14:30:43Z"
    message: ""
    reason: NotMember
    status: "False"
    type: GroupLinked
```

- Updated the parent group's members with this child group added:

```yaml
spec:
  groupName: vmg-root
status:
  conditions:
  - lastTransitionTime: "2025-08-22T14:33:00Z"
    message: ""
    reason: "True"
    status: "True"
    type: Ready
  - lastTransitionTime: "2025-08-22T14:33:00Z"
    message: ""
    reason: "True"
    status: "True"
    type: GroupLinked
```

- Updated the child group with a VM member added (VM.Spec.GroupName points to child group)

```yaml
# Child group's conditions
conditions:
  - lastTransitionTime: "2025-08-22T15:37:34Z"
    message: ""
    reason: "True"
    status: "True"
    type: Ready
  - lastTransitionTime: "2025-08-22T14:33:00Z"
    message: ""
    reason: "True"
    status: "True"
    type: GroupLinked
  members:
  - conditions:
    - lastTransitionTime: "2025-08-22T15:37:34Z"
      message: ""
      reason: "True"
      status: "True"
      type: GroupLinked
    - lastTransitionTime: "2025-08-22T15:37:34Z"
      message: ""
      reason: "True"
      status: "True"
      type: PlacementReady
    kind: VirtualMachine
    name: vm-1
    placement:
      name: vm-1
      pool: resgroup-95
      zoneID: domain-c38
    powerState: PoweredOn

# VM's conditions
conditions:
  - lastTransitionTime: "2025-08-22T15:37:34Z"
    message: ""
    reason: "True"
    status: "True"
    type: GroupLinked
  ...
  - lastTransitionTime: "2025-08-22T15:37:34Z"
    message: ""
    reason: "True"
    status: "True"
    type: VirtualMachineConditionPlacementReady
  - lastTransitionTime: "2025-08-22T15:38:08Z"
    message: ""
    reason: "True"
    status: "True"
    type: VirtualMachineCreated
```

**Please add a release note if necessary**:

```release-note
Set group linked condition for nested child groups.
```