### PR TITLE
:seedling: Use upstream consts for Zone and Host name label keys

### DIFF
--- a/controllers/virtualmachine/volume/volume_controller.go
+++ b/controllers/virtualmachine/volume/volume_controller.go
@@ -41,7 +41,6 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/constants"
 	"github.com/vmware-tanzu/vm-operator/pkg/record"
-	"github.com/vmware-tanzu/vm-operator/pkg/topology"
 	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
 	vmopv1util "github.com/vmware-tanzu/vm-operator/pkg/util/vmopv1"
 )
@@ -861,7 +860,7 @@ func (r *Reconciler) handlePVCWithWFFC(
 	zoneName := ctx.VM.Status.Zone
 	if zoneName == "" {
 		// Fallback to the label value if Status hasn't been updated yet.
-		zoneName = ctx.VM.Labels[topology.KubernetesTopologyZoneLabelKey]
+		zoneName = ctx.VM.Labels[corev1.LabelTopologyZone]
 		if zoneName == "" {
 			return fmt.Errorf("VM does not have Zone set")
 		}

--- a/pkg/providers/vsphere/placement/zone_placement.go
+++ b/pkg/providers/vsphere/placement/zone_placement.go
@@ -17,6 +17,7 @@ import (
 	"github.com/vmware/govmomi/vim25/mo"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 	"golang.org/x/exp/maps"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -69,7 +70,7 @@ type DatastoreResult struct {
 func doesVMNeedPlacement(vmCtx pkgctx.VirtualMachineContext) (res Result) {
 	res.ZonePlacement = true
 
-	if zoneName := vmCtx.VM.Labels[topology.KubernetesTopologyZoneLabelKey]; zoneName != "" {
+	if zoneName := vmCtx.VM.Labels[corev1.LabelTopologyZone]; zoneName != "" {
 		// Zone has already been selected.
 		res.ZoneName = zoneName
 	} else {
@@ -385,7 +386,7 @@ func Placement(
 		vmCtx,
 		client,
 		vcClient,
-		vmCtx.VM.Labels[topology.KubernetesTopologyZoneLabelKey],
+		vmCtx.VM.Labels[corev1.LabelTopologyZone],
 		vmCtx.VM.Namespace,
 		constraints.ChildRPName)
 	if err != nil {

--- a/pkg/providers/vsphere/placement/zone_placement_test.go
+++ b/pkg/providers/vsphere/placement/zone_placement_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/vmware/govmomi/simulator"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -22,7 +23,6 @@ import (
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/constants"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/placement"
-	"github.com/vmware-tanzu/vm-operator/pkg/topology"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
@@ -117,7 +117,7 @@ func vcSimPlacement() {
 				zone := &topologyv1.Zone{}
 
 				JustBeforeEach(func() {
-					vm.Labels[topology.KubernetesTopologyZoneLabelKey] = zoneName
+					vm.Labels[corev1.LabelTopologyZone] = zoneName
 					obj := &topologyv1.Zone{
 						ObjectMeta: metav1.ObjectMeta{
 							Namespace:  vm.Namespace,
@@ -136,7 +136,7 @@ func vcSimPlacement() {
 					Expect(result.ZonePlacement).To(BeTrue())
 					Expect(result.ZoneName).To(Equal(zoneName))
 					Expect(result.HostMoRef).To(BeNil())
-					Expect(vm.Labels).To(HaveKeyWithValue(topology.KubernetesTopologyZoneLabelKey, zoneName))
+					Expect(vm.Labels).To(HaveKeyWithValue(corev1.LabelTopologyZone, zoneName))
 
 					// Current contract is the caller must look this up based on the pre-assigned zone but
 					// we might want to change that later.
@@ -262,7 +262,7 @@ func vcSimPlacement() {
 					const hostMoID = "foobar-host-42"
 
 					BeforeEach(func() {
-						vm.Labels[topology.KubernetesTopologyZoneLabelKey] = "my-zone"
+						vm.Labels[corev1.LabelTopologyZone] = "my-zone"
 						vm.Annotations[constants.InstanceStorageSelectedNodeMOIDAnnotationKey] = hostMoID
 					})
 
@@ -335,7 +335,7 @@ func vcSimPlacement() {
 				zoneName := "in the zone"
 
 				JustBeforeEach(func() {
-					vm.Labels[topology.KubernetesTopologyZoneLabelKey] = zoneName
+					vm.Labels[corev1.LabelTopologyZone] = zoneName
 				})
 
 				It("returns success with same zone", func() {
@@ -345,7 +345,7 @@ func vcSimPlacement() {
 					Expect(result.ZonePlacement).To(BeTrue())
 					Expect(result.ZoneName).To(Equal(zoneName))
 					Expect(result.HostMoRef).To(BeNil())
-					Expect(vm.Labels).To(HaveKeyWithValue(topology.KubernetesTopologyZoneLabelKey, zoneName))
+					Expect(vm.Labels).To(HaveKeyWithValue(corev1.LabelTopologyZone, zoneName))
 
 					// Current contract is the caller must look this up based on the pre-assigned zone but
 					// we might want to change that later.
@@ -454,7 +454,7 @@ func vcSimPlacement() {
 				const hostMoID = "foobar-host-42"
 
 				BeforeEach(func() {
-					vm.Labels[topology.KubernetesTopologyZoneLabelKey] = "my-zone"
+					vm.Labels[corev1.LabelTopologyZone] = "my-zone"
 					vm.Annotations[constants.InstanceStorageSelectedNodeMOIDAnnotationKey] = hostMoID
 				})
 

--- a/pkg/providers/vsphere/virtualmachine/backup.go
+++ b/pkg/providers/vsphere/virtualmachine/backup.go
@@ -29,7 +29,6 @@ import (
 	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 	pkgerr "github.com/vmware-tanzu/vm-operator/pkg/errors"
 	res "github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/resources"
-	"github.com/vmware-tanzu/vm-operator/pkg/topology"
 	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
 )
 
@@ -309,7 +308,7 @@ func trimBackupFields(obj client.Object) {
 		// Remove the zone label from the VM. When a VM is restored /
 		// failed over, VM operator detects the VM's resource pool and
 		// retroactively populates the VM's zone label.
-		delete(labels, topology.KubernetesTopologyZoneLabelKey)
+		delete(labels, corev1.LabelTopologyZone)
 		obj.SetLabels(labels)
 	}
 

--- a/pkg/providers/vsphere/virtualmachine/backup_test.go
+++ b/pkg/providers/vsphere/virtualmachine/backup_test.go
@@ -27,7 +27,6 @@ import (
 	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/virtualmachine"
-	"github.com/vmware-tanzu/vm-operator/pkg/topology"
 	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 	"github.com/vmware-tanzu/vm-operator/test/testutil"
@@ -1153,7 +1152,7 @@ func getExpectedBackupObjectYAML(obj client.Object) string {
 	}
 
 	if labels := obj.GetLabels(); len(labels) > 0 {
-		delete(labels, topology.KubernetesTopologyZoneLabelKey)
+		delete(labels, corev1.LabelTopologyZone)
 		obj.SetLabels(labels)
 	}
 

--- a/pkg/providers/vsphere/virtualmachine/configspec.go
+++ b/pkg/providers/vsphere/virtualmachine/configspec.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"slices"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	vimtypes "github.com/vmware/govmomi/vim25/types"
@@ -16,7 +17,6 @@ import (
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/constants"
-	"github.com/vmware-tanzu/vm-operator/pkg/topology"
 	"github.com/vmware-tanzu/vm-operator/pkg/util"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	vmopv1util "github.com/vmware-tanzu/vm-operator/pkg/util/vmopv1"
@@ -177,7 +177,7 @@ func genConfigSpecAffinityPolicies(
 			// in the VM affinity policy.  Not additional labels.
 			// Note that the validation webhook will ensure that the VM also has the label that it specifies in the affinity policy.
 			for _, affinityTerm := range affinity.VMAffinity.RequiredDuringSchedulingIgnoredDuringExecution {
-				if affinityTerm.TopologyKey == topology.KubernetesTopologyZoneLabelKey {
+				if affinityTerm.TopologyKey == corev1.LabelTopologyZone {
 					// Generate a tag name using the key value pair specified in the label selector.
 					for key, value := range affinityTerm.LabelSelector.MatchLabels {
 						// TODO: there should be a more concrete way generate the tag name.
@@ -208,7 +208,7 @@ func genConfigSpecAffinityPolicies(
 			}
 
 			for _, affinityTerm := range affinity.VMAffinity.PreferredDuringSchedulingIgnoredDuringExecution {
-				if affinityTerm.TopologyKey == topology.KubernetesTopologyZoneLabelKey {
+				if affinityTerm.TopologyKey == corev1.LabelTopologyZone {
 					// Generate a tag name using the key value pair specified in the label selector.
 					for key, value := range affinityTerm.LabelSelector.MatchLabels {
 						// TODO: there should be a more concrete way generate the tag name.
@@ -246,7 +246,7 @@ func genConfigSpecAffinityPolicies(
 
 			// Handle PreferredDuringSchedulingIgnoredDuringExecution terms
 			for _, affinityTerm := range affinity.VMAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution {
-				if affinityTerm.TopologyKey == topology.KubernetesTopologyZoneLabelKey {
+				if affinityTerm.TopologyKey == corev1.LabelTopologyZone {
 					labels, err := extractLabelsFromSelector(affinityTerm.LabelSelector)
 					if err != nil {
 						vmCtx.Logger.Error(err, "Anti-affinity policy specifies an invalid label selector")

--- a/pkg/providers/vsphere/virtualmachine/configspec_test.go
+++ b/pkg/providers/vsphere/virtualmachine/configspec_test.go
@@ -22,7 +22,6 @@ import (
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/constants"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/virtualmachine"
-	"github.com/vmware-tanzu/vm-operator/pkg/topology"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
@@ -231,7 +230,7 @@ var _ = Describe("CreateConfigSpec", func() {
 											},
 										},
 									},
-									TopologyKey: topology.KubernetesTopologyZoneLabelKey,
+									TopologyKey: corev1.LabelTopologyZone,
 								},
 							},
 						},
@@ -305,7 +304,7 @@ var _ = Describe("CreateConfigSpec", func() {
 											},
 										},
 									},
-									TopologyKey: topology.KubernetesTopologyZoneLabelKey,
+									TopologyKey: corev1.LabelTopologyZone,
 								},
 							},
 						},
@@ -379,7 +378,7 @@ var _ = Describe("CreateConfigSpec", func() {
 											},
 										},
 									},
-									TopologyKey: topology.KubernetesTopologyZoneLabelKey,
+									TopologyKey: corev1.LabelTopologyZone,
 								},
 								{
 									LabelSelector: &metav1.LabelSelector{
@@ -387,7 +386,7 @@ var _ = Describe("CreateConfigSpec", func() {
 											"environment": "prod",
 										},
 									},
-									TopologyKey: topology.KubernetesTopologyZoneLabelKey,
+									TopologyKey: corev1.LabelTopologyZone,
 								},
 							},
 						},
@@ -455,7 +454,7 @@ var _ = Describe("CreateConfigSpec", func() {
 											"environment": "prod",
 										},
 									},
-									TopologyKey: topology.KubernetesTopologyZoneLabelKey,
+									TopologyKey: corev1.LabelTopologyZone,
 								},
 							},
 						},
@@ -496,7 +495,7 @@ var _ = Describe("CreateConfigSpec", func() {
 											},
 										},
 									},
-									TopologyKey: topology.KubernetesTopologyZoneLabelKey,
+									TopologyKey: corev1.LabelTopologyZone,
 								},
 							},
 						},
@@ -537,7 +536,7 @@ var _ = Describe("CreateConfigSpec", func() {
 											},
 										},
 									},
-									TopologyKey: topology.KubernetesTopologyZoneLabelKey,
+									TopologyKey: corev1.LabelTopologyZone,
 								},
 							},
 						},

--- a/pkg/providers/vsphere/vmlifecycle/update_status.go
+++ b/pkg/providers/vsphere/vmlifecycle/update_status.go
@@ -19,6 +19,7 @@ import (
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/govmomi/vmdk"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apierrorsutil "k8s.io/apimachinery/pkg/util/errors"
@@ -292,7 +293,7 @@ func reconcileStatusZone(
 
 	var errs []error
 
-	zoneName := vmCtx.VM.Labels[topology.KubernetesTopologyZoneLabelKey]
+	zoneName := vmCtx.VM.Labels[corev1.LabelTopologyZone]
 	if zoneName == "" {
 		clusterMoRef, err := vcenter.GetResourcePoolOwnerMoRef(
 			vmCtx, vcVM.Client(), vmCtx.MoVM.ResourcePool.Value)
@@ -307,7 +308,7 @@ func reconcileStatusZone(
 				if vmCtx.VM.Labels == nil {
 					vmCtx.VM.Labels = map[string]string{}
 				}
-				vmCtx.VM.Labels[topology.KubernetesTopologyZoneLabelKey] = zoneName
+				vmCtx.VM.Labels[corev1.LabelTopologyZone] = zoneName
 			}
 		}
 	}

--- a/pkg/providers/vsphere/vmprovider_vm.go
+++ b/pkg/providers/vsphere/vmprovider_vm.go
@@ -703,7 +703,7 @@ func (vs *vSphereVMProvider) createVirtualMachine(
 			if ctx.VM.Labels == nil {
 				ctx.VM.Labels = map[string]string{}
 			}
-			ctx.VM.Labels[topology.KubernetesTopologyZoneLabelKey] = zoneName
+			ctx.VM.Labels[corev1.LabelTopologyZone] = zoneName
 		}
 	}
 
@@ -759,7 +759,7 @@ func (vs *vSphereVMProvider) createVirtualMachineAsync(
 				if ctx.VM.Labels == nil {
 					ctx.VM.Labels = map[string]string{}
 				}
-				ctx.VM.Labels[topology.KubernetesTopologyZoneLabelKey] = zoneName
+				ctx.VM.Labels[corev1.LabelTopologyZone] = zoneName
 			}
 		}
 
@@ -1611,7 +1611,7 @@ func processPlacementResult(
 			}
 			// Note if the VM create fails for some reason, but this label gets updated on the k8s VM,
 			// then this is the pre-assigned zone on later create attempts.
-			vmCtx.VM.Labels[topology.KubernetesTopologyZoneLabelKey] = result.ZoneName
+			vmCtx.VM.Labels[corev1.LabelTopologyZone] = result.ZoneName
 		}
 	}
 
@@ -1628,7 +1628,7 @@ func (vs *vSphereVMProvider) vmCreateGetFolderAndRPMoIDs(
 		// We did not do placement so find this namespace/zone ResourcePool and Folder.
 
 		nsFolderMoID, rpMoID, err := topology.GetNamespaceFolderAndRPMoID(vmCtx, vs.k8sClient,
-			vmCtx.VM.Labels[topology.KubernetesTopologyZoneLabelKey], vmCtx.VM.Namespace)
+			vmCtx.VM.Labels[corev1.LabelTopologyZone], vmCtx.VM.Namespace)
 		if err != nil {
 			return err
 		}
@@ -2309,7 +2309,7 @@ func (vs *vSphereVMProvider) vmCreateGenConfigSpecImage(
 
 	// Inherit the image's vAppConfig.
 	createArgs.ConfigSpec.VAppConfig = imgConfigSpec.VAppConfig
-	
+
 	// Merge the image's extra config.
 	if srcEC, err := virtualmachine.FilteredExtraConfig(
 		imgConfigSpec.ExtraConfig,

--- a/pkg/topology/availability_zones.go
+++ b/pkg/topology/availability_zones.go
@@ -15,16 +15,6 @@ import (
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 )
 
-const (
-	// KubernetesTopologyZoneLabelKey is the label used to specify the
-	// availability zone for a VM.
-	KubernetesTopologyZoneLabelKey = "topology.kubernetes.io/zone"
-
-	// KubernetesTopologyHostLabelKey is the label used to specify the
-	// host for a VM.
-	KubernetesTopologyHostLabelKey = "kubernetes.io/hostname"
-)
-
 var (
 	// ErrNoAvailabilityZones occurs when no availability zones are detected.
 	ErrNoAvailabilityZones = errors.New("no availability zones")

--- a/webhooks/virtualmachine/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator.go
@@ -1586,12 +1586,12 @@ func (v validator) validateAvailabilityZone(
 
 	var allErrs field.ErrorList
 
-	zoneLabelPath := field.NewPath("metadata", "labels").Key(topology.KubernetesTopologyZoneLabelKey)
+	zoneLabelPath := field.NewPath("metadata", "labels").Key(corev1.LabelTopologyZone)
 
 	if oldVM != nil {
 		// Once the zone has been set then make sure the field is immutable.
-		if oldVal := oldVM.Labels[topology.KubernetesTopologyZoneLabelKey]; oldVal != "" {
-			newVal := vm.Labels[topology.KubernetesTopologyZoneLabelKey]
+		if oldVal := oldVM.Labels[corev1.LabelTopologyZone]; oldVal != "" {
+			newVal := vm.Labels[corev1.LabelTopologyZone]
 
 			// Privileged accounts are allowed to update the
 			// availability zone label on the VM. This is used during
@@ -1608,7 +1608,7 @@ func (v validator) validateAvailabilityZone(
 	}
 
 	// Validate the name of the provided availability zone.
-	if zoneName := vm.Labels[topology.KubernetesTopologyZoneLabelKey]; zoneName != "" {
+	if zoneName := vm.Labels[corev1.LabelTopologyZone]; zoneName != "" {
 		if pkgcfg.FromContext(ctx).Features.WorkloadDomainIsolation {
 			// Validate the name of the provided zone. It is the same name as az.
 			zone, err := topology.GetZone(ctx.Context, v.client, zoneName, vm.Namespace)
@@ -2167,9 +2167,9 @@ func (v validator) validateVMAffinity(
 					}
 				}
 
-				if rs.TopologyKey != topology.KubernetesTopologyZoneLabelKey {
+				if rs.TopologyKey != corev1.LabelTopologyZone {
 					allErrs = append(allErrs, field.NotSupported(
-						p.Child("topologyKey"), rs.TopologyKey, []string{topology.KubernetesTopologyZoneLabelKey}))
+						p.Child("topologyKey"), rs.TopologyKey, []string{corev1.LabelTopologyZone}))
 				}
 			}
 		}
@@ -2202,9 +2202,9 @@ func (v validator) validateVMAffinity(
 					}
 				}
 
-				if rs.TopologyKey != topology.KubernetesTopologyZoneLabelKey {
+				if rs.TopologyKey != corev1.LabelTopologyZone {
 					allErrs = append(allErrs, field.NotSupported(
-						p.Child("topologyKey"), rs.TopologyKey, []string{topology.KubernetesTopologyZoneLabelKey}))
+						p.Child("topologyKey"), rs.TopologyKey, []string{corev1.LabelTopologyZone}))
 				}
 			}
 		}
@@ -2239,9 +2239,9 @@ func (v validator) validateVMAffinity(
 					}
 				}
 
-				if rs.TopologyKey != topology.KubernetesTopologyZoneLabelKey {
+				if rs.TopologyKey != corev1.LabelTopologyZone {
 					allErrs = append(allErrs, field.NotSupported(
-						p.Child("topologyKey"), rs.TopologyKey, []string{topology.KubernetesTopologyZoneLabelKey}))
+						p.Child("topologyKey"), rs.TopologyKey, []string{corev1.LabelTopologyZone}))
 				}
 			}
 		}
@@ -2272,9 +2272,9 @@ func (v validator) validateVMAffinity(
 					}
 				}
 
-				if rs.TopologyKey != "" && rs.TopologyKey != topology.KubernetesTopologyHostLabelKey {
+				if rs.TopologyKey != "" && rs.TopologyKey != corev1.LabelHostname {
 					allErrs = append(allErrs, field.NotSupported(
-						p.Child("topologyKey"), rs.TopologyKey, []string{"", topology.KubernetesTopologyHostLabelKey}))
+						p.Child("topologyKey"), rs.TopologyKey, []string{"", corev1.LabelHostname}))
 				}
 			}
 		}

--- a/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
@@ -35,7 +35,6 @@ import (
 	pkgconst "github.com/vmware-tanzu/vm-operator/pkg/constants"
 	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/config"
-	"github.com/vmware-tanzu/vm-operator/pkg/topology"
 	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	vmopv1util "github.com/vmware-tanzu/vm-operator/pkg/util/vmopv1"
@@ -313,7 +312,7 @@ func unitTestsValidateCreate() {
 			Entry("should allow when VM specifies no availability zone, there are availability zones and zones",
 				testParams{
 					setup: func(ctx *unitValidatingWebhookContext) {
-						delete(ctx.vm.Labels, topology.KubernetesTopologyZoneLabelKey)
+						delete(ctx.vm.Labels, corev1.LabelTopologyZone)
 					},
 					expectAllowed: true,
 				},
@@ -321,7 +320,7 @@ func unitTestsValidateCreate() {
 			Entry("should allow when VM specifies no availability zone, there are no availability zones or zones",
 				testParams{
 					setup: func(ctx *unitValidatingWebhookContext) {
-						delete(ctx.vm.Labels, topology.KubernetesTopologyZoneLabelKey)
+						delete(ctx.vm.Labels, corev1.LabelTopologyZone)
 						Expect(ctx.Client.Delete(ctx, builder.DummyAvailabilityZone())).To(Succeed())
 						Expect(ctx.Client.Delete(ctx, builder.DummyZone(dummyNamespaceName))).To(Succeed())
 					},
@@ -332,7 +331,7 @@ func unitTestsValidateCreate() {
 				testParams{
 					setup: func(ctx *unitValidatingWebhookContext) {
 						zoneName := builder.DummyZoneName
-						ctx.vm.Labels[topology.KubernetesTopologyZoneLabelKey] = zoneName
+						ctx.vm.Labels[corev1.LabelTopologyZone] = zoneName
 					},
 					expectAllowed: true,
 				},
@@ -345,7 +344,7 @@ func unitTestsValidateCreate() {
 						})
 						zoneName := builder.DummyZoneName
 						ctx.vm.Labels[vmopv1util.KubernetesNodeLabelKey] = ""
-						ctx.vm.Labels[topology.KubernetesTopologyZoneLabelKey] = zoneName
+						ctx.vm.Labels[corev1.LabelTopologyZone] = zoneName
 						Expect(ctx.Client.Delete(ctx, builder.DummyZone(dummyNamespaceName))).To(Succeed())
 					},
 					expectAllowed: true,
@@ -356,7 +355,7 @@ func unitTestsValidateCreate() {
 					setup: func(ctx *unitValidatingWebhookContext) {
 						zoneName := builder.DummyZoneName
 						ctx.vm.Labels[vmopv1util.KubernetesNodeLabelKey] = ""
-						ctx.vm.Labels[topology.KubernetesTopologyZoneLabelKey] = zoneName
+						ctx.vm.Labels[corev1.LabelTopologyZone] = zoneName
 						Expect(ctx.Client.Delete(ctx, builder.DummyZone(dummyNamespaceName))).To(Succeed())
 					},
 					expectAllowed: false,
@@ -366,7 +365,7 @@ func unitTestsValidateCreate() {
 				testParams{
 					setup: func(ctx *unitValidatingWebhookContext) {
 						zoneName := builder.DummyZoneName
-						ctx.vm.Labels[topology.KubernetesTopologyZoneLabelKey] = zoneName
+						ctx.vm.Labels[corev1.LabelTopologyZone] = zoneName
 						Expect(ctx.Client.Delete(ctx, builder.DummyZone(dummyNamespaceName))).To(Succeed())
 					},
 					expectAllowed: false,
@@ -379,7 +378,7 @@ func unitTestsValidateCreate() {
 							config.Features.WorkloadDomainIsolation = true
 						})
 						zoneName := builder.DummyZoneName
-						ctx.vm.Labels[topology.KubernetesTopologyZoneLabelKey] = zoneName
+						ctx.vm.Labels[corev1.LabelTopologyZone] = zoneName
 						zone := &topologyv1.Zone{}
 						Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: zoneName, Namespace: dummyNamespaceName}, zone)).To(Succeed())
 						zone.Finalizers = []string{"test"}
@@ -397,7 +396,7 @@ func unitTestsValidateCreate() {
 							ctx.IsPrivilegedAccount = true
 						})
 						zoneName := builder.DummyZoneName
-						ctx.vm.Labels[topology.KubernetesTopologyZoneLabelKey] = zoneName
+						ctx.vm.Labels[corev1.LabelTopologyZone] = zoneName
 						zone := &topologyv1.Zone{}
 						Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: zoneName, Namespace: dummyNamespaceName}, zone)).To(Succeed())
 						zone.Finalizers = []string{"test"}
@@ -415,7 +414,7 @@ func unitTestsValidateCreate() {
 							ctx.UserInfo.Username = "system:serviceaccount:svc-tkg-domain-c52:default"
 						})
 						zoneName := builder.DummyZoneName
-						ctx.vm.Labels[topology.KubernetesTopologyZoneLabelKey] = zoneName
+						ctx.vm.Labels[corev1.LabelTopologyZone] = zoneName
 						zone := &topologyv1.Zone{}
 						Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: zoneName, Namespace: dummyNamespaceName}, zone)).To(Succeed())
 						zone.Finalizers = []string{"test"}
@@ -429,7 +428,7 @@ func unitTestsValidateCreate() {
 				testParams{
 					setup: func(ctx *unitValidatingWebhookContext) {
 						zoneName := builder.DummyZoneName
-						ctx.vm.Labels[topology.KubernetesTopologyZoneLabelKey] = zoneName
+						ctx.vm.Labels[corev1.LabelTopologyZone] = zoneName
 						Expect(ctx.Client.Delete(ctx, builder.DummyAvailabilityZone())).To(Succeed())
 						Expect(ctx.Client.Delete(ctx, builder.DummyZone(dummyNamespaceName))).To(Succeed())
 					},
@@ -439,7 +438,7 @@ func unitTestsValidateCreate() {
 			Entry("should deny when VM specifies invalid availability zone, there are availability zones and zones",
 				testParams{
 					setup: func(ctx *unitValidatingWebhookContext) {
-						ctx.vm.Labels[topology.KubernetesTopologyZoneLabelKey] = "invalid"
+						ctx.vm.Labels[corev1.LabelTopologyZone] = "invalid"
 					},
 					expectAllowed: false,
 				},
@@ -447,7 +446,7 @@ func unitTestsValidateCreate() {
 			Entry("should deny when VM specifies invalid availability zone, there are no availability zones or zones",
 				testParams{
 					setup: func(ctx *unitValidatingWebhookContext) {
-						ctx.vm.Labels[topology.KubernetesTopologyZoneLabelKey] = "invalid"
+						ctx.vm.Labels[corev1.LabelTopologyZone] = "invalid"
 						Expect(ctx.Client.Delete(ctx, builder.DummyAvailabilityZone())).To(Succeed())
 						Expect(ctx.Client.Delete(ctx, builder.DummyZone(dummyNamespaceName))).To(Succeed())
 					},
@@ -3534,15 +3533,15 @@ func unitTestsValidateUpdate() {
 			ctx.vm.Spec.Reserved.ResourcePolicyName = "policy" + updateSuffix
 		}
 		if args.assignZoneName {
-			ctx.vm.Labels[topology.KubernetesTopologyZoneLabelKey] = builder.DummyZoneName
+			ctx.vm.Labels[corev1.LabelTopologyZone] = builder.DummyZoneName
 		}
 		if args.changeZoneName {
-			ctx.oldVM.Labels[topology.KubernetesTopologyZoneLabelKey] = builder.DummyZoneName
+			ctx.oldVM.Labels[corev1.LabelTopologyZone] = builder.DummyZoneName
 			if args.unsetZone {
 				// Remove the zone label to test unsetting zone
-				delete(ctx.vm.Labels, topology.KubernetesTopologyZoneLabelKey)
+				delete(ctx.vm.Labels, corev1.LabelTopologyZone)
 			} else {
-				ctx.vm.Labels[topology.KubernetesTopologyZoneLabelKey] = builder.DummyZoneName + updateSuffix
+				ctx.vm.Labels[corev1.LabelTopologyZone] = builder.DummyZoneName + updateSuffix
 			}
 		}
 
@@ -3624,7 +3623,7 @@ func unitTestsValidateUpdate() {
 		Entry("should allow empty bios uuid change", updateArgs{changeBiosUUID: true}, true, nil, nil),
 		Entry("should allow initial zone assignment", updateArgs{assignZoneName: true}, true, nil, nil),
 		Entry("should deny zone change for non-privileged user", updateArgs{changeZoneName: true}, false,
-			field.Invalid(field.NewPath("metadata", "labels").Key(topology.KubernetesTopologyZoneLabelKey), builder.DummyZoneName+updateSuffix, "field is immutable").Error(), nil),
+			field.Invalid(field.NewPath("metadata", "labels").Key(corev1.LabelTopologyZone), builder.DummyZoneName+updateSuffix, "field is immutable").Error(), nil),
 		Entry("should allow zone change for privileged user", updateArgs{changeZoneName: true, isServiceUser: true}, true, nil, nil),
 		Entry("should allow zone unset for privileged user", updateArgs{changeZoneName: true, isServiceUser: true, unsetZone: true}, true, nil, nil),
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

While browsing through some code upstream, I found that these are defined upstream.  So, there's no point in maintaining our own variables.  This has a few added benefits of reducing imports in packages -- including reducing dependence in WCP service since we need to reference the zone label during restore.


**Please add a release note if necessary**:

```release-note
NONE
```