### PR TITLE
🌱 Match VPC SubnetPort without MAC address set

### DIFF
--- a/pkg/providers/vsphere/network/devices.go
+++ b/pkg/providers/vsphere/network/devices.go
@@ -274,10 +274,21 @@ func findMatchingEthCardVPCSubnetPort(
 			continue
 		}
 
-		// TODO: Relax this to check for just MacAddress during VPC backup/restore.
 		ethCard := bEthCard.GetVirtualEthernetCard()
-		if ethCard.ExternalId == subnetPort.Status.Attachment.ID &&
-			strings.EqualFold(ethCard.MacAddress, subnetPort.Status.NetworkInterfaceConfig.MACAddress) {
+
+		macAddress := subnetPort.Status.NetworkInterfaceConfig.MACAddress
+		if macAddress == vpcIgnoreMacAddr {
+			macAddress = ""
+		}
+
+		if macAddress != "" {
+			if !strings.EqualFold(macAddress, ethCard.MacAddress) {
+				continue
+			}
+		}
+
+		// TODO: Relax this to check during VPC backup/restore.
+		if ethCard.ExternalId == subnetPort.Status.Attachment.ID {
 			return i
 		}
 	}


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

In certain situations, the SubnetPort might not have a MAC address set in its Status, so only try to match on it if set, like we do for VDS.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note
NONE
```