### PR TITLE
✨Add snapshot condition report

### DIFF
--- a/api/v1alpha5/virtualmachinesnapshot_types.go
+++ b/api/v1alpha5/virtualmachinesnapshot_types.go
@@ -79,11 +79,41 @@ type QuiesceSpec struct {
 const (
 	// VirtualMachineSnapshotReadyCondition represents the condition
 	// that the virtual machine snapshot is ready.
+	// It's ready only when both VirtualMachineSnapshotCreatedCondition
+	// and VirtualMachineSnapshotCSIVolumeSyncedCondition are true.
 	VirtualMachineSnapshotReadyCondition = "VirtualMachineSnapshotReady"
 
-	// VirtualMachineSnapshotInProgressReason represents that a
-	// snapshot is in progress.
-	VirtualMachineSnapshotInProgressReason = "VirtualMachineSnapshotInProgress"
+	// VirtualMachineSnapshotWaitingForCreationReason documents that the virtual machine
+	// snapshot is waiting for creation.
+	VirtualMachineSnapshotWaitingForCreationReason = "VirtualMachineSnapshotWaitingForCreation"
+
+	// VirtualMachineSnapshotWaitingForCSISyncReason documents that the virtual machine
+	// snapshot is waiting for CSI volume sync.
+	VirtualMachineSnapshotWaitingForCSISyncReason = "VirtualMachineSnapshotWaitingForCSISync"
+)
+
+const (
+	// VirtualMachineSnapshotCreatedCondition exposes the status of
+	// the virtual machine snapshot creation.
+	VirtualMachineSnapshotCreatedCondition = "VirtualMachineSnapshotCreated"
+
+	// VirtualMachineSnapshotCreationInProgressReason documents that the
+	// virtual machine snapshot creation is in progress.
+	VirtualMachineSnapshotCreationInProgressReason = "VirtualMachineSnapshotCreationInProgress"
+
+	// VirtualMachineSnapshotCreationFailedReason documents that the virtual machine
+	// snapshot creation has failed.
+	VirtualMachineSnapshotCreationFailedReason = "VirtualMachineSnapshotCreationFailed"
+)
+
+const (
+	// VirtualMachineSnapshotCSIVolumeSyncedCondition expose the status of
+	// syncing CSI volume for this virtual machine snapshot.
+	VirtualMachineSnapshotCSIVolumeSyncedCondition = "VirtualMachineSnapshotCSISynced"
+
+	// VirtualMachineSnapshotCSIVolumeSyncInProgressReason documents that the
+	// CSI volume sync is in progress for this virtual machine snapshot.
+	VirtualMachineSnapshotCSIVolumeSyncInProgressReason = "VirtualMachineSnapshotCSISyncInProgress"
 )
 
 // VirtualMachineSnapshotStatus defines the observed state of VirtualMachineSnapshot.
@@ -170,11 +200,11 @@ type VirtualMachineSnapshot struct {
 	Status VirtualMachineSnapshotStatus `json:"status,omitempty"`
 }
 
-func (vmSnapshot *VirtualMachineSnapshot) NamespacedName() string {
+func (vmSnapshot VirtualMachineSnapshot) NamespacedName() string {
 	return vmSnapshot.Namespace + "/" + vmSnapshot.Name
 }
 
-func (vmSnapshot *VirtualMachineSnapshot) GetConditions() []metav1.Condition {
+func (vmSnapshot VirtualMachineSnapshot) GetConditions() []metav1.Condition {
 	return vmSnapshot.Status.Conditions
 }
 

--- a/controllers/virtualmachine/storagepolicyusage/storagepolicyusage_controller_intg_test.go
+++ b/controllers/virtualmachine/storagepolicyusage/storagepolicyusage_controller_intg_test.go
@@ -248,7 +248,7 @@ func intgTestsReconcile() {
 						Namespace: ctx.Namespace,
 						Name:      "vm-snapshot-1",
 						Annotations: map[string]string{
-							constants.CSIVSphereVolumeSyncAnnotationKey: constants.CSIVSphereVolumeSyncAnnotationValueRequest,
+							constants.CSIVSphereVolumeSyncAnnotationKey: constants.CSIVSphereVolumeSyncAnnotationValueRequested,
 						},
 					},
 					Spec: vmopv1.VirtualMachineSnapshotSpec{

--- a/controllers/virtualmachine/storagepolicyusage/storagepolicyusage_controller_unit_test.go
+++ b/controllers/virtualmachine/storagepolicyusage/storagepolicyusage_controller_unit_test.go
@@ -1117,7 +1117,7 @@ func unitTestsReconcileSPUForVMSnapshot() {
 			When("CSI driver has not completed the sync of the volume", func() {
 				BeforeEach(func() {
 					vmSnapshot1.Annotations = map[string]string{
-						constants.CSIVSphereVolumeSyncAnnotationKey: constants.CSIVSphereVolumeSyncAnnotationValueRequest,
+						constants.CSIVSphereVolumeSyncAnnotationKey: constants.CSIVSphereVolumeSyncAnnotationValueRequested,
 					}
 				})
 
@@ -1234,10 +1234,10 @@ func unitTestsReconcileSPUForVMSnapshot() {
 			When("CSI driver has not completed the sync of the volume on both VMs", func() {
 				BeforeEach(func() {
 					vmSnapshot1.Annotations = map[string]string{
-						constants.CSIVSphereVolumeSyncAnnotationKey: constants.CSIVSphereVolumeSyncAnnotationValueRequest,
+						constants.CSIVSphereVolumeSyncAnnotationKey: constants.CSIVSphereVolumeSyncAnnotationValueRequested,
 					}
 					vmSnapshot2.Annotations = map[string]string{
-						constants.CSIVSphereVolumeSyncAnnotationKey: constants.CSIVSphereVolumeSyncAnnotationValueRequest,
+						constants.CSIVSphereVolumeSyncAnnotationKey: constants.CSIVSphereVolumeSyncAnnotationValueRequested,
 					}
 				})
 				It("should report the snapshot's reserved capacity with sum of the two VMs' reserved capacity, ignore the used capacity", func() {
@@ -1281,7 +1281,7 @@ func unitTestsReconcileSPUForVMSnapshot() {
 			When("CSI driver has not completed the sync of the volume on one VM, but completed on the other", func() {
 				BeforeEach(func() {
 					vmSnapshot1.Annotations = map[string]string{
-						constants.CSIVSphereVolumeSyncAnnotationKey: constants.CSIVSphereVolumeSyncAnnotationValueRequest,
+						constants.CSIVSphereVolumeSyncAnnotationKey: constants.CSIVSphereVolumeSyncAnnotationValueRequested,
 					}
 					vmSnapshot2.Annotations = map[string]string{
 						constants.CSIVSphereVolumeSyncAnnotationKey: constants.CSIVSphereVolumeSyncAnnotationValueCompleted,

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -196,10 +196,10 @@ const (
 	// annotation.
 	CSIVSphereVolumeSyncAnnotationKey = "csi.vsphere.volume.sync"
 
-	// CSIVSphereVolumeSyncAnnotationValueRequest is the annotation value for the
+	// CSIVSphereVolumeSyncAnnotationValueRequested is the annotation value for the
 	// CSIVSphereVolumeSync annotation. It is used to inform the CSI driver to
 	// update SPU for the attached volumes.
-	CSIVSphereVolumeSyncAnnotationValueRequest = "requested"
+	CSIVSphereVolumeSyncAnnotationValueRequested = "requested"
 
 	// CSIVSphereVolumeSyncAnnotationValueCompleted is the annotation value for the
 	// CSIVSphereVolumeSync annotation. It is used to indicate that the CSI driver

--- a/pkg/util/kube/vmsnapshot.go
+++ b/pkg/util/kube/vmsnapshot.go
@@ -160,7 +160,7 @@ func PatchSnapshotSuccessStatus(
 		snap.Status.PowerState = vmopv1.VirtualMachinePowerStateOff
 	}
 
-	pkgcnd.MarkTrue(snap, vmopv1.VirtualMachineSnapshotReadyCondition)
+	pkgcnd.MarkTrue(snap, vmopv1.VirtualMachineSnapshotCreatedCondition)
 
 	if err := k8sClient.Status().Patch(ctx, snap, snapPatch); err != nil {
 		return fmt.Errorf(

--- a/pkg/util/kube/vmsnapshot_test.go
+++ b/pkg/util/kube/vmsnapshot_test.go
@@ -324,7 +324,7 @@ var _ = Describe("PatchSnapshotSuccessStatus", func() {
 			}
 		})
 
-		When("snapshot patched with vm info and ready condition", func() {
+		When("snapshot patched with vm info and created condition", func() {
 			BeforeEach(func() {
 				vmCtx.VM.Status = vmopv1.VirtualMachineStatus{
 					UniqueID: "dummyID",
@@ -351,7 +351,7 @@ var _ = Describe("PatchSnapshotSuccessStatus", func() {
 				Expect(snapObj.Status.UniqueID).To(Equal(snapMoRef.Value))
 				Expect(snapObj.Status.Quiesced).To(BeTrue())
 				Expect(snapObj.Status.PowerState).To(Equal(vmopv1.VirtualMachinePowerStateOff))
-				Expect(conditions.IsTrue(snapObj, vmopv1.VirtualMachineSnapshotReadyCondition)).To(BeTrue())
+				Expect(conditions.IsTrue(snapObj, vmopv1.VirtualMachineSnapshotCreatedCondition)).To(BeTrue())
 			})
 
 			DescribeTable("memory and power state", func(


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
Add snapshot condition report.
```
// indicate whether snapshot is ready
- VirtualMachineSnapshotReadyCondition
     // indicate whether snapshot is created
    - VirtualMachineSnapshotCreatedCondition
     // indicate whether csi volume sync has been done for this snapshot
    - VirtualMachineSnapshotCSIVolumeSyncedCondition
```

For `VirtualMachineSnapshotCreatedCondition`
1. Not setting it by default
2. When reconcileSnapshot sees the snapshot has `VirtualMachineSnapshotCreatedCondition` set to true, then skip
3. When snapshot is being created, set reason to `in progress`
4. If creation failed, set reason to `failed`
5. Set to true once snapshot is created.
6. ReconcileSnapshotRevert will only process the snapshot if it has `VirtualMachineSnapshotReadyCondition` set to true, means it needs to have `VirtualMachineSnapshotCSIVolumeSyncedCondition` to true as well.

For `VirtualMachineSnapshotCSIVolumeSyncedCondition`
1. Not setting it by default
2. Set to `requested` once VMSnapshot controller sets the csi sync annotation, only after `VirtualMachineSnapshotCreatedCondition` is true
3. Set to true once the annotation is set to completed

For `VirtualMachineSnapshotReadyCondition`
Only set to true when both `VirtualMachineSnapshotCreatedCondition` and `VirtualMachineSnapshotCSIVolumeSyncedCondition` are ready

Besides above:
1. Refactored some tests as well.
2. Also remove some of the vmCtx.Logger.Error


<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    7. If a release note is not required, please write "NONE".
-->


```release-note
Add snapshot condition report
```