### PR TITLE
🌱 Skip VM with zone label and address recreated VM in group placement

### DIFF
--- a/api/v1alpha2/virtualmachinegroup_types.go
+++ b/api/v1alpha2/virtualmachinegroup_types.go
@@ -6,6 +6,7 @@ package v1alpha2
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 const (
@@ -159,9 +160,6 @@ type VirtualMachineGroupPlacementDatastoreStatus struct {
 }
 
 type VirtualMachinePlacementStatus struct {
-	// Name is the name of VirtualMachine member of this group.
-	Name string `json:"name"`
-
 	// +optional
 
 	// Zone describes the recommended zone for this VM.
@@ -196,6 +194,11 @@ type VirtualMachineGroupMemberStatus struct {
 	// Kind is the kind of this member, which can be either VirtualMachine or
 	// VirtualMachineGroup.
 	Kind string `json:"kind"`
+
+	// +optional
+
+	// UID is the K8s metadata UID of this current member object.
+	UID types.UID `json:"uid,omitempty"`
 
 	// +optional
 

--- a/api/v1alpha2/zz_generated.conversion.go
+++ b/api/v1alpha2/zz_generated.conversion.go
@@ -26,6 +26,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+	types "k8s.io/apimachinery/pkg/types"
 )
 
 func init() {
@@ -2252,6 +2253,7 @@ func Convert_v1alpha5_VirtualMachineGroupList_To_v1alpha2_VirtualMachineGroupLis
 func autoConvert_v1alpha2_VirtualMachineGroupMemberStatus_To_v1alpha5_VirtualMachineGroupMemberStatus(in *VirtualMachineGroupMemberStatus, out *v1alpha5.VirtualMachineGroupMemberStatus, s conversion.Scope) error {
 	out.Name = in.Name
 	out.Kind = in.Kind
+	out.UID = types.UID(in.UID)
 	out.Placement = (*v1alpha5.VirtualMachinePlacementStatus)(unsafe.Pointer(in.Placement))
 	out.PowerState = (*v1alpha5.VirtualMachinePowerState)(unsafe.Pointer(in.PowerState))
 	out.Conditions = *(*[]v1.Condition)(unsafe.Pointer(&in.Conditions))
@@ -2266,6 +2268,7 @@ func Convert_v1alpha2_VirtualMachineGroupMemberStatus_To_v1alpha5_VirtualMachine
 func autoConvert_v1alpha5_VirtualMachineGroupMemberStatus_To_v1alpha2_VirtualMachineGroupMemberStatus(in *v1alpha5.VirtualMachineGroupMemberStatus, out *VirtualMachineGroupMemberStatus, s conversion.Scope) error {
 	out.Name = in.Name
 	out.Kind = in.Kind
+	out.UID = types.UID(in.UID)
 	out.Placement = (*VirtualMachinePlacementStatus)(unsafe.Pointer(in.Placement))
 	out.PowerState = (*VirtualMachinePowerState)(unsafe.Pointer(in.PowerState))
 	out.Conditions = *(*[]v1.Condition)(unsafe.Pointer(&in.Conditions))
@@ -3167,7 +3170,6 @@ func Convert_v1alpha5_VirtualMachineNetworkStatus_To_v1alpha2_VirtualMachineNetw
 }
 
 func autoConvert_v1alpha2_VirtualMachinePlacementStatus_To_v1alpha5_VirtualMachinePlacementStatus(in *VirtualMachinePlacementStatus, out *v1alpha5.VirtualMachinePlacementStatus, s conversion.Scope) error {
-	out.Name = in.Name
 	out.Zone = in.Zone
 	out.Node = in.Node
 	out.Pool = in.Pool
@@ -3181,7 +3183,6 @@ func Convert_v1alpha2_VirtualMachinePlacementStatus_To_v1alpha5_VirtualMachinePl
 }
 
 func autoConvert_v1alpha5_VirtualMachinePlacementStatus_To_v1alpha2_VirtualMachinePlacementStatus(in *v1alpha5.VirtualMachinePlacementStatus, out *VirtualMachinePlacementStatus, s conversion.Scope) error {
-	out.Name = in.Name
 	out.Zone = in.Zone
 	out.Node = in.Node
 	out.Pool = in.Pool

--- a/api/v1alpha3/virtualmachinegroup_types.go
+++ b/api/v1alpha3/virtualmachinegroup_types.go
@@ -6,6 +6,7 @@ package v1alpha3
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 const (
@@ -159,9 +160,6 @@ type VirtualMachineGroupPlacementDatastoreStatus struct {
 }
 
 type VirtualMachinePlacementStatus struct {
-	// Name is the name of VirtualMachine member of this group.
-	Name string `json:"name"`
-
 	// +optional
 
 	// Zone describes the recommended zone for this VM.
@@ -196,6 +194,11 @@ type VirtualMachineGroupMemberStatus struct {
 	// Kind is the kind of this member, which can be either VirtualMachine or
 	// VirtualMachineGroup.
 	Kind string `json:"kind"`
+
+	// +optional
+
+	// UID is the K8s metadata UID of this current member object.
+	UID types.UID `json:"uid,omitempty"`
 
 	// +optional
 

--- a/api/v1alpha3/zz_generated.conversion.go
+++ b/api/v1alpha3/zz_generated.conversion.go
@@ -24,6 +24,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+	types "k8s.io/apimachinery/pkg/types"
 )
 
 func init() {
@@ -2344,6 +2345,7 @@ func Convert_v1alpha5_VirtualMachineGroupList_To_v1alpha3_VirtualMachineGroupLis
 func autoConvert_v1alpha3_VirtualMachineGroupMemberStatus_To_v1alpha5_VirtualMachineGroupMemberStatus(in *VirtualMachineGroupMemberStatus, out *v1alpha5.VirtualMachineGroupMemberStatus, s conversion.Scope) error {
 	out.Name = in.Name
 	out.Kind = in.Kind
+	out.UID = types.UID(in.UID)
 	out.Placement = (*v1alpha5.VirtualMachinePlacementStatus)(unsafe.Pointer(in.Placement))
 	out.PowerState = (*v1alpha5.VirtualMachinePowerState)(unsafe.Pointer(in.PowerState))
 	out.Conditions = *(*[]v1.Condition)(unsafe.Pointer(&in.Conditions))
@@ -2358,6 +2360,7 @@ func Convert_v1alpha3_VirtualMachineGroupMemberStatus_To_v1alpha5_VirtualMachine
 func autoConvert_v1alpha5_VirtualMachineGroupMemberStatus_To_v1alpha3_VirtualMachineGroupMemberStatus(in *v1alpha5.VirtualMachineGroupMemberStatus, out *VirtualMachineGroupMemberStatus, s conversion.Scope) error {
 	out.Name = in.Name
 	out.Kind = in.Kind
+	out.UID = types.UID(in.UID)
 	out.Placement = (*VirtualMachinePlacementStatus)(unsafe.Pointer(in.Placement))
 	out.PowerState = (*VirtualMachinePowerState)(unsafe.Pointer(in.PowerState))
 	out.Conditions = *(*[]v1.Condition)(unsafe.Pointer(&in.Conditions))
@@ -3234,7 +3237,6 @@ func Convert_v1alpha5_VirtualMachineNetworkStatus_To_v1alpha3_VirtualMachineNetw
 }
 
 func autoConvert_v1alpha3_VirtualMachinePlacementStatus_To_v1alpha5_VirtualMachinePlacementStatus(in *VirtualMachinePlacementStatus, out *v1alpha5.VirtualMachinePlacementStatus, s conversion.Scope) error {
-	out.Name = in.Name
 	out.Zone = in.Zone
 	out.Node = in.Node
 	out.Pool = in.Pool
@@ -3248,7 +3250,6 @@ func Convert_v1alpha3_VirtualMachinePlacementStatus_To_v1alpha5_VirtualMachinePl
 }
 
 func autoConvert_v1alpha5_VirtualMachinePlacementStatus_To_v1alpha3_VirtualMachinePlacementStatus(in *v1alpha5.VirtualMachinePlacementStatus, out *VirtualMachinePlacementStatus, s conversion.Scope) error {
-	out.Name = in.Name
 	out.Zone = in.Zone
 	out.Node = in.Node
 	out.Pool = in.Pool

--- a/api/v1alpha4/virtualmachinegroup_types.go
+++ b/api/v1alpha4/virtualmachinegroup_types.go
@@ -6,6 +6,7 @@ package v1alpha4
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 const (
@@ -159,9 +160,6 @@ type VirtualMachineGroupPlacementDatastoreStatus struct {
 }
 
 type VirtualMachinePlacementStatus struct {
-	// Name is the name of VirtualMachine member of this group.
-	Name string `json:"name"`
-
 	// +optional
 
 	// Zone describes the recommended zone for this VM.
@@ -196,6 +194,11 @@ type VirtualMachineGroupMemberStatus struct {
 	// Kind is the kind of this member, which can be either VirtualMachine or
 	// VirtualMachineGroup.
 	Kind string `json:"kind"`
+
+	// +optional
+
+	// UID is the K8s metadata UID of this current member object.
+	UID types.UID `json:"uid,omitempty"`
 
 	// +optional
 

--- a/api/v1alpha4/zz_generated.conversion.go
+++ b/api/v1alpha4/zz_generated.conversion.go
@@ -24,6 +24,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+	types "k8s.io/apimachinery/pkg/types"
 )
 
 func init() {
@@ -2510,6 +2511,7 @@ func Convert_v1alpha5_VirtualMachineGroupList_To_v1alpha4_VirtualMachineGroupLis
 func autoConvert_v1alpha4_VirtualMachineGroupMemberStatus_To_v1alpha5_VirtualMachineGroupMemberStatus(in *VirtualMachineGroupMemberStatus, out *v1alpha5.VirtualMachineGroupMemberStatus, s conversion.Scope) error {
 	out.Name = in.Name
 	out.Kind = in.Kind
+	out.UID = types.UID(in.UID)
 	out.Placement = (*v1alpha5.VirtualMachinePlacementStatus)(unsafe.Pointer(in.Placement))
 	out.PowerState = (*v1alpha5.VirtualMachinePowerState)(unsafe.Pointer(in.PowerState))
 	out.Conditions = *(*[]v1.Condition)(unsafe.Pointer(&in.Conditions))
@@ -2524,6 +2526,7 @@ func Convert_v1alpha4_VirtualMachineGroupMemberStatus_To_v1alpha5_VirtualMachine
 func autoConvert_v1alpha5_VirtualMachineGroupMemberStatus_To_v1alpha4_VirtualMachineGroupMemberStatus(in *v1alpha5.VirtualMachineGroupMemberStatus, out *VirtualMachineGroupMemberStatus, s conversion.Scope) error {
 	out.Name = in.Name
 	out.Kind = in.Kind
+	out.UID = types.UID(in.UID)
 	out.Placement = (*VirtualMachinePlacementStatus)(unsafe.Pointer(in.Placement))
 	out.PowerState = (*VirtualMachinePowerState)(unsafe.Pointer(in.PowerState))
 	out.Conditions = *(*[]v1.Condition)(unsafe.Pointer(&in.Conditions))
@@ -3400,7 +3403,6 @@ func Convert_v1alpha5_VirtualMachineNetworkStatus_To_v1alpha4_VirtualMachineNetw
 }
 
 func autoConvert_v1alpha4_VirtualMachinePlacementStatus_To_v1alpha5_VirtualMachinePlacementStatus(in *VirtualMachinePlacementStatus, out *v1alpha5.VirtualMachinePlacementStatus, s conversion.Scope) error {
-	out.Name = in.Name
 	out.Zone = in.Zone
 	out.Node = in.Node
 	out.Pool = in.Pool
@@ -3414,7 +3416,6 @@ func Convert_v1alpha4_VirtualMachinePlacementStatus_To_v1alpha5_VirtualMachinePl
 }
 
 func autoConvert_v1alpha5_VirtualMachinePlacementStatus_To_v1alpha4_VirtualMachinePlacementStatus(in *v1alpha5.VirtualMachinePlacementStatus, out *VirtualMachinePlacementStatus, s conversion.Scope) error {
-	out.Name = in.Name
 	out.Zone = in.Zone
 	out.Node = in.Node
 	out.Pool = in.Pool

--- a/api/v1alpha5/virtualmachinegroup_types.go
+++ b/api/v1alpha5/virtualmachinegroup_types.go
@@ -6,6 +6,7 @@ package v1alpha5
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 const (
@@ -20,11 +21,6 @@ const (
 	// VirtualMachineGroupMemberConditionPlacementReady indicates that the
 	// member has a placement decision ready.
 	VirtualMachineGroupMemberConditionPlacementReady = "PlacementReady"
-
-	// VirtualMachineGroupMemberAlreadyPlacedReason indicates that the
-	// group member already exists on the back-end infrastructure
-	// (e.g., vSphere) and therefore does not require placement.
-	VirtualMachineGroupMemberAlreadyPlacedReason = "AlreadyPlaced"
 )
 
 // GroupMember describes a member of a VirtualMachineGroup.
@@ -164,9 +160,6 @@ type VirtualMachineGroupPlacementDatastoreStatus struct {
 }
 
 type VirtualMachinePlacementStatus struct {
-	// Name is the name of VirtualMachine member of this group.
-	Name string `json:"name"`
-
 	// +optional
 
 	// Zone describes the recommended zone for this VM.
@@ -201,6 +194,11 @@ type VirtualMachineGroupMemberStatus struct {
 	// Kind is the kind of this member, which can be either VirtualMachine or
 	// VirtualMachineGroup.
 	Kind string `json:"kind"`
+
+	// +optional
+
+	// UID is the K8s metadata UID of this current member object.
+	UID types.UID `json:"uid,omitempty"`
 
 	// +optional
 

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachinegroups.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachinegroups.yaml
@@ -361,10 +361,6 @@ spec:
                             - name
                             type: object
                           type: array
-                        name:
-                          description: Name is the name of VirtualMachine member of
-                            this group.
-                          type: string
                         node:
                           description: Node describes the recommended node for this
                             VM.
@@ -377,8 +373,6 @@ spec:
                           description: Zone describes the recommended zone for this
                             VM.
                           type: string
-                      required:
-                      - name
                       type: object
                     powerState:
                       description: |-
@@ -389,6 +383,10 @@ spec:
                       - PoweredOff
                       - PoweredOn
                       - Suspended
+                      type: string
+                    uid:
+                      description: UID is the K8s metadata UID of this current member
+                        object.
                       type: string
                   required:
                   - kind
@@ -750,10 +748,6 @@ spec:
                             - name
                             type: object
                           type: array
-                        name:
-                          description: Name is the name of VirtualMachine member of
-                            this group.
-                          type: string
                         node:
                           description: Node describes the recommended node for this
                             VM.
@@ -766,8 +760,6 @@ spec:
                           description: Zone describes the recommended zone for this
                             VM.
                           type: string
-                      required:
-                      - name
                       type: object
                     powerState:
                       description: |-
@@ -778,6 +770,10 @@ spec:
                       - PoweredOff
                       - PoweredOn
                       - Suspended
+                      type: string
+                    uid:
+                      description: UID is the K8s metadata UID of this current member
+                        object.
                       type: string
                   required:
                   - kind
@@ -1139,10 +1135,6 @@ spec:
                             - name
                             type: object
                           type: array
-                        name:
-                          description: Name is the name of VirtualMachine member of
-                            this group.
-                          type: string
                         node:
                           description: Node describes the recommended node for this
                             VM.
@@ -1155,8 +1147,6 @@ spec:
                           description: Zone describes the recommended zone for this
                             VM.
                           type: string
-                      required:
-                      - name
                       type: object
                     powerState:
                       description: |-
@@ -1167,6 +1157,10 @@ spec:
                       - PoweredOff
                       - PoweredOn
                       - Suspended
+                      type: string
+                    uid:
+                      description: UID is the K8s metadata UID of this current member
+                        object.
                       type: string
                   required:
                   - kind
@@ -1528,10 +1522,6 @@ spec:
                             - name
                             type: object
                           type: array
-                        name:
-                          description: Name is the name of VirtualMachine member of
-                            this group.
-                          type: string
                         node:
                           description: Node describes the recommended node for this
                             VM.
@@ -1544,8 +1534,6 @@ spec:
                           description: Zone describes the recommended zone for this
                             VM.
                           type: string
-                      required:
-                      - name
                       type: object
                     powerState:
                       description: |-
@@ -1556,6 +1544,10 @@ spec:
                       - PoweredOff
                       - PoweredOn
                       - Suspended
+                      type: string
+                    uid:
+                      description: UID is the K8s metadata UID of this current member
+                        object.
                       type: string
                   required:
                   - kind

--- a/controllers/virtualmachinegroup/virtualmachinegroup_controller_test.go
+++ b/controllers/virtualmachinegroup/virtualmachinegroup_controller_test.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -123,6 +124,7 @@ var _ = Describe(
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: vm1Key.Namespace,
 					Name:      vm1Key.Name,
+					UID:       types.UID(uuid.NewString()),
 				},
 				Spec: vmopv1.VirtualMachineSpec{
 					ImageName:    dummyImage,
@@ -136,6 +138,7 @@ var _ = Describe(
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: vm2Key.Namespace,
 					Name:      vm2Key.Name,
+					UID:       types.UID(uuid.NewString()),
 				},
 				Spec: vmopv1.VirtualMachineSpec{
 					ImageName:    dummyImage,
@@ -149,6 +152,7 @@ var _ = Describe(
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: vm3Key.Namespace,
 					Name:      vm3Key.Name,
+					UID:       types.UID(uuid.NewString()),
 				},
 				Spec: vmopv1.VirtualMachineSpec{
 					ImageName:    dummyImage,
@@ -417,12 +421,23 @@ var _ = Describe(
 		})
 
 		Context("Placement", func() {
+			var (
+				groupPlacementCallCount            int
+				setVMUniqueID                      func(vmKey types.NamespacedName, uniqueID string)
+				setVMZoneLabel                     func(vmKey types.NamespacedName, zoneName string)
+				verifyGroupPlacementReadyCondition func(groupKey types.NamespacedName, memberCount int)
+			)
+
 			BeforeEach(func() {
+				groupPlacementCallCount = 0
+
 				intgFakeVMProvider.Lock()
 				intgFakeVMProvider.PlaceVirtualMachineGroupFn = func(
 					ctx context.Context,
 					group *vmopv1.VirtualMachineGroup,
 					groupPlacement []providers.VMGroupPlacement) error {
+
+					groupPlacementCallCount++
 
 					for _, grpPlacement := range groupPlacement {
 						for _, vm := range grpPlacement.VMMembers {
@@ -451,13 +466,39 @@ var _ = Describe(
 				}
 				intgFakeVMProvider.Unlock()
 
-				setVMUniqueID := func(vmKey types.NamespacedName, uniqueID string) {
+				setVMUniqueID = func(vmKey types.NamespacedName, uniqueID string) {
 					GinkgoHelper()
 					vm := &vmopv1.VirtualMachine{}
 					Expect(ctx.Client.Get(ctx, vmKey, vm)).To(Succeed())
 					vmCopy := vm.DeepCopy()
 					vmCopy.Status.UniqueID = uniqueID
 					Expect(ctx.Client.Status().Patch(ctx, vmCopy, client.MergeFrom(vm))).To(Succeed())
+				}
+
+				setVMZoneLabel = func(vmKey types.NamespacedName, zoneName string) {
+					GinkgoHelper()
+					vm := &vmopv1.VirtualMachine{}
+					Expect(ctx.Client.Get(ctx, vmKey, vm)).To(Succeed())
+					vmCopy := vm.DeepCopy()
+					if vmCopy.Labels == nil {
+						vmCopy.Labels = make(map[string]string)
+					}
+					vmCopy.Labels[corev1.LabelTopologyZone] = zoneName
+					Expect(ctx.Client.Patch(ctx, vmCopy, client.MergeFrom(vm))).To(Succeed())
+				}
+
+				verifyGroupPlacementReadyCondition = func(groupKey types.NamespacedName, memberCount int) {
+					GinkgoHelper()
+					Eventually(func(g Gomega) {
+						group := &vmopv1.VirtualMachineGroup{}
+						g.Expect(ctx.Client.Get(ctx, groupKey, group)).To(Succeed())
+						g.Expect(group.Status.Members).To(HaveLen(memberCount))
+						for _, ms := range group.Status.Members {
+							if ms.Kind == virtualMachineKind {
+								g.Expect(conditions.IsTrue(&ms, vmopv1.VirtualMachineGroupMemberConditionPlacementReady)).To(BeTrue())
+							}
+						}
+					}, "5s", "100ms").Should(Succeed())
 				}
 
 				By("setting up group-1 with members vm-1, vm-3, and vmgroup-2")
@@ -483,43 +524,92 @@ var _ = Describe(
 						},
 					},
 				}, vmGroup1Key.Name)
+			})
 
+			JustBeforeEach(func() {
+				// Assign VMs to groups in JustBeforeEach() so that we can modify
+				// VM objects before triggering reconciliation for group placement.
 				By("assigning VMs to groups")
 				assignVMToGroup(vm1Key, vmGroup1Key.Name)
 				assignVMToGroup(vm3Key, vmGroup1Key.Name)
 				assignVMToGroup(vm2Key, vmGroup2Key.Name)
 
-				By("setting up existing VMs")
-				setVMUniqueID(vm3Key, "vm-345")
-				setVMUniqueID(vm2Key, "vm-123")
+				By("triggering reconciliation of groups")
+				reconcileVMG(vmGroup1Key)
+				reconcileVMG(vmGroup2Key)
 			})
 
-			It("should update groups with placement ready condition", func() {
+			When("VM member status has PlacementReady condition true and matching UID", func() {
+				JustBeforeEach(func() {
+					By("waiting for initial group placement")
+					verifyGroupPlacementReadyCondition(vmGroup1Key, 3)
+					verifyGroupPlacementReadyCondition(vmGroup2Key, 1)
 
-				expectPlacementCondition := func(g Gomega, groupKey types.NamespacedName, vmName, expectedReason string) {
-					group := &vmopv1.VirtualMachineGroup{}
-					g.Expect(ctx.Client.Get(ctx, groupKey, group)).To(Succeed())
+					By("resetting group placement call count after initial placement")
+					groupPlacementCallCount = 0
+				})
 
-					var member *vmopv1.VirtualMachineGroupMemberStatus
-					for i := range group.Status.Members {
-						if group.Status.Members[i].Name == vmName && group.Status.Members[i].Kind == "VirtualMachine" {
-							member = &group.Status.Members[i]
-							break
+				It("should skip placing VM by group and mark PlacementReady true", func() {
+					By("triggering reconciliation of groups")
+					reconcileVMG(vmGroup1Key)
+					reconcileVMG(vmGroup2Key)
+
+					By("verifying group placement call count remains 0")
+					Consistently(func(g Gomega) {
+						g.Expect(groupPlacementCallCount).To(BeZero())
+					}, "2s", "100ms").Should(Succeed())
+
+					By("verifying group placement ready condition remains true")
+					verifyGroupPlacementReadyCondition(vmGroup1Key, 3)
+					verifyGroupPlacementReadyCondition(vmGroup2Key, 1)
+				})
+			})
+
+			When("VM doesn't have PlacementReady condition true but already has uniqueID", func() {
+				BeforeEach(func() {
+					By("setting uniqueID to VMs before adding to group")
+					setVMUniqueID(vm1Key, "vm-unique-id-1")
+					setVMUniqueID(vm2Key, "vm-unique-id-2")
+					setVMUniqueID(vm3Key, "vm-unique-id-3")
+
+					By("verifying VM has uniqueID before adding to group")
+					Eventually(func(g Gomega) {
+						for _, vmKey := range []types.NamespacedName{vm1Key, vm2Key, vm3Key} {
+							vm := &vmopv1.VirtualMachine{}
+							g.Expect(ctx.Client.Get(ctx, vmKey, vm)).To(Succeed())
+							g.Expect(vm.Status.UniqueID).ToNot(BeEmpty())
 						}
-					}
-					g.Expect(member).ToNot(BeNil())
-					g.Expect(conditions.IsTrue(member, vmopv1.VirtualMachineGroupMemberConditionPlacementReady)).To(BeTrue())
-					if expectedReason != "" {
-						c := conditions.Get(member, vmopv1.VirtualMachineGroupMemberConditionPlacementReady)
-						g.Expect(c.Reason).To(Equal(expectedReason))
-					}
-				}
+					}, "5s", "100ms").Should(Succeed())
+				})
 
-				Eventually(func(g Gomega) {
-					expectPlacementCondition(g, vmGroup2Key, vm2Key.Name, vmopv1.VirtualMachineGroupMemberAlreadyPlacedReason)
-					expectPlacementCondition(g, vmGroup1Key, vm1Key.Name, "") // No AlreadyExists reason if VM was placed through regular group controller driven placement.
-					expectPlacementCondition(g, vmGroup1Key, vm3Key.Name, vmopv1.VirtualMachineGroupMemberAlreadyPlacedReason)
-				}, "5s", "100ms").Should(Succeed())
+				It("should skip placing VM by group and mark PlacementReady true", func() {
+					verifyGroupPlacementReadyCondition(vmGroup1Key, 3)
+					verifyGroupPlacementReadyCondition(vmGroup2Key, 1)
+					Expect(groupPlacementCallCount).To(BeZero(), "VM with uniqueID should not be placed by group")
+				})
+			})
+
+			When("VM doesn't have PlacementReady nor uniqueID but has zone label", func() {
+				BeforeEach(func() {
+					By("setting zone label to VMs before adding to group")
+					setVMZoneLabel(vm1Key, "zone-a")
+					setVMZoneLabel(vm2Key, "zone-b")
+					setVMZoneLabel(vm3Key, "zone-c")
+				})
+
+				It("should skip placing VM by group and mark PlacementReady true", func() {
+					verifyGroupPlacementReadyCondition(vmGroup1Key, 3)
+					verifyGroupPlacementReadyCondition(vmGroup2Key, 1)
+					Expect(groupPlacementCallCount).To(BeZero(), "VM with zone label should not be placed by group")
+				})
+			})
+
+			When("VM needs placement by group", func() {
+				It("should place the VM by provider", func() {
+					verifyGroupPlacementReadyCondition(vmGroup1Key, 3)
+					verifyGroupPlacementReadyCondition(vmGroup2Key, 1)
+					Expect(groupPlacementCallCount).To(BeEquivalentTo(1), "VM should be placed by group")
+				})
 			})
 		})
 

--- a/pkg/providers/vsphere/vmprovider_vm_group.go
+++ b/pkg/providers/vsphere/vmprovider_vm_group.go
@@ -13,11 +13,11 @@ import (
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	pkgcond "github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+	pkglog "github.com/vmware-tanzu/vm-operator/pkg/log"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
 	vcclient "github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/client"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/placement"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/virtualmachine"
-	pkglog "github.com/vmware-tanzu/vm-operator/pkg/log"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 )
 
@@ -202,7 +202,7 @@ func applyPlacementResultsToGroups(
 				idx = len(vmGroup.Status.Members) - 1
 			}
 
-			vmGroup.Status.Members[idx].Placement = placeResultToGroupMemberPlacement(vm.Name, &result)
+			vmGroup.Status.Members[idx].Placement = placeResultToGroupMemberPlacement(&result)
 			// TODO: Clear this on failure for the root group
 			pkgcond.MarkTrue(&vmGroup.Status.Members[idx], vmopv1.VirtualMachineGroupMemberConditionPlacementReady)
 		}
@@ -221,11 +221,9 @@ func findVMMemberStatus(vmName string, members []vmopv1.VirtualMachineGroupMembe
 }
 
 func placeResultToGroupMemberPlacement(
-	vmName string,
 	result *placement.Result) *vmopv1.VirtualMachinePlacementStatus {
 
 	placementStatus := &vmopv1.VirtualMachinePlacementStatus{}
-	placementStatus.Name = vmName
 	placementStatus.Zone = result.ZoneName
 	placementStatus.Pool = result.PoolMoRef.Value
 

--- a/pkg/providers/vsphere/vmprovider_vm_group_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_group_test.go
@@ -155,7 +155,6 @@ func vmGroupTests() {
 		ExpectWithOffset(1, ms.Kind).To(Equal("VirtualMachine"), "Unexpected Kind")
 		ExpectWithOffset(1, ms.Placement).ToNot(BeNil(), "Missing Placement")
 		ExpectWithOffset(1, pkgcond.IsTrue(&ms, vmopv1.VirtualMachineGroupMemberConditionPlacementReady)).To(BeTrue(), "No placement ready condition")
-		ExpectWithOffset(1, ms.Placement.Name).ToNot(BeEmpty(), "Missing Placement Name")
 		ExpectWithOffset(1, ms.Placement.Zone).ToNot(BeEmpty(), "Missing Placement Zone")
 		ExpectWithOffset(1, ms.Placement.Pool).ToNot(BeEmpty(), "Missing Placement Pool")
 		ExpectWithOffset(1, ms.Placement.Node).To(BeEmpty(), "Has Placement Node")


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR updates the VM Group controller during group placement reconciliation by: 
- Skipping VM members that already have the `topology.kubernetes.io/zone` label, preventing unnecessary DRS placement (VM controller already ignores the group placement result for these VMs).
- Reassigning placement for VM members whose UID does not match the group member status, ensuring accurate placement status when a VM is recreated with the same name but not removed from the group.

All the required API changes are backported to v1alpha2 to maintain compatibility with VKS (still on v1a2).


**Which issue(s) is/are addressed by this PR?** 

Fixes N/A.


**Are there any special notes for your reviewer**:

- Rewrote the group placement tests to verify all the cases that we skip and do placement by group.
- Deployed this change to an internal testbed and validated the following:

```console
# Create a VM with a zone label and verify it is not placed in the group member status.
members:
  - conditions:
    - lastTransitionTime: "2025-09-29T23:56:18Z"
      message: ""
      reason: "True"
      status: "True"
      type: GroupLinked
    - lastTransitionTime: "2025-09-29T23:56:18Z"
      message: ""
      reason: "True"
      status: "True"
      type: PlacementReady
    kind: VirtualMachine
    name: vm-af-1 --------------------------------> VM with "topology.kubernetes.io/zone" set
    uid: e6245eba-147c-42ae-85be-014c5f3d091b
    
  members:
  - conditions:
    - lastTransitionTime: "2025-09-29T23:56:14Z"
      message: ""
      reason: "True"
      status: "True"
      type: GroupLinked
    - lastTransitionTime: "2025-09-29T23:56:18Z"
      message: ""
      reason: "True"
      status: "True"
      type: PlacementReady
    kind: VirtualMachine
    name: vm-1 --------------------------------> VM without "topology.kubernetes.io/zone" set
    placement:
      name: ""
      pool: resgroup-77
      zoneID: domain-c36
    powerState: PoweredOn
    uid: a3ddb647-798a-4020-beb2-f683f7de0e24

# Check VMOP logs to confirm that VMs with matching UIDs are not being re-placed:
I0929 23:56:55.266221       1 virtualmachinegroup_controller.go:643] "Group already has placement condition ready for VM, skipping" logger="virtualmachinegroup-controller" VirtualMachineGroup="sdiliyaer-test/vmg-root" reconcileID="05c16719-8023-493c-abe3-0295d8173bfd" vmName="vm-af-1" vmUID="e6245eba-147c-42ae-85be-014c5f3d091b"
I0929 23:56:55.266400       1 virtualmachinegroup_controller.go:643] "Group already has placement condition ready for VM, skipping" logger="virtualmachinegroup-controller" VirtualMachineGroup="sdiliyaer-test/vmg-root" reconcileID="05c16719-8023-493c-abe3-0295d8173bfd" vmName="vm-1" vmUID="a3ddb647-798a-4020-beb2-f683f7de0e24"

# Recreate VM with the same name without removing it from the group and verify group placement member status is updated:
 members:
  - conditions:
    - lastTransitionTime: "2025-09-30T01:01:35Z"
      message: ""
      reason: "True"
      status: "True"
      type: GroupLinked
    - lastTransitionTime: "2025-09-30T00:59:07Z"
      message: ""
      reason: "True"
      status: "True"
      type: PlacementReady
    kind: VirtualMachine
    name: vm-af-1
    placement:
      name: ""
      pool: resgroup-77
      zoneID: domain-c36
    uid: fd2aaac9-cd69-4a0b-9822-39125e5a7883
```


**Please add a release note if necessary**:

```release-note
Skip VM with zone label and address recreated VM in group placement.
```
