### PR TITLE
✨ Generate VmPlacementPolicies for host-level AF and AAF during Placement

### DIFF
--- a/pkg/providers/vsphere/placement/cluster_placement.go
+++ b/pkg/providers/vsphere/placement/cluster_placement.go
@@ -225,13 +225,14 @@ func getClusterPlacementRecommendations(
 	finder *find.Finder,
 	resourcePoolsMoRefs []vimtypes.ManagedObjectReference,
 	configSpecs []vimtypes.VirtualMachineConfigSpec,
-	needDatastorePlacement bool) (map[string]Recommendation, error) {
+	needHostPlacement, needDatastorePlacement bool) (map[string]Recommendation, error) {
 
 	logger := pkglog.FromContextOrDefault(ctx)
 	placementSpec := vimtypes.PlaceVmsXClusterSpec{
 		PlacementType:           string(vimtypes.PlaceVmsXClusterSpecPlacementTypeCreateAndPowerOn),
 		ResourcePools:           resourcePoolsMoRefs,
 		VmPlacementSpecs:        make([]vimtypes.PlaceVmsXClusterSpecVmPlacementSpec, len(configSpecs)),
+		HostRecommRequired:      &needHostPlacement,
 		DatastoreRecommRequired: &needDatastorePlacement,
 	}
 

--- a/pkg/providers/vsphere/placement/group_placement.go
+++ b/pkg/providers/vsphere/placement/group_placement.go
@@ -107,5 +107,6 @@ func getGroupPlacementRecommendations(
 		finder,
 		candidateRPMoRefs,
 		configSpecs,
+		true,
 		needDatastorePlacement)
 }

--- a/pkg/providers/vsphere/placement/zone_placement.go
+++ b/pkg/providers/vsphere/placement/zone_placement.go
@@ -351,6 +351,7 @@ func getPlacementRecommendation(
 			finder,
 			candidateRPMoRefs,
 			[]vimtypes.VirtualMachineConfigSpec{configSpec},
+			false,
 			needDatastorePlacement)
 		if err != nil {
 			return Recommendation{}, fmt.Errorf("PlaceVmsXCluster failed: %w", err)

--- a/pkg/providers/vsphere/virtualmachine/affinity.go
+++ b/pkg/providers/vsphere/virtualmachine/affinity.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 )
@@ -79,7 +80,6 @@ func genConfigSpecAffinityPolicies(
 // processVMAffinity returns placement policies for VM affinity rules.
 // VM affinity is bidirectional, so we only need to send in the label specified
 // in the VM affinity policy. Not additional labels.
-// Note: only zone topology is supported for VM affinity.
 func processVMAffinity(
 	vmCtx pkgctx.VirtualMachineContext,
 	affinity *vmopv1.VMAffinitySpec) []vimtypes.BaseVmPlacementPolicy {
@@ -99,6 +99,22 @@ func processVMAffinity(
 		})
 	}
 
+	// Process host-topology affinity terms only when VMAffinityDuringExecution is enabled.
+	if pkgcfg.FromContext(vmCtx).Features.VMAffinityDuringExecution {
+		// Process required affinity terms associated with host topology.
+		requiredHostTagIDs := buildTagIDsFromHostTopology(
+			vmCtx,
+			affinity.RequiredDuringSchedulingPreferredDuringExecution,
+		)
+		for _, tagID := range requiredHostTagIDs {
+			placementPols = append(placementPols, &vimtypes.VmVmAffinity{
+				AffinedVmsTag:    tagID,
+				PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
+				PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyHost),
+			})
+		}
+	}
+
 	// Process preferred affinity terms associated with zone topology.
 	preferredZoneTagIDs := buildTagIDsFromZoneTopology(
 		vmCtx,
@@ -112,13 +128,28 @@ func processVMAffinity(
 		})
 	}
 
