### PR TITLE
🐛 Add host topology support for VM Affinity PreferredDuringScheduling

### DIFF
--- a/webhooks/virtualmachine/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator.go
@@ -3265,9 +3265,20 @@ func (v validator) validateVMAffinity(
 					}
 				}
 
-				if rs.TopologyKey != corev1.LabelTopologyZone {
-					allErrs = append(allErrs, field.NotSupported(
-						p.Child("topologyKey"), rs.TopologyKey, []string{corev1.LabelTopologyZone}))
+				if pkgcfg.FromContext(ctx).Features.VMAffinityDuringExecution {
+					// When VMAffinityDuringExecution capability is enabled,
+					// either zone or host topology key is allowed for affinity required terms.
+					if rs.TopologyKey != corev1.LabelTopologyZone && rs.TopologyKey != corev1.LabelHostname {
+						allErrs = append(allErrs, field.NotSupported(
+							p.Child("topologyKey"), rs.TopologyKey, []string{corev1.LabelTopologyZone, corev1.LabelHostname}))
+					}
+				} else {
+					// Without VMAffinityDuringExecution capability enabled,
+					// only zone topology key is allowed for affinity required terms.
+					if rs.TopologyKey != corev1.LabelTopologyZone {
+						allErrs = append(allErrs, field.NotSupported(
+							p.Child("topologyKey"), rs.TopologyKey, []string{corev1.LabelTopologyZone}))
+					}
 				}
 			}
 		}

--- a/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
@@ -4172,6 +4172,43 @@ func unitTestsValidateCreate() {
 				},
 			),
 
+			Entry("allow VM Affinity PreferredDuringSchedulingPreferredDuringExecution with Host topology key when VMAffinityDuringExecution is enabled",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+							config.Features.VMAffinityDuringExecution = true
+						})
+						ctx.vm.Spec.Affinity.VMAffinity = &vmopv1.VMAffinitySpec{
+							PreferredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+								{
+									TopologyKey: corev1.LabelHostname,
+								},
+							},
+						}
+					},
+					expectAllowed: true,
+				},
+			),
+
+			Entry("disallow VM Affinity PreferredDuringSchedulingPreferredDuringExecution with unsupported topology key even with VMAffinityDuringExecution enabled",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+							config.Features.VMAffinityDuringExecution = true
+						})
+						ctx.vm.Spec.Affinity.VMAffinity = &vmopv1.VMAffinitySpec{
+							PreferredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+								{
+									TopologyKey: "unsupported-key",
+								},
+							},
+						}
+					},
+					validate: doValidateWithMsg(
+						`spec.affinity.vmAffinity.preferredDuringSchedulingPreferredDuringExecution[0].topologyKey: Unsupported value: "unsupported-key": supported values: "topology.kubernetes.io/zone", "kubernetes.io/hostname"`),
+				},
+			),
+
 			Entry("disallow VM Affinity PreferredDuringSchedulingPreferredDuringExecution with empty topology key",
 				testParams{
 					setup: func(ctx *unitValidatingWebhookContext) {
@@ -4461,6 +4498,25 @@ func unitTestsValidateCreate() {
 					},
 					validate: doValidateWithMsg(
 						`spec.affinity.vmAntiAffinity.preferredDuringSchedulingPreferredDuringExecution[0].labelSelector.matchExpressions[0].key: Forbidden: label selector can not contain VM Operator managed labels (vmoperator.vmware.com)`),
+				},
+			),
+
+			Entry("disallow VM Anti Affinity PreferredDuringSchedulingPreferredDuringExecution with unsupported topology key when VMAffinityDuringExecution is enabled",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+							config.Features.VMAffinityDuringExecution = true
+						})
+						ctx.vm.Spec.Affinity.VMAntiAffinity = &vmopv1.VMAntiAffinitySpec{
+							PreferredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+								{
+									TopologyKey: "unsupported-key",
+								},
+							},
+						}
+					},
+					validate: doValidateWithMsg(
+						`spec.affinity.vmAntiAffinity.preferredDuringSchedulingPreferredDuringExecution[0].topologyKey: Unsupported value: "unsupported-key": supported values: "topology.kubernetes.io/zone", "kubernetes.io/hostname"`),
 				},
 			),
 		)


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

When VMAffinityDuringExecution feature flag is enabled:
- Allow both zone and host topology keys for preferred scheduling
- Maintain backward compatibility when feature flag is disabled (zone only)
- Apply consistent host topology support across Required and Preferred scheduling

Test coverage added:
- VM Affinity PreferredDuringScheduling with host topology key acceptance
- VM Affinity PreferredDuringScheduling with unsupported topology key rejection
- VM Anti-Affinity PreferredDuringScheduling with unsupported topology key rejection

This enables users to specify kubernetes.io/hostname topology keys for VM affinity preferred scheduling when the VMAffinityDuringExecution capability is enabled.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note

```