### PR TITLE
🐛 Do not unset NetOP network name with default network

### DIFF
--- a/pkg/providers/vsphere/network/network.go
+++ b/pkg/providers/vsphere/network/network.go
@@ -390,7 +390,11 @@ func createNetOPNetworkInterface(
 		netIf.Labels[VMNameLabel] = vmCtx.VM.Name
 		netIf.Labels[VMInterfaceNameLabel] = interfaceSpec.Name
 
-		netIf.Spec.NetworkName = networkRefName
+		// NetOp will update the Spec with the default network name so we don't clear that
+		// here if using the default network.
+		if networkRefName != "" {
+			netIf.Spec.NetworkName = networkRefName
+		}
 		// NetOP only defines a VMXNet3 type, but it doesn't really matter for our purposes.
 		netIf.Spec.Type = netopv1alpha1.NetworkInterfaceTypeVMXNet3
 		return nil


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

NetOP will update the NetworkInterface Spec with the default network name so we don't want to then clear it.

Noticed when tracking down the cause of NetworkInterface with a high generation count.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #

**Are there any special notes for your reviewer**:

**Please add a release note if necessary**:

```release-note
NONE
```