### PR TITLE
Handle publishing of encrypted VMs for inventory-backed ContentLibraries

### DIFF
--- a/api/v1alpha5/virtualmachinepublishrequest_types.go
+++ b/api/v1alpha5/virtualmachinepublishrequest_types.go
@@ -57,6 +57,11 @@ const (
 	// the VirtualMachinePublishRequest hasn't been created.
 	SourceVirtualMachineNotCreatedReason = "SourceVirtualMachineNotCreated"
 
+	// SourceVirtualMachineUnsupportedEncryptionReason documents that the
+	// source VM of the VirtualMachinePublishRequest has a mix of encrypted
+	// and unencrypted disks.
+	SourceVirtualMachineUnsupportedEncryptionReason = "SourceVirtualMachineUnsupportedEncryption"
+
 	// TargetContentLibraryNotExistReason documents that the target content
 	// library of the VirtualMachinePublishRequest doesn't exist.
 	TargetContentLibraryNotExistReason = "TargetContentLibraryNotExist"
@@ -73,6 +78,11 @@ const (
 	// content library of the VirtualMachinePublishRequest failed quota
 	// validation.
 	TargetContentLibraryFailedQuotaCheckReason = "TargetContentLibraryFailedQuotaCheck"
+
+	// TargetContentLibraryIncompatibleStorageClassReason documents that the
+	// target content library of the VirtualMachinePublishRequest has a storage
+	// class which is incompatible with the encryption status of the source VM.
+	TargetContentLibraryIncompatibleStorageClassReason = "TargetContentLibraryIncompatibleStorageClass"
 
 	// TargetItemAlreadyExistsReason documents that an item with the same name
 	// as the VirtualMachinePublishRequest's target item name exists in

--- a/pkg/providers/vsphere/virtualmachine/extraconfig.go
+++ b/pkg/providers/vsphere/virtualmachine/extraconfig.go
@@ -24,6 +24,7 @@ var (
 	extraConfigDenyKeyPrefixes = [...]string{
 		"guestinfo.",
 		"vmservice.",
+		"imageregistry.",
 	}
 	extraConfigAllowKeys = [...]string{
 		"vmservice.virtualmachine.pvc.disk.data",
@@ -46,19 +47,6 @@ func GetExtraConfigFromObject(
 	}
 
 	return o.Config.ExtraConfig, nil
-}
-
-func GetFilteredExtraConfigFromObject(
-	ctx context.Context,
-	vm *object.VirtualMachine,
-	reset bool) (pkgutil.OptionValues, error) {
-	var extraConfig pkgutil.OptionValues
-	var err error
-	if extraConfig, err = GetExtraConfigFromObject(ctx, vm); err != nil {
-		return nil, err
-	}
-
-	return FilteredExtraConfig(extraConfig, reset)
 }
 
 // FilteredExtraConfig removes or resets those key entries which have prefix

--- a/pkg/providers/vsphere/virtualmachine/extraconfig_test.go
+++ b/pkg/providers/vsphere/virtualmachine/extraconfig_test.go
@@ -49,7 +49,7 @@ func extraConfigTests() {
 	unchangedTestFn := func(reset bool) {
 		before, err := virtualmachine.GetExtraConfigFromObject(ctx, vcVM)
 		Expect(err).ToNot(HaveOccurred())
-		after, err := virtualmachine.GetFilteredExtraConfigFromObject(ctx, vcVM, reset)
+		after, err := virtualmachine.FilteredExtraConfig(before, reset)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(after.Diff(before...)).To(BeNil())
 	}
@@ -101,6 +101,7 @@ func extraConfigTests() {
 			toBeRemoved = pkgutil.OptionValues{
 				&vimtypes.OptionValue{Key: strings.ToUpper("guestinfo.v1"), Value: "v1"},
 				&vimtypes.OptionValue{Key: "vmservice.v2", Value: "v2"},
+				&vimtypes.OptionValue{Key: "imageregistry.itemSeed", Value: "1234"},
 			}
 		)
 		BeforeEach(func() {
@@ -110,7 +111,7 @@ func extraConfigTests() {
 		testFn := func(reset bool) {
 			before, err := virtualmachine.GetExtraConfigFromObject(ctx, vcVM)
 			Expect(err).ToNot(HaveOccurred())
-			after, err := virtualmachine.GetFilteredExtraConfigFromObject(ctx, vcVM, reset)
+			after, err := virtualmachine.FilteredExtraConfig(before, reset)
 			Expect(err).ToNot(HaveOccurred())
 			if reset {
 				for k := range toBeRemoved.StringMap() {
@@ -137,12 +138,14 @@ func extraConfigTests() {
 		})
 
 		testFn := func(reset bool) {
-			out, err := virtualmachine.GetFilteredExtraConfigFromObject(ctx, vcVM, reset)
+			before, err := virtualmachine.GetExtraConfigFromObject(ctx, vcVM)
+			Expect(err).NotTo(HaveOccurred())
+			after, err := virtualmachine.FilteredExtraConfig(before, reset)
 			if reset {
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("failed to filter extraConfig"))
 				Expect(err.Error()).To(ContainSubstring("expected value's datatype string"))
-				Expect(out).To(BeNil())
+				Expect(after).To(BeNil())
 			} else {
 				Expect(err).ToNot(HaveOccurred())
 			}

--- a/pkg/providers/vsphere/virtualmachine/publish_test.go
+++ b/pkg/providers/vsphere/virtualmachine/publish_test.go
@@ -120,7 +120,7 @@ func publishTests() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(t.Wait(ctx)).To(Succeed())
 
-			itemID, err := virtualmachine.CloneVM(vmCtx, ctx.VCClient.Client, vmPub, clv1a2, "1234", "")
+			itemID, err := virtualmachine.CloneVM(vmCtx, ctx.VCClient.Client, vmPub, clv1a2, "1234")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(itemID).NotTo(BeNil())
 		})
@@ -130,7 +130,7 @@ func publishTests() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(state).To(Equal(vimtypes.VirtualMachinePowerStatePoweredOn))
 
-			itemID, err := virtualmachine.CloneVM(vmCtx, ctx.VCClient.Client, vmPub, clv1a2, "1234", "")
+			itemID, err := virtualmachine.CloneVM(vmCtx, ctx.VCClient.Client, vmPub, clv1a2, "1234")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(itemID).NotTo(BeNil())
 		})

--- a/pkg/providers/vsphere/vmprovider_vm.go
+++ b/pkg/providers/vsphere/vmprovider_vm.go
@@ -375,7 +375,7 @@ func (vs *vSphereVMProvider) PublishVirtualMachine(
 			}
 			logger.V(4).Info("Publishing VM as cloned template")
 
-			return virtualmachine.CloneVM(vmCtx, client.VimClient(), vmPub, v1a2contentLibrary, storagePolicyID, actID)
+			return virtualmachine.CloneVM(vmCtx, client.VimClient(), vmPub, v1a2contentLibrary, storagePolicyID)
 		}
 	}
 	logger.V(4).Info("Publishing VM as OVF")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->

This PR adds logic to the VirtualMachinePublishRequest controller to handle encrypted VMs when publishing to an inventory-back ContentLibrary. There are three pieces:

- Encrypted VMs cannot be published to content library whose storage class does not support encryption
- Publish requests whose source VMs have a mix of encrypted and unencrypted disks will be rejected
- For encrypted VMs which are allowed, we set the storage policy of the target content library on each of the disks in the configSpec that is passed into the cloneSpec

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Handle publishing of encrypted Virtual Machines for inventory-backed Content Libraries.
```