### PR TITLE
🌱 Add E2E tests for boot disk storage policy validation on VMs

### DIFF
--- a/.cursor/rules/e2e-sync-with-changes.mdc
+++ b/.cursor/rules/e2e-sync-with-changes.mdc
@@ -13,6 +13,9 @@ When changing VM Operator behavior that is observable on a WCP supervisor cluste
 
 Prefer extending existing suites under `test/e2e/vmservice/` (see `vmservice/virtualmachine/`), correct Ginkgo `Label(...)` usage, and shared helpers (`lib/vmoperator`, `manifestbuilders`, `infrastructure/vsphere`) per `test/e2e/README.md`.
 
+
+When the change set is **only** new or extended E2E coverage (no product or API contract change), **do not** modify code under `./pkg` or `./api` unless you find a potential bug. Limit the diff to `test/e2e`, E2E-only helpers, test-only manifests, and test-run documentation. If a test truly requires new product or API surface, ship that behavior and the tests together in one change set instead of coupling a test-only PR to `pkg` / `api` edits.
+
 **Do not** land product-only changes that clearly require E2E updates without adjusting tests in the same effort (unless the team has explicitly scoped E2E as follow-up — then say so in the PR/summary).
 
 How to run and write tests (commands, labels, config): **`test/e2e/README.md`**. Cheatsheet when editing E2E files: **`.cursor/rules/e2e-testing.mdc`**.

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -38,7 +38,7 @@ test/e2e/
 1. **Access to a WCP cluster** with VM Operator deployed
 2. **vSphere environment** with proper permissions
 3. **Kubeconfig** for the WCP supervisor cluster
-4. **Go 1.21+** installed locally
+4. **Go 1.26+** installed locally
 
 ### Configuration
 

--- a/test/e2e/fixtures/yaml/vmoperator/virtualmachines/v1a6singlevm.yaml.in
+++ b/test/e2e/fixtures/yaml/vmoperator/virtualmachines/v1a6singlevm.yaml.in
@@ -1,4 +1,4 @@
-apiVersion: vmoperator.vmware.com/v1alpha5
+apiVersion: vmoperator.vmware.com/v1alpha6
 kind: VirtualMachine
 metadata:
   name: {{.Name}}
@@ -131,68 +131,12 @@ spec:
           topologyKey: {{.TopologyKey}}
         {{- end}}
       {{- end}}
-      {{- if .Affinity.VMAffinity.PreferredDuringSchedulingPreferredDuringExecution}}
-      preferredDuringSchedulingPreferredDuringExecution:
-        {{- range .Affinity.VMAffinity.PreferredDuringSchedulingPreferredDuringExecution}}
-        {{- if .LabelSelector}}
-        - labelSelector:
-          {{- if .LabelSelector.MatchLabels}}
-            matchLabels:
-              {{- range $key, $value := .LabelSelector.MatchLabels}}
-              {{$key}}: "{{$value}}"
-              {{- end}}
-          {{- end}}
-          {{- if .LabelSelector.MatchExpressions}}
-            matchExpressions:
-              {{- range .LabelSelector.MatchExpressions}}
-              - key: {{.Key}}
-                operator: {{.Operator}}
-                {{- if .Values}}
-                values:
-                  {{- range .Values}}
-                  - "{{.}}"
-                  {{- end}}
-                {{- end}}
-              {{- end}}
-          {{- end}}
-          {{- end}}
-          topologyKey: {{.TopologyKey}}
-        {{- end}}
-      {{- end}}
     {{- end}}
     {{- if .Affinity.VMAntiAffinity}}
     vmAntiAffinity:
       {{- if .Affinity.VMAntiAffinity.RequiredDuringSchedulingPreferredDuringExecution}}
       requiredDuringSchedulingPreferredDuringExecution:
         {{- range .Affinity.VMAntiAffinity.RequiredDuringSchedulingPreferredDuringExecution}}
