### PR TITLE
✨ Convert VM in extra config of snapshot to newest APIVersion

### DIFF
--- a/controllers/virtualmachinesnapshot/virtualmachinesnapshot_controller.go
+++ b/controllers/virtualmachinesnapshot/virtualmachinesnapshot_controller.go
@@ -197,7 +197,6 @@ func (r *Reconciler) ReconcileNormal(ctx *pkgctx.VirtualMachineSnapshotContext) 
 
 	if vmSnapshot.Status.Storage.Requested == nil {
 		ctx.Logger.V(4).Info("Updating snapshot's status requested capacity")
-		vmSnapshot.Status.Storage.Requested = []vmopv1.VirtualMachineSnapshotStorageStatusRequested{}
 		requested, err := kubeutil.CalculateReservedForSnapshotPerStorageClass(ctx, r.Client, r.Logger, *vmSnapshot)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to calculate requested capacity for snapshot: %w", err)

--- a/pkg/providers/vsphere/virtualmachine/snapshot_test.go
+++ b/pkg/providers/vsphere/virtualmachine/snapshot_test.go
@@ -529,13 +529,15 @@ func snapShotTests() {
 
 			When("Get the snapshot size of Snapshot-1", func() {
 				It("returns the size by adding size of file 3, 4, 17, 18", func() {
-					Expect(virtualmachine.GetSnapshotSize(vmCtx, &snapshot1)).To(Equal(int64(0.5*oneGiBInBytes + 500 + 500 + 2*oneGiBInBytes)))
+					Expect(virtualmachine.GetSnapshotSize(vmCtx, &snapshot1)).
+						To(Equal(int64(0.5*oneGiBInBytes + 500 + 500 + 2*oneGiBInBytes)))
 				})
 			})
 
 			When("Get the snapshot size of Snapshot-2", func() {
 				It("returns the size by adding size of file 5, 6, 19", func() {
-					Expect(virtualmachine.GetSnapshotSize(vmCtx, &snapshot2)).To(Equal(int64(1*oneGiBInBytes + 500 + 1*oneGiBInBytes)))
+					Expect(virtualmachine.GetSnapshotSize(vmCtx, &snapshot2)).
+						To(Equal(int64(1*oneGiBInBytes + 500 + 1*oneGiBInBytes)))
 				})
 			})
 		})

--- a/pkg/providers/vsphere/vmlifecycle/update_status.go
+++ b/pkg/providers/vsphere/vmlifecycle/update_status.go
@@ -1440,8 +1440,8 @@ func updateSnapshotChildrenStatus(
 		patch := ctrlclient.MergeFrom(curSnapshot.DeepCopy())
 		curSnapshot.Status.Children = children
 		if err := k8sClient.Status().Patch(vmCtx, curSnapshot, patch); err != nil {
-			vmCtx.Logger.Error(err, "Failed to update snapshot children status", "snapshotName", curSnapshot.Name)
-			return nil, err
+			return nil, fmt.Errorf("failed to update snapshot children status %q: %w",
+				curSnapshot.Name, err)
 		}
 	}
 
@@ -1471,9 +1471,8 @@ func getSnapshotCR(
 
 	if err := k8sClient.Get(vmCtx, objKey, vmSnapshot); err != nil {
 		if !apierrors.IsNotFound(err) {
-			vmCtx.Logger.Error(err, "Failed to get VirtualMachineSnapshot",
-				"snapshotName", snapshotName)
-			return nil, err
+			return nil, fmt.Errorf("failed to get VirtualMachineSnapshot %q: %w",
+				snapshotName, err)
 		}
 
 		// TODO (Lubron): We can just store an object with External kind

--- a/pkg/providers/vsphere/vmprovider_vm_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_test.go
@@ -4700,7 +4700,8 @@ func vmTests() {
 					Expect(err).ToNot(HaveOccurred())
 					Expect(conditions.IsTrue(updatedSnapshot, vmopv1.VirtualMachineSnapshotReadyCondition)).To(BeTrue())
 					Expect(updatedSnapshot.Status.Quiesced).To(BeTrue())
-					Expect(updatedSnapshot.Status.PowerState).To(Equal(vm.Status.PowerState))
+					// Snapshot should be powered off since memory is not included in the snapshot
+					Expect(updatedSnapshot.Status.PowerState).To(Equal(vmopv1.VirtualMachinePowerStateOff))
 				})
 			})
 

