### PR TITLE
🐛 Adjust event recorder names to comply with events.k8s.io API validation and its implementation by controller-runtime

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,7 +9,6 @@ rules:
   resources:
   - configmaps
   - endpoints
-  - events
   - persistentvolumeclaims
   - services
   verbs:
@@ -165,6 +164,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
 - apiGroups:
   - iaas.vmware.com
   resources:

--- a/controllers/contentlibrary/utils/controller_builder.go
+++ b/controllers/contentlibrary/utils/controller_builder.go
@@ -54,14 +54,13 @@ func AddToManager(
 		controlledItemTypeName = reflect.TypeOf(controlledItemType).Elem().Name()
 
 		controllerNameShort = fmt.Sprintf("%s-controller", strings.ToLower(controlledItemTypeName))
-		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
 	)
 
 	r := NewReconciler(
 		ctx,
 		mgr.GetClient(),
 		ctrl.Log.WithName("controllers").WithName(controlledItemTypeName),
-		record.New(mgr.GetEventRecorder(controllerNameLong)),
+		record.New(mgr.GetEventRecorder(controllerNameShort)),
 		ctx.VMProvider,
 		controlledItemTypeName,
 	)

--- a/controllers/contentlibrary/utils/controller_builder_v1a2.go
+++ b/controllers/contentlibrary/utils/controller_builder_v1a2.go
@@ -48,14 +48,13 @@ func AddToManagerV1A2(
 		controlledItemTypeName = reflect.TypeOf(controlledItemType).Elem().Name()
 
 		controllerNameShort = fmt.Sprintf("%s-controller", strings.ToLower(controlledItemTypeName))
-		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
 	)
 
 	r := NewReconcilerV1A2(
 		ctx,
 		mgr.GetClient(),
 		ctrl.Log.WithName("controllers").WithName(controlledItemTypeName),
-		record.New(mgr.GetEventRecorder(controllerNameLong)),
+		record.New(mgr.GetEventRecorder(controllerNameShort)),
 		ctx.VMProvider,
 		controlledItemTypeName,
 	)

--- a/controllers/infra/capability/configmap/configmap_capability_controller.go
+++ b/controllers/infra/capability/configmap/configmap_capability_controller.go
@@ -36,7 +36,6 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		controlledType      = &corev1.ConfigMap{}
 		controllerName      = "capability-configmap"
 		controllerNameShort = fmt.Sprintf("%s-controller", controllerName)
-		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
 	)
 
 	cache, err := pkgmgr.NewNamespacedCacheForObject(
@@ -53,7 +52,7 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		mgr.GetClient(),
 		cache,
 		ctrl.Log.WithName("controllers").WithName(controllerName),
-		record.New(mgr.GetEventRecorder(controllerNameLong)),
+		record.New(mgr.GetEventRecorder(controllerNameShort)),
 	)
 
 	// This controller is also run on the non-leaders (webhooks) pods too

--- a/controllers/infra/capability/crd/crd_capability_controller.go
+++ b/controllers/infra/capability/crd/crd_capability_controller.go
@@ -31,14 +31,13 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		controlledType      = &capv1.Capabilities{}
 		controllerName      = "capability-crd"
 		controllerNameShort = fmt.Sprintf("%s-controller", controllerName)
-		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
 	)
 
 	r := NewReconciler(
 		ctx,
 		mgr.GetClient(),
 		ctrl.Log.WithName("controllers").WithName(controllerName),
-		record.New(mgr.GetEventRecorder(controllerNameLong)),
+		record.New(mgr.GetEventRecorder(controllerNameShort)),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/controllers/infra/configmap/infra_configmap_controller.go
+++ b/controllers/infra/configmap/infra_configmap_controller.go
@@ -34,14 +34,13 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		controlledType      = &corev1.ConfigMap{}
 		controllerName      = "infra-configmap"
 		controllerNameShort = fmt.Sprintf("%s-controller", controllerName)
-		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
 	)
 
 	r := NewReconciler(
 		ctx,
 		mgr.GetClient(),
 		ctrl.Log.WithName("controllers").WithName(controllerName),
-		record.New(mgr.GetEventRecorder(controllerNameLong)),
+		record.New(mgr.GetEventRecorder(controllerNameShort)),
 		ctx.Namespace,
 		ctx.VMProvider,
 	)

