### PR TITLE
🐛  Add ChangeTrackingEnabled to watched VM property

### DIFF
--- a/pkg/util/vsphere/watcher/watcher.go
+++ b/pkg/util/vsphere/watcher/watcher.go
@@ -37,6 +37,7 @@ func DefaultWatchedPropertyPaths() []string {
 	return []string{
 		"config.annotation",
 
+		"config.changeTrackingEnabled",
 		"config.extraConfig",
 		"config.hardware.device",
 		"config.keyId",


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

We'll reconfigure the VM to update the ChangeTrackingEnabled prop when the VM Spec ChangeBlockTracking is updated. We need to include this field in the watcher so that we will reconcile the VM after the reconfigure.

Without this, if the VM is powered on and this was the only field in the reconfigure, we will not timely reconcile the VM to do the InvokeFSR task to actually enable CBT.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

**Please add a release note if necessary**:


```release-note
Add the VM config.ChangeTrackingEnabled property path to the VM watcher service so Reconfigures that change this property will result in an event and later reconciliation. 
```