### PR TITLE
🐛 Allow non-VKS node VMs with zone label to participate in group placement

### DIFF
--- a/controllers/virtualmachinegroup/virtualmachinegroup_controller.go
+++ b/controllers/virtualmachinegroup/virtualmachinegroup_controller.go
@@ -36,6 +36,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/patch"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
 	"github.com/vmware-tanzu/vm-operator/pkg/record"
+	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 	vmopv1util "github.com/vmware-tanzu/vm-operator/pkg/util/vmopv1"
 )
 
@@ -689,18 +690,35 @@ func (r *Reconciler) getVMForPlacement(
 		return nil, nil
 	}
 
-	// If VM has a zone label, skip group placement to respect zone override.
 	if zoneName := vm.Labels[corev1.LabelTopologyZone]; zoneName != "" {
+		isVksNodeVM := kubeutil.HasCAPILabels(vm.Labels)
+		// A zone-labeled VM bypasses group placement to honor its zone override
+		// when VMAffinityDuringExecution is disabled, or when it is a VKS node
+		// (CAPI-managed) which must stay pinned to its assigned zone.
+		if !pkgcfg.FromContext(ctx).Features.VMAffinityDuringExecution ||
+			isVksNodeVM {
+			pkglog.FromContextOrDefault(ctx).V(4).Info(
+				"VM has explicit zone label, skipping group placement",
+				"vmName", vmName,
+				"zoneName", zoneName,
+			)
+			return nil, nil
+		}
+
+		// Feature enabled + non-VKS: fall through so the zone-labeled VM still
+		// participates in group placement for DRS host recommendations.
 		pkglog.FromContextOrDefault(ctx).V(4).Info(
-			"VM has explicit zone label, skipping group placement",
+			"VM has explicit zone label but participates in group placement "+
+				"(VMAffinityDuringExecution enabled, non-VKS)",
 			"vmName", vmName,
 			"zoneName", zoneName,
 		)
-		return nil, nil
 	}
 
 	// VMG doesn't have a PlacementReady condition true for this VM (UID).
-	// VM is not already placed, nor has a zone label override.
+	// VM is not already placed, and either has no zone label override or is a
+	// non-VKS zone-labeled VM participating in group placement for VM-VM
+	// Affinity/Anti-Affinity at host host level within the zone.
 	// Return this VM to get it placed by the group.
 	return vm, nil
 }

