### PR TITLE
🐛 fix: clear SubnetId when editing NIC backing during subnet change

### DIFF
--- a/pkg/providers/vsphere/network/reconcile.go
+++ b/pkg/providers/vsphere/network/reconcile.go
@@ -26,7 +26,6 @@ func ReconcileNetworkInterfaces(
 	results *NetworkInterfaceResults,
 	currentEthCards object.VirtualDeviceList,
 ) ([]vimtypes.BaseVirtualDeviceConfigSpec, error) {
-
 	var deviceChanges []vimtypes.BaseVirtualDeviceConfigSpec
 
 	for idx, r := range results.Results {
@@ -51,6 +50,12 @@ func ReconcileNetworkInterfaces(
 				ethDev.AddressType = r.Device.(vimtypes.BaseVirtualEthernetCard).GetVirtualEthernetCard().AddressType
 				ethDev.MacAddress = r.Device.(vimtypes.BaseVirtualEthernetCard).GetVirtualEthernetCard().MacAddress
 				ethDev.ExternalId = r.Device.(vimtypes.BaseVirtualEthernetCard).GetVirtualEthernetCard().ExternalId
+
+				// Clear SubnetID when the backing changes to ensure we don't have a
+				// mismatch between the subnet ID and the port group specified in the
+				// backing. The subnetID is populated by the platform automatically when
+				// the network adapter is connected to a subnet.
+				ethDev.SubnetId = ""
 
 				deviceChanges = append(deviceChanges, &vimtypes.VirtualDeviceConfigSpec{
 					Device:    editDev,
@@ -89,8 +94,8 @@ func findExistingEthCardForOrphanedCR(
 	_ context.Context,
 	interfaceName string,
 	orphanedObjects []ctrlclient.Object,
-	currentEthCards object.VirtualDeviceList) int {
-
+	currentEthCards object.VirtualDeviceList,
+) int {
 	findMatchFn := func(obj ctrlclient.Object) int {
 		switch netIf := obj.(type) {
 		case *netopv1alpha1.NetworkInterface:
@@ -137,8 +142,8 @@ func findExistingEthCardForOrphanedCR(
 
 func FindMatchingEthCard(
 	currentEthCards object.VirtualDeviceList,
-	ethCard vimtypes.BaseVirtualEthernetCard) int {
-
+	ethCard vimtypes.BaseVirtualEthernetCard,
+) int {
 	ethDev := ethCard.GetVirtualEthernetCard()
 	matchingIdx := -1
 

--- a/pkg/providers/vsphere/network/reconcile_test.go
+++ b/pkg/providers/vsphere/network/reconcile_test.go
@@ -68,10 +68,20 @@ var _ = Describe("ReconcileNetworkInterfaces", func() {
 							PortgroupKey: "pg-1",
 						},
 					}
-				case builder.NetworkEnvNSXT, builder.NetworkEnvVPC:
+				case builder.NetworkEnvNSXT:
 					ethCard.GetVirtualEthernetCard().MacAddress = "my-mac"
 					ethCard.GetVirtualEthernetCard().AddressType = string(vimtypes.VirtualEthernetCardMacTypeAssigned)
 					ethCard.GetVirtualEthernetCard().ExternalId = "my-ext-id"
+					ethCard.GetVirtualEthernetCard().Backing = &vimtypes.VirtualEthernetCardDistributedVirtualPortBackingInfo{
+						Port: vimtypes.DistributedVirtualSwitchPortConnection{
+							PortgroupKey: "pg-1",
+						},
+					}
+				case builder.NetworkEnvVPC:
+					ethCard.GetVirtualEthernetCard().MacAddress = "my-mac"
+					ethCard.GetVirtualEthernetCard().AddressType = string(vimtypes.VirtualEthernetCardMacTypeAssigned)
+					ethCard.GetVirtualEthernetCard().ExternalId = "my-ext-id"
+					ethCard.GetVirtualEthernetCard().SubnetId = "/projects/my-project/vpcs/foo/subnets/old-subnet"
 					ethCard.GetVirtualEthernetCard().Backing = &vimtypes.VirtualEthernetCardDistributedVirtualPortBackingInfo{
 						Port: vimtypes.DistributedVirtualSwitchPortConnection{
 							PortgroupKey: "pg-1",
@@ -182,6 +192,7 @@ var _ = Describe("ReconcileNetworkInterfaces", func() {
 					dc0 := deviceChanges[0].GetVirtualDeviceConfigSpec()
 					Expect(dc0.Operation).To(Equal(vimtypes.VirtualDeviceConfigSpecOperationEdit))
 					Expect(dc0.Device.GetVirtualDevice().Backing).To(Equal(ethCard.GetVirtualEthernetCard().Backing))
+					Expect(dc0.Device.(vimtypes.BaseVirtualEthernetCard).GetVirtualEthernetCard().SubnetId).To(BeEmpty())
 				})
 
 				When("Network Interface CR is old and does not have interface name label", func() {
@@ -197,6 +208,7 @@ var _ = Describe("ReconcileNetworkInterfaces", func() {
 						dc0 := deviceChanges[0].GetVirtualDeviceConfigSpec()
 						Expect(dc0.Operation).To(Equal(vimtypes.VirtualDeviceConfigSpecOperationEdit))
 						Expect(dc0.Device.GetVirtualDevice().Backing).To(Equal(ethCard.GetVirtualEthernetCard().Backing))
+						Expect(dc0.Device.(vimtypes.BaseVirtualEthernetCard).GetVirtualEthernetCard().SubnetId).To(BeEmpty())
 					})
 				})
 			})


### PR DESCRIPTION
Crossport of ##1621

When a VM's network interface is moved to a new subnet, the orphaned network interface CR edit path in ReconcileNetworkInterfaces updates the NIC's backing and ExternalId but left the stale SubnetId intact. vSphere validates that the SubnetId's logical switch matches the new DVPG's logicalSwitchUuid, so sending a mismatched SubnetId causes the reconfigure to fail with:

  "A specified parameter was not correct: device.backing
   Mismatch detected between DVPG and subnet ID"

Clear SubnetId when overwriting the NIC's backing, mirroring the same pattern already used in VPCPostRestoreBackingFixup.

Testing Done:
- Snippet after running e2e test added in this change:

```
Testing VM Services VIRTUAL-MACHINE VM-NETWORKING Should allow network interface to be moved to a different subnet when mutability cap is enabled [devops, viadmin, virtualmachine, vmservice, smoke]
/Users/parunesh/go/src/aruneshpa/vm-operator/test/e2e/vmservice/vmservice/virtualmachine/vm_networking.go:226
  I0526 11:19:51.246888    4338 command_runner.go:134] Running command via SSH; remote: 10.192.0.68:22, command: python /usr/sbin/feature-state-wrapper.py WCP_Supervisor_Async_Upgrade
  I0526 11:19:51.516186    4338 command_runner.go:152] Ran command via SSH; remote: 10.192.0.68:22, command: PYTHONWARNINGS=ignore python /usr/sbin/feature-state-wrapper.py WCP_Supervisor_Async_Upgrade, output: enabled
  , error: <nil>
  STEP: Creating custom SubnetSet @ 05/26/26 11:19:51.691
subnetset.crd.nsx.vmware.com/custom-subnetset created

  STEP: Verify that we have a Subnet or SubnetSet CRD @ 05/26/26 11:19:52.288
virtualmachine.vmoperator.vmware.com/vm-networking-neul created

  STEP: Verifying the existence of VM CR in etcd @ 05/26/26 11:19:52.774
  STEP: Verify that the VirtualMachine has a Unique ID/MOID @ 05/26/26 11:19:52.826
  STEP: Change network interface to a different subnet @ 05/26/26 11:20:03.587
  STEP: Wait for VM to be reconfigured with updated EthernetCard @ 05/26/26 11:20:04.618
  STEP: Power on VM @ 05/26/26 11:20:04.658
  STEP: Waiting for VM power state to reach PoweredOn @ 05/26/26 11:20:05.012
  STEP: Verify that an IP (ipv4) is allocated to the VirtualMachine 'vmsvc-e2e-2pyz6f/vm-networking-neul' @ 05/26/26 11:20:25.306
  STEP: Powered On VM should still have one EthernetCard configured @ 05/26/26 11:21:15.89
virtualmachine.vmoperator.vmware.com "vm-networking-neul" deleted from
vmsvc-e2e-2pyz6f namespace
```

```release-note
Unset subnet ID on NIC reconfigure
```

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note

```