### PR TITLE
:bug: Fix issue where publish requests to inventory-backed CL was not marked complete

### DIFF
--- a/controllers/virtualmachinepublishrequest/virtualmachinepublishrequest_controller_intg_test.go
+++ b/controllers/virtualmachinepublishrequest/virtualmachinepublishrequest_controller_intg_test.go
@@ -138,7 +138,7 @@ func intgTestsReconcile() {
 					intgFakeVMProvider.Lock()
 					intgFakeVMProvider.GetTasksByActIDFn = func(_ context.Context, actID string) ([]vimtypes.TaskInfo, error) {
 						task := vimtypes.TaskInfo{
-							DescriptionId: virtualmachinepublishrequest.TaskDescriptionID,
+							DescriptionId: virtualmachinepublishrequest.OVFCaptureTaskDescriptionID,
 							State:         vimtypes.TaskInfoStateQueued,
 						}
 						return []vimtypes.TaskInfo{task}, nil
@@ -168,7 +168,7 @@ func intgTestsReconcile() {
 					intgFakeVMProvider.Lock()
 					intgFakeVMProvider.GetTasksByActIDFn = func(_ context.Context, actID string) ([]vimtypes.TaskInfo, error) {
 						task := vimtypes.TaskInfo{
-							DescriptionId: virtualmachinepublishrequest.TaskDescriptionID,
+							DescriptionId: virtualmachinepublishrequest.OVFCaptureTaskDescriptionID,
 							State:         vimtypes.TaskInfoStateRunning,
 						}
 						return []vimtypes.TaskInfo{task}, nil
@@ -200,7 +200,7 @@ func intgTestsReconcile() {
 					intgFakeVMProvider.Lock()
 					intgFakeVMProvider.GetTasksByActIDFn = func(_ context.Context, actID string) ([]vimtypes.TaskInfo, error) {
 						task := vimtypes.TaskInfo{
-							DescriptionId: virtualmachinepublishrequest.TaskDescriptionID,
+							DescriptionId: virtualmachinepublishrequest.OVFCaptureTaskDescriptionID,
 							State:         vimtypes.TaskInfoStateSuccess,
 							Result:        vimtypes.ManagedObjectReference{Type: "ContentLibraryItem", Value: fmt.Sprintf("clibitem-%s", itemID)},
 						}

--- a/pkg/context/virtualmachinepublishrequest_context.go
+++ b/pkg/context/virtualmachinepublishrequest_context.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-logr/logr"
 
 	imgregv1a1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha1"
+	imgregv1 "github.com/vmware-tanzu/image-registry-operator-api/api/v1alpha2"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 )
@@ -18,11 +19,13 @@ import (
 // VirtualMachinePublishRequestContext is the context used for VirtualMachinePublishRequestControllers.
 type VirtualMachinePublishRequestContext struct {
 	context.Context
-	Logger           logr.Logger
-	VMPublishRequest *vmopv1.VirtualMachinePublishRequest
-	VM               *vmopv1.VirtualMachine
-	ContentLibrary   *imgregv1a1.ContentLibrary
-	ItemID           string
+	Logger             logr.Logger
+	VMPublishRequest   *vmopv1.VirtualMachinePublishRequest
+	VM                 *vmopv1.VirtualMachine
+	ContentLibrary     *imgregv1a1.ContentLibrary
+	ContentLibraryV1A2 *imgregv1.ContentLibrary
+	ContentLibraryType imgregv1.LibraryType
+	ItemID             string
 	// SkipPatch indicates whether we should skip patching the object after reconcile
 	// because Status is updated separately in the publishing case due to CL API limitations.
 	SkipPatch bool

--- a/pkg/providers/fake/fake_vm_provider.go
+++ b/pkg/providers/fake/fake_vm_provider.go
@@ -44,6 +44,8 @@ type funcs struct {
 
 	GetItemFromLibraryByNameFn   func(ctx context.Context, contentLibrary, itemName string) (*library.Item, error)
 	GetItemFromInventoryByNameFn func(ctx context.Context, contentLibrary, itemName string) (object.Reference, error)
+	GetCloneTasksForVMFn         func(ctx context.Context, vm *vmopv1.VirtualMachine, moID, descriptionID string) ([]vimtypes.TaskInfo, error)
+	ContainsExtraConfigEntryFn   func(ctx context.Context, objVM *object.VirtualMachine, key, value string) (bool, error)
 	UpdateContentLibraryItemFn   func(ctx context.Context, itemID, newName string, newDescription *string) error
 	SyncVirtualMachineImageFn    func(ctx context.Context, cli, vmi client.Object) error
 
@@ -289,6 +291,30 @@ func (s *VMProvider) GetItemFromInventoryByName(ctx context.Context, contentLibr
 	}
 
 	return nil, nil
+}
+
+func (s *VMProvider) GetCloneTasksForVM(ctx context.Context, vm *vmopv1.VirtualMachine, moID, descriptionID string) ([]vimtypes.TaskInfo, error) {
+	_ = pkgcfg.FromContext(ctx)
+
+	s.Lock()
+	defer s.Unlock()
+	if s.GetCloneTasksForVMFn != nil {
+		return s.GetCloneTasksForVMFn(ctx, vm, moID, descriptionID)
+	}
+
+	return nil, nil
+}
+
+func (s *VMProvider) ContainsExtraConfigEntry(ctx context.Context, objVM *object.VirtualMachine, key, value string) (bool, error) {
+	_ = pkgcfg.FromContext(ctx)
+
+	s.Lock()
+	defer s.Unlock()
+	if s.ContainsExtraConfigEntryFn != nil {
+		return s.ContainsExtraConfigEntryFn(ctx, objVM, key, value)
+	}
+
+	return false, nil
 }
 
 func (s *VMProvider) UpdateContentLibraryItem(ctx context.Context, itemID, newName string, newDescription *string) error {

--- a/pkg/providers/vm_provider_interface.go
+++ b/pkg/providers/vm_provider_interface.go
@@ -59,6 +59,9 @@ type VirtualMachineProviderInterface interface {
 
 	GetItemFromLibraryByName(ctx context.Context, contentLibrary, itemName string) (*library.Item, error)
 	GetItemFromInventoryByName(ctx context.Context, contentLibrary, itemName string) (object.Reference, error)
+	GetCloneTasksForVM(ctx context.Context, vm *vmopv1.VirtualMachine, moID, descriptionID string) ([]vimtypes.TaskInfo, error)
+	ContainsExtraConfigEntry(ctx context.Context, objVM *object.VirtualMachine, key, value string) (bool, error)
+
 	UpdateContentLibraryItem(ctx context.Context, itemID, newName string, newDescription *string) error
 	SyncVirtualMachineImage(ctx context.Context, cli, vmi ctrlclient.Object) error
 

--- a/pkg/providers/vsphere/virtualmachine/publish.go
+++ b/pkg/providers/vsphere/virtualmachine/publish.go
@@ -88,9 +88,6 @@ func CloneVM(
 			Folder: &folderRef,
 			// Causes a linked clone to be unlinked and consolidated
 			DiskMoveType: string(vimtypes.VirtualMachineRelocateDiskMoveOptionsMoveAllDiskBackingsAndDisallowSharing),
-			Profile: []vimtypes.BaseVirtualMachineProfileSpec{
-				&vimtypes.VirtualMachineDefinedProfileSpec{ProfileId: storagePolicyID},
-			},
 		},
 		Template: true,
 		Config: &vimtypes.VirtualMachineConfigSpec{
@@ -102,6 +99,12 @@ func CloneVM(
 				},
 			},
 		},
+	}
+
+	if storagePolicyID != "" {
+		cloneSpec.Location.Profile = []vimtypes.BaseVirtualMachineProfileSpec{
+			&vimtypes.VirtualMachineDefinedProfileSpec{ProfileId: storagePolicyID},
+		}
 	}
 
 	vmCtx.Logger.Info("Publishing VM as template",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->

There was an issue where a VM Publish Request to an inventory-backed Content Library was not being marked completed. This was due to a call to CLS failing during the check for the vmi. This check needed to be updated to account for non-CLS backed libraries in order to allow for this check to succeed.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NONE
```