### PR TITLE
✨ Gate IPv6 API fields and validation behind the supports_workload_ipv6 supervisor capability

### DIFF
--- a/api/v1alpha6/virtualmachineservice_types.go
+++ b/api/v1alpha6/virtualmachineservice_types.go
@@ -82,7 +82,7 @@ type LoadBalancerIngress struct {
 // +kubebuilder:validation:XValidation:rule="self.type != 'ExternalName' || ((!has(self.ipFamilies) || size(self.ipFamilies) == 0) && !has(self.ipFamilyPolicy))",message="ipFamilies and ipFamilyPolicy may not be set when type is ExternalName"
 // +kubebuilder:validation:XValidation:rule="!has(self.ipFamilies) || size(self.ipFamilies) < 2 || self.ipFamilies[0] != self.ipFamilies[1]",message="ipFamilies must not contain duplicate entries"
 // +kubebuilder:validation:XValidation:rule="!has(self.ipFamilies) || self.ipFamilies.all(f, f == 'IPv4' || f == 'IPv6')",message="each ipFamilies entry must be IPv4 or IPv6"
-// +kubebuilder:validation:XValidation:rule="!has(oldSelf.ipFamilies) || (has(self.ipFamilies) && self.ipFamilies[0] == oldSelf.ipFamilies[0])",message="the primary IP family may not be changed or removed once set"
+// +kubebuilder:validation:XValidation:rule="self.type == 'ExternalName' || !has(oldSelf.ipFamilies) || size(oldSelf.ipFamilies) == 0 || (has(self.ipFamilies) && size(self.ipFamilies) > 0 && self.ipFamilies[0] == oldSelf.ipFamilies[0])",message="the primary IP family may not be changed or removed once set"
 
 // VirtualMachineServiceSpec defines the desired state of VirtualMachineService.
 type VirtualMachineServiceSpec struct {

--- a/api/v1alpha6/virtualmachineservice_types.go
+++ b/api/v1alpha6/virtualmachineservice_types.go
@@ -82,6 +82,7 @@ type LoadBalancerIngress struct {
 // +kubebuilder:validation:XValidation:rule="self.type != 'ExternalName' || ((!has(self.ipFamilies) || size(self.ipFamilies) == 0) && !has(self.ipFamilyPolicy))",message="ipFamilies and ipFamilyPolicy may not be set when type is ExternalName"
 // +kubebuilder:validation:XValidation:rule="!has(self.ipFamilies) || size(self.ipFamilies) < 2 || self.ipFamilies[0] != self.ipFamilies[1]",message="ipFamilies must not contain duplicate entries"
 // +kubebuilder:validation:XValidation:rule="!has(self.ipFamilies) || self.ipFamilies.all(f, f == 'IPv4' || f == 'IPv6')",message="each ipFamilies entry must be IPv4 or IPv6"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.ipFamilies) || (has(self.ipFamilies) && self.ipFamilies[0] == oldSelf.ipFamilies[0])",message="the primary IP family may not be changed or removed once set"
 
 // VirtualMachineServiceSpec defines the desired state of VirtualMachineService.
 type VirtualMachineServiceSpec struct {

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachineservices.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachineservices.yaml
@@ -1050,6 +1050,9 @@ spec:
             - message: each ipFamilies entry must be IPv4 or IPv6
               rule: '!has(self.ipFamilies) || self.ipFamilies.all(f, f == ''IPv4''
                 || f == ''IPv6'')'
+            - message: the primary IP family may not be changed or removed once set
+              rule: '!has(oldSelf.ipFamilies) || (has(self.ipFamilies) && self.ipFamilies[0]
+                == oldSelf.ipFamilies[0])'
           status:
             description: |-
               VirtualMachineServiceStatus defines the observed state of

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachineservices.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachineservices.yaml
@@ -1051,8 +1051,9 @@ spec:
               rule: '!has(self.ipFamilies) || self.ipFamilies.all(f, f == ''IPv4''
                 || f == ''IPv6'')'
             - message: the primary IP family may not be changed or removed once set
-              rule: '!has(oldSelf.ipFamilies) || (has(self.ipFamilies) && self.ipFamilies[0]
-                == oldSelf.ipFamilies[0])'
+              rule: self.type == 'ExternalName' || !has(oldSelf.ipFamilies) || size(oldSelf.ipFamilies)
+                == 0 || (has(self.ipFamilies) && size(self.ipFamilies) > 0 && self.ipFamilies[0]
+                == oldSelf.ipFamilies[0])
           status:
             description: |-
               VirtualMachineServiceStatus defines the observed state of

--- a/controllers/virtualmachineservice/virtualmachineservice_controller.go
+++ b/controllers/virtualmachineservice/virtualmachineservice_controller.go
@@ -412,22 +412,26 @@ func (r *ReconcileVirtualMachineService) createOrUpdateService(ctx *pkgctx.Virtu
 		service.Spec.LoadBalancerIP = vmService.Spec.LoadBalancerIP
 		service.Spec.LoadBalancerSourceRanges = vmService.Spec.LoadBalancerSourceRanges
 
-		// Set IPFamilies and IPFamilyPolicy for dual-stack support
-		// These fields only apply to ClusterIP and LoadBalancer types
-		// They are wiped when type is ExternalName
-		if vmService.Spec.Type != vmopv1.VirtualMachineServiceTypeExternalName {
-			// Only overwrite when the VirtualMachineService specifies ipFamilies so we do not clear
-			// values defaulted or stored by the apiserver when the CR omits them.
-			if len(vmService.Spec.IPFamilies) > 0 {
-				service.Spec.IPFamilies = vmService.Spec.IPFamilies
+		// IPFamilies and IPFamilyPolicy are dual-stack fields gated by the WorkloadIPv6 capability.
+		// When the capability is disabled, existing values on the Service are left untouched so that
+		// live dual-stack Services continue to function without unexpected changes.
+		if pkgcfg.FromContext(ctx).Features.WorkloadIPv6 {
+			// These fields only apply to ClusterIP and LoadBalancer types;
+			// they are wiped when type is ExternalName.
+			if vmService.Spec.Type != vmopv1.VirtualMachineServiceTypeExternalName {
+				// Only overwrite when the VirtualMachineService specifies ipFamilies so we do not clear
+				// values defaulted or stored by the apiserver when the CR omits them.
+				if len(vmService.Spec.IPFamilies) > 0 {
+					service.Spec.IPFamilies = vmService.Spec.IPFamilies
+				}
+				if vmService.Spec.IPFamilyPolicy != nil {
+					service.Spec.IPFamilyPolicy = vmService.Spec.IPFamilyPolicy
+				}
+			} else {
+				// Clear IPFamilies and IPFamilyPolicy for ExternalName services
+				service.Spec.IPFamilies = nil
+				service.Spec.IPFamilyPolicy = nil
 			}
-			if vmService.Spec.IPFamilyPolicy != nil {
-				service.Spec.IPFamilyPolicy = vmService.Spec.IPFamilyPolicy
-			}
-		} else {
-			// Clear IPFamilies and IPFamilyPolicy for ExternalName services
-			service.Spec.IPFamilies = nil
-			service.Spec.IPFamilyPolicy = nil
 		}
 
 		if service.Spec.Type == corev1.ServiceTypeLoadBalancer {

--- a/controllers/virtualmachineservice/virtualmachineservice_controller_intg_test.go
+++ b/controllers/virtualmachineservice/virtualmachineservice_controller_intg_test.go
@@ -408,10 +408,10 @@ func intgTestsReconcile() {
 
 					svcKey := client.ObjectKeyFromObject(vmService)
 					svc := &corev1.Service{}
-					Consistently(func(g Gomega) {
-						err := ctx.Client.Get(ctx, svcKey, svc)
-						g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
-					}).Should(Succeed())
+				Consistently(func(g Gomega) {
+					err := ctx.Client.Get(ctx, svcKey, svc)
+					g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+				}, "3s").Should(Succeed())
 				})
 			})
 		})