-        {{- if .LabelSelector}}
-        - labelSelector:
-          {{- if .LabelSelector.MatchLabels}}
-            matchLabels:
-              {{- range $key, $value := .LabelSelector.MatchLabels}}
-              {{$key}}: "{{$value}}"
-              {{- end}}
-          {{- end}}
-          {{- if .LabelSelector.MatchExpressions}}
-            matchExpressions:
-              {{- range .LabelSelector.MatchExpressions}}
-              - key: {{.Key}}
-                operator: {{.Operator}}
-                {{- if .Values}}
-                values:
-                  {{- range .Values}}
-                  - "{{.}}"
-                  {{- end}}
-                {{- end}}
-              {{- end}}
-          {{- end}}
-          {{- end}}
-          topologyKey: {{.TopologyKey}}
-        {{- end}}
-      {{- end}}
-      {{- if .Affinity.VMAntiAffinity.PreferredDuringSchedulingPreferredDuringExecution}}
-      preferredDuringSchedulingPreferredDuringExecution:
-        {{- range .Affinity.VMAntiAffinity.PreferredDuringSchedulingPreferredDuringExecution}}
         {{- if .LabelSelector}}
         - labelSelector:
           {{- if .LabelSelector.MatchLabels}}

--- a/test/e2e/manifestbuilders/virtualmachine.go
+++ b/test/e2e/manifestbuilders/virtualmachine.go
@@ -176,6 +176,14 @@ func GetVirtualMachineYamlA5(vmYaml VirtualMachineYaml) []byte {
 	return vmYamlBytes
 }
 
