### PR TITLE
🐛 Update API fuzzer tests

### DIFF
--- a/api/test/utilconversion/fuzztests/conversion_fuzz.go
+++ b/api/test/utilconversion/fuzztests/conversion_fuzz.go
@@ -15,9 +15,11 @@ package fuzztests
 
 import (
 	"math/rand"
+	"time"
 
 	//nolint:depguard
 	"github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
@@ -42,14 +44,27 @@ func GetFuzzer(scheme *runtime.Scheme, funcs ...fuzzer.FuzzerFuncs) *randfill.Fi
 				// fuzzed and always resulted in `nil` values.
 				// This implementation is somewhat similar to the one provided
 				// in the metafuzzer.Funcs.
-				func(input *metav1.Time, c randfill.Continue) {
-					if input != nil {
-						var sec, nsec uint32
-						c.Fill(&sec)
-						c.Fill(&nsec)
-						fuzzed := metav1.Unix(int64(sec), int64(nsec)).Rfc3339Copy()
-						input.Time = fuzzed.Time
+				func(input **metav1.Time, c randfill.Continue) {
+					if c.Bool() {
+						// Leave the Time sometimes nil to also get coverage for this case.
+						return
 					}
+					now := metav1.NewTime(time.Now().Add(time.Duration(-c.Intn(3600)) * time.Second)).Rfc3339Copy()
+					*input = &now
+				},
+				// Custom fuzzer for intstr.IntOrString which does not get fuzzed otherwise.
+				func(in **intstr.IntOrString, c randfill.Continue) {
+					if c.Bool() {
+						// Leave the IntOrString sometimes nil to also get coverage for this case.
+						return
+					}
+					if c.Bool() {
+						// Set the IntOrString sometimes empty to also get coverage for this case.
+						*in = &intstr.IntOrString{}
+						return
+					}
+					v := intstr.FromInt32(c.Int31n(50))
+					*in = &v
 				},
 			}
 		},
@@ -103,7 +118,10 @@ func SpokeHubSpoke(input FuzzTestFuncInput) {
 			input.SpokeAfterMutation(spokeAfter)
 		}
 
-		gomega.ExpectWithOffset(1, apiequality.Semantic.DeepEqual(spokeBefore, spokeAfter)).To(gomega.BeTrue(), cmp.Diff(spokeBefore, spokeAfter))
+		if !apiequality.Semantic.DeepEqual(spokeBefore, spokeAfter) {
+			diff := cmp.Diff(spokeBefore, spokeAfter)
+			gomega.ExpectWithOffset(1, false).To(gomega.BeTrue(), diff)
+		}
 	}
 }
 
@@ -127,6 +145,9 @@ func HubSpokeHub(input FuzzTestFuncInput) {
 			input.HubAfterMutation(hubAfter)
 		}
 
-		gomega.ExpectWithOffset(1, apiequality.Semantic.DeepEqual(hubBefore, hubAfter)).To(gomega.BeTrue(), cmp.Diff(hubBefore, hubAfter))
+		if !apiequality.Semantic.DeepEqual(hubBefore, hubAfter) {
+			diff := cmp.Diff(hubBefore, hubAfter)
+			gomega.ExpectWithOffset(1, false).To(gomega.BeTrue(), diff)
+		}
 	}
 }

--- a/api/test/v1alpha1/conversion_test.go
+++ b/api/test/v1alpha1/conversion_test.go
@@ -5,6 +5,9 @@
 package v1alpha1_test
 
 import (
+	"encoding/json"
+	"reflect"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -12,11 +15,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
+	ctrlconversion "sigs.k8s.io/controller-runtime/pkg/conversion"
 	"sigs.k8s.io/randfill"
 
 	"github.com/vmware-tanzu/vm-operator/api/test/utilconversion/fuzztests"
 	vmopv1a1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+	vmopv1common "github.com/vmware-tanzu/vm-operator/api/v1alpha6/common"
 )
 
 var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
@@ -88,6 +93,12 @@ var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 				Scheme: scheme,
 				Hub:    &vmopv1.VirtualMachineImage{},
 				Spoke:  &vmopv1a1.VirtualMachineImage{},
+				SpokeAfterMutation: func(convertible ctrlconversion.Convertible) {
+					vmImage := convertible.(*vmopv1a1.VirtualMachineImage)
+					if vmImage.Spec.ProviderRef.Name != "" {
+						vmImage.Spec.ProviderRef.Namespace = vmImage.Namespace
+					}
+				},
 				FuzzerFuncs: []fuzzer.FuzzerFuncs{
 					overrideVirtualMachineImageFieldsFuncs,
 				},
@@ -170,6 +181,7 @@ var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 			})
 		})
 	})