--- a/controllers/virtualmachineservice/virtualmachineservice_controller_intg_test.go
+++ b/controllers/virtualmachineservice/virtualmachineservice_controller_intg_test.go
@@ -16,6 +16,7 @@ import (
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
@@ -385,6 +386,19 @@ func intgTestsReconcile() {
 			Context("RequireDualStack with empty ipFamilies", func() {
 				BeforeEach(func() {
 					vmServiceName = "test-vm-service-require-empty-ipf"
+					// RequireDualStack is a dual-stack field; the controller only propagates
+					// it to the Service when WorkloadIPv6 is enabled. Enable it here so
+					// that the envtest single-stack cluster rejects the Service, which is
+					// what this spec is asserting.
+					pkgcfg.SetContext(suite, func(config *pkgcfg.Config) {
+						config.Features.WorkloadIPv6 = true
+					})
+				})
+
+				AfterEach(func() {
+					pkgcfg.SetContext(suite, func(config *pkgcfg.Config) {
+						config.Features.WorkloadIPv6 = false
+					})
 				})
 
 				It("does not create a child Service", func() {

--- a/controllers/virtualmachineservice/virtualmachineservice_controller_unit_test.go
+++ b/controllers/virtualmachineservice/virtualmachineservice_controller_unit_test.go
@@ -131,6 +131,10 @@ func unitTestsReconcile() {
 			Logger:    ctx.Logger.WithName(vmService.Name),
 			VMService: vmService,
 		}
+
+		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+			config.Features.WorkloadIPv6 = true
+		})
 	})
 
 	AfterEach(func() {
@@ -196,9 +200,6 @@ func unitTestsReconcile() {
 
 			Context("IPFamilies and IPFamilyPolicy", func() {
 				It("Copies IPFamilies to Service spec when WorkloadIPv6 is enabled", func() {
-					pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-						config.Features.WorkloadIPv6 = true
-					})
 					vmService.Spec.IPFamilies = []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}
 					err := reconciler.ReconcileNormal(vmServiceCtx)
 					Expect(err).NotTo(HaveOccurred())
@@ -208,9 +209,6 @@ func unitTestsReconcile() {
 				})
 
 				It("Copies IPFamilyPolicy to Service spec when WorkloadIPv6 is enabled", func() {
-					pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-						config.Features.WorkloadIPv6 = true
-					})
 					policy := corev1.IPFamilyPolicyPreferDualStack
 					vmService.Spec.IPFamilyPolicy = &policy
 					err := reconciler.ReconcileNormal(vmServiceCtx)
@@ -244,9 +242,6 @@ func unitTestsReconcile() {
 				})
 
 				It("Clears IPFamilies and IPFamilyPolicy for ExternalName services when WorkloadIPv6 is enabled", func() {
-					pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-						config.Features.WorkloadIPv6 = true
-					})
 					vmService.Spec.Type = vmopv1.VirtualMachineServiceTypeExternalName
 					vmService.Spec.IPFamilies = []corev1.IPFamily{corev1.IPv4Protocol}
 					policy := corev1.IPFamilyPolicySingleStack
@@ -495,13 +490,6 @@ func unitTestsReconcile() {
 			var labelSelector, vmLabels map[string]string
 			var vm1, vm2, vm3 *vmopv1.VirtualMachine
 
-			// All endpoint tests exercise dual-stack IPFamily propagation and filtering.
-			JustBeforeEach(func() {
-				pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-					config.Features.WorkloadIPv6 = true
-				})
-			})
-
 			BeforeEach(func() {
 				endpoints = &corev1.Endpoints{}
 				labelSelector = map[string]string{"my-app": "dummy-label"}
@@ -742,12 +730,6 @@ func unitTestsReconcile() {
 				var ipv4VM *vmopv1.VirtualMachine
 				var ipv6VM *vmopv1.VirtualMachine
 
-				JustBeforeEach(func() {
-					pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-						config.Features.WorkloadIPv6 = true
-					})
-				})
-
 				BeforeEach(func() {
 					dualStackVM = &vmopv1.VirtualMachine{
 						ObjectMeta: metav1.ObjectMeta{
@@ -826,12 +808,6 @@ func unitTestsReconcile() {
 				var dualStackVM *vmopv1.VirtualMachine
 				var ipv4VM *vmopv1.VirtualMachine
 				var ipv6VM *vmopv1.VirtualMachine
-
-				JustBeforeEach(func() {
-					pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-						config.Features.WorkloadIPv6 = true
-					})
-				})
 
 				BeforeEach(func() {
 					dualStackVM = &vmopv1.VirtualMachine{
@@ -930,20 +906,15 @@ func unitTestsReconcile() {
 				})
 
 				JustBeforeEach(func() {
-					// First reconciliation: Service created, but no VMs yet
+					// First reconciliation: Service created, but no VMs yet.
+					// The outer JustBeforeEach already consumed the OpCreate event.
 					err := reconciler.ReconcileNormal(vmServiceCtx)
 					Expect(err).NotTo(HaveOccurred())
-					// Service may be created or updated depending on test execution order
-					// Drain any events (Create or Update) to ensure event channel is ready
-					select {
-					case <-ctx.Events:
-					default:
-					}
 					Expect(ctx.Client.Get(ctx, objKey, endpoints)).To(Succeed())
-					// Initially, endpoints should be empty
+					// Initially, endpoints should be empty.
 					Expect(endpoints.Subsets).To(BeEmpty())
 
-					// Now create a VM that matches the selector (simulating VM created after service)
+					// Now create a VM that matches the selector (simulating VM created after service).
 					newVM = &vmopv1.VirtualMachine{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "new-vm",
@@ -1174,12 +1145,6 @@ func unitTestsReconcile() {
 			var vm1 *vmopv1.VirtualMachine
 			var labelSelector, vmLabels map[string]string
 
-			JustBeforeEach(func() {
-				pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-					config.Features.WorkloadIPv6 = true
-				})
-			})
-
 			BeforeEach(func() {
 				labelSelector = map[string]string{"my-app": "dummy-label"}
 				vmLabels = map[string]string{"my-app": "dummy-label", "other": "label"}
@@ -1250,8 +1215,6 @@ func unitTestsReconcile() {
 			var vm1 *vmopv1.VirtualMachine
 
 			BeforeEach(func() {
-				// WorkloadIPv6 is false by default; do not set it here to verify
-				// that endpoint generation still works when IPv6 capability is off.
 				endpoints = &corev1.Endpoints{}
 				vmService.Spec.Selector = map[string]string{"app": "test"}
 				vmService.Spec.Ports = []vmopv1.VirtualMachineServicePort{vmServicePort1}
@@ -1274,11 +1237,11 @@ func unitTestsReconcile() {
 			})
 
 			JustBeforeEach(func() {
+				pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+					config.Features.WorkloadIPv6 = false
+				})
 				Expect(reconciler.ReconcileNormal(vmServiceCtx)).To(Succeed())
-				select {
-				case <-ctx.Events:
-				default:
-				}
+				Expect(ctx.Events).Should(Receive(ContainSubstring(virtualmachineservice.OpCreate)))
 			})
 
 			It("generates IPv4 endpoints after apiserver defaults IPFamilies to [IPv4]", func() {

--- a/controllers/virtualmachineservice/virtualmachineservice_controller_unit_test.go
+++ b/controllers/virtualmachineservice/virtualmachineservice_controller_unit_test.go
@@ -195,7 +195,10 @@ func unitTestsReconcile() {
 			})
 
 			Context("IPFamilies and IPFamilyPolicy", func() {
-				It("Copies IPFamilies to Service spec", func() {
+				It("Copies IPFamilies to Service spec when WorkloadIPv6 is enabled", func() {
+					pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+						config.Features.WorkloadIPv6 = true
+					})
 					vmService.Spec.IPFamilies = []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}
 					err := reconciler.ReconcileNormal(vmServiceCtx)
 					Expect(err).NotTo(HaveOccurred())
@@ -204,7 +207,10 @@ func unitTestsReconcile() {
 					Expect(service.Spec.IPFamilies).To(ContainElements(corev1.IPv4Protocol, corev1.IPv6Protocol))
 				})
 
-				It("Copies IPFamilyPolicy to Service spec", func() {
+				It("Copies IPFamilyPolicy to Service spec when WorkloadIPv6 is enabled", func() {
+					pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+						config.Features.WorkloadIPv6 = true
+					})
 					policy := corev1.IPFamilyPolicyPreferDualStack
 					vmService.Spec.IPFamilyPolicy = &policy
 					err := reconciler.ReconcileNormal(vmServiceCtx)
@@ -214,7 +220,33 @@ func unitTestsReconcile() {
 					Expect(*service.Spec.IPFamilyPolicy).To(Equal(corev1.IPFamilyPolicyPreferDualStack))
 				})
 
-				It("Clears IPFamilies and IPFamilyPolicy for ExternalName services", func() {
+				It("does not propagate IPFamilies to Service when WorkloadIPv6 is disabled", func() {
+					pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+						config.Features.WorkloadIPv6 = false
+					})
+					vmService.Spec.IPFamilies = []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}
+					err := reconciler.ReconcileNormal(vmServiceCtx)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(ctx.Client.Get(ctx, objKey, service)).To(Succeed())
+					Expect(service.Spec.IPFamilies).To(BeEmpty())
+				})
+
+				It("does not propagate IPFamilyPolicy to Service when WorkloadIPv6 is disabled", func() {
+					pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+						config.Features.WorkloadIPv6 = false
+					})
+					policy := corev1.IPFamilyPolicyPreferDualStack
+					vmService.Spec.IPFamilyPolicy = &policy
+					err := reconciler.ReconcileNormal(vmServiceCtx)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(ctx.Client.Get(ctx, objKey, service)).To(Succeed())
+					Expect(service.Spec.IPFamilyPolicy).To(BeNil())
+				})
+
+				It("Clears IPFamilies and IPFamilyPolicy for ExternalName services when WorkloadIPv6 is enabled", func() {
+					pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+						config.Features.WorkloadIPv6 = true
+					})
 					vmService.Spec.Type = vmopv1.VirtualMachineServiceTypeExternalName
 					vmService.Spec.IPFamilies = []corev1.IPFamily{corev1.IPv4Protocol}
 					policy := corev1.IPFamilyPolicySingleStack
@@ -463,6 +495,13 @@ func unitTestsReconcile() {
 			var labelSelector, vmLabels map[string]string
 			var vm1, vm2, vm3 *vmopv1.VirtualMachine
 
+			// All endpoint tests exercise dual-stack IPFamily propagation and filtering.
+			JustBeforeEach(func() {
+				pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+					config.Features.WorkloadIPv6 = true
+				})
+			})
+
 			BeforeEach(func() {
 				endpoints = &corev1.Endpoints{}
 				labelSelector = map[string]string{"my-app": "dummy-label"}
@@ -703,6 +742,12 @@ func unitTestsReconcile() {
 				var ipv4VM *vmopv1.VirtualMachine
 				var ipv6VM *vmopv1.VirtualMachine
 
+				JustBeforeEach(func() {
+					pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+						config.Features.WorkloadIPv6 = true
+					})
+				})
+
 				BeforeEach(func() {
 					dualStackVM = &vmopv1.VirtualMachine{
 						ObjectMeta: metav1.ObjectMeta{
@@ -781,6 +826,12 @@ func unitTestsReconcile() {
 				var dualStackVM *vmopv1.VirtualMachine
 				var ipv4VM *vmopv1.VirtualMachine
 				var ipv6VM *vmopv1.VirtualMachine
+
+				JustBeforeEach(func() {
+					pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+						config.Features.WorkloadIPv6 = true
+					})
+				})
 
 				BeforeEach(func() {
 					dualStackVM = &vmopv1.VirtualMachine{
@@ -1123,6 +1174,12 @@ func unitTestsReconcile() {
 			var vm1 *vmopv1.VirtualMachine
 			var labelSelector, vmLabels map[string]string
 
+			JustBeforeEach(func() {
+				pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+					config.Features.WorkloadIPv6 = true
+				})
+			})
+
 			BeforeEach(func() {
 				labelSelector = map[string]string{"my-app": "dummy-label"}
 				vmLabels = map[string]string{"my-app": "dummy-label", "other": "label"}
@@ -1185,6 +1242,57 @@ func unitTestsReconcile() {
 					Expect(ctx.Client.Get(ctx, objKey, endpoints)).To(Succeed())
 					Expect(endpoints.Subsets).ToNot(BeEmpty())
 				})
+			})
+		})
+
+		Context("Endpoint generation with WorkloadIPv6 disabled", func() {
+			var endpoints *corev1.Endpoints
+			var vm1 *vmopv1.VirtualMachine
+
+			BeforeEach(func() {
+				// WorkloadIPv6 is false by default; do not set it here to verify
+				// that endpoint generation still works when IPv6 capability is off.
+				endpoints = &corev1.Endpoints{}
+				vmService.Spec.Selector = map[string]string{"app": "test"}
+				vmService.Spec.Ports = []vmopv1.VirtualMachineServicePort{vmServicePort1}
+				// VMS has no ipFamilies/ipFamilyPolicy (webhook prevents setting them when
+				// WorkloadIPv6 is disabled).
+
+				vm1 = &vmopv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-vm",
+						Namespace: vmService.Namespace,
+						Labels:    map[string]string{"app": "test"},
+					},
+					Status: vmopv1.VirtualMachineStatus{
+						Network: &vmopv1.VirtualMachineNetworkStatus{
+							PrimaryIP4: "10.0.0.1",
+						},
+					},
+				}
+				initObjects = append(initObjects, vm1)
+			})
+
+			JustBeforeEach(func() {
+				Expect(reconciler.ReconcileNormal(vmServiceCtx)).To(Succeed())
+				select {
+				case <-ctx.Events:
+				default:
+				}
+			})
+
+			It("generates IPv4 endpoints after apiserver defaults IPFamilies to [IPv4]", func() {
+				// Simulate what the k8s apiserver does for any new Service (default to [IPv4]).
+				// In production the apiserver writes IPFamilies=[IPv4] on create; the next
+				// reconcile generates endpoints using those families.
+				simulateAPIServerDefaultedIPFamilies(ctx, objKey)
+
+				Expect(reconciler.ReconcileNormal(vmServiceCtx)).To(Succeed())
+				Expect(ctx.Client.Get(ctx, objKey, endpoints)).To(Succeed())
+
+				Expect(endpoints.Subsets).To(HaveLen(1))
+				Expect(endpoints.Subsets[0].Addresses).To(HaveLen(1))
+				Expect(endpoints.Subsets[0].Addresses[0].IP).To(Equal("10.0.0.1"))
 			})
 		})
 	})

--- a/pkg/config/capabilities/capabilities.go
+++ b/pkg/config/capabilities/capabilities.go
@@ -116,6 +116,10 @@ const (
 	// defined in the Supervisor capabilities CRD for enabling different network
 	// providers in different namespaces.
 	CapabilityKeyPerNamespaceNetworkProvider = "supports_per_namespace_network_provider"
+
+	// CapabilityKeyWorkloadIPv6 is the name of the capability key defined in
+	// the Supervisor capabilities CRD for IPv6 support for VM service workloads.
+	CapabilityKeyWorkloadIPv6 = "supports_workload_ipv6"
 )
 
 var (
@@ -286,6 +290,8 @@ func updateCapabilitiesFeaturesFromCRD(
 			fs.TelcoVMServiceAPI = capStatus.Activated
 		case CapabilityKeyPerNamespaceNetworkProvider:
 			fs.PerNamespaceNetworkProvider = capStatus.Activated
+		case CapabilityKeyWorkloadIPv6:
+			fs.WorkloadIPv6 = capStatus.Activated
 		}
 
 	}

--- a/pkg/config/capabilities/capabilities_test.go
+++ b/pkg/config/capabilities/capabilities_test.go
@@ -183,6 +183,9 @@ var _ = Describe("UpdateCapabilities", func() {
 						capabilities.CapabilityKeyPerNamespaceNetworkProvider: {
 							Activated: true,
 						},
+						capabilities.CapabilityKeyWorkloadIPv6: {
+							Activated: true,
+						},
 					}
 					Expect(client.Status().Patch(ctx, &obj, objPatch)).To(Succeed())
 				})
@@ -206,6 +209,7 @@ var _ = Describe("UpdateCapabilities", func() {
 							config.Features.StoragePolicyMutability = true
 							config.Features.VMVlanSubinterface = true
 							config.Features.PerNamespaceNetworkProvider = true
+							config.Features.WorkloadIPv6 = true
 						})
 					})
 					Specify("capabilities did not change", func() {
@@ -261,6 +265,9 @@ var _ = Describe("UpdateCapabilities", func() {
 					})
 					Specify(capabilities.CapabilityKeyPerNamespaceNetworkProvider, func() {
 						Expect(pkgcfg.FromContext(ctx).Features.PerNamespaceNetworkProvider).To(BeTrue())
+					})
+					Specify(capabilities.CapabilityKeyWorkloadIPv6, func() {
+						Expect(pkgcfg.FromContext(ctx).Features.WorkloadIPv6).To(BeTrue())
 					})
 				})
 
@@ -318,6 +325,9 @@ var _ = Describe("UpdateCapabilities", func() {
 					})
 					Specify(capabilities.CapabilityKeyPerNamespaceNetworkProvider, func() {
 						Expect(pkgcfg.FromContext(ctx).Features.PerNamespaceNetworkProvider).To(BeTrue())
+					})
+					Specify(capabilities.CapabilityKeyWorkloadIPv6, func() {
+						Expect(pkgcfg.FromContext(ctx).Features.WorkloadIPv6).To(BeTrue())
 					})
 				})
 			})
@@ -384,6 +394,9 @@ var _ = Describe("UpdateCapabilities", func() {
 						capabilities.CapabilityKeyPerNamespaceNetworkProvider: {
 							Activated: false,
 						},
+						capabilities.CapabilityKeyWorkloadIPv6: {
+							Activated: false,
+						},
 					}
 					Expect(client.Status().Patch(ctx, &obj, objPatch)).To(Succeed())
 				})
@@ -442,6 +455,9 @@ var _ = Describe("UpdateCapabilities", func() {
 					Specify(capabilities.CapabilityKeyPerNamespaceNetworkProvider, func() {
 						Expect(pkgcfg.FromContext(ctx).Features.PerNamespaceNetworkProvider).To(BeFalse())
 					})
+					Specify(capabilities.CapabilityKeyWorkloadIPv6, func() {
+						Expect(pkgcfg.FromContext(ctx).Features.WorkloadIPv6).To(BeFalse())
+					})
 				})
 
 				When("the capabilities are different", func() {
@@ -457,6 +473,7 @@ var _ = Describe("UpdateCapabilities", func() {
 							config.Features.GuestCustomizationVCDParity = true
 							config.Features.StoragePolicyMutability = true
 							config.Features.VMVlanSubinterface = true
+							config.Features.WorkloadIPv6 = true
 						})
 					})
 					Specify("capabilities changed", func() {
@@ -512,6 +529,9 @@ var _ = Describe("UpdateCapabilities", func() {
 					})
 					Specify(capabilities.CapabilityKeyPerNamespaceNetworkProvider, func() {
 						Expect(pkgcfg.FromContext(ctx).Features.PerNamespaceNetworkProvider).To(BeFalse())
+					})
+					Specify(capabilities.CapabilityKeyWorkloadIPv6, func() {
+						Expect(pkgcfg.FromContext(ctx).Features.WorkloadIPv6).To(BeFalse())
 					})
 				})
 			})
@@ -846,6 +866,19 @@ var _ = Describe("UpdateCapabilitiesFeatures", func() {
 				Expect(pkgcfg.FromContext(ctx).Features.PerNamespaceNetworkProvider).To(BeTrue())
 			})
 		})
