### PR TITLE
🐛Register conversion function to pointer of scheme

### DIFF
--- a/api/test/v1alpha1/conversion_test.go
+++ b/api/test/v1alpha1/conversion_test.go
@@ -241,6 +241,17 @@ func overrideVirtualMachineFieldsFuncs(codecs runtimeserializer.CodecFactory) []
 	}
 }
 
+var _ = Describe("Client-side conversion", func() {
+	It("should convert VirtualMachine from current API version to latest API version", func() {
+		scheme := runtime.NewScheme()
+		Expect(vmopv1a1.AddToScheme(scheme)).To(Succeed())
+		Expect(vmopv1.AddToScheme(scheme)).To(Succeed())
+		vm1 := &vmopv1a1.VirtualMachine{}
+		vm2 := &vmopv1.VirtualMachine{}
+		Expect(scheme.Convert(vm1, vm2, nil)).To(Succeed())
+	})
+})
+
 func overrideVirtualMachineClassFieldsFuncs(codecs runtimeserializer.CodecFactory) []interface{} {
 	return []interface{}{
 		func(classSpec *vmopv1.VirtualMachineClassSpec, c randfill.Continue) {

--- a/api/test/v1alpha2/conversion_test.go
+++ b/api/test/v1alpha2/conversion_test.go
@@ -229,6 +229,17 @@ var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 	})
 })
 
+var _ = Describe("Client-side conversion", func() {
+	It("should convert VirtualMachine from current API version to latest API version", func() {
+		scheme := runtime.NewScheme()
+		Expect(vmopv1a2.AddToScheme(scheme)).To(Succeed())
+		Expect(vmopv1.AddToScheme(scheme)).To(Succeed())
+		vm1 := &vmopv1a2.VirtualMachine{}
+		vm2 := &vmopv1.VirtualMachine{}
+		Expect(scheme.Convert(vm1, vm2, nil)).To(Succeed())
+	})
+})
+
 func overrideVirtualMachineFieldsFuncs(codecs runtimeserializer.CodecFactory) []interface{} {
 	return []interface{}{
 		func(vmSpec *vmopv1a2.VirtualMachineSpec, c randfill.Continue) {

--- a/api/test/v1alpha3/conversion_test.go
+++ b/api/test/v1alpha3/conversion_test.go
@@ -252,6 +252,17 @@ var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 	})
 })
 
+var _ = Describe("Client-side conversion", func() {
+	It("should convert VirtualMachine from current API version to latest API version", func() {
+		scheme := runtime.NewScheme()
+		Expect(vmopv1a3.AddToScheme(scheme)).To(Succeed())
+		Expect(vmopv1.AddToScheme(scheme)).To(Succeed())
+		vm1 := &vmopv1a3.VirtualMachine{}
+		vm2 := &vmopv1.VirtualMachine{}
+		Expect(scheme.Convert(vm1, vm2, nil)).To(Succeed())
+	})
+})
+
 func overrideVirtualMachineFieldsFuncs(codecs runtimeserializer.CodecFactory) []interface{} {
 	return []interface{}{
 		func(vmSpec *vmopv1a3.VirtualMachineSpec, c randfill.Continue) {

--- a/api/test/v1alpha4/conversion_test.go
+++ b/api/test/v1alpha4/conversion_test.go
@@ -252,6 +252,17 @@ var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 	})
 })
 
