### PR TITLE
🌱 Gate StoragePolicyMutability capability behind FSS Env Var

### DIFF
--- a/config/local/vmoperator/local_env_var_patch.yaml
+++ b/config/local/vmoperator/local_env_var_patch.yaml
@@ -39,6 +39,8 @@ spec:
           value: "false"
         - name: FSS_WCP_SUPERVISOR_ASYNC_UPGRADE
           value: "false"
+        - name: FSS_VM_PVC_STORAGE_POLICY_MUTABILITY
+          value: "false"
 
         #
         # Feature state switch flags beneath this line are enabled on main and

--- a/config/wcp/vmoperator/manager_env_var_patch.yaml
+++ b/config/wcp/vmoperator/manager_env_var_patch.yaml
@@ -118,6 +118,12 @@
     name: FSS_WCP_VMSERVICE_FAST_DEPLOY
     value: "<FSS_WCP_VMSERVICE_FAST_DEPLOY_VALUE>"
 
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: FSS_VM_PVC_STORAGE_POLICY_MUTABILITY
+    value: "<FSS_VM_PVC_STORAGE_POLICY_MUTABILITY_VALUE>"
+
 #
 # Feature state switch flags beneath this line are enabled on main and only
 # retained in this file because it is used by internal testing to determine the

--- a/controllers/storage/controllers.go
+++ b/controllers/storage/controllers.go
@@ -42,7 +42,7 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		}
 	}
 
