### PR TITLE
🐛 fix: Clear SubnetId when editing NIC backing during subnet change

### DIFF
--- a/pkg/providers/vsphere/network/reconcile.go
+++ b/pkg/providers/vsphere/network/reconcile.go
@@ -26,7 +26,6 @@ func ReconcileNetworkInterfaces(
 	results *NetworkInterfaceResults,
 	currentEthCards object.VirtualDeviceList,
 ) ([]vimtypes.BaseVirtualDeviceConfigSpec, error) {
-
 	var deviceChanges []vimtypes.BaseVirtualDeviceConfigSpec
 
 	for idx, r := range results.Results {
@@ -51,6 +50,12 @@ func ReconcileNetworkInterfaces(
 				ethDev.AddressType = r.Device.(vimtypes.BaseVirtualEthernetCard).GetVirtualEthernetCard().AddressType
 				ethDev.MacAddress = r.Device.(vimtypes.BaseVirtualEthernetCard).GetVirtualEthernetCard().MacAddress
 				ethDev.ExternalId = r.Device.(vimtypes.BaseVirtualEthernetCard).GetVirtualEthernetCard().ExternalId
+
+				// Clear SubnetID when the backing changes to ensure we don't have a
+				// mismatch between the subnet ID and the port group specified in the
+				// backing. The subnetID is populated by the platform automatically when
+				// the network adapter is connected to a subnet.
+				ethDev.SubnetId = ""
 
 				deviceChanges = append(deviceChanges, &vimtypes.VirtualDeviceConfigSpec{
 					Device:    editDev,
@@ -89,8 +94,8 @@ func findExistingEthCardForOrphanedCR(
 	_ context.Context,
 	interfaceName string,
 	orphanedObjects []ctrlclient.Object,
-	currentEthCards object.VirtualDeviceList) int {
-
+	currentEthCards object.VirtualDeviceList,
+) int {
 	findMatchFn := func(obj ctrlclient.Object) int {
 		switch netIf := obj.(type) {
 		case *netopv1alpha1.NetworkInterface:
@@ -137,8 +142,8 @@ func findExistingEthCardForOrphanedCR(
 
 func FindMatchingEthCard(
 	currentEthCards object.VirtualDeviceList,
-	ethCard vimtypes.BaseVirtualEthernetCard) int {
-
+	ethCard vimtypes.BaseVirtualEthernetCard,
+) int {
 	ethDev := ethCard.GetVirtualEthernetCard()
 	matchingIdx := -1
 

--- a/pkg/providers/vsphere/network/reconcile_test.go
+++ b/pkg/providers/vsphere/network/reconcile_test.go
@@ -68,10 +68,20 @@ var _ = Describe("ReconcileNetworkInterfaces", func() {
 							PortgroupKey: "pg-1",
 						},
 					}
-				case builder.NetworkEnvNSXT, builder.NetworkEnvVPC:
+				case builder.NetworkEnvNSXT:
 					ethCard.GetVirtualEthernetCard().MacAddress = "my-mac"
 					ethCard.GetVirtualEthernetCard().AddressType = string(vimtypes.VirtualEthernetCardMacTypeAssigned)
 					ethCard.GetVirtualEthernetCard().ExternalId = "my-ext-id"
+					ethCard.GetVirtualEthernetCard().Backing = &vimtypes.VirtualEthernetCardDistributedVirtualPortBackingInfo{
+						Port: vimtypes.DistributedVirtualSwitchPortConnection{
+							PortgroupKey: "pg-1",
+						},
+					}
+				case builder.NetworkEnvVPC:
+					ethCard.GetVirtualEthernetCard().MacAddress = "my-mac"
+					ethCard.GetVirtualEthernetCard().AddressType = string(vimtypes.VirtualEthernetCardMacTypeAssigned)
+					ethCard.GetVirtualEthernetCard().ExternalId = "my-ext-id"
+					ethCard.GetVirtualEthernetCard().SubnetId = "/projects/my-project/vpcs/foo/subnets/old-subnet"
 					ethCard.GetVirtualEthernetCard().Backing = &vimtypes.VirtualEthernetCardDistributedVirtualPortBackingInfo{
 						Port: vimtypes.DistributedVirtualSwitchPortConnection{
 							PortgroupKey: "pg-1",
@@ -182,6 +192,7 @@ var _ = Describe("ReconcileNetworkInterfaces", func() {
 					dc0 := deviceChanges[0].GetVirtualDeviceConfigSpec()
 					Expect(dc0.Operation).To(Equal(vimtypes.VirtualDeviceConfigSpecOperationEdit))
 					Expect(dc0.Device.GetVirtualDevice().Backing).To(Equal(ethCard.GetVirtualEthernetCard().Backing))
+					Expect(dc0.Device.(vimtypes.BaseVirtualEthernetCard).GetVirtualEthernetCard().SubnetId).To(BeEmpty())
 				})
 
 				When("Network Interface CR is old and does not have interface name label", func() {
@@ -197,6 +208,7 @@ var _ = Describe("ReconcileNetworkInterfaces", func() {
 						dc0 := deviceChanges[0].GetVirtualDeviceConfigSpec()
 						Expect(dc0.Operation).To(Equal(vimtypes.VirtualDeviceConfigSpecOperationEdit))
 						Expect(dc0.Device.GetVirtualDevice().Backing).To(Equal(ethCard.GetVirtualEthernetCard().Backing))
+						Expect(dc0.Device.(vimtypes.BaseVirtualEthernetCard).GetVirtualEthernetCard().SubnetId).To(BeEmpty())
 					})
 				})
 			})

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_networking.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_networking.go
@@ -222,4 +222,118 @@ func VMNetworkSpec(ctx context.Context, inputGetter func() VMNetworkSpecInput) {
 		ethCards = object.VirtualDeviceList(vmMO.Config.Hardware.Device).SelectByType((*types.VirtualEthernetCard)(nil))
 		Expect(ethCards).To(HaveLen(2), "VM config should have two EthernetCards")
 	})
+
+	It("Should allow network interface to be moved to a different subnet when mutability cap is enabled", Label("smoke"), func() {
+		if !isVMMutableNetworksCapEnabled {
+			Skip("VM Mutable Networks capability is not enabled")
+		}
+
+		if !vmoperator.IsNetworkNsxtVPC(ctx, svClusterClient, config) {
+			Skip("Test requires VPC networking environment to create SubnetSet")
+		}
+
+		subnetSetName := "custom-subnetset"
+
+		By("Creating custom SubnetSet")
+		Eventually(func(g Gomega) {
+			sYaml := utils.CreateSubnetOrSubnetSetYaml(utils.SubnetSetKind, subnetSetName, input.WCPNamespaceName, utils.DHCPConfig, true)
+			g.Expect(clusterProxy.CreateWithArgs(ctx, sYaml)).To(Succeed(), "failed to create the SubnetSet: %s", string(sYaml))
+		}, config.GetIntervals("default", "wait-subnet-creation")...).Should(Succeed(), "Timed out in creating SubnetSet")
+		vmservice.VerifySubnetOrSubnetSetCreation(ctx, config, svClusterClient, input.WCPNamespaceName, subnetSetName, utils.SubnetSetKind)
+
+		DeferCleanup(func() {
+			vmoperator.DeleteSubnetOrSubnetSet(ctx, svClusterClient, input.WCPNamespaceName, subnetSetName, utils.SubnetSetKind)
+			vmoperator.WaitForSubnetOrSubnetSetToBeDeleted(ctx, config, svClusterClient, input.WCPNamespaceName, subnetSetName, utils.SubnetSetKind)
+		})
+
+		vmParameters := manifestbuilders.VirtualMachineYaml{
+			Namespace:        input.WCPNamespaceName,
+			Name:             vmName,
+			ImageName:        linuxVMIName,
+			VMClassName:      clusterResources.VMClassName,
+			StorageClassName: clusterResources.StorageClassName,
+			PowerState:       "PoweredOff",
+		}
+		vmYaml = manifestbuilders.GetVirtualMachineYamlA2(vmParameters)
+		Expect(clusterProxy.CreateWithArgs(ctx, vmYaml)).To(Succeed(), "failed to create virtualmachine:\n %s", string(vmYaml))
+
+		vmoperator.WaitForVirtualMachineToExist(ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
+		vmoperator.WaitForVirtualMachineMOID(ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
+		vmMoID := vmoperator.GetVirtualMachineMOID(ctx, svClusterClient, input.WCPNamespaceName, vmName)
+		vmMoRef := types.ManagedObjectReference{Type: "VirtualMachine", Value: vmMoID}
+
+		vCenterClient := vcenter.NewVimClientFromKubeconfig(ctx, clusterProxy.GetKubeconfigPath())
+		propCollector := property.DefaultCollector(vCenterClient)
+
+		var vmMO mo.VirtualMachine
+		Expect(propCollector.RetrieveOne(ctx, vmMoRef, []string{"config"}, &vmMO)).To(Succeed())
+		ethCards := object.VirtualDeviceList(vmMO.Config.Hardware.Device).SelectByType((*types.VirtualEthernetCard)(nil))
+		Expect(ethCards).To(HaveLen(1), "VM config should have one EthernetCard")
+
+		By("Change network interface to a different subnet")
+
+		key := ctrlclient.ObjectKey{Name: vmName, Namespace: input.WCPNamespaceName}
+		Eventually(func() bool {
+			vm := &vmopv1a3.VirtualMachine{}
+
+			err := svClusterClient.Get(ctx, key, vm)
+			if err != nil {
+				e2eframework.Logf("retry due to: %v", err)
+				return false
+			}
+
+			Expect(vm.Spec.Network).ToNot(BeNil())
+			Expect(vm.Spec.Network.Interfaces).To(HaveLen(1))
+
+			// Change the network name to the custom SubnetSet
+			vm.Spec.Network.Interfaces[0].Network.Name = subnetSetName
+			vm.Spec.Network.Interfaces[0].Network.Kind = utils.SubnetSetKind
+			vm.Spec.Network.Interfaces[0].Network.APIVersion = "crd.nsx.vmware.com/v1alpha1"
+
+			err = svClusterClient.Update(ctx, vm)
+			if err != nil {
+				e2eframework.Logf("retry due to: %v", err)
+				return false
+			}
+
+			return true
+		}, config.GetIntervals("default", "wait-virtual-machine-resize")...).Should(BeTrue(), "Timed out updating VirtualMachine %s to change subnet", vmName)
+
+		By("Wait for VM to be reconfigured with updated EthernetCard")
+		Eventually(func(g Gomega) {
+			g.Expect(propCollector.RetrieveOne(ctx, vmMoRef, []string{"config"}, &vmMO)).To(Succeed())
+			ethCards := object.VirtualDeviceList(vmMO.Config.Hardware.Device).SelectByType((*types.VirtualEthernetCard)(nil))
+			g.Expect(ethCards).To(HaveLen(1), "VM should still have one EthernetCard configured")
+			// We can add validation here to actually check the ethCard.  For now, just validate that
+			// the reconfiguring the NIC to connect to a different network succeeds.
+		}, config.GetIntervals("default", "wait-virtual-machine-resize")...).Should(Succeed(), "VM reconfigured with updated EthernetCard")
+
+		By("Power on VM")
+		Eventually(func() bool {
+			vm := &vmopv1a3.VirtualMachine{}
+			err := svClusterClient.Get(ctx, key, vm)
+			if err != nil {
+				e2eframework.Logf("retry due to: %v", err)
+				return false
+			}
+
+			vm.Spec.PowerState = vmopv1a3.VirtualMachinePowerStateOn
+
+			err = svClusterClient.Update(ctx, vm)
+			if err != nil {
+				e2eframework.Logf("retry due to: %v", err)
+				return false
+			}
+
+			return true
+		}, config.GetIntervals("default", "wait-virtual-machine-powerstate")...).Should(BeTrue(), "Timed out updating VirtualMachine %s PowerState to On", vmName)
+
+		vmoperator.WaitForVirtualMachinePowerState(ctx, config, svClusterClient, input.WCPNamespaceName, vmName, "PoweredOn")
+		vmoperator.WaitForVirtualMachineIP(ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
+
+		By("Powered On VM should still have one EthernetCard configured")
+		Expect(propCollector.RetrieveOne(ctx, vmMoRef, []string{"config"}, &vmMO)).To(Succeed())
+		ethCards = object.VirtualDeviceList(vmMO.Config.Hardware.Device).SelectByType((*types.VirtualEthernetCard)(nil))
+		Expect(ethCards).To(HaveLen(1), "VM config should have one EthernetCard")
+	})
 }


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

When a VM's network interface is moved to a new subnet, the orphaned network interface CR edit path in ReconcileNetworkInterfaces updates the NIC's backing and ExternalId but left the stale SubnetId intact. vSphere validates that the SubnetId's logical switch matches the new DVPG's logicalSwitchUuid, so sending a mismatched SubnetId causes the reconfigure to fail with:

  "A specified parameter was not correct: device.backing
   Mismatch detected between DVPG and subnet ID"

Clear the subnetId to avoid this conflict.  Also add an end to end test to verify that this works.


Testing Done:
```
Testing VM Services VIRTUAL-MACHINE VM-NETWORKING Should allow network interface to be moved to a different subnet when mutability cap is enabled [devops, viadmin, virtualmachine, vmservice, smoke]
/Users/parunesh/go/src/aruneshpa/vm-operator/test/e2e/vmservice/vmservice/virtualmachine/vm_networking.go:226
  I0526 11:19:51.246888    4338 command_runner.go:134] Running command via SSH; remote: 10.192.0.68:22, command: python /usr/sbin/feature-state-wrapper.py WCP_Supervisor_Async_Upgrade
  I0526 11:19:51.516186    4338 command_runner.go:152] Ran command via SSH; remote: 10.192.0.68:22, command: PYTHONWARNINGS=ignore python /usr/sbin/feature-state-wrapper.py WCP_Supervisor_Async_Upgrade, output: enabled
  , error: <nil>
  STEP: Creating custom SubnetSet @ 05/26/26 11:19:51.691
subnetset.crd.nsx.vmware.com/custom-subnetset created

  STEP: Verify that we have a Subnet or SubnetSet CRD @ 05/26/26 11:19:52.288
virtualmachine.vmoperator.vmware.com/vm-networking-neul created

  STEP: Verifying the existence of VM CR in etcd @ 05/26/26 11:19:52.774
  STEP: Verify that the VirtualMachine has a Unique ID/MOID @ 05/26/26 11:19:52.826
  STEP: Change network interface to a different subnet @ 05/26/26 11:20:03.587
  STEP: Wait for VM to be reconfigured with updated EthernetCard @ 05/26/26 11:20:04.618
  STEP: Power on VM @ 05/26/26 11:20:04.658
  STEP: Waiting for VM power state to reach PoweredOn @ 05/26/26 11:20:05.012
  STEP: Verify that an IP (ipv4) is allocated to the VirtualMachine 'vmsvc-e2e-2pyz6f/vm-networking-neul' @ 05/26/26 11:20:25.306
  STEP: Powered On VM should still have one EthernetCard configured @ 05/26/26 11:21:15.89
virtualmachine.vmoperator.vmware.com "vm-networking-neul" deleted from
vmsvc-e2e-2pyz6f namespace
```



**Please add a release note if necessary**:

```release-note
Clear SubnetId when editing NIC backing during subnet change
```