### PR TITLE
🌱Update VM Volume status from batchAttachment

### DIFF
--- a/api/v1alpha5/virtualmachine_storage_types.go
+++ b/api/v1alpha5/virtualmachine_storage_types.go
@@ -188,6 +188,7 @@ type PersistentVolumeClaimVolumeSource struct {
 	DiskMode VolumeDiskMode `json:"diskMode,omitempty"`
 
 	// +optional
+	// +kubebuilder:default=None
 
 	// SharingMode describes the volume's desired sharing mode.
 	//

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachinereplicasets.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachinereplicasets.yaml
@@ -2907,6 +2907,7 @@ spec:
                                     Default false.
                                   type: boolean
                                 sharingMode:
+                                  default: None
                                   description: |-
                                     SharingMode describes the volume's desired sharing mode.
 

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -12152,6 +12152,7 @@ spec:
                             Default false.
                           type: boolean
                         sharingMode:
+                          default: None
                           description: |-
                             SharingMode describes the volume's desired sharing mode.
 

--- a/controllers/virtualmachine/volume/volume_controller.go
+++ b/controllers/virtualmachine/volume/volume_controller.go
@@ -1,5 +1,5 @@
 // © Broadcom. All Rights Reserved.
-// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: Apache-2.0
 
 package volume
@@ -1003,19 +1003,6 @@ func (r *Reconciler) deleteOrphanedAttachments(ctx *pkgctx.VolumeContext, attach
 	return apierrorsutil.NewAggregate(errs)
 }
 
-// The CSI controller sometimes puts the serialized SOAP error into the CnsNodeVmAttachment
-// error field, which contains things like OpIds and pointers that change on every failed
-// reconcile attempt. Using this error as-is causes VM object churn, so try to avoid that
-// here. The full error message is always available in the CnsNodeVmAttachment.
-func sanitizeCNSErrorMessage(msg string) string {
-	if strings.Contains(msg, "opId:") {
-		idx := strings.Index(msg, ":")
-		return msg[:idx]
-	}
-
-	return msg
-}
-
 func attachmentToVolumeStatus(
 	volumeName string,
 	attachment cnsv1alpha1.CnsNodeVmAttachment) vmopv1.VirtualMachineVolumeStatus {
@@ -1024,7 +1011,7 @@ func attachmentToVolumeStatus(
 		Name:     volumeName, // Name of the volume as in the Spec
 		Attached: attachment.Status.Attached,
 		DiskUUID: attachment.Status.AttachmentMetadata[cnsv1alpha1.AttributeFirstClassDiskUUID],
-		Error:    sanitizeCNSErrorMessage(attachment.Status.Error),
+		Error:    pkgutil.SanitizeCNSErrorMessage(attachment.Status.Error),
 		Type:     vmopv1.VolumeTypeManaged,
 	}
 }

--- a/controllers/virtualmachine/volume/volume_controller_intg_test.go
+++ b/controllers/virtualmachine/volume/volume_controller_intg_test.go
@@ -1,5 +1,5 @@
 // © Broadcom. All Rights Reserved.
-// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: Apache-2.0
 
 package volume_test

--- a/controllers/virtualmachine/volume/volume_controller_suite_test.go
+++ b/controllers/virtualmachine/volume/volume_controller_suite_test.go
@@ -1,5 +1,5 @@
 // © Broadcom. All Rights Reserved.
-// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: Apache-2.0
 
 package volume_test

--- a/controllers/virtualmachine/volumebatch/volumebatch_controller_intg_test.go
+++ b/controllers/virtualmachine/volumebatch/volumebatch_controller_intg_test.go
@@ -1,0 +1,397 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package volumebatch_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	cnsv1alpha1 "github.com/vmware-tanzu/vm-operator/external/vsphere-csi-driver/api/v1alpha1"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
+	"github.com/vmware-tanzu/vm-operator/pkg/util"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+func intgTests() {
+	Describe(
+		"Reconcile",
+		Label(
+			testlabels.Controller,
+			testlabels.EnvTest,
+			testlabels.API,
+		),
+		intgTestsReconcile,
+	)
+}
+
+func intgTestsReconcile() {
+	var (
+		ctx *builder.IntegrationTestContext
+
+		vm             *vmopv1.VirtualMachine
+		vmKey          types.NamespacedName
+		vmVolume1      vmopv1.VirtualMachineVolume
+		vmVolume2      vmopv1.VirtualMachineVolume
+		pvc1           *corev1.PersistentVolumeClaim
+		pvc2           *corev1.PersistentVolumeClaim
+		dummyBiosUUID  string
+		dummyDiskUUID1 string
+		dummyDiskUUID2 string
+	)
+
+	BeforeEach(func() {
+		ctx = suite.NewIntegrationTestContext()
+
+		dummyBiosUUID = uuid.New().String()
+		dummyDiskUUID1 = uuid.New().String()
+		dummyDiskUUID2 = uuid.New().String()
+
+		vmVolume1 = vmopv1.VirtualMachineVolume{
+			Name: "cns-volume-1",
+			VirtualMachineVolumeSource: vmopv1.VirtualMachineVolumeSource{
+				PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
+					PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: "pvc-volume-1",
+					},
+				},
+			},
+		}
+
+		pvc1 = &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      vmVolume1.VirtualMachineVolumeSource.PersistentVolumeClaim.ClaimName,
+				Namespace: ctx.Namespace,
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse("1Gi"),
+					},
+				},
+				AccessModes: []corev1.PersistentVolumeAccessMode{
+					corev1.ReadWriteOnce,
+				},
+			},
+		}
+
+		vmVolume2 = vmopv1.VirtualMachineVolume{
+			Name: "cns-volume-2",
+			VirtualMachineVolumeSource: vmopv1.VirtualMachineVolumeSource{
+				PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
+					PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: "pvc-volume-2",
+					},
+				},
+			},
+		}
+
+		pvc2 = &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      vmVolume2.VirtualMachineVolumeSource.PersistentVolumeClaim.ClaimName,
+				Namespace: ctx.Namespace,
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse("2Gi"),
+					},
+				},
+				AccessModes: []corev1.PersistentVolumeAccessMode{
+					corev1.ReadWriteOnce,
+				},
+			},
+		}
+
+		vm = &vmopv1.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ctx.Namespace,
+				Name:      "dummy-vm",
+			},
+			Spec: vmopv1.VirtualMachineSpec{
+				ImageName:  "dummy-image",
+				PowerState: vmopv1.VirtualMachinePowerStateOff,
+			},
+		}
+		vmKey = types.NamespacedName{Name: vm.Name, Namespace: vm.Namespace}
+
+	})
+
+	AfterEach(func() {
+		ctx.AfterEach()
+		ctx = nil
+	})
+
+	getVirtualMachine := func(objKey types.NamespacedName) *vmopv1.VirtualMachine {
+		vm := &vmopv1.VirtualMachine{}
+		if err := ctx.Client.Get(ctx, objKey, vm); err != nil {
+			return nil
+		}
+		return vm
+	}
+
+	getCnsNodeVMBatchAttachment := func(vm *vmopv1.VirtualMachine) *cnsv1alpha1.CnsNodeVmBatchAttachment {
+		objectKey := client.ObjectKey{Name: util.CNSBatchAttachmentNameForVM(vm.Name), Namespace: vm.Namespace}
+		attachment := &cnsv1alpha1.CnsNodeVmBatchAttachment{}
+		if err := ctx.Client.Get(ctx, objectKey, attachment); err == nil {
+			return attachment
+		}
+		return nil
+	}
+
+	Context("Reconcile", func() {
+
+		AfterEach(func() {
+			err := ctx.Client.Delete(ctx, vm)
+			Expect(err == nil || apierrors.IsNotFound(err)).To(BeTrue())
+		})
+
+		When("VM has a pause annotation", func() {
+			BeforeEach(func() {
+				vm.Annotations = make(map[string]string)
+				vm.Annotations[vmopv1.PauseAnnotation] = "true"
+			})
+
+			It("Reconciles VM", func() {
+				Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
+
+				vm = getVirtualMachine(vmKey)
+				Expect(vm).ToNot(BeNil())
+
+				By("VM has no volumes", func() {
+					Expect(vm.Spec.Volumes).To(BeEmpty())
+					Expect(vm.Status.Volumes).To(BeEmpty())
+				})
+
+				By("Assign VM BiosUUID", func() {
+					vm.Status.BiosUUID = dummyBiosUUID
+					Expect(ctx.Client.Status().Update(ctx, vm)).To(Succeed())
+				})
+
+				By("Add CNS volume to Spec.Volumes", func() {
+					vm.Spec.Volumes = append(vm.Spec.Volumes, vmVolume1)
+					Expect(ctx.Client.Update(ctx, vm)).To(Succeed())
+				})
+
+				By("CnsNodeVmBatchAttachment should not be created for volume", func() {
+					Consistently(func(g Gomega) {
+						g.Expect(getCnsNodeVMBatchAttachment(vm)).To(BeNil())
+					}, "3s").Should(Succeed())
+				})
+			})
+		})
+
+		It("Reconciles VirtualMachine Spec.Volumes", func() {
+			Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
+
+			vm = getVirtualMachine(vmKey)
+			Expect(vm).ToNot(BeNil())
+
+			By("VM has no volumes", func() {
+				Expect(vm.Spec.Volumes).To(BeEmpty())
+				Expect(vm.Status.Volumes).To(BeEmpty())
+			})
+
+			By("Assign VM BiosUUID", func() {
+				vm.Status.BiosUUID = dummyBiosUUID
+				Expect(ctx.Client.Status().Update(ctx, vm)).To(Succeed())
+			})
+
+			By("Add CNS volume to Spec.Volumes", func() {
+				By("Create PVC and Bind", func() {
+					Expect(ctx.Client.Create(ctx, pvc1)).To(Succeed())
+					pvc1.Status.Phase = corev1.ClaimBound
+					Expect(ctx.Client.Status().Update(ctx, pvc1)).To(Succeed())
+				})
+				vm.Spec.Volumes = append(vm.Spec.Volumes, vmVolume1)
+				Expect(ctx.Client.Update(ctx, vm)).To(Succeed())
+			})
+
+			By("CnsNodeVmBatchAttachment should be created for volume", func() {
+				var attachment *cnsv1alpha1.CnsNodeVmBatchAttachment
+				Eventually(func(g Gomega) {
+					attachment = getCnsNodeVMBatchAttachment(vm)
+					g.Expect(attachment).ToNot(BeNil())
+				}).Should(Succeed())
+
+				Expect(attachment.Spec.NodeUUID).To(Equal(dummyBiosUUID))
+				Expect(attachment.Spec.Volumes).To(HaveLen(1))
+				Expect(attachment.Spec.Volumes[0].Name).To(Equal(vmVolume1.Name))
+			})
+
+			By("VM Status.Volume should have entry for volume", func() {
+				var vm *vmopv1.VirtualMachine
+				Eventually(func(g Gomega) {
+					vm = getVirtualMachine(vmKey)
+					g.Expect(vm).ToNot(BeNil())
+					g.Expect(vm.Status.Volumes).To(HaveLen(1))
+				}).Should(Succeed())
+
+				volStatus := vm.Status.Volumes[0]
+				Expect(volStatus.Name).To(Equal(vmVolume1.Name))
+				Expect(volStatus.Attached).To(BeFalse())
+			})
+
+			errMsg := "dummy error message"
+
+			By("Simulate CNS update batchAttachment with volume status", func() {
+				attachment := getCnsNodeVMBatchAttachment(vm)
+				Expect(attachment).ToNot(BeNil())
+				attachment.Status.VolumeStatus = append(
+					attachment.Status.VolumeStatus,
+					cnsv1alpha1.VolumeStatus{
+						Name: vmVolume1.Name,
+						PersistentVolumeClaim: cnsv1alpha1.PersistentVolumeClaimStatus{
+							Attached:  true,
+							Diskuuid:  dummyDiskUUID1,
+							ClaimName: vmVolume1.PersistentVolumeClaim.ClaimName,
+							Error:     errMsg,
+						},
+					},
+				)
+
+				Expect(ctx.Client.Status().Update(ctx, attachment)).To(Succeed())
+			})
+
+			By("VM Status.Volume should reflect attached volume", func() {
+				var vm *vmopv1.VirtualMachine
+				Eventually(func(g Gomega) {
+					vm = getVirtualMachine(vmKey)
+					g.Expect(vm).ToNot(BeNil())
+					g.Expect(vm.Status.Volumes).To(HaveLen(1))
+					g.Expect(vm.Status.Volumes[0].Attached).To(BeTrue())
+				}).Should(Succeed())
+
+				volStatus := vm.Status.Volumes[0]
+				Expect(volStatus.Name).To(Equal(vmVolume1.Name))
+				Expect(volStatus.DiskUUID).To(Equal(dummyDiskUUID1))
+				Expect(volStatus.Error).To(Equal(errMsg))
+			})
+		})
+
+		It("Reconciles VirtualMachine with multiple Spec.Volumes", func() {
+			Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
+
+			By("Assign VM BiosUUID", func() {
+				vm.Status.BiosUUID = dummyBiosUUID
+				Expect(ctx.Client.Status().Update(ctx, vm)).To(Succeed())
+			})
+
+			By("Add CNS volume to Spec.Volumes", func() {
+				By("Create PVCs and Bind", func() {
+					Expect(ctx.Client.Create(ctx, pvc1)).To(Succeed())
+					pvc1.Status.Phase = corev1.ClaimBound
+					Expect(ctx.Client.Status().Update(ctx, pvc1)).To(Succeed())
+
+					Expect(ctx.Client.Create(ctx, pvc2)).To(Succeed())
+					pvc2.Status.Phase = corev1.ClaimBound
+					Expect(ctx.Client.Status().Update(ctx, pvc2)).To(Succeed())
+				})
+				vm.Spec.Volumes = append(vm.Spec.Volumes, vmVolume1, vmVolume2)
+				Expect(ctx.Client.Update(ctx, vm)).To(Succeed())
+			})
+
+			By("CnsNodeVmBatchAttachment should be created", func() {
+				var attachment *cnsv1alpha1.CnsNodeVmBatchAttachment
+				Eventually(func(g Gomega) {
+					attachment = getCnsNodeVMBatchAttachment(vm)
+					g.Expect(attachment).ToNot(BeNil())
+				}).Should(Succeed())
+
+				Expect(attachment.Spec.NodeUUID).To(Equal(dummyBiosUUID))
+				Expect(attachment.Spec.Volumes).To(HaveLen(2))
+				Expect(attachment.Spec.Volumes[0].Name).To(Equal(vmVolume1.Name))
+				Expect(attachment.Spec.Volumes[1].Name).To(Equal(vmVolume2.Name))
+			})
+
+			By("VM Status.Volume should have entry for volume1 and volume2", func() {
+				Eventually(func(g Gomega) {
+					vm = getVirtualMachine(vmKey)
+					g.Expect(vm).ToNot(BeNil())
+					g.Expect(vm.Status.Volumes).To(HaveLen(2))
+				}).Should(Succeed())
+
+				volStatus := vm.Status.Volumes[0]
+				Expect(volStatus.Name).To(Equal(vmVolume1.Name))
+				Expect(volStatus.Attached).To(BeFalse())
+
+				volStatus = vm.Status.Volumes[1]
+				Expect(volStatus.Name).To(Equal(vmVolume2.Name))
+				Expect(volStatus.Attached).To(BeFalse())
+			})
+
+			By("Simulate CNS attachment for volume1", func() {
+				attachment := getCnsNodeVMBatchAttachment(vm)
+				Expect(attachment).ToNot(BeNil())
+				attachment.Status.VolumeStatus = append(
+					attachment.Status.VolumeStatus,
+					cnsv1alpha1.VolumeStatus{
+						Name: vmVolume1.Name,
+						PersistentVolumeClaim: cnsv1alpha1.PersistentVolumeClaimStatus{
+							Attached:  true,
+							Diskuuid:  dummyDiskUUID1,
+							ClaimName: vmVolume1.PersistentVolumeClaim.ClaimName,
+						},
+					},
+				)
+
+				Expect(ctx.Client.Status().Update(ctx, attachment)).To(Succeed())
+			})
+
+			By("Simulate CNS attachment for volume2", func() {
+				attachment := getCnsNodeVMBatchAttachment(vm)
+				Expect(attachment).ToNot(BeNil())
+				attachment.Status.VolumeStatus = append(
+					attachment.Status.VolumeStatus,
+					cnsv1alpha1.VolumeStatus{
+						Name: vmVolume2.Name,
+						PersistentVolumeClaim: cnsv1alpha1.PersistentVolumeClaimStatus{
+							Attached:  true,
+							Diskuuid:  dummyDiskUUID2,
+							ClaimName: vmVolume2.PersistentVolumeClaim.ClaimName,
+						},
+					},
+				)
+
+				Expect(ctx.Client.Status().Update(ctx, attachment)).To(Succeed())
+			})
+
+			By("VM Status.Volume should reflect attached volumes", func() {
+				Eventually(func(g Gomega) {
+					vm = getVirtualMachine(vmKey)
+					g.Expect(vm).ToNot(BeNil())
+					g.Expect(vm.Status.Volumes).To(HaveLen(2))
+					g.Expect(vm.Status.Volumes[0].Attached).To(BeTrue())
+					g.Expect(vm.Status.Volumes[1].Attached).To(BeTrue())
+				}).Should(Succeed(), "Waiting VM Status.Volumes to show attached")
+			})
+
+			By("Remove CNS volume1 from VM Spec.Volumes", func() {
+				vm = getVirtualMachine(vmKey)
+				Expect(vm).ToNot(BeNil())
+				vm.Spec.Volumes = []vmopv1.VirtualMachineVolume{vmVolume2}
+				Expect(ctx.Client.Update(ctx, vm)).To(Succeed())
+			})
+
+			By("VM Status.Volumes should still only have entry for volume volume2", func() {
+				// I'm not sure if we have a better way to check for this.
+				Eventually(func(g Gomega) {
+					vm = getVirtualMachine(vmKey)
+					g.Expect(vm).ToNot(BeNil())
+					g.Expect(vm.Status.Volumes).To(HaveLen(1))
+				}).Should(Succeed())
+			})
+		})
+	})
+}

