### PR TITLE
:seedling: Do not include already existing VMs in placement call

### DIFF
--- a/api/v1alpha5/virtualmachinegroup_types.go
+++ b/api/v1alpha5/virtualmachinegroup_types.go
@@ -20,6 +20,11 @@ const (
 	// VirtualMachineGroupMemberConditionPlacementReady indicates that the
 	// member has a placement decision ready.
 	VirtualMachineGroupMemberConditionPlacementReady = "PlacementReady"
+
+	// VirtualMachineGroupMemberAlreadyPlacedReason indicates that the
+	// group member already exists on the back-end infrastructure
+	// (e.g., vSphere) and therefore does not require placement.
+	VirtualMachineGroupMemberAlreadyPlacedReason = "AlreadyPlaced"
 )
 
 // GroupMember describes a member of a VirtualMachineGroup.


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This change modifies the group placement workflow such that we no longer try to ask DRS for recommendation to place VMs that already exist on vSphere.  For now, this change is done by checking that the VM's status.uniqueID is set.  This is safe for the most part since status update is one of the first things we do during a reconcile and uniqueID is one of the first fields to be updated.

A new reason is introduced for the
VirtualMachineGroupMemberPlacementReady condition called "AlreadyPlaced" which represents a VM that is already placed.

Additionally, this change also handled steady state update of a Group's member statuses.  If a Group's member status is wiped, we populate those with PlacementReady condition with "AlreadyPlaced" reason.

Some other minor cleanups in the tests.


Testing Done:
1. Import / adopting a VM:
- Created a VM
- Created a group with the VM as the member
- Modified the VM to point to the group (spec.groupName)
- Verified that the condition was set:
```
  members:
  - conditions:
    - lastTransitionTime: "2025-09-06T01:15:52Z"
      message: ""
      reason: "True"
      status: "True"
      type: GroupLinked
    - lastTransitionTime: "2025-09-06T01:15:52Z"
      message: VM already placed
      reason: AlreadyPlaced
      status: "True"
      type: PlacementReady
```

2. Steady state status reconstruction
- After the above test, patched the object to remove the status.
```
 kubectl patch vmg -n parunesh-ns vmg --type=json --subresource=status   -p='[{"op": "replace", "path": "/status", "value": {}}]'
virtualmachinegroup.vmoperator.vmware.com/vmg patched
```
- Verified that the Status was re-populated:
```
  members:
  - conditions:
    - lastTransitionTime: "2025-09-06T01:18:15Z"
      message: ""
      reason: "True"
      status: "True"
      type: GroupLinked
    - lastTransitionTime: "2025-09-06T01:18:15Z"
      message: VM already placed
      reason: AlreadyPlaced
      status: "True"
      type: PlacementReady
```


**Please add a release note if necessary**:

```release-note
Do not include already existing VMs in placement call
```