--- a/pkg/util/kube/vmsnapshot.go
+++ b/pkg/util/kube/vmsnapshot.go
@@ -43,7 +43,7 @@ func CalculateReservedForSnapshotPerStorageClass(
 
 	// Add the VM's memory to the total reserved capacity.
 	if vmSnapshot.Spec.Memory {
-		// Fetch the requested memory size from the VMClass.
+		// TODO(lubron): Fetch the requested memory size from the VM.status.hardware.memory.reservation.
 		vmClass := &vmopv1.VirtualMachineClass{}
 		if err := k8sClient.Get(ctx, ctrlclient.ObjectKey{Namespace: vmSnapshot.Namespace, Name: vm.Spec.ClassName}, vmClass); err != nil {
 			return nil, fmt.Errorf("failed to get VMClass %s: %w", vm.Spec.ClassName, err)
@@ -156,6 +156,9 @@ func PatchSnapshotSuccessStatus(
 	snap.Status.UniqueID = snapRef.Reference().Value
 	snap.Status.Quiesced = snap.Spec.Quiesce != nil
 	snap.Status.PowerState = vmPowerState
+	if !snap.Spec.Memory {
+		snap.Status.PowerState = vmopv1.VirtualMachinePowerStateOff
+	}
 
 	pkgcnd.MarkTrue(snap, vmopv1.VirtualMachineSnapshotReadyCondition)
 

--- a/test/builder/dummies.go
+++ b/test/builder/dummies.go
@@ -322,7 +322,8 @@ func DummyInstanceStorageVirtualMachineVolumes() []vmopv1.VirtualMachineVolume {
 func DummyBasicVirtualMachine(name, namespace string) *vmopv1.VirtualMachine {
 	return &vmopv1.VirtualMachine{
 		TypeMeta: metav1.TypeMeta{
-			Kind: "VirtualMachine",
+			Kind:       "VirtualMachine",
+			APIVersion: vmopv1.GroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
@@ -610,7 +611,7 @@ func DummyVirtualMachineSnapshot(namespace, name, vmName string) *vmopv1.Virtual
 	return &vmopv1.VirtualMachineSnapshot{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "VirtualMachineSnapshot",
-			APIVersion: "vmoperator.vmware.com/v1alpha5",
+			APIVersion: vmopv1.GroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -622,7 +623,7 @@ func DummyVirtualMachineSnapshot(namespace, name, vmName string) *vmopv1.Virtual
 		},
 		Spec: vmopv1.VirtualMachineSnapshotSpec{
 			VMRef: &vmopv1common.LocalObjectRef{
-				APIVersion: "vmoperator.vmware.com/v1alpha5",
+				APIVersion: vmopv1.GroupVersion.String(),
 				Kind:       "VirtualMachine",
 				Name:       vmName,
 			},


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**
There is chance that the VM Spec's content of a Snapshot doesn't have the VM with latest apiVersion. When revert to snapshot, this PR extracts and converts the spec to latest (v1alpha5) version of VM.
Also fix the powerstate, it should match what the `vmsnapshot.spec.memory` is set, not the state of the vm

This can't be unit tested since snapshot.config is immutable.
Test in e2e env instead

**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->

Testing done:
Have a v1alpha4 env, create a vm, create a snapshot, then upgrade vmop to this commit. Then try revert VM
```
I0828 00:22:12.168815       1 vmprovider_vm.go:1447] "Restoring VM spec from snapshot" logger="virtualmachine-controller" VirtualMachine="lubron-test/lubron-vm" reconcileID="46b291c0-b3c1-4e89-af45-edda928c1377" vmYAML=<
	apiVersion: vmoperator.vmware.com/v1alpha4 <------------------------ old version
	kind: VirtualMachine
	metadata:
	  annotations:
	    virtualmachine.vmoperator.vmware.com/first-boot-done: "true"
	    vmoperator.vmware.com/backup-version: "1756334440810"
	    vmoperator.vmware.com/bootstrap-hash-configspec: 2e1472b57af294d1
	    vmoperator.vmware.com/created-at-build-version: 0.1.0+9f82dc9+1.8.6+3f87d1c6+24915676
	    vmoperator.vmware.com/created-at-schema-version: v1alpha4
	    vmoperator.vmware.com/last-resized-vm-class: '{"name":"best-effort-small","uid":"1d6d340c-bcab-46af-87bf-f110ead8ca4b","generation":1}'
	    vmoperator.vmware.com/manager-id: 894204e9-71ec-478e-b8cf-0723216a4120
	    vmoperator.vmware.com/upgraded-to-build-version: 0.1.0+9f82dc9+1.8.6+3f87d1c6+24915676
	    vmoperator.vmware.com/upgraded-to-schema-version: v1alpha4
	  creationTimestamp: "2025-08-27T22:39:56Z"
	  finalizers:
	  - vmoperator.vmware.com/virtualmachine
	  generation: 1
	  labels:
	    topology.kubernetes.io/zone: zone-3
	  name: lubron-vm
	  namespace: lubron-test
	  resourceVersion: "6402796"
	  uid: 5ccb3183-1ec1-40cb-ab27-586bb0fb5560
	spec:
	  biosUUID: f48a7485-68c6-4d34-b905-20941ef93e7f
	  bootstrap:
	    cloudInit:
	      cloudConfig:
	        users:
	        - lock_passwd: false
	          name: kubo
	          passwd:
	            key: lubron-passwd
	            name: lubron-vm-bootstrap-data
	          shell: /bin/bash
	          ssh_authorized_keys:
	          - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCtBUpyyY3bLM2h/mqsjktPkGv8lgAnf+ntRml/mAZQVwKkHiylEacuurjoHffl2DI6ZDbfrSheqUg9ur8o2lAM17aJiRTnx8LJYeVhswpG3edBw8Vh0SRQtx6o1GoQy+9fqKUDGYO5WC4ZpSpf8tjoIuFKDGq6WAGUJi73urDGLZwVAMGUnJK1z+6twtUHJt8rR6XJs8vKhiUgb2zdCLnkkoO3U296Ni6lxZh/Y6vWDWrsbVnsvS3M8Kg8dYiCrwoSvuVsdhRIZZf1T8kHFCVmQEd5Ahf0uj9gswvwnqlt1AfXX8n3H8X6QxOn+jySBIFCj46mpBeqRn87LQR/nEMlT/d5x1YYxe7furdCGxfmBaF/brKFdbeQFSLZCCGxOMga+sm6gdvFqogb2YgwFXx+w2Y/0DORqX+FffKxDm5k4aUDvzi/0z0tT+XUjuQkJiSauo2I5O1ALeForzBh9on8ZT/Z+Nk1UuAkQmpkoAX2v77LD2jLmU80kjuRuB+ojOQtFUgxXaAwWNP9vVPSYkhpXjq3aziLGKlNO5n9hEiIPHGS6sB7Nc8vEfDlIot/Vd0sGL041Pgkc/OftVvgt7wu4swqIOA0Z1PoBy2pkvK71Oay0nii4Amt9RenH9bdXZylCad0vUEVLnvxOAETjHvU0zffNvqaJHCL/y6v7WuZDQ==
	          sudo: ALL=(ALL) NOPASSWD:ALL
	      instanceID: f48a7485-68c6-4d34-b905-20941ef93e7f
	  className: best-effort-small
	  image:
	    kind: VirtualMachineImage
	    name: vmi-a9f326cd8761ff409
	  imageName: vmi-a9f326cd8761ff409
	  instanceUUID: 7e2fafe1-af72-4af8-ab74-e35fbebd46f2
	  network:
	    interfaces:
	    - name: eth0
	      network:
	        apiVersion: netoperator.vmware.com/v1alpha1
	        kind: Network
	        name: ""
	  powerOffMode: TrySoft
	  powerState: PoweredOn
	  promoteDisksMode: Online
	  restartMode: TrySoft
	  storageClass: wcpglobal-storage-profile
	  suspendMode: TrySoft
	status: {}
 >
I0828 00:22:12.194534       1 vmprovider_vm.go:1481] "VM custom resource has been restored from snapshot" logger="virtualmachine-controller" VirtualMachine="lubron-test/lubron-vm" reconcileID="46b291c0-b3c1-4e89-af45-edda928c1377" restoredAnnotations={"virtualmachine.vmoperator.vmware.com/first-boot-done":"true","vmoperator.vmware.com/backup-version":"1756334440810","vmoperator.vmware.com/bootstrap-hash-configspec":"2e1472b57af294d1","vmoperator.vmware.com/created-at-build-version":"0.1.0+9f82dc9+1.8.6+3f87d1c6+24915676","vmoperator.vmware.com/created-at-schema-version":"v1alpha4","vmoperator.vmware.com/last-resized-vm-class":"{\"name\":\"best-effort-small\",\"uid\":\"1d6d340c-bcab-46af-87bf-f110ead8ca4b\",\"generation\":1}","vmoperator.vmware.com/manager-id":"894204e9-71ec-478e-b8cf-0723216a4120","vmoperator.vmware.com/upgraded-to-build-version":"0.1.0+9f82dc9+1.8.6+3f87d1c6+24915676","vmoperator.vmware.com/upgraded-to-schema-version":"v1alpha4"} restoredLabels={"topology.kubernetes.io/zone":"zone-3"}
I0828 00:22:12.194687       1 vmprovider_vm.go:1380] "VM spec restoration completed" logger="virtualmachine-controller" VirtualMachine="lubron-test/lubron-vm" reconcileID="46b291c0-b3c1-4e89-af45-edda928c1377" afterRestoreAnnotations={"virtualmachine.vmoperator.vmware.com/first-boot-done":"true","vmoperator.vmware.com/backup-version":"1756334440810","vmoperator.vmware.com/bootstrap-hash-configspec":"2e1472b57af294d1","vmoperator.vmware.com/created-at-build-version":"0.1.0+9f82dc9+1.8.6+3f87d1c6+24915676","vmoperator.vmware.com/created-at-schema-version":"v1alpha4","vmoperator.vmware.com/last-resized-vm-class":"{\"name\":\"best-effort-small\",\"uid\":\"1d6d340c-bcab-46af-87bf-f110ead8ca4b\",\"generation\":1}","vmoperator.vmware.com/manager-id":"894204e9-71ec-478e-b8cf-0723216a4120","vmoperator.vmware.com/upgraded-to-build-version":"0.1.0+9f82dc9+1.8.6+3f87d1c6+24915676","vmoperator.vmware.com/upgraded-to-schema-version":"v1alpha4"} afterRestoreLabels={"topology.kubernetes.io/zone":"zone-3"} afterRestoreSpecCurrentSnapshot=null
I0828 00:22:12.194753       1 vmprovider_vm.go:1385] "Successfully completed snapshot revert and restored VM spec, requeuing for next reconcile" logger="virtualmachine-controller" VirtualMachine="lubron-test/lubron-vm" reconcileID="46b291c0-b3c1-4e89-af45-edda928c1377" snapshotName="sn-1"
I0828 00:22:12.194793       1 vmprovider_vm.go:860] "Snapshot revert completed successfully, requeuing reconcile" logger="virtualmachine-controller" VirtualMachine="lubron-test/lubron-vm" reconcileID="46b291c0-b3c1-4e89-af45-edda928c1377"
```

And this is restored snapshot, it was converted to v5
```
root@423ccd7dbd8c110404ff88d677694138 [ ~ ]# k get vmsnapshot -A -oyaml
apiVersion: v1
items:
- apiVersion: vmoperator.vmware.com/v1alpha5
  kind: VirtualMachineSnapshot
  metadata:
    annotations:
      csi.vsphere.volume.sync: requested
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"vmoperator.vmware.com/v1alpha4","kind":"VirtualMachineSnapshot","metadata":{"annotations":{},"name":"sn-1","namespace":"lubron-test"},"spec":{"vmRef":{"apiVersion":"vmoperator.vmware.com/v1alpha4","kind":"VirtualMachine","name":"lubron-vm"}}}
    creationTimestamp: "2025-08-27T23:29:23Z"
    finalizers:
    - vmoperator.vmware.com/virtualmachinesnapshot
    generation: 1
    name: sn-1
    namespace: lubron-test
    ownerReferences:
    - apiVersion: vmoperator.vmware.com/v1alpha5
      kind: VirtualMachine
      name: lubron-vm
      uid: 5ccb3183-1ec1-40cb-ab27-586bb0fb5560
    resourceVersion: "6463249"
    uid: fab3e9e4-8c69-4e0b-b6a5-c483f57b131a
  spec:
    vmRef:
      apiVersion: vmoperator.vmware.com/v1alpha4
      kind: VirtualMachine
      name: lubron-vm
  status:
    conditions:
    - lastTransitionTime: "2025-08-27T23:29:24Z"
      message: ""
      reason: "True"
      status: "True"
      type: VirtualMachineSnapshotReady
    storage:
      requested:
      - storageClass: wcpglobal-storage-profile
        total: 10Gi
      used: "1438671141"
    uniqueID: snapshot-248
kind: List
metadata:
  resourceVersion: ""
```

**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
None
```