### PR TITLE
🐛 Classic disk reg: defer CRV until batch CSI signal

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -38,6 +38,9 @@ extend-ignore-re = [
     # VMIs
     "vmi-.*",
 
+    # Because "ba" is a fair variable name.
+    "[bB][aA]",
+
     # -- Taken from https://github.com/crate-ci/typos/blob/master/docs/reference.md
     # Next-line ignore. Use // spellchecker:ignore-next-line
     "(#|//)\\s*spellchecker:ignore-next-line\\n.*",

--- a/controllers/virtualmachine/virtualmachine/virtualmachine_controller.go
+++ b/controllers/virtualmachine/virtualmachine/virtualmachine_controller.go
@@ -197,6 +197,16 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		)
 	}
 
+	// Watch CnsNodeVMBatchAttachment in order to account for the volume
+	// registration race outlined/fixed in
+	// https://github.com/vmware-tanzu/vm-operator/pull/1572.
+	builder = builder.Watches(
+		&cnsv1alpha1.CnsNodeVMBatchAttachment{},
+		handler.EnqueueRequestsFromMapFunc(
+			vmopv1util.CnsNodeVMBatchAttachmentToVirtualMachineMapper(ctx),
+		),
+	)
+
 	return builder.Complete(r)
 }
 

--- a/controllers/virtualmachine/volumebatch/volumebatch_controller.go
+++ b/controllers/virtualmachine/volumebatch/volumebatch_controller.go
@@ -544,8 +544,12 @@ func (r *Reconciler) processBatchAttachmentAndFilterVolumeSpecs(
 			continue
 		}
 
-		// Ignore pvcs that are not bound.
-		if pvc.Status.Phase != corev1.ClaimBound {
+		// Include unbound PVCs when dataSourceRef points at this VM (classic disk
+		// placeholder PVCs created by unmanaged volume register) so CSI can list
+		// them in the batch attachment spec before they are bound.
+		dsRefToVM := pvcDataSourceRefPointsToVM(&pvc, ctx.VM)
+
+		if pvc.Status.Phase != corev1.ClaimBound && !dsRefToVM {
 			ctx.Logger.V(4).Info("PVC is not bound",
 				"pvcName", pvc.Name,
 				"volName", vol.Name,
@@ -579,6 +583,19 @@ func (r *Reconciler) processBatchAttachmentAndFilterVolumeSpecs(
 	}
 
 	return volumeSpecs, retErr
+}
+
+// pvcDataSourceRefPointsToVM reports whether the PVC's dataSourceRef selects
+// this VirtualMachine in the same API group (VM Operator classic placeholder PVCs).
+func pvcDataSourceRefPointsToVM(pvc *corev1.PersistentVolumeClaim, vm *vmopv1.VirtualMachine) bool {
+	ds := pvc.Spec.DataSourceRef
+	if ds == nil || ds.Kind != "VirtualMachine" || ds.Name != vm.Name {
+		return false
+	}
+	if ds.APIGroup == nil || *ds.APIGroup != vmopv1.GroupVersion.Group {
+		return false
+	}
+	return true
 }
 
 func (r *Reconciler) getPVC(

--- a/pkg/providers/vsphere/vmprovider_vm_unmanaged_volumes_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_unmanaged_volumes_test.go
@@ -207,6 +207,13 @@ func vmUnmanagedVolumesTests() {
 			Expect(pvc.OwnerReferences[0].Name).To(Equal(vm.Name))
 			Expect(pvc.OwnerReferences[0].Controller).To(BeNil())
 
+			// Do not refresh vm from the API here: registration sets claimName on
+			// the in-memory VM before ErrPendingRegister, but that spec change is
+			// not yet on the server; a Get would drop claimName and break phase 2.
+			createBatchAttachWithPVCVolumeIDCacheMiss(ctx, ctx.Client, vm, claimName)
+			Expect(createOrUpdateVM(ctx, vmProvider, vm)).
+				To(MatchError(vsphere.ErrRegisterVolumes))
+
 			// Check that CnsRegisterVolume was created.
 			crv := &cnsv1alpha1.CnsRegisterVolume{}
 			Expect(ctx.Client.Get(ctx, client.ObjectKey{
@@ -234,6 +241,19 @@ func vmUnmanagedVolumesTests() {
 			Expect(ctx.Client.Status().Update(ctx, pvc)).To(Succeed())
 			vm.Status.Volumes[0].Attached = true
 			Expect(ctx.Client.Status().Update(ctx, vm)).To(Succeed())
+
+			// Status update can resync the VM from the API; phase-1 claimName may
+			// only exist in memory until later persistence, so ensure spec matches
+			// the PVC before the final reconcile.
+			Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(vm), vm)).To(Succeed())
+			v0 := &vm.Spec.Volumes[0]
+			if v0.PersistentVolumeClaim == nil {
+				v0.PersistentVolumeClaim = &vmopv1.PersistentVolumeClaimVolumeSource{}
+			}
+			if v0.PersistentVolumeClaim.ClaimName != claimName {
+				v0.PersistentVolumeClaim.ClaimName = claimName
+				Expect(ctx.Client.Update(ctx, vm)).To(Succeed())
+			}
 
 			// Trigger another reconciliation
 			Expect(createOrUpdateVM(ctx, vmProvider, vm)).To(Succeed())
@@ -428,6 +448,11 @@ func vmUnmanagedVolumesTests() {
 			Expect(pvc.OwnerReferences[0].Name).To(Equal(vm.Name))
 			Expect(pvc.OwnerReferences[0].Controller).To(BeNil())
 
+			Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(vm), vm)).To(Succeed())
+			createBatchAttachWithPVCVolumeIDCacheMiss(ctx, ctx.Client, vm, claimName)
+			Expect(createOrUpdateVM(ctx, vmProvider, vm)).
+				To(MatchError(vsphere.ErrRegisterVolumes))
+
 			// Check that CnsRegisterVolume was created.
 			crv := &cnsv1alpha1.CnsRegisterVolume{}
 			Expect(ctx.Client.Get(ctx, client.ObjectKey{
@@ -469,6 +494,34 @@ func vmUnmanagedVolumesTests() {
 				vm, vmconfunmanagedvolsreg.Condition)).To(BeTrue())
 		})
 	})
+}
+
+// createBatchAttachWithPVCVolumeIDCacheMiss creates a CnsNodeVMBatchAttachment
+// whose status matches the phase-2 gate in unmanaged volume registration (CSI
+// volume ID cache miss). Without this object, registerUnmanagedDisks does not
+// create CnsRegisterVolume.
+func createBatchAttachWithPVCVolumeIDCacheMiss(
+	ctx context.Context,
+	k8sClient client.Client,
+	vm *vmopv1.VirtualMachine,
+	claimName string,
+) {
+	ba := &cnsv1alpha1.CnsNodeVMBatchAttachment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pkgutil.CNSBatchAttachmentNameForVM(vm.Name),
+			Namespace: vm.Namespace,
+		},
+		Status: cnsv1alpha1.CnsNodeVMBatchAttachmentStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:    cnsv1alpha1.ConditionReady,
+					Status:  metav1.ConditionFalse,
+					Message: "failed to find volumeID for PVC " + claimName,
+				},
+			},
+		},
+	}
+	Expect(k8sClient.Create(ctx, ba)).To(Succeed())
 }
 
 // fakeProfileManager is a mock PBM ProfileManager for testing.