+
 	Context("VirtualMachineSetResourcePolicy", func() {
 		BeforeEach(func() {
 			input = fuzztests.FuzzTestFuncInput{
@@ -191,10 +203,36 @@ var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 	})
 })
 
+// nolint:gocyclo
 func overrideVirtualMachineFieldsFuncs(codecs runtimeserializer.CodecFactory) []interface{} {
 	return []interface{}{
 		func(vmSpec *vmopv1a1.VirtualMachineSpec, c randfill.Continue) {
-			c.Fill(vmSpec)
+			c.FillNoCustom(vmSpec)
+
+			if md := vmSpec.VmMetadata; md != nil {
+				t := []vmopv1a1.VirtualMachineMetadataTransport{
+					vmopv1a1.VirtualMachineMetadataCloudInitTransport,
+					vmopv1a1.VirtualMachineMetadataOvfEnvTransport,
+					vmopv1a1.VirtualMachineMetadataSysprepTransport,
+					vmopv1a1.VirtualMachineMetadataVAppConfigTransport,
+				}
+				md.Transport = t[c.Intn(len(t))]
+
+				if md.SecretName != "" && md.ConfigMapName != "" {
+					if c.Bool() {
+						md.SecretName = ""
+					} else {
+						md.ConfigMapName = ""
+					}
+				}
+			}
+
+			for i := range vmSpec.NetworkInterfaces {
+				t := []string{"nsx-t", "nsx-t-subnet", "nsx-t-subnetset", "vsphere-distributed"}
+				vmSpec.NetworkInterfaces[i].NetworkType = t[c.Intn(len(t))]
+				vmSpec.NetworkInterfaces[i].ProviderRef = nil
+				vmSpec.NetworkInterfaces[i].EthernetCardType = ""
+			}
 
 			var volumes []vmopv1a1.VirtualMachineVolume
 			for _, vol := range vmSpec.Volumes {
@@ -207,14 +245,30 @@ func overrideVirtualMachineFieldsFuncs(codecs runtimeserializer.CodecFactory) []
 
 			if opts := vmSpec.AdvancedOptions; opts != nil {
 				if provOpts := opts.DefaultVolumeProvisioningOptions; provOpts != nil {
-					if provOpts.ThinProvisioned != nil {
+					if provOpts.ThinProvisioned != nil && provOpts.EagerZeroed != nil {
 						// Both cannot be set.
+						if c.Bool() {
+							provOpts.ThinProvisioned = nil
+						} else {
+							provOpts.EagerZeroed = nil
+						}
+					}
+
+					if provOpts.EagerZeroed != nil && !*provOpts.EagerZeroed {
 						provOpts.EagerZeroed = nil
+					}
+
+					if reflect.DeepEqual(provOpts, &vmopv1a1.VirtualMachineVolumeProvisioningOptions{}) {
+						vmSpec.AdvancedOptions.DefaultVolumeProvisioningOptions = nil
 					}
 				}
 
 				if opts.ChangeBlockTracking != nil && !*opts.ChangeBlockTracking {
 					opts.ChangeBlockTracking = nil
+				}
+
+				if reflect.DeepEqual(opts, &vmopv1a1.VirtualMachineAdvancedOptions{}) {
+					vmSpec.AdvancedOptions = nil
 				}
 			}
 
@@ -222,21 +276,81 @@ func overrideVirtualMachineFieldsFuncs(codecs runtimeserializer.CodecFactory) []
 			vmSpec.Ports = nil
 		},
 		func(vmSpec *vmopv1.VirtualMachineSpec, c randfill.Continue) {
-			c.Fill(vmSpec)
+			c.FillNoCustom(vmSpec)
+
+			if vmSpec.Image != nil {
+				vmSpec.Image.Name = vmSpec.ImageName
+			}
+
+			// TODO: Conversion
+			if vmSpec.Class != nil {
+				vmSpec.Class = nil
+			}
+
+			vmSpec.Volumes = nil
+
+			if rs := vmSpec.Reserved; rs != nil {
+				if rs.ResourcePolicyName == "" {
+					vmSpec.Reserved = nil
+				}
+			}
+
+			if bs := vmSpec.Bootstrap; bs != nil {
+				// v1a1 has just single for the bootstrap type field (transport) so
+				// adjust the filled to valid bootstrap combinations.
+				switch c.Rand.Intn(4) {
+				case 0: // CloudInit
+					bs.LinuxPrep = nil
+					bs.Sysprep = nil
+					bs.VAppConfig = nil
+				case 1: // LinuxPrep
+					bs.CloudInit = nil
+					bs.Sysprep = nil
+					if c.Bool() {
+						bs.VAppConfig = nil
+					}
+				case 2: // Sysprep
+					bs.CloudInit = nil
+					bs.LinuxPrep = nil
+					if c.Bool() {
+						bs.VAppConfig = nil
+					}
+				case 3: // vAppConfig
+					bs.CloudInit = nil
+					bs.LinuxPrep = nil
+					bs.Sysprep = nil
+				}
+
+				if reflect.DeepEqual(bs, &vmopv1.VirtualMachineBootstrapSpec{}) {
+					vmSpec.Bootstrap = nil
+				}
+			}
 		},
 		func(vmStatus *vmopv1a1.VirtualMachineStatus, c randfill.Continue) {
-			c.Fill(vmStatus)
-			overrideConditionsSeverity(vmStatus.Conditions)
+			c.FillNoCustom(vmStatus)
+			overrideConditions(vmStatus.Conditions)
 
-			// Do not exist in nextver.
+			for i := range vmStatus.NetworkInterfaces {
+				// Connected does not exist in nextver so assume it is true.
+				vmStatus.NetworkInterfaces[i].Connected = true
+			}
+
+			// Does not exist in nextver.
 			vmStatus.Phase = vmopv1a1.Unknown
 		},
 		func(vmStatus *vmopv1.VirtualMachineStatus, c randfill.Continue) {
-			c.Fill(vmStatus)
+			c.FillNoCustom(vmStatus)
 			overrideConditionsObservedGeneration(vmStatus.Conditions)
 
 			vmStatus.Class = nil
 			vmStatus.Network = nil
+		},
+		func(sel *vmopv1common.SecretKeySelector, c randfill.Continue) {
+			sel.Name = "foo"
+			sel.Key = c.String(0)
+		},
+		func(msg *json.RawMessage, c randfill.Continue) {
+			*msg = []byte(`{"foo":"bar"}`)
 		},
 	}
 }
@@ -255,14 +369,14 @@ var _ = Describe("Client-side conversion", func() {
 func overrideVirtualMachineClassFieldsFuncs(codecs runtimeserializer.CodecFactory) []interface{} {
 	return []interface{}{
 		func(classSpec *vmopv1.VirtualMachineClassSpec, c randfill.Continue) {
-			c.Fill(classSpec)
+			c.FillNoCustom(classSpec)
 
 			// Since all random byte arrays are not valid JSON
 			// Passing an empty string as a valid input
 			classSpec.ConfigSpec = []byte("")
 		},
 		func(classSpec *vmopv1a1.VirtualMachineClassSpec, c randfill.Continue) {
-			c.Fill(classSpec)
+			c.FillNoCustom(classSpec)
 
 			// Since all random byte arrays are not valid JSON
 			// Passing an empty string as a valid input
@@ -274,7 +388,11 @@ func overrideVirtualMachineClassFieldsFuncs(codecs runtimeserializer.CodecFactor
 func overrideVirtualMachineImageFieldsFuncs(codecs runtimeserializer.CodecFactory) []interface{} {
 	return []interface{}{
 		func(imageSpec *vmopv1a1.VirtualMachineImageSpec, c randfill.Continue) {
-			c.Fill(imageSpec)
+			c.FillNoCustom(imageSpec)
+
+			// This same type is used in both the namespace and cluster
+			// scoped types so we don't determine the NS backfill here.
+			imageSpec.ProviderRef = vmopv1a1.ContentProviderReference{}
 
 			if imageSpec.OVFEnv != nil {
 				m := make(map[string]vmopv1a1.OvfProperty, len(imageSpec.OVFEnv))
@@ -296,8 +414,12 @@ func overrideVirtualMachineImageFieldsFuncs(codecs runtimeserializer.CodecFactor
 			imageSpec.ProviderRef.Namespace = ""
 		},
 		func(imageStatus *vmopv1a1.VirtualMachineImageStatus, c randfill.Continue) {
-			c.Fill(imageStatus)
-			overrideConditionsSeverity(imageStatus.Conditions)
+			c.FillNoCustom(imageStatus)
+
+			overrideConditions(imageStatus.Conditions)
+
+			// TODO: Figure out the default ready conditions backfill.
+			imageStatus.Conditions = nil
 
 			// Do not exist in nextver.
 			imageStatus.ImageSupported = nil
@@ -306,20 +428,33 @@ func overrideVirtualMachineImageFieldsFuncs(codecs runtimeserializer.CodecFactor
 			imageStatus.Uuid = ""
 			imageStatus.InternalId = ""
 			imageStatus.PowerState = ""
+
+			// This is backed from annotation.
+			imageStatus.ContentLibraryRef = nil //nolint:staticcheck
 		},
 		func(osInfo *vmopv1.VirtualMachineImageOSInfo, c randfill.Continue) {
-			c.Fill(osInfo)
+			c.FillNoCustom(osInfo)
 			// TODO: Need to save serialized object to support lossless conversions.
 			osInfo.ID = ""
 		},
 		func(imageStatus *vmopv1.VirtualMachineImageStatus, c randfill.Continue) {
-			c.Fill(imageStatus)
+			c.FillNoCustom(imageStatus)
+
+			for i := range imageStatus.VMwareSystemProperties {
+				k := imageStatus.VMwareSystemProperties[i].Key
+				imageStatus.VMwareSystemProperties[i].Key = "vmware-system-" + k
+			}
+
 			overrideConditionsObservedGeneration(imageStatus.Conditions)
+			imageStatus.Conditions = nil
+
 			// TODO: Need to save serialized object to support lossless conversions.
+			imageStatus.Type = ""
+			imageStatus.Disks = nil
 			imageStatus.Capabilities = nil
 		},
 		func(imageSpec *vmopv1.VirtualMachineImageSpec, c randfill.Continue) {
-			c.Fill(imageSpec)
+			c.FillNoCustom(imageSpec)
 			if pr := imageSpec.ProviderRef; pr != nil {
 				if pr.APIVersion == "" && pr.Kind == "" && pr.Name == "" {
 					imageSpec.ProviderRef = nil
@@ -333,7 +468,7 @@ func overrideVirtualMachinePublishRequestFieldsFuncs(codecs runtimeserializer.Co
 	return []interface{}{
 		func(publishStatus *vmopv1a1.VirtualMachinePublishRequestStatus, c randfill.Continue) {
 			c.Fill(publishStatus)
-			overrideConditionsSeverity(publishStatus.Conditions)
+			overrideConditions(publishStatus.Conditions)
 		},
 		func(publishStatus *vmopv1.VirtualMachinePublishRequestStatus, c randfill.Continue) {
 			c.Fill(publishStatus)
@@ -342,10 +477,17 @@ func overrideVirtualMachinePublishRequestFieldsFuncs(codecs runtimeserializer.Co
 	}
 }
 
-func overrideConditionsSeverity(conditions []vmopv1a1.Condition) {
-	// metav1.Conditions do not have this field, so on down conversions it will always be empty.
+func overrideConditions(conditions []vmopv1a1.Condition) {
 	for i := range conditions {
+		// metav1.Conditions do not have this field, so on down conversions it
+		// will always be empty.
 		conditions[i].Severity = ""
+
+		// metav1.Conditions required this field so we'll backfill it so set it
+		// to some value.
+		if conditions[i].Reason == "" {
+			conditions[i].Reason = "reason is now required"
+		}
 	}
 }
 

--- a/api/test/v1alpha1/virtualmachine_conversion_test.go
+++ b/api/test/v1alpha1/virtualmachine_conversion_test.go
@@ -338,11 +338,13 @@ func TestVirtualMachineConversion(t *testing.T) {
 				Reserved: &vmopv1.VirtualMachineReservedSpec{
 					ResourcePolicyName: "my-resource-policy",
 				},
-				MinHardwareVersion: 42,
-				InstanceUUID:       uuid.NewString(),
-				BiosUUID:           uuid.NewString(),
-				GuestID:            "my-guest-id",
-				PromoteDisksMode:   vmopv1.VirtualMachinePromoteDisksModeOffline,
+				MinHardwareVersion:  42,
+				InstanceUUID:        uuid.NewString(),
+				BiosUUID:            uuid.NewString(),
+				GuestID:             "my-guest-id",
+				CurrentSnapshotName: "my-snapshot-name",
+				GroupName:           "my-group",
+				PromoteDisksMode:    vmopv1.VirtualMachinePromoteDisksModeOffline,
 				BootOptions: &vmopv1.VirtualMachineBootOptions{
 					Firmware:  vmopv1.VirtualMachineBootOptionsFirmwareTypeEFI,
 					BootDelay: &metav1.Duration{Duration: time.Second * 10},

--- a/api/test/v1alpha2/conversion_test.go
+++ b/api/test/v1alpha2/conversion_test.go
@@ -14,10 +14,12 @@ import (
 	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
 	"k8s.io/apimachinery/pkg/runtime"
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
+	ctrlconversion "sigs.k8s.io/controller-runtime/pkg/conversion"
 	"sigs.k8s.io/randfill"
 
 	"github.com/vmware-tanzu/vm-operator/api/test/utilconversion/fuzztests"
 	vmopv1a2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	vmopv1a2sysprep "github.com/vmware-tanzu/vm-operator/api/v1alpha2/sysprep"
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 	vmopv1sysprep "github.com/vmware-tanzu/vm-operator/api/v1alpha6/sysprep"
 )
@@ -45,6 +47,12 @@ var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 				Scheme: scheme,
 				Hub:    &vmopv1.VirtualMachine{},
 				Spoke:  &vmopv1a2.VirtualMachine{},
+				SpokeAfterMutation: func(convertible ctrlconversion.Convertible) {
+					vm := convertible.(*vmopv1a2.VirtualMachine)
+					// This field was removed in v1a3 but we'll try to populate it
+					// back that doesn't work with random fuzzed data.
+					vm.Status.Image = nil
+				},
 				FuzzerFuncs: []fuzzer.FuzzerFuncs{
 					overrideVirtualMachineFieldsFuncs,
 				},
@@ -68,6 +76,9 @@ var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 				Scheme: scheme,
 				Hub:    &vmopv1.VirtualMachineClass{},
 				Spoke:  &vmopv1a2.VirtualMachineClass{},
+				FuzzerFuncs: []fuzzer.FuzzerFuncs{
+					overrideVirtualMachineFieldsFuncs,
+				},
 			}
 		})
 		Context("Spoke-Hub-Spoke", func() {
@@ -243,7 +254,7 @@ var _ = Describe("Client-side conversion", func() {
 func overrideVirtualMachineFieldsFuncs(codecs runtimeserializer.CodecFactory) []interface{} {
 	return []interface{}{
 		func(vmSpec *vmopv1a2.VirtualMachineSpec, c randfill.Continue) {
-			c.Fill(vmSpec)
+			c.FillNoCustom(vmSpec)
 
 			if bs := vmSpec.Bootstrap; bs != nil {
 				if bs.Sysprep != nil && bs.Sysprep.Sysprep != nil {
@@ -254,15 +265,40 @@ func overrideVirtualMachineFieldsFuncs(codecs runtimeserializer.CodecFactory) []
 					if len(sysPrep.GUIRunOnce.Commands) == 0 {
 						sysPrep.GUIRunOnce.Commands = nil
 					}
+
+					// In v1a3, UserData was changed to a non-pointer field. Change a nil pointer into an
+					// empty struct.
+					if sysPrep.UserData == nil {
+						sysPrep.UserData = &vmopv1a2sysprep.UserData{}
+					}
+
+					// In v1a3, JoinDomain was removed and instead the Spec.Network.DomainName
+					// is used.
+					if sysPrep.Identification != nil && sysPrep.Identification.JoinDomain != "" {
+						if vmSpec.Network == nil {
+							vmSpec.Network = &vmopv1a2.VirtualMachineNetworkSpec{}
+						}
+					}
 				}
 			}
 		},
 		func(vmSpec *vmopv1.VirtualMachineSpec, c randfill.Continue) {
-			c.Fill(vmSpec)
+			c.FillNoCustom(vmSpec)
+
+			// TODO: Conversion
+			if vmSpec.Class != nil {
+				vmSpec.Class = nil
+			}
 
 			if bs := vmSpec.Bootstrap; bs != nil {
 				if bs.Sysprep != nil && bs.Sysprep.Sysprep != nil {
 					sysPrep := vmSpec.Bootstrap.Sysprep
+
+					if sysPrep.Sysprep.GUIRunOnce != nil {
+						if len(sysPrep.Sysprep.GUIRunOnce.Commands) == 0 {
+							sysPrep.Sysprep.GUIRunOnce = nil
+						}
+					}
 
 					// Match the check done in sysprep conversion.
 					if reflect.DeepEqual(sysPrep.Sysprep, &vmopv1sysprep.Sysprep{}) {
@@ -272,13 +308,13 @@ func overrideVirtualMachineFieldsFuncs(codecs runtimeserializer.CodecFactory) []
 			}
 		},
 		func(vmStatus *vmopv1a2.VirtualMachineStatus, c randfill.Continue) {
-			c.Fill(vmStatus)
+			c.FillNoCustom(vmStatus)
 
 			// This field was removed in v1a3.
 			vmStatus.Image = nil
 		},
 		func(msg *json.RawMessage, c randfill.Continue) {
-			*msg = []byte(`{"foo": "bar"}`)
+			*msg = []byte(`{"foo":"bar"}`)
 		},
 	}
 }
@@ -286,11 +322,12 @@ func overrideVirtualMachineFieldsFuncs(codecs runtimeserializer.CodecFactory) []
 func overrideVirtualMachineImageFieldsFuncs(codecs runtimeserializer.CodecFactory) []interface{} {
 	return []interface{}{
 		func(vmiStatus *vmopv1.VirtualMachineImageStatus, c randfill.Continue) {
-			c.Fill(vmiStatus)
+			c.FillNoCustom(vmiStatus)
 
-			// Since only VMOP updates the CVMI/VMI's we didn't bother with conversion
-			// when adding this field.
+			// Since only VMOP updates the CVMI/VMI's we didn't bother
+			// with conversion when adding this field.
 			vmiStatus.Disks = nil
+			vmiStatus.Type = ""
 		},
 	}
 }

--- a/api/test/v1alpha2/virtualmachine_conversion_test.go
+++ b/api/test/v1alpha2/virtualmachine_conversion_test.go
@@ -375,11 +375,13 @@ func TestVirtualMachineConversion(t *testing.T) {
 				Reserved: &vmopv1.VirtualMachineReservedSpec{
 					ResourcePolicyName: "my-resource-policy",
 				},
-				MinHardwareVersion: 42,
-				InstanceUUID:       uuid.NewString(),
-				BiosUUID:           uuid.NewString(),
-				GuestID:            "my-guest-id",
-				PromoteDisksMode:   vmopv1.VirtualMachinePromoteDisksModeOffline,
+				MinHardwareVersion:  42,
+				InstanceUUID:        uuid.NewString(),
+				BiosUUID:            uuid.NewString(),
+				GuestID:             "my-guest-id",
+				CurrentSnapshotName: "my-snapshot-name",
+				GroupName:           "my-group",
+				PromoteDisksMode:    vmopv1.VirtualMachinePromoteDisksModeOffline,
 				BootOptions: &vmopv1.VirtualMachineBootOptions{
 					Firmware:  vmopv1.VirtualMachineBootOptionsFirmwareTypeEFI,
 					BootDelay: &metav1.Duration{Duration: time.Second * 10},

--- a/api/test/v1alpha3/conversion_test.go
+++ b/api/test/v1alpha3/conversion_test.go
@@ -243,11 +243,11 @@ var _ = Describe("Client-side conversion", func() {
 func overrideVirtualMachineImageFieldsFuncs(codecs runtimeserializer.CodecFactory) []interface{} {
 	return []interface{}{
 		func(status *vmopv1.VirtualMachineImageStatus, c randfill.Continue) {
-			c.Fill(status)
+			c.FillNoCustom(status)
 			status.Disks = nil
 		},
 		func(status *vmopv1a3.VirtualMachineImageStatus, c randfill.Continue) {
-			c.Fill(status)
+			c.FillNoCustom(status)
 			status.Disks = nil
 		},
 	}
@@ -256,22 +256,29 @@ func overrideVirtualMachineImageFieldsFuncs(codecs runtimeserializer.CodecFactor
 func overrideVirtualMachineFieldsFuncs(codecs runtimeserializer.CodecFactory) []interface{} {
 	return []interface{}{
 		func(vmSpec *vmopv1a3.VirtualMachineSpec, c randfill.Continue) {
-			c.Fill(vmSpec)
+			c.FillNoCustom(vmSpec)
 
 			if bs := vmSpec.Bootstrap; bs != nil {
 				if bs.Sysprep != nil && bs.Sysprep.Sysprep != nil {
-					sysPrep := vmSpec.Bootstrap.Sysprep.Sysprep
+					sysPrep := bs.Sysprep.Sysprep
 
 					// In v1a3, GUIRunOnce was changed to a pointer field. Change the empty slice into a nil
 					// field so reflect.DeepEqual() determines correctly if GUIRunOnce is unset.
-					if len(sysPrep.GUIRunOnce.Commands) == 0 {
-						sysPrep.GUIRunOnce.Commands = nil
+					if sysPrep.GUIRunOnce != nil {
+						if len(sysPrep.GUIRunOnce.Commands) == 0 {
+							sysPrep.GUIRunOnce.Commands = nil
+						}
 					}
 				}
 			}
 		},
 		func(vmSpec *vmopv1.VirtualMachineSpec, c randfill.Continue) {
-			c.Fill(vmSpec)
+			c.FillNoCustom(vmSpec)
+
+			// TODO: Conversion
+			if vmSpec.Class != nil {
+				vmSpec.Class = nil
+			}
 
 			if bs := vmSpec.Bootstrap; bs != nil {
 				if bs.Sysprep != nil && bs.Sysprep.Sysprep != nil {
@@ -284,11 +291,8 @@ func overrideVirtualMachineFieldsFuncs(codecs runtimeserializer.CodecFactory) []
 				}
 			}
 		},
-		func(vmStatus *vmopv1a3.VirtualMachineStatus, c randfill.Continue) {
-			c.Fill(vmStatus)
-		},
 		func(msg *json.RawMessage, c randfill.Continue) {
-			*msg = []byte(`{"foo": "bar"}`)
+			*msg = []byte(`{"foo":"bar"}`)
 		},
 	}
 }

--- a/api/test/v1alpha3/virtualmachine_conversion_test.go
+++ b/api/test/v1alpha3/virtualmachine_conversion_test.go
@@ -366,11 +366,13 @@ func TestVirtualMachineConversion(t *testing.T) {
 						Reserved: &vmopv1.VirtualMachineReservedSpec{
 							ResourcePolicyName: "my-resource-policy",
 						},
-						MinHardwareVersion: 42,
-						InstanceUUID:       uuid.NewString(),
-						BiosUUID:           uuid.NewString(),
-						GuestID:            "my-guest-id",
-						PromoteDisksMode:   vmopv1.VirtualMachinePromoteDisksModeOffline,
+						MinHardwareVersion:  42,
+						InstanceUUID:        uuid.NewString(),
+						BiosUUID:            uuid.NewString(),
+						GuestID:             "my-guest-id",
+						CurrentSnapshotName: "my-snapshot-name",
+						GroupName:           "my-group",
+						PromoteDisksMode:    vmopv1.VirtualMachinePromoteDisksModeOffline,
 						BootOptions: &vmopv1.VirtualMachineBootOptions{
 							Firmware:  vmopv1.VirtualMachineBootOptionsFirmwareTypeEFI,
 							BootDelay: &metav1.Duration{Duration: time.Second * 10},

--- a/api/test/v1alpha4/conversion_test.go
+++ b/api/test/v1alpha4/conversion_test.go
@@ -6,7 +6,6 @@ package v1alpha4_test
 
 import (
 	"encoding/json"
-	"reflect"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -19,7 +18,6 @@ import (
 	"github.com/vmware-tanzu/vm-operator/api/test/utilconversion/fuzztests"
 	vmopv1a4 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
-	vmopv1sysprep "github.com/vmware-tanzu/vm-operator/api/v1alpha6/sysprep"
 )
 
 var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
@@ -243,11 +241,11 @@ var _ = Describe("Client-side conversion", func() {
 func overrideVirtualMachineImageFieldsFuncs(codecs runtimeserializer.CodecFactory) []interface{} {
 	return []interface{}{
 		func(status *vmopv1.VirtualMachineImageStatus, c randfill.Continue) {
-			c.Fill(status)
+			c.FillNoCustom(status)
 			status.Disks = nil
 		},
 		func(status *vmopv1a4.VirtualMachineImageStatus, c randfill.Continue) {
-			c.Fill(status)
+			c.FillNoCustom(status)
 			status.Disks = nil
 		},
 	}
@@ -255,40 +253,16 @@ func overrideVirtualMachineImageFieldsFuncs(codecs runtimeserializer.CodecFactor
 
 func overrideVirtualMachineFieldsFuncs(codecs runtimeserializer.CodecFactory) []interface{} {
 	return []interface{}{
-		func(vmSpec *vmopv1a4.VirtualMachineSpec, c randfill.Continue) {
-			c.Fill(vmSpec)
-
-			if bs := vmSpec.Bootstrap; bs != nil {
-				if bs.Sysprep != nil && bs.Sysprep.Sysprep != nil {
-					sysPrep := vmSpec.Bootstrap.Sysprep.Sysprep
-
-					// In v1a3, GUIRunOnce was changed to a pointer field. Change the empty slice into a nil
-					// field so reflect.DeepEqual() determines correctly if GUIRunOnce is unset.
-					if len(sysPrep.GUIRunOnce.Commands) == 0 {
-						sysPrep.GUIRunOnce.Commands = nil
-					}
-				}
-			}
-		},
 		func(vmSpec *vmopv1.VirtualMachineSpec, c randfill.Continue) {
-			c.Fill(vmSpec)
+			c.FillNoCustom(vmSpec)
 
-			if bs := vmSpec.Bootstrap; bs != nil {
-				if bs.Sysprep != nil && bs.Sysprep.Sysprep != nil {
-					sysPrep := vmSpec.Bootstrap.Sysprep
-
-					// Match the check done in sysprep conversion.
-					if reflect.DeepEqual(sysPrep.Sysprep, &vmopv1sysprep.Sysprep{}) {
-						sysPrep.Sysprep = nil
-					}
-				}
+			// TODO: Conversion
+			if vmSpec.Class != nil {
+				vmSpec.Class = nil
 			}
-		},
-		func(vmStatus *vmopv1a4.VirtualMachineStatus, c randfill.Continue) {
-			c.Fill(vmStatus)
 		},
 		func(msg *json.RawMessage, c randfill.Continue) {
-			*msg = []byte(`{"foo": "bar"}`)
+			*msg = []byte(`{"foo":"bar"}`)
 		},
 	}
 }

--- a/api/test/v1alpha4/virtualmachine_conversion_test.go
+++ b/api/test/v1alpha4/virtualmachine_conversion_test.go
@@ -292,11 +292,13 @@ func TestVirtualMachineConversion(t *testing.T) {
 						Reserved: &vmopv1.VirtualMachineReservedSpec{
 							ResourcePolicyName: "my-resource-policy",
 						},
-						MinHardwareVersion: 42,
-						InstanceUUID:       uuid.NewString(),
-						BiosUUID:           uuid.NewString(),
-						GuestID:            "my-guest-id",
-						PromoteDisksMode:   vmopv1.VirtualMachinePromoteDisksModeOffline,
+						MinHardwareVersion:  42,
+						InstanceUUID:        uuid.NewString(),
+						BiosUUID:            uuid.NewString(),
+						GuestID:             "my-guest-id",
+						CurrentSnapshotName: "my-snapshot-name",
+						GroupName:           "my-group",
+						PromoteDisksMode:    vmopv1.VirtualMachinePromoteDisksModeOffline,
 						BootOptions: &vmopv1.VirtualMachineBootOptions{
 							Firmware:  vmopv1.VirtualMachineBootOptionsFirmwareTypeEFI,
 							BootDelay: &metav1.Duration{Duration: time.Second * 10},

--- a/api/test/v1alpha5/conversion_test.go
+++ b/api/test/v1alpha5/conversion_test.go
@@ -6,7 +6,6 @@ package v1alpha5_test
 
 import (
 	"encoding/json"
-	"reflect"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -19,7 +18,6 @@ import (
 	"github.com/vmware-tanzu/vm-operator/api/test/utilconversion/fuzztests"
 	vmopv1a5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
-	vmopv1sysprep "github.com/vmware-tanzu/vm-operator/api/v1alpha6/sysprep"
 )
 
 var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
@@ -108,9 +106,6 @@ var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 				Scheme: scheme,
 				Hub:    &vmopv1.VirtualMachineImage{},
 				Spoke:  &vmopv1a5.VirtualMachineImage{},
-				FuzzerFuncs: []fuzzer.FuzzerFuncs{
-					overrideVirtualMachineImageFieldsFuncs,
-				},
 			}
 		})
 		Context("Spoke-Hub-Spoke", func() {
@@ -131,9 +126,6 @@ var _ = Describe("FuzzyConversion", Label("api", "fuzz"), func() {
 				Scheme: scheme,
 				Hub:    &vmopv1.ClusterVirtualMachineImage{},
 				Spoke:  &vmopv1a5.ClusterVirtualMachineImage{},
-				FuzzerFuncs: []fuzzer.FuzzerFuncs{
-					overrideVirtualMachineImageFieldsFuncs,
-				},
 			}
 		})
 		Context("Spoke-Hub-Spoke", func() {
@@ -260,55 +252,10 @@ var _ = Describe("Client-side conversion", func() {
 	})
 })
 
-func overrideVirtualMachineImageFieldsFuncs(codecs runtimeserializer.CodecFactory) []interface{} {
-	return []interface{}{
-		func(status *vmopv1.VirtualMachineImageStatus, c randfill.Continue) {
-			c.Fill(status)
-			status.Disks = nil
-		},
-		func(status *vmopv1a5.VirtualMachineImageStatus, c randfill.Continue) {
-			c.Fill(status)
-			status.Disks = nil
-		},
-	}
-}
-
 func overrideVirtualMachineFieldsFuncs(codecs runtimeserializer.CodecFactory) []interface{} {
 	return []interface{}{
-		func(vmSpec *vmopv1a5.VirtualMachineSpec, c randfill.Continue) {
-			c.Fill(vmSpec)
-
-			if bs := vmSpec.Bootstrap; bs != nil {
-				if bs.Sysprep != nil && bs.Sysprep.Sysprep != nil {
-					sysPrep := vmSpec.Bootstrap.Sysprep.Sysprep
-
-					// In v1a3, GUIRunOnce was changed to a pointer field. Change the empty slice into a nil
-					// field so reflect.DeepEqual() determines correctly if GUIRunOnce is unset.
-					if len(sysPrep.GUIRunOnce.Commands) == 0 {
-						sysPrep.GUIRunOnce.Commands = nil
-					}
-				}
-			}
-		},
-		func(vmSpec *vmopv1.VirtualMachineSpec, c randfill.Continue) {
-			c.Fill(vmSpec)
-
-			if bs := vmSpec.Bootstrap; bs != nil {
-				if bs.Sysprep != nil && bs.Sysprep.Sysprep != nil {
-					sysPrep := vmSpec.Bootstrap.Sysprep
-
-					// Match the check done in sysprep conversion.
-					if reflect.DeepEqual(sysPrep.Sysprep, &vmopv1sysprep.Sysprep{}) {
-						sysPrep.Sysprep = nil
-					}
-				}
-			}
-		},
-		func(vmStatus *vmopv1a5.VirtualMachineStatus, c randfill.Continue) {
-			c.Fill(vmStatus)
-		},
 		func(msg *json.RawMessage, c randfill.Continue) {
-			*msg = []byte(`{"foo": "bar"}`)
+			*msg = []byte(`{"foo":"bar"}`)
 		},
 	}
 }

--- a/api/test/v1alpha5/virtualmachine_conversion_test.go
+++ b/api/test/v1alpha5/virtualmachine_conversion_test.go
@@ -18,6 +18,7 @@ import (
 	vmopv1a5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 	vmopv1common "github.com/vmware-tanzu/vm-operator/api/v1alpha6/common"
+	vmopv1sysprep "github.com/vmware-tanzu/vm-operator/api/v1alpha6/sysprep"
 )
 
 func TestVirtualMachineConversion(t *testing.T) {
@@ -52,6 +53,27 @@ func TestVirtualMachineConversion(t *testing.T) {
 				hub: &vmopv1.VirtualMachine{
 					Spec: vmopv1.VirtualMachineSpec{
 						Bootstrap: nil,
+					},
+				},
+			},
+			{
+				name: "spec.bootstrap.sysprep.sysprep",
+				hub: &vmopv1.VirtualMachine{
+					Spec: vmopv1.VirtualMachineSpec{
+						Bootstrap: &vmopv1.VirtualMachineBootstrapSpec{
+							Sysprep: &vmopv1.VirtualMachineBootstrapSysprepSpec{
+								Sysprep: &vmopv1sysprep.Sysprep{
+									ExpirePasswordAfterNextLogin: true,
+									ScriptText: &vmopv1common.ValueOrSecretKeySelector{
+										From: &vmopv1common.SecretKeySelector{
+											Name: "sc-name",
+											Key:  "sc-key",
+										},
+										Value: ptr.To("sc-value"),
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/api/v1alpha1/virtualmachine_conversion.go
+++ b/api/v1alpha1/virtualmachine_conversion.go
@@ -831,6 +831,10 @@ func restore_v1alpha6_VirtualMachineImage(dst, src *vmopv1.VirtualMachine) {
 	dst.Spec.ImageName = src.Spec.ImageName
 }
 
+func restore_v1alpha6_VirtualMachineCurrentSnapshotName(dst, src *vmopv1.VirtualMachine) {
+	dst.Spec.CurrentSnapshotName = src.Spec.CurrentSnapshotName
+}
+
 func restore_v1alpha6_VirtualMachineBootstrapSpec(
 	dst, src *vmopv1.VirtualMachine) {
 
@@ -842,6 +846,13 @@ func restore_v1alpha6_VirtualMachineBootstrapSpec(
 
 	dstBootstrap := dst.Spec.Bootstrap
 	if dstBootstrap == nil {
+		// v1a1 doesn't have a way to represent an empty bootstrap structure
+		// so restore that here.
+		if reflect.DeepEqual(&srcBootstrap, &vmopv1.VirtualMachineBootstrapSpec{}) {
+			dst.Spec.Bootstrap = &vmopv1.VirtualMachineBootstrapSpec{}
+			return
+		}
+
 		// v1a1 doesn't have a way to represent standalone LinuxPrep or Disabled.
 		// If we didn't do a conversion in convert_v1alpha1_VmMetadata_To_v1alpha6_BootstrapSpec()
 		// but we saved a LinuxPrep or Disabled in the conversion annotation, restore that here.
@@ -884,6 +895,7 @@ func restore_v1alpha6_VirtualMachineBootstrapSpec(
 			dstLinuxPrep.ExpirePasswordAfterNextLogin = srcLinuxPrep.ExpirePasswordAfterNextLogin
 			dstLinuxPrep.Password = srcLinuxPrep.Password
 			dstLinuxPrep.ScriptText = srcLinuxPrep.ScriptText
+			dstLinuxPrep.CustomizeAtNextPowerOn = srcLinuxPrep.CustomizeAtNextPowerOn
 		}
 	}
 
@@ -916,7 +928,7 @@ func restore_v1alpha6_VirtualMachineNetworkSpec(
 	dst, src *vmopv1.VirtualMachine) {
 
 	srcNetwork := src.Spec.Network
-	if srcNetwork == nil || apiequality.Semantic.DeepEqual(*srcNetwork, vmopv1.VirtualMachineNetworkSpec{}) {
+	if srcNetwork == nil {
 		// Nothing to restore.
 		return
 	}
@@ -1048,14 +1060,16 @@ func restore_v1alpha6_VirtualMachineHardware(dst, src *vmopv1.VirtualMachine) {
 	}
 }
 
-func restore_v1alpha6_VirtualMachineAdvancedProps(dst, src *vmopv1.VirtualMachine) {
-	if src.Spec.Advanced == nil {
+func restore_v1alpha6_VirtualMachineAdvanced(dst, src *vmopv1.VirtualMachine) {
+	adv := src.Spec.Advanced
+	if adv == nil {
 		return
 	}
+
 	if dst.Spec.Advanced == nil {
 		dst.Spec.Advanced = &vmopv1.VirtualMachineAdvancedSpec{}
 	}
-	adv := src.Spec.Advanced
+	dst.Spec.Advanced.DefaultVolumeProvisioningMode = adv.DefaultVolumeProvisioningMode
 	dst.Spec.Advanced.PreferHTEnabled = adv.PreferHTEnabled
 	dst.Spec.Advanced.HugePages1GEnabled = adv.HugePages1GEnabled
 	dst.Spec.Advanced.TimeTrackerLowLatencyEnabled = adv.TimeTrackerLowLatencyEnabled
@@ -1334,7 +1348,8 @@ func (src *VirtualMachine) ConvertTo(dstRaw ctrlconversion.Hub) error {
 	restore_v1alpha6_VirtualMachineHardware(dst, restored)
 	restore_v1alpha6_VirtualMachinePolicies(dst, restored)
 	restore_v1alpha6_VirtualMachineVolumeAttributesClassName(dst, restored)
-	restore_v1alpha6_VirtualMachineAdvancedProps(dst, restored)
+	restore_v1alpha6_VirtualMachineAdvanced(dst, restored)
+	restore_v1alpha6_VirtualMachineCurrentSnapshotName(dst, restored)
 
 	// END RESTORE
 

--- a/api/v1alpha1/virtualmachineimage_conversion.go
+++ b/api/v1alpha1/virtualmachineimage_conversion.go
@@ -121,6 +121,7 @@ func convert_v1alpha6_VirtualMachineImageStatusConditions_To_v1alpha1_VirtualMac
 		imageProviderReadyCondition = trueCondition(VirtualMachineImageProviderReadyCondition)
 		imageSyncedCondition = falseConditionWithReason(VirtualMachineImageSyncedCondition)
 	default:
+		// BMV: This looks suspicious in the case that the VMI just doesn't yet have any conditions?!?
 		securityCompliantCondition = trueCondition(VirtualMachineImageProviderSecurityComplianceCondition)
 		imageProviderReadyCondition = trueCondition(VirtualMachineImageProviderReadyCondition)
 		imageSyncedCondition = trueCondition(VirtualMachineImageSyncedCondition)

--- a/api/v1alpha2/virtualmachine_conversion.go
+++ b/api/v1alpha2/virtualmachine_conversion.go
@@ -80,14 +80,15 @@ func Convert_v1alpha6_VirtualMachineNetworkInterfaceSpec_To_v1alpha2_VirtualMach
 	return autoConvert_v1alpha6_VirtualMachineNetworkInterfaceSpec_To_v1alpha2_VirtualMachineNetworkInterfaceSpec(in, out, s)
 }
 
-func restore_v1alpha6_VirtualMachineAdvancedProps(dst, src *vmopv1.VirtualMachine) {
-	if src.Spec.Advanced == nil {
+func restore_v1alpha6_VirtualMachineAdvanced(dst, src *vmopv1.VirtualMachine) {
+	adv := src.Spec.Advanced
+	if adv == nil {
 		return
 	}
+
 	if dst.Spec.Advanced == nil {
 		dst.Spec.Advanced = &vmopv1.VirtualMachineAdvancedSpec{}
 	}
-	adv := src.Spec.Advanced
 	dst.Spec.Advanced.PreferHTEnabled = adv.PreferHTEnabled
 	dst.Spec.Advanced.HugePages1GEnabled = adv.HugePages1GEnabled
 	dst.Spec.Advanced.TimeTrackerLowLatencyEnabled = adv.TimeTrackerLowLatencyEnabled
@@ -498,6 +499,10 @@ func restore_v1alpha6_VirtualMachineNetworkVLANs(dst, src *vmopv1.VirtualMachine
 	dst.Spec.Network.VLANs = src.Spec.Network.VLANs
 }
 
+func restore_v1alpha6_VirtualMachineCurrentSnapshotName(dst, src *vmopv1.VirtualMachine) {
+	dst.Spec.CurrentSnapshotName = src.Spec.CurrentSnapshotName
+}
+
 // ConvertTo converts this VirtualMachine to the Hub version.
 func (src *VirtualMachine) ConvertTo(dstRaw ctrlconversion.Hub) error {
 	dst := dstRaw.(*vmopv1.VirtualMachine)
@@ -532,8 +537,9 @@ func (src *VirtualMachine) ConvertTo(dstRaw ctrlconversion.Hub) error {
 	restore_v1alpha6_VirtualMachineAffinity(dst, restored)
 	restore_v1alpha6_VirtualMachineVolumeAttributesClassName(dst, restored)
 	restore_v1alpha6_VirtualMachineNetworkVLANs(dst, restored)
-	restore_v1alpha6_VirtualMachineAdvancedProps(dst, restored)
+	restore_v1alpha6_VirtualMachineAdvanced(dst, restored)
 	restore_v1alpha6_VirtualMachineNetworkInterfaces(dst, restored)
+	restore_v1alpha6_VirtualMachineCurrentSnapshotName(dst, restored)
 
 	// END RESTORE
 

--- a/api/v1alpha3/virtualmachine_conversion.go
+++ b/api/v1alpha3/virtualmachine_conversion.go
@@ -139,14 +139,15 @@ func Convert_v1alpha6_VirtualMachineNetworkInterfaceSpec_To_v1alpha3_VirtualMach
 	return autoConvert_v1alpha6_VirtualMachineNetworkInterfaceSpec_To_v1alpha3_VirtualMachineNetworkInterfaceSpec(in, out, s)
 }
 
-func restore_v1alpha6_VirtualMachineAdvancedProps(dst, src *vmopv1.VirtualMachine) {
-	if src.Spec.Advanced == nil {
+func restore_v1alpha6_VirtualMachineAdvanced(dst, src *vmopv1.VirtualMachine) {
+	adv := src.Spec.Advanced
+	if adv == nil {
 		return
 	}
+
 	if dst.Spec.Advanced == nil {
 		dst.Spec.Advanced = &vmopv1.VirtualMachineAdvancedSpec{}
 	}
-	adv := src.Spec.Advanced
 	dst.Spec.Advanced.PreferHTEnabled = adv.PreferHTEnabled
 	dst.Spec.Advanced.HugePages1GEnabled = adv.HugePages1GEnabled
 	dst.Spec.Advanced.TimeTrackerLowLatencyEnabled = adv.TimeTrackerLowLatencyEnabled
@@ -442,6 +443,10 @@ func restore_v1alpha6_VirtualMachineNetworkVLANs(dst, src *vmopv1.VirtualMachine
 	dst.Spec.Network.VLANs = src.Spec.Network.VLANs
 }
 
+func restore_v1alpha6_VirtualMachineCurrentSnapshotName(dst, src *vmopv1.VirtualMachine) {
+	dst.Spec.CurrentSnapshotName = src.Spec.CurrentSnapshotName
+}
+
 // ConvertTo converts this VirtualMachine to the Hub version.
 func (src *VirtualMachine) ConvertTo(dstRaw ctrlconversion.Hub) error {
 	dst := dstRaw.(*vmopv1.VirtualMachine)
@@ -470,8 +475,9 @@ func (src *VirtualMachine) ConvertTo(dstRaw ctrlconversion.Hub) error {
 	restore_v1alpha6_VirtualMachineAffinity(dst, restored)
 	restore_v1alpha6_VirtualMachineVolumeAttributesClassName(dst, restored)
 	restore_v1alpha6_VirtualMachineNetworkVLANs(dst, restored)
-	restore_v1alpha6_VirtualMachineAdvancedProps(dst, restored)
+	restore_v1alpha6_VirtualMachineAdvanced(dst, restored)
 	restore_v1alpha6_VirtualMachineNetworkInterfaces(dst, restored)
+	restore_v1alpha6_VirtualMachineCurrentSnapshotName(dst, restored)
 
 	// END RESTORE
 

--- a/api/v1alpha4/virtualmachine_conversion.go
+++ b/api/v1alpha4/virtualmachine_conversion.go
@@ -82,14 +82,15 @@ func Convert_v1alpha6_VirtualMachineNetworkInterfaceSpec_To_v1alpha4_VirtualMach
 	return autoConvert_v1alpha6_VirtualMachineNetworkInterfaceSpec_To_v1alpha4_VirtualMachineNetworkInterfaceSpec(in, out, s)
 }
 
-func restore_v1alpha6_VirtualMachineAdvancedProps(dst, src *vmopv1.VirtualMachine) {
-	if src.Spec.Advanced == nil {
+func restore_v1alpha6_VirtualMachineAdvanced(dst, src *vmopv1.VirtualMachine) {
+	adv := src.Spec.Advanced
+	if adv == nil {
 		return
 	}
+
 	if dst.Spec.Advanced == nil {
 		dst.Spec.Advanced = &vmopv1.VirtualMachineAdvancedSpec{}
 	}
-	adv := src.Spec.Advanced
 	dst.Spec.Advanced.PreferHTEnabled = adv.PreferHTEnabled
 	dst.Spec.Advanced.HugePages1GEnabled = adv.HugePages1GEnabled
 	dst.Spec.Advanced.TimeTrackerLowLatencyEnabled = adv.TimeTrackerLowLatencyEnabled
@@ -370,6 +371,10 @@ func restore_v1alpha6_VirtualMachineNetworkVLANs(dst, src *vmopv1.VirtualMachine
 	dst.Spec.Network.VLANs = src.Spec.Network.VLANs
 }
 
+func restore_v1alpha6_VirtualMachineCurrentSnapshotName(dst, src *vmopv1.VirtualMachine) {
+	dst.Spec.CurrentSnapshotName = src.Spec.CurrentSnapshotName
+}
+
 func restore_v1alpha6_VirtualMachineVolumes(dst, src *vmopv1.VirtualMachine) {
 	srcVolMap := map[string]*vmopv1.VirtualMachineVolume{}
 	for i := range src.Spec.Volumes {
@@ -423,8 +428,9 @@ func (src *VirtualMachine) ConvertTo(dstRaw ctrlconversion.Hub) error {
 	restore_v1alpha6_VirtualMachineVolumes(dst, restored)
 	restore_v1alpha6_VirtualMachineVolumeAttributesClassName(dst, restored)
 	restore_v1alpha6_VirtualMachineNetworkVLANs(dst, restored)
-	restore_v1alpha6_VirtualMachineAdvancedProps(dst, restored)
+	restore_v1alpha6_VirtualMachineAdvanced(dst, restored)
 	restore_v1alpha6_VirtualMachineNetworkInterfaces(dst, restored)
+	restore_v1alpha6_VirtualMachineCurrentSnapshotName(dst, restored)
 
 	// END RESTORE
 

--- a/api/v1alpha5/sysprep/conversion/v1alpha5/sysprep_conversion.go
+++ b/api/v1alpha5/sysprep/conversion/v1alpha5/sysprep_conversion.go
@@ -10,10 +10,11 @@ import (
 	apiconversion "k8s.io/apimachinery/pkg/conversion"
 
 	vmopv1a5sysprep "github.com/vmware-tanzu/vm-operator/api/v1alpha5/sysprep"
+	vmopv1common "github.com/vmware-tanzu/vm-operator/api/v1alpha6/common"
 	vmopv1sysprep "github.com/vmware-tanzu/vm-operator/api/v1alpha6/sysprep"
 )
 
-// Convert_sysprep_Sysprep_To_sysprep_Sysprep converts the Sysprep from v1alpha6
+// Convert_sysprep_Sysprep_To_sysprep_Sysprep converts the Sysprep from v1alpha5
 // to v1alpha6.
 // Please see https://github.com/kubernetes/code-generator/issues/172 for why
 // this function exists in this directory structure.
@@ -24,6 +25,19 @@ func Convert_sysprep_Sysprep_To_sysprep_Sysprep(
 	out.GUIUnattended = (*vmopv1sysprep.GUIUnattended)(unsafe.Pointer(in.GUIUnattended))
 	out.LicenseFilePrintData = (*vmopv1sysprep.LicenseFilePrintData)(unsafe.Pointer(in.LicenseFilePrintData))
 	out.UserData = *(*vmopv1sysprep.UserData)(unsafe.Pointer(&in.UserData))
+	out.ExpirePasswordAfterNextLogin = in.ExpirePasswordAfterNextLogin
+
+	if sc := in.ScriptText; sc != nil {
+		out.ScriptText = &vmopv1common.ValueOrSecretKeySelector{
+			Value: sc.Value,
+		}
+		if sc.From != nil {
+			out.ScriptText.From = &vmopv1common.SecretKeySelector{
+				Name: sc.From.Name,
+				Key:  sc.From.Key,
+			}
+		}
+	}
 
 	if id := in.Identification; id != nil {
 		out.Identification = &vmopv1sysprep.Identification{

--- a/api/v1alpha5/sysprep/conversion/v1alpha6/sysprep_conversion.go
+++ b/api/v1alpha5/sysprep/conversion/v1alpha6/sysprep_conversion.go
@@ -9,12 +9,13 @@ import (
 
 	apiconversion "k8s.io/apimachinery/pkg/conversion"
 
+	vmopv1a5common "github.com/vmware-tanzu/vm-operator/api/v1alpha5/common"
 	vmopv1a5sysprep "github.com/vmware-tanzu/vm-operator/api/v1alpha5/sysprep"
 	vmopv1sysprep "github.com/vmware-tanzu/vm-operator/api/v1alpha6/sysprep"
 )
 
 // Convert_sysprep_Sysprep_To_sysprep_Sysprep converts the Sysprep from v1alpha6
-// to v1alpha6.
+// to v1alpha5.
 // Please see https://github.com/kubernetes/code-generator/issues/172 for why
 // this function exists in this directory structure.
 func Convert_sysprep_Sysprep_To_sysprep_Sysprep(
@@ -24,6 +25,19 @@ func Convert_sysprep_Sysprep_To_sysprep_Sysprep(
 	out.GUIUnattended = (*vmopv1a5sysprep.GUIUnattended)(unsafe.Pointer(in.GUIUnattended))
 	out.LicenseFilePrintData = (*vmopv1a5sysprep.LicenseFilePrintData)(unsafe.Pointer(in.LicenseFilePrintData))
 	out.UserData = *(*vmopv1a5sysprep.UserData)(unsafe.Pointer(&in.UserData))
+	out.ExpirePasswordAfterNextLogin = in.ExpirePasswordAfterNextLogin
+
+	if sc := in.ScriptText; sc != nil {
+		out.ScriptText = &vmopv1a5common.ValueOrSecretKeySelector{
+			Value: sc.Value,
+		}
+		if sc.From != nil {
+			out.ScriptText.From = &vmopv1a5common.SecretKeySelector{
+				Name: sc.From.Name,
+				Key:  sc.From.Key,
+			}
+		}
+	}
 
 	if id := in.Identification; id != nil {
 		out.Identification = &vmopv1a5sysprep.Identification{

--- a/api/v1alpha5/virtualmachine_conversion.go
+++ b/api/v1alpha5/virtualmachine_conversion.go
@@ -44,14 +44,15 @@ func Convert_v1alpha6_VirtualMachineNetworkInterfaceSpec_To_v1alpha5_VirtualMach
 	return autoConvert_v1alpha6_VirtualMachineNetworkInterfaceSpec_To_v1alpha5_VirtualMachineNetworkInterfaceSpec(in, out, s)
 }
 
-func restore_v1alpha6_VirtualMachineAdvancedProps(dst, src *vmopv1.VirtualMachine) {
-	if src.Spec.Advanced == nil {
+func restore_v1alpha6_VirtualMachineAdvanced(dst, src *vmopv1.VirtualMachine) {
+	adv := src.Spec.Advanced
+	if adv == nil {
 		return
 	}
+
 	if dst.Spec.Advanced == nil {
 		dst.Spec.Advanced = &vmopv1.VirtualMachineAdvancedSpec{}
 	}
-	adv := src.Spec.Advanced
 	dst.Spec.Advanced.PreferHTEnabled = adv.PreferHTEnabled
 	dst.Spec.Advanced.HugePages1GEnabled = adv.HugePages1GEnabled
 	dst.Spec.Advanced.TimeTrackerLowLatencyEnabled = adv.TimeTrackerLowLatencyEnabled
@@ -144,7 +145,7 @@ func (src *VirtualMachine) ConvertTo(dstRaw ctrlconversion.Hub) error {
 	restore_v1alpha6_VirtualMachineBootstrapDisabled(dst, restored)
 	restore_v1alpha6_VirtualMachineVolumeAttributesClassName(dst, restored)
 	restore_v1alpha6_VirtualMachineNetworkVLANs(dst, restored)
-	restore_v1alpha6_VirtualMachineAdvancedProps(dst, restored)
+	restore_v1alpha6_VirtualMachineAdvanced(dst, restored)
 	restore_v1alpha6_VirtualMachineNetworkInterfaces(dst, restored)
 
 	// END RESTORE


### PR DESCRIPTION


**What does this PR do, and why is it needed?**


It looks like a dependency change caused the API version conversion fuzzer to not actually do any fuzzing when we also specified override funcs because FillNoCustom() needs to be called instead.

Add some missing backfilling for CurrentSnapshotName and Sysprep ScriptText

Cleanup various override functions: these had kind of been copy & pasted from prior version but the reason needing them in the prior version may no longer be needed in the next version.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:




**Please add a release note if necessary**:

```release-note
NONE
```