### PR TITLE
🌱Refactor some snapshot related code

### DIFF
--- a/pkg/providers/vsphere/virtualmachine/snapshot.go
+++ b/pkg/providers/vsphere/virtualmachine/snapshot.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/mo"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
@@ -36,28 +37,35 @@ var (
 	ErrMultipleSnapshots = errors.New("multiple snapshots found")
 )
 
-func SnapshotVirtualMachine(args SnapshotArgs) (*vimtypes.ManagedObjectReference, error) {
+func SnapshotVirtualMachine(
+	args SnapshotArgs) (*vimtypes.VirtualMachineSnapshotTree, error) {
 	snapshotName := args.VMSnapshot.Name
 
 	logger := args.VMCtx.Logger.WithValues("snapshotName", snapshotName)
-	snapMoRef, _ := args.VcVM.FindSnapshot(args.VMCtx, snapshotName) // TODO: Use our FindSnapshot impl and check error?
-	if snapMoRef != nil {
-		logger.Info("Snapshot already exists")
-		// Return early, snapshot found
-		return snapMoRef, nil
+	snapNode, err := FindSnapshot(args.VMCtx.MoVM, snapshotName)
+	// If it's other error except ErrMultipleSnapshots, that means it's either
+	// ErrSnapshotNotFound or ErrNoSnapshots, continue.
+	if errors.Is(err, ErrMultipleSnapshots) {
+		return nil, err
 	}
 
-	// If no snapshot was found, create it
+	if snapNode != nil {
+		logger.Info("Snapshot already exists")
+		// Return early, snapshot found.
+		return snapNode, nil
+	}
+
+	// If no snapshot was found, create it.
 	logger.Info("Creating Snapshot of VirtualMachine")
-	snapMoRef, err := CreateSnapshot(args)
+	snapNode, err = CreateSnapshot(args)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create snapshot for VM: %w", err)
 	}
 
-	return snapMoRef, nil
+	return snapNode, nil
 }
 
-func CreateSnapshot(args SnapshotArgs) (*vimtypes.ManagedObjectReference, error) {
+func CreateSnapshot(args SnapshotArgs) (*vimtypes.VirtualMachineSnapshotTree, error) {
 	snapObj := args.VMSnapshot
 	var quiesceSpec *vimtypes.VirtualMachineGuestQuiesceSpec
 	if quiesce := snapObj.Spec.Quiesce; quiesce != nil {
@@ -66,27 +74,51 @@ func CreateSnapshot(args SnapshotArgs) (*vimtypes.ManagedObjectReference, error)
 		}
 	}
 
-	t, err := args.VcVM.CreateSnapshotEx(args.VMCtx, snapObj.Name, snapObj.Spec.Description, snapObj.Spec.Memory, quiesceSpec)
+	t, err := args.VcVM.CreateSnapshotEx(
+		args.VMCtx,
+		snapObj.Name,
+		snapObj.Spec.Description,
+		snapObj.Spec.Memory,
+		quiesceSpec)
 	if err != nil {
 		return nil, err
 	}
 
 	taskInfo, err := t.WaitForResult(args.VMCtx)
 	if err != nil {
-		args.VMCtx.Logger.V(5).Error(err, "create snapshot task failed", "taskInfo", taskInfo)
+		if taskInfo != nil {
+			args.VMCtx.Logger.V(4).Error(err, "create snapshot task failed",
+				"taskInfo", taskInfo)
+		}
+		return nil, fmt.Errorf("failed to create snapshot: %w", err)
+	}
+
+	// Fetch the newest snapshot tree.
+	moVM := mo.VirtualMachine{}
+	if err := args.VcVM.Properties(
+		args.VMCtx,
+		args.VcVM.Reference(),
+		[]string{"snapshot"},
+		&moVM); err != nil {
 		return nil, err
 	}
 
-	snapMoRef, ok := taskInfo.Result.(vimtypes.ManagedObjectReference)
-	if !ok {
-		return nil, fmt.Errorf("create vmSnapshot task failed: %v", taskInfo.Result)
+	// TaskInfo can only be converted to ManagedObjectReference type,
+	// to fetch the VirtualMachineSnapshotTree type, we need to traverse the tree.
+	newSnap, err := FindSnapshot(moVM, snapObj.Name)
+	if err != nil {
+		return nil, err
 	}
 
-	return &snapMoRef, nil
+	return newSnap, nil
 }
 
 func DeleteSnapshot(args SnapshotArgs) error {
-	t, err := args.VcVM.RemoveSnapshot(args.VMCtx, args.VMSnapshot.Name, args.RemoveChildren, args.Consolidate)
+	t, err := args.VcVM.RemoveSnapshot(
+		args.VMCtx,
+		args.VMSnapshot.Name,
+		args.RemoveChildren,
+		args.Consolidate)
 	if err != nil {
 		// Catch the not found error from govmomi:
 		// https://github.com/vmware/govmomi/blob/v0.52.0-alpha.0/object/virtual_machine.go#L784
@@ -111,30 +143,31 @@ func DeleteSnapshot(args SnapshotArgs) error {
 // we maintain our version because we don't want to make another
 // property collector round trip to fetch those properties again.
 func FindSnapshot(
-	vmCtx pkgctx.VirtualMachineContext,
-	snapshotName string) (*vimtypes.ManagedObjectReference, error) {
+	moVM mo.VirtualMachine,
+	snapshotName string) (*vimtypes.VirtualMachineSnapshotTree, error) {
 
-	o := vmCtx.MoVM
-	if o.Snapshot == nil || len(o.Snapshot.RootSnapshotList) == 0 {
+	if moVM.Snapshot == nil || len(moVM.Snapshot.RootSnapshotList) == 0 {
 		return nil, ErrNoSnapshots
 	}
 
 	m := make(snapshotMap)
-	m.add("", o.Snapshot.RootSnapshotList)
+	m.add("", moVM.Snapshot.RootSnapshotList)
 
 	s := m[snapshotName]
 	switch len(s) {
 	case 0:
-		return nil, fmt.Errorf("snapshot %q not found: %w", snapshotName, ErrSnapshotNotFound)
+		return nil, fmt.Errorf("snapshot %q not found: %w",
+			snapshotName, ErrSnapshotNotFound)
 	case 1:
 		return &s[0], nil
 	default:
-		return nil, fmt.Errorf("%q resolves to %d snapshots: %w", snapshotName, len(s), ErrMultipleSnapshots)
+		return nil, fmt.Errorf("%q resolves to %d snapshots: %w",
+			snapshotName, len(s), ErrMultipleSnapshots)
 	}
 }
 
 // snapshotMap is a custom type that traverses over the entire snapshot tree.
-type snapshotMap map[string][]vimtypes.ManagedObjectReference
+type snapshotMap map[string][]vimtypes.VirtualMachineSnapshotTree
 
 func (m snapshotMap) add(parent string, tree []vimtypes.VirtualMachineSnapshotTree) {
 	for i, st := range tree {
@@ -148,7 +181,7 @@ func (m snapshotMap) add(parent string, tree []vimtypes.VirtualMachineSnapshotTr
 		}
 
 		for _, name := range names {
-			m[name] = append(m[name], tree[i].Snapshot)
+			m[name] = append(m[name], tree[i])
 		}
 
 		m.add(sname, st.ChildSnapshotList)
@@ -158,17 +191,22 @@ func (m snapshotMap) add(parent string, tree []vimtypes.VirtualMachineSnapshotTr
 // GetSnapshotSize calculates the size of a given snapshot in bytes. It includes
 // the memory file, the vmdk files, and the vmsn file, and excludes FCDs.
 // The algorithm use almost the same logic as how VC UI calculates the snapshot size.
-// The only difference is that this function does not include the size of FCDs.
-func GetSnapshotSize(vmCtx pkgctx.VirtualMachineContext, vmSnapshot *vimtypes.ManagedObjectReference) int64 {
+// The only difference is that this function does not include the size of FCDs,
+// and returns an error if the snapshot is not found.
+func GetSnapshotSize(logger logr.Logger,
+	moVM mo.VirtualMachine,
+	vmSnapshot *vimtypes.ManagedObjectReference) (int64, error) {
 	if vmSnapshot == nil || vmSnapshot.Value == "" {
-		vmCtx.Logger.V(5).Info("vmSnapshot is nil or empty")
-		return 0
+		return 0, fmt.Errorf("moSnapshot is nil or empty")
 	}
 
-	vmLayout := vmCtx.MoVM.LayoutEx
+	if moVM.Config == nil {
+		return 0, fmt.Errorf("moVM.Config is nil")
+	}
+
+	vmLayout := moVM.LayoutEx
 	if vmLayout == nil {
-		vmCtx.Logger.V(5).Info("vmCtx.MoVM.LayoutEx is nil, skip calculating snapshot size")
-		return 0
+		return 0, fmt.Errorf("moVM.LayoutEx is nil")
 	}
 
 	var snapshot *vimtypes.VirtualMachineFileLayoutExSnapshotLayout
@@ -180,11 +218,11 @@ func GetSnapshotSize(vmCtx pkgctx.VirtualMachineContext, vmSnapshot *vimtypes.Ma
 	}
 
 	if snapshot == nil {
-		// TODO: Error if snapshot not found?
-		return 0
+		return 0, fmt.Errorf("snapshot with reference %q"+
+			" not found in vmLayout.Snapshot", vmSnapshot.Value)
 	}
 
-	fcdDeviceKeySet := getFCDDeviceKeySet(vmCtx)
+	fcdDeviceKeySet := getFCDDeviceKeySet(moVM)
 	fileKeyMap := make(map[int32]int64)
 	for _, file := range vmLayout.File {
 		fileKeyMap[file.Key] = file.Size
@@ -194,11 +232,11 @@ func GetSnapshotSize(vmCtx pkgctx.VirtualMachineContext, vmSnapshot *vimtypes.Ma
 
 	// Add the file key for the snapshot memory (.vmem) file if present.
 	if snapshot.MemoryKey != -1 {
-		vmCtx.Logger.V(5).Info("Adding memoryKey", "memoryKey", snapshot.MemoryKey)
+		logger.V(5).Info("Adding memoryKey", "memoryKey", snapshot.MemoryKey)
 		total += fileKeyMap[snapshot.MemoryKey]
 	}
 
-	vmCtx.Logger.V(5).Info("Adding the file key for snapshot (.vmsn) file", "dataKey", snapshot.DataKey)
+	logger.V(5).Info("Adding the file key for snapshot (.vmsn) file", "dataKey", snapshot.DataKey)
 	total += fileKeyMap[snapshot.DataKey]
 
 	// Add the disk files for the child most delta disk which is the last item in the disk chain.
@@ -207,19 +245,19 @@ func GetSnapshotSize(vmCtx pkgctx.VirtualMachineContext, vmSnapshot *vimtypes.Ma
 			// A VM snapshot creates a delta disk for all disks of a VM -- including PVCs that are
 			// backed by FCDs. Since the usage of the delta disks created on PVCs will already be
 			// reported by the VolumeSnapshot SPU, we skip those here to avoid double counting.
-			vmCtx.Logger.V(5).Info("Skipping the disk file of the FCD", "diskKey", disk.Key)
+			logger.V(5).Info("Skipping the disk file of the FCD", "diskKey", disk.Key)
 			continue
 		}
 
 		if len(disk.Chain) == 0 {
-			vmCtx.Logger.V(5).Info("Skipping the disk since its chain is empty", "diskKey", disk.Key)
+			logger.V(5).Info("Skipping the disk since its chain is empty", "diskKey", disk.Key)
 			continue
 		}
 
 		// File keys for the child most delta disk
 		childMostFileKeys := disk.Chain[len(disk.Chain)-1].FileKey
 		if len(childMostFileKeys) > 0 {
-			vmCtx.Logger.V(5).Info("Adding file key for the child most delta disk of the snapshot",
+			logger.V(5).Info("Adding file key for the child most delta disk of the snapshot",
 				"fileKey", childMostFileKeys)
 			for _, fileKey := range childMostFileKeys {
 				total += fileKeyMap[fileKey]
@@ -227,13 +265,13 @@ func GetSnapshotSize(vmCtx pkgctx.VirtualMachineContext, vmSnapshot *vimtypes.Ma
 		}
 	}
 
-	return total
+	return total, nil
 }
 
 // getFCDDeviceKeySet returns a set of device keys of disk devices that are FCDs.
-func getFCDDeviceKeySet(vmCtx pkgctx.VirtualMachineContext) sets.Set[int32] {
+func getFCDDeviceKeySet(moVM mo.VirtualMachine) sets.Set[int32] {
 	deviceKeysSet := sets.Set[int32]{}
-	device := object.VirtualDeviceList(vmCtx.MoVM.Config.Hardware.Device)
+	device := object.VirtualDeviceList(moVM.Config.Hardware.Device)
 	for _, d := range device.SelectByType(&vimtypes.VirtualDisk{}) {
 		disk := d.(*vimtypes.VirtualDisk)
 		if disk.VDiskId == nil || disk.VDiskId.Id == "" { // FCDs have VDiskId.
@@ -244,41 +282,4 @@ func getFCDDeviceKeySet(vmCtx pkgctx.VirtualMachineContext) sets.Set[int32] {
 	}
 
 	return deviceKeysSet
-}
-
-// GetParentSnapshot finds the parent snapshot of a given snapshot name.
-func GetParentSnapshot(vmCtx pkgctx.VirtualMachineContext, vcVM *object.VirtualMachine, vmSnapshotName string) (*vimtypes.VirtualMachineSnapshotTree, error) {
-	var o mo.VirtualMachine
-
-	err := vcVM.Properties(vmCtx, vcVM.Reference(), []string{"snapshot"}, &o)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get snapshot: %w", err)
-	}
-
-	if o.Snapshot == nil || len(o.Snapshot.RootSnapshotList) == 0 {
-		return nil, nil
-	}
-
-	parent := getParentSnapshotHelper(nil, o.Snapshot.RootSnapshotList, vmSnapshotName)
-	if parent != nil {
-		return parent, nil
-	}
-
-	return nil, nil
-}
-
-func getParentSnapshotHelper(
-	parent *vimtypes.VirtualMachineSnapshotTree,
-	children []vimtypes.VirtualMachineSnapshotTree,
-	target string) *vimtypes.VirtualMachineSnapshotTree {
-	for _, child := range children {
-		if child.Name == target {
-			return parent
-		}
-		parent := getParentSnapshotHelper(&child, child.ChildSnapshotList, target)
-		if parent != nil {
-			return parent
-		}
-	}
-	return nil
 }

--- a/pkg/providers/vsphere/vmprovider_vm.go
+++ b/pkg/providers/vsphere/vmprovider_vm.go
@@ -1215,14 +1215,8 @@ func (vs *vSphereVMProvider) reconcilePowerState(
 
 	// Translate the VM's current power state into the VM Op power state
 	// value.
-	switch vmCtx.MoVM.Summary.Runtime.PowerState {
-	case vimtypes.VirtualMachinePowerStatePoweredOn:
-		currentPowerState = vmopv1.VirtualMachinePowerStateOn
-	case vimtypes.VirtualMachinePowerStatePoweredOff:
-		currentPowerState = vmopv1.VirtualMachinePowerStateOff
-	case vimtypes.VirtualMachinePowerStateSuspended:
-		currentPowerState = vmopv1.VirtualMachinePowerStateSuspended
-	}
+	currentPowerState = vmopv1util.ConvertPowerState(vmCtx.Logger,
+		vmCtx.MoVM.Summary.Runtime.PowerState)
 
 	switch desiredPowerState {
 

--- a/pkg/providers/vsphere/vmprovider_vm_snapshot.go
+++ b/pkg/providers/vsphere/vmprovider_vm_snapshot.go
@@ -34,6 +34,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/vmlifecycle"
 	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
 	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
+	vmopv1util "github.com/vmware-tanzu/vm-operator/pkg/util/vmopv1"
 )
 
 // DeleteSnapshot deletes the snapshot from the VM.
@@ -108,19 +109,20 @@ func (vs *vSphereVMProvider) GetSnapshotSize(
 		return 0, fmt.Errorf("failed to get VirtualMachine %q: %w", vmCtx.VM.Name, err)
 	}
 
+	moVM := mo.VirtualMachine{}
 	if err := vcVM.Properties(
 		ctx, vcVM.Reference(),
 		[]string{"snapshot", "layoutEx", "config.hardware.device"},
-		&vmCtx.MoVM); err != nil {
+		&moVM); err != nil {
 		return 0, err
 	}
 
-	vmSnapshot, err := virtualmachine.FindSnapshot(vmCtx, vmSnapshotName)
+	vmSnapshot, err := virtualmachine.FindSnapshot(moVM, vmSnapshotName)
 	if err != nil {
 		return 0, fmt.Errorf("failed to find snapshot %q: %w", vmSnapshotName, err)
 	}
 
-	return virtualmachine.GetSnapshotSize(vmCtx, vmSnapshot), nil
+	return virtualmachine.GetSnapshotSize(logger, moVM, &vmSnapshot.Snapshot)
 }
 
 // SyncVMSnapshotTreeStatus syncs the VM's current and root snapshots status.
@@ -338,8 +340,8 @@ func (vs *vSphereVMProvider) reconcileSnapshotRevertDoTask(
 	}
 
 	// Check if the VM has a snapshot by the desired name.
-	ref, err := virtualmachine.FindSnapshot(vmCtx, desiredSnapshotName)
-	if err != nil || ref == nil {
+	snapNode, err := virtualmachine.FindSnapshot(vmCtx.MoVM, desiredSnapshotName)
+	if err != nil || snapNode == nil {
 		err := fmt.Errorf("failed to find vSphere snapshot %q: %w",
 			desiredSnapshotName, err)
 
@@ -351,6 +353,8 @@ func (vs *vSphereVMProvider) reconcileSnapshotRevertDoTask(
 
 		return err
 	}
+
+	ref := &snapNode.Snapshot
 
 	logger = logger.WithValues("desiredSnapshotRef", ref.Value)
 	vmCtx.Context = logr.NewContext(vmCtx.Context, logger)
@@ -406,7 +410,7 @@ func (vs *vSphereVMProvider) reconcileSnapshotRevertDoTask(
 		"beforeRestoreSpecCurrentSnapshot", vmCtx.VM.Spec.CurrentSnapshot)
 
 	if err := vs.restoreVMSpecFromSnapshot(
-		vmCtx, vcVM, obj, ref); err != nil {
+		vmCtx, vcVM, obj, snapNode); err != nil {
 
 		err := fmt.Errorf(
 			"failed to restore vm spec and metadata from snapshot: %w", err)
@@ -522,9 +526,12 @@ func (vs *vSphereVMProvider) restoreVMSpecFromSnapshot(
 	vmCtx pkgctx.VirtualMachineContext,
 	vcVM *object.VirtualMachine,
 	snapCR *vmopv1.VirtualMachineSnapshot,
-	snapObj *vimtypes.ManagedObjectReference) error {
+	snapNode *vimtypes.VirtualMachineSnapshotTree) error {
+	if snapNode == nil {
+		return fmt.Errorf("snapshot node is nil")
+	}
 
-	vmYAML, err := vs.getVMYamlFromSnapshot(vmCtx, vcVM, snapCR, snapObj)
+	vmYAML, err := vs.getVMYamlFromSnapshot(vmCtx, vcVM, snapCR, snapNode.Snapshot)
 	if err != nil {
 		return fmt.Errorf("failed to parse VM spec from snapshot: %w", err)
 	}
@@ -536,7 +543,7 @@ func (vs *vSphereVMProvider) restoreVMSpecFromSnapshot(
 
 	vmCtx.Logger.V(5).Info("Restoring VM spec from snapshot", "vmYAML", vmYAML)
 	// Unmarshal and convert VM from yaml in snapshot based on API version
-	vm, err := vs.unmarshalAndConvertVMFromYAML(vmCtx, vmYAML)
+	vm, err := vs.unmarshalAndConvertVMFromYAML(vmYAML)
 	if err != nil {
 		return fmt.Errorf("failed to unmarshal and convert VM from snapshot: %w", err)
 	}
@@ -560,10 +567,11 @@ func (vs *vSphereVMProvider) restoreVMSpecFromSnapshot(
 	// Empty out the status.
 	vmCtx.VM.Status = vmopv1.VirtualMachineStatus{}
 
-	// reconcile the power state of the VM post revert
-	if err := vs.reconcilePostRevertPowerState(vmCtx, snapObj); err != nil {
-		return fmt.Errorf("failed to reconcile power state post revert: %w", err)
-	}
+	// Reconcile the power state of the VM post revert.
+	// vpxd sets the power state of the snapshot to Off if a VM which is On
+	// is snapshotted without the memory state. We don't need to separately
+	// handle that case here.
+	vmCtx.VM.Spec.PowerState = vmopv1util.ConvertPowerState(vmCtx.Logger, snapNode.State)
 
 	// Note that since we swapped out the annotations from the
 	// snapshot, it will implicitly remove the "restore-in-progress"
@@ -581,7 +589,7 @@ func (vs *vSphereVMProvider) getVMYamlFromSnapshot(
 	vmCtx pkgctx.VirtualMachineContext,
 	vcVM *object.VirtualMachine,
 	snap *vmopv1.VirtualMachineSnapshot,
-	snapRef *vimtypes.ManagedObjectReference) (string, error) {
+	snapRef vimtypes.ManagedObjectReference) (string, error) {
 
 	var (
 		moSnap mo.VirtualMachineSnapshot
@@ -590,7 +598,7 @@ func (vs *vSphereVMProvider) getVMYamlFromSnapshot(
 
 	// Fetch the config stored with the snapshot.
 	if err := vcVM.Properties(
-		vmCtx, *snapRef, []string{"config"}, &moSnap); err != nil {
+		vmCtx, snapRef, []string{"config"}, &moSnap); err != nil {
 
 		return "", fmt.Errorf("failed to fetch snapshot config: %w", err)
 	}
@@ -893,7 +901,7 @@ func (vs *vSphereVMProvider) reconcileCurrentSnapshot(
 	}
 
 	logger.Info("Creating snapshot on vSphere")
-	snapMoRef, err := virtualmachine.SnapshotVirtualMachine(snapArgs)
+	snapNode, err := virtualmachine.SnapshotVirtualMachine(snapArgs)
 	if err != nil {
 		// Mark the snapshot as failed and clear in-progress status
 		// TODO: we wait for in-progress snapshots to complete when
@@ -910,9 +918,10 @@ func (vs *vSphereVMProvider) reconcileCurrentSnapshot(
 	// Update the snapshot status with the successful result
 	if err = kubeutil.PatchSnapshotSuccessStatus(
 		vmCtx,
+		logger,
 		vs.k8sClient,
 		snapshotToProcess,
-		snapMoRef,
+		snapNode,
 		vmCtx.VM.Spec.PowerState); err != nil {
 
 		return fmt.Errorf("failed to update snapshot %q status: %w",
@@ -940,15 +949,13 @@ func (vs *vSphereVMProvider) reconcileCurrentSnapshot(
 // unmarshalAndConvertVMFromYAML unmarshals VM YAML from snapshot and converts it
 // to the latest version of VirtualMachine.
 func (vs *vSphereVMProvider) unmarshalAndConvertVMFromYAML(
-	vmCtx pkgctx.VirtualMachineContext,
 	vmYAML string) (*vmopv1.VirtualMachine, error) {
 
 	decUnstructured := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
 
 	unstructuredObj := &unstructured.Unstructured{}
 	if _, _, err := decUnstructured.Decode([]byte(vmYAML), nil, unstructuredObj); err != nil {
-		vmCtx.Logger.Error(err, "failed to decode VM YAML in to Unstructured object")
-		return nil, err
+		return nil, fmt.Errorf("failed to decode VM YAML in to Unstructured object: %w", err)
 	}
 
 	// Convert it to newest version of VirtualMachine.
@@ -960,38 +967,4 @@ func (vs *vSphereVMProvider) unmarshalAndConvertVMFromYAML(
 	}
 
 	return vm, nil
-}
-
-func (vs *vSphereVMProvider) reconcilePostRevertPowerState(
-	vmCtx pkgctx.VirtualMachineContext,
-	snapObj *vimtypes.ManagedObjectReference) error {
-
-	snap := vmlifecycle.FindSnapshotInTree(vmCtx.MoVM.Snapshot.RootSnapshotList, snapObj.Value)
-	if snap == nil {
-		// weird situation here
-		// the snapshot being processed doesn't exist in the snapshot tree
-		// this shouldn't be happening
-		return fmt.Errorf("snapshot %s not found in VM Snapshot Tree", snapObj.Value)
-	}
-
-	// vpxd sets the power state of the snapshot to Off if a VM which is On
-	// is snapshotted without the memory state. We don't need to separately
-	// handle that case here.
-	switch snap.State {
-	case vimtypes.VirtualMachinePowerStatePoweredOn:
-		vmCtx.VM.Spec.PowerState = vmopv1.VirtualMachinePowerStateOn
-	case vimtypes.VirtualMachinePowerStatePoweredOff:
-		vmCtx.VM.Spec.PowerState = vmopv1.VirtualMachinePowerStateOff
-	case vimtypes.VirtualMachinePowerStateSuspended:
-		vmCtx.VM.Spec.PowerState = vmopv1.VirtualMachinePowerStateSuspended
-	default:
-		// Unknown state, log and default to off
-		// this is very very unlikely to happen
-		vmCtx.Logger.Info(
-			"Unknown snapshot power state, defaulting to Off",
-			"snapshotState", snap.State)
-		vmCtx.VM.Spec.PowerState = vmopv1.VirtualMachinePowerStateOff
-	}
-
-	return nil
 }

--- a/pkg/providers/vsphere/vmprovider_vm_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_test.go
@@ -52,7 +52,6 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/constants"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/virtualmachine"
-	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/vmlifecycle"
 	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
 	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
@@ -3276,7 +3275,8 @@ func vmTests() {
 						Expect(moVM.Snapshot.CurrentSnapshot).ToNot(BeNil())
 
 						// Find the snapshot name in the tree to verify it matches
-						currentSnap := vmlifecycle.FindSnapshotInTree(moVM.Snapshot.RootSnapshotList, moVM.Snapshot.CurrentSnapshot.Value)
+						currentSnap, err := virtualmachine.FindSnapshot(moVM, moVM.Snapshot.CurrentSnapshot.Value)
+						Expect(err).ToNot(HaveOccurred())
 						Expect(currentSnap).ToNot(BeNil())
 						Expect(currentSnap.Name).To(Equal(vmSnapshot.Name))
 					})
@@ -3305,9 +3305,10 @@ func vmTests() {
 							Expect(moVM.Snapshot).ToNot(BeNil())
 
 							// verify that the snapshot's power state is powered off
-							snapshot := vmlifecycle.FindSnapshotInTree(moVM.Snapshot.RootSnapshotList, moVM.Snapshot.CurrentSnapshot.Value)
-							Expect(snapshot).ToNot(BeNil())
-							Expect(snapshot.State).To(Equal(vimtypes.VirtualMachinePowerStatePoweredOff))
+							currentSnapshot, err := virtualmachine.FindSnapshot(moVM, moVM.Snapshot.CurrentSnapshot.Value)
+							Expect(err).ToNot(HaveOccurred())
+							Expect(currentSnapshot).ToNot(BeNil())
+							Expect(currentSnapshot.State).To(Equal(vimtypes.VirtualMachinePowerStatePoweredOff))
 
 							// Snapshot should be owned by the VM resource.
 							Expect(controllerutil.SetOwnerReference(vm, vmSnapshot, ctx.Scheme)).To(Succeed())
@@ -3677,7 +3678,9 @@ func vmTests() {
 						Expect(moVM.Snapshot.CurrentSnapshot).ToNot(BeNil())
 
 						// The current snapshot name should still be the original
-						currentSnap := vmlifecycle.FindSnapshotInTree(moVM.Snapshot.RootSnapshotList, moVM.Snapshot.CurrentSnapshot.Value)
+						currentSnap, err := virtualmachine.FindSnapshot(moVM, moVM.Snapshot.CurrentSnapshot.Value)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(currentSnap).ToNot(BeNil())
 						Expect(currentSnap.Name).To(Equal(vmSnapshot.Name))
 					})
 				})

--- a/pkg/util/kube/vmsnapshot.go
+++ b/pkg/util/kube/vmsnapshot.go
@@ -12,11 +12,12 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	pkgcnd "github.com/vmware-tanzu/vm-operator/pkg/conditions"
+	vmopv1util "github.com/vmware-tanzu/vm-operator/pkg/util/vmopv1"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
-	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // CalculateReservedForSnapshotPerStorageClass calculates the reserved capacity for a snapshot.
@@ -147,18 +148,17 @@ func CalculateReservedForSnapshotPerStorageClass(
 // of the snapshot operation.
 func PatchSnapshotSuccessStatus(
 	ctx context.Context,
+	logger logr.Logger,
 	k8sClient ctrlclient.Client,
 	snap *vmopv1.VirtualMachineSnapshot,
-	snapRef *vimtypes.ManagedObjectReference,
+	snapNode *vimtypes.VirtualMachineSnapshotTree,
 	vmPowerState vmopv1.VirtualMachinePowerState) error {
 
 	snapPatch := ctrlclient.MergeFrom(snap.DeepCopy())
-	snap.Status.UniqueID = snapRef.Reference().Value
+	snap.Status.UniqueID = snapNode.Snapshot.Reference().Value
 	snap.Status.Quiesced = snap.Spec.Quiesce != nil
 	snap.Status.PowerState = vmPowerState
-	if !snap.Spec.Memory {
-		snap.Status.PowerState = vmopv1.VirtualMachinePowerStateOff
-	}
+	snap.Status.PowerState = vmopv1util.ConvertPowerState(logger, snapNode.State)
 
 	pkgcnd.MarkTrue(snap, vmopv1.VirtualMachineSnapshotCreatedCondition)
 

--- a/pkg/util/vmopv1/vm.go
+++ b/pkg/util/vmopv1/vm.go
@@ -487,3 +487,21 @@ func GetContextWithWorkloadDomainIsolation(
 	// line in the call stack will use the updated value.
 	return pkgcfg.WithContext(ctx, cfg)
 }
+
+// ConvertPowerState converts a govomomi type power state to a
+// VM Operator type power state.
+func ConvertPowerState(logger logr.Logger,
+	powerState vimtypes.VirtualMachinePowerState) vmopv1.VirtualMachinePowerState {
+	switch powerState {
+	case vimtypes.VirtualMachinePowerStatePoweredOn:
+		return vmopv1.VirtualMachinePowerStateOn
+	case vimtypes.VirtualMachinePowerStatePoweredOff:
+		return vmopv1.VirtualMachinePowerStateOff
+	case vimtypes.VirtualMachinePowerStateSuspended:
+		return vmopv1.VirtualMachinePowerStateSuspended
+	default:
+		logger.Info("Unknown snapshot power state, defaulting to Off",
+			"powerState", powerState)
+		return vmopv1.VirtualMachinePowerStateOff
+	}
+}

--- a/pkg/util/vmopv1/vm_test.go
+++ b/pkg/util/vmopv1/vm_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -1052,7 +1053,7 @@ var _ = Describe("GroupToVMsMapperFn", func() {
 					Status: vmopv1.VirtualMachineStatus{
 						Conditions: []metav1.Condition{
 							linkedTrueCondition,
-							metav1.Condition{
+							{
 								Type:   vmopv1.VirtualMachineConditionPlacementReady,
 								Status: metav1.ConditionFalse,
 							},
@@ -1085,7 +1086,7 @@ var _ = Describe("GroupToVMsMapperFn", func() {
 					Status: vmopv1.VirtualMachineStatus{
 						Conditions: []metav1.Condition{
 							linkedTrueCondition,
-							metav1.Condition{
+							{
 								Type:   vmopv1.VirtualMachineConditionPlacementReady,
 								Status: metav1.ConditionTrue,
 							},
@@ -1168,5 +1169,34 @@ var _ = DescribeTable("GetContextWithWorkloadDomainIsolation",
 			},
 		},
 		true,
+	),
+)
+
+var _ = DescribeTable("ConvertPowerState",
+	func(
+		powerState vimtypes.VirtualMachinePowerState,
+		expected vmopv1.VirtualMachinePowerState,
+	) {
+		Ω(vmopv1util.ConvertPowerState(logr.Discard(), powerState)).Should(Equal(expected))
+	},
+	Entry(
+		"powered on",
+		vimtypes.VirtualMachinePowerStatePoweredOn,
+		vmopv1.VirtualMachinePowerStateOn,
+	),
+	Entry(
+		"powered off",
+		vimtypes.VirtualMachinePowerStatePoweredOff,
+		vmopv1.VirtualMachinePowerStateOff,
+	),
+	Entry(
+		"suspended",
+		vimtypes.VirtualMachinePowerStateSuspended,
+		vmopv1.VirtualMachinePowerStateSuspended,
+	),
+	Entry(
+		"unknown",
+		vimtypes.VirtualMachinePowerState("unknown"),
+		vmopv1.VirtualMachinePowerStateOff,
 	),
 )

--- a/pkg/vmconfig/diskpromo/diskpromo_reconciler_test.go
+++ b/pkg/vmconfig/diskpromo/diskpromo_reconciler_test.go
@@ -359,7 +359,6 @@ var _ = Describe("Reconcile", Label(testlabels.V1Alpha5), func() {
 										b.Parent = &vimtypes.VirtualDiskFlatVer2BackingInfo{}
 									}
 								}
-
 							}
 
 							// Expect no task when no child disks that are not


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**
Refactoring snapshot code
1. Change `FindSnapshot` to return `VirtualMachineSnapshotTree` instead of `ManagedObjectReference`.
2. Change `SnapshotVirtualMachine` to return `VirtualMachineSnapshotTree` so following tasks could use it.
3. Not update `vmCtx.MoVM` while doing Property() call to fetch "snapshot" property, since `vmCtx.MoVM` will be shared by all the reconcile functions in updateVirtualMachine
4. Remove `FindSnapshotInTree` and `GetParentSnapshot` since they are not used anymore
5. `PatchSnapshotSuccessStatus` uses snapshot.state as source of truth to get powerstate
6. Add `ConvertPowerState` func to convert  `vimtypes.VirtualMachinePowerState` to `vmopv1.VirtualMachinePowerState`
7. Some logging clean up




**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    6. If a release note is not required, please write "NONE".
-->

```release-note
None
```