### PR TITLE
[x-port] Remove caBundle from conversion webhook defs

### DIFF
--- a/config/crd/patches/webhook_in_clustervirtualmachineimages.yaml
+++ b/config/crd/patches/webhook_in_clustervirtualmachineimages.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/crd/patches/webhook_in_virtualmachineclasses.yaml
+++ b/config/crd/patches/webhook_in_virtualmachineclasses.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/crd/patches/webhook_in_virtualmachineimages.yaml
+++ b/config/crd/patches/webhook_in_virtualmachineimages.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/crd/patches/webhook_in_virtualmachinepublishrequests.yaml
+++ b/config/crd/patches/webhook_in_virtualmachinepublishrequests.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/crd/patches/webhook_in_virtualmachines.yaml
+++ b/config/crd/patches/webhook_in_virtualmachines.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/crd/patches/webhook_in_virtualmachineservices.yaml
+++ b/config/crd/patches/webhook_in_virtualmachineservices.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/crd/patches/webhook_in_virtualmachinesetresourcepolicies.yaml
+++ b/config/crd/patches/webhook_in_virtualmachinesetresourcepolicies.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/crd/patches/webhook_in_virtualmachinewebconsolerequests.yaml
+++ b/config/crd/patches/webhook_in_virtualmachinewebconsolerequests.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Remove caBundle from conversion webhook defs
This is a x-port of #649 for the upcoming patch release on 8.0 U3.

**Please add a release note if necessary**:

```release-note
Remove caBundle from conversion webhook defs
```