### PR TITLE
🐛 fix: E2E Dockerfile for encryption and perms issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ infrastructure-components.yaml
 # E2E tests
 test/e2e/**/test_logs
 e2e-tests
+kubectl

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -58,17 +58,22 @@ RUN tdnf update -y && \
         build-essential \
         glibc-devel \
         go \
+        sudo \
         && \
     rm -rf /var/cache/tdnf
 
-ARG KUBECTL_VERSION=v1.32.0
-ARG KUBECTL_URL=https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl
-RUN curl -fsSL "${KUBECTL_URL}" -o /usr/local/bin/kubectl && \
-    chmod +x /usr/local/bin/kubectl
+# kubectl is always staged into the build context as ./kubectl before docker build runs.
+# This is to support passing the kubectl binary from the build system.
+COPY kubectl /usr/local/bin/kubectl
+RUN chmod +x /usr/local/bin/kubectl
 
-# Create non-root user early 
-RUN groupadd -g 1000 vmoperator && \
-    useradd -u 1000 -g vmoperator -s /bin/bash -m vmoperator
+# Create non-root user early
+# GID 201 (mts) matches the testing system's NFS log directory group, required for writing test artifacts.
+# vmoperator is granted passwordless sudo (scoped to chmod only) so it can fix NFS directory
+RUN groupadd -g 201 mts && \
+    groupadd -g 1000 vmoperator && \
+    useradd -u 1000 -g vmoperator -G mts -s /bin/bash -m vmoperator && \
+    echo "vmoperator ALL=(ALL) NOPASSWD: /bin/chmod" >> /etc/sudoers
 
 # Create directories and set up convenience scripts
 RUN mkdir -p /vm-operator /tmp/go-cache && \
@@ -77,7 +82,10 @@ RUN mkdir -p /vm-operator /tmp/go-cache && \
 WORKDIR /vm-operator
 
 COPY --from=builder --chown=vmoperator:vmoperator /vm-operator/hack/setup-testbed-env.sh ./hack/setup-testbed-env.sh
-RUN ln -sf /vm-operator/hack/setup-testbed-env.sh /usr/local/bin/setup-testbed-env
+COPY --from=builder --chown=vmoperator:vmoperator /vm-operator/hack/wait-for-artifact-dir.sh ./hack/wait-for-artifact-dir.sh
+RUN ln -sf /vm-operator/hack/setup-testbed-env.sh /usr/local/bin/setup-testbed-env && \
+    ln -sf /vm-operator/hack/wait-for-artifact-dir.sh /usr/local/bin/wait-for-artifact-dir && \
+    chmod +x /vm-operator/hack/wait-for-artifact-dir.sh
 
 COPY --from=builder --chown=vmoperator:vmoperator /vm-operator/Makefile ./Makefile
 COPY --from=builder --chown=vmoperator:vmoperator /vm-operator/e2e-tests ./e2e-tests

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ IMAGE ?= vmoperator-controller
 IMAGE_TAG ?= latest
 IMG ?= ${IMAGE}:${IMAGE_TAG}
 
-# E2E test image configuration  
+# E2E test image configuration
 E2E_BASE_IMAGE ?= mirror.gcr.io/library/photon:5.0
 E2E_IMAGE ?= vmoperator-e2e
 E2E_IMG ?= ${E2E_IMAGE}:${IMAGE_TAG}
@@ -951,6 +951,11 @@ verify-wcp-manifests: ## Verify the WCP manifests
 e2e-image-build: GOOS=linux
 e2e-image-build: ## Build E2E test container image
 	@echo "Building VM Operator E2E test image..."
+	@# Stage kubectl into the build context. This is to support passing the kubectl binary from the build system.
+	@if [ ! -s kubectl ]; then \
+		echo "Downloading kubectl $(E2E_KUBECTL_VERSION)..."; \
+		curl -fsSL "https://dl.k8s.io/release/$(E2E_KUBECTL_VERSION)/bin/linux/amd64/kubectl" -o kubectl && chmod +x kubectl; \
+	fi
 	$(CRI_BIN) build \
 	  -f Dockerfile.e2e \
 	  -t "$(E2E_IMAGE):$(IMAGE_TAG)" \