--- a/controllers/virtualmachinegroup/virtualmachinegroup_controller_test.go
+++ b/controllers/virtualmachinegroup/virtualmachinegroup_controller_test.go
@@ -23,9 +23,11 @@ import (
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 	vspherepolv1 "github.com/vmware-tanzu/vm-operator/external/vsphere-policy/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	"github.com/vmware-tanzu/vm-operator/pkg/constants"
 	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
+	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
@@ -502,6 +504,18 @@ var _ = Describe(
 					Expect(ctx.Client.Patch(ctx, vmCopy, client.MergeFrom(vm))).To(Succeed())
 				}
 
+				setVMCAPILabel = func(vmKey types.NamespacedName) {
+					GinkgoHelper()
+					vm := &vmopv1.VirtualMachine{}
+					Expect(ctx.Client.Get(ctx, vmKey, vm)).To(Succeed())
+					vmCopy := vm.DeepCopy()
+					if vmCopy.Labels == nil {
+						vmCopy.Labels = make(map[string]string)
+					}
+					vmCopy.Labels[kubeutil.CAPWClusterRoleLabelKey] = "worker"
+					Expect(ctx.Client.Patch(ctx, vmCopy, client.MergeFrom(vm))).To(Succeed())
+				}
+
 				verifyGroupPlacementReadyCondition = func(
 					groupKey types.NamespacedName,
 					memberCount int,
@@ -701,6 +715,71 @@ var _ = Describe(
 					verifyGroupPlacementReadyCondition(vmGroup1Key, 3, "")
 					verifyGroupPlacementReadyCondition(vmGroup2Key, 1, "")
 					Expect(groupPlacementCallCount.Load()).To(BeEquivalentTo(1), "VM should be placed by group")
+				})
+			})
+
+			When("VMAffinityDuringExecution is enabled", func() {
+				var oldVMAffinityDuringExecution bool
+
+				BeforeEach(func() {
+					oldVMAffinityDuringExecution = pkgcfg.FromContext(suite.Context).Features.VMAffinityDuringExecution
+					pkgcfg.SetContext(suite.Context, func(config *pkgcfg.Config) {
+						config.Features.VMAffinityDuringExecution = true
+					})
+				})
+
+				AfterEach(func() {
+					pkgcfg.SetContext(suite.Context, func(config *pkgcfg.Config) {
+						config.Features.VMAffinityDuringExecution = oldVMAffinityDuringExecution
+					})
+				})
+
+				When("VM has a zone label and is a VKS node", func() {
+					BeforeEach(func() {
+						By("setting zone and CAPI labels on VMs before adding to group")
+						setVMZoneLabel(vm1Key, "zone-a")
+						setVMZoneLabel(vm2Key, "zone-b")
+						setVMZoneLabel(vm3Key, "zone-c")
+						setVMCAPILabel(vm1Key)
+						setVMCAPILabel(vm2Key)
+						setVMCAPILabel(vm3Key)
+					})
+
+					It("should skip group placement to respect zone override", func() {
+						By("verifying provider was not called for group placement")
+						Consistently(func(g Gomega) {
+							g.Expect(groupPlacementCallCount.Load()).To(BeZero(),
+								"VKS nodes with zone label should not be placed by group")
+						}, "3s", "100ms").Should(Succeed())
+
+						By("verifying PlacementReady is not set on member status")
+						Consistently(func(g Gomega) {
+							group := &vmopv1.VirtualMachineGroup{}
+							g.Expect(ctx.Client.Get(ctx, vmGroup1Key, group)).To(Succeed())
+							g.Expect(group.Status.Members).To(HaveLen(3))
+							for _, ms := range group.Status.Members {
+								if ms.Kind == virtualMachineKind {
+									g.Expect(conditions.Get(&ms, vmopv1.VirtualMachineGroupMemberConditionPlacementReady)).To(BeNil())
+								}
+							}
+						}, "3s").Should(Succeed())
+					})
+				})
+
+				When("VM has a zone label and is not a VKS node", func() {
+					BeforeEach(func() {
+						By("setting zone label (without CAPI labels) on VMs before adding to group")
+						setVMZoneLabel(vm1Key, "zone-a")
+						setVMZoneLabel(vm2Key, "zone-b")
+						setVMZoneLabel(vm3Key, "zone-c")
+					})
+
+					It("should place the VM by group", func() {
+						verifyGroupPlacementReadyCondition(vmGroup1Key, 3, "")
+						verifyGroupPlacementReadyCondition(vmGroup2Key, 1, "")
+						Expect(groupPlacementCallCount.Load()).To(BeEquivalentTo(1),
+							"non-VKS zone-labeled VM should be placed by group")
+					})
 				})
 			})
 		})

--- a/pkg/providers/vsphere/virtualmachine/configspec.go
+++ b/pkg/providers/vsphere/virtualmachine/configspec.go
@@ -329,9 +329,12 @@ func CreateConfigSpecForPlacement(
 	return configSpec, nil
 }
 
-// CalculateAffinityConstraints calculates the constraints based on vm object in vmCtx & creation/placement
-// workflow.
-func CalculateAffinityConstraints(vmCtx pkgctx.VirtualMachineContext, isCreateVM bool) AffinityRuleConstraints {
+// CalculateAffinityConstraints calculates the constraints based on vm object
+// in vmCtx & creation/placement workflow.
+func CalculateAffinityConstraints(
+	vmCtx pkgctx.VirtualMachineContext,
+	isCreateVM bool,
+) AffinityRuleConstraints {
 	constraints := AffinityRuleConstraints{}
 	if pkgcfg.FromContext(vmCtx).Features.VMPlacementPolicies {
 		constraints.ConfigureZoneRules = true
@@ -347,9 +350,19 @@ func CalculateAffinityConstraints(vmCtx pkgctx.VirtualMachineContext, isCreateVM
 		constraints.ConfigureHostRules = false
 	}
 
-	if isCreateVM {
-		// Zonal rules are ignored during VM Creation as DRS does not differentiate between topologies for persisted policies.
-		// Persistent policies are treated at Host Topology.
+	// ConfigureZoneRules = false when:
+	//   1. VM Creation: DRS doesn't differentiate topologies for persisted policies.
+	//   2. VKS Node: Never get zonal policies (VMs are already zone-constrained).
+	//   3. VMAffinityDuringExecution + Zone Label: Already zone-constrained
+	//
+	//   isCreateVM? → isVksNodeVM? → (VMAffinityDuringExecution + ZoneLabel)?
+	//    ↓YES (any)       ↓YES              ↓YES     		↓NO
+	//    FALSE            FALSE             FALSE    		TRUE
+	//
+	if isCreateVM ||
+		isVksNodeVM ||
+		(pkgcfg.FromContext(vmCtx).Features.VMAffinityDuringExecution &&
+			kubeutil.HasZoneLabel(vmCtx.VM.Labels)) {
 		constraints.ConfigureZoneRules = false
 	}
 

--- a/pkg/providers/vsphere/virtualmachine/configspec_test.go
+++ b/pkg/providers/vsphere/virtualmachine/configspec_test.go
@@ -963,7 +963,7 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 		})
 	})
 
