### PR TITLE
:sparkles: Generate documentation from CRDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -312,6 +312,7 @@ GOLANGCI_LINT_ABS_PATH := $(abspath $(GOLANGCI_LINT))
 GO_MOD_DIRS_TO_LINT := $(GO_MOD_DIRS)
 GO_MOD_DIRS_TO_LINT := $(filter-out ./external%,$(GO_MOD_DIRS_TO_LINT))
 GO_MOD_DIRS_TO_LINT := $(filter-out ./hack/tools%,$(GO_MOD_DIRS_TO_LINT))
+GO_MOD_DIRS_TO_LINT := $(filter-out ./api-docs%,$(GO_MOD_DIRS_TO_LINT))
 GO_LINT_DIR_TARGETS := $(addprefix lint-,$(GO_MOD_DIRS_TO_LINT))
 
 .PHONY: $(GO_LINT_DIR_TARGETS)

--- a/api-docs/.gitignore
+++ b/api-docs/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+generated/
+go.sum

--- a/api-docs/Makefile
+++ b/api-docs/Makefile
@@ -1,0 +1,84 @@
+# Makefile for API Documentation Generation
+
+# The api-docs image referenced here is being sourced from
+# https://github-vcf.devops.broadcom.net/vcf/wcp-ci/tree/master/api-doc-tool
+#
+# WARNING: The Go version baked into this image must be compatible with the
+# go directive in go.mod. If either is updated, verify the other still matches
+# or the vendor/docs-generation step will fail with a version mismatch.
+API_DOCS_IMAGE ?= wcp-docker-local.packages.vcfd.broadcom.net/tools/api-docs:699a6a4
+DOCKER_RUN := docker run --platform=linux/amd64 \
+  -v $(CURDIR):$(CURDIR) -w $(CURDIR) --rm $(API_DOCS_IMAGE)
+
+# Prefer native binaries when present on PATH (faster for local dev).
+# CI hosts that only ship the Docker image fall back to the container.
+CRD_REF_DOCS_NATIVE := $(shell command -v crd-ref-docs 2>/dev/null)
+ASCIIDOCTOR_NATIVE  := $(shell command -v asciidoctor 2>/dev/null)
+
+ifneq ($(CRD_REF_DOCS_NATIVE),)
+CRD_REF_DOCS := $(CRD_REF_DOCS_NATIVE)
+else
+CRD_REF_DOCS := $(DOCKER_RUN) crd-ref-docs
+endif
+
+ifneq ($(ASCIIDOCTOR_NATIVE),)
+ASCIIDOCTOR := $(ASCIIDOCTOR_NATIVE)
+else
+ASCIIDOCTOR := $(DOCKER_RUN) asciidoctor
+endif
+
+.PHONY: help setup vendor docs docs-grouped docs-html docs-html-grouped \
+        clean all package
+
+help: ## Show this help message
+	@echo "Available targets:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | \
+	  awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+setup: ## Verify crd-ref-docs tool availability
+	@echo "Verifying crd-ref-docs..."
+	$(CRD_REF_DOCS) --version
+
+vendor: ## Vendor API dependencies for documentation generation
+	@echo "Tidying go modules..."
+	go mod tidy
+	@echo "Vendoring dependencies..."
+	go mod vendor
+
+docs: vendor ## Generate API documentation in Asciidoc format
+	@echo "Generating API documentation..."
+	mkdir -p generated/single
+	$(CRD_REF_DOCS) --config crd-ref-docs.config.yaml \
+		--source-path vendor \
+		--output-path generated/single/api-docs.asciidoc
+
+docs-grouped: vendor ## Generate API documentation in Asciidoc format, one file per group
+	@echo "Generating API documentation (grouped)..."
+	mkdir -p generated/grouped
+	$(CRD_REF_DOCS) --config crd-ref-docs.config.yaml \
+		--source-path vendor \
+		--output-path generated/grouped/ \
+		--output-mode=group
+
+docs-html: docs ## Generate API documentation in HTML format
+	@echo "Generating HTML (single)..."
+	$(ASCIIDOCTOR) generated/single/api-docs.asciidoc \
+		-a stylesheet=$(CURDIR)/boot-yeti.css \
+		-o generated/single/api-docs.html
+
+docs-html-grouped: docs-grouped ## Generate HTML documentation, one file per group
+	@echo "Generating HTML (grouped)..."
+	$(ASCIIDOCTOR) generated/grouped/* \
+		-a stylesheet=$(CURDIR)/boot-yeti.css
+
+clean: ## Clean generated files
+	@echo "Cleaning generated files..."
+	rm -rf vendor/ generated/ go.sum
+
+all: ## Run complete documentation generation pipeline with HTML output
+	$(MAKE) clean
+	$(MAKE) setup
+	$(MAKE) docs-html docs-html-grouped
+
+package: all ## Generate docs and assemble into publish/
+	cp generated/single/api-docs.html publish/api-docs.html

--- a/api-docs/boot-yeti.css
+++ b/api-docs/boot-yeti.css
@@ -1,0 +1,347 @@
+/* Based on Yeti from Bootswatch (https://bootswatch.com/yeti/) */
+@import url("//fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,700italic,400,300,700");
+
+/* document body (contains all content) */
+body {
+  font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 15px;
+  line-height: 1.4;
+  color: #222222;
+  background-color: #ffffff;
+  margin-left: 10%;
+  margin-right: 10%;
+}
+
+/* document header (contains title etc) */
+#header {
+  width: 100%;
+}
+#header>h1 {
+  border-bottom: 1px solid #ddddd8;
+  padding-bottom: 8px;
+}
+
+/* headings */
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-weight: 300;
+  line-height: 1.1;
+  color: inherit;
+}
+h1,
+h2,
+h3 {
+  margin-top: 21px;
+  margin-bottom: 10.5px;
+}
+h4,
+h5,
+h6 {
+  margin-top: 10.5px;
+  margin-bottom: 10.5px;
+}
+h1 {
+  font-size: 4em;
+/*   font-size: 39px; */
+}
+h2 {
+  font-size: 32px;
+}
+h3 {
+  font-size: 26px;
+}
+h4 {
+  font-size: 19px;
+}
+h5 {
+  font-size: 15px;
+}
+h6 {
+  font-size: 13px;
+}
+
+/* plain paragraph text */
+.paragraph {
+/*   font-family: sans-serif; */
+  margin: 0 0 10.5px;
+}
+p {
+  margin: 0 0 10.5px;
+}
+
+/* blockquote text */
+.quoteblock {
+  font-style: italic;
+}
+blockquote {
+  padding: 10.5px 21px;
+  margin: 0 0 21px;
+  font-size: 18.75px;
+  border-left: 5px solid #dddddd;
+}
+blockquote p:last-child,
+blockquote ul:last-child,
+blockquote ol:last-child {
+  margin-bottom: 0;
+}
+.blockquote-reverse,
+blockquote.pull-right {
+  padding-right: 15px;
+  padding-left: 0;
+  border-right: 5px solid #dddddd;
+  border-left: 0;
+  text-align: right;
+}
+.blockquote-reverse footer:before,
+blockquote.pull-right footer:before,
+.blockquote-reverse small:before,
+blockquote.pull-right small:before,
+.blockquote-reverse .small:before,
+blockquote.pull-right .small:before {
+  content: '';
+}
+.blockquote-reverse footer:after,
+blockquote.pull-right footer:after,
+.blockquote-reverse small:after,
+blockquote.pull-right small:after,
+.blockquote-reverse .small:after,
+blockquote.pull-right .small:after {
+  content: '\00A0 \2014';
+}
+
+/* blockquote attribution text */
+.attribution,
+.cite,
+blockquote footer,
+blockquote small,
+blockquote .small {
+  display: block;
+  line-height: 1.4;
+  color: #6f6f6f;
+}
+.attribution:before,
+blockquote footer:before,
+blockquote small:before,
+blockquote .small:before {
+  content: '\2014 \00A0';
+}
+
+/* unordered list */
+ul, ol {
+  margin-top: 0;
+  margin-bottom: 10.5px;
+}
+ul ul,
+ol ul,
+ul ol,
+ol ol {
+  margin-bottom: 0;
+}
+
+/* links */
+a {
+  color: #008cba;
+  text-decoration: none;
+}
+a:hover,
+a:focus {
+  color: #008cba;
+  text-decoration: underline;
+}
+a:focus {
+  outline: 5px auto -webkit-focus-ring-color;
+  outline-offset: -2px;
+}
+
+/* horizontal rules */
+hr {
+  margin-top: 21px;
+  margin-bottom: 21px;
+  border: 0;
+  border-top: 1px solid #dddddd;
+}
+
+/* table */
+table {
+  background-color: transparent;
+  width: 100%;
+  max-width: 100%;
+  margin-bottom: 21px;
+  border-collapse: collapse;
+}
+table col[class*="col-"] {
+  position: static;
+  float: none;
+  display: table-column;
+}
+table td[class*="col-"],
+table th[class*="col-"] {
+  position: static;
+  float: none;
+  display: table-cell;
+}
+
+/* table caption */
+caption {
+  padding-top: 8px;
+  padding-bottom: 8px;
+  color: #999999;
+  text-align: left;
+}
+
+/* table header row */
+thead {
+  border-bottom: 2px solid #dddddd;
+}
+
+/* table header cell */
+th {
+  text-align: left;
+  padding-left: 8px;
+}
+
+/* table footer */
+tfoot {
+  color: #807F81;
+  border-top: 1px solid #dddddd;
+}
+
+/* table cell */
+td {
+  border-top: 1px solid #dddddd;
+}
+td p {
+  margin: auto;
+  padding: 8px;
+}
+
+/* table body */
+tbody > tr:nth-of-type(odd) {
+  background-color: #f9f9f9;
+}
+tbody > tr:hover {
+  background-color: #f5f5f5;
+}
+
+/* inline code */
+code,
+kbd,
+pre,
+samp {
+  font-family: monospace, monospace;
+  font-size: 1em;
+}
+code {
+  padding: 2px 4px;
+  font-size: 90%;
+  color: #333333;
+  background-color: #f5f5f5;
+  border-radius: 0;
+}
+kbd {
+  padding: 2px 4px;
+  font-size: 90%;
+  color: #ffffff;
+  background-color: #333333;
+  border-radius: 0;
+  -webkit-box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.25);
+          box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.25);
+}
+kbd kbd {
+  padding: 0;
+  font-size: 100%;
+  font-weight: bold;
+  -webkit-box-shadow: none;
+          box-shadow: none;
+}
+pre {
+  display: block;
+  padding: 10px;
+  margin: 0 0 10.5px;
+  font-size: 14px;
+  line-height: 1.4;
+  word-break: break-all;
+  word-wrap: break-word;
+  color: #333333;
+  background-color: #f5f5f5;
+  border: 1px solid #cccccc;
+  border-radius: 0;
+}
+pre code {
+  padding: 0;
+  font-size: inherit;
+  color: inherit;
+  white-space: pre-wrap;
+  background-color: transparent;
+  border-radius: 0;
+}
+
+/* image */
+img {
+  max-width: 100%;
+  vertical-align: middle;
+}
+
+/* footer section */
+#footer {
+  margin-top: 22px;
+  padding: 14px 16px;
+  color: #ffffff;
+  background-color: #333333;
+}
+
+/* responsiveness fixes */
+video {
+  max-width: 100%;
+}
+
+/* table of Contents sidebar */
+#toctitle {
+  color: #ffffff;
+}
+
+#toc ul {
+  display: inline;
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+}
+
+#toc li {
+  display: block;
+}
+
+#toc a {
+  background-color: #333333;
+  float: left;
+  color: white;
+  text-align: center;
+  padding: 14px 16px;
+  text-decoration: none;
+}
+
+#toc li a:hover {
+  background-color: #272727;
+  text-decoration: none;
+}
+
+#toc:after {
+  content: " ";
+  visibility: hidden;
+  display: block;
+  height: 0;
+  clear: both;
+}
+
+@media all and (max-width: 600px) {
+  table {
+    width: 55vw !important;
+    font-size: 3vw;
+  }
+}