--- a/pkg/util/vmopv1/storage.go
+++ b/pkg/util/vmopv1/storage.go
@@ -1,0 +1,49 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package vmopv1
+
+import (
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cnsv1alpha1 "github.com/vmware-tanzu/vm-operator/external/vsphere-csi-driver/api/v1alpha1"
+)
+
+// csiErrFindFailPrefix is the substring produced by the vsphere-csi-driver
+// batch attachment helper when a PVC in the batch spec is not yet present in
+// the CSI controller's volume ID cache.
+const csiErrFindFailPrefix = "failed to find volumeID for PVC"
+
+// CnsNodeVMBatchAttachmentReportsCacheMiss returns true when the provided
+// CnsNodeVMBatchAttachment reports a PVC volume-ID cache miss in any of its
+// status conditions, either at the top level or within per-volume status.
+func CnsNodeVMBatchAttachmentReportsCacheMiss(
+	ba *cnsv1alpha1.CnsNodeVMBatchAttachment,
+) bool {
+	if batchAttachConditionsIncludeCacheMissMsg(ba.Status.Conditions) {
+		return true
+	}
+	for _, v := range ba.Status.VolumeStatus {
+		if batchAttachConditionsIncludeCacheMissMsg(
+			v.PersistentVolumeClaim.Conditions) {
+			return true
+		}
+	}
+	return false
+}
+
+// batchAttachConditionsIncludeCacheMissMsg reports whether any condition's
+// message or reason contains the CSI batch volume-ID cache miss substring.
+func batchAttachConditionsIncludeCacheMissMsg(
+	conditions []metav1.Condition) bool {
+	for _, c := range conditions {
+		if strings.Contains(c.Message, csiErrFindFailPrefix) ||
+			strings.Contains(c.Reason, csiErrFindFailPrefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/util/vmopv1/storage_test.go
+++ b/pkg/util/vmopv1/storage_test.go
@@ -1,0 +1,80 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package vmopv1_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	cnsv1alpha1 "github.com/vmware-tanzu/vm-operator/external/vsphere-csi-driver/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	vmopv1util "github.com/vmware-tanzu/vm-operator/pkg/util/vmopv1"
+)
+
+var _ = Describe("CnsNodeVMBatchAttachmentReportsCacheMiss", func() {
+	const csiErrMsg = "failed to find volumeID for PVC pvc-0"
+
+	It("should return false for an attachment with no conditions", func() {
+		ba := &cnsv1alpha1.CnsNodeVMBatchAttachment{}
+		Expect(vmopv1util.CnsNodeVMBatchAttachmentReportsCacheMiss(ba)).To(BeFalse())
+	})
+
+	It("should return false when no condition contains the cache miss substring", func() {
+		ba := &cnsv1alpha1.CnsNodeVMBatchAttachment{}
+		ba.Status.Conditions = []metav1.Condition{
+			{Type: "Ready", Status: metav1.ConditionFalse, Reason: "AttachFailed", Message: "some other error"},
+		}
+		Expect(vmopv1util.CnsNodeVMBatchAttachmentReportsCacheMiss(ba)).To(BeFalse())
+	})
+
+	It("should return true when a top-level condition message contains the cache miss substring", func() {
+		ba := &cnsv1alpha1.CnsNodeVMBatchAttachment{}
+		ba.Status.Conditions = []metav1.Condition{
+			{Type: "Ready", Status: metav1.ConditionFalse, Reason: "Failed", Message: csiErrMsg},
+		}
+		Expect(vmopv1util.CnsNodeVMBatchAttachmentReportsCacheMiss(ba)).To(BeTrue())
+	})
+
+	It("should return true when a top-level condition reason contains the cache miss substring", func() {
+		ba := &cnsv1alpha1.CnsNodeVMBatchAttachment{}
+		ba.Status.Conditions = []metav1.Condition{
+			{Type: "Ready", Status: metav1.ConditionFalse, Reason: csiErrMsg, Message: ""},
+		}
+		Expect(vmopv1util.CnsNodeVMBatchAttachmentReportsCacheMiss(ba)).To(BeTrue())
+	})
+
+	It("should return true when a per-volume condition message contains the cache miss substring", func() {
+		ba := &cnsv1alpha1.CnsNodeVMBatchAttachment{}
+		ba.Status.VolumeStatus = []cnsv1alpha1.VolumeStatus{
+			{
+				Name: "vol-0",
+				PersistentVolumeClaim: cnsv1alpha1.PersistentVolumeClaimStatus{
+					ClaimName: "pvc-0",
+					Conditions: []metav1.Condition{
+						{Type: "VolumeAttached", Status: metav1.ConditionFalse, Reason: "AttachFailed", Message: csiErrMsg},
+					},
+				},
+			},
+		}
+		Expect(vmopv1util.CnsNodeVMBatchAttachmentReportsCacheMiss(ba)).To(BeTrue())
+	})
+
+	It("should return false when per-volume conditions do not contain the cache miss substring", func() {
+		ba := &cnsv1alpha1.CnsNodeVMBatchAttachment{}
+		ba.Status.VolumeStatus = []cnsv1alpha1.VolumeStatus{
+			{
+				Name: "vol-0",
+				PersistentVolumeClaim: cnsv1alpha1.PersistentVolumeClaimStatus{
+					ClaimName: "pvc-0",
+					Conditions: []metav1.Condition{
+						{Type: "VolumeAttached", Status: metav1.ConditionFalse, Reason: "AttachFailed", Message: "disk is busy"},
+					},
+				},
+			},
+		}
+		Expect(vmopv1util.CnsNodeVMBatchAttachmentReportsCacheMiss(ba)).To(BeFalse())
+	})
+})

--- a/pkg/util/vmopv1/vm.go
+++ b/pkg/util/vmopv1/vm.go
@@ -24,6 +24,7 @@ import (
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 	byokv1 "github.com/vmware-tanzu/vm-operator/external/byok/api/v1alpha1"
+	cnsv1alpha1 "github.com/vmware-tanzu/vm-operator/external/vsphere-csi-driver/api/v1alpha1"
 	pkgcond "github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgconst "github.com/vmware-tanzu/vm-operator/pkg/constants"
@@ -33,6 +34,7 @@ import (
 )
 
 const (
+	vmKind            = "VirtualMachine"
 	vmiKind           = "VirtualMachineImage"
 	cvmiKind          = "Cluster" + vmiKind
 	imgNotFoundFormat = "no VM image exists for %q in namespace or cluster scope"
@@ -423,7 +425,7 @@ func CnsRegisterVolumeToVirtualMachineMapper(
 		var requests []reconcile.Request
 
 		for _, ownerRef := range o.GetOwnerReferences() {
-			if ownerRef.Kind == "VirtualMachine" {
+			if ownerRef.Kind == vmKind {
 				requests = append(requests, reconcile.Request{
 					NamespacedName: client.ObjectKey{
 						Namespace: o.GetNamespace(),
@@ -437,6 +439,72 @@ func CnsRegisterVolumeToVirtualMachineMapper(
 		if len(requests) > 0 {
 			logger.V(4).Info(
 				"Reconciling VMs due to CnsRegisterVolume watch",
+				"requests", requests)
+		}
+
+		return requests
+	}
+}
+
+// CnsNodeVMBatchAttachmentToVirtualMachineMapper returns a mapper function
+// used to enqueue reconcile requests for VMs in response to an event on the
+// CnsNodeVMBatchAttachment resource.
+// A reconcile request is only enqueued when all of the following are true:
+//   - The CnsNodeVMBatchAttachment has an owner reference with Kind
+//     "VirtualMachine".
+//   - CnsNodeVMBatchAttachmentReportsCacheMiss returns true for the object.
+func CnsNodeVMBatchAttachmentToVirtualMachineMapper(
+	ctx context.Context,
+) handler.MapFunc {
+
+	if ctx == nil {
+		panic("context is nil")
+	}
+
+	return func(ctx context.Context, o client.Object) []reconcile.Request {
+		if ctx == nil {
+			panic("context is nil")
+		}
+		if o == nil {
+			panic("object is nil")
+		}
+
+		ba, ok := o.(*cnsv1alpha1.CnsNodeVMBatchAttachment)
+		if !ok {
+			panic(fmt.Sprintf("object is %T", o))
+		}
+
+		logger := pkglog.FromContextOrDefault(ctx).
+			WithValues("name", o.GetName(), "namespace", o.GetNamespace())
+
+		// Only enqueue for batch attachments that report a PVC volume-ID
+		// cache miss; this is the signal that CSI has not yet resolved the
+		// volume and a VM reconciliation should be triggered.
+		if !CnsNodeVMBatchAttachmentReportsCacheMiss(ba) {
+			logger.V(4).Info(
+				"Skipping CnsNodeVMBatchAttachment without PVC volume-ID cache miss")
+			return nil
+		}
+
+		var requests []reconcile.Request
+
+		for _, ownerRef := range o.GetOwnerReferences() {
+			if ownerRef.Kind == vmKind {
+				requests = append(requests, reconcile.Request{
+					NamespacedName: client.ObjectKey{
+						Namespace: o.GetNamespace(),
+						Name:      ownerRef.Name,
+					},
+				})
+				logger.V(4).Info(
+					"Queuing VM reconciliation due to CnsNodeVMBatchAttachment cache miss",
+					"vmName", ownerRef.Name)
+			}
+		}
+
+		if len(requests) > 0 {
+			logger.V(4).Info(
+				"Reconciling VMs due to CnsNodeVMBatchAttachment watch",
 				"requests", requests)
 		}
 

--- a/pkg/util/vmopv1/vm_test.go
+++ b/pkg/util/vmopv1/vm_test.go
@@ -1138,6 +1138,141 @@ var _ = Describe("CnsRegisterVolumeToVirtualMachineMapper", func() {
 	})
 })
 
+var _ = Describe("CnsNodeVMBatchAttachmentToVirtualMachineMapper", func() {
+	const (
+		vmName    = "test-vm"
+		namespace = "test-namespace"
+	)
+
+	var (
+		ctx        context.Context
+		vm         *vmopv1.VirtualMachine
+		mapperFunc func(context.Context, ctrlclient.Object) []reconcile.Request
+
+		newBA = func(
+			ownerKind string,
+			topConditions []metav1.Condition,
+			volConditions []metav1.Condition,
+		) *cnsv1alpha1.CnsNodeVMBatchAttachment {
+			ba := &cnsv1alpha1.CnsNodeVMBatchAttachment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ba",
+					Namespace: namespace,
+				},
+			}
+			if ownerKind != "" {
+				ba.OwnerReferences = []metav1.OwnerReference{
+					{
+						APIVersion: vmopv1.GroupVersion.String(),
+						Kind:       ownerKind,
+						Name:       vmName,
+					},
+				}
+			}
+			ba.Status.Conditions = topConditions
+			if len(volConditions) > 0 {
+				ba.Status.VolumeStatus = []cnsv1alpha1.VolumeStatus{
+					{
+						Name: "vol-0",
+						PersistentVolumeClaim: cnsv1alpha1.PersistentVolumeClaimStatus{
+							ClaimName:  "pvc-0",
+							Conditions: volConditions,
+						},
+					},
+				}
+			}
+			return ba
+		}
+
+		cacheMissCondition = metav1.Condition{
+			Type:    "VolumeAttached",
+			Status:  metav1.ConditionFalse,
+			Reason:  "failed to find volumeID for PVC pvc-0",
+			Message: "failed to find volumeID for PVC pvc-0",
+		}
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		vm = &vmopv1.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      vmName,
+				Namespace: namespace,
+			},
+		}
+		mapperFunc = vmopv1util.CnsNodeVMBatchAttachmentToVirtualMachineMapper(ctx)
+	})
+
+	It("should panic with nil context", func() {
+		Expect(func() {
+			ctx = nil
+			vmopv1util.CnsNodeVMBatchAttachmentToVirtualMachineMapper(ctx)
+		}).To(Panic())
+	})
+
+	Context("when the inner mapper function is called with nil context", func() {
+		It("should panic", func() {
+			Expect(func() {
+				mapperFunc(nil, newBA("VirtualMachine", nil, nil))
+			}).To(Panic())
+		})
+	})
+
+	Context("when the inner mapper function is called with nil object", func() {
+		It("should panic", func() {
+			Expect(func() {
+				mapperFunc(ctx, nil)
+			}).To(Panic())
+		})
+	})
+
+	Context("when CnsNodeVMBatchAttachment has no owner reference", func() {
+		It("should return no reconcile requests even with a cache miss condition", func() {
+			ba := newBA("", []metav1.Condition{cacheMissCondition}, nil)
+			requests := mapperFunc(ctx, ba)
+			Expect(requests).To(BeEmpty())
+		})
+	})
+
+	Context("when CnsNodeVMBatchAttachment has a non-VM owner reference", func() {
+		It("should return no reconcile requests even with a cache miss condition", func() {
+			ba := newBA("SomeOtherKind", []metav1.Condition{cacheMissCondition}, nil)
+			requests := mapperFunc(ctx, ba)
+			Expect(requests).To(BeEmpty())
+		})
+	})
+
+	Context("when CnsNodeVMBatchAttachment has a VM owner reference", func() {
+		Context("but reports no cache miss", func() {
+			It("should return no reconcile requests", func() {
+				ba := newBA("VirtualMachine", nil, nil)
+				requests := mapperFunc(ctx, ba)
+				Expect(requests).To(BeEmpty())
+			})
+		})
+
+		Context("and reports a cache miss in top-level status conditions", func() {
+			It("should return a reconcile request for the owner VM", func() {
+				ba := newBA("VirtualMachine", []metav1.Condition{cacheMissCondition}, nil)
+				requests := mapperFunc(ctx, ba)
+				Expect(requests).To(HaveLen(1))
+				Expect(requests[0].NamespacedName.Name).To(Equal(vm.Name))
+				Expect(requests[0].NamespacedName.Namespace).To(Equal(vm.Namespace))
+			})
+		})
+
+		Context("and reports a cache miss in per-volume status conditions", func() {
+			It("should return a reconcile request for the owner VM", func() {
+				ba := newBA("VirtualMachine", nil, []metav1.Condition{cacheMissCondition})
+				requests := mapperFunc(ctx, ba)
+				Expect(requests).To(HaveLen(1))
+				Expect(requests[0].NamespacedName.Name).To(Equal(vm.Name))
+				Expect(requests[0].NamespacedName.Namespace).To(Equal(vm.Namespace))
+			})
+		})
+	})
+})
+
 var _ = Describe("PVCToVirtualMachineVolumeClaimNameMapper", func() {
 	const (
 		namespaceName = "fake"

--- a/pkg/util/vmopv1/vmgroup.go
+++ b/pkg/util/vmopv1/vmgroup.go
@@ -23,7 +23,6 @@ import (
 )
 
 const (
-	vmKind  = "VirtualMachine"
 	vmgKind = "VirtualMachineGroup"
 )
 

--- a/pkg/vmconfig/volumes/unmanaged/register/unmanagedvolumes_register.go
+++ b/pkg/vmconfig/volumes/unmanaged/register/unmanagedvolumes_register.go
@@ -30,8 +30,10 @@ import (
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	pkgerr "github.com/vmware-tanzu/vm-operator/pkg/errors"
 	pkglog "github.com/vmware-tanzu/vm-operator/pkg/log"
+	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
 	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
+	vmopv1util "github.com/vmware-tanzu/vm-operator/pkg/util/vmopv1"
 	pkgvol "github.com/vmware-tanzu/vm-operator/pkg/util/volumes"
 	pkgdatastore "github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/datastore"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmconfig"
@@ -497,6 +499,12 @@ func ensureUnmanagedDisksHaveUpdatedCapacity(
 	return nil
 }
 
+// registerUnmanagedDisks uses a two-phase flow:
+//  1. Ensure every unmanaged classic disk has a PVC and claimName on the VM
+//     spec, then return pending so the volume batch controller can add unbound
+//     PVCs (dataSourceRef → VM) to CnsNodeVMBatchAttachment.
+//  2. On a later reconcile, wait until batch status shows the CSI volume-ID
+//     cache miss text, then ensure CnsRegisterVolume for pending PVCs.
 func registerUnmanagedDisks(
 	ctx context.Context,
 	k8sClient ctrlclient.Client,
@@ -504,72 +512,104 @@ func registerUnmanagedDisks(
 	vm *vmopv1.VirtualMachine,
 	info pkgvol.VolumeInfo) (bool, error) {
 
-	var hasPending bool
-
 	logger := pkglog.FromContextOrDefault(ctx).WithName("registerUnmanagedDisks")
 	logger.Info(
 		"Registering unmanaged disks",
 		"disks", info.Disks,
 		"volumes", info.Volumes)
 
+	var wroteClaims bool
+
 	for _, di := range info.Disks {
-		// Step 1: Look for the volume entry from spec.volumes.
-		if volume, ok := info.Volumes[di.Target.String()]; ok {
-			// Step 2: Check if a PVC already exists for this volume.
-			pvcName := volume.Name
-			if pvc := volume.PersistentVolumeClaim; pvc != nil {
-				if pvc.ClaimName != "" {
-					pvcName = pvc.ClaimName
-				}
-			}
+		volume, ok := info.Volumes[di.Target.String()]
+		if !ok {
+			continue
+		}
 
-			logger.Info("Processing unmanaged disk",
-				"disk", di, "volume", volume, "isFCD", di.FCD)
-
-			// Step 3: Ensure PVC exists (create if needed).
-			pvc, err := ensurePVCForUnmanagedDisk(
-				ctx,
-				k8sClient,
-				vm,
-				pvcName,
-				di)
-			if err != nil {
-				return false, fmt.Errorf(
-					"failed to ensure pvc %s for disk %s: %w",
-					pvcName, di.UUID, err)
-			}
-
-			// Step 4: Write the name of the PVC back to the entry in
-			//         spec.volumes.
-			if volume.PersistentVolumeClaim == nil {
-				volume.PersistentVolumeClaim = &vmopv1.PersistentVolumeClaimVolumeSource{}
-			}
-			volume.PersistentVolumeClaim.ClaimName = pvc.Name
-
-			switch pvc.Status.Phase {
-			case "", corev1.ClaimPending:
-				// Step 5: PVC is not bound - ensure CnsRegisterVolume exists.
-				// This ensures that if the CnsRegisterVolume was deleted prematurely,
-				// it will be re-created.
-				logger.V(4).Info("PVC is pending, ensuring CnsRegisterVolume exists",
-					"pvc", pvc.Name,
-					"isFCD", di.FCD)
-
-				if _, err := ensureCnsRegisterVolumeForDisk(
-					ctx,
-					k8sClient,
-					vimClient,
-					vm,
-					pvc,
-					di); err != nil {
-
-					return false, fmt.Errorf(
-						"failed to ensure CnsRegisterVolume %s: %w",
-						pvc.Name, err)
-				}
-				hasPending = true
+		pvcName := volume.Name
+		if pvc := volume.PersistentVolumeClaim; pvc != nil {
+			if pvc.ClaimName != "" {
+				pvcName = pvc.ClaimName
 			}
 		}
+
+		logger.Info("Phase 1: ensure PVC and claim for unmanaged disk",
+			"disk", di, "volume", volume, "isFCD", di.FCD)
+
+		pvc, err := ensurePVCForUnmanagedDisk(ctx, k8sClient, vm, pvcName, di)
+		if err != nil {
+			return false, fmt.Errorf(
+				"failed to ensure pvc %s for disk %s: %w",
+				pvcName, di.UUID, err)
+		}
+
+		if volume.PersistentVolumeClaim == nil ||
+			volume.PersistentVolumeClaim.ClaimName != pvc.Name {
+			wroteClaims = true
+		}
+		if volume.PersistentVolumeClaim == nil {
+			volume.PersistentVolumeClaim = &vmopv1.PersistentVolumeClaimVolumeSource{}
+		}
+		volume.PersistentVolumeClaim.ClaimName = pvc.Name
+	}
+
+	if wroteClaims {
+		return true, nil
+	}
+
+	batchShowsPVCVolumeIDCacheMiss, err := batchAttachReportsMissingPVCVolumeIDInCache(
+		ctx, k8sClient, vm)
+	if err != nil {
+		return false, err
+	}
+
+	var hasPending bool
+
+	for _, di := range info.Disks {
+		volume, ok := info.Volumes[di.Target.String()]
+		if !ok {
+			continue
+		}
+
+		pvcName := volume.Name
+		if pvc := volume.PersistentVolumeClaim; pvc != nil {
+			if pvc.ClaimName != "" {
+				pvcName = pvc.ClaimName
+			}
+		}
+
+		pvcObj := &corev1.PersistentVolumeClaim{}
+		key := ctrlclient.ObjectKey{Namespace: vm.Namespace, Name: pvcName}
+		if err := k8sClient.Get(ctx, key, pvcObj); err != nil {
+			return false, fmt.Errorf("failed to get pvc %s for registration phase: %w", key, err)
+		}
+
+		pending := pvcObj.Status.Phase == "" || pvcObj.Status.Phase == corev1.ClaimPending
+		if !pending {
+			continue
+		}
+
+		if !batchShowsPVCVolumeIDCacheMiss {
+			hasPending = true
+			continue
+		}
+
+		logger.V(4).Info("Phase 2: PVC pending, batch status shows volume ID cache miss; ensuring CnsRegisterVolume",
+			"pvc", pvcObj.Name,
+			"isFCD", di.FCD)
+
+		if _, err := ensureCnsRegisterVolumeForDisk(
+			ctx,
+			k8sClient,
+			vimClient,
+			vm,
+			pvcObj,
+			di); err != nil {
+			return false, fmt.Errorf(
+				"failed to ensure CnsRegisterVolume %s: %w",
+				pvcObj.Name, err)
+		}
+		hasPending = true
 	}
 
 	return hasPending, nil
@@ -897,8 +937,10 @@ func cleanupCompletedCnsRegisterVolumesForVM(
 	var errs []error
 	for _, crv := range crvList.Items {
 		if !crv.Status.Registered {
-			logger.V(4).Info("Skipping deletion of CnsRegisterVolume - not yet registered",
-				"crv", crv.Name, "crvStatusError", crv.Status.Error)
+			logger.V(4).Info(
+				"Skipping deletion of CnsRegisterVolume - not yet registered",
+				"crv", crv.Name,
+				"crvStatusError", crv.Status.Error)
 			continue
 		}
 
@@ -936,4 +978,35 @@ func cleanupVolumeStatus(vm *vmopv1.VirtualMachine) {
 				return false
 			}
 		})
+}
+
+// batchAttachReportsMissingPVCVolumeIDInCache returns true when the
+// CnsNodeVMBatchAttachment status conditions include the CSI driver's volume-ID
+// cache miss text (GetVolumeIDFromPVCName). CSI does not surface this per PVC
+// on the object; the reconciler treats any condition message containing
+// csiErrFailedToFindVolumeIDForPVCPrefix as the signal that it is safe to
+// ensure CnsRegisterVolume for pending placeholder PVCs.
+func batchAttachReportsMissingPVCVolumeIDInCache(
+	ctx context.Context,
+	k8sClient ctrlclient.Client,
+	vm *vmopv1.VirtualMachine,
+) (bool, error) {
+
+	ba := &cnsv1alpha1.CnsNodeVMBatchAttachment{}
+	key := ctrlclient.ObjectKey{
+		Namespace: vm.Namespace,
+		Name:      pkgutil.CNSBatchAttachmentNameForVM(vm.Name),
+	}
+	if err := k8sClient.Get(ctx, key, ba); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	if vmopv1util.CnsNodeVMBatchAttachmentReportsCacheMiss(ba) {
+		return true, nil
+	}
+
+	return false, nil
 }

--- a/pkg/vmconfig/volumes/unmanaged/register/unmanagedvolumes_register_test.go
+++ b/pkg/vmconfig/volumes/unmanaged/register/unmanagedvolumes_register_test.go
@@ -45,6 +45,32 @@ import (
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
+// createBatchAttachWithPVCVolumeIDCacheMiss creates a CnsNodeVMBatchAttachment
+// whose status matches the phase-2 gate in register (CSI volume ID cache miss).
+func createBatchAttachWithPVCVolumeIDCacheMiss(
+	ctx context.Context,
+	k8sClient ctrlclient.Client,
+	vm *vmopv1.VirtualMachine,
+	claimName string,
+) {
+	ba := &cnsv1alpha1.CnsNodeVMBatchAttachment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      vm.Name,
+			Namespace: vm.Namespace,
+		},
+		Status: cnsv1alpha1.CnsNodeVMBatchAttachmentStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:    cnsv1alpha1.ConditionReady,
+					Status:  metav1.ConditionFalse,
+					Message: "failed to find volumeID for PVC " + claimName,
+				},
+			},
+		},
+	}
+	Expect(k8sClient.Create(ctx, ba)).To(Succeed())
+}
+
 var _ = Describe("New", func() {
 	It("should return a reconciler", func() {
 		Expect(unmanagedvolsreg.New()).ToNot(BeNil())
@@ -431,6 +457,16 @@ var _ = Describe("Reconcile", func() {
 					expectedStorage := *kubeutil.BytesToResource(2 * 1024 * 1024 * 1024)
 					Expect(pvc.Spec.Resources.Requests[corev1.ResourceStorage].Equal(expectedStorage)).To(BeTrue())
 
+					createBatchAttachWithPVCVolumeIDCacheMiss(ctx, k8sClient, vm, claimName)
+
+					Expect(unmanagedvolsreg.Reconcile(
+						ctx,
+						k8sClient,
+						vimClient,
+						vm,
+						moVM,
+						configSpec)).To(MatchError(unmanagedvolsreg.ErrPendingRegister))
+
 					// Verify CnsRegisterVolume was created
 					crv := &cnsv1alpha1.CnsRegisterVolume{}
 					Expect(k8sClient.Get(ctx, ctrlclient.ObjectKey{
@@ -546,6 +582,16 @@ var _ = Describe("Reconcile", func() {
 					Expect(pvc.Spec.AccessModes).To(ContainElement(corev1.ReadWriteMany))
 					expectedStorage := *kubeutil.BytesToResource(2 * 1024 * 1024 * 1024)
 					Expect(pvc.Spec.Resources.Requests[corev1.ResourceStorage].Equal(expectedStorage)).To(BeTrue())
+
+					createBatchAttachWithPVCVolumeIDCacheMiss(ctx, k8sClient, vm, claimName)
+
+					Expect(unmanagedvolsreg.Reconcile(
+						ctx,
+						k8sClient,
+						vimClient,
+						vm,
+						moVM,
+						configSpec)).To(MatchError(unmanagedvolsreg.ErrPendingRegister))
 
 					// Verify CnsRegisterVolume was created
 					crv := &cnsv1alpha1.CnsRegisterVolume{}
@@ -690,296 +736,296 @@ var _ = Describe("Reconcile", func() {
 				})
 			})
 
-		When("VM has an EncryptionClassName in spec.crypto", func() {
-			JustBeforeEach(func() {
-				pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-					config.Features.VMSharedDisks = true
+			When("VM has an EncryptionClassName in spec.crypto", func() {
+				JustBeforeEach(func() {
+					pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+						config.Features.VMSharedDisks = true
+					})
+
+					Expect(unmanagedvolsfill.Reconcile(
+						ctx,
+						nil,
+						nil,
+						vm,
+						moVM,
+						nil)).To(MatchError(unmanagedvolsfill.ErrPendingBackfill))
+					Expect(unmanagedvolsfill.Reconcile(
+						ctx,
+						nil,
+						nil,
+						vm,
+						moVM,
+						nil)).To(Succeed())
 				})
 
-				Expect(unmanagedvolsfill.Reconcile(
-					ctx,
-					nil,
-					nil,
-					vm,
-					moVM,
-					nil)).To(MatchError(unmanagedvolsfill.ErrPendingBackfill))
-				Expect(unmanagedvolsfill.Reconcile(
-					ctx,
-					nil,
-					nil,
-					vm,
-					moVM,
-					nil)).To(Succeed())
-			})
+				BeforeEach(func() {
+					vm.Spec.Crypto = &vmopv1.VirtualMachineCryptoSpec{
+						EncryptionClassName: "my-enc-class",
+					}
 
-			BeforeEach(func() {
-				vm.Spec.Crypto = &vmopv1.VirtualMachineCryptoSpec{
-					EncryptionClassName: "my-enc-class",
-				}
+					// Start with empty volumes - let Reconcile add them
+					vm.Spec.Volumes = []vmopv1.VirtualMachineVolume{}
 
-				// Start with empty volumes - let Reconcile add them
-				vm.Spec.Volumes = []vmopv1.VirtualMachineVolume{}
-
-				disk := &vimtypes.VirtualDisk{
-					VirtualDevice: vimtypes.VirtualDevice{
-						Key:           300,
-						ControllerKey: 200,
-						UnitNumber:    ptr.To(int32(0)),
-						Backing: &vimtypes.VirtualDiskFlatVer2BackingInfo{
-							VirtualDeviceFileBackingInfo: vimtypes.VirtualDeviceFileBackingInfo{
-								FileName: "[LocalDS_0] vm1/enc-disk.vmdk",
-							},
-							Uuid: "disk-uuid-enc",
-						},
-					},
-					CapacityInBytes: 2 * 1024 * 1024 * 1024,
-				}
-
-				scsiController := &vimtypes.VirtualSCSIController{
-					VirtualController: vimtypes.VirtualController{
+					disk := &vimtypes.VirtualDisk{
 						VirtualDevice: vimtypes.VirtualDevice{
-							Key: 200,
+							Key:           300,
+							ControllerKey: 200,
+							UnitNumber:    ptr.To(int32(0)),
+							Backing: &vimtypes.VirtualDiskFlatVer2BackingInfo{
+								VirtualDeviceFileBackingInfo: vimtypes.VirtualDeviceFileBackingInfo{
+									FileName: "[LocalDS_0] vm1/enc-disk.vmdk",
+								},
+								Uuid: "disk-uuid-enc",
+							},
 						},
-						BusNumber: 1,
-					},
-				}
+						CapacityInBytes: 2 * 1024 * 1024 * 1024,
+					}
 
-				moVM.Config = &vimtypes.VirtualMachineConfigInfo{
-					Hardware: vimtypes.VirtualHardware{
-						Device: []vimtypes.BaseVirtualDevice{
-							scsiController,
-							disk,
+					scsiController := &vimtypes.VirtualSCSIController{
+						VirtualController: vimtypes.VirtualController{
+							VirtualDevice: vimtypes.VirtualDevice{
+								Key: 200,
+							},
+							BusNumber: 1,
 						},
-					},
-				}
-			})
+					}
 
-			It("should set the PVC encryption class annotation on created PVCs", func() {
-				Expect(unmanagedvolsreg.Reconcile(
-					ctx,
-					k8sClient,
-					vimClient,
-					vm,
-					moVM,
-					configSpec)).To(MatchError(unmanagedvolsreg.ErrPendingRegister))
-
-				claimName := vmopv1util.FindByTargetID(
-					vmopv1.VirtualControllerTypeSCSI,
-					1, 0, vm.Spec.Volumes...).PersistentVolumeClaim.ClaimName
-
-				var pvc corev1.PersistentVolumeClaim
-				Expect(k8sClient.Get(ctx, ctrlclient.ObjectKey{
-					Namespace: vm.Namespace,
-					Name:      claimName,
-				}, &pvc)).To(Succeed())
-
-				Expect(pvc.Annotations[pkgconst.PVCEncryptionClassNameAnnotation]).To(
-					Equal("my-enc-class"))
-				Expect(pvc.Annotations[unmanagedvolsreg.DiskBackingAnnotation]).ToNot(BeEmpty())
-			})
-		})
-
-		When("VM has no crypto spec", func() {
-			JustBeforeEach(func() {
-				pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-					config.Features.VMSharedDisks = true
+					moVM.Config = &vimtypes.VirtualMachineConfigInfo{
+						Hardware: vimtypes.VirtualHardware{
+							Device: []vimtypes.BaseVirtualDevice{
+								scsiController,
+								disk,
+							},
+						},
+					}
 				})
 
-				Expect(unmanagedvolsfill.Reconcile(
-					ctx,
-					nil,
-					nil,
-					vm,
-					moVM,
-					nil)).To(MatchError(unmanagedvolsfill.ErrPendingBackfill))
-				Expect(unmanagedvolsfill.Reconcile(
-					ctx,
-					nil,
-					nil,
-					vm,
-					moVM,
-					nil)).To(Succeed())
+				It("should set the PVC encryption class annotation on created PVCs", func() {
+					Expect(unmanagedvolsreg.Reconcile(
+						ctx,
+						k8sClient,
+						vimClient,
+						vm,
+						moVM,
+						configSpec)).To(MatchError(unmanagedvolsreg.ErrPendingRegister))
+
+					claimName := vmopv1util.FindByTargetID(
+						vmopv1.VirtualControllerTypeSCSI,
+						1, 0, vm.Spec.Volumes...).PersistentVolumeClaim.ClaimName
+
+					var pvc corev1.PersistentVolumeClaim
+					Expect(k8sClient.Get(ctx, ctrlclient.ObjectKey{
+						Namespace: vm.Namespace,
+						Name:      claimName,
+					}, &pvc)).To(Succeed())
+
+					Expect(pvc.Annotations[pkgconst.PVCEncryptionClassNameAnnotation]).To(
+						Equal("my-enc-class"))
+					Expect(pvc.Annotations[unmanagedvolsreg.DiskBackingAnnotation]).ToNot(BeEmpty())
+				})
 			})
 
-			BeforeEach(func() {
-				vm.Spec.Crypto = nil
+			When("VM has no crypto spec", func() {
+				JustBeforeEach(func() {
+					pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+						config.Features.VMSharedDisks = true
+					})
 
-				// Start with empty volumes - let Reconcile add them
-				vm.Spec.Volumes = []vmopv1.VirtualMachineVolume{}
-
-				disk := &vimtypes.VirtualDisk{
-					VirtualDevice: vimtypes.VirtualDevice{
-						Key:           300,
-						ControllerKey: 200,
-						UnitNumber:    ptr.To(int32(0)),
-						Backing: &vimtypes.VirtualDiskFlatVer2BackingInfo{
-							VirtualDeviceFileBackingInfo: vimtypes.VirtualDeviceFileBackingInfo{
-								FileName: "[LocalDS_0] vm1/noenc-disk.vmdk",
-							},
-							Uuid: "disk-uuid-noenc",
-						},
-					},
-					CapacityInBytes: 2 * 1024 * 1024 * 1024,
-				}
-
-				scsiController := &vimtypes.VirtualSCSIController{
-					VirtualController: vimtypes.VirtualController{
-						VirtualDevice: vimtypes.VirtualDevice{
-							Key: 200,
-						},
-						BusNumber: 1,
-					},
-				}
-
-				moVM.Config = &vimtypes.VirtualMachineConfigInfo{
-					Hardware: vimtypes.VirtualHardware{
-						Device: []vimtypes.BaseVirtualDevice{
-							scsiController,
-							disk,
-						},
-					},
-				}
-			})
-
-			It("should not set the PVC encryption class annotation on created PVCs", func() {
-				Expect(unmanagedvolsreg.Reconcile(
-					ctx,
-					k8sClient,
-					vimClient,
-					vm,
-					moVM,
-					configSpec)).To(MatchError(unmanagedvolsreg.ErrPendingRegister))
-
-				claimName := vmopv1util.FindByTargetID(
-					vmopv1.VirtualControllerTypeSCSI,
-					1, 0, vm.Spec.Volumes...).PersistentVolumeClaim.ClaimName
-
-				var pvc corev1.PersistentVolumeClaim
-				Expect(k8sClient.Get(ctx, ctrlclient.ObjectKey{
-					Namespace: vm.Namespace,
-					Name:      claimName,
-				}, &pvc)).To(Succeed())
-
-				Expect(pvc.Annotations).ToNot(HaveKey(pkgconst.PVCEncryptionClassNameAnnotation))
-				Expect(pvc.Annotations[unmanagedvolsreg.DiskBackingAnnotation]).ToNot(BeEmpty())
-			})
-		})
-
-		When("VM has crypto spec with empty EncryptionClassName", func() {
-			JustBeforeEach(func() {
-				pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-					config.Features.VMSharedDisks = true
+					Expect(unmanagedvolsfill.Reconcile(
+						ctx,
+						nil,
+						nil,
+						vm,
+						moVM,
+						nil)).To(MatchError(unmanagedvolsfill.ErrPendingBackfill))
+					Expect(unmanagedvolsfill.Reconcile(
+						ctx,
+						nil,
+						nil,
+						vm,
+						moVM,
+						nil)).To(Succeed())
 				})
 
-				Expect(unmanagedvolsfill.Reconcile(
-					ctx,
-					nil,
-					nil,
-					vm,
-					moVM,
-					nil)).To(MatchError(unmanagedvolsfill.ErrPendingBackfill))
-				Expect(unmanagedvolsfill.Reconcile(
-					ctx,
-					nil,
-					nil,
-					vm,
-					moVM,
-					nil)).To(Succeed())
-			})
+				BeforeEach(func() {
+					vm.Spec.Crypto = nil
 
-			BeforeEach(func() {
-				vm.Spec.Crypto = &vmopv1.VirtualMachineCryptoSpec{
-					EncryptionClassName: "",
-				}
+					// Start with empty volumes - let Reconcile add them
+					vm.Spec.Volumes = []vmopv1.VirtualMachineVolume{}
 
-				// Start with empty volumes - let Reconcile add them
-				vm.Spec.Volumes = []vmopv1.VirtualMachineVolume{}
-
-				disk := &vimtypes.VirtualDisk{
-					VirtualDevice: vimtypes.VirtualDevice{
-						Key:           300,
-						ControllerKey: 200,
-						UnitNumber:    ptr.To(int32(0)),
-						Backing: &vimtypes.VirtualDiskFlatVer2BackingInfo{
-							VirtualDeviceFileBackingInfo: vimtypes.VirtualDeviceFileBackingInfo{
-								FileName: "[LocalDS_0] vm1/emptyenc-disk.vmdk",
-							},
-							Uuid: "disk-uuid-emptyenc",
-						},
-					},
-					CapacityInBytes: 2 * 1024 * 1024 * 1024,
-				}
-
-				scsiController := &vimtypes.VirtualSCSIController{
-					VirtualController: vimtypes.VirtualController{
+					disk := &vimtypes.VirtualDisk{
 						VirtualDevice: vimtypes.VirtualDevice{
-							Key: 200,
+							Key:           300,
+							ControllerKey: 200,
+							UnitNumber:    ptr.To(int32(0)),
+							Backing: &vimtypes.VirtualDiskFlatVer2BackingInfo{
+								VirtualDeviceFileBackingInfo: vimtypes.VirtualDeviceFileBackingInfo{
+									FileName: "[LocalDS_0] vm1/noenc-disk.vmdk",
+								},
+								Uuid: "disk-uuid-noenc",
+							},
 						},
-						BusNumber: 1,
-					},
-				}
+						CapacityInBytes: 2 * 1024 * 1024 * 1024,
+					}
 
-				moVM.Config = &vimtypes.VirtualMachineConfigInfo{
-					Hardware: vimtypes.VirtualHardware{
-						Device: []vimtypes.BaseVirtualDevice{
-							scsiController,
-							disk,
+					scsiController := &vimtypes.VirtualSCSIController{
+						VirtualController: vimtypes.VirtualController{
+							VirtualDevice: vimtypes.VirtualDevice{
+								Key: 200,
+							},
+							BusNumber: 1,
 						},
-					},
-				}
+					}
+
+					moVM.Config = &vimtypes.VirtualMachineConfigInfo{
+						Hardware: vimtypes.VirtualHardware{
+							Device: []vimtypes.BaseVirtualDevice{
+								scsiController,
+								disk,
+							},
+						},
+					}
+				})
+
+				It("should not set the PVC encryption class annotation on created PVCs", func() {
+					Expect(unmanagedvolsreg.Reconcile(
+						ctx,
+						k8sClient,
+						vimClient,
+						vm,
+						moVM,
+						configSpec)).To(MatchError(unmanagedvolsreg.ErrPendingRegister))
+
+					claimName := vmopv1util.FindByTargetID(
+						vmopv1.VirtualControllerTypeSCSI,
+						1, 0, vm.Spec.Volumes...).PersistentVolumeClaim.ClaimName
+
+					var pvc corev1.PersistentVolumeClaim
+					Expect(k8sClient.Get(ctx, ctrlclient.ObjectKey{
+						Namespace: vm.Namespace,
+						Name:      claimName,
+					}, &pvc)).To(Succeed())
+
+					Expect(pvc.Annotations).ToNot(HaveKey(pkgconst.PVCEncryptionClassNameAnnotation))
+					Expect(pvc.Annotations[unmanagedvolsreg.DiskBackingAnnotation]).ToNot(BeEmpty())
+				})
 			})
 
-			It("should not set the PVC encryption class annotation on created PVCs", func() {
-				Expect(unmanagedvolsreg.Reconcile(
-					ctx,
-					k8sClient,
-					vimClient,
-					vm,
-					moVM,
-					configSpec)).To(MatchError(unmanagedvolsreg.ErrPendingRegister))
+			When("VM has crypto spec with empty EncryptionClassName", func() {
+				JustBeforeEach(func() {
+					pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+						config.Features.VMSharedDisks = true
+					})
 
-				claimName := vmopv1util.FindByTargetID(
-					vmopv1.VirtualControllerTypeSCSI,
-					1, 0, vm.Spec.Volumes...).PersistentVolumeClaim.ClaimName
+					Expect(unmanagedvolsfill.Reconcile(
+						ctx,
+						nil,
+						nil,
+						vm,
+						moVM,
+						nil)).To(MatchError(unmanagedvolsfill.ErrPendingBackfill))
+					Expect(unmanagedvolsfill.Reconcile(
+						ctx,
+						nil,
+						nil,
+						vm,
+						moVM,
+						nil)).To(Succeed())
+				})
 
-				var pvc corev1.PersistentVolumeClaim
-				Expect(k8sClient.Get(ctx, ctrlclient.ObjectKey{
-					Namespace: vm.Namespace,
-					Name:      claimName,
-				}, &pvc)).To(Succeed())
+				BeforeEach(func() {
+					vm.Spec.Crypto = &vmopv1.VirtualMachineCryptoSpec{
+						EncryptionClassName: "",
+					}
 
-				Expect(pvc.Annotations).ToNot(HaveKey(pkgconst.PVCEncryptionClassNameAnnotation))
-				Expect(pvc.Annotations[unmanagedvolsreg.DiskBackingAnnotation]).ToNot(BeEmpty())
+					// Start with empty volumes - let Reconcile add them
+					vm.Spec.Volumes = []vmopv1.VirtualMachineVolume{}
+
+					disk := &vimtypes.VirtualDisk{
+						VirtualDevice: vimtypes.VirtualDevice{
+							Key:           300,
+							ControllerKey: 200,
+							UnitNumber:    ptr.To(int32(0)),
+							Backing: &vimtypes.VirtualDiskFlatVer2BackingInfo{
+								VirtualDeviceFileBackingInfo: vimtypes.VirtualDeviceFileBackingInfo{
+									FileName: "[LocalDS_0] vm1/emptyenc-disk.vmdk",
+								},
+								Uuid: "disk-uuid-emptyenc",
+							},
+						},
+						CapacityInBytes: 2 * 1024 * 1024 * 1024,
+					}
+
+					scsiController := &vimtypes.VirtualSCSIController{
+						VirtualController: vimtypes.VirtualController{
+							VirtualDevice: vimtypes.VirtualDevice{
+								Key: 200,
+							},
+							BusNumber: 1,
+						},
+					}
+
+					moVM.Config = &vimtypes.VirtualMachineConfigInfo{
+						Hardware: vimtypes.VirtualHardware{
+							Device: []vimtypes.BaseVirtualDevice{
+								scsiController,
+								disk,
+							},
+						},
+					}
+				})
+
+				It("should not set the PVC encryption class annotation on created PVCs", func() {
+					Expect(unmanagedvolsreg.Reconcile(
+						ctx,
+						k8sClient,
+						vimClient,
+						vm,
+						moVM,
+						configSpec)).To(MatchError(unmanagedvolsreg.ErrPendingRegister))
+
+					claimName := vmopv1util.FindByTargetID(
+						vmopv1.VirtualControllerTypeSCSI,
+						1, 0, vm.Spec.Volumes...).PersistentVolumeClaim.ClaimName
+
+					var pvc corev1.PersistentVolumeClaim
+					Expect(k8sClient.Get(ctx, ctrlclient.ObjectKey{
+						Namespace: vm.Namespace,
+						Name:      claimName,
+					}, &pvc)).To(Succeed())
+
+					Expect(pvc.Annotations).ToNot(HaveKey(pkgconst.PVCEncryptionClassNameAnnotation))
+					Expect(pvc.Annotations[unmanagedvolsreg.DiskBackingAnnotation]).ToNot(BeEmpty())
+				})
 			})
-		})
 
-		When("PVC exists and is bound", func() {
-			BeforeEach(func() {
-				// Set up VM with volumes already in spec
-				vm.Spec.Volumes = []vmopv1.VirtualMachineVolume{
-					{
-						Name: "disk-uuid-789",
-						VirtualMachineVolumeSource: vmopv1.VirtualMachineVolumeSource{
-							PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
-								PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
-									ClaimName: "my-vm-134e95b6",
+			When("PVC exists and is bound", func() {
+				BeforeEach(func() {
+					// Set up VM with volumes already in spec
+					vm.Spec.Volumes = []vmopv1.VirtualMachineVolume{
+						{
+							Name: "disk-uuid-789",
+							VirtualMachineVolumeSource: vmopv1.VirtualMachineVolumeSource{
+								PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
+									PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+										ClaimName: "my-vm-134e95b6",
+									},
 								},
 							},
+							ControllerType:      vmopv1.VirtualControllerTypeIDE,
+							ControllerBusNumber: ptr.To(int32(0)),
+							UnitNumber:          ptr.To(int32(0)),
 						},
-						ControllerType:      vmopv1.VirtualControllerTypeIDE,
-						ControllerBusNumber: ptr.To(int32(0)),
-						UnitNumber:          ptr.To(int32(0)),
-					},
-				}
+					}
 
-				// Create bound PVC
-				boundPVC := &corev1.PersistentVolumeClaim{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "my-vm-134e95b6",
-						Namespace: vm.Namespace,
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: vmopv1.GroupVersion.String(),
+					// Create bound PVC
+					boundPVC := &corev1.PersistentVolumeClaim{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "my-vm-134e95b6",
+							Namespace: vm.Namespace,
+							OwnerReferences: []metav1.OwnerReference{
+								{
+									APIVersion: vmopv1.GroupVersion.String(),
 									Kind:       "VirtualMachine",
 									Name:       vm.Name,
 									UID:        vm.UID,
@@ -1201,6 +1247,16 @@ var _ = Describe("Reconcile", func() {
 					Expect(pvc.Spec.DataSourceRef).ToNot(BeNil())
 					Expect(pvc.Spec.DataSourceRef.Kind).To(Equal("VirtualMachine"))
 					Expect(pvc.Spec.DataSourceRef.Name).To(Equal(vm.Name))
+
+					createBatchAttachWithPVCVolumeIDCacheMiss(ctx, k8sClient, vm, "my-vm-f3069b5c")
+
+					Expect(unmanagedvolsreg.Reconcile(
+						ctx,
+						k8sClient,
+						vimClient,
+						vm,
+						moVM,
+						configSpec)).To(MatchError(unmanagedvolsreg.ErrPendingRegister))
 
 					// Verify CnsRegisterVolume was created
 					crv := &cnsv1alpha1.CnsRegisterVolume{}
@@ -1587,7 +1643,7 @@ var _ = Describe("Reconcile", func() {
 				})
 
 				It("should handle complete reconciliation cycle", func() {
-					// First reconciliation: should create PVC and CnsRegisterVolume.
+					// First reconciliation: create PVC and write claim (phase 1).
 					Expect(unmanagedvolsreg.Reconcile(
 						ctx,
 						k8sClient,
@@ -1610,6 +1666,16 @@ var _ = Describe("Reconcile", func() {
 					// Set the PVC status to Pending for the test
 					pvc.Status.Phase = corev1.ClaimPending
 					Expect(k8sClient.Status().Update(ctx, pvc)).To(Succeed())
+
+					createBatchAttachWithPVCVolumeIDCacheMiss(ctx, k8sClient, vm, claimName)
+
+					Expect(unmanagedvolsreg.Reconcile(
+						ctx,
+						k8sClient,
+						vimClient,
+						vm,
+						moVM,
+						configSpec)).To(MatchError(unmanagedvolsreg.ErrPendingRegister))
 
 					// Verify CnsRegisterVolume was created
 					crv := &cnsv1alpha1.CnsRegisterVolume{}
@@ -1867,6 +1933,13 @@ var _ = Describe("Reconcile", func() {
 				})
 
 				It("should return error", func() {
+					Expect(unmanagedvolsreg.Reconcile(
+						ctx, k8sClient, vimClient, vm, moVM, configSpec)).To(
+						MatchError(unmanagedvolsreg.ErrPendingRegister))
+					claimName := vmopv1util.FindByTargetID(
+						vmopv1.VirtualControllerTypeIDE,
+						0, 0, vm.Spec.Volumes...).PersistentVolumeClaim.ClaimName
+					createBatchAttachWithPVCVolumeIDCacheMiss(ctx, k8sClient, vm, claimName)
 					err := unmanagedvolsreg.Reconcile(ctx, k8sClient, vimClient, vm, moVM, configSpec)
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("failed to ensure CnsRegisterVolume"))
@@ -1930,6 +2003,13 @@ var _ = Describe("Reconcile", func() {
 				})
 
 				It("should return error", func() {
+					Expect(unmanagedvolsreg.Reconcile(
+						ctx, k8sClient, vimClient, vm, moVM, configSpec)).To(
+						MatchError(unmanagedvolsreg.ErrPendingRegister))
+					claimName := vmopv1util.FindByTargetID(
+						vmopv1.VirtualControllerTypeIDE,
+						0, 0, vm.Spec.Volumes...).PersistentVolumeClaim.ClaimName
+					createBatchAttachWithPVCVolumeIDCacheMiss(ctx, k8sClient, vm, claimName)
 					err := unmanagedvolsreg.Reconcile(ctx, k8sClient, vimClient, vm, moVM, configSpec)
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("failed to get CnsRegisterVolume"))
@@ -2836,6 +2916,17 @@ var _ = Describe("Reconcile", func() {
 			})
 
 			It("should return error", func() {
+				Expect(unmanagedvolsreg.Reconcile(
+					ctx,
+					k8sClient,
+					vimClient,
+					vm,
+					moVM,
+					configSpec)).To(MatchError(unmanagedvolsreg.ErrPendingRegister))
+				claimName := vmopv1util.FindByTargetID(
+					vmopv1.VirtualControllerTypeIDE,
+					0, 0, vm.Spec.Volumes...).PersistentVolumeClaim.ClaimName
+				createBatchAttachWithPVCVolumeIDCacheMiss(ctx, k8sClient, vm, claimName)
 				err := unmanagedvolsreg.Reconcile(
 					ctx,
 					k8sClient,
@@ -3297,7 +3388,11 @@ var _ = Describe("Reconcile", func() {
 					}, crv)
 					Expect(apierrors.IsNotFound(err)).To(BeTrue())
 
-					// Reconcile should create the CRV
+					Expect(unmanagedvolsreg.Reconcile(ctx, k8sClient, vimClient, vm, moVM, configSpec)).To(
+						MatchError(unmanagedvolsreg.ErrPendingRegister))
+
+					createBatchAttachWithPVCVolumeIDCacheMiss(ctx, k8sClient, vm, "regular-pvc")
+
 					err = unmanagedvolsreg.Reconcile(ctx, k8sClient, vimClient, vm, moVM, configSpec)
 					Expect(err).To(MatchError(unmanagedvolsreg.ErrPendingRegister))
 


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

When AllDisksArePVCs is enabled, ensure placeholder PVCs and VM claimNames in phase one, then reconcile pending until CnsNodeVMBatchAttachment status reflects the CSI driver's volume-ID cache miss for the PVC. Only then create CnsRegisterVolume, avoiding races with the batch attachment path.

The volume batch controller now includes unbound PVCs whose dataSourceRef targets the VM (same API group), so CSI can observe them in the batch spec before binding.

Adds tests for the deferred CRV lifecycle under this feature flag.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

@skogta helpfully, and clearly, outlined the possible race below:

T1: Batch attach Reconcile https://github.com/vmware-tanzu/vm-operator/issues/1 starts
- Reads current batch attach spec (without new PVC)

T2: VM Operator updates batch attach spec
- Adds unbound PVC to spec
- Immediately creates CnsRegisterVolume

T3: CnsRegisterVolume completes quickly
- PVC binds and gets volume ID
- Volume becomes "attached" to VM in vCenter

T4: Reconcile https://github.com/vmware-tanzu/vm-operator/issues/1 continues (still using old spec)
- Sees newly bound volume attached to VM
- But volume is NOT in the spec it read at T1
- Adds volume to "detach list"

T5: Reconcile https://github.com/vmware-tanzu/vm-operator/issues/1 detaches the volume
- Even though VM Operator intended it to stay attached


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Wait for signal from CSI that its seen unbounded volumes before doing CnsRegisterVolume.
```