### PR TITLE
✨ Simplify VM create network interface provisioning

### DIFF
--- a/controllers/virtualmachine/virtualmachine/virtualmachine_controller.go
+++ b/controllers/virtualmachine/virtualmachine/virtualmachine_controller.go
@@ -22,10 +22,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	netopv1alpha1 "github.com/vmware-tanzu/net-operator-api/api/v1alpha1"
 	vpcv1alpha1 "github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 	byokv1 "github.com/vmware-tanzu/vm-operator/external/byok/api/v1alpha1"
+	ncpv1alpha1 "github.com/vmware-tanzu/vm-operator/external/ncp/api/v1alpha1"
 	cnsv1alpha1 "github.com/vmware-tanzu/vm-operator/external/vsphere-csi-driver/api/v1alpha1"
 	vspherepolv1 "github.com/vmware-tanzu/vm-operator/external/vsphere-policy/api/v1alpha1"
 	pkgcond "github.com/vmware-tanzu/vm-operator/pkg/conditions"
@@ -180,19 +182,36 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 			handler.EnqueueRequestForOwner(
 				mgr.GetScheme(),
 				mgr.GetRESTMapper(),
-				&vmopv1.VirtualMachine{},
-				handler.OnlyControllerOwner()),
+				&vmopv1.VirtualMachine{}),
 		)
 	}
 
-	if pkgcfg.FromContext(ctx).NetworkProviderType == pkgcfg.NetworkProviderTypeVPC {
+	switch pkgcfg.FromContext(ctx).NetworkProviderType {
+	case pkgcfg.NetworkProviderTypeVDS:
+		builder = builder.Watches(
+			&netopv1alpha1.NetworkInterface{},
+			handler.EnqueueRequestForOwner(
+				mgr.GetScheme(),
+				mgr.GetRESTMapper(),
+				&vmopv1.VirtualMachine{}),
+		)
+
+	case pkgcfg.NetworkProviderTypeNSXT:
+		builder = builder.Watches(
+			&ncpv1alpha1.VirtualNetworkInterface{},
+			handler.EnqueueRequestForOwner(
+				mgr.GetScheme(),
+				mgr.GetRESTMapper(),
+				&vmopv1.VirtualMachine{}),
+		)
+
+	case pkgcfg.NetworkProviderTypeVPC:
 		builder = builder.Watches(
 			&vpcv1alpha1.SubnetPort{},
 			handler.EnqueueRequestForOwner(
 				mgr.GetScheme(),
 				mgr.GetRESTMapper(),
-				&vmopv1.VirtualMachine{},
-				handler.OnlyControllerOwner()),
+				&vmopv1.VirtualMachine{}),
 		)
 	}
 

--- a/pkg/errors/norequeue_error.go
+++ b/pkg/errors/norequeue_error.go
@@ -6,6 +6,7 @@ package errors
 
 import (
 	"errors"
+	"fmt"
 )
 
 // NoRequeueError may be returned from any part of a reconcile call stack and the