-	Context("AF/AFF policies", func() {
+	Context("AF/AAF policies", func() {
 		BeforeEach(func() {
 			pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
 				config.Features.VMPlacementPolicies = true
@@ -1742,35 +1742,9 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 					})
 
 					// policies are ignored as cluster modules is used for VMs with capv labels
-					It("should ignore host affinity policies and keep zone affinity policies", func() {
-						Expect(configSpec.VmPlacementPolicies).To(HaveLen(2))
-
-						pols := []vimtypes.BaseVmPlacementPolicy{
-							&vimtypes.VmVmAffinity{
-								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
-								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyVSphereZone),
-								AffinedVmsTag: vimtypes.TagId{
-									NameId: &vimtypes.TagIdNameId{
-										Tag:      fmt.Sprintf("%s:%s", "env", "prod"),
-										Category: vmCtx.VM.Namespace,
-									},
-								},
-							},
-							&vimtypes.VmToVmGroupsAntiAffinity{
-								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
-								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyVSphereZone),
-								AntiAffinedVmGroupTags: []vimtypes.TagId{
-									{
-										NameId: &vimtypes.TagIdNameId{
-											Tag:      fmt.Sprintf("%s:%s", "env", "dev"),
-											Category: vmCtx.VM.Namespace,
-										},
-									},
-								},
-							},
-						}
-						Expect(configSpec.VmPlacementPolicies).To(ConsistOf(pols))
-						assertVMTags(configSpec, []string{"env:prod"}, vmCtx.VM.Namespace)
+					It("should ignore both host and zone affinity policies", func() {
+						Expect(configSpec.VmPlacementPolicies).To(HaveLen(0))
+						assertVMTags(configSpec, []string{}, vmCtx.VM.Namespace)
 					})
 				})
 				Context("VKS node VM with both host and zone topology keys with capw labels", func() {
@@ -1826,35 +1800,9 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 					})
 
 					// policies are ignored as cluster modules is used for VMs with capw labels
-					It("should ignore host affinity policies and keep zone affinity policies", func() {
-						Expect(configSpec.VmPlacementPolicies).To(HaveLen(2))
-
-						pols := []vimtypes.BaseVmPlacementPolicy{
-							&vimtypes.VmVmAffinity{
-								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
-								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyVSphereZone),
-								AffinedVmsTag: vimtypes.TagId{
-									NameId: &vimtypes.TagIdNameId{
-										Tag:      fmt.Sprintf("%s:%s", "env", "prod"),
-										Category: vmCtx.VM.Namespace,
-									},
-								},
-							},
-							&vimtypes.VmToVmGroupsAntiAffinity{
-								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
-								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyVSphereZone),
-								AntiAffinedVmGroupTags: []vimtypes.TagId{
-									{
-										NameId: &vimtypes.TagIdNameId{
-											Tag:      fmt.Sprintf("%s:%s", "env", "dev"),
-											Category: vmCtx.VM.Namespace,
-										},
-									},
-								},
-							},
-						}
-						Expect(configSpec.VmPlacementPolicies).To(ConsistOf(pols))
-						assertVMTags(configSpec, []string{"env:prod"}, vmCtx.VM.Namespace)
+					It("should ignore both host affinity and zone affinity policies", func() {
+						Expect(configSpec.VmPlacementPolicies).To(HaveLen(0))
+						assertVMTags(configSpec, []string{}, vmCtx.VM.Namespace)
 					})
 				})
 			})
@@ -2249,7 +2197,7 @@ var _ = Describe("CalculateAffinityConstraints", func() {
 				}
 			})
 
