### PR TITLE
:bug: Fix typo in cloud-init docs

### DIFF
--- a/docs/tutorials/deploy-vm/cloudinit.md
+++ b/docs/tutorials/deploy-vm/cloudinit.md
@@ -62,4 +62,4 @@ The example below illustrates a `VirtualMachine` resource that specifies a Cloud
         My super secret message.
     ```
 
-For more information, please refer to the documentation [documentation](./../../concepts/workloads/guest.md#cloud-init) for the Cloud-Init bootstrap provider.
+For more information, please refer to the [documentation](./../../concepts/workloads/guest.md#cloud-init) for the Cloud-Init bootstrap provider.


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Fix a typo in the documentation.

**Please add a release note if necessary**:

```release-note
NONE
```

<!-- readthedocs-preview vm-operator start -->
----
📚 Documentation preview 📚: https://vm-operator--1197.org.readthedocs.build/en/1197/

<!-- readthedocs-preview vm-operator end -->