--- a/controllers/infra/node/infra_node_controller.go
+++ b/controllers/infra/node/infra_node_controller.go
@@ -34,14 +34,13 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		controllerName      = "infra-node"
 		controlledType      = &corev1.Node{}
 		controllerNameShort = fmt.Sprintf("%s-controller", controllerName)
-		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
 	)
 
 	r := NewReconciler(
 		ctx,
 		mgr.GetClient(),
 		ctrl.Log.WithName("controllers").WithName(controllerName),
-		record.New(mgr.GetEventRecorder(controllerNameLong)),
+		record.New(mgr.GetEventRecorder(controllerNameShort)),
 		ctx.VMProvider,
 	)
 

--- a/controllers/infra/secret/infra_secret_controller.go
+++ b/controllers/infra/secret/infra_secret_controller.go
@@ -37,7 +37,6 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		controlledType      = &corev1.Secret{}
 		controllerName      = "infra-secret"
 		controllerNameShort = fmt.Sprintf("%s-controller", controllerName)
-		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
 	)
 
 	vcCredsKey := ctrlclient.ObjectKey{
@@ -59,7 +58,7 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		ctx,
 		cache,
 		ctrl.Log.WithName("controllers").WithName(controllerName),
-		record.New(mgr.GetEventRecorder(controllerNameLong)),
+		record.New(mgr.GetEventRecorder(controllerNameShort)),
 		ctx.VMProvider,
 		vcCredsKey,
 	)

--- a/controllers/infra/validatingwebhookconfiguration/validatingwebhookconfiguration_controller.go
+++ b/controllers/infra/validatingwebhookconfiguration/validatingwebhookconfiguration_controller.go
@@ -39,14 +39,13 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		controlledTypeName = reflect.TypeOf(controlledType).Elem().Name()
 
 		controllerNameShort = fmt.Sprintf("%s-controller", strings.ToLower(controlledTypeName))
-		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
 	)
 
 	r := NewReconciler(
 		ctx,
 		mgr.GetClient(),
 		ctrl.Log.WithName("controllers").WithName(controlledTypeName),
-		record.New(mgr.GetEventRecorder(controllerNameLong)),
+		record.New(mgr.GetEventRecorder(controllerNameShort)),
 	)
 
 	c, err := controller.New(controllerNameShort, mgr, controller.Options{

--- a/controllers/infra/zone/zone_controller.go
+++ b/controllers/infra/zone/zone_controller.go
@@ -41,14 +41,13 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		controlledTypeName = reflect.TypeOf(controlledType).Elem().Name()
 
 		controllerNameShort = fmt.Sprintf("%s-controller", strings.ToLower(controlledTypeName))
-		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
 	)
 
 	r := NewReconciler(
 		ctx,
 		mgr.GetClient(),
 		ctrl.Log.WithName("controllers").WithName(controlledTypeName),
-		record.New(mgr.GetEventRecorder(controllerNameLong)),
+		record.New(mgr.GetEventRecorder(controllerNameShort)),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/controllers/storage/storageclass/storageclass_controller.go
+++ b/controllers/storage/storageclass/storageclass_controller.go
@@ -34,14 +34,13 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		controlledTypeName = reflect.TypeOf(controlledType).Elem().Name()
 
 		controllerNameShort = fmt.Sprintf("%s-controller", strings.ToLower(controlledTypeName))
-		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
 	)
 
 	r := NewReconciler(
 		ctx,
 		mgr.GetClient(),
 		ctrl.Log.WithName("controllers").WithName(controlledTypeName),
-		record.New(mgr.GetEventRecorder(controllerNameLong)))
+		record.New(mgr.GetEventRecorder(controllerNameShort)))
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(controlledType).

--- a/controllers/storage/storagepolicy/storagepolicy_controller.go
+++ b/controllers/storage/storagepolicy/storagepolicy_controller.go
@@ -32,14 +32,13 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		controlledTypeName = reflect.TypeOf(controlledType).Elem().Name()
 
 		controllerNameShort = fmt.Sprintf("%s-controller", strings.ToLower(controlledTypeName))
