### PR TITLE
:seedling: Enable v1a2 (cluster)contentlibraryitem controller(s)

### DIFF
--- a/controllers/contentlibrary/clustercontentlibraryitem/clustercontentlibraryitem_controller.go
+++ b/controllers/contentlibrary/clustercontentlibraryitem/clustercontentlibraryitem_controller.go
@@ -8,8 +8,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	imgregv1a1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha1"
+	imgregv1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha2"
 
 	"github.com/vmware-tanzu/vm-operator/controllers/contentlibrary/utils"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 )
 
@@ -20,9 +22,8 @@ import (
 
 // AddToManager adds this package's controller to the provided manager.
 func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) error {
-	// TODO: (abaruni) Enable this once sync image work is completed
-	//	if pkgcfg.FromContext(ctx).Features.InventoryContentLibrary {
-	//		return utils.AddToManagerV1A2(ctx, mgr, &imgregv1.ClusterContentLibraryItem{})
-	//	}
+	if pkgcfg.FromContext(ctx).Features.InventoryContentLibrary {
+		return utils.AddToManagerV1A2(ctx, mgr, &imgregv1.ClusterContentLibraryItem{})
+	}
 	return utils.AddToManager(ctx, mgr, &imgregv1a1.ClusterContentLibraryItem{})
 }

--- a/controllers/contentlibrary/contentlibraryitem/contentlibraryitem_controller.go
+++ b/controllers/contentlibrary/contentlibraryitem/contentlibraryitem_controller.go
@@ -8,8 +8,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	imgregv1a1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha1"
+	imgregv1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha2"
 
 	"github.com/vmware-tanzu/vm-operator/controllers/contentlibrary/utils"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 )
 
@@ -20,9 +22,8 @@ import (
 
 // AddToManager adds this package's controller to the provided manager.
 func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) error {
-	// TODO: (abaruni) Enable this once sync image work is completed
-	//	if pkgcfg.FromContext(ctx).Features.InventoryContentLibrary {
-	//		return utils.AddToManagerV1A2(ctx, mgr, &imgregv1.ContentLibraryItem{})
-	//	}
+	if pkgcfg.FromContext(ctx).Features.InventoryContentLibrary {
+		return utils.AddToManagerV1A2(ctx, mgr, &imgregv1.ContentLibraryItem{})
+	}
 	return utils.AddToManager(ctx, mgr, &imgregv1a1.ContentLibraryItem{})
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->

Work had already been done to refactor the ContentLibraryItem and ClusterContentLibraryItem controllers to use the v1alpha2 ImageRegistry API. This PR enables these controllers by uncommenting the block where `AddToManager` is invoked.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```