### PR TITLE
🌱 Test: e2e for VM-VM affinity/antiaffinity placement policies at host topology

### DIFF
--- a/test/e2e/fixtures/yaml/vmoperator/virtualmachines/v1a5singlevm.yaml.in
+++ b/test/e2e/fixtures/yaml/vmoperator/virtualmachines/v1a5singlevm.yaml.in
@@ -134,12 +134,68 @@ spec:
           topologyKey: {{.TopologyKey}}
         {{- end}}
       {{- end}}
+      {{- if .Affinity.VMAffinity.PreferredDuringSchedulingPreferredDuringExecution}}
+      preferredDuringSchedulingPreferredDuringExecution:
+        {{- range .Affinity.VMAffinity.PreferredDuringSchedulingPreferredDuringExecution}}
+        {{- if .LabelSelector}}
+        - labelSelector:
+          {{- if .LabelSelector.MatchLabels}}
+            matchLabels:
+              {{- range $key, $value := .LabelSelector.MatchLabels}}
+              {{$key}}: "{{$value}}"
+              {{- end}}
+          {{- end}}
+          {{- if .LabelSelector.MatchExpressions}}
+            matchExpressions:
+              {{- range .LabelSelector.MatchExpressions}}
+              - key: {{.Key}}
+                operator: {{.Operator}}
+                {{- if .Values}}
+                values:
+                  {{- range .Values}}
+                  - "{{.}}"
+                  {{- end}}
+                {{- end}}
+              {{- end}}
+          {{- end}}
+          {{- end}}
+          topologyKey: {{.TopologyKey}}
+        {{- end}}
+      {{- end}}
     {{- end}}
     {{- if .Affinity.VMAntiAffinity}}
     vmAntiAffinity:
       {{- if .Affinity.VMAntiAffinity.RequiredDuringSchedulingPreferredDuringExecution}}
       requiredDuringSchedulingPreferredDuringExecution:
         {{- range .Affinity.VMAntiAffinity.RequiredDuringSchedulingPreferredDuringExecution}}
+        {{- if .LabelSelector}}
+        - labelSelector:
+          {{- if .LabelSelector.MatchLabels}}
+            matchLabels:
+              {{- range $key, $value := .LabelSelector.MatchLabels}}
+              {{$key}}: "{{$value}}"
+              {{- end}}
+          {{- end}}
+          {{- if .LabelSelector.MatchExpressions}}
+            matchExpressions:
+              {{- range .LabelSelector.MatchExpressions}}
+              - key: {{.Key}}
+                operator: {{.Operator}}
+                {{- if .Values}}
+                values:
+                  {{- range .Values}}
+                  - "{{.}}"
+                  {{- end}}
+                {{- end}}
+              {{- end}}
+          {{- end}}
+          {{- end}}
+          topologyKey: {{.TopologyKey}}
+        {{- end}}
+      {{- end}}
+      {{- if .Affinity.VMAntiAffinity.PreferredDuringSchedulingPreferredDuringExecution}}
+      preferredDuringSchedulingPreferredDuringExecution:
+        {{- range .Affinity.VMAntiAffinity.PreferredDuringSchedulingPreferredDuringExecution}}
         {{- if .LabelSelector}}
         - labelSelector:
           {{- if .LabelSelector.MatchLabels}}

--- a/test/e2e/infrastructure/vsphere/cluster.go
+++ b/test/e2e/infrastructure/vsphere/cluster.go
@@ -1,0 +1,38 @@
+package vsphere
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/mo"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+)
+
+// GetHostsForCluster queries a specific vSphere cluster for its host membership.
+func GetHostsForCluster(ctx context.Context, client *vim25.Client, clusterMoID string) ([]string, error) {
+	// Create cluster object reference
+	cluster := object.NewClusterComputeResource(
+		client,
+		vimtypes.ManagedObjectReference{
+			Type:  string(vimtypes.ManagedObjectTypeClusterComputeResource),
+			Value: clusterMoID,
+		},
+	)
+
+	// Query cluster properties to get host references
+	var cr mo.ComputeResource
+	err := cluster.Properties(ctx, cluster.Reference(), []string{"host"}, &cr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cluster properties: %w", err)
+	}
+
+	// Extract host IDs from the references
+	hostIDs := make([]string, len(cr.Host))
+	for i, hostRef := range cr.Host {
+		hostIDs[i] = hostRef.Value
+	}
+
+	return hostIDs, nil
+}

