### PR TITLE
🐛  Fix PVC based test failures on VSAN based deployments due to EZT

### DIFF
--- a/test/e2e/infrastructure/vsphere/vcenter/storage.go
+++ b/test/e2e/infrastructure/vsphere/vcenter/storage.go
@@ -27,6 +27,8 @@ const (
 	volumeAllocationNamespace     = "com.vmware.storage.volumeallocation"
 	volumeAllocationTypeID        = "VolumeAllocationType"
 	fullyInitializedValue         = "Fully initialized"
+	datastoreTypeVSAND            = "vsanD"
+	datastoreTypeVSAN             = "vsan"
 )
 
 // GetStoragePolicyIDFromName looks up a storage profile by name and returns its ID.
@@ -268,6 +270,15 @@ func GetOrCreateVsanDirectStoragePolicyID(ctx context.Context, client *vim25.Cli
 
 // IsVSANDEnabledCluster checks if given wcp enabled cluster is enabled with vsand capability.
 func IsVSANDEnabledCluster(ctx context.Context, client *vim25.Client, kubeconfigPath string) (bool, error) {
+	return isDatastoreTypeEnabledOnCluster(ctx, client, kubeconfigPath, datastoreTypeVSAND)
+}
+
+// IsVSANEnabledCluster checks if given wcp enabled cluster is enabled with vsan capability.
+func IsVSANEnabledCluster(ctx context.Context, client *vim25.Client, kubeconfigPath string) (bool, error) {
+	return isDatastoreTypeEnabledOnCluster(ctx, client, kubeconfigPath, datastoreTypeVSAN)
+}
+
+func isDatastoreTypeEnabledOnCluster(ctx context.Context, client *vim25.Client, kubeconfigPath, datastoreType string) (bool, error) {
 	clusterMOID := GetClusterMoIDFromKubeconfig(ctx, kubeconfigPath)
 	if clusterMOID == "" {
 		return false, errors.New("could not fetch cluster moid from wcp cluster config")
@@ -280,15 +291,12 @@ func IsVSANDEnabledCluster(ctx context.Context, client *vim25.Client, kubeconfig
 			Value: clusterMOID,
 		},
 	)
-
-	return clusterConfiguredWithVsand(ctx, cluster)
+	return clusterConfiguredWithDatastoreType(ctx, cluster, datastoreType)
 }
 
-func clusterConfiguredWithVsand(ctx context.Context, cluster *object.ClusterComputeResource) (bool, error) {
+func clusterConfiguredWithDatastoreType(ctx context.Context, cluster *object.ClusterComputeResource, datastoreType string) (bool, error) {
 	var cr mo.ComputeResource
-
-	err := cluster.Properties(ctx, cluster.Reference(), []string{"datastore"}, &cr)
-	if err != nil {
+	if err := cluster.Properties(ctx, cluster.Reference(), []string{"datastore"}, &cr); err != nil {
 		return false, err
 	}
 
@@ -297,16 +305,13 @@ func clusterConfiguredWithVsand(ctx context.Context, cluster *object.ClusterComp
 	}
 
 	var datastores []mo.Datastore
-
 	pc := property.DefaultCollector(cluster.Client())
-
-	err = pc.Retrieve(ctx, cr.Datastore, []string{"summary"}, &datastores)
-	if err != nil {
+	if err := pc.Retrieve(ctx, cr.Datastore, []string{"summary"}, &datastores); err != nil {
 		return false, err
 	}
 
 	for _, d := range datastores {
-		if d.Summary.Type == "vsanD" {
+		if d.Summary.Type == datastoreType {
 			return true, nil
 		}
 	}

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_hardware.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_hardware.go
@@ -735,6 +735,111 @@ func VMHardwareSpec(ctx context.Context, inputGetter func() VMHardwareSpecInput)
 					UnitNumber:          ptr.To(int32(1)),
 				}, 1)...)
 
+				// We are adding a PVC explicitly assigned to SCSI:1 and without a unit number.
+				pvcs = append(pvcs, createPvcsFromSpec(input, vmName, manifestbuilders.PVC{
+					StorageClassName:    clusterResources.StorageClassName,
+					ControllerType:      ptr.To(vmopv1a5.VirtualControllerTypeSCSI),
+					ControllerBusNumber: ptr.To(int32(1)),
+				}, 1)...)
+
+				// TODO(Faisal A): Enable this after fixing the issues with the NVME controller status.
+				// We are adding a PVC explicitly assigned to NVME:1 and without a unit number.
+				// pvcs = append(pvcs, createPvcsFromSpec(input, vmPrefix, manifestbuilders.PVC{
+				// 	StorageClassName:    clusterResources.StorageClassName,
+				// 	ControllerType:      ptr.To(vmopv1a5.VirtualControllerTypeNVME),
+				// 	ControllerBusNumber: ptr.To(int32(1)),
+				// }, 1)...)
+
+				// // We are adding a PVC explicitly assigned to SATA:1 and without a unit number.
+				pvcs = append(pvcs, createPvcsFromSpec(input, vmName, manifestbuilders.PVC{
+					StorageClassName:    clusterResources.StorageClassName,
+					ControllerType:      ptr.To(vmopv1a5.VirtualControllerTypeSATA),
+					ControllerBusNumber: ptr.To(int32(1)),
+				}, 1)...)
+
+				return testSpec{
+					pvcs: pvcs,
+					hardware: vmopv1a5.VirtualMachineHardwareSpec{
+						SCSIControllers: []vmopv1a5.SCSIControllerSpec{
+							{
+								BusNumber: 1,
+								Type:      vmopv1a5.SCSIControllerTypeParaVirtualSCSI,
+							},
+							{
+								BusNumber: 2,
+								Type:      vmopv1a5.SCSIControllerTypeParaVirtualSCSI,
+							},
+							{
+								BusNumber:   3,
+								Type:        vmopv1a5.SCSIControllerTypeParaVirtualSCSI,
+								SharingMode: vmopv1a5.VirtualControllerSharingModePhysical,
+							},
+						},
+						NVMEControllers: []vmopv1a5.NVMEControllerSpec{
+							{
+								BusNumber: 1,
+							},
+						},
+						SATAControllers: []vmopv1a5.SATAControllerSpec{
+							{
+								BusNumber: 1,
+							},
+						},
+					},
+				}
+			}),
+			Entry("create a virtual machine with a combination of placements, controller types, and sharing modes with ezt", func() testSpec {
+				vCenterClient = vcenter.NewVimClientFromKubeconfig(ctx, clusterProxy.GetKubeconfigPath())
+				defer vcenter.LogoutVimClient(vCenterClient)
+
+				isVSANEnabled, err := vcenter.IsVSANEnabledCluster(ctx, vCenterClient, clusterProxy.GetKubeconfigPath())
+				Expect(err).To(BeNil())
+				isVSANDEnabled, err := vcenter.IsVSANDEnabledCluster(ctx, vCenterClient, clusterProxy.GetKubeconfigPath())
+				Expect(err).To(BeNil())
+
+				if isVSANDEnabled || isVSANEnabled {
+					Skip("Skipping EZT storage profile tests as VSAN Datastore is present")
+				}
+
+				pvcs := []manifestbuilders.PVC{}
+
+				// We are adding 5 PVCs without explicit assignment.
+				pvcs = append(pvcs, createPvcsFromSpec(input, vmName, manifestbuilders.PVC{
+					StorageClassName: clusterResources.StorageClassName,
+				}, 5)...)
+
+				// We are adding a PVC with a persistent disk mode.
+				pvcs = append(pvcs, createPvcsFromSpec(input, vmName, manifestbuilders.PVC{
+					StorageClassName: clusterResources.StorageClassName,
+					DiskMode:         ptr.To(string(vmopv1a5.VolumeDiskModePersistent)),
+				}, 1)...)
+
+				// We are adding a PVC with a independent persistent disk mode.
+				pvcs = append(pvcs, createPvcsFromSpec(input, vmName, manifestbuilders.PVC{
+					StorageClassName: clusterResources.StorageClassName,
+					DiskMode:         ptr.To(string(vmopv1a5.VolumeDiskModeIndependentPersistent)),
+				}, 1)...)
+
+				// We are adding a PVC with a independent non persistent disk mode.
+				pvcs = append(pvcs, createPvcsFromSpec(input, vmName, manifestbuilders.PVC{
+					StorageClassName: clusterResources.StorageClassName,
+					DiskMode:         ptr.To(string(vmopv1a5.VolumeDiskModeIndependentNonPersistent)),
+				}, 1)...)
+
+				// We are adding a PVC with a non persistent disk mode.
+				pvcs = append(pvcs, createPvcsFromSpec(input, vmName, manifestbuilders.PVC{
+					StorageClassName: clusterResources.StorageClassName,
+					DiskMode:         ptr.To(string(vmopv1a5.VolumeDiskModeNonPersistent)),
+				}, 1)...)
+
+				// We are adding a PVC explicitly assigned to a SCSI:1:1.
+				pvcs = append(pvcs, createPvcsFromSpec(input, vmName, manifestbuilders.PVC{
+					StorageClassName:    clusterResources.StorageClassName,
+					ControllerType:      ptr.To(vmopv1a5.VirtualControllerTypeSCSI),
+					ControllerBusNumber: ptr.To(int32(1)),
+					UnitNumber:          ptr.To(int32(1)),
+				}, 1)...)
+
 				// We are adding a PVC explicitly assigned to a SCSI:2:2 with a multi-writer sharing mode.
 				pvcs = append(pvcs, createPvcsFromSpec(input, vmName, manifestbuilders.PVC{
 					StorageClassName:    eztStorageProfileName,


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
Fix PVC based test failures on VSAN based deployments.



Verified EZT test skipped on VSAN setup.
Verified EZT test successful on VMFS setup.
```
2 Tests successful on VMFS based non-nsx setup
TEST_FOCUS="create a virtual machine with a combination of placements, controller types, and sharing modes" make test-e2e-ginkgo
Running E2E tests (ginkgo CLI)...
hack/tools/bin/linux_amd64/ginkgo --v --junit-report=./test-results.xml --focus=create a virtual machine with a combination of placements, controller types, and sharing modes ./test/e2e/vmservice -- -e2e.e2e-config=/dbc/lvn-dbc2472/ad007502/code/github/vmop-nsx-repro/test/e2e/vmservice/config/wcp.yaml -e2e.artifactFolder=test_logs
Running Suite: VM Service E2E suite - /home/ad007502/code/github/vmop-nsx-repro/test/e2e/vmservice
==================================================================================================
Random Seed: 1779919351

Will run 2 of 125 specs
------------------------------

------------------------------
[ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
autogenerated by Ginkgo
[ReportAfterSuite] PASSED [0.013 seconds]
------------------------------

Ran 2 of 125 Specs in 509.446 seconds
SUCCESS! -- 2 Passed | 0 Failed | 5 Pending | 118 Skipped
PASS

Ginkgo ran 1 suite in 8m34.695811297s
Test Suite Passed
```

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #NA


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
NA
```