+		Context(capabilities.CapabilityKeyWorkloadIPv6, func() {
+			BeforeEach(func() {
+				Expect(pkgcfg.FromContext(ctx).Features.WorkloadIPv6).To(BeFalse())
+				obj.Status.Supervisor[capabilities.CapabilityKeyWorkloadIPv6] = capv1.CapabilityStatus{
+					Activated: true,
+				}
+			})
+			Specify("Enabled", func() {
+				Expect(ok).To(BeTrue())
+				Expect(diff).To(Equal("WorkloadIPv6=true"))
+				Expect(pkgcfg.FromContext(ctx).Features.WorkloadIPv6).To(BeTrue())
+			})
+		})
 	})
 })
 
@@ -913,6 +946,9 @@ var _ = Describe("WouldUpdateCapabilitiesFeatures", func() {
 			capabilities.CapabilityKeyPerNamespaceNetworkProvider: {
 				Activated: true,
 			},
+			capabilities.CapabilityKeyWorkloadIPv6: {
+				Activated: true,
+			},
 		}
 
 		ok, diff = false, ""
@@ -943,6 +979,7 @@ var _ = Describe("WouldUpdateCapabilitiesFeatures", func() {
 					config.Features.StoragePolicyMutability = true
 					config.Features.VMVlanSubinterface = true
 					config.Features.PerNamespaceNetworkProvider = true
+					config.Features.WorkloadIPv6 = true
 				})
 			})
 			Specify("capabilities did not change", func() {
@@ -1000,6 +1037,9 @@ var _ = Describe("WouldUpdateCapabilitiesFeatures", func() {
 			Specify(capabilities.CapabilityKeyPerNamespaceNetworkProvider, func() {
 				Expect(pkgcfg.FromContext(ctx).Features.PerNamespaceNetworkProvider).To(BeTrue())
 			})
+			Specify(capabilities.CapabilityKeyWorkloadIPv6, func() {
+				Expect(pkgcfg.FromContext(ctx).Features.WorkloadIPv6).To(BeTrue())
+			})
 		})
 
 		When("the capabilities are different", func() {
@@ -1020,11 +1060,12 @@ var _ = Describe("WouldUpdateCapabilitiesFeatures", func() {
 					config.Features.StoragePolicyMutability = false
 					config.Features.VMVlanSubinterface = false
 					config.Features.PerNamespaceNetworkProvider = false
+					config.Features.WorkloadIPv6 = false
 				})
 			})
 			Specify("capabilities changed", func() {
 				Expect(ok).To(BeTrue())
-				Expect(diff).To(Equal("BringYourOwnEncryptionKey=true,GuestCustomizationVCDParity=true,ImmutableClasses=true,InventoryContentLibrary=true,MutableNetworks=true,PerNamespaceNetworkProvider=true,StoragePolicyMutability=true,TKGMultipleCL=true,VMAffinityDuringExecution=true,VMGroups=true,VMPlacementPolicies=true,VMSharedDisks=true,VMSnapshots=true,VMVlanSubinterface=true,VMWaitForFirstConsumerPVC=true,VSpherePolicies=true,WorkloadDomainIsolation=true"))
+				Expect(diff).To(Equal("BringYourOwnEncryptionKey=true,GuestCustomizationVCDParity=true,ImmutableClasses=true,InventoryContentLibrary=true,MutableNetworks=true,PerNamespaceNetworkProvider=true,StoragePolicyMutability=true,TKGMultipleCL=true,VMAffinityDuringExecution=true,VMGroups=true,VMPlacementPolicies=true,VMSharedDisks=true,VMSnapshots=true,VMVlanSubinterface=true,VMWaitForFirstConsumerPVC=true,VSpherePolicies=true,WorkloadDomainIsolation=true,WorkloadIPv6=true"))
 			})
 			Specify(capabilities.CapabilityKeyBringYourOwnKeyProvider, func() {
 				Expect(pkgcfg.FromContext(ctx).Features.BringYourOwnEncryptionKey).To(BeFalse())
@@ -1076,6 +1117,9 @@ var _ = Describe("WouldUpdateCapabilitiesFeatures", func() {
 			})
 			Specify(capabilities.CapabilityKeyPerNamespaceNetworkProvider, func() {
 				Expect(pkgcfg.FromContext(ctx).Features.PerNamespaceNetworkProvider).To(BeFalse())
+			})
+			Specify(capabilities.CapabilityKeyWorkloadIPv6, func() {
+				Expect(pkgcfg.FromContext(ctx).Features.WorkloadIPv6).To(BeFalse())
 			})
 		})
 	})

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -204,6 +204,7 @@ type FeatureStates struct {
 	VMVlanSubinterface          bool
 	TelcoVMServiceAPI           bool
 	PerNamespaceNetworkProvider bool
+	WorkloadIPv6                bool
 }
 
 type InstanceStorage struct {

--- a/pkg/crd/crd.go
+++ b/pkg/crd/crd.go
@@ -344,13 +344,56 @@ func Install( //nolint:gocyclo
 						}
 					}
 
