### PR TITLE
✨ Persist VmPlacementPolicies and TagSpecs during VM creation

### DIFF
--- a/pkg/providers/vsphere/virtualmachine/affinity.go
+++ b/pkg/providers/vsphere/virtualmachine/affinity.go
@@ -11,12 +11,59 @@ import (
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 )
+
+// extractAffinityLabelsFromVM extracts all "key:value" labels referenced
+// in the VM's affinity and anti-affinity rules.
+// Returns a set where keys are "key:value" strings
+// that are used in affinity rules.
+func extractAffinityLabelsFromVM(vmCtx pkgctx.VirtualMachineContext) sets.Set[string] {
+	affinity := vmCtx.VM.Spec.Affinity
+	if affinity == nil {
+		return nil
+	}
+
+	affinityLabels := sets.New[string]()
+
+	// helper to extract "key:value" labels from VMAffinityTerm slice
+	extractFromTerms := func(terms []vmopv1.VMAffinityTerm) {
+		for _, term := range terms {
+			if term.LabelSelector == nil {
+				continue
+			}
+
+			labels, err := extractLabelsFromSelector(term.LabelSelector)
+			if err != nil {
+				vmCtx.Logger.V(4).Error(err, "invalid label selector")
+				continue
+			}
+
+			for _, label := range labels {
+				affinityLabels.Insert(label)
+			}
+		}
+	}
+
+	// process VM affinity rules
+	if affinity.VMAffinity != nil {
+		extractFromTerms(affinity.VMAffinity.RequiredDuringSchedulingPreferredDuringExecution)
+		extractFromTerms(affinity.VMAffinity.PreferredDuringSchedulingPreferredDuringExecution)
+	}
+
+	// process VM anti-affinity rules
+	if affinity.VMAntiAffinity != nil {
+		extractFromTerms(affinity.VMAntiAffinity.RequiredDuringSchedulingPreferredDuringExecution)
+		extractFromTerms(affinity.VMAntiAffinity.PreferredDuringSchedulingPreferredDuringExecution)
+	}
+
+	return affinityLabels
+}
 
 // genConfigSpecTagSpecsFromVMLabels generates tag specs from VM labels.
 // This is required when setting affinity/anti-affinity policies on the VM.