-		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
 	)
 
 	r := NewReconciler(
 		ctx,
 		mgr.GetClient(),
 		ctrl.Log.WithName("controllers").WithName(controlledTypeName),
-		record.New(mgr.GetEventRecorder(controllerNameLong)),
+		record.New(mgr.GetEventRecorder(controllerNameShort)),
 		ctx.VMProvider)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/controllers/storage/storagepolicyquota/storagepolicyquota_controller.go
+++ b/controllers/storage/storagepolicyquota/storagepolicyquota_controller.go
@@ -38,14 +38,13 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		controlledTypeName = reflect.TypeOf(controlledType).Elem().Name()
 
 		controllerNameShort = fmt.Sprintf("%s-controller", strings.ToLower(controlledTypeName))
-		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
 	)
 
 	r := NewReconciler(
 		ctx,
 		mgr.GetClient(),
 		ctrl.Log.WithName("controllers").WithName(controlledTypeName),
-		record.New(mgr.GetEventRecorder(controllerNameLong)),
+		record.New(mgr.GetEventRecorder(controllerNameShort)),
 		ctx.Namespace,
 	)
 

--- a/controllers/storage/volumeattributesclass/volumeattributesclass_controller.go
+++ b/controllers/storage/volumeattributesclass/volumeattributesclass_controller.go
@@ -34,14 +34,13 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		controlledTypeName = reflect.TypeOf(controlledType).Elem().Name()
 
 		controllerNameShort = fmt.Sprintf("%s-controller", strings.ToLower(controlledTypeName))
-		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
 	)
 
 	r := NewReconciler(
 		ctx,
 		mgr.GetClient(),
 		ctrl.Log.WithName("controllers").WithName(controlledTypeName),
-		record.New(mgr.GetEventRecorder(controllerNameLong)))
+		record.New(mgr.GetEventRecorder(controllerNameShort)))
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(controlledType).

--- a/controllers/virtualmachine/storagepolicyusage/storagepolicyusage_controller.go
+++ b/controllers/virtualmachine/storagepolicyusage/storagepolicyusage_controller.go
@@ -36,7 +36,6 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 	var (
 		controllerName      = "storagepolicyusage"
 		controllerNameShort = fmt.Sprintf("%s-controller", strings.ToLower(controllerName))
-		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
 	)
 
 	// Index the VM's spec.storageClass field to make it easy to list VMs in a
@@ -56,7 +55,7 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		ctx,
 		mgr.GetClient(),
 		ctrl.Log.WithName("controllers").WithName(controllerName),
-		record.New(mgr.GetEventRecorder(controllerNameLong)),
+		record.New(mgr.GetEventRecorder(controllerNameShort)),
 	)
 
 	c, err := controller.New(controllerName, mgr, controller.Options{

--- a/controllers/virtualmachine/virtualmachine/virtualmachine_controller.go
+++ b/controllers/virtualmachine/virtualmachine/virtualmachine_controller.go
@@ -69,7 +69,6 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		controlledTypeName = reflect.TypeOf(controlledType).Elem().Name()
 
 		controllerNameShort = fmt.Sprintf("%s-controller", strings.ToLower(controlledTypeName))
-		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
 	)
 
 	proberManager, err := prober.AddToManager(ctx, mgr, ctx.VMProvider)
@@ -81,7 +80,7 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		ctx,
 		mgr.GetClient(),
 		ctrl.Log.WithName("controllers").WithName(controlledTypeName),
-		record.New(mgr.GetEventRecorder(controllerNameLong)),
+		record.New(mgr.GetEventRecorder(controllerNameShort)),
 		ctx.VMProvider,
 		proberManager)
 
