### PR TITLE
🐛 Add missing v1a6 version conversion bits

### DIFF
--- a/api/v1alpha4/virtualmachineclassinstance_conversion.go
+++ b/api/v1alpha4/virtualmachineclassinstance_conversion.go
@@ -1,0 +1,23 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha4
+
+import (
+	ctrlconversion "sigs.k8s.io/controller-runtime/pkg/conversion"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+)
+
+// ConvertTo converts this VirtualMachineClassInstance to the Hub version.
+func (src *VirtualMachineClassInstance) ConvertTo(dstRaw ctrlconversion.Hub) error {
+	dst := dstRaw.(*vmopv1.VirtualMachineClassInstance)
+	return Convert_v1alpha4_VirtualMachineClassInstance_To_v1alpha6_VirtualMachineClassInstance(src, dst, nil)
+}
+
+// ConvertFrom converts the hub version to this VirtualMachineClassInstance.
+func (dst *VirtualMachineClassInstance) ConvertFrom(srcRaw ctrlconversion.Hub) error {
+	src := srcRaw.(*vmopv1.VirtualMachineClassInstance)
+	return Convert_v1alpha6_VirtualMachineClassInstance_To_v1alpha4_VirtualMachineClassInstance(src, dst, nil)
+}

--- a/api/v1alpha5/virtualmachineclassinstance_conversion.go
+++ b/api/v1alpha5/virtualmachineclassinstance_conversion.go
@@ -1,0 +1,35 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha5
+
+import (
+	ctrlconversion "sigs.k8s.io/controller-runtime/pkg/conversion"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+)
+
+// ConvertTo converts this VirtualMachineClassInstance to the Hub version.
+func (src *VirtualMachineClassInstance) ConvertTo(dstRaw ctrlconversion.Hub) error {
+	dst := dstRaw.(*vmopv1.VirtualMachineClassInstance)
+	return Convert_v1alpha5_VirtualMachineClassInstance_To_v1alpha6_VirtualMachineClassInstance(src, dst, nil)
+}
+
+// ConvertFrom converts the hub version to this VirtualMachineClassInstance.
+func (dst *VirtualMachineClassInstance) ConvertFrom(srcRaw ctrlconversion.Hub) error {
+	src := srcRaw.(*vmopv1.VirtualMachineClassInstance)
+	return Convert_v1alpha6_VirtualMachineClassInstance_To_v1alpha5_VirtualMachineClassInstance(src, dst, nil)
+}
+
+// ConvertTo converts this VirtualMachineClassInstanceList to the Hub version.
+func (src *VirtualMachineClassInstanceList) ConvertTo(dstRaw ctrlconversion.Hub) error {
+	dst := dstRaw.(*vmopv1.VirtualMachineClassInstanceList)
+	return Convert_v1alpha5_VirtualMachineClassInstanceList_To_v1alpha6_VirtualMachineClassInstanceList(src, dst, nil)
+}
+
+// ConvertFrom converts the hub version to this VirtualMachineClassInstanceList.
+func (dst *VirtualMachineClassInstanceList) ConvertFrom(srcRaw ctrlconversion.Hub) error {
+	src := srcRaw.(*vmopv1.VirtualMachineClassInstanceList)
+	return Convert_v1alpha6_VirtualMachineClassInstanceList_To_v1alpha5_VirtualMachineClassInstanceList(src, dst, nil)
+}

--- a/api/v1alpha5/virtualmachinegroup_publishrequest_conversion.go
+++ b/api/v1alpha5/virtualmachinegroup_publishrequest_conversion.go
@@ -1,0 +1,35 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha5
+
+import (
+	ctrlconversion "sigs.k8s.io/controller-runtime/pkg/conversion"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+)
+
+// ConvertTo converts this VirtualMachineGroupPublishRequest to the Hub version.
+func (src *VirtualMachineGroupPublishRequest) ConvertTo(dstRaw ctrlconversion.Hub) error {
+	dst := dstRaw.(*vmopv1.VirtualMachineGroupPublishRequest)
+	return Convert_v1alpha5_VirtualMachineGroupPublishRequest_To_v1alpha6_VirtualMachineGroupPublishRequest(src, dst, nil)
+}
+
+// ConvertFrom converts the hub version to this VirtualMachineGroupPublishRequest.
+func (dst *VirtualMachineGroupPublishRequest) ConvertFrom(srcRaw ctrlconversion.Hub) error {
+	src := srcRaw.(*vmopv1.VirtualMachineGroupPublishRequest)
+	return Convert_v1alpha6_VirtualMachineGroupPublishRequest_To_v1alpha5_VirtualMachineGroupPublishRequest(src, dst, nil)
+}
+
+// ConvertTo converts this VirtualMachineGroupPublishRequestList to the Hub version.
+func (src *VirtualMachineGroupPublishRequestList) ConvertTo(dstRaw ctrlconversion.Hub) error {
+	dst := dstRaw.(*vmopv1.VirtualMachineGroupPublishRequestList)
+	return Convert_v1alpha5_VirtualMachineGroupPublishRequestList_To_v1alpha6_VirtualMachineGroupPublishRequestList(src, dst, nil)
+}
+
+// ConvertFrom converts the hub version to this VirtualMachineGroupPublishRequestList.
+func (dst *VirtualMachineGroupPublishRequestList) ConvertFrom(srcRaw ctrlconversion.Hub) error {
+	src := srcRaw.(*vmopv1.VirtualMachineGroupPublishRequestList)
+	return Convert_v1alpha6_VirtualMachineGroupPublishRequestList_To_v1alpha5_VirtualMachineGroupPublishRequestList(src, dst, nil)
+}

