### PR TITLE
🌱Add mutating webhook for rac and wsfc workload

### DIFF
--- a/webhooks/virtualmachine/mutation/virtualmachine_mutator_intg_test.go
+++ b/webhooks/virtualmachine/mutation/virtualmachine_mutator_intg_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -289,21 +290,23 @@ func intgTestsMutating() {
 		)
 
 		shouldMutateImageButNotImageName := func() {
-			ExpectWithOffset(1, ctx.Client.Create(ctx, ctx.vm)).To(Succeed())
+			GinkgoHelper()
+			Expect(ctx.Client.Create(ctx, ctx.vm)).To(Succeed())
 			modified := &vmopv1.VirtualMachine{}
-			ExpectWithOffset(1, ctx.Client.Get(ctx, client.ObjectKeyFromObject(ctx.vm), modified)).To(Succeed())
-			ExpectWithOffset(1, modified.Spec.Image).ToNot(BeNil())
-			ExpectWithOffset(1, modified.Spec.Image.Kind).To(Equal(vmiKind))
-			ExpectWithOffset(1, modified.Spec.Image.Name).To(Equal(builder.DummyVMIName))
-			ExpectWithOffset(1, modified.Spec.ImageName).To(Equal(ctx.vm.Spec.ImageName))
+			Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(ctx.vm), modified)).To(Succeed())
+			Expect(modified.Spec.Image).ToNot(BeNil())
+			Expect(modified.Spec.Image.Kind).To(Equal(vmiKind))
+			Expect(modified.Spec.Image.Name).To(Equal(builder.DummyVMIName))
+			Expect(modified.Spec.ImageName).To(Equal(ctx.vm.Spec.ImageName))
 		}
 
 		shouldNotMutateImageOrImageName := func() {
-			ExpectWithOffset(1, ctx.Client.Create(ctx, ctx.vm)).To(Succeed())
+			GinkgoHelper()
+			Expect(ctx.Client.Create(ctx, ctx.vm)).To(Succeed())
 			modified := &vmopv1.VirtualMachine{}
-			ExpectWithOffset(1, ctx.Client.Get(ctx, client.ObjectKeyFromObject(ctx.vm), modified)).To(Succeed())
-			ExpectWithOffset(1, modified.Spec.Image).To(Equal(ctx.vm.Spec.Image))
-			ExpectWithOffset(1, modified.Spec.ImageName).To(Equal(ctx.vm.Spec.ImageName))
+			Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(ctx.vm), modified)).To(Succeed())
+			Expect(modified.Spec.Image).To(Equal(ctx.vm.Spec.Image))
+			Expect(modified.Spec.ImageName).To(Equal(ctx.vm.Spec.ImageName))
 		}
 
 		When("Creating VirtualMachine", func() {
@@ -783,6 +786,72 @@ func intgTestsMutating() {
 				updated := &vmopv1.VirtualMachine{}
 				Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(ctx.vm), updated)).To(Succeed())
 				Expect(updated.Annotations).ToNot(HaveKey(constants.ApplyPowerStateTimeAnnotation))
+			})
+		})
+	})
+
+	Context("SetPVCVolumeDefaultsOnCreate", func() {
+		JustBeforeEach(func() {
+			err := ctx.Client.Create(ctx, ctx.vm)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		When("Feature gate is not enabled by default", func() {
+			When("vm has multiple pvcs with different application types", func() {
+				BeforeEach(func() {
+					ctx.vm.Spec.Volumes = []vmopv1.VirtualMachineVolume{
+						{
+							Name: "test-volume",
+							VirtualMachineVolumeSource: vmopv1.VirtualMachineVolumeSource{
+								PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
+									PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+										ClaimName: "test-pvc",
+									},
+									ApplicationType: vmopv1.VolumeApplicationTypeOracleRAC,
+								},
+							},
+						},
+						{
+							Name: "test-volume-2",
+							VirtualMachineVolumeSource: vmopv1.VirtualMachineVolumeSource{
+								PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
+									PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+										ClaimName: "test-pvc-2",
+									},
+									ApplicationType: vmopv1.VolumeApplicationTypeMicrosoftWSFC,
+								},
+							},
+						},
+						{
+							Name: "test-volume-3",
+							VirtualMachineVolumeSource: vmopv1.VirtualMachineVolumeSource{
+								PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
+									PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+										ClaimName: "test-pvc-3",
+									},
+								},
+							},
+						},
+					}
+
+				})
+
+				It("should only set the disk mode to persistent, and leave the rest empty", func() {
+					vm := &vmopv1.VirtualMachine{}
+					Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(ctx.vm), vm)).To(Succeed())
+					Expect(vm.Spec.Volumes[0].PersistentVolumeClaim.DiskMode).
+						To(Equal(vmopv1.VolumeDiskModePersistent))
+					Expect(vm.Spec.Volumes[0].PersistentVolumeClaim.SharingMode).
+						To(BeEmpty())
+					Expect(vm.Spec.Volumes[1].PersistentVolumeClaim.DiskMode).
+						To(Equal(vmopv1.VolumeDiskModePersistent))
+					Expect(vm.Spec.Volumes[1].PersistentVolumeClaim.SharingMode).
+						To(BeEmpty())
+					Expect(vm.Spec.Volumes[2].PersistentVolumeClaim.DiskMode).
+						To(Equal(vmopv1.VolumeDiskModePersistent))
+					Expect(vm.Spec.Volumes[2].PersistentVolumeClaim.SharingMode).
+						To(BeEmpty())
+				})
 			})
 		})
 	})

