### PR TITLE
:seedling: Backport spec.groupName to v1alpha2 and newer versions

### DIFF
--- a/api/test/v1alpha2/virtualmachine_conversion_test.go
+++ b/api/test/v1alpha2/virtualmachine_conversion_test.go
@@ -431,6 +431,16 @@ func TestVirtualMachineConversion(t *testing.T) {
 		hubSpokeHub(g, &hub, &vmopv1.VirtualMachine{}, &vmopv1a2.VirtualMachine{})
 	})
 
+	t.Run("VirtualMachine hub-spoke-hub with spec.groupName", func(t *testing.T) {
+		g := NewWithT(t)
+		hub := vmopv1.VirtualMachine{
+			Spec: vmopv1.VirtualMachineSpec{
+				GroupName: "my-group",
+			},
+		}
+		hubSpokeHub(g, &hub, &vmopv1.VirtualMachine{}, &vmopv1a2.VirtualMachine{})
+	})
+
 	t.Run("VirtualMachine status.storage", func(t *testing.T) {
 		t.Run("hub-spoke-hub", func(t *testing.T) {
 			g := NewWithT(t)

--- a/api/test/v1alpha3/virtualmachine_conversion_test.go
+++ b/api/test/v1alpha3/virtualmachine_conversion_test.go
@@ -276,6 +276,14 @@ func TestVirtualMachineConversion(t *testing.T) {
 				},
 			},
 			{
+				name: "spec.groupName",
+				hub: &vmopv1.VirtualMachine{
+					Spec: vmopv1.VirtualMachineSpec{
+						GroupName: "my-group",
+					},
+				},
+			},
+			{
 				name: "spec.bootstrap.cloudInit.waitOnNetwork6",
 				hub: &vmopv1.VirtualMachine{
 					Spec: vmopv1.VirtualMachineSpec{

--- a/api/test/v1alpha4/virtualmachine_conversion_test.go
+++ b/api/test/v1alpha4/virtualmachine_conversion_test.go
@@ -276,6 +276,14 @@ func TestVirtualMachineConversion(t *testing.T) {
 				},
 			},
 			{
+				name: "spec.bootstrap.cloudInit.waitOnNetwork4",
+				hub: &vmopv1.VirtualMachine{
+					Spec: vmopv1.VirtualMachineSpec{
+						GroupName: "my-group",
+					},
+				},
+			},
+			{
 				name: "spec.bootstrap.cloudInit.waitOnNetwork6",
 				hub: &vmopv1.VirtualMachine{
 					Spec: vmopv1.VirtualMachineSpec{

--- a/api/v1alpha2/virtualmachine_conversion.go
+++ b/api/v1alpha2/virtualmachine_conversion.go
@@ -151,10 +151,6 @@ func Convert_v1alpha5_VirtualMachine_To_v1alpha2_VirtualMachine(
 	return nil
 }
 
-func restore_v1alpha5_VirtualMachineGroupName(dst, src *vmopv1.VirtualMachine) {
-	dst.Spec.GroupName = src.Spec.GroupName
-}
-
 func restore_v1alpha5_VirtualMachineCryptoSpec(dst, src *vmopv1.VirtualMachine) {
 	dst.Spec.Crypto = src.Spec.Crypto
 }
@@ -311,10 +307,6 @@ func restore_v1alpha5_VirtualMachineBootOptions(dst, src *vmopv1.VirtualMachine)
 	dst.Spec.BootOptions = src.Spec.BootOptions
 }
 
-func restore_v1alpha5_VirtualMachineAffinitySpec(dst, src *vmopv1.VirtualMachine) {
-	dst.Spec.Affinity = src.Spec.Affinity
-}
-
 // ConvertTo converts this VirtualMachine to the Hub version.
 func (src *VirtualMachine) ConvertTo(dstRaw ctrlconversion.Hub) error {
 	dst := dstRaw.(*vmopv1.VirtualMachine)
@@ -341,8 +333,6 @@ func (src *VirtualMachine) ConvertTo(dstRaw ctrlconversion.Hub) error {
 	restore_v1alpha5_VirtualMachineCryptoSpec(dst, restored)
 	restore_v1alpha5_VirtualMachinePromoteDisksMode(dst, restored)
 	restore_v1alpha5_VirtualMachineBootOptions(dst, restored)
-	restore_v1alpha5_VirtualMachineAffinitySpec(dst, restored)
-	restore_v1alpha5_VirtualMachineGroupName(dst, restored)
 
 	// END RESTORE
 

--- a/api/v1alpha2/virtualmachine_types.go
+++ b/api/v1alpha2/virtualmachine_types.go
@@ -405,6 +405,21 @@ type VirtualMachineSpec struct {
 	// behavior. In other words, please be careful when choosing to upgrade a
 	// VM to a newer hardware version.
 	MinHardwareVersion int32 `json:"minHardwareVersion,omitempty"`
+
+	// +optional
+
+	// GroupName indicates the name of the VirtualMachineGroup to which this
+	// VM belongs.
+	//
+	// VMs that belong to a group do not drive their own placement, rather that
+	// is handled by the group.
+	//
+	// When this field is set to a valid group that contains this VM as a
+	// member, an owner reference to that group is added to this VM.
+	//
+	// When this field is deleted or changed, any existing owner reference to
+	// the previous group will be removed from this VM.
+	GroupName string `json:"groupName,omitempty"`
 }
 
 // VirtualMachineReservedSpec describes a set of VM configuration options
@@ -565,6 +580,22 @@ func (vm *VirtualMachine) GetConditions() []metav1.Condition {
 
 func (vm *VirtualMachine) SetConditions(conditions []metav1.Condition) {
 	vm.Status.Conditions = conditions
+}
+
+func (vm *VirtualMachine) GetGroupName() string {
+	return vm.Spec.GroupName
+}
+
+func (vm *VirtualMachine) SetGroupName(value string) {
+	vm.Spec.GroupName = value
+}
+
+func (vm *VirtualMachine) GetPowerState() VirtualMachinePowerState {
+	return vm.Status.PowerState
+}
+
+func (vm *VirtualMachine) SetPowerState(value VirtualMachinePowerState) {
+	vm.Spec.PowerState = value
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha2/zz_generated.conversion.go
+++ b/api/v1alpha2/zz_generated.conversion.go
@@ -3756,6 +3756,7 @@ func autoConvert_v1alpha2_VirtualMachineSpec_To_v1alpha5_VirtualMachineSpec(in *
 	out.Advanced = (*v1alpha5.VirtualMachineAdvancedSpec)(unsafe.Pointer(in.Advanced))
 	out.Reserved = (*v1alpha5.VirtualMachineReservedSpec)(unsafe.Pointer(in.Reserved))
 	out.MinHardwareVersion = in.MinHardwareVersion
+	out.GroupName = in.GroupName
 	return nil
 }
 
@@ -3807,7 +3808,7 @@ func autoConvert_v1alpha5_VirtualMachineSpec_To_v1alpha2_VirtualMachineSpec(in *
 	// WARNING: in.PromoteDisksMode requires manual conversion: does not exist in peer-type
 	// WARNING: in.BootOptions requires manual conversion: does not exist in peer-type
 	// WARNING: in.CurrentSnapshot requires manual conversion: does not exist in peer-type
-	// WARNING: in.GroupName requires manual conversion: does not exist in peer-type
+	out.GroupName = in.GroupName
 	return nil
 }
 

--- a/api/v1alpha3/virtualmachine_conversion.go
+++ b/api/v1alpha3/virtualmachine_conversion.go
@@ -119,20 +119,12 @@ func Convert_v1alpha3_VirtualMachineStatus_To_v1alpha5_VirtualMachineStatus(
 	return nil
 }
 
-func restore_v1alpha5_VirtualMachineGroupName(dst, src *vmopv1.VirtualMachine) {
-	dst.Spec.GroupName = src.Spec.GroupName
-}
-
 func restore_v1alpha5_VirtualMachinePromoteDisksMode(dst, src *vmopv1.VirtualMachine) {
 	dst.Spec.PromoteDisksMode = src.Spec.PromoteDisksMode
 }
 
 func restore_v1alpha5_VirtualMachineBootOptions(dst, src *vmopv1.VirtualMachine) {
 	dst.Spec.BootOptions = src.Spec.BootOptions
-}
-
-func restore_v1alpha5_VirtualMachineAffinitySpec(dst, src *vmopv1.VirtualMachine) {
-	dst.Spec.Affinity = src.Spec.Affinity
 }
 
 // ConvertTo converts this VirtualMachine to the Hub version.
@@ -153,8 +145,6 @@ func (src *VirtualMachine) ConvertTo(dstRaw ctrlconversion.Hub) error {
 	restore_v1alpha5_VirtualMachineBootstrapCloudInitWaitOnNetwork(dst, restored)
 	restore_v1alpha5_VirtualMachinePromoteDisksMode(dst, restored)
 	restore_v1alpha5_VirtualMachineBootOptions(dst, restored)
-	restore_v1alpha5_VirtualMachineAffinitySpec(dst, restored)
-	restore_v1alpha5_VirtualMachineGroupName(dst, restored)
 
 	// END RESTORE
 

--- a/api/v1alpha3/virtualmachine_types.go
+++ b/api/v1alpha3/virtualmachine_types.go
@@ -712,6 +712,21 @@ type VirtualMachineSpec struct {
 	//
 	// This field is required when the VM has any CD-ROM devices attached.
 	GuestID string `json:"guestID,omitempty"`
+
+	// +optional
+
+	// GroupName indicates the name of the VirtualMachineGroup to which this
+	// VM belongs.
+	//
+	// VMs that belong to a group do not drive their own placement, rather that
+	// is handled by the group.
+	//
+	// When this field is set to a valid group that contains this VM as a
+	// member, an owner reference to that group is added to this VM.
+	//
+	// When this field is deleted or changed, any existing owner reference to
+	// the previous group will be removed from this VM.
+	GroupName string `json:"groupName,omitempty"`
 }
 
 // VirtualMachineReservedSpec describes a set of VM configuration options
@@ -921,6 +936,22 @@ func (vm *VirtualMachine) GetConditions() []metav1.Condition {
 
 func (vm *VirtualMachine) SetConditions(conditions []metav1.Condition) {
 	vm.Status.Conditions = conditions
+}
+
+func (vm *VirtualMachine) GetGroupName() string {
+	return vm.Spec.GroupName
+}
+
+func (vm *VirtualMachine) SetGroupName(value string) {
+	vm.Spec.GroupName = value
+}
+
+func (vm *VirtualMachine) GetPowerState() VirtualMachinePowerState {
+	return vm.Status.PowerState
+}
+
+func (vm *VirtualMachine) SetPowerState(value VirtualMachinePowerState) {
+	vm.Spec.PowerState = value
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha3/zz_generated.conversion.go
+++ b/api/v1alpha3/zz_generated.conversion.go
@@ -4341,6 +4341,7 @@ func autoConvert_v1alpha3_VirtualMachineSpec_To_v1alpha5_VirtualMachineSpec(in *
 	out.InstanceUUID = in.InstanceUUID
 	out.BiosUUID = in.BiosUUID
 	out.GuestID = in.GuestID
+	out.GroupName = in.GroupName
 	return nil
 }
 
@@ -4384,7 +4385,7 @@ func autoConvert_v1alpha5_VirtualMachineSpec_To_v1alpha3_VirtualMachineSpec(in *
 	// WARNING: in.PromoteDisksMode requires manual conversion: does not exist in peer-type
 	// WARNING: in.BootOptions requires manual conversion: does not exist in peer-type
 	// WARNING: in.CurrentSnapshot requires manual conversion: does not exist in peer-type
-	// WARNING: in.GroupName requires manual conversion: does not exist in peer-type
+	out.GroupName = in.GroupName
 	return nil
 }
 

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachinereplicasets.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachinereplicasets.yaml
@@ -2041,6 +2041,20 @@ spec:
                               Defaults to true if omitted.
                             type: boolean
                         type: object
+                      groupName:
+                        description: |-
+                          GroupName indicates the name of the VirtualMachineGroup to which this
+                          VM belongs.
+
+                          VMs that belong to a group do not drive their own placement, rather that
+                          is handled by the group.
+
+                          When this field is set to a valid group that contains this VM as a
+                          member, an owner reference to that group is added to this VM.
+
+                          When this field is deleted or changed, any existing owner reference to
+                          the previous group will be removed from this VM.
+                        type: string
                       guestID:
                         description: |-
                           GuestID describes the desired guest operating system identifier for a VM.

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -2433,6 +2433,20 @@ spec:
                   ClassName describes the name of the VirtualMachineClass resource used to
                   deploy this VM.
                 type: string
+              groupName:
+                description: |-
+                  GroupName indicates the name of the VirtualMachineGroup to which this
+                  VM belongs.
+
+                  VMs that belong to a group do not drive their own placement, rather that
+                  is handled by the group.
+
+                  When this field is set to a valid group that contains this VM as a
+                  member, an owner reference to that group is added to this VM.
+
+                  When this field is deleted or changed, any existing owner reference to
+                  the previous group will be removed from this VM.
+                type: string
               imageName:
                 description: |-
                   ImageName describes the name of the image resource used to deploy this
@@ -5785,6 +5799,20 @@ spec:
                       Defaults to true if omitted.
                     type: boolean
                 type: object
+              groupName:
+                description: |-
+                  GroupName indicates the name of the VirtualMachineGroup to which this
+                  VM belongs.
+
+                  VMs that belong to a group do not drive their own placement, rather that
+                  is handled by the group.
+
+                  When this field is set to a valid group that contains this VM as a
+                  member, an owner reference to that group is added to this VM.
+
+                  When this field is deleted or changed, any existing owner reference to
+                  the previous group will be removed from this VM.
+                type: string
               guestID:
                 description: |-
                   GuestID describes the desired guest operating system identifier for a VM.


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This change backports the spec.groupName field to v1alpha2 and older versions so external consumers that depend on older version of our API can leverage these.

### Testing Done:
- Created a `VirtualMachineGroup` on v1alpha2
- Created a VM with `spec.groupName` set to the group name from above
- Fetched the VM resource on different API versions to validate that the group name was set.

```
root@4213d57c641bc91043db1866567916a1 [ ~ ]# k get --raw  https://127.0.0.1:6443/apis/vmoperator.vmware.com/v1alpha2/namespaces/parunesh-ns/virtualmachines/np-3-2 | jq -r '.spec.groupName'
vmg

root@4213d57c641bc91043db1866567916a1 [ ~ ]# k get --raw  https://127.0.0.1:6443/apis/vmoperator.vmware.com/v1alpha3/namespaces/parunesh-ns/virtualmachines/np-3-2 | jq -r '.spec.groupName'
vmg

root@4213d57c641bc91043db1866567916a1 [ ~ ]# k get --raw  https://127.0.0.1:6443/apis/vmoperator.vmware.com/v1alpha4/namespaces/parunesh-ns/virtualmachines/np-3-2 | jq -r '.spec.groupName'
vmg

root@4213d57c641bc91043db1866567916a1 [ ~ ]# k get --raw  https://127.0.0.1:6443/apis/vmoperator.vmware.com/v1alpha5/namespaces/parunesh-ns/virtualmachines/np-3-2 | jq -r '.spec.groupName'
vmg
```

**Are there any special notes for your reviewer**:

See #1071 and #1121 for other changes that backport the affinity, and the `VirtualMachineGroup` APIs.


**Please add a release note if necessary**:

```release-note
Backport spec.groupName to v1alpha2 and newer versions
```