--- a/hack/install-pykmip.sh
+++ b/hack/install-pykmip.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -x
+
+# Install https://github.com/OpenKMIP/PyKMIP
+# Used as KMS for encrypting VMs
+
+# VDS/photon:
+#  server == /usr/bin/pykmip-server
+#  pip3 not installed
+# NSX/ubuntu:
+#  server == /usr/local/bin/pykmip-server
+#  pip3 already installed
+if ! type -p pykmip-server >/dev/null ; then
+  if ! type -p pip3 >/dev/null ; then
+    python3 -m ensurepip
+    pip3 install --upgrade pip
+  fi
+
+  pip3 install pykmip
+
+  # currently by default there are no shared ciphers between
+  # vCenter/qClient + pykmip, patch the default TLS1.2 suite for now.
+  # See: https://bugzilla-vcf.lvn.broadcom.net/show_bug.cgi?id=3428705
+  site=$(python3 -c 'import site; print(site.getsitepackages()[0])')
+  sed -i -e "s/'ECDHE-RSA-AES128-SHA256',/'ECDHE-RSA-AES128-SHA',/g" \
+      "$site"/kmip/services/auth.py
+fi
+
+mkdir -p /etc/pykmip
+
+cat > /etc/pykmip/server.conf <<EOF
+[server]
+hostname=0.0.0.0
+port=5696
+ca_path=/root/pykmip-crt.pem
+certificate_path=/root/pykmip-crt.pem
+key_path=/root/pykmip-key.pem
+auth_suite=TLS1.2
+policy_path=/etc/pykmip
+enable_tls_client_auth=False
+logging_level=DEBUG
+database_path=/etc/pykmip/pykmip_server.db
+EOF
+
+cat > /lib/systemd/system/pykmip.service <<EOF
+[Unit]
+Description=PyKMIP
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart=$(type -p pykmip-server | head -n1)
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+pushd /etc/systemd/system/multi-user.target.wants >/dev/null
+if [ ! -e pykmip.service ] ; then
+  ln -s /lib/systemd/system/pykmip.service .
+fi
+popd >/dev/null
+
+systemctl restart pykmip
+systemctl status pykmip
+
+iptables -A INPUT -p tcp --dport 5696 -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT
+iptables -A OUTPUT -p tcp --sport 5696 -m conntrack --ctstate ESTABLISHED -j ACCEPT
+iptables --list

--- a/hack/kms.sh
+++ b/hack/kms.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+# This script installs and configures a Native and Standard (PyKMIP) Key Provider for use by vCenter.
+# To run directly (default vds password below, nsx password is generated):
+# % export GOVC_URL="Administrator@vsphere.local:${vc_pass}@${vc_host}"
+# % GATEWAY_VM_PASSWORD=vmware ./hack/kms.sh install
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -x
+
+export GOVC_URL # set in main()
+export GOVC_INSECURE=true
+GATEWAY_VM_USERNAME="${GATEWAY_VM_USERNAME:-root}"
+GATEWAY_VM_PASSWORD="${GATEWAY_VM_PASSWORD:-vmware}"
+script_dir="$(dirname "$0")"
+crt_dir="$script_dir/tools/bin"
+
+find_gateway_ip() {
+  mgmtCidr="$1"
+
+  # VDS:
+  #  vm == external-gateway
+  # NSX:
+  #  vm == external-vm-gateway
+  vm=$(govc find / -type m -name external*gateway)
+
+  # Use grepcidr if available, otherwise fallback to grep for common management networks
+  if command -v grepcidr >/dev/null 2>&1; then
+    govc vm.ip -a -v4 "$vm" | tr ',' '\n' | grepcidr "$mgmtCidr"
+  else
+    # Fallback: get first non-169.254.x.x IP (avoid link-local)
+    govc vm.ip -a -v4 "$vm" | tr ',' '\n' | grep -v "^169\.254\." | head -n1
+  fi
+}
+
+install() {
+  if [ ! -e "$crt_dir/pykmip-crt.pem" ] ; then
+    mkdir -p "$crt_dir"
+    openssl req -x509 -newkey rsa:4096 -sha256 -days 365 -nodes \
+            -subj "/C=US/ST=CA/L=PA/O=Broadcom/OU=VCF/CN=pykmip" \
+            -keyout "$crt_dir"/pykmip-key.pem -out "$crt_dir"/pykmip-crt.pem
+  fi
+
+  target="$1@$2"
+  password=$3
+
+  sshpass -p "$password" scp -o PubkeyAuthentication=no -o StrictHostKeyChecking=no "$crt_dir"/pykmip-*.pem "$script_dir"/install-pykmip.sh "$target":
+  sshpass -p "$password" ssh -o PubkeyAuthentication=no -o StrictHostKeyChecking=no "$target" /bin/bash ./install-pykmip.sh
+
+  setup "$2" || echo "KMS setup failed"
+}
+
+# See also: vCenter -> Configure -> Security -> Key Providers
+setup() {
+  ip="$1"
+
+  name=gce2e-standard
+  if ! govc kms.ls "$name" 2> /dev/null ; then
+    govc kms.add -n pykmip -a "$ip" "$name"
+  fi
+  crt=$(cat "$crt_dir/pykmip-crt.pem")
+  key=$(cat "$crt_dir/pykmip-key.pem")
+
+  # Note: using the same key pair for the server (pykmip) and client (vCenter)
+  govc kms.trust -server-cert "$crt" -client-cert "$crt" -client-key "$key" "$name"
+  govc kms.ls "$name"
+
+  name=gce2e-native
+  if ! govc kms.ls "$name" 2> /dev/null ; then
+    govc kms.add -tpm=false -N "$name"
+  fi
+  # Take a backup (and throw it away), required to activate the provider
+  govc kms.export -f /dev/null "$name"
+
+  govc kms.ls "$name"
+}
+
+main() {
+  if [ "$#" -ge 2 ]; then
+    GOVC_URL="$2"
+  fi
+  mgmtCidr='10.0.0.0/8'
+  if [ "$#" -ge 3 ]; then
+    mgmtCidr="$3"
+  fi
+
+  case $1 in
+    "install")
+      install "$GATEWAY_VM_USERNAME" "$(find_gateway_ip "$mgmtCidr")" "$GATEWAY_VM_PASSWORD"
+      ;;
+    "setup")
+      setup "$(find_gateway_ip "$mgmtCidr")"
+      ;;
+    *)
+      echo "unknown command: $1"
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"

