### PR TITLE
🐛 Respect IDE controllers in VMIs

### DIFF
--- a/pkg/util/ensure_disk_controller_test.go
+++ b/pkg/util/ensure_disk_controller_test.go
@@ -1950,6 +1950,68 @@ var _ = DescribeTable(
 	),
 
 	//
+	// IDE (in ConfigSpec)
+	//
+	Entry(
+		"attach disk to IDE controller in ConfigSpec when adding disk and existing devices includes only PCI controller",
+		&vimtypes.VirtualMachineConfigSpec{
+			Version: vmx20,
+			DeviceChange: []vimtypes.BaseVirtualDeviceConfigSpec{
+				&vimtypes.VirtualDeviceConfigSpec{
+					Operation: vimtypes.VirtualDeviceConfigSpecOperationAdd,
+					Device: &vimtypes.VirtualIDEController{
+						VirtualController: vimtypes.VirtualController{
+							VirtualDevice: vimtypes.VirtualDevice{
+								ControllerKey: 100,
+								Key:           -10,
+							},
+						},
+					},
+				},
+				&vimtypes.VirtualDeviceConfigSpec{
+					Operation: vimtypes.VirtualDeviceConfigSpecOperationAdd,
+					Device:    &vimtypes.VirtualDisk{},
+				},
+			},
+		},
+		[]vimtypes.BaseVirtualDevice{
+			&vimtypes.VirtualPCIController{
+				VirtualController: vimtypes.VirtualController{
+					VirtualDevice: vimtypes.VirtualDevice{
+						Key: 100,
+					},
+				},
+			},
+		},
+		nil,
+		&vimtypes.VirtualMachineConfigSpec{
+			Version: vmx20,
+			DeviceChange: []vimtypes.BaseVirtualDeviceConfigSpec{
+				&vimtypes.VirtualDeviceConfigSpec{
+					Operation: vimtypes.VirtualDeviceConfigSpecOperationAdd,
+					Device: &vimtypes.VirtualIDEController{
+						VirtualController: vimtypes.VirtualController{
+							VirtualDevice: vimtypes.VirtualDevice{
+								ControllerKey: 100,
+								Key:           -10,
+							},
+						},
+					},
+				},
+				&vimtypes.VirtualDeviceConfigSpec{
+					Operation: vimtypes.VirtualDeviceConfigSpecOperationAdd,
+					Device: &vimtypes.VirtualDisk{
+						VirtualDevice: vimtypes.VirtualDevice{
+							ControllerKey: -10,
+							UnitNumber:    ptr.To[int32](0),
+						},
+					},
+				},
+			},
+		},
+	),
+
+	//
 	// First SCSI HBA is full
 	//
 	Entry(


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This patch fixes an issue where IDE controllers from VM images were not being respected when determining if a virtual disk pointed to an existing controller when building the ConfigSpec to place/create a VM.

This resulted in the VM being parented to a new controller, even though none was created since the IDE controller already existed.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Respect IDE controllers from VM images.
```