### PR TITLE
⚠️ Fix group placement status zone field name

### DIFF
--- a/api/v1alpha2/virtualmachinegroup_types.go
+++ b/api/v1alpha2/virtualmachinegroup_types.go
@@ -165,7 +165,7 @@ type VirtualMachinePlacementStatus struct {
 	// +optional
 
 	// Zone describes the recommended zone for this VM.
-	Zone string `json:"zoneID,omitempty"`
+	Zone string `json:"zone,omitempty"`
 
 	// +optional
 

--- a/api/v1alpha3/virtualmachinegroup_types.go
+++ b/api/v1alpha3/virtualmachinegroup_types.go
@@ -165,7 +165,7 @@ type VirtualMachinePlacementStatus struct {
 	// +optional
 
 	// Zone describes the recommended zone for this VM.
-	Zone string `json:"zoneID,omitempty"`
+	Zone string `json:"zone,omitempty"`
 
 	// +optional
 

--- a/api/v1alpha4/virtualmachinegroup_types.go
+++ b/api/v1alpha4/virtualmachinegroup_types.go
@@ -165,7 +165,7 @@ type VirtualMachinePlacementStatus struct {
 	// +optional
 
 	// Zone describes the recommended zone for this VM.
-	Zone string `json:"zoneID,omitempty"`
+	Zone string `json:"zone,omitempty"`
 
 	// +optional
 

--- a/api/v1alpha5/virtualmachinegroup_types.go
+++ b/api/v1alpha5/virtualmachinegroup_types.go
@@ -170,7 +170,7 @@ type VirtualMachinePlacementStatus struct {
 	// +optional
 
 	// Zone describes the recommended zone for this VM.
-	Zone string `json:"zoneID,omitempty"`
+	Zone string `json:"zone,omitempty"`
 
 	// +optional
 

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachinegroups.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachinegroups.yaml
@@ -373,7 +373,7 @@ spec:
                           description: Pool describes the recommended resource pool
                             for this VM.
                           type: string
-                        zoneID:
+                        zone:
                           description: Zone describes the recommended zone for this
                             VM.
                           type: string
@@ -762,7 +762,7 @@ spec:
                           description: Pool describes the recommended resource pool
                             for this VM.
                           type: string
-                        zoneID:
+                        zone:
                           description: Zone describes the recommended zone for this
                             VM.
                           type: string
@@ -1151,7 +1151,7 @@ spec:
                           description: Pool describes the recommended resource pool
                             for this VM.
                           type: string
-                        zoneID:
+                        zone:
                           description: Zone describes the recommended zone for this
                             VM.
                           type: string
@@ -1540,7 +1540,7 @@ spec:
                           description: Pool describes the recommended resource pool
                             for this VM.
                           type: string
-                        zoneID:
+                        zone:
                           description: Zone describes the recommended zone for this
                             VM.
                           type: string


### PR DESCRIPTION


**What does this PR do, and why is it needed?**

The Zone had an field name of zoneID. Update that to match it member name.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

Nothing should be using these field yet - in any API version - so it is kind of now or never. 

**Please add a release note if necessary**:

```release-note
Update VirtualMachinePlacementStatus Zone JSON field name to be "zone"
```