### PR TITLE
🐛 Fix setting Sysprep password without AutoLogin

### DIFF
--- a/pkg/providers/vsphere/sysprep/secret.go
+++ b/pkg/providers/vsphere/sysprep/secret.go
@@ -42,7 +42,7 @@ func GetSysprepSecretData(
 		}
 	}
 
-	if guiUnattended := in.GUIUnattended; guiUnattended != nil && guiUnattended.AutoLogon {
+	if guiUnattended := in.GUIUnattended; guiUnattended != nil && guiUnattended.Password != nil {
 		err := util.GetSecretData(
 			ctx,
 			k8sClient,
@@ -124,7 +124,7 @@ func GetSecretResources(
 		captureSecret(s, in.UserData.ProductID.Name)
 	}
 
-	if guiUnattended := in.GUIUnattended; guiUnattended != nil && guiUnattended.AutoLogon {
+	if guiUnattended := in.GUIUnattended; guiUnattended != nil && guiUnattended.Password != nil {
 		s, err := util.GetSecretResource(
 			ctx,
 			k8sClient,
@@ -147,6 +147,20 @@ func GetSecretResources(
 				return nil, err
 			}
 			captureSecret(s, dap.Name)
+		}
+	}
+
+	if st := in.ScriptText; st != nil {
+		if st.From != nil && st.From.Name != "" {
+			s, err := util.GetSecretResource(
+				ctx,
+				k8sClient,
+				secretNamespace,
+				st.From.Name)
+			if err != nil {
+				return nil, err
+			}
+			captureSecret(s, st.From.Name)
 		}
 	}
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Setting the password with Sysprep does not require AutoLogin, but AutoLogon requires the password to be set. The validation webhook was correct but the check to later determine if the password was set was incorrect.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note
Setting the administrator password with inline Sysprep should not require AutoLogin to be true 
```