+// GetVirtualMachineYamlA6 returns a v1alpha6 VirtualMachine YAML from a templated fixture.
+func GetVirtualMachineYamlA6(vmYaml VirtualMachineYaml) []byte {
+	vmYamlIn := fixtures.ReadFile(vmYamlDir, "v1a6singlevm.yaml.in")
+	vmYamlBytes, _ := ReadVirtualMachineTemplate(vmYaml, vmYamlIn)
+
+	return vmYamlBytes
+}
+
 // GetPersistentVolumeClaimYaml renders a single PersistentVolumeClaim manifest from
 // the same PVC fields used by GetVirtualMachineYamlA5 (see createPvcsFromSpec).
 func GetPersistentVolumeClaimYaml(pvc PVC) []byte {

--- a/test/e2e/utils/bootdisk.go
+++ b/test/e2e/utils/bootdisk.go
@@ -1,0 +1,277 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/pbm"
+	pbmtypes "github.com/vmware/govmomi/pbm/types"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/mo"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	vmopv1a6 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+)
+
+// FindBootDiskVolumeStatus identifies the boot disk entry inside
+// vm.Status.Volumes without relying on any dedicated "isBootDisk" marker.
+//
+// Detection order (first match wins):
+//  1. A status entry whose Type == VolumeTypeClassic.  Classic disks are
+//     OVF/template-deployed boot disks;
+//  2. A status entry whose Name matches a spec.volumes entry that has
+//     removable == false.  When a VM is deployed from an OVF image the
+//     controller marks image disks as removable=false to protect them.
+//  3. The first status entry whose Name matches any spec.volumes entry
+//     (regardless of type).  Catches VMs that only have a single managed
+//     data-disk listed in spec (unusual but possible in test fixtures).
+//
+// Returns nil when no boot disk can be identified (e.g. no volumes have
+// been attached yet).
+func FindBootDiskVolumeStatus(vm *vmopv1a6.VirtualMachine) *vmopv1a6.VirtualMachineVolumeStatus {
+	// Pass 1 – Classic disk (OVF boot disk).
+	for i := range vm.Status.Volumes {
+		if vm.Status.Volumes[i].Type == vmopv1a6.VolumeTypeClassic {
+			return &vm.Status.Volumes[i]
+		}
+	}
+
+	// Build a name→index map for quick status lookups.
+	statusIdx := make(map[string]int, len(vm.Status.Volumes))
+	for i := range vm.Status.Volumes {
+		statusIdx[vm.Status.Volumes[i].Name] = i
+	}
+
+	// Pass 2 – spec.volumes entry that is explicitly non-removable.
+	for _, sv := range vm.Spec.Volumes {
+		if sv.Removable != nil && !*sv.Removable {
+			if i, ok := statusIdx[sv.Name]; ok {
+				return &vm.Status.Volumes[i]
+			}
+		}
+	}
+
+	// Pass 3 – first spec.volumes entry present in status (fallback).
+	for _, sv := range vm.Spec.Volumes {
+		if i, ok := statusIdx[sv.Name]; ok {
+			return &vm.Status.Volumes[i]
+		}
+	}
+
+	return nil
+}
+
+// StorageClassNameForBootDisk resolves the Kubernetes StorageClass name that
+// backs the boot disk identified by bootVol.
+//
+// Two paths are used depending on the volume type:
+//
+//   - Managed (PVC-backed): reads spec.volumes to find the PersistentVolumeClaim
+//     claim name, fetches the PVC, and returns its spec.storageClassName.  This
+//     is the common case for WCP VM-Service VMs whose boot disk is promoted to
+//     an FCD and tracked as a PVC.  PBM is not used because QueryAssociatedProfiles
+//     with "virtualDiskId" does not reliably return a profile for FCD-backed disks.
+//
+//   - Classic (OVF template disk, no PVC): queries PBM via QueryAssociatedProfiles
+//     using the disk's device key and maps the returned profile ID to a
+//     StorageClass by matching the "storagePolicyID" parameter.
+func StorageClassNameForBootDisk(
+	ctx context.Context,
+	vimClient *vim25.Client,
+	k8sClient ctrlclient.Client,
+	vm *vmopv1a6.VirtualMachine,
+	bootVol *vmopv1a6.VirtualMachineVolumeStatus,
+) (string, error) {
+	if bootVol.Type == vmopv1a6.VolumeTypeManaged {
+		return storageClassNameForManagedDisk(ctx, k8sClient, vm, bootVol.Name)
+	}
+	// Classic disk: use PBM.
+	deviceKey, err := diskDeviceKeyByUUID(ctx, vimClient, vm.Status.UniqueID, bootVol.DiskUUID)
+	if err != nil {
+		return "", err
+	}
+	profileID, err := pbmProfileIDForDisk(ctx, vimClient, vm.Status.UniqueID, deviceKey)
+	if err != nil {
+		return "", err
+	}
+	if profileID == "" {
+		return "", fmt.Errorf("PBM returned no storage profile for classic boot disk %q on VM %s/%s",
+			bootVol.Name, vm.Namespace, vm.Name)
+	}
+	candidates, err := storageClassNameForPolicyID(ctx, k8sClient, profileID)
+	if err != nil {
+		return "", err
+	}
+
+	// Honour the class the user explicitly requested.
+	for _, c := range candidates {
+		if c == vm.Spec.StorageClass {
+			return c, nil
+		}
+	}
+	return "", fmt.Errorf("StorageClass %q not found among candidates %v for storage policy ID %q on VM %s/%s",
+		vm.Spec.StorageClass, candidates, profileID, vm.Namespace, vm.Name)
+}
+
+// storageClassNameForManagedDisk finds the spec.volumes entry matching volName,
+// fetches its backing PVC, and returns the PVC's spec.storageClassName.
+func storageClassNameForManagedDisk(
+	ctx context.Context,
+	k8sClient ctrlclient.Client,
+	vm *vmopv1a6.VirtualMachine,
+	volName string,
+) (string, error) {
+	// Find the matching spec.volumes entry to get the PVC claim name.
+	var claimName string
+	for _, sv := range vm.Spec.Volumes {
+		if sv.Name == volName && sv.PersistentVolumeClaim != nil {
+			claimName = sv.PersistentVolumeClaim.ClaimName
+			break
+		}
+	}
+	if claimName == "" {
+		return "", fmt.Errorf("no PersistentVolumeClaim found in spec.volumes for volume %q on VM %s/%s",
+			volName, vm.Namespace, vm.Name)
+	}
+
+	var pvc corev1.PersistentVolumeClaim
+	if err := k8sClient.Get(ctx, types.NamespacedName{
+		Namespace: vm.Namespace,
+		Name:      claimName,
+	}, &pvc); err != nil {
+		return "", fmt.Errorf("get PVC %s/%s for boot disk %q: %w",
+			vm.Namespace, claimName, volName, err)
+	}
+
+	if pvc.Spec.StorageClassName == nil || *pvc.Spec.StorageClassName == "" {
+		return "", fmt.Errorf("PVC %s/%s for boot disk %q has no storageClassName",
+			vm.Namespace, claimName, volName)
+	}
+
+	return *pvc.Spec.StorageClassName, nil
+}
+
+// diskDeviceKeyByUUID retrieves the vSphere device key for a virtual disk
+// identified by its backing UUID.  It fetches config.hardware.device from the
+// VM via the property collector and searches for a VirtualDisk whose
+// VirtualDiskFlatVer2BackingInfo (or similar) reports the given UUID.
+func diskDeviceKeyByUUID(
+	ctx context.Context,
+	vimClient *vim25.Client,
+	vmMoID string,
+	diskUUID string,
+) (int32, error) {
+	pc := property.DefaultCollector(vimClient)
+	moRef := vimtypes.ManagedObjectReference{Type: "VirtualMachine", Value: vmMoID}
+
+	var vmMO mo.VirtualMachine
+	if err := pc.RetrieveOne(ctx, moRef, []string{"config.hardware.device"}, &vmMO); err != nil {
+		return 0, fmt.Errorf("retrieve VM hardware devices for %s: %w", vmMoID, err)
+	}
+	if vmMO.Config == nil {
+		return 0, fmt.Errorf("VM %s has no config", vmMoID)
+	}
+
+	normalised := strings.ToLower(diskUUID)
+
+	for _, dev := range object.VirtualDeviceList(vmMO.Config.Hardware.Device).SelectByType((*vimtypes.VirtualDisk)(nil)) {
+		disk := dev.(*vimtypes.VirtualDisk)
+		if uuid := virtualDiskBackingUUID(disk); strings.ToLower(uuid) == normalised {
+			return disk.Key, nil
+		}
+	}
+
+	return 0, fmt.Errorf("no virtual disk with UUID %q found on VM %s", diskUUID, vmMoID)
+}
+
+// virtualDiskBackingUUID extracts the UUID from the most common virtual disk
+// backing types used on WCP supervisor clusters.
+func virtualDiskBackingUUID(disk *vimtypes.VirtualDisk) string {
+	switch b := disk.Backing.(type) {
+	case *vimtypes.VirtualDiskFlatVer2BackingInfo:
+		return b.Uuid
+	case *vimtypes.VirtualDiskSparseVer2BackingInfo:
+		return b.Uuid
+	case *vimtypes.VirtualDiskRawDiskMappingVer1BackingInfo:
+		return b.Uuid
+	case *vimtypes.VirtualDiskRawDiskVer2BackingInfo:
+		return b.Uuid
+	}
+	return ""
+}
+
+// pbmProfileIDForDisk queries the vSphere Storage Policy Service (PBM) for
+// the profile assigned to a specific virtual disk identified by its device key
+// on the given VM.
+//
+// The PBM objectRef key format for a virtual disk is "<vm-moid>:<device-key>".
+// See https://developer.broadcom.com/xapis/vmware-storage-policy-api/latest/pbm.ServerObjectRef.html
+func pbmProfileIDForDisk(
+	ctx context.Context,
+	vimClient *vim25.Client,
+	vmMoID string,
+	deviceKey int32,
+) (string, error) {
+	pbmClient, err := pbm.NewClient(ctx, vimClient)
+	if err != nil {
+		return "", fmt.Errorf("create PBM client: %w", err)
+	}
+
+	ref := pbmtypes.PbmServerObjectRef{
+		ObjectType: "virtualDiskId",
+		Key:        fmt.Sprintf("%s:%d", vmMoID, deviceKey),
+	}
+
+	results, err := pbmClient.QueryAssociatedProfiles(ctx, []pbmtypes.PbmServerObjectRef{ref})
+	if err != nil {
+		return "", fmt.Errorf("PBM QueryAssociatedProfiles for disk %s:%d: %w", vmMoID, deviceKey, err)
+	}
+
+	for _, r := range results {
+		for _, p := range r.ProfileId {
+			if p.UniqueId != "" {
+				return p.UniqueId, nil
+			}
+		}
+	}
+
+	return "", nil
+}
+
+// storageClassNameForPolicyID scans all StorageClass objects visible to
+// k8sClient and returns the names of all StorageClasses whose "storagePolicyID"
+// parameter matches profileID.  The caller is responsible for selecting the
+// most appropriate candidate (e.g. by honouring the user's spec.storageClass).
+func storageClassNameForPolicyID(
+	ctx context.Context,
+	k8sClient ctrlclient.Client,
+	profileID string,
+) ([]string, error) {
+	var list storagev1.StorageClassList
+	if err := k8sClient.List(ctx, &list); err != nil {
+		return nil, fmt.Errorf("list StorageClasses: %w", err)
+	}
+
+	var matches []string
+	for _, sc := range list.Items {
+		if sc.Parameters["storagePolicyID"] == profileID {
+			matches = append(matches, sc.Name)
+		}
+	}
+
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("no StorageClass found for storage policy ID %q", profileID)
+	}
+	return matches, nil
+}

