### PR TITLE
🐛Set missing default value for bool variable in unit test

### DIFF
--- a/pkg/util/vsphere/vm/power_state_test.go
+++ b/pkg/util/vsphere/vm/power_state_test.go
@@ -121,6 +121,7 @@ func powerStateTests() {
 			expectedErr = nil                                              // default
 			fetchProperties = true                                         // default
 			initialPowerState = vimtypes.VirtualMachinePowerStatePoweredOn // default
+			skipPostSetPowerStateVerification = false                      // default
 		})
 
 		JustBeforeEach(func() {
@@ -483,6 +484,7 @@ func powerStateTests() {
 							BeforeEach(func() {
 								fetchProperties = false
 								expectedResult = vmutil.PowerOpResultNone
+								skipPostSetPowerStateVerification = true
 							})
 							It("should not power off the VM because it thinks it already is", func() {})
 						})


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->
If a common bool variable is used among tests without initializing explicitly, then setting the value in one of them might impact the result in another test. Issue can only be discovered when running the single test.

For example, when running single test below with
```
ginkgo --json-report ./ginkgo.report -focus "SetPowerState when Powering off a VM that is suspended using hard off and the incorrect power state is cached in the managed object and fetchProperties is false should not power off the VM because it thinks it already is" ./pkg/util/vsphere/vm
```
Result
```
  [JustBeforeEach] /Users/sdiliyaer/vm-operator/pkg/util/vsphere/vm/power_state_test.go:126
  [It] /Users/sdiliyaer/vm-operator/pkg/util/vsphere/vm/power_state_test.go:487

  [FAILED] Expected
      <types.VirtualMachinePowerState>: suspended
  to equal
      <types.VirtualMachinePowerState>: poweredOff
  In [JustBeforeEach] at: /Users/sdiliyaer/vm-operator/pkg/util/vsphere/vm/power_state_test.go:173 @ 09/17/25 16:58:55.949
```

So this PR sets the default value of `skipPostSetPowerStateVerification` and set it to true when needed.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
None
```