@@ -31,10 +78,30 @@ func genConfigSpecTagSpecsFromVMLabels(
 
 	tagsToAdd := make([]vimtypes.TagSpec, 0, len(filteredLabels))
 
-	// Any label on the VM can participate in an affinity/anti-affinity policy.
-	// It does not matter if a label is not participating in any policy.
-	// It could be specified by this, or any other VM's placement policy later.
+	policyLabels := sets.New[string]()
+	if pkgcfg.FromContext(vmCtx).Features.VMAffinityDuringExecution {
+		policyLabels = extractAffinityLabelsFromVM(vmCtx)
+	}
+
+	// Any label on the VM can participate in an affinity/anti-affinity
+	// policy.
+	//
+	// For when VMAffinityDuringExecution is enabled,
+	// 	When VM is created, labels which only participate in affinity/anti-affinity
+	// 	policies are added to the configSpec.TagSpecs.
+	// 	This is because DRS expects tags which are ONLY referenced in
+	// 	affinity/anti-affinity policies.
+	//
+	// TODO(for Day 2 operations):
+	// 	When VM is updated and policies are added which refer more labels,
+	// 	this method is called again and the tags are added to the
+	// 	configSpec.TagSpecs.
 	for key, value := range filteredLabels {
+		if pkgcfg.FromContext(vmCtx).Features.VMAffinityDuringExecution &&
+			!policyLabels.Has(key+":"+value) {
+			continue
+		}
+
 		tagsToAdd = append(tagsToAdd, vimtypes.TagSpec{
 			ArrayUpdateSpec: vimtypes.ArrayUpdateSpec{
 				Operation: vimtypes.ArrayUpdateOperationAdd,
@@ -232,7 +299,7 @@ func buildTagIDsFromTopology(
 
 		termLabels, err := extractLabelsFromSelector(term.LabelSelector)
 		if err != nil {
-			vmCtx.Logger.Error(err, "invalid label selector")
+			vmCtx.Logger.V(4).Error(err, "invalid label selector")
 			continue
 		}
 

--- a/pkg/providers/vsphere/virtualmachine/configspec.go
+++ b/pkg/providers/vsphere/virtualmachine/configspec.go
@@ -151,6 +151,12 @@ func CreateConfigSpec(
 		initResourceAllocation(&configSpec.MemoryAllocation)
 	}
 
+	// Apply placement policies and tag specs when feature is enabled
+	if pkgcfg.FromContext(vmCtx).Features.VMAffinityDuringExecution {
+		genConfigSpecAffinityPolicies(vmCtx, &configSpec)
+		genConfigSpecTagSpecsFromVMLabels(vmCtx, &configSpec)
+	}
+
 	return configSpec
 }
 

--- a/pkg/providers/vsphere/virtualmachine/configspec_test.go
+++ b/pkg/providers/vsphere/virtualmachine/configspec_test.go
@@ -465,6 +465,199 @@ var _ = Describe("CreateConfigSpec", func() {
 			})
 		})
 	})
+
+	Context("AF/AAF policies", func() {
+		BeforeEach(func() {
+			pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
+				config.Features.VMAffinityDuringExecution = true
+			})
+		})
+
+		When("VM spec has affinity policies set", func() {
+			Context("required affinity policy with zone topology key", func() {
+				BeforeEach(func() {
+					vmCtx.VM.Labels = map[string]string{
+						"app":                          "db",
+						"env":                          "prod",
+						"zone":                         "us-west",
+						"vmoperator.vmware.com/paused": "true", // should be filtered out
+					}
+
+					vmCtx.VM.Spec.Affinity = &vmopv1.AffinitySpec{
+						VMAffinity: &vmopv1.VMAffinitySpec{
+							RequiredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"env": "prod",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "app",
+												Values:   []string{"db"},
+												Operator: metav1.LabelSelectorOpIn,
+											},
+										},
+									},
+									TopologyKey: corev1.LabelTopologyZone,
+								},
+							},
+						},
+					}
+				})
+
+				It("should have placement policies and tag specs", func() {
+					// Expect 2 policies: one for MatchLabels "env:prod" and one for MatchExpressions "app:db"
+					Expect(configSpec.VmPlacementPolicies).To(HaveLen(2))
+
+					// Verify both policies are VmVmAffinity
+					for _, pol := range configSpec.VmPlacementPolicies {
+						policy, ok := pol.(*vimtypes.VmVmAffinity)
+						Expect(ok).To(BeTrue())
+						Expect(policy.PolicyStrictness).To(Equal(string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution)))
+						Expect(policy.PolicyTopology).To(Equal(string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyVSphereZone)))
+						Expect(policy.AffinedVmsTag.NameId.Tag).To(BeElementOf("env:prod", "app:db"))
+						Expect(policy.AffinedVmsTag.NameId.Category).To(Equal(vmCtx.VM.Namespace))
+					}
+
+					// Only labels referenced in affinity rules should be included as tags
+					// Affinity rules reference "env" and "app" keys, so only those labels should be present
+					// "zone:us-west" should be excluded since "zone" is not referenced in any affinity rule
+					expectedTagNames := []string{"app:db", "env:prod"}
+					assertVMTags(configSpec, expectedTagNames, vmCtx.VM.Namespace)
+				})
+			})
+
+			Context("anti-affinity policy with zone topology key", func() {
+				BeforeEach(func() {
+					vmCtx.VM.Labels = map[string]string{
+						"app": "web",
+						"env": "prod",
+					}
+
+					vmCtx.VM.Spec.Affinity = &vmopv1.AffinitySpec{
+						VMAntiAffinity: &vmopv1.VMAntiAffinitySpec{
+							RequiredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "web",
+										},
+									},
+									TopologyKey: corev1.LabelTopologyZone,
+								},
+							},
+						},
+					}
+				})
+
+				It("should have anti-affinity policies and tag specs", func() {
+					Expect(configSpec.VmPlacementPolicies).To(HaveLen(1))
+					policy, ok := configSpec.VmPlacementPolicies[0].(*vimtypes.VmToVmGroupsAntiAffinity)
+					Expect(ok).To(BeTrue())
+					Expect(policy.PolicyStrictness).To(Equal(string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution)))
+					Expect(policy.PolicyTopology).To(Equal(string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyVSphereZone)))
+					Expect(policy.AntiAffinedVmGroupTags).To(HaveLen(1))
+					Expect(policy.AntiAffinedVmGroupTags[0].NameId.Tag).To(Equal("app:web"))
+					Expect(policy.AntiAffinedVmGroupTags[0].NameId.Category).To(Equal(vmCtx.VM.Namespace))
+
+					// Check TagSpecs for VM labels
+					expectedTagNames := []string{"app:web"}
+					assertVMTags(configSpec, expectedTagNames, vmCtx.VM.Namespace)
+				})
+			})
+		})
+
+		When("VM spec has no affinity policies but has labels", func() {
+			BeforeEach(func() {
+				vmCtx.VM.Labels = map[string]string{
+					"app": "standalone",
+					"env": "test",
+				}
+				vmCtx.VM.Spec.Affinity = nil
+			})
+
+			It("should not have any tag specs when no affinity rules exist", func() {
+				Expect(configSpec.VmPlacementPolicies).To(BeEmpty())
+				Expect(configSpec.TagSpecs).To(BeEmpty())
+			})
+		})
+
+		When("VM has labels but affinity only references some of them", func() {
+			BeforeEach(func() {
+				vmCtx.VM.Labels = map[string]string{
+					"app":                          "web",
+					"env":                          "prod",
+					"tier":                         "frontend",
+					"version":                      "1.0",
+					"owner":                        "team-a",
+					"vmoperator.vmware.com/paused": "true", // should be filtered out
+				}
+
+				vmCtx.VM.Spec.Affinity = &vmopv1.AffinitySpec{
+					VMAffinity: &vmopv1.VMAffinitySpec{
+						RequiredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+							{
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"app": "web",
+									},
+									MatchExpressions: []metav1.LabelSelectorRequirement{
+										{
+											Key:      "env",
+											Values:   []string{"prod", "staging"},
+											Operator: metav1.LabelSelectorOpIn,
+										},
+									},
+								},
+								TopologyKey: corev1.LabelTopologyZone,
+							},
+						},
+					},
+				}
+			})
+
+			It("should only include labels referenced in affinity rules", func() {
+				Expect(configSpec.VmPlacementPolicies).To(HaveLen(3))
+
+				// Only "app" and "env" keys are referenced in affinity rules
+				// "tier", "version", and "owner" labels should be excluded from tags
+				expectedTagNames := []string{"app:web", "env:prod"}
+				assertVMTags(configSpec, expectedTagNames, vmCtx.VM.Namespace)
+			})
+		})
+
+		When("VMAffinityDuringExecution feature flag is disabled", func() {
+			BeforeEach(func() {
+				pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
+					config.Features.VMAffinityDuringExecution = false
+				})
+
+				vmCtx.VM.Labels = map[string]string{
+					"app": "test",
+				}
+				vmCtx.VM.Spec.Affinity = &vmopv1.AffinitySpec{
+					VMAffinity: &vmopv1.VMAffinitySpec{
+						RequiredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+							{
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"app": "test",
+									},
+								},
+								TopologyKey: corev1.LabelTopologyZone,
+							},
+						},
+					},
+				}
+			})
+
+			It("should not have placement policies or tag specs", func() {
+				Expect(configSpec.VmPlacementPolicies).To(BeEmpty())
+				Expect(configSpec.TagSpecs).To(BeEmpty())
+			})
+		})
+	})
 })
 
 var _ = Describe("CreateConfigSpecForPlacement", func() {
@@ -1113,7 +1306,13 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 
 						Expect(configSpec.VmPlacementPolicies).To(HaveLen(4))
 						Expect(configSpec.VmPlacementPolicies).To(ConsistOf(pols))
-						assertVMTags(configSpec, []string{"vm-label1:vm-value1", "vm-label2:vm-value2"}, vmCtx.VM.Namespace)
+						// With VMAffinityDuringExecution enabled, only labels
+						// referenced in affinity rules are added as TagSpecs
+						// Since VM labels ("vm-label1", "vm-label2") don't
+						//  match affinity rule references
+						// ("component", "tier", "environment"),
+						// no TagSpecs should be generated
+						Expect(configSpec.TagSpecs).To(BeEmpty())
 					})
 				})
 