--- a/test/e2e/infrastructure/vsphere/wcp/api.go
+++ b/test/e2e/infrastructure/vsphere/wcp/api.go
@@ -231,6 +231,8 @@ type WorkloadManagementAPI interface {
 	CreateComputePolicy(spec ComputePolicySpec) (string, error)
 	CreateInfraPolicy(spec InfraPolicySpec) error
 	UpdateNamespaceWithInfraPolicies(namespace string, policyNames ...string) error
+	ListComputePolicyTagUsage(categoryName, tagName string) ([]TagUsageEntry, error)
+	GetVMPolicyCompliance(policyID, vmMoid string) (VMPolicyComplianceStatus, error)
 
 	// NSX APIs
 	GetSupervisorLoadBalancerProvider(supervisorID string) (string, error)

--- a/test/e2e/infrastructure/vsphere/wcp/dcli_client.go
+++ b/test/e2e/infrastructure/vsphere/wcp/dcli_client.go
@@ -44,7 +44,11 @@ const (
 	namespaceManagementSupervisors     = namespaceManagement + " supervisors"
 	namespaceMgmtSupervisorsSvServices = namespaceManagementSupervisors + " supervisorservices +show-unreleased"
 	namespaceManagementVMClassServices = namespaceManagement + "virtualmachineclasses +show-unreleased"
+	computePoliciesPrefix              = " compute policies"
+	computePolicies                    = dcliVCenterPrefix + computePoliciesPrefix
+	computePolicyTagUsages             = computePolicies + " tagusage list "
 	virtualmachine                     = dcliVCenterPrefix + "vm"
+	virtualmachineComputePolicy        = virtualmachine + computePoliciesPrefix + " get "
 	consumptiondomainsPrefix           = "consumptiondomains "
 	zones                              = dcliVCenterPrefix + consumptiondomainsPrefix + "zones"
 	cryptoManager                      = dcliVCenterPrefix + "cryptomanager"
@@ -2221,4 +2225,51 @@ func (d *wcpDcliClient) ListHostIDs() ([]string, error) {
 	}
 
 	return hostIDs, nil
+}
+
+// ListComputePolicyTagUsage lists compute policy tag usage entries filtered by category name and tag name.
+func (d *wcpDcliClient) ListComputePolicyTagUsage(categoryName, tagName string) ([]TagUsageEntry, error) {
+	cmd := fmt.Sprintf("%s %s", computePolicyTagUsages, jsonFormatter)
+
+	resp, err := d.dcliClient.RunDCLICommand(cmd)
+	if err != nil {
+		return nil, DcliError{
+			rawResponse: string(resp),
+			baseErr:     err,
+		}
+	}
+
+	var all []TagUsageEntry
+	if err = json.Unmarshal(resp, &all); err != nil {
+		return nil, err
+	}
+
+	var filtered []TagUsageEntry
+	for _, e := range all {
+		if e.CategoryName == categoryName && e.TagName == tagName {
+			filtered = append(filtered, e)
+		}
+	}
+
+	return filtered, nil
+}
+
+// GetVMPolicyCompliance returns the compliance status of a VM against a compute policy.
+func (d *wcpDcliClient) GetVMPolicyCompliance(policyID, vmMoid string) (VMPolicyComplianceStatus, error) {
+	cmd := fmt.Sprintf("%s --policy %s --vm %s %s", virtualmachineComputePolicy, policyID, vmMoid, jsonFormatter)
+
+	resp, err := d.dcliClient.RunDCLICommand(cmd)
+	if err != nil {
+		return VMPolicyComplianceStatus{}, DcliError{
+			rawResponse: string(resp),
+			baseErr:     err,
+		}
+	}
+
+	var status VMPolicyComplianceStatus
+	if err = json.Unmarshal(resp, &status); err != nil {
+		return VMPolicyComplianceStatus{}, err
+	}
+
+	return status, nil
 }

--- a/test/e2e/infrastructure/vsphere/wcp/iaas_policies.go
+++ b/test/e2e/infrastructure/vsphere/wcp/iaas_policies.go
@@ -33,3 +33,20 @@ type InfraPolicySpec struct {
 	MatchWorkloadLabel map[string]string
 	EnforcementMode    InfraPolicyEnforcementMode
 }
+
+// TagUsageEntry is a single entry from the compute policies tag-usage list.
+type TagUsageEntry struct {
+	Capability        string `json:"capability"`
+	CategoryName      string `json:"category_name"`
+	TagType           string `json:"tag_type"`
+	TagName           string `json:"tag_name"`
+	PolicyDescription string `json:"policy_description"`
+	PolicyName        string `json:"policy_name"`
+	Tag               string `json:"tag"`
+	Policy            string `json:"policy"`
+}
+
+// VMPolicyComplianceStatus is the compliance result for a VM against a compute policy.
+type VMPolicyComplianceStatus struct {
+	Status string `json:"status"`
+}

--- a/test/e2e/utils/tanzu_topology.go
+++ b/test/e2e/utils/tanzu_topology.go
@@ -5,11 +5,21 @@ package utils
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/vmware/govmomi/vim25"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	topologyv1 "github.com/vmware-tanzu/vm-operator/external/tanzu-topology/api/v1alpha1"
+	"github.com/vmware-tanzu/vm-operator/test/e2e/infrastructure/vsphere"
+	"github.com/vmware-tanzu/vm-operator/test/e2e/infrastructure/vsphere/vcenter"
 )
