### PR TITLE
🌱 Validate Network API Group and Kind based on network provider

### DIFF
--- a/webhooks/virtualmachine/mutation/virtualmachine_mutator.go
+++ b/webhooks/virtualmachine/mutation/virtualmachine_mutator.go
@@ -501,6 +501,8 @@ func setDefaultNetworkInterfaceNetwork(
 	}
 
 	mutated := false
+	// Fill in any empty fields with that should be there based on the network
+	// provider. The validation webhook will fail for invalid combinations.
 	if ifaceNetwork.APIVersion == "" {
 		ifaceNetwork.APIVersion = networkRef.APIVersion
 		mutated = true
@@ -553,39 +555,42 @@ func AddDefaultNetworkInterface(
 	client ctrlclient.Client,
 	vm *vmopv1.VirtualMachine) bool {
 
-	// Continue to support this ad-hoc v1a1 annotation. I don't think need or want to have this annotation
-	// in v1a2: Disabled mostly already covers it. We could map between the two for version conversion, but
-	// they do mean slightly different things, and kind of complicated to know what to do like if the annotation
-	// is removed.
-	if _, ok := vm.Annotations[v1alpha1.NoDefaultNicAnnotation]; ok {
-		if vm.Spec.Network == nil || len(vm.Spec.Network.Interfaces) == 0 {
-			return false
-		}
-	}
-
-	if vm.Spec.Network != nil && vm.Spec.Network.Disabled {
-		return false
-	}
-
 	ok, networkRef := getDefaultNetworkRef(ctx, client)
 	if !ok {
+		// TODO(BV): This really can't fail but will need to change for provider migrated namespaces.
 		return false
 	}
 
-	if vm.Spec.Network == nil {
-		vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
-	}
+	if vm.Spec.Network == nil || len(vm.Spec.Network.Interfaces) == 0 {
+		// Continue to support this ad-hoc v1a1 annotation. I don't think need or want to have
+		// this annotation in v1a2: Disabled mostly already covers it. We could map between the
+		// two for version conversion, but they do mean slightly different things, and kind of
+		// complicated to know what to do like if the annotation is removed.
+		if _, ok := vm.Annotations[v1alpha1.NoDefaultNicAnnotation]; ok {
+			return false
+		}
 
-	var updated bool
-	if len(vm.Spec.Network.Interfaces) == 0 {
+		if vm.Spec.Network != nil && vm.Spec.Network.Disabled {
+			return false
+		}
+
+		if vm.Spec.Network == nil {
+			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
+		}
+
+		// Add the default interface.
 		vm.Spec.Network.Interfaces = []vmopv1.VirtualMachineNetworkInterfaceSpec{
 			{
 				Name:    defaultInterfaceName,
 				Network: &networkRef,
 			},
 		}
-		updated = true
-	} else {
+
+		return true
+	}
+
+	var updated bool
+	if vm.Spec.Network != nil {
 		for i := range vm.Spec.Network.Interfaces {
 			if ok := setDefaultNetworkInterfaceNetwork(vm, i, networkRef); ok {
 				updated = true

--- a/webhooks/virtualmachine/mutation/virtualmachine_mutator_unit_test.go
+++ b/webhooks/virtualmachine/mutation/virtualmachine_mutator_unit_test.go
@@ -194,6 +194,42 @@ func unitTestsMutating() {
 				})
 			})
 
+			When("Disabled is true", func() {
+				BeforeEach(func() {
+					pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+						config.NetworkProviderType = pkgcfg.NetworkProviderTypeVDS
+					})
+				})
+
+				BeforeEach(func() {
+					ctx.vm.Spec.Network.Disabled = true
+				})
+
+				It("Should not add default network interface", func() {
+					Expect(mutation.AddDefaultNetworkInterface(&ctx.WebhookRequestContext, ctx.Client, ctx.vm)).To(BeFalse())
+					Expect(ctx.vm.Spec.Network.Interfaces).To(BeEmpty())
+				})
+
+				Context("Interfaces is not empty", func() {
+					BeforeEach(func() {
+						ctx.vm.Spec.Network.Interfaces = []vmopv1.VirtualMachineNetworkInterfaceSpec{
+							{
+								Name: "eth0",
+							},
+						}
+					})
+
+					It("back fills Network ref", func() {
+						Expect(mutation.AddDefaultNetworkInterface(&ctx.WebhookRequestContext, ctx.Client, ctx.vm)).To(BeTrue())
+						Expect(ctx.vm.Spec.Network.Interfaces).Should(HaveLen(1))
+						Expect(ctx.vm.Spec.Network.Interfaces[0].Name).Should(Equal("eth0"))
+						Expect(ctx.vm.Spec.Network.Interfaces[0].Network).ShouldNot(BeNil())
+						Expect(ctx.vm.Spec.Network.Interfaces[0].Network.Kind).Should(Equal("Network"))
+						Expect(ctx.vm.Spec.Network.Interfaces[0].Network.APIVersion).Should(Equal("netoperator.vmware.com/v1alpha1"))
+					})
+				})
+			})
+
 			When("NoNetwork annotation is set", func() {
 				BeforeEach(func() {
 					pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {

--- a/webhooks/virtualmachine/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator.go
@@ -33,11 +33,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	netopv1alpha1 "github.com/vmware-tanzu/net-operator-api/api/v1alpha1"
 	vpcv1alpha1 "github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 	vmopv1common "github.com/vmware-tanzu/vm-operator/api/v1alpha6/common"
 	"github.com/vmware-tanzu/vm-operator/api/v1alpha6/sysprep"
+	ncpv1alpha1 "github.com/vmware-tanzu/vm-operator/external/ncp/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/pkg/builder"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgconst "github.com/vmware-tanzu/vm-operator/pkg/constants"
@@ -1050,6 +1052,66 @@ var macAddressSupportNetworkGroups = []string{
 	vpcv1alpha1.GroupVersion.Group,
 }
 
+type networkProviderValidation struct {
+	group      string
+	apiVersion string
+	kinds      []string
+}
+
+var networkProviderValidations = map[pkgcfg.NetworkProviderType]networkProviderValidation{
+	pkgcfg.NetworkProviderTypeVDS: {
+		group:      netopv1alpha1.SchemeGroupVersion.Group,
+		apiVersion: netopv1alpha1.SchemeGroupVersion.String(),
+		kinds:      []string{"Network"},
+	},
+	pkgcfg.NetworkProviderTypeNSXT: {
+		group:      ncpv1alpha1.SchemeGroupVersion.Group,
+		apiVersion: ncpv1alpha1.SchemeGroupVersion.String(),
+		kinds:      []string{"VirtualNetwork"},
+	},
+	pkgcfg.NetworkProviderTypeVPC: {
+		group:      vpcv1alpha1.GroupVersion.Group,
+		apiVersion: vpcv1alpha1.SchemeGroupVersion.String(),
+		kinds:      []string{"Subnet", "SubnetSet"},
+	},
+}
+
+func (v validator) validateNetworkInterfaceNetworkRef(
+	ctx *pkgctx.WebhookRequestContext,
+	interfacePath *field.Path,
+	networkGV schema.GroupVersion,
+	networkKind string) field.ErrorList {
+
+	var allErrs field.ErrorList
+
+	networkProvider := pkgcfg.FromContext(ctx).NetworkProviderType
+	supported, ok := networkProviderValidations[networkProvider]
+	if !ok {
+		// No supported for this provider type (e.g., Named network provider).
+		return allErrs
+	}
+
+	if networkGV.Group != "" && networkGV.Group != supported.group {
+		// We don't care about the version for anything but show the user provided
+		// APIVersion since that is the field the group comes from. For supported,
+		// just show the version we're importing which is OK'ish since none of the
+		// providers have moved past v1a1.
+		allErrs = append(allErrs, field.NotSupported(
+			interfacePath.Child("network", "apiVersion"),
+			networkGV.String(),
+			[]string{supported.apiVersion}))
+	}
+
+	if networkKind != "" && !slices.Contains(supported.kinds, networkKind) {
+		allErrs = append(allErrs, field.NotSupported(
+			interfacePath.Child("network", "kind"),
+			networkKind,
+			supported.kinds))
+	}
+
+	return allErrs
+}
+
 //nolint:gocyclo
 func (v validator) validateNetworkInterfaceSpec(
 	ctx *pkgctx.WebhookRequestContext,
@@ -1057,14 +1119,18 @@ func (v validator) validateNetworkInterfaceSpec(
 	interfaceSpec vmopv1.VirtualMachineNetworkInterfaceSpec,
 	vmName string) field.ErrorList {
 
-	var allErrs field.ErrorList
-	var networkIfCRName string
-	var networkAPIVersion string
-	var networkName string
+	var (
+		allErrs           field.ErrorList
+		networkIfCRName   string
+		networkAPIVersion string
+		networkName       string
+		networkKind       string
+	)
 
 	if interfaceSpec.Network != nil {
 		networkAPIVersion = interfaceSpec.Network.APIVersion
 		networkName = interfaceSpec.Network.Name
+		networkKind = interfaceSpec.Network.Kind
 	}
 
 	var networkGV schema.GroupVersion
@@ -1076,6 +1142,8 @@ func (v validator) validateNetworkInterfaceSpec(
 			networkGV = gv
 		}
 	}
+
+	allErrs = append(allErrs, v.validateNetworkInterfaceNetworkRef(ctx, interfacePath, networkGV, networkKind)...)
 
 	// The networkInterface CR name ("vmName-networkName-interfaceName" or "vmName-interfaceName") needs to be a DNS1123 Label
 	if networkName != "" {

--- a/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
@@ -3179,6 +3179,218 @@ func unitTestsValidateCreate() {
 				},
 			),
 		)
+
+		DescribeTable("network create - validate network provider API group and kind", doTest,
+
+			Entry("allow VirtualNetwork kind with NSXT provider",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+							config.NetworkProviderType = pkgcfg.NetworkProviderTypeNSXT
+						})
+						ctx.vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{
+							Interfaces: []vmopv1.VirtualMachineNetworkInterfaceSpec{
+								{
+									Name: "eth0",
+									Network: &common.PartialObjectRef{
+										TypeMeta: metav1.TypeMeta{
+											APIVersion: "vmware.com/v1alpha1",
+											Kind:       "VirtualNetwork",
+										},
+										Name: "my-network",
+									},
+								},
+							},
+						}
+					},
+					expectAllowed: true,
+				},
+			),
+			Entry("disallow incorrect API group and kind with NSXT provider",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+							config.NetworkProviderType = pkgcfg.NetworkProviderTypeNSXT
+						})
+						ctx.vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{
+							Interfaces: []vmopv1.VirtualMachineNetworkInterfaceSpec{
+								{
+									Name: "eth0",
+									Network: &common.PartialObjectRef{
+										TypeMeta: metav1.TypeMeta{
+											APIVersion: "crd.nsx.vmware.com/v1alpha1",
+											Kind:       "VirtualNetwork",
+										},
+										Name: "my-network",
+									},
+								},
+								{
+									Name: "eth1",
+									Network: &common.PartialObjectRef{
+										TypeMeta: metav1.TypeMeta{
+											APIVersion: "vmware.com/v1alpha1",
+											Kind:       "SubnetSet",
+										},
+										Name: "my-network-2",
+									},
+								},
+							},
+						}
+					},
+					validate: doValidateWithMsg(
+						`spec.network.interfaces[0].network.apiVersion: Unsupported value: "crd.nsx.vmware.com/v1alpha1": supported values: "vmware.com/v1alpha1"`,
+						`spec.network.interfaces[1].network.kind: Unsupported value: "SubnetSet": supported values: "VirtualNetwork"`),
+				},
+			),
+
+			Entry("allow Network kind with VDS provider",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+							config.NetworkProviderType = pkgcfg.NetworkProviderTypeVDS
+						})
+						ctx.vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{
+							Interfaces: []vmopv1.VirtualMachineNetworkInterfaceSpec{
+								{
+									Name: "eth0",
+									Network: &common.PartialObjectRef{
+										TypeMeta: metav1.TypeMeta{
+											APIVersion: "netoperator.vmware.com/v1alpha1",
+											Kind:       "Network",
+										},
+										Name: "my-network",
+									},
+								},
+							},
+						}
+					},
+					expectAllowed: true,
+				},
+			),
+			Entry("disallow incorrect API group and kind with VDS provider",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+							config.NetworkProviderType = pkgcfg.NetworkProviderTypeVDS
+						})
+						ctx.vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{
+							Interfaces: []vmopv1.VirtualMachineNetworkInterfaceSpec{
+								{
+									Name: "eth0",
+									Network: &common.PartialObjectRef{
+										TypeMeta: metav1.TypeMeta{
+											APIVersion: "vmware.com/v1alpha1",
+											Kind:       "Network",
+										},
+										Name: "my-network",
+									},
+								},
+								{
+									Name: "eth1",
+									Network: &common.PartialObjectRef{
+										TypeMeta: metav1.TypeMeta{
+											APIVersion: "netoperator.vmware.com/v1alpha1",
+											Kind:       "VirtualNetwork",
+										},
+										Name: "my-network-2",
+									},
+								},
+							},
+						}
+					},
+					validate: doValidateWithMsg(
+						`spec.network.interfaces[0].network.apiVersion: Unsupported value: "vmware.com/v1alpha1": supported values: "netoperator.vmware.com/v1alpha1"`,
+						`spec.network.interfaces[1].network.kind: Unsupported value: "VirtualNetwork": supported values: "Network"`),
+				},
+			),
+
+			Entry("allow SubnetSet kind with VPC provider",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+							config.NetworkProviderType = pkgcfg.NetworkProviderTypeVPC
+						})
+						ctx.vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{
+							Interfaces: []vmopv1.VirtualMachineNetworkInterfaceSpec{
+								{
+									Name: "eth0",
+									Network: &common.PartialObjectRef{
+										TypeMeta: metav1.TypeMeta{
+											APIVersion: "crd.nsx.vmware.com/v1alpha1",
+											Kind:       "SubnetSet",
+										},
+										Name: "my-network",
+									},
+								},
+							},
+						}
+					},
+					expectAllowed: true,
+				},
+			),
+			Entry("allow Subnet kind with VPC provider",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+							config.NetworkProviderType = pkgcfg.NetworkProviderTypeVPC
+						})
+						ctx.vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{
+							Interfaces: []vmopv1.VirtualMachineNetworkInterfaceSpec{
+								{
+									Name: "eth0",
+									Network: &common.PartialObjectRef{
+										TypeMeta: metav1.TypeMeta{
+											APIVersion: "crd.nsx.vmware.com/v1alpha1",
+											Kind:       "Subnet",
+										},
+										Name: "my-network",
+									},
+								},
+							},
+						}
+					},
+					expectAllowed: true,
+				},
+			),
+
+			Entry("disallow incorrect API group and kind with VPC provider",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+							config.NetworkProviderType = pkgcfg.NetworkProviderTypeVPC
+						})
+						ctx.vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{
+							Interfaces: []vmopv1.VirtualMachineNetworkInterfaceSpec{
+								{
+									Name: "eth0",
+									Network: &common.PartialObjectRef{
+										TypeMeta: metav1.TypeMeta{
+											APIVersion: "vmware.com/v1alpha1",
+											Kind:       "SubnetSet",
+										},
+										Name: "my-network",
+									},
+								},
+								{
+									Name: "eth1",
+									Network: &common.PartialObjectRef{
+										TypeMeta: metav1.TypeMeta{
+											APIVersion: "crd.nsx.vmware.com/v1alpha1",
+											Kind:       "VirtualNetwork",
+										},
+										Name: "my-network-2",
+									},
+								},
+							},
+						}
+					},
+					validate: doValidateWithMsg(
+						`spec.network.interfaces[0].network.apiVersion: Unsupported value: "vmware.com/v1alpha1": supported values: "crd.nsx.vmware.com/v1alpha1"`,
+						`spec.network.interfaces[1].network.kind: Unsupported value: "VirtualNetwork": supported values: "Subnet", "SubnetSet"`),
+				},
+			),
+		)
+
 		DescribeTable("network create - host and domain names", doTest,
 
 			Entry("allow simple host name",


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

Generally these will be left empty so the VM mutation webhook will default in the correct values, but also validate upfront to what is supported based on the configured network provider type.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:



**Please add a release note if necessary**:

```release-note
In the VM validation webhook, validate that the network interface Network API Group and Kind is supported based on the network provider.
```