### PR TITLE
🐛 Reinstate Logic of #1533 and Fix bug introduced by #1540 on StoragePolicy Status Field

### DIFF
--- a/controllers/virtualmachineimagecache/virtualmachineimagecache_controller.go
+++ b/controllers/virtualmachineimagecache/virtualmachineimagecache_controller.go
@@ -378,13 +378,15 @@ func (r *reconciler) reconcileLocations(
 				GetDatastoreInfo().SupportedVDiskFormats...)
 
 		isEnc, err := kubeutil.IsEncryptedStorageProfile(ctx, r.Client, spec.ProfileID)
-		if err != nil {
+		// TODO: Verify if we should propagate the error when the storage profile is not found
+		if ctrlclient.IgnoreNotFound(err) != nil {
 			conditions = conditions.MarkError(
 				vmopv1.ReadyConditionType,
 				conditionReasonFailed,
 				err)
 			status.Conditions = conditions
 			continue
+
 		}
 
 		// Update the srcFiles elements with the profile and format info.

--- a/controllers/virtualmachineimagecache/virtualmachineimagecache_controller.go
+++ b/controllers/virtualmachineimagecache/virtualmachineimagecache_controller.go
@@ -378,15 +378,13 @@ func (r *reconciler) reconcileLocations(
 				GetDatastoreInfo().SupportedVDiskFormats...)
 
 		isEnc, err := kubeutil.IsEncryptedStorageProfile(ctx, r.Client, spec.ProfileID)
-		// TODO: Verify if we should propagate the error when the storage profile is not found
-		if ctrlclient.IgnoreNotFound(err) != nil {
+		if err != nil {
 			conditions = conditions.MarkError(
 				vmopv1.ReadyConditionType,
 				conditionReasonFailed,
 				err)
 			status.Conditions = conditions
 			continue
-
 		}
 
 		// Update the srcFiles elements with the profile and format info.

--- a/pkg/providers/vsphere/vmprovider_vm.go
+++ b/pkg/providers/vsphere/vmprovider_vm.go
@@ -2296,11 +2296,11 @@ func (vs *vSphereVMProvider) vmCreateGetStoragePrereqs(
 		return err
 	}
 
-	// The storage profile ID can be obtained from the StorageClass or VolumeAttributesClass (VAC) object, depending if the StoragePolicyMutability feature is enabled.
 	storageProfileID, err := kubeutil.GetStoragePolicyID(vmCtx, vs.k8sClient, *vmCtx.VM)
 	if err != nil {
 		return err
 	}
+
 	isEnc, err := kubeutil.IsEncryptedStorageProfile(vmCtx, vs.k8sClient, storageProfileID)
 	if err != nil {
 		return err

--- a/pkg/providers/vsphere/vmprovider_vm.go
+++ b/pkg/providers/vsphere/vmprovider_vm.go
@@ -2296,9 +2296,12 @@ func (vs *vSphereVMProvider) vmCreateGetStoragePrereqs(
 		return err
 	}
 
-	storageProfileID := vmStorage.StorageClassToPolicyID[vmStorageClass]
-	isEnc, _, err := kubeutil.IsEncryptedStorageClass(
-		vmCtx, vs.k8sClient, vmCtx.VM.Spec.StorageClass)
+	// The storage profile ID can be obtained from the StorageClass or VolumeAttributesClass (VAC) object, depending if the StoragePolicyMutability feature is enabled.
+	storageProfileID, err := kubeutil.GetStoragePolicyID(vmCtx, vs.k8sClient, *vmCtx.VM)
+	if err != nil {
+		return err
+	}
+	isEnc, err := kubeutil.IsEncryptedStorageProfile(vmCtx, vs.k8sClient, storageProfileID)
 	if err != nil {
 		return err
 	}

--- a/pkg/providers/vsphere/vmprovider_vm_storage_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_storage_test.go
@@ -134,22 +134,11 @@ func vmStorageTests() {
 			testConfig.WithoutStorageClass = true
 		})
 
-		It("Creates VM", func() {
+		It("Fails to create VM", func() {
 			Expect(vm.Spec.StorageClass).To(BeEmpty())
 
-			vcVM, err := createOrUpdateAndGetVcVM(ctx, vmProvider, vm)
-			Expect(err).ToNot(HaveOccurred())
-
-			var o mo.VirtualMachine
-			Expect(vcVM.Properties(ctx, vcVM.Reference(), nil, &o)).To(Succeed())
-
-			By("has expected datastore", func() {
-				datastore, err := ctx.Finder.DefaultDatastore(ctx)
-				Expect(err).ToNot(HaveOccurred())
-
-				Expect(o.Datastore).To(HaveLen(1))
-				Expect(o.Datastore[0]).To(Equal(datastore.Reference()))
-			})
+			_, err := createOrUpdateAndGetVcVM(ctx, vmProvider, vm)
+			Expect(err).To(HaveOccurred())
 		})
 	})
 

--- a/pkg/util/kube/storage.go
+++ b/pkg/util/kube/storage.go
@@ -188,8 +188,13 @@ func GetStoragePolicyIDFromVolumeAttributesClass(obj storagev1.VolumeAttributesC
 }
 
 // GetStoragePolicyID returns the storage policy ID for a given VM.
-// Abstracting from the source of the policy ID (StorageClass or VolumeAttributesClass (VAC) object).
-// Throw an error if VAC field is used while the capability is disabled.
+// The storage policy ID can be obtained from the VolumeAttributesClass (VAC)
+// object, depending on if the StoragePolicyMutability feature is enabled.
+// If the feature is disabled or VAC doesn't specify the policy ID,
+// the storage policy ID is obtained from the StorageClass.
+//
+// Throws an error if the VolumeAttributesClass field is used while the
+// StoragePolicyMutability feature is disabled.
 func GetStoragePolicyID(
 	ctx context.Context,
 	k8sClient ctrlclient.Client,
@@ -205,7 +210,10 @@ func GetStoragePolicyID(
 		objKind = internal.VolumeAttributesClassKind
 
 		if !pkgcfg.FromContext(ctx).Features.StoragePolicyMutability {
-			return "", fmt.Errorf("%s %q object is specified but capability is not enabled", objKind, objName)
+			return "", fmt.Errorf(
+				"%s %q object is specified but capability is not enabled", 
+				objKind, objName,
+			)
 		}
 		vac := &storagev1.VolumeAttributesClass{}
 		if err := k8sClient.Get(ctx, ctrlclient.ObjectKey{Name: objName}, vac); err != nil {
@@ -291,17 +299,59 @@ func IsEncryptedStorageProfile(
 	k8sClient ctrlclient.Client,
 	profileID string) (bool, error) {
 
-	var obj infrav1.StoragePolicy
+	foundStorageProfile := false
+
+	if pkgcfg.FromContext(ctx).Features.StoragePolicyMutability {
+		var volumeAttributesClasses storagev1.VolumeAttributesClassList
+		if err := k8sClient.List(ctx, &volumeAttributesClasses); err != nil {
+			return false, err
+		}
+		foundStorageProfile = slices.IndexFunc(volumeAttributesClasses.Items,
+			func(volumeAttributesClass storagev1.VolumeAttributesClass) bool {
+				pid, _ := GetStoragePolicyIDFromVolumeAttributesClass(volumeAttributesClass)
+				return pid == profileID
+			},
+		) != -1
+	}
+
+	if !foundStorageProfile {
+		var storageClasses storagev1.StorageClassList
+		if err := k8sClient.List(ctx, &storageClasses); err != nil {
+			return false, err
+		}
+		foundStorageProfile = slices.IndexFunc(storageClasses.Items,
+			func(storageClass storagev1.StorageClass) bool {
+				pid, _ := GetStoragePolicyIDFromStorageClass(storageClass)
+				return pid == profileID
+			},
+		) != -1
+	}
+
+	if !foundStorageProfile {
+		return false, fmt.Errorf(
+			"storage class with profile ID %s not found",
+			profileID,
+		)
+	}
+
+	storagePolicyName := GetStoragePolicyObjectName(profileID)
+	if storagePolicyName == "" {
+		return false, fmt.Errorf(
+			"was not able to construct a storage policy name for profile ID %s",
+			profileID,
+		)
+	}
+
 	key := ctrlclient.ObjectKey{
 		Namespace: pkgcfg.FromContext(ctx).PodNamespace,
-		Name:      GetStoragePolicyObjectName(profileID),
+		Name:      storagePolicyName,
 	}
-
-	if err := k8sClient.Get(ctx, key, &obj); err != nil {
+	var storagePolicy infrav1.StoragePolicy
+	if err := k8sClient.Get(ctx, key, &storagePolicy); err != nil {
 		return false, err
 	}
-	return obj.Status.Encrypted, nil
 
+	return storagePolicy.Status.Encrypted, nil
 }
 
 // GetStoragePolicyObjectName returns the expected name of a StoragePolicy

--- a/pkg/util/kube/storage.go
+++ b/pkg/util/kube/storage.go
@@ -291,30 +291,17 @@ func IsEncryptedStorageProfile(
 	k8sClient ctrlclient.Client,
 	profileID string) (bool, error) {
 
-	var obj storagev1.StorageClassList
-	if err := k8sClient.List(ctx, &obj); err != nil {
+	var obj infrav1.StoragePolicy
+	key := ctrlclient.ObjectKey{
+		Namespace: pkgcfg.FromContext(ctx).PodNamespace,
+		Name:      GetStoragePolicyObjectName(profileID),
+	}
+
+	if err := k8sClient.Get(ctx, key, &obj); err != nil {
 		return false, err
 	}
+	return obj.Status.Encrypted, nil
 
-	for i := range obj.Items {
-		if pid, _ := GetStoragePolicyIDFromStorageClass(obj.Items[i]); pid == profileID {
-			var (
-				obj infrav1.StoragePolicy
-				key = ctrlclient.ObjectKey{
-					Namespace: pkgcfg.FromContext(ctx).PodNamespace,
-					Name:      GetStoragePolicyObjectName(pid),
-				}
-			)
-			if key.Name != "" {
-				if err := k8sClient.Get(ctx, key, &obj); err != nil {
-					return false, ctrlclient.IgnoreNotFound(err)
-				}
-				return obj.Status.Encrypted, nil
-			}
-		}
-	}
-
-	return false, nil
 }
 
 // GetStoragePolicyObjectName returns the expected name of a StoragePolicy

--- a/pkg/util/kube/storage_test.go
+++ b/pkg/util/kube/storage_test.go
@@ -644,6 +644,7 @@ var _ = Describe("IsEncryptedStorageProfile", func() {
 		client        ctrlclient.Client
 		funcs         interceptor.Funcs
 		withObjs      []ctrlclient.Object
+		storageClass  storagev1.StorageClass
 		storagePolicy infrav1.StoragePolicy
 		profileID     string
 	)
@@ -654,6 +655,15 @@ var _ = Describe("IsEncryptedStorageProfile", func() {
 		})
 		funcs = interceptor.Funcs{}
 		profileID = uuid.NewString()
+		storageClass = storagev1.StorageClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fakeString,
+				UID:  types.UID(uuid.NewString()),
+			},
+			Parameters: map[string]string{
+				internal.StoragePolicyIDParameter: profileID,
+			},
+		}
 		storagePolicy = infrav1.StoragePolicy{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: fakeString,
@@ -667,6 +677,7 @@ var _ = Describe("IsEncryptedStorageProfile", func() {
 				Encrypted: true,
 			},
 		}
+		withObjs = []ctrlclient.Object{&storageClass}
 	})
 
 	JustBeforeEach(func() {
@@ -684,20 +695,141 @@ var _ = Describe("IsEncryptedStorageProfile", func() {
 			ctx, client, profileID)
 	})
 
-	When("there is not a StoragePolicy", func() {
-		It("should return false", func() {
+	When("getting the StorageClass returns an error", func() {
+		BeforeEach(func() {
+			funcs.List = func(
+				ctx context.Context,
+				client ctrlclient.WithWatch,
+				list ctrlclient.ObjectList,
+				opts ...ctrlclient.ListOption) error {
+
+				if _, ok := list.(*storagev1.StorageClassList); ok {
+					return apierrors.NewInternalError(errors.New(fakeString))
+				}
+
+				return client.List(ctx, list, opts...)
+			}
+		})
+		It("should return the error", func() {
+			Expect(err).To(MatchError(apierrors.NewInternalError(errors.New(fakeString)).Error()))
+			Expect(ok).To(BeFalse())
+		})
+	})
+
+	When("there are no StorageClasses", func() {
+		BeforeEach(func() {
+			withObjs = nil
+		})
+		It("should return an error", func() {
 			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not found"))
+			Expect(ok).To(BeFalse())
+		})
+	})
+
+	When("there is a StorageClass but does not match the profile ID", func() {
+		BeforeEach(func() {
+			profileID += "1"
+		})
+		It("should return an error", func() {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not found"))
+			Expect(ok).To(BeFalse())
+		})
+	})
+
+	When("there is not a StoragePolicy", func() {
+		It("should return an error", func() {
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
 			Expect(ok).To(BeFalse())
 		})
 	})
 
 	When("there is a StoragePolicy that matches the profile ID", func() {
 		BeforeEach(func() {
-			withObjs = []ctrlclient.Object{&storagePolicy}
+			withObjs = append(withObjs, &storagePolicy)
 		})
 		It("should return true", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ok).To(BeTrue())
+		})
+	})
+
+	Context("when StoragePolicyMutability feature is enabled", func() {
+		var vac storagev1.VolumeAttributesClass
+
+		BeforeEach(func() {
+			ctx = pkgcfg.WithConfig(pkgcfg.Config{
+				PodNamespace: fakeString,
+				Features: pkgcfg.FeatureStates{
+					StoragePolicyMutability: true,
+				},
+			})
+			vac = storagev1.VolumeAttributesClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: fakeString + "-vac",
+					UID:  types.UID(uuid.NewString()),
+				},
+				Parameters: map[string]string{
+					internal.StoragePolicyIDParameter: profileID,
+				},
+			}
+		})
+
+		When("getting the VolumeAttributesClass returns an error", func() {
+			BeforeEach(func() {
+				funcs.List = func(
+					ctx context.Context,
+					client ctrlclient.WithWatch,
+					list ctrlclient.ObjectList,
+					opts ...ctrlclient.ListOption) error {
+
+					if _, ok := list.(*storagev1.VolumeAttributesClassList); ok {
+						return apierrors.NewInternalError(errors.New(fakeString))
+					}
+
+					return client.List(ctx, list, opts...)
+				}
+			})
+			It("should return the error", func() {
+				Expect(err).To(MatchError(apierrors.NewInternalError(errors.New(fakeString)).Error()))
+				Expect(ok).To(BeFalse())
+			})
+		})
+
+		When("there are no VolumeAttributesClasses but StorageClass matches", func() {
+			BeforeEach(func() {
+				withObjs = []ctrlclient.Object{&storageClass, &storagePolicy}
+			})
+			It("should return true", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeTrue())
+			})
+		})
+
+		When("VolumeAttributesClass matches the profile ID", func() {
+			BeforeEach(func() {
+				// Remove StorageClass to ensure it's found via VAC
+				withObjs = []ctrlclient.Object{&vac, &storagePolicy}
+			})
+			It("should return true", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeTrue())
+			})
+		})
+
+		When("neither matches the profile ID", func() {
+			BeforeEach(func() {
+				vac.Parameters[internal.StoragePolicyIDParameter] = profileID + "1"
+				storageClass.Parameters[internal.StoragePolicyIDParameter] = profileID + "1"
+				withObjs = []ctrlclient.Object{&vac, &storageClass}
+			})
+			It("should return an error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("not found"))
+				Expect(ok).To(BeFalse())
+			})
 		})
 	})
 })

