### PR TITLE
:bug: Do not drop spec.affinity on up convert

### DIFF
--- a/api/v1alpha2/virtualmachine_conversion.go
+++ b/api/v1alpha2/virtualmachine_conversion.go
@@ -414,14 +414,6 @@ func restore_v1alpha5_VirtualMachineCryptoVTPM(dst, src *vmopv1.VirtualMachine) 
 	}
 }
 
-func restore_v1alpha5_VirtualMachineAffinity(dst, src *vmopv1.VirtualMachine) {
-	if src.Spec.Affinity == nil {
-		dst.Spec.Affinity = nil
-	} else {
-		dst.Spec.Affinity = src.Spec.Affinity.DeepCopy()
-	}
-}
-
 // ConvertTo converts this VirtualMachine to the Hub version.
 func (src *VirtualMachine) ConvertTo(dstRaw ctrlconversion.Hub) error {
 	dst := dstRaw.(*vmopv1.VirtualMachine)
@@ -453,7 +445,6 @@ func (src *VirtualMachine) ConvertTo(dstRaw ctrlconversion.Hub) error {
 	restore_v1alpha5_VirtualMachineHardware(dst, restored)
 	restore_v1alpha5_VirtualMachinePolicies(dst, restored)
 	restore_v1alpha5_VirtualMachineCryptoVTPM(dst, restored)
-	restore_v1alpha5_VirtualMachineAffinity(dst, restored)
 
 	// END RESTORE
 

--- a/api/v1alpha3/virtualmachine_conversion.go
+++ b/api/v1alpha3/virtualmachine_conversion.go
@@ -352,14 +352,6 @@ func restore_v1alpha5_VirtualMachineCryptoVTPM(dst, src *vmopv1.VirtualMachine) 
 	}
 }
 
