### PR TITLE
🐛 Validate max unit number for volume controllers

### DIFF
--- a/webhooks/virtualmachine/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator.go
@@ -1613,6 +1613,32 @@ func (v validator) validateControllerFields(
 		))
 	}
 
+	if vol.ControllerType != "" && vol.UnitNumber != nil {
+		var maxUnitNumber int32
+		switch vol.ControllerType {
+		case vmopv1.VirtualControllerTypeIDE:
+			maxUnitNumber = 1 // 2 slots: 0, 1
+		case vmopv1.VirtualControllerTypeNVME:
+			// NVMe supports 15 disks in older HW versions, but up to 255 in HW version 21.
+			// Since we don't know the HW version here, we use the maximum possible.
+			maxUnitNumber = 255
+		case vmopv1.VirtualControllerTypeSATA:
+			maxUnitNumber = 29 // 30 slots: 0-29
+		case vmopv1.VirtualControllerTypeSCSI:
+			// PVSCSI supports 64 disks (65 targets), others 15 disks (16 targets).
+			// We use 64 as the maximum possible unit number for SCSI to accommodate PVSCSI.
+			maxUnitNumber = 64
+		}
+
+		if *vol.UnitNumber > maxUnitNumber {
+			allErrs = append(allErrs, field.Invalid(
+				volPath.Child("unitNumber"),
+				*vol.UnitNumber,
+				fmt.Sprintf("maximum unit number for %s controller is %d", vol.ControllerType, maxUnitNumber),
+			))
+		}
+	}
+
 	return allErrs
 }
 

--- a/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
@@ -482,6 +482,58 @@ func unitTestsValidateCreate() {
 					),
 				},
 			),
+			Entry("should deny PVC volume with unitNumber exceeding maximum for SCSI controller",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						ctx.vm.Spec.Volumes[0].ControllerType = vmopv1.VirtualControllerTypeSCSI
+						ctx.vm.Spec.Volumes[0].ControllerBusNumber = ptr.To(int32(0))
+						ctx.vm.Spec.Volumes[0].UnitNumber = ptr.To(int32(65))
+					},
+					expectAllowed: false,
+					validate: doValidateWithMsg(
+						"spec.volumes[0].unitNumber: Invalid value: 65: maximum unit number for SCSI controller is 64",
+					),
+				},
+			),
+			Entry("should deny PVC volume with unitNumber exceeding maximum for NVME controller",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						ctx.vm.Spec.Volumes[0].ControllerType = vmopv1.VirtualControllerTypeNVME
+						ctx.vm.Spec.Volumes[0].ControllerBusNumber = ptr.To(int32(0))
+						ctx.vm.Spec.Volumes[0].UnitNumber = ptr.To(int32(256))
+					},
+					expectAllowed: false,
+					validate: doValidateWithMsg(
+						"spec.volumes[0].unitNumber: Invalid value: 256: maximum unit number for NVME controller is 255",
+					),
+				},
+			),
+			Entry("should deny PVC volume with unitNumber exceeding maximum for IDE controller",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						ctx.vm.Spec.Volumes[0].ControllerType = vmopv1.VirtualControllerTypeIDE
+						ctx.vm.Spec.Volumes[0].ControllerBusNumber = ptr.To(int32(0))
+						ctx.vm.Spec.Volumes[0].UnitNumber = ptr.To(int32(2))
+					},
+					expectAllowed: false,
+					validate: doValidateWithMsg(
+						"spec.volumes[0].unitNumber: Invalid value: 2: maximum unit number for IDE controller is 1",
+					),
+				},
+			),
+			Entry("should deny PVC volume with unitNumber exceeding maximum for SATA controller",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						ctx.vm.Spec.Volumes[0].ControllerType = vmopv1.VirtualControllerTypeSATA
+						ctx.vm.Spec.Volumes[0].ControllerBusNumber = ptr.To(int32(0))
+						ctx.vm.Spec.Volumes[0].UnitNumber = ptr.To(int32(30))
+					},
+					expectAllowed: false,
+					validate: doValidateWithMsg(
+						"spec.volumes[0].unitNumber: Invalid value: 30: maximum unit number for SATA controller is 29",
+					),
+				},
+			),
 			Entry("should deny PVC volume with controllerBusNumber and unitNumber but no controllerType",
 				testParams{
 					setup: func(ctx *unitValidatingWebhookContext) {


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR adds validation to the VirtualMachine webhook to ensure that when a volume is explicitly attached to a controller, its unitNumber does not exceed the maximum allowed for that controller type.

For example, a SCSI controller (like PVSCSI) supports a maximum of 64 disks (unit numbers 0-64, skipping 7). If a user specifies a unitNumber of 65 or higher, the webhook will now reject the configuration.

Testing Done:
- Verified in a real env that when creating a VM that specifies invalid number of volumes (more than the available slots), API server rejects the request.  For all 4 types of controllers:
```
# SCSI
Error from server (spec.volumes[64].unitNumber: Invalid value: 65:
maximum unit number for SCSI controller is 64): error when creating
"65-vols-explicit.yaml": admission webhook
"default.validating.virtualmachine.v1alpha6.vmoperator.vmware.com"
denied the request: spec.volumes[64].unitNumber: Invalid value: 65:
maximum unit number for SCSI controller is 64

# NVME
Error from server (spec.volumes[0].unitNumber: Invalid value: 256:
maximum unit number for NVME controller is 255): error when creating
"invalid-nvme.yaml": admission webhook
"default.validating.virtualmachine.v1alpha6.vmoperator.vmware.com"
denied the request: spec.volumes[0].unitNumber: Invalid value: 256:
maximum unit number for NVME controller is 255

# IDE
Error from server (spec.volumes[0].unitNumber: Invalid value: 2:
maximum unit number for IDE controller is 1): error when creating
"invalid-ide.yaml": admission webhook
"default.validating.virtualmachine.v1alpha6.vmoperator.vmware.com"
denied the request: spec.volumes[0].unitNumber: Invalid value: 2:
maximum unit number for IDE controller is 1

# SATA
Error from server (spec.volumes[0].unitNumber: Invalid value: 30:
maximum unit number for SATA controller is 29): error when creating
"invalid-sata.yaml": admission webhook
"default.validating.virtualmachine.v1alpha6.vmoperator.vmware.com"
denied the request: spec.volumes[0].unitNumber: Invalid value: 30:
maximum unit number for SATA controller is 29
```


**Please add a release note if necessary**:

```release-note
Validate max unit number for volume controllers
```