### PR TITLE
:bug: Add DiskMode and SharingModel to VirtualMachineVolumeStatus

### DIFF
--- a/pkg/providers/vsphere/vmlifecycle/update_status.go
+++ b/pkg/providers/vsphere/vmlifecycle/update_status.go
@@ -1488,6 +1488,12 @@ func updateVolumeStatus(vmCtx pkgctx.VirtualMachineContext) {
 					vm.Status.Volumes[diskIndex].ControllerBusNumber = &c.Bus
 					vm.Status.Volumes[diskIndex].ControllerType = c.Type
 				}
+				if diskMode, err := pkgutil.GetVolumeDiskModeFromDiskMode(di.DiskMode); err == nil {
+					vm.Status.Volumes[diskIndex].DiskMode = diskMode
+				}
+				if sharingMode, err := pkgutil.GetVolumeSharingModeFromDiskSharing(di.Sharing); err == nil {
+					vm.Status.Volumes[diskIndex].SharingMode = sharingMode
+				}
 			}
 
 			// Classic disk should be converted to PVC in the end.
@@ -1533,6 +1539,12 @@ func updateVolumeStatus(vmCtx pkgctx.VirtualMachineContext) {
 				if c, ok := info.Controllers[di.ControllerKey]; ok {
 					volStatus.ControllerBusNumber = &c.Bus
 					volStatus.ControllerType = c.Type
+				}
+				if diskMode, err := pkgutil.GetVolumeDiskModeFromDiskMode(di.DiskMode); err == nil {
+					volStatus.DiskMode = diskMode
+				}
+				if sharingMode, err := pkgutil.GetVolumeSharingModeFromDiskSharing(di.Sharing); err == nil {
+					volStatus.SharingMode = sharingMode
 				}
 			}
 

