### PR TITLE
🌱 Consolidate test logging initialization across test suites

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -209,6 +209,7 @@ linters:
           - $all
           - "!$test"
           - "!**/test/builder/*.go"
+          - "!**/test/builder/log/*.go"
           - "!**/matcher.go"
           - "!**/pkg/util/kube/storage.go"
           allow:

--- a/controllers/storage/storagepolicy/storagepolicy_controller_suite_test.go
+++ b/controllers/storage/storagepolicy/storagepolicy_controller_suite_test.go
@@ -9,15 +9,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"k8s.io/klog/v2"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
-
-func init() {
-	klog.SetOutput(GinkgoWriter)
-	logf.SetLogger(klog.Background())
-}
 
 func TestStoragePolicyController(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/builder/builder_suite_test.go
+++ b/pkg/builder/builder_suite_test.go
@@ -17,17 +17,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/events"
-	"k8s.io/klog/v2"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	pkgmgr "github.com/vmware-tanzu/vm-operator/pkg/manager"
+	_ "github.com/vmware-tanzu/vm-operator/test/builder/log"
 )
-
-func init() {
-	klog.SetOutput(GinkgoWriter)
-	logf.SetLogger(klog.Background())
-}
 
 func TestKube(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/config/capabilities/capabilities_suite_test.go
+++ b/pkg/config/capabilities/capabilities_suite_test.go
@@ -9,15 +9,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"k8s.io/klog/v2"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
-
-func init() {
-	klog.SetOutput(GinkgoWriter)
-	logf.SetLogger(klog.Background())
-}
 
 func TestCapabilities(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/config/env/env_suite_test.go
+++ b/pkg/config/env/env_suite_test.go
@@ -9,6 +9,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	_ "github.com/vmware-tanzu/vm-operator/test/builder/log"
 )
 
 func TestEnv(t *testing.T) {

--- a/pkg/context/generic/generic_suite_test.go
+++ b/pkg/context/generic/generic_suite_test.go
@@ -10,14 +10,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/klog/v2"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	_ "github.com/vmware-tanzu/vm-operator/test/builder/log"
 )
-
-func init() {
-	klog.SetOutput(GinkgoWriter)
-	logf.SetLogger(klog.Background())
-}
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/context/operation/operation_suite_test.go
+++ b/pkg/context/operation/operation_suite_test.go
@@ -10,14 +10,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/klog/v2"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	_ "github.com/vmware-tanzu/vm-operator/test/builder/log"
 )
-
-func init() {
-	klog.SetOutput(GinkgoWriter)
-	logf.SetLogger(klog.Background())
-}
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/crd/crd_suite_test.go
+++ b/pkg/crd/crd_suite_test.go
@@ -10,15 +10,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/klog/v2"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	_ "github.com/vmware-tanzu/vm-operator/test/builder/log"
 )
-
-func init() {
-	klog.InitFlags(nil)
-	klog.SetOutput(GinkgoWriter)
-	logf.SetLogger(klog.Background())
-}
 
 func TestCRD(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/mem/mem_suite_test.go
+++ b/pkg/mem/mem_suite_test.go
@@ -9,6 +9,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	_ "github.com/vmware-tanzu/vm-operator/test/builder/log"
 )
 
 func TestMem(t *testing.T) {

--- a/pkg/providers/vsphere/storage/storage_suite_test.go
+++ b/pkg/providers/vsphere/storage/storage_suite_test.go
@@ -10,14 +10,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/klog/v2"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	_ "github.com/vmware-tanzu/vm-operator/test/builder/log"
 )
-
-func init() {
-	klog.SetOutput(GinkgoWriter)
-	logf.SetLogger(klog.Background())
-}
 
 func TestStorage(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/providers/vsphere/upgrade/virtualmachine/vm_schema_upgrade_suite_test.go
+++ b/pkg/providers/vsphere/upgrade/virtualmachine/vm_schema_upgrade_suite_test.go
@@ -9,12 +9,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/klog/v2"
 )
