### PR TITLE
🌱 Add Capability for shared disks

### DIFF
--- a/pkg/config/capabilities/capabilities.go
+++ b/pkg/config/capabilities/capabilities.go
@@ -73,6 +73,12 @@ const (
 	// defined in the Supervisor capabilities CRD for the VM WFFC PVC
 	// capability.
 	CapabilityKeyVMWaitForFirstConsumerPVC = "supports_VM_service_WFFC_PVC"
+
+	// CapabilityKeySharedDisks is the name of the capability key
+	// defined in the Supervisor capabilities CRD for the VM Service's support
+	// for shared disks. This capability is introduced as a part of Oracle RAC
+	// and Microsoft WSFC workloads support.
+	CapabilityKeySharedDisks = "supports_shared_disks_with_VM_service_VMs"
 )
 
 var (
@@ -225,6 +231,8 @@ func updateCapabilitiesFeaturesFromCRD(
 			fs.VMPlacementPolicies = capStatus.Activated
 		case CapabilityKeyVMWaitForFirstConsumerPVC:
 			fs.VMWaitForFirstConsumerPVC = capStatus.Activated
+		case CapabilityKeySharedDisks:
+			fs.VMSharedDisks = capStatus.Activated
 		}
 
 	}

--- a/pkg/config/capabilities/capabilities_test.go
+++ b/pkg/config/capabilities/capabilities_test.go
@@ -162,6 +162,9 @@ var _ = Describe("UpdateCapabilities", func() {
 						capabilities.CapabilityKeyVMWaitForFirstConsumerPVC: {
 							Activated: true,
 						},
+						capabilities.CapabilityKeySharedDisks: {
+							Activated: true,
+						},
 					}
 					Expect(client.Status().Patch(ctx, &obj, objPatch)).To(Succeed())
 				})
@@ -178,6 +181,7 @@ var _ = Describe("UpdateCapabilities", func() {
 							config.Features.InventoryContentLibrary = true
 							config.Features.VMPlacementPolicies = true
 							config.Features.VMWaitForFirstConsumerPVC = true
+							config.Features.VMSharedDisks = true
 						})
 					})
 					Specify("capabilities did not change", func() {
@@ -212,6 +216,9 @@ var _ = Describe("UpdateCapabilities", func() {
 					})
 					Specify(capabilities.CapabilityKeyVMWaitForFirstConsumerPVC, func() {
 						Expect(pkgcfg.FromContext(ctx).Features.VMWaitForFirstConsumerPVC).To(BeTrue())
+					})
+					Specify(capabilities.CapabilityKeySharedDisks, func() {
+						Expect(pkgcfg.FromContext(ctx).Features.VMSharedDisks).To(BeTrue())
 					})
 				})
 
@@ -248,6 +255,9 @@ var _ = Describe("UpdateCapabilities", func() {
 					})
 					Specify(capabilities.CapabilityKeyVMWaitForFirstConsumerPVC, func() {
 						Expect(pkgcfg.FromContext(ctx).Features.VMWaitForFirstConsumerPVC).To(BeTrue())
+					})
+					Specify(capabilities.CapabilityKeySharedDisks, func() {
+						Expect(pkgcfg.FromContext(ctx).Features.VMSharedDisks).To(BeTrue())
 					})
 				})
 			})
@@ -293,6 +303,9 @@ var _ = Describe("UpdateCapabilities", func() {
 						capabilities.CapabilityKeyVMWaitForFirstConsumerPVC: {
 							Activated: false,
 						},
+						capabilities.CapabilityKeySharedDisks: {
+							Activated: false,
+						},
 					}
 					Expect(client.Status().Patch(ctx, &obj, objPatch)).To(Succeed())
 				})
@@ -330,6 +343,9 @@ var _ = Describe("UpdateCapabilities", func() {
 					Specify(capabilities.CapabilityKeyVMWaitForFirstConsumerPVC, func() {
 						Expect(pkgcfg.FromContext(ctx).Features.VMWaitForFirstConsumerPVC).To(BeFalse())
 					})
+					Specify(capabilities.CapabilityKeySharedDisks, func() {
+						Expect(pkgcfg.FromContext(ctx).Features.VMSharedDisks).To(BeFalse())
+					})
 				})
 
 				When("the capabilities are different", func() {
@@ -341,6 +357,7 @@ var _ = Describe("UpdateCapabilities", func() {
 							config.Features.MutableNetworks = true
 							config.Features.VMGroups = true
 							config.Features.VMWaitForFirstConsumerPVC = true
+							config.Features.VMSharedDisks = true
 						})
 					})
 					Specify("capabilities changed", func() {
@@ -375,6 +392,9 @@ var _ = Describe("UpdateCapabilities", func() {
 					})
 					Specify(capabilities.CapabilityKeyVMWaitForFirstConsumerPVC, func() {
 						Expect(pkgcfg.FromContext(ctx).Features.VMWaitForFirstConsumerPVC).To(BeFalse())
+					})
+					Specify(capabilities.CapabilityKeySharedDisks, func() {
+						Expect(pkgcfg.FromContext(ctx).Features.VMSharedDisks).To(BeFalse())
 					})
 				})
 			})
@@ -618,6 +638,19 @@ var _ = Describe("UpdateCapabilitiesFeatures", func() {
 				Expect(pkgcfg.FromContext(ctx).Features.VMWaitForFirstConsumerPVC).To(BeTrue())
 			})
 		})
