### PR TITLE
[x-port] [9.1] ChangeBlockTracking fixes

### DIFF
--- a/pkg/providers/vsphere/session/session_vm_update.go
+++ b/pkg/providers/vsphere/session/session_vm_update.go
@@ -430,7 +430,7 @@ func (s *Session) poweredOnReconfigure(
 		return fmt.Errorf("update CD-ROM device connection error: %w", err)
 	}
 
-	if err := doReconfigure(
+	err := doReconfigure(
 		logr.NewContext(
 			vmCtx,
 			vmCtx.Logger.WithName("poweredOnReconfigure"),
@@ -439,12 +439,18 @@ func (s *Session) poweredOnReconfigure(
 		vmCtx.VM,
 		vcVM,
 		vmCtx.MoVM,
-		*configSpec); err != nil {
+		*configSpec)
 
-		return err
+	if errors.Is(err, ErrReconfigure) {
+		if cbtErr := s.reconcilePoweredOnChangeBlockTracking(vmCtx, configSpec); cbtErr != nil {
+			// The Reconfigure has been performed but we have no way to later determine if
+			// this needs to be called. We used to just this best effort after a reconfigure
+			// so continue to do that here for now. See vmon-3868 for a more complete fix.
+			vmCtx.Logger.Error(cbtErr, "Failed to update CBT for powered on VM")
+		}
 	}
 
-	if err := s.reconcileChangeTracking(vmCtx, configSpec); err != nil {
+	if err != nil {
 		return err
 	}
 
@@ -1291,29 +1297,21 @@ func reconcileAnnotationsToExtraConfig(
 		configSpec)
 }
 
-func (s *Session) reconcileChangeTracking(
+func (s *Session) reconcilePoweredOnChangeBlockTracking(
 	vmCtx pkgctx.VirtualMachineContext,
 	configSpec *vimtypes.VirtualMachineConfigSpec) error {
-
-	vmCtx.Logger.V(4).Info("Reconciling change tracking")
-
-	if vmCtx.MoVM.Runtime.PowerState !=
-		vimtypes.VirtualMachinePowerStatePoweredOn {
-
-		vmCtx.Logger.V(4).Info("Skipping reconciliation of change tracking " +
-			"of vm that is not powered on")
-		return nil
-	}
-
-	if configSpec.ChangeTrackingEnabled == nil {
-		vmCtx.Logger.V(4).Info("Skipping reconciliation of change tracking " +
-			"of vm where feature is not enabled")
-		return nil
-	}
 
 	// Special case for CBT: in order for CBT change take effect for a powered
 	// on VM, a checkpoint save/restore is needed. The FSR call allows CBT to
 	// take effect for powered-on VMs.
+
+	if configSpec.ChangeTrackingEnabled == nil {
+		return nil
+	}
+
+	vmCtx.Logger.Info("Invoking FSR for ChangeBlockTracking update",
+		"enabled", configSpec.ChangeTrackingEnabled)
+
 	if err := s.invokeFsrVirtualMachine(vmCtx); err != nil {
 		return fmt.Errorf("failed to invoke FSR for CBT update: %w", err)
 	}

--- a/pkg/providers/vsphere/vmprovider_vm_cbt_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_cbt_test.go
@@ -1,0 +1,224 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package vsphere_test
+
+import (
+	"context"
+	"reflect"
+	"sync/atomic"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vim25/mo"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
+	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
+	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
+	"github.com/vmware-tanzu/vm-operator/pkg/providers"
+	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
+	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/internal"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+func init() {
+	// Register InvokeFSR_TaskRequest so that vcsim's UnmarshalBody can parse
+	// the SOAP body for InvokeFSR_Task calls. Without this registration
+	// UnmarshalBody fails with "no vmomi type defined for 'InvokeFSR_Task'"
+	// before call() is reached, which means Map.Handler is never invoked and
+	// fsrInvoked is never set. vcsim does not natively implement InvokeFSR_Task,
+	// so the handler intercepts it and returns MethodNotFound.
+	vimtypes.Add("InvokeFSR_Task",
+		reflect.TypeOf((*internal.InvokeFSR_TaskRequest)(nil)).Elem())
+}
+
+func vmCBTTests() {
+	var (
+		parentCtx   context.Context
+		initObjects []client.Object
+		testConfig  builder.VCSimTestConfig
+		ctx         *builder.TestContextForVCSim
+		vmProvider  providers.VirtualMachineProviderInterface
+		nsInfo      builder.WorkloadNamespaceInfo
+
+		vm      *vmopv1.VirtualMachine
+		vmClass *vmopv1.VirtualMachineClass
+	)
+
+	BeforeEach(func() {
+		parentCtx = pkgcfg.NewContextWithDefaultConfig()
+		parentCtx = ctxop.WithContext(parentCtx)
+		parentCtx = ovfcache.WithContext(parentCtx)
+		parentCtx = cource.WithContext(parentCtx)
+		pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
+			config.AsyncCreateEnabled = false
+			config.AsyncSignalEnabled = false
+		})
+		testConfig = builder.VCSimTestConfig{
+			WithContentLibrary: true,
+		}
+
+		vmClass = builder.DummyVirtualMachineClassGenName()
+		vm = builder.DummyBasicVirtualMachine("test-vm", "")
+
+		if vm.Spec.Network == nil {
+			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
+		}
+		vm.Spec.Network.Disabled = true
+	})
+
+	JustBeforeEach(func() {
+		ctx = suite.NewTestContextForVCSimWithParentContext(
+			parentCtx, testConfig, initObjects...)
+		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+			config.MaxDeployThreadsOnProvider = 1
+		})
+		vmProvider = vsphere.NewVSphereVMProviderFromClient(
+			ctx, ctx.Client, ctx.Recorder)
+		nsInfo = ctx.CreateWorkloadNamespace()
+
+		vmClass.Namespace = nsInfo.Namespace
+		Expect(ctx.Client.Create(ctx, vmClass)).To(Succeed())
+
+		clusterVMI1 := &vmopv1.ClusterVirtualMachineImage{}
+
+		if testConfig.WithContentLibrary {
+			Expect(ctx.Client.Get(
+				ctx, client.ObjectKey{Name: ctx.ContentLibraryItem1Name},
+				clusterVMI1)).To(Succeed())
+		} else {
+			vsphere.SkipVMImageCLProviderCheck = true
+			clusterVMI1 = builder.DummyClusterVirtualMachineImage("DC0_C0_RP0_VM0")
+			Expect(ctx.Client.Create(ctx, clusterVMI1)).To(Succeed())
+			conditions.MarkTrue(clusterVMI1, vmopv1.ReadyConditionType)
+			Expect(ctx.Client.Status().Update(ctx, clusterVMI1)).To(Succeed())
+		}
+
+		vm.Namespace = nsInfo.Namespace
+		vm.Spec.ClassName = vmClass.Name
+		vm.Spec.ImageName = clusterVMI1.Name
+		vm.Spec.Image.Kind = cvmiKind
+		vm.Spec.Image.Name = clusterVMI1.Name
+		vm.Spec.StorageClass = ctx.StorageClassName
+
+		Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		vsphere.SkipVMImageCLProviderCheck = false
+		ctx.AfterEach()
+		ctx = nil
+		initObjects = nil
+	})
+
+	Context("powered-on VM", func() {
+		When("ChangeBlockTracking is updated", func() {
+			var fsrInvoked atomic.Bool
+
+			JustBeforeEach(func() {
+				// Deploy and power on the VM without CBT before installing
+				// the intercept handler.
+				Expect(createOrUpdateVM(ctx, vmProvider, vm)).To(Succeed())
+				Expect(vm.Status.PowerState).To(Equal(vmopv1.VirtualMachinePowerStateOn))
+
+				// vcsim does not natively implement InvokeFSR_Task, so the
+				// Map.Handler intercepts the call, records that FSR was attempted,
+				// and returns MethodNotFound. reconcilePoweredOnChangeBlockTracking
+				// treats FSR failure as best-effort: it logs the error but does not
+				// propagate it, so the overall reconcile still succeeds.
+				fsrInvoked.Store(false)
+				ctx.SimulatorContext().Map.Handler = func(
+					_ *simulator.Context,
+					m *simulator.Method) (mo.Reference, vimtypes.BaseMethodFault) {
+
+					if m.Name == "InvokeFSR_Task" {
+						fsrInvoked.Store(true)
+						return nil, &vimtypes.MethodNotFound{
+							Receiver: m.This,
+							Method:   m.Name,
+						}
+					}
+					return nil, nil
+				}
+			})
+
+			AfterEach(func() {
+				ctx.SimulatorContext().Map.Handler = nil
+			})
+
+			It("invokes FSR and updates the ConfigSpec when CBT changes", func() {
+				vcVM := ctx.GetVMFromMoID(vm.Status.UniqueID)
+				Expect(vcVM).ToNot(BeNil())
+
+				var moVM mo.VirtualMachine
+
+				By("enabling CBT on the powered-on VM", func() {
+					vm.Spec.Advanced = &vmopv1.VirtualMachineAdvancedSpec{
+						ChangeBlockTracking: ptr.To(true),
+					}
+					Expect(createOrUpdateVM(ctx, vmProvider, vm)).To(Succeed())
+					Expect(vcVM.Properties(ctx, vcVM.Reference(), []string{"config"}, &moVM)).To(Succeed())
+				})
+
+				By("verifying CBT is enabled in the VM config", func() {
+					Expect(moVM.Config.ChangeTrackingEnabled).To(HaveValue(BeTrue()))
+				})
+
+				By("verifying the status reflects CBT enabled", func() {
+					Expect(vm.Status.ChangeBlockTracking).To(HaveValue(BeTrue()))
+				})
+
+				By("verifying FSR was attempted to apply CBT on the live VM", func() {
+					Expect(fsrInvoked.Load()).To(BeTrue())
+				})
+
+				By("disabling CBT on the powered-on VM", func() {
+					fsrInvoked.Store(false)
+					vm.Spec.Advanced.ChangeBlockTracking = ptr.To(false)
+					Expect(createOrUpdateVM(ctx, vmProvider, vm)).To(Succeed())
+					Expect(vcVM.Properties(ctx, vcVM.Reference(), []string{"config"}, &moVM)).To(Succeed())
+				})
+
+				By("verifying CBT is disabled in the VM config", func() {
+					Expect(moVM.Config.ChangeTrackingEnabled).To(HaveValue(BeFalse()))
+				})
+
+				By("verifying the status reflects CBT disabled", func() {
+					Expect(vm.Status.ChangeBlockTracking).To(HaveValue(BeFalse()))
+				})
+
+				By("verifying FSR was attempted again to apply the CBT change", func() {
+					Expect(fsrInvoked.Load()).To(BeTrue())
+				})
+			})
+
+			It("does not invoke FSR when CBT did not change", func() {
+				// Enable CBT on the first reconcile. The configSpec includes
+				// ChangeTrackingEnabled, doReconfigure returns ErrReconfigure,
+				// and reconcilePoweredOnChangeBlockTracking invokes FSR.
+				vm.Spec.Advanced = &vmopv1.VirtualMachineAdvancedSpec{
+					ChangeBlockTracking: ptr.To(true),
+				}
+				Expect(createOrUpdateVM(ctx, vmProvider, vm)).To(Succeed())
+				Expect(fsrInvoked.Load()).To(BeTrue(),
+					"FSR should be attempted when CBT is first enabled on a powered-on VM")
+
+				fsrInvoked.Store(false)
+				Expect(createOrUpdateVM(ctx, vmProvider, vm)).To(Succeed())
+
+				By("verifying FSR is not re-attempted when CBT did not change", func() {
+					Expect(fsrInvoked.Load()).To(BeFalse())
+				})
+			})
+		})
+	})
+}

--- a/pkg/providers/vsphere/vsphere_suite_test.go
+++ b/pkg/providers/vsphere/vsphere_suite_test.go
@@ -31,6 +31,7 @@ func vcSimTests() {
 	Describe("ResourcePolicyTests", resourcePolicyTests)
 	Describe("VAppConfigExpressionProperties", vAppConfigExpressionTests)
 	Describe("VirtualMachine", vmTests)
+	Describe("VirtualMachine - CBT", vmCBTTests)
 	Describe("VirtualMachineE2E", vmE2ETests)
 	Describe("VirtualMachineResize", vmResizeTests)
 	Describe("VirtualMachineUtilsTest", vmUtilTests)

--- a/pkg/util/vsphere/watcher/watcher.go
+++ b/pkg/util/vsphere/watcher/watcher.go
@@ -37,6 +37,7 @@ func DefaultWatchedPropertyPaths() []string {
 	return []string{
 		"config.annotation",
 
+		"config.changeTrackingEnabled",
 		"config.extraConfig",
 		"config.hardware.device",
 		"config.keyId",


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

Crossport for two CBT changes:
 - https://github.com/vmware-tanzu/vm-operator/pull/1613
 - https://github.com/vmware-tanzu/vm-operator/pull/1635

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note
Address issues with ChangeBlockTracking not be enabled/disabled for a powered on VM
```