### PR TITLE
🌱 Update WFFC PVCs earlier in volume reconciliation

### DIFF
--- a/controllers/virtualmachine/volume/volume_controller_intg_test.go
+++ b/controllers/virtualmachine/volume/volume_controller_intg_test.go
@@ -534,7 +534,7 @@ func intgTestsReconcile() {
 				Expect(attachment.Spec.VolumeName).To(Equal(vmVolume1.PersistentVolumeClaim.ClaimName))
 
 				// Add our own finalizer so it hangs around after the delete below.
-				attachment.Finalizers = append(attachment.Finalizers, "test-finalizer")
+				attachment.Finalizers = append(attachment.Finalizers, "vmoperator.vmware.com/test-finalizer")
 				Expect(ctx.Client.Update(ctx, attachment)).To(Succeed())
 			})
 


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

For WFFC PVCs set the selected-node annotation before the check for single stepping the attachments, so ideally we can update all the PVCs together to reduce the total time needed to bind all of the PVCs.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

**Please add a release note if necessary**:

```release-note
NONE
```