@@ -279,7 +278,8 @@ type Reconciler struct {
 // +kubebuilder:rbac:groups=cns.vmware.com,resources=storagepolicyquotas,verbs=get;list;watch
 // +kubebuilder:rbac:groups=crd.nsx.vmware.com,resources=subnetports,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=crd.nsx.vmware.com,resources=subnetports/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups="",resources=events;configmaps,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="events.k8s.io",resources=events,verbs=create;update;patch
 // +kubebuilder:rbac:groups="",resources=resourcequotas;namespaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups=encryption.vmware.com,resources=encryptionclasses,verbs=get;list;watch
 

--- a/controllers/virtualmachine/volume/volume_controller.go
+++ b/controllers/virtualmachine/volume/volume_controller.go
@@ -49,7 +49,6 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 	var (
 		controllerName      = "volume"
 		controllerNameShort = fmt.Sprintf("%s-controller", strings.ToLower(controllerName))
-		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
 	)
 
 	if err := mgr.GetFieldIndexer().IndexField(
@@ -67,7 +66,7 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		ctx,
 		mgr.GetClient(),
 		ctrl.Log.WithName("controllers").WithName("volume"),
-		record.New(mgr.GetEventRecorder(controllerNameLong)),
+		record.New(mgr.GetEventRecorder(controllerNameShort)),
 		ctx.VMProvider,
 	)
 

--- a/controllers/virtualmachine/volumebatch/volumebatch_controller.go
+++ b/controllers/virtualmachine/volumebatch/volumebatch_controller.go
@@ -69,7 +69,6 @@ const (
 func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) error {
 	var (
 		controllerNameShort = fmt.Sprintf("%s-controller", strings.ToLower(controllerName))
-		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
 	)
 
 	// Set up field index for CnsNodeVmAttachment by NodeUUID to efficiently query legacy attachments
@@ -107,7 +106,7 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		ctx,
 		mgr.GetClient(),
 		ctrl.Log.WithName("controllers").WithName("volumebatch"),
-		record.New(mgr.GetEventRecorder(controllerNameLong)),
+		record.New(mgr.GetEventRecorder(controllerNameShort)),
 		ctx.VMProvider,
 	)
 

--- a/controllers/virtualmachineclass/virtualmachineclass_controller.go
+++ b/controllers/virtualmachineclass/virtualmachineclass_controller.go
@@ -38,14 +38,13 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		controlledTypeName = reflect.TypeOf(controlledType).Elem().Name()
 
 		controllerNameShort = fmt.Sprintf("%s-controller", strings.ToLower(controlledTypeName))
-		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
 	)
 
 	r := NewReconciler(
 		ctx,
 		mgr.GetClient(),
 		ctrl.Log.WithName("controllers").WithName(controlledTypeName),
-		record.New(mgr.GetEventRecorder(controllerNameLong)),
+		record.New(mgr.GetEventRecorder(controllerNameShort)),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/controllers/virtualmachinegroup/virtualmachinegroup_controller.go
+++ b/controllers/virtualmachinegroup/virtualmachinegroup_controller.go
@@ -52,7 +52,6 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		controlledTypeName = reflect.TypeOf(controlledType).Elem().Name()
 
 		controllerNameShort = fmt.Sprintf("%s-controller", strings.ToLower(controlledTypeName))
-		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
 	)
 
 	r := NewReconciler(
@@ -60,7 +59,7 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		mgr.GetClient(),
 		mgr.GetAPIReader(),
 		ctrl.Log.WithName("controllers").WithName(controlledTypeName),
-		record.New(mgr.GetEventRecorder(controllerNameLong)),
+		record.New(mgr.GetEventRecorder(controllerNameShort)),
 		ctx.VMProvider,
 	)
 

--- a/controllers/virtualmachinegrouppublishrequest/virtualmachinegrouppublishrequest_controller.go
+++ b/controllers/virtualmachinegrouppublishrequest/virtualmachinegrouppublishrequest_controller.go
@@ -49,14 +49,13 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		controlledTypeName = reflect.TypeOf(controlledType).Elem().Name()
 
 		controllerNameShort = fmt.Sprintf("%s-controller", strings.ToLower(controlledTypeName))
-		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
 	)
 	r := NewReconciler(
 		ctx,
 		mgr.GetClient(),
 		mgr.GetAPIReader(),
 		ctrl.Log.WithName("controllers").WithName(controlledTypeName),
-		record.New(mgr.GetEventRecorder(controllerNameLong)),
+		record.New(mgr.GetEventRecorder(controllerNameShort)),
 		ctx.VMProvider,
 	)
 	return ctrl.NewControllerManagedBy(mgr).

--- a/controllers/virtualmachineimagecache/virtualmachineimagecache_controller.go
+++ b/controllers/virtualmachineimagecache/virtualmachineimagecache_controller.go
@@ -63,14 +63,13 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		controlledTypeName = reflect.TypeOf(controlledType).Elem().Name()
 
 		controllerNameShort = fmt.Sprintf("%s-controller", strings.ToLower(controlledTypeName))
