### PR TITLE
:bug: Use updated api-tools to generate API docs

### DIFF
--- a/api-docs/Makefile
+++ b/api-docs/Makefile
@@ -6,7 +6,7 @@
 # WARNING: The Go version baked into this image must be compatible with the
 # go directive in go.mod. If either is updated, verify the other still matches
 # or the vendor/docs-generation step will fail with a version mismatch.
-API_DOCS_IMAGE ?= wcp-docker-local.packages.vcfd.broadcom.net/tools/api-docs:699a6a4
+API_DOCS_IMAGE ?= wcp-docker-local.packages.vcfd.broadcom.net/tools/api-docs:4d81416
 DOCKER_RUN := docker run --platform=linux/amd64 \
   -v $(CURDIR):$(CURDIR) -w $(CURDIR) --rm $(API_DOCS_IMAGE)
 

--- a/api-docs/crd-ref-docs.config.yaml
+++ b/api-docs/crd-ref-docs.config.yaml
@@ -36,6 +36,3 @@ render:
     - name: Protocol
       package: k8s.io/api/core/v1
       link: https://pkg.go.dev/k8s.io/api/core/v1#Protocol
-    - name: TypedLocalObjectReference
-      package: k8s.io/api/core/v1
-      link: https://pkg.go.dev/k8s.io/api/core/v1#TypedLocalObjectReference


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Use updated api-tools to generate API docs


**Please add a release note if necessary**:

```release-note
Use updated api-tools to generate API docs
```