### PR TITLE
🌱  Emit a condition for a failed snapshot revert operation

### DIFF
--- a/api/v1alpha5/virtualmachine_types.go
+++ b/api/v1alpha5/virtualmachine_types.go
@@ -59,6 +59,32 @@ const (
 )
 
 const (
+	// VirtualMachineSnapshotRevertSucceeded indicates that the VM
+	// has been reverted to a snapshot.
+	VirtualMachineSnapshotRevertSucceeded = "VirtualMachineSnapshotRevertSucceeded"
+
+	// VirtualMachineSnapshotRevertInProgressReason indicates that the
+	// revert operation is in progress.
+	VirtualMachineSnapshotRevertInProgressReason = "VirtualMachineSnapshotRevertInProgress"
+
+	// VirtualMachineSnapshotRevertTaskFailedReason indicates that the
+	// revert operation is invalid.
+	VirtualMachineSnapshotRevertTaskFailedReason = "VirtualMachineSnapshotRevertTaskFailed"
+
+	// VirtualMachineSnapshotRevertFailedInvalidVMManifestReason indicates
+	// that the revert operation has failed due to invalid VM spec to revert to.
+	VirtualMachineSnapshotRevertFailedInvalidVMManifestReason = "VirtualMachineSnapshotRevertFailedInvalidVMManifest"
+
+	// VirtualMachineSnapshotRevertSkippedReason indicates that the
+	// revert operation was skipped.
+	VirtualMachineSnapshotRevertSkippedReason = "VirtualMachineSnapshotRevertSkipped"
+
+	// VirtualMachineSnapshotRevertFailedReason indicates that the
+	// revert operation failed for some reason.
+	VirtualMachineSnapshotRevertFailedReason = "VirtualMachineSnapshotRevertFailed"
+)
+
+const (
 	// GuestBootstrapCondition exposes the status of guest bootstrap from within
 	// the guest OS, when available.
 	GuestBootstrapCondition = "GuestBootstrap"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -162,6 +162,14 @@ const (
 	// VirtualMachineSnapshotRevertInProgressAnnotationKey is the
 	// annotation key to indicate that a VM snapshot revert is in
 	// progress.
+	//
+	// This annotation is set when a snapshot revert operation is initiated
+	// and is removed once the operation completes successfully.
+	//
+	// If the revert operation fails, this annotation may remain on the VM,
+	// indicating that the revert is still in progress. In such cases, manual
+	// intervention will be required to remove the annotation and retry the
+	// revert operation.
 	VirtualMachineSnapshotRevertInProgressAnnotationKey = "vmoperator.vmware.com/snapshot-revert-in-progress"
 
 	// VMProvKeepDisksExtraConfigKey is set in ExtraConfig with the value a

--- a/pkg/providers/vsphere/vmprovider_vm_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_test.go
@@ -3071,6 +3071,13 @@ func vmTests() {
 						err := createOrUpdateVM(ctx, vmProvider, vm)
 						Expect(err).To(HaveOccurred())
 						Expect(err.Error()).To(ContainSubstring("virtualmachinesnapshots.vmoperator.vmware.com \"test-revert-snap\" not found"))
+
+						Expect(conditions.IsFalse(vm,
+							vmopv1.VirtualMachineSnapshotRevertSucceeded,
+						)).To(BeTrue())
+						Expect(conditions.GetReason(vm,
+							vmopv1.VirtualMachineSnapshotRevertSucceeded,
+						)).To(Equal(vmopv1.VirtualMachineSnapshotRevertFailedReason))
 					})
 				})
 
@@ -3083,7 +3090,7 @@ func vmTests() {
 						}
 					})
 
-					It("should fail with snapshot CR not found error", func() {
+					It("should fail with snapshot CR not ready error", func() {
 						// Create snapshot CR but don't mark it as ready.
 						Expect(ctx.Client.Create(ctx, vmSnapshot)).To(Succeed())
 
@@ -3098,6 +3105,11 @@ func vmTests() {
 						Expect(err.Error()).To(ContainSubstring(
 							fmt.Sprintf("skipping revert for not-ready snapshot %q",
 								vmSnapshot.Name)))
+						Expect(conditions.IsFalse(vm,
+							vmopv1.VirtualMachineSnapshotRevertSucceeded)).To(BeTrue())
+						Expect(conditions.GetReason(vm,
+							vmopv1.VirtualMachineSnapshotRevertSucceeded,
+						)).To(Equal(vmopv1.VirtualMachineSnapshotRevertSkippedReason))
 					})
 				})
 
@@ -3226,6 +3238,95 @@ func vmTests() {
 						pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
 							config.Features.VMImportNewNet = true
 						})
