### PR TITLE
🌱 Make VirtualMachineService LB provider per namespace

### DIFF
--- a/controllers/virtualmachineservice/providers/loadbalancer_provider.go
+++ b/controllers/virtualmachineservice/providers/loadbalancer_provider.go
@@ -8,7 +8,7 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 
@@ -65,7 +65,7 @@ type LoadbalancerProvider interface {
 	GetToBeRemovedServiceAnnotations(ctx context.Context, vmService *vmopv1.VirtualMachineService) (map[string]string, error)
 }
 
-func GetLoadbalancerProviderByType(mgr manager.Manager, providerType string) (LoadbalancerProvider, error) {
+func GetLoadbalancerProviderByType(client client.Client, providerType string) (LoadbalancerProvider, error) {
 	if providerType == NSXTLoadBalancer {
 		return NsxtLoadBalancerProvider(), nil
 	}

--- a/controllers/virtualmachineservice/virtualmachineservice_controller.go
+++ b/controllers/virtualmachineservice/virtualmachineservice_controller.go
@@ -54,24 +54,11 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
 	)
 
-	lbProviderType := pkgcfg.FromContext(ctx).LoadBalancerProvider
-	if lbProviderType == "" {
-		if pkgcfg.FromContext(ctx).NetworkProviderType == pkgcfg.NetworkProviderTypeNSXT || pkgcfg.FromContext(ctx).NetworkProviderType == pkgcfg.NetworkProviderTypeVPC {
-			lbProviderType = providers.NSXTLoadBalancer
-		}
-	}
-
-	lbProvider, err := providers.GetLoadbalancerProviderByType(mgr, lbProviderType)
-	if err != nil {
-		return err
-	}
-
 	r := NewReconciler(
 		ctx,
 		mgr.GetClient(),
 		ctrl.Log.WithName("controllers").WithName(controlledTypeName),
 		record.New(mgr.GetEventRecorder(controllerNameLong)),
-		lbProvider,
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -94,14 +81,12 @@ func NewReconciler(
 	client client.Client,
 	logger logr.Logger,
 	recorder record.Recorder,
-	lbProvider providers.LoadbalancerProvider,
 ) *ReconcileVirtualMachineService {
 	return &ReconcileVirtualMachineService{
-		Context:              ctx,
-		Client:               client,
-		log:                  logger,
-		recorder:             recorder,
-		loadbalancerProvider: lbProvider,
+		Context:  ctx,
+		Client:   client,
+		log:      logger,
+		recorder: recorder,
 	}
 }
 
@@ -111,9 +96,8 @@ var _ reconcile.Reconciler = &ReconcileVirtualMachineService{}
 type ReconcileVirtualMachineService struct {
 	Context context.Context
 	client.Client
-	log                  logr.Logger
-	recorder             record.Recorder
-	loadbalancerProvider providers.LoadbalancerProvider
+	log      logr.Logger
+	recorder record.Recorder
 }
 
 // Reconcile reads that state of the cluster for a VirtualMachineService object and makes changes based on the state read
@@ -168,14 +152,12 @@ func (r *ReconcileVirtualMachineService) ReconcileDelete(ctx *pkgctx.VirtualMach
 
 		endpoint := &corev1.Endpoints{ObjectMeta: objectMeta}
 		if err := r.Client.Delete(ctx, endpoint); client.IgnoreNotFound(err) != nil {
-			ctx.Logger.Error(err, "Failed to delete Endpoints")
-			return err
+			return fmt.Errorf("failed to delete Endpoints: %w", err)
 		}
 
 		service := &corev1.Service{ObjectMeta: objectMeta}
 		if err := r.Client.Delete(ctx, service); client.IgnoreNotFound(err) != nil {
-			ctx.Logger.Error(err, "Failed to delete Service")
-			return err
+			return fmt.Errorf("failed to delete Service: %w", err)
 		}
 
 		ctx.Logger.Info("Delete VirtualMachineService")
@@ -203,11 +185,26 @@ func (r *ReconcileVirtualMachineService) ReconcileNormal(ctx *pkgctx.VirtualMach
 	}
 
 	if err := r.reconcileVMService(ctx); err != nil {
-		ctx.Logger.Error(err, "Failed to reconcile VirtualMachineService")
-		return err
+		return fmt.Errorf("failed to reconcile VirtualMachineService: %w", err)
 	}
 
 	return nil
+}
+
+func (r *ReconcileVirtualMachineService) getLoadBalancerProvider(ctx context.Context) (providers.LoadbalancerProvider, error) {
+	lbProviderType := pkgcfg.FromContext(ctx).LoadBalancerProvider
+	if lbProviderType == "" {
+		switch pkgcfg.FromContext(ctx).NetworkProviderType {
+		case pkgcfg.NetworkProviderTypeNSXT, pkgcfg.NetworkProviderTypeVPC:
+			// This LB provider dates back to the initial release which was NSXT only, but
+			// we have no way to determine what the actual LB is. So continue to set these
+			// based on network provider, but this is hack ideally this would be expressed
+			// in another way like a LoadBalancerClass.
+			lbProviderType = providers.NSXTLoadBalancer
+		}
+	}
+
+	return providers.GetLoadbalancerProviderByType(r.Client, lbProviderType)
 }
 
 func (r *ReconcileVirtualMachineService) reconcileVMService(ctx *pkgctx.VirtualMachineServiceContext) error {
@@ -217,19 +214,22 @@ func (r *ReconcileVirtualMachineService) reconcileVMService(ctx *pkgctx.VirtualM
 	vmService := ctx.VMService
 
 	if vmService.Spec.Type == vmopv1.VirtualMachineServiceTypeLoadBalancer {
-		// Get LoadBalancer to attach
-		err := r.loadbalancerProvider.EnsureLoadBalancer(ctx, vmService)
+		lbProvider, err := r.getLoadBalancerProvider(ctx)
 		if err != nil {
-			ctx.Logger.Error(err, "Failed to create or get load balancer for VM Service")
-			return err
+			return fmt.Errorf("failed to get load balancer provider: %w", err)
+		}
+
+		// Get LoadBalancer to attach
+		err = lbProvider.EnsureLoadBalancer(ctx, vmService)
+		if err != nil {
+			return fmt.Errorf("failed to create or get load balancer for VM Service: %w", err)
 		}
 
 		// Get the provider specific annotations for service and add them to the VMService as
 		// that's where Service inherits the values.
-		annotations, err := r.loadbalancerProvider.GetServiceAnnotations(ctx, vmService)
+		annotations, err := lbProvider.GetServiceAnnotations(ctx, vmService)
 		if err != nil {
-			ctx.Logger.Error(err, "Failed to get loadbalancer annotations for service")
-			return err
+			return fmt.Errorf("failed to get load balancer annotations for service: %w", err)
 		}
 
 		if vmService.Annotations == nil {
@@ -246,17 +246,16 @@ func (r *ReconcileVirtualMachineService) reconcileVMService(ctx *pkgctx.VirtualM
 
 		// Get the provider specific labels for Service and add them to the vm service
 		// as that's where Service inherits the values.
-		labels, err := r.loadbalancerProvider.GetServiceLabels(ctx, vmService)
+		svcLabels, err := lbProvider.GetServiceLabels(ctx, vmService)
 		if err != nil {
-			ctx.Logger.Error(err, "Failed to get loadbalancer labels for service")
-			return err
+			return fmt.Errorf("failed to get load balancer labels for service: %w", err)
 		}
 
 		if vmService.Labels == nil {
 			vmService.Labels = make(map[string]string)
 		}
 
-		for k, v := range labels {
+		for k, v := range svcLabels {
 			if oldValue, ok := vmService.Labels[k]; ok {
 				ctx.Logger.V(5).Info("Replacing previous label value on VM Service",
 					"key", k, "oldValue", oldValue, "newValue", v)
@@ -267,8 +266,7 @@ func (r *ReconcileVirtualMachineService) reconcileVMService(ctx *pkgctx.VirtualM
 
 	service, err := r.createOrUpdateService(ctx)
 	if err != nil {
-		ctx.Logger.Error(err, "Failed to update VirtualMachineService k8s Service")
-		return err
+		return fmt.Errorf("failed to update VirtualMachineService k8s Service: %w", err)
 	}
 
 	ctx.Logger.V(5).Info("Service spec.ipFamilies",
@@ -277,14 +275,12 @@ func (r *ReconcileVirtualMachineService) reconcileVMService(ctx *pkgctx.VirtualM
 
 	err = r.createOrUpdateEndpoints(ctx, service)
 	if err != nil {
-		ctx.Logger.Error(err, "Failed to update VirtualMachineService Endpoints")
-		return err
+		return fmt.Errorf("failed to update VirtualMachineService Endpoints: %w", err)
 	}
 
 	err = r.updateVMService(ctx, service)
 	if err != nil {
-		ctx.Logger.Error(err, "Failed to update VirtualMachineService Status")
-		return err
+		return fmt.Errorf("failed to update VirtualMachineService Status: %w", err)
 	}
 
 	return nil
@@ -314,8 +310,8 @@ func (r *ReconcileVirtualMachineService) virtualMachineToVirtualMachineServiceMa
 	}
 }
 
-// Set labels and annotations on the Service from the VirtualMachineService. Some loadbalancer providers (currently
-// only NCP) need to filter or translate labels and annotations too.
+// Set labels and annotations on the Service from the VirtualMachineService. Some load balancer
+// providers (currently only NCP) need to filter or translate labels and annotations too.
 func (r *ReconcileVirtualMachineService) setServiceAnnotationsAndLabels(
 	ctx *pkgctx.VirtualMachineServiceContext,
 	service *corev1.Service) error {
@@ -339,10 +335,14 @@ func (r *ReconcileVirtualMachineService) setServiceAnnotationsAndLabels(
 	}
 
 	// Explicitly remove provider specific annotations
-	annotationsToBeRemoved, err := r.loadbalancerProvider.GetToBeRemovedServiceAnnotations(ctx, ctx.VMService)
+	lbProvider, err := r.getLoadBalancerProvider(ctx)
 	if err != nil {
-		ctx.Logger.Error(err, "Failed to get loadbalancer specific annotations to remove from Service")
-		return err
+		return fmt.Errorf("failed to get load balancer provider: %w", err)
+	}
+
+	annotationsToBeRemoved, err := lbProvider.GetToBeRemovedServiceAnnotations(ctx, ctx.VMService)
+	if err != nil {
+		return fmt.Errorf("failed to get load balancer specific annotations to remove from Service: %w", err)
 	}
 	for k := range annotationsToBeRemoved {
 		ctx.Logger.V(5).Info("Removing annotation from service", "key", k)
@@ -365,10 +365,9 @@ func (r *ReconcileVirtualMachineService) setServiceAnnotationsAndLabels(
 	}
 
 	// Explicitly remove provider specific labels
-	labelsToBeRemoved, err := r.loadbalancerProvider.GetToBeRemovedServiceLabels(ctx, ctx.VMService)
+	labelsToBeRemoved, err := lbProvider.GetToBeRemovedServiceLabels(ctx, ctx.VMService)
 	if err != nil {
-		ctx.Logger.Error(err, "Failed to get loadbalancer specific labels to remove from Service")
-		return err
+		return fmt.Errorf("failed to get load balancer specific labels to remove from Service: %w", err)
 	}
 	for k := range labelsToBeRemoved {
 		ctx.Logger.V(5).Info("Removing label from Service", "key", k)

--- a/controllers/virtualmachineservice/virtualmachineservice_controller_unit_test.go
+++ b/controllers/virtualmachineservice/virtualmachineservice_controller_unit_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachineservice/providers"
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachineservice/utils"
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
@@ -123,7 +124,6 @@ func unitTestsReconcile() {
 			ctx.Client,
 			ctx.Logger,
 			ctx.Recorder,
-			providers.NoopLoadbalancerProvider{},
 		)
 
 		vmServiceCtx = &pkgctx.VirtualMachineServiceContext{
@@ -1237,7 +1237,6 @@ func nsxtLBProviderTestsReconcile() {
 		initObjects []client.Object
 		ctx         *builder.UnitTestContextForController
 
-		lbProvider   providers.LoadbalancerProvider
 		reconciler   *virtualmachineservice.ReconcileVirtualMachineService
 		vmServiceCtx *pkgctx.VirtualMachineServiceContext
 
@@ -1285,13 +1284,14 @@ func nsxtLBProviderTestsReconcile() {
 
 	JustBeforeEach(func() {
 		ctx = suite.NewUnitTestContextForController(initObjects...)
-		lbProvider = providers.NsxtLoadBalancerProvider()
+		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+			config.NetworkProviderType = pkgcfg.NetworkProviderTypeNSXT
+		})
 		reconciler = virtualmachineservice.NewReconciler(
 			ctx,
 			ctx.Client,
 			ctx.Logger,
 			ctx.Recorder,
-			lbProvider,
 		)
 
 		vmServiceCtx = &pkgctx.VirtualMachineServiceContext{
@@ -1398,32 +1398,26 @@ func nsxtLBProviderTestsReconcile() {
 			})
 
 			It("Should update the k8s Service to remove the provider specific annotations regarding healthCheckNodePort", func() {
-				if service.Annotations == nil {
-					service.Annotations = make(map[string]string)
-				}
+				const port = "30012"
 
-				vmService.Annotations[utils.AnnotationServiceHealthCheckNodePortKey] = "30012"
-				annotations, err := lbProvider.GetServiceAnnotations(ctx, vmService)
-				Expect(err).ToNot(HaveOccurred())
-				for k, v := range annotations {
-					service.Annotations[k] = v
-				}
-				Expect(ctx.Client.Update(ctx, service)).To(Succeed())
-
-				err = reconciler.ReconcileNormal(vmServiceCtx)
-				Expect(err).ShouldNot(HaveOccurred())
-
+				vmService.Annotations[utils.AnnotationServiceHealthCheckNodePortKey] = port
+				Expect(reconciler.ReconcileNormal(vmServiceCtx)).To(Succeed())
 				expectEvent(ctx, ContainSubstring(virtualmachineservice.OpUpdate))
 
-				newService := &corev1.Service{}
-				Expect(ctx.Client.Get(ctx, objKey, newService)).To(Succeed())
-				By("ensuring the provider specific annotations are removed from the new service")
-				annotationsToBeRemoved, err := lbProvider.GetToBeRemovedServiceAnnotations(ctx, vmService)
-				Expect(err).ToNot(HaveOccurred())
-				for k := range annotationsToBeRemoved {
-					_, exist := newService.Annotations[k]
-					Expect(exist).To(BeFalse())
-				}
+				By("Service should have NSX annotations", func() {
+					service := &corev1.Service{}
+					Expect(ctx.Client.Get(ctx, objKey, service)).To(Succeed())
+					Expect(service.Annotations).To(HaveKeyWithValue(providers.ServiceLoadBalancerHealthCheckNodePortTagKey, port))
+				})
+
+				delete(vmService.Annotations, utils.AnnotationServiceHealthCheckNodePortKey)
+				Expect(reconciler.ReconcileNormal(vmServiceCtx)).To(Succeed())
+
+				By("Service should not have NSX annotations", func() {
+					service := &corev1.Service{}
+					Expect(ctx.Client.Get(ctx, objKey, service)).To(Succeed())
+					Expect(service.Annotations).ToNot(HaveKey(providers.ServiceLoadBalancerHealthCheckNodePortTagKey))
+				})
 			})
 		})
 	})


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Instead of setting up the LB provider once at controller init time, move it so it is done during the reconcile. Note that this still depends on the global network provider but eventually we'll need to support this per NS.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note
NONE
```