+
+// ZoneHostInfo contains host information for a specific zone.
+type ZoneHostInfo struct {
+	ZoneName string
+	HostIDs  []string
+}
 
 func ListAvailabilityZones(ctx context.Context, client ctrlclient.Client) (*topologyv1.AvailabilityZoneList, error) {
 	availabilityZoneList := &topologyv1.AvailabilityZoneList{}
@@ -33,4 +43,64 @@ func ListZonesByNamespace(ctx context.Context, client ctrlclient.Client, ns stri
 	}
 
 	return zoneList, nil
+}
+
+// GetHostsPerZone returns accurate mapping of zone names to their associated host IDs.
+func GetHostsPerZone(ctx context.Context, k8sClient ctrlclient.Client, kubeconfigPath string) ([]ZoneHostInfo, error) {
+	// Get all availability zones (cluster-scoped)
+	availabilityZones, err := ListAvailabilityZones(ctx, k8sClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list availability zones: %w", err)
+	}
+
+	// Create vSphere client
+	vimClient := vcenter.NewVimClientFromKubeconfigFile(ctx, kubeconfigPath)
+	if vimClient == nil {
+		return nil, fmt.Errorf("failed to create vSphere client")
+	}
+	defer vcenter.LogoutVimClient(vimClient)
+
+	var zoneHostInfos []ZoneHostInfo
+
+	// For each availability zone, query its cluster(s) for hosts
+	for _, az := range availabilityZones.Items {
+		hostIDs, err := getHostsForAvailabilityZone(ctx, vimClient, &az)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get hosts for zone %s: %w", az.Name, err)
+		}
+
+		zoneInfo := ZoneHostInfo{
+			ZoneName: az.Name,
+			HostIDs:  hostIDs,
+		}
+		zoneHostInfos = append(zoneHostInfos, zoneInfo)
+	}
+
+	return zoneHostInfos, nil
+}
+
+// getHostsForAvailabilityZone queries vSphere to get all hosts in the clusters associated with an availability zone.
+func getHostsForAvailabilityZone(ctx context.Context, client *vim25.Client, az *topologyv1.AvailabilityZone) ([]string, error) {
+	var allHostIDs []string
+
+	// Handle both single and multiple cluster MoIDs
+	clusterMoIDs := az.Spec.ClusterComputeResourceMoIDs
+	if len(clusterMoIDs) == 0 && az.Spec.ClusterComputeResourceMoId != "" {
+		clusterMoIDs = []string{az.Spec.ClusterComputeResourceMoId}
+	}
+
+	if len(clusterMoIDs) == 0 {
+		return nil, fmt.Errorf("no cluster compute resource MoIDs found for availability zone %s", az.Name)
+	}
+
+	// Query each cluster for its hosts
+	for _, clusterMoID := range clusterMoIDs {
+		hostIDs, err := vsphere.GetHostsForCluster(ctx, client, clusterMoID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get hosts for cluster %s: %w", clusterMoID, err)
+		}
+		allHostIDs = append(allHostIDs, hostIDs...)
+	}
+
+	return allHostIDs, nil
 }

--- a/test/e2e/vmservice/config/kind.yaml
+++ b/test/e2e/vmservice/config/kind.yaml
@@ -46,6 +46,7 @@ intervals:
   default/wait-virtual-machine-vmip: ["5m", "10s"]
   default/wait-virtual-machine-image-creation: ["20s", "2s"]
   default/consistent-virtual-machine-condition: ["30s", "5s"]
+  default/wait-virtual-machine-compute-policy-status-update: ["5m", "10s"]
 
   default/wait-config-map-creation: ["2m", "5s"]
   default/wait-secret-creation: ["2m", "5s"]

--- a/test/e2e/vmservice/config/wcp.yaml
+++ b/test/e2e/vmservice/config/wcp.yaml
@@ -101,6 +101,7 @@ intervals:
   default/wait-storage-class-ready: ["5m", "15s"]
   default/wait-namespace-ready: ["5m", "10s"]
   default/wait-backup-to-complete: ["10m", "5s"]
+  default/wait-virtual-machine-compute-policy-status-update: ["5m", "10s"]
 
   default/wait-config-map-creation: ["3m", "10s"]
   default/wait-secret-creation: ["3m", "10s"]