+					if !features.WorkloadIPv6 {
+						if err := removeFields(
+							ctx,
+							k,
+							obj,
+							shouldRemoveFields,
+							specFieldPath("network", "interfaces", "[]", "ipamModes"),
+						); err != nil {
+
+							return err
+						}
+					}
+
 					return nil
 				}); err != nil {
 
 				return err
 			}
 
-		// case "VirtualMachineService":
+		case "VirtualMachineService":
+			if err := updateOrDeleteUnstructured(
+				ctx,
+				k8sClient,
+				true,
+				c,
+				k,
+				func(
+					kind string,
+					obj *unstructured.Unstructured,
+					shouldRemoveFields bool) error {
+
+					if !features.WorkloadIPv6 {
+						if err := removeFields(
+							ctx,
+							k,
+							obj,
+							shouldRemoveFields,
+							specFieldPath("ipFamilies"),
+							specFieldPath("ipFamilyPolicy"),
+						); err != nil {
+
+							return err
+						}
+					}
+
+					return nil
+				}); err != nil {
+
+				return err
+			}
 		// case "VirtualMachineSetResourcePolicy":
 		case "VirtualMachineSnapshot":
 			if err := updateOrDeleteUnstructured(

--- a/pkg/crd/crd.go
+++ b/pkg/crd/crd.go
@@ -342,6 +342,17 @@ func Install( //nolint:gocyclo
 
 							return err
 						}
+						if err := removeValidationRules(
+							ctx,
+							k,
+							obj,
+							shouldRemoveFields,
+							specCELPath("network", "interfaces", "[]"),
+							"vmxnet3",
+						); err != nil {
+
+							return err
+						}
 					}
 
 					if !features.WorkloadIPv6 {
@@ -351,6 +362,17 @@ func Install( //nolint:gocyclo
 							obj,
 							shouldRemoveFields,
 							specFieldPath("network", "interfaces", "[]", "ipamModes"),
+						); err != nil {
+
+							return err
+						}
+						if err := removeValidationRules(
+							ctx,
+							k,
+							obj,
+							shouldRemoveFields,
+							specCELPath("network", "interfaces", "[]"),
+							"ipamModes",
 						); err != nil {
 
 							return err
@@ -383,6 +405,18 @@ func Install( //nolint:gocyclo
 							shouldRemoveFields,
 							specFieldPath("ipFamilies"),
 							specFieldPath("ipFamilyPolicy"),
+						); err != nil {
+
+							return err
+						}
+						if err := removeValidationRules(
+							ctx,
+							k,
+							obj,
+							shouldRemoveFields,
+							specCELPath(),
+							"ipFamilies",
+							"ipFamilyPolicy",
 						); err != nil {
 
 							return err
@@ -647,4 +681,95 @@ func statusFieldPath(fieldNames ...string) []string {
 		result = append(result, "properties", name)
 	}
 	return result
+}
+
+// specCELPath returns the path to the x-kubernetes-validations array for a
+// spec schema object, relative to a CRD version entry. With no arguments it
+// returns the spec-level validations path. With arguments it returns the
+// validations path for the schema at that field path (use "[]" for array
+// items, e.g. "network", "interfaces", "[]").
+func specCELPath(fieldNames ...string) []string {
+	if len(fieldNames) == 0 {
+		return []string{"schema", "openAPIV3Schema", "properties", "spec", "x-kubernetes-validations"}
+	}
+	return append(specFieldPath(fieldNames...), "x-kubernetes-validations")
+}
+
+// removeValidationRules removes x-kubernetes-validations entries from the
+// schema object at validationsPath that reference (by "self.<fieldName>"
+// substring match) any of the given fieldNames. This prevents the
+// kube-apiserver from rejecting a CRD because a CEL rule references a field
+// that was removed from the schema.
+func removeValidationRules(
+	ctx context.Context,
+	k string,
+	c *unstructured.Unstructured,
+	shouldRemove bool,
+	validationsPath []string,
+	fieldNames ...string) error {
+
+	if !shouldRemove {
+		return nil
+	}
+
+	versions, _, err := unstructured.NestedSlice(c.Object, "spec", "versions")
+	if err != nil {
+		return fmt.Errorf("failed to get crd %s versions: %w", k, err)
+	}
+
+	changed := false
+	for i := range versions {
+		v := versions[i].(map[string]any)
+
+		existing, _, _ := unstructured.NestedSlice(v, validationsPath...)
+		if len(existing) == 0 {
+			continue
+		}
+
+		versionChanged := false
+		var filtered []interface{}
+		for _, entry := range existing {
+			ruleMap, ok := entry.(map[string]interface{})
+			if !ok {
+				filtered = append(filtered, entry)
+				continue
+			}
+			ruleText, _ := ruleMap["rule"].(string)
+
+			references := false
+			for _, fieldName := range fieldNames {
+				// Use "self.<fieldName>" to avoid substring false-positives
+				// (e.g. matching "type" inside "type(self)").
+				if strings.Contains(ruleText, "self."+fieldName) {
+					references = true
+					break
+				}
+			}
+			if references {
+				versionChanged = true
+				changed = true
+			} else {
+				filtered = append(filtered, entry)
+			}
+		}
+
+		if versionChanged {
+			if len(filtered) == 0 {
+				unstructured.RemoveNestedField(v, validationsPath...)
+			} else if err := unstructured.SetNestedSlice(v, filtered, validationsPath...); err != nil {
+				return fmt.Errorf("failed to update CEL rules for crd %q: %w", k, err)
+			}
+		}
+	}
+
+	if changed {
+		pkglog.FromContextOrDefault(ctx).Info(
+			"Removing CRD CEL rules referencing removed fields",
+			"kind", k,
+			"fields", strings.Join(fieldNames, ","))
+		if err := unstructured.SetNestedSlice(c.Object, versions, "spec", "versions"); err != nil {
+			return fmt.Errorf("failed to update versions for crd %q: %w", k, err)
+		}
+	}
+	return nil
 }

--- a/pkg/crd/crd_intg_test.go
+++ b/pkg/crd/crd_intg_test.go
@@ -1,0 +1,46 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package crd_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
+	pkgcrd "github.com/vmware-tanzu/vm-operator/pkg/crd"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
+)
+
+// These tests apply mutated CRD schemas to a real kube-apiserver and verify
+// acceptance. The fake-client unit tests cannot catch CEL compilation errors
+// since the fake client skips schema validation — only a real apiserver runs
+// the CEL type-checker at CRD apply time.
+var _ = Describe(
+	"Install against real API server",
+	Label(testlabels.EnvTest),
+	func() {
+
+		It("should accept CRDs with all capabilities disabled", func() {
+			ctx := pkgcfg.WithConfig(pkgcfg.Config{
+				CRDCleanupEnabled: true,
+				Features:          pkgcfg.FeatureStates{},
+			})
+			// The kube-apiserver will reject the CRD if any x-kubernetes-validations
+			// entry references a field that was removed from the schema.
+			Expect(pkgcrd.Install(ctx, envTestClient, nil)).To(Succeed())
+		})
+
+		It("should accept CRDs with all capabilities enabled", func() {
+			ctx := pkgcfg.WithConfig(pkgcfg.Config{
+				CRDCleanupEnabled: true,
+				Features: pkgcfg.FeatureStates{
+					WorkloadIPv6:      true,
+					TelcoVMServiceAPI: true,
+				},
+			})
+			Expect(pkgcrd.Install(ctx, envTestClient, nil)).To(Succeed())
+		})
+	},
+)

--- a/pkg/crd/crd_suite_test.go
+++ b/pkg/crd/crd_suite_test.go
@@ -5,15 +5,59 @@
 package crd_test
 
 import (
+	goruntime "runtime"
+	"path/filepath"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
+	"github.com/vmware-tanzu/vm-operator/test/testutil"
 	_ "github.com/vmware-tanzu/vm-operator/test/builder/log"
+)
+
+var (
+	envTestEnv    *envtest.Environment
+	envTestClient ctrlclient.Client
 )
 
 func TestCRD(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "CRD Test Suite")
 }