--- a/pkg/providers/vsphere/vmlifecycle/update_status_test.go
+++ b/pkg/providers/vsphere/vmlifecycle/update_status_test.go
@@ -2041,6 +2041,8 @@ var _ = Describe("UpdateStatus", func() {
 								UnitNumber:          ptr.To[int32](3),
 								ControllerType:      vmopv1.VirtualControllerTypeSCSI,
 								ControllerBusNumber: ptr.To[int32](0),
+								DiskMode:            vmopv1.VolumeDiskModePersistent,
+								SharingMode:         vmopv1.VolumeSharingModeNone,
 							},
 							{
 								Name:       pkgutil.GeneratePVCName("disk", "101"),
@@ -2051,6 +2053,8 @@ var _ = Describe("UpdateStatus", func() {
 								Requested:  kubeutil.BytesToResource(1 * oneGiBInBytes),
 								Used:       kubeutil.BytesToResource(500 + (0.25 * oneGiBInBytes)),
 								UnitNumber: ptr.To[int32](0),
+								DiskMode:    vmopv1.VolumeDiskModePersistent,
+								SharingMode: vmopv1.VolumeSharingModeNone,
 							},
 							{
 								Name:       pkgutil.GeneratePVCName("disk", "102"),
@@ -2061,6 +2065,8 @@ var _ = Describe("UpdateStatus", func() {
 								Requested:  kubeutil.BytesToResource(2 * oneGiBInBytes),
 								Used:       kubeutil.BytesToResource(500 + (0.5 * oneGiBInBytes)),
 								UnitNumber: ptr.To[int32](0),
+								DiskMode:    vmopv1.VolumeDiskModePersistent,
+								SharingMode: vmopv1.VolumeSharingModeNone,
 							},
 							{
 								Name:       pkgutil.GeneratePVCName("disk", "103"),
@@ -2071,6 +2077,8 @@ var _ = Describe("UpdateStatus", func() {
 								Requested:  kubeutil.BytesToResource(3 * oneGiBInBytes),
 								Used:       kubeutil.BytesToResource(500 + (1 * oneGiBInBytes)),
 								UnitNumber: ptr.To[int32](0),
+								DiskMode:    vmopv1.VolumeDiskModePersistent,
+								SharingMode: vmopv1.VolumeSharingModeNone,
 							},
 							{
 								Name:       pkgutil.GeneratePVCName("disk", "104"),
@@ -2081,6 +2089,8 @@ var _ = Describe("UpdateStatus", func() {
 								Requested:  kubeutil.BytesToResource(4 * oneGiBInBytes),
 								Used:       kubeutil.BytesToResource(500 + (2 * oneGiBInBytes)),
 								UnitNumber: ptr.To[int32](0),
+								DiskMode:    vmopv1.VolumeDiskModePersistent,
+								SharingMode: vmopv1.VolumeSharingModeNone,
 							},
 						}))
 					})
@@ -2136,6 +2146,8 @@ var _ = Describe("UpdateStatus", func() {
 							UnitNumber:          ptr.To[int32](3),
 							ControllerType:      vmopv1.VirtualControllerTypeSCSI,
 							ControllerBusNumber: ptr.To[int32](0),
+							DiskMode:            vmopv1.VolumeDiskModePersistent,
+							SharingMode:         vmopv1.VolumeSharingModeNone,
 						},
 					))
 
@@ -2160,6 +2172,8 @@ var _ = Describe("UpdateStatus", func() {
 							UnitNumber:          ptr.To[int32](3),
 							ControllerType:      vmopv1.VirtualControllerTypeSCSI,
 							ControllerBusNumber: ptr.To[int32](0),
+							DiskMode:            vmopv1.VolumeDiskModePersistent,
+							SharingMode:         vmopv1.VolumeSharingModeNone,
 						},
 						{
 							Name:       pkgutil.GeneratePVCName("disk", "101"),
@@ -2170,6 +2184,8 @@ var _ = Describe("UpdateStatus", func() {
 							Requested:  kubeutil.BytesToResource(1 * oneGiBInBytes),
 							Used:       kubeutil.BytesToResource(500 + (0.25 * oneGiBInBytes)),
 							UnitNumber: ptr.To[int32](0),
+							DiskMode:    vmopv1.VolumeDiskModePersistent,
+							SharingMode: vmopv1.VolumeSharingModeNone,
 						},
 						{
 							Name:       pkgutil.GeneratePVCName("disk", "102"),
@@ -2180,6 +2196,8 @@ var _ = Describe("UpdateStatus", func() {
 							Requested:  kubeutil.BytesToResource(2 * oneGiBInBytes),
 							Used:       kubeutil.BytesToResource(500 + (0.5 * oneGiBInBytes)),
 							UnitNumber: ptr.To[int32](0),
+							DiskMode:    vmopv1.VolumeDiskModePersistent,
+							SharingMode: vmopv1.VolumeSharingModeNone,
 						},
 						{
 							Name:       pkgutil.GeneratePVCName("disk", "103"),
@@ -2190,6 +2208,8 @@ var _ = Describe("UpdateStatus", func() {
 							Requested:  kubeutil.BytesToResource(3 * oneGiBInBytes),
 							Used:       kubeutil.BytesToResource(500 + (1 * oneGiBInBytes)),
 							UnitNumber: ptr.To[int32](0),
+							DiskMode:    vmopv1.VolumeDiskModePersistent,
+							SharingMode: vmopv1.VolumeSharingModeNone,
 						},
 						{
 							Name:       pkgutil.GeneratePVCName("disk", "104"),
@@ -2200,6 +2220,8 @@ var _ = Describe("UpdateStatus", func() {
 							Requested:  kubeutil.BytesToResource(4 * oneGiBInBytes),
 							Used:       kubeutil.BytesToResource(500 + (2 * oneGiBInBytes)),
 							UnitNumber: ptr.To[int32](0),
+							DiskMode:    vmopv1.VolumeDiskModePersistent,
+							SharingMode: vmopv1.VolumeSharingModeNone,
 						},
 					}))
 				})

--- a/pkg/providers/vsphere/vmlifecycle/update_status_test.go
+++ b/pkg/providers/vsphere/vmlifecycle/update_status_test.go
@@ -2087,6 +2087,30 @@ var _ = Describe("UpdateStatus", func() {
 				})
 			})
 
+			When("VMSharedDisks feature is enabled and a classic disk has multi-writer sharing", func() {
+				BeforeEach(func() {
+					pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
+						config.Features.VMSharedDisks = true
+					})
+					d := vmCtx.MoVM.Config.Hardware.Device[1].(*vimtypes.VirtualDisk)
+					b := d.Backing.(*vimtypes.VirtualDiskFlatVer2BackingInfo)
+					b.Sharing = string(vimtypes.VirtualDiskSharingSharingMultiWriter)
+					b.DiskMode = string(vimtypes.VirtualDiskModeIndependent_persistent)
+				})
+				Specify("status.volumes includes SharingMode and DiskMode for the classic disk", func() {
+					var disk100 *vmopv1.VirtualMachineVolumeStatus
+					for i := range vmCtx.VM.Status.Volumes {
+						if vmCtx.VM.Status.Volumes[i].DiskUUID == "100" {
+							disk100 = &vmCtx.VM.Status.Volumes[i]
+							break
+						}
+					}
+					Expect(disk100).ToNot(BeNil())
+					Expect(disk100.SharingMode).To(Equal(vmopv1.VolumeSharingModeMultiWriter))
+					Expect(disk100.DiskMode).To(Equal(vmopv1.VolumeDiskModeIndependentPersistent))
+				})
+			})
+
 			When("vm.status.volumes does not have pvcs, but one of the classic disks is already converted to FCD", func() {
 				BeforeEach(func() {
 					pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {


### PR DESCRIPTION
As part of building my e2e test. Minor fix was needed where VirtualMachineVolumeStatus does not contain DiskMode or SharingMode. It is correctly backfilled to spec.volumes but status was never updated.

- Fix update_status.go based on DiskInfo to update DiskMode and SharingMode
- Added Unit tests
- Update unit test data for DiskMode and SharingMode which will be non empty in live run.

```
status:
  volumes:
  - attached: true
    controllerBusNumber: 0
    controllerType: SCSI
    diskMode: Persistent
    diskUUID: 6000C292-f03f-5039-071a-186fc575036b
    limit: 16Gi
    name: brownfield-vm-hardware-ax07-5bd895c1
    requested: 16Gi
    sharingMode: None
    type: Managed
    unitNumber: 0
    used: "17179869705"
  - attached: true
    controllerBusNumber: 1
    controllerType: SCSI
    diskMode: Persistent
    diskUUID: 6000C295-90d2-fb41-9585-4eac40343a16
    limit: 10Mi
    name: brownfield-vm-hardware-ax07-b1b63869
    requested: 10Mi
    sharingMode: MultiWriter
    type: Managed
    unitNumber: 0
    used: "10486223"
 ```
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note

```