### PR TITLE
🌱 Add external/vim to e2e go.mod replace section

### DIFF
--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -16,6 +16,7 @@ replace (
 	github.com/vmware-tanzu/vm-operator/external/ncp => ../../external/ncp
 	github.com/vmware-tanzu/vm-operator/external/storage-policy-quota => ../../external/storage-policy-quota
 	github.com/vmware-tanzu/vm-operator/external/tanzu-topology => ../../external/tanzu-topology
+	github.com/vmware-tanzu/vm-operator/external/vim/api => ./external/vim/api
 	github.com/vmware-tanzu/vm-operator/external/vsphere-csi-driver => ../../external/vsphere-csi-driver
 	github.com/vmware-tanzu/vm-operator/external/vsphere-policy => ../../external/vsphere-policy
 	github.com/vmware-tanzu/vm-operator/pkg/backup/api => ../../pkg/backup/api


### PR DESCRIPTION



**What does this PR do, and why is it needed?**

Without this Goland mod sync in its directory is broken since it uses go list that fails with:

```
$ go list -m -json all
go: github.com/vmware-tanzu/vm-operator/external/vim/api@v0.0.0-00010101000000-000000000000: invalid version: unknown revision 000000000000

```
**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

**Please add a release note if necessary**:


```release-note
NONE
```