@@ -18,6 +19,12 @@ type NoRequeueError struct {
 	// returning a TerminalError. This is helpful when the error is intended to
 	// stop the reconciliation loop, but not intended to be logged as an error.
 	DoNotErr bool
+}
+
+// NoRequeueErrorf returns a NoRequeueError with the message from the
+// formatted string.
+func NoRequeueErrorf(format string, a ...any) NoRequeueError {
+	return NoRequeueError{Message: fmt.Sprintf(format, a...)}
 }
 
 func (e NoRequeueError) Error() string {
@@ -47,4 +54,10 @@ func IsNoRequeueNoError(err error) bool {
 // NoRequeueNoErr returns a NoRequeueErr with DoNotErr=true.
 func NoRequeueNoErr(msg string) error {
 	return NoRequeueError{Message: msg, DoNotErr: true}
+}
+
+// NoRequeueNoErrorf returns a NoRequeueErr with DoNotErr=true with the
+// message from the formatted string.
+func NoRequeueNoErrorf(format string, a ...any) error {
+	return NoRequeueError{Message: fmt.Sprintf(format, a...), DoNotErr: true}
 }

--- a/pkg/providers/vsphere/network/netop_assignment_mode_test.go
+++ b/pkg/providers/vsphere/network/netop_assignment_mode_test.go
@@ -12,7 +12,6 @@ import (
 
 	netopv1alpha1 "github.com/vmware-tanzu/net-operator-api/api/v1alpha1"
 
-	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/network"
 )
@@ -85,12 +84,12 @@ var _ = Describe("NetOP assignment mode helpers",
 				netopv1alpha1.NetworkInterfaceIPAssignmentModeNone),
 		)
 
-		DescribeTable("NetOPInterfaceIPFamilyPolicyFromIPAMModes",
+		DescribeTable("IPAMModesToNetOPInterfaceIPFamilyPolicy",
 			func(modes []corev1.IPFamily, want netopv1alpha1.NetworkInterfaceIPFamilyPolicy) {
-				Expect(network.NetOPInterfaceIPFamilyPolicyFromIPAMModes(modes)).To(Equal(want))
+				Expect(network.IPAMModesToNetOPInterfaceIPFamilyPolicy(modes)).To(Equal(want))
 			},
-			Entry("nil slice defaults to IPv4Only", []corev1.IPFamily(nil), netopv1alpha1.NetworkInterfaceIPFamilyPolicyIPv4Only),
-			Entry("empty slice defaults to IPv4Only", []corev1.IPFamily{}, netopv1alpha1.NetworkInterfaceIPFamilyPolicyIPv4Only),
+			Entry("nil slice returns empty string", []corev1.IPFamily(nil), netopv1alpha1.NetworkInterfaceIPFamilyPolicy("")),
+			Entry("empty slice returns empty string", []corev1.IPFamily{}, netopv1alpha1.NetworkInterfaceIPFamilyPolicy("")),
 			Entry("IPv4 only", []corev1.IPFamily{corev1.IPv4Protocol}, netopv1alpha1.NetworkInterfaceIPFamilyPolicyIPv4Only),
 			Entry("IPv6 only", []corev1.IPFamily{corev1.IPv6Protocol}, netopv1alpha1.NetworkInterfaceIPFamilyPolicyIPv6Only),
 			Entry("dual stack order v4 v6",
@@ -101,40 +100,4 @@ var _ = Describe("NetOP assignment mode helpers",
 				netopv1alpha1.NetworkInterfaceIPFamilyPolicyDualStack),
 		)
 
-		Describe("SyncNetOPIPFamilyPolicyFromIPAMModes", func() {
-			It("clears NetOP IPFamilyPolicy when VM IPAMModes is nil and NetOP had a policy", func() {
-				netIf := &netopv1alpha1.NetworkInterface{
-					Spec: netopv1alpha1.NetworkInterfaceSpec{
-						IPFamilyPolicy: netopv1alpha1.NetworkInterfaceIPFamilyPolicyDualStack,
-					},
-				}
-				iface := &vmopv1.VirtualMachineNetworkInterfaceSpec{Name: "eth0"}
-				network.SyncNetOPIPFamilyPolicyFromIPAMModes(iface, netIf)
-				Expect(netIf.Spec.IPFamilyPolicy).To(Equal(netopv1alpha1.NetworkInterfaceIPFamilyPolicy("")))
-			})
-
-			It("clears NetOP IPFamilyPolicy when VM IPAMModes is empty slice", func() {
-				netIf := &netopv1alpha1.NetworkInterface{
-					Spec: netopv1alpha1.NetworkInterfaceSpec{
-						IPFamilyPolicy: netopv1alpha1.NetworkInterfaceIPFamilyPolicyIPv6Only,
-					},
-				}
-				iface := &vmopv1.VirtualMachineNetworkInterfaceSpec{
-					Name:      "eth0",
-					IPAMModes: []corev1.IPFamily{},
-				}
-				network.SyncNetOPIPFamilyPolicyFromIPAMModes(iface, netIf)
-				Expect(netIf.Spec.IPFamilyPolicy).To(Equal(netopv1alpha1.NetworkInterfaceIPFamilyPolicy("")))
-			})
-
-			It("sets NetOP IPFamilyPolicy when VM IPAMModes is non-empty", func() {
-				netIf := &netopv1alpha1.NetworkInterface{}
-				iface := &vmopv1.VirtualMachineNetworkInterfaceSpec{
-					Name:      "eth0",
-					IPAMModes: []corev1.IPFamily{corev1.IPv6Protocol},
-				}
-				network.SyncNetOPIPFamilyPolicyFromIPAMModes(iface, netIf)
-				Expect(netIf.Spec.IPFamilyPolicy).To(Equal(netopv1alpha1.NetworkInterfaceIPFamilyPolicyIPv6Only))
-			})
-		})
 	})

--- a/pkg/providers/vsphere/network/network.go
+++ b/pkg/providers/vsphere/network/network.go
@@ -31,6 +31,7 @@ import (
 	vpcv1alpha1 "github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
 
 	ncpv1alpha1 "github.com/vmware-tanzu/vm-operator/external/ncp/api/v1alpha1"
+	pkgerr "github.com/vmware-tanzu/vm-operator/pkg/errors"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 	"github.com/vmware-tanzu/vm-operator/pkg"
@@ -82,6 +83,17 @@ type NetworkInterfaceRoute struct {
 	Metric int32
 }
 
+// Device contains the information from the network interface CR needed to create or
+// configure a virtual ethernet card device on a VM.
+type Device struct {
+	InterfaceObj ctrlclient.Object
+
+	Backing    object.NetworkReference
+	NetworkID  string
+	MacAddress string
+	ExternalID string
+}
+
 const (
 	retryInterval           = 100 * time.Millisecond
 	defaultEthernetCardType = "vmxnet3"
@@ -100,7 +112,314 @@ const (
 var (
 	// RetryTimeout is var so tests can change it to shorten tests until we get rid of the poll.
 	RetryTimeout = 15 * time.Second
+
+	// ErrNetworkInterfaceTypeNotSupported is returned when the network interface specifies
+	// type that is not supported by the configured network provider. The VM validation
+	// webhook enforces what is supported so this is not an expected error.
+	ErrNetworkInterfaceTypeNotSupported = errors.New("network provider is not supported")
+
+	// ErrNetworkInterfaceNotReady is returned when the network interface is not ready.
+	ErrNetworkInterfaceNotReady = pkgerr.NoRequeueErrorf("network interface is not ready")
 )
+
+// CreateNetworkDevices ensures all network interface CRs exist for the VM's network
+// spec, then checks whether every interface is ready. If all are ready it returns
+// the corresponding Device values. If any are not ready it returns an error;
+// the caller should rely on watches to be re-triggered when the CRs become ready.
+func CreateNetworkDevices(
+	ctx context.Context,
+	vm *vmopv1.VirtualMachine,
+	client ctrlclient.Client,
+	vimClient *vim25.Client,
+	finder *find.Finder,
+) ([]Device, error) {
+
+	networkSpec := vm.Spec.Network
+	if networkSpec == nil {
+		return nil, nil
+	}
+
+	switch pkgcfg.FromContext(ctx).NetworkProviderType {
+	case pkgcfg.NetworkProviderTypeNamed:
+		// Named network is a testing only hack that does not have a CR so
+		// handle it separately.
+		return createNetworkDevicesForNamedNetwork(ctx, vm, finder)
+	case "":
+		return nil, fmt.Errorf("no network provider set")
+	}
+
+	objs := make([]ctrlclient.Object, 0, len(networkSpec.Interfaces))
+	var errs []error
+
+	// Create all the network interface CRs. The VM may have multiple interfaces so we
+	// want to create them all up front so they can be reconciled concurrently.
+	for _, interfaceSpec := range networkSpec.Interfaces {
+		group, err := getNetworkInterfaceAPIGroup(ctx, interfaceSpec)
+		if err != nil {
+			// Not expected.
+			errs = append(errs,
+				fmt.Errorf("error getting network APIGroup for %s: %w", interfaceSpec.Name, err))
+			continue
+		}
+
+		var obj ctrlclient.Object
+
+		switch group {
+		case netopv1alpha1.GroupName:
+			obj, err = createNetOPNetworkInterface(ctx, vm, client, &interfaceSpec)
+		case ncpv1alpha1.SchemeGroupVersion.Group:
+			obj, err = createNCPNetworkInterface(ctx, vm, client, &interfaceSpec)
+		case vpcv1alpha1.SchemeGroupVersion.Group:
+			obj, err = createVPCNetworkInterface(ctx, vm, client, &interfaceSpec)
+		default:
+			err = fmt.Errorf("unsupported network API Group: %q", group)
+		}
+
+		if err != nil {
+			// TODO: Update per-interface Status.
+			errs = append(errs,
+				fmt.Errorf("error creating interface %s: %w", interfaceSpec.Name, err))
+			continue
+		}
+
+		objs = append(objs, obj)
+	}
+
+	if len(errs) != 0 {
+		return nil, errors.Join(errs...)
+	}
+
+	devices := make([]Device, 0, len(objs))
+
+	// For each interface, if its network interface CR is ready, get the information
+	// needed from it for the device.
+	for i, interfaceSpec := range networkSpec.Interfaces {
+		obj := objs[i]
+
+		var dev Device
+		var err error
+
+		switch ifaceCR := obj.(type) {
+		case *netopv1alpha1.NetworkInterface:
+			dev, err = getNetOPNetworkInterfaceDevice(ctx, vimClient, ifaceCR, interfaceSpec)
+		case *ncpv1alpha1.VirtualNetworkInterface:
+			dev, err = getNCPNetworkInterfaceDevice(ctx, vimClient, nil, ifaceCR)
+		case *vpcv1alpha1.SubnetPort:
+			dev, err = getVPCSubnetPortDevice(ctx, vimClient, nil, ifaceCR)
+		default:
+			err = fmt.Errorf("unsupported network interface CR type: %T", obj)
+		}
+
+		if err != nil {
+			// TODO: Update per-interface Status.
+			errs = append(errs,
+				fmt.Errorf("error getting device for interface %s: %w", interfaceSpec.Name, err))
+			continue
+		}
+
+		devices = append(devices, dev)
+	}
+
+	if len(errs) != 0 {
+		return nil, errors.Join(errs...)
+	}
+
+	return devices, nil
+}
+
+// getNetworkInterfaceAPIGroup returns the API Group name for this interface.
+// This is used to determine which network interface CR type to create for the
+// interface.
+func getNetworkInterfaceAPIGroup(
+	ctx context.Context,
+	interfaceSpec vmopv1.VirtualMachineNetworkInterfaceSpec) (string, error) {
+
+	// The VM mutation and validation wehbooks ensure this that is set and that it
+	// is a supported value. But for any VM that just happened to be created before
+	// we started to do this and has never been updated, fallback to the old behavior
+	// based on the provider type.
+	network := interfaceSpec.Network
+	if network == nil || network.APIVersion == "" {
+		var group string
+		switch pkgcfg.FromContext(ctx).NetworkProviderType {
+		case pkgcfg.NetworkProviderTypeVDS:
+			group = netopv1alpha1.GroupName
+		case pkgcfg.NetworkProviderTypeNSXT:
+			group = ncpv1alpha1.SchemeGroupVersion.Group
+		case pkgcfg.NetworkProviderTypeVPC:
+			group = vpcv1alpha1.SchemeGroupVersion.Group
+		}
+		return group, nil
+	}
+
+	gv, err := schema.ParseGroupVersion(network.APIVersion)
+	if err != nil {
+		return "", pkgerr.NoRequeueErrorf("invalid API Version: %s", network.APIVersion)
+	}
+
+	return gv.Group, nil
+}
+
+func getNetOPNetworkInterfaceDevice(
+	_ context.Context,
+	vimClient *vim25.Client,
+	netIf *netopv1alpha1.NetworkInterface,
+	interfaceSpec vmopv1.VirtualMachineNetworkInterfaceSpec) (Device, error) {
+
+	var dev Device
+
+	readyCond := findNetOPCondition(netIf, netopv1alpha1.NetworkInterfaceReady)
+	if readyCond == nil || readyCond.Status != corev1.ConditionTrue {
+		failCond := findNetOPCondition(netIf, netopv1alpha1.NetworkInterfaceFailure)
+		if failCond != nil && failCond.Status == corev1.ConditionTrue {
+			return dev, fmt.Errorf("%w: failure - %s: %s", ErrNetworkInterfaceNotReady,
+				failCond.Reason, failCond.Message)
+		}
+
+		if readyCond != nil && readyCond.Status == corev1.ConditionFalse &&
+			readyCond.Reason != "" && readyCond.Message != "" {
+			return dev, fmt.Errorf("%w: %s - %s", ErrNetworkInterfaceNotReady,
+				readyCond.Reason, readyCond.Message)
+		}
+
+		return dev, ErrNetworkInterfaceNotReady
+	}
+
+	// The NetworkInterface does not have a MAC address in its Spec, nor does it
+	// ever generate in Status, but if the user requested a specific one assign
+	// that here so we'll use it for the device's MAC.
+	macAddr := netIf.Status.MacAddress
+	if interfaceSpec.MACAddr != "" {
+		macAddr = interfaceSpec.MACAddr
+	}
+
+	pgObjRef := vimtypes.ManagedObjectReference{
+		Type:  string(vimtypes.ManagedObjectTypeDistributedVirtualPortgroup),
+		Value: netIf.Status.NetworkID,
+	}
+
+	return Device{
+		InterfaceObj: netIf,
+		Backing:      object.NewDistributedVirtualPortgroup(vimClient, pgObjRef),
+		NetworkID:    pgObjRef.Value,
+		MacAddress:   macAddr,
+		ExternalID:   netIf.Status.ExternalID,
+	}, nil
+}
+
+func getNCPNetworkInterfaceDevice(
+	ctx context.Context,
+	vimClient *vim25.Client,
+	clusterMoRef *vimtypes.ManagedObjectReference,
+	vnetIf *ncpv1alpha1.VirtualNetworkInterface) (Device, error) {
+
+	var dev Device
+
+	var readyCond *ncpv1alpha1.VirtualNetworkCondition
+	for _, cond := range vnetIf.Status.Conditions {
+		// NOTE: For whatever reason, the contributed NCP code used Contains.
+		if strings.Contains(cond.Type, "Ready") && strings.Contains(cond.Status, "True") {
+			readyCond = &cond
+		}
+	}
+
+	if readyCond == nil {
+		for _, cond := range vnetIf.Status.Conditions {
+			if strings.Contains(cond.Type, "Ready") && !strings.Contains(cond.Status, "True") {
+				if cond.Reason != "" && cond.Message != "" {
+					return dev, fmt.Errorf("%w: %s - %s", ErrNetworkInterfaceNotReady,
+						cond.Reason, cond.Message)
+				}
+
+				return dev, ErrNetworkInterfaceNotReady
+			}
+		}
+
+		return dev, ErrNetworkInterfaceNotReady
+	}
+
+	if vnetIf.Status.ProviderStatus == nil {
+		return dev, pkgerr.NoRequeueNoErr("ready network interface does not have provider status")
+	}
+
+	networkID := vnetIf.Status.ProviderStatus.NsxLogicalSwitchID
+
+	var backing object.NetworkReference
+	if clusterMoRef != nil {
+		ccr := object.NewClusterComputeResource(vimClient, *clusterMoRef)
+		networkRef, err := searchNsxtNetworkReference(ctx, ccr, networkID)
+		if err != nil {
+			return dev, err
+		}
+		backing = networkRef
+	} else {
+		backing = newNSXOpaqueNetwork(networkID)
+	}
+
+	return Device{
+		InterfaceObj: vnetIf,
+		Backing:      backing,
+		NetworkID:    networkID,
+		MacAddress:   vnetIf.Status.MacAddress,
+		ExternalID:   vnetIf.Status.InterfaceID,
+	}, nil
+}
+
+func getVPCSubnetPortDevice(
+	ctx context.Context,
+	vimClient *vim25.Client,
+	clusterMoRef *vimtypes.ManagedObjectReference,
+	subnetPort *vpcv1alpha1.SubnetPort) (Device, error) {
+
+	var dev Device
+
+	var readyCond *vpcv1alpha1.Condition
+	for _, cond := range subnetPort.Status.Conditions {
+		if cond.Type == vpcv1alpha1.Ready {
+			readyCond = &cond
+			break
+		}
+	}
+
+	if readyCond == nil {
+		return dev, ErrNetworkInterfaceNotReady
+	}
+
+	if readyCond.Status != corev1.ConditionTrue {
+		return dev, fmt.Errorf("%w: %s - %s", ErrNetworkInterfaceNotReady,
+			readyCond.Reason, readyCond.Message)
+	}
+
+	networkID := subnetPort.Status.NetworkInterfaceConfig.LogicalSwitchUUID
+	if networkID == "" {
+		return dev, pkgerr.NoRequeueErrorf("ready network interface does not have LogicalSwitchUUID")
+	}
+
+	var backing object.NetworkReference
+	if clusterMoRef != nil {
+		ccr := object.NewClusterComputeResource(vimClient, *clusterMoRef)
+		networkRef, err := searchNsxtNetworkReference(ctx, ccr, networkID)
+		if err != nil {
+			return dev, err
+		}
+		backing = networkRef
+	} else {
+		backing = newNSXOpaqueNetwork(networkID)
+	}
+
+	macAddr := subnetPort.Status.NetworkInterfaceConfig.MACAddress
+	if macAddr == vpcIgnoreMacAddr {
+		macAddr = ""
+	}
+
+	return Device{
+		InterfaceObj: subnetPort,
+		Backing:      backing,
+		NetworkID:    networkID,
+		MacAddress:   macAddr,
+		ExternalID:   subnetPort.Status.Attachment.ID,
+	}, nil
+}
 
 // CreateAndWaitForNetworkInterfaces creates the appropriate CRs for the VM's network
 // interfaces, and then waits for them to be reconciled by NCP (NSX-T) or NetOP (VDS).
@@ -152,13 +471,13 @@ func CreateAndWaitForNetworkInterfaces(
 
 		switch networkType {
 		case pkgcfg.NetworkProviderTypeVDS:
-			result, err = createNetOPNetworkInterface(vmCtx, client, vimClient, &interfaceSpec)
+			result, err = createAndWaitNetOPNetworkInterface(vmCtx, client, vimClient, &interfaceSpec)
 		case pkgcfg.NetworkProviderTypeNSXT:
-			result, err = createNCPNetworkInterface(vmCtx, client, vimClient, clusterMoRef, &interfaceSpec)
+			result, err = createAndWaitNCPNetworkInterface(vmCtx, client, vimClient, clusterMoRef, &interfaceSpec)
 		case pkgcfg.NetworkProviderTypeVPC:
-			result, err = createVPCNetworkInterface(vmCtx, client, vimClient, clusterMoRef, &interfaceSpec)
+			result, err = createAndWaitVPCNetworkInterface(vmCtx, client, vimClient, clusterMoRef, &interfaceSpec)
 		case pkgcfg.NetworkProviderTypeNamed:
-			result, err = createNamedNetworkInterface(vmCtx, finder, &interfaceSpec)
+			result, err = createAndWaitNamedNetworkInterface(vmCtx, finder, interfaceSpec)
 		default:
 			err = fmt.Errorf("unsupported network provider envvar value: %q", networkType)
 		}
@@ -301,15 +620,39 @@ func applyInterfaceSpecToResult(
 	}
 }
 
-func createNamedNetworkInterface(
-	vmCtx pkgctx.VirtualMachineContext,
+func createNetworkDevicesForNamedNetwork(
+	ctx context.Context,
+	vm *vmopv1.VirtualMachine,
+	finder *find.Finder) ([]Device, error) {
+
+	devices := make([]Device, 0, len(vm.Spec.Network.Interfaces))
+	for _, interfaceSpec := range vm.Spec.Network.Interfaces {
+		r, err := createAndWaitNamedNetworkInterface(ctx, finder, interfaceSpec)
+		if err != nil {
+			return nil, err
+		}
+
+		devices = append(devices, Device{
+			Backing:    r.Backing,
+			NetworkID:  r.NetworkID,
+			MacAddress: r.MacAddress,
+			ExternalID: r.ExternalID,
+		})
+	}
+
+	return devices, nil
+}
+
+func createAndWaitNamedNetworkInterface(
+	ctx context.Context,
 	finder *find.Finder,
-	interfaceSpec *vmopv1.VirtualMachineNetworkInterfaceSpec) (*NetworkInterfaceResult, error) {
+	interfaceSpec vmopv1.VirtualMachineNetworkInterfaceSpec) (*NetworkInterfaceResult, error) {
 
 	var (
 		networkRefName string
 		networkRefType metav1.TypeMeta
 	)
+
 	if netRef := interfaceSpec.Network; netRef != nil {
 		networkRefName = netRef.Name
 		networkRefType = netRef.TypeMeta
@@ -323,7 +666,7 @@ func createNamedNetworkInterface(
 		return nil, fmt.Errorf("network name is required")
 	}
 
-	backing, err := finder.Network(vmCtx, networkRefName)
+	backing, err := finder.Network(ctx, networkRefName)
 	if err != nil {
 		return nil, fmt.Errorf("unable to find named network %q: %w", networkRefName, err)
 	}
@@ -357,88 +700,77 @@ func NetOPCRName(vmName, networkName, interfaceName string, isV1A1 bool) string 
 	return name
 }
 
-// SyncNetOPIPFamilyPolicyFromIPAMModes sets or clears the NetOP IPFamilyPolicy from the VM IPAMModes.
-// When IPAMModes is empty, the policy is cleared so NetOP can apply its default.
-func SyncNetOPIPFamilyPolicyFromIPAMModes(interfaceSpec *vmopv1.VirtualMachineNetworkInterfaceSpec, netIf *netopv1alpha1.NetworkInterface) {
-	if len(interfaceSpec.IPAMModes) > 0 {
-		netIf.Spec.IPFamilyPolicy = NetOPInterfaceIPFamilyPolicyFromIPAMModes(interfaceSpec.IPAMModes)
-	} else {
-		netIf.Spec.IPFamilyPolicy = ""
-	}
-}
-
 func createNetOPNetworkInterface(
-	vmCtx pkgctx.VirtualMachineContext,
+	ctx context.Context,
+	vm *vmopv1.VirtualMachine,
 	client ctrlclient.Client,
-	vimClient *vim25.Client,
-	interfaceSpec *vmopv1.VirtualMachineNetworkInterfaceSpec) (*NetworkInterfaceResult, error) {
+	interfaceSpec *vmopv1.VirtualMachineNetworkInterfaceSpec) (
+	*netopv1alpha1.NetworkInterface, error) {
 
-	var (
-		networkRefName string
-		networkRefType metav1.TypeMeta
-	)
-
-	if netRef := interfaceSpec.Network; netRef != nil {
-		// If Name is empty, NetOP will try to select the namespace default.
-		networkRefName = netRef.Name
-		networkRefType = netRef.TypeMeta
+	if pkgcfg.FromContext(ctx).NetworkProviderType != pkgcfg.NetworkProviderTypeVDS {
+		return nil, ErrNetworkInterfaceTypeNotSupported
 	}
 
-	if kind := networkRefType.Kind; kind != "" && kind != "Network" {
-		return nil, fmt.Errorf("network kind %q is not supported for VDS", kind)
+	var networkName string
+	if netRef := interfaceSpec.Network; netRef != nil {
+		// If unset, NetOP will select the NS default.
+		networkName = netRef.Name
 	}
 
 	netIf := &netopv1alpha1.NetworkInterface{}
 	netIfKey := types.NamespacedName{
-		Namespace: vmCtx.VM.Namespace,
-		Name:      NetOPCRName(vmCtx.VM.Name, networkRefName, interfaceSpec.Name, true),
+		Namespace: vm.Namespace,
+		Name:      NetOPCRName(vm.Name, networkName, interfaceSpec.Name, true),
 	}
 
 	// Check if a networkIf object exists with the older (v1a1) naming convention.
-	if err := client.Get(vmCtx, netIfKey, netIf); err != nil {
+	if err := client.Get(ctx, netIfKey, netIf); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return nil, err
 		}
 
 		// If NotFound set the netIf to the new v1a2 naming convention.
 		netIf.ObjectMeta = metav1.ObjectMeta{
-			Name:      NetOPCRName(vmCtx.VM.Name, networkRefName, interfaceSpec.Name, false),
-			Namespace: vmCtx.VM.Namespace,
+			Name:      NetOPCRName(vm.Name, networkName, interfaceSpec.Name, false),
+			Namespace: vm.Namespace,
 		}
 	}
 
-	_, err := controllerutil.CreateOrPatch(vmCtx, client, netIf, func() error {
-		if err := SetNetworkInterfaceOwnerRef(vmCtx.VM, netIf, client.Scheme()); err != nil {
-			// If this fails we likely have an object name collision, and we're in a tough spot.
+	_, err := controllerutil.CreateOrPatch(ctx, client, netIf, func() error {
+		if err := SetNetworkInterfaceOwnerRef(vm, netIf, client.Scheme()); err != nil {
 			return err
 		}
-
-		/* We can only set this once we know all the hosts have been upgraded.
-		if netIf.ResourceVersion == "" {
-			// For new interfaces, set the ExternalID so we can better uniquely identify them.
-			netIf.Spec.ExternalID = uuid.NewString()
-		}
-		*/
 
 		if netIf.Labels == nil {
 			netIf.Labels = map[string]string{}
 		}
-		netIf.Labels[VMNameLabel] = vmCtx.VM.Name
+		netIf.Labels[VMNameLabel] = vm.Name
 		netIf.Labels[VMInterfaceNameLabel] = interfaceSpec.Name
 
 		// NetOp will update the Spec with the default network name so we don't clear that
 		// here if using the default network.
-		if networkRefName != "" {
-			netIf.Spec.NetworkName = networkRefName
+		if networkName != "" {
+			netIf.Spec.NetworkName = networkName
 		}
+
 		// NetOP only defines a VMXNet3 type, but it doesn't really matter for our purposes.
 		netIf.Spec.Type = netopv1alpha1.NetworkInterfaceTypeVMXNet3
-		// Set or clear IPFamilyPolicy from VM IPAMModes. When IPAMModes is empty, clear
-		// the policy so NetOP can apply its default (and updates remove a prior policy).
-		SyncNetOPIPFamilyPolicyFromIPAMModes(interfaceSpec, netIf)
+
+		netIf.Spec.IPFamilyPolicy = IPAMModesToNetOPInterfaceIPFamilyPolicy(interfaceSpec.IPAMModes)
+
 		return nil
 	})
 
+	return netIf, err
+}
+
+func createAndWaitNetOPNetworkInterface(
+	vmCtx pkgctx.VirtualMachineContext,
+	client ctrlclient.Client,
+	vimClient *vim25.Client,
+	interfaceSpec *vmopv1.VirtualMachineNetworkInterfaceSpec) (*NetworkInterfaceResult, error) {
+
+	netIf, err := createNetOPNetworkInterface(vmCtx, vmCtx.VM, client, interfaceSpec)
 	if err != nil {
 		return nil, err
 	}
@@ -484,26 +816,29 @@ func EffectiveNetOPIPv6AssignmentMode(st netopv1alpha1.NetworkInterfaceStatus) n
 	return netopv1alpha1.NetworkInterfaceIPAssignmentModeNone
 }
 
-// NetOPInterfaceIPFamilyPolicyFromIPAMModes maps spec IPAMModes (Kubernetes IP families) to
-// NetOP NetworkInterfaceIPFamilyPolicy. With both families present it returns DualStack;
-// IPv6 alone returns IPv6-only; otherwise IPv4-only (including empty input).
-func NetOPInterfaceIPFamilyPolicyFromIPAMModes(ipamModes []corev1.IPFamily) netopv1alpha1.NetworkInterfaceIPFamilyPolicy {
+// IPAMModesToNetOPInterfaceIPFamilyPolicy maps spec IPAMModes (Kubernetes IP families) to
+// NetOP NetworkInterfaceIPFamilyPolicy. When both families are present it returns DualStack.
+func IPAMModesToNetOPInterfaceIPFamilyPolicy(ipamModes []corev1.IPFamily) netopv1alpha1.NetworkInterfaceIPFamilyPolicy {
 	hasV4, hasV6 := false, false
 	for _, f := range ipamModes {
-		if f == corev1.IPv4Protocol {
+		switch f {
+		case corev1.IPv4Protocol:
 			hasV4 = true
-		}
-		if f == corev1.IPv6Protocol {
+		case corev1.IPv6Protocol:
 			hasV6 = true
 		}
 	}
+
 	switch {
 	case hasV4 && hasV6:
 		return netopv1alpha1.NetworkInterfaceIPFamilyPolicyDualStack
 	case hasV6:
 		return netopv1alpha1.NetworkInterfaceIPFamilyPolicyIPv6Only
-	default:
+	case hasV4:
 		return netopv1alpha1.NetworkInterfaceIPFamilyPolicyIPv4Only
+	default:
+		// No modes so use NetOP default.
+		return ""
 	}
 }
 
@@ -512,7 +847,7 @@ func netOpNetIfToResult(
 	netIf *netopv1alpha1.NetworkInterface) *NetworkInterfaceResult {
 
 	pgObjRef := vimtypes.ManagedObjectReference{
-		Type:  "DistributedVirtualPortgroup",
+		Type:  string(vimtypes.ManagedObjectTypeDistributedVirtualPortgroup),
 		Value: netIf.Status.NetworkID,
 	}
 
@@ -594,12 +929,14 @@ func waitForReadyNetworkInterface(
 		if wait.Interrupted(err) {
 			// Try to return a more meaningful error when timed out.
 			if cond := findNetOPCondition(netIf, netopv1alpha1.NetworkInterfaceFailure); cond != nil && cond.Status == corev1.ConditionTrue {
-				return nil, fmt.Errorf("network interface failure: %s - %s", cond.Reason, cond.Message)
+				return nil, fmt.Errorf("%w: failure - %s: %s", ErrNetworkInterfaceNotReady,
+					cond.Reason, cond.Message)
 			}
 			if cond := findNetOPCondition(netIf, netopv1alpha1.NetworkInterfaceReady); cond != nil && cond.Status == corev1.ConditionFalse {
-				return nil, fmt.Errorf("network interface is not ready: %s - %s", cond.Reason, cond.Message)
+				return nil, fmt.Errorf("%w: %s - %s", ErrNetworkInterfaceNotReady,
+					cond.Reason, cond.Message)
 			}
-			return nil, fmt.Errorf("network interface is not ready yet")
+			return nil, ErrNetworkInterfaceNotReady
 		}
 
 		return nil, err
@@ -629,63 +966,68 @@ func NCPCRName(vmName, networkName, interfaceName string, isV1A1 bool) string {
 	return name
 }
 
+// createNCPNetworkInterface creates or patches the NCP VirtualNetworkInterface CR for the
+// given interface spec. It does not wait for the CR to become ready.
 func createNCPNetworkInterface(
-	vmCtx pkgctx.VirtualMachineContext,
+	ctx context.Context,
+	vm *vmopv1.VirtualMachine,
 	client ctrlclient.Client,
-	vimClient *vim25.Client,
-	clusterMoRef *vimtypes.ManagedObjectReference,
-	interfaceSpec *vmopv1.VirtualMachineNetworkInterfaceSpec) (*NetworkInterfaceResult, error) {
+	interfaceSpec *vmopv1.VirtualMachineNetworkInterfaceSpec) (*ncpv1alpha1.VirtualNetworkInterface, error) {
 
-	var (
-		networkRefName string
-		networkRefType metav1.TypeMeta
-	)
-
-	if netRef := interfaceSpec.Network; netRef != nil {
-		// If Name is empty, NCP will use the namespace default.
-		networkRefName = netRef.Name
-		networkRefType = netRef.TypeMeta
+	if pkgcfg.FromContext(ctx).NetworkProviderType != pkgcfg.NetworkProviderTypeNSXT {
+		return nil, ErrNetworkInterfaceTypeNotSupported
 	}
 
-	// TODO: Do we need to still support the odd-ball NetOP in NSX-T? Sigh. Do that check here if needed.
-	if kind := networkRefType.Kind; kind != "" && kind != "VirtualNetwork" {
-		return nil, fmt.Errorf("network kind %q is not supported for NCP", kind)
+	var networkName string
+	if netRef := interfaceSpec.Network; netRef != nil {
+		networkName = netRef.Name
 	}
 
 	vnetIf := &ncpv1alpha1.VirtualNetworkInterface{}
 	vnetIfKey := types.NamespacedName{
-		Namespace: vmCtx.VM.Namespace,
-		Name:      NCPCRName(vmCtx.VM.Name, networkRefName, interfaceSpec.Name, true),
+		Namespace: vm.Namespace,
+		Name:      NCPCRName(vm.Name, networkName, interfaceSpec.Name, true),
 	}
 
-	// check if a networkIf object exists with the older (v1a1) naming convention
-	if err := client.Get(vmCtx, vnetIfKey, vnetIf); err != nil {
+	// Check if a VirtualNetworkInterface exists with the older (v1a1) naming convention.
+	if err := client.Get(ctx, vnetIfKey, vnetIf); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return nil, err
 		}
 
-		// if notFound set the vnetIf to use the new v1a2 naming convention
+		// If NotFound set the vnetIf to the new v1a2 naming convention.
 		vnetIf.ObjectMeta = metav1.ObjectMeta{
-			Name:      NCPCRName(vmCtx.VM.Name, networkRefName, interfaceSpec.Name, false),
-			Namespace: vmCtx.VM.Namespace,
+			Name:      NCPCRName(vm.Name, networkName, interfaceSpec.Name, false),
+			Namespace: vm.Namespace,
 		}
 	}
 
-	_, err := controllerutil.CreateOrPatch(vmCtx, client, vnetIf, func() error {
-		if err := SetNetworkInterfaceOwnerRef(vmCtx.VM, vnetIf, client.Scheme()); err != nil {
+	_, err := controllerutil.CreateOrPatch(ctx, client, vnetIf, func() error {
+		if err := SetNetworkInterfaceOwnerRef(vm, vnetIf, client.Scheme()); err != nil {
 			return err
 		}
 
 		if vnetIf.Labels == nil {
 			vnetIf.Labels = map[string]string{}
 		}
-		vnetIf.Labels[VMNameLabel] = vmCtx.VM.Name
+		vnetIf.Labels[VMNameLabel] = vm.Name
 		vnetIf.Labels[VMInterfaceNameLabel] = interfaceSpec.Name
 
-		vnetIf.Spec.VirtualNetwork = networkRefName
+		vnetIf.Spec.VirtualNetwork = networkName
 		return nil
 	})
 
+	return vnetIf, err
+}
+
+func createAndWaitNCPNetworkInterface(
+	vmCtx pkgctx.VirtualMachineContext,
+	client ctrlclient.Client,
+	vimClient *vim25.Client,
+	clusterMoRef *vimtypes.ManagedObjectReference,
+	interfaceSpec *vmopv1.VirtualMachineNetworkInterfaceSpec) (*NetworkInterfaceResult, error) {
+
+	vnetIf, err := createNCPNetworkInterface(vmCtx, vmCtx.VM, client, interfaceSpec)
 	if err != nil {
 		return nil, err
 	}
@@ -763,67 +1105,62 @@ func VPCCRName(vmName, networkName, interfaceName string) string {
 }
 
 func createVPCNetworkInterface(
-	vmCtx pkgctx.VirtualMachineContext,
+	ctx context.Context,
+	vm *vmopv1.VirtualMachine,
 	client ctrlclient.Client,
-	vimClient *vim25.Client,
-	clusterMoRef *vimtypes.ManagedObjectReference,
-	interfaceSpec *vmopv1.VirtualMachineNetworkInterfaceSpec) (*NetworkInterfaceResult, error) {
+	interfaceSpec *vmopv1.VirtualMachineNetworkInterfaceSpec) (*vpcv1alpha1.SubnetPort, error) {
+
+	if pkgcfg.FromContext(ctx).NetworkProviderType != pkgcfg.NetworkProviderTypeVPC {
+		return nil, ErrNetworkInterfaceTypeNotSupported
+	}
 
 	var (
-		networkRefName string
-		networkRefType metav1.TypeMeta
+		networkName string
+		networkType metav1.TypeMeta
 	)
 
 	if netRef := interfaceSpec.Network; netRef != nil {
-		networkRefName = netRef.Name
-		networkRefType = netRef.TypeMeta
+		networkName = netRef.Name
+		networkType = netRef.TypeMeta
 	}
 
-	vpcSubnetPort := &vpcv1alpha1.SubnetPort{
+	subnetPort := &vpcv1alpha1.SubnetPort{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      VPCCRName(vmCtx.VM.Name, networkRefName, interfaceSpec.Name),
-			Namespace: vmCtx.VM.Namespace,
+			Name:      VPCCRName(vm.Name, networkName, interfaceSpec.Name),
+			Namespace: vm.Namespace,
 		},
 	}
 
-	switch networkRefType.Kind {
+	switch networkType.Kind {
 	case "SubnetSet", "":
-		vpcSubnetPort.Spec.SubnetSet = networkRefName
+		subnetPort.Spec.SubnetSet = networkName
 	case "Subnet":
-		vpcSubnetPort.Spec.Subnet = networkRefName
+		subnetPort.Spec.Subnet = networkName
 	default:
-		return nil, fmt.Errorf("network kind %q is not supported for VPC", networkRefType.Kind)
+		return nil, pkgerr.NoRequeueErrorf("network kind %q is not supported for VPC", networkType.Kind)
 	}
 
-	_, err := controllerutil.CreateOrPatch(vmCtx, client, vpcSubnetPort, func() error {
-		if err := SetNetworkInterfaceOwnerRef(vmCtx.VM, vpcSubnetPort, client.Scheme()); err != nil {
+	_, err := controllerutil.CreateOrPatch(ctx, client, subnetPort, func() error {
+		if err := SetNetworkInterfaceOwnerRef(vm, subnetPort, client.Scheme()); err != nil {
 			return err
 		}
 
-		if vpcSubnetPort.Labels == nil {
-			vpcSubnetPort.Labels = map[string]string{}
+		if subnetPort.Labels == nil {
+			subnetPort.Labels = map[string]string{}
 		}
-		vpcSubnetPort.Labels[VMNameLabel] = vmCtx.VM.Name
-		vpcSubnetPort.Labels[VMInterfaceNameLabel] = interfaceSpec.Name
+		subnetPort.Labels[VMNameLabel] = vm.Name
+		subnetPort.Labels[VMInterfaceNameLabel] = interfaceSpec.Name
 
-		if vpcSubnetPort.Annotations == nil {
-			vpcSubnetPort.Annotations = make(map[string]string)
+		if subnetPort.Annotations == nil {
+			subnetPort.Annotations = make(map[string]string)
 		}
-		vpcSubnetPort.Annotations[constants.VPCAttachmentRef] = "virtualmachine/" + vmCtx.VM.Name + "/" + interfaceSpec.Name
+		subnetPort.Annotations[constants.VPCAttachmentRef] = "virtualmachine/" + vm.Name + "/" + interfaceSpec.Name
 
-		vpcSubnetPort.Spec.AddressBindings = nil
+		subnetPort.Spec.AddressBindings = nil
 
-		// TBD: It doesn't look like VPC actually reconciles if these change.
 		switch {
 		case len(interfaceSpec.Addresses) > 0:
 			for _, ipCidr := range interfaceSpec.Addresses {
-				// Our interface spec IPs include the CIDR but VPC takes just
-				// the IP address. This can lead to funkiness if the user
-				// specified an invalid prefix for this network. Here is what
-				// we're going to do: applyInterfaceSpecToResult() will just use
-				// whatever comes back in the SubnetPort Status, ignoring the
-				// user prefix. It might be nicer to allow bare IPs only when
-				// using VPC.
 				ip, _, err := pkgutil.ParseIP(ipCidr)
 
 				var skipReason string
@@ -843,15 +1180,11 @@ func createVPCNetworkInterface(
 				}
 
 				if skipReason != "" {
-					vmCtx.Logger.Info(
-						"Skipping IP address",
-						"ip", ipCidr,
-						"reason", skipReason)
 					continue
 				}
 
 				// Despite being a list, VPC currently only supports just one PortAddressBinding.
-				vpcSubnetPort.Spec.AddressBindings = []vpcv1alpha1.PortAddressBinding{
+				subnetPort.Spec.AddressBindings = []vpcv1alpha1.PortAddressBinding{
 					{
 						IPAddress:  ip.String(),
 						MACAddress: strings.ToLower(interfaceSpec.MACAddr),
@@ -860,10 +1193,7 @@ func createVPCNetworkInterface(
 				break
 			}
 		case interfaceSpec.MACAddr != "":
-			// TBD: VPC will default the MAC when only specifying an IP, but
-			// will not do IPAM when only the specifying the MAC, but they'll
-			// have to fix that for no IPAM, right, right?
-			vpcSubnetPort.Spec.AddressBindings = []vpcv1alpha1.PortAddressBinding{
+			subnetPort.Spec.AddressBindings = []vpcv1alpha1.PortAddressBinding{
 				{
 					MACAddress: strings.ToLower(interfaceSpec.MACAddr),
 				},
@@ -873,16 +1203,27 @@ func createVPCNetworkInterface(
 		return nil
 	})
 
+	return subnetPort, err
+}
+
+func createAndWaitVPCNetworkInterface(
+	vmCtx pkgctx.VirtualMachineContext,
+	client ctrlclient.Client,
+	vimClient *vim25.Client,
+	clusterMoRef *vimtypes.ManagedObjectReference,
+	interfaceSpec *vmopv1.VirtualMachineNetworkInterfaceSpec) (*NetworkInterfaceResult, error) {
+
+	subnetPort, err := createVPCNetworkInterface(vmCtx, vmCtx.VM, client, interfaceSpec)
 	if err != nil {
 		return nil, err
 	}
 
-	vpcSubnetPort, err = waitForReadyVPCSubnetPort(vmCtx, client, vpcSubnetPort.Name)
+	subnetPort, err = waitForReadyVPCSubnetPort(vmCtx, client, subnetPort.Name)
 	if err != nil {
 		return nil, err
 	}
 
-	return vpcSubnetPortToResult(vmCtx, vimClient, clusterMoRef, vpcSubnetPort)
+	return vpcSubnetPortToResult(vmCtx, vimClient, clusterMoRef, subnetPort)
 }
 
 func vpcSubnetPortToResult(
@@ -974,10 +1315,11 @@ func waitForReadyVPCSubnetPort(
 			// Try to return a more meaningful error when timed out.
 			for _, cond := range subnetPort.Status.Conditions {
 				if cond.Type == vpcv1alpha1.Ready && cond.Status != corev1.ConditionTrue {
-					return nil, fmt.Errorf("network interface is not ready: %s - %s", cond.Reason, cond.Message)
+					return nil, fmt.Errorf("%w: %s - %s", ErrNetworkInterfaceNotReady,
+						cond.Reason, cond.Message)
 				}
 			}
-			return nil, fmt.Errorf("network interface is not ready yet")
+			return nil, ErrNetworkInterfaceNotReady
 		}
 
 		return nil, err
@@ -1015,11 +1357,12 @@ func waitForReadyNCPNetworkInterface(
 			// Try to return a more meaningful error when timed out.
 			for _, cond := range vnetIf.Status.Conditions {
 				if strings.Contains(cond.Type, "Ready") && !strings.Contains(cond.Status, "True") {
-					return nil, fmt.Errorf("network interface is not ready: %s - %s", cond.Reason, cond.Message)
+					return nil, fmt.Errorf("%w: %s - %s", ErrNetworkInterfaceNotReady,
+						cond.Reason, cond.Message)
 				}
 			}
 			// TODO: NCP also has an annotation but that usually doesn't provide very useful details.
-			return nil, fmt.Errorf("network interface is not ready yet")
+			return nil, ErrNetworkInterfaceNotReady
 		}
 
 		return nil, err
@@ -1076,20 +1419,39 @@ func CreateDefaultEthCard(
 	ctx context.Context,
 	result *NetworkInterfaceResult) (vimtypes.BaseVirtualDevice, error) {
 
-	backing, err := result.Backing.EthernetCardBackingInfo(ctx)
+	return createDefaultEthCardFromDevice(ctx, result.Backing, result.MacAddress, result.ExternalID)
+}
+
+// CreateDefaultEthCardFromNetworkDevice creates a default Ethernet card from a Device.
+// This is used during VM create when the VM Class ConfigSpec does not have a device entry for
+// a VM Spec network interface.
+func CreateDefaultEthCardFromNetworkDevice(
+	ctx context.Context,
+	dev *Device) (vimtypes.BaseVirtualDevice, error) {
+
+	return createDefaultEthCardFromDevice(ctx, dev.Backing, dev.MacAddress, dev.ExternalID)
+}
+
+func createDefaultEthCardFromDevice(
+	ctx context.Context,
+	backing object.NetworkReference,
+	macAddress string,
+	externalID string) (vimtypes.BaseVirtualDevice, error) {
+
+	cardBacking, err := backing.EthernetCardBackingInfo(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("unable to get ethernet card backing info for network %v: %w", result.Backing.Reference(), err)
+		return nil, fmt.Errorf("unable to get ethernet card backing info for network %v: %w", backing.Reference(), err)
 	}
 
-	dev, err := object.EthernetCardTypes().CreateEthernetCard(defaultEthernetCardType, backing)
+	dev, err := object.EthernetCardTypes().CreateEthernetCard(defaultEthernetCardType, cardBacking)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create ethernet card network %v: %w", result.Backing.Reference(), err)
+		return nil, fmt.Errorf("unable to create ethernet card network %v: %w", backing.Reference(), err)
 	}
 
 	ethCard := dev.(vimtypes.BaseVirtualEthernetCard).GetVirtualEthernetCard()
-	ethCard.ExternalId = result.ExternalID
-	if result.MacAddress != "" {
-		ethCard.MacAddress = result.MacAddress
+	ethCard.ExternalId = externalID
+	if macAddress != "" {
+		ethCard.MacAddress = macAddress
 		ethCard.AddressType = string(vimtypes.VirtualEthernetCardMacTypeManual)
 	} else {
 		ethCard.AddressType = string(vimtypes.VirtualEthernetCardMacTypeGenerated) // TODO: Or TypeAssigned?
@@ -1105,15 +1467,40 @@ func ApplyInterfaceResultToVirtualEthCard(
 	ethCard *vimtypes.VirtualEthernetCard,
 	result *NetworkInterfaceResult) error {
 
-	backing, err := result.Backing.EthernetCardBackingInfo(ctx)
-	if err != nil {
-		return fmt.Errorf("unable to get ethernet card backing info for network %v: %w", result.NetworkID, err)
-	}
-	ethCard.Backing = backing
+	return applyNetworkDeviceToEthCard(ctx, ethCard, result.Backing, result.NetworkID, result.MacAddress, result.ExternalID)
+}
 
-	ethCard.ExternalId = result.ExternalID
-	if result.MacAddress != "" {
-		ethCard.MacAddress = result.MacAddress
+// ApplyNetworkDeviceToVirtualEthCard applies a Device to an existing Ethernet device
+// from the class ConfigSpec. This is used during VM create.
+func ApplyNetworkDeviceToVirtualEthCard(
+	ctx context.Context,
+	ethCard *vimtypes.VirtualEthernetCard,
+	dev *Device) error {
+
+	return applyNetworkDeviceToEthCard(ctx, ethCard, dev.Backing, "", dev.MacAddress, dev.ExternalID)
+}
+
+func applyNetworkDeviceToEthCard(
+	ctx context.Context,
+	ethCard *vimtypes.VirtualEthernetCard,
+	backing object.NetworkReference,
+	networkID string,
+	macAddress string,
+	externalID string) error {
+
+	cardBacking, err := backing.EthernetCardBackingInfo(ctx)
+	if err != nil {
+		errRef := networkID
+		if errRef == "" {
+			errRef = backing.Reference().Value
+		}
+		return fmt.Errorf("unable to get ethernet card backing info for network %v: %w", errRef, err)
+	}
+	ethCard.Backing = cardBacking
+
+	ethCard.ExternalId = externalID
+	if macAddress != "" {
+		ethCard.MacAddress = macAddress
 		ethCard.AddressType = string(vimtypes.VirtualEthernetCardMacTypeManual)
 	} else { //nolint:staticcheck
 		// BMV: IMO this must be Generated/TypeAssigned to avoid major foot gun, but we have tests assuming

--- a/pkg/providers/vsphere/network/network_test.go
+++ b/pkg/providers/vsphere/network/network_test.go
@@ -5,6 +5,7 @@
 package network_test
 
 import (
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -308,7 +309,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 				Expect(ctx.NetworkRef.Reference().Type).To(Equal("DistributedVirtualPortgroup"))
 
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
+				Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
 				Expect(results.Results).To(BeEmpty())
 
 				var externalID string
@@ -394,7 +395,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 
 				It("returns success with expected mac address", func() {
 					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
+					Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
 					Expect(results.Results).To(BeEmpty())
 
 					By("simulate successful NetOP reconcile", func() {
@@ -433,7 +434,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 			When("DHCP is enabled", func() {
 				It("returns success", func() {
 					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
+					Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
 					Expect(results.Results).To(BeEmpty())
 
 					By("simulate successful NetOP reconcile", func() {
@@ -475,7 +476,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 			When("DHCP is enabled for both IPv4 and IPv6", func() {
 				It("returns success with both DHCP flags set", func() {
 					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
+					Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
 					Expect(results.Results).To(BeEmpty())
 
 					By("simulate successful NetOP reconcile with explicit IPv6 DHCP", func() {
@@ -518,7 +519,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 			When("IPv4 uses DHCP and IPv6 uses static pool", func() {
 				It("returns DHCP4 with IPv6 IPConfigs only", func() {
 					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
+					Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
 					Expect(results.Results).To(BeEmpty())
 
 					By("simulate NetOP mixed assignment modes", func() {
@@ -571,7 +572,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 			When("IPv4 uses static pool and IPv6 uses DHCP", func() {
 				It("returns DHCP6 with IPv4 IPConfigs only", func() {
 					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
+					Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
 					Expect(results.Results).To(BeEmpty())
 
 					By("simulate NetOP mixed assignment modes", func() {
@@ -624,7 +625,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 			When("No IPAM is enabled", func() {
 				It("returns success", func() {
 					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
+					Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
 					Expect(results.Results).To(BeEmpty())
 
 					By("simulate successful NetOP reconcile", func() {
@@ -684,7 +685,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 					Expect(ctx.NetworkRef.Reference().Type).To(Equal("DistributedVirtualPortgroup"))
 
 					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
+					Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
 					Expect(results.Results).To(BeEmpty())
 
 					By("simulate successful NetOP reconcile", func() {
@@ -773,7 +774,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 
 			It("returns success with multiple IPv6 addresses", func() {
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
+				Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
 
 				By("simulate successful NetOP reconcile with multiple IPv6", func() {
 					netInterface := &netopv1alpha1.NetworkInterface{
@@ -840,7 +841,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 
 			It("returns success with multiple IPv4 addresses", func() {
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
+				Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
 
 				By("simulate successful NetOP reconcile with multiple IPv4", func() {
 					netInterface := &netopv1alpha1.NetworkInterface{
@@ -907,7 +908,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 
 			It("returns success with user addresses overriding NetOP", func() {
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
+				Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
 
 				By("simulate successful NetOP reconcile", func() {
 					netInterface := &netopv1alpha1.NetworkInterface{
@@ -977,7 +978,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 
 			It("returns success with user gateways overriding NetOP", func() {
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
+				Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
 
 				By("simulate successful NetOP reconcile", func() {
 					netInterface := &netopv1alpha1.NetworkInterface{
@@ -1048,7 +1049,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 
 			It("returns success with gateways cleared", func() {
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
+				Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
 
 				By("simulate successful NetOP reconcile", func() {
 					netInterface := &netopv1alpha1.NetworkInterface{
@@ -1116,7 +1117,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 
 			It("returns success with DHCP4 enabled and static IPv6", func() {
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
+				Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
 
 				By("simulate successful NetOP reconcile", func() {
 					netInterface := &netopv1alpha1.NetworkInterface{
@@ -1186,7 +1187,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 
 			It("returns success with static IPv4 and DHCP6 enabled", func() {
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
+				Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
 
 				By("simulate successful NetOP reconcile", func() {
 					netInterface := &netopv1alpha1.NetworkInterface{
@@ -1255,7 +1256,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 
 			It("returns success with user gateways overriding NetOP", func() {
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
+				Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
 
 				By("simulate successful NetOP reconcile", func() {
 					netInterface := &netopv1alpha1.NetworkInterface{
@@ -1312,8 +1313,8 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 				BeforeEach(func() {
 					networkSpec.Interfaces = []vmopv1.VirtualMachineNetworkInterfaceSpec{
 						{
-							Name:    interfaceName,
-							Network: &common.PartialObjectRef{Name: networkName},
+							Name:      interfaceName,
+							Network:   &common.PartialObjectRef{Name: networkName},
 							IPAMModes: []corev1.IPFamily{corev1.IPv4Protocol},
 						},
 					}
@@ -1321,7 +1322,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 
 				It("creates NetworkInterface CR with IPv4Only policy", func() {
 					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
+					Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
 
 					By("verify NetworkInterface CR has IPv4Only policy", func() {
 						netInterface := &netopv1alpha1.NetworkInterface{
@@ -1340,8 +1341,8 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 				BeforeEach(func() {
 					networkSpec.Interfaces = []vmopv1.VirtualMachineNetworkInterfaceSpec{
 						{
-							Name:    interfaceName,
-							Network: &common.PartialObjectRef{Name: networkName},
+							Name:      interfaceName,
+							Network:   &common.PartialObjectRef{Name: networkName},
 							IPAMModes: []corev1.IPFamily{corev1.IPv6Protocol},
 						},
 					}
@@ -1349,7 +1350,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 
 				It("creates NetworkInterface CR with IPv6Only policy", func() {
 					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
+					Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
 
 					By("verify NetworkInterface CR has IPv6Only policy", func() {
 						netInterface := &netopv1alpha1.NetworkInterface{
@@ -1380,7 +1381,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 
 				It("creates NetworkInterface CR with DualStack policy", func() {
 					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
+					Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
 
 					By("verify NetworkInterface CR has DualStack policy", func() {
 						netInterface := &netopv1alpha1.NetworkInterface{
@@ -1408,7 +1409,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 
 				It("creates NetworkInterface CR without IPFamilyPolicy set", func() {
 					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
+					Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
 
 					By("verify NetworkInterface CR does not have NetOP IPFamilyPolicy set", func() {
 						netInterface := &netopv1alpha1.NetworkInterface{
@@ -1428,13 +1429,13 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 				BeforeEach(func() {
 					networkSpec.Interfaces = []vmopv1.VirtualMachineNetworkInterfaceSpec{
 						{
-							Name:    "eth0",
-							Network: &common.PartialObjectRef{Name: networkName},
+							Name:      "eth0",
+							Network:   &common.PartialObjectRef{Name: networkName},
 							IPAMModes: []corev1.IPFamily{corev1.IPv4Protocol},
 						},
 						{
-							Name:    "eth1",
-							Network: &common.PartialObjectRef{Name: networkName},
+							Name:      "eth1",
+							Network:   &common.PartialObjectRef{Name: networkName},
 							IPAMModes: []corev1.IPFamily{corev1.IPv6Protocol},
 						},
 						{
@@ -1450,7 +1451,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 
 				It("creates NetworkInterface CRs with correct policies for each interface", func() {
 					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
+					Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
 
 					expectedPolicies := map[string]netopv1alpha1.NetworkInterfaceIPFamilyPolicy{
 						"eth0": netopv1alpha1.NetworkInterfaceIPFamilyPolicyIPv4Only,
@@ -1538,7 +1539,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 				Expect(ctx.NetworkRef.Reference().Type).To(Equal("DistributedVirtualPortgroup"))
 
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
+				Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
 				Expect(results.Results).To(BeEmpty())
 
 				By("simulate successful NCP reconcile", func() {
@@ -1650,7 +1651,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 					Expect(ctx.NetworkRef.Reference().Type).To(Equal("DistributedVirtualPortgroup"))
 
 					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
+					Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
 					Expect(results.Results).To(BeEmpty())
 
 					By("simulate successful NCP reconcile", func() {
@@ -1777,7 +1778,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 				Expect(ctx.NetworkRef.Reference().Type).To(Equal("DistributedVirtualPortgroup"))
 
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
+				Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
 				Expect(results.Results).To(BeEmpty())
 
 				By("simulate successful NSX Operator reconcile", func() {
@@ -1879,7 +1880,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 
 				It("returns success with expected MAC address", func() {
 					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
+					Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
 					Expect(results.Results).To(BeEmpty())
 
 					By("simulate successful NSX Operator reconcile", func() {
@@ -1950,7 +1951,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 
 				It("returns success with multiple IP addresses", func() {
 					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
+					Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
 					Expect(results.Results).To(BeEmpty())
 
 					By("simulate successful NSX Operator reconcile", func() {
@@ -2043,7 +2044,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 
 				It("creates SubnetPort with only MAC address when all IPs are invalid", func() {
 					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
+					Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
 					Expect(results.Results).To(BeEmpty())
 
 					By("simulate successful NSX Operator reconcile", func() {
@@ -2128,7 +2129,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 
 				It("processes valid IPs and logs skipped invalid ones", func() {
 					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
+					Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
 					Expect(results.Results).To(BeEmpty())
 
 					By("simulate successful NSX Operator reconcile", func() {
@@ -2228,7 +2229,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 			Context("DHCP is enabled", func() {
 				It("returns success", func() {
 					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
+					Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
 					Expect(results.Results).To(BeEmpty())
 
 					By("simulate successful NSX Operator reconcile", func() {
@@ -2278,7 +2279,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 			Context("NoIPAM is enabled", func() {
 				It("returns success", func() {
 					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
+					Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
 					Expect(results.Results).To(BeEmpty())
 
 					By("simulate successful NSX Operator reconcile", func() {
@@ -2330,9 +2331,9 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 
 var _ = Describe("SetNetworkInterfaceOwnerRef", func() {
 	var (
-		vm           *vmopv1.VirtualMachine
-		netInterface *netopv1alpha1.NetworkInterface
-		client       client.Client
+		vm     *vmopv1.VirtualMachine
+		netIf  *netopv1alpha1.NetworkInterface
+		client client.Client
 	)
 
 	BeforeEach(func() {
@@ -2343,7 +2344,7 @@ var _ = Describe("SetNetworkInterfaceOwnerRef", func() {
 				UID:       "my-vm-uid",
 			},
 		}
-		netInterface = &netopv1alpha1.NetworkInterface{
+		netIf = &netopv1alpha1.NetworkInterface{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-interface",
 				Namespace: vm.Namespace,
@@ -2355,38 +2356,726 @@ var _ = Describe("SetNetworkInterfaceOwnerRef", func() {
 
 	When("Network interface has VM owner ref", func() {
 		It("owner ref gets upgraded to controller ref", func() {
-			Expect(controllerutil.SetOwnerReference(vm, netInterface, client.Scheme())).To(Succeed())
+			Expect(controllerutil.SetOwnerReference(vm, netIf, client.Scheme())).To(Succeed())
 
-			err := network.SetNetworkInterfaceOwnerRef(vm, netInterface, client.Scheme())
+			err := network.SetNetworkInterfaceOwnerRef(vm, netIf, client.Scheme())
 			Expect(err).ToNot(HaveOccurred())
-			Expect(netInterface.OwnerReferences).To(HaveLen(1))
-			Expect(metav1.IsControlledBy(netInterface, vm)).To(BeTrue())
+			Expect(netIf.OwnerReferences).To(HaveLen(1))
+			Expect(metav1.IsControlledBy(netIf, vm)).To(BeTrue())
 		})
 	})
 
 	When("Network interface already has a controller ref", func() {
 		It("VM is added as owner ref", func() {
 			cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "my-cm", Namespace: vm.Namespace, UID: "my-cm-uid"}}
-			Expect(controllerutil.SetControllerReference(cm, netInterface, client.Scheme())).To(Succeed())
+			Expect(controllerutil.SetControllerReference(cm, netIf, client.Scheme())).To(Succeed())
 
-			err := network.SetNetworkInterfaceOwnerRef(vm, netInterface, client.Scheme())
+			err := network.SetNetworkInterfaceOwnerRef(vm, netIf, client.Scheme())
 			Expect(err).ToNot(HaveOccurred())
-			Expect(netInterface.OwnerReferences).To(HaveLen(2))
-			Expect(netInterface.OwnerReferences[0].Name).To(Equal(cm.Name))
-			Expect(netInterface.OwnerReferences[1].Name).To(Equal(vm.Name))
-			Expect(metav1.IsControlledBy(netInterface, cm)).To(BeTrue())
+			Expect(netIf.OwnerReferences).To(HaveLen(2))
+			Expect(netIf.OwnerReferences[0].Name).To(Equal(cm.Name))
+			Expect(netIf.OwnerReferences[1].Name).To(Equal(vm.Name))
+			Expect(metav1.IsControlledBy(netIf, cm)).To(BeTrue())
 		})
 	})
 
 	When("Network interface already has a controller ref that is a VM", func() {
 		It("New VM is not added as owner ref", func() {
 			ownerVM := &vmopv1.VirtualMachine{ObjectMeta: metav1.ObjectMeta{Name: "my-vm-1", Namespace: vm.Namespace}}
-			Expect(controllerutil.SetControllerReference(ownerVM, netInterface, client.Scheme())).To(Succeed())
+			Expect(controllerutil.SetControllerReference(ownerVM, netIf, client.Scheme())).To(Succeed())
 
-			err := network.SetNetworkInterfaceOwnerRef(vm, netInterface, client.Scheme())
+			err := network.SetNetworkInterfaceOwnerRef(vm, netIf, client.Scheme())
 			Expect(err).To(HaveOccurred())
-			Expect(netInterface.OwnerReferences).To(HaveLen(1))
-			Expect(metav1.IsControlledBy(netInterface, ownerVM)).To(BeTrue())
+			Expect(netIf.OwnerReferences).To(HaveLen(1))
+			Expect(metav1.IsControlledBy(netIf, ownerVM)).To(BeTrue())
+		})
+	})
+})
+
+var _ = Describe("CreateNetworkDevices", Label(testlabels.VCSim), func() {
+
+	const (
+		interfaceName0 = "eth0"
+		interfaceName1 = "eth1"
+		networkName0   = "my-network"
+		networkName1   = "my-network-1"
+		macAddress0    = "01:02:03:04:05:06"
+		macAddress1    = "00:AA:BB:CC:DD:FF"
+		externalID0    = "my-external-id"
+		externalID1    = "my-external-id-1"
+	)
+
+	var (
+		ctx         *builder.TestContextForVCSim
+		testConfig  builder.VCSimTestConfig
+		initObjects []client.Object
+
+		vm            *vmopv1.VirtualMachine
+		interfaceKey0 client.ObjectKey
+		interfaceKey1 client.ObjectKey
+		devices       []network.Device
+		err           error
+
+		netOPNetworkTypeMeta = metav1.TypeMeta{
+			APIVersion: netopv1alpha1.SchemeGroupVersion.String(),
+			Kind:       "Network",
+		}
+		nsxtNetworkTypeMeta = metav1.TypeMeta{
+			APIVersion: ncpv1alpha1.SchemeGroupVersion.String(),
+			Kind:       "VirtualNetwork",
+		}
+		vpcNetworkTypeMeta = metav1.TypeMeta{
+			APIVersion: vpcv1alpha1.SchemeGroupVersion.String(),
+			Kind:       "SubnetSet",
+		}
+	)
+
+	BeforeEach(func() {
+		testConfig = builder.VCSimTestConfig{}
+
+		vm = &vmopv1.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "create-net-dev-vm",
+				Namespace: "create-net-dev-ns",
+				UID:       "create-net-dev-uid",
+			},
+		}
+	})
+
+	JustBeforeEach(func() {
+		ctx = suite.NewTestContextForVCSim(testConfig, initObjects...)
+
+		devices, err = network.CreateNetworkDevices(
+			ctx,
+			vm,
+			ctx.Client,
+			ctx.VCClient.Client,
+			ctx.Finder)
+	})
+
+	AfterEach(func() {
+		ctx.AfterEach()
+		ctx = nil
+		initObjects = nil
+	})
+
+	Context("network spec is nil", func() {
+		It("returns nil devices and no error", func() {
+			Expect(err).ToNot(HaveOccurred())
+			Expect(devices).To(BeNil())
+		})
+	})
+
+	Context("Named Network", func() {
+		const namedNetwork = "DC0_DVPG0"
+
+		BeforeEach(func() {
+			testConfig.WithNetworkEnv = builder.NetworkEnvNamed
+			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{
+				Interfaces: []vmopv1.VirtualMachineNetworkInterfaceSpec{
+					{
+						Name:    interfaceName0,
+						Network: &common.PartialObjectRef{Name: namedNetwork},
+					},
+				},
+			}
+		})
+
+		It("returns success with backing", func() {
+			Expect(err).ToNot(HaveOccurred())
+			Expect(devices).To(HaveLen(1))
+
+			dev := devices[0]
+			Expect(dev.Backing).ToNot(BeNil())
+			backing, err := dev.Backing.EthernetCardBackingInfo(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			backingInfo, ok := backing.(*vimtypes.VirtualEthernetCardDistributedVirtualPortBackingInfo)
+			Expect(ok).To(BeTrue())
+			Expect(backingInfo.Port.PortgroupKey).To(Equal(ctx.NetworkRef.Reference().Value))
+		})
+
+		Context("Named Network with MAC address", func() {
+			BeforeEach(func() {
+				vm.Spec.Network.Interfaces[0].MACAddr = macAddress0
+			})
+
+			It("returns device with MAC address", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(devices).To(HaveLen(1))
+				Expect(devices[0].MacAddress).To(Equal(macAddress0))
+			})
+		})
+	})
+
+	Context("VDS", func() {
+
+		BeforeEach(func() {
+			testConfig.WithNetworkEnv = builder.NetworkEnvVDS
+			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{
+				Interfaces: []vmopv1.VirtualMachineNetworkInterfaceSpec{
+					{
+						Name: interfaceName0,
+						Network: &common.PartialObjectRef{
+							TypeMeta: netOPNetworkTypeMeta,
+							Name:     networkName0,
+						},
+					},
+					{
+						Name: interfaceName1,
+						Network: &common.PartialObjectRef{
+							TypeMeta: netOPNetworkTypeMeta,
+							Name:     networkName1,
+						},
+					},
+				},
+			}
+
+			interfaceKey0 = client.ObjectKey{
+				Name:      network.NetOPCRName(vm.Name, networkName0, interfaceName0, false),
+				Namespace: vm.Namespace,
+			}
+
+			interfaceKey1 = client.ObjectKey{
+				Name:      network.NetOPCRName(vm.Name, networkName1, interfaceName1, false),
+				Namespace: vm.Namespace,
+			}
+		})
+
+		Context("interface is not ready", func() {
+			It("returns not-ready error and creates the interface", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
+				Expect(devices).To(BeEmpty())
+
+				netIf := &netopv1alpha1.NetworkInterface{}
+				Expect(ctx.Client.Get(ctx, interfaceKey0, netIf)).To(Succeed())
+				Expect(metav1.IsControlledBy(netIf, vm)).To(BeTrue())
+				Expect(netIf.Labels).To(HaveKeyWithValue(network.VMNameLabel, vm.Name))
+				Expect(netIf.Labels).To(HaveKeyWithValue(network.VMInterfaceNameLabel, interfaceName0))
+				Expect(netIf.Spec.NetworkName).To(Equal(networkName0))
+
+				Expect(ctx.Client.Get(ctx, interfaceKey1, netIf)).To(Succeed())
+				Expect(metav1.IsControlledBy(netIf, vm)).To(BeTrue())
+				Expect(netIf.Labels).To(HaveKeyWithValue(network.VMNameLabel, vm.Name))
+				Expect(netIf.Labels).To(HaveKeyWithValue(network.VMInterfaceNameLabel, interfaceName1))
+				Expect(netIf.Spec.NetworkName).To(Equal(networkName1))
+			})
+
+			DescribeTableSubtree("interface spec with IPAMModes",
+				func(modes []corev1.IPFamily, expected netopv1alpha1.NetworkInterfaceIPFamilyPolicy) {
+					BeforeEach(func() {
+						vm.Spec.Network.Interfaces[0].IPAMModes = modes
+					})
+
+					It("interface IPFamilyPolicy is set", func() {
+						Expect(err).To(HaveOccurred())
+						Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
+						Expect(devices).To(BeEmpty())
+
+						netIf := &netopv1alpha1.NetworkInterface{}
+						Expect(ctx.Client.Get(ctx, interfaceKey0, netIf)).To(Succeed())
+						Expect(netIf.Spec.IPFamilyPolicy).To(Equal(expected))
+					})
+				},
+				Entry("None", []corev1.IPFamily{}, netopv1alpha1.NetworkInterfaceIPFamilyPolicy("")),
+				Entry("IPv4", []corev1.IPFamily{corev1.IPv4Protocol}, netopv1alpha1.NetworkInterfaceIPFamilyPolicyIPv4Only),
+				Entry("IPv6", []corev1.IPFamily{corev1.IPv6Protocol}, netopv1alpha1.NetworkInterfaceIPFamilyPolicyIPv6Only),
+				Entry("Dual", []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}, netopv1alpha1.NetworkInterfaceIPFamilyPolicyDualStack),
+			)
+		})
+
+		Context("interface is ready", func() {
+			BeforeEach(func() {
+				netIf0 := &netopv1alpha1.NetworkInterface{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      interfaceKey0.Name,
+						Namespace: interfaceKey0.Namespace,
+					},
+					Status: netopv1alpha1.NetworkInterfaceStatus{
+						NetworkID:  "dvpg-portgroup-0",
+						MacAddress: macAddress0,
+						ExternalID: externalID0,
+						Conditions: []netopv1alpha1.NetworkInterfaceCondition{
+							{
+								Type:   netopv1alpha1.NetworkInterfaceReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				}
+
+				netIf1 := &netopv1alpha1.NetworkInterface{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      interfaceKey1.Name,
+						Namespace: interfaceKey1.Namespace,
+					},
+					Status: netopv1alpha1.NetworkInterfaceStatus{
+						NetworkID:  "dvpg-portgroup-1",
+						MacAddress: macAddress1,
+						ExternalID: externalID1,
+						Conditions: []netopv1alpha1.NetworkInterfaceCondition{
+							{
+								Type:   netopv1alpha1.NetworkInterfaceReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				}
+
+				initObjects = append(initObjects, netIf0, netIf1)
+			})
+
+			It("returns success with backing", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(devices).To(HaveLen(2))
+
+				dev0 := devices[0]
+				Expect(dev0.NetworkID).To(Equal("dvpg-portgroup-0"))
+				Expect(dev0.Backing).ToNot(BeNil())
+				Expect(dev0.MacAddress).To(Equal(macAddress0))
+				Expect(dev0.ExternalID).To(Equal(externalID0))
+
+				dev1 := devices[1]
+				Expect(dev1.NetworkID).To(Equal("dvpg-portgroup-1"))
+				Expect(dev1.Backing).ToNot(BeNil())
+				Expect(dev1.MacAddress).To(Equal(macAddress1))
+				Expect(dev1.ExternalID).To(Equal(externalID1))
+			})
+		})
+
+		Context("interface has failure condition", func() {
+			BeforeEach(func() {
+				netIf0 := &netopv1alpha1.NetworkInterface{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      interfaceKey0.Name,
+						Namespace: interfaceKey0.Namespace,
+					},
+					Status: netopv1alpha1.NetworkInterfaceStatus{
+						Conditions: []netopv1alpha1.NetworkInterfaceCondition{
+							{
+								Type:    netopv1alpha1.NetworkInterfaceFailure,
+								Status:  corev1.ConditionTrue,
+								Reason:  "SomeReason",
+								Message: "something went wrong",
+							},
+						},
+					},
+				}
+
+				netIf1 := &netopv1alpha1.NetworkInterface{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      interfaceKey1.Name,
+						Namespace: interfaceKey1.Namespace,
+					},
+					Status: netopv1alpha1.NetworkInterfaceStatus{
+						NetworkID:  "dvpg-portgroup-key",
+						MacAddress: macAddress1,
+						ExternalID: externalID1,
+						Conditions: []netopv1alpha1.NetworkInterfaceCondition{
+							{
+								Type:   netopv1alpha1.NetworkInterfaceReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				}
+
+				initObjects = append(initObjects, netIf0, netIf1)
+			})
+
+			It("returns failure error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
+				Expect(err).To(MatchError("error getting device for interface eth0: network interface is not ready: failure - SomeReason: something went wrong"))
+			})
+		})
+	})
+
+	Context("NSXT", func() {
+		BeforeEach(func() {
+			testConfig.WithNetworkEnv = builder.NetworkEnvNSXT
+			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{
+				Interfaces: []vmopv1.VirtualMachineNetworkInterfaceSpec{
+					{
+						Name: interfaceName0,
+						Network: &common.PartialObjectRef{
+							TypeMeta: nsxtNetworkTypeMeta,
+							Name:     networkName0,
+						},
+					},
+					{
+						Name: interfaceName1,
+						Network: &common.PartialObjectRef{
+							TypeMeta: nsxtNetworkTypeMeta,
+							Name:     networkName1,
+						},
+					},
+				},
+			}
+
+			interfaceKey0 = client.ObjectKey{
+				Name:      network.NCPCRName(vm.Name, networkName0, interfaceName0, false),
+				Namespace: vm.Namespace,
+			}
+
+			interfaceKey1 = client.ObjectKey{
+				Name:      network.NCPCRName(vm.Name, networkName1, interfaceName1, false),
+				Namespace: vm.Namespace,
+			}
+		})
+
+		Context("interface is not ready", func() {
+			It("returns not-ready error and creates the interface", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
+				Expect(devices).To(BeEmpty())
+
+				vnetIf := &ncpv1alpha1.VirtualNetworkInterface{}
+				Expect(ctx.Client.Get(ctx, interfaceKey0, vnetIf)).To(Succeed())
+				Expect(metav1.IsControlledBy(vnetIf, vm)).To(BeTrue())
+				Expect(vnetIf.Labels).To(HaveKeyWithValue(network.VMNameLabel, vm.Name))
+				Expect(vnetIf.Labels).To(HaveKeyWithValue(network.VMInterfaceNameLabel, interfaceName0))
+				Expect(vnetIf.Spec.VirtualNetwork).To(Equal(networkName0))
+
+				Expect(ctx.Client.Get(ctx, interfaceKey1, vnetIf)).To(Succeed())
+				Expect(metav1.IsControlledBy(vnetIf, vm)).To(BeTrue())
+				Expect(vnetIf.Labels).To(HaveKeyWithValue(network.VMNameLabel, vm.Name))
+				Expect(vnetIf.Labels).To(HaveKeyWithValue(network.VMInterfaceNameLabel, interfaceName1))
+				Expect(vnetIf.Spec.VirtualNetwork).To(Equal(networkName1))
+			})
+		})
+
+		Context("interface is ready", func() {
+			BeforeEach(func() {
+				vnetIf0 := &ncpv1alpha1.VirtualNetworkInterface{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      interfaceKey0.Name,
+						Namespace: interfaceKey0.Namespace,
+					},
+					Status: ncpv1alpha1.VirtualNetworkInterfaceStatus{
+						InterfaceID: externalID0,
+						MacAddress:  macAddress0,
+						ProviderStatus: &ncpv1alpha1.VirtualNetworkInterfaceProviderStatus{
+							NsxLogicalSwitchID: builder.GetNsxTLogicalSwitchUUID(0),
+						},
+						Conditions: []ncpv1alpha1.VirtualNetworkCondition{
+							{
+								Type:   "Ready",
+								Status: "True",
+							},
+						},
+					},
+				}
+
+				vnetIf1 := &ncpv1alpha1.VirtualNetworkInterface{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      interfaceKey1.Name,
+						Namespace: interfaceKey1.Namespace,
+					},
+					Status: ncpv1alpha1.VirtualNetworkInterfaceStatus{
+						InterfaceID: externalID1,
+						MacAddress:  macAddress1,
+						ProviderStatus: &ncpv1alpha1.VirtualNetworkInterfaceProviderStatus{
+							NsxLogicalSwitchID: builder.GetNsxTLogicalSwitchUUID(1),
+						},
+						Conditions: []ncpv1alpha1.VirtualNetworkCondition{
+							{
+								Type:   "Ready",
+								Status: "True",
+							},
+						},
+					},
+				}
+
+				initObjects = append(initObjects, vnetIf0, vnetIf1)
+			})
+
+			It("returns success with backing and identifiers", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(devices).To(HaveLen(2))
+
+				dev0 := devices[0]
+				Expect(dev0.NetworkID).To(Equal(builder.GetNsxTLogicalSwitchUUID(0)))
+				Expect(dev0.Backing).ToNot(BeNil())
+				Expect(dev0.ExternalID).To(Equal(externalID0))
+				Expect(dev0.MacAddress).To(Equal(macAddress0))
+
+				backing0, err := dev0.Backing.EthernetCardBackingInfo(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				opaqueNetwork0, ok := backing0.(*vimtypes.VirtualEthernetCardOpaqueNetworkBackingInfo)
+				Expect(ok).To(BeTrue())
+				Expect(opaqueNetwork0.OpaqueNetworkId).To(Equal(dev0.NetworkID))
+
+				dev1 := devices[1]
+				Expect(dev1.NetworkID).To(Equal(builder.GetNsxTLogicalSwitchUUID(1)))
+				Expect(dev1.Backing).ToNot(BeNil())
+				Expect(dev1.ExternalID).To(Equal(externalID1))
+				Expect(dev1.MacAddress).To(Equal(macAddress1))
+
+				backing1, err := dev1.Backing.EthernetCardBackingInfo(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				opaqueNetwork1, ok := backing1.(*vimtypes.VirtualEthernetCardOpaqueNetworkBackingInfo)
+				Expect(ok).To(BeTrue())
+				Expect(opaqueNetwork1.OpaqueNetworkId).To(Equal(dev1.NetworkID))
+			})
+		})
+
+		Context("interface is not ready", func() {
+			BeforeEach(func() {
+				vnetIf := &ncpv1alpha1.VirtualNetworkInterface{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      interfaceKey0.Name,
+						Namespace: interfaceKey0.Namespace,
+					},
+					Status: ncpv1alpha1.VirtualNetworkInterfaceStatus{
+						ProviderStatus: &ncpv1alpha1.VirtualNetworkInterfaceProviderStatus{
+							NsxLogicalSwitchID: builder.GetNsxTLogicalSwitchUUID(0),
+						},
+						Conditions: []ncpv1alpha1.VirtualNetworkCondition{
+							{
+								Type:    "Ready",
+								Status:  "False",
+								Reason:  "ProvisioningFailed",
+								Message: "subnet not found",
+							},
+						},
+					},
+				}
+				initObjects = append(initObjects, vnetIf)
+			})
+
+			It("returns not-ready error with reason", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
+				Expect(err.Error()).To(ContainSubstring("network interface is not ready: ProvisioningFailed - subnet not found"))
+			})
+		})
+
+		Context("interface is ready but missing provider status", func() {
+			BeforeEach(func() {
+				vnetIf := &ncpv1alpha1.VirtualNetworkInterface{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      interfaceKey0.Name,
+						Namespace: interfaceKey0.Namespace,
+					},
+					Status: ncpv1alpha1.VirtualNetworkInterfaceStatus{
+						Conditions: []ncpv1alpha1.VirtualNetworkCondition{
+							{
+								Type:   "Ready",
+								Status: "True",
+							},
+						},
+					},
+				}
+				initObjects = append(initObjects, vnetIf)
+			})
+
+			It("returns error about missing provider status", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("ready network interface does not have provider status"))
+			})
+		})
+	})
+
+	Context("VPC", func() {
+		BeforeEach(func() {
+			testConfig.WithNetworkEnv = builder.NetworkEnvVPC
+			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{
+				Interfaces: []vmopv1.VirtualMachineNetworkInterfaceSpec{
+					{
+						Name: interfaceName0,
+						Network: &common.PartialObjectRef{
+							TypeMeta: vpcNetworkTypeMeta,
+							Name:     networkName0,
+						},
+					},
+					{
+						Name: interfaceName1,
+						Network: &common.PartialObjectRef{
+							TypeMeta: vpcNetworkTypeMeta,
+							Name:     networkName1,
+						},
+					},
+				},
+			}
+
+			interfaceKey0 = client.ObjectKey{
+				Name:      network.VPCCRName(vm.Name, networkName0, interfaceName0),
+				Namespace: vm.Namespace,
+			}
+
+			interfaceKey1 = client.ObjectKey{
+				Name:      network.VPCCRName(vm.Name, networkName1, interfaceName1),
+				Namespace: vm.Namespace,
+			}
+		})
+
+		Context("interface is not ready", func() {
+			It("returns not-ready error and creates the interface", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
+				Expect(devices).To(BeEmpty())
+
+				subnetPort := &vpcv1alpha1.SubnetPort{}
+				Expect(ctx.Client.Get(ctx, interfaceKey0, subnetPort)).To(Succeed())
+				Expect(metav1.IsControlledBy(subnetPort, vm)).To(BeTrue())
+				Expect(subnetPort.Labels).To(HaveKeyWithValue(network.VMNameLabel, vm.Name))
+				Expect(subnetPort.Labels).To(HaveKeyWithValue(network.VMInterfaceNameLabel, interfaceName0))
+				Expect(subnetPort.Spec.SubnetSet).To(Equal(networkName0))
+
+				Expect(ctx.Client.Get(ctx, interfaceKey1, subnetPort)).To(Succeed())
+				Expect(metav1.IsControlledBy(subnetPort, vm)).To(BeTrue())
+				Expect(subnetPort.Labels).To(HaveKeyWithValue(network.VMNameLabel, vm.Name))
+				Expect(subnetPort.Labels).To(HaveKeyWithValue(network.VMInterfaceNameLabel, interfaceName1))
+				Expect(subnetPort.Spec.SubnetSet).To(Equal(networkName1))
+			})
+
+			DescribeTableSubtree("interface spec with addresses",
+				func(addresses []string, macAddress string, expectedIP string) {
+					BeforeEach(func() {
+						vm.Spec.Network.Interfaces[0].Addresses = addresses
+						vm.Spec.Network.Interfaces[0].MACAddr = macAddress
+					})
+
+					It("SubnetPort AddressBindings are set correctly", func() {
+						Expect(err).To(HaveOccurred())
+						Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
+						Expect(devices).To(BeEmpty())
+
+						subnetPort := &vpcv1alpha1.SubnetPort{}
+						Expect(ctx.Client.Get(ctx, interfaceKey0, subnetPort)).To(Succeed())
+
+						if expectedIP != "" {
+							Expect(subnetPort.Spec.AddressBindings).To(HaveLen(1))
+							Expect(subnetPort.Spec.AddressBindings[0].IPAddress).To(Equal(expectedIP))
+							Expect(subnetPort.Spec.AddressBindings[0].MACAddress).To(Equal(strings.ToLower(macAddress)))
+						} else if macAddress != "" {
+							Expect(subnetPort.Spec.AddressBindings).To(HaveLen(1))
+							Expect(subnetPort.Spec.AddressBindings[0].IPAddress).To(BeEmpty())
+							Expect(subnetPort.Spec.AddressBindings[0].MACAddress).To(Equal(strings.ToLower(macAddress)))
+						} else {
+							Expect(subnetPort.Spec.AddressBindings).To(BeEmpty())
+						}
+					})
+				},
+				Entry("No addresses or MAC", []string{}, "", ""),
+				Entry("IPv4 address with MAC", []string{"192.168.1.100/24"}, macAddress0, "192.168.1.100"),
+				Entry("IPv6 address with MAC", []string{"2001:db8::100/64"}, macAddress0, "2001:db8::100"),
+				Entry("Multiple addresses (only first is used)", []string{"192.168.1.100/24", "192.168.1.101/24"}, macAddress0, "192.168.1.100"),
+				Entry("Only MAC address", []string{}, macAddress0, ""),
+				Entry("Invalid IP address skipped", []string{"256.256.256.256/24", "192.168.1.100/24"}, macAddress0, "192.168.1.100"),
+			)
+
+			Context("Default to SubnetSet", func() {
+				BeforeEach(func() {
+					vm.Spec.Network.Interfaces[0].Network.Kind = ""
+				})
+
+				It("interface is created with SubnetSet set", func() {
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
+					Expect(devices).To(BeEmpty())
+
+					subnetPort := &vpcv1alpha1.SubnetPort{}
+					Expect(ctx.Client.Get(ctx, interfaceKey0, subnetPort)).To(Succeed())
+					Expect(subnetPort.Spec.SubnetSet).To(Equal(networkName0))
+				})
+			})
+
+			Context("Subnet", func() {
+				BeforeEach(func() {
+					vm.Spec.Network.Interfaces[0].Network.Kind = "Subnet"
+				})
+
+				It("interface is created with Subnet assigned", func() {
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
+					Expect(devices).To(BeEmpty())
+
+					subnetPort := &vpcv1alpha1.SubnetPort{}
+					Expect(ctx.Client.Get(ctx, interfaceKey0, subnetPort)).To(Succeed())
+					Expect(subnetPort.Spec.Subnet).To(Equal(networkName0))
+				})
+			})
+		})
+
+		Context("interface is ready", func() {
+			BeforeEach(func() {
+				subnetPort0 := &vpcv1alpha1.SubnetPort{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      interfaceKey0.Name,
+						Namespace: interfaceKey0.Namespace,
+					},
+					Status: vpcv1alpha1.SubnetPortStatus{
+						Attachment: vpcv1alpha1.PortAttachment{
+							ID: externalID0,
+						},
+						NetworkInterfaceConfig: vpcv1alpha1.NetworkInterfaceConfig{
+							LogicalSwitchUUID: builder.GetVPCTLogicalSwitchUUID(0),
+							MACAddress:        macAddress0,
+						},
+						Conditions: []vpcv1alpha1.Condition{
+							{
+								Type:   vpcv1alpha1.Ready,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				}
+
+				subnetPort1 := &vpcv1alpha1.SubnetPort{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      interfaceKey1.Name,
+						Namespace: interfaceKey1.Namespace,
+					},
+					Status: vpcv1alpha1.SubnetPortStatus{
+						Attachment: vpcv1alpha1.PortAttachment{
+							ID: externalID1,
+						},
+						NetworkInterfaceConfig: vpcv1alpha1.NetworkInterfaceConfig{
+							LogicalSwitchUUID: builder.GetVPCTLogicalSwitchUUID(1),
+							MACAddress:        macAddress1,
+						},
+						Conditions: []vpcv1alpha1.Condition{
+							{
+								Type:   vpcv1alpha1.Ready,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				}
+
+				initObjects = append(initObjects, subnetPort0, subnetPort1)
+			})
+
+			It("returns success", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(devices).To(HaveLen(2))
+
+				dev0 := devices[0]
+				Expect(dev0.NetworkID).To(Equal(builder.GetVPCTLogicalSwitchUUID(0)))
+				Expect(dev0.Backing).ToNot(BeNil())
+				Expect(dev0.MacAddress).To(Equal(macAddress0))
+				Expect(dev0.ExternalID).To(Equal(externalID0))
+
+				backing0, err := dev0.Backing.EthernetCardBackingInfo(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				opaqueNetwork0, ok := backing0.(*vimtypes.VirtualEthernetCardOpaqueNetworkBackingInfo)
+				Expect(ok).To(BeTrue())
+				Expect(opaqueNetwork0.OpaqueNetworkId).To(Equal(dev0.NetworkID))
+
+				dev1 := devices[1]
+				Expect(dev1.NetworkID).To(Equal(builder.GetVPCTLogicalSwitchUUID(1)))
+				Expect(dev1.Backing).ToNot(BeNil())
+				Expect(dev1.MacAddress).To(Equal(macAddress1))
+				Expect(dev1.ExternalID).To(Equal(externalID1))
+
+				backing1, err := dev1.Backing.EthernetCardBackingInfo(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				opaqueNetwork1, ok := backing1.(*vimtypes.VirtualEthernetCardOpaqueNetworkBackingInfo)
+				Expect(ok).To(BeTrue())
+				Expect(opaqueNetwork1.OpaqueNetworkId).To(Equal(dev1.NetworkID))
+			})
 		})
 	})
 })

--- a/pkg/providers/vsphere/vmprovider_vm.go
+++ b/pkg/providers/vsphere/vmprovider_vm.go
@@ -113,7 +113,7 @@ type VMCreateArgs struct {
 	ChildFolderName       string
 	ClusterMoRef          vimtypes.ManagedObjectReference
 
-	NetworkResults network.NetworkInterfaceResults
+	NetworkDevices []network.Device
 }
 
 // TODO: Until we sort out what the Session becomes.
@@ -2328,25 +2328,24 @@ func (vs *vSphereVMProvider) vmCreateDoNetworking(
 	vcClient *vcclient.Client,
 	createArgs *VMCreateArgs) error {
 
-	networkSpec := vmCtx.VM.Spec.Network
-	if networkSpec == nil || networkSpec.Disabled {
+	if vmCtx.VM.Spec.Network == nil || vmCtx.VM.Spec.Network.Disabled {
 		pkgcnd.Delete(vmCtx.VM, vmopv1.VirtualMachineConditionNetworkReady)
 		return nil
 	}
 
-	results, err := network.CreateAndWaitForNetworkInterfaces(
+	devices, err := network.CreateNetworkDevices(
 		vmCtx,
+		vmCtx.VM,
 		vs.k8sClient,
 		vcClient.VimClient(),
-		vcClient.Finder(),
-		nil, // Don't know the CCR yet (needed to resolve backings for NSX-T)
-		networkSpec)
+		vcClient.Finder())
 	if err != nil {
-		pkgcnd.MarkError(vmCtx.VM, vmopv1.VirtualMachineConditionNetworkReady, "NotReady", err)
+		pkgcnd.MarkFalse(vmCtx.VM, vmopv1.VirtualMachineConditionNetworkReady,
+			"NotReady", "%v", err)
 		return err
 	}
 
-	createArgs.NetworkResults = results
+	createArgs.NetworkDevices = devices
 	pkgcnd.MarkTrue(vmCtx.VM, vmopv1.VirtualMachineConditionNetworkReady)
 
 	return nil
@@ -2939,7 +2938,7 @@ func (vs *vSphereVMProvider) vmCreateGenConfigSpecZipNetworkInterfaces(
 		return nil
 	}
 
-	resultsIdx := 0
+	devIdx := 0
 	var unmatchedEthDevices []int
 
 	for idx := range createArgs.ConfigSpec.DeviceChange {
@@ -2951,12 +2950,12 @@ func (vs *vSphereVMProvider) vmCreateGenConfigSpecZipNetworkInterfaces(
 		device := spec.Device
 		ethCard := device.(vimtypes.BaseVirtualEthernetCard).GetVirtualEthernetCard()
 
-		if resultsIdx < len(createArgs.NetworkResults.Results) {
-			err := network.ApplyInterfaceResultToVirtualEthCard(vmCtx, ethCard, &createArgs.NetworkResults.Results[resultsIdx])
+		if devIdx < len(createArgs.NetworkDevices) {
+			err := network.ApplyNetworkDeviceToVirtualEthCard(vmCtx, ethCard, &createArgs.NetworkDevices[devIdx])
 			if err != nil {
 				return err
 			}
-			resultsIdx++
+			devIdx++
 
 		} else {
 			// This ConfigSpec Ethernet device does not have a corresponding entry in the VM Spec, so we
@@ -2980,8 +2979,8 @@ func (vs *vSphereVMProvider) vmCreateGenConfigSpecZipNetworkInterfaces(
 
 	// Any remaining VM Spec network interfaces were not matched with a device in the ConfigSpec, so
 	// create a default virtual ethernet card for them.
-	for i := resultsIdx; i < len(createArgs.NetworkResults.Results); i++ {
-		ethCardDev, err := network.CreateDefaultEthCard(vmCtx, &createArgs.NetworkResults.Results[i])
+	for i := devIdx; i < len(createArgs.NetworkDevices); i++ {
+		ethCardDev, err := network.CreateDefaultEthCardFromNetworkDevice(vmCtx, &createArgs.NetworkDevices[i])
 		if err != nil {
 			return err
 		}

--- a/pkg/providers/vsphere/vmprovider_vm_network_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_network_test.go
@@ -306,22 +306,11 @@ func vmNetworkTests() {
 				It("should succeed", func() {
 					err := createOrUpdateVM(ctx, vmProvider, vm)
 					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
+					Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
 					Expect(conditions.IsFalse(vm, vmopv1.VirtualMachineConditionNetworkReady)).To(BeTrue())
 
 					By("simulate successful network provider reconcile", func() {
 						np.simulateInterfaceReconcile(ctx, vm, vm.Spec.Network.Interfaces[0], 0)
-					})
-
-					{
-						// TODO: We should create all the interface CRs up front.
-						err := createOrUpdateVM(ctx, vmProvider, vm)
-						Expect(err).To(HaveOccurred())
-						Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
-						Expect(conditions.IsFalse(vm, vmopv1.VirtualMachineConditionNetworkReady)).To(BeTrue())
-					}
-
-					By("simulate successful network provider reconcile", func() {
 						np.simulateInterfaceReconcile(ctx, vm, vm.Spec.Network.Interfaces[1], 1)
 					})
 
@@ -490,7 +479,7 @@ func vmNetworkTests() {
 					It("should succeed", func() {
 						err := createOrUpdateVM(ctx, vmProvider, vm)
 						Expect(err).To(HaveOccurred())
-						Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
+						Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
 						Expect(conditions.IsFalse(vm, vmopv1.VirtualMachineConditionNetworkReady)).To(BeTrue())
 
 						By("simulate successful network provider reconcile", func() {
@@ -537,8 +526,8 @@ func vmNetworkTests() {
 							vm.Spec.PowerState = vmopv1.VirtualMachinePowerStateOff
 							err = createOrUpdateVM(ctx, vmProvider, vm)
 							Expect(err).To(HaveOccurred())
-							Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
-							Expect(vcVM.PowerState(ctx)).To(Equal(vimtypes.VirtualMachinePowerStatePoweredOff))
+							Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
+							Expect(vcVM.PowerState(ctx)).To(Equal(vimtypes.VirtualMachinePowerStatePoweredOn))
 						})
 
 						By("simulate successful network provider reconcile on added interface", func() {
@@ -686,22 +675,11 @@ func vmNetworkTests() {
 					It("should succeed", func() {
 						err := createOrUpdateVM(ctx, vmProvider, vm)
 						Expect(err).To(HaveOccurred())
-						Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
+						Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
 						Expect(conditions.IsFalse(vm, vmopv1.VirtualMachineConditionNetworkReady)).To(BeTrue())
 
 						By("simulate successful network provider reconcile", func() {
 							np.simulateInterfaceReconcile(ctx, vm, vm.Spec.Network.Interfaces[0], 0)
-						})
-
-						{
-							// TODO: We should create all the interface CRs up front.
-							err := createOrUpdateVM(ctx, vmProvider, vm)
-							Expect(err).To(HaveOccurred())
-							Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
-							Expect(conditions.IsFalse(vm, vmopv1.VirtualMachineConditionNetworkReady)).To(BeTrue())
-						}
-
-						By("simulate successful network provider reconcile", func() {
 							np.simulateInterfaceReconcile(ctx, vm, vm.Spec.Network.Interfaces[1], 1)
 						})
 
@@ -749,8 +727,8 @@ func vmNetworkTests() {
 							vm.Spec.PowerState = vmopv1.VirtualMachinePowerStateOff
 							err = createOrUpdateVM(ctx, vmProvider, vm)
 							Expect(err).To(HaveOccurred())
-							Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
-							Expect(vcVM.PowerState(ctx)).To(Equal(vimtypes.VirtualMachinePowerStatePoweredOff))
+							Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
+							Expect(vcVM.PowerState(ctx)).To(Equal(vimtypes.VirtualMachinePowerStatePoweredOn))
 						})
 
 						By("simulate successful network provider reconcile on updated interface", func() {
@@ -826,7 +804,7 @@ func vmNetworkTests() {
 							vm.Spec.PowerState = vmopv1.VirtualMachinePowerStateOn
 							err = createOrUpdateVM(ctx, vmProvider, vm)
 							Expect(err).To(HaveOccurred())
-							Expect(err.Error()).To(ContainSubstring("network interface is not ready yet"))
+							Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
 							Expect(vcVM.PowerState(ctx)).To(Equal(vimtypes.VirtualMachinePowerStatePoweredOff))
 						})
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Replace blocking network interface polling with watch-based reconciliation and introduce NetworkDevice type for create flow optimizations.

This is the first in several in addressing the cruft that has built up around the network interfaces. Issues in the Update path will be next.

- Add CreateNetworkDevices function for VM create that creates all network interface CRs and checks readiness without polling, returning NetworkDevices containing just what is needed for the ethernet card device
- Add VM controller watches for NetworkInterface, VirtualNetworkInterface, and SubnetPort so the polling can be removed.
- Keep existing CreateAndWaitForNetworkInterfaces for update path that needs full NetworkInterfaceResult with bootstrap customization fields The interface CR create code is shared between the two function

The create flow now creates all interface CRs, immediately checks readiness, and returns either devices or an error. Controller watches ensure prompt re-reconciliation when CRs become ready, eliminating the 15-second polling timeout that blocked VM creation. This will speed up creation of VMs with network interfaces.

Parts of this change facilitate later work such as mixed network provider setups, and BYO network interface.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note
During VM create, do no poll each network interface CR. Instead, use a Watch() to reconcile the VM when the CR is updated.
```