@@ -1171,7 +1370,12 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 
 						Expect(configSpec.VmPlacementPolicies).To(HaveLen(2))
 						Expect(configSpec.VmPlacementPolicies).To(ConsistOf(pols))
-						assertVMTags(configSpec, []string{"vm-label1:vm-value1", "vm-label2:vm-value2"}, vmCtx.VM.Namespace)
+						// With VMAffinityDuringExecution enabled, only labels
+						// referenced in affinity rules are added as TagSpecs
+						// Since VM labels ("vm-label1", "vm-label2") don't match
+						// affinity rule references ("component", "environment"),
+						// no TagSpecs should be generated
+						Expect(configSpec.TagSpecs).To(BeEmpty())
 					})
 				})
 
@@ -1255,7 +1459,12 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 						}
 
 						Expect(configSpec.VmPlacementPolicies).To(ConsistOf(expectedPolicies))
-						assertVMTags(configSpec, []string{"vm-label1:vm-value1", "vm-label2:vm-value2"}, vmCtx.VM.Namespace)
+						// With VMAffinityDuringExecution enabled, only labels
+						// referenced in affinity rules are added as TagSpecs
+						// Since VM labels ("vm-label1", "vm-label2") don't match
+						// affinity rule references ("component", "tier", "environment"),
+						// no TagSpecs should be generated
+						Expect(configSpec.TagSpecs).To(BeEmpty())
 					})
 				})
 