--- a/api/v1alpha5/virtualmachinesnapshot_conversion.go
+++ b/api/v1alpha5/virtualmachinesnapshot_conversion.go
@@ -1,0 +1,35 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha5
+
+import (
+	ctrlconversion "sigs.k8s.io/controller-runtime/pkg/conversion"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+)
+
+// ConvertTo converts this VirtualMachineSnapshot to the Hub version.
+func (src *VirtualMachineSnapshot) ConvertTo(dstRaw ctrlconversion.Hub) error {
+	dst := dstRaw.(*vmopv1.VirtualMachineSnapshot)
+	return Convert_v1alpha5_VirtualMachineSnapshot_To_v1alpha6_VirtualMachineSnapshot(src, dst, nil)
+}
+
+// ConvertFrom converts the hub version to this VirtualMachineSnapshot.
+func (dst *VirtualMachineSnapshot) ConvertFrom(srcRaw ctrlconversion.Hub) error {
+	src := srcRaw.(*vmopv1.VirtualMachineSnapshot)
+	return Convert_v1alpha6_VirtualMachineSnapshot_To_v1alpha5_VirtualMachineSnapshot(src, dst, nil)
+}
+
+// ConvertTo converts this VirtualMachineSnapshotList to the Hub version.
+func (src *VirtualMachineSnapshotList) ConvertTo(dstRaw ctrlconversion.Hub) error {
+	dst := dstRaw.(*vmopv1.VirtualMachineSnapshotList)
+	return Convert_v1alpha5_VirtualMachineSnapshotList_To_v1alpha6_VirtualMachineSnapshotList(src, dst, nil)
+}
+
+// ConvertFrom converts the hub version to this VirtualMachineSnapshotList.
+func (dst *VirtualMachineSnapshotList) ConvertFrom(srcRaw ctrlconversion.Hub) error {
+	src := srcRaw.(*vmopv1.VirtualMachineSnapshotList)
+	return Convert_v1alpha6_VirtualMachineSnapshotList_To_v1alpha5_VirtualMachineSnapshotList(src, dst, nil)
+}

--- a/api/v1alpha6/virtualmachineclassinstance_conversion.go
+++ b/api/v1alpha6/virtualmachineclassinstance_conversion.go
@@ -1,0 +1,11 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha6
+
+// Hub marks VirtualMachineClassInstance as a conversion hub.
+func (*VirtualMachineClassInstance) Hub() {}
+
+// Hub marks VirtualMachineClassInstanceList as a conversion hub.
+func (*VirtualMachineClassInstanceList) Hub() {}

--- a/api/v1alpha6/virtualmachinegroup_publishrequest_conversion.go
+++ b/api/v1alpha6/virtualmachinegroup_publishrequest_conversion.go
@@ -1,0 +1,11 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha6
+
+// Hub marks VirtualMachineGroupPublishRequest as a conversion hub.
+func (*VirtualMachineGroupPublishRequest) Hub() {}
+
+// Hub marks VirtualMachineGroupPublishRequestList as a conversion hub.
+func (*VirtualMachineGroupPublishRequestList) Hub() {}

--- a/api/v1alpha6/virtualmachinesnapshot_conversion.go
+++ b/api/v1alpha6/virtualmachinesnapshot_conversion.go
@@ -1,0 +1,11 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha6
+
+// Hub marks VirtualMachineSnapshot as a conversion hub.
+func (*VirtualMachineSnapshot) Hub() {}
+
+// Hub marks VirtualMachineSnapshotList as a conversion hub.
+func (*VirtualMachineSnapshotList) Hub() {}

--- a/webhooks/conversion/v1alpha4/webhooks.go
+++ b/webhooks/conversion/v1alpha4/webhooks.go
@@ -9,6 +9,7 @@ import (
 	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
 
 	vmopv1a4 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 )
 
@@ -26,6 +27,15 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) err
 		Complete(); err != nil {
 
 		return err
+	}
+
+	if pkgcfg.FromContext(ctx).Features.ImmutableClasses {
+		if err := ctrl.NewWebhookManagedBy(mgr).
+			For(&vmopv1a4.VirtualMachineClassInstance{}).
+			Complete(); err != nil {
+
+			return err
+		}
 	}
 
 	if err := ctrl.NewWebhookManagedBy(mgr).