+	// Process host-topology affinity terms only when VMAffinityDuringExecution is enabled.
+	if pkgcfg.FromContext(vmCtx).Features.VMAffinityDuringExecution {
+		// Process preferred affinity terms associated with host topology.
+		preferredHostTagIDs := buildTagIDsFromHostTopology(
+			vmCtx,
+			affinity.PreferredDuringSchedulingPreferredDuringExecution,
+		)
+		for _, tagID := range preferredHostTagIDs {
+			placementPols = append(placementPols, &vimtypes.VmVmAffinity{
+				AffinedVmsTag:    tagID,
+				PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessPreferredDuringPlacementPreferredDuringExecution),
+				PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyHost),
+			})
+		}
+	}
+
 	return placementPols
 }
 
 // processVMAntiAffinity returns placement policies from VM anti-affinity rules.
-// Use a single VmToVmGroupsAntiAffinity policy if the labels are non-empty.
-// Note: only zone topology is processed for VM anti-affinity; host topology
-// will be handled by ClusterModules.
+// Use a single VmToVmGroupsAntiAffinity policy per topology/strictness
+// combination if the labels are non-empty.
 func processVMAntiAffinity(
 	vmCtx pkgctx.VirtualMachineContext,
 	antiAffinity *vmopv1.VMAntiAffinitySpec) []vimtypes.BaseVmPlacementPolicy {
@@ -138,6 +169,21 @@ func processVMAntiAffinity(
 		})
 	}
 
+	// Process host-topology anti-affinity terms only when VMAffinityDuringExecution is enabled.
+	if pkgcfg.FromContext(vmCtx).Features.VMAffinityDuringExecution {
+		requiredHostTagIDs := buildTagIDsFromHostTopology(
+			vmCtx,
+			antiAffinity.RequiredDuringSchedulingPreferredDuringExecution,
+		)
+		for _, tagID := range requiredHostTagIDs {
+			placementPols = append(placementPols, &vimtypes.VmVmAntiAffinity{
+				AntiAffinedVmsTag: tagID,
+				PolicyStrictness:  string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
+				PolicyTopology:    string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyHost),
+			})
+		}
+	}
+
 	// Process preferred anti-affinity terms associated with zone topology.
 	preferredZoneTagIDs := buildTagIDsFromZoneTopology(
 		vmCtx,
@@ -151,20 +197,36 @@ func processVMAntiAffinity(
 		})
 	}
 
+	// Process host-topology anti-affinity terms only when VMAffinityDuringExecution is enabled.
+	if pkgcfg.FromContext(vmCtx).Features.VMAffinityDuringExecution {
+		preferredHostTagIDs := buildTagIDsFromHostTopology(
+			vmCtx,
+			antiAffinity.PreferredDuringSchedulingPreferredDuringExecution,
+		)
+		for _, tagID := range preferredHostTagIDs {
+			placementPols = append(placementPols, &vimtypes.VmVmAntiAffinity{
+				AntiAffinedVmsTag: tagID,
+				PolicyStrictness:  string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessPreferredDuringPlacementPreferredDuringExecution),
+				PolicyTopology:    string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyHost),
+			})
+		}
+	}
+
 	return placementPols
 }
 
-// buildTagIDsFromZoneTopology returns a list of TagIds built from the given
-// affinity/anti-affinity terms that have zone topology.
+// buildTagIDsFromTopology returns a list of TagIds built from the given
+// affinity/anti-affinity terms that match the specified topology key.
 // Terms with other topology types are ignored.
