### PR TITLE
:bug: Update SyncVirtualMachineImage check to account for v1alpha2 ContentLibraryItem and ClusterContentLibraryItem types

### DIFF
--- a/pkg/providers/vsphere/vmprovider.go
+++ b/pkg/providers/vsphere/vmprovider.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	imgregv1a1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha1"
+	imgregv1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha2"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	pkgcnd "github.com/vmware-tanzu/vm-operator/pkg/conditions"
@@ -198,6 +199,14 @@ func (vs *vSphereVMProvider) SyncVirtualMachineImage(
 		itemID = string(cli.Spec.UUID)
 		itemVersion = cli.Status.ContentVersion
 		itemType = cli.Status.Type
+	case *imgregv1.ContentLibraryItem:
+		itemID = cli.Spec.ID
+		itemVersion = cli.Status.ContentVersion
+		itemType = imgregv1a1.ContentLibraryItemType(cli.Status.Type)
+	case *imgregv1.ClusterContentLibraryItem:
+		itemID = cli.Spec.ID
+		itemVersion = cli.Status.ContentVersion
+		itemType = imgregv1a1.ContentLibraryItemType(cli.Status.Type)
 	default:
 		return fmt.Errorf("unexpected content library item K8s object type %T", cli)
 	}

--- a/pkg/providers/vsphere/vmprovider_test.go
+++ b/pkg/providers/vsphere/vmprovider_test.go
@@ -17,6 +17,7 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	imgregv1a1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha1"
+	imgregv1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha2"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
@@ -154,6 +155,13 @@ var _ = Describe("SyncVirtualMachineImage", func() {
 			err := vmProvider.SyncVirtualMachineImage(ctx, &imgregv1a1.ContentLibrary{}, &vmopv1.VirtualMachineImage{})
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("unexpected content library item K8s object type %T", &imgregv1a1.ContentLibrary{})))
+		})
+	})
+
+	When("content library item is a v1alpha2 type", func() {
+		It("should not return an error", func() {
+			err := vmProvider.SyncVirtualMachineImage(ctx, &imgregv1.ContentLibraryItem{}, &vmopv1.VirtualMachineImage{})
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->



There is a gap in what was delivered in https://github.com/vmware-tanzu/vm-operator/commit/7199b4bcd933945bef12469b94c34a90dee72589 and what was delivered in https://github.com/vmware-tanzu/vm-operator/commit/529ce6757ffd73cd7bba108fa1456fb3c5b4ac56 and https://github.com/vmware-tanzu/vm-operator/commit/fe407bb79e359987988a0da2a4fea41b7093bbbe

As a result, v1alpha2 ContentLibraryItems are failing this check https://github.com/vmware-tanzu/vm-operator/blob/main/pkg/providers/vsphere/vmprovider.go#L202 called by https://github.com/vmware-tanzu/vm-operator/blob/main/controllers/contentlibrary/utils/controller_builder_v1a2.go#L503

This PR updates the `SyncVirtualMachineImage` function to also account for the v1alpha2 ContentLibraryItem and ClusterContentLibraryItem types


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```