### PR TITLE
:seedling: Allow v1alpha2 spec.target.location.apiVersion in VirtualMachinePublishRequest validating webhook

### DIFF
--- a/webhooks/virtualmachinepublishrequest/validation/virtualmachinepublishrequest_validator.go
+++ b/webhooks/virtualmachinepublishrequest/validation/virtualmachinepublishrequest_validator.go
@@ -20,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	imgregv1a1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha1"
+	imgregv1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha2"
 
 	vmopv1a1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	vmopv1a2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
@@ -162,9 +163,10 @@ func (v validator) validateTargetLocation(ctx *pkgctx.WebhookRequestContext, vmp
 		allErrs = append(allErrs, field.Required(targetLocationNamePath, ""))
 	}
 
-	if vmpub.Spec.Target.Location.APIVersion != imgregv1a1.GroupVersion.String() {
+	if vmpub.Spec.Target.Location.APIVersion != imgregv1a1.GroupVersion.String() &&
+		vmpub.Spec.Target.Location.APIVersion != imgregv1.GroupVersion.String() {
 		allErrs = append(allErrs, field.NotSupported(targetLocationPath.Child("apiVersion"),
-			vmpub.Spec.Target.Location.APIVersion, []string{imgregv1a1.GroupVersion.String(), ""}))
+			vmpub.Spec.Target.Location.APIVersion, []string{imgregv1a1.GroupVersion.String(), imgregv1.GroupVersion.String(), ""}))
 	}
 
 	if vmpub.Spec.Target.Location.Kind != reflect.TypeOf(imgregv1a1.ContentLibrary{}).Name() {

--- a/webhooks/virtualmachinepublishrequest/validation/virtualmachinepublishrequest_validator_unit_test.go
+++ b/webhooks/virtualmachinepublishrequest/validation/virtualmachinepublishrequest_validator_unit_test.go
@@ -197,7 +197,7 @@ func unitTestsValidateCreate() {
 				[]string{"VirtualMachine", ""}).Error(), nil),
 		Entry("should deny invalid target location API version", createArgs{invalidTargetLocationAPIVersion: true}, false,
 			field.NotSupported(targetLocationPath.Child("apiVersion"), invalidAPIVersion,
-				[]string{"imageregistry.vmware.com/v1alpha1", ""}).Error(), nil),
+				[]string{"imageregistry.vmware.com/v1alpha1", "imageregistry.vmware.com/v1alpha2", ""}).Error(), nil),
 		Entry("should deny invalid target location kind", createArgs{invalidTargetLocationKind: true}, false,
 			field.NotSupported(targetLocationPath.Child("kind"), "ClusterContentLibrary",
 				[]string{"ContentLibrary", ""}).Error(), nil),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```