--- a/api-docs/crd-ref-docs.config.yaml
+++ b/api-docs/crd-ref-docs.config.yaml
@@ -1,0 +1,41 @@
+processor:
+  ignoreGroupVersions:
+    - "^v1$"
+    - "\\.k8s.io"
+  ignoreTypes:
+    - "Docker"
+    - ".*List$"
+  ignoreFields:
+    - "TypeMeta$"
+    - "ListMeta$"
+
+render:
+  kubernetesVersion: 1.33
+  knownTypes:
+    - name: ObjectMeta
+      package: k8s.io/apimachinery/pkg/apis/meta/v1
+      link: https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ObjectMeta
+    - name: TypeMeta
+      package: k8s.io/apimachinery/pkg/apis/meta/v1
+      link: https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#TypeMeta
+    - name: Condition
+      package: k8s.io/apimachinery/pkg/apis/meta/v1
+      link: https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Condition
+    - name: CustomResourceValidation
+      package: k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
+      link: https://pkg.go.dev/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1#CustomResourceValidation
+    - name: Quantity
+      package: k8s.io/apimachinery/pkg/api/resource
+      link: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#quantity-resource-core
+    - name: IPFamily
+      package: k8s.io/api/core/v1
+      link: https://pkg.go.dev/k8s.io/api/core/v1#IPFamily
+    - name: IPFamilyPolicy
+      package: k8s.io/api/core/v1
+      link: https://pkg.go.dev/k8s.io/api/core/v1#IPFamilyPolicy
+    - name: Protocol
+      package: k8s.io/api/core/v1
+      link: https://pkg.go.dev/k8s.io/api/core/v1#Protocol
+    - name: TypedLocalObjectReference
+      package: k8s.io/api/core/v1
+      link: https://pkg.go.dev/k8s.io/api/core/v1#TypedLocalObjectReference

