### PR TITLE
✨  test/e2e: add MarshalObjects utility and migrate v1alpha5 placement-policy VM sites

### DIFF
--- a/test/e2e/manifestbuilders/yaml.go
+++ b/test/e2e/manifestbuilders/yaml.go
@@ -1,0 +1,48 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package manifestbuilders
+
+import (
+	"bytes"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	e2eframework "k8s.io/kubernetes/test/e2e/framework"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+)
+
+// MarshalObjects marshals one or more controller-runtime objects to a
+// multi-document YAML byte slice suitable for piping to kubectl.
+// It uses the scheme to populate TypeMeta on each object before marshaling.
+func MarshalObjects(scheme *runtime.Scheme, objs ...ctrlclient.Object) ([]byte, error) {
+	var buf bytes.Buffer
+	for i, obj := range objs {
+		gvks, _, err := scheme.ObjectKinds(obj)
+		if err != nil {
+			return nil, fmt.Errorf("getting GVK for %T: %w", obj, err)
+		}
+		obj.GetObjectKind().SetGroupVersionKind(gvks[0])
+
+		b, err := yaml.Marshal(obj)
+		if err != nil {
+			return nil, fmt.Errorf("marshaling %T: %w", obj, err)
+		}
+		if i > 0 {
+			buf.WriteString("---\n")
+		}
+		buf.Write(b)
+	}
+	return buf.Bytes(), nil
+}
+
+// MustMarshalObjects is like MarshalObjects but calls e2eframework.Failf on error.
+func MustMarshalObjects(scheme *runtime.Scheme, objs ...ctrlclient.Object) []byte {
+	b, err := MarshalObjects(scheme, objs...)
+	if err != nil {
+		e2eframework.Failf("MustMarshalObjects: %v", err)
+	}
+	return b
+}

--- a/test/e2e/vmservice/vmservice/virtualmachine/virtualmachinelcm.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/virtualmachinelcm.go
@@ -833,16 +833,22 @@ func VMSpec(ctx context.Context, inputGetter func() VMSpecInput) {
 			By("Deploying a VM without any explicit policies")
 			tmpNamespaceVMIName, err = vmoperator.WaitForVirtualMachineImageName(ctx, &config.Config, svClusterClient, tmpNamespaceName, linuxImageDisplayName)
 			Expect(err).NotTo(HaveOccurred(), "failed to get the VMI name in namespace %q", tmpNamespaceName)
-			vmParameters := manifestbuilders.VirtualMachineYaml{
-				Namespace:        tmpNamespaceName,
-				Name:             vmName,
-				ImageName:        tmpNamespaceVMIName,
-				VMClassName:      clusterResources.VMClassName,
-				StorageClassName: clusterResources.StorageClassName,
-				ResourcePolicy:   clusterResources.VMResourcePolicyName,
-				PowerState:       "PoweredOn",
+			vm := &vmopv1a5.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      vmName,
+					Namespace: tmpNamespaceName,
+				},
+				Spec: vmopv1a5.VirtualMachineSpec{
+					ClassName:    clusterResources.VMClassName,
+					ImageName:    tmpNamespaceVMIName,
+					StorageClass: clusterResources.StorageClassName,
+					PowerState:   vmopv1a5.VirtualMachinePowerStateOn,
+					Reserved: &vmopv1a5.VirtualMachineReservedSpec{
+						ResourcePolicyName: clusterResources.VMResourcePolicyName,
+					},
+				},
 			}
-			vmYaml = manifestbuilders.GetVirtualMachineYamlA5(vmParameters)
+			vmYaml = manifestbuilders.MustMarshalObjects(clusterProxy.GetScheme(), vm)
 			e2eframework.Logf("VM YAML without spec.policies:\n%s", string(vmYaml))
 			Expect(clusterProxy.CreateWithArgs(ctx, vmYaml)).To(Succeed(), "failed to create virtualmachine:\n %s", string(vmYaml))
 			vmoperator.WaitForVirtualMachineCreation(ctx, config, svClusterClient, tmpNamespaceName, vmName)