-			It("should disable host rules even when VMAffinityDuringExecution is enabled", func() {
+			It("should disable both host and zone rules when VMAffinityDuringExecution is enabled", func() {
 				pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
 					config.Features.VMPlacementPolicies = true
 					config.Features.VMAffinityDuringExecution = true
@@ -2257,10 +2205,10 @@ var _ = Describe("CalculateAffinityConstraints", func() {
 
 				constraints := virtualmachine.CalculateAffinityConstraints(vmCtx, false)
 				Expect(constraints.ConfigureHostRules).To(BeFalse(), "VKS node VMs should disable host rules")
-				Expect(constraints.ConfigureZoneRules).To(BeTrue(), "Zone rules should still be enabled")
+				Expect(constraints.ConfigureZoneRules).To(BeFalse(), "VKS node VMs should never get zonal policies")
 			})
 
-			It("should keep zone rules enabled when VMPlacementPolicies is enabled", func() {
+			It("should ignore zone rules even when VMPlacementPolicies is enabled", func() {
 				pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
 					config.Features.VMPlacementPolicies = true
 					config.Features.VMAffinityDuringExecution = false
@@ -2268,7 +2216,7 @@ var _ = Describe("CalculateAffinityConstraints", func() {
 
 				constraints := virtualmachine.CalculateAffinityConstraints(vmCtx, false)
 				Expect(constraints.ConfigureHostRules).To(BeFalse())
-				Expect(constraints.ConfigureZoneRules).To(BeTrue())
+				Expect(constraints.ConfigureZoneRules).To(BeFalse(), "VKS node VMs should never get zonal policies")
 			})
 		})
 
@@ -2347,73 +2295,112 @@ var _ = Describe("CalculateAffinityConstraints", func() {
 				})
 			})
 
-			It("should disable host rules but allow zone rules", func() {
+			It("should disable both host and zone rules", func() {
 				constraints := virtualmachine.CalculateAffinityConstraints(vmCtx, false)
 				Expect(constraints.ConfigureHostRules).To(BeFalse(), "VKS nodes should disable host rules")
-				Expect(constraints.ConfigureZoneRules).To(BeTrue(), "Zone rules should be enabled for placement")
+				Expect(constraints.ConfigureZoneRules).To(BeFalse(), "VKS nodes should never get zonal policies")
 			})
 		})
 
 		When("regular VM with different flag combinations", func() {
-			BeforeEach(func() {
-				vm.Labels = map[string]string{
-					"app": "test-app",
-				}
+			When("VM does not have zone label", func() {
+				BeforeEach(func() {
+					vm.Labels = map[string]string{
+						"app": "test-app",
+					}
+				})
+
+				It("should respect feature flags during placement workflow", func() {
+					testCases := []struct {
+						vmPlacement  bool
+						vmAffinity   bool
+						expectedZone bool
+						expectedHost bool
+						description  string
+					}{
+						{false, false, false, false, "no flags enabled"},
+						{true, false, true, false, "only placement enabled"},
+						{false, true, false, true, "only affinity enabled"},
+						{true, true, true, true, "both flags enabled"},
+					}
+
+					for _, tc := range testCases {
+						pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
+							config.Features.VMPlacementPolicies = tc.vmPlacement
+							config.Features.VMAffinityDuringExecution = tc.vmAffinity
+						})
+
+						constraints := virtualmachine.CalculateAffinityConstraints(vmCtx, false)
+						Expect(constraints.ConfigureHostRules).To(Equal(tc.expectedHost),
+							"Host rules mismatch for case: %s", tc.description)
+						Expect(constraints.ConfigureZoneRules).To(Equal(tc.expectedZone),
+							"Zone rules mismatch for case: %s", tc.description)
+					}
+				})
+
+				It("should disable zone rules during creation workflow regardless of flags", func() {
+					testCases := []struct {
+						vmPlacement  bool
+						vmAffinity   bool
+						expectedHost bool
+						description  string
+					}{
+						{false, false, false, "no flags enabled"},
+						{true, false, false, "only placement enabled"},
+						{false, true, true, "only affinity enabled"},
+						{true, true, true, "both flags enabled"},
+					}
+
+					for _, tc := range testCases {
+						pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
+							config.Features.VMPlacementPolicies = tc.vmPlacement
+							config.Features.VMAffinityDuringExecution = tc.vmAffinity
+						})
+
+						constraints := virtualmachine.CalculateAffinityConstraints(vmCtx, true)
+						Expect(constraints.ConfigureHostRules).To(Equal(tc.expectedHost),
+							"Host rules mismatch for case: %s", tc.description)
+						Expect(constraints.ConfigureZoneRules).To(BeFalse(),
+							"Zone rules should always be false during creation for case: %s", tc.description)
+					}
+				})
 			})
 
-			It("should respect feature flags during placement workflow", func() {
-				testCases := []struct {
-					vmPlacement  bool
-					vmAffinity   bool
-					expectedZone bool
-					expectedHost bool
-					description  string
-				}{
-					{false, false, false, false, "no flags enabled"},
-					{true, false, true, false, "only placement enabled"},
-					{false, true, false, true, "only affinity enabled"},
-					{true, true, true, true, "both flags enabled"},
-				}
+			When("VM has zone label", func() {
+				BeforeEach(func() {
+					vm.Labels = map[string]string{
+						"app":                         "test-app",
+						"topology.kubernetes.io/zone": "zone-a",
+					}
+				})
 
-				for _, tc := range testCases {
-					pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
-						config.Features.VMPlacementPolicies = tc.vmPlacement
-						config.Features.VMAffinityDuringExecution = tc.vmAffinity
-					})
+				It("should respect VMAffinityDuringExecution feature for zone-labeled VMs", func() {
+					testCases := []struct {
+						vmPlacement  bool
+						vmAffinity   bool
+						expectedZone bool
+						expectedHost bool
+						description  string
+					}{
+						{false, false, false, false, "no flags enabled"},
+						{true, false, true, false, "only placement enabled"},
+						{false, true, false, true, "only affinity enabled - zone label disables zone rules"},
+						{true, true, false, true, "both flags enabled - zone label disables zone rules"},
+					}
 
-					constraints := virtualmachine.CalculateAffinityConstraints(vmCtx, false)
-					Expect(constraints.ConfigureHostRules).To(Equal(tc.expectedHost),
-						"Host rules mismatch for case: %s", tc.description)
-					Expect(constraints.ConfigureZoneRules).To(Equal(tc.expectedZone),
-						"Zone rules mismatch for case: %s", tc.description)
-				}
-			})
+					for _, tc := range testCases {
+						pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
+							config.Features.VMPlacementPolicies = tc.vmPlacement
+							config.Features.VMAffinityDuringExecution = tc.vmAffinity
+						})
 
-			It("should disable zone rules during creation workflow regardless of flags", func() {
-				testCases := []struct {
-					vmPlacement  bool
-					vmAffinity   bool
-					expectedHost bool
-					description  string
-				}{
-					{false, false, false, "no flags enabled"},
-					{true, false, false, "only placement enabled"},
-					{false, true, true, "only affinity enabled"},
-					{true, true, true, "both flags enabled"},
-				}
-
-				for _, tc := range testCases {
-					pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
-						config.Features.VMPlacementPolicies = tc.vmPlacement
-						config.Features.VMAffinityDuringExecution = tc.vmAffinity
-					})
-
-					constraints := virtualmachine.CalculateAffinityConstraints(vmCtx, true)
-					Expect(constraints.ConfigureHostRules).To(Equal(tc.expectedHost),
-						"Host rules mismatch for case: %s", tc.description)
-					Expect(constraints.ConfigureZoneRules).To(BeFalse(),
-						"Zone rules should always be false during creation for case: %s", tc.description)
-				}
+						constraints := virtualmachine.CalculateAffinityConstraints(vmCtx, false)
+						Expect(constraints.ConfigureHostRules).To(Equal(tc.expectedHost),
+							"Host rules mismatch for case: %s", tc.description)
+						Expect(constraints.ConfigureZoneRules).To(Equal(tc.expectedZone),
+							"Zone rules mismatch for case: %s", tc.description)
+					}
+				})
 			})
 		})
 	})