--- a/test/e2e/vmservice/consts/consts.go
+++ b/test/e2e/vmservice/consts/consts.go
@@ -28,11 +28,12 @@ const (
 
 	JumpboxPodVMName = "jumpbox"
 
-	VMGroupsCapabilityName                = "supports_VM_service_VM_groups"
-	VirtualMachineSnapshotCapabilityName  = "supports_VM_service_VM_snapshots"
-	VMPlacementPoliciesCapabilityName     = "supports_VM_service_VM_placement_policies"
-	InventoryContentLibraryCapabilityName = "supports_inventory_content_library"
-	SharedDisksCapabilityName             = "supports_shared_disks_with_VM_service_VMs"
-	AllDisksArePVCapabilityName           = "supports_vm_service_all_disks_are_pvcs"
-	IaaSComputePoliciesCapabilityName     = "supports_iaas_compute_policies"
+	VMGroupsCapabilityName                  = "supports_VM_service_VM_groups"
+	VirtualMachineSnapshotCapabilityName    = "supports_VM_service_VM_snapshots"
+	VMPlacementPoliciesCapabilityName       = "supports_VM_service_VM_placement_policies"
+	VMAffinityDuringExecutionCapabilityName = "supports_VM_service_VM_affinity_during_execution"
+	InventoryContentLibraryCapabilityName   = "supports_inventory_content_library"
+	SharedDisksCapabilityName               = "supports_shared_disks_with_VM_service_VMs"
+	AllDisksArePVCapabilityName             = "supports_vm_service_all_disks_are_pvcs"
+	IaaSComputePoliciesCapabilityName       = "supports_iaas_compute_policies"
 )

--- a/test/e2e/vmservice/skipper/skipper.go
+++ b/test/e2e/vmservice/skipper/skipper.go
@@ -109,3 +109,19 @@ func SkipUnlessSnapshotFSSEnabled(ctx context.Context, vmSvcClusterProxy *common
 		framework.SkipInternalf(1, "skip the test due to %s is disabled.", utils.SupervisorVMSnapshotFSS)
 	}
 }