-func buildTagIDsFromZoneTopology(
+func buildTagIDsFromTopology(
 	vmCtx pkgctx.VirtualMachineContext,
-	terms []vmopv1.VMAffinityTerm) []vimtypes.TagId {
+	terms []vmopv1.VMAffinityTerm,
+	topologyKey string) []vimtypes.TagId {
 
 	var tagIDs []vimtypes.TagId
 
 	for _, term := range terms {
-		if term.TopologyKey != corev1.LabelTopologyZone {
+		if term.TopologyKey != topologyKey {
 			continue
 		}
 
@@ -186,6 +248,24 @@ func buildTagIDsFromZoneTopology(
 	}
 
 	return tagIDs
+}
+
+// buildTagIDsFromZoneTopology returns a list of TagIds built from the given
+// affinity/anti-affinity terms that have zone topology.
+func buildTagIDsFromZoneTopology(
+	vmCtx pkgctx.VirtualMachineContext,
+	terms []vmopv1.VMAffinityTerm) []vimtypes.TagId {
+
+	return buildTagIDsFromTopology(vmCtx, terms, corev1.LabelTopologyZone)
+}
+
+// buildTagIDsFromHostTopology returns a list of TagIds built from the given
+// affinity/anti-affinity terms that have host topology.
+func buildTagIDsFromHostTopology(
+	vmCtx pkgctx.VirtualMachineContext,
+	terms []vmopv1.VMAffinityTerm) []vimtypes.TagId {
+
+	return buildTagIDsFromTopology(vmCtx, terms, corev1.LabelHostname)
 }
 
 // extractLabelsFromSelector extracts all labels from a LabelSelector, handling both

--- a/pkg/providers/vsphere/virtualmachine/configspec_test.go
+++ b/pkg/providers/vsphere/virtualmachine/configspec_test.go
@@ -1025,69 +1025,468 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 				})
 			})
 
-			Context("with unsupported topology key (host with affinity)", func() {
+			When("VMAffinityDuringExecution feature is enabled", func() {
 				BeforeEach(func() {
-					vmCtx.VM.Spec.Affinity = &vmopv1.AffinitySpec{
-						VMAffinity: &vmopv1.VMAffinitySpec{
-							RequiredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
-								{
-									LabelSelector: &metav1.LabelSelector{
-										MatchLabels: map[string]string{
-											"component": "web",
-										},
-										MatchExpressions: []metav1.LabelSelectorRequirement{
-											{
-												Key:      "tier",
-												Operator: metav1.LabelSelectorOpIn,
-												Values:   []string{"frontend", "backend"},
-											},
-										},
-									},
-									TopologyKey: corev1.LabelHostname,
-								},
-								{
-									LabelSelector: &metav1.LabelSelector{
-										MatchLabels: map[string]string{
-											"environment": "prod",
-										},
-									},
-									TopologyKey: corev1.LabelHostname,
-								},
-							},
-							PreferredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
-								{
-									LabelSelector: &metav1.LabelSelector{
-										MatchLabels: map[string]string{
-											"component": "web",
-										},
-										MatchExpressions: []metav1.LabelSelectorRequirement{
-											{
-												Key:      "tier",
-												Operator: metav1.LabelSelectorOpIn,
-												Values:   []string{"frontend", "backend"},
-											},
-										},
-									},
-									TopologyKey: corev1.LabelHostname,
-								},
-								{
-									LabelSelector: &metav1.LabelSelector{
-										MatchLabels: map[string]string{
-											"environment": "prod",
-										},
-									},
-									TopologyKey: corev1.LabelHostname,
-								},
-							},
-						},
-					}
+					pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
+						config.Features.VMAffinityDuringExecution = true
+					})
 				})
 
-				It("creates a minimal policy with VM tags but no anti-affinity rules", func() {
-					Expect(configSpec.VmPlacementPolicies).To(BeEmpty())
+				Context("required affinity policy with host topology key", func() {
+					BeforeEach(func() {
+						vmCtx.VM.Spec.Affinity = &vmopv1.AffinitySpec{
+							VMAffinity: &vmopv1.VMAffinitySpec{
+								RequiredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"component": "web",
+											},
+											MatchExpressions: []metav1.LabelSelectorRequirement{
+												{
+													Key:      "tier",
+													Operator: metav1.LabelSelectorOpIn,
+													Values:   []string{"frontend", "backend"},
+												},
+											},
+										},
+										TopologyKey: corev1.LabelHostname,
+									},
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"environment": "prod",
+											},
+										},
+										TopologyKey: corev1.LabelHostname,
+									},
+								},
+							},
+						}
+					})
 
