### PR TITLE
🌱Initial support for multiple network types

### DIFF
--- a/pkg/providers/vsphere/network/network.go
+++ b/pkg/providers/vsphere/network/network.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25"
@@ -118,6 +119,10 @@ var (
 
 	// ErrNetworkInterfaceNotReady is returned when the network interface is not ready.
 	ErrNetworkInterfaceNotReady = pkgerr.NoRequeueErrorf("network interface is not ready")
+
+	// ErrNetworkInterfaceBackingNotSupported is returned when the network interface specifies a
+	// backing type that is not supported.
+	ErrNetworkInterfaceBackingNotSupported = pkgerr.NoRequeueErrorf("network interface backing type not supported")
 )
 
 // CreateNetworkDevices ensures all network interface CRs exist for the VM's network
@@ -199,7 +204,7 @@ func CreateNetworkDevices(
 
 		switch ifaceCR := obj.(type) {
 		case *netopv1alpha1.NetworkInterface:
-			dev, err = getNetOPNetworkInterfaceDevice(ctx, vimClient, ifaceCR, interfaceSpec)
+			dev, err = getNetOPNetworkInterfaceDevice(ctx, vimClient, ifaceCR, nil, interfaceSpec)
 		case *ncpv1alpha1.VirtualNetworkInterface:
 			dev, err = getNCPNetworkInterfaceDevice(ctx, vimClient, nil, ifaceCR)
 		case *vpcv1alpha1.SubnetPort:
@@ -259,9 +264,10 @@ func getNetworkInterfaceAPIGroup(
 }
 
 func getNetOPNetworkInterfaceDevice(
-	_ context.Context,
+	ctx context.Context,
 	vimClient *vim25.Client,
 	netIf *netopv1alpha1.NetworkInterface,
+	clusterMoRef *vimtypes.ManagedObjectReference,
 	interfaceSpec vmopv1.VirtualMachineNetworkInterfaceSpec) (Device, error) {
 
 	var dev Device
@@ -284,13 +290,10 @@ func getNetOPNetworkInterfaceDevice(
 	}
 
 	networkID := netIf.Status.NetworkID
-	backing := object.NewDistributedVirtualPortgroup(
-		vimClient,
-		vimtypes.ManagedObjectReference{
-			Type:  string(vimtypes.ManagedObjectTypeDistributedVirtualPortgroup),
-			Value: networkID,
-		},
-	)
+	backing, err := getNetworkInterfaceBacking(ctx, vimClient, clusterMoRef, networkID, true, false)
+	if err != nil {
+		return dev, err
+	}
 
 	// The NetworkInterface does not have a MAC address in its Spec, nor does NetOP
 	// generate one in Status. If one was specified in the interface spec, set that
@@ -346,17 +349,9 @@ func getNCPNetworkInterfaceDevice(
 	}
 
 	networkID := vnetIf.Status.ProviderStatus.NsxLogicalSwitchID
-
-	var backing object.NetworkReference
-	if clusterMoRef != nil {
-		ccr := object.NewClusterComputeResource(vimClient, *clusterMoRef)
-		networkRef, err := searchNsxtNetworkReference(ctx, ccr, networkID)
-		if err != nil {
-			return dev, err
-		}
-		backing = networkRef
-	} else {
-		backing = newNSXOpaqueNetwork(networkID)
+	backing, err := getNetworkInterfaceBacking(ctx, vimClient, clusterMoRef, networkID, false, true)
+	if err != nil {
+		return dev, err
 	}
 
 	return Device{
@@ -398,16 +393,9 @@ func getVPCSubnetPortDevice(
 		return dev, pkgerr.NoRequeueErrorf("ready network interface does not have LogicalSwitchUUID")
 	}
 
-	var backing object.NetworkReference
-	if clusterMoRef != nil {
-		ccr := object.NewClusterComputeResource(vimClient, *clusterMoRef)
-		networkRef, err := searchNsxtNetworkReference(ctx, ccr, networkID)
-		if err != nil {
-			return dev, err
-		}
-		backing = networkRef
-	} else {
-		backing = newNSXOpaqueNetwork(networkID)
+	backing, err := getNetworkInterfaceBacking(ctx, vimClient, clusterMoRef, networkID, false, true)
+	if err != nil {
+		return dev, err
 	}
 
 	// A MAC address in the InterfaceSpec will have been set in the SubnetPort
@@ -425,6 +413,61 @@ func getVPCSubnetPortDevice(
 		MacAddress:   macAddress,
 		ExternalID:   subnetPort.Status.Attachment.ID,
 	}, nil
+}
+
+func getNetworkInterfaceBacking(
+	ctx context.Context,
+	vimClient *vim25.Client,
+	clusterMoRef *vimtypes.ManagedObjectReference,
+	networkID string,
+	supportMoID, supportLSUUID bool) (object.NetworkReference, error) {
+
+	// Determine if this is a MoID of a backing type we support.
+	if supportMoID {
+		switch {
+		case strings.HasPrefix(networkID, "dvportgroup-"):
+			return object.NewDistributedVirtualPortgroup(
+				vimClient,
+				vimtypes.ManagedObjectReference{
+					Type:  string(vimtypes.ManagedObjectTypeDistributedVirtualPortgroup),
+					Value: networkID,
+				},
+			), nil
+
+		case strings.HasPrefix(networkID, "network-"):
+			if !pkgcfg.FromContext(ctx).Features.PerNamespaceNetworkProvider {
+				return nil, ErrNetworkInterfaceBackingNotSupported
+			}
+
+			return object.NewNetwork(
+				vimClient,
+				vimtypes.ManagedObjectReference{
+					Type:  string(vimtypes.ManagedObjectTypeNetwork),
+					Value: networkID,
+				},
+			), nil
+		}
+	}
+
+	// Determine if this is a UUID for a LogicalSwitchUUID.
+	if supportLSUUID {
+		if _, err := uuid.Parse(networkID); err == nil {
+			// For a stretched SV setup, each CCR may have a different DVPG.
+			// For placement and create, we use the OpaqueBacking. Otherwise,
+			// resolve the DVPG for the VM's CCR.
+			var backing object.NetworkReference
+			if clusterMoRef != nil {
+				ccr := object.NewClusterComputeResource(vimClient, *clusterMoRef)
+				backing, err = searchNsxtNetworkReference(ctx, ccr, networkID)
+			} else {
+				backing = newNSXOpaqueNetwork(networkID)
+			}
+
+			return backing, err
+		}
+	}
+
+	return nil, fmt.Errorf("%w: %s", ErrNetworkInterfaceBackingNotSupported, networkID)
 }
 
 // CreateAndWaitForNetworkInterfaces creates the appropriate CRs for the VM's network
@@ -470,7 +513,7 @@ func CreateAndWaitForNetworkInterfaces(
 
 		switch networkType {
 		case pkgcfg.NetworkProviderTypeVDS:
-			dev, bs, err = createAndWaitNetOPNetworkInterface(vmCtx, client, vimClient, interfaceSpec)
+			dev, bs, err = createAndWaitNetOPNetworkInterface(vmCtx, client, vimClient, clusterMoRef, interfaceSpec)
 		case pkgcfg.NetworkProviderTypeNSXT:
 			dev, bs, err = createAndWaitNCPNetworkInterface(vmCtx, client, vimClient, clusterMoRef, interfaceSpec)
 		case pkgcfg.NetworkProviderTypeVPC:
@@ -653,6 +696,7 @@ func createAndWaitNetOPNetworkInterface(
 	vmCtx pkgctx.VirtualMachineContext,
 	client ctrlclient.Client,
 	vimClient *vim25.Client,
+	clusterMoRef *vimtypes.ManagedObjectReference,
 	interfaceSpec vmopv1.VirtualMachineNetworkInterfaceSpec,
 ) (Device, Bootstrap, error) {
 
@@ -661,7 +705,7 @@ func createAndWaitNetOPNetworkInterface(
 		return Device{}, Bootstrap{}, err
 	}
 
-	dev, err := getNetOPNetworkInterfaceDevice(vmCtx, vimClient, netIf, interfaceSpec)
+	dev, err := getNetOPNetworkInterfaceDevice(vmCtx, vimClient, netIf, clusterMoRef, interfaceSpec)
 	if err != nil {
 		if errors.Is(err, ErrNetworkInterfaceNotReady) {
 			netIf, err = waitForReadyNetworkInterface(vmCtx, client, netIf.Name)
@@ -670,7 +714,7 @@ func createAndWaitNetOPNetworkInterface(
 			return Device{}, Bootstrap{}, err
 		}
 
-		dev, err = getNetOPNetworkInterfaceDevice(vmCtx, vimClient, netIf, interfaceSpec)
+		dev, err = getNetOPNetworkInterfaceDevice(vmCtx, vimClient, netIf, clusterMoRef, interfaceSpec)
 		if err != nil {
 			return Device{}, Bootstrap{}, err
 		}

--- a/pkg/providers/vsphere/network/network_test.go
+++ b/pkg/providers/vsphere/network/network_test.go
@@ -121,14 +121,13 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 					Expect(err).ToNot(HaveOccurred())
 					backingInfo, ok := backing.(*vimtypes.VirtualEthernetCardDistributedVirtualPortBackingInfo)
 					Expect(ok).To(BeTrue())
-					Expect(backingInfo.Port.PortgroupKey).To(Equal(ctx.NetworkRef.Reference().Value))
+					Expect(backingInfo.Port.PortgroupKey).To(Equal(ctx.GetNetwork(0).Backing.Reference().Value))
 				})
 
 				Expect(result.DHCP4).To(BeFalse())
 				Expect(result.NoIPAM).To(BeFalse())
 				Expect(result.DHCP6).To(BeTrue()) // Only enabled if explicitly requested (which it is above).
 			})
-
 		})
 
 		Context("network does not exist", func() {
@@ -174,7 +173,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 
 			It("returns success", func() {
 				// Assert test env is what we expect.
-				Expect(ctx.NetworkRef.Reference().Type).To(Equal("DistributedVirtualPortgroup"))
+				Expect(ctx.GetNetwork(0).Backing.Reference().Type).To(Equal("DistributedVirtualPortgroup"))
 
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
@@ -199,7 +198,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 					Expect(externalID).To(BeEmpty())
 
 					netInterface.Status.ExternalID = externalID
-					netInterface.Status.NetworkID = ctx.NetworkRef.Reference().Value
+					netInterface.Status.NetworkID = ctx.GetNetwork(0).Backing.Reference().Value
 					netInterface.Status.MacAddress = "" // NetOP doesn't set this.
 					netInterface.Status.IPAssignmentMode = netopv1alpha1.NetworkInterfaceIPAssignmentModeStaticPool
 					netInterface.Status.IPv6AssignmentMode = netopv1alpha1.NetworkInterfaceIPAssignmentModeStaticPool
@@ -239,9 +238,9 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 				result := results.Results[0]
 				Expect(result.MacAddress).To(BeEmpty())
 				Expect(result.ExternalID).To(Equal(externalID))
-				Expect(result.NetworkID).To(Equal(ctx.NetworkRef.Reference().Value))
+				Expect(result.NetworkID).To(Equal(ctx.GetNetwork(0).Backing.Reference().Value))
 				Expect(result.Backing).ToNot(BeNil())
-				Expect(result.Backing.Reference()).To(Equal(ctx.NetworkRef.Reference()))
+				Expect(result.Backing.Reference()).To(Equal(ctx.GetNetwork(0).Backing.Reference()))
 				Expect(result.Name).To(Equal(interfaceName))
 				Expect(result.GuestDeviceName).To(Equal(interfaceName))
 
@@ -274,7 +273,8 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 							},
 						}
 						Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(netInterface), netInterface)).To(Succeed())
-						// No NetworkInterface Spec.MacAddress.
+						// No NetworkInterface Spec.MacAddress field to set.
+						netInterface.Status.NetworkID = ctx.GetNetwork(0).Backing.Reference().Value
 						netInterface.Status.Conditions = []netopv1alpha1.NetworkInterfaceCondition{
 							{
 								Type:   netopv1alpha1.NetworkInterfaceReady,
@@ -313,6 +313,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 							},
 						}
 						Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(netInterface), netInterface)).To(Succeed())
+						netInterface.Status.NetworkID = ctx.GetNetwork(0).Backing.Reference().Value
 						netInterface.Status.IPAssignmentMode = netopv1alpha1.NetworkInterfaceIPAssignmentModeDHCP
 						netInterface.Status.Conditions = []netopv1alpha1.NetworkInterfaceCondition{
 							{
@@ -355,7 +356,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 							},
 						}
 						Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(netInterface), netInterface)).To(Succeed())
