### PR TITLE
🐛 Only skip PVCs with VirtualMachine as the DSRef

### DIFF
--- a/pkg/util/kube/storage.go
+++ b/pkg/util/kube/storage.go
@@ -69,9 +69,13 @@ func GetPVCZoneConstraints(
 	var zones sets.Set[string]
 
 	for _, pvc := range pvcs {
-		if pvc.Spec.DataSourceRef != nil {
-			// Do not worry about PVCs with data source refs.
-			continue
+		if dsRef := pvc.Spec.DataSourceRef; dsRef != nil && dsRef.APIGroup != nil {
+			// Skip the zonal constraint check for PVCs with us as the DataSourceRef since
+			// those disks are in the placement ConfigSpec. Note that the reference may
+			// point to another object type such as VolumeSnapshot.
+			if *dsRef.APIGroup == vmopv1.GroupVersion.Group && dsRef.Kind == "VirtualMachine" {
+				continue
+			}
 		}
 
 		var z sets.Set[string]

--- a/pkg/util/kube/storage_test.go
+++ b/pkg/util/kube/storage_test.go
@@ -449,6 +449,61 @@ var _ = Describe("GetPVCZoneConstraints", func() {
 			Expect(zones.UnsortedList()).To(ConsistOf("zone1"))
 		})
 	})
+
+	Context("PVC with DataSourceRef", func() {
+
+		It("skips zone constraints when DataSourceRef points to a VirtualMachine", func() {
+			pvcs := []corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "clone-from-vm-pvc",
+						Annotations: map[string]string{
+							"csi.vsphere.volume-accessible-topology": `[{"topology.kubernetes.io/zone":"zone-is-ignored"}]`,
+						},
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						DataSourceRef: &corev1.TypedObjectReference{
+							APIGroup: ptr.To(vmopv1.GroupVersion.Group),
+							Kind:     "VirtualMachine",
+							Name:     "source-vm",
+						},
+					},
+					Status: corev1.PersistentVolumeClaimStatus{
+						Phase: corev1.ClaimBound,
+					},
+				},
+			}
+			zones, err := kubeutil.GetPVCZoneConstraints(nil, pvcs)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(zones).To(BeNil())
+		})
+
+		It("still applies zone constraints when DataSourceRef is not a VirtualMachine", func() {
+			pvcs := []corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "restore-from-snapshot-pvc",
+						Annotations: map[string]string{
+							"csi.vsphere.volume-accessible-topology": `[{"topology.kubernetes.io/zone":"zone-from-snapshot-pvc"}]`,
+						},
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						DataSourceRef: &corev1.TypedObjectReference{
+							APIGroup: ptr.To("snapshot.storage.k8s.io"),
+							Kind:     "VolumeSnapshot",
+							Name:     "src-snap",
+						},
+					},
+					Status: corev1.PersistentVolumeClaimStatus{
+						Phase: corev1.ClaimBound,
+					},
+				},
+			}
+			zones, err := kubeutil.GetPVCZoneConstraints(nil, pvcs)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(zones.UnsortedList()).To(ConsistOf("zone-from-snapshot-pvc"))
+		})
+	})
 })
 
 var _ = DescribeTableSubtree("GetPVCZoneConstraints Table",


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

A PVC can have other DataSourceRef types, such snapshot.storage.k8s.io/VolumeSnapshot if created from a snapshot, that its zonal constraint should still be considered until we put all PVCs in the placement ConfigSpec.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note
During VM placement honor the PVC zonal constraints for PVCs with non VirtualMachine DataSourceRef, such as VolumeSnapshot.
```