### PR TITLE
🐛 fix: Clear SubnetId when editing NIC backing during subnet change

### DIFF
--- a/pkg/providers/vsphere/network/reconcile.go
+++ b/pkg/providers/vsphere/network/reconcile.go
@@ -26,7 +26,6 @@ func ReconcileNetworkInterfaces(
 	results *NetworkInterfaceResults,
 	currentEthCards object.VirtualDeviceList,
 ) ([]vimtypes.BaseVirtualDeviceConfigSpec, error) {
-
 	var deviceChanges []vimtypes.BaseVirtualDeviceConfigSpec
 
 	for idx, r := range results.Results {
@@ -51,6 +50,12 @@ func ReconcileNetworkInterfaces(
 				ethDev.AddressType = r.Device.(vimtypes.BaseVirtualEthernetCard).GetVirtualEthernetCard().AddressType
 				ethDev.MacAddress = r.Device.(vimtypes.BaseVirtualEthernetCard).GetVirtualEthernetCard().MacAddress
 				ethDev.ExternalId = r.Device.(vimtypes.BaseVirtualEthernetCard).GetVirtualEthernetCard().ExternalId
+
+				// Clear SubnetID when the backing changes to ensure we don't have a
+				// mismatch between the subnet ID and the port group specified in the
+				// backing. The subnetID is populated by the platform automatically when
+				// the network adapter is connected to a subnet.
+				ethDev.SubnetId = ""
 
 				deviceChanges = append(deviceChanges, &vimtypes.VirtualDeviceConfigSpec{
 					Device:    editDev,
@@ -89,8 +94,8 @@ func findExistingEthCardForOrphanedCR(
 	_ context.Context,
 	interfaceName string,
 	orphanedObjects []ctrlclient.Object,
-	currentEthCards object.VirtualDeviceList) int {
-
+	currentEthCards object.VirtualDeviceList,
+) int {
 	findMatchFn := func(obj ctrlclient.Object) int {
 		switch netIf := obj.(type) {
 		case *netopv1alpha1.NetworkInterface:
@@ -137,8 +142,8 @@ func findExistingEthCardForOrphanedCR(
 
 func FindMatchingEthCard(
 	currentEthCards object.VirtualDeviceList,
-	ethCard vimtypes.BaseVirtualEthernetCard) int {
-
+	ethCard vimtypes.BaseVirtualEthernetCard,
+) int {
 	ethDev := ethCard.GetVirtualEthernetCard()
 	matchingIdx := -1
 

--- a/pkg/providers/vsphere/network/reconcile_test.go
+++ b/pkg/providers/vsphere/network/reconcile_test.go
@@ -68,10 +68,20 @@ var _ = Describe("ReconcileNetworkInterfaces", func() {
 							PortgroupKey: "pg-1",
 						},
 					}
-				case builder.NetworkEnvNSXT, builder.NetworkEnvVPC:
+				case builder.NetworkEnvNSXT:
 					ethCard.GetVirtualEthernetCard().MacAddress = "my-mac"
 					ethCard.GetVirtualEthernetCard().AddressType = string(vimtypes.VirtualEthernetCardMacTypeAssigned)
 					ethCard.GetVirtualEthernetCard().ExternalId = "my-ext-id"
+					ethCard.GetVirtualEthernetCard().Backing = &vimtypes.VirtualEthernetCardDistributedVirtualPortBackingInfo{
+						Port: vimtypes.DistributedVirtualSwitchPortConnection{
+							PortgroupKey: "pg-1",
+						},
+					}
+				case builder.NetworkEnvVPC:
+					ethCard.GetVirtualEthernetCard().MacAddress = "my-mac"
+					ethCard.GetVirtualEthernetCard().AddressType = string(vimtypes.VirtualEthernetCardMacTypeAssigned)
+					ethCard.GetVirtualEthernetCard().ExternalId = "my-ext-id"
+					ethCard.GetVirtualEthernetCard().SubnetId = "/projects/my-project/vpcs/foo/subnets/old-subnet"
 					ethCard.GetVirtualEthernetCard().Backing = &vimtypes.VirtualEthernetCardDistributedVirtualPortBackingInfo{
 						Port: vimtypes.DistributedVirtualSwitchPortConnection{
 							PortgroupKey: "pg-1",
@@ -182,6 +192,7 @@ var _ = Describe("ReconcileNetworkInterfaces", func() {
 					dc0 := deviceChanges[0].GetVirtualDeviceConfigSpec()
 					Expect(dc0.Operation).To(Equal(vimtypes.VirtualDeviceConfigSpecOperationEdit))
 					Expect(dc0.Device.GetVirtualDevice().Backing).To(Equal(ethCard.GetVirtualEthernetCard().Backing))
+					Expect(dc0.Device.(vimtypes.BaseVirtualEthernetCard).GetVirtualEthernetCard().SubnetId).To(BeEmpty())
 				})
 
 				When("Network Interface CR is old and does not have interface name label", func() {
@@ -197,6 +208,7 @@ var _ = Describe("ReconcileNetworkInterfaces", func() {
 						dc0 := deviceChanges[0].GetVirtualDeviceConfigSpec()
 						Expect(dc0.Operation).To(Equal(vimtypes.VirtualDeviceConfigSpecOperationEdit))
 						Expect(dc0.Device.GetVirtualDevice().Backing).To(Equal(ethCard.GetVirtualEthernetCard().Backing))
+						Expect(dc0.Device.(vimtypes.BaseVirtualEthernetCard).GetVirtualEthernetCard().SubnetId).To(BeEmpty())
 					})
 				})
 			})

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_networking.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_networking.go
@@ -1,0 +1,339 @@
+// Copyright (c) 2025 Broadcom. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package virtualmachine
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/crypto/ssh"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+	e2eframework "k8s.io/kubernetes/test/e2e/framework"
+	capiutil "sigs.k8s.io/cluster-api/util"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	vmopv1a3 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+
+	"github.com/vmware-tanzu/vm-operator/test/e2e/appple2e/util"
+	"github.com/vmware-tanzu/vm-operator/test/e2e/framework"
+	e2essh "github.com/vmware-tanzu/vm-operator/test/e2e/infrastructure/vsphere/ssh"
+	"github.com/vmware-tanzu/vm-operator/test/e2e/infrastructure/vsphere/testbed"
+	"github.com/vmware-tanzu/vm-operator/test/e2e/infrastructure/vsphere/vcenter"
+	"github.com/vmware-tanzu/vm-operator/test/e2e/infrastructure/vsphere/wcp"
+	"github.com/vmware-tanzu/vm-operator/test/e2e/manifestbuilders"
+	"github.com/vmware-tanzu/vm-operator/test/e2e/utils"
+	"github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/common"
+	e2eConfig "github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/config"
+	"github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/consts"
+	"github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/lib/vmoperator"
+	"github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/skipper"
+	"github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/vmservice"
+	"github.com/vmware-tanzu/vm-operator/test/e2e/wcpframework"
+)
+
+type VMNetworkSpecInput struct {
+	Config           *e2eConfig.E2EConfig
+	ClusterProxy     wcpframework.WCPClusterProxyInterface
+	WCPClient        wcp.WorkloadManagementAPI
+	ArtifactFolder   string
+	WCPNamespaceName string
+}
+
+func VMNetworkSpec(ctx context.Context, inputGetter func() VMNetworkSpecInput) {
+	const (
+		specName           = "vm-networking"
+		mutableNetworksCap = "supports_VM_service_mutable_networks"
+	)
+
+	var (
+		input            VMNetworkSpecInput
+		wcpClient        wcp.WorkloadManagementAPI
+		config           *e2eConfig.E2EConfig
+		clusterProxy     *common.VMServiceClusterProxy
+		svClusterClient  ctrlclient.Client
+		clusterResources *e2eConfig.Resources
+		tmpNamespaceCtx  wcpframework.NamespaceContext
+		vmYaml           []byte
+		vmName           string
+
+		isVMMutableNetworksCapEnabled bool
+		linuxImageDisplayName         string
+		linuxVMIName                  string
+	)
+
+	BeforeEach(func() {
+		input = inputGetter()
+		Expect(input.Config).ToNot(BeNil(), "Invalid argument. input.E2EConfig can't be nil when calling %s spec", specName)
+		Expect(input.Config.InfraConfig).ToNot(BeNil(), "Invalid argument. input.E2EConfig.InfraConfig can't be nil when calling %s spec", specName)
+		skipper.SkipUnlessInfraIs(input.Config.InfraConfig.InfraName, consts.WCP)
+
+		Expect(input.ClusterProxy).ToNot(BeNil(), "Invalid argument. input.SVClusterProxy can't be nil when calling %s spec", specName)
+		Expect(input.WCPNamespaceName).ToNot(BeEmpty(), "Invalid argument. input.WCPNamespaceName can't be empty when calling %s spec", specName)
+		Expect(os.MkdirAll(input.ArtifactFolder, 0755)).To(Succeed(), "Invalid argument. input.ArtifactFolder can't be created for %s spec", specName)
+
+		svClusterProxy := input.ClusterProxy
+		wcpClient = input.WCPClient
+		config = input.Config
+		clusterResources = config.InfraConfig.ManagementClusterConfig.Resources
+		clusterProxy = input.ClusterProxy.(*common.VMServiceClusterProxy)
+		svClusterClient = clusterProxy.GetClient()
+		cancelPodWatches := framework.WatchPodLogsAndEventsInNamespaces(ctx, []string{config.GetVariable("VMOPNamespace")}, clusterProxy.GetClientSet(), filepath.Join(input.ArtifactFolder, specName))
+		DeferCleanup(cancelPodWatches)
+
+		linuxImageDisplayName = vmservice.GetDefaultImageDisplayName(clusterResources)
+		vmYaml = nil
+		tmpNamespaceCtx = wcpframework.NamespaceContext{}
+		vmName = fmt.Sprintf("%s-%s", specName, capiutil.RandomString(4))
+
+		var err error
+		linuxVMIName, err = vmoperator.WaitForVirtualMachineImageName(ctx, &config.Config, svClusterClient, input.WCPNamespaceName, linuxImageDisplayName)
+		Expect(err).NotTo(HaveOccurred(), "failed to get VMI name for display name %q in namespace %q", linuxImageDisplayName, input.WCPNamespaceName)
+
+		sshCommandRunner, _ := e2essh.NewSSHCommandRunner(
+			vcenter.GetVCPNIDFromKubeconfigFile(ctx, svClusterProxy.GetKubeconfigPath()),
+			vcenter.VCSSHPort, testbed.RootUsername, []ssh.AuthMethod{ssh.Password(testbed.RootPassword)})
+		isAsyncSvUpgradeEnabled, _ := util.IsFSSEnabled(sshCommandRunner, utils.SupervisorAsyncUpgradeFSS)
+		isVMMutableNetworksCapEnabled = utils.IsSupervisorCapabilityEnabled(ctx,
+			svClusterProxy.GetClientSet(), svClusterProxy.GetDynamicClient(), mutableNetworksCap, isAsyncSvUpgradeEnabled)
+	})
+
+	AfterEach(func() {
+		vmNamespaceName := input.WCPNamespaceName
+		if tmpNamespaceCtx.GetNamespace() != nil {
+			vmNamespaceName = tmpNamespaceCtx.GetNamespace().Name
+		}
+
+		if CurrentGinkgoTestDescription().Failed {
+			vmoperator.DescribeResourceIfExists(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), vmNamespaceName, vmName, "vm")
+		}
+
+		// Delete the virtual machine if it was created.
+		if len(vmYaml) > 0 {
+			Expect(clusterProxy.DeleteWithArgs(ctx, vmYaml)).To(Succeed(), "failed to delete virtualmachine")
+			// Verify that virtual machine does not exist.
+			vmoperator.WaitForVirtualMachineToBeDeleted(ctx, config, svClusterClient, vmNamespaceName, vmName)
+		}
+
+		// Delete the temporary namespace if it was created.
+		if tmpNamespaceCtx.GetNamespace() != nil {
+			clusterProxy.DeleteWCPNamespace(tmpNamespaceCtx)
+			wcp.WaitForNamespaceDeleted(wcpClient, tmpNamespaceCtx.GetNamespace().Name)
+		}
+	})
+
+	It("Should allow network interface to be added to VirtualMachine when mutability cap is enabled", Label("smoke"), func() {
+		if !isVMMutableNetworksCapEnabled {
+			Skip("VM Mutable Networks capability is not enabled")
+		}
+
+		vmParameters := manifestbuilders.VirtualMachineYaml{
+			Namespace:        input.WCPNamespaceName,
+			Name:             vmName,
+			ImageName:        linuxVMIName,
+			VMClassName:      clusterResources.VMClassName,
+			StorageClassName: clusterResources.StorageClassName,
+			PowerState:       "PoweredOff",
+		}
+		vmYaml = manifestbuilders.GetVirtualMachineYamlA2(vmParameters)
+		Expect(clusterProxy.CreateWithArgs(ctx, vmYaml)).To(Succeed(), "failed to create virtualmachine:\n %s", string(vmYaml))
+
+		vmoperator.WaitForVirtualMachineToExist(ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
+		vmoperator.WaitForVirtualMachineMOID(ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
+		vmMoID := vmoperator.GetVirtualMachineMOID(ctx, svClusterClient, input.WCPNamespaceName, vmName)
+		vmMoRef := types.ManagedObjectReference{Type: "VirtualMachine", Value: vmMoID}
+
+		vCenterClient := vcenter.NewVimClientFromKubeconfig(ctx, clusterProxy.GetKubeconfigPath())
+		propCollector := property.DefaultCollector(vCenterClient)
+
+		var vmMO mo.VirtualMachine
+		Expect(propCollector.RetrieveOne(ctx, vmMoRef, []string{"config"}, &vmMO)).To(Succeed())
+		ethCards := object.VirtualDeviceList(vmMO.Config.Hardware.Device).SelectByType((*types.VirtualEthernetCard)(nil))
+		Expect(ethCards).To(HaveLen(1), "VM config should have one EthernetCard")
+
+		By("Add second network interface to VM Spec")
+
+		key := ctrlclient.ObjectKey{Name: vmName, Namespace: input.WCPNamespaceName}
+		Eventually(func() bool {
+			vm := &vmopv1a3.VirtualMachine{}
+
+			err := svClusterClient.Get(ctx, key, vm)
+			if err != nil {
+				e2eframework.Logf("retry due to: %v", err)
+				return false
+			}
+
+			Expect(vm.Spec.Network).ToNot(BeNil())
+			Expect(vm.Spec.Network.Interfaces).To(HaveLen(1))
+			vm.Spec.Network.Interfaces = append(vm.Spec.Network.Interfaces, vm.Spec.Network.Interfaces[0])
+
+			vm.Spec.Network.Interfaces[1].Name = "eth1"
+
+			err = svClusterClient.Update(ctx, vm)
+			if err != nil {
+				e2eframework.Logf("retry due to: %v", err)
+				return false
+			}
+
+			return true
+		}, config.GetIntervals("default", "wait-virtual-machine-resize")...).Should(BeTrue(), "Timed out updating VirtualMachine %s to add second network interface", vmName)
+
+		By("Wait for VM to be reconfigured with second EthernetCard")
+		Eventually(func(g Gomega) {
+			g.Expect(propCollector.RetrieveOne(ctx, vmMoRef, []string{"config"}, &vmMO)).To(Succeed())
+			ethCards := object.VirtualDeviceList(vmMO.Config.Hardware.Device).SelectByType((*types.VirtualEthernetCard)(nil))
+			g.Expect(ethCards).To(HaveLen(2), "VM should have two EthernetCards configured")
+		}, config.GetIntervals("default", "wait-virtual-machine-resize")...).Should(Succeed(), "VM reconfigured with second EthernetCard")
+
+		By("Power on VM")
+		Eventually(func() bool {
+			vm := &vmopv1a3.VirtualMachine{}
+
+			err := svClusterClient.Get(ctx, key, vm)
+			if err != nil {
+				e2eframework.Logf("retry due to: %v", err)
+				return false
+			}
+
+			vm.Spec.PowerState = vmopv1a3.VirtualMachinePowerStateOn
+
+			err = svClusterClient.Update(ctx, vm)
+			if err != nil {
+				e2eframework.Logf("retry due to: %v", err)
+				return false
+			}
+
+			return true
+		}, config.GetIntervals("default", "wait-virtual-machine-powerstate")...).Should(BeTrue(), "Timed out updating VirtualMachine %s PowerState to On", vmName)
+		vmoperator.WaitForVirtualMachinePowerState(ctx, config, svClusterClient, input.WCPNamespaceName, vmName, "PoweredOn")
+		vmoperator.WaitForVirtualMachineIP(ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
+
+		By("Powered On VM should still have two EthernetCards configured")
+		Expect(propCollector.RetrieveOne(ctx, vmMoRef, []string{"config"}, &vmMO)).To(Succeed())
+		ethCards = object.VirtualDeviceList(vmMO.Config.Hardware.Device).SelectByType((*types.VirtualEthernetCard)(nil))
+		Expect(ethCards).To(HaveLen(2), "VM config should have two EthernetCards")
+	})
+
+	It("Should allow network interface to be moved to a different subnet when mutability cap is enabled", Label("smoke"), func() {
+		if !isVMMutableNetworksCapEnabled {
+			Skip("VM Mutable Networks capability is not enabled")
+		}
+
+		if !vmoperator.IsNetworkNsxtVPC(ctx, svClusterClient, config) {
+			Skip("Test requires VPC networking environment to create SubnetSet")
+		}
+
+		subnetSetName := "custom-subnetset"
+
+		By("Creating custom SubnetSet")
+		Eventually(func(g Gomega) {
+			sYaml := utils.CreateSubnetOrSubnetSetYaml(utils.SubnetSetKind, subnetSetName, input.WCPNamespaceName, utils.DHCPConfig, true)
+			g.Expect(clusterProxy.CreateWithArgs(ctx, sYaml)).To(Succeed(), "failed to create the SubnetSet: %s", string(sYaml))
+		}, config.GetIntervals("default", "wait-subnet-creation")...).Should(Succeed(), "Timed out in creating SubnetSet")
+		vmservice.VerifySubnetOrSubnetSetCreation(ctx, config, svClusterClient, input.WCPNamespaceName, subnetSetName, utils.SubnetSetKind)
+
+		DeferCleanup(func() {
+			vmoperator.DeleteSubnetOrSubnetSet(ctx, svClusterClient, input.WCPNamespaceName, subnetSetName, utils.SubnetSetKind)
+			vmoperator.WaitForSubnetOrSubnetSetToBeDeleted(ctx, config, svClusterClient, input.WCPNamespaceName, subnetSetName, utils.SubnetSetKind)
+		})
+
+		vmParameters := manifestbuilders.VirtualMachineYaml{
+			Namespace:        input.WCPNamespaceName,
+			Name:             vmName,
+			ImageName:        linuxVMIName,
+			VMClassName:      clusterResources.VMClassName,
+			StorageClassName: clusterResources.StorageClassName,
+			PowerState:       "PoweredOff",
+		}
+		vmYaml = manifestbuilders.GetVirtualMachineYamlA2(vmParameters)
+		Expect(clusterProxy.CreateWithArgs(ctx, vmYaml)).To(Succeed(), "failed to create virtualmachine:\n %s", string(vmYaml))
+
+		vmoperator.WaitForVirtualMachineToExist(ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
+		vmoperator.WaitForVirtualMachineMOID(ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
+		vmMoID := vmoperator.GetVirtualMachineMOID(ctx, svClusterClient, input.WCPNamespaceName, vmName)
+		vmMoRef := types.ManagedObjectReference{Type: "VirtualMachine", Value: vmMoID}
+
+		vCenterClient := vcenter.NewVimClientFromKubeconfig(ctx, clusterProxy.GetKubeconfigPath())
+		propCollector := property.DefaultCollector(vCenterClient)
+
+		var vmMO mo.VirtualMachine
+		Expect(propCollector.RetrieveOne(ctx, vmMoRef, []string{"config"}, &vmMO)).To(Succeed())
+		ethCards := object.VirtualDeviceList(vmMO.Config.Hardware.Device).SelectByType((*types.VirtualEthernetCard)(nil))
+		Expect(ethCards).To(HaveLen(1), "VM config should have one EthernetCard")
+
+		By("Change network interface to a different subnet")
+
+		key := ctrlclient.ObjectKey{Name: vmName, Namespace: input.WCPNamespaceName}
+		Eventually(func() bool {
+			vm := &vmopv1a3.VirtualMachine{}
+
+			err := svClusterClient.Get(ctx, key, vm)
+			if err != nil {
+				e2eframework.Logf("retry due to: %v", err)
+				return false
+			}
+
+			Expect(vm.Spec.Network).ToNot(BeNil())
+			Expect(vm.Spec.Network.Interfaces).To(HaveLen(1))
+
+			// Change the network name to the custom SubnetSet
+			vm.Spec.Network.Interfaces[0].Network.Name = subnetSetName
+			vm.Spec.Network.Interfaces[0].Network.Kind = utils.SubnetSetKind
+			vm.Spec.Network.Interfaces[0].Network.APIVersion = "crd.nsx.vmware.com/v1alpha1"
+
+			err = svClusterClient.Update(ctx, vm)
+			if err != nil {
+				e2eframework.Logf("retry due to: %v", err)
+				return false
+			}
+
+			return true
+		}, config.GetIntervals("default", "wait-virtual-machine-resize")...).Should(BeTrue(), "Timed out updating VirtualMachine %s to change subnet", vmName)
+
+		By("Wait for VM to be reconfigured with updated EthernetCard")
+		Eventually(func(g Gomega) {
+			g.Expect(propCollector.RetrieveOne(ctx, vmMoRef, []string{"config"}, &vmMO)).To(Succeed())
+			ethCards := object.VirtualDeviceList(vmMO.Config.Hardware.Device).SelectByType((*types.VirtualEthernetCard)(nil))
+			g.Expect(ethCards).To(HaveLen(1), "VM should still have one EthernetCard configured")
+			// We can add validation here to actually check the ethCard.  For now, just validate that
+			// the reconfiguring the NIC to connect to a different network succeeds.
+		}, config.GetIntervals("default", "wait-virtual-machine-resize")...).Should(Succeed(), "VM reconfigured with updated EthernetCard")
+
+		By("Power on VM")
+		Eventually(func() bool {
+			vm := &vmopv1a3.VirtualMachine{}
+			err := svClusterClient.Get(ctx, key, vm)
+			if err != nil {
+				e2eframework.Logf("retry due to: %v", err)
+				return false
+			}
+
+			vm.Spec.PowerState = vmopv1a3.VirtualMachinePowerStateOn
+
+			err = svClusterClient.Update(ctx, vm)
+			if err != nil {
+				e2eframework.Logf("retry due to: %v", err)
+				return false
+			}
+
+			return true
+		}, config.GetIntervals("default", "wait-virtual-machine-powerstate")...).Should(BeTrue(), "Timed out updating VirtualMachine %s PowerState to On", vmName)
+
+		vmoperator.WaitForVirtualMachinePowerState(ctx, config, svClusterClient, input.WCPNamespaceName, vmName, "PoweredOn")
+		vmoperator.WaitForVirtualMachineIP(ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
+
+		By("Powered On VM should still have one EthernetCard configured")
+		Expect(propCollector.RetrieveOne(ctx, vmMoRef, []string{"config"}, &vmMO)).To(Succeed())
+		ethCards = object.VirtualDeviceList(vmMO.Config.Hardware.Device).SelectByType((*types.VirtualEthernetCard)(nil))
+		Expect(ethCards).To(HaveLen(1), "VM config should have one EthernetCard")
+	})
+}


### PR DESCRIPTION
> **Cherry-pick of #1621 into `release/vc-9.1.0`**

**What does this PR do, and why is it needed?**

When a VM's network interface is moved to a new subnet, the orphaned network interface CR edit path in `ReconcileNetworkInterfaces` updates the NIC's backing and `ExternalId` but left the stale `SubnetId` intact. vSphere validates that the `SubnetId`'s logical switch matches the new DVPG's `logicalSwitchUuid`, so sending a mismatched `SubnetId` causes the reconfigure to fail with:

  "A specified parameter was not correct: device.backing
   Mismatch detected between DVPG and subnet ID"

Clear the `subnetId` to avoid this conflict. Also add an end to end test to verify that this works.


Testing Done:
```
Testing VM Services VIRTUAL-MACHINE VM-NETWORKING Should allow network interface to be moved to a different subnet when mutability cap is enabled [devops, viadmin, virtualmachine, vmservice, smoke]
/Users/parunesh/go/src/aruneshpa/vm-operator/test/e2e/vmservice/vmservice/virtualmachine/vm_networking.go:226
  I0526 11:19:51.246888    4338 command_runner.go:134] Running command via SSH; remote: 10.192.0.68:22, command: python /usr/sbin/feature-state-wrapper.py WCP_Supervisor_Async_Upgrade
  I0526 11:19:51.516186    4338 command_runner.go:152] Ran command via SSH; remote: 10.192.0.68:22, command: PYTHONWARNINGS=ignore python /usr/sbin/feature-state-wrapper.py WCP_Supervisor_Async_Upgrade, output: enabled
  , error: <nil>
  STEP: Creating custom SubnetSet @ 05/26/26 11:19:51.691
subnetset.crd.nsx.vmware.com/custom-subnetset created

  STEP: Verify that we have a Subnet or SubnetSet CRD @ 05/26/26 11:19:52.288
virtualmachine.vmoperator.vmware.com/vm-networking-neul created

  STEP: Verifying the existence of VM CR in etcd @ 05/26/26 11:19:52.774
  STEP: Verify that the VirtualMachine has a Unique ID/MOID @ 05/26/26 11:19:52.826
  STEP: Change network interface to a different subnet @ 05/26/26 11:20:03.587
  STEP: Wait for VM to be reconfigured with updated EthernetCard @ 05/26/26 11:20:04.618
  STEP: Power on VM @ 05/26/26 11:20:04.658
  STEP: Waiting for VM power state to reach PoweredOn @ 05/26/26 11:20:05.012
  STEP: Verify that an IP (ipv4) is allocated to the VirtualMachine 'vmsvc-e2e-2pyz6f/vm-networking-neul' @ 05/26/26 11:20:25.306
  STEP: Powered On VM should still have one EthernetCard configured @ 05/26/26 11:21:15.89
virtualmachine.vmoperator.vmware.com "vm-networking-neul" deleted from
vmsvc-e2e-2pyz6f namespace
```



**Please add a release note if necessary**:

```release-note
Clear SubnetId when editing NIC backing during subnet change
```

Made with [Cursor](https://cursor.com)