@@ -966,24 +972,30 @@ func VMSpec(ctx context.Context, inputGetter func() VMSpecInput) {
 
 			By("Creating a new VM with explicitly specified the optional policy match by guest ID")
 			vmName = fmt.Sprintf("%s-%s", specName, capiutil.RandomString(4))
-			vmParameters := manifestbuilders.VirtualMachineYaml{
-				Namespace:        tmpNamespaceName,
-				Name:             vmName,
-				GuestID:          linuxImageGuestID,
-				ImageName:        tmpNamespaceVMIName,
-				VMClassName:      clusterResources.VMClassName,
-				StorageClassName: clusterResources.StorageClassName,
-				ResourcePolicy:   clusterResources.VMResourcePolicyName,
-				PowerState:       "PoweredOn",
-				Policies: []vmopv1a5.PolicySpec{
-					{
-						APIVersion: "vsphere.policy.vmware.com/v1alpha1",
-						Kind:       "ComputePolicy",
-						Name:       opPolicyNameMatchByGuestID,
+			vm := &vmopv1a5.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      vmName,
+					Namespace: tmpNamespaceName,
+				},
+				Spec: vmopv1a5.VirtualMachineSpec{
+					ClassName:    clusterResources.VMClassName,
+					GuestID:      linuxImageGuestID,
+					ImageName:    tmpNamespaceVMIName,
+					StorageClass: clusterResources.StorageClassName,
+					PowerState:   vmopv1a5.VirtualMachinePowerStateOn,
+					Reserved: &vmopv1a5.VirtualMachineReservedSpec{
+						ResourcePolicyName: clusterResources.VMResourcePolicyName,
+					},
+					Policies: []vmopv1a5.PolicySpec{
+						{
+							APIVersion: "vsphere.policy.vmware.com/v1alpha1",
+							Kind:       "ComputePolicy",
+							Name:       opPolicyNameMatchByGuestID,
+						},
 					},
 				},
 			}
-			vmYaml = manifestbuilders.GetVirtualMachineYamlA5(vmParameters)
+			vmYaml = manifestbuilders.MustMarshalObjects(clusterProxy.GetScheme(), vm)
 			e2eframework.Logf("Creating VM with explicit spec.policies:\n%s", string(vmYaml))
 			Expect(clusterProxy.CreateWithArgs(ctx, vmYaml)).To(Succeed(), "failed to create VM with explicitly specified optional policy")
 			vmoperator.WaitForVirtualMachineCreation(ctx, config, svClusterClient, tmpNamespaceName, vmName)
@@ -993,15 +1005,15 @@ func VMSpec(ctx context.Context, inputGetter func() VMSpecInput) {
 			vmservice.VerifyVMTagsAndPolicyAssignment(ctx, config, svClusterClient, tagManager, tmpNamespaceName, vmName, policyNameToVMTagID, expectedPolicyNames)
 
 			By("Updating the VM's labels and policies to match by label")
-			vmParameters.Labels = matchLabel
-			vmParameters.Policies = []vmopv1a5.PolicySpec{
+			vm.Labels = matchLabel
+			vm.Spec.Policies = []vmopv1a5.PolicySpec{
 				{
 					APIVersion: "vsphere.policy.vmware.com/v1alpha1",
 					Kind:       "ComputePolicy",
 					Name:       opPolicyNameMatchByLabel,
 				},
 			}
-			vmYaml = manifestbuilders.GetVirtualMachineYamlA5(vmParameters)
+			vmYaml = manifestbuilders.MustMarshalObjects(clusterProxy.GetScheme(), vm)
 			e2eframework.Logf("Updating VM's labels and spec.policies:\n%s", string(vmYaml))
 			Expect(clusterProxy.ApplyWithArgs(ctx, vmYaml)).To(Succeed(), "failed to apply updated VM YAML")
 
@@ -1017,9 +1029,9 @@ func VMSpec(ctx context.Context, inputGetter func() VMSpecInput) {
 				Expect(vmLabels).To(HaveKey(key))
 				delete(vmLabels, key)
 			}
-			vmParameters.Labels = vmLabels
-			vmParameters.Policies = []vmopv1a5.PolicySpec{}
-			vmYaml = manifestbuilders.GetVirtualMachineYamlA5(vmParameters)
+			vm.Labels = vmLabels
+			vm.Spec.Policies = nil
+			vmYaml = manifestbuilders.MustMarshalObjects(clusterProxy.GetScheme(), vm)
 			e2eframework.Logf("Updating VM's labels:\n%s", string(vmYaml))
 			Expect(clusterProxy.ApplyWithArgs(ctx, vmYaml)).To(Succeed(), "failed to apply updated VM YAML")
 


### PR DESCRIPTION


**What does this PR do, and why is it needed?**

Add MarshalObjects / MustMarshalObjects to manifestbuilders to marshal controller-runtime objects to multi-document YAML suitable for piping to kubectl, stamping TypeMeta on each object via scheme lookup before marshaling.

Convert the four v1alpha5 call sites in virtualmachinelcm.go (placement-policy BeforeEach and It block) from the VirtualMachineYaml intermediary struct + GetVirtualMachineYamlA5 template to inline vmopv1a5.VirtualMachine structs. Each VM object is assigned to its own variable to make the eventual Phase 4 swap to svClusterClient.Create(ctx, vm) a one-line change per call site.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:



**Please add a release note if necessary**:

```release-note
NONE
```