### PR TITLE
🌱Set disableAutoRegistration in EC key when revert snapshot

### DIFF
--- a/pkg/providers/vsphere/vmlifecycle/update_status.go
+++ b/pkg/providers/vsphere/vmlifecycle/update_status.go
@@ -30,12 +30,12 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+	pkglog "github.com/vmware-tanzu/vm-operator/pkg/log"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/constants"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/network"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/vcenter"
 	vmoprecord "github.com/vmware-tanzu/vm-operator/pkg/record"
 	"github.com/vmware-tanzu/vm-operator/pkg/topology"
-	pkglog "github.com/vmware-tanzu/vm-operator/pkg/log"
 	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
 	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 	vmopv1util "github.com/vmware-tanzu/vm-operator/pkg/util/vmopv1"
@@ -1388,6 +1388,9 @@ func SyncVMSnapshotTreeStatus(
 func updateSnapshotTreeChildrenStatus(
 	vmCtx pkgctx.VirtualMachineContext,
 	k8sClient ctrlclient.Client) error {
+
+	vmCtx.Logger.V(4).Info("Updating snapshot tree children status")
+
 	mo := vmCtx.MoVM
 	if mo.Snapshot == nil || len(mo.Snapshot.RootSnapshotList) == 0 {
 		return nil
@@ -1491,7 +1494,7 @@ func updateCurrentSnapshotStatus(
 	vmCtx pkgctx.VirtualMachineContext,
 	k8sClient ctrlclient.Client) error {
 
-	vmCtx.Logger.V(5).Info("Updating current snapshot in VM status")
+	vmCtx.Logger.V(4).Info("Updating current snapshot in VM status")
 
 	vm := vmCtx.VM
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

Revert snapshot will restore VM Spec from Extra Config. This will trigger WCP auto registration, which adds `paused` label to the VM. So we want to skip the registration so reconciliation could continue.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note

```