--- a/webhooks/virtualmachine/mutation/virtualmachine_mutator_unit_test.go
+++ b/webhooks/virtualmachine/mutation/virtualmachine_mutator_unit_test.go
@@ -1843,4 +1843,143 @@ func unitTestsMutating() {
 			})
 		})
 	})
+
+	Describe("SetPVCVolumeDefaultsOnCreate", func() {
+		var (
+			vm         *vmopv1.VirtualMachine
+			wasMutated bool
+			err        error
+		)
+
+		BeforeEach(func() {
+			vm = ctx.vm.DeepCopy()
+			vm.Spec.Volumes = []vmopv1.VirtualMachineVolume{
+				{
+					Name: "test-volume",
+					VirtualMachineVolumeSource: vmopv1.VirtualMachineVolumeSource{
+						PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
+							PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: "test-pvc",
+							},
+						},
+					},
+				},
+			}
+		})
+
+		JustBeforeEach(func() {
+			wasMutated, err = mutation.SetPVCVolumeDefaultsOnCreate(&ctx.WebhookRequestContext, ctx.Client, vm)
+		})
+
+		When("vm has pvc and it doesn't have application type", func() {
+			It("should not set any defaults", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(wasMutated).To(BeFalse())
+				Expect(vm.Spec.Volumes[0].PersistentVolumeClaim.ApplicationType).To(BeEmpty())
+			})
+		})
+
+		When("vm has pvc and it has application type OracleRAC", func() {
+			BeforeEach(func() {
+				vm.Spec.Volumes[0].PersistentVolumeClaim.ApplicationType = vmopv1.VolumeApplicationTypeOracleRAC
+			})
+
+			It("should set the default PVC volume application type", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(wasMutated).To(BeTrue())
+				Expect(vm.Spec.Volumes[0].PersistentVolumeClaim.DiskMode).To(Equal(vmopv1.VolumeDiskModeIndependentPersistent))
+				Expect(vm.Spec.Volumes[0].PersistentVolumeClaim.SharingMode).To(Equal(vmopv1.VolumeSharingModeMultiWriter))
+			})
+		})
+
+		When("vm has pvc and it has application type MicrosoftWSFC", func() {
+			BeforeEach(func() {
+				vm.Spec.Volumes[0].PersistentVolumeClaim.ApplicationType = vmopv1.VolumeApplicationTypeMicrosoftWSFC
+			})
+
+			It("should set the default PVC volume application type", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(wasMutated).To(BeTrue())
+				Expect(vm.Spec.Volumes[0].PersistentVolumeClaim.DiskMode).To(Equal(vmopv1.VolumeDiskModeIndependentPersistent))
+			})
+		})
+
+		When("vm has pvc and it has application type other than OracleRAC or MicrosoftWSFC", func() {
+			BeforeEach(func() {
+				vm.Spec.Volumes[0].PersistentVolumeClaim.ApplicationType = vmopv1.VolumeApplicationTypeOracleRAC
+				vm.Spec.Volumes = append(vm.Spec.Volumes, vmopv1.VirtualMachineVolume{
+					Name: "test-volume-2",
+					VirtualMachineVolumeSource: vmopv1.VirtualMachineVolumeSource{
+						PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
+							PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: "test-pvc-2",
+							},
+							ApplicationType: "invalid",
+						},
+					},
+				})
+			})
+
+			It("should return error with unsupported application type", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(
+					"spec[1].persistentVolumeClaim.applicationType: " +
+						"Unsupported value: \"invalid\":" +
+						" supported values: \"OracleRAC\", \"MicrosoftWSFC\""))
+				Expect(wasMutated).To(BeFalse())
+			})
+		})
+
+		When("vm has multiple pvcs and different application types", func() {
+			BeforeEach(func() {
+				vm.Spec.Volumes[0].PersistentVolumeClaim.ApplicationType = vmopv1.VolumeApplicationTypeOracleRAC
+				vm.Spec.Volumes = append(vm.Spec.Volumes,
+					vmopv1.VirtualMachineVolume{
+						Name: "test-volume-2",
+						VirtualMachineVolumeSource: vmopv1.VirtualMachineVolumeSource{
+							PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
+								PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: "test-pvc-2",
+								},
+								ApplicationType: vmopv1.VolumeApplicationTypeMicrosoftWSFC,
+							},
+						},
+					},
+					vmopv1.VirtualMachineVolume{
+						Name: "test-volume-3",
+						VirtualMachineVolumeSource: vmopv1.VirtualMachineVolumeSource{
+							PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
+								PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: "test-pvc-3",
+								},
+							},
+						},
+					},
+				)
+			})
+
+			It("should set the PVC volume with correct disk mode and sharing mode", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(wasMutated).To(BeTrue())
+				Expect(vm.Spec.Volumes[0].PersistentVolumeClaim.DiskMode).To(Equal(vmopv1.VolumeDiskModeIndependentPersistent))
+				Expect(vm.Spec.Volumes[0].PersistentVolumeClaim.SharingMode).To(Equal(vmopv1.VolumeSharingModeMultiWriter))
+				Expect(vm.Spec.Volumes[1].PersistentVolumeClaim.DiskMode).To(Equal(vmopv1.VolumeDiskModeIndependentPersistent))
+				Expect(vm.Spec.Volumes[1].PersistentVolumeClaim.SharingMode).To(BeEmpty())
+				Expect(vm.Spec.Volumes[2].PersistentVolumeClaim.DiskMode).To(BeEmpty())
+				Expect(vm.Spec.Volumes[2].PersistentVolumeClaim.SharingMode).To(BeEmpty())
+			})
+		})
+
+		When("vm has no pvc", func() {
+			BeforeEach(func() {
+				vm.Spec.Volumes = []vmopv1.VirtualMachineVolume{}
+			})
+
+			It("should not set any defaults disk mode and sharing mode", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(wasMutated).To(BeFalse())
+			})
+		})
+	})
+
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

Auto fill PVC's config based on the application type.

Referenced from the API definition [here](https://github.com/vmware-tanzu/vm-operator/blob/main/api/v1alpha5/virtualmachine_storage_types.go#L106-L124)
```
	//   - OracleRAC      -- The volume is configured with
	//                       diskMode=IndependentPersistent and
	//                       sharingMode=MultiWriter
	//   - MicrosoftWSFC  -- The volume is configured with
	//                       diskMode=IndependentPersistent
```

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    3. If a release note is not required, please write "NONE".
-->

```release-note
Add mutating webhook for rac and wsfc workload
```