### PR TITLE
🐛 Clear out the snapshot revert condition on no op

### DIFF
--- a/pkg/providers/vsphere/vmprovider_vm_snapshot.go
+++ b/pkg/providers/vsphere/vmprovider_vm_snapshot.go
@@ -274,6 +274,13 @@ func (vs *vSphereVMProvider) reconcileSnapshotRevertDoTask(
 	// If no spec.currentSnapshot is specified, nothing to revert to.
 	if vmCtx.VM.Spec.CurrentSnapshot == nil {
 		logger.V(4).Info("Skipping revert for empty spec.currentSnapshot")
+
+		// Clear any existing snapshot revert condition.
+		// This handles the case where a previous revert
+		// failed and the user removed spec.currentSnapshot
+		// to abort the revert.
+		pkgcnd.Delete(vmCtx.VM, vmopv1.VirtualMachineSnapshotRevertSucceeded)
+
 		return nil
 	}
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

When a user tries to revert to a snapshot, a condition is set on the VM to indicate the status of the revert operation.

If for some reason, the revert operation fails to
complete, the condition remains on the VM. The user can either take mitigation steps or abort the revert operation. When a user aborts the revert operation, we should clear out the condition.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

Manually tested on a testbed in addition to adding the vcsim tests.


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note

```