### PR TITLE
:bug: Return early when BatchAttach spec creation errors out

### DIFF
--- a/controllers/virtualmachine/volumebatch/volumebatch_controller.go
+++ b/controllers/virtualmachine/volumebatch/volumebatch_controller.go
@@ -67,9 +67,7 @@ const (
 
 // AddToManager adds this package's controller to the provided manager.
 func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) error {
-	var (
-		controllerNameShort = fmt.Sprintf("%s-controller", strings.ToLower(controllerName))
-	)
+	controllerNameShort := fmt.Sprintf("%s-controller", strings.ToLower(controllerName))
 
 	// Set up field index for CnsNodeVmAttachment by NodeUUID to efficiently query legacy attachments
 	if err := mgr.GetFieldIndexer().IndexField(
@@ -160,7 +158,6 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 			return fmt.Errorf(
 				"failed to start VirtualMachine watch "+
 					"for CnsRegisterVolume: %w", err)
-
 		}
 	}
 
@@ -208,7 +205,8 @@ func NewReconciler(
 	client client.Client,
 	logger logr.Logger,
 	recorder record.Recorder,
-	vmProvider providers.VirtualMachineProviderInterface) *Reconciler {
+	vmProvider providers.VirtualMachineProviderInterface,
+) *Reconciler {
 	return &Reconciler{
 		Context:    ctx,
 		Client:     client,
@@ -392,12 +390,11 @@ func (r *Reconciler) ReconcileNormal(ctx *pkgctx.VolumeContext) error {
 	// Process volumes and create/update batch attachment.
 	// filter Volume spec that doesn't cause error and return them
 	// for constructing the VM's volumeStatus.
-	filteredVolumeSpecsForBatch, processErr :=
-		r.processBatchAttachmentAndFilterVolumeSpecs(
-			ctx,
-			volumeSpecsForBatch,
-			batchAttachment,
-		)
+	filteredVolumeSpecsForBatch, processErr := r.processBatchAttachmentAndFilterVolumeSpecs(
+		ctx,
+		volumeSpecsForBatch,
+		batchAttachment,
+	)
 	if processErr != nil {
 		ctx.Logger.Error(processErr, "Error processing CnsNodeVMBatchAttachments")
 		// Keep going to return aggregated error below.
@@ -466,7 +463,6 @@ func (r *Reconciler) ReconcileNormal(ctx *pkgctx.VolumeContext) error {
 func (r *Reconciler) getBatchAttachmentForVM(
 	ctx *pkgctx.VolumeContext,
 ) (*cnsv1alpha1.CnsNodeVMBatchAttachment, error) {
-
 	attachment := &cnsv1alpha1.CnsNodeVMBatchAttachment{}
 
 	if err := r.Client.Get(ctx, client.ObjectKey{
@@ -496,7 +492,6 @@ func (r *Reconciler) processBatchAttachmentAndFilterVolumeSpecs(
 	vmVolumeSpecsForBatch []vmopv1.VirtualMachineVolume,
 	batchAttachment *cnsv1alpha1.CnsNodeVMBatchAttachment,
 ) ([]cnsv1alpha1.VolumeSpec, error) {
-
 	var (
 		toBeBuiltPvcVols  = make([]vmopv1.VirtualMachineVolume, 0)
 		existingVolVolKey = sets.New[string]()
@@ -567,6 +562,14 @@ func (r *Reconciler) processBatchAttachmentAndFilterVolumeSpecs(
 	volumeSpecs, err := r.buildVolumeSpecs(toBeBuiltPvcVols, ctx.VM.Status.Hardware)
 	if err != nil {
 		retErr = errOrNoRequeueErr(retErr, err)
+		// If we failed to build the volume specs (e.g. waiting for a controller),
+		// we must abort the batch update to avoid detaching existing volumes.
+		// Return the existing volume specs so the VM status doesn't mark them as detaching.
+		var existingSpecs []cnsv1alpha1.VolumeSpec
+		if batchAttachment != nil {
+			existingSpecs = batchAttachment.Spec.Volumes
+		}
+		return existingSpecs, retErr
 	}
 
 	// Create or update batch attachment.
@@ -601,7 +604,6 @@ func (r *Reconciler) getPVC(
 	ctx *pkgctx.VolumeContext,
 	pvcName string,
 ) (corev1.PersistentVolumeClaim, error) {
-
 	pvc := corev1.PersistentVolumeClaim{}
 	pvcKey := client.ObjectKey{
 		Namespace: ctx.VM.Namespace,
@@ -619,8 +621,8 @@ func (r *Reconciler) getPVC(
 // CnsNodeVMBatchAttachment.
 func (r *Reconciler) createOrUpdateBatchAttachment(
 	ctx *pkgctx.VolumeContext,
-	volumeSpecs []cnsv1alpha1.VolumeSpec) error {
-
+	volumeSpecs []cnsv1alpha1.VolumeSpec,
+) error {
 	// Validate the volume specs before attempting to create/update
 	if err := r.validateVolumeSpecs(ctx, volumeSpecs); err != nil {
 		return fmt.Errorf("volume spec validation failed: %w", err)
@@ -661,7 +663,6 @@ func (r *Reconciler) createOrUpdateBatchAttachment(
 
 			return nil
 		})
-
 	if err != nil {
 		return fmt.Errorf("failed to create or patch CnsNodeVMBatchAttachment %s: %w",
 			attachmentName, err)
@@ -685,7 +686,6 @@ func (r *Reconciler) buildVolumeSpecs(
 	volumes []vmopv1.VirtualMachineVolume,
 	hardware *vmopv1.VirtualMachineHardwareStatus,
 ) ([]cnsv1alpha1.VolumeSpec, error) {
-
 	// Return nil and wait for next reconcile when the status is updated if
 	// hardware is nil Or noops when there is no volumes to be attached.
 	if hardware == nil || len(volumes) == 0 {
@@ -771,8 +771,8 @@ func (r *Reconciler) buildVolumeSpecs(
 
 func (r *Reconciler) applyApplicationTypePresets(
 	vol *vmopv1.VirtualMachineVolume,
-	cnsSpec *cnsv1alpha1.VolumeSpec) error {
-
+	cnsSpec *cnsv1alpha1.VolumeSpec,
+) error {
 	switch vol.ApplicationType {
 	case vmopv1.VolumeApplicationTypeOracleRAC:
 		// OracleRAC preset: diskMode=IndependentPersistent, sharingMode=MultiWriter
@@ -807,7 +807,6 @@ func (r *Reconciler) getVMVolStatusesFromBatchAttachment(
 	volumeSpecs []cnsv1alpha1.VolumeSpec,
 	existingVMManagedVolStatus map[string]vmopv1.VirtualMachineVolumeStatus,
 ) []vmopv1.VirtualMachineVolumeStatus {
-
 	// Update VM.Status.Volumes based on the batch attachment status
 	volumeStatuses := make([]vmopv1.VirtualMachineVolumeStatus, 0, len(ctx.VM.Status.Volumes))
 
@@ -875,7 +874,6 @@ func (r *Reconciler) getVMVolStatusesFromBatchAttachment(
 				ctx,
 				attachVolStatus.PersistentVolumeClaim.ClaimName,
 				&vmVolStatus); err != nil {
-
 				ctx.Logger.Error(err, "failed to get volume status limit")
 			}
 		}
@@ -895,8 +893,8 @@ func (r *Reconciler) getVMVolStatusesFromBatchAttachment(
 
 func (r *Reconciler) updateVolumeStatusWithPVCInfo(
 	ctx *pkgctx.VolumeContext,
-	pvcName string, status *vmopv1.VirtualMachineVolumeStatus) error {
-
+	pvcName string, status *vmopv1.VirtualMachineVolumeStatus,
+) error {
 	pvc := &corev1.PersistentVolumeClaim{}
 	pvcKey := client.ObjectKey{
 		Namespace: ctx.VM.Namespace,
@@ -940,7 +938,6 @@ func (r *Reconciler) handlePVCWithWFFC(
 	volume vmopv1.VirtualMachineVolume,
 	pvc corev1.PersistentVolumeClaim,
 ) error {
-
 	if volume.PersistentVolumeClaim.InstanceVolumeClaim != nil {
 		return nil
 	}
@@ -1038,8 +1035,8 @@ func (r *Reconciler) validateVolumeSpecs(_ *pkgctx.VolumeContext, _ []cnsv1alpha
 
 func (r *Reconciler) deleteOrphanedAttachments(
 	ctx *pkgctx.VolumeContext,
-	attachments []cnsv1alpha1.CnsNodeVmAttachment) error {
-
+	attachments []cnsv1alpha1.CnsNodeVmAttachment,
+) error {
 	var retErr error
 
 	for i := range attachments {
@@ -1062,8 +1059,8 @@ func (r *Reconciler) deleteOrphanedAttachments(
 
 func (r *Reconciler) attachmentsToDelete(
 	ctx *pkgctx.VolumeContext,
-	attachments map[string]cnsv1alpha1.CnsNodeVmAttachment) []cnsv1alpha1.CnsNodeVmAttachment {
-
+	attachments map[string]cnsv1alpha1.CnsNodeVmAttachment,
+) []cnsv1alpha1.CnsNodeVmAttachment {
 	if len(attachments) == 0 {
 		return nil
 	}
@@ -1104,7 +1101,6 @@ func getVolumeStatusesWithDetachingVolumeInLegacyAttachment(
 	ctx *pkgctx.VolumeContext,
 	orphanedAttachmentsMap map[string]cnsv1alpha1.CnsNodeVmAttachment,
 ) []vmopv1.VirtualMachineVolumeStatus {
-
 	// Maintain mapping of diskUUID -> attachment.
 	uuidAttachments := make(map[string]cnsv1alpha1.CnsNodeVmAttachment, len(orphanedAttachmentsMap))
 	for _, attachment := range orphanedAttachmentsMap {
@@ -1140,7 +1136,6 @@ func getVolumeStatusWithDetachingVolumeFromBatchAttachment(
 	existingAttachVolStatus map[string]cnsv1alpha1.VolumeStatus,
 	volumeSpecs []cnsv1alpha1.VolumeSpec,
 ) []vmopv1.VirtualMachineVolumeStatus {
-
 	var volumeStatuses []vmopv1.VirtualMachineVolumeStatus
 
 	attachVolSpecNames := sets.New[string]()
@@ -1166,8 +1161,8 @@ func getVolumeStatusWithDetachingVolumeFromBatchAttachment(
 
 func attachmentStatusToVolumeStatus(
 	volName string,
-	volStatus cnsv1alpha1.VolumeStatus) vmopv1.VirtualMachineVolumeStatus {
-
+	volStatus cnsv1alpha1.VolumeStatus,
+) vmopv1.VirtualMachineVolumeStatus {
 	attached := false
 	messages := []string{}
 
@@ -1199,8 +1194,8 @@ func attachmentStatusToVolumeStatus(
 
 func legacyAttachmentToVolumeStatus(
 	volumeName string,
-	attachment cnsv1alpha1.CnsNodeVmAttachment) vmopv1.VirtualMachineVolumeStatus {
-
+	attachment cnsv1alpha1.CnsNodeVmAttachment,
+) vmopv1.VirtualMachineVolumeStatus {
 	return vmopv1.VirtualMachineVolumeStatus{
 		Name:     volumeName, // Name of the volume as in the Spec
 		Attached: attachment.Status.Attached,
@@ -1219,7 +1214,6 @@ func (r *Reconciler) getVMVolStatusesFromLegacyAttachments(
 	existingVMManagedVolStatus map[string]vmopv1.VirtualMachineVolumeStatus,
 	vmVolumeSpecsForLegacy []vmopv1.VirtualMachineVolume,
 ) []vmopv1.VirtualMachineVolumeStatus {
-
 	var volumeStatuses []vmopv1.VirtualMachineVolumeStatus
 
 	// Maintain the mapping of LegacyAttachmentName -> Attachment.
@@ -1246,7 +1240,6 @@ func (r *Reconciler) getVMVolStatusesFromLegacyAttachments(
 					ctx,
 					vol.PersistentVolumeClaim.ClaimName,
 					&vmVolStatus); err != nil {
-
 					ctx.Logger.Error(err, "failed to get volume status limit")
 				}
 
@@ -1288,7 +1281,6 @@ func updateVMVolumeStatus(
 	ctx *pkgctx.VolumeContext,
 	v1, v2 []vmopv1.VirtualMachineVolumeStatus,
 ) {
-
 	// Remove any managed volumes from the existing status.
 	ctx.VM.Status.Volumes = slices.DeleteFunc(ctx.VM.Status.Volumes,
 		func(e vmopv1.VirtualMachineVolumeStatus) bool {
@@ -1312,7 +1304,6 @@ func categorizeVolumeSpecs(
 	ctx *pkgctx.VolumeContext,
 	legacyAttachments map[string]cnsv1alpha1.CnsNodeVmAttachment,
 ) (forBatch, forLegacy []vmopv1.VirtualMachineVolume) {
-
 	// Filter volumes that have PVC source and are not already tracked
 	// by legacy CnsNodeVmAttachment
 	volumeSpecsForBatch := []vmopv1.VirtualMachineVolume{}
@@ -1356,8 +1347,8 @@ func categorizeVolumeSpecs(
 // info from existing VM managed volume status.
 func updateVolumeStatusWithExistingVMStatus(
 	vmVolStatus *vmopv1.VirtualMachineVolumeStatus,
-	existingVMManagedVolStatusMap map[string]vmopv1.VirtualMachineVolumeStatus) {
-
+	existingVMManagedVolStatusMap map[string]vmopv1.VirtualMachineVolumeStatus,
+) {
 	existingVolStatus := existingVMManagedVolStatusMap[vmVolStatus.Name]
 
 	vmVolStatus.Used = existingVolStatus.Used

--- a/controllers/virtualmachine/volumebatch/volumebatch_controller_unit_test.go
+++ b/controllers/virtualmachine/volumebatch/volumebatch_controller_unit_test.go
@@ -78,7 +78,6 @@ func unitTestsReconcile() {
 	)
 
 	BeforeEach(func() {
-
 		vm = &vmopv1.VirtualMachine{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "dummy-vm",
@@ -150,11 +149,9 @@ func unitTestsReconcile() {
 				Phase: corev1.ClaimBound,
 			},
 		}
-
 	})
 
 	JustBeforeEach(func() {
-
 		ctx = suite.NewUnitTestContextForController()
 
 		// Replace the fake client with our own that has the expected index.
@@ -201,7 +198,6 @@ func unitTestsReconcile() {
 	})
 
 	getCNSBatchAttachmentForVolumeName := func(ctx *builder.UnitTestContextForController, vm *vmopv1.VirtualMachine) *cnsv1alpha1.CnsNodeVMBatchAttachment {
-
 		GinkgoHelper()
 
 		objectKey := client.ObjectKey{Name: util.CNSBatchAttachmentNameForVM(vm.Name), Namespace: vm.Namespace}
@@ -368,17 +364,16 @@ func unitTestsReconcile() {
 					vm.Spec.Volumes[0].DiskMode = "UnsupportedDiskMode"
 				})
 
-				It("returns NoRequeueError and batch attachment has no volumes", func() {
+				It("returns NoRequeueError and batch attachment is not created", func() {
 					err := reconciler.ReconcileNormal(volCtx)
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("unsupported disk mode"))
 					Expect(err.Error()).To(ContainSubstring("UnsupportedDiskMode"))
 					Expect(err.Error()).To(ContainSubstring(volumeName1))
 
-					// Verify batch attachment exists but has no volumes
+					// Verify batch attachment is not created
 					attachment := getCNSBatchAttachmentForVolumeName(ctx, vm)
-					Expect(attachment).NotTo(BeNil())
-					Expect(attachment.Spec.Volumes).To(BeEmpty())
+					Expect(attachment).To(BeNil())
 
 					// Verify VM status volumes is empty
 					Expect(vm.Status.Volumes).To(BeEmpty())
@@ -390,17 +385,16 @@ func unitTestsReconcile() {
 					vm.Spec.Volumes[0].SharingMode = "UnsupportedSharingMode"
 				})
 
-				It("returns NoRequeueError and batch attachment has no volumes", func() {
+				It("returns NoRequeueError and batch attachment is not created", func() {
 					err := reconciler.ReconcileNormal(volCtx)
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("unsupported sharing mode"))
 					Expect(err.Error()).To(ContainSubstring("UnsupportedSharingMode"))
 					Expect(err.Error()).To(ContainSubstring(volumeName1))
 
-					// Verify batch attachment exists but has no volumes
+					// Verify batch attachment is not created
 					attachment := getCNSBatchAttachmentForVolumeName(ctx, vm)
-					Expect(attachment).NotTo(BeNil())
-					Expect(attachment.Spec.Volumes).To(BeEmpty())
+					Expect(attachment).To(BeNil())
 
 					// Verify VM status volumes is empty
 					Expect(vm.Status.Volumes).To(BeEmpty())
@@ -1056,7 +1050,6 @@ func unitTestsReconcile() {
 				})
 
 				It("returns success", func() {
-
 					err := reconciler.ReconcileNormal(volCtx)
 					Expect(err).ToNot(HaveOccurred())
 
@@ -1072,7 +1065,6 @@ func unitTestsReconcile() {
 				})
 
 				When("Collecting limit and usage information", func() {
-
 					classicDisk1 := func() vmopv1.VirtualMachineVolumeStatus {
 						return vmopv1.VirtualMachineVolumeStatus{
 							Name:     "my-disk-0",
@@ -1106,7 +1098,6 @@ func unitTestsReconcile() {
 					})
 
 					assertBaselineVolStatus := func() {
-
 						GinkgoHelper()
 
 						err := reconciler.ReconcileNormal(volCtx)
@@ -1143,7 +1134,6 @@ func unitTestsReconcile() {
 						})
 
 						assertPVCHasUsage := func() {
-
 							GinkgoHelper()
 
 							Expect(vm.Status.Volumes[3].Used).To(Equal(ptr.To(resource.MustParse("1Gi"))))
@@ -1172,9 +1162,7 @@ func unitTestsReconcile() {
 						})
 
 						When("PVC resource exists with limit or request", func() {
-
 							assertPVCHasLimit := func() {
-
 								GinkgoHelper()
 
 								Expect(vm.Status.Volumes[3].Limit).To(Equal(ptr.To(resource.MustParse("20Gi"))))
@@ -1225,7 +1213,6 @@ func unitTestsReconcile() {
 					})
 
 					When("Existing status has crypto info for a PVC", func() {
-
 						newCryptoStatus := func() *vmopv1.VirtualMachineVolumeCryptoStatus {
 							return &vmopv1.VirtualMachineVolumeCryptoStatus{
 								ProviderID: "my-provider-id",
@@ -1234,7 +1221,6 @@ func unitTestsReconcile() {
 						}
 
 						assertPVCHasCrypto := func() {
-
 							GinkgoHelper()
 
 							Expect(vm.Status.Volumes[3].Crypto).To(Equal(newCryptoStatus()))
@@ -1495,6 +1481,64 @@ func unitTestsReconcile() {
 				})
 			})
 
+			When("VM Spec.Volumes has a new volume that causes an error in buildVolumeSpecs", func() {
+				BeforeEach(func() {
+					vmVol1 := *vmVolumeWithPVC1
+
+					// VM Spec has existing volume and a new volume with unsupported disk mode.
+					vmVolWithUnsupportedMode := *vmVolumeWithPVC2
+					vmVolWithUnsupportedMode.DiskMode = "UnsupportedDiskMode"
+					vm.Spec.Volumes = append(vm.Spec.Volumes, vmVol1, vmVolWithUnsupportedMode)
+					initObjects = append(initObjects, boundPVC1, boundPVC2)
+
+					// Old attachment points to vmVol1.
+					attachment = cnsBatchAttachmentForVMVolume(vm, []vmopv1.VirtualMachineVolume{vmVol1})
+					attachment.Status.VolumeStatus = append(attachment.Status.VolumeStatus,
+						cnsv1alpha1.VolumeStatus{
+							Name: vmVol1.Name,
+							PersistentVolumeClaim: cnsv1alpha1.PersistentVolumeClaimStatus{
+								ClaimName: claimName1,
+								Conditions: []metav1.Condition{
+									{
+										Type:    cnsv1alpha1.ConditionAttached,
+										Status:  metav1.ConditionTrue,
+										Reason:  "True",
+										Message: "",
+									},
+								},
+							},
+						},
+					)
+
+					vm.Status.Volumes = []vmopv1.VirtualMachineVolumeStatus{
+						{
+							Name:     vmVol1.Name,
+							Attached: true,
+							Type:     vmopv1.VolumeTypeManaged,
+						},
+					}
+
+					initObjects = append(initObjects, attachment)
+				})
+
+				It("returns error and does not update batch attachment or VM status", func() {
+					err := reconciler.ReconcileNormal(volCtx)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("unsupported disk mode"))
+
+					// Verify batch attachment is not updated (still has 1 volume)
+					attachment := getCNSBatchAttachmentForVolumeName(ctx, vm)
+					Expect(attachment).ToNot(BeNil())
+					Expect(attachment.Spec.Volumes).To(HaveLen(1))
+					Expect(attachment.Spec.Volumes[0].Name).To(Equal(vmVolumeWithPVC1.Name))
+
+					// Verify VM status volumes is not updated (still has 1 volume, no -detaching suffix)
+					Expect(vm.Status.Volumes).To(HaveLen(1))
+					Expect(vm.Status.Volumes[0].Name).To(Equal(vmVolumeWithPVC1.Name))
+					Expect(vm.Status.Volumes[0].Attached).To(BeTrue())
+				})
+			})
+
 			When("existing CnsNodeVMBatchAttachment has detaching volume in status", func() {
 				BeforeEach(func() {
 					attachment.Status.VolumeStatus = append(attachment.Status.VolumeStatus,
@@ -1604,7 +1648,8 @@ func unitTestsReconcile() {
 
 func cnsBatchAttachmentForVMVolume(
 	vm *vmopv1.VirtualMachine,
-	vmVols []vmopv1.VirtualMachineVolume) *cnsv1alpha1.CnsNodeVMBatchAttachment {
+	vmVols []vmopv1.VirtualMachineVolume,
+) *cnsv1alpha1.CnsNodeVMBatchAttachment {
 	batchAttachment := &cnsv1alpha1.CnsNodeVMBatchAttachment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      util.CNSBatchAttachmentNameForVM(vm.Name),
@@ -1632,7 +1677,10 @@ func cnsBatchAttachmentForVMVolume(
 	for _, vmVol := range vmVols {
 		batchAttachment.Spec.Volumes = append(batchAttachment.Spec.Volumes,
 			cnsv1alpha1.VolumeSpec{
-				Name: vmVol.PersistentVolumeClaim.ClaimName,
+				Name: vmVol.Name,
+				PersistentVolumeClaim: cnsv1alpha1.PersistentVolumeClaimSpec{
+					ClaimName: vmVol.PersistentVolumeClaim.ClaimName,
+				},
 			})
 	}
 
@@ -1644,8 +1692,8 @@ func assertVMVolStatusFromBatchAttachmentStatus(
 	attachment *cnsv1alpha1.CnsNodeVMBatchAttachment,
 	vmVolStatusIndex,
 	attachmentStatusIndex int,
-	detachingSuffix bool) {
-
+	detachingSuffix bool,
+) {
 	GinkgoHelper()
 
 	Expect(len(vm.Status.Volumes)).To(BeNumerically(">", vmVolStatusIndex), fmt.Sprintf("vm volume status should have len larger than %d", vmVolStatusIndex))
@@ -1668,8 +1716,8 @@ func assertVMVolStatusFromBatchAttachmentSpec(
 	vm *vmopv1.VirtualMachine,
 	attachment *cnsv1alpha1.CnsNodeVMBatchAttachment,
 	vmVolStatusIndex,
-	attachmentStatusIndex int) {
-
+	attachmentStatusIndex int,
+) {
 	GinkgoHelper()
 
 	Expect(len(vm.Status.Volumes)).To(BeNumerically(">", vmVolStatusIndex), fmt.Sprintf("vm volume status should have len larger than %d", vmVolStatusIndex))
@@ -1687,8 +1735,8 @@ func assertVMVolStatusFromBatchAttachmentSpec(
 func assertVMVolStatusFromLegacyAttachment(
 	name string,
 	attachment *cnsv1alpha1.CnsNodeVmAttachment,
-	vmVolStatus vmopv1.VirtualMachineVolumeStatus) {
-
+	vmVolStatus vmopv1.VirtualMachineVolumeStatus,
+) {
 	GinkgoHelper()
 
 	diskUUID := attachment.Status.AttachmentMetadata[cnsv1alpha1.AttributeFirstClassDiskUUID]


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Currently, when preparing the BatchAttach spec for all volumes, if we fail early enough, we end up patching the BatchAttach with empty spec resulting in CSI detaching all disks from the VM.  This is intermittent because in the next reconcile, as long as we are able to successfully prepare the batch attach spec, the disks will be re-attached.

One situation where this shows up is when a volume specifies a controller that not been added to the VM yet.  In this case, the reconcile must return early and wait for the new controller to be added so disks can be attached to that.


**Are there any special notes for your reviewer**:

All the other cosmetic changes in this commit are a result of Cursor following the convention that we have set up.  I am choosing to go through with that in this commit for the sake of maintaining consistency.   If it becomes too distracting for the review, I can drop that.


**Please add a release note if necessary**:

```release-note
Return early when BatchAttach spec creation errors out
```