### PR TITLE
🌱Fix snapshot related field name in VM spec removal logic

### DIFF
--- a/pkg/crd/crd.go
+++ b/pkg/crd/crd.go
@@ -229,7 +229,7 @@ func Install(
 							k,
 							obj,
 							shouldRemoveFields,
-							specFieldPath("currentSnapshot"),
+							specFieldPath("currentSnapshotName"),
 							statusFieldPath("currentSnapshot"),
 							statusFieldPath("rootSnapshots")); err != nil {
 

--- a/pkg/crd/crd_test.go
+++ b/pkg/crd/crd_test.go
@@ -204,7 +204,7 @@ var _ = Describe("Install", func() {
 				},
 				Entry("bootOptions", "bootOptions"),
 				Entry("class", "class"),
-				Entry("currentSnapshot", "currentSnapshot"),
+				Entry("currentSnapshotName", "currentSnapshotName"),
 				Entry("groupName", "groupName"),
 				Entry("policies", "policies"),
 			)
@@ -525,7 +525,7 @@ var _ = Describe("Install", func() {
 					}
 				})
 
-				DescribeTable("vm api should not have removed spec fields",
+				DescribeTable("vm api should have removed spec fields",
 					func(field string) {
 						fields := []string{
 							"schema",
@@ -544,7 +544,7 @@ var _ = Describe("Install", func() {
 					Entry("policies", "policies"),
 				)
 
-				DescribeTable("vm api should not have removed status fields",
+				DescribeTable("vm api should have removed status fields",
 					func(field string) {
 						fields := []string{
 							"schema",
@@ -561,7 +561,6 @@ var _ = Describe("Install", func() {
 					Entry("policies", "policies"),
 				)
 			})
-
 		})
 
 		When("CRD cleanup is enabled", func() {
@@ -651,7 +650,7 @@ var _ = Describe("Install", func() {
 						},
 						Entry("bootOptions", "bootOptions"),
 						Entry("class", "class"),
-						Entry("currentSnapshot", "currentSnapshot"),
+						Entry("currentSnapshotName", "currentSnapshotName"),
 						Entry("groupName", "groupName"),
 						Entry("policies", "policies"),
 					)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

`currentSnapshot` was changed to `currentSnapshotName` in https://github.com/vmware-tanzu/vm-operator/pull/1196. Then we should also update the field when removing snapshot related field from vm spec.

Fix some of the test description.


```release-note
None
```