--- a/api-docs/go.mod
+++ b/api-docs/go.mod
@@ -1,0 +1,29 @@
+module github.com/vmware-tanzu/vm-operator/api-docs
+
+go 1.23.0
+
+replace github.com/vmware-tanzu/vm-operator/api => ../api
+
+require github.com/vmware-tanzu/vm-operator/api v0.0.0-00010101000000-000000000000
+
+require (
+	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
+	github.com/go-logr/logr v1.4.2 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/x448/float16 v0.8.4 // indirect
+	golang.org/x/net v0.26.0 // indirect
+	golang.org/x/text v0.16.0 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	k8s.io/api v0.31.0 // indirect
+	k8s.io/apimachinery v0.31.0 // indirect
+	k8s.io/klog/v2 v2.130.1 // indirect
+	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 // indirect
+	sigs.k8s.io/controller-runtime v0.19.0 // indirect
+	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
+)

--- a/api-docs/main.go
+++ b/api-docs/main.go
@@ -1,0 +1,38 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package main is a stub module whose imports determine which API packages are
+// vendored and therefore included in the generated CRD reference documentation.
+package main
+
+import (
+	_ "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+
+	_ "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	_ "github.com/vmware-tanzu/vm-operator/api/v1alpha2/cloudinit"
+	_ "github.com/vmware-tanzu/vm-operator/api/v1alpha2/common"
+	_ "github.com/vmware-tanzu/vm-operator/api/v1alpha2/sysprep"
+
+	_ "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	_ "github.com/vmware-tanzu/vm-operator/api/v1alpha3/cloudinit"
+	_ "github.com/vmware-tanzu/vm-operator/api/v1alpha3/common"
+	_ "github.com/vmware-tanzu/vm-operator/api/v1alpha3/sysprep"
+
+	_ "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	_ "github.com/vmware-tanzu/vm-operator/api/v1alpha4/cloudinit"
+	_ "github.com/vmware-tanzu/vm-operator/api/v1alpha4/common"
+	_ "github.com/vmware-tanzu/vm-operator/api/v1alpha4/sysprep"
+
+	_ "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
+	_ "github.com/vmware-tanzu/vm-operator/api/v1alpha5/cloudinit"
+	_ "github.com/vmware-tanzu/vm-operator/api/v1alpha5/common"
+	_ "github.com/vmware-tanzu/vm-operator/api/v1alpha5/sysprep"
+
+	_ "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+	_ "github.com/vmware-tanzu/vm-operator/api/v1alpha6/cloudinit"
+	_ "github.com/vmware-tanzu/vm-operator/api/v1alpha6/common"
+	_ "github.com/vmware-tanzu/vm-operator/api/v1alpha6/sysprep"
+)
+
+func main() {}