--- a/hack/wait-for-artifact-dir.sh
+++ b/hack/wait-for-artifact-dir.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -e
+
+#
+# wait-for-artifact-dir.sh - Wait for E2E_ARTIFACT_FOLDER to exist and become writable
+#
+# Spins until the directory specified by E2E_ARTIFACT_FOLDER exists, then
+# makes it group-writable so that tests can write logs and artifacts into it.
+# Exits 1 on timeout (10 minutes).
+#
+# Usage:
+#   export E2E_ARTIFACT_FOLDER=/path/to/artifacts
+#   wait-for-artifact-dir.sh
+#
+
+TIMEOUT_SECONDS=600
+POLL_INTERVAL=5
+
+if [[ -z "$E2E_ARTIFACT_FOLDER" ]]; then
+    echo "[wait-for-artifact-dir] ERROR: E2E_ARTIFACT_FOLDER is not set"
+    exit 1
+fi
+
+echo "[wait-for-artifact-dir] Waiting for artifact directory: $E2E_ARTIFACT_FOLDER"
+echo "[wait-for-artifact-dir] Timeout: ${TIMEOUT_SECONDS}s ($(( TIMEOUT_SECONDS / 60 )) minutes)"
+
+elapsed=0
+while [[ ! -d "$E2E_ARTIFACT_FOLDER" ]]; do
+    if [[ $elapsed -ge $TIMEOUT_SECONDS ]]; then
+        echo "[wait-for-artifact-dir] ERROR: Timed out after ${TIMEOUT_SECONDS}s waiting for $E2E_ARTIFACT_FOLDER"
+        exit 1
+    fi
+    sleep $POLL_INTERVAL
+    elapsed=$(( elapsed + POLL_INTERVAL ))
+    if (( elapsed % 60 == 0 )); then
+        echo "[wait-for-artifact-dir] Still waiting... (${elapsed}s / ${TIMEOUT_SECONDS}s)"
+    fi
+done
+
+echo "[wait-for-artifact-dir] Directory found (after ${elapsed}s)"
+ls -la "$E2E_ARTIFACT_FOLDER"
+
+sudo chmod g+w "$E2E_ARTIFACT_FOLDER"
+sudo chmod -R g+w "$E2E_ARTIFACT_FOLDER" || true
+echo "[wait-for-artifact-dir] Made directory group-writable"
+ls -la "$E2E_ARTIFACT_FOLDER"
+
+exit 0


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Improve the Dockerfile E2E to pull kubectl from local, wait for the logs dir to be created, and setup the KMS for the tests, which are required for the build pipeline.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # NA


**Are there any special notes for your reviewer**:

NA

**Please add a release note if necessary**:
NA