+					})
+					It("should fail the revert if the snapshot wasn't imported", func() {
+						if vm.Labels == nil {
+							vm.Labels = make(map[string]string)
+						}
+
+						// skip creation of backup VMResourceYAMLExtraConfigKey
+						// by setting the CAPV cluster role label
+						vm.Labels[kubeutil.CAPVClusterRoleLabelKey] = ""
+
+						// Create VM first
+						vcVM, err := createOrUpdateAndGetVcVM(ctx, vmProvider, vm)
+						Expect(err).ToNot(HaveOccurred())
+
+						// make sure the VM doesn't have the ExtraConfig stamped
+						var moVM mo.VirtualMachine
+						Expect(vcVM.Properties(ctx, vcVM.Reference(), nil, &moVM)).To(Succeed())
+						Expect(moVM.Config.ExtraConfig).ToNot(BeNil())
+						ecMap := pkgutil.OptionValues(moVM.Config.ExtraConfig).StringMap()
+						Expect(ecMap).ToNot(HaveKey(backupapi.VMResourceYAMLExtraConfigKey))
+
+						// Create first snapshot in vCenter
+						task, err := vcVM.CreateSnapshot(
+							ctx, vmSnapshot.Name, "first snapshot", false, false)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(task.Wait(ctx)).To(Succeed())
+
+						// Create first snapshot CR and Mark the snapshot as ready
+						// so that the snapshot workflow doesn't try to create it.
+						conditions.MarkTrue(vmSnapshot, vmopv1.VirtualMachineSnapshotReadyCondition)
+						Expect(ctx.Client.Create(ctx, vmSnapshot)).To(Succeed())
+
+						// Snapshot should be owned by the VM resource.
+						o := vmopv1.VirtualMachine{}
+						Expect(ctx.Client.Get(
+							ctx, client.ObjectKeyFromObject(vm), &o)).To(Succeed())
+						Expect(controllerutil.SetOwnerReference(
+							&o, vmSnapshot, ctx.Scheme)).To(Succeed())
+						Expect(ctx.Client.Update(ctx, vmSnapshot)).To(Succeed())
+
+						// mark the snapshot as ready because snapshot workflow
+						// will skip because of the CAPV cluster role label
+						cur := &vmopv1.VirtualMachineSnapshot{}
+						Expect(ctx.Client.Get(
+							ctx, client.ObjectKeyFromObject(vmSnapshot), cur)).To(Succeed())
+						conditions.MarkTrue(cur, vmopv1.VirtualMachineSnapshotReadyCondition)
+						Expect(ctx.Client.Status().Update(ctx, cur)).To(Succeed())
+
+						// we don't need the CAPI label anymore
+						labels := vm.Labels
+						delete(labels, kubeutil.CAPVClusterRoleLabelKey)
+						vm.Labels = labels
+						Expect(ctx.Client.Update(ctx, vm)).To(Succeed())
+
+						// modify the VM Spec to tinker with some flag
+						Expect(vm.Spec.PowerOffMode).To(Equal(vmopv1.VirtualMachinePowerOpModeHard))
+						vm.Spec.PowerOffMode = vmopv1.VirtualMachinePowerOpModeSoft
+						Expect(ctx.Client.Update(ctx, vm)).To(Succeed())
+
+						// Create second snapshot
+						secondSnapshot = builder.DummyVirtualMachineSnapshot("", "test-second-snap", vm.Name)
+						secondSnapshot.Namespace = nsInfo.Namespace
+
+						task, err = vcVM.CreateSnapshot(ctx, secondSnapshot.Name, "second snapshot", false, false)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(task.Wait(ctx)).To(Succeed())
+
+						// Create second snapshot CR and Mark the snapshot as ready
+						// so that the snapshot workflow doesn't try to create it.
+						conditions.MarkTrue(secondSnapshot, vmopv1.VirtualMachineSnapshotReadyCondition)
+						// Snapshot should be owned by the VM resource.
+						Expect(controllerutil.SetOwnerReference(&o, secondSnapshot, ctx.Scheme)).To(Succeed())
+						Expect(ctx.Client.Create(ctx, secondSnapshot)).To(Succeed())
+
+						// Set desired snapshot to first snapshot (perform a revert from second to first)
+						vm.Spec.CurrentSnapshot = &vmopv1common.LocalObjectRef{
+							APIVersion: vmSnapshot.APIVersion,
+							Kind:       vmSnapshot.Kind,
+							Name:       vmSnapshot.Name,
+						}
+
+						err = createOrUpdateVM(ctx, vmProvider, vm)
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).To(ContainSubstring("no VM YAML in snapshot config"))
+						Expect(conditions.IsFalse(vm,
+							vmopv1.VirtualMachineSnapshotRevertSucceeded)).To(BeTrue())
+						Expect(conditions.GetReason(vm,
+							vmopv1.VirtualMachineSnapshotRevertSucceeded,
+						)).To(Equal(vmopv1.VirtualMachineSnapshotRevertFailedInvalidVMManifestReason))
 					})
 
 					It("should successfully revert to desired snapshot and approximate the VM Spec", func() {
@@ -3412,6 +3513,8 @@ func vmTests() {
 						// VM status should still point to first snapshot because revert was skipped
 						Expect(vm.Status.CurrentSnapshot).ToNot(BeNil())
 						Expect(vm.Status.CurrentSnapshot.Name).To(Equal(vmSnapshot.Name))
+						Expect(conditions.IsFalse(vm, vmopv1.VirtualMachineSnapshotRevertSucceeded)).To(BeTrue())
+						Expect(conditions.GetReason(vm, vmopv1.VirtualMachineSnapshotRevertSucceeded)).To(Equal(vmopv1.VirtualMachineSnapshotRevertSkippedReason))
 
 						// Verify the snapshot in vCenter is still the original one (no revert happened)
 						var moVM mo.VirtualMachine

--- a/pkg/providers/vsphere/vmprovider_vm_utils.go
+++ b/pkg/providers/vsphere/vmprovider_vm_utils.go
@@ -48,6 +48,25 @@ func errToConditionReasonAndMessage(err error) (string, string) {
 	}
 }
 
+func errorMessageFromTaskInfoWithKey(taskInfo *vimtypes.TaskInfo, key string) string {
+	if taskInfo == nil || taskInfo.Error == nil || taskInfo.Error.Fault == nil {
+		return ""
+	}
+
+	fault := taskInfo.Error.Fault.GetMethodFault()
+	if fault == nil || len(fault.FaultMessage) == 0 {
+		return ""
+	}
+
+	for _, fm := range fault.FaultMessage {
+		if fm.Key == key {
+			return fm.Message
+		}
+	}
+
+	return ""
+}
+
 func GetVirtualMachineClass(
 	vmCtx pkgctx.VirtualMachineContext,
 	k8sClient ctrlclient.Client) (vmopv1.VirtualMachineClass, error) {


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

When a snapshot revert operation fails, we now emit a condition on the VirtualMachine object to indicate the failure. This condition provides details about the failure, allowing users to understand the reason behind the unsuccessful revert attempt.

Once the revert operation fails, users will see a condition named `VirtualMachineSnapshotRevertSucceeded` set to `False` on the VirtualMachine object. The condition's message will contain information about the error encountered during the revert process.

Also, enhances documentations for the `VirtualMachineSnapshotRevertInProgressAnnotationKey` to clarify its behavior in failure scenarios.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

None

**Are there any special notes for your reviewer**:

### Manual testing is done on a VC
1. A VM is created with a PVC, and then two VM snapshots were created in succession `sn-1 -> sn-2`. Such were created to have a few revert points to revert to.
2. With that running state, a CSI `VolumeSnapshot` was taken of the PVC.
3. Then another VM snapshot was taken `sn-3` to create another revert point for testing.

Now with the VM running with a state after `sn-3`, we attempt a revert to `sn-1`. This fails with a resulting state of VM.

```
root@420ff86af566197915ddbd611ec9ccab [ ~ ]# k get vm vm -o yaml
apiVersion: vmoperator.vmware.com/v1alpha5
kind: VirtualMachine
metadata:
  annotations:
    ...
    vmoperator.vmware.com/snapshot-revert-in-progress: ""
    ...
  creationTimestamp: "2025-08-28T10:57:24Z"
  finalizers:
  - vmoperator.vmware.com/virtualmachine
  generation: 6
  labels:
    topology.kubernetes.io/zone: domain-c36
  name: vm
  namespace: nabarun
  resourceVersion: "3243679"
  uid: a92fa694-efc5-431b-aeb9-ad046b5fbda9
spec:
  ...
  currentSnapshot:
    apiVersion: vmoperator.vmware.com/v1alpha5
    kind: VirtualMachineSnapshot
    name: sn-1
  ...
  volumes:
  - name: data-disk
    persistentVolumeClaim:
      claimName: vm-data-disk
status:
  ...
  conditions:
  ...
  - lastTransitionTime: "2025-08-29T06:12:59Z"
    message: 'An error occurred while reverting to a snapshot: The specified snapshot
      is not revertable. The virtual machine cannot be reverted when crossing a CSI
      VolumeSnapshot. Please delete the VolumeSnapshots and retry the revert.'
    reason: VirtualMachineSnapshotRevertInvalid
    status: "False"
    type: VirtualMachineSnapshotRevertSucceeded
  ...
  currentSnapshot:
    apiVersion: vmoperator.vmware.com/v1alpha5
    kind: VirtualMachineSnapshot
    name: sn-3
  ...
```

And the following events were in the event log.

```
root@420ff86af566197915ddbd611ec9ccab [ ~ ]# k get events
LAST SEEN   TYPE      REASON          OBJECT              MESSAGE
16m         Normal    UpdateSuccess   virtualmachine/vm   Update success
85s         Normal    UpdateSuccess   virtualmachine/vm   Update success
85s         Warning   UpdateFailure   virtualmachine/vm   failed to reconcile snapshot revert: The operation is not allowed in the current state.
```

### vcsim tests

Future TODO: To add a way in govmomi to inject faults and check for them.

**Please add a release note if necessary**:

```release-note
🌱  Emit a condition for a failed snapshot revert operation
```