### PR TITLE
🌱 Don't always backfill VM Status.Zone from label

### DIFF
--- a/pkg/providers/vsphere/vmlifecycle/update_status.go
+++ b/pkg/providers/vsphere/vmlifecycle/update_status.go
@@ -375,14 +375,18 @@ func reconcileStatusZone(
 
 	var errs []error
 
-	zoneName := vmCtx.VM.Labels[corev1.LabelTopologyZone]
-	if zoneName == "" {
+	zoneLabel := vmCtx.VM.Labels[corev1.LabelTopologyZone]
+	zoneStatus := vmCtx.VM.Status.Zone
+
+	// The label value is protected by the VM validation webhook for non-privileged users,
+	// but in case the value was accidentally changed by like kube-admin relook the zone.
+	if zoneLabel == "" || zoneLabel != zoneStatus {
 		clusterMoRef, err := vcenter.GetResourcePoolOwnerMoRef(
 			vmCtx, vcVM.Client(), vmCtx.MoVM.ResourcePool.Value)
 		if err != nil {
 			errs = append(errs, err)
 		} else {
-			zoneName, err = topology.LookupZoneForClusterMoID(
+			zoneName, err := topology.LookupZoneForClusterMoID(
 				vmCtx, k8sClient, clusterMoRef.Value)
 			if err != nil {
 				errs = append(errs, err)
@@ -391,12 +395,9 @@ func reconcileStatusZone(
 					vmCtx.VM.Labels = map[string]string{}
 				}
 				vmCtx.VM.Labels[corev1.LabelTopologyZone] = zoneName
+				vmCtx.VM.Status.Zone = zoneName
 			}
 		}
-	}
-
-	if zoneName != "" {
-		vmCtx.VM.Status.Zone = zoneName
 	}
 
 	return errs


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

When either is unset, or they have different values, lookup the VM's zone and assign the zone to the label and status. To avoid a lookup if both the label and status are set to the same value, we'll just trust what is there.

The label value is protected by the validation webhook for non privileged users, but if the label does happen to get changed - like by kube-admin - relook the correct zone.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:


```release-note
NONE
```