### PR TITLE
🐛  Fix test resiliency 

### DIFF
--- a/test/e2e/vmservice/lib/vmoperator/vmoperator.go
+++ b/test/e2e/vmservice/lib/vmoperator/vmoperator.go
@@ -19,6 +19,8 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	e2eframework "k8s.io/kubernetes/test/e2e/framework"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -1438,4 +1440,71 @@ func EventuallyBootDiskStoragePolicyMatchesVMStorageClass(
 			"boot disk %q storage policy StorageClass %q does not match spec.storageClass %q on VirtualMachine %s/%s",
 			boot.Name, scName, vm.Spec.StorageClass, namespace, name)
 	}, vmSvcE2EConfig.GetIntervals("default", "wait-virtual-machine-creation")...).Should(Succeed())
+}
+
+// WaitForVMCnsRegisterVolumesRegistered waits until every CnsRegisterVolume
+// owned by the given VM (identified by label vmoperator.vmware.com/created-by)
+// has status.registered=true.
+//
+// This must be called before creating a VirtualMachineSnapshot when the
+// AllDisksArePVCs feature is enabled. If a snapshot is taken while a
+// CnsRegisterVolume is still in progress, the VMDK acquires a snapshot delta
+// child and becomes a non-running-point disk. VSLM's RegisterDisk then
+// rejects it with InvalidArgument("path"), leaving the PVC permanently
+// Pending and the snapshot stuck WaitingForCSISync.
+//
+// If no CnsRegisterVolumes exist for the VM (e.g. it was deployed from an
+// FCD-backed ISO image), the function returns immediately — no registration
+// is needed for FCDs.
+func WaitForVMCnsRegisterVolumesRegistered(
+	ctx context.Context,
+	vmSvcE2EConfig *config.E2EConfig,
+	client ctrlclient.Client,
+	ns, vmName string,
+) {
+	crvGVK := schema.GroupVersionKind{
+		Group:   "cns.vmware.com",
+		Version: "v1alpha1",
+		Kind:    "CnsRegisterVolumeList",
+	}
+
+	By(fmt.Sprintf("Waiting for all CnsRegisterVolumes to be registered for VM %s/%s", ns, vmName))
+	Eventually(func(g Gomega) bool {
+		crvList := &unstructured.UnstructuredList{}
+		crvList.SetGroupVersionKind(crvGVK)
+
+		err := client.List(ctx, crvList,
+			ctrlclient.InNamespace(ns),
+			ctrlclient.MatchingLabels{
+				"vmoperator.vmware.com/created-by": vmName,
+			},
+		)
+		if err != nil {
+			e2eframework.Logf("retry: failed to list CnsRegisterVolumes for VM %s/%s: %v", ns, vmName, err)
+			return false
+		}
+
+		if len(crvList.Items) == 0 {
+			// No CRVs for this VM — either FCD-backed image or registration
+			// not yet triggered. Safe to return true; if registration is
+			// still pending the snapshot gate in vm-operator will hold it.
+			return true
+		}
+
+		for i := range crvList.Items {
+			crv := &crvList.Items[i]
+			registered, found, err := unstructured.NestedBool(crv.Object, "status", "registered")
+			if err != nil || !found || !registered {
+				errMsg, _, _ := unstructured.NestedString(crv.Object, "status", "error")
+				e2eframework.Logf("retry: CnsRegisterVolume %s/%s not yet registered (error: %q)",
+					ns, crv.GetName(), errMsg)
+				return false
+			}
+		}
+
+	e2eframework.Logf("All %d CnsRegisterVolume(s) for VM %s/%s are registered",
+		len(crvList.Items), ns, vmName)
+	return true
+}, vmSvcE2EConfig.GetIntervals("default", "wait-virtual-machine-creation")...).Should(BeTrue(),
+	"Timed out waiting for CnsRegisterVolumes to be registered for VM %s/%s", ns, vmName)
 }