-	if features.StoragePolicyMutability {
+	if features.StoragePolicyMutability && features.PVCStoragePolicyMutability {
 		if err := volumeattributesclass.AddToManager(ctx, mgr); err != nil {
 			return fmt.Errorf("failed to initialize VolumeAttributesClass controller: %w", err)
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -188,6 +188,7 @@ type FeatureStates struct {
 	BringYourOwnEncryptionKey   bool // FSS_WCP_VMSERVICE_BYOK
 	SVAsyncUpgrade              bool // FSS_WCP_SUPERVISOR_ASYNC_UPGRADE
 	FastDeploy                  bool // FSS_WCP_VMSERVICE_FAST_DEPLOY
+	PVCStoragePolicyMutability  bool // FSS_VM_PVC_STORAGE_POLICY_MUTABILITY
 	MutableNetworks             bool
 	VMGroups                    bool
 	ImmutableClasses            bool

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -68,6 +68,7 @@ func FromEnv() Config {
 	setBool(env.FSSVMIncrementalRestore, &config.Features.VMIncrementalRestore)
 	setBool(env.FSSBringYourOwnEncryptionKey, &config.Features.BringYourOwnEncryptionKey)
 	setBool(env.FSSFastDeploy, &config.Features.FastDeploy)
+	setBool(env.FSSPVCStoragePolicyMutability, &config.Features.PVCStoragePolicyMutability)
 	setBool(env.FSSSVAsyncUpgrade, &config.Features.SVAsyncUpgrade)
 	if !config.Features.SVAsyncUpgrade {
 		// When SVAsyncUpgrade is enabled, we'll later use the capability CM to determine if

--- a/pkg/config/env/env.go
+++ b/pkg/config/env/env.go
@@ -62,6 +62,7 @@ const (
 	FSSBringYourOwnEncryptionKey
 	FSSSVAsyncUpgrade
 	FSSFastDeploy
+	FSSPVCStoragePolicyMutability
 	_varNameEnd
 )
 
@@ -195,6 +196,8 @@ func (n VarName) String() string {
 		return "FSS_WCP_SUPERVISOR_ASYNC_UPGRADE"
 	case FSSFastDeploy:
 		return "FSS_WCP_VMSERVICE_FAST_DEPLOY"
+	case FSSPVCStoragePolicyMutability:
+		return "FSS_VM_PVC_STORAGE_POLICY_MUTABILITY"
 	}
 	panic("unknown environment variable")
 }

--- a/pkg/config/env_test.go
+++ b/pkg/config/env_test.go
@@ -104,6 +104,7 @@ var _ = Describe(
 					Expect(os.Setenv("FSS_WCP_VMSERVICE_BYOK", "true")).To(Succeed())
 					Expect(os.Setenv("FSS_WCP_SUPERVISOR_ASYNC_UPGRADE", "false")).To(Succeed())
 					Expect(os.Setenv("FSS_WCP_VMSERVICE_FAST_DEPLOY", "true")).To(Succeed())
+					Expect(os.Setenv("FSS_VM_PVC_STORAGE_POLICY_MUTABILITY", "true")).To(Succeed())
 					Expect(os.Setenv("FSS_PODVMONSTRETCHEDSUPERVISOR", "false")).To(Succeed())
 					Expect(os.Setenv("CREATE_VM_REQUEUE_DELAY", "125h")).To(Succeed())
 					Expect(os.Setenv("POWERED_ON_VM_HAS_IP_REQUEUE_DELAY", "126h")).To(Succeed())
@@ -151,16 +152,17 @@ var _ = Describe(
 						WebhookSecretVolumeMountPath: pkgcfg.Default().WebhookSecretVolumeMountPath,
 						CRDCleanupEnabled:            true,
 						Features: pkgcfg.FeatureStates{
-							InstanceStorage:           false,
-							K8sWorkloadMgmtAPI:        true,
-							VMResize:                  true,
-							VMResizeCPUMemory:         true,
-							VMImportNewNet:            true,
-							VMIncrementalRestore:      true,
-							BringYourOwnEncryptionKey: true,
-							SVAsyncUpgrade:            false, // Capability gate so tested below
-							WorkloadDomainIsolation:   true,
-							FastDeploy:                true,
+							InstanceStorage:            false,
+							K8sWorkloadMgmtAPI:         true,
+							VMResize:                   true,
+							VMResizeCPUMemory:          true,
+							VMImportNewNet:             true,
+							VMIncrementalRestore:       true,
+							BringYourOwnEncryptionKey:  true,
+							SVAsyncUpgrade:             false, // Capability gate so tested below
+							WorkloadDomainIsolation:    true,
+							FastDeploy:                 true,
+							PVCStoragePolicyMutability: true,
 						},
 						CreateVMRequeueDelay:         125 * time.Hour,
 						PoweredOnVMHasIPRequeueDelay: 126 * time.Hour,

--- a/pkg/util/kube/storage.go
+++ b/pkg/util/kube/storage.go
@@ -213,9 +213,10 @@ func GetStoragePolicyID(
 		objName = vm.Spec.VolumeAttributesClassName
 		objKind = internal.VolumeAttributesClassKind
 
-		if !pkgcfg.FromContext(ctx).Features.StoragePolicyMutability {
+		if !pkgcfg.FromContext(ctx).Features.StoragePolicyMutability ||
+			!pkgcfg.FromContext(ctx).Features.PVCStoragePolicyMutability {
 			return "", fmt.Errorf(
-				"%s %q object is specified but capability is not enabled", 
+				"%s %q object is specified but capability is not enabled",
 				objKind, objName,
 			)
 		}
@@ -305,7 +306,8 @@ func IsEncryptedStorageProfile(
 
 	foundStorageProfile := false
 
-	if pkgcfg.FromContext(ctx).Features.StoragePolicyMutability {
+	if pkgcfg.FromContext(ctx).Features.StoragePolicyMutability &&
+		pkgcfg.FromContext(ctx).Features.PVCStoragePolicyMutability {
 		var volumeAttributesClasses storagev1.VolumeAttributesClassList
 		if err := k8sClient.List(ctx, &volumeAttributesClasses); err != nil {
 			return false, err

--- a/pkg/util/kube/storage_test.go
+++ b/pkg/util/kube/storage_test.go
@@ -192,11 +192,11 @@ var _ = Describe("GetStoragePolicyID", func() {
 			})
 		})
 
-		When("StoragePolicyMutability feature is enabled", func() {
+		When("StoragePolicyMutability feature and FSS PVCStoragePolicyMutability are enabled", func() {
 			BeforeEach(func() {
 				ctx = pkgcfg.WithConfig(pkgcfg.Config{
 					PodNamespace: fakeString,
-					Features:     pkgcfg.FeatureStates{StoragePolicyMutability: true},
+					Features:     pkgcfg.FeatureStates{StoragePolicyMutability: true, PVCStoragePolicyMutability: true},
 				})
 			})
 
@@ -811,14 +811,15 @@ var _ = Describe("IsEncryptedStorageProfile", func() {
 		})
 	})
 
-	Context("when StoragePolicyMutability feature is enabled", func() {
+	Context("when StoragePolicyMutability feature and FSS PVCStoragePolicyMutability are enabled", func() {
 		var vac storagev1.VolumeAttributesClass
 
 		BeforeEach(func() {
 			ctx = pkgcfg.WithConfig(pkgcfg.Config{
 				PodNamespace: fakeString,
 				Features: pkgcfg.FeatureStates{
-					StoragePolicyMutability: true,
+					StoragePolicyMutability:    true,
+					PVCStoragePolicyMutability: true,
 				},
 			})
 			vac = storagev1.VolumeAttributesClass{

--- a/pkg/util/vsphere/storage/storage_policy.go
+++ b/pkg/util/vsphere/storage/storage_policy.go
@@ -100,8 +100,9 @@ func GetStoragePolicyStatus(
 		return infrav1.StoragePolicyStatus{}, err
 	}
 
-	// Collect volume attributes class name only if capability is enabled.
-	if pkgcfg.FromContext(ctx).Features.StoragePolicyMutability {
+	// Collect volume attributes class name only if capability and FSS are enabled.
+	if pkgcfg.FromContext(ctx).Features.StoragePolicyMutability &&
+		pkgcfg.FromContext(ctx).Features.PVCStoragePolicyMutability {
 		if err := getVolumeAttributesClassName(
 			ctx,
 			k8sClient,

--- a/pkg/util/vsphere/storage/storage_policy_test.go
+++ b/pkg/util/vsphere/storage/storage_policy_test.go
@@ -293,10 +293,10 @@ var _ = Describe("GetStoragePolicyStatus", func() {
 						)
 					})
 					
-					Context("when StoragePolicyMutability capability is enabled", func() {
+					Context("when StoragePolicyMutability capability and FSS PVCStoragePolicyMutability are enabled", func() {
 						BeforeEach(func() {
 							ctx = pkgcfg.WithContext(ctx, pkgcfg.Config{
-								Features: pkgcfg.FeatureStates{StoragePolicyMutability: true},
+								Features: pkgcfg.FeatureStates{StoragePolicyMutability: true, PVCStoragePolicyMutability: true},
 							})
 						})
 						It("should return the policy status", func() {
@@ -400,10 +400,10 @@ var _ = Describe("GetStoragePolicyStatus", func() {
 					})
 				})
 
-				Context("when StoragePolicyMutability capability is enabled", func() {
+				Context("when StoragePolicyMutability capability and FSS PVCStoragePolicyMutability are enabled", func() {
 					BeforeEach(func() {
 						ctx = pkgcfg.WithContext(ctx, pkgcfg.Config{
-							Features: pkgcfg.FeatureStates{StoragePolicyMutability: true},
+							Features: pkgcfg.FeatureStates{StoragePolicyMutability: true, PVCStoragePolicyMutability: true},
 						})
 					})
 					It("should return the policy status with the VAC", func() {
@@ -469,10 +469,10 @@ var _ = Describe("GetStoragePolicyStatus", func() {
 						)
 					})
 
-					Context("when StoragePolicyMutability capability is enabled", func() {
+					Context("when StoragePolicyMutability capability and FSS PVCStoragePolicyMutability are enabled", func() {
 						BeforeEach(func() {
 							ctx = pkgcfg.WithContext(ctx, pkgcfg.Config{
-								Features: pkgcfg.FeatureStates{StoragePolicyMutability: true},
+								Features: pkgcfg.FeatureStates{StoragePolicyMutability: true, PVCStoragePolicyMutability: true},
 							})
 						})
 						It("should return the policy status", func() {
@@ -538,10 +538,10 @@ var _ = Describe("GetStoragePolicyStatus", func() {
 						)
 					})
 
-					Context("when StoragePolicyMutability capability is enabled", func() {
+					Context("when StoragePolicyMutability capability and FSS PVCStoragePolicyMutability are enabled", func() {
 						BeforeEach(func() {
 							ctx = pkgcfg.WithContext(ctx, pkgcfg.Config{
-								Features: pkgcfg.FeatureStates{StoragePolicyMutability: true},
+								Features: pkgcfg.FeatureStates{StoragePolicyMutability: true, PVCStoragePolicyMutability: true},
 							})
 						})
 						It("should return the policy status", func() {
@@ -608,10 +608,10 @@ var _ = Describe("GetStoragePolicyStatus", func() {
 						)
 					})
 
-					Context("when StoragePolicyMutability capability is enabled", func() {
+					Context("when StoragePolicyMutability capability and FSS PVCStoragePolicyMutability are enabled", func() {
 						BeforeEach(func() {
 							ctx = pkgcfg.WithContext(ctx, pkgcfg.Config{
-								Features: pkgcfg.FeatureStates{StoragePolicyMutability: true},
+								Features: pkgcfg.FeatureStates{StoragePolicyMutability: true, PVCStoragePolicyMutability: true},
 							})
 						})
 						It("should return the policy status", func() {
@@ -678,10 +678,10 @@ var _ = Describe("GetStoragePolicyStatus", func() {
 						)
 					})
 
-					Context("when StoragePolicyMutability capability is enabled", func() {
+					Context("when StoragePolicyMutability capability and FSS PVCStoragePolicyMutability are enabled", func() {
 						BeforeEach(func() {
 							ctx = pkgcfg.WithContext(ctx, pkgcfg.Config{
-								Features: pkgcfg.FeatureStates{StoragePolicyMutability: true},
+								Features: pkgcfg.FeatureStates{StoragePolicyMutability: true, PVCStoragePolicyMutability: true},
 							})
 						})
 						It("should return the policy status", func() {
@@ -752,10 +752,10 @@ var _ = Describe("GetStoragePolicyStatus", func() {
 						)
 					})
 
-					Context("when StoragePolicyMutability capability is enabled", func() {
+					Context("when StoragePolicyMutability capability and FSS PVCStoragePolicyMutability are enabled", func() {
 						BeforeEach(func() {
 							ctx = pkgcfg.WithContext(ctx, pkgcfg.Config{
-								Features: pkgcfg.FeatureStates{StoragePolicyMutability: true},
+								Features: pkgcfg.FeatureStates{StoragePolicyMutability: true, PVCStoragePolicyMutability: true},
 							})
 						})
 						It("should return the policy status", func() {
@@ -826,10 +826,10 @@ var _ = Describe("GetStoragePolicyStatus", func() {
 						)
 					})
 
-					Context("when StoragePolicyMutability capability is enabled", func() {
+					Context("when StoragePolicyMutability capability and FSS PVCStoragePolicyMutability are enabled", func() {
 						BeforeEach(func() {
 							ctx = pkgcfg.WithContext(ctx, pkgcfg.Config{
-								Features: pkgcfg.FeatureStates{StoragePolicyMutability: true},
+								Features: pkgcfg.FeatureStates{StoragePolicyMutability: true, PVCStoragePolicyMutability: true},
 							})
 						})
 						It("should return the policy status", func() {
@@ -925,10 +925,10 @@ var _ = Describe("GetStoragePolicyStatus", func() {
 						)
 					})
 
-					Context("when StoragePolicyMutability capability is enabled", func() {
+					Context("when StoragePolicyMutability capability and FSS PVCStoragePolicyMutability are enabled", func() {
 						BeforeEach(func() {
 							ctx = pkgcfg.WithContext(ctx, pkgcfg.Config{
-								Features: pkgcfg.FeatureStates{StoragePolicyMutability: true},
+								Features: pkgcfg.FeatureStates{StoragePolicyMutability: true, PVCStoragePolicyMutability: true},
 							})
 						})
 						It("should return the policy status", func() {

--- a/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
@@ -1726,6 +1726,7 @@ func unitTestsValidateCreate() {
 			pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
 				config.Features.PodVMOnStretchedSupervisor = true
 				config.Features.StoragePolicyMutability = true
+				config.Features.PVCStoragePolicyMutability = true
 			})
 		})
 
@@ -1825,11 +1826,38 @@ func unitTestsValidateCreate() {
 			),
 		)
 
-		Context("StoragePolicyMutability is disabled", func() {
+		Context("StoragePolicyMutability capability is disabled", func() {
 
 			BeforeEach(func() {
 				pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
 					config.Features.StoragePolicyMutability = false
+					config.Features.PVCStoragePolicyMutability = true
+				})
+			})
+
+			DescribeTable("VAC create", doTest,
+				Entry("block create if VAC is specified",
+					testParams{
+						setup: func(ctx *unitValidatingWebhookContext) {
+							storageClass := builder.DummyStorageClassWithID("id-from-storageclass")
+							Expect(ctx.Client.Create(ctx, storageClass)).To(Succeed())
+							ctx.vm.Spec.StorageClass = storageClass.Name
+
+							ctx.vm.Spec.VolumeAttributesClassName = builder.DummyVolumeAttributesClassName
+						},
+						validate: doValidateWithMsg(
+							`spec.volumeAttributesClassName: Invalid value: "dummy-vac": VolumeAttributesClass "dummy-vac" object is specified but capability is not enabled`),
+					},
+				),
+			)
+		})
+
+		Context("FSS PVCStoragePolicyMutability is disabled", func() {
+
+			BeforeEach(func() {
+				pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+					config.Features.StoragePolicyMutability = true
+					config.Features.PVCStoragePolicyMutability = false
 				})
 			})
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This patch implements vmop-3713 via env-var FSS `PVCStoragePolicyMutability` (FSS_VM_PVC_STORAGE_POLICY_MUTABILITY) as a required AND condition alongside the `StoragePolicyMutability` capability in all feature-gated code path. The `VolumeAttributesClass` only takes effect when both the WCP feature switch and the cluster FSS capability are active.
Unit tests are updated to set both flags in enabled paths and include explicit disabled contexts for each flag independently.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note

```