### PR TITLE
🐛 Fix typecast for VM total memory

### DIFF
--- a/pkg/providers/vsphere/vmlifecycle/update_status.go
+++ b/pkg/providers/vsphere/vmlifecycle/update_status.go
@@ -171,7 +171,7 @@ func reconcileStatusHardware(
 	}
 
 	var (
-		memTotal       = config.Hardware.MemoryMB
+		memTotal       = int64(config.Hardware.MemoryMB)
 		memReservation int64
 	)
 	if a := config.MemoryAllocation; a != nil {
@@ -188,7 +188,7 @@ func reconcileStatusHardware(
 
 		if r := memTotal; r > 0 {
 			b := r * 1000 * 1000
-			q := kubeutil.BytesToResource(int64(b))
+			q := kubeutil.BytesToResource(b)
 			vmCtx.VM.Status.Hardware.Memory.Total = q
 		}
 		if r := memReservation; r > 0 {

--- a/pkg/providers/vsphere/vmlifecycle/update_status_test.go
+++ b/pkg/providers/vsphere/vmlifecycle/update_status_test.go
@@ -7,6 +7,7 @@ package vmlifecycle_test
 import (
 	"context"
 	"fmt"
+	"math"
 	"slices"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -2959,6 +2960,18 @@ var _ = Describe("Hardware status", func() {
 
 					Expect(vmCtx.VM.Status.Hardware).ToNot(BeNil())
 					Expect(vmCtx.VM.Status.Hardware.Memory.Total).To(BeNil())
+				})
+			})
+
+			When("memory is larger than math.MaxInt32 bytes", func() {
+				BeforeEach(func() {
+					vmCtx.MoVM.Config.Hardware.MemoryMB = math.MaxInt32/(1000*1000) + 1
+				})
+
+				It("should set the memory status", func() {
+					err := vmlifecycle.ReconcileStatus(vmCtx, ctx.Client, vcVM, data)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(vmCtx.VM.Status.Hardware.Memory.Total.String()).To(Equal("2148M"))
 				})
 			})
 		})


### PR DESCRIPTION
The patch fixes the integer overflow issue when setting vm.status.hardware.memory from MoVM. The memory is stored as int32 in MoVM which leads to an integer overflow when multiplying it by 10^6.

Before:
<img width="185" height="244" alt="Screenshot 2025-09-23 at 6 46 01 PM" src="https://github.com/user-attachments/assets/a7aafbd1-a148-4acb-8425-025092c51b83" />

After:
<img width="169" height="237" alt="Screenshot 2025-09-23 at 6 47 22 PM" src="https://github.com/user-attachments/assets/066f36af-0fec-4393-bd09-d2f4c57594f4" />


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # N/A


**Are there any special notes for your reviewer**:

N/A

**Please add a release note if necessary**:

```release-note
NONE
```