### PR TITLE
:book: Fix YAML formatting in guest.md

### DIFF
--- a/docs/concepts/workloads/guest.md
+++ b/docs/concepts/workloads/guest.md
@@ -35,7 +35,7 @@ The `VirtualMachine` API directly supports specifying a Cloud-Init [cloud config
 
 === "VirtualMachine"
 
-    ``` yaml
+    ```yaml
     apiVersion: vmoperator.vmware.com/v1alpha6
     kind: VirtualMachine
     metadata:
@@ -76,7 +76,7 @@ The `VirtualMachine` API directly supports specifying a Cloud-Init [cloud config
 
 === "Secret"
 
-    ``` yaml
+    ```yaml
     apiVersion: v1
     kind: Secret
     metadata:


### PR DESCRIPTION
Correct YAML code block formatting in guest.md.

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

This PR fixes bad indentation for the yaml field.
As a result in the markdown it does not render properly.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

No issue raised


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
fix bad indentation for the yaml field
```

<!-- readthedocs-preview vm-operator start -->
----
📚 Documentation preview 📚: https://vm-operator--1578.org.readthedocs.build/en/1578/

<!-- readthedocs-preview vm-operator end -->