### PR TITLE
🐛 Fix data race in VirtualMachineImageCache test

### DIFF
--- a/controllers/virtualmachineimagecache/virtualmachineimagecache_controller_test.go
+++ b/controllers/virtualmachineimagecache/virtualmachineimagecache_controller_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"path"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -689,6 +690,8 @@ var _ = Describe(
 	})
 
 type fakeClient struct {
+	sync.RWMutex
+
 	fakeCLSProvdr bool
 	fakeSRIClient bool
 
@@ -771,6 +774,9 @@ type fakeClient struct {
 }
 
 func (m *fakeClient) reset() {
+	m.Lock()
+	defer m.Unlock()
+
 	m.fakeCLSProvdr = false
 	m.fakeSRIClient = false
 
@@ -796,6 +802,9 @@ func (m *fakeClient) newContentLibraryProviderFn(
 	context.Context,
 	*rest.Client) clprov.Provider {
 
+	m.RLock()
+	defer m.RUnlock()
+
 	if m.fakeCLSProvdr {
 		return m
 	}
@@ -804,6 +813,9 @@ func (m *fakeClient) newContentLibraryProviderFn(
 
 func (m *fakeClient) newCacheStorageURIsClientFn(
 	c *vim25.Client) clsutil.CacheStorageURIsClient {
+
+	m.RLock()
+	defer m.RUnlock()
 
 	if m.fakeSRIClient {
 		return m
@@ -815,6 +827,9 @@ func (m *fakeClient) DatastoreFileExists(
 	ctx context.Context,
 	name string,
 	datacenter *object.Datacenter) error {
+
+	m.RLock()
+	defer m.RUnlock()
 
 	if fn := m.datastoreFileExistsFn; fn != nil {
 		return fn(ctx, name, datacenter)
@@ -828,6 +843,9 @@ func (m *fakeClient) CopyVirtualDisk(
 	dstName string, dstDatacenter *object.Datacenter,
 	dstSpec vimtypes.BaseVirtualDiskSpec, force bool) (*object.Task, error) {
 
+	m.RLock()
+	defer m.RUnlock()
+
 	if fn := m.copyVirtualDiskFn; fn != nil {
 		return fn(ctx, srcName, srcDatacenter, dstName, dstDatacenter, dstSpec, force)
 	}
@@ -839,6 +857,9 @@ func (m *fakeClient) CopyDatastoreFile(
 	srcName string, srcDatacenter *object.Datacenter,
 	dstName string, dstDatacenter *object.Datacenter,
 	force bool) (*object.Task, error) {
+
+	m.RLock()
+	defer m.RUnlock()
 
 	if fn := m.copyDatastoreFileFn; fn != nil {
 		return fn(ctx, srcName, srcDatacenter, dstName, dstDatacenter, force)
@@ -852,6 +873,9 @@ func (m *fakeClient) MakeDirectory(
 	datacenter *object.Datacenter,
 	createParentDirectories bool) error {
 
+	m.RLock()
+	defer m.RUnlock()
+
 	if fn := m.makeDirectoryFn; fn != nil {
 		return fn(ctx, name, datacenter, createParentDirectories)
 	}
@@ -860,6 +884,9 @@ func (m *fakeClient) MakeDirectory(
 
 func (m *fakeClient) WaitForTask(
 	ctx context.Context, task *object.Task) error {
+
+	m.RLock()
+	defer m.RUnlock()
 
 	if fn := m.waitForTaskFn; fn != nil {
 		return fn(ctx, task)
@@ -870,6 +897,9 @@ func (m *fakeClient) WaitForTask(
 func (m *fakeClient) GetLibraryItems(
 	ctx context.Context,
 	libraryID string) ([]library.Item, error) {
+
+	m.RLock()
+	defer m.RUnlock()
 
 	if fn := m.getLibraryItemsFn; fn != nil {
 		return fn(ctx, libraryID)
@@ -883,6 +913,9 @@ func (m *fakeClient) GetLibraryItem(
 	itemName string,
 	notFoundReturnErr bool) (*library.Item, error) {
 
+	m.RLock()
+	defer m.RUnlock()
+
 	if fn := m.getLibraryItemFn; fn != nil {
 		return fn(ctx, libraryID, itemName, notFoundReturnErr)
 	}
@@ -893,6 +926,9 @@ func (m *fakeClient) GetLibraryItemID(
 	ctx context.Context,
 	itemID string) (*library.Item, error) {
 
+	m.RLock()
+	defer m.RUnlock()
+
 	if fn := m.getLibraryItemIDFn; fn != nil {
 		return fn(ctx, itemID)
 	}
@@ -902,6 +938,9 @@ func (m *fakeClient) GetLibraryItemID(
 func (m *fakeClient) ListLibraryItems(
 	ctx context.Context,
 	libraryID string) ([]string, error) {
+
+	m.RLock()
+	defer m.RUnlock()
 
 	if fn := m.listLibraryItemsFn; fn != nil {
 		return fn(ctx, libraryID)
@@ -915,6 +954,9 @@ func (m *fakeClient) UpdateLibraryItem(
 	newName string,
 	newDescription *string) error {
 
+	m.RLock()
+	defer m.RUnlock()
+
 	if fn := m.updateLibraryItemFn; fn != nil {
 		return fn(ctx, itemID, newName, newDescription)
 	}
@@ -925,6 +967,9 @@ func (m *fakeClient) RetrieveOvfEnvelopeFromLibraryItem(
 	ctx context.Context,
 	item *library.Item) (*ovf.Envelope, error) {
 
+	m.RLock()
+	defer m.RUnlock()
+
 	if fn := m.retrieveOvfEnvelopeFromLibraryItemFn; fn != nil {
 		return fn(ctx, item)
 	}
@@ -934,6 +979,9 @@ func (m *fakeClient) RetrieveOvfEnvelopeFromLibraryItem(
 func (m *fakeClient) RetrieveOvfEnvelopeByLibraryItemID(
 	ctx context.Context,
 	itemID string) (*ovf.Envelope, error) {
+
+	m.RLock()
+	defer m.RUnlock()
 
 	if fn := m.retrieveOvfEnvelopeByLibraryItemIDFn; fn != nil {
 		return fn(ctx, itemID)
@@ -946,6 +994,9 @@ func (m *fakeClient) SyncLibraryItem(
 	item *library.Item,
 	force bool) error {
 
+	m.RLock()
+	defer m.RUnlock()
+
 	if fn := m.syncLibraryItemFn; fn != nil {
 		return fn(ctx, item, force)
 	}
@@ -955,6 +1006,9 @@ func (m *fakeClient) SyncLibraryItem(
 func (m *fakeClient) ListLibraryItemStorage(
 	ctx context.Context,
 	itemID string) ([]library.Storage, error) {
+
+	m.RLock()
+	defer m.RUnlock()
 
 	if fn := m.listLibraryItemStorageFn; fn != nil {
 		return fn(ctx, itemID)
@@ -967,6 +1021,9 @@ func (m *fakeClient) ResolveLibraryItemStorage(
 	datacenter *object.Datacenter,
 	storage []library.Storage) error {
 
+	m.RLock()
+	defer m.RUnlock()
+
 	if fn := m.resolveLibraryItemStorageFn; fn != nil {
 		return fn(ctx, datacenter, storage)
 	}
@@ -977,6 +1034,9 @@ func (m *fakeClient) CreateLibraryItem(
 	ctx context.Context,
 	item library.Item,
 	path string) error {
+
+	m.RLock()
+	defer m.RUnlock()
 
 	if fn := m.createLibraryItemFn; fn != nil {
 		return fn(ctx, item, path)


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR updates the fakeClient in VMIC test with `sync.RWMutex` to prevent concurrent reads/writes between test cleanup and controller goroutines. See https://github.com/vmware-tanzu/vm-operator/actions/runs/18137320993/job/51619344403?pr=1214 for the data race error.


**Which issue(s) is/are addressed by this PR?** 

Fixes N/A.


**Are there any special notes for your reviewer**:

Passed when locally running `for i in {1..10}; do  echo "Run $i"; go test -count=1 -race ./controllers/virtualmachineimagecache/... -ginkgo.focus="cannot cache storage uris" || break; done` with this change (pervasively failing on main).


**Please add a release note if necessary**:

```release-note
Fix data race in VirtualMachineImageCache test.
```