--- a/controllers/virtualmachine/volumebatch/volumebatch_controller_suite_test.go
+++ b/controllers/virtualmachine/volumebatch/volumebatch_controller_suite_test.go
@@ -11,7 +11,7 @@ import (
 
 	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
 
-	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachine/volume"
+	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachine/volumebatch"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	providerfake "github.com/vmware-tanzu/vm-operator/pkg/providers/fake"
@@ -22,14 +22,14 @@ var intgFakeVMProvider = providerfake.NewVMProvider()
 
 var suite = builder.NewTestSuiteForControllerWithContext(
 	pkgcfg.NewContextWithDefaultConfig(),
-	volume.AddToManager,
+	volumebatch.AddToManager,
 	func(ctx *pkgctx.ControllerManagerContext, _ ctrlmgr.Manager) error {
 		ctx.VMProvider = intgFakeVMProvider
 		return nil
 	})
 
 func TestBatchVolume(t *testing.T) {
-	suite.Register(t, "Volume batch controller suite", nil, unitTests)
+	suite.Register(t, "Volume batch controller suite", intgTests, unitTests)
 }
 
 var _ = BeforeSuite(suite.BeforeSuite)

--- a/controllers/virtualmachinesnapshot/virtualmachinesnapshot_controller.go
+++ b/controllers/virtualmachinesnapshot/virtualmachinesnapshot_controller.go
@@ -133,8 +133,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 				vmSnapshot.Namespace,
 				sc)
 		}