-
-func init() {
-	klog.SetOutput(GinkgoWriter)
-}
 
 func TestVMSchemaUpgrade(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/util/kube/cource/cource_suite_test.go
+++ b/pkg/util/kube/cource/cource_suite_test.go
@@ -10,14 +10,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/klog/v2"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	_ "github.com/vmware-tanzu/vm-operator/test/builder/log"
 )
-
-func init() {
-	klog.SetOutput(GinkgoWriter)
-	logf.SetLogger(klog.Background())
-}
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/util/kube/internal/internal_kube_suite_test.go
+++ b/pkg/util/kube/internal/internal_kube_suite_test.go
@@ -10,14 +10,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/klog/v2"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	_ "github.com/vmware-tanzu/vm-operator/test/builder/log"
 )
-
-func init() {
-	klog.SetOutput(GinkgoWriter)
-	logf.SetLogger(klog.Background())
-}
 
 func TestKube(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/util/kube/spq/spq_suite_test.go
+++ b/pkg/util/kube/spq/spq_suite_test.go
@@ -10,14 +10,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/klog/v2"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	_ "github.com/vmware-tanzu/vm-operator/test/builder/log"
 )
-
-func init() {
-	klog.SetOutput(GinkgoWriter)
-	logf.SetLogger(klog.Background())
-}
 
 func TestKube(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/util/netplan/netplan_suite_test.go
+++ b/pkg/util/netplan/netplan_suite_test.go
@@ -9,6 +9,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	_ "github.com/vmware-tanzu/vm-operator/test/builder/log"
 )
 
 func TestNetplan(t *testing.T) {

--- a/pkg/util/paused/paused_suite_test.go
+++ b/pkg/util/paused/paused_suite_test.go
@@ -10,14 +10,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/klog/v2"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	_ "github.com/vmware-tanzu/vm-operator/test/builder/log"
 )
-
-func init() {
-	klog.SetOutput(GinkgoWriter)
-	logf.SetLogger(klog.Background())
-}
 
 func TestPtr(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/util/ptr/ptr_suite_test.go
+++ b/pkg/util/ptr/ptr_suite_test.go
@@ -10,14 +10,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/klog/v2"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	_ "github.com/vmware-tanzu/vm-operator/test/builder/log"
 )
-
-func init() {
-	klog.SetOutput(GinkgoWriter)
-	logf.SetLogger(klog.Background())
-}
 
 func TestPtr(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/util/util_suite_test.go
+++ b/pkg/util/util_suite_test.go
@@ -9,6 +9,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	_ "github.com/vmware-tanzu/vm-operator/test/builder/log"
 )
 
 func TestUtil(t *testing.T) {

--- a/pkg/util/volumes/volumes_util_suite_test.go
+++ b/pkg/util/volumes/volumes_util_suite_test.go
@@ -10,14 +10,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/klog/v2"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	_ "github.com/vmware-tanzu/vm-operator/test/builder/log"
 )
-
-func init() {
-	klog.SetOutput(GinkgoWriter)
-	logf.SetLogger(klog.Background())
-}
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/util/vsphere/client/client_suite_test.go
+++ b/pkg/util/vsphere/client/client_suite_test.go
@@ -9,6 +9,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	_ "github.com/vmware-tanzu/vm-operator/test/builder/log"
 )
 
 func TestClient(t *testing.T) {

--- a/pkg/util/vsphere/datastore/datastore_suite_test.go
+++ b/pkg/util/vsphere/datastore/datastore_suite_test.go
@@ -10,14 +10,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/klog/v2"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	_ "github.com/vmware-tanzu/vm-operator/test/builder/log"
 )
-
-func init() {
-	klog.SetOutput(GinkgoWriter)
-	logf.SetLogger(klog.Background())
-}
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/util/vsphere/library/library_suite_test.go
+++ b/pkg/util/vsphere/library/library_suite_test.go
@@ -10,13 +10,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/klog/v2"
+	_ "github.com/vmware-tanzu/vm-operator/test/builder/log"
 )
