### PR TITLE
:seedling: Bump up golang version to handle CVE GO-2025-3956

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/vm-operator
 
-go 1.24.4
+go 1.24.7
 
 replace (
 	github.com/vmware-tanzu/vm-operator/api => ./api


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Golang released CVE GO-2025-3956 which is addressed in 1.24.6.  Bump up to the latest version of 1.24.

**Please add a release note if necessary**:

```release-note
Bump up golang version to handle CVE GO-2025-3956
```