-					// VM tags should still be attached (without VM Operator managed labels) even though anti-affinity policy failed.
-					assertVMTags(configSpec, []string{"vm-label1:vm-value1", "vm-label2:vm-value2"}, vmCtx.VM.Namespace)
+					It("config spec should have the expected host-level affinity policies", func() {
+						Expect(configSpec.VmPlacementPolicies).To(HaveLen(4))
+
+						pols := []vimtypes.BaseVmPlacementPolicy{
+							&vimtypes.VmVmAffinity{
+								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
+								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyHost),
+								AffinedVmsTag: vimtypes.TagId{
+									NameId: &vimtypes.TagIdNameId{
+										Tag:      "component:web",
+										Category: vmCtx.VM.Namespace,
+									},
+								},
+							},
+							&vimtypes.VmVmAffinity{
+								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
+								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyHost),
+								AffinedVmsTag: vimtypes.TagId{
+									NameId: &vimtypes.TagIdNameId{
+										Tag:      "tier:frontend",
+										Category: vmCtx.VM.Namespace,
+									},
+								},
+							},
+							&vimtypes.VmVmAffinity{
+								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
+								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyHost),
+								AffinedVmsTag: vimtypes.TagId{
+									NameId: &vimtypes.TagIdNameId{
+										Tag:      "tier:backend",
+										Category: vmCtx.VM.Namespace,
+									},
+								},
+							},
+							&vimtypes.VmVmAffinity{
+								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
+								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyHost),
+								AffinedVmsTag: vimtypes.TagId{
+									NameId: &vimtypes.TagIdNameId{
+										Tag:      "environment:prod",
+										Category: vmCtx.VM.Namespace,
+									},
+								},
+							},
+						}
+
+						Expect(configSpec.VmPlacementPolicies).To(HaveLen(4))
+						Expect(configSpec.VmPlacementPolicies).To(ConsistOf(pols))
+						assertVMTags(configSpec, []string{"vm-label1:vm-value1", "vm-label2:vm-value2"}, vmCtx.VM.Namespace)
+					})
+				})
+
+				Context("preferred affinity policy with host topology key", func() {
+					BeforeEach(func() {
+						vmCtx.VM.Spec.Affinity = &vmopv1.AffinitySpec{
+							VMAffinity: &vmopv1.VMAffinitySpec{
+								PreferredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"component": "web",
+											},
+										},
+										TopologyKey: corev1.LabelHostname,
+									},
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"environment": "prod",
+											},
+										},
+										TopologyKey: corev1.LabelHostname,
+									},
+								},
+							},
+						}
+					})
+
+					It("config spec should have the expected host-level affinity policies", func() {
+						Expect(configSpec.VmPlacementPolicies).To(HaveLen(2))
+
+						pols := []vimtypes.BaseVmPlacementPolicy{
+							&vimtypes.VmVmAffinity{
+								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessPreferredDuringPlacementPreferredDuringExecution),
+								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyHost),
+								AffinedVmsTag: vimtypes.TagId{
+									NameId: &vimtypes.TagIdNameId{
+										Tag:      "component:web",
+										Category: vmCtx.VM.Namespace,
+									},
+								},
+							},
+							&vimtypes.VmVmAffinity{
+								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessPreferredDuringPlacementPreferredDuringExecution),
+								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyHost),
+								AffinedVmsTag: vimtypes.TagId{
+									NameId: &vimtypes.TagIdNameId{
+										Tag:      "environment:prod",
+										Category: vmCtx.VM.Namespace,
+									},
+								},
+							},
+						}
+
+						Expect(configSpec.VmPlacementPolicies).To(HaveLen(2))
+						Expect(configSpec.VmPlacementPolicies).To(ConsistOf(pols))
+						assertVMTags(configSpec, []string{"vm-label1:vm-value1", "vm-label2:vm-value2"}, vmCtx.VM.Namespace)
+					})
+				})
+
+				Context("required anti-affinity policy with host topology key", func() {
+					BeforeEach(func() {
+						vmCtx.VM.Spec.Affinity = &vmopv1.AffinitySpec{
+							VMAntiAffinity: &vmopv1.VMAntiAffinitySpec{
+								RequiredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"component": "web",
+											},
+											MatchExpressions: []metav1.LabelSelectorRequirement{
+												{
+													Key:      "tier",
+													Operator: metav1.LabelSelectorOpIn,
+													Values:   []string{"frontend", "backend"},
+												},
+											},
+										},
+										TopologyKey: corev1.LabelHostname,
+									},
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"environment": "prod",
+											},
+										},
+										TopologyKey: corev1.LabelHostname,
+									},
+								},
+							},
+						}
+					})
+
+					It("creates multiple VmVmAntiAffinity policies with host topology", func() {
+						Expect(configSpec.VmPlacementPolicies).To(HaveLen(4))
+
+						expectedPolicies := []vimtypes.BaseVmPlacementPolicy{
+							&vimtypes.VmVmAntiAffinity{
+								AntiAffinedVmsTag: vimtypes.TagId{
+									NameId: &vimtypes.TagIdNameId{
+										Tag:      "component:web",
+										Category: vmCtx.VM.Namespace,
+									},
+								},
+								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
+								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyHost),
+							},
+							&vimtypes.VmVmAntiAffinity{
+								AntiAffinedVmsTag: vimtypes.TagId{
+									NameId: &vimtypes.TagIdNameId{
+										Tag:      "tier:frontend",
+										Category: vmCtx.VM.Namespace,
+									},
+								},
+								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
+								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyHost),
+							},
+							&vimtypes.VmVmAntiAffinity{
+								AntiAffinedVmsTag: vimtypes.TagId{
+									NameId: &vimtypes.TagIdNameId{
+										Tag:      "tier:backend",
+										Category: vmCtx.VM.Namespace,
+									},
+								},
+								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
+								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyHost),
+							},
+							&vimtypes.VmVmAntiAffinity{
+								AntiAffinedVmsTag: vimtypes.TagId{
+									NameId: &vimtypes.TagIdNameId{
+										Tag:      "environment:prod",
+										Category: vmCtx.VM.Namespace,
+									},
+								},
+								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
+								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyHost),
+							},
+						}
+
+						Expect(configSpec.VmPlacementPolicies).To(ConsistOf(expectedPolicies))
+						assertVMTags(configSpec, []string{"vm-label1:vm-value1", "vm-label2:vm-value2"}, vmCtx.VM.Namespace)
+					})
+				})
+
+				Context("preferred anti-affinity policy with host topology key", func() {
+					BeforeEach(func() {
+						vmCtx.VM.Spec.Affinity = &vmopv1.AffinitySpec{
+							VMAntiAffinity: &vmopv1.VMAntiAffinitySpec{
+								PreferredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"component": "web",
+											},
+										},
+										TopologyKey: corev1.LabelHostname,
+									},
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"environment": "prod",
+											},
+										},
+										TopologyKey: corev1.LabelHostname,
+									},
+								},
+							},
+						}
+					})
+
+					It("creates multiple VmVmAntiAffinity policies with host topology", func() {
+						Expect(configSpec.VmPlacementPolicies).To(HaveLen(2))
+
+						expectedPolicies := []vimtypes.BaseVmPlacementPolicy{
+							&vimtypes.VmVmAntiAffinity{
+								AntiAffinedVmsTag: vimtypes.TagId{
+									NameId: &vimtypes.TagIdNameId{
+										Tag:      "component:web",
+										Category: vmCtx.VM.Namespace,
+									},
+								},
+								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessPreferredDuringPlacementPreferredDuringExecution),
+								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyHost),
+							},
+							&vimtypes.VmVmAntiAffinity{
+								AntiAffinedVmsTag: vimtypes.TagId{
+									NameId: &vimtypes.TagIdNameId{
+										Tag:      "environment:prod",
+										Category: vmCtx.VM.Namespace,
+									},
+								},
+								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessPreferredDuringPlacementPreferredDuringExecution),
+								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyHost),
+							},
+						}
+
+						Expect(configSpec.VmPlacementPolicies).To(ConsistOf(expectedPolicies))
+						assertVMTags(configSpec, []string{"vm-label1:vm-value1", "vm-label2:vm-value2"}, vmCtx.VM.Namespace)
+					})
+				})
+
+				Context("mixed zone and host topology anti-affinity terms", func() {
+					BeforeEach(func() {
+						vmCtx.VM.Spec.Affinity = &vmopv1.AffinitySpec{
+							VMAntiAffinity: &vmopv1.VMAntiAffinitySpec{
+								RequiredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"zone-label": "zone-value",
+											},
+										},
+										TopologyKey: corev1.LabelTopologyZone,
+									},
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"host-label": "host-value",
+											},
+										},
+										TopologyKey: corev1.LabelHostname,
+									},
+								},
+							},
+						}
+					})
+
+					It("creates separate policies for zone and host topologies", func() {
+						Expect(configSpec.VmPlacementPolicies).To(HaveLen(2))
+
+						pols := []vimtypes.BaseVmPlacementPolicy{
+							&vimtypes.VmToVmGroupsAntiAffinity{
+								AntiAffinedVmGroupTags: []vimtypes.TagId{
+									{
+										NameId: &vimtypes.TagIdNameId{
+											Tag:      "zone-label:zone-value",
+											Category: vmCtx.VM.Namespace,
+										},
+									},
+								},
+								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
+								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyVSphereZone),
+							},
+							&vimtypes.VmVmAntiAffinity{
+								AntiAffinedVmsTag: vimtypes.TagId{
+									NameId: &vimtypes.TagIdNameId{
+										Tag:      "host-label:host-value",
+										Category: vmCtx.VM.Namespace,
+									},
+								},
+								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
+								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyHost),
+							},
+						}
+
+						Expect(configSpec.VmPlacementPolicies).To(HaveLen(2))
+						Expect(configSpec.VmPlacementPolicies).To(ConsistOf(pols))
+						assertVMTags(configSpec, []string{"vm-label1:vm-value1", "vm-label2:vm-value2"}, vmCtx.VM.Namespace)
+					})
+				})
+			})
+
+			When("VMAffinityDuringExecution feature is disabled", func() {
+				Context("host topology affinity terms are ignored", func() {
+					BeforeEach(func() {
+						vmCtx.VM.Spec.Affinity = &vmopv1.AffinitySpec{
+							VMAffinity: &vmopv1.VMAffinitySpec{
+								RequiredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"component": "web",
+											},
+										},
+										TopologyKey: corev1.LabelHostname,
+									},
+								},
+								PreferredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"environment": "prod",
+											},
+										},
+										TopologyKey: corev1.LabelHostname,
+									},
+								},
+							},
+						}
+					})
+
+					It("produces no placement policies", func() {
+						Expect(configSpec.VmPlacementPolicies).To(BeEmpty())
+						assertVMTags(configSpec, []string{"vm-label1:vm-value1", "vm-label2:vm-value2"}, vmCtx.VM.Namespace)
+					})
+				})
+
+				Context("host topology anti-affinity terms are ignored", func() {
+					BeforeEach(func() {
+						vmCtx.VM.Spec.Affinity = &vmopv1.AffinitySpec{
+							VMAntiAffinity: &vmopv1.VMAntiAffinitySpec{
+								RequiredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"component": "web",
+											},
+										},
+										TopologyKey: corev1.LabelHostname,
+									},
+								},
+								PreferredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"environment": "prod",
+											},
+										},
+										TopologyKey: corev1.LabelHostname,
+									},
+								},
+							},
+						}
+					})
+
+					It("produces no placement policies", func() {
+						Expect(configSpec.VmPlacementPolicies).To(BeEmpty())
+						assertVMTags(configSpec, []string{"vm-label1:vm-value1", "vm-label2:vm-value2"}, vmCtx.VM.Namespace)
+					})
+				})
+
+				Context("mixed zone and host topology terms only produce zone policies", func() {
+					BeforeEach(func() {
+						vmCtx.VM.Spec.Affinity = &vmopv1.AffinitySpec{
+							VMAntiAffinity: &vmopv1.VMAntiAffinitySpec{
+								RequiredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"zone-label": "zone-value",
+											},
+										},
+										TopologyKey: corev1.LabelTopologyZone,
+									},
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"host-label": "host-value",
+											},
+										},
+										TopologyKey: corev1.LabelHostname,
+									},
+								},
+							},
+						}
+					})
+
+					It("creates only the zone topology policy", func() {
+						Expect(configSpec.VmPlacementPolicies).To(HaveLen(1))
+
+						policy, ok := configSpec.VmPlacementPolicies[0].(*vimtypes.VmToVmGroupsAntiAffinity)
+						Expect(ok).To(BeTrue())
+						Expect(policy.PolicyTopology).To(Equal(string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyVSphereZone)))
+						Expect(policy.AntiAffinedVmGroupTags).To(ConsistOf(vimtypes.TagId{
+							NameId: &vimtypes.TagIdNameId{
+								Tag:      "zone-label:zone-value",
+								Category: vmCtx.VM.Namespace,
+							},
+						}))
+
+						assertVMTags(configSpec, []string{"vm-label1:vm-value1", "vm-label2:vm-value2"}, vmCtx.VM.Namespace)
+					})
 				})
 			})
 