-
-func init() {
-	klog.InitFlags(nil)
-	klog.SetOutput(GinkgoWriter)
-}
 
 func TestContentLibrary(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/util/vsphere/storage/storage_policy_suite_test.go
+++ b/pkg/util/vsphere/storage/storage_policy_suite_test.go
@@ -10,14 +10,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/klog/v2"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	_ "github.com/vmware-tanzu/vm-operator/test/builder/log"
 )
-
-func init() {
-	klog.SetOutput(GinkgoWriter)
-	logf.SetLogger(klog.Background())
-}
 
 func TestStorage(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/util/vsphere/watcher/watcher_suite_test.go
+++ b/pkg/util/vsphere/watcher/watcher_suite_test.go
@@ -9,6 +9,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	_ "github.com/vmware-tanzu/vm-operator/test/builder/log"
 )
 
 func TestWatcher(t *testing.T) {

--- a/pkg/vmconfig/anno2extraconfig/anno2extraconfig_reconciler_suite_test.go
+++ b/pkg/vmconfig/anno2extraconfig/anno2extraconfig_reconciler_suite_test.go
@@ -10,14 +10,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/klog/v2"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	_ "github.com/vmware-tanzu/vm-operator/test/builder/log"
 )
-
-func init() {
-	klog.SetOutput(GinkgoWriter)
-	logf.SetLogger(klog.Background())
-}
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/vmconfig/bootoptions/bootoptions_reconciler_suite_test.go
+++ b/pkg/vmconfig/bootoptions/bootoptions_reconciler_suite_test.go
@@ -10,14 +10,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/klog/v2"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	_ "github.com/vmware-tanzu/vm-operator/test/builder/log"
 )
-
-func init() {
-	klog.SetOutput(GinkgoWriter)
-	logf.SetLogger(klog.Background())
-}
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/vmconfig/cdrom/cdrom_reconciler_suite_test.go
+++ b/pkg/vmconfig/cdrom/cdrom_reconciler_suite_test.go
@@ -10,14 +10,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/klog/v2"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	_ "github.com/vmware-tanzu/vm-operator/test/builder/log"
 )
-
-func init() {
-	klog.SetOutput(GinkgoWriter)
-	logf.SetLogger(klog.Background())
-}
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/vmconfig/crypto/crypto_reconciler_suite_test.go
+++ b/pkg/vmconfig/crypto/crypto_reconciler_suite_test.go
@@ -10,16 +10,10 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/klog/v2"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	_ "github.com/vmware-tanzu/vm-operator/test/builder/log"
 )
 
 const fakeString = "fake"
-
-func init() {
-	klog.SetOutput(GinkgoWriter)
-	logf.SetLogger(klog.Background())
-}
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/vmconfig/diskpromo/diskpromo_reconciler_suite_test.go
+++ b/pkg/vmconfig/diskpromo/diskpromo_reconciler_suite_test.go
@@ -10,14 +10,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/klog/v2"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	_ "github.com/vmware-tanzu/vm-operator/test/builder/log"
 )
-
-func init() {
-	klog.SetOutput(GinkgoWriter)
-	logf.SetLogger(klog.Background())
-}
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/vmconfig/policy/policy_reconciler_suite_test.go
+++ b/pkg/vmconfig/policy/policy_reconciler_suite_test.go
@@ -10,14 +10,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/klog/v2"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	_ "github.com/vmware-tanzu/vm-operator/test/builder/log"
 )
-
-func init() {
-	klog.SetOutput(GinkgoWriter)
-	logf.SetLogger(klog.Background())
-}
 
 func TestPolicy(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/vmconfig/virtualcontroller/virtualcontroller_reconciler_suite_test.go
+++ b/pkg/vmconfig/virtualcontroller/virtualcontroller_reconciler_suite_test.go
@@ -10,14 +10,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/klog/v2"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	_ "github.com/vmware-tanzu/vm-operator/test/builder/log"
 )
