### PR TITLE
🌱 Downgrade API module to Go 1.23

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,8 +1,12 @@
 module github.com/vmware-tanzu/vm-operator/api
 
-go 1.24.0
-
-toolchain go1.24.4
+//
+// DO NOT UPGRADE
+//
+// This is kept as low as possible to be compatible for consumers. Please speak
+// with akutz before touching this or any dependencies in this file. Thanks!
+//
+go 1.23.0
 
 require (
 	k8s.io/api v0.31.0


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch downgrades the API module to Go 1.23 to make it more compatible for binaries consuming the APIs. This was not previously possible due to the API conversion tests, but those were moved to a separate sub-module, so now this is feasible.



**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Downgrade API module to Go 1.23.
```