### PR TITLE
🌱 Reverts a VM to the same power state as that of the snapshot

### DIFF
--- a/pkg/providers/vsphere/vmprovider_vm_snapshot.go
+++ b/pkg/providers/vsphere/vmprovider_vm_snapshot.go
@@ -444,6 +444,11 @@ func (vs *vSphereVMProvider) restoreVMSpecFromSnapshot(
 	// Empty out the status.
 	vmCtx.VM.Status = vmopv1.VirtualMachineStatus{}
 
+	// reconcile the power state of the VM post revert
+	if err := vs.reconcilePostRevertPowerState(vmCtx, snapObj); err != nil {
+		return fmt.Errorf("failed to reconcile power state post revert: %w", err)
+	}
+
 	// Note that since we swapped out the annotations from the
 	// snapshot, it will implicitly remove the "restore-in-progress"
 	// annotation. But go ahead and clean it up again in case the
@@ -482,7 +487,7 @@ func (vs *vSphereVMProvider) getVMYamlFromSnapshot(
 		// If the Snapshot has ImportedSnapshotAnnotation, then approximate the
 		// VM spec.
 		return getVMYamlFromSnapshotFromSynthesizedSpec(
-			vmCtx, snap, moSnap, snapRef)
+			vmCtx, snap, moSnap)
 	}
 
 	logger.V(4).Info("Found backup data in snapshot config",
@@ -501,8 +506,7 @@ func (vs *vSphereVMProvider) getVMYamlFromSnapshot(
 func getVMYamlFromSnapshotFromSynthesizedSpec(
 	vmCtx pkgctx.VirtualMachineContext,
 	snapCR *vmopv1.VirtualMachineSnapshot,
-	moSnap mo.VirtualMachineSnapshot,
-	snap *vimtypes.ManagedObjectReference) (string, error) {
+	moSnap mo.VirtualMachineSnapshot) (string, error) {
 
 	logger := pkglog.FromContextOrDefault(vmCtx)
 
@@ -535,28 +539,6 @@ func getVMYamlFromSnapshotFromSynthesizedSpec(
 			APIVersion: vmopv1.GroupVersion.String(),
 		},
 		Spec: synthesizeVMSpecForSnapshot(*vmCtx.VM, vmCtx.MoVM, moSnap),
-	}
-
-	// Inferred from the power state of the snapshot
-	// It doesn't matter what the power state of the VM is at the time of
-	// revert.
-	// The VM is always reverted in the same power state as the snapshot.
-	snapshot := vmlifecycle.FindSnapshotInTree(
-		vmCtx.MoVM.Snapshot.RootSnapshotList, snap.Value)
-	if snapshot == nil {
-		// weird situation here
-		// the snapshot being processed doesn't exist in the snapshot tree
-		// this shouldn't be happening
-		return "", fmt.Errorf(
-			"failed to find snapshot %q in tree", snap.Value)
-	}
-
-	// Convert from vimtypes.VirtualMachinePowerState to
-	// vmopv1.VirtualMachinePowerState
-	if snapshot.State == vimtypes.VirtualMachinePowerStatePoweredOn {
-		vm.Spec.PowerState = vmopv1.VirtualMachinePowerStateOn
-	} else {
-		vm.Spec.PowerState = vmopv1.VirtualMachinePowerStateOff
 	}
 
 	// Number of elements in the spec.network.interfaces list must be same
@@ -862,4 +844,38 @@ func (vs *vSphereVMProvider) unmarshalAndConvertVMFromYAML(
 	}
 
 	return vm, nil
+}
+
+func (vs *vSphereVMProvider) reconcilePostRevertPowerState(
+	vmCtx pkgctx.VirtualMachineContext,
+	snapObj *vimtypes.ManagedObjectReference) error {
+
+	snap := vmlifecycle.FindSnapshotInTree(vmCtx.MoVM.Snapshot.RootSnapshotList, snapObj.Value)
+	if snap == nil {
+		// weird situation here
+		// the snapshot being processed doesn't exist in the snapshot tree
+		// this shouldn't be happening
+		return fmt.Errorf("snapshot %s not found in VM Snapshot Tree", snapObj.Value)
+	}
+
+	// vpxd sets the power state of the snapshot to Off if a VM which is On
+	// is snapshotted without the memory state. We don't need to separately
+	// handle that case here.
+	switch snap.State {
+	case vimtypes.VirtualMachinePowerStatePoweredOn:
+		vmCtx.VM.Spec.PowerState = vmopv1.VirtualMachinePowerStateOn
+	case vimtypes.VirtualMachinePowerStatePoweredOff:
+		vmCtx.VM.Spec.PowerState = vmopv1.VirtualMachinePowerStateOff
+	case vimtypes.VirtualMachinePowerStateSuspended:
+		vmCtx.VM.Spec.PowerState = vmopv1.VirtualMachinePowerStateSuspended
+	default:
+		// Unknown state, log and default to off
+		// this is very very unlikely to happen
+		vmCtx.Logger.Info(
+			"Unknown snapshot power state, defaulting to Off",
+			"snapshotState", snap.State)
+		vmCtx.VM.Spec.PowerState = vmopv1.VirtualMachinePowerStateOff
+	}
+
+	return nil
 }

--- a/pkg/providers/vsphere/vmprovider_vm_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_test.go
@@ -3171,9 +3171,7 @@ func vmTests() {
 						// Mark the snapshot as ready so that the snapshot workflow doesn't try to create it.
 						conditions.MarkTrue(secondSnapshot, vmopv1.VirtualMachineSnapshotReadyCondition)
 						// Snapshot should be owned by the VM resource.
-						Expect(controllerutil.SetOwnerReference(&o, vmSnapshot, ctx.Scheme)).To(Succeed())
 						Expect(controllerutil.SetOwnerReference(&o, secondSnapshot, ctx.Scheme)).To(Succeed())
-						Expect(ctx.Client.Update(ctx, vmSnapshot)).To(Succeed())
 						Expect(ctx.Client.Create(ctx, secondSnapshot)).To(Succeed())
 
 						// Set desired snapshot to first snapshot (revert from second to first)
@@ -3208,6 +3206,83 @@ func vmTests() {
 						currentSnap := vmlifecycle.FindSnapshotInTree(moVM.Snapshot.RootSnapshotList, moVM.Snapshot.CurrentSnapshot.Value)
 						Expect(currentSnap).ToNot(BeNil())
 						Expect(currentSnap.Name).To(Equal(vmSnapshot.Name))
+					})
+
+					Context("and the snapshot was taken when VM was powered on and is now powered off", func() {
+						It("should successfully power on the VM after reverting to a Snapshot in PoweredOn state", func() {
+							// Create VM first
+							vcVM, err := createOrUpdateAndGetVcVM(ctx, vmProvider, vm)
+							Expect(err).ToNot(HaveOccurred())
+
+							// Create first snapshot in vCenter
+							task, err := vcVM.CreateSnapshot(ctx, vmSnapshot.Name, "first snapshot", false, false)
+							Expect(err).ToNot(HaveOccurred())
+							Expect(task.Wait(ctx)).To(Succeed())
+
+							// Create first snapshot CR
+							// Mark the snapshot as ready so that the snapshot workflow doesn't try to create it.
+							conditions.MarkTrue(vmSnapshot, vmopv1.VirtualMachineSnapshotReadyCondition)
+							Expect(ctx.Client.Create(ctx, vmSnapshot)).To(Succeed())
+
+							// Verify the snapshot is actually current in vCenter
+							var moVM mo.VirtualMachine
+							Expect(vcVM.Properties(ctx, vcVM.Reference(), []string{"snapshot"}, &moVM)).To(Succeed())
+							Expect(moVM.Snapshot).ToNot(BeNil())
+
+							// verify that the snapshot's power state is powered off
+							snapshot := vmlifecycle.FindSnapshotInTree(moVM.Snapshot.RootSnapshotList, moVM.Snapshot.CurrentSnapshot.Value)
+							Expect(snapshot).ToNot(BeNil())
+							Expect(snapshot.State).To(Equal(vimtypes.VirtualMachinePowerStatePoweredOff))
+
+							// Snapshot should be owned by the VM resource.
+							Expect(controllerutil.SetOwnerReference(vm, vmSnapshot, ctx.Scheme)).To(Succeed())
+							Expect(ctx.Client.Update(ctx, vmSnapshot)).To(Succeed())
+
+							// Create second snapshot
+							secondSnapshot = builder.DummyVirtualMachineSnapshotWithMemory("", "test-second-snap", vm.Name)
+							secondSnapshot.Namespace = nsInfo.Namespace
+
+							task, err = vcVM.CreateSnapshot(ctx, secondSnapshot.Name, "second snapshot", true, false)
+							Expect(err).ToNot(HaveOccurred())
+							Expect(task.Wait(ctx)).To(Succeed())
+
+							// Create second snapshot CR
+							// Mark the snapshot as ready so that the snapshot workflow doesn't try to create it.
+							conditions.MarkTrue(secondSnapshot, vmopv1.VirtualMachineSnapshotReadyCondition)
+							// Snapshot should be owned by the VM resource.
+							Expect(controllerutil.SetOwnerReference(vm, secondSnapshot, ctx.Scheme)).To(Succeed())
+							Expect(ctx.Client.Create(ctx, secondSnapshot)).To(Succeed())
+
+							// Verify the VM is powered on
+							Expect(vm.Status.PowerState).To(Equal(vmopv1.VirtualMachinePowerStateOn))
+							state, err := vcVM.PowerState(ctx)
+							Expect(err).ToNot(HaveOccurred())
+							Expect(state).To(Equal(vimtypes.VirtualMachinePowerStatePoweredOn))
+
+							// Set desired snapshot to first snapshot (revert from second to first)
+							vm.Spec.CurrentSnapshot = &vmopv1common.LocalObjectRef{
+								APIVersion: vmSnapshot.APIVersion,
+								Kind:       vmSnapshot.Kind,
+								Name:       vmSnapshot.Name,
+							}
+
+							// Revert to the first snapshot
+							err = createOrUpdateVM(ctx, vmProvider, vm)
+							Expect(err).ToNot(HaveOccurred())
+
+							// Verify VM status reflects the reverted snapshot
+							Expect(vm.Status.CurrentSnapshot).ToNot(BeNil())
+							Expect(vm.Status.CurrentSnapshot.Name).To(Equal(vmSnapshot.Name))
+
+							// Verify the spec.currentSnapshot is cleared.
+							Expect(vm.Spec.CurrentSnapshot).To(BeNil())
+
+							// Verify the VM is powered off
+							Expect(vm.Status.PowerState).To(Equal(vmopv1.VirtualMachinePowerStateOff))
+							state, err = vcVM.PowerState(ctx)
+							Expect(err).ToNot(HaveOccurred())
+							Expect(state).To(Equal(vimtypes.VirtualMachinePowerStatePoweredOff))
+						})
 					})
 				})
 