-func restore_v1alpha5_VirtualMachineAffinity(dst, src *vmopv1.VirtualMachine) {
-	if src.Spec.Affinity == nil {
-		dst.Spec.Affinity = nil
-	} else {
-		dst.Spec.Affinity = src.Spec.Affinity.DeepCopy()
-	}
-}
-
 // ConvertTo converts this VirtualMachine to the Hub version.
 func (src *VirtualMachine) ConvertTo(dstRaw ctrlconversion.Hub) error {
 	dst := dstRaw.(*vmopv1.VirtualMachine)
@@ -384,8 +376,6 @@ func (src *VirtualMachine) ConvertTo(dstRaw ctrlconversion.Hub) error {
 	restore_v1alpha5_VirtualMachineVolumes(dst, restored)
 	restore_v1alpha5_VirtualMachineHardware(dst, restored)
 	restore_v1alpha5_VirtualMachinePolicies(dst, restored)
-	restore_v1alpha5_VirtualMachineCryptoVTPM(dst, restored)
-	restore_v1alpha5_VirtualMachineAffinity(dst, restored)
 	restore_v1alpha5_VirtualMachineCryptoVTPM(dst, restored)
 
 	// END RESTORE

--- a/api/v1alpha4/virtualmachine_conversion.go
+++ b/api/v1alpha4/virtualmachine_conversion.go
@@ -286,14 +286,6 @@ func restore_v1alpha5_VirtualMachineBootstrapDisabled(dst, src *vmopv1.VirtualMa
 	}
 }
 
-func restore_v1alpha5_VirtualMachineAffinity(dst, src *vmopv1.VirtualMachine) {
-	if src.Spec.Affinity == nil {
-		dst.Spec.Affinity = nil
-	} else {
-		dst.Spec.Affinity = src.Spec.Affinity.DeepCopy()
-	}
-}
-
 func restore_v1alpha5_VirtualMachineVolumes(dst, src *vmopv1.VirtualMachine) {
 	srcVolMap := map[string]*vmopv1.VirtualMachineVolume{}
 	for i := range src.Spec.Volumes {
@@ -337,7 +329,6 @@ func (src *VirtualMachine) ConvertTo(dstRaw ctrlconversion.Hub) error {
 	restore_v1alpha5_VirtualMachineBootstrapLinuxPrep(dst, restored)
 	restore_v1alpha5_VirtualMachineBootstrapSysprep(dst, restored)
 	restore_v1alpha5_VirtualMachineBootstrapDisabled(dst, restored)
-	restore_v1alpha5_VirtualMachineAffinity(dst, restored)
 	restore_v1alpha5_VirtualMachineVolumes(dst, restored)
 
 	// END RESTORE


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

If a VM is created on v1alpha2 API version, conversion webhooks store the object marshaled at v1alpha5 (storage version) on the object.

Then, when the object is modified again on v1alpha2 version so that now the payload contains the spec.affinity, our conversion code simply restores the field from the stored annotation -- completely dropping the field during conversion.  Instead, what should happen is that the field should correctly be preserved and our validation webhooks should deny that since affinity is an immutable fields.


**Testing Done:**

- Currently:
  - 1. Create a VM on v1alpha2
```
root@422833dbe3475f4c8d61f99e674e934d [ ~ ]# cat v1a2vm.yaml
apiVersion: vmoperator.vmware.com/v1alpha2
kind: VirtualMachine
metadata:
  name: parunesh-vm
  namespace: parunesh-ns
spec:
  className: best-effort-small
  storageClass: wcpglobal-storage-profile
  imageName: jammy-server-cloudimg-amd64
  powerState: PoweredOn
  bootstrap:
    cloudInit: {}
```

  - 2. Patch VM to specify Affinity (should succeed -- confirms bug)
```
root@422833dbe3475f4c8d61f99e674e934d [ ~ ]# kubectl apply --server-side=false -f - <<'EOF'
apiVersion: vmoperator.vmware.com/v1alpha2
kind: VirtualMachine
metadata:
  name: parunesh-vm
  namespace: parunesh-ns
spec:
  className: best-effort-small
  storageClass: wcpglobal-storage-profile
  imageName: jammy-server-cloudimg-amd64
  powerState: PoweredOn
  bootstrap:
    cloudInit: {}
  affinity:
    vmAffinity:
      requiredDuringSchedulingPreferredDuringExecution:
        - topologyKey: topology.kubernetes.io/zone
          labelSelector:
            matchLabels:
              my-label: my-value
EOF
virtualmachine.vmoperator.vmware.com/parunesh-vm configured
```

- But with patched VM Operator, the same patch request fails:
```
root@422833dbe3475f4c8d61f99e674e934d [ ~ ]# kubectl apply --server-side=false -f - <<'EOF'
apiVersion: vmoperator.vmware.com/v1alpha2
kind: VirtualMachine
metadata:
  name: parunesh-vm
  namespace: parunesh-ns
spec:
  className: best-effort-small
  storageClass: wcpglobal-storage-profile
  imageName: jammy-server-cloudimg-amd64
  powerState: PoweredOn
  bootstrap:
    cloudInit: {}
  affinity:
    vmAffinity:
      requiredDuringSchedulingPreferredDuringExecution:
        - topologyKey: topology.kubernetes.io/zone
          labelSelector:
            matchLabels:
              my-label: my-value
EOF
Error from server (spec.affinity: Forbidden: updating Affinity is not allowed): error when applying patch:
{"spec":{"affinity":{"vmAffinity":{"requiredDuringSchedulingPreferredDuringExecution":[{"labelSelector":{"matchLabels":{"my-label":"my-value"}},"topologyKey":"topology.kubernetes.io/zone"}]}}}}
to:
Resource: "vmoperator.vmware.com/v1alpha2, Resource=virtualmachines", GroupVersionKind: "vmoperator.vmware.com/v1alpha2, Kind=VirtualMachine"
Name: "parunesh-vm", Namespace: "parunesh-ns"
for: "STDIN": error when patching "STDIN": admission webhook
"default.validating.virtualmachine.v1alpha5.vmoperator.vmware.com"
denied the request: spec.affinity: Forbidden: updating Affinity is not
allowed
```

**Please add a release note if necessary**:

```release-note
Do not drop spec.affinity on up convert
```