-						netInterface.Status.IPAssignmentMode = netopv1alpha1.NetworkInterfaceIPAssignmentModeDHCP
+						netInterface.Status.NetworkID = ctx.GetNetwork(0).Backing.Reference().Value
 						netInterface.Status.IPv6AssignmentMode = netopv1alpha1.NetworkInterfaceIPAssignmentModeDHCP
 						netInterface.Status.Conditions = []netopv1alpha1.NetworkInterfaceCondition{
 							{
@@ -398,6 +399,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 							},
 						}
 						Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(netInterface), netInterface)).To(Succeed())
+						netInterface.Status.NetworkID = ctx.GetNetwork(0).Backing.Reference().Value
 						netInterface.Status.IPAssignmentMode = netopv1alpha1.NetworkInterfaceIPAssignmentModeDHCP
 						netInterface.Status.IPv6AssignmentMode = netopv1alpha1.NetworkInterfaceIPAssignmentModeStaticPool
 						netInterface.Status.IPConfigs = []netopv1alpha1.IPConfig{
@@ -451,6 +453,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 							},
 						}
 						Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(netInterface), netInterface)).To(Succeed())
+						netInterface.Status.NetworkID = ctx.GetNetwork(0).Backing.Reference().Value
 						netInterface.Status.IPAssignmentMode = netopv1alpha1.NetworkInterfaceIPAssignmentModeStaticPool
 						netInterface.Status.IPv6AssignmentMode = netopv1alpha1.NetworkInterfaceIPAssignmentModeDHCP
 						netInterface.Status.IPConfigs = []netopv1alpha1.IPConfig{
@@ -504,6 +507,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 							},
 						}
 						Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(netInterface), netInterface)).To(Succeed())
+						netInterface.Status.NetworkID = ctx.GetNetwork(0).Backing.Reference().Value
 						netInterface.Status.IPAssignmentMode = netopv1alpha1.NetworkInterfaceIPAssignmentModeNone
 						netInterface.Status.Conditions = []netopv1alpha1.NetworkInterfaceCondition{
 							{
@@ -550,7 +554,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 
 				It("returns success", func() {
 					// Assert test env is what we expect.
-					Expect(ctx.NetworkRef.Reference().Type).To(Equal("DistributedVirtualPortgroup"))
+					Expect(ctx.GetNetwork(0).Backing.Reference().Type).To(Equal("DistributedVirtualPortgroup"))
 
 					Expect(err).To(HaveOccurred())
 					Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
@@ -569,7 +573,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 						Expect(netInterface.Labels).To(HaveKeyWithValue(network.VMInterfaceNameLabel, interfaceName))
 						Expect(netInterface.Spec.NetworkName).To(Equal(networkName))
 
-						netInterface.Status.NetworkID = ctx.NetworkRef.Reference().Value
+						netInterface.Status.NetworkID = ctx.GetNetwork(0).Backing.Reference().Value
 						netInterface.Status.MacAddress = "" // NetOP doesn't set this.
 						netInterface.Status.IPAssignmentMode = netopv1alpha1.NetworkInterfaceIPAssignmentModeStaticPool
 						netInterface.Status.IPv6AssignmentMode = netopv1alpha1.NetworkInterfaceIPAssignmentModeStaticPool
@@ -609,9 +613,9 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 					result := results.Results[0]
 					Expect(result.MacAddress).To(BeEmpty())
 					Expect(result.ExternalID).To(BeEmpty())
-					Expect(result.NetworkID).To(Equal(ctx.NetworkRef.Reference().Value))
+					Expect(result.NetworkID).To(Equal(ctx.GetNetwork(0).Backing.Reference().Value))
 					Expect(result.Backing).ToNot(BeNil())
-					Expect(result.Backing.Reference()).To(Equal(ctx.NetworkRef.Reference()))
+					Expect(result.Backing.Reference()).To(Equal(ctx.GetNetwork(0).Backing.Reference()))
 					Expect(result.Name).To(Equal(interfaceName))
 					Expect(result.GuestDeviceName).To(Equal(interfaceName))
 
@@ -652,7 +656,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 						},
 					}
 					Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(netInterface), netInterface)).To(Succeed())
