### PR TITLE
🐛 fix: Making the E2E Docker more configurable

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -31,7 +31,7 @@ RUN cd test/e2e/vmservice && go test -c -o /vm-operator/e2e-tests .
 # Runtime stage - minimal image with compiled tests
 FROM ${BASE_IMAGE} AS runtime
 
-# Build information (moved to runtime stage)
+# Build information
 ARG BUILD_BRANCH
 ARG BUILD_COMMIT  
 ARG BUILD_NUMBER
@@ -61,10 +61,10 @@ RUN tdnf update -y && \
         && \
     rm -rf /var/cache/tdnf
 
-# Install kubectl
-RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
-    chmod +x kubectl && \
-    mv kubectl /usr/local/bin/
+ARG KUBECTL_VERSION=v1.32.0
+ARG KUBECTL_URL=https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl
+RUN curl -fsSL "${KUBECTL_URL}" -o /usr/local/bin/kubectl && \
+    chmod +x /usr/local/bin/kubectl
 
 # Create non-root user early 
 RUN groupadd -g 1000 vmoperator && \

--- a/Makefile
+++ b/Makefile
@@ -987,6 +987,8 @@ e2e-image-remove: ## Remove E2E test container image
 #   LABEL_FILTER           - Ginkgo label filter (e.g., "smoke", "!extended-functional")
 #   FLAKE_ATTEMPTS         - Number of retry attempts for flaky tests
 #   E2E_PREBUILT_BINARY    - Path to `go test -c` output (default: $(ROOT_DIR)e2e-tests)
+#   E2E_ARTIFACT_FOLDER    - Directory for test artifacts/logs (default: test_logs)
+#   E2E_ARGS               - Override all e2e binary arguments (e.g. from CI pipelines)
 
 E2E_PREBUILT_BINARY ?= $(ROOT_DIR)e2e-tests
 
@@ -1003,10 +1005,9 @@ test-e2e-prebuilt: ## Run e2e tests using precompiled binary. Used by the E2E co
 	@test -x "$(E2E_PREBUILT_BINARY)" || { echo "error: $(E2E_PREBUILT_BINARY) missing or not executable. Run: cd test/e2e/vmservice && go test -c -o ../../../e2e-tests ."; exit 1; }
 	@echo "Running E2E tests (prebuilt $(E2E_PREBUILT_BINARY))..."
 	@$(eval GINKGO_ARGS := --ginkgo.v)
-	@$(eval E2E_ARGS := -e2e.e2e-config="$(ROOT_DIR)test/e2e/vmservice/config/wcp.yaml" -e2e.artifactFolder=test_logs)
+	@$(eval E2E_ARGS := -e2e.e2e-config="$(ROOT_DIR)test/e2e/vmservice/config/wcp.yaml" -e2e.artifactFolder=$(or $(E2E_ARTIFACT_FOLDER),test_logs))
 	$(if $(TEST_FOCUS),$(eval GINKGO_ARGS += --ginkgo.focus="$(TEST_FOCUS)"))
 	$(if $(TEST_SKIP),$(eval GINKGO_ARGS += --ginkgo.skip="$(TEST_SKIP)"))
-	$(if $(TEST_SKIP),$(eval E2E_ARGS += -e2e.test-skip="$(TEST_SKIP)"))
 	$(if $(LABEL_FILTER),$(eval GINKGO_ARGS += --ginkgo.label-filter="$(LABEL_FILTER)"))
 	$(if $(FLAKE_ATTEMPTS),$(eval GINKGO_ARGS += --ginkgo.flake-attempts=$(FLAKE_ATTEMPTS)))
 	$(if $(E2E_NAMESPACE),$(eval export E2E_NAMESPACE=$(E2E_NAMESPACE)))
@@ -1017,10 +1018,9 @@ test-e2e-ginkgo: | $(GINKGO)
 test-e2e-ginkgo: ## Run e2e tests using ginkgo CLI (compile + run)
 	@echo "Running E2E tests (ginkgo compile)..."
 	@$(eval GINKGO_ARGS := -v)
-	@$(eval E2E_ARGS := -e2e.e2e-config="$(ROOT_DIR)test/e2e/vmservice/config/wcp.yaml" -e2e.artifactFolder=test_logs)
+	@$(eval E2E_ARGS := -e2e.e2e-config="$(ROOT_DIR)test/e2e/vmservice/config/wcp.yaml" -e2e.artifactFolder=$(or $(E2E_ARTIFACT_FOLDER),test_logs))
 	$(if $(TEST_FOCUS),$(eval GINKGO_ARGS += --focus="$(TEST_FOCUS)"))
 	$(if $(TEST_SKIP),$(eval GINKGO_ARGS += --skip="$(TEST_SKIP)"))
-	$(if $(TEST_SKIP),$(eval E2E_ARGS += -e2e.test-skip="$(TEST_SKIP)"))
 	$(if $(LABEL_FILTER),$(eval GINKGO_ARGS += --label-filter="$(LABEL_FILTER)"))
 	$(if $(FLAKE_ATTEMPTS),$(eval GINKGO_ARGS += --flake-attempts=$(FLAKE_ATTEMPTS)))
 	$(if $(E2E_NAMESPACE),$(eval export E2E_NAMESPACE=$(E2E_NAMESPACE)))


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR exposes an argument for the download path of Kubectl and an argument for where to store the logs.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # NA

**Are there any special notes for your reviewer**:
NA

**Please add a release note if necessary**:

```release-note
fix: Making the E2E Docker more configurable
```