--- a/webhooks/conversion/v1alpha5/webhooks.go
+++ b/webhooks/conversion/v1alpha5/webhooks.go
@@ -1,5 +1,5 @@
 // © Broadcom. All Rights Reserved.
-// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: Apache-2.0
 
 package v1alpha5
@@ -8,70 +8,108 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
 
-	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+	vmopv1a5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 )
 
 func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) error {
 
 	if err := ctrl.NewWebhookManagedBy(mgr).
-		For(&vmopv1.VirtualMachine{}).
+		For(&vmopv1a5.ClusterVirtualMachineImage{}).
 		Complete(); err != nil {
 
 		return err
 	}
 
 	if err := ctrl.NewWebhookManagedBy(mgr).
-		For(&vmopv1.VirtualMachineClass{}).
+		For(&vmopv1a5.VirtualMachine{}).
 		Complete(); err != nil {
 
 		return err
 	}
 
 	if err := ctrl.NewWebhookManagedBy(mgr).
-		For(&vmopv1.VirtualMachineImage{}).
+		For(&vmopv1a5.VirtualMachineClass{}).
+		Complete(); err != nil {
+
+		return err
+	}
+
+	if pkgcfg.FromContext(ctx).Features.ImmutableClasses {
+		if err := ctrl.NewWebhookManagedBy(mgr).
+			For(&vmopv1a5.VirtualMachineClassInstance{}).
+			Complete(); err != nil {
+
+			return err
+		}
+	}
+
+	if err := ctrl.NewWebhookManagedBy(mgr).
+		For(&vmopv1a5.VirtualMachineGroup{}).
 		Complete(); err != nil {
 
 		return err
 	}
 
 	if err := ctrl.NewWebhookManagedBy(mgr).
-		For(&vmopv1.ClusterVirtualMachineImage{}).
+		For(&vmopv1a5.VirtualMachineGroupPublishRequest{}).
 		Complete(); err != nil {
 
 		return err
 	}
 
 	if err := ctrl.NewWebhookManagedBy(mgr).
-		For(&vmopv1.VirtualMachineImageCache{}).
+		For(&vmopv1a5.VirtualMachineImage{}).
 		Complete(); err != nil {
 
 		return err
 	}
 
 	if err := ctrl.NewWebhookManagedBy(mgr).
-		For(&vmopv1.VirtualMachinePublishRequest{}).
+		For(&vmopv1a5.VirtualMachineImageCache{}).
 		Complete(); err != nil {
 
 		return err
 	}
 
 	if err := ctrl.NewWebhookManagedBy(mgr).
-		For(&vmopv1.VirtualMachineService{}).
+		For(&vmopv1a5.VirtualMachinePublishRequest{}).
 		Complete(); err != nil {
 
 		return err
 	}
 
 	if err := ctrl.NewWebhookManagedBy(mgr).
-		For(&vmopv1.VirtualMachineSetResourcePolicy{}).
+		For(&vmopv1a5.VirtualMachineReplicaSet{}).
 		Complete(); err != nil {
 
 		return err
 	}
 
 	if err := ctrl.NewWebhookManagedBy(mgr).
-		For(&vmopv1.VirtualMachineWebConsoleRequest{}).
+		For(&vmopv1a5.VirtualMachineService{}).
+		Complete(); err != nil {
+
+		return err
+	}
+
+	if err := ctrl.NewWebhookManagedBy(mgr).
+		For(&vmopv1a5.VirtualMachineSetResourcePolicy{}).
+		Complete(); err != nil {
+
+		return err
+	}
+
+	if err := ctrl.NewWebhookManagedBy(mgr).
+		For(&vmopv1a5.VirtualMachineSnapshot{}).
+		Complete(); err != nil {
+
+		return err
+	}
+
+	if err := ctrl.NewWebhookManagedBy(mgr).
+		For(&vmopv1a5.VirtualMachineWebConsoleRequest{}).
 		Complete(); err != nil {
 
 		return err

--- a/webhooks/conversion/v1alpha6/webhooks.go
+++ b/webhooks/conversion/v1alpha6/webhooks.go
@@ -9,6 +9,7 @@ import (
 	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 )
 
@@ -35,11 +36,13 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) err
 		return err
 	}
 
-	if err := ctrl.NewWebhookManagedBy(mgr).
-		For(&vmopv1.VirtualMachineClassInstance{}).
-		Complete(); err != nil {
+	if pkgcfg.FromContext(ctx).Features.ImmutableClasses {
+		if err := ctrl.NewWebhookManagedBy(mgr).
+			For(&vmopv1.VirtualMachineClassInstance{}).
+			Complete(); err != nil {
 
-		return err
+			return err
+		}
 	}
 
 	if err := ctrl.NewWebhookManagedBy(mgr).


### PR DESCRIPTION


**What does this PR do, and why is it needed?**

Add stuff that the old new-schema-version.py missed when a type was just added in the now prior Hub version.

While here, also add conversion for VirtualMachineClassInstance since that wasn't done between v1a4 and v1a5.



**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:



**Please add a release note if necessary**:

```release-note
NONE
```