### PR TITLE
🐛Only reconcile SPU for Snapshot when feature is enabled

### DIFF
--- a/controllers/virtualmachine/storagepolicyusage/storagepolicyusage_controller.go
+++ b/controllers/virtualmachine/storagepolicyusage/storagepolicyusage_controller.go
@@ -141,12 +141,14 @@ func (r *Reconciler) ReconcileNormal(
 			"failed to list VMs in namespace %s: %w", namespace, err)
 	}
 
-	errs := []error{}
+	var errs []error
 	if err := r.ReconcileSPUForVM(ctx, namespace, scName, list.Items); err != nil {
 		errs = append(errs, err)
 	}
-	if err := r.ReconcileSPUForVMSnapshot(ctx, namespace, scName, list.Items); err != nil {
-		errs = append(errs, err)
+	if pkgcfg.FromContext(ctx).Features.VMSnapshots {
+		if err := r.ReconcileSPUForVMSnapshot(ctx, namespace, scName, list.Items); err != nil {
+			errs = append(errs, err)
+		}
 	}
 
 	return apierrorsutil.NewAggregate(errs)

--- a/controllers/virtualmachine/storagepolicyusage/storagepolicyusage_controller_intg_test.go
+++ b/controllers/virtualmachine/storagepolicyusage/storagepolicyusage_controller_intg_test.go
@@ -345,7 +345,8 @@ func intgTestsReconcile() {
 				g.Expect(spuForVM.Status.ResourceTypeLevelQuotaUsage.Used).To(Equal(ptr.To(resource.MustParse("70Gi"))))
 			}, time.Second*5).Should(Succeed())
 
-			Eventually(func(g Gomega) {
+			// The SPU for VMSnapshot should not be updated since the feature is disabled.
+			Consistently(func(g Gomega) {
 				var spuForVMSnapshot spqv1.StoragePolicyUsage
 				g.Expect(ctx.Client.Get(
 					ctx,
@@ -355,11 +356,7 @@ func intgTestsReconcile() {
 					},
 					&spuForVMSnapshot),
 				).To(Succeed())
-				g.Expect(spuForVMSnapshot.Status.ResourceTypeLevelQuotaUsage).ToNot(BeNil())
-				g.Expect(spuForVMSnapshot.Status.ResourceTypeLevelQuotaUsage.Reserved).ToNot(BeNil())
-				g.Expect(spuForVMSnapshot.Status.ResourceTypeLevelQuotaUsage.Reserved).To(Equal(ptr.To(resource.MustParse("15Gi"))))
-				g.Expect(spuForVMSnapshot.Status.ResourceTypeLevelQuotaUsage.Used).ToNot(BeNil())
-				g.Expect(spuForVMSnapshot.Status.ResourceTypeLevelQuotaUsage.Used).To(Equal(ptr.To(resource.MustParse("20Gi"))))
+				g.Expect(spuForVMSnapshot.Status.ResourceTypeLevelQuotaUsage).To(BeNil())
 			}, time.Second*5).Should(Succeed())
 		})
 	})


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**
Now I could see error in VMOP reconciling SPU for snapshot even the feature is not enabled. It doesn't cause issue, just producing red herring error log.

1. Updated logic to only reconcile SPU for VMSnapshot when the feature is enabled.
2. Updated test cases to test cases when snapshot feature is enabled or not.

**Testing**
Verified after turn off the snapshot feature flag, VMOP no longer reports error of not finding SPU for snapshot

**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
None
```