### PR TITLE
🌱 Go 1.26.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.26.3' # TODO (brito-rafa) GO-2026-4986, GO-2026-4982, GO-2026-4980, GO-2026-4977, GO-2026-4971
+        go-version: ${{ env.GO_VERSION }}
         go-version-file: 'go.mod'
         cache: true
         cache-dependency-path: '**/go.sum'

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/vm-operator
 
-go 1.26.2
+go 1.26.3
 
 replace (
 	github.com/vmware-tanzu/vm-operator/api => ./api

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/vm-operator/hack/tools
 
-go 1.26.2
+go 1.26.3
 
 // The version of Ginkgo must match the one from ../../go.mod.
 require github.com/onsi/ginkgo/v2 v2.28.1

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/vm-operator/test/e2e
 
-go 1.26.2
+go 1.26.3
 
 replace (
 	github.com/onsi/ginkgo/v2 => github.com/onsi/ginkgo/v2 v2.28.1


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Bump Go to 1.26.3

The updated version addresses the following:
GO-2026-4986, GO-2026-4982, GO-2026-4980, GO-2026-4977, GO-2026-4971

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

All tests passed locally and updated on the internal repo already.


**Please add a release note if necessary**:

```release-note
Go 1.26.3
```