-		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
 	)
 
 	r := &reconciler{
 		Context:    ctx,
 		Client:     mgr.GetClient(),
 		Logger:     ctx.Logger.WithName("controllers").WithName(controlledTypeName),
-		Recorder:   record.New(mgr.GetEventRecorder(controllerNameLong)),
+		Recorder:   record.New(mgr.GetEventRecorder(controllerNameShort)),
 		VMProvider: ctx.VMProvider,
 
 		newCLSProvdrFn: newContentLibraryProviderOrDefault(ctx),

--- a/controllers/virtualmachinepublishrequest/virtualmachinepublishrequest_controller.go
+++ b/controllers/virtualmachinepublishrequest/virtualmachinepublishrequest_controller.go
@@ -83,7 +83,6 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		controlledTypeName = reflect.TypeOf(controlledType).Elem().Name()
 
 		controllerNameShort = fmt.Sprintf("%s-controller", strings.ToLower(controlledTypeName))
-		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
 	)
 
 	r := NewReconciler(
@@ -91,7 +90,7 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		mgr.GetClient(),
 		mgr.GetAPIReader(),
 		ctrl.Log.WithName("controllers").WithName(controlledTypeName),
-		record.New(mgr.GetEventRecorder(controllerNameLong)),
+		record.New(mgr.GetEventRecorder(controllerNameShort)),
 		ctx.VMProvider,
 	)
 

--- a/controllers/virtualmachinereplicaset/virtualmachinereplicaset_controller.go
+++ b/controllers/virtualmachinereplicaset/virtualmachinereplicaset_controller.go
@@ -78,14 +78,13 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		controlledTypeName = reflect.TypeOf(controlledType).Elem().Name()
 
 		controllerNameShort = fmt.Sprintf("%s-controller", strings.ToLower(controlledTypeName))
-		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
 	)
 
 	r := NewReconciler(
 		ctx,
 		mgr.GetClient(),
 		ctrl.Log.WithName("controllers").WithName(controlledTypeName),
-		record.New(mgr.GetEventRecorder(controllerNameLong)))
+		record.New(mgr.GetEventRecorder(controllerNameShort)))
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(controlledType).

--- a/controllers/virtualmachineservice/virtualmachineservice_controller.go
+++ b/controllers/virtualmachineservice/virtualmachineservice_controller.go
@@ -51,14 +51,13 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		controlledTypeName = reflect.TypeOf(controlledType).Elem().Name()
 
 		controllerNameShort = fmt.Sprintf("%s-controller", strings.ToLower(controlledTypeName))
-		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
 	)
 
 	r := NewReconciler(
 		ctx,
 		mgr.GetClient(),
 		ctrl.Log.WithName("controllers").WithName(controlledTypeName),
-		record.New(mgr.GetEventRecorder(controllerNameLong)),
+		record.New(mgr.GetEventRecorder(controllerNameShort)),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/controllers/virtualmachinesnapshot/virtualmachinesnapshot_controller.go
+++ b/controllers/virtualmachinesnapshot/virtualmachinesnapshot_controller.go
@@ -53,14 +53,13 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		controlledTypeName = reflect.TypeOf(controlledType).Elem().Name()
 
 		controllerNameShort = fmt.Sprintf("%s-controller", strings.ToLower(controlledTypeName))
-		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
 	)
 
 	r := NewReconciler(
 		ctx,
 		mgr.GetClient(),
 		ctrl.Log.WithName("controllers").WithName(controlledTypeName),
-		record.New(mgr.GetEventRecorder(controllerNameLong)),
+		record.New(mgr.GetEventRecorder(controllerNameShort)),
 		ctx.VMProvider,
 	)
 

--- a/controllers/virtualmachinewebconsolerequest/v1alpha1/webconsolerequest_controller.go
+++ b/controllers/virtualmachinewebconsolerequest/v1alpha1/webconsolerequest_controller.go
@@ -42,14 +42,13 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		controlledTypeName = reflect.TypeOf(controlledType).Elem().Name()
 
 		controllerNameShort = fmt.Sprintf("%s-controller", strings.ToLower(controlledTypeName))
-		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
 	)
 
 	r := NewReconciler(
 		ctx,
 		mgr.GetClient(),
 		ctrl.Log.WithName("controllers").WithName(controlledTypeName),
-		record.New(mgr.GetEventRecorder(controllerNameLong)),
+		record.New(mgr.GetEventRecorder(controllerNameShort)),
 		ctx.VMProvider,
 	)
 