+
+func SkipUnlessSupervisorHasAtleastOneZoneWithHostCount(ctx context.Context, vmSvcClusterProxy *common.VMServiceClusterProxy, minHostCount int) {
+	zoneHostInfos, err := utils.GetHostsPerZone(ctx, vmSvcClusterProxy.GetClient(), vmSvcClusterProxy.GetKubeconfigPath())
+	Expect(err).NotTo(HaveOccurred(), "failed to list zones with hosts")
+
+	minHostsRequirementSatisfied := false
+	for _, zoneHostInfo := range zoneHostInfos {
+		if len(zoneHostInfo.HostIDs) >= minHostCount {
+			minHostsRequirementSatisfied = true
+			break
+		}
+	}
+	if !minHostsRequirementSatisfied {
+		framework.SkipInternalf(1, "skip the test as minimum host for zone should atleast be %d", minHostCount)
+	}
+}

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_group.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_group.go
@@ -706,7 +706,6 @@ func VMGroupSpec(ctx context.Context, inputGetter func() VMGroupSpecInput) {
 		AfterEach(func() {
 			if tmpNamespaceName != "" {
 				clusterProxy.DeleteWCPNamespace(tmpNamespaceCtx)
-
 				tmpNamespaceName = ""
 			}
 		})
@@ -940,6 +939,418 @@ func VMGroupSpec(ctx context.Context, inputGetter func() VMGroupSpecInput) {
 				vmservice.VerifyVMTagsAndPolicyAssignment(ctx, config, svClusterClient, tagManager, tmpNamespaceName, vm3Name, policyNameToTagID, policyNames[2:3])
 				// VM4 with tier=1 label should have the 1st mandatory policy applied.
 				vmservice.VerifyVMTagsAndPolicyAssignment(ctx, config, svClusterClient, tagManager, tmpNamespaceName, vm4Name, policyNameToTagID, policyNames[:1])
+			})
+
+		})
+	})
+
+	Context("Group placement with affinity and anti-affinity at host topology", func() {
+		const (
+			requiredDuringSchedulingPreferredDuringExecution  = "requiredDuringSchedulingPreferredDuringExecution"
+			preferredDuringSchedulingPreferredDuringExecution = "preferredDuringSchedulingPreferredDuringExecution"
+		)
+
+		var (
+			tmpNamespaceName string
+			tmpNamespaceCtx  wcpframework.NamespaceContext
+		)
+
+		// getVMHostFromVmodlFunc retrieves the host moref value from vSphere directly.
+		// Use this before power-on, when vm.Status.Host is not yet populated.
+		getVMHostFromVmodlFunc := func(vmName string) string {
+			GinkgoHelper()
+
+			moid := vmoperator.GetVirtualMachineMOID(ctx, svClusterClient, tmpNamespaceName, vmName)
+			vmMoRef := types.ManagedObjectReference{Type: "VirtualMachine", Value: moid}
+
+			propCollector := property.DefaultCollector(vCenterClient)
+			var vmMO mo.VirtualMachine
+			Expect(propCollector.RetrieveOne(ctx, vmMoRef, []string{"runtime.host"}, &vmMO)).To(Succeed())
+			Expect(vmMO.Runtime.Host).ToNot(BeNil())
+
+			return vmMO.Runtime.Host.Value
+		}
+
+		// getVMHostFunc retrieves the host from vm.Status.Host.
+		// Use this after power-on, once the operator has updated the status.
+		getVMHostFunc := func(vmName string) string {
+			GinkgoHelper()
+
+			var host string
+			Eventually(func(g Gomega) {
+				vm, err := utils.GetVirtualMachine(ctx, svClusterClient, tmpNamespaceName, vmName)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(vm.Status.Host).ToNot(BeEmpty())
+				host = vm.Status.Host
+			}, config.GetIntervals("default", "wait-virtual-machine-creation")...).Should(Succeed())
+
+			return host
+		}
+
+		powerOnVMFunc := func(vmName string) {
+			GinkgoHelper()
+
+			vm, err := utils.GetVirtualMachineA5(ctx, svClusterClient, tmpNamespaceName, vmName)
+			Expect(err).ToNot(HaveOccurred(), "failed to get VirtualMachine %s", vmName)
+			vmPatch := vm.DeepCopy()
+			vmPatch.Spec.PowerState = vmopv1a5.VirtualMachinePowerStateOn
+			Expect(svClusterClient.Patch(ctx, vmPatch, ctrlclient.MergeFrom(vm))).
+				To(Succeed(), "failed to patch powerState for vm %s", vmName)
+		}
+
+		createHostVMWithAffinityAndAntiAffinityFunc := func(vmName, affinityType, label string, affinityTiers, antiAffinityTiers []string) {
+			GinkgoHelper()
+
+			labels := make(map[string]string)
+			labels["tier"] = label
+
+			var affinityLabelSelector *vmopv1a5.VMAffinitySpec
+			if len(affinityTiers) > 0 {
+				terms := []vmopv1a5.VMAffinityTerm{
+					{
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "tier",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   affinityTiers,
+								},
+							},
+						},
+						TopologyKey: "kubernetes.io/hostname",
+					},
+				}
+				if affinityType == requiredDuringSchedulingPreferredDuringExecution {
+					affinityLabelSelector = &vmopv1a5.VMAffinitySpec{
+						RequiredDuringSchedulingPreferredDuringExecution: terms,
+					}
+				} else if affinityType == preferredDuringSchedulingPreferredDuringExecution {
+					affinityLabelSelector = &vmopv1a5.VMAffinitySpec{
+						PreferredDuringSchedulingPreferredDuringExecution: terms,
+					}
+				}
+			}
+
+			var antiAffinityLabelSelector *vmopv1a5.VMAntiAffinitySpec
+			if len(antiAffinityTiers) > 0 {
+				terms := []vmopv1a5.VMAffinityTerm{
+					{
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "tier",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   antiAffinityTiers,
+								},
+							},
+						},
+						TopologyKey: "kubernetes.io/hostname",
+					},
+				}
+				if affinityType == requiredDuringSchedulingPreferredDuringExecution {
+					antiAffinityLabelSelector = &vmopv1a5.VMAntiAffinitySpec{
+						RequiredDuringSchedulingPreferredDuringExecution: terms,
+					}
+				} else if affinityType == preferredDuringSchedulingPreferredDuringExecution {
+					antiAffinityLabelSelector = &vmopv1a5.VMAntiAffinitySpec{
+						PreferredDuringSchedulingPreferredDuringExecution: terms,
+					}
+				}
+			}
+
+			vmParameters := manifestbuilders.VirtualMachineYaml{
+				Namespace:        tmpNamespaceName,
+				Name:             vmName,
+				GroupName:        vmgRootName,
+				Labels:           labels,
+				ImageName:        linuxImageDisplayName,
+				VMClassName:      clusterResources.VMClassName,
+				StorageClassName: clusterResources.StorageClassName,
+				PowerState:       string(vmopv1a5.VirtualMachinePowerStateOff),
+				Affinity: &vmopv1a5.AffinitySpec{
+					VMAffinity:     affinityLabelSelector,
+					VMAntiAffinity: antiAffinityLabelSelector,
+				},
+			}
+			vmYAML := manifestbuilders.GetVirtualMachineYamlA5(vmParameters)
+			e2eframework.Logf("VM YAML:\n%s", string(vmYAML))
+			Expect(clusterProxy.ApplyWithArgs(ctx, vmYAML)).To(Succeed(), "failed to create vm %s:\n %s", vmName, string(vmYAML))
+		}
+
+		verifyAffinity := func(vmHosts map[string]string, affinedVms []string) {
+			GinkgoHelper()
+
+			if len(affinedVms) <= 1 {
+				return
+			}
+
+			vm1Host, ok := vmHosts[affinedVms[0]]
+			Expect(ok).To(BeTrue())
+			Expect(vm1Host).ToNot(BeEmpty())
+
+			for i := 1; i < len(affinedVms); i++ {
+				vmNHost, ok := vmHosts[affinedVms[i]]
+				Expect(ok).To(BeTrue())
+				Expect(vmNHost).To(Equal(vm1Host))
+			}
+		}
+
+		// all hosts of Vms must be different from each other.
+		verifyAntiAffinity := func(vmHosts map[string]string, antiAffinedVms []string) {
+			GinkgoHelper()
+
+			if len(antiAffinedVms) <= 1 {
+				return
+			}
+
+			seen := make(map[string]string, len(antiAffinedVms))
+			for _, vmName := range antiAffinedVms {
+				host, ok := vmHosts[vmName]
+				Expect(ok).To(BeTrue())
+				Expect(host).ToNot(BeEmpty())
+				Expect(seen).ToNot(HaveKey(host), "VMs %s and %s are both on host %s, but anti-affinity requires them to be on different hosts", seen[host], vmName, host)
+				seen[host] = vmName
+			}
+		}
+
+		runVmVmAffinityAtHostTopoTest := func(affinityType string, affinedVms, antiAffinedVms []string) {
+			GinkgoHelper()
+
+			vmgParameters := manifestbuilders.VirtualMachineGroupYaml{
+				Namespace: tmpNamespaceName,
+				Name:      vmgRootName,
+				BootOrder: []manifestbuilders.BootOrder{
+					{
+						Members: []vmopv1a5.GroupMember{},
+					},
+				},
+			}
+			for _, v := range vmMemberNames {
+				vmgParameters.BootOrder[0].Members = append(vmgParameters.BootOrder[0].Members,
+					vmopv1a5.GroupMember{Kind: vmKind, Name: v})
+			}
+
+			vmgRootYaml = manifestbuilders.GetVirtualMachineGroupWithBootOrderYaml(vmgParameters)
+			e2eframework.Logf("VirtualMachineGroup YAML:\n%s", string(vmgRootYaml))
+			Expect(clusterProxy.CreateWithArgs(ctx, vmgRootYaml)).To(Succeed())
+
+			affinedSet := make(map[string]bool, len(affinedVms))
+			for _, v := range affinedVms {
+				affinedSet[v] = true
+			}
+			antiAffinedSet := make(map[string]bool, len(antiAffinedVms))
+			for _, v := range antiAffinedVms {
+				antiAffinedSet[v] = true
+			}
+
+			for _, v := range vmMemberNames {
+				labelTier := "1"
+				if antiAffinedSet[v] {
+					labelTier = "2"
+				}
+
+				var affinityTiers, antiAffinityTiers []string
+				if affinedSet[v] {
+					affinityTiers = []string{"1"}
+				}
+				if antiAffinedSet[v] {
+					antiAffinityTiers = []string{"2"}
+				}
+				createHostVMWithAffinityAndAntiAffinityFunc(v, affinityType, labelTier, affinityTiers, antiAffinityTiers)
+			}
+
+			By("Waiting for all VMs to be created in vSphere (powered off)")
+
+			for _, vmName := range vmMemberNames {
+				vmoperator.WaitForVirtualMachineConditionCreated(ctx, config, svClusterClient, tmpNamespaceName, vmName)
+			}
+
+			By("Verifying host placement before power-on via vSphere vmodl as vm.status.host may not be populated yet.")
+			vmHosts := make(map[string]string)
+			for _, v := range vmMemberNames {
+				vmHosts[v] = getVMHostFromVmodlFunc(v)
+			}
+
+			// Check placement enforcement for requiredDuringScheduling
+			// This is skipped for preferredDuringScheduling as that is non-deterministic.
+			if affinityType == requiredDuringSchedulingPreferredDuringExecution {
+				By("Verifying all VMs are placed on different hosts before poweron, i.e. placement is as expected")
+				verifyAffinity(vmHosts, affinedVms)
+				verifyAntiAffinity(vmHosts, antiAffinedVms)
+			}
+
+			By("Powering on all VMs")
+			for _, vmName := range vmMemberNames {
+				powerOnVMFunc(vmName)
+			}
+			for _, vmName := range vmMemberNames {
+				vmoperator.WaitForVirtualMachinePowerState(ctx, config, svClusterClient, tmpNamespaceName, vmName, "PoweredOn")
+			}
+
+			By("Verifying vm.Status.Host is populated for all VMs after power-on")
+			for _, vmName := range vmMemberNames {
+				Expect(getVMHostFunc(vmName)).ToNot(BeEmpty())
+			}
+
+			By("Verifying each VM is configured with the policy with the correct tags.")
+
+			// Build the set of tier labels that are actually in use so we can look up
+			// each policy ID once and then check each VM against its own policy.
+			tierLabels := make(map[string]string) // tier label -> policy ID
+			if len(affinedVms) > 0 {
+				tierLabels["tier:1"] = ""
+			}
+			if len(antiAffinedVms) > 0 {
+				tierLabels["tier:2"] = ""
+			}
+
+			for tagLabel := range tierLabels {
+				Eventually(func(g Gomega) {
+					entries, err := input.WCPClient.ListComputePolicyTagUsage(tmpNamespaceName, tagLabel)
+					g.Expect(err).ToNot(HaveOccurred())
+					g.Expect(entries).ToNot(BeEmpty())
+					g.Expect(entries[0].Policy).ToNot(BeEmpty())
+					tierLabels[tagLabel] = entries[0].Policy
+				}, config.GetIntervals("default", "wait-virtual-machine-compute-policy-status-update")...).Should(Succeed(),
+					"timed out waiting for compute policy tag usage entry for tag %s in namespace %s", tagLabel, tmpNamespaceName)
+			}
+
+			// vmPolicyID maps each VM to the policy ID it should be checked against.
+			vmPolicyID := make(map[string]string, len(vmMemberNames))
+			for _, vmName := range affinedVms {
+				vmPolicyID[vmName] = tierLabels["tier:1"]
+			}
+			for _, vmName := range antiAffinedVms {
+				vmPolicyID[vmName] = tierLabels["tier:2"]
+			}
+
+			for _, vmName := range vmMemberNames {
+				policyID := vmPolicyID[vmName]
+				Eventually(func(g Gomega) string {
+					vm, err := utils.GetVirtualMachine(ctx, svClusterClient, tmpNamespaceName, vmName)
+					g.Expect(err).ToNot(HaveOccurred())
+					g.Expect(vm.Status.UniqueID).ToNot(BeEmpty())
+
+					status, err := input.WCPClient.GetVMPolicyCompliance(policyID, vm.Status.UniqueID)
+					g.Expect(err).ToNot(HaveOccurred())
+
+					return status.Status
+				}, config.GetIntervals("default", "wait-virtual-machine-compute-policy-status-update")...).
+					Should(Or(Equal("COMPLIANT"), Equal("NOT_COMPLIANT")), "expected VM %s to have a compliance status for policy %s", vmName, policyID)
+			}
+		}
+
+		BeforeEach(func() {
+			skipper.SkipUnlessStretchSupervisorIsEnabled()
+			skipper.SkipUnlessSupervisorCapabilityEnabled(ctx, clusterProxy, consts.VMPlacementPoliciesCapabilityName)
+			skipper.SkipUnlessSupervisorCapabilityEnabled(ctx, clusterProxy, consts.VMAffinityDuringExecutionCapabilityName)
+			skipper.SkipUnlessSupervisorHasAtleastOneZoneWithHostCount(ctx, clusterProxy, 3)
+
+			supervisorID := vcenter.GetSupervisorIDFromKubeconfig(ctx, config.InfraConfig.KubeconfigPath)
+			Expect(supervisorID).ToNot(BeEmpty(), "Supervisor ID should not be empty")
+			zoneList, err := clusterProxy.GetZonesBoundWithSupervisor(supervisorID)
+			Expect(err).ToNot(HaveOccurred(), "failed to get zones bound with Supervisor")
+
+			By("Creating a temporary namespace")
+
+			vmserviceCLID := vmservice.GetContentLibraryUUIDByName(consts.VMServiceCLName, input.WCPClient)
+			clIDs := []string{vmserviceCLID}
+			vmClassNames := []string{clusterResources.VMClassName}
+			vmsvcSpecs := wcp.NewVMServiceSpecDetails(vmClassNames, clIDs)
+			tmpNamespaceCtx, err = clusterProxy.CreateWCPNamespace(ctx, config, vmsvcSpecs, clusterResources.StorageClassName, clusterResources.WorkerStorageClassName, fmt.Sprintf("%s-%s", specName, capiutil.RandomString(6)), input.ArtifactFolder)
+			Expect(err).ToNot(HaveOccurred(), "failed to create wcp namespace")
+			Expect(tmpNamespaceCtx.GetNamespace()).ToNot(BeNil(), "namespace should not be nil")
+			tmpNamespaceName = tmpNamespaceCtx.GetNamespace().Name
+			wcp.WaitForNamespaceReady(input.WCPClient, tmpNamespaceName)
+
+			By("Ensuring the Linux image is available in the temp namespace")
+
+			_, err = vmoperator.WaitForVirtualMachineImageName(ctx, &config.Config, svClusterClient, tmpNamespaceName, linuxImageDisplayName)
+			Expect(err).NotTo(HaveOccurred(), "failed to get VMI by display name %q in namespace %q", linuxImageDisplayName, tmpNamespaceName)
+
+			By("Binding all zones to the temporary namespace")
+
+			namespaceZones, err := utils.ListZonesByNamespace(ctx, input.ClusterProxy.GetClient(), tmpNamespaceName)
+			Expect(err).NotTo(HaveOccurred())
+
+			boundZones := make(map[string]struct{}, len(namespaceZones.Items))
+			for _, zone := range namespaceZones.Items {
+				boundZones[zone.Name] = struct{}{}
+			}
+
+			unboundZones := []string{}
+
+			for _, zone := range zoneList.Zones {
+				if _, ok := boundZones[zone.Zone]; !ok {
+					unboundZones = append(unboundZones, zone.Zone)
+				}
+			}
+
+			if len(unboundZones) > 0 {
+				_, err = clusterProxy.UpdateNamespaceWithZones(ctx, tmpNamespaceName, unboundZones, svClusterClient)
+				Expect(err).ToNot(HaveOccurred(), "failed to update namespace with Zones")
+			}
+
+		})
+
+		AfterEach(func() {
+			if tmpNamespaceName != "" {
+				clusterProxy.DeleteWCPNamespace(tmpNamespaceCtx)
+				tmpNamespaceName = ""
+			}
+		})
+
+		When("Group placement with affinity and anti-affinity at host topology", func() {
+			It("Should create 4 VMs with preferred host AF with each other", func() {
+				By("Creating a VirtualMachineGroup with 4 VM-kind members")
+				vmMemberNames = []string{vm1Name, vm2Name, vm3Name, vm4Name}
+				runVmVmAffinityAtHostTopoTest(preferredDuringSchedulingPreferredDuringExecution,
+					[]string{vm1Name, vm2Name, vm3Name, vm4Name},
+					[]string{})
+
+			})
+
+			It("Should create 3 VMs with preferred host AAF with each other", func() {
+				By("Creating a VirtualMachineGroup with 3 VM-kind members")
+				vmMemberNames = []string{vm1Name, vm2Name, vm3Name}
+				runVmVmAffinityAtHostTopoTest(preferredDuringSchedulingPreferredDuringExecution,
+					[]string{},
+					[]string{vm1Name, vm2Name, vm3Name})
+
+			})
+
+			It("Should create VMs with preferred host AF (2vms) & AAF (2vms)", func() {
+				By("Creating a VirtualMachineGroup with 4 VM-kind members")
+				vmMemberNames = []string{vm1Name, vm2Name, vm3Name, vm4Name}
+				runVmVmAffinityAtHostTopoTest(preferredDuringSchedulingPreferredDuringExecution,
+					[]string{vm1Name, vm2Name},
+					[]string{vm3Name, vm4Name})
+			})
+
+			It("Should create 4 VMs with required host AF with each other", func() {
+				By("Creating a VirtualMachineGroup with 4 VM-kind members")
+				vmMemberNames = []string{vm1Name, vm2Name, vm3Name, vm4Name}
+				runVmVmAffinityAtHostTopoTest(requiredDuringSchedulingPreferredDuringExecution,
+					[]string{vm1Name, vm2Name, vm3Name, vm4Name},
+					[]string{})
+
+			})
+
+			It("Should create 3 VMs with required host AAF with each other", func() {
+				By("Creating a VirtualMachineGroup with 3 VM-kind members")
+				vmMemberNames = []string{vm1Name, vm2Name, vm3Name}
+				runVmVmAffinityAtHostTopoTest(requiredDuringSchedulingPreferredDuringExecution,
+					[]string{},
+					[]string{vm1Name, vm2Name, vm3Name})
+
+			})
+
+			It("Should create VMs with required host AF (2vms) & AAF (2vms)", func() {
+				By("Creating a VirtualMachineGroup with 4 VM-kind members")
+				vmMemberNames = []string{vm1Name, vm2Name, vm3Name, vm4Name}
+				runVmVmAffinityAtHostTopoTest(requiredDuringSchedulingPreferredDuringExecution,
+					[]string{vm1Name, vm2Name},
+					[]string{vm3Name, vm4Name})
 			})
 		})
 	})


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Add e2e tests for VmVm Affinity/AntiAffinity at host topology.
Tests include
1. 4 VMs with requiredForScheduling Affinity
2. 3 VMs with requiredForScheduling AntiAffinity
3. 2 VMs with requiredForScheduling Affinity & 2 VMs with requiredForScheduling AntiAffinity
4. 4 VMs with preferredForScheduling Affinity
5. 3 VMs with preferredForScheduling AntiAffinity
6. 2 VMs with preferredForScheduling Affinity & 2 VMs with preferredForScheduling AntiAffinity

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # NA


**Are there any special notes for your reviewer**:

NA

**Please add a release note if necessary**:
```
Tests executed successively on dev environment.
Ran 6 of 115 Specs in 1648.614 seconds
SUCCESS! -- 6 Passed | 0 Failed | 5 Pending | 104 Skipped
PASS
```