### PR TITLE
fix: clear SubnetId when editing NIC backing during subnet change

### DIFF
--- a/pkg/providers/vsphere/network/reconcile.go
+++ b/pkg/providers/vsphere/network/reconcile.go
@@ -51,6 +51,9 @@ func ReconcileNetworkInterfaces(
 				ethDev.AddressType = r.Device.(vimtypes.BaseVirtualEthernetCard).GetVirtualEthernetCard().AddressType
 				ethDev.MacAddress = r.Device.(vimtypes.BaseVirtualEthernetCard).GetVirtualEthernetCard().MacAddress
 				ethDev.ExternalId = r.Device.(vimtypes.BaseVirtualEthernetCard).GetVirtualEthernetCard().ExternalId
+				// Clear SubnetId when the backing changes to avoid a vSphere error:
+				// "device.backing Mismatch detected between DVPG and subnet ID"
+				ethDev.SubnetId = ""
 
 				deviceChanges = append(deviceChanges, &vimtypes.VirtualDeviceConfigSpec{
 					Device:    editDev,

--- a/pkg/providers/vsphere/network/reconcile_test.go
+++ b/pkg/providers/vsphere/network/reconcile_test.go
@@ -158,6 +158,10 @@ var _ = Describe("ReconcileNetworkInterfaces", func() {
 			When("Edit", func() {
 				BeforeEach(func() {
 					curEthCard := *ethCard.GetVirtualEthernetCard()
+					// Simulate a stale SubnetId on the existing NIC (e.g. from a previous subnet).
+					// This should be cleared when the backing changes to avoid:
+					// "device.backing Mismatch detected between DVPG and subnet ID"
+					curEthCard.SubnetId = "/projects/project-quality/vpcs/foo/subnets/old-subnet"
 
 					ethCard.GetVirtualEthernetCard().Backing = &vimtypes.VirtualEthernetCardDistributedVirtualPortBackingInfo{
 						Port: vimtypes.DistributedVirtualSwitchPortConnection{
@@ -175,13 +179,17 @@ var _ = Describe("ReconcileNetworkInterfaces", func() {
 					currentEthCards = append(currentEthCards, &curEthCard)
 				})
 
-				It("Returns Edit Operation", func() {
+				It("Returns Edit Operation with SubnetId cleared", func() {
 					Expect(err).ToNot(HaveOccurred())
 
 					Expect(deviceChanges).To(HaveLen(1))
 					dc0 := deviceChanges[0].GetVirtualDeviceConfigSpec()
 					Expect(dc0.Operation).To(Equal(vimtypes.VirtualDeviceConfigSpecOperationEdit))
 					Expect(dc0.Device.GetVirtualDevice().Backing).To(Equal(ethCard.GetVirtualEthernetCard().Backing))
+					// SubnetId must be cleared to avoid vSphere rejecting the reconfigure with:
+					// "device.backing Mismatch detected between DVPG and subnet ID"
+					editedEthCard := dc0.Device.(vimtypes.BaseVirtualEthernetCard).GetVirtualEthernetCard()
+					Expect(editedEthCard.SubnetId).To(BeEmpty())
 				})
 
 				When("Network Interface CR is old and does not have interface name label", func() {
@@ -190,13 +198,15 @@ var _ = Describe("ReconcileNetworkInterfaces", func() {
 						delete(obj.GetLabels(), network.VMInterfaceNameLabel)
 					})
 
-					It("Returns Edit Operation", func() {
+					It("Returns Edit Operation with SubnetId cleared", func() {
 						Expect(err).ToNot(HaveOccurred())
 
 						Expect(deviceChanges).To(HaveLen(1))
 						dc0 := deviceChanges[0].GetVirtualDeviceConfigSpec()
 						Expect(dc0.Operation).To(Equal(vimtypes.VirtualDeviceConfigSpecOperationEdit))
 						Expect(dc0.Device.GetVirtualDevice().Backing).To(Equal(ethCard.GetVirtualEthernetCard().Backing))
+						editedEthCard := dc0.Device.(vimtypes.BaseVirtualEthernetCard).GetVirtualEthernetCard()
+						Expect(editedEthCard.SubnetId).To(BeEmpty())
 					})
 				})
 			})


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

When a VM's network interface is moved to a new subnet, the orphaned network interface CR edit path in ReconcileNetworkInterfaces updates the NIC's backing and ExternalId but left the stale SubnetId intact. vSphere validates that the SubnetId's logical switch matches the new DVPG's logicalSwitchUuid, so sending a mismatched SubnetId causes the reconfigure to fail with:

  "A specified parameter was not correct: device.backing
   Mismatch detected between DVPG and subnet ID"

Clear SubnetId when overwriting the NIC's backing, mirroring the same pattern already used in VPCPostRestoreBackingFixup.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:
Test:
1. Create a vm with one subnet
2. Poweroff vm
3. Change VM subnet
4. Power on
5. No error, VM power on without issue

**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    6. If a release note is not required, please write "NONE".
-->

```release-note
None
```