### PR TITLE
🌱 Temporarily use GO 1.26.2 in Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,10 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version: '1.26.2' # TODO (brito-rafa)  For GO-2026-4865
+                             # GO-2026-4866, GO-2026-4869, GO-2026-4870
+                             # GO-2026-4946, GO-2026-4947
+                             # remove once internal builds use 1.26.2
         go-version-file: 'go.mod'
         cache: true
         cache-dependency-path: '**/go.sum'


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This patch updates the ci.yml GH action file to use Go1.26.2 so that vulncheck will not complain. This patch will be reverted once the internal VM Op builds can be moved onto Go1.26.2.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # N/A


**Are there any special notes for your reviewer**:

Practice was adopted previously so we have clean checks until we have an internal Go1.26.2.

**Please add a release note if necessary**:

```release-note
Temporarily use Go1.26.2 when running vulncheck in GH actions.
```