--- a/api-docs/publish/index.html
+++ b/api-docs/publish/index.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+    <body>
+        <h1>VM Service API Documentation</h1>
+    </body>
+</html>

--- a/api-docs/publish/meta-data.json
+++ b/api-docs/publish/meta-data.json
@@ -1,0 +1,22 @@
+{
+    "navigations":
+    [
+        {
+            "name": "Getting Started",
+            "url": "/index.html",
+            "hidden": false
+        },
+        {
+            "name": "VM Service",
+            "hidden": false,
+            "navigations":
+            [
+                {
+                    "name": "API Reference",
+                    "url": "/api-docs.html",
+                    "hidden": false
+                }
+            ]
+        }
+    ]
+}

--- a/go.mod
+++ b/go.mod
@@ -66,6 +66,8 @@ require (
 	sigs.k8s.io/yaml v1.6.0
 )
 
+require k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
+
 require (
 	cel.dev/expr v0.25.1 // indirect
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
@@ -134,7 +136,6 @@ require (
 	k8s.io/apiserver v0.36.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	k8s.io/streaming v0.36.0 // indirect
-	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR introduces the background work to generate API documentation from our types using crd-ref-docs.  The docs generated by this PR will be pushed to the developer portal via some automation alongside docs from other services.

A separate PR will integrate the doc generation with build process so we have reproducible documentation along with our binaries.

**Please add a release note if necessary**:

```release-note
Generate documentation from CRDs
```