+
+func envTestsEnabled() bool {
+	return Label(testlabels.EnvTest).MatchesLabelFilter(GinkgoLabelFilter())
+}
+
+var _ = BeforeSuite(func() {
+	if !envTestsEnabled() {
+		return
+	}
+
+	rootDir := testutil.GetRootDirOrDie()
+	envTestEnv = &envtest.Environment{
+		BinaryAssetsDirectory: filepath.Join(rootDir, "hack", "tools", "bin", goruntime.GOOS+"_"+goruntime.GOARCH),
+	}
+
+	cfg, err := envTestEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+
+	scheme := runtime.NewScheme()
+	Expect(apiextensionsv1.AddToScheme(scheme)).To(Succeed())
+
+	envTestClient, err = ctrlclient.New(cfg, ctrlclient.Options{Scheme: scheme})
+	Expect(err).NotTo(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	if envTestEnv != nil {
+		Expect(envTestEnv.Stop()).To(Succeed())
+	}
+})

--- a/pkg/crd/crd_test.go
+++ b/pkg/crd/crd_test.go
@@ -170,7 +170,7 @@ var _ = Describe("Install", func() {
 		client = nil
 	})
 
-	assertField := func(expected bool, fields ...string) {
+	assertFieldForCRD := func(crdName string, expected bool, fields ...string) {
 		GinkgoHelper()
 
 		obj := unstructured.Unstructured{
@@ -178,7 +178,7 @@ var _ = Describe("Install", func() {
 		}
 		obj.SetAPIVersion("apiextensions.k8s.io/v1")
 		obj.SetKind("CustomResourceDefinition")
-		obj.SetName("virtualmachines.vmoperator.vmware.com")
+		obj.SetName(crdName)
 
 		Expect(client.Get(
 			ctx,
@@ -202,6 +202,16 @@ var _ = Describe("Install", func() {
 			}
 		}
 		Expect(hasField).To(Equal(expected))
+	}
+
+	assertField := func(expected bool, fields ...string) {
+		GinkgoHelper()
+		assertFieldForCRD("virtualmachines.vmoperator.vmware.com", expected, fields...)
+	}
+
+	assertVMSvcField := func(expected bool, fields ...string) {
+		GinkgoHelper()
+		assertFieldForCRD("virtualmachineservices.vmoperator.vmware.com", expected, fields...)
 	}
 
 	When("no crds are installed", func() {
@@ -251,9 +261,19 @@ var _ = Describe("Install", func() {
 				Entry("network interface vNUMANodeID", "network.interfaces.[].vNUMANodeID"),
 				Entry("network interface vmxnet3", "network.interfaces.[].vmxnet3"),
 				Entry("network interface advancedProperties", "network.interfaces.[].advancedProperties"),
+				Entry("network interface ipamModes", "network.interfaces.[].ipamModes"),
 				Entry("resources", "resources"),
 				Entry("cpuAdvanced", "cpuAdvanced"),
 				Entry("memoryAdvanced", "memoryAdvanced"),
+			)
+
+			DescribeTable("vm service api should not have spec fields",
+				func(field string) {
+					fields := specFieldPath(field)
+					assertVMSvcField(false, fields...)
+				},
+				Entry("ipFamilies", "ipFamilies"),
+				Entry("ipFamilyPolicy", "ipFamilyPolicy"),
 			)
 
 			DescribeTable("vm api should not have status fields",
@@ -534,6 +554,34 @@ var _ = Describe("Install", func() {
 				Entry("volumes controllerBusNumber", "volumes.[].controllerBusNumber"),
 				Entry("volumes controllerType", "volumes.[].controllerType"),
 				Entry("hardware controllers", "hardware.controllers"),
+			)
+		})
+
+		When("WorkloadIPv6 is enabled", func() {
+			BeforeEach(func() {
+				pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+					config.Features.WorkloadIPv6 = true
+				})
+			})
+			It("should get the expected crds", func() {
+				var obj apiextensionsv1.CustomResourceDefinitionList
+				Expect(client.List(ctx, &obj)).To(Succeed())
+				assertCRDsConsistOf(obj.Items, basesNonGated...)
+			})
+			DescribeTable("vm api should have spec fields",
+				func(field string) {
+					fields := specFieldPath(field)
+					assertField(true, fields...)
+				},
+				Entry("network interface ipamModes", "network.interfaces.[].ipamModes"),
+			)
+			DescribeTable("vm service api should have spec fields",
+				func(field string) {
+					fields := specFieldPath(field)
+					assertVMSvcField(true, fields...)
+				},
+				Entry("ipFamilies", "ipFamilies"),
+				Entry("ipFamilyPolicy", "ipFamilyPolicy"),
 			)
 		})
 

--- a/pkg/crd/crd_test.go
+++ b/pkg/crd/crd_test.go
@@ -214,6 +214,39 @@ var _ = Describe("Install", func() {
 		assertFieldForCRD("virtualmachineservices.vmoperator.vmware.com", expected, fields...)
 	}
 
+	assertCELRulesContaining := func(crdName string, celPath []string, fieldRef string, expectPresent bool) {
+		GinkgoHelper()
+
+		obj := unstructured.Unstructured{Object: map[string]any{}}
+		obj.SetAPIVersion("apiextensions.k8s.io/v1")
+		obj.SetKind("CustomResourceDefinition")
+		obj.SetName(crdName)
+		Expect(client.Get(ctx, ctrlclient.ObjectKeyFromObject(&obj), &obj)).To(Succeed())
+
+		versions, _, err := unstructured.NestedSlice(obj.Object, "spec", "versions")
+		Expect(err).ToNot(HaveOccurred())
+
+		found := false
+		for j := range versions {
+			v := versions[j].(map[string]any)
+			rules, _, _ := unstructured.NestedSlice(v, celPath...)
+			for _, r := range rules {
+				ruleMap, ok := r.(map[string]any)
+				if !ok {
+					continue
+				}
+				if ruleText, _ := ruleMap["rule"].(string); strings.Contains(ruleText, fieldRef) {
+					found = true
+					break
+				}
+			}
+			if found {
+				break
+			}
+		}
+		Expect(found).To(Equal(expectPresent))
+	}
+
 	When("no crds are installed", func() {
 		When("no capabilities are enabled", func() {
 			It("should get the expected crds", func() {
@@ -275,6 +308,33 @@ var _ = Describe("Install", func() {
 				Entry("ipFamilies", "ipFamilies"),
 				Entry("ipFamilyPolicy", "ipFamilyPolicy"),
 			)
+
+			It("vm api should not have CEL rules referencing vmxnet3", func() {
+				assertCELRulesContaining(
+					"virtualmachines.vmoperator.vmware.com",
+					specCELPath("network.interfaces.[]"),
+					"vmxnet3",
+					false,
+				)
+			})
+
+			It("vm api should not have CEL rules referencing ipamModes", func() {
+				assertCELRulesContaining(
+					"virtualmachines.vmoperator.vmware.com",
+					specCELPath("network.interfaces.[]"),
+					"ipamModes",
+					false,
+				)
+			})
+
+			It("vm service api should not have CEL rules referencing ipFamilies", func() {
+				assertCELRulesContaining(
+					"virtualmachineservices.vmoperator.vmware.com",
+					specCELPath(""),
+					"ipFamilies",
+					false,
+				)
+			})
 
 			DescribeTable("vm api should not have status fields",
 				func(field string) {
@@ -469,6 +529,15 @@ var _ = Describe("Install", func() {
 				},
 				Entry("extraConfig", "extraConfig"),
 			)
+
+			It("vm api should have CEL rules referencing vmxnet3", func() {
+				assertCELRulesContaining(
+					"virtualmachines.vmoperator.vmware.com",
+					specCELPath("network.interfaces.[]"),
+					"vmxnet3",
+					true,
+				)
+			})
 		})
 
 		When("VM shared disks (OracleRAC) is enabled", func() {
@@ -583,6 +652,24 @@ var _ = Describe("Install", func() {
 				Entry("ipFamilies", "ipFamilies"),
 				Entry("ipFamilyPolicy", "ipFamilyPolicy"),
 			)
+
+			It("vm api should have CEL rules referencing ipamModes", func() {
+				assertCELRulesContaining(
+					"virtualmachines.vmoperator.vmware.com",
+					specCELPath("network.interfaces.[]"),
+					"ipamModes",
+					true,
+				)
+			})
+
+			It("vm service api should have CEL rules referencing ipFamilies", func() {
+				assertCELRulesContaining(
+					"virtualmachineservices.vmoperator.vmware.com",
+					specCELPath(""),
+					"ipFamilies",
+					true,
+				)
+			})
 		})
 
 		When("fast deploy is enabled", func() {
@@ -940,6 +1027,19 @@ func specFieldPath(fieldPath string) []string {
 func statusFieldPath(fieldPath string) []string {
 	fieldNames := strings.Split(fieldPath, ".")
 	return buildFieldPath("status", fieldNames...)
+}
+
+// specCELPath returns the path to x-kubernetes-validations for a schema object
+// relative to a CRD version entry. An empty fieldPath returns the spec-level
+// validations path; otherwise fieldPath is a dot-separated chain where "[]"
+// denotes array items (e.g. "network.interfaces.[]").
+func specCELPath(fieldPath string) []string {
+	if fieldPath == "" {
+		return []string{"schema", "openAPIV3Schema", "properties", "spec", "x-kubernetes-validations"}
+	}
+	fieldNames := strings.Split(fieldPath, ".")
+	path := buildFieldPath("spec", fieldNames...)
+	return append(path, "x-kubernetes-validations")
 }
 
 func buildFieldPath(parentField string, fieldNames ...string) []string {

--- a/pkg/providers/vsphere/network/network.go
+++ b/pkg/providers/vsphere/network/network.go
@@ -756,7 +756,12 @@ func createNetOPNetworkInterface(
 		// NetOP only defines a VMXNet3 type, but it doesn't really matter for our purposes.
 		netIf.Spec.Type = netopv1alpha1.NetworkInterfaceTypeVMXNet3
 
-		netIf.Spec.IPFamilyPolicy = IPAMModesToNetOPInterfaceIPFamilyPolicy(interfaceSpec.IPAMModes)
+		// IPFamilyPolicy is a new field introduced for IPv6 support.
+		// Only set it when the WorkloadIPv6 capability is active so that this
+		// field is not sent to NetOP when IPv6 is disabled.
+		if pkgcfg.FromContext(ctx).Features.WorkloadIPv6 {
+			netIf.Spec.IPFamilyPolicy = IPAMModesToNetOPInterfaceIPFamilyPolicy(interfaceSpec.IPAMModes)
+		}
 
 		return nil
 	})

--- a/pkg/providers/vsphere/network/network_test.go
+++ b/pkg/providers/vsphere/network/network_test.go
@@ -1309,6 +1309,41 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 		})
 
 		Context("IPAMModes", func() {
+			// IPFamilyPolicy is a WorkloadIPv6 capability feature; enable it for all
+			// sub-contexts that verify the field is properly propagated to NetOP.
+			BeforeEach(func() {
+				testConfig.WithWorkloadIPv6 = true
+			})
+
+			Context("WorkloadIPv6 capability disabled", func() {
+				BeforeEach(func() {
+					testConfig.WithWorkloadIPv6 = false
+					networkSpec.Interfaces = []vmopv1.VirtualMachineNetworkInterfaceSpec{
+						{
+							Name:      interfaceName,
+							Network:   &common.PartialObjectRef{Name: networkName},
+							IPAMModes: []corev1.IPFamily{corev1.IPv4Protocol},
+						},
+					}
+				})
+
+				It("does not set IPFamilyPolicy on NetworkInterface CR", func() {
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
+
+					By("verify NetworkInterface CR does not have IPFamilyPolicy set", func() {
+						netInterface := &netopv1alpha1.NetworkInterface{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      network.NetOPCRName(vm.Name, networkName, interfaceName, false),
+								Namespace: vm.Namespace,
+							},
+						}
+						Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(netInterface), netInterface)).To(Succeed())
+						Expect(netInterface.Spec.IPFamilyPolicy).To(Equal(netopv1alpha1.NetworkInterfaceIPFamilyPolicy("")))
+					})
+				})
+			})
+
 			Context("IPv4Only policy", func() {
 				BeforeEach(func() {
 					networkSpec.Interfaces = []vmopv1.VirtualMachineNetworkInterfaceSpec{
@@ -2564,6 +2599,7 @@ var _ = Describe("CreateNetworkDevices", Label(testlabels.VCSim), func() {
 			DescribeTableSubtree("interface spec with IPAMModes",
 				func(modes []corev1.IPFamily, expected netopv1alpha1.NetworkInterfaceIPFamilyPolicy) {
 					BeforeEach(func() {
+						testConfig.WithWorkloadIPv6 = true
 						vm.Spec.Network.Interfaces[0].IPAMModes = modes
 					})
 

--- a/test/builder/vcsim_test_context.go
+++ b/test/builder/vcsim_test_context.go
@@ -147,6 +147,9 @@ type VCSimTestConfig struct {
 	// WithoutNativeKeyProvider disables the creation of the native key provider
 	// in vcsim.
 	WithoutNativeKeyProvider bool
+
+	// WithWorkloadIPv6 enables the WorkloadIPv6 feature flag.
+	WithWorkloadIPv6 bool
 }
 
 type TestContextForVCSim struct {
@@ -589,6 +592,7 @@ func (c *TestContextForVCSim) setupEnv(config VCSimTestConfig) {
 		cc.Features.WorkloadDomainIsolation = !config.WithoutWorkloadDomainIsolation
 		cc.Features.VMIncrementalRestore = config.WithVMIncrementalRestore
 		cc.Features.VMSnapshots = config.WithVMSnapshots
+		cc.Features.WorkloadIPv6 = config.WithWorkloadIPv6
 	})
 }
 

--- a/webhooks/virtualmachine/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator.go
@@ -1234,6 +1234,13 @@ func (v validator) validateNetworkInterfaceSpec(
 			interfacePath.Child("advancedProperties"), interfaceSpec.AdvancedProperties)...)
 	}
 
+	if len(interfaceSpec.IPAMModes) > 0 && !pkgcfg.FromContext(ctx).Features.WorkloadIPv6 {
+		allErrs = append(allErrs, field.Forbidden(
+			interfacePath.Child("ipamModes"),
+			fmt.Sprintf(featureNotEnabled, "WorkloadIPv6"),
+		))
+	}
+
 	// Validate VMXNet3 configuration if present
 	if interfaceSpec.VMXNet3 != nil {
 		if interfaceSpec.Type != vmopv1.VirtualMachineNetworkInterfaceTypeVMXNet3 {

--- a/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
@@ -2913,6 +2913,62 @@ func unitTestsValidateCreate() {
 				},
 			),
 
+			Entry("disallow spec.network.interfaces[i].ipamModes when WorkloadIPv6 capability is disabled",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+							config.Features.WorkloadIPv6 = false
+						})
+						ctx.vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{
+							Interfaces: []vmopv1.VirtualMachineNetworkInterfaceSpec{
+								{
+									Name:      "eth0",
+									IPAMModes: []corev1.IPFamily{corev1.IPv6Protocol},
+								},
+							},
+						}
+					},
+					validate: doValidateWithMsg(
+						`spec.network.interfaces[0].ipamModes: Forbidden: the WorkloadIPv6 feature is not enabled`,
+					),
+				},
+			),
+
+			Entry("allow spec.network.interfaces[i].ipamModes when WorkloadIPv6 capability is enabled",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+							config.Features.WorkloadIPv6 = true
+						})
+						ctx.vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{
+							Interfaces: []vmopv1.VirtualMachineNetworkInterfaceSpec{
+								{
+									Name:      "eth0",
+									IPAMModes: []corev1.IPFamily{corev1.IPv6Protocol},
+								},
+							},
+						}
+					},
+					expectAllowed: true,
+				},
+			),
+
+			Entry("allow empty ipamModes when WorkloadIPv6 capability is disabled",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+							config.Features.WorkloadIPv6 = false
+						})
+						ctx.vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{
+							Interfaces: []vmopv1.VirtualMachineNetworkInterfaceSpec{
+								{Name: "eth0"},
+							},
+						}
+					},
+					expectAllowed: true,
+				},
+			),
+
 			Entry("allow valid VLANs parameter",
 				testParams{
 					setup: func(ctx *unitValidatingWebhookContext) {

--- a/webhooks/virtualmachineservice/validation/virtualmachineservice_validator.go
+++ b/webhooks/virtualmachineservice/validation/virtualmachineservice_validator.go
@@ -26,6 +26,7 @@ import (
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 	"github.com/vmware-tanzu/vm-operator/pkg/builder"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/webhooks/common"
 )
@@ -204,6 +205,21 @@ func (v validator) validateSpec(ctx *pkgctx.WebhookRequestContext, vmService *vm
 					),
 				)
 			}
+		}
+	}
+
+	if !pkgcfg.FromContext(ctx).Features.WorkloadIPv6 {
+		if len(vmService.Spec.IPFamilies) > 0 {
+			allErrs = append(allErrs, field.Forbidden(
+				specPath.Child("ipFamilies"),
+				"the WorkloadIPv6 feature is not enabled",
+			))
+		}
+		if vmService.Spec.IPFamilyPolicy != nil {
+			allErrs = append(allErrs, field.Forbidden(
+				specPath.Child("ipFamilyPolicy"),
+				"the WorkloadIPv6 feature is not enabled",
+			))
 		}
 	}
 

--- a/webhooks/virtualmachineservice/validation/virtualmachineservice_validator_intg_test.go
+++ b/webhooks/virtualmachineservice/validation/virtualmachineservice_validator_intg_test.go
@@ -12,6 +12,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
@@ -104,6 +105,17 @@ func intgTestsValidateCreate() {
 	)
 
 	Describe("CRD schema and CEL (ipFamilies and ipFamilyPolicy)", func() {
+		BeforeEach(func() {
+			pkgcfg.UpdateContext(suite, func(config *pkgcfg.Config) {
+				config.Features.WorkloadIPv6 = true
+			})
+		})
+		AfterEach(func() {
+			pkgcfg.UpdateContext(suite, func(config *pkgcfg.Config) {
+				config.Features.WorkloadIPv6 = false
+			})
+		})
+
 		It("allows LoadBalancer with dual-stack ipFamilies and PreferDualStack policy", func() {
 			vmSvc := ctx.vmService.DeepCopy()
 			vmSvc.Spec.IPFamilies = []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}

--- a/webhooks/virtualmachineservice/validation/virtualmachineservice_validator_intg_test.go
+++ b/webhooks/virtualmachineservice/validation/virtualmachineservice_validator_intg_test.go
@@ -222,6 +222,37 @@ func intgTestsValidateUpdate() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
+
+	Describe("CEL: ipFamilies primary family immutability", func() {
+		BeforeEach(func() {
+			pkgcfg.UpdateContext(suite, func(config *pkgcfg.Config) {
+				config.Features.WorkloadIPv6 = true
+			})
+		})
+		AfterEach(func() {
+			pkgcfg.UpdateContext(suite, func(config *pkgcfg.Config) {
+				config.Features.WorkloadIPv6 = false
+			})
+		})
+
+		It("rejects changing the primary IP family", func() {
+			ctx.vmService.Spec.IPFamilies = []corev1.IPFamily{corev1.IPv4Protocol}
+			Expect(ctx.Client.Update(ctx, ctx.vmService)).To(Succeed())
+
+			ctx.vmService.Spec.IPFamilies = []corev1.IPFamily{corev1.IPv6Protocol}
+			updateErr := ctx.Client.Update(ctx, ctx.vmService)
+			Expect(apierrors.IsInvalid(updateErr)).To(BeTrue())
+			Expect(updateErr.Error()).To(ContainSubstring("primary IP family may not be changed or removed once set"))
+		})
+
+		It("allows adding a secondary IP family without changing the primary", func() {
+			ctx.vmService.Spec.IPFamilies = []corev1.IPFamily{corev1.IPv4Protocol}
+			Expect(ctx.Client.Update(ctx, ctx.vmService)).To(Succeed())
+
+			ctx.vmService.Spec.IPFamilies = []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}
+			Expect(ctx.Client.Update(ctx, ctx.vmService)).To(Succeed())
+		})
+	})
 }
 
 func intgTestsValidateDelete() {

--- a/webhooks/virtualmachineservice/validation/virtualmachineservice_validator_intg_test.go
+++ b/webhooks/virtualmachineservice/validation/virtualmachineservice_validator_intg_test.go
@@ -106,6 +106,11 @@ func intgTestsValidateCreate() {
 
 	Describe("CRD schema and CEL (ipFamilies and ipFamilyPolicy)", func() {
 		BeforeEach(func() {
+			// WorkloadIPv6 must be enabled so the validating webhook does not reject
+			// requests that set ipFamilies or ipFamilyPolicy before CEL can run.
+			// (CEL enforces schema rules from the CRD itself and runs before the
+			// validating webhook; however the "allows" test in this block requires
+			// that the webhook also permits the request.)
 			pkgcfg.UpdateContext(suite, func(config *pkgcfg.Config) {
 				config.Features.WorkloadIPv6 = true
 			})
@@ -225,6 +230,8 @@ func intgTestsValidateUpdate() {
 
 	Describe("CEL: ipFamilies primary family immutability", func() {
 		BeforeEach(func() {
+			// WorkloadIPv6 must be enabled so the validating webhook does not reject
+			// requests that set ipFamilies before CEL can enforce the immutability rule.
 			pkgcfg.UpdateContext(suite, func(config *pkgcfg.Config) {
 				config.Features.WorkloadIPv6 = true
 			})

--- a/webhooks/virtualmachineservice/validation/virtualmachineservice_validator_unit_test.go
+++ b/webhooks/virtualmachineservice/validation/virtualmachineservice_validator_unit_test.go
@@ -8,12 +8,15 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
@@ -245,6 +248,62 @@ func unitTestsValidateCreate() {
 			},
 		),
 	)
+
+	When("WorkloadIPv6 capability is disabled", func() {
+		BeforeEach(func() {
+			pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+				config.Features.WorkloadIPv6 = false
+			})
+		})
+
+		It("should deny ipFamilies when set", func() {
+			ctx.vmService.Spec.IPFamilies = []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}
+			var err error
+			ctx.WebhookRequestContext.Obj, err = builder.ToUnstructured(ctx.vmService)
+			Expect(err).ToNot(HaveOccurred())
+			response := ctx.ValidateCreate(&ctx.WebhookRequestContext)
+			Expect(response.Allowed).To(BeFalse())
+			Expect(string(response.Result.Reason)).To(ContainSubstring("spec.ipFamilies: Forbidden: the WorkloadIPv6 feature is not enabled"))
+		})
+
+		It("should deny ipFamilyPolicy when set", func() {
+			policy := corev1.IPFamilyPolicyPreferDualStack
+			ctx.vmService.Spec.IPFamilyPolicy = &policy
+			var err error
+			ctx.WebhookRequestContext.Obj, err = builder.ToUnstructured(ctx.vmService)
+			Expect(err).ToNot(HaveOccurred())
+			response := ctx.ValidateCreate(&ctx.WebhookRequestContext)
+			Expect(response.Allowed).To(BeFalse())
+			Expect(string(response.Result.Reason)).To(ContainSubstring("spec.ipFamilyPolicy: Forbidden: the WorkloadIPv6 feature is not enabled"))
+		})
+
+		It("should allow when ipFamilies and ipFamilyPolicy are unset", func() {
+			var err error
+			ctx.WebhookRequestContext.Obj, err = builder.ToUnstructured(ctx.vmService)
+			Expect(err).ToNot(HaveOccurred())
+			response := ctx.ValidateCreate(&ctx.WebhookRequestContext)
+			Expect(response.Allowed).To(BeTrue())
+		})
+	})
+
+	When("WorkloadIPv6 capability is enabled", func() {
+		BeforeEach(func() {
+			pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+				config.Features.WorkloadIPv6 = true
+			})
+		})
+
+		It("should allow ipFamilies and ipFamilyPolicy when set", func() {
+			policy := corev1.IPFamilyPolicyPreferDualStack
+			ctx.vmService.Spec.IPFamilies = []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}
+			ctx.vmService.Spec.IPFamilyPolicy = ptr.To(policy)
+			var err error
+			ctx.WebhookRequestContext.Obj, err = builder.ToUnstructured(ctx.vmService)
+			Expect(err).ToNot(HaveOccurred())
+			response := ctx.ValidateCreate(&ctx.WebhookRequestContext)
+			Expect(response.Allowed).To(BeTrue())
+		})
+	})
 }
 
 func unitTestsValidateUpdate() {


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Introduces a capability gate (`WorkloadIPv6`) that controls whether IPv6-related API fields, CEL validation rules, webhook validation, and NetOP integration are active on a given Supervisor cluster.

The IPv6 workload fields (`ipFamilies`, `ipFamilyPolicy` on `VirtualMachineService`; `ipamModes` on `VirtualMachine` network interfaces) were added to the API in a prior change but need to be hidden on clusters that do not yet support IPv6. This PR wires up the `supports_workload_ipv6` Supervisor capabilities CRD key to a new `FeatureStates.WorkloadIPv6` flag, then enforces that gate at every layer:

- **Capabilities** (`pkg/config/capabilities`): Reads `supports_workload_ipv6` from the Supervisor capabilities CRD and populates `FeatureStates.WorkloadIPv6`.
- **CRD install** (`pkg/crd`): When the capability is absent, strips the `ipFamilies`/`ipFamilyPolicy` fields from the `VirtualMachineService` CRD schema and the `ipamModes` field from `VirtualMachine` network-interface items. Also removes any CEL `x-kubernetes-validations` rules that reference the stripped fields — preventing kube-apiserver from rejecting a CRD where a CEL rule names a field that no longer exists in the schema.
- **Webhooks** (`webhooks/validation`): VM and VMService admission webhooks skip IPv6-specific validation when the capability is disabled.
- **NetOP integration** (`pkg/providers/vsphere/network`): `IPFamilyPolicy` is only forwarded to the NetOP interface spec when `WorkloadIPv6` is active.
- **API** (`api/v1alpha6`): Adds a CEL immutability rule preventing the primary IP family from being changed once set.

**Which issue(s) is/are addressed by this PR?** *(optional)*:

Fixes #


**Are there any special notes for your reviewer**:

- `removeValidationRules` in `pkg/crd/crd.go` matches CEL rules by scanning for the substring `"self.<fieldName>"` rather than a strict equality check. This is intentional — it avoids false positives from tokens like `type` appearing inside `type(self)` — but reviewers should verify the heuristic is sufficient for all current CEL rules on these CRDs.
- The `VirtualMachineService` CRD case in `Install()` was previously commented out; this PR activates it.
- Tests cover the capability parsing path, the CRD field-stripping logic (unit + integration), the webhook validation gates, and the NetOP IPFamilyPolicy guarding.

**Please add a release note if necessary**:

```release-note
VM Operator now gates the IPv6 workload API fields (`ipFamilies`, `ipFamilyPolicy` on VirtualMachineService; `ipamModes` on VM network interfaces) behind the `supports_workload_ipv6` Supervisor capability. Clusters that do not advertise this capability will not expose these fields in CRD schemas, webhooks, or NetOP integration.