--- a/pkg/util/kube/storage_test.go
+++ b/pkg/util/kube/storage_test.go
@@ -644,7 +644,6 @@ var _ = Describe("IsEncryptedStorageProfile", func() {
 		client        ctrlclient.Client
 		funcs         interceptor.Funcs
 		withObjs      []ctrlclient.Object
-		storageClass  storagev1.StorageClass
 		storagePolicy infrav1.StoragePolicy
 		profileID     string
 	)
@@ -655,15 +654,6 @@ var _ = Describe("IsEncryptedStorageProfile", func() {
 		})
 		funcs = interceptor.Funcs{}
 		profileID = uuid.NewString()
-		storageClass = storagev1.StorageClass{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: fakeString,
-				UID:  types.UID(uuid.NewString()),
-			},
-			Parameters: map[string]string{
-				internal.StoragePolicyIDParameter: profileID,
-			},
-		}
 		storagePolicy = infrav1.StoragePolicy{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: fakeString,
@@ -677,7 +667,6 @@ var _ = Describe("IsEncryptedStorageProfile", func() {
 				Encrypted: true,
 			},
 		}
-		withObjs = []ctrlclient.Object{&storageClass}
 	})
 
 	JustBeforeEach(func() {
@@ -695,57 +684,16 @@ var _ = Describe("IsEncryptedStorageProfile", func() {
 			ctx, client, profileID)
 	})
 
-	When("getting the StorageClass returns an error", func() {
-		BeforeEach(func() {
-			funcs.List = func(
-				ctx context.Context,
-				client ctrlclient.WithWatch,
-				list ctrlclient.ObjectList,
-				opts ...ctrlclient.ListOption) error {
-
-				if _, ok := list.(*storagev1.StorageClassList); ok {
-					return apierrors.NewInternalError(errors.New(fakeString))
-				}
-
-				return client.List(ctx, list, opts...)
-			}
-		})
-		It("should return the error", func() {
-			Expect(err).To(MatchError(apierrors.NewInternalError(errors.New(fakeString)).Error()))
-			Expect(ok).To(BeFalse())
-		})
-	})
-
-	When("there are no StorageClasses", func() {
-		BeforeEach(func() {
-			withObjs = nil
-		})
-		It("should return false", func() {
-			Expect(err).ToNot(HaveOccurred())
-			Expect(ok).To(BeFalse())
-		})
-	})
-
-	When("there is a StorageClass but does not match the profile ID", func() {
-		BeforeEach(func() {
-			profileID += "1"
-		})
-		It("should return false", func() {
-			Expect(err).ToNot(HaveOccurred())
-			Expect(ok).To(BeFalse())
-		})
-	})
-
 	When("there is not a StoragePolicy", func() {
 		It("should return false", func() {
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).To(HaveOccurred())
 			Expect(ok).To(BeFalse())
 		})
 	})
 
 	When("there is a StoragePolicy that matches the profile ID", func() {
 		BeforeEach(func() {
-			withObjs = append(withObjs, &storagePolicy)
+			withObjs = []ctrlclient.Object{&storagePolicy}
 		})
 		It("should return true", func() {
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/util/vsphere/storage/storage_policy.go
+++ b/pkg/util/vsphere/storage/storage_policy.go
@@ -19,6 +19,7 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1 "github.com/vmware-tanzu/vm-operator/external/infra/api/v1alpha1"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 )
 
 // GetStoragePolicyStatus returns the storage policy status for a given profile
@@ -99,15 +100,17 @@ func GetStoragePolicyStatus(
 		return infrav1.StoragePolicyStatus{}, err
 	}
 
-	// Collect volume attributes class name.
-	if err := getVolumeAttributesClassName(
-		ctx,
-		k8sClient,
-		p,
-		profileID,
-		&status); err != nil {
+	// Collect volume attributes class name only if capability is enabled.
+	if pkgcfg.FromContext(ctx).Features.StoragePolicyMutability {
+		if err := getVolumeAttributesClassName(
+			ctx,
+			k8sClient,
+			p,
+			profileID,
+			&status); err != nil {
 
-		return infrav1.StoragePolicyStatus{}, err
+			return infrav1.StoragePolicyStatus{}, err
+		}
 	}
 
 	// Sort the slices in the status.

--- a/pkg/util/vsphere/storage/storage_policy_test.go
+++ b/pkg/util/vsphere/storage/storage_policy_test.go
@@ -282,7 +282,7 @@ var _ = Describe("GetStoragePolicyStatus", func() {
 					Expect(status.DiskProvisioningMode).To(BeEmpty())
 				})
 
-				Context("backed by a volume attributes class", func() {
+				When("backed by a volume attributes class", func() {
 					BeforeEach(func() {
 						withObjs = append(withObjs,
 							&storagev1.VolumeAttributesClass{
@@ -291,15 +291,27 @@ var _ = Describe("GetStoragePolicyStatus", func() {
 								},
 							},
 						)
-						ctx = pkgcfg.WithConfig(pkgcfg.Config{
-							Features: pkgcfg.FeatureStates{StoragePolicyMutability: true},
+					})
+					
+					Context("when StoragePolicyMutability capability is enabled", func() {
+						BeforeEach(func() {
+							ctx = pkgcfg.WithContext(ctx, pkgcfg.Config{
+								Features: pkgcfg.FeatureStates{StoragePolicyMutability: true},
+							})
+						})
+						It("should return the policy status", func() {
+							Expect(err).ToNot(HaveOccurred())
+							Expect(status).ToNot(BeZero())
+							Expect(status.VolumeAttributesClass).To(Equal("sector-format-512"))
 						})
 					})
-					It("should return the policy status", func() {
-						Expect(err).ToNot(HaveOccurred())
-						Expect(status).ToNot(BeZero())
-
-						Expect(status.VolumeAttributesClass).To(Equal("sector-format-512"))
+					
+					Context("when StoragePolicyMutability capability is not enabled", func() {
+						It("should return the policy status without the VAC", func() {
+							Expect(err).ToNot(HaveOccurred())
+							Expect(status).ToNot(BeZero())
+							Expect(status.VolumeAttributesClass).To(BeEmpty())
+						})
 					})
 				})
 			})
@@ -357,7 +369,7 @@ var _ = Describe("GetStoragePolicyStatus", func() {
 				})
 			})
 
-			When("The profileID references an existing 512n policy, the storage class objects do not exist but the associated VAC object does but capability is not enabled", func() {
+			When("The profileID references an existing 512n policy, the storage class objects do not exist but the associated VAC object does", func() {
 				BeforeEach(func() {
 					profileID = profileMap.namesToID["sector-format-512"]
 					withObjs = append(withObjs,
@@ -371,50 +383,42 @@ var _ = Describe("GetStoragePolicyStatus", func() {
 				JustBeforeEach(func() {
 					Expect(profileID).ToNot(BeEmpty())
 				})
-				It("should return the policy status", func() {
-					Expect(err).ToNot(HaveOccurred())
-					Expect(status).ToNot(BeZero())
-					Expect(status.StorageClasses).To(HaveLen(0))
-					Expect(status.VolumeAttributesClass).To(BeEmpty())
-					Expect(status.Datastores).To(HaveLen(1))
-					Expect(status.Datastores[0].ID.ObjectID).To(Equal(datastore1Ref.Value))
-					Expect(status.Datastores[0].ID.ServerID).To(Equal(datastore1Ref.ServerGUID))
-					Expect(status.Datastores[0].Type).To(Equal(datastore1K8sType))
-					Expect(status.Encrypted).To(BeFalse())
-					Expect(status.DiskFormat).To(Equal(infrav1.DiskFormat512n))
-					Expect(status.DiskProvisioningMode).To(BeEmpty())
-				})
-			})
 
-			When("The profileID references an existing 512n policy, the storage class objects do not exist but the associated VAC object does and capabililty is enabled", func() {
-				BeforeEach(func() {
-					profileID = profileMap.namesToID["sector-format-512"]
-					withObjs = append(withObjs,
-						&storagev1.VolumeAttributesClass{
-							ObjectMeta: metav1.ObjectMeta{
-								Name: "sector-format-512",
-							},
-						},
-					)
-					ctx = pkgcfg.WithConfig(pkgcfg.Config{
-						Features: pkgcfg.FeatureStates{StoragePolicyMutability: true},
+				Context("when StoragePolicyMutability capability is not enabled", func() {
+					It("should return the policy status without the VAC", func() {
+						Expect(err).ToNot(HaveOccurred())
+						Expect(status).ToNot(BeZero())
+						Expect(status.StorageClasses).To(HaveLen(0))
+						Expect(status.VolumeAttributesClass).To(BeEmpty())
+						Expect(status.Datastores).To(HaveLen(1))
+						Expect(status.Datastores[0].ID.ObjectID).To(Equal(datastore1Ref.Value))
+						Expect(status.Datastores[0].ID.ServerID).To(Equal(datastore1Ref.ServerGUID))
+						Expect(status.Datastores[0].Type).To(Equal(datastore1K8sType))
+						Expect(status.Encrypted).To(BeFalse())
+						Expect(status.DiskFormat).To(Equal(infrav1.DiskFormat512n))
+						Expect(status.DiskProvisioningMode).To(BeEmpty())
 					})
 				})
-				JustBeforeEach(func() {
-					Expect(profileID).ToNot(BeEmpty())
-				})
-				It("should return the policy status", func() {
-					Expect(err).ToNot(HaveOccurred())
-					Expect(status).ToNot(BeZero())
-					Expect(status.StorageClasses).To(HaveLen(0))
-					Expect(status.VolumeAttributesClass).To(Equal("sector-format-512"))
-					Expect(status.Datastores).To(HaveLen(1))
-					Expect(status.Datastores[0].ID.ObjectID).To(Equal(datastore1Ref.Value))
-					Expect(status.Datastores[0].ID.ServerID).To(Equal(datastore1Ref.ServerGUID))
-					Expect(status.Datastores[0].Type).To(Equal(datastore1K8sType))
-					Expect(status.Encrypted).To(BeFalse())
-					Expect(status.DiskFormat).To(Equal(infrav1.DiskFormat512n))
-					Expect(status.DiskProvisioningMode).To(BeEmpty())
+
+				Context("when StoragePolicyMutability capability is enabled", func() {
+					BeforeEach(func() {
+						ctx = pkgcfg.WithContext(ctx, pkgcfg.Config{
+							Features: pkgcfg.FeatureStates{StoragePolicyMutability: true},
+						})
+					})
+					It("should return the policy status with the VAC", func() {
+						Expect(err).ToNot(HaveOccurred())
+						Expect(status).ToNot(BeZero())
+						Expect(status.StorageClasses).To(HaveLen(0))
+						Expect(status.VolumeAttributesClass).To(Equal("sector-format-512"))
+						Expect(status.Datastores).To(HaveLen(1))
+						Expect(status.Datastores[0].ID.ObjectID).To(Equal(datastore1Ref.Value))
+						Expect(status.Datastores[0].ID.ServerID).To(Equal(datastore1Ref.ServerGUID))
+						Expect(status.Datastores[0].Type).To(Equal(datastore1K8sType))
+						Expect(status.Encrypted).To(BeFalse())
+						Expect(status.DiskFormat).To(Equal(infrav1.DiskFormat512n))
+						Expect(status.DiskProvisioningMode).To(BeEmpty())
+					})
 				})
 			})
 
@@ -454,7 +458,7 @@ var _ = Describe("GetStoragePolicyStatus", func() {
 					Expect(status.DiskProvisioningMode).To(BeEmpty())
 				})
 
-				Context("backed by a volume attributes class", func() {
+				When("backed by a volume attributes class", func() {
 					BeforeEach(func() {
 						withObjs = append(withObjs,
 							&storagev1.VolumeAttributesClass{
@@ -463,15 +467,27 @@ var _ = Describe("GetStoragePolicyStatus", func() {
 								},
 							},
 						)
-						ctx = pkgcfg.WithConfig(pkgcfg.Config{
-							Features: pkgcfg.FeatureStates{StoragePolicyMutability: true},
+					})
+
+					Context("when StoragePolicyMutability capability is enabled", func() {
+						BeforeEach(func() {
+							ctx = pkgcfg.WithContext(ctx, pkgcfg.Config{
+								Features: pkgcfg.FeatureStates{StoragePolicyMutability: true},
+							})
+						})
+						It("should return the policy status", func() {
+							Expect(err).ToNot(HaveOccurred())
+							Expect(status).ToNot(BeZero())
+							Expect(status.VolumeAttributesClass).To(Equal("sector-format-4k"))
 						})
 					})
-					It("should return the policy status", func() {
-						Expect(err).ToNot(HaveOccurred())
-						Expect(status).ToNot(BeZero())
 
-						Expect(status.VolumeAttributesClass).To(Equal("sector-format-4k"))
+					Context("when StoragePolicyMutability capability is not enabled", func() {
+						It("should return the policy status without the VAC", func() {
+							Expect(err).ToNot(HaveOccurred())
+							Expect(status).ToNot(BeZero())
+							Expect(status.VolumeAttributesClass).To(BeEmpty())
+						})
 					})
 				})
 			})
@@ -511,7 +527,7 @@ var _ = Describe("GetStoragePolicyStatus", func() {
 					Expect(status.DiskFormat).To(BeEmpty())
 					Expect(status.DiskProvisioningMode).To(Equal(infrav1.DiskProvisioningModeThin))
 				})
-				Context("backed by a volume attributes class", func() {
+				When("backed by a volume attributes class", func() {
 					BeforeEach(func() {
 						withObjs = append(withObjs,
 							&storagev1.VolumeAttributesClass{
@@ -520,15 +536,27 @@ var _ = Describe("GetStoragePolicyStatus", func() {
 								},
 							},
 						)
-						ctx = pkgcfg.WithConfig(pkgcfg.Config{
-							Features: pkgcfg.FeatureStates{StoragePolicyMutability: true},
+					})
+
+					Context("when StoragePolicyMutability capability is enabled", func() {
+						BeforeEach(func() {
+							ctx = pkgcfg.WithContext(ctx, pkgcfg.Config{
+								Features: pkgcfg.FeatureStates{StoragePolicyMutability: true},
+							})
+						})
+						It("should return the policy status", func() {
+							Expect(err).ToNot(HaveOccurred())
+							Expect(status).ToNot(BeZero())
+							Expect(status.VolumeAttributesClass).To(Equal("vmfs-provisioning-thin"))
 						})
 					})
-					It("should return the policy status", func() {
-						Expect(err).ToNot(HaveOccurred())
-						Expect(status).ToNot(BeZero())
 
-						Expect(status.VolumeAttributesClass).To(Equal("vmfs-provisioning-thin"))
+					Context("when StoragePolicyMutability capability is not enabled", func() {
+						It("should return the policy status without the VAC", func() {
+							Expect(err).ToNot(HaveOccurred())
+							Expect(status).ToNot(BeZero())
+							Expect(status.VolumeAttributesClass).To(BeEmpty())
+						})
 					})
 				})
 			})
@@ -569,7 +597,7 @@ var _ = Describe("GetStoragePolicyStatus", func() {
 					Expect(status.DiskProvisioningMode).To(Equal(infrav1.DiskProvisioningModeThick))
 				})
 
-				Context("backed by a volume attributes class", func() {
+				When("backed by a volume attributes class", func() {
 					BeforeEach(func() {
 						withObjs = append(withObjs,
 							&storagev1.VolumeAttributesClass{
@@ -578,15 +606,27 @@ var _ = Describe("GetStoragePolicyStatus", func() {
 								},
 							},
 						)
-						ctx = pkgcfg.WithConfig(pkgcfg.Config{
-							Features: pkgcfg.FeatureStates{StoragePolicyMutability: true},
+					})
+
+					Context("when StoragePolicyMutability capability is enabled", func() {
+						BeforeEach(func() {
+							ctx = pkgcfg.WithContext(ctx, pkgcfg.Config{
+								Features: pkgcfg.FeatureStates{StoragePolicyMutability: true},
+							})
+						})
+						It("should return the policy status", func() {
+							Expect(err).ToNot(HaveOccurred())
+							Expect(status).ToNot(BeZero())
+							Expect(status.VolumeAttributesClass).To(Equal("vmfs-provisioning-thick"))
 						})
 					})
-					It("should return the policy status", func() {
-						Expect(err).ToNot(HaveOccurred())
-						Expect(status).ToNot(BeZero())
 
-						Expect(status.VolumeAttributesClass).To(Equal("vmfs-provisioning-thick"))
+					Context("when StoragePolicyMutability capability is not enabled", func() {
+						It("should return the policy status without the VAC", func() {
+							Expect(err).ToNot(HaveOccurred())
+							Expect(status).ToNot(BeZero())
+							Expect(status.VolumeAttributesClass).To(BeEmpty())
+						})
 					})
 				})
 			})
@@ -627,7 +667,7 @@ var _ = Describe("GetStoragePolicyStatus", func() {
 					Expect(status.DiskProvisioningMode).To(Equal(infrav1.DiskProvisioningModeThickEagerZero))
 				})
 
-				Context("backed by a volume attributes class", func() {
+				When("backed by a volume attributes class", func() {
 					BeforeEach(func() {
 						withObjs = append(withObjs,
 							&storagev1.VolumeAttributesClass{
@@ -636,15 +676,27 @@ var _ = Describe("GetStoragePolicyStatus", func() {
 								},
 							},
 						)
-						ctx = pkgcfg.WithConfig(pkgcfg.Config{
-							Features: pkgcfg.FeatureStates{StoragePolicyMutability: true},
+					})
+
+					Context("when StoragePolicyMutability capability is enabled", func() {
+						BeforeEach(func() {
+							ctx = pkgcfg.WithContext(ctx, pkgcfg.Config{
+								Features: pkgcfg.FeatureStates{StoragePolicyMutability: true},
+							})
+						})
+						It("should return the policy status", func() {
+							Expect(err).ToNot(HaveOccurred())
+							Expect(status).ToNot(BeZero())
+							Expect(status.VolumeAttributesClass).To(Equal("vmfs-provisioning-thick-eager-zero"))
 						})
 					})
-					It("should return the policy status", func() {
-						Expect(err).ToNot(HaveOccurred())
-						Expect(status).ToNot(BeZero())
 
-						Expect(status.VolumeAttributesClass).To(Equal("vmfs-provisioning-thick-eager-zero"))
+					Context("when StoragePolicyMutability capability is not enabled", func() {
+						It("should return the policy status without the VAC", func() {
+							Expect(err).ToNot(HaveOccurred())
+							Expect(status).ToNot(BeZero())
+							Expect(status.VolumeAttributesClass).To(BeEmpty())
+						})
 					})
 				})
 
@@ -689,7 +741,7 @@ var _ = Describe("GetStoragePolicyStatus", func() {
 					Expect(status.DiskProvisioningMode).To(Equal(infrav1.DiskProvisioningModeThin))
 				})
 
-				Context("backed by a volume attributes class", func() {
+				When("backed by a volume attributes class", func() {
 					BeforeEach(func() {
 						withObjs = append(withObjs,
 							&storagev1.VolumeAttributesClass{
@@ -698,15 +750,27 @@ var _ = Describe("GetStoragePolicyStatus", func() {
 								},
 							},
 						)
-						ctx = pkgcfg.WithConfig(pkgcfg.Config{
-							Features: pkgcfg.FeatureStates{StoragePolicyMutability: true},
+					})
+
+					Context("when StoragePolicyMutability capability is enabled", func() {
+						BeforeEach(func() {
+							ctx = pkgcfg.WithContext(ctx, pkgcfg.Config{
+								Features: pkgcfg.FeatureStates{StoragePolicyMutability: true},
+							})
+						})
+						It("should return the policy status", func() {
+							Expect(err).ToNot(HaveOccurred())
+							Expect(status).ToNot(BeZero())
+							Expect(status.VolumeAttributesClass).To(Equal("vsan-provisioning-thin"))
 						})
 					})
-					It("should return the policy status", func() {
-						Expect(err).ToNot(HaveOccurred())
-						Expect(status).ToNot(BeZero())
 
-						Expect(status.VolumeAttributesClass).To(Equal("vsan-provisioning-thin"))
+					Context("when StoragePolicyMutability capability is not enabled", func() {
+						It("should return the policy status without the VAC", func() {
+							Expect(err).ToNot(HaveOccurred())
+							Expect(status).ToNot(BeZero())
+							Expect(status.VolumeAttributesClass).To(BeEmpty())
+						})
 					})
 				})
 
@@ -751,7 +815,7 @@ var _ = Describe("GetStoragePolicyStatus", func() {
 					Expect(status.DiskProvisioningMode).To(Equal(infrav1.DiskProvisioningModeThick))
 				})
 
-				Context("backed by a volume attributes class", func() {
+				When("backed by a volume attributes class", func() {
 					BeforeEach(func() {
 						withObjs = append(withObjs,
 							&storagev1.VolumeAttributesClass{
@@ -760,15 +824,27 @@ var _ = Describe("GetStoragePolicyStatus", func() {
 								},
 							},
 						)
-						ctx = pkgcfg.WithConfig(pkgcfg.Config{
-							Features: pkgcfg.FeatureStates{StoragePolicyMutability: true},
+					})
+
+					Context("when StoragePolicyMutability capability is enabled", func() {
+						BeforeEach(func() {
+							ctx = pkgcfg.WithContext(ctx, pkgcfg.Config{
+								Features: pkgcfg.FeatureStates{StoragePolicyMutability: true},
+							})
+						})
+						It("should return the policy status", func() {
+							Expect(err).ToNot(HaveOccurred())
+							Expect(status).ToNot(BeZero())
+							Expect(status.VolumeAttributesClass).To(Equal("vsan-provisioning-thick"))
 						})
 					})
-					It("should return the policy status", func() {
-						Expect(err).ToNot(HaveOccurred())
-						Expect(status).ToNot(BeZero())
 
-						Expect(status.VolumeAttributesClass).To(Equal("vsan-provisioning-thick"))
+					Context("when StoragePolicyMutability capability is not enabled", func() {
+						It("should return the policy status without the VAC", func() {
+							Expect(err).ToNot(HaveOccurred())
+							Expect(status).ToNot(BeZero())
+							Expect(status.VolumeAttributesClass).To(BeEmpty())
+						})
 					})
 				})
 			})
@@ -838,7 +914,7 @@ var _ = Describe("GetStoragePolicyStatus", func() {
 					})
 				})
 
-				Context("backed by a volume attributes class", func() {
+				When("backed by a volume attributes class", func() {
 					BeforeEach(func() {
 						withObjs = append(withObjs,
 							&storagev1.VolumeAttributesClass{
@@ -847,15 +923,27 @@ var _ = Describe("GetStoragePolicyStatus", func() {
 								},
 							},
 						)
-						ctx = pkgcfg.WithConfig(pkgcfg.Config{
-							Features: pkgcfg.FeatureStates{StoragePolicyMutability: true},
+					})
+
+					Context("when StoragePolicyMutability capability is enabled", func() {
+						BeforeEach(func() {
+							ctx = pkgcfg.WithContext(ctx, pkgcfg.Config{
+								Features: pkgcfg.FeatureStates{StoragePolicyMutability: true},
+							})
+						})
+						It("should return the policy status", func() {
+							Expect(err).ToNot(HaveOccurred())
+							Expect(status).ToNot(BeZero())
+							Expect(status.VolumeAttributesClass).To(Equal("vm-encryption-policy"))
 						})
 					})
-					It("should return the policy status", func() {
-						Expect(err).ToNot(HaveOccurred())
-						Expect(status).ToNot(BeZero())
 
-						Expect(status.VolumeAttributesClass).To(Equal("vm-encryption-policy"))
+					Context("when StoragePolicyMutability capability is not enabled", func() {
+						It("should return the policy status without the VAC", func() {
+							Expect(err).ToNot(HaveOccurred())
+							Expect(status).ToNot(BeZero())
+							Expect(status.VolumeAttributesClass).To(BeEmpty())
+						})
 					})
 				})
 			})

--- a/pkg/util/vsphere/storage/storage_policy_test.go
+++ b/pkg/util/vsphere/storage/storage_policy_test.go
@@ -291,6 +291,9 @@ var _ = Describe("GetStoragePolicyStatus", func() {
 								},
 							},
 						)
+						ctx = pkgcfg.WithConfig(pkgcfg.Config{
+							Features: pkgcfg.FeatureStates{StoragePolicyMutability: true},
+						})
 					})
 					It("should return the policy status", func() {
 						Expect(err).ToNot(HaveOccurred())
@@ -354,7 +357,7 @@ var _ = Describe("GetStoragePolicyStatus", func() {
 				})
 			})
 
-			When("The profileID references an existing 512n policy, the storage class objects do not exist but the associated VAC object does", func() {
+			When("The profileID references an existing 512n policy, the storage class objects do not exist but the associated VAC object does but capability is not enabled", func() {
 				BeforeEach(func() {
 					profileID = profileMap.namesToID["sector-format-512"]
 					withObjs = append(withObjs,
@@ -364,6 +367,38 @@ var _ = Describe("GetStoragePolicyStatus", func() {
 							},
 						},
 					)
+				})
+				JustBeforeEach(func() {
+					Expect(profileID).ToNot(BeEmpty())
+				})
+				It("should return the policy status", func() {
+					Expect(err).ToNot(HaveOccurred())
+					Expect(status).ToNot(BeZero())
+					Expect(status.StorageClasses).To(HaveLen(0))
+					Expect(status.VolumeAttributesClass).To(BeEmpty())
+					Expect(status.Datastores).To(HaveLen(1))
+					Expect(status.Datastores[0].ID.ObjectID).To(Equal(datastore1Ref.Value))
+					Expect(status.Datastores[0].ID.ServerID).To(Equal(datastore1Ref.ServerGUID))
+					Expect(status.Datastores[0].Type).To(Equal(datastore1K8sType))
+					Expect(status.Encrypted).To(BeFalse())
+					Expect(status.DiskFormat).To(Equal(infrav1.DiskFormat512n))
+					Expect(status.DiskProvisioningMode).To(BeEmpty())
+				})
+			})
+
+			When("The profileID references an existing 512n policy, the storage class objects do not exist but the associated VAC object does and capabililty is enabled", func() {
+				BeforeEach(func() {
+					profileID = profileMap.namesToID["sector-format-512"]
+					withObjs = append(withObjs,
+						&storagev1.VolumeAttributesClass{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "sector-format-512",
+							},
+						},
+					)
+					ctx = pkgcfg.WithConfig(pkgcfg.Config{
+						Features: pkgcfg.FeatureStates{StoragePolicyMutability: true},
+					})
 				})
 				JustBeforeEach(func() {
 					Expect(profileID).ToNot(BeEmpty())
@@ -428,6 +463,9 @@ var _ = Describe("GetStoragePolicyStatus", func() {
 								},
 							},
 						)
+						ctx = pkgcfg.WithConfig(pkgcfg.Config{
+							Features: pkgcfg.FeatureStates{StoragePolicyMutability: true},
+						})
 					})
 					It("should return the policy status", func() {
 						Expect(err).ToNot(HaveOccurred())
@@ -482,6 +520,9 @@ var _ = Describe("GetStoragePolicyStatus", func() {
 								},
 							},
 						)
+						ctx = pkgcfg.WithConfig(pkgcfg.Config{
+							Features: pkgcfg.FeatureStates{StoragePolicyMutability: true},
+						})
 					})
 					It("should return the policy status", func() {
 						Expect(err).ToNot(HaveOccurred())
@@ -537,6 +578,9 @@ var _ = Describe("GetStoragePolicyStatus", func() {
 								},
 							},
 						)
+						ctx = pkgcfg.WithConfig(pkgcfg.Config{
+							Features: pkgcfg.FeatureStates{StoragePolicyMutability: true},
+						})
 					})
 					It("should return the policy status", func() {
 						Expect(err).ToNot(HaveOccurred())
@@ -592,6 +636,9 @@ var _ = Describe("GetStoragePolicyStatus", func() {
 								},
 							},
 						)
+						ctx = pkgcfg.WithConfig(pkgcfg.Config{
+							Features: pkgcfg.FeatureStates{StoragePolicyMutability: true},
+						})
 					})
 					It("should return the policy status", func() {
 						Expect(err).ToNot(HaveOccurred())
@@ -651,6 +698,9 @@ var _ = Describe("GetStoragePolicyStatus", func() {
 								},
 							},
 						)
+						ctx = pkgcfg.WithConfig(pkgcfg.Config{
+							Features: pkgcfg.FeatureStates{StoragePolicyMutability: true},
+						})
 					})
 					It("should return the policy status", func() {
 						Expect(err).ToNot(HaveOccurred())
@@ -710,6 +760,9 @@ var _ = Describe("GetStoragePolicyStatus", func() {
 								},
 							},
 						)
+						ctx = pkgcfg.WithConfig(pkgcfg.Config{
+							Features: pkgcfg.FeatureStates{StoragePolicyMutability: true},
+						})
 					})
 					It("should return the policy status", func() {
 						Expect(err).ToNot(HaveOccurred())
@@ -794,6 +847,9 @@ var _ = Describe("GetStoragePolicyStatus", func() {
 								},
 							},
 						)
+						ctx = pkgcfg.WithConfig(pkgcfg.Config{
+							Features: pkgcfg.FeatureStates{StoragePolicyMutability: true},
+						})
 					})
 					It("should return the policy status", func() {
 						Expect(err).ToNot(HaveOccurred())

--- a/pkg/vmconfig/crypto/crypto_reconciler_pre.go
+++ b/pkg/vmconfig/crypto/crypto_reconciler_pre.go
@@ -1328,10 +1328,13 @@ func isEncryptedProfile(ctx context.Context,
 	spec vimtypes.BaseVirtualMachineProfileSpec) (bool, error) {
 
 	if profile, ok := spec.(*vimtypes.VirtualMachineDefinedProfileSpec); ok {
-		return kubeutil.IsEncryptedStorageProfile(
-			ctx,
+
+		isEnc, err := kubeutil.IsEncryptedStorageProfile(ctx,
 			args.k8sClient,
 			profile.ProfileId)
+
+		// TODO: Verify if we should propagate the error when the storage profile is not found
+		return isEnc, ctrlclient.IgnoreNotFound(err)
 	}
 	return false, nil
 }

--- a/pkg/vmconfig/crypto/crypto_reconciler_pre.go
+++ b/pkg/vmconfig/crypto/crypto_reconciler_pre.go
@@ -660,11 +660,10 @@ func doOp(
 	args reconcileArgs,
 	fn func(context.Context, reconcileArgs) (string, Reason, []string, error)) error {
 
-	// Please note, the return err is ignored here since it is not used anywhere
-	// in the various functions that can be "fn." The reason the pattern is
-	// retained is to avoid any refactoring later if there *does* need to be an
-	// error returned from one of these functions.
-	op, reason, msgs, _ := fn(ctx, args)
+	op, reason, msgs, err := fn(ctx, args)
+	if err != nil {
+		return err
+	}
 
 	if reason == 0 && len(msgs) == 0 {
 		internal.SetOperation(ctx, op)
@@ -1328,13 +1327,10 @@ func isEncryptedProfile(ctx context.Context,
 	spec vimtypes.BaseVirtualMachineProfileSpec) (bool, error) {
 
 	if profile, ok := spec.(*vimtypes.VirtualMachineDefinedProfileSpec); ok {
-
-		isEnc, err := kubeutil.IsEncryptedStorageProfile(ctx,
+		return kubeutil.IsEncryptedStorageProfile(
+			ctx,
 			args.k8sClient,
 			profile.ProfileId)
-
-		// TODO: Verify if we should propagate the error when the storage profile is not found
-		return isEnc, ctrlclient.IgnoreNotFound(err)
 	}
 	return false, nil
 }

--- a/pkg/vmconfig/crypto/crypto_reconciler_pre_test.go
+++ b/pkg/vmconfig/crypto/crypto_reconciler_pre_test.go
@@ -27,6 +27,7 @@ import (
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 	byokv1 "github.com/vmware-tanzu/vm-operator/external/byok/api/v1alpha1"
+	infrav1 "github.com/vmware-tanzu/vm-operator/external/infra/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgconst "github.com/vmware-tanzu/vm-operator/pkg/constants"
@@ -886,6 +887,29 @@ var _ = Describe("Reconcile", Label(testlabels.Crypto), func() {
 							})
 						})
 
+						When("adding encrypted disk with missing policy", func() {
+							BeforeEach(func() {
+								configSpec.DeviceChange = []vimtypes.BaseVirtualDeviceConfigSpec{
+									&vimtypes.VirtualDeviceConfigSpec{
+										Backing: &vimtypes.VirtualDeviceConfigSpecBackingSpec{
+											Crypto: &vimtypes.CryptoSpecEncrypt{},
+										},
+										Device:    &vimtypes.VirtualDisk{},
+										Operation: vimtypes.VirtualDeviceConfigSpecOperationAdd,
+										Profile: []vimtypes.BaseVirtualMachineProfileSpec{
+											&vimtypes.VirtualMachineDefinedProfileSpec{
+												ProfileId: "missing-policy",
+											},
+										},
+									},
+								}
+							})
+							It("should return a not found error", func() {
+								Expect(err).To(HaveOccurred())
+								Expect(err.Error()).To(ContainSubstring("storage class with profile ID missing-policy not found"))
+							})
+						})
+
 						When("adding encrypted disk sans policy", func() {
 							BeforeEach(func() {
 								configSpec.DeviceChange = []vimtypes.BaseVirtualDeviceConfigSpec{
@@ -902,6 +926,23 @@ var _ = Describe("Reconcile", Label(testlabels.Crypto), func() {
 										},
 									},
 								}
+								withObjs = append(withObjs, &storagev1.StorageClass{
+									ObjectMeta: metav1.ObjectMeta{
+										Name: "fake-storage-class",
+									},
+									Parameters: map[string]string{
+										"storagePolicyID": fakeString,
+									},
+								})
+								withObjs = append(withObjs, &infrav1.StoragePolicy{
+									ObjectMeta: metav1.ObjectMeta{
+										Namespace: pkgcfg.FromContext(ctx).PodNamespace,
+										Name:      kubeutil.GetStoragePolicyObjectName(fakeString),
+									},
+									Status: infrav1.StoragePolicyStatus{
+										Encrypted: false,
+									},
+								})
 							})
 							It(shouldSetEncryptionSyncedWithInvalidChanges, func() {
 								Expect(err).ToNot(HaveOccurred())

--- a/test/builder/vcsim_test_context.go
+++ b/test/builder/vcsim_test_context.go
@@ -61,6 +61,7 @@ import (
 	// _ "github.com/vmware/govmomi/pbm/simulator"
 
 	byokv1 "github.com/vmware-tanzu/vm-operator/external/byok/api/v1alpha1"
+	infrav1 "github.com/vmware-tanzu/vm-operator/external/infra/api/v1alpha1"
 	spqv1 "github.com/vmware-tanzu/vm-operator/external/storage-policy-quota/api/v1alpha2"
 	topologyv1 "github.com/vmware-tanzu/vm-operator/external/tanzu-topology/api/v1alpha1"
 
@@ -73,6 +74,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/record"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
+	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 	pkgclient "github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/client"
 	"github.com/vmware-tanzu/vm-operator/test/testutil"
 )
@@ -1133,6 +1135,17 @@ func (c *TestContextForVCSim) setupK8sConfig(config VCSimTestConfig) {
 			},
 		})).To(Succeed())
 
+		defaultStoragePolicy := &infrav1.StoragePolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: c.PodNamespace,
+				Name:      kubeutil.GetStoragePolicyObjectName(c.StorageProfileID),
+			},
+			Spec: infrav1.StoragePolicySpec{
+				ID: c.StorageProfileID,
+			},
+		}
+		Expect(c.Client.Create(c, defaultStoragePolicy)).To(Succeed())
+
 		c.EncryptedStorageClassName = "vm-encryption-policy"
 		c.EncryptedStorageProfileID = pbmsim.DefaultEncryptionProfileID
 
@@ -1145,6 +1158,21 @@ func (c *TestContextForVCSim) setupK8sConfig(config VCSimTestConfig) {
 				"storagePolicyID": c.EncryptedStorageProfileID,
 			},
 		})).To(Succeed())
+
+		encryptedStoragePolicy := &infrav1.StoragePolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: c.PodNamespace,
+				Name:      kubeutil.GetStoragePolicyObjectName(c.EncryptedStorageProfileID),
+			},
+			Spec: infrav1.StoragePolicySpec{
+				ID: c.EncryptedStorageProfileID,
+			},
+			Status: infrav1.StoragePolicyStatus{
+				Encrypted: true,
+			},
+		}
+		Expect(c.Client.Create(c, encryptedStoragePolicy)).To(Succeed())
+		Expect(c.Client.Status().Update(c, encryptedStoragePolicy)).To(Succeed())
 	}
 
 	if !config.WithoutNativeKeyProvider {


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This patch reinstates the logic originally introduced in PR #1533 (and reversed by #1547), which allows the VM creation process to derive the storage policy ID from either a StorageClass or a VolumeAttributesClass (VAC) when the capability is enabled.
The original implementation was reverted due to failures in gce2e encryption tests.
On this PR, we resolved the root cause of the gce2e encryption test failures by adding a missing capability check around the status updates of Storage Policy objects for the VolumeAttributesClasses field (originally introduced in PR #1540).
During the investigation, we acknowledged that storage policy objects may not be immediately ready for encryption checks, as they require a multi-step lifecycle (creation by the StorageClass controller followed by population by the StoragePolicy controller).
We slightly updated the logic of the function `IsEncryptedStorageProfile` which we no longer "swallow" the NotFound error - as suggested (and agreed to address it eventually) during revision of  #1533 . This function is called by other components and to minimize impact and ensure backward compatibility for other callers, the IgnoreNotFound was added when applicable. We added the storage policy object as part of vcsim test context to represent the realist production scenario.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # N/A

**Are there any special notes for your reviewer**:

Same code from #1533  + adding missing capability check from PR #1540 + no longer ignoring error if Storage Policy does not exist 

**Please add a release note if necessary**:

```release-note
Addresses bug when Storage Policy objects on VM Operator namespace were not properly reconciled when running on Kubernetes version v1.33 and below. 
Allows the VM creation process to derive the storage policy ID from either a StorageClass or a VolumeAttributesClass (VAC) when the capability is enabled
```