--- a/test/e2e/utils/vmop.go
+++ b/test/e2e/utils/vmop.go
@@ -21,6 +21,7 @@ import (
 	vmopv1a2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	vmopv1a3 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	vmopv1a5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
+	vmopv1a6 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 
 	spqv1 "github.com/vmware-tanzu/vm-operator/external/storage-policy-quota/api/v1alpha1"
 )
@@ -82,6 +83,22 @@ func GetVirtualMachineA3(ctx context.Context, client ctrlclient.Client, ns, name
 // TODO: the above should return vmopv1a5, but requires some refactoring of existing tests.
 func GetVirtualMachineA5(ctx context.Context, client ctrlclient.Client, ns, name string) (*vmopv1a5.VirtualMachine, error) {
 	virtualMachine := &vmopv1a5.VirtualMachine{}
+
+	key := types.NamespacedName{
+		Namespace: ns,
+		Name:      name,
+	}
+
+	err := client.Get(ctx, key, virtualMachine)
+	if err != nil {
+		return nil, err
+	}
+
+	return virtualMachine, nil
+}
+
+func GetVirtualMachineA6(ctx context.Context, client ctrlclient.Client, ns, name string) (*vmopv1a6.VirtualMachine, error) {
+	virtualMachine := &vmopv1a6.VirtualMachine{}
 
 	key := types.NamespacedName{
 		Namespace: ns,

--- a/test/e2e/vmservice/common/scheme.go
+++ b/test/e2e/vmservice/common/scheme.go
@@ -16,6 +16,7 @@ import (
 	vmopv1a2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	vmopv1a3 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	vmopv1a5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
+	vmopv1a6 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 	imageregistryv1alpha1 "github.com/vmware-tanzu/vm-operator/external/image-registry-operator/api/v1alpha1"
 	imageregistryv1alpha2 "github.com/vmware-tanzu/vm-operator/external/image-registry-operator/api/v1alpha2"
 	mopv1alpha2 "github.com/vmware-tanzu/vm-operator/external/mobility-operator/api/v1alpha2"
@@ -74,6 +75,11 @@ func addSchemes(sc *runtime.Scheme) {
 	err = vmopv1a5.AddToScheme(sc)
 	if err != nil {
 		e2eframework.Failf("unable add v1alpha5 VMOP APIs to scheme: %v", err)
+	}
+
+	err = vmopv1a6.AddToScheme(sc)
+	if err != nil {
+		e2eframework.Failf("unable add v1alpha6 VMOP APIs to scheme: %v", err)
 	}
 
 	err = mopv1alpha2.AddToScheme(sc)

--- a/test/e2e/vmservice/lib/vmoperator/vmoperator.go
+++ b/test/e2e/vmservice/lib/vmoperator/vmoperator.go
@@ -14,6 +14,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/vmware/govmomi/vim25"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -28,6 +29,7 @@ import (
 	vmopv1a2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	vmopv1a3 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	vmopv1a5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
+	vmopv1a6 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 	ncpv1alpha1 "github.com/vmware-tanzu/vm-operator/external/ncp/api/v1alpha1"
 	vpcv1alpha1 "github.com/vmware-tanzu/vm-operator/external/nsx-operator/api/vpc/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/framework"
@@ -1316,4 +1318,58 @@ func VerifyVMDeleted(
 		return false
 	}, vmSvcE2EConfig.GetIntervals("default", "wait-virtual-machine-deletion")...).Should(BeTrue(),
 		"Timed out waiting for VirtualMachine to be deleted")
+}
+
+// EventuallyBootDiskStoragePolicyMatchesVMStorageClass polls until the boot
+// disk identified in vm.Status.Volumes has a vSphere storage profile whose
+// corresponding Kubernetes StorageClass name matches vm.Spec.StorageClass.
+//
+// Boot disk identification uses FindBootDiskVolumeStatus (Classic → non-
+// removable spec entry → first spec entry).  The profile is resolved via PBM
+// QueryAssociatedProfiles using the disk's backing UUID and the VM's MoID
+// (status.uniqueID).  The profile ID is then mapped to a StorageClass name
+// via the "storagePolicyID" parameter on StorageClass objects in the cluster.
+//
+// The caller must supply an authenticated vimClient (vim25.Client) so that
+// this helper can reach vSphere without establishing its own connection.
+func EventuallyBootDiskStoragePolicyMatchesVMStorageClass(
+	ctx context.Context,
+	vmSvcE2EConfig *config.E2EConfig,
+	vimClient *vim25.Client,
+	k8sClient ctrlclient.Client,
+	namespace, name string,
+) {
+	GinkgoHelper()
+
+	Eventually(func(g Gomega) {
+		vm, err := utils.GetVirtualMachineA6(ctx, k8sClient, namespace, name)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		g.Expect(vm.Spec.StorageClass).NotTo(BeEmpty(),
+			"VirtualMachine %s/%s must set spec.storageClass for boot disk assertion",
+			namespace, name)
+
+		g.Expect(vm.Status.UniqueID).NotTo(BeEmpty(),
+			"VirtualMachine %s/%s has no status.uniqueID yet; VM may not be powered on",
+			namespace, name)
+
+		boot := utils.FindBootDiskVolumeStatus(vm)
+		g.Expect(boot).NotTo(BeNil(),
+			"no boot disk found in status.volumes for VirtualMachine %s/%s", namespace, name)
+
+		if boot.Type == vmopv1a6.VolumeTypeManaged {
+			g.Expect(boot.DiskUUID).NotTo(BeEmpty(),
+				"boot disk %q in VirtualMachine %s/%s has no diskUUID yet", boot.Name, namespace, name)
+		}
+
+		scName, err := utils.StorageClassNameForBootDisk(
+			ctx, vimClient, k8sClient, vm, boot)
+		g.Expect(err).NotTo(HaveOccurred(),
+			"StorageClassNameForBootDisk failed for boot disk %q on VirtualMachine %s/%s",
+			boot.Name, namespace, name)
+
+		g.Expect(scName).To(Equal(vm.Spec.StorageClass),
+			"boot disk %q storage policy StorageClass %q does not match spec.storageClass %q on VirtualMachine %s/%s",
+			boot.Name, scName, vm.Spec.StorageClass, namespace, name)
+	}, vmSvcE2EConfig.GetIntervals("default", "wait-virtual-machine-creation")...).Should(Succeed())
 }

--- a/test/e2e/vmservice/vmservice/virtualmachine/virtualmachinelcm.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/virtualmachinelcm.go
@@ -464,6 +464,24 @@ func VMSpec(ctx context.Context, inputGetter func() VMSpecInput) {
 		vmoperator.WaitForVirtualMachineCreation(ctx, config, svClusterClient, tmpNamespaceName, vmName)
 	})
 
+	It("Should verify boot disk storage policy matches VM spec.storageClass after power-on", Label("experimental"), func() {
+		vmParameters := manifestbuilders.VirtualMachineYaml{
+			Namespace:        input.WCPNamespaceName,
+			Name:             vmName,
+			ImageName:        linuxImageDisplayName,
+			VMClassName:      clusterResources.VMClassName,
+			StorageClassName: clusterResources.StorageClassName,
+			ResourcePolicy:   clusterResources.VMResourcePolicyName,
+			PowerState:       poweredOnState,
+		}
+		vmYaml = manifestbuilders.GetVirtualMachineYamlA6(vmParameters)
+		Expect(clusterProxy.CreateWithArgs(ctx, vmYaml)).To(Succeed(), "failed to create virtualmachine:\n %s", string(vmYaml))
+		vmoperator.WaitForVirtualMachineCreation(ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
+
+		By("Verifying boot disk storage policy matches spec.storageClass")
+		vmoperator.EventuallyBootDiskStoragePolicyMatchesVMStorageClass(ctx, config, vCenterClient, svClusterClient, input.WCPNamespaceName, vmName)
+	})
+
 	It("Should emit a condition for a VMClass that doesn't exist in the cluster for a Virtual Machine creation", func() {
 		vmClassName := "test-vmClass"
 		expectedCondition := metav1.Condition{

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_encryption.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_encryption.go
@@ -119,10 +119,10 @@ func VMEncryptionSpec(ctx context.Context, inputGetter func() VMEncryptionInput)
 		Expect(err).NotTo(HaveOccurred(), "failed to get the VM Image name in namespace %q", tmpNamespaceName)
 
 		By(utils.E2EEncryptionStorageProfileName + " should exist")
-		Expect(utils.EnsureE2EEncryptionStorageInNamespace(ctx, vCenterClient, 
-			wcpClient, clusterProxy.GetClientSet(), svClusterClient, *config, 
+		Expect(utils.EnsureE2EEncryptionStorageInNamespace(ctx, vCenterClient,
+			wcpClient, clusterProxy.GetClientSet(), svClusterClient, *config,
 			tmpNamespaceName, clusterResources.StorageClassName)).
-			To(Succeed(), "failed to ensure encryption storage in namespace %s", 
+			To(Succeed(), "failed to ensure encryption storage in namespace %s",
 				tmpNamespaceName)
 
 		defaultKeyProviderID, err = cryptoManager.GetDefaultKmsClusterID(ctx, nil, true)
@@ -154,6 +154,28 @@ func VMEncryptionSpec(ctx context.Context, inputGetter func() VMEncryptionInput)
 		_ = cryptoManager.SetDefaultKmsClusterId(ctx, defaultKeyProviderID, nil)
 
 		vcenter.LogoutVimClient(vCenterClient)
+	})
+
+	It("Should verify boot disk storage policy matches VM spec.storageClass for an encrypted VM", Label("experimental"), func() {
+		useKeyProvider(ctx, cryptoManager, nativeKeyProviderID)
+
+		By("Create VM using encryption storage policy")
+		vmParameters := manifestbuilders.VirtualMachineYaml{
+			Namespace:        tmpNamespaceName,
+			Name:             vmName,
+			ImageName:        vmiName,
+			VMClassName:      "best-effort-small",
+			StorageClassName: utils.E2EEncryptionStorageClassName,
+			ResourcePolicy:   clusterResources.VMResourcePolicyName,
+			PowerState:       "PoweredOn",
+		}
+		vmYaml = manifestbuilders.GetVirtualMachineYamlA6(vmParameters)
+		Expect(clusterProxy.CreateWithArgs(ctx, vmYaml)).Should(Succeed(), "failed to create virtualmachine:\n %s", string(vmYaml))
+
+		vmoperator.WaitForVirtualMachineCreation(ctx, config, svClusterClient, tmpNamespaceName, vmName)
+
+		By("Verifying boot disk storage policy matches spec.storageClass for encrypted VM")
+		vmoperator.EventuallyBootDiskStoragePolicyMatchesVMStorageClass(ctx, config, vCenterClient, svClusterClient, tmpNamespaceName, vmName)
 	})
 
 	It("Create an Encrypted VirtualMachine using encryption storage policy", Label("smoke"), func() {


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This patch introduces new test utilities for verifying that boot disk storage policies match VM spec.storageClass, in both standard VM lifecycle and encryption scenarios. It has been flagged as "experimental".

```
Testing VM Services VIRTUAL-MACHINE VM-LCM Should verify boot disk storage policy matches VM spec.storageClass after power-on [devops, viadmin, virtualmachine, vmservice, experimental]
./vm-operator/test/e2e/vmservice/vmservice/virtualmachine/virtualmachinelcm.go:467
virtualmachine.vmoperator.vmware.com/vm-lcm-fhko created

  STEP: Verify that a single VirtualMachine 'vmsvc-e2e-pvy4wt/vm-lcm-fhko' is created @ 05/07/26 10:25:59.817
  STEP: Verifying the existence of VM CR in etcd @ 05/07/26 10:25:59.817
  STEP: Waiting for vSphere VM to be created @ 05/07/26 10:25:59.912
  STEP: Waiting for VM power state to reach PoweredOn @ 05/07/26 10:26:10.067
  STEP: Verify that an IP (ipv4) is allocated to the VirtualMachine 'vmsvc-e2e-pvy4wt/vm-lcm-fhko' @ 05/07/26 10:26:41.238
  STEP: Verifying boot disk storage policy matches spec.storageClass @ 05/07/26 10:28:14.472
virtualmachine.vmoperator.vmware.com "vm-lcm-fhko" deleted from vmsvc-e2e-pvy4wt namespace
```


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

Tests have been flagged as "experimental". And added some a cursor rule to avoid make unnecessary changes on the api/contract.

**Please add a release note if necessary**:

```release-note

```