### PR TITLE
🌱 Update base image to distroless photon 5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,15 @@
-ARG BASE_IMAGE=gcr.io/distroless/base-debian12
+ARG BASE_IMAGE=mirror.gcr.io/library/photon:5.0
 
 # Copy the controller-manager into a thin image
 FROM ${BASE_IMAGE}
 
+## --------------------------------------
+## Cleanup (Distroless image)
+## --------------------------------------
+
+RUN tdnf makecache && tdnf -y update && \
+    rm /etc/tdnf/protected.d/tdnf.conf && tdnf -y autoremove photon-repos tdnf && \
+    rm -rf /var/cache/tdnf /usr/lib/{rpm,tdnf} /usr/lib/sysimage/{rpm,tdnf} /etc/{rpm,tdnf}
 
 ## --------------------------------------
 ## Environment variables

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ WEBHOOK_ROOT      ?= $(MANIFEST_ROOT)/webhook
 RBAC_ROOT         ?= $(MANIFEST_ROOT)/rbac
 
 # Image URL to use all building/pushing image targets
-BASE_IMAGE ?= gcr.io/distroless/base-debian12
+BASE_IMAGE ?= mirror.gcr.io/library/photon:5.0
 IMAGE ?= vmoperator-controller
 IMAGE_TAG ?= latest
 IMG ?= ${IMAGE}:${IMAGE_TAG}


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

To align with the rest of the VMware images, I am updating this base Docker image to use Photon 5.0. I am also cleaning up the image to make it distroless.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # vmop-3718

**Are there any special notes for your reviewer**:
I have patched a Supervisor cluster with this version and ran few e2e tests for sanity check.

**Please add a release note if necessary**:

```release-note
Update base image to distroless photon 5.0
```