### PR TITLE
🌱 Fix data race in VMIC controller test

### DIFF
--- a/controllers/virtualmachineimagecache/virtualmachineimagecache_controller_test.go
+++ b/controllers/virtualmachineimagecache/virtualmachineimagecache_controller_test.go
@@ -348,6 +348,8 @@ var _ = Describe(
 			})
 
 			BeforeEach(func() {
+				provider.Lock()
+				defer provider.Unlock()
 				provider.VSphereClientFn = func(ctx context.Context) (*vsclient.Client, error) {
 					return vsclient.NewClient(ctx, vcSimCtx.VCClientConfig)
 				}


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Writing to the fake provider vSphereClient may race with the controller reading it from the fake provider.

Seen in https://github.com/vmware-tanzu/vm-operator/actions/runs/24476299421/job/71529316798?pr=1554

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #

**Are there any special notes for your reviewer**:

**Please add a release note if necessary**:

```release-note
NONE
```