### PR TITLE
🌱Allow passing private NPM registry for quicktype install

### DIFF
--- a/hack/quicktype/Makefile
+++ b/hack/quicktype/Makefile
@@ -97,9 +97,22 @@ image-build-quicktype: $(QUICKTYPE_IMAGE_RECEIPT)
 ## Binaries
 ## --------------------------------------
 
+# Allow passing private NPM registry url and token.
+NPM_FLAGS :=
+ifneq ($(strip $(NPM_REGISTRY)),)
+  # Registry set (no token required)
+  NPM_REGISTRY := $(NPM_REGISTRY:https://%=%)
+  NPM_FLAGS := --registry='https://$(NPM_REGISTRY)'
+
+  # If a token is provided, add auth
+  ifneq ($(strip $(NPM_TOKEN)),)
+    NPM_FLAGS += --//'$(NPM_REGISTRY)':_authToken='$(NPM_TOKEN)'
+  endif
+endif
+
 quicktype: $(QUICKTYPE)
 $(QUICKTYPE): $(QUICK_DIR)/package.json
-	cd $(QUICK_DIR) && npm ci --user quicktype
+	cd $(QUICK_DIR) && npm ci $(NPM_FLAGS) quicktype
 
 
 ## --------------------------------------

--- a/pkg/util/cloudinit/schema/README.md
+++ b/pkg/util/cloudinit/schema/README.md
@@ -13,3 +13,6 @@ This directory contains schema files relates to Cloud-Init:
 ## Generating the Go source code
 
 Run `make generate-go` to generate the Go source code. If the local system has `npm`, it is used, otherwise a container image is used with either Docker or Podman.
+
+This relies on `npm ci quicktype`. If you need to use a private npm registry which might require authentication,
+you can set `NPM_TOKEN` and `NPM_REGISTRY` variables.`

--- a/pkg/util/netplan/schema/README.md
+++ b/pkg/util/netplan/schema/README.md
@@ -13,3 +13,6 @@ This directory contains schema files relates to Netplan:
 ## Generating the Go source code
 
 Run `make generate-go` to generate the Go source code. If the local system has `npm`, it is used, otherwise a container image is used with either Docker or Podman.
+
+This relies on `npm ci quicktype`. If you need to use a private npm registry which might require authentication,
+you can set `NPM_TOKEN` and `NPM_REGISTRY` variables.`


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

There might be time a private npm registry is preferred, and it might require auth. Added two new variables that could be passed when running `make generate-go`/ `make-generate` .
```
NPM_TOKEN ## registry token
NPM_REGISTRY ## registry url
``` 




**Are there any special notes for your reviewer**:

Tested:
```
NPM_REGISTRY=<redacted> NPM_TOKEN=<redacted> make -C ./pkg/util/netplan/schema generate-go  && rm -rf hack/quicktype/node_modules
cd ../../../../hack/quicktype && npm ci --registry=<redacted> --//<redacted>:_authToken=<redacted> quicktype

added 114 packages in 4s

9 packages are looking for funding
  run `npm fund` for details
```

**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
None
```