### PR TITLE
:seedling: Allow privileged users to unset the zone annotation on the VM

### DIFF
--- a/webhooks/virtualmachine/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator.go
@@ -1592,6 +1592,17 @@ func (v validator) validateAvailabilityZone(
 		// Once the zone has been set then make sure the field is immutable.
 		if oldVal := oldVM.Labels[topology.KubernetesTopologyZoneLabelKey]; oldVal != "" {
 			newVal := vm.Labels[topology.KubernetesTopologyZoneLabelKey]
+
+			// Privileged accounts are allowed to update the
+			// availability zone label on the VM. This is used during
+			// restore, or a fail-over where the restored environment
+			// may not have access to the zone from backup.
+			//
+			// All other modifications are rejected.
+			if ctx.IsPrivilegedAccount {
+				return allErrs
+			}
+
 			return append(allErrs, validation.ValidateImmutableField(newVal, oldVal, zoneLabelPath)...)
 		}
 	}

--- a/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
@@ -3476,6 +3476,7 @@ func unitTestsValidateUpdate() {
 		changeResourcePolicy        bool
 		assignZoneName              bool
 		changeZoneName              bool
+		unsetZone                   bool
 		isSysprepTransportUsed      bool
 		withInstanceStorageVolumes  bool
 		changeInstanceStorageVolume bool
@@ -3535,7 +3536,12 @@ func unitTestsValidateUpdate() {
 		}
 		if args.changeZoneName {
 			ctx.oldVM.Labels[topology.KubernetesTopologyZoneLabelKey] = builder.DummyZoneName
-			ctx.vm.Labels[topology.KubernetesTopologyZoneLabelKey] = builder.DummyZoneName + updateSuffix
+			if args.unsetZone {
+				// Remove the zone label to test unsetting zone
+				delete(ctx.vm.Labels, topology.KubernetesTopologyZoneLabelKey)
+			} else {
+				ctx.vm.Labels[topology.KubernetesTopologyZoneLabelKey] = builder.DummyZoneName + updateSuffix
+			}
 		}
 
 		if args.withInstanceStorageVolumes {
@@ -3615,6 +3621,10 @@ func unitTestsValidateUpdate() {
 		Entry("should allow empty instance uuid change", updateArgs{changeInstanceUUID: true}, true, nil, nil),
 		Entry("should allow empty bios uuid change", updateArgs{changeBiosUUID: true}, true, nil, nil),
 		Entry("should allow initial zone assignment", updateArgs{assignZoneName: true}, true, nil, nil),
+		Entry("should deny zone change for non-privileged user", updateArgs{changeZoneName: true}, false,
+			field.Invalid(field.NewPath("metadata", "labels").Key(topology.KubernetesTopologyZoneLabelKey), builder.DummyZoneName+updateSuffix, "field is immutable").Error(), nil),
+		Entry("should allow zone change for privileged user", updateArgs{changeZoneName: true, isServiceUser: true}, true, nil, nil),
+		Entry("should allow zone unset for privileged user", updateArgs{changeZoneName: true, isServiceUser: true, unsetZone: true}, true, nil, nil),
 
 		Entry("should deny instance storage volume name change, when user is SSO user", updateArgs{changeInstanceStorageVolume: true}, false,
 			field.Forbidden(volumesPath, "adding or modifying instance storage volume claim(s) is not allowed").Error(), nil),


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Backup Restore and Disaster recovery workflows rely on the backup YAML packaged in the VM.  The backup YAML does not contain the zone annotation because the VM can be restored, or failed-over on a different zone than where it was created.

During restore, when the VM is applied with empty zone label from the backup, VM operator should allow that request.  During reconciliation, if the VM exists, we perform a reverse lookup of the zone from the resource pool where the VM exists.  VM operator then also adds the zone label on the VM.


**Are there any special notes for your reviewer**:

See #1135 for the PR that removed the zone annotation from the backup.


**Please add a release note if necessary**:

```release-note
Allow privileged users to unset the zone annotation on the VM
```