### PR TITLE
🌱 Allow host-level topology key in VMAffinity with feature flag

### DIFF
--- a/webhooks/virtualmachine/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator.go
@@ -2971,9 +2971,20 @@ func (v validator) validateVMAffinity(
 					}
 				}
 
-				if rs.TopologyKey != corev1.LabelTopologyZone {
-					allErrs = append(allErrs, field.NotSupported(
-						p.Child("topologyKey"), rs.TopologyKey, []string{corev1.LabelTopologyZone}))
+				if pkgcfg.FromContext(ctx).Features.VMAffinityDuringExecution {
+					// When VMAffinityDuringExecution capability is enabled,
+					// either zone or host topology key is allowed for affinity required terms.
+					if rs.TopologyKey != corev1.LabelTopologyZone && rs.TopologyKey != corev1.LabelHostname {
+						allErrs = append(allErrs, field.NotSupported(
+							p.Child("topologyKey"), rs.TopologyKey, []string{corev1.LabelTopologyZone, corev1.LabelHostname}))
+					}
+				} else {
+					// Without VMAffinityDuringExecution capability enabled,
+					// only zone topology key is allowed for affinity required terms.
+					if rs.TopologyKey != corev1.LabelTopologyZone {
+						allErrs = append(allErrs, field.NotSupported(
+							p.Child("topologyKey"), rs.TopologyKey, []string{corev1.LabelTopologyZone}))
+					}
 				}
 			}
 		}

--- a/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
@@ -4053,6 +4053,141 @@ func unitTestsValidateCreate() {
 				},
 			),
 
+			Entry("disallow VM Affinity with RequiredDuringSchedulingPreferredDuringExecution and Host topology key when VMAffinityDuringExecution is disabled",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						ctx.vm.Spec.Affinity.VMAffinity = &vmopv1.VMAffinitySpec{
+							RequiredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+								{
+									TopologyKey: corev1.LabelHostname,
+								},
+							},
+						}
+					},
+					validate: doValidateWithMsg(
+						`spec.affinity.vmAffinity.requiredDuringSchedulingPreferredDuringExecution[0].topologyKey: Unsupported value: "kubernetes.io/hostname": supported values: "topology.kubernetes.io/zone"`),
+				},
+			),
+
+			Entry("allow VM Affinity with RequiredDuringSchedulingPreferredDuringExecution and Host topology key when VMAffinityDuringExecution is enabled",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+							config.Features.VMAffinityDuringExecution = true
+						})
+						ctx.vm.Spec.Affinity.VMAffinity = &vmopv1.VMAffinitySpec{
+							RequiredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+								{
+									TopologyKey: corev1.LabelHostname,
+								},
+							},
+						}
+					},
+					expectAllowed: true,
+				},
+			),
+
+			Entry("disallow VM Affinity with RequiredDuringSchedulingPreferredDuringExecution and unsupported topology key even with VMAffinityDuringExecution enabled",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+							config.Features.VMAffinityDuringExecution = true
+						})
+						ctx.vm.Spec.Affinity.VMAffinity = &vmopv1.VMAffinitySpec{
+							RequiredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+								{
+									TopologyKey: "unsupported-key",
+								},
+							},
+						}
+					},
+					validate: doValidateWithMsg(
+						`spec.affinity.vmAffinity.requiredDuringSchedulingPreferredDuringExecution[0].topologyKey: Unsupported value: "unsupported-key": supported values: "topology.kubernetes.io/zone", "kubernetes.io/hostname"`),
+				},
+			),
+
+			Entry("disallow VM Affinity with RequiredDuringSchedulingPreferredDuringExecution and unsupported operator",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						ctx.vm.Spec.Affinity.VMAffinity = &vmopv1.VMAffinitySpec{
+							RequiredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "foo",
+												Operator: metav1.LabelSelectorOpNotIn,
+												Values:   []string{"bar"},
+											},
+										},
+									},
+									TopologyKey: corev1.LabelTopologyZone,
+								},
+							},
+						}
+					},
+					validate: doValidateWithMsg(
+						`spec.affinity.vmAffinity.requiredDuringSchedulingPreferredDuringExecution[0].labelSelector.matchExpressions[0].operator: Unsupported value: "NotIn": supported values: "In"`),
+				},
+			),
+
+			Entry("disallow VM Affinity PreferredDuringSchedulingPreferredDuringExecution with Host topology key",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						ctx.vm.Spec.Affinity.VMAffinity = &vmopv1.VMAffinitySpec{
+							PreferredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+								{
+									TopologyKey: corev1.LabelHostname,
+								},
+							},
+						}
+					},
+					validate: doValidateWithMsg(
+						`spec.affinity.vmAffinity.preferredDuringSchedulingPreferredDuringExecution[0].topologyKey: Unsupported value: "kubernetes.io/hostname": supported values: "topology.kubernetes.io/zone"`),
+				},
+			),
+
+			Entry("disallow VM Affinity PreferredDuringSchedulingPreferredDuringExecution with empty topology key",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						ctx.vm.Spec.Affinity.VMAffinity = &vmopv1.VMAffinitySpec{
+							PreferredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+								{
+									TopologyKey: "",
+								},
+							},
+						}
+					},
+					validate: doValidateWithMsg(
+						`spec.affinity.vmAffinity.preferredDuringSchedulingPreferredDuringExecution[0].topologyKey: Unsupported value: "": supported values: "topology.kubernetes.io/zone"`),
+				},
+			),
+
+			Entry("disallow VM Affinity PreferredDuringSchedulingPreferredDuringExecution with unsupported operator",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						ctx.vm.Spec.Affinity.VMAffinity = &vmopv1.VMAffinitySpec{
+							PreferredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "foo",
+												Operator: metav1.LabelSelectorOpNotIn,
+												Values:   []string{"bar"},
+											},
+										},
+									},
+									TopologyKey: corev1.LabelTopologyZone,
+								},
+							},
+						}
+					},
+					validate: doValidateWithMsg(
+						`spec.affinity.vmAffinity.preferredDuringSchedulingPreferredDuringExecution[0].labelSelector.matchExpressions[0].operator: Unsupported value: "NotIn": supported values: "In"`),
+				},
+			),
+
 			Entry("allow VM Anti Affinity with RequiredDuringSchedulingPreferredDuringExecution and Zone topology key for non-privileged users",
 				testParams{
 					setup: func(ctx *unitValidatingWebhookContext) {


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Allow `kubernetes.io/hostname` as a valid topology key for VMAffinity RequiredDuringScheduling when VMAffinityDuringExecution feature flag is enabled.

- Add feature flag check for hostname topology key validation
- Add comprehensive test coverage for all VMAffinity validation scenarios
- Maintain backward compatibility (zone-only when feature disabled)

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #

**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:


```release-note
🌱 Allow host-level topology key in VMAffinity with feature flag
```