### PR TITLE
🌱 Add PVC WFFC capability

### DIFF
--- a/controllers/virtualmachine/volume/volume_controller.go
+++ b/controllers/virtualmachine/volume/volume_controller.go
@@ -35,13 +35,13 @@ import (
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgconst "github.com/vmware-tanzu/vm-operator/pkg/constants"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+	pkglog "github.com/vmware-tanzu/vm-operator/pkg/log"
 	pkgmgr "github.com/vmware-tanzu/vm-operator/pkg/manager"
 	"github.com/vmware-tanzu/vm-operator/pkg/patch"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/constants"
 	"github.com/vmware-tanzu/vm-operator/pkg/record"
 	"github.com/vmware-tanzu/vm-operator/pkg/topology"
-	pkglog "github.com/vmware-tanzu/vm-operator/pkg/log"
 	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
 	vmopv1util "github.com/vmware-tanzu/vm-operator/pkg/util/vmopv1"
 )
@@ -844,6 +844,10 @@ func (r *Reconciler) handlePVCWithWFFC(
 
 	if mode := sc.VolumeBindingMode; mode == nil || *mode != storagev1.VolumeBindingWaitForFirstConsumer {
 		return nil
+	}
+
+	if !pkgcfg.FromContext(ctx).Features.VMWaitForFirstConsumerPVC {
+		return fmt.Errorf("PVC with WFFC storage class support is not enabled")
 	}
 
 	zoneName := ctx.VM.Status.Zone

--- a/controllers/virtualmachine/volume/volume_controller_unit_test.go
+++ b/controllers/virtualmachine/volume/volume_controller_unit_test.go
@@ -686,9 +686,28 @@ func unitTestsReconcile() {
 				vm.Status.Zone = zoneName
 			})
 
+			JustBeforeEach(func() {
+				pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+					config.Features.VMWaitForFirstConsumerPVC = true
+				})
+			})
+
 			AfterEach(func() {
 				storageClass = nil
 				wffcPVC = nil
+			})
+
+			Context("Feature is disabled", func() {
+				JustBeforeEach(func() {
+					pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+						config.Features.VMWaitForFirstConsumerPVC = false
+					})
+				})
+
+				It("returns error", func() {
+					err := reconciler.ReconcileNormal(volCtx)
+					Expect(err).To(MatchError("PVC with WFFC storage class support is not enabled"))
+				})
 			})
 
 			When("PVC does not exist", func() {

--- a/pkg/config/capabilities/capabilities.go
+++ b/pkg/config/capabilities/capabilities.go
@@ -68,6 +68,11 @@ const (
 	// defined in the Supervisor capabilities CRD for the VM placement policy
 	// capability.
 	CapabilityKeyVMPlacementPolicies = "supports_VM_service_VM_placement_policies"
+
+	// CapabilityKeyVMWaitForFirstConsumerPVC is the name of the capability key
+	// defined in the Supervisor capabilities CRD for the VM WFFC PVC
+	// capability.
+	CapabilityKeyVMWaitForFirstConsumerPVC = "supports_VM_service_WFFC_PVC"
 )
 
 var (
@@ -218,6 +223,8 @@ func updateCapabilitiesFeaturesFromCRD(
 			fs.InventoryContentLibrary = capStatus.Activated
 		case CapabilityKeyVMPlacementPolicies:
 			fs.VMPlacementPolicies = capStatus.Activated
+		case CapabilityKeyVMWaitForFirstConsumerPVC:
+			fs.VMWaitForFirstConsumerPVC = capStatus.Activated
 		}
 
 	}

--- a/pkg/config/capabilities/capabilities_test.go
+++ b/pkg/config/capabilities/capabilities_test.go
@@ -159,6 +159,9 @@ var _ = Describe("UpdateCapabilities", func() {
 						capabilities.CapabilityKeyVMPlacementPolicies: {
 							Activated: true,
 						},
+						capabilities.CapabilityKeyVMWaitForFirstConsumerPVC: {
+							Activated: true,
+						},
 					}
 					Expect(client.Status().Patch(ctx, &obj, objPatch)).To(Succeed())
 				})
@@ -174,6 +177,7 @@ var _ = Describe("UpdateCapabilities", func() {
 							config.Features.VMSnapshots = true
 							config.Features.InventoryContentLibrary = true
 							config.Features.VMPlacementPolicies = true
+							config.Features.VMWaitForFirstConsumerPVC = true
 						})
 					})
 					Specify("capabilities did not change", func() {
@@ -205,6 +209,9 @@ var _ = Describe("UpdateCapabilities", func() {
 					})
 					Specify(capabilities.CapabilityKeyVMPlacementPolicies, func() {
 						Expect(pkgcfg.FromContext(ctx).Features.VMPlacementPolicies).To(BeTrue())
+					})
+					Specify(capabilities.CapabilityKeyVMWaitForFirstConsumerPVC, func() {
+						Expect(pkgcfg.FromContext(ctx).Features.VMWaitForFirstConsumerPVC).To(BeTrue())
 					})
 				})
 
