### PR TITLE
🌱 Add FIPS-only mode enforcement for Linux builds and enable CGO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,9 @@ export BUILD_BRANCH
 export BUILD_COMMIT
 export BUILD_VERSION
 
-CGO_ENABLED ?= 0
+# Enable CGO to use BoringCrypto for Go FIPS compliance on Linux.
+CGO_ENABLED ?= 1
+GOEXPERIMENT ?= boringcrypto
 
 BUILDINFO_LDFLAGS = "\
 -X $(PROJECT_SLUG)/pkg.BuildVersion=$(BUILD_VERSION) \

--- a/fips_only_linux.go
+++ b/fips_only_linux.go
@@ -1,0 +1,9 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux && boringcrypto
+
+package main
+
+import _ "crypto/tls/fipsonly"


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR adds a `fips_only_linux.go` file with `import _ "crypto/tls/fipsonly"` to enforce FIPS-only mode for Linux builds. It also enables `CGO` and adds `GOEXPERIMENT= boringcrypto` to use BoringCrypto for Go FIPS compliance on Linux.

These changes are required to build VMOP with FIPS compliant.

**Which issue(s) is/are addressed by this PR?** 

Fixes N/A.


**Are there any special notes for your reviewer**:

Built an internal cayman_vmop from this change and verified the binary is using BoringCrypto:

```console
$ go version manager
manager.1: go1.24.7 X:boringcrypto

$ strings manager | grep boringcrypto_FIPS_mode
_cgo_39a3e70c2c46_Cfunc__goboringcrypto_FIPS_mode
_goboringcrypto_FIPS_mode
crypto/internal/boring._Cfunc__goboringcrypto_FIPS_mode
```


**Please add a release note if necessary**:

```release-note
Add FIPS-only mode enforcement for Linux builds and enable CGO.
```