### PR TITLE
🌱 Allow VM Spec.Bootstrap to be mutable

### DIFF
--- a/webhooks/virtualmachine/validation/virtualmachine_validator_intg_test.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator_intg_test.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
-	"github.com/vmware-tanzu/vm-operator/api/v1alpha5/common"
 	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
@@ -275,43 +274,6 @@ func intgTestsValidateUpdate() {
 	Context("VirtualMachine update while VM is powered on", func() {
 		BeforeEach(func() {
 			ctx.vm.Spec.PowerState = vmopv1.VirtualMachinePowerStateOn
-		})
-
-		When("Bootstrap is updated", func() {
-			BeforeEach(func() {
-				ctx.vm.Spec.Bootstrap = &vmopv1.VirtualMachineBootstrapSpec{
-					CloudInit: &vmopv1.VirtualMachineBootstrapCloudInitSpec{
-						RawCloudConfig: &common.SecretKeySelector{},
-					},
-				}
-			})
-
-			It("rejects the request", func() {
-				expectedReason := field.Forbidden(field.NewPath("spec", "bootstrap"),
-					"updates to this field is not allowed when VM power is on").Error()
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring(expectedReason))
-			})
-		})
-
-		When("Network is updated", func() {
-			BeforeEach(func() {
-				ctx.vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{
-					HostName: "my-new-name",
-					Interfaces: []vmopv1.VirtualMachineNetworkInterfaceSpec{
-						{
-							Name: "eth100",
-						},
-					},
-				}
-			})
-
-			It("rejects the request", func() {
-				expectedReason := field.Forbidden(field.NewPath("spec", "network", "interfaces").Index(0).Child("name"),
-					"field is immutable").Error()
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring(expectedReason))
-			})
 		})
 
 		When("Volume for PVC is added", func() {


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Previously we would restrict we restrict the bootstrap to only be changed with the VM was "off", but there isn't really a good reason to do so. The customization will be applied on the next powering on transition. Instead, just restrict the bootstrap provider type from being changed.

Remove a bogus "network can't change while powered on" test: this was just testing network mutability or not since we had no network related checks for just powered on.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note
Allow the VM Spec.Bootstrap to be updated, but the provider type cannot be changed
```