+
 		reconcileSnapshotReadyCondition(vmSnapshot)
-		vmSnapshotCtx.Logger.Info("Patching VirtualMachineSnapshot", "snapshot", vmSnapshot)
+
+		vmSnapshotCtx.Logger.V(4).Info("Patching VirtualMachineSnapshot",
+			"snapshot", vmSnapshot)
 		if err := patchHelper.Patch(ctx, vmSnapshot); err != nil {
 			if reterr == nil {
 				reterr = err

--- a/pkg/util/cns_test.go
+++ b/pkg/util/cns_test.go
@@ -35,3 +35,21 @@ var _ = Describe("BuildControllerKey", func() {
 		Expect(key).To(Equal(""))
 	})
 })
+
+var _ = DescribeTable("SanitizeCNSErrorMessage",
+	func(original, expected string) {
+		Expect(util.SanitizeCNSErrorMessage(original)).To(Equal(expected))
+	},
+	Entry("leave empty message untouched", "", ""),
+	Entry("leave normal message with ':' untouched", "error: this is wrong", "error: this is wrong"),
+	Entry("sanitize aweful error message", `failed to attach cns volume: \"88854b48-2b1c-43f8-8889-de4b5ca2cab5\" to node vm: \"VirtualMachine:vm-42
+[VirtualCenterHost: vc.vmware.com, UUID: 42080725-d6b0-c045-b24e-29c4dadca6f2, Datacenter: Datacenter
+[Datacenter: Datacenter:datacenter, VirtualCenterHost: vc.vmware.com]]\".
+fault: \"(*vimtypes.LocalizedMethodFault)(0xc003d9b9a0)({\\n DynamicData: (vimtypes.DynamicData)
+{\\n },\\n Fault: (*vimtypes.ResourceInUse)(0xc002e69080)({\\n VimFault: (vimtypes.VimFault)
+{\\n MethodFault: (vimtypes.MethodFault) {\\n FaultCause: (*vimtypes.LocalizedMethodFault)(\u003cnil\u003e),\\n
+FaultMessage: ([]vimtypes.LocalizableMessage) \u003cnil\u003e\\n }\\n },\\n Type: (string) \\\"\\\",\\n Name:
+(string) (len=6) \\\"volume\\\"\\n }),\\n LocalizedMessage: (string) (len=32)
+\\\"The resource 'volume' is in use.\\\"\\n})\\n\". opId: \"67d69c68\""
+`, "failed to attach cns volume"),
+)