-					netInterface.Status.NetworkID = ctx.NetworkRef.Reference().Value
+					netInterface.Status.NetworkID = ctx.GetNetwork(0).Backing.Reference().Value
 					netInterface.Status.IPAssignmentMode = netopv1alpha1.NetworkInterfaceIPAssignmentModeStaticPool
 					netInterface.Status.IPv6AssignmentMode = netopv1alpha1.NetworkInterfaceIPAssignmentModeStaticPool
 					netInterface.Status.IPConfigs = []netopv1alpha1.IPConfig{
@@ -719,7 +723,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 						},
 					}
 					Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(netInterface), netInterface)).To(Succeed())
-					netInterface.Status.NetworkID = ctx.NetworkRef.Reference().Value
+					netInterface.Status.NetworkID = ctx.GetNetwork(0).Backing.Reference().Value
 					netInterface.Status.IPAssignmentMode = netopv1alpha1.NetworkInterfaceIPAssignmentModeStaticPool
 					netInterface.Status.IPConfigs = []netopv1alpha1.IPConfig{
 						{
@@ -963,6 +967,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 							} else {
 								Expect(err).ToNot(HaveOccurred())
 							}
+							netInterface.Status.NetworkID = ctx.GetNetwork(0).Backing.Reference().Value
 							netInterface.Status.Conditions = []netopv1alpha1.NetworkInterfaceCondition{
 								{
 									Type:   netopv1alpha1.NetworkInterfaceReady,
@@ -1024,7 +1029,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 
 			It("returns success", func() {
 				// Assert test env is what we expect.
-				Expect(ctx.NetworkRef.Reference().Type).To(Equal("DistributedVirtualPortgroup"))
+				Expect(ctx.GetNetwork(0).Backing.Reference().Type).To(Equal("DistributedVirtualPortgroup"))
 
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
@@ -1046,7 +1051,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 					netInterface.Status.InterfaceID = interfaceID
 					netInterface.Status.MacAddress = macAddress
 					netInterface.Status.ProviderStatus = &ncpv1alpha1.VirtualNetworkInterfaceProviderStatus{
-						NsxLogicalSwitchID: builder.GetNsxTLogicalSwitchUUID(0),
+						NsxLogicalSwitchID: ctx.GetNetwork(0).LogicalSwitchUUID,
 					}
 					netInterface.Status.IPAddresses = []ncpv1alpha1.VirtualNetworkInterfaceIP{
 						{
@@ -1082,7 +1087,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 				result := results.Results[0]
 				Expect(result.MacAddress).To(Equal(macAddress))
 				Expect(result.ExternalID).To(Equal(interfaceID))
-				Expect(result.NetworkID).To(Equal(builder.GetNsxTLogicalSwitchUUID(0)))
+				Expect(result.NetworkID).To(Equal(ctx.GetNetwork(0).LogicalSwitchUUID))
 				Expect(result.Name).To(Equal(interfaceName))
 
 				Expect(result.Backing).ToNot(BeNil())
@@ -1090,7 +1095,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 				Expect(err).ToNot(HaveOccurred())
 				opaqueNetwork, ok := backing.(*vimtypes.VirtualEthernetCardOpaqueNetworkBackingInfo)
 				Expect(ok).To(BeTrue())
-				Expect(opaqueNetwork.OpaqueNetworkId).To(Equal(builder.NsxTLogicalSwitchUUID))
+				Expect(opaqueNetwork.OpaqueNetworkId).To(Equal(ctx.GetNetwork(0).LogicalSwitchUUID))
 
 				Expect(result.IPConfigs).To(HaveLen(2))
 				ipConfig := result.IPConfigs[0]
@@ -1115,7 +1120,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 
 					Expect(results.Results).To(HaveLen(1))
 					Expect(results.Results[0].Backing).ToNot(BeNil())
-					Expect(results.Results[0].Backing.Reference()).To(Equal(ctx.NetworkRef.Reference()))
+					Expect(results.Results[0].Backing.Reference()).To(Equal(ctx.GetNetwork(0).Backing.Reference()))
 				})
 			})
 
@@ -1136,7 +1141,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 
 				It("returns success", func() {
 					// Assert test env is what we expect.
-					Expect(ctx.NetworkRef.Reference().Type).To(Equal("DistributedVirtualPortgroup"))
+					Expect(ctx.GetNetwork(0).Backing.Reference().Type).To(Equal("DistributedVirtualPortgroup"))
 
 					Expect(err).To(HaveOccurred())
 					Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
@@ -1156,7 +1161,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 						netInterface.Status.InterfaceID = interfaceID
 						netInterface.Status.MacAddress = macAddress
 						netInterface.Status.ProviderStatus = &ncpv1alpha1.VirtualNetworkInterfaceProviderStatus{
-							NsxLogicalSwitchID: builder.GetNsxTLogicalSwitchUUID(0),
+							NsxLogicalSwitchID: ctx.GetNetwork(0).LogicalSwitchUUID,
 						}
 						netInterface.Status.IPAddresses = []ncpv1alpha1.VirtualNetworkInterfaceIP{
 							{
@@ -1192,7 +1197,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 					result := results.Results[0]
 					Expect(result.MacAddress).To(Equal(macAddress))
 					Expect(result.ExternalID).To(Equal(interfaceID))
-					Expect(result.NetworkID).To(Equal(builder.GetNsxTLogicalSwitchUUID(0)))
+					Expect(result.NetworkID).To(Equal(ctx.GetNetwork(0).LogicalSwitchUUID))
 					Expect(result.Name).To(Equal(interfaceName))
 
 					Expect(result.Backing).ToNot(BeNil())
@@ -1200,7 +1205,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 					Expect(err).ToNot(HaveOccurred())
 					opaqueNetwork, ok := backing.(*vimtypes.VirtualEthernetCardOpaqueNetworkBackingInfo)
 					Expect(ok).To(BeTrue())
-					Expect(opaqueNetwork.OpaqueNetworkId).To(Equal(builder.NsxTLogicalSwitchUUID))
+					Expect(opaqueNetwork.OpaqueNetworkId).To(Equal(ctx.GetNetwork(0).LogicalSwitchUUID))
 
 					Expect(result.IPConfigs).To(HaveLen(2))
 					ipConfig := result.IPConfigs[0]
@@ -1225,7 +1230,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 
 						Expect(results.Results).To(HaveLen(1))
 						Expect(results.Results[0].Backing).ToNot(BeNil())
-						Expect(results.Results[0].Backing.Reference()).To(Equal(ctx.NetworkRef.Reference()))
+						Expect(results.Results[0].Backing.Reference()).To(Equal(ctx.GetNetwork(0).Backing.Reference()))
 					})
 				})
 			})
@@ -1263,7 +1268,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 
 			It("returns success", func() {
 				// Assert test env is what we expect.
-				Expect(ctx.NetworkRef.Reference().Type).To(Equal("DistributedVirtualPortgroup"))
+				Expect(ctx.GetNetwork(0).Backing.Reference().Type).To(Equal("DistributedVirtualPortgroup"))
 
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
@@ -1287,7 +1292,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 
 					subnetPort.Status.Attachment.ID = interfaceID
 					subnetPort.Status.NetworkInterfaceConfig.MACAddress = macAddress
-					subnetPort.Status.NetworkInterfaceConfig.LogicalSwitchUUID = builder.GetVPCTLogicalSwitchUUID(0)
+					subnetPort.Status.NetworkInterfaceConfig.LogicalSwitchUUID = ctx.GetNetwork(0).LogicalSwitchUUID
 					subnetPort.Status.NetworkInterfaceConfig.IPAddresses = []vpcv1alpha1.NetworkInterfaceIPAddress{
 						{
 							IPAddress: "192.168.1.110/24",
@@ -1320,7 +1325,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 				result := results.Results[0]
 				Expect(result.MacAddress).To(Equal(macAddress))
 				Expect(result.ExternalID).To(Equal(interfaceID))
-				Expect(result.NetworkID).To(Equal(builder.GetVPCTLogicalSwitchUUID(0)))
+				Expect(result.NetworkID).To(Equal(ctx.GetNetwork(0).LogicalSwitchUUID))
 				Expect(result.Name).To(Equal(interfaceName))
 
 				Expect(result.Backing).ToNot(BeNil())
@@ -1328,7 +1333,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 				Expect(err).ToNot(HaveOccurred())
 				opaqueNetwork, ok := backing.(*vimtypes.VirtualEthernetCardOpaqueNetworkBackingInfo)
 				Expect(ok).To(BeTrue())
-				Expect(opaqueNetwork.OpaqueNetworkId).To(Equal(builder.VPCLogicalSwitchUUID))
+				Expect(opaqueNetwork.OpaqueNetworkId).To(Equal(ctx.GetNetwork(0).LogicalSwitchUUID))
 
 				Expect(result.IPConfigs).To(HaveLen(2))
 				ipConfig := result.IPConfigs[0]
@@ -1353,7 +1358,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 
 					Expect(results.Results).To(HaveLen(1))
 					Expect(results.Results[0].Backing).ToNot(BeNil())
-					Expect(results.Results[0].Backing.Reference()).To(Equal(ctx.NetworkRef.Reference()))
+					Expect(results.Results[0].Backing.Reference()).To(Equal(ctx.GetNetwork(0).Backing.Reference()))
 				})
 			})
 
@@ -1385,7 +1390,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 						Expect(subnetPort.Spec.AddressBindings[0].MACAddress).To(Equal(macAddress))
 
 						subnetPort.Status.Attachment.ID = interfaceID
-						subnetPort.Status.NetworkInterfaceConfig.LogicalSwitchUUID = builder.GetVPCTLogicalSwitchUUID(0)
+						subnetPort.Status.NetworkInterfaceConfig.LogicalSwitchUUID = ctx.GetNetwork(0).LogicalSwitchUUID
 						subnetPort.Status.NetworkInterfaceConfig.MACAddress = macAddress
 						subnetPort.Status.NetworkInterfaceConfig.IPAddresses = []vpcv1alpha1.NetworkInterfaceIPAddress{
 							{
@@ -1463,7 +1468,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 						*/
 
 						subnetPort.Status.Attachment.ID = interfaceID
-						subnetPort.Status.NetworkInterfaceConfig.LogicalSwitchUUID = builder.GetVPCTLogicalSwitchUUID(0)
+						subnetPort.Status.NetworkInterfaceConfig.LogicalSwitchUUID = ctx.GetNetwork(0).LogicalSwitchUUID
 						subnetPort.Status.NetworkInterfaceConfig.MACAddress = macAddress
 						subnetPort.Status.NetworkInterfaceConfig.IPAddresses = []vpcv1alpha1.NetworkInterfaceIPAddress{
 							{
@@ -1548,7 +1553,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 						Expect(subnetPort.Spec.AddressBindings).To(BeEmpty())
 
 						subnetPort.Status.Attachment.ID = interfaceID
-						subnetPort.Status.NetworkInterfaceConfig.LogicalSwitchUUID = builder.GetVPCTLogicalSwitchUUID(0)
+						subnetPort.Status.NetworkInterfaceConfig.LogicalSwitchUUID = ctx.GetNetwork(0).LogicalSwitchUUID
 						subnetPort.Status.NetworkInterfaceConfig.MACAddress = macAddress
 						subnetPort.Status.NetworkInterfaceConfig.IPAddresses = []vpcv1alpha1.NetworkInterfaceIPAddress{
 							{
@@ -1642,7 +1647,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 						*/
 
 						subnetPort.Status.Attachment.ID = interfaceID
-						subnetPort.Status.NetworkInterfaceConfig.LogicalSwitchUUID = builder.GetVPCTLogicalSwitchUUID(0)
+						subnetPort.Status.NetworkInterfaceConfig.LogicalSwitchUUID = ctx.GetNetwork(0).LogicalSwitchUUID
 						subnetPort.Status.NetworkInterfaceConfig.MACAddress = macAddress
 						subnetPort.Status.NetworkInterfaceConfig.IPAddresses = []vpcv1alpha1.NetworkInterfaceIPAddress{
 							{
@@ -1730,7 +1735,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 						Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(subnetPort), subnetPort)).To(Succeed())
 
 						subnetPort.Status.Attachment.ID = interfaceID
-						subnetPort.Status.NetworkInterfaceConfig.LogicalSwitchUUID = builder.GetVPCTLogicalSwitchUUID(0)
+						subnetPort.Status.NetworkInterfaceConfig.LogicalSwitchUUID = ctx.GetNetwork(0).LogicalSwitchUUID
 						subnetPort.Status.NetworkInterfaceConfig.DHCPDeactivatedOnSubnet = false
 						subnetPort.Status.NetworkInterfaceConfig.IPAddresses = []vpcv1alpha1.NetworkInterfaceIPAddress{
 							{
@@ -1780,7 +1785,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 						Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(subnetPort), subnetPort)).To(Succeed())
 
 						subnetPort.Status.Attachment.ID = interfaceID
-						subnetPort.Status.NetworkInterfaceConfig.LogicalSwitchUUID = builder.GetVPCTLogicalSwitchUUID(0)
+						subnetPort.Status.NetworkInterfaceConfig.LogicalSwitchUUID = ctx.GetNetwork(0).LogicalSwitchUUID
 						subnetPort.Status.NetworkInterfaceConfig.DHCPDeactivatedOnSubnet = true
 						subnetPort.Status.NetworkInterfaceConfig.IPAddresses = []vpcv1alpha1.NetworkInterfaceIPAddress{
 							{
@@ -1979,7 +1984,7 @@ var _ = Describe("CreateNetworkDevices", Label(testlabels.VCSim), func() {
 			Expect(err).ToNot(HaveOccurred())
 			backingInfo, ok := backing.(*vimtypes.VirtualEthernetCardDistributedVirtualPortBackingInfo)
 			Expect(ok).To(BeTrue())
-			Expect(backingInfo.Port.PortgroupKey).To(Equal(ctx.NetworkRef.Reference().Value))
+			Expect(backingInfo.Port.PortgroupKey).To(Equal(ctx.GetNetwork(0).Backing.Reference().Value))
 		})
 
 		Context("Named Network with MAC address", func() {
@@ -1999,6 +2004,8 @@ var _ = Describe("CreateNetworkDevices", Label(testlabels.VCSim), func() {
 
 		BeforeEach(func() {
 			testConfig.WithNetworkEnv = builder.NetworkEnvVDS
+			testConfig.NumNetworks = 2
+
 			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{
 				Interfaces: []vmopv1.VirtualMachineNetworkInterfaceSpec{
 					{
@@ -2073,59 +2080,66 @@ var _ = Describe("CreateNetworkDevices", Label(testlabels.VCSim), func() {
 			)
 		})
 
-		Context("interface is ready", func() {
-			BeforeEach(func() {
-				netIf0 := &netopv1alpha1.NetworkInterface{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      interfaceKey0.Name,
-						Namespace: interfaceKey0.Namespace,
-					},
-					Status: netopv1alpha1.NetworkInterfaceStatus{
-						NetworkID:  "dvpg-portgroup-0",
-						MacAddress: macAddress0,
-						ExternalID: externalID0,
-						Conditions: []netopv1alpha1.NetworkInterfaceCondition{
-							{
-								Type:   netopv1alpha1.NetworkInterfaceReady,
-								Status: corev1.ConditionTrue,
-							},
-						},
-					},
-				}
+		netOPReconcile := func(objKey client.ObjectKey, r func(s *netopv1alpha1.NetworkInterfaceStatus)) {
+			netIf := &netopv1alpha1.NetworkInterface{}
+			Expect(ctx.Client.Get(ctx, objKey, netIf)).To(Succeed())
+			r(&netIf.Status)
+			Expect(ctx.Client.Status().Update(ctx, netIf)).To(Succeed())
+		}
 
-				netIf1 := &netopv1alpha1.NetworkInterface{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      interfaceKey1.Name,
-						Namespace: interfaceKey1.Namespace,
-					},
-					Status: netopv1alpha1.NetworkInterfaceStatus{
-						NetworkID:  "dvpg-portgroup-1",
-						MacAddress: macAddress1,
-						ExternalID: externalID1,
-						Conditions: []netopv1alpha1.NetworkInterfaceCondition{
-							{
-								Type:   netopv1alpha1.NetworkInterfaceReady,
-								Status: corev1.ConditionTrue,
-							},
-						},
-					},
-				}
-
-				initObjects = append(initObjects, netIf0, netIf1)
-			})
-
+		Context("interfaces become ready", func() {
 			It("returns success with backing", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
+				Expect(devices).To(BeEmpty())
+
+				By("Mark interfaces as ready", func() {
+					netOPReconcile(interfaceKey0, func(s *netopv1alpha1.NetworkInterfaceStatus) {
+						*s = netopv1alpha1.NetworkInterfaceStatus{
+							NetworkID:  ctx.GetNetwork(0).Backing.Reference().Value,
+							MacAddress: macAddress0,
+							ExternalID: externalID0,
+							Conditions: []netopv1alpha1.NetworkInterfaceCondition{
+								{
+									Type:   netopv1alpha1.NetworkInterfaceReady,
+									Status: corev1.ConditionTrue,
+								},
+							},
+						}
+					})
+
+					netOPReconcile(interfaceKey1, func(s *netopv1alpha1.NetworkInterfaceStatus) {
+						*s = netopv1alpha1.NetworkInterfaceStatus{
+							NetworkID:  ctx.GetNetwork(1).Backing.Reference().Value,
+							MacAddress: macAddress1,
+							ExternalID: externalID1,
+							Conditions: []netopv1alpha1.NetworkInterfaceCondition{
+								{
+									Type:   netopv1alpha1.NetworkInterfaceReady,
+									Status: corev1.ConditionTrue,
+								},
+							},
+						}
+					})
+				})
+
+				devices, err = network.CreateNetworkDevices(
+					ctx,
+					vm,
+					ctx.Client,
+					ctx.VCClient.Client,
+					ctx.Finder)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(devices).To(HaveLen(2))
 
 				dev0 := devices[0]
-				Expect(dev0.NetworkID).To(Equal("dvpg-portgroup-0"))
+				Expect(dev0.NetworkID).To(Equal(ctx.GetNetwork(0).Backing.Reference().Value))
 				Expect(dev0.Backing).ToNot(BeNil())
 				Expect(dev0.MacAddress).To(Equal(macAddress0))
 				Expect(dev0.ExternalID).To(Equal(externalID0))
 
 				dev1 := devices[1]
-				Expect(dev1.NetworkID).To(Equal("dvpg-portgroup-1"))
+				Expect(dev1.NetworkID).To(Equal(ctx.GetNetwork(1).Backing.Reference().Value))
 				Expect(dev1.Backing).ToNot(BeNil())
 				Expect(dev1.MacAddress).To(Equal(macAddress1))
 				Expect(dev1.ExternalID).To(Equal(externalID1))
@@ -2157,7 +2171,7 @@ var _ = Describe("CreateNetworkDevices", Label(testlabels.VCSim), func() {
 						Namespace: interfaceKey1.Namespace,
 					},
 					Status: netopv1alpha1.NetworkInterfaceStatus{
-						NetworkID:  "dvpg-portgroup-key",
+						NetworkID:  "dvportgroup-42",
 						MacAddress: macAddress1,
 						ExternalID: externalID1,
 						Conditions: []netopv1alpha1.NetworkInterfaceCondition{
@@ -2181,8 +2195,18 @@ var _ = Describe("CreateNetworkDevices", Label(testlabels.VCSim), func() {
 	})
 
 	Context("NSXT", func() {
+
+		ncpReconcile := func(k client.ObjectKey, r func(s *ncpv1alpha1.VirtualNetworkInterfaceStatus)) {
+			vnetIf := &ncpv1alpha1.VirtualNetworkInterface{}
+			Expect(ctx.Client.Get(ctx, k, vnetIf)).To(Succeed())
+			r(&vnetIf.Status)
+			Expect(ctx.Client.Status().Update(ctx, vnetIf)).To(Succeed())
+		}
+
 		BeforeEach(func() {
 			testConfig.WithNetworkEnv = builder.NetworkEnvNSXT
+			testConfig.NumNetworks = 2
+
 			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{
 				Interfaces: []vmopv1.VirtualMachineNetworkInterfaceSpec{
 					{
@@ -2234,57 +2258,57 @@ var _ = Describe("CreateNetworkDevices", Label(testlabels.VCSim), func() {
 			})
 		})
 
-		Context("interface is ready", func() {
-			BeforeEach(func() {
-				vnetIf0 := &ncpv1alpha1.VirtualNetworkInterface{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      interfaceKey0.Name,
-						Namespace: interfaceKey0.Namespace,
-					},
-					Status: ncpv1alpha1.VirtualNetworkInterfaceStatus{
-						InterfaceID: externalID0,
-						MacAddress:  macAddress0,
-						ProviderStatus: &ncpv1alpha1.VirtualNetworkInterfaceProviderStatus{
-							NsxLogicalSwitchID: builder.GetNsxTLogicalSwitchUUID(0),
-						},
-						Conditions: []ncpv1alpha1.VirtualNetworkCondition{
-							{
-								Type:   "Ready",
-								Status: "True",
-							},
-						},
-					},
-				}
-
-				vnetIf1 := &ncpv1alpha1.VirtualNetworkInterface{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      interfaceKey1.Name,
-						Namespace: interfaceKey1.Namespace,
-					},
-					Status: ncpv1alpha1.VirtualNetworkInterfaceStatus{
-						InterfaceID: externalID1,
-						MacAddress:  macAddress1,
-						ProviderStatus: &ncpv1alpha1.VirtualNetworkInterfaceProviderStatus{
-							NsxLogicalSwitchID: builder.GetNsxTLogicalSwitchUUID(1),
-						},
-						Conditions: []ncpv1alpha1.VirtualNetworkCondition{
-							{
-								Type:   "Ready",
-								Status: "True",
-							},
-						},
-					},
-				}
-
-				initObjects = append(initObjects, vnetIf0, vnetIf1)
-			})
-
+		Context("interfaces become ready", func() {
 			It("returns success with backing and identifiers", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
+				Expect(devices).To(BeEmpty())
+
+				By("Mark interfaces as ready", func() {
+					ncpReconcile(interfaceKey0, func(s *ncpv1alpha1.VirtualNetworkInterfaceStatus) {
+						*s = ncpv1alpha1.VirtualNetworkInterfaceStatus{
+							InterfaceID: externalID0,
+							MacAddress:  macAddress0,
+							ProviderStatus: &ncpv1alpha1.VirtualNetworkInterfaceProviderStatus{
+								NsxLogicalSwitchID: ctx.GetNetwork(0).LogicalSwitchUUID,
+							},
+							Conditions: []ncpv1alpha1.VirtualNetworkCondition{
+								{
+									Type:   "Ready",
+									Status: "True",
+								},
+							},
+						}
+					})
+
+					ncpReconcile(interfaceKey1, func(s *ncpv1alpha1.VirtualNetworkInterfaceStatus) {
+						*s = ncpv1alpha1.VirtualNetworkInterfaceStatus{
+							InterfaceID: externalID1,
+							MacAddress:  macAddress1,
+							ProviderStatus: &ncpv1alpha1.VirtualNetworkInterfaceProviderStatus{
+								NsxLogicalSwitchID: ctx.GetNetwork(1).LogicalSwitchUUID,
+							},
+							Conditions: []ncpv1alpha1.VirtualNetworkCondition{
+								{
+									Type:   "Ready",
+									Status: "True",
+								},
+							},
+						}
+					})
+				})
+
+				devices, err = network.CreateNetworkDevices(
+					ctx,
+					vm,
+					ctx.Client,
+					ctx.VCClient.Client,
+					ctx.Finder)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(devices).To(HaveLen(2))
 
 				dev0 := devices[0]
-				Expect(dev0.NetworkID).To(Equal(builder.GetNsxTLogicalSwitchUUID(0)))
+				Expect(dev0.NetworkID).To(Equal(ctx.GetNetwork(0).LogicalSwitchUUID))
 				Expect(dev0.Backing).ToNot(BeNil())
 				Expect(dev0.ExternalID).To(Equal(externalID0))
 				Expect(dev0.MacAddress).To(Equal(macAddress0))
@@ -2296,7 +2320,7 @@ var _ = Describe("CreateNetworkDevices", Label(testlabels.VCSim), func() {
 				Expect(opaqueNetwork0.OpaqueNetworkId).To(Equal(dev0.NetworkID))
 
 				dev1 := devices[1]
-				Expect(dev1.NetworkID).To(Equal(builder.GetNsxTLogicalSwitchUUID(1)))
+				Expect(dev1.NetworkID).To(Equal(ctx.GetNetwork(1).LogicalSwitchUUID))
 				Expect(dev1.Backing).ToNot(BeNil())
 				Expect(dev1.ExternalID).To(Equal(externalID1))
 				Expect(dev1.MacAddress).To(Equal(macAddress1))
@@ -2317,9 +2341,6 @@ var _ = Describe("CreateNetworkDevices", Label(testlabels.VCSim), func() {
 						Namespace: interfaceKey0.Namespace,
 					},
 					Status: ncpv1alpha1.VirtualNetworkInterfaceStatus{
-						ProviderStatus: &ncpv1alpha1.VirtualNetworkInterfaceProviderStatus{
-							NsxLogicalSwitchID: builder.GetNsxTLogicalSwitchUUID(0),
-						},
 						Conditions: []ncpv1alpha1.VirtualNetworkCondition{
 							{
 								Type:    "Ready",
@@ -2367,8 +2388,18 @@ var _ = Describe("CreateNetworkDevices", Label(testlabels.VCSim), func() {
 	})
 
 	Context("VPC", func() {
+
+		vpcReconcile := func(objKey client.ObjectKey, r func(s *vpcv1alpha1.SubnetPortStatus)) {
+			subnetPort := &vpcv1alpha1.SubnetPort{}
+			Expect(ctx.Client.Get(ctx, objKey, subnetPort)).To(Succeed())
+			r(&subnetPort.Status)
+			Expect(ctx.Client.Status().Update(ctx, subnetPort)).To(Succeed())
+		}
+
 		BeforeEach(func() {
 			testConfig.WithNetworkEnv = builder.NetworkEnvVPC
+			testConfig.NumNetworks = 2
+
 			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{
 				Interfaces: []vmopv1.VirtualMachineNetworkInterfaceSpec{
 					{
@@ -2488,61 +2519,61 @@ var _ = Describe("CreateNetworkDevices", Label(testlabels.VCSim), func() {
 			})
 		})
 
-		Context("interface is ready", func() {
-			BeforeEach(func() {
-				subnetPort0 := &vpcv1alpha1.SubnetPort{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      interfaceKey0.Name,
-						Namespace: interfaceKey0.Namespace,
-					},
-					Status: vpcv1alpha1.SubnetPortStatus{
-						Attachment: vpcv1alpha1.PortAttachment{
-							ID: externalID0,
-						},
-						NetworkInterfaceConfig: vpcv1alpha1.NetworkInterfaceConfig{
-							LogicalSwitchUUID: builder.GetVPCTLogicalSwitchUUID(0),
-							MACAddress:        macAddress0,
-						},
-						Conditions: []vpcv1alpha1.Condition{
-							{
-								Type:   vpcv1alpha1.Ready,
-								Status: corev1.ConditionTrue,
+		Context("interfaces become ready", func() {
+			It("returns success with backing", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
+				Expect(devices).To(BeEmpty())
+
+				By("Mark interfaces as ready", func() {
+					vpcReconcile(interfaceKey0, func(s *vpcv1alpha1.SubnetPortStatus) {
+						*s = vpcv1alpha1.SubnetPortStatus{
+							Attachment: vpcv1alpha1.PortAttachment{
+								ID: externalID0,
 							},
-						},
-					},
-				}
-
-				subnetPort1 := &vpcv1alpha1.SubnetPort{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      interfaceKey1.Name,
-						Namespace: interfaceKey1.Namespace,
-					},
-					Status: vpcv1alpha1.SubnetPortStatus{
-						Attachment: vpcv1alpha1.PortAttachment{
-							ID: externalID1,
-						},
-						NetworkInterfaceConfig: vpcv1alpha1.NetworkInterfaceConfig{
-							LogicalSwitchUUID: builder.GetVPCTLogicalSwitchUUID(1),
-							MACAddress:        macAddress1,
-						},
-						Conditions: []vpcv1alpha1.Condition{
-							{
-								Type:   vpcv1alpha1.Ready,
-								Status: corev1.ConditionTrue,
+							NetworkInterfaceConfig: vpcv1alpha1.NetworkInterfaceConfig{
+								LogicalSwitchUUID: ctx.GetNetwork(0).LogicalSwitchUUID,
+								MACAddress:        macAddress0,
 							},
-						},
-					},
-				}
+							Conditions: []vpcv1alpha1.Condition{
+								{
+									Type:   vpcv1alpha1.Ready,
+									Status: corev1.ConditionTrue,
+								},
+							},
+						}
+					})
 
-				initObjects = append(initObjects, subnetPort0, subnetPort1)
-			})
+					vpcReconcile(interfaceKey1, func(s *vpcv1alpha1.SubnetPortStatus) {
+						*s = vpcv1alpha1.SubnetPortStatus{
+							Attachment: vpcv1alpha1.PortAttachment{
+								ID: externalID1,
+							},
+							NetworkInterfaceConfig: vpcv1alpha1.NetworkInterfaceConfig{
+								LogicalSwitchUUID: ctx.GetNetwork(1).LogicalSwitchUUID,
+								MACAddress:        macAddress1,
+							},
+							Conditions: []vpcv1alpha1.Condition{
+								{
+									Type:   vpcv1alpha1.Ready,
+									Status: corev1.ConditionTrue,
+								},
+							},
+						}
+					})
+				})
 
-			It("returns success", func() {
+				devices, err = network.CreateNetworkDevices(
+					ctx,
+					vm,
+					ctx.Client,
+					ctx.VCClient.Client,
+					ctx.Finder)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(devices).To(HaveLen(2))
 
 				dev0 := devices[0]
-				Expect(dev0.NetworkID).To(Equal(builder.GetVPCTLogicalSwitchUUID(0)))
+				Expect(dev0.NetworkID).To(Equal(ctx.GetNetwork(0).LogicalSwitchUUID))
 				Expect(dev0.Backing).ToNot(BeNil())
 				Expect(dev0.MacAddress).To(Equal(macAddress0))
 				Expect(dev0.ExternalID).To(Equal(externalID0))
@@ -2554,7 +2585,7 @@ var _ = Describe("CreateNetworkDevices", Label(testlabels.VCSim), func() {
 				Expect(opaqueNetwork0.OpaqueNetworkId).To(Equal(dev0.NetworkID))
 
 				dev1 := devices[1]
-				Expect(dev1.NetworkID).To(Equal(builder.GetVPCTLogicalSwitchUUID(1)))
+				Expect(dev1.NetworkID).To(Equal(ctx.GetNetwork(1).LogicalSwitchUUID))
 				Expect(dev1.Backing).ToNot(BeNil())
 				Expect(dev1.MacAddress).To(Equal(macAddress1))
 				Expect(dev1.ExternalID).To(Equal(externalID1))

--- a/pkg/providers/vsphere/network/nsxt_test.go
+++ b/pkg/providers/vsphere/network/nsxt_test.go
@@ -5,9 +5,12 @@
 package network_test
 
 import (
-	"github.com/go-logr/logr"
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/go-logr/logr"
 	"github.com/vmware/govmomi/object"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -67,11 +70,11 @@ var _ = Describe("VPCPostRestoreBackingFixup", Label(testlabels.VCSim), func() {
 
 		initEthCard := func(idx int) vimtypes.VirtualVmxnet3 {
 			dev := vimtypes.VirtualVmxnet3{}
-			backing, err := ctx.NetworkRefs[idx].EthernetCardBackingInfo(ctx)
+			backing, err := ctx.GetNetwork(idx).Backing.EthernetCardBackingInfo(ctx)
 			Expect(err).NotTo(HaveOccurred())
 			dev.Backing = backing
 			dev.MacAddress = macAddress1
-			dev.ExternalId = builder.GetVPCTLogicalSwitchUUID(idx)
+			dev.ExternalId = fmt.Sprintf("dummy-extid-%d", idx)
 			dev.SubnetId = dummySubnetID
 			return dev
 		}
@@ -82,7 +85,7 @@ var _ = Describe("VPCPostRestoreBackingFixup", Label(testlabels.VCSim), func() {
 		dev2.MacAddress = macAddress2
 
 		initNetworkResult := func(idx int, dev vimtypes.BaseVirtualEthernetCard) network.NetworkInterfaceResult {
-			dvpgMoRef := ctx.NetworkRefs[idx].Reference()
+			dvpgMoRef := ctx.GetNetwork(idx).Backing.Reference()
 
 			ethCard := dev.GetVirtualEthernetCard()
 			r := network.NetworkInterfaceResult{}

--- a/pkg/providers/vsphere/vmprovider_vm_network_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_network_test.go
@@ -26,6 +26,7 @@ import (
 
 	netopv1alpha1 "github.com/vmware-tanzu/net-operator-api/api/v1alpha1"
 	vpcv1alpha1 "github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
+
 	ncpv1alpha1 "github.com/vmware-tanzu/vm-operator/external/ncp/api/v1alpha1"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
@@ -369,7 +370,7 @@ func vmNetworkTests() {
 						Expect(ctx.Client.Get(ctx, objKey, subnetPort)).To(Succeed())
 
 						subnetPort.Status.Attachment.ID += "-restored"
-						subnetPort.Status.NetworkInterfaceConfig.LogicalSwitchUUID = builder.GetVPCTLogicalSwitchUUID(restoredNetworkIdx)
+						subnetPort.Status.NetworkInterfaceConfig.LogicalSwitchUUID = ctx.GetNetwork(restoredNetworkIdx).LogicalSwitchUUID
 						Expect(ctx.Client.Status().Update(ctx, subnetPort)).To(Succeed())
 
 						restoredExtID = subnetPort.Status.Attachment.ID
@@ -888,7 +889,7 @@ func (v vdsNetworkProvider) simulateInterfaceReconcile(
 	Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(netInterface), netInterface)).To(Succeed())
 	Expect(netInterface.Spec.NetworkName).To(Equal(networkName))
 
-	netInterface.Status.NetworkID = ctx.NetworkRefs[networkIdx].Reference().Value
+	netInterface.Status.NetworkID = ctx.GetNetwork(networkIdx).Backing.Reference().Value
 	netInterface.Status.ExternalID = extID(networkName, interfaceName)
 	netInterface.Status.MacAddress = "" // NetOP doesn't set this.
 	netInterface.Status.IPConfigs = []netopv1alpha1.IPConfig{
@@ -919,7 +920,7 @@ func (v vdsNetworkProvider) assertEthernetCard(
 	ethCard := dev.(vimtypes.BaseVirtualEthernetCard).GetVirtualEthernetCard()
 	backingInfo, ok := ethCard.Backing.(*vimtypes.VirtualEthernetCardDistributedVirtualPortBackingInfo)
 	Expect(ok).Should(BeTrue())
-	ExpectWithOffset(1, backingInfo.Port.PortgroupKey).To(Equal(ctx.NetworkRefs[networkIdx].Reference().Value))
+	ExpectWithOffset(1, backingInfo.Port.PortgroupKey).To(Equal(ctx.GetNetwork(networkIdx).Backing.Reference().Value))
 	Expect(ethCard.MacAddress).ToNot(BeEmpty())
 	Expect(ethCard.ExternalId).To(Equal(extID(networkName, interfaceName)))
 
@@ -964,7 +965,7 @@ func (n nsxtNetworkProvider) simulateInterfaceReconcile(
 	netInterface.Status.InterfaceID = extID(networkName, interfaceName)
 	netInterface.Status.MacAddress = fmt.Sprintf("01-23-45-67-89-%02X", ifaceIdx)
 	netInterface.Status.ProviderStatus = &ncpv1alpha1.VirtualNetworkInterfaceProviderStatus{
-		NsxLogicalSwitchID: builder.GetNsxTLogicalSwitchUUID(networkIdx),
+		NsxLogicalSwitchID: ctx.GetNetwork(networkIdx).LogicalSwitchUUID,
 	}
 	netInterface.Status.IPAddresses = []ncpv1alpha1.VirtualNetworkInterfaceIP{
 		{
@@ -994,7 +995,7 @@ func (n nsxtNetworkProvider) assertEthernetCard(
 	ethCard := dev.(vimtypes.BaseVirtualEthernetCard).GetVirtualEthernetCard()
 	backingInfo, ok := ethCard.Backing.(*vimtypes.VirtualEthernetCardDistributedVirtualPortBackingInfo)
 	Expect(ok).Should(BeTrue())
-	Expect(backingInfo.Port.PortgroupKey).To(Equal(ctx.NetworkRefs[networkIdx].Reference().Value))
+	Expect(backingInfo.Port.PortgroupKey).To(Equal(ctx.GetNetwork(networkIdx).Backing.Reference().Value))
 	Expect(ethCard.MacAddress).To(Equal(fmt.Sprintf("01-23-45-67-89-%02X", ifaceIdx)))
 	Expect(ethCard.ExternalId).To(Equal(extID(networkName, interfaceName)))
 }
@@ -1037,7 +1038,7 @@ func (v vpcNetworkProvider) simulateInterfaceReconcile(
 
 	subnetPort.Status.Attachment.ID = extID(networkName, interfaceName)
 	subnetPort.Status.NetworkInterfaceConfig.MACAddress = fmt.Sprintf("01-23-45-67-89-%02X", ifaceIdx)
-	subnetPort.Status.NetworkInterfaceConfig.LogicalSwitchUUID = builder.GetVPCTLogicalSwitchUUID(networkIdx)
+	subnetPort.Status.NetworkInterfaceConfig.LogicalSwitchUUID = ctx.GetNetwork(networkIdx).LogicalSwitchUUID
 	subnetPort.Status.NetworkInterfaceConfig.IPAddresses = []vpcv1alpha1.NetworkInterfaceIPAddress{
 		{
 			IPAddress: fmt.Sprintf("192.168.1.11%d/24", ifaceIdx),
@@ -1065,7 +1066,7 @@ func (v vpcNetworkProvider) assertEthernetCard(
 	ethCard := dev.(vimtypes.BaseVirtualEthernetCard).GetVirtualEthernetCard()
 	backingInfo, ok := ethCard.Backing.(*vimtypes.VirtualEthernetCardDistributedVirtualPortBackingInfo)
 	Expect(ok).Should(BeTrue())
-	Expect(backingInfo.Port.PortgroupKey).To(Equal(ctx.NetworkRefs[networkIdx].Reference().Value))
+	Expect(backingInfo.Port.PortgroupKey).To(Equal(ctx.GetNetwork(networkIdx).Backing.Reference().Value))
 	Expect(ethCard.MacAddress).To(Equal(fmt.Sprintf("01-23-45-67-89-%02X", ifaceIdx)))
 	Expect(ethCard.ExternalId).To(Equal(extID(networkName, interfaceName)))
 }

--- a/test/builder/vcsim_test_context.go
+++ b/test/builder/vcsim_test_context.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -72,9 +73,9 @@ import (
 	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 	pkgmgr "github.com/vmware-tanzu/vm-operator/pkg/manager"
 	"github.com/vmware-tanzu/vm-operator/pkg/record"
+	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
-	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 	pkgclient "github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/client"
 	"github.com/vmware-tanzu/vm-operator/test/testutil"
 )
@@ -86,18 +87,12 @@ const (
 	NetworkEnvNSXT  = NetworkEnv("nsx-t")
 	NetworkEnvVPC   = NetworkEnv("nsx-t-vpc")
 	NetworkEnvNamed = NetworkEnv("named")
-
-	NsxTLogicalSwitchUUID = "nsxt-dummy-ls-uuid"
-	VPCLogicalSwitchUUID  = "vpc-dummy-ls-uuid"
 )
 
 // VCSimTestConfig configures the vcsim environment.
 type VCSimTestConfig struct {
 	// NumFaultDomains is the number of zones.
 	NumFaultDomains int
-
-	// NumNetworks is the number of networks.
-	NumNetworks int
 
 	// NumDatastores is the number of datastores.
 	NumDatastores int
@@ -140,6 +135,13 @@ type VCSimTestConfig struct {
 	// WithNetworkEnv is the network environment type.
 	WithNetworkEnv NetworkEnv
 
+	// NumNetworks is the number of networks.
+	NumNetworks int
+
+	// WithNetworkConfig determines the network configuration. Takes precedence
+	// over WithNetworkEnv and NumNetworks.
+	WithNetworkConfig []VCSimNetworkConfig
+
 	// WithoutEncryptionClass disables the creation of the EncryptionClass
 	// resource in each workload namespace.
 	WithoutEncryptionClass bool
@@ -150,6 +152,12 @@ type VCSimTestConfig struct {
 
 	// WithWorkloadIPv6 enables the WorkloadIPv6 feature flag.
 	WithWorkloadIPv6 bool
+}
+
+// VCSimNetworkConfig describes the type and configuration of a network
+// to configure on vcsim.
+type VCSimNetworkConfig struct {
+	Provider pkgcfg.NetworkProviderType
 }
 
 type TestContextForVCSim struct {
@@ -216,10 +224,8 @@ type TestContextForVCSim struct {
 	CategoryID string
 	TagID      string
 
-	networkEnv   NetworkEnv
-	networkCount int
-	NetworkRef   object.NetworkReference
-	NetworkRefs  []object.NetworkReference
+	networkConfig []VCSimNetworkConfig
+	networks      []VCSimNetwork
 
 	model             *simulator.Model
 	server            *simulator.Server
@@ -229,6 +235,12 @@ type TestContextForVCSim struct {
 	folder *object.Folder
 
 	azCCRs map[string][]*object.ClusterComputeResource
+}
+
+type VCSimNetwork struct {
+	Provider          pkgcfg.NetworkProviderType
+	Backing           object.NetworkReference
+	LogicalSwitchUUID string // NSXT/VCP only
 }
 
 type IntegrationTestContextForVCSim struct {
@@ -251,20 +263,6 @@ const (
 	// clustersPerZone is how many clusters to create per zone.
 	clustersPerZone = 1
 )
-
-func GetNsxTLogicalSwitchUUID(idx int) string {
-	if idx == 0 {
-		return NsxTLogicalSwitchUUID
-	}
-	return fmt.Sprintf("%s-%d", NsxTLogicalSwitchUUID, idx)
-}
-
-func GetVPCTLogicalSwitchUUID(idx int) string {
-	if idx == 0 {
-		return VPCLogicalSwitchUUID
-	}
-	return fmt.Sprintf("%s-%d", VPCLogicalSwitchUUID, idx)
-}
 
 func NewTestContextForVCSim(
 	parentCtx context.Context,
@@ -379,8 +377,24 @@ func newTestContextForVCSim(
 	ctx.ClustersPerZone = clustersPerZone
 	ctx.workloadDomainIsolation = !config.WithoutWorkloadDomainIsolation
 
-	ctx.networkEnv = config.WithNetworkEnv
-	ctx.networkCount = max(1, config.NumNetworks)
+	if len(config.WithNetworkConfig) > 0 {
+		Expect(config.WithNetworkEnv).To(BeEmpty())
+		Expect(config.NumNetworks).To(BeZero())
+		ctx.networkConfig = config.WithNetworkConfig
+	} else if config.WithNetworkEnv != "" {
+		c := VCSimNetworkConfig{}
+		switch config.WithNetworkEnv {
+		case NetworkEnvVDS:
+			c.Provider = pkgcfg.NetworkProviderTypeVDS
+		case NetworkEnvNSXT:
+			c.Provider = pkgcfg.NetworkProviderTypeNSXT
+		case NetworkEnvVPC:
+			c.Provider = pkgcfg.NetworkProviderTypeVPC
+		case NetworkEnvNamed:
+			c.Provider = pkgcfg.NetworkProviderTypeNamed
+		}
+		ctx.networkConfig = slices.Repeat([]VCSimNetworkConfig{c}, max(1, config.NumNetworks))
+	}
 
 	return ctx
 }
@@ -570,17 +584,8 @@ func (c *TestContextForVCSim) setupEnv(config VCSimTestConfig) {
 	pkgcfg.SetContext(c, func(cc *pkgcfg.Config) {
 		cc.PodNamespace = c.PodNamespace
 
-		switch config.WithNetworkEnv {
-		case NetworkEnvVDS:
-			cc.NetworkProviderType = pkgcfg.NetworkProviderTypeVDS
-		case NetworkEnvNSXT:
-			cc.NetworkProviderType = pkgcfg.NetworkProviderTypeNSXT
-		case NetworkEnvVPC:
-			cc.NetworkProviderType = pkgcfg.NetworkProviderTypeVPC
-		case NetworkEnvNamed:
-			cc.NetworkProviderType = pkgcfg.NetworkProviderTypeNamed
-		default:
-			cc.NetworkProviderType = ""
+		if len(c.networkConfig) > 0 {
+			cc.NetworkProviderType = c.networkConfig[0].Provider
 		}
 
 		cc.ContentAPIWait = 1 * time.Second
@@ -608,7 +613,7 @@ func (c *TestContextForVCSim) setupVCSim(config VCSimTestConfig) {
 	vcModel.Host = 0
 	vcModel.Cluster = c.ZoneCount * c.ClustersPerZone
 	vcModel.ClusterHost = 2
-	vcModel.Portgroup = c.networkCount
+	vcModel.Portgroup = len(c.networkConfig)
 	vcModel.Datastore = max(config.NumDatastores, 1)
 
 	Expect(vcModel.Create()).To(Succeed())
@@ -663,27 +668,33 @@ func (c *TestContextForVCSim) setupVCSim(config VCSimTestConfig) {
 		}
 	}
 
-	for i := range c.networkCount {
+	for i, cfg := range c.networkConfig {
+		network := VCSimNetwork{
+			Provider: cfg.Provider,
+		}
+
 		networkRef, err := c.Finder.Network(c, fmt.Sprintf("DC0_DVPG%d", i))
 		Expect(err).ToNot(HaveOccurred())
-		if i == 0 {
-			c.NetworkRef = networkRef
-		}
-		c.NetworkRefs = append(c.NetworkRefs, networkRef)
+		network.Backing = networkRef
 
-		switch c.networkEnv {
-		case NetworkEnvVDS:
+		switch cfg.Provider {
+		case pkgcfg.NetworkProviderTypeVDS:
 			// Nothing more needed for VDS.
-		case NetworkEnvNSXT, NetworkEnvVPC:
-			dvpg, ok := vcModel.Map().Get(networkRef.Reference()).(*simulator.DistributedVirtualPortgroup)
-			Expect(ok).To(BeTrue())
-			if c.networkEnv == NetworkEnvNSXT {
-				dvpg.Config.LogicalSwitchUuid = GetNsxTLogicalSwitchUUID(i)
-			} else {
-				dvpg.Config.LogicalSwitchUuid = GetVPCTLogicalSwitchUUID(i)
+		case pkgcfg.NetworkProviderTypeNSXT, pkgcfg.NetworkProviderTypeVPC:
+			network.LogicalSwitchUUID = uuid.NewString()
+
+			dvpgSpec := vimtypes.DVPortgroupConfigSpec{
+				BackingType:       "nsx",
+				LogicalSwitchUuid: network.LogicalSwitchUUID,
 			}
-			dvpg.Config.BackingType = "nsx"
+
+			task, err := object.NewDistributedVirtualPortgroup(
+				c.VCClient.Client, networkRef.Reference()).Reconfigure(c, dvpgSpec)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(task.Wait(c)).To(Succeed())
 		}
+
+		c.networks = append(c.networks, network)
 	}
 
 	c.VCClientConfig = pkgclient.Config{
@@ -1289,6 +1300,11 @@ func (c *TestContextForVCSim) GetAZClusterComputes(azName string) []*object.Clus
 	ccrs, ok := c.azCCRs[azName]
 	Expect(ok).To(BeTrue())
 	return ccrs
+}
+
+func (c *TestContextForVCSim) GetNetwork(idx int) VCSimNetwork {
+	Expect(idx).To(BeNumerically("<", len(c.networks)), "Invalid network index")
+	return c.networks[idx]
 }
 
 func (c *TestContextForVCSim) CreateVirtualMachineSetResourcePolicy(


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

In the future, a namespace may support multiple providers, and a NetworkInterface may front an VCP SubnetPort. Do the initial plumbing of supporting that here.

Pull out the getting of the network interface backing into a common function.

Instead of a single field to configure the type of provider when creating a vcsim test context, allow for multiple ones to be provided. Maps all the existing usage on to this new way, and they will be migrated later.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # vmop-3554


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note
NONE
```