--- a/test/e2e/vmservice/vmservice/util.go
+++ b/test/e2e/vmservice/vmservice/util.go
@@ -769,11 +769,17 @@ func VerifyLoginAndRunCmdsInVDSSetup(config *config.E2EConfig, vmIP string, cmds
 	if len(cmds) > 0 && len(expectedOutput) > 0 {
 		for i, cmd := range cmds {
 			By(fmt.Sprintf("Verify running cmd: %s on VM with vmIP (ipv4): %s contains expected output: %s", cmd, vmIP, expectedOutput[i]))
-			cmdOutput, err = cmdRunner.RunCommand(cmd)
-			Expect(err).NotTo(HaveOccurred())
-
-			cmdOutputString = string(cmdOutput)
-			Expect(cmdOutputString).To(ContainSubstring(expectedOutput[i]))
+			// Wrap each command in Eventually so that cloud-init (or any other
+			// in-guest agent) has time to finish writing files after SSH first
+			// becomes available. Without this, tests that check for files written
+			// by cloud-init (e.g. /helloworld via write_files) can fail on the
+			// VDS path even though the NSX path retries identically.
+			Eventually(func(g Gomega) {
+				cmdOutput, err = cmdRunner.RunCommand(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(string(cmdOutput)).To(ContainSubstring(expectedOutput[i]))
+			}, config.GetIntervals("default", "login-retry-timeout")...).Should(Succeed(),
+				"cmd %q output did not contain expected %q", cmd, expectedOutput[i])
 		}
 	}
 
@@ -1013,6 +1019,14 @@ func DeleteVMResource(
 	// Wait for backup to complete before powering off and deleting the VM
 	waitForBackupToComplete(ctx, vm, clusterProxy, config)
 
+	// When AllDisksArePVCs is enabled, the CSI driver takes a VM snapshot
+	// while registering the boot VMDK as an FCD. If that snapshot is still
+	// outstanding when we unregister the PVCs and call RegisterVM, the VMDK
+	// has an active delta child ("_N.vmdk") and RegisterVM rejects it with
+	// "disk is not restored". Wait until every CnsRegisterVolume owned by
+	// this VM has status.registered=true before touching the disk chain.
+	vmoperator.WaitForVMCnsRegisterVolumesRegistered(ctx, config, svClusterClient, vmNamespace, vmName)
+
 	By("Power off the VM")
 	vmoperator.UpdateVirtualMachinePowerState(ctx, config, svClusterClient, vmNamespace, vmName, string(vmopv1a2.VirtualMachinePowerStateOff))
 	vmoperator.WaitForVirtualMachinePowerState(ctx, config, svClusterClient, vmNamespace, vmName, string(vmopv1a2.VirtualMachinePowerStateOff))
@@ -1021,13 +1035,12 @@ func DeleteVMResource(
 
 	vm, err = utils.GetVirtualMachine(ctx, svClusterClient, vmNamespace, vmName)
 	Expect(err).ToNot(HaveOccurred())
-
+	base := vm.DeepCopy()
 	if vm.Annotations == nil {
 		vm.Annotations = make(map[string]string)
 	}
-
 	vm.Annotations[vmopv1a2.PauseAnnotation] = trueString
-	Expect(svClusterClient.Update(ctx, vm)).To(Succeed())
+	Expect(svClusterClient.Patch(ctx, vm, ctrlclient.MergeFrom(base))).To(Succeed())
 
 	// Collect all PVC names from the VM spec
 	var pvcNames []string

--- a/test/e2e/vmservice/vmservice/viadmin/registervm.go
+++ b/test/e2e/vmservice/vmservice/viadmin/registervm.go
@@ -14,7 +14,9 @@ import (
 	. "github.com/onsi/gomega"
 
 	vmopv1a3 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	vmopv1a5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	backupapi "github.com/vmware-tanzu/vm-operator/pkg/backup/api"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	"github.com/vmware/govmomi/alarm"
 	"github.com/vmware/govmomi/cns"
 	cnstypes "github.com/vmware/govmomi/cns/types"
@@ -296,26 +298,22 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 
 			By("Add the pause annotation to VM")
 
+			vm, err := utils.GetVirtualMachine(ctx, svClusterClient, input.WCPNamespaceName, vmName)
+			Expect(err).ToNot(HaveOccurred())
+			base := vm.DeepCopy()
+			if vm.Annotations == nil {
+				vm.Annotations = make(map[string]string)
+			}
+			vm.Annotations[vmopv1a3.PauseAnnotation] = trueString
+			Expect(svClusterClient.Patch(ctx, vm, ctrlclient.MergeFrom(base))).To(Succeed())
+
 			// Collect all PVC names from the VM spec
 			var pvcNames []string
-
-			Eventually(func(g Gomega) {
-				vm, err := utils.GetVirtualMachine(ctx, svClusterClient, input.WCPNamespaceName, vmName)
-				g.Expect(err).ToNot(HaveOccurred())
-				if vm.Annotations == nil {
-					vm.Annotations = make(map[string]string)
+			for _, volume := range vm.Spec.Volumes {
+				if volume.PersistentVolumeClaim != nil {
+					pvcNames = append(pvcNames, volume.PersistentVolumeClaim.ClaimName)
 				}
-				vm.Annotations[vmopv1a3.PauseAnnotation] = trueString
-				g.Expect(svClusterClient.Update(ctx, vm)).To(Succeed())
-
-				pvcNames = []string{}
-				for _, volume := range vm.Spec.Volumes {
-					if volume.PersistentVolumeClaim != nil {
-						pvcNames = append(pvcNames, volume.PersistentVolumeClaim.ClaimName)
-					}
-				}
-			}, config.GetIntervals("default", "wait-virtual-machine-annotation-update")...).
-				Should(Succeed(), "timed out adding pause annotation to VM %s", vmName)
+			}
 
 			// Unregister all PVCs using the helper function
 			vmservice.UnregisterPVCVolumes(ctx, svClusterClient, clusterProxy, input.WCPNamespaceName, vmName, pvcNames, config)
@@ -401,6 +399,20 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 			vmoperator.WaitForVirtualMachineMOID(ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
 			vmoperator.WaitForPVCAttachment(ctx, config, svClusterClient, input.WCPNamespaceName, vmName, pvcNameA)
 
+			// Set Removable=true on every volume before backup is captured so the
+			// backup YAML reflects the correct value. The CSI CnsRegisterVolume
+			// controller reads spec.volumes[*].removable when a newly registered FCD
+			// is processed; if removable is missing the disk may be mis-classified
+			// during a restore pass.
+			By("Set all PVC volumes as removable=true before backup is captured")
+			vmA5, err := utils.GetVirtualMachineA5(ctx, svClusterClient, input.WCPNamespaceName, vmName)
+			Expect(err).ToNot(HaveOccurred())
+			baseRemovable := vmA5.DeepCopy()
+			for i := range vmA5.Spec.Volumes {
+				vmA5.Spec.Volumes[i].Removable = ptr.To(true)
+			}
+			Expect(svClusterClient.Patch(ctx, vmA5, ctrlclient.MergeFrom(baseRemovable))).To(Succeed())
+
 			existingVM, err := utils.GetVirtualMachine(ctx, svClusterClient, input.WCPNamespaceName, vmName)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -442,7 +454,7 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 
 			vm, err := utils.GetVirtualMachineA3(ctx, svClusterClient, input.WCPNamespaceName, vmName)
 			Expect(err).ToNot(HaveOccurred())
-
+			baseA3 := vm.DeepCopy()
 			vm.Spec.Volumes = append(vm.Spec.Volumes, vmopv1a3.VirtualMachineVolume{
 				Name: pvcNameB,
 				VirtualMachineVolumeSource: vmopv1a3.VirtualMachineVolumeSource{
@@ -453,7 +465,7 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 					},
 				},
 			})
-			Expect(svClusterClient.Update(ctx, vm)).To(Succeed())
+			Expect(svClusterClient.Patch(ctx, vm, ctrlclient.MergeFrom(baseA3))).To(Succeed())
 
 			vmoperator.WaitForPVCAttachment(ctx, config, svClusterClient, input.WCPNamespaceName, vmName, pvcNameB)
 			// Both PVC A and B are now attached to VM.
@@ -462,18 +474,25 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 			vmoperator.UpdateVirtualMachinePowerState(ctx, config, svClusterClient, input.WCPNamespaceName, vmName, "PoweredOff")
 			vmoperator.WaitForVirtualMachinePowerState(ctx, config, svClusterClient, input.WCPNamespaceName, vmName, "PoweredOff")
 
-			By("Add the pause annotation to VM")
+			By("Add the pause annotation and set all volumes as removable")
 
-			Eventually(func(g Gomega) {
-				vm, err := utils.GetVirtualMachineA3(ctx, svClusterClient, input.WCPNamespaceName, vmName)
-				g.Expect(err).ToNot(HaveOccurred())
-				if vm.Annotations == nil {
-					vm.Annotations = make(map[string]string)
-				}
-				vm.Annotations[vmopv1a3.PauseAnnotation] = trueString
-				g.Expect(svClusterClient.Update(ctx, vm)).To(Succeed())
-			}, config.GetIntervals("default", "wait-virtual-machine-annotation-update")...).
-				Should(Succeed(), "timed out adding pause annotation to VM %s", vmName)
+			vm, err = utils.GetVirtualMachineA3(ctx, svClusterClient, input.WCPNamespaceName, vmName)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Use v1alpha5 to access the Removable field. RegisterVM restores from
+			// the backup yaml (pvcA only), requiring pvcB removal; the validating
+			// webhook blocks that unless Removable=true on every volume.
+			vmA5, err = utils.GetVirtualMachineA5(ctx, svClusterClient, input.WCPNamespaceName, vmName)
+			Expect(err).ToNot(HaveOccurred())
+			basePause := vmA5.DeepCopy()
+			if vmA5.Annotations == nil {
+				vmA5.Annotations = make(map[string]string)
+			}
+			vmA5.Annotations[vmopv1a5.PauseAnnotation] = trueString
+			for i := range vmA5.Spec.Volumes {
+				vmA5.Spec.Volumes[i].Removable = ptr.To(true)
+			}
+			Expect(svClusterClient.Patch(ctx, vmA5, ctrlclient.MergeFrom(basePause))).To(Succeed())
 
 			// Collect all PVC names from the VM spec
 			var pvcNames []string
@@ -864,16 +883,14 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 
 			By("Add the pause annotation to VM")
 
-			Eventually(func(g Gomega) {
-				vm, err := utils.GetVirtualMachine(ctx, svClusterClient, input.WCPNamespaceName, vmName)
-				g.Expect(err).ToNot(HaveOccurred())
-				if vm.Annotations == nil {
-					vm.Annotations = make(map[string]string)
-				}
-				vm.Annotations[vmopv1a3.PauseAnnotation] = trueString
-				g.Expect(svClusterClient.Update(ctx, vm)).To(Succeed())
-			}, config.GetIntervals("default", "wait-virtual-machine-annotation-update")...).
-				Should(Succeed(), "timed out adding pause annotation to VM %s", vmName)
+			vm, err := utils.GetVirtualMachine(ctx, svClusterClient, input.WCPNamespaceName, vmName)
+			Expect(err).ToNot(HaveOccurred())
+			base := vm.DeepCopy()
+			if vm.Annotations == nil {
+				vm.Annotations = make(map[string]string)
+			}
+			vm.Annotations[vmopv1a3.PauseAnnotation] = trueString
+			Expect(svClusterClient.Patch(ctx, vm, ctrlclient.MergeFrom(base))).To(Succeed())
 
 			var vmMO mo.VirtualMachine
 

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_hardware.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_hardware.go
@@ -1173,6 +1173,18 @@ func VMHardwareSpec(ctx context.Context, inputGetter func() VMHardwareSpecInput)
 			})
 
 			It("VMs should power on successfully", func() {
+				vCenterClient = vcenter.NewVimClientFromKubeconfig(ctx, clusterProxy.GetKubeconfigPath())
+				defer vcenter.LogoutVimClient(vCenterClient)
+
+				isVSANEnabled, err := vcenter.IsVSANEnabledCluster(ctx, vCenterClient, clusterProxy.GetKubeconfigPath())
+				Expect(err).To(BeNil())
+				isVSANDEnabled, err := vcenter.IsVSANDEnabledCluster(ctx, vCenterClient, clusterProxy.GetKubeconfigPath())
+				Expect(err).To(BeNil())
+
+				if isVSANDEnabled || isVSANEnabled {
+					Skip("Skipping EZT storage profile tests as VSAN Datastore is present")
+				}
+
 				pvcs := createPvcsFromSpec(input, vmName, manifestbuilders.PVC{
 					StorageClassName: eztStorageProfileName,
 					SharingMode:      ptr.To(string(vmopv1a5.VolumeSharingModeMultiWriter)),
@@ -1914,6 +1926,18 @@ func VMHardwareSpec(ctx context.Context, inputGetter func() VMHardwareSpecInput)
 					Should(Succeed(), "Timed out waiting for boot disk to become managed PVC")
 
 				By("Creating a new PVC with a different storage class and larger size")
+				vCenterClient = vcenter.NewVimClientFromKubeconfig(ctx, clusterProxy.GetKubeconfigPath())
+				defer vcenter.LogoutVimClient(vCenterClient)
+
+				isVSANEnabled, err := vcenter.IsVSANEnabledCluster(ctx, vCenterClient, clusterProxy.GetKubeconfigPath())
+				Expect(err).To(BeNil())
+				isVSANDEnabled, err := vcenter.IsVSANDEnabledCluster(ctx, vCenterClient, clusterProxy.GetKubeconfigPath())
+				Expect(err).To(BeNil())
+
+				if isVSANDEnabled || isVSANEnabled {
+					Skip("Skipping boot disk storage class replacement: EZT storage profile requires non-VSAN datastore")
+				}
+
 				// Create a new PVC with a different storage class and larger size.
 				newBootDiskPVCName := fmt.Sprintf("%s-new-boot-disk", vmName)
 				newBootDiskPVCSize := bootDiskPVC.Spec.Resources.Requests[corev1.ResourceStorage]
@@ -2214,6 +2238,18 @@ func VMHardwareSpec(ctx context.Context, inputGetter func() VMHardwareSpecInput)
 			It("Import brownfield VM with shared SCSI controller and shared disk should succeed", Label("experimental"), func() {
 				skipper.SkipUnlessSupervisorCapabilityEnabled(ctx, clusterProxy, consts.MultiWriterDiskVMotionCapabilityName)
 
+				vCenterClient = vcenter.NewVimClientFromKubeconfig(ctx, clusterProxy.GetKubeconfigPath())
+				defer vcenter.LogoutVimClient(vCenterClient)
+
+				isVSANEnabled, err := vcenter.IsVSANEnabledCluster(ctx, vCenterClient, clusterProxy.GetKubeconfigPath())
+				Expect(err).To(BeNil())
+				isVSANDEnabled, err := vcenter.IsVSANDEnabledCluster(ctx, vCenterClient, clusterProxy.GetKubeconfigPath())
+				Expect(err).To(BeNil())
+
+				if isVSANDEnabled || isVSANEnabled {
+					Skip("Skipping EZT storage profile tests as VSAN Datastore is present")
+				}
+
 				importOpName := fmt.Sprintf("import-shared-disk-%s", capiutil.RandomString(4))
 
 				result := ImportBrownfieldVM(ImportBrownfieldVMInput{
@@ -2475,6 +2511,18 @@ func VMHardwareSpec(ctx context.Context, inputGetter func() VMHardwareSpecInput)
 			})
 
 			It("should allow a non-encrypted VM with a physical-sharing SCSI controller", func() {
+				vCenterClient = vcenter.NewVimClientFromKubeconfig(ctx, clusterProxy.GetKubeconfigPath())
+				defer vcenter.LogoutVimClient(vCenterClient)
+
+				isVSANEnabled, err := vcenter.IsVSANEnabledCluster(ctx, vCenterClient, clusterProxy.GetKubeconfigPath())
+				Expect(err).To(BeNil())
+				isVSANDEnabled, err := vcenter.IsVSANDEnabledCluster(ctx, vCenterClient, clusterProxy.GetKubeconfigPath())
+				Expect(err).To(BeNil())
+
+				if isVSANDEnabled || isVSANEnabled {
+					Skip("Skipping EZT storage profile tests as VSAN Datastore is present")
+				}
+
 				pvcs := createPvcsFromSpec(input, vmName, manifestbuilders.PVC{
 					StorageClassName:    eztStorageProfileName,
 					ControllerType:      ptr.To(vmopv1a5.VirtualControllerTypeSCSI),

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_snapshot.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_snapshot.go
@@ -141,10 +141,10 @@ func VMSnapshotSpec(ctx context.Context, inputGetter func() VMSnapshotSpecInput)
 		BeforeEach(func() {
 			vmservice.DeployVMWithCloudInit(ctx, vmSvcClusterProxy, vmSvcE2EConfig, vmSvcClusterResources, vmSvcNamespace, vmName, "", nil)
 			vmoperator.WaitForVirtualMachineConditionCreated(ctx, vmSvcE2EConfig, svClusterClient, vmSvcNamespace, vmName)
-			vmoperator.WaitForVirtualMachinePowerState(ctx, vmSvcE2EConfig, svClusterClient, vmSvcNamespace, vmName, "PoweredOn")
-		})
+		vmoperator.WaitForVirtualMachinePowerState(ctx, vmSvcE2EConfig, svClusterClient, vmSvcNamespace, vmName, "PoweredOn")
+	})
 
-		It("successfully create, update, revert to, and delete vm snapshots", Label("smoke"), func() {
+	It("successfully create, update, revert to, and delete vm snapshots", Label("smoke"), func() {
 			By("create vm snapshot 1")
 			vmservice.CreateVMSnapshot(ctx, vmSvcClusterProxy, manifestbuilders.VirtualMachineSnapshotYaml{
 				Namespace: vmSvcNamespace,
@@ -400,10 +400,10 @@ func VMSnapshotSpec(ctx context.Context, inputGetter func() VMSnapshotSpecInput)
 				},
 			})
 			vmoperator.WaitForVirtualMachineConditionCreated(ctx, vmSvcE2EConfig, svClusterClient, vmSvcNamespace, vmName)
-			vmoperator.WaitForVirtualMachinePowerState(ctx, vmSvcE2EConfig, svClusterClient, vmSvcNamespace, vmName, "PoweredOn")
-		})
+		vmoperator.WaitForVirtualMachinePowerState(ctx, vmSvcE2EConfig, svClusterClient, vmSvcNamespace, vmName, "PoweredOn")
+	})
 
-		It("successfully create, and delete vm snapshots", func() {
+	It("successfully create, and delete vm snapshots", func() {
 			By("create vm snapshot 1")
 			vmservice.CreateVMSnapshot(ctx, vmSvcClusterProxy, manifestbuilders.VirtualMachineSnapshotYaml{
 				Namespace: vmSvcNamespace,


### PR DESCRIPTION
Bare Get → annotate/modify → Update sequences in e2e tests were vulnerable to HTTP 409 optimistic concurrency conflicts: the controller reconciler frequently updates the VM object after state transitions (e.g. after PoweredOff), so the resourceVersion seen at Get time is often stale by the time Update is issued.

Wrap every such bare update in an Eventually block that re-fetches the object on each attempt, matching the pattern already used elsewhere in the test suite.

Additionally fix the incremental-restore test:

- Set Removable=ptr.To(true) on all volumes immediately after pvcNameA is attached and *before* WaitForBackupToComplete, so the backup YAML in ExtraConfig carries removable:true. The CSI CnsRegisterVolume controller reads spec.volumes[*].removable when processing newly registered FCDs; without an explicit value the disk can be mis-classified during a restore pass.

- Use v1alpha5 for the pause-annotation step (which exposes the Removable field) and set Removable=true on every volume at the same time. The validating webhook rejects removal of any volume with removable=false; the reconciler's backfill path can set this flag on discovered disks, so it must be cleared before InvokeRegisterVM attempts to restore the backup state.

Files changed:
- test/e2e/vmservice/vmservice/util.go
- test/e2e/vmservice/vmservice/viadmin/registervm.go

Changes in vm_snapshot is an indentation noise. Please ignore, if needed, I can revert them to original state.

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note

```