--- a/webhooks/virtualmachine/mutation/virtualmachine_mutator_intg_test.go
+++ b/webhooks/virtualmachine/mutation/virtualmachine_mutator_intg_test.go
@@ -836,21 +836,21 @@ func intgTestsMutating() {
 
 				})
 
-				It("should only set the disk mode to persistent, and leave the rest empty", func() {
+				It("should only set the disk mode to persistent, sharing mode to none, and leave the rest empty", func() {
 					vm := &vmopv1.VirtualMachine{}
 					Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(ctx.vm), vm)).To(Succeed())
 					Expect(vm.Spec.Volumes[0].PersistentVolumeClaim.DiskMode).
 						To(Equal(vmopv1.VolumeDiskModePersistent))
 					Expect(vm.Spec.Volumes[0].PersistentVolumeClaim.SharingMode).
-						To(BeEmpty())
+						To(Equal(vmopv1.VolumeSharingModeNone))
 					Expect(vm.Spec.Volumes[1].PersistentVolumeClaim.DiskMode).
 						To(Equal(vmopv1.VolumeDiskModePersistent))
 					Expect(vm.Spec.Volumes[1].PersistentVolumeClaim.SharingMode).
-						To(BeEmpty())
+						To(Equal(vmopv1.VolumeSharingModeNone))
 					Expect(vm.Spec.Volumes[2].PersistentVolumeClaim.DiskMode).
 						To(Equal(vmopv1.VolumeDiskModePersistent))
 					Expect(vm.Spec.Volumes[2].PersistentVolumeClaim.SharingMode).
-						To(BeEmpty())
+						To(Equal(vmopv1.VolumeSharingModeNone))
 				})
 			})
 		})


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

Implement logic that updates VM's volume status when batchAttachment has corresponding volume updates.

1. Logic is mostly copied from volume_controller.go
2. When batchAttachment already has volume status and PVC is not changed, create VM volume status based on that. If PVC is changed, or no status in batchAttachment, create basic volume status.
3. Add default sharingMode value to the API
4. Add integration test as well



**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    5. If a release note is not required, please write "NONE".
-->

```release-note
Implement logic that updates VM's volume status when batchAttachment has corresponding volume updates.
```