### PR TITLE
:bug: Revert pull request #1533 - VM Create and storage policy ID 

### DIFF
--- a/pkg/providers/vsphere/vmprovider_vm.go
+++ b/pkg/providers/vsphere/vmprovider_vm.go
@@ -2296,12 +2296,9 @@ func (vs *vSphereVMProvider) vmCreateGetStoragePrereqs(
 		return err
 	}
 
-	// The storage profile ID can be obtained from the StorageClass or VolumeAttributesClass (VAC) object.
-	storageProfileID, err := kubeutil.GetStoragePolicyID(vmCtx, vs.k8sClient, *vmCtx.VM)
-	if err != nil {
-		return err
-	}
-	isEnc, err := kubeutil.IsEncryptedStorageProfile(vmCtx, vs.k8sClient, storageProfileID)
+	storageProfileID := vmStorage.StorageClassToPolicyID[vmStorageClass]
+	isEnc, _, err := kubeutil.IsEncryptedStorageClass(
+		vmCtx, vs.k8sClient, vmCtx.VM.Spec.StorageClass)
 	if err != nil {
 		return err
 	}

--- a/pkg/providers/vsphere/vmprovider_vm_storage_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_storage_test.go
@@ -134,12 +134,22 @@ func vmStorageTests() {
 			testConfig.WithoutStorageClass = true
 		})
 
-		It("Fails to create VM", func() {
+		It("Creates VM", func() {
 			Expect(vm.Spec.StorageClass).To(BeEmpty())
 
-			_, err := createOrUpdateAndGetVcVM(ctx, vmProvider, vm)
-			Expect(err).To(HaveOccurred())
+			vcVM, err := createOrUpdateAndGetVcVM(ctx, vmProvider, vm)
+			Expect(err).ToNot(HaveOccurred())
 
+			var o mo.VirtualMachine
+			Expect(vcVM.Properties(ctx, vcVM.Reference(), nil, &o)).To(Succeed())
+
+			By("has expected datastore", func() {
+				datastore, err := ctx.Finder.DefaultDatastore(ctx)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(o.Datastore).To(HaveLen(1))
+				Expect(o.Datastore[0]).To(Equal(datastore.Reference()))
+			})
 		})
 	})
 

--- a/pkg/util/kube/storage.go
+++ b/pkg/util/kube/storage.go
@@ -289,20 +289,32 @@ func IsEncryptedStorageClass(
 func IsEncryptedStorageProfile(
 	ctx context.Context,
 	k8sClient ctrlclient.Client,
-	policyID string) (bool, error) {
+	profileID string) (bool, error) {
 
-	var obj infrav1.StoragePolicy
-	key := ctrlclient.ObjectKey{
-		Namespace: pkgcfg.FromContext(ctx).PodNamespace,
-		Name:      GetStoragePolicyObjectName(policyID),
+	var obj storagev1.StorageClassList
+	if err := k8sClient.List(ctx, &obj); err != nil {
+		return false, err
 	}
 
-	if err := k8sClient.Get(ctx, key, &obj); err != nil {
-		return false, ctrlclient.IgnoreNotFound(err)
+	for i := range obj.Items {
+		if pid, _ := GetStoragePolicyIDFromStorageClass(obj.Items[i]); pid == profileID {
+			var (
+				obj infrav1.StoragePolicy
+				key = ctrlclient.ObjectKey{
+					Namespace: pkgcfg.FromContext(ctx).PodNamespace,
+					Name:      GetStoragePolicyObjectName(pid),
+				}
+			)
+			if key.Name != "" {
+				if err := k8sClient.Get(ctx, key, &obj); err != nil {
+					return false, ctrlclient.IgnoreNotFound(err)
+				}
+				return obj.Status.Encrypted, nil
+			}
+		}
 	}
 
-	return obj.Status.Encrypted, nil
-
+	return false, nil
 }
 
 // GetStoragePolicyObjectName returns the expected name of a StoragePolicy

--- a/pkg/util/kube/storage_test.go
+++ b/pkg/util/kube/storage_test.go
@@ -644,6 +644,7 @@ var _ = Describe("IsEncryptedStorageProfile", func() {
 		client        ctrlclient.Client
 		funcs         interceptor.Funcs
 		withObjs      []ctrlclient.Object
+		storageClass  storagev1.StorageClass
 		storagePolicy infrav1.StoragePolicy
 		profileID     string
 	)
@@ -654,6 +655,15 @@ var _ = Describe("IsEncryptedStorageProfile", func() {
 		})
 		funcs = interceptor.Funcs{}
 		profileID = uuid.NewString()
+		storageClass = storagev1.StorageClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fakeString,
+				UID:  types.UID(uuid.NewString()),
+			},
+			Parameters: map[string]string{
+				internal.StoragePolicyIDParameter: profileID,
+			},
+		}
 		storagePolicy = infrav1.StoragePolicy{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: fakeString,
@@ -667,6 +677,7 @@ var _ = Describe("IsEncryptedStorageProfile", func() {
 				Encrypted: true,
 			},
 		}
+		withObjs = []ctrlclient.Object{&storageClass}
 	})
 
 	JustBeforeEach(func() {
@@ -684,6 +695,47 @@ var _ = Describe("IsEncryptedStorageProfile", func() {
 			ctx, client, profileID)
 	})
 
+	When("getting the StorageClass returns an error", func() {
+		BeforeEach(func() {
+			funcs.List = func(
+				ctx context.Context,
+				client ctrlclient.WithWatch,
+				list ctrlclient.ObjectList,
+				opts ...ctrlclient.ListOption) error {
+
+				if _, ok := list.(*storagev1.StorageClassList); ok {
+					return apierrors.NewInternalError(errors.New(fakeString))
+				}
+
+				return client.List(ctx, list, opts...)
+			}
+		})
+		It("should return the error", func() {
+			Expect(err).To(MatchError(apierrors.NewInternalError(errors.New(fakeString)).Error()))
+			Expect(ok).To(BeFalse())
+		})
+	})
+
+	When("there are no StorageClasses", func() {
+		BeforeEach(func() {
+			withObjs = nil
+		})
+		It("should return false", func() {
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ok).To(BeFalse())
+		})
+	})
+
+	When("there is a StorageClass but does not match the profile ID", func() {
+		BeforeEach(func() {
+			profileID += "1"
+		})
+		It("should return false", func() {
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ok).To(BeFalse())
+		})
+	})
+
 	When("there is not a StoragePolicy", func() {
 		It("should return false", func() {
 			Expect(err).ToNot(HaveOccurred())
@@ -693,7 +745,7 @@ var _ = Describe("IsEncryptedStorageProfile", func() {
 
 	When("there is a StoragePolicy that matches the profile ID", func() {
 		BeforeEach(func() {
-			withObjs = []ctrlclient.Object{&storagePolicy}
+			withObjs = append(withObjs, &storagePolicy)
 		})
 		It("should return true", func() {
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
This PR reverts PR #1533 - VM Create to retrieve storage policy ID agnostically from StorageClass or VolumeAttributesClass wrapped by a capability flag.
Under the new retrieval simplified logic of storage profile, the reco tests failed to detect encryption from storage policy objects. Reinstating original code until more reco tests are validated. 

**What does this PR do, and why is it needed?**

Revert changes introduced on commit `5f2890c`.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #

Revert changes introduced on commit `5f2890c`.

**Please add a release note if necessary**:

```release-note

```