+		Context(capabilities.CapabilityKeySharedDisks, func() {
+			BeforeEach(func() {
+				Expect(pkgcfg.FromContext(ctx).Features.VMSharedDisks).To(BeFalse())
+				obj.Status.Supervisor[capabilities.CapabilityKeySharedDisks] = capv1.CapabilityStatus{
+					Activated: true,
+				}
+			})
+			Specify("Enabled", func() {
+				Expect(ok).To(BeTrue())
+				Expect(diff).To(Equal("VMSharedDisks=true"))
+				Expect(pkgcfg.FromContext(ctx).Features.VMSharedDisks).To(BeTrue())
+			})
+		})
 	})
 })
 
@@ -664,6 +697,9 @@ var _ = Describe("WouldUpdateCapabilitiesFeatures", func() {
 			capabilities.CapabilityKeyVMWaitForFirstConsumerPVC: {
 				Activated: true,
 			},
+			capabilities.CapabilityKeySharedDisks: {
+				Activated: true,
+			},
 		}
 
 		ok, diff = false, ""
@@ -687,6 +723,7 @@ var _ = Describe("WouldUpdateCapabilitiesFeatures", func() {
 					config.Features.InventoryContentLibrary = true
 					config.Features.VMPlacementPolicies = true
 					config.Features.VMWaitForFirstConsumerPVC = true
+					config.Features.VMSharedDisks = true
 				})
 			})
 			Specify("capabilities did not change", func() {
@@ -723,6 +760,9 @@ var _ = Describe("WouldUpdateCapabilitiesFeatures", func() {
 			Specify(capabilities.CapabilityKeyVMWaitForFirstConsumerPVC, func() {
 				Expect(pkgcfg.FromContext(ctx).Features.VMWaitForFirstConsumerPVC).To(BeTrue())
 			})
+			Specify(capabilities.CapabilityKeySharedDisks, func() {
+				Expect(pkgcfg.FromContext(ctx).Features.VMSharedDisks).To(BeTrue())
+			})
 		})
 
 		When("the capabilities are different", func() {
@@ -736,11 +776,12 @@ var _ = Describe("WouldUpdateCapabilitiesFeatures", func() {
 					config.Features.ImmutableClasses = false
 					config.Features.InventoryContentLibrary = false
 					config.Features.VMWaitForFirstConsumerPVC = false
+					config.Features.VMSharedDisks = false
 				})
 			})
 			Specify("capabilities changed", func() {
 				Expect(ok).To(BeTrue())
-				Expect(diff).To(Equal("BringYourOwnEncryptionKey=true,ImmutableClasses=true,InventoryContentLibrary=true,MutableNetworks=true,TKGMultipleCL=true,VMGroups=true,VMPlacementPolicies=true,VMSnapshots=true,VMWaitForFirstConsumerPVC=true,WorkloadDomainIsolation=true"))
+				Expect(diff).To(Equal("BringYourOwnEncryptionKey=true,ImmutableClasses=true,InventoryContentLibrary=true,MutableNetworks=true,TKGMultipleCL=true,VMGroups=true,VMPlacementPolicies=true,VMSharedDisks=true,VMSnapshots=true,VMWaitForFirstConsumerPVC=true,WorkloadDomainIsolation=true"))
 			})
 			Specify(capabilities.CapabilityKeyBringYourOwnKeyProvider, func() {
 				Expect(pkgcfg.FromContext(ctx).Features.BringYourOwnEncryptionKey).To(BeFalse())
@@ -771,6 +812,9 @@ var _ = Describe("WouldUpdateCapabilitiesFeatures", func() {
 			})
 			Specify(capabilities.CapabilityKeyVMWaitForFirstConsumerPVC, func() {
 				Expect(pkgcfg.FromContext(ctx).Features.VMWaitForFirstConsumerPVC).To(BeFalse())
+			})
+			Specify(capabilities.CapabilityKeySharedDisks, func() {
+				Expect(pkgcfg.FromContext(ctx).Features.VMSharedDisks).To(BeFalse())
 			})
 		})
 	})

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -196,6 +196,7 @@ type FeatureStates struct {
 	VMPlacementPolicies        bool
 	VSpherePolicies            bool
 	VMWaitForFirstConsumerPVC  bool
+	VMSharedDisks              bool
 }
 
 type InstanceStorage struct {


### PR DESCRIPTION
This patch introduces a new 'VMSharedDisks' feature that is set by the Supervisor Capability CRD entry
'supports_shared_disks_with_VM_service_VMs'. The 'VMSharedDisks' feature will be used to guard code changes relate to shared disks, mainly to support Oracle RAC and Microsoft WSFC workloads.


Testing:

- When the capability is deactivated. 

<img width="1787" height="378" alt="Screenshot 2025-09-16 at 2 01 10 PM" src="https://github.com/user-attachments/assets/23d9137b-5a36-43c2-afc4-f6d20c25487c" />

- When the capability is activated. 

<img width="1788" height="389" alt="Screenshot 2025-09-16 at 2 11 26 PM" src="https://github.com/user-attachments/assets/c1a66aab-cce6-406d-85e8-e366b7126377" />


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # N/A


**Are there any special notes for your reviewer**:

N/A
**Please add a release note if necessary**:

```release-note
Add Capability for shared disks
```