### PR TITLE
🌱 Temporarily use Go 1.26.3 in Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version: '1.26.3' # TODO (brito-rafa) GO-2026-4986, GO-2026-4982, GO-2026-4980, GO-2026-4977, GO-2026-4971
         go-version-file: 'go.mod'
         cache: true
         cache-dependency-path: '**/go.sum'


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This patch updates the ci.yml GH action file to use Go1.26.3 so that vulncheck will not complain. This patch will be reverted once the internal VM Op builds can be moved onto Go1.26.3.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

Practice was adopted previously so we have clean checks until we have an internal Go1.26.3.


**Please add a release note if necessary**:

```release-note

```