@@ -238,6 +245,9 @@ var _ = Describe("UpdateCapabilities", func() {
 					})
 					Specify(capabilities.CapabilityKeyVMPlacementPolicies, func() {
 						Expect(pkgcfg.FromContext(ctx).Features.VMPlacementPolicies).To(BeTrue())
+					})
+					Specify(capabilities.CapabilityKeyVMWaitForFirstConsumerPVC, func() {
+						Expect(pkgcfg.FromContext(ctx).Features.VMWaitForFirstConsumerPVC).To(BeTrue())
 					})
 				})
 			})
@@ -280,6 +290,9 @@ var _ = Describe("UpdateCapabilities", func() {
 						capabilities.CapabilityKeyVMPlacementPolicies: {
 							Activated: false,
 						},
+						capabilities.CapabilityKeyVMWaitForFirstConsumerPVC: {
+							Activated: false,
+						},
 					}
 					Expect(client.Status().Patch(ctx, &obj, objPatch)).To(Succeed())
 				})
@@ -314,6 +327,9 @@ var _ = Describe("UpdateCapabilities", func() {
 					Specify(capabilities.CapabilityKeyVMPlacementPolicies, func() {
 						Expect(pkgcfg.FromContext(ctx).Features.VMPlacementPolicies).To(BeFalse())
 					})
+					Specify(capabilities.CapabilityKeyVMWaitForFirstConsumerPVC, func() {
+						Expect(pkgcfg.FromContext(ctx).Features.VMWaitForFirstConsumerPVC).To(BeFalse())
+					})
 				})
 
 				When("the capabilities are different", func() {
@@ -324,6 +340,7 @@ var _ = Describe("UpdateCapabilities", func() {
 							config.Features.WorkloadDomainIsolation = true
 							config.Features.MutableNetworks = true
 							config.Features.VMGroups = true
+							config.Features.VMWaitForFirstConsumerPVC = true
 						})
 					})
 					Specify("capabilities changed", func() {
@@ -355,6 +372,9 @@ var _ = Describe("UpdateCapabilities", func() {
 					})
 					Specify(capabilities.CapabilityKeyVMPlacementPolicies, func() {
 						Expect(pkgcfg.FromContext(ctx).Features.VMPlacementPolicies).To(BeFalse())
+					})
+					Specify(capabilities.CapabilityKeyVMWaitForFirstConsumerPVC, func() {
+						Expect(pkgcfg.FromContext(ctx).Features.VMWaitForFirstConsumerPVC).To(BeFalse())
 					})
 				})
 			})
@@ -585,6 +605,19 @@ var _ = Describe("UpdateCapabilitiesFeatures", func() {
 				Expect(pkgcfg.FromContext(ctx).Features.VMPlacementPolicies).To(BeTrue())
 			})
 		})
+		Context(capabilities.CapabilityKeyVMWaitForFirstConsumerPVC, func() {
+			BeforeEach(func() {
+				Expect(pkgcfg.FromContext(ctx).Features.VMWaitForFirstConsumerPVC).To(BeFalse())
+				obj.Status.Supervisor[capabilities.CapabilityKeyVMWaitForFirstConsumerPVC] = capv1.CapabilityStatus{
+					Activated: true,
+				}
+			})
+			Specify("Enabled", func() {
+				Expect(ok).To(BeTrue())
+				Expect(diff).To(Equal("VMWaitForFirstConsumerPVC=true"))
+				Expect(pkgcfg.FromContext(ctx).Features.VMWaitForFirstConsumerPVC).To(BeTrue())
+			})
+		})
 	})
 })
 
