### PR TITLE
:bug: Fix Group member test flake

### DIFF
--- a/controllers/virtualmachinegroup/virtualmachinegroup_controller_test.go
+++ b/controllers/virtualmachinegroup/virtualmachinegroup_controller_test.go
@@ -315,7 +315,7 @@ var _ = Describe(
 		})
 
 		Context("Members", func() {
-			BeforeEach(func() {
+			JustBeforeEach(func() {
 				setupGroupWithMembers(vmGroup1Key, []vmopv1.VirtualMachineGroupBootOrderGroup{
 					{
 						Members: []vmopv1.GroupMember{


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

The group member tests rely on the parent group reconciliation to be triggered to update their status.  We don't queue a reconciliation for the parent group when the members are deleted.  The current test was racing against the member deletion causing the member object to be garbage collected, and the parent group to be reconciled.

This change modifies the order of the set up function so the parent group reconcile is triggered _after_ we have finished modifying the members.

Testing done:
- Ran the failing test 20 times using Ginkgo repeat.
