### PR TITLE
 🌱 Verify  if a VM Template is Associated with a VM Publish Request

### DIFF
--- a/api/v1alpha5/virtualmachinepublishrequest_types.go
+++ b/api/v1alpha5/virtualmachinepublishrequest_types.go
@@ -112,6 +112,10 @@ const (
 	// VirtualMachinePublishRequestManagedByLabelKey is the label key to identify VirtualMachinePublishRequest that
 	// is created as a part of the VirtualMachineGroupPublishRequest.
 	VirtualMachinePublishRequestManagedByLabelKey = GroupName + "/virtualmachinepublishrequest-managed-by"
+
+	// VirtualMachinePublishRequestUUIDLabelKey is the label key to store UUID of the VirtualMachinePublishRequest that
+	// clones a source virtual machine, as a virtual machine template.
+	VirtualMachinePublishRequestUUIDLabelKey = GroupName + "/virtualmachinepublishrequest-uuid"
 )
 
 // VirtualMachinePublishRequestSource is the source of a publication request,

--- a/controllers/virtualmachinepublishrequest/virtualmachinepublishrequest_controller_unit_test.go
+++ b/controllers/virtualmachinepublishrequest/virtualmachinepublishrequest_controller_unit_test.go
@@ -732,34 +732,6 @@ func unitTestsReconcile() {
 						vmopv1.VirtualMachinePublishRequestConditionUploaded)).To(BeTrue())
 				})
 			})
-
-			When("Publishing to inventory", func() {
-				When("Prior task succeeded", func() {
-					JustBeforeEach(func() {
-						pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-							config.Features.InventoryContentLibrary = true
-						})
-						clv1a2 := builder.DummyContentLibraryV1A2("dummy-cl", vm.Namespace, "dummy-id")
-						Expect(ctx.Client.Create(ctx, clv1a2)).To(Succeed())
-
-						fakeVMProvider.GetItemFromInventoryByNameFn = func(ctx context.Context,
-							contentLibrary, itemName string) (object.Reference, error) {
-							return &object.VirtualMachine{}, nil
-						}
-					})
-
-					It("target valid and mark Upload to true", func() {
-						_, err := reconciler.ReconcileNormal(vmpubCtx)
-						Expect(err).NotTo(HaveOccurred())
-
-						// Update TargetValid condition.
-						Expect(conditions.IsTrue(vmpub,
-							vmopv1.VirtualMachinePublishRequestConditionTargetValid)).To(BeTrue())
-						Expect(conditions.IsTrue(vmpub,
-							vmopv1.VirtualMachinePublishRequestConditionUploaded)).To(BeTrue())
-					})
-				})
-			})
 		})
 	})
 }

--- a/pkg/providers/vsphere/virtualmachine/publish.go
+++ b/pkg/providers/vsphere/virtualmachine/publish.go
@@ -75,8 +75,6 @@ func CloneVM(
 	cl *imgregv1.ContentLibrary,
 	storagePolicyID, actID string) (string, error) {
 
-	descriptionPrefix := fmt.Sprintf(itemDescriptionFormat, string(vmPubReq.UID))
-
 	targetName := vmPubReq.Status.TargetRef.Item.Name
 
 	folderRef := vimtypes.ManagedObjectReference{
@@ -95,7 +93,13 @@ func CloneVM(
 		},
 		Template: true,
 		Config: &vimtypes.VirtualMachineConfigSpec{
-			Annotation: descriptionPrefix + vmPubReq.Status.TargetRef.Item.Description,
+			Annotation: vmPubReq.Status.TargetRef.Item.Description,
+			ExtraConfig: []vimtypes.BaseOptionValue{
+				&vimtypes.OptionValue{
+					Key:   vmopv1.VirtualMachinePublishRequestUUIDLabelKey,
+					Value: string(vmPubReq.UID),
+				},
+			},
 		},
 	}
 

--- a/pkg/providers/vsphere/vmlifecycle/create_fastdeploy.go
+++ b/pkg/providers/vsphere/vmlifecycle/create_fastdeploy.go
@@ -18,6 +18,7 @@ import (
 	"github.com/vmware/govmomi/vim25"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgconst "github.com/vmware-tanzu/vm-operator/pkg/constants"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
@@ -151,6 +152,13 @@ func fastDeploy(
 			}
 		}
 	}
+
+	// If a VM template is cloned via a VM publish request, the VM publish
+	// request UUID is added to the extraConfig. The UUID is removed when the
+	// template is used to clone a new VM.
+	createArgs.ConfigSpec.ExtraConfig = pkgutil.OptionValues(
+		createArgs.ConfigSpec.ExtraConfig).Delete(
+		vmopv1.VirtualMachinePublishRequestUUIDLabelKey)
 
 	// If any error occurs after this point, the newly created VM directory and
 	// its contents need to be cleaned up.


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
The PR adds the VM publish request's UUID to the cloned VM template's extra configurations, so it could be used to verify if the VM template is associated with a VM publish request. The UUID extra configuration is removed when the VM template is used for creating a new VM. 


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # N/A


**Are there any special notes for your reviewer**:
More integration tests will be added once the final end-to-end flow for publishing an inventory VM is complete.  


**Please add a release note if necessary**:
```release-note
N/A
```