-
-func init() {
-	klog.SetOutput(GinkgoWriter)
-	logf.SetLogger(klog.Background())
-}
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/vmconfig/vmconfig_reconciler_suite_test.go
+++ b/pkg/vmconfig/vmconfig_reconciler_suite_test.go
@@ -10,14 +10,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/klog/v2"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	_ "github.com/vmware-tanzu/vm-operator/test/builder/log"
 )
-
-func init() {
-	klog.SetOutput(GinkgoWriter)
-	logf.SetLogger(klog.Background())
-}
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/vmconfig/volumes/unmanaged/backfill/unmanagedvolumes_backfill_suite_test.go
+++ b/pkg/vmconfig/volumes/unmanaged/backfill/unmanagedvolumes_backfill_suite_test.go
@@ -10,14 +10,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/klog/v2"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	_ "github.com/vmware-tanzu/vm-operator/test/builder/log"
 )
-
-func init() {
-	klog.SetOutput(GinkgoWriter)
-	logf.SetLogger(klog.Background())
-}
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/vmconfig/volumes/unmanaged/register/unmanagedvolumes_register_suite_test.go
+++ b/pkg/vmconfig/volumes/unmanaged/register/unmanagedvolumes_register_suite_test.go
@@ -10,14 +10,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/klog/v2"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	_ "github.com/vmware-tanzu/vm-operator/test/builder/log"
 )
-
-func init() {
-	klog.SetOutput(GinkgoWriter)
-	logf.SetLogger(klog.Background())
-}
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/test/builder/log/init.go
+++ b/test/builder/log/init.go
@@ -1,0 +1,25 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package log
+
+import (
+	"github.com/onsi/ginkgo/v2"
+
+	"k8s.io/klog/v2"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// init setups the logging so the output is shown during the tests. Note
+// that test/builder imports this package so generally only need to import
+// this directly for more standalone tests.
+func init() {
+	klog.InitFlags(nil)
+	klog.SetOutput(ginkgo.GinkgoWriter)
+	logf.SetLogger(klog.Background())
+
+	// TODO(akutz) This is kind of handy, but ultimately it makes discerning
+	//             test-specific logs from regular log non-trivial.
+	// GinkgoLogr = klog.Background()
+}

--- a/test/builder/test_suite.go
+++ b/test/builder/test_suite.go
@@ -23,7 +23,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/go-logr/logr"
-
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -31,13 +30,10 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
-	"k8s.io/klog/v2"
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-
-	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/yaml"
@@ -51,6 +47,7 @@ import (
 	pkgmgr "github.com/vmware-tanzu/vm-operator/pkg/manager"
 	pkgmgrinit "github.com/vmware-tanzu/vm-operator/pkg/manager/init"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
+	_ "github.com/vmware-tanzu/vm-operator/test/builder/log" // Configure logging during testing
 	"github.com/vmware-tanzu/vm-operator/test/testutil"
 )
 
@@ -65,16 +62,6 @@ type InitEnvFn func(
 	ctx context.Context,
 	mgr pkgmgr.Manager,
 	client client.Client)
-
-func init() {
-	klog.InitFlags(nil)
-	klog.SetOutput(GinkgoWriter)
-	logf.SetLogger(klog.Background())
-
-	// TODO(akutz) This is kind of handy, but ultimately it makes discerning
-	//             test-specific logs from regular log non-trivial.
-	// GinkgoLogr = klog.Background()
-}
 
 // TestSuite is used for unit and integration testing builder. Each TestSuite
 // contains one independent test environment and a controller manager.


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

Extract duplicate logging setup code into a centralized test/builder/log package to remove duplicate init() functions.

Changes:
- Add test/builder/log/init.go with centralized logging setup
- Remove duplicate init() functions from test suite files
- Replace individual logging imports with centralized log package import

Also make an AI assisted sweep to add import on test packages that need it but were missing it.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

**Please add a release note if necessary**:

```release-note
NONE
```