### PR TITLE
[x-port] [9.1] Simplify GetContextWithWorkloadDomainIsolation

### DIFF
--- a/controllers/virtualmachine/virtualmachine/virtualmachine_controller.go
+++ b/controllers/virtualmachine/virtualmachine/virtualmachine_controller.go
@@ -369,7 +369,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 
 	// Update the type of placement logic based on whether or not the VM is a
 	// Kubernetes node and the WorkloadDomainIsolation capability.
-	ctx = vmopv1util.GetContextWithWorkloadDomainIsolation(ctx, *vm)
+	ctx = vmopv1util.GetContextWithWorkloadDomainIsolation(ctx, vm)
 	if !pkgcfg.FromContext(ctx).Features.WorkloadDomainIsolation {
 		logger.Info("Disabled WorkloadDomainIsolation capability for this VM")
 	}

--- a/pkg/util/vmopv1/vm.go
+++ b/pkg/util/vmopv1/vm.go
@@ -508,27 +508,26 @@ func IsKubernetesNode(vm vmopv1.VirtualMachine) bool {
 // WorkloadDomainIsolation capability set to a value based on the provided VM.
 func GetContextWithWorkloadDomainIsolation(
 	ctx context.Context,
-	vm vmopv1.VirtualMachine) context.Context {
+	vm *vmopv1.VirtualMachine) context.Context {
 
-	// Create a copy of the config so the WorkloadDomainIsolation capability
-	// may be altered for just this VM.
+	// Typically the WorkloadDomainIsolation will be enabled but older
+	// versions of vSphere Kubernetes Service (VKS) do not support
+	// that feature so it will be disabled. However, an old VKS version
+	// should not impact non-VKS VMs so enable it for just those VMs.
+
 	cfg := pkgcfg.FromContext(ctx)
-
-	// By default the WorkloadDomainIsolation capability is enabled for all
-	// VMs.
-	cfg.Features.WorkloadDomainIsolation = true
-
-	// If the VM is a Kubernetes node, the WorkloadDomainIsolation
-	// capability is determined by inspecting the value of the cluster's
-	// capability, which may be disabled based on the version of the vSphere
-	// Kubernetes Service (VKS).
-	if IsKubernetesNode(vm) {
-		cfg.Features.WorkloadDomainIsolation = pkgcfg.FromContext(ctx).
-			Features.WorkloadDomainIsolation
+	if cfg.Features.WorkloadDomainIsolation {
+		return ctx
 	}
 
+	if IsKubernetesNode(*vm) {
+		return ctx
+	}
+
+	// Enable WorkloadDomainIsolation for this non-VKS VM.
 	// Layer the updated Config into the context so all logic beneath this
 	// line in the call stack will use the updated value.
+	cfg.Features.WorkloadDomainIsolation = true
 	return pkgcfg.WithContext(ctx, cfg)
 }
 

--- a/pkg/util/vmopv1/vm_test.go
+++ b/pkg/util/vmopv1/vm_test.go
@@ -944,15 +944,32 @@ var _ = DescribeTable("GetContextWithWorkloadDomainIsolation",
 	func(
 		ctx context.Context,
 		vm vmopv1.VirtualMachine,
-		expected bool,
+		expected, identical bool,
 	) {
-		c := vmopv1util.GetContextWithWorkloadDomainIsolation(ctx, vm)
+		c := vmopv1util.GetContextWithWorkloadDomainIsolation(ctx, &vm)
 		Ω(pkgcfg.FromContext(c).Features.WorkloadDomainIsolation).Should(Equal(expected))
+		if identical {
+			Ω(c).Should(BeIdenticalTo(ctx))
+		} else {
+			Ω(c).ShouldNot(BeIdenticalTo(ctx))
+		}
 	},
 	Entry(
 		"is not kubernetes node",
 		pkgcfg.NewContext(),
 		vmopv1.VirtualMachine{},
+		true,
+		false,
+	),
+	Entry(
+		"is not kubernetes node with capability enabled",
+		pkgcfg.WithConfig(pkgcfg.Config{
+			Features: pkgcfg.FeatureStates{
+				WorkloadDomainIsolation: true,
+			},
+		}),
+		vmopv1.VirtualMachine{},
+		true,
 		true,
 	),
 	Entry(
@@ -966,6 +983,7 @@ var _ = DescribeTable("GetContextWithWorkloadDomainIsolation",
 			},
 		},
 		false,
+		true,
 	),
 	Entry(
 		"is kubernetes node with capability enabled",
@@ -981,6 +999,7 @@ var _ = DescribeTable("GetContextWithWorkloadDomainIsolation",
 				},
 			},
 		},
+		true,
 		true,
 	),
 )

--- a/webhooks/virtualmachine/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator.go
@@ -150,7 +150,7 @@ func (v validator) ValidateCreate(ctx *pkgctx.WebhookRequestContext) admission.R
 		return webhook.Errored(http.StatusBadRequest, err)
 	}
 
-	ctx.Context = vmopv1util.GetContextWithWorkloadDomainIsolation(ctx.Context, *vm)
+	ctx.Context = vmopv1util.GetContextWithWorkloadDomainIsolation(ctx.Context, vm)
 	if !pkgcfg.FromContext(ctx).Features.WorkloadDomainIsolation {
 		ctx.Logger.Info("Disabled WorkloadDomainIsolation capability for this VM")
 	}
@@ -245,7 +245,7 @@ func (v validator) ValidateUpdate(ctx *pkgctx.WebhookRequestContext) admission.R
 		return webhook.Errored(http.StatusBadRequest, err)
 	}
 
-	ctx.Context = vmopv1util.GetContextWithWorkloadDomainIsolation(ctx.Context, *vm)
+	ctx.Context = vmopv1util.GetContextWithWorkloadDomainIsolation(ctx.Context, vm)
 	if !pkgcfg.FromContext(ctx).Features.WorkloadDomainIsolation {
 		ctx.Logger.Info("Disabled WorkloadDomainIsolation capability for this VM")
 	}


### PR DESCRIPTION



**What does this PR do, and why is it needed?**

Crossport of #1497

The common case is that the WorkloadDomainIsolation feature is already enabled so no changes to the context will be needed so the existing context can be returned.

This was prompted by observations of high memory allocation here, especially for lots of VM validation webhook requests, since a new config would be allocated on the heap for every request.

While here, change this to take a VM function pointer since that is what all the callers of this are already passing around.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:


```release-note
Address issue with high memory usage in the VM validation webhook
```