--- a/controllers/virtualmachinewebconsolerequest/webconsolerequest_controller.go
+++ b/controllers/virtualmachinewebconsolerequest/webconsolerequest_controller.go
@@ -40,14 +40,13 @@ func addToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		controlledTypeName = reflect.TypeOf(controlledType).Elem().Name()
 
 		controllerNameShort = fmt.Sprintf("%s-controller", strings.ToLower(controlledTypeName))
-		controllerNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
 	)
 
 	r := NewReconciler(
 		ctx,
 		mgr.GetClient(),
 		ctrl.Log.WithName("controllers").WithName(controlledTypeName),
-		record.New(mgr.GetEventRecorder(controllerNameLong)),
+		record.New(mgr.GetEventRecorder(controllerNameShort)),
 		ctx.VMProvider,
 	)
 

--- a/controllers/vspherepolicy/policyevaluation/policyevaluation_controller.go
+++ b/controllers/vspherepolicy/policyevaluation/policyevaluation_controller.go
@@ -42,15 +42,13 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 
 		controllerNameShort = fmt.Sprintf(
 			"%s-controller", strings.ToLower(controlledTypeName))
-		controllerNameLong = fmt.Sprintf(
-			"%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
 	)
 
 	r := NewReconciler(
 		ctx,
 		mgr.GetClient(),
 		ctrl.Log.WithName("controllers").WithName(controlledTypeName),
-		record.New(mgr.GetEventRecorder(controllerNameLong)),
+		record.New(mgr.GetEventRecorder(controllerNameShort)),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/pkg/builder/mutating_webhook.go
+++ b/pkg/builder/mutating_webhook.go
@@ -63,7 +63,6 @@ func NewMutatingWebhook(
 	}
 
 	webhookNameShort := generateMutateName(webhookName, mutator.For())
-	webhookNameLong := fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, webhookNameShort)
 	webhookPath := "/" + webhookNameShort
 
 	// Build the WebhookContext.
@@ -72,7 +71,7 @@ func NewMutatingWebhook(
 		Name:                            webhookNameShort,
 		Namespace:                       ctx.Namespace,
 		ServiceAccountName:              ctx.ServiceAccountName,
-		Recorder:                        record.New(mgr.GetEventRecorder(webhookNameLong)),
+		Recorder:                        record.New(mgr.GetEventRecorder(webhookNameShort)),
 		Logger:                          ctx.Logger.WithName(webhookNameShort),
 		EnableWebhookClientVerification: ctx.EnableWebhookClientVerification,
 	}

--- a/pkg/builder/validating_webhook.go
+++ b/pkg/builder/validating_webhook.go
@@ -71,7 +71,6 @@ func NewValidatingWebhook(
 	var (
 		webhookNameShort = generateValidateName(webhookName, validator.For())
 		webhookPath      = "/" + webhookNameShort
-		webhookNameLong  = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, webhookNameShort)
 	)
 
 	// Build the webhookContext.
@@ -80,7 +79,7 @@ func NewValidatingWebhook(
 		Name:                            webhookNameShort,
 		Namespace:                       ctx.Namespace,
 		ServiceAccountName:              ctx.ServiceAccountName,
-		Recorder:                        record.New(mgr.GetEventRecorder(webhookNameLong)),
+		Recorder:                        record.New(mgr.GetEventRecorder(webhookNameShort)),
 		Logger:                          ctx.Logger.WithName(webhookNameShort),
 		EnableWebhookClientVerification: ctx.EnableWebhookClientVerification,
 	}