--- a/pkg/providers/vsphere/vmprovider_vm.go
+++ b/pkg/providers/vsphere/vmprovider_vm.go
@@ -1621,11 +1621,18 @@ func (vs *vSphereVMProvider) vmCreateDoPlacement(
 
 	defer func() {
 		if retErr != nil {
-			pkgcond.MarkError(
+			// processPlacementResult may already have set a more specific
+			// reason (e.g. ZoneMismatch); only fall back to the generic
+			// NotReady reason when the condition is not already False.
+			if !pkgcond.IsFalse(
 				vmCtx.VM,
-				vmopv1.VirtualMachineConditionPlacementReady,
-				"NotReady",
-				retErr)
+				vmopv1.VirtualMachineConditionPlacementReady) {
+				pkgcond.MarkError(
+					vmCtx.VM,
+					vmopv1.VirtualMachineConditionPlacementReady,
+					"NotReady",
+					retErr)
+			}
 		} else {
 			pkgcond.MarkTrue(
 				vmCtx.VM,
@@ -1666,9 +1673,17 @@ func (vs *vSphereVMProvider) vmCreateDoPlacement(
 			return fmt.Errorf("VM is not linked to its group")
 		}
 
-		// If the VM has an explicit zone label, skip group placement
-		// and use the regular placement flow to respect the zone override.
-		if zoneName := vmCtx.VM.Labels[corev1.LabelTopologyZone]; zoneName == "" {
+		// Place the VM via its group when it has no zone label, or (with
+		// VMAffinityDuringExecution enabled) when it is a zone-labeled non-VKS
+		// VM so it can still benefit from DRS host recommendations. Zone-labeled
+		// VKS nodes, and any zone-labeled VM when the feature is disabled, use
+		// the regular placement flow to honor the zone override.
+		zoneName := vmCtx.VM.Labels[corev1.LabelTopologyZone]
+		useGroupPlacement := zoneName == "" ||
+			(pkgcfg.FromContext(vmCtx).Features.VMAffinityDuringExecution &&
+				!kubeutil.HasCAPILabels(vmCtx.VM.Labels))
+
+		if useGroupPlacement {
 			vmCtx.Logger.Info(
 				"Getting VM placement result from its group",
 				"groupName", vmCtx.VM.Spec.GroupName,
@@ -1819,6 +1834,34 @@ func processPlacementResult(
 	vcClient *vcclient.Client,
 	createArgs *VMCreateArgs,
 	result placement.Result) error {
+
+	isVksNodeVM := kubeutil.HasCAPILabels(vmCtx.VM.Labels)
+	// When VMAffinityDuringExecution is enabled, a zone-labeled non-VKS VM took
+	// part in group/DRS placement; the chosen zone must still match its pinned
+	// zone label. A mismatch means the VM would be relocated to a different
+	// zone, so block placement and surface a ZoneMismatch condition for the
+	// user to reconcile the label with the desired placement. VKS nodes and VMs
+	// without a zone label are unaffected.
+	if pkgcfg.FromContext(vmCtx).Features.VMAffinityDuringExecution {
+		if zoneLabel := vmCtx.VM.Labels[corev1.LabelTopologyZone]; zoneLabel != "" &&
+			!isVksNodeVM &&
+			result.ZoneName != "" &&
+			result.ZoneName != zoneLabel {
+
+			pkgcond.MarkFalse(
+				vmCtx.VM,
+				vmopv1.VirtualMachineConditionPlacementReady,
+				"ZoneMismatch",
+				"placement selected zone %q which differs from the VM zone label %q",
+				result.ZoneName, zoneLabel)
+
+			return pkgerr.NoRequeueError{
+				Message: fmt.Sprintf(
+					"placement zone %q does not match VM zone label %q",
+					result.ZoneName, zoneLabel),
+			}
+		}
+	}
 
 	if result.ZoneName != "" {
 		if pkgcfg.FromContext(vmCtx).Features.FastDeploy {

--- a/pkg/providers/vsphere/vmprovider_vm_group_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_group_test.go
@@ -22,6 +22,7 @@ import (
 	pkgerr "github.com/vmware-tanzu/vm-operator/pkg/errors"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
+	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
@@ -417,6 +418,121 @@ func vmGroupTests() {
 				err := vmProvider.CreateOrUpdateVirtualMachine(ctx, vm)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("VM is not linked to its group"))
+			})
+		})
+
+		Context("when VMAffinityDuringExecution is enabled", func() {
+			JustBeforeEach(func() {
+				pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+					config.Features.VMAffinityDuringExecution = true
+				})
+			})
+
+			When("VM is a VKS node", func() {
+				JustBeforeEach(func() {
+					vm.Labels[kubeutil.CAPWClusterRoleLabelKey] = "worker"
+					Expect(ctx.Client.Update(ctx, vm)).To(Succeed())
+				})
+
+				It("should bypass group placement and honor the zone override", func() {
+					err := vmProvider.CreateOrUpdateVirtualMachine(ctx, vm)
+					Expect(err).To(HaveOccurred())
+					Expect(pkgerr.IsNoRequeueError(err)).To(BeTrue())
+					Expect(err).To(MatchError(vsphere.ErrCreate))
+
+					// Verify VM was created
+					Expect(vm.Status.UniqueID).ToNot(BeEmpty())
+				})
+			})
+
+			When("VM is not a VKS node", func() {
+				var (
+					groupZone string
+					groupHost string
+					groupPool string
+				)
+
+				setGroupPlacementReady := func(placementZone string) {
+					GinkgoHelper()
+					ccrs := ctx.GetAZClusterComputes(placementZone)
+					Expect(ccrs).ToNot(BeEmpty())
+					hosts, err := ccrs[0].Hosts(ctx)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(hosts).ToNot(BeEmpty())
+					groupHost = hosts[0].Reference().Value
+
+					nsRP := ctx.GetResourcePoolForNamespace(nsInfo.Namespace, placementZone, "")
+					Expect(nsRP).ToNot(BeNil())
+					groupPool = nsRP.Reference().Value
+
+					Expect(ctx.Client.Get(
+						ctx, client.ObjectKeyFromObject(vmGroup), vmGroup)).To(Succeed())
+					vmGroup.Status.Members = []vmopv1.VirtualMachineGroupMemberStatus{
+						{
+							Name: vm.Name,
+							Kind: "VirtualMachine",
+							Conditions: []metav1.Condition{
+								{
+									Type:   vmopv1.VirtualMachineGroupMemberConditionPlacementReady,
+									Status: metav1.ConditionTrue,
+								},
+							},
+							Placement: &vmopv1.VirtualMachinePlacementStatus{
+								Zone: placementZone,
+								Node: groupHost,
+								Pool: groupPool,
+							},
+						},
+					}
+					Expect(ctx.Client.Status().Update(ctx, vmGroup)).To(Succeed())
+				}
+
+				When("group placement zone matches the VM zone label", func() {
+					JustBeforeEach(func() {
+						groupZone = zoneName
+						setGroupPlacementReady(groupZone)
+					})
+
+					It("should place the VM by group in its zone", func() {
+						err := vmProvider.CreateOrUpdateVirtualMachine(ctx, vm)
+						Expect(err).To(HaveOccurred())
+						Expect(pkgerr.IsNoRequeueError(err)).To(BeTrue())
+						Expect(err).To(MatchError(vsphere.ErrCreate))
+
+						// Verify VM was created
+						Expect(vm.Status.UniqueID).ToNot(BeEmpty())
+					})
+				})
+
+				When("group placement zone differs from the VM zone label", func() {
+					JustBeforeEach(func() {
+						Expect(len(ctx.ZoneNames)).To(BeNumerically(">", 1))
+
+						// get a random zone that is different from the VM zone
+						groupZone = zoneName
+						for groupZone == zoneName {
+							groupZone = ctx.ZoneNames[rand.Intn(len(ctx.ZoneNames))]
+						}
+						setGroupPlacementReady(groupZone)
+					})
+
+					It("should block placement with a ZoneMismatch condition", func() {
+						err := vmProvider.CreateOrUpdateVirtualMachine(ctx, vm)
+						Expect(err).To(HaveOccurred())
+						Expect(pkgerr.IsNoRequeueError(err)).To(BeTrue())
+						Expect(err.Error()).To(ContainSubstring("does not match VM zone label"))
+
+						By("VM is not created", func() {
+							Expect(vm.Status.UniqueID).To(BeEmpty())
+						})
+						By("PlacementReady is False with ZoneMismatch reason", func() {
+							c := conditions.Get(vm, vmopv1.VirtualMachineConditionPlacementReady)
+							Expect(c).ToNot(BeNil())
+							Expect(c.Status).To(Equal(metav1.ConditionFalse))
+							Expect(c.Reason).To(Equal("ZoneMismatch"))
+						})
+					})
+				})
 			})
 		})
 	})

--- a/pkg/util/kube/label.go
+++ b/pkg/util/kube/label.go
@@ -6,6 +6,8 @@ package kube
 
 import (
 	"strings"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -28,6 +30,14 @@ func HasCAPILabels(labels map[string]string) bool {
 	_, hasCAPVLabel := labels[CAPVClusterRoleLabelKey]
 
 	return hasCAPWLabel || hasCAPVLabel
+}
+
+// HasZoneLabel returns true if the VM has a label indicating it is pinned to a zone.
+func HasZoneLabel(labels map[string]string) bool {
+	labelValue, hasZoneLabel := labels[corev1.LabelTopologyZone]
+
+	return hasZoneLabel && labelValue != ""
+
 }
 
 // HasVMOperatorLabels returns true if the given labels map has a label key

--- a/pkg/util/kube/label_test.go
+++ b/pkg/util/kube/label_test.go
@@ -7,6 +7,7 @@ package kube_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 
 	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 )
@@ -32,6 +33,49 @@ var _ = Describe("Label", func() {
 		It("should return false if the VM has no Cluster API related labels", func() {
 			vmLabels := map[string]string{}
 			Expect(kubeutil.HasCAPILabels(vmLabels)).To(BeFalse())
+		})
+	})
+
+	Context("HasZoneLabel", func() {
+
+		It("should return true if the VM has a zone label", func() {
+			vmLabels := map[string]string{
+				corev1.LabelTopologyZone: "us-west-1a",
+			}
+			Expect(kubeutil.HasZoneLabel(vmLabels)).To(BeTrue())
+		})
+
+		It("should return false if the VM has a zone label with empty value", func() {
+			vmLabels := map[string]string{
+				corev1.LabelTopologyZone: "",
+			}
+			Expect(kubeutil.HasZoneLabel(vmLabels)).To(BeFalse())
+		})
+
+		It("should return true if the VM has a zone label along with other labels", func() {
+			vmLabels := map[string]string{
+				"app":                    "my-app",
+				corev1.LabelTopologyZone: "us-west-1a",
+				"version":                "1.0",
+			}
+			Expect(kubeutil.HasZoneLabel(vmLabels)).To(BeTrue())
+		})
+
+		It("should return false if the VM has no zone label", func() {
+			vmLabels := map[string]string{
+				"app":     "my-app",
+				"version": "1.0",
+			}
+			Expect(kubeutil.HasZoneLabel(vmLabels)).To(BeFalse())
+		})
+
+		It("should return false if the VM has an empty labels map", func() {
+			vmLabels := map[string]string{}
+			Expect(kubeutil.HasZoneLabel(vmLabels)).To(BeFalse())
+		})
+
+		It("should return false if the VM labels map is nil", func() {
+			Expect(kubeutil.HasZoneLabel(nil)).To(BeFalse())
 		})
 	})
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

When VMAffinityDuringExecution feature is enabled, zone-labeled VMs can now
participate in group placement to receive DRS host recommendations while still
respecting their zone labels. VKS nodes continue to bypass group placement
to maintain their zone pinning behavior unchanged.

Key changes:
- Zone-labeled VMs get optimal host placement within their assigned zones
- VKS nodes preserve existing zone override behavior
- Zone mismatch validation prevents VMs from being placed in wrong zones
- Backward compatibility maintained when feature flag is disabled

Changes by file:
- controllers/virtualmachinegroup_controller.go: Updated getVMForPlacement
  to allow non-VKS zone-labeled VMs in group placement when feature enabled
- pkg/providers/vsphere/vmprovider_vm.go: Modified placement result path
  to honor recommendations from DRS placement logic even for zone-labeled
  VMs which are not VKS nodes, added zone mismatch validation in
  processPlacementResult to prevent VMs from being placed in wrong zones,
  made error handling condition-aware to preserve ZoneMismatch reasons
- pkg/providers/vsphere/virtualmachine/configspec.go: Refactored
  CalculateAffinityConstraints to disable zone rules for VKS nodes,
  and VMAffinityDuringExecution+zone-labeled VMs.
- pkg/providers/vsphere/virtualmachine/configspec_test.go: Updated test
  expectations for VKS node zone rule behavior, added test cases for
  VMAffinityDuringExecution scenarios with zone-labeled VMs
- controllers/virtualmachinegroup_controller_test.go: Added test coverage
  for VKS vs non-VKS behavior with feature flag enabled
- pkg/providers/vsphere/vmprovider_vm_group_test.go: Added test scenarios
  for zone match, mismatch, and VKS bypass cases
- pkg/util/kube/label.go: Added HasZoneLabel helper function
- pkg/util/kube/label_test.go: Added test cases for HasZoneLabel helper function


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes vmop-3796


**Are there any special notes for your reviewer**:

- VMG + VM creation with Zone Label + VM-VM Host AF
- VMG + VM creation with Zone Label + VM-VM Host AAF
- VMG + VM creation with VKS Node labels + Zone Label
- VMGroup E2E Suite was run with the changes on a testbed with FF enabled

**Please add a release note if necessary**:

```release-note
Allow non-VKS node VMs with zone label to participate in group placement
```