### PR TITLE
:seedling: Go 1.26.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,10 +195,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.26.2' # TODO (brito-rafa)  For GO-2026-4865
-                             # GO-2026-4866, GO-2026-4869, GO-2026-4870
-                             # GO-2026-4946, GO-2026-4947
-                             # remove once internal builds use 1.26.2
+        go-version: ${{ env.GO_VERSION }}
         go-version-file: 'go.mod'
         cache: true
         cache-dependency-path: '**/go.sum'

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/vm-operator
 
-go 1.26.1
+go 1.26.2
 
 replace (
 	github.com/vmware-tanzu/vm-operator/api => ./api

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/vm-operator/hack/tools
 
-go 1.26.1
+go 1.26.2
 
 // The version of Ginkgo must match the one from ../../go.mod.
 require github.com/onsi/ginkgo/v2 v2.23.4


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Bump Go to 1.26.2

The updated version addresses the following CVEs:
CVE-2026-32282
CVE-2026-32289
CVE-2026-33810
CVE-2026-27144
CVE-2026-27143
CVE-2026-32288
CVE-2026-32283
CVE-2026-27140

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

All tests passed locally.

**Please add a release note if necessary**:

```release-note
Go 1.26.2
```