+var _ = Describe("Client-side conversion", func() {
+	It("should convert VirtualMachine from current API version to latest API version", func() {
+		scheme := runtime.NewScheme()
+		Expect(vmopv1a4.AddToScheme(scheme)).To(Succeed())
+		Expect(vmopv1.AddToScheme(scheme)).To(Succeed())
+		vm1 := &vmopv1a4.VirtualMachine{}
+		vm2 := &vmopv1.VirtualMachine{}
+		Expect(scheme.Convert(vm1, vm2, nil)).To(Succeed())
+	})
+})
+
 func overrideVirtualMachineFieldsFuncs(codecs runtimeserializer.CodecFactory) []interface{} {
 	return []interface{}{
 		func(vmSpec *vmopv1a4.VirtualMachineSpec, c randfill.Continue) {

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -26,7 +26,7 @@ var (
 	objectTypes = []runtime.Object{}
 
 	// localSchemeBuilder is used for type conversions.
-	localSchemeBuilder = schemeBuilder
+	localSchemeBuilder = &schemeBuilder
 )
 
 func addKnownTypes(scheme *runtime.Scheme) error {

--- a/api/v1alpha2/groupversion_info.go
+++ b/api/v1alpha2/groupversion_info.go
@@ -26,7 +26,7 @@ var (
 	objectTypes = []runtime.Object{}
 
 	// localSchemeBuilder is used for type conversions.
-	localSchemeBuilder = schemeBuilder
+	localSchemeBuilder = &schemeBuilder
 )
 
 func addKnownTypes(scheme *runtime.Scheme) error {

--- a/api/v1alpha3/groupversion_info.go
+++ b/api/v1alpha3/groupversion_info.go
@@ -26,7 +26,7 @@ var (
 	objectTypes = []runtime.Object{}
 
 	// localSchemeBuilder is used for type conversions.
-	localSchemeBuilder = schemeBuilder
+	localSchemeBuilder = &schemeBuilder
 )
 
 func addKnownTypes(scheme *runtime.Scheme) error {

--- a/api/v1alpha4/groupversion_info.go
+++ b/api/v1alpha4/groupversion_info.go
@@ -26,7 +26,7 @@ var (
 	objectTypes = []runtime.Object{}
 
 	// localSchemeBuilder is used for type conversions.
-	localSchemeBuilder = schemeBuilder
+	localSchemeBuilder = &schemeBuilder
 )
 
 func addKnownTypes(scheme *runtime.Scheme) error {

--- a/external/byok/api/v1alpha1/groupversion_info.go
+++ b/external/byok/api/v1alpha1/groupversion_info.go
@@ -24,9 +24,6 @@ var (
 	AddToScheme = schemeBuilder.AddToScheme
 
 	objectTypes = []runtime.Object{}
-
-	// localSchemeBuilder is used for type conversions.
-	localSchemeBuilder = schemeBuilder
 )
 
 func addKnownTypes(scheme *runtime.Scheme) error {

--- a/external/capabilities/api/v1alpha1/groupversion_info.go
+++ b/external/capabilities/api/v1alpha1/groupversion_info.go
@@ -24,9 +24,6 @@ var (
 	AddToScheme = schemeBuilder.AddToScheme
 
 	objectTypes = []runtime.Object{}
-
-	// localSchemeBuilder is used for type conversions.
-	localSchemeBuilder = schemeBuilder
 )
 
 func addKnownTypes(scheme *runtime.Scheme) error {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**
When trying to convert unstructured object (v1alpha4.VM) to v1alpha5.VM running
```
k8sClient.Scheme().Convert(unstructuredObj, vm, nil) 
```
Got below error
```
failed to reconcile snapshot revert: converting (v1alpha4.VirtualMachine) to (v1alpha5.VirtualMachine): unknown conversion 
```
 This is because here https://github.com/vmware-tanzu/vm-operator/blob/8cd71daf2c6142ddef8329f0bfa1082ed367676a/api/v1alpha4/groupversion_info.go#L29
```
localSchemeBuilder = schemeBuilder
```
localSchemeBuilder is a copy, not a pointer to schemeBuilder. 

While code here https://github.com/vmware-tanzu/vm-operator/blob/8cd71daf2c6142ddef8329f0bfa1082ed367676a/api/v1alpha4/zz_generated.conversion.go#L32 register the func to the copy. 
```
localSchemeBuilder.Register(RegisterConversions)
```
So the conversion functions in `RegisterConversions` are not actually registered.


Server-side (apiserver) conversion webhook use Hub/Spoke pattern which delegates to Convert_* functions, but they do not use the scheme’s RegisterConversions automatically. So server side conversion doesn't get impacted, so this bug was never discovered.
This happens when someone tries to explicitly call the scheme.Convert() from client.

Update the api/apimachinery package in api folder as well


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
None
```