--- a/pkg/providers/vsphere/vmprovider_vmgroup_test.go
+++ b/pkg/providers/vsphere/vmprovider_vmgroup_test.go
@@ -177,7 +177,7 @@ var _ = Describe(
 			Expect(pkgcond.IsTrue(&ms, vmopv1.VirtualMachineGroupMemberConditionPlacementReady)).To(BeTrue(), "No placement ready condition")
 			Expect(ms.Placement.Zone).ToNot(BeEmpty(), "Missing Placement Zone")
 			Expect(ms.Placement.Pool).ToNot(BeEmpty(), "Missing Placement Pool")
-			Expect(ms.Placement.Node).To(BeEmpty(), "Has Placement Node")
+			Expect(ms.Placement.Node).ToNot(BeEmpty(), "Missing Placement Node")
 			if pkgcfg.FromContext(ctx).Features.FastDeploy {
 				Expect(ms.Placement.Datastores).ToNot(BeEmpty(), "Missing Placement Datastores")
 				// Verify against VirtualMachineImageCache.Status


### PR DESCRIPTION
Previously, `processVMAffinity()` and `processVMAntiAffinity()` only translated zone-topology terms (`topologyKey: topology.kubernetes.io/zone`) into `VmPlacementPolicies`. Host-topology terms (`topologyKey: kubernetes.io/hostname`) were silently skipped with the expectation that ClusterModules would handle host-level anti-affinity.

**What does this PR do, and why is it needed?**

> This **only** handles passing TagSpecs and PlacementPolicies during Placement recommendations call. There will be a future PR which adds support for passing both during `CreateVM` call.

- Refactors `buildTagIDsFromZoneTopology` into a generic `buildTagIDsFromTopology(vmCtx, terms, topologyKey)` with thin wrappers `buildTagIDsFromZoneTopology` and `buildTagIDsFromHostTopology` to avoid duplicating the tag extraction logic.
- Extends `processVMAffinity` to generate `VmVmAffinity` policies with Host topology for both required and preferred terms.
- Extends `processVMAntiAffinity` to generate `VmVmAntiAffinity` policies with Host topology for both required and preferred terms. Each topology/strictness combination produces a separate policy object.
- Gates the host-topology processing behind a feature-gate
- Adds tests for required/preferred host-level affinity and anti-affinity, mixed zone+host topology terms, and verifies that host-topology terms are silently skipped when `VMAffinityDuringExecution` is disabled while zone-topology terms continue to work.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #

**Are there any special notes for your reviewer**:

- Unit tests are added.
- Manually tested AF and AAF policies.

**Please add a release note if necessary**:

```release-note
Handle Host level AF/AAF policies using VMVMAntiAffinity policies
```