@@ -1312,7 +1521,12 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 						}
 
 						Expect(configSpec.VmPlacementPolicies).To(ConsistOf(expectedPolicies))
-						assertVMTags(configSpec, []string{"vm-label1:vm-value1", "vm-label2:vm-value2"}, vmCtx.VM.Namespace)
+						// With VMAffinityDuringExecution enabled, only labels
+						// referenced in affinity rules are added as TagSpecs
+						// Since VM labels ("vm-label1", "vm-label2") don't match
+						// affinity rule references ("component", "environment"),
+						// no TagSpecs should be generated
+						Expect(configSpec.TagSpecs).To(BeEmpty())
 					})
 				})
 
@@ -1372,7 +1586,12 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 
 						Expect(configSpec.VmPlacementPolicies).To(HaveLen(2))
 						Expect(configSpec.VmPlacementPolicies).To(ConsistOf(pols))
-						assertVMTags(configSpec, []string{"vm-label1:vm-value1", "vm-label2:vm-value2"}, vmCtx.VM.Namespace)
+						// With VMAffinityDuringExecution enabled, only labels
+						// referenced in affinity rules are added as TagSpecs
+						// Since VM labels ("vm-label1", "vm-label2") don't match
+						// affinity rule references ("zone-label", "host-label"),
+						// no TagSpecs should be generated
+						Expect(configSpec.TagSpecs).To(BeEmpty())
 					})
 				})
 			})


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Currently, VM placement policies and tag specifications are only
generated during placement recommendation calls via
`CreateConfigSpecForPlacement()`. This change extends the same logic
to `CreateConfigSpec()` to ensure placement policies are consistently
applied during actual VM creation.

Key changes:
- Add `genConfigSpecAffinityPolicies()` and `genConfigSpecTagSpecsFromVMLabels()`
  calls to `CreateConfigSpec()` when `VMAffinityDuringExecution` feature is enabled
- Implement `extractAffinityLabelsFromVM()` to optimize TagSpec generation by 
  only including VM labels that are referenced in affinity/anti-affinity rules
- Add comprehensive unit tests for placement policy generation and TagSpec
  optimization in `CreateConfigSpec` test suite
- Ensure consistent behavior between placement and creation flows

This ensures that VMs created with affinity/anti-affinity rules will have
the proper placement policies applied to the vSphere ConfigSpec during
creation. The TagSpec optimization reduces unnecessary vSphere tags by
only creating tags for labels that are actually used in DRS placement
policies.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note

```