@@ -628,6 +661,9 @@ var _ = Describe("WouldUpdateCapabilitiesFeatures", func() {
 			capabilities.CapabilityKeyVMPlacementPolicies: {
 				Activated: true,
 			},
+			capabilities.CapabilityKeyVMWaitForFirstConsumerPVC: {
+				Activated: true,
+			},
 		}
 
 		ok, diff = false, ""
@@ -650,6 +686,7 @@ var _ = Describe("WouldUpdateCapabilitiesFeatures", func() {
 					config.Features.VMSnapshots = true
 					config.Features.InventoryContentLibrary = true
 					config.Features.VMPlacementPolicies = true
+					config.Features.VMWaitForFirstConsumerPVC = true
 				})
 			})
 			Specify("capabilities did not change", func() {
@@ -683,6 +720,9 @@ var _ = Describe("WouldUpdateCapabilitiesFeatures", func() {
 			Specify(capabilities.CapabilityKeyVMPlacementPolicies, func() {
 				Expect(pkgcfg.FromContext(ctx).Features.VMPlacementPolicies).To(BeTrue())
 			})
+			Specify(capabilities.CapabilityKeyVMWaitForFirstConsumerPVC, func() {
+				Expect(pkgcfg.FromContext(ctx).Features.VMWaitForFirstConsumerPVC).To(BeTrue())
+			})
 		})
 
 		When("the capabilities are different", func() {
@@ -695,11 +735,12 @@ var _ = Describe("WouldUpdateCapabilitiesFeatures", func() {
 					config.Features.VMGroups = false
 					config.Features.ImmutableClasses = false
 					config.Features.InventoryContentLibrary = false
+					config.Features.VMWaitForFirstConsumerPVC = false
 				})
 			})
 			Specify("capabilities changed", func() {
 				Expect(ok).To(BeTrue())
-				Expect(diff).To(Equal("BringYourOwnEncryptionKey=true,ImmutableClasses=true,InventoryContentLibrary=true,MutableNetworks=true,TKGMultipleCL=true,VMGroups=true,VMPlacementPolicies=true,VMSnapshots=true,WorkloadDomainIsolation=true"))
+				Expect(diff).To(Equal("BringYourOwnEncryptionKey=true,ImmutableClasses=true,InventoryContentLibrary=true,MutableNetworks=true,TKGMultipleCL=true,VMGroups=true,VMPlacementPolicies=true,VMSnapshots=true,VMWaitForFirstConsumerPVC=true,WorkloadDomainIsolation=true"))
 			})
 			Specify(capabilities.CapabilityKeyBringYourOwnKeyProvider, func() {
 				Expect(pkgcfg.FromContext(ctx).Features.BringYourOwnEncryptionKey).To(BeFalse())
@@ -727,6 +768,9 @@ var _ = Describe("WouldUpdateCapabilitiesFeatures", func() {
 			})
 			Specify(capabilities.CapabilityKeyVMPlacementPolicies, func() {
 				Expect(pkgcfg.FromContext(ctx).Features.VMPlacementPolicies).To(BeFalse())
+			})
+			Specify(capabilities.CapabilityKeyVMWaitForFirstConsumerPVC, func() {
+				Expect(pkgcfg.FromContext(ctx).Features.VMWaitForFirstConsumerPVC).To(BeFalse())
 			})
 		})
 	})

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -195,6 +195,7 @@ type FeatureStates struct {
 	InventoryContentLibrary    bool
 	VMPlacementPolicies        bool
 	VSpherePolicies            bool
+	VMWaitForFirstConsumerPVC  bool
 }
 
 type InstanceStorage struct {


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

This capability was only added for CCI support, and the local changes CSI maintains for the selected-node-is-zone annotation does not have a corresponding cap flag, but go ahead and add a basic check during our PVC WFFC reconciliation.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note
NONE
```