--- a/pkg/manager/init/init_providers.go
+++ b/pkg/manager/init/init_providers.go
@@ -5,8 +5,6 @@
 package manager
 
 import (
-	"fmt"
-
 	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
 
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
@@ -17,8 +15,7 @@ import (
 func InitializeProviders(
 	ctx *pkgctx.ControllerManagerContext,
 	mgr ctrlmgr.Manager) error {
-	vmProviderName := fmt.Sprintf("%s/%s/vmProvider", ctx.Namespace, ctx.Name)
-	recorder := record.New(mgr.GetEventRecorder(vmProviderName))
+	recorder := record.New(mgr.GetEventRecorder("vmProvider"))
 	ctx.VMProvider = vsphere.NewVSphereVMProviderFromClient(ctx, mgr.GetClient(), recorder)
 	return nil
 }

--- a/webhooks/unifiedstoragequota/validation/unifiedstoragequota_validator.go
+++ b/webhooks/unifiedstoragequota/validation/unifiedstoragequota_validator.go
@@ -100,7 +100,6 @@ type VMSnapshotRequestedCapacityHandler struct {
 func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) error {
 
 	logger := ctx.Logger.WithName(webhookName)
-	webhookNameLong := fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, webhookName)
 
 	// Build the webhookContext.
 	webhookContext := &pkgctx.WebhookContext{
@@ -108,7 +107,7 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) err
 		Name:               webhookName,
 		Namespace:          ctx.Namespace,
 		ServiceAccountName: ctx.ServiceAccountName,
-		Recorder:           record.New(mgr.GetEventRecorder(webhookNameLong)),
+		Recorder:           record.New(mgr.GetEventRecorder(webhookName)),
 		Logger:             logger,
 	}
 	// Initialize the webhook's decoder.


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

The migration to controller-runtime 0.23.1 introduced stricter validation for event recorder names using the events.k8s.io API group.
The new API enforces that reportingController names must be valid Kubernetes qualified names matching the regex: ([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9] and as per controller-runtime implementation, it must be less than [96 characters](https://github.com/kubernetes-sigs/controller-runtime/issues/3511).

Previous event recorder names used the pattern:
"namespace/pod-name/component-name" (e.g., "vmware-system-vmop/ vmware-system-vmop-controller-manager-dc666487-t6nmn/virtualmachine-controller")

This violated the qualified name constraint by containing two forward slashes and exceeding the  limit, causing validation errors: "Invalid value: reportingController must be a valid qualified name".

Even changing to event record format of `controllerNameLong = fmt.Sprintf("%s.%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)`, we are bitten by the indirect length limitation as per controller-runtime implementation.

Example:
```
E0501 20:33:03.500254       1 event_broadcaster.go:270] "Server rejected event (will not retry!)" err="Event \"windows-laav-a2.18ab8b3faaa83129\" is invalid: reportingInstance: Invalid value: \"\": can have at most 128 characters" event="&Event{ObjectMeta:{windows-laav-a2.18ab8b3faaa83129  vmsvc-e2e-so7rzi    0 0001-01-01 00:00:00 +0000 UTC <nil> <nil> map[] map[] [] [] []},EventTime:2026-05-01 20:33:03.490136698 +0000 UTC m=+27.204947134,Series:nil,ReportingController:vmware-system-vmop.vmware-system-vmop-controller-manager-7f885ffff5-mlnhc/virtualmachine-controller,ReportingInstance:vmware-system-vmop.vmware-system-vmop-controller-manager-7f885ffff5-mlnhc/virtualmachine-controller-423b393286e26d68e9777202c42da01a,Action:UpdateSuccess,Reason:UpdateSuccess,Regarding:{VirtualMachine vmsvc-e2e-so7rzi windows-laav-a2 a228f522-3a3b-43e9-8b5e-36eaa1b92e12 vmoperator.vmware.com/v1alpha6 5978637 },Related:nil,Note:Update success,Type:Normal,DeprecatedSource:{ },DeprecatedFirstTimestamp:0001-01-01 00:00:00 +0000 UTC,DeprecatedLastTimestamp:0001-01-01 00:00:00 +0000 UTC,DeprecatedCount:0,}"
```
Event recorders now use simple component names like "virtualmachine-controller" and "vmProvider"  so we do not miss events to satisfy the events.k8s.io API validation requirements as implemented by controller-runtime 0.23.1+.

Additionally, this patch adds necessary RBAC for the events.k8s.io API group.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

Rationale and testing are documented on VMSVC-3694.
A fix is recommended to be on controller-runtime and an issue has been opened: https://github.com/kubernetes-sigs/controller-runtime/issues/3511.

**Please add a release note if necessary**:

```release-note
Using events.k8s.io API group for events as per controller-runtime upgrade to 0.23.1. There is stricter rules for events names and there was a need to reduce the name from "namespace/pod-name/component-name" to only "component-name".
```