--- a/test/builder/dummies.go
+++ b/test/builder/dummies.go
@@ -636,6 +636,36 @@ func DummyVirtualMachineSnapshot(namespace, name, vmName string) *vmopv1.Virtual
 	}
 }
 
+func DummyVirtualMachineSnapshotWithMemory(namespace, name, vmName string) *vmopv1.VirtualMachineSnapshot {
+	return &vmopv1.VirtualMachineSnapshot{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "VirtualMachineSnapshot",
+			APIVersion: "vmoperator.vmware.com/v1alpha5",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Finalizers: []string{
+				"vmoperator.vmware.com/virtualmachinesnapshot",
+			},
+			Annotations: map[string]string{},
+		},
+		Spec: vmopv1.VirtualMachineSnapshotSpec{
+			VMRef: &vmopv1common.LocalObjectRef{
+				APIVersion: "vmoperator.vmware.com/v1alpha5",
+				Kind:       "VirtualMachine",
+				Name:       vmName,
+			},
+			Memory: true,
+			Quiesce: &vmopv1.QuiesceSpec{
+				Timeout: &metav1.Duration{
+					Duration: 10 * time.Minute,
+				},
+			},
+		},
+	}
+}
+
 func DummyImageAndItemObjectsForCdromBacking(
 	name, ns, kind, storageURI, libItemUUID string,
 	imgReady, imgCached bool, imgSize resource.Quantity, imgHasProviderRef, itemObjExists bool,


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

For non-imported snapshots, so far the power state was being taken from the backed up VM YAML in ExtraConfig for the snapshot. This might not be the correct power state because, for example, in the case when one takes a snapshot of a Powered On VM without it's memory state, the snapshot power state would be off. The VM's resultant power state post revert should also be off.

**Are there any special notes for your reviewer**:

None


**Please add a release note if necessary**:

```release-note
Reverts a VM to the same power state as that of the snapshot
```