### PR TITLE
🐛 fix(vmlifecycle): prevent premature VirtualMachineGuestNetworkConfigSynced=True

### DIFF
--- a/pkg/providers/vsphere/vmlifecycle/update_status.go
+++ b/pkg/providers/vsphere/vmlifecycle/update_status.go
@@ -599,6 +599,27 @@ func findInterfaceContainingIP(ip string, ifaces []vmopv1.VirtualMachineNetworkI
 	return -1
 }
 
+// primaryIPsInNICData returns true when the per-NIC data from gi.Net[] is
+// either absent (nothing to cross-check) or already contains every non-empty
+// primary IP. When gi.IpAddress (fast, summary scalar set by vCenter) and
+// gi.Net[] (slow, per-NIC data published by VMware Tools) diverge across a
+// reconcile loop this returns false, preventing a premature Synced condition.
+func primaryIPsInNICData(
+	ip4, ip6 string,
+	ifaces []vmopv1.VirtualMachineNetworkInterfaceStatus) bool {
+
+	if len(ifaces) == 0 {
+		return true
+	}
+	if ip4 != "" && findInterfaceContainingIP(ip4, ifaces) < 0 {
+		return false
+	}
+	if ip6 != "" && findInterfaceContainingIP(ip6, ifaces) < 0 {
+		return false
+	}
+	return true
+}
+
 // extractIPsFromInterface extracts IP addresses of the specified family from an interface.
 func extractIPsFromInterface(iface vmopv1.VirtualMachineNetworkInterfaceStatus, isIPv4Required bool, validatePrimaryIP func(string) net.IP) []string {
 	var result []string
@@ -1228,11 +1249,21 @@ func updateGuestNetworkStatus(
 		//             - The VM has IPv4 but not IPv6 and vice versa
 		//             - The network may be disabled, not have interfaces, etc.
 		if primaryIP4 != "" || primaryIP6 != "" {
-			c := conditions.TrueCondition(
-				vmopv1.VirtualMachineGuestNetworkConfigSynced)
-			c.Reason = "Synced"
-			c.Message = fmt.Sprintf("IPv4=%q, IPv6=%q", primaryIP4, primaryIP6)
-			conditions.Set(vm, c)
+			if primaryIPsInNICData(primaryIP4, primaryIP6, ifaceStatuses) {
+				c := conditions.TrueCondition(
+					vmopv1.VirtualMachineGuestNetworkConfigSynced)
+				c.Reason = "Synced"
+				c.Message = fmt.Sprintf(
+					"IPv4=%q, IPv6=%q", primaryIP4, primaryIP6)
+				conditions.Set(vm, c)
+			} else {
+				conditions.MarkFalse(vm,
+					vmopv1.VirtualMachineGuestNetworkConfigSynced,
+					"NotSynced",
+					"guest primary IPs (IPv4=%q, IPv6=%q)"+
+						" not yet reflected in per-NIC data",
+					primaryIP4, primaryIP6)
+			}
 		} else {
 			conditions.MarkFalse(
 				vm,

--- a/pkg/providers/vsphere/vmlifecycle/update_status_test.go
+++ b/pkg/providers/vsphere/vmlifecycle/update_status_test.go
@@ -1424,6 +1424,146 @@ var _ = Describe("UpdateStatus", func() {
 				})
 			})
 
+			When("gi.IpAddress and per-NIC IP (gi.Net[]) disagree", func() {
+				// Simulates the re-import race: vCenter updates gi.IpAddress via
+				// the NSX portgroup assignment before VMware Tools inside the guest
+				// publishes the updated IP to gi.Net[].
+
+				// makeStaleNIC returns a single-NIC gi.Net[] whose reported IP
+				// differs from the summary gi.IpAddress.
+				makeStaleNIC := func(ip string) []vimtypes.GuestNicInfo {
+					return []vimtypes.GuestNicInfo{
+						{
+							DeviceConfigId: 4000,
+							MacAddress:     "00:50:56:00:00:01",
+							IpConfig: &vimtypes.NetIpConfigInfo{
+								IpAddress: []vimtypes.NetIpConfigInfoIpAddress{
+									{IpAddress: ip, State: "preferred"},
+								},
+							},
+						},
+					}
+				}
+
+				assertStaleCondition := func(primaryIP string) {
+					GinkgoHelper()
+					cond := conditions.Get(vmCtx.VM, vmopv1.VirtualMachineGuestNetworkConfigSynced)
+					Expect(cond).ToNot(BeNil())
+					Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+					Expect(cond.Reason).To(Equal("NotSynced"))
+					Expect(cond.Message).To(
+						ContainSubstring("not yet reflected in per-NIC data"))
+					Expect(cond.Message).To(ContainSubstring(primaryIP))
+				}
+
+				When("primary IP is IPv4", func() {
+					BeforeEach(func() {
+						vmCtx.MoVM.Guest.IpAddress = validIP4
+						vmCtx.MoVM.Guest.Net = makeStaleNIC("10.0.0.1")
+					})
+
+					It("should set VirtualMachineGuestNetworkConfigSynced condition to False", func() {
+						assertStaleCondition(validIP4)
+					})
+				})
+
+				When("primary IP is IPv6", func() {
+					BeforeEach(func() {
+						vmCtx.MoVM.Guest.IpAddress = validIP6
+						vmCtx.MoVM.Guest.Net = makeStaleNIC("FD00:F53B:82E4::99")
+					})
+
+					It("should set VirtualMachineGuestNetworkConfigSynced condition to False", func() {
+						assertStaleCondition(validIP6)
+					})
+				})
+			})
+
+			When("gi.IpAddress and per-NIC IP (gi.Net[]) agree", func() {
+				// makeMatchingNIC returns a single-NIC gi.Net[] that contains
+				// every provided IP, mirroring what VMware Tools would publish
+				// once it catches up with the vCenter summary.
+				makeMatchingNIC := func(ips ...string) []vimtypes.GuestNicInfo {
+					addrs := make([]vimtypes.NetIpConfigInfoIpAddress, len(ips))
+					for i, ip := range ips {
+						addrs[i] = vimtypes.NetIpConfigInfoIpAddress{
+							IpAddress: ip,
+							State:     "preferred",
+						}
+					}
+					return []vimtypes.GuestNicInfo{
+						{
+							DeviceConfigId: 4000,
+							MacAddress:     "00:50:56:00:00:01",
+							IpConfig: &vimtypes.NetIpConfigInfo{
+								IpAddress: addrs,
+							},
+						},
+					}
+				}
+
+				When("primary IP is IPv4", func() {
+					BeforeEach(func() {
+						vmCtx.MoVM.Guest.IpAddress = validIP4
+						vmCtx.MoVM.Guest.Net = makeMatchingNIC(validIP4)
+					})
+
+					It("should set VirtualMachineGuestNetworkConfigSynced condition to True", func() {
+						cond := conditions.Get(vmCtx.VM, vmopv1.VirtualMachineGuestNetworkConfigSynced)
+						Expect(cond).ToNot(BeNil())
+						Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+						Expect(cond.Reason).To(Equal("Synced"))
+						Expect(cond.Message).To(ContainSubstring("IPv4=\"192.168.0.2\""))
+					})
+				})
+
+				When("primary IP is IPv6", func() {
+					BeforeEach(func() {
+						vmCtx.MoVM.Guest.IpAddress = validIP6
+						vmCtx.MoVM.Guest.Net = makeMatchingNIC(validIP6)
+					})
+
+					It("should set VirtualMachineGuestNetworkConfigSynced condition to True", func() {
+						cond := conditions.Get(vmCtx.VM, vmopv1.VirtualMachineGuestNetworkConfigSynced)
+						Expect(cond).ToNot(BeNil())
+						Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+						Expect(cond.Reason).To(Equal("Synced"))
+						Expect(cond.Message).To(ContainSubstring("IPv6=\"FD00:F53B:82E4::54\""))
+					})
+				})
+
+				When("primary IPs are both IPv4 and IPv6", func() {
+					BeforeEach(func() {
+						vmCtx.VM.Spec.Bootstrap = &vmopv1.VirtualMachineBootstrapSpec{
+							CloudInit: &vmopv1.VirtualMachineBootstrapCloudInitSpec{},
+						}
+						vmCtx.MoVM.Guest.IpAddress = validIP4
+						vmCtx.MoVM.Config = &vimtypes.VirtualMachineConfigInfo{
+							ExtraConfig: []vimtypes.BaseOptionValue{
+								&vimtypes.OptionValue{
+									Key:   "guestinfo.local-ipv4",
+									Value: validIP4,
+								},
+								&vimtypes.OptionValue{
+									Key:   "guestinfo.local-ipv6",
+									Value: validIP6,
+								},
+							},
+						}
+						vmCtx.MoVM.Guest.Net = makeMatchingNIC(validIP4, validIP6)
+					})
+
+					It("should set VirtualMachineGuestNetworkConfigSynced condition to True", func() {
+						cond := conditions.Get(vmCtx.VM, vmopv1.VirtualMachineGuestNetworkConfigSynced)
+						Expect(cond).ToNot(BeNil())
+						Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+						Expect(cond.Reason).To(Equal("Synced"))
+						Expect(cond.Message).To(ContainSubstring("IPv4=\"192.168.0.2\""))
+						Expect(cond.Message).To(ContainSubstring("IPv6=\"FD00:F53B:82E4::54\""))
+					})
+				})
+			})
+
 			When("guest property is nil", func() {
 				BeforeEach(func() {
 					vmCtx.MoVM.Guest = nil
@@ -2045,50 +2185,50 @@ var _ = Describe("UpdateStatus", func() {
 								SharingMode:         vmopv1.VolumeSharingModeNone,
 							},
 							{
-								Name:       pkgutil.GeneratePVCName("disk", "101"),
-								DiskUUID:   "101",
-								Type:       vmopv1.VolumeTypeClassic,
-								Attached:   true,
-								Limit:      kubeutil.BytesToResource(1 * oneGiBInBytes),
-								Requested:  kubeutil.BytesToResource(1 * oneGiBInBytes),
-								Used:       kubeutil.BytesToResource(500 + (0.25 * oneGiBInBytes)),
-								UnitNumber: ptr.To[int32](0),
+								Name:        pkgutil.GeneratePVCName("disk", "101"),
+								DiskUUID:    "101",
+								Type:        vmopv1.VolumeTypeClassic,
+								Attached:    true,
+								Limit:       kubeutil.BytesToResource(1 * oneGiBInBytes),
+								Requested:   kubeutil.BytesToResource(1 * oneGiBInBytes),
+								Used:        kubeutil.BytesToResource(500 + (0.25 * oneGiBInBytes)),
+								UnitNumber:  ptr.To[int32](0),
 								DiskMode:    vmopv1.VolumeDiskModePersistent,
 								SharingMode: vmopv1.VolumeSharingModeNone,
 							},
 							{
-								Name:       pkgutil.GeneratePVCName("disk", "102"),
-								DiskUUID:   "102",
-								Type:       vmopv1.VolumeTypeClassic,
-								Attached:   true,
-								Limit:      kubeutil.BytesToResource(2 * oneGiBInBytes),
-								Requested:  kubeutil.BytesToResource(2 * oneGiBInBytes),
-								Used:       kubeutil.BytesToResource(500 + (0.5 * oneGiBInBytes)),
-								UnitNumber: ptr.To[int32](0),
+								Name:        pkgutil.GeneratePVCName("disk", "102"),
+								DiskUUID:    "102",
+								Type:        vmopv1.VolumeTypeClassic,
+								Attached:    true,
+								Limit:       kubeutil.BytesToResource(2 * oneGiBInBytes),
+								Requested:   kubeutil.BytesToResource(2 * oneGiBInBytes),
+								Used:        kubeutil.BytesToResource(500 + (0.5 * oneGiBInBytes)),
+								UnitNumber:  ptr.To[int32](0),
 								DiskMode:    vmopv1.VolumeDiskModePersistent,
 								SharingMode: vmopv1.VolumeSharingModeNone,
 							},
 							{
-								Name:       pkgutil.GeneratePVCName("disk", "103"),
-								DiskUUID:   "103",
-								Type:       vmopv1.VolumeTypeClassic,
-								Attached:   true,
-								Limit:      kubeutil.BytesToResource(3 * oneGiBInBytes),
-								Requested:  kubeutil.BytesToResource(3 * oneGiBInBytes),
-								Used:       kubeutil.BytesToResource(500 + (1 * oneGiBInBytes)),
-								UnitNumber: ptr.To[int32](0),
+								Name:        pkgutil.GeneratePVCName("disk", "103"),
+								DiskUUID:    "103",
+								Type:        vmopv1.VolumeTypeClassic,
+								Attached:    true,
+								Limit:       kubeutil.BytesToResource(3 * oneGiBInBytes),
+								Requested:   kubeutil.BytesToResource(3 * oneGiBInBytes),
+								Used:        kubeutil.BytesToResource(500 + (1 * oneGiBInBytes)),
+								UnitNumber:  ptr.To[int32](0),
 								DiskMode:    vmopv1.VolumeDiskModePersistent,
 								SharingMode: vmopv1.VolumeSharingModeNone,
 							},
 							{
-								Name:       pkgutil.GeneratePVCName("disk", "104"),
-								DiskUUID:   "104",
-								Type:       vmopv1.VolumeTypeClassic,
-								Attached:   true,
-								Limit:      kubeutil.BytesToResource(4 * oneGiBInBytes),
-								Requested:  kubeutil.BytesToResource(4 * oneGiBInBytes),
-								Used:       kubeutil.BytesToResource(500 + (2 * oneGiBInBytes)),
-								UnitNumber: ptr.To[int32](0),
+								Name:        pkgutil.GeneratePVCName("disk", "104"),
+								DiskUUID:    "104",
+								Type:        vmopv1.VolumeTypeClassic,
+								Attached:    true,
+								Limit:       kubeutil.BytesToResource(4 * oneGiBInBytes),
+								Requested:   kubeutil.BytesToResource(4 * oneGiBInBytes),
+								Used:        kubeutil.BytesToResource(500 + (2 * oneGiBInBytes)),
+								UnitNumber:  ptr.To[int32](0),
 								DiskMode:    vmopv1.VolumeDiskModePersistent,
 								SharingMode: vmopv1.VolumeSharingModeNone,
 							},
@@ -2176,50 +2316,50 @@ var _ = Describe("UpdateStatus", func() {
 							SharingMode:         vmopv1.VolumeSharingModeNone,
 						},
 						{
-							Name:       pkgutil.GeneratePVCName("disk", "101"),
-							DiskUUID:   "101",
-							Type:       vmopv1.VolumeTypeClassic,
-							Attached:   true,
-							Limit:      kubeutil.BytesToResource(1 * oneGiBInBytes),
-							Requested:  kubeutil.BytesToResource(1 * oneGiBInBytes),
-							Used:       kubeutil.BytesToResource(500 + (0.25 * oneGiBInBytes)),
-							UnitNumber: ptr.To[int32](0),
+							Name:        pkgutil.GeneratePVCName("disk", "101"),
+							DiskUUID:    "101",
+							Type:        vmopv1.VolumeTypeClassic,
+							Attached:    true,
+							Limit:       kubeutil.BytesToResource(1 * oneGiBInBytes),
+							Requested:   kubeutil.BytesToResource(1 * oneGiBInBytes),
+							Used:        kubeutil.BytesToResource(500 + (0.25 * oneGiBInBytes)),
+							UnitNumber:  ptr.To[int32](0),
 							DiskMode:    vmopv1.VolumeDiskModePersistent,
 							SharingMode: vmopv1.VolumeSharingModeNone,
 						},
 						{
-							Name:       pkgutil.GeneratePVCName("disk", "102"),
-							DiskUUID:   "102",
-							Type:       vmopv1.VolumeTypeClassic,
-							Attached:   true,
-							Limit:      kubeutil.BytesToResource(2 * oneGiBInBytes),
-							Requested:  kubeutil.BytesToResource(2 * oneGiBInBytes),
-							Used:       kubeutil.BytesToResource(500 + (0.5 * oneGiBInBytes)),
-							UnitNumber: ptr.To[int32](0),
+							Name:        pkgutil.GeneratePVCName("disk", "102"),
+							DiskUUID:    "102",
+							Type:        vmopv1.VolumeTypeClassic,
+							Attached:    true,
+							Limit:       kubeutil.BytesToResource(2 * oneGiBInBytes),
+							Requested:   kubeutil.BytesToResource(2 * oneGiBInBytes),
+							Used:        kubeutil.BytesToResource(500 + (0.5 * oneGiBInBytes)),
+							UnitNumber:  ptr.To[int32](0),
 							DiskMode:    vmopv1.VolumeDiskModePersistent,
 							SharingMode: vmopv1.VolumeSharingModeNone,
 						},
 						{
-							Name:       pkgutil.GeneratePVCName("disk", "103"),
-							DiskUUID:   "103",
-							Type:       vmopv1.VolumeTypeClassic,
-							Attached:   true,
-							Limit:      kubeutil.BytesToResource(3 * oneGiBInBytes),
-							Requested:  kubeutil.BytesToResource(3 * oneGiBInBytes),
-							Used:       kubeutil.BytesToResource(500 + (1 * oneGiBInBytes)),
-							UnitNumber: ptr.To[int32](0),
+							Name:        pkgutil.GeneratePVCName("disk", "103"),
+							DiskUUID:    "103",
+							Type:        vmopv1.VolumeTypeClassic,
+							Attached:    true,
+							Limit:       kubeutil.BytesToResource(3 * oneGiBInBytes),
+							Requested:   kubeutil.BytesToResource(3 * oneGiBInBytes),
+							Used:        kubeutil.BytesToResource(500 + (1 * oneGiBInBytes)),
+							UnitNumber:  ptr.To[int32](0),
 							DiskMode:    vmopv1.VolumeDiskModePersistent,
 							SharingMode: vmopv1.VolumeSharingModeNone,
 						},
 						{
-							Name:       pkgutil.GeneratePVCName("disk", "104"),
-							DiskUUID:   "104",
-							Type:       vmopv1.VolumeTypeClassic,
-							Attached:   true,
-							Limit:      kubeutil.BytesToResource(4 * oneGiBInBytes),
-							Requested:  kubeutil.BytesToResource(4 * oneGiBInBytes),
-							Used:       kubeutil.BytesToResource(500 + (2 * oneGiBInBytes)),
-							UnitNumber: ptr.To[int32](0),
+							Name:        pkgutil.GeneratePVCName("disk", "104"),
+							DiskUUID:    "104",
+							Type:        vmopv1.VolumeTypeClassic,
+							Attached:    true,
+							Limit:       kubeutil.BytesToResource(4 * oneGiBInBytes),
+							Requested:   kubeutil.BytesToResource(4 * oneGiBInBytes),
+							Used:        kubeutil.BytesToResource(500 + (2 * oneGiBInBytes)),
+							UnitNumber:  ptr.To[int32](0),
 							DiskMode:    vmopv1.VolumeDiskModePersistent,
 							SharingMode: vmopv1.VolumeSharingModeNone,
 						},


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

gi.IpAddress (the vCenter summary scalar) is updated by vCenter/NSX
the moment a portgroup assignment changes, while gi.Net[] (per-NIC
detail) is only updated once VMware Tools inside the guest publishes
the new configuration.  During a VM re-import or live-migration these
two fields can diverge across reconcile loops: gi.IpAddress already
carries the new IP while gi.Net[] still reflects the old one.

The previous condition-setting logic checked only gi.IpAddress, so it
could set VirtualMachineGuestNetworkConfigSynced=True before the guest
had actually converged, giving consumers a false signal.

This change introduces a cross-check: when gi.Net[] is non-empty,
every non-empty primary IP (IPv4 and/or IPv6) must be present in the
per-NIC interface statuses before the condition is set to True.  When
gi.Net[] is absent (VMware Tools not yet running), the check is
skipped so existing behaviour for those VMs is preserved.

**Which issue(s) is/are addressed by this PR?** *(optional)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note
NONE
```