### PR TITLE
[x-port] [9.1.1] Host Affinity & AntiAffinity

### DIFF
--- a/controllers/virtualmachinegroup/virtualmachinegroup_controller.go
+++ b/controllers/virtualmachinegroup/virtualmachinegroup_controller.go
@@ -36,6 +36,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/patch"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
 	"github.com/vmware-tanzu/vm-operator/pkg/record"
+	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 	vmopv1util "github.com/vmware-tanzu/vm-operator/pkg/util/vmopv1"
 )
 
@@ -690,18 +691,35 @@ func (r *Reconciler) getVMForPlacement(
 		return nil, nil
 	}
 
-	// If VM has a zone label, skip group placement to respect zone override.
 	if zoneName := vm.Labels[corev1.LabelTopologyZone]; zoneName != "" {
+		isVksNodeVM := kubeutil.HasCAPILabels(vm.Labels)
+		// A zone-labeled VM bypasses group placement to honor its zone override
+		// when VMAffinityDuringExecution is disabled, or when it is a VKS node
+		// (CAPI-managed) which must stay pinned to its assigned zone.
+		if !pkgcfg.FromContext(ctx).Features.VMAffinityDuringExecution ||
+			isVksNodeVM {
+			pkglog.FromContextOrDefault(ctx).V(4).Info(
+				"VM has explicit zone label, skipping group placement",
+				"vmName", vmName,
+				"zoneName", zoneName,
+			)
+			return nil, nil
+		}
+
+		// Feature enabled + non-VKS: fall through so the zone-labeled VM still
+		// participates in group placement for DRS host recommendations.
 		pkglog.FromContextOrDefault(ctx).V(4).Info(
-			"VM has explicit zone label, skipping group placement",
+			"VM has explicit zone label but participates in group placement "+
+				"(VMAffinityDuringExecution enabled, non-VKS)",
 			"vmName", vmName,
 			"zoneName", zoneName,
 		)
-		return nil, nil
 	}
 
 	// VMG doesn't have a PlacementReady condition true for this VM (UID).
-	// VM is not already placed, nor has a zone label override.
+	// VM is not already placed, and either has no zone label override or is a
+	// non-VKS zone-labeled VM participating in group placement for VM-VM
+	// Affinity/Anti-Affinity at host host level within the zone.
 	// Return this VM to get it placed by the group.
 	return vm, nil
 }

--- a/controllers/virtualmachinegroup/virtualmachinegroup_controller_test.go
+++ b/controllers/virtualmachinegroup/virtualmachinegroup_controller_test.go
@@ -23,9 +23,11 @@ import (
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	vspherepolv1 "github.com/vmware-tanzu/vm-operator/external/vsphere-policy/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	"github.com/vmware-tanzu/vm-operator/pkg/constants"
 	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
+	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
@@ -502,6 +504,18 @@ var _ = Describe(
 					Expect(ctx.Client.Patch(ctx, vmCopy, client.MergeFrom(vm))).To(Succeed())
 				}
 
+				setVMCAPILabel = func(vmKey types.NamespacedName) {
+					GinkgoHelper()
+					vm := &vmopv1.VirtualMachine{}
+					Expect(ctx.Client.Get(ctx, vmKey, vm)).To(Succeed())
+					vmCopy := vm.DeepCopy()
+					if vmCopy.Labels == nil {
+						vmCopy.Labels = make(map[string]string)
+					}
+					vmCopy.Labels[kubeutil.CAPWClusterRoleLabelKey] = "worker"
+					Expect(ctx.Client.Patch(ctx, vmCopy, client.MergeFrom(vm))).To(Succeed())
+				}
+
 				verifyGroupPlacementReadyCondition = func(
 					groupKey types.NamespacedName,
 					memberCount int,
@@ -694,6 +708,71 @@ var _ = Describe(
 					verifyGroupPlacementReadyCondition(vmGroup1Key, 3, "")
 					verifyGroupPlacementReadyCondition(vmGroup2Key, 1, "")
 					Expect(groupPlacementCallCount.Load()).To(BeEquivalentTo(1), "VM should be placed by group")
+				})
+			})
+
+			When("VMAffinityDuringExecution is enabled", func() {
+				var oldVMAffinityDuringExecution bool
+
+				BeforeEach(func() {
+					oldVMAffinityDuringExecution = pkgcfg.FromContext(suite.Context).Features.VMAffinityDuringExecution
+					pkgcfg.SetContext(suite.Context, func(config *pkgcfg.Config) {
+						config.Features.VMAffinityDuringExecution = true
+					})
+				})
+
+				AfterEach(func() {
+					pkgcfg.SetContext(suite.Context, func(config *pkgcfg.Config) {
+						config.Features.VMAffinityDuringExecution = oldVMAffinityDuringExecution
+					})
+				})
+
+				When("VM has a zone label and is a VKS node", func() {
+					BeforeEach(func() {
+						By("setting zone and CAPI labels on VMs before adding to group")
+						setVMZoneLabel(vm1Key, "zone-a")
+						setVMZoneLabel(vm2Key, "zone-b")
+						setVMZoneLabel(vm3Key, "zone-c")
+						setVMCAPILabel(vm1Key)
+						setVMCAPILabel(vm2Key)
+						setVMCAPILabel(vm3Key)
+					})
+
+					It("should skip group placement to respect zone override", func() {
+						By("verifying provider was not called for group placement")
+						Consistently(func(g Gomega) {
+							g.Expect(groupPlacementCallCount.Load()).To(BeZero(),
+								"VKS nodes with zone label should not be placed by group")
+						}, "3s", "100ms").Should(Succeed())
+
+						By("verifying PlacementReady is not set on member status")
+						Consistently(func(g Gomega) {
+							group := &vmopv1.VirtualMachineGroup{}
+							g.Expect(ctx.Client.Get(ctx, vmGroup1Key, group)).To(Succeed())
+							g.Expect(group.Status.Members).To(HaveLen(3))
+							for _, ms := range group.Status.Members {
+								if ms.Kind == virtualMachineKind {
+									g.Expect(conditions.Get(&ms, vmopv1.VirtualMachineGroupMemberConditionPlacementReady)).To(BeNil())
+								}
+							}
+						}, "3s").Should(Succeed())
+					})
+				})
+
+				When("VM has a zone label and is not a VKS node", func() {
+					BeforeEach(func() {
+						By("setting zone label (without CAPI labels) on VMs before adding to group")
+						setVMZoneLabel(vm1Key, "zone-a")
+						setVMZoneLabel(vm2Key, "zone-b")
+						setVMZoneLabel(vm3Key, "zone-c")
+					})
+
+					It("should place the VM by group", func() {
+						verifyGroupPlacementReadyCondition(vmGroup1Key, 3, "")
+						verifyGroupPlacementReadyCondition(vmGroup2Key, 1, "")
+						Expect(groupPlacementCallCount.Load()).To(BeEquivalentTo(1),
+							"non-VKS zone-labeled VM should be placed by group")
+					})
 				})
 			})
 		})

--- a/pkg/config/capabilities/capabilities.go
+++ b/pkg/config/capabilities/capabilities.go
@@ -91,6 +91,11 @@ const (
 	// CapabilityKeyAllDisksArePVCs is the name of the capability key defined in
 	// the Supervisor capabilities CRD for enabling all disks as PVCs in VM Op.
 	CapabilityKeyAllDisksArePVCs = "supports_vm_service_all_disks_are_pvcs"
+
+	// CapabilityKeyVMAffinityDuringExecution is the name of the capability key defined in
+	// the Supervisor capabilities CRD for enabling affinity/anti-affinity rules
+	// for VM Placement during execution.
+	CapabilityKeyVMAffinityDuringExecution = "supports_VM_service_VM_affinity_during_execution"
 )
 
 var (
@@ -251,6 +256,8 @@ func updateCapabilitiesFeaturesFromCRD(
 			fs.VSpherePolicies = capStatus.Activated
 		case CapabilityKeyAllDisksArePVCs:
 			fs.AllDisksArePVCs = capStatus.Activated
+		case CapabilityKeyVMAffinityDuringExecution:
+			fs.VMAffinityDuringExecution = capStatus.Activated
 		}
 
 	}

--- a/pkg/config/capabilities/capabilities_test.go
+++ b/pkg/config/capabilities/capabilities_test.go
@@ -171,6 +171,9 @@ var _ = Describe("UpdateCapabilities", func() {
 						capabilities.CapabilityKeyVSpherePolicies: {
 							Activated: true,
 						},
+						capabilities.CapabilityKeyVMAffinityDuringExecution: {
+							Activated: true,
+						},
 					}
 					Expect(client.Status().Patch(ctx, &obj, objPatch)).To(Succeed())
 				})
@@ -190,6 +193,7 @@ var _ = Describe("UpdateCapabilities", func() {
 							config.Features.VMSharedDisks = true
 							config.Features.GuestCustomizationVCDParity = true
 							config.Features.VSpherePolicies = true
+							config.Features.VMAffinityDuringExecution = true
 						})
 					})
 					Specify("capabilities did not change", func() {
@@ -233,6 +237,9 @@ var _ = Describe("UpdateCapabilities", func() {
 					})
 					Specify(capabilities.CapabilityKeyVSpherePolicies, func() {
 						Expect(pkgcfg.FromContext(ctx).Features.VSpherePolicies).To(BeTrue())
+					})
+					Specify(capabilities.CapabilityKeyVMAffinityDuringExecution, func() {
+						Expect(pkgcfg.FromContext(ctx).Features.VMAffinityDuringExecution).To(BeTrue())
 					})
 				})
 
@@ -278,6 +285,9 @@ var _ = Describe("UpdateCapabilities", func() {
 					})
 					Specify(capabilities.CapabilityKeyVSpherePolicies, func() {
 						Expect(pkgcfg.FromContext(ctx).Features.VSpherePolicies).To(BeTrue())
+					})
+					Specify(capabilities.CapabilityKeyVMAffinityDuringExecution, func() {
+						Expect(pkgcfg.FromContext(ctx).Features.VMAffinityDuringExecution).To(BeTrue())
 					})
 				})
 			})
@@ -332,6 +342,9 @@ var _ = Describe("UpdateCapabilities", func() {
 						capabilities.CapabilityKeyVSpherePolicies: {
 							Activated: false,
 						},
+						capabilities.CapabilityKeyVMAffinityDuringExecution: {
+							Activated: false,
+						},
 					}
 					Expect(client.Status().Patch(ctx, &obj, objPatch)).To(Succeed())
 				})
@@ -377,6 +390,9 @@ var _ = Describe("UpdateCapabilities", func() {
 					})
 					Specify(capabilities.CapabilityKeyVSpherePolicies, func() {
 						Expect(pkgcfg.FromContext(ctx).Features.VSpherePolicies).To(BeFalse())
+					})
+					Specify(capabilities.CapabilityKeyVMAffinityDuringExecution, func() {
+						Expect(pkgcfg.FromContext(ctx).Features.VMAffinityDuringExecution).To(BeFalse())
 					})
 				})
 
@@ -434,6 +450,9 @@ var _ = Describe("UpdateCapabilities", func() {
 					})
 					Specify(capabilities.CapabilityKeyVSpherePolicies, func() {
 						Expect(pkgcfg.FromContext(ctx).Features.VSpherePolicies).To(BeFalse())
+					})
+					Specify(capabilities.CapabilityKeyVMAffinityDuringExecution, func() {
+						Expect(pkgcfg.FromContext(ctx).Features.VMAffinityDuringExecution).To(BeFalse())
 					})
 				})
 			})
@@ -716,6 +735,19 @@ var _ = Describe("UpdateCapabilitiesFeatures", func() {
 				Expect(pkgcfg.FromContext(ctx).Features.VSpherePolicies).To(BeTrue())
 			})
 		})
+		Context(capabilities.CapabilityKeyVMAffinityDuringExecution, func() {
+			BeforeEach(func() {
+				Expect(pkgcfg.FromContext(ctx).Features.VMAffinityDuringExecution).To(BeFalse())
+				obj.Status.Supervisor[capabilities.CapabilityKeyVMAffinityDuringExecution] = capv1.CapabilityStatus{
+					Activated: true,
+				}
+			})
+			Specify("Enabled", func() {
+				Expect(ok).To(BeTrue())
+				Expect(diff).To(Equal("VMAffinityDuringExecution=true"))
+				Expect(pkgcfg.FromContext(ctx).Features.VMAffinityDuringExecution).To(BeTrue())
+			})
+		})
 	})
 })
 
@@ -771,6 +803,9 @@ var _ = Describe("WouldUpdateCapabilitiesFeatures", func() {
 			capabilities.CapabilityKeyVSpherePolicies: {
 				Activated: true,
 			},
+			capabilities.CapabilityKeyVMAffinityDuringExecution: {
+				Activated: true,
+			},
 		}
 
 		ok, diff = false, ""
@@ -797,6 +832,7 @@ var _ = Describe("WouldUpdateCapabilitiesFeatures", func() {
 					config.Features.VMSharedDisks = true
 					config.Features.GuestCustomizationVCDParity = true
 					config.Features.VSpherePolicies = true
+					config.Features.VMAffinityDuringExecution = true
 				})
 			})
 			Specify("capabilities did not change", func() {
@@ -842,6 +878,10 @@ var _ = Describe("WouldUpdateCapabilitiesFeatures", func() {
 			Specify(capabilities.CapabilityKeyVSpherePolicies, func() {
 				Expect(pkgcfg.FromContext(ctx).Features.VSpherePolicies).To(BeTrue())
 			})
+			Specify(capabilities.CapabilityKeyVMAffinityDuringExecution, func() {
+				Expect(pkgcfg.FromContext(ctx).Features.VMAffinityDuringExecution).To(BeTrue())
+			})
+
 		})
 
 		When("the capabilities are different", func() {
@@ -858,11 +898,12 @@ var _ = Describe("WouldUpdateCapabilitiesFeatures", func() {
 					config.Features.VMSharedDisks = false
 					config.Features.GuestCustomizationVCDParity = false
 					config.Features.VSpherePolicies = false
+					config.Features.VMAffinityDuringExecution = false
 				})
 			})
 			Specify("capabilities changed", func() {
 				Expect(ok).To(BeTrue())
-				Expect(diff).To(Equal("BringYourOwnEncryptionKey=true,GuestCustomizationVCDParity=true,ImmutableClasses=true,InventoryContentLibrary=true,MutableNetworks=true,TKGMultipleCL=true,VMGroups=true,VMPlacementPolicies=true,VMSharedDisks=true,VMSnapshots=true,VMWaitForFirstConsumerPVC=true,VSpherePolicies=true,WorkloadDomainIsolation=true"))
+				Expect(diff).To(Equal("BringYourOwnEncryptionKey=true,GuestCustomizationVCDParity=true,ImmutableClasses=true,InventoryContentLibrary=true,MutableNetworks=true,TKGMultipleCL=true,VMAffinityDuringExecution=true,VMGroups=true,VMPlacementPolicies=true,VMSharedDisks=true,VMSnapshots=true,VMWaitForFirstConsumerPVC=true,VSpherePolicies=true,WorkloadDomainIsolation=true"))
 			})
 			Specify(capabilities.CapabilityKeyBringYourOwnKeyProvider, func() {
 				Expect(pkgcfg.FromContext(ctx).Features.BringYourOwnEncryptionKey).To(BeFalse())
@@ -902,6 +943,9 @@ var _ = Describe("WouldUpdateCapabilitiesFeatures", func() {
 			})
 			Specify(capabilities.CapabilityKeyVSpherePolicies, func() {
 				Expect(pkgcfg.FromContext(ctx).Features.VSpherePolicies).To(BeFalse())
+			})
+			Specify(capabilities.CapabilityKeyVMAffinityDuringExecution, func() {
+				Expect(pkgcfg.FromContext(ctx).Features.VMAffinityDuringExecution).To(BeFalse())
 			})
 		})
 	})

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -199,6 +199,7 @@ type FeatureStates struct {
 	VMSharedDisks               bool
 	GuestCustomizationVCDParity bool
 	AllDisksArePVCs             bool
+	VMAffinityDuringExecution   bool
 }
 
 type InstanceStorage struct {

--- a/pkg/providers/vsphere/placement/cluster_placement.go
+++ b/pkg/providers/vsphere/placement/cluster_placement.go
@@ -224,13 +224,14 @@ func getClusterPlacementRecommendations(
 	finder *find.Finder,
 	resourcePoolsMoRefs []vimtypes.ManagedObjectReference,
 	configSpecs []vimtypes.VirtualMachineConfigSpec,
-	needDatastorePlacement bool) (map[string]Recommendation, error) {
+	needHostPlacement, needDatastorePlacement bool) (map[string]Recommendation, error) {
 
 	logger := pkglog.FromContextOrDefault(ctx)
 	placementSpec := vimtypes.PlaceVmsXClusterSpec{
 		PlacementType:           string(vimtypes.PlaceVmsXClusterSpecPlacementTypeCreateAndPowerOn),
 		ResourcePools:           resourcePoolsMoRefs,
 		VmPlacementSpecs:        make([]vimtypes.PlaceVmsXClusterSpecVmPlacementSpec, len(configSpecs)),
+		HostRecommRequired:      &needHostPlacement,
 		DatastoreRecommRequired: &needDatastorePlacement,
 	}
 

--- a/pkg/providers/vsphere/placement/group_placement.go
+++ b/pkg/providers/vsphere/placement/group_placement.go
@@ -107,5 +107,6 @@ func getGroupPlacementRecommendations(
 		finder,
 		candidateRPMoRefs,
 		configSpecs,
+		true,
 		needDatastorePlacement)
 }

--- a/pkg/providers/vsphere/placement/zone_placement.go
+++ b/pkg/providers/vsphere/placement/zone_placement.go
@@ -351,6 +351,7 @@ func getPlacementRecommendation(
 			finder,
 			candidateRPMoRefs,
 			[]vimtypes.VirtualMachineConfigSpec{configSpec},
+			false,
 			needDatastorePlacement)
 		if err != nil {
 			return Recommendation{}, fmt.Errorf("PlaceVmsXCluster failed: %w", err)

--- a/pkg/providers/vsphere/virtualmachine/affinity.go
+++ b/pkg/providers/vsphere/virtualmachine/affinity.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 )
@@ -79,7 +80,6 @@ func genConfigSpecAffinityPolicies(
 // processVMAffinity returns placement policies for VM affinity rules.
 // VM affinity is bidirectional, so we only need to send in the label specified
 // in the VM affinity policy. Not additional labels.
-// Note: only zone topology is supported for VM affinity.
 func processVMAffinity(
 	vmCtx pkgctx.VirtualMachineContext,
 	affinity *vmopv1.VMAffinitySpec) []vimtypes.BaseVmPlacementPolicy {
@@ -99,6 +99,22 @@ func processVMAffinity(
 		})
 	}
 
+	// Process host-topology affinity terms only when VMAffinityDuringExecution is enabled.
+	if pkgcfg.FromContext(vmCtx).Features.VMAffinityDuringExecution {
+		// Process required affinity terms associated with host topology.
+		requiredHostTagIDs := buildTagIDsFromHostTopology(
+			vmCtx,
+			affinity.RequiredDuringSchedulingPreferredDuringExecution,
+		)
+		for _, tagID := range requiredHostTagIDs {
+			placementPols = append(placementPols, &vimtypes.VmVmAffinity{
+				AffinedVmsTag:    tagID,
+				PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
+				PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyHost),
+			})
+		}
+	}
+
 	// Process preferred affinity terms associated with zone topology.
 	preferredZoneTagIDs := buildTagIDsFromZoneTopology(
 		vmCtx,
@@ -112,13 +128,28 @@ func processVMAffinity(
 		})
 	}
 
+	// Process host-topology affinity terms only when VMAffinityDuringExecution is enabled.
+	if pkgcfg.FromContext(vmCtx).Features.VMAffinityDuringExecution {
+		// Process preferred affinity terms associated with host topology.
+		preferredHostTagIDs := buildTagIDsFromHostTopology(
+			vmCtx,
+			affinity.PreferredDuringSchedulingPreferredDuringExecution,
+		)
+		for _, tagID := range preferredHostTagIDs {
+			placementPols = append(placementPols, &vimtypes.VmVmAffinity{
+				AffinedVmsTag:    tagID,
+				PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessPreferredDuringPlacementPreferredDuringExecution),
+				PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyHost),
+			})
+		}
+	}
+
 	return placementPols
 }
 
 // processVMAntiAffinity returns placement policies from VM anti-affinity rules.
-// Use a single VmToVmGroupsAntiAffinity policy if the labels are non-empty.
-// Note: only zone topology is processed for VM anti-affinity; host topology
-// will be handled by ClusterModules.
+// Use a single VmToVmGroupsAntiAffinity policy per topology/strictness
+// combination if the labels are non-empty.
 func processVMAntiAffinity(
 	vmCtx pkgctx.VirtualMachineContext,
 	antiAffinity *vmopv1.VMAntiAffinitySpec) []vimtypes.BaseVmPlacementPolicy {
@@ -138,6 +169,21 @@ func processVMAntiAffinity(
 		})
 	}
 
+	// Process host-topology anti-affinity terms only when VMAffinityDuringExecution is enabled.
+	if pkgcfg.FromContext(vmCtx).Features.VMAffinityDuringExecution {
+		requiredHostTagIDs := buildTagIDsFromHostTopology(
+			vmCtx,
+			antiAffinity.RequiredDuringSchedulingPreferredDuringExecution,
+		)
+		for _, tagID := range requiredHostTagIDs {
+			placementPols = append(placementPols, &vimtypes.VmVmAntiAffinity{
+				AntiAffinedVmsTag: tagID,
+				PolicyStrictness:  string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
+				PolicyTopology:    string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyHost),
+			})
+		}
+	}
+
 	// Process preferred anti-affinity terms associated with zone topology.
 	preferredZoneTagIDs := buildTagIDsFromZoneTopology(
 		vmCtx,
@@ -151,20 +197,36 @@ func processVMAntiAffinity(
 		})
 	}
 
+	// Process host-topology anti-affinity terms only when VMAffinityDuringExecution is enabled.
+	if pkgcfg.FromContext(vmCtx).Features.VMAffinityDuringExecution {
+		preferredHostTagIDs := buildTagIDsFromHostTopology(
+			vmCtx,
+			antiAffinity.PreferredDuringSchedulingPreferredDuringExecution,
+		)
+		for _, tagID := range preferredHostTagIDs {
+			placementPols = append(placementPols, &vimtypes.VmVmAntiAffinity{
+				AntiAffinedVmsTag: tagID,
+				PolicyStrictness:  string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessPreferredDuringPlacementPreferredDuringExecution),
+				PolicyTopology:    string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyHost),
+			})
+		}
+	}
+
 	return placementPols
 }
 
-// buildTagIDsFromZoneTopology returns a list of TagIds built from the given
-// affinity/anti-affinity terms that have zone topology.
+// buildTagIDsFromTopology returns a list of TagIds built from the given
+// affinity/anti-affinity terms that match the specified topology key.
 // Terms with other topology types are ignored.
-func buildTagIDsFromZoneTopology(
+func buildTagIDsFromTopology(
 	vmCtx pkgctx.VirtualMachineContext,
-	terms []vmopv1.VMAffinityTerm) []vimtypes.TagId {
+	terms []vmopv1.VMAffinityTerm,
+	topologyKey string) []vimtypes.TagId {
 
 	var tagIDs []vimtypes.TagId
 
 	for _, term := range terms {
-		if term.TopologyKey != corev1.LabelTopologyZone {
+		if term.TopologyKey != topologyKey {
 			continue
 		}
 
@@ -186,6 +248,24 @@ func buildTagIDsFromZoneTopology(
 	}
 
 	return tagIDs
+}
+
+// buildTagIDsFromZoneTopology returns a list of TagIds built from the given
+// affinity/anti-affinity terms that have zone topology.
+func buildTagIDsFromZoneTopology(
+	vmCtx pkgctx.VirtualMachineContext,
+	terms []vmopv1.VMAffinityTerm) []vimtypes.TagId {
+
+	return buildTagIDsFromTopology(vmCtx, terms, corev1.LabelTopologyZone)
+}
+
+// buildTagIDsFromHostTopology returns a list of TagIds built from the given
+// affinity/anti-affinity terms that have host topology.
+func buildTagIDsFromHostTopology(
+	vmCtx pkgctx.VirtualMachineContext,
+	terms []vmopv1.VMAffinityTerm) []vimtypes.TagId {
+
+	return buildTagIDsFromTopology(vmCtx, terms, corev1.LabelHostname)
 }
 
 // extractLabelsFromSelector extracts all labels from a LabelSelector, handling both

--- a/pkg/providers/vsphere/virtualmachine/affinity.go
+++ b/pkg/providers/vsphere/virtualmachine/affinity.go
@@ -11,12 +11,59 @@ import (
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 )
+
+// extractAffinityLabelsFromVM extracts all "key:value" labels referenced
+// in the VM's affinity and anti-affinity rules.
+// Returns a set where keys are "key:value" strings
+// that are used in affinity rules.
+func extractAffinityLabelsFromVM(vmCtx pkgctx.VirtualMachineContext) sets.Set[string] {
+	affinity := vmCtx.VM.Spec.Affinity
+	if affinity == nil {
+		return nil
+	}
+
+	affinityLabels := sets.New[string]()
+
+	// helper to extract "key:value" labels from VMAffinityTerm slice
+	extractFromTerms := func(terms []vmopv1.VMAffinityTerm) {
+		for _, term := range terms {
+			if term.LabelSelector == nil {
+				continue
+			}
+
+			labels, err := extractLabelsFromSelector(term.LabelSelector)
+			if err != nil {
+				vmCtx.Logger.V(4).Error(err, "invalid label selector")
+				continue
+			}
+
+			for _, label := range labels {
+				affinityLabels.Insert(label)
+			}
+		}
+	}
+
+	// process VM affinity rules
+	if affinity.VMAffinity != nil {
+		extractFromTerms(affinity.VMAffinity.RequiredDuringSchedulingPreferredDuringExecution)
+		extractFromTerms(affinity.VMAffinity.PreferredDuringSchedulingPreferredDuringExecution)
+	}
+
+	// process VM anti-affinity rules
+	if affinity.VMAntiAffinity != nil {
+		extractFromTerms(affinity.VMAntiAffinity.RequiredDuringSchedulingPreferredDuringExecution)
+		extractFromTerms(affinity.VMAntiAffinity.PreferredDuringSchedulingPreferredDuringExecution)
+	}
+
+	return affinityLabels
+}
 
 // genConfigSpecTagSpecsFromVMLabels generates tag specs from VM labels.
 // This is required when setting affinity/anti-affinity policies on the VM.
@@ -31,10 +78,30 @@ func genConfigSpecTagSpecsFromVMLabels(
 
 	tagsToAdd := make([]vimtypes.TagSpec, 0, len(filteredLabels))
 
-	// Any label on the VM can participate in an affinity/anti-affinity policy.
-	// It does not matter if a label is not participating in any policy.
-	// It could be specified by this, or any other VM's placement policy later.
+	policyLabels := sets.New[string]()
+	if pkgcfg.FromContext(vmCtx).Features.VMAffinityDuringExecution {
+		policyLabels = extractAffinityLabelsFromVM(vmCtx)
+	}
+
+	// Any label on the VM can participate in an affinity/anti-affinity
+	// policy.
+	//
+	// For when VMAffinityDuringExecution is enabled,
+	// 	When VM is created, labels which only participate in affinity/anti-affinity
+	// 	policies are added to the configSpec.TagSpecs.
+	// 	This is because DRS expects tags which are ONLY referenced in
+	// 	affinity/anti-affinity policies.
+	//
+	// TODO(for Day 2 operations):
+	// 	When VM is updated and policies are added which refer more labels,
+	// 	this method is called again and the tags are added to the
+	// 	configSpec.TagSpecs.
 	for key, value := range filteredLabels {
+		if pkgcfg.FromContext(vmCtx).Features.VMAffinityDuringExecution &&
+			!policyLabels.Has(key+":"+value) {
+			continue
+		}
+
 		tagsToAdd = append(tagsToAdd, vimtypes.TagSpec{
 			ArrayUpdateSpec: vimtypes.ArrayUpdateSpec{
 				Operation: vimtypes.ArrayUpdateOperationAdd,
@@ -232,7 +299,7 @@ func buildTagIDsFromTopology(
 
 		termLabels, err := extractLabelsFromSelector(term.LabelSelector)
 		if err != nil {
-			vmCtx.Logger.Error(err, "invalid label selector")
+			vmCtx.Logger.V(4).Error(err, "invalid label selector")
 			continue
 		}
 

--- a/pkg/providers/vsphere/virtualmachine/affinity.go
+++ b/pkg/providers/vsphere/virtualmachine/affinity.go
@@ -14,16 +14,22 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
-	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 )
+
+// AffinityRuleConstraints defines constraints for configuring for affinity configuration at the topology level.
+// The flags are configured based on certain VM labels & the nature of affinity config: placement time vs create time.
+type AffinityRuleConstraints struct {
+	ConfigureHostRules bool
+	ConfigureZoneRules bool
+}
 
 // extractAffinityLabelsFromVM extracts all "key:value" labels referenced
 // in the VM's affinity and anti-affinity rules.
 // Returns a set where keys are "key:value" strings
 // that are used in affinity rules.
-func extractAffinityLabelsFromVM(vmCtx pkgctx.VirtualMachineContext) sets.Set[string] {
+func extractAffinityLabelsFromVM(vmCtx pkgctx.VirtualMachineContext, constraints AffinityRuleConstraints) sets.Set[string] {
 	affinity := vmCtx.VM.Spec.Affinity
 	if affinity == nil {
 		return nil
@@ -35,6 +41,14 @@ func extractAffinityLabelsFromVM(vmCtx pkgctx.VirtualMachineContext) sets.Set[st
 	extractFromTerms := func(terms []vmopv1.VMAffinityTerm) {
 		for _, term := range terms {
 			if term.LabelSelector == nil {
+				continue
+			}
+
+			if term.TopologyKey == corev1.LabelTopologyZone && !constraints.ConfigureZoneRules {
+				continue
+			}
+
+			if term.TopologyKey == corev1.LabelHostname && !constraints.ConfigureHostRules {
 				continue
 			}
 
@@ -69,7 +83,12 @@ func extractAffinityLabelsFromVM(vmCtx pkgctx.VirtualMachineContext) sets.Set[st
 // This is required when setting affinity/anti-affinity policies on the VM.
 func genConfigSpecTagSpecsFromVMLabels(
 	vmCtx pkgctx.VirtualMachineContext,
-	configSpec *vimtypes.VirtualMachineConfigSpec) {
+	configSpec *vimtypes.VirtualMachineConfigSpec,
+	constraints AffinityRuleConstraints) {
+
+	if !constraints.ConfigureHostRules && !constraints.ConfigureZoneRules {
+		return
+	}
 
 	filteredLabels := kubeutil.RemoveVMOperatorLabels(vmCtx.VM.Labels)
 	if len(filteredLabels) == 0 {
@@ -78,10 +97,7 @@ func genConfigSpecTagSpecsFromVMLabels(
 
 	tagsToAdd := make([]vimtypes.TagSpec, 0, len(filteredLabels))
 
-	policyLabels := sets.New[string]()
-	if pkgcfg.FromContext(vmCtx).Features.VMAffinityDuringExecution {
-		policyLabels = extractAffinityLabelsFromVM(vmCtx)
-	}
+	policyLabels := extractAffinityLabelsFromVM(vmCtx, constraints)
 
 	// Any label on the VM can participate in an affinity/anti-affinity
 	// policy.
@@ -97,8 +113,8 @@ func genConfigSpecTagSpecsFromVMLabels(
 	// 	this method is called again and the tags are added to the
 	// 	configSpec.TagSpecs.
 	for key, value := range filteredLabels {
-		if pkgcfg.FromContext(vmCtx).Features.VMAffinityDuringExecution &&
-			!policyLabels.Has(key+":"+value) {
+		// VM Creation should only contain policyLabels.
+		if !policyLabels.Has(key + ":" + value) {
 			continue
 		}
 
@@ -122,7 +138,8 @@ func genConfigSpecTagSpecsFromVMLabels(
 // affinity/anti-affinity rules.
 func genConfigSpecAffinityPolicies(
 	vmCtx pkgctx.VirtualMachineContext,
-	configSpec *vimtypes.VirtualMachineConfigSpec) {
+	configSpec *vimtypes.VirtualMachineConfigSpec,
+	constraints AffinityRuleConstraints) {
 
 	affinity := vmCtx.VM.Spec.Affinity
 	if affinity == nil {
@@ -132,11 +149,12 @@ func genConfigSpecAffinityPolicies(
 	var placementPols []vimtypes.BaseVmPlacementPolicy //nolint:prealloc
 
 	if affinity.VMAffinity != nil {
-		placementPols = append(placementPols, processVMAffinity(vmCtx, affinity.VMAffinity)...)
+		placementPols = append(placementPols, processVMAffinity(vmCtx, affinity.VMAffinity, constraints)...)
 	}
 
 	if affinity.VMAntiAffinity != nil {
-		placementPols = append(placementPols, processVMAntiAffinity(vmCtx, affinity.VMAntiAffinity)...)
+		placementPols = append(placementPols,
+			processVMAntiAffinity(vmCtx, affinity.VMAntiAffinity, constraints)...)
 	}
 
 	if len(placementPols) > 0 {
@@ -149,25 +167,28 @@ func genConfigSpecAffinityPolicies(
 // in the VM affinity policy. Not additional labels.
 func processVMAffinity(
 	vmCtx pkgctx.VirtualMachineContext,
-	affinity *vmopv1.VMAffinitySpec) []vimtypes.BaseVmPlacementPolicy {
+	affinity *vmopv1.VMAffinitySpec,
+	constraints AffinityRuleConstraints) []vimtypes.BaseVmPlacementPolicy {
 
 	var placementPols []vimtypes.BaseVmPlacementPolicy //nolint:prealloc
 
-	// Process required affinity terms associated with zone topology.
-	requiredZoneTagIDs := buildTagIDsFromZoneTopology(
-		vmCtx,
-		affinity.RequiredDuringSchedulingPreferredDuringExecution,
-	)
-	for _, tagID := range requiredZoneTagIDs {
-		placementPols = append(placementPols, &vimtypes.VmVmAffinity{
-			AffinedVmsTag:    tagID,
-			PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
-			PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyVSphereZone),
-		})
+	if constraints.ConfigureZoneRules {
+		// Process required affinity terms associated with zone topology.
+		requiredZoneTagIDs := buildTagIDsFromZoneTopology(
+			vmCtx,
+			affinity.RequiredDuringSchedulingPreferredDuringExecution,
+		)
+		for _, tagID := range requiredZoneTagIDs {
+			placementPols = append(placementPols, &vimtypes.VmVmAffinity{
+				AffinedVmsTag:    tagID,
+				PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
+				PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyVSphereZone),
+			})
+		}
 	}
 
 	// Process host-topology affinity terms only when VMAffinityDuringExecution is enabled.
-	if pkgcfg.FromContext(vmCtx).Features.VMAffinityDuringExecution {
+	if constraints.ConfigureHostRules {
 		// Process required affinity terms associated with host topology.
 		requiredHostTagIDs := buildTagIDsFromHostTopology(
 			vmCtx,
@@ -182,21 +203,23 @@ func processVMAffinity(
 		}
 	}
 
-	// Process preferred affinity terms associated with zone topology.
-	preferredZoneTagIDs := buildTagIDsFromZoneTopology(
-		vmCtx,
-		affinity.PreferredDuringSchedulingPreferredDuringExecution,
-	)
-	for _, tagID := range preferredZoneTagIDs {
-		placementPols = append(placementPols, &vimtypes.VmVmAffinity{
-			AffinedVmsTag:    tagID,
-			PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessPreferredDuringPlacementPreferredDuringExecution),
-			PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyVSphereZone),
-		})
+	if constraints.ConfigureZoneRules {
+		// Process preferred affinity terms associated with zone topology.
+		preferredZoneTagIDs := buildTagIDsFromZoneTopology(
+			vmCtx,
+			affinity.PreferredDuringSchedulingPreferredDuringExecution,
+		)
+		for _, tagID := range preferredZoneTagIDs {
+			placementPols = append(placementPols, &vimtypes.VmVmAffinity{
+				AffinedVmsTag:    tagID,
+				PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessPreferredDuringPlacementPreferredDuringExecution),
+				PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyVSphereZone),
+			})
+		}
 	}
 
 	// Process host-topology affinity terms only when VMAffinityDuringExecution is enabled.
-	if pkgcfg.FromContext(vmCtx).Features.VMAffinityDuringExecution {
+	if constraints.ConfigureHostRules {
 		// Process preferred affinity terms associated with host topology.
 		preferredHostTagIDs := buildTagIDsFromHostTopology(
 			vmCtx,
@@ -219,25 +242,28 @@ func processVMAffinity(
 // combination if the labels are non-empty.
 func processVMAntiAffinity(
 	vmCtx pkgctx.VirtualMachineContext,
-	antiAffinity *vmopv1.VMAntiAffinitySpec) []vimtypes.BaseVmPlacementPolicy {
+	antiAffinity *vmopv1.VMAntiAffinitySpec,
+	constraints AffinityRuleConstraints) []vimtypes.BaseVmPlacementPolicy {
 
 	var placementPols []vimtypes.BaseVmPlacementPolicy //nolint:prealloc
 
-	// Process required anti-affinity terms associated with zone topology.
-	requiredZoneTagIDs := buildTagIDsFromZoneTopology(
-		vmCtx,
-		antiAffinity.RequiredDuringSchedulingPreferredDuringExecution,
-	)
-	if len(requiredZoneTagIDs) > 0 {
-		placementPols = append(placementPols, &vimtypes.VmToVmGroupsAntiAffinity{
-			AntiAffinedVmGroupTags: requiredZoneTagIDs,
-			PolicyStrictness:       string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
-			PolicyTopology:         string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyVSphereZone),
-		})
+	if constraints.ConfigureZoneRules {
+		// Process required anti-affinity terms associated with zone topology.
+		requiredZoneTagIDs := buildTagIDsFromZoneTopology(
+			vmCtx,
+			antiAffinity.RequiredDuringSchedulingPreferredDuringExecution,
+		)
+		if len(requiredZoneTagIDs) > 0 {
+			placementPols = append(placementPols, &vimtypes.VmToVmGroupsAntiAffinity{
+				AntiAffinedVmGroupTags: requiredZoneTagIDs,
+				PolicyStrictness:       string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
+				PolicyTopology:         string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyVSphereZone),
+			})
+		}
 	}
 
 	// Process host-topology anti-affinity terms only when VMAffinityDuringExecution is enabled.
-	if pkgcfg.FromContext(vmCtx).Features.VMAffinityDuringExecution {
+	if constraints.ConfigureHostRules {
 		requiredHostTagIDs := buildTagIDsFromHostTopology(
 			vmCtx,
 			antiAffinity.RequiredDuringSchedulingPreferredDuringExecution,
@@ -251,21 +277,23 @@ func processVMAntiAffinity(
 		}
 	}
 
-	// Process preferred anti-affinity terms associated with zone topology.
-	preferredZoneTagIDs := buildTagIDsFromZoneTopology(
-		vmCtx,
-		antiAffinity.PreferredDuringSchedulingPreferredDuringExecution,
-	)
-	if len(preferredZoneTagIDs) > 0 {
-		placementPols = append(placementPols, &vimtypes.VmToVmGroupsAntiAffinity{
-			AntiAffinedVmGroupTags: preferredZoneTagIDs,
-			PolicyStrictness:       string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessPreferredDuringPlacementPreferredDuringExecution),
-			PolicyTopology:         string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyVSphereZone),
-		})
+	if constraints.ConfigureZoneRules {
+		// Process preferred anti-affinity terms associated with zone topology.
+		preferredZoneTagIDs := buildTagIDsFromZoneTopology(
+			vmCtx,
+			antiAffinity.PreferredDuringSchedulingPreferredDuringExecution,
+		)
+		if len(preferredZoneTagIDs) > 0 {
+			placementPols = append(placementPols, &vimtypes.VmToVmGroupsAntiAffinity{
+				AntiAffinedVmGroupTags: preferredZoneTagIDs,
+				PolicyStrictness:       string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessPreferredDuringPlacementPreferredDuringExecution),
+				PolicyTopology:         string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyVSphereZone),
+			})
+		}
 	}
 
 	// Process host-topology anti-affinity terms only when VMAffinityDuringExecution is enabled.
-	if pkgcfg.FromContext(vmCtx).Features.VMAffinityDuringExecution {
+	if constraints.ConfigureHostRules {
 		preferredHostTagIDs := buildTagIDsFromHostTopology(
 			vmCtx,
 			antiAffinity.PreferredDuringSchedulingPreferredDuringExecution,

--- a/pkg/providers/vsphere/virtualmachine/configspec.go
+++ b/pkg/providers/vsphere/virtualmachine/configspec.go
@@ -151,6 +151,12 @@ func CreateConfigSpec(
 		initResourceAllocation(&configSpec.MemoryAllocation)
 	}
 
+	// Apply placement policies and tag specs when feature is enabled
+	if pkgcfg.FromContext(vmCtx).Features.VMAffinityDuringExecution {
+		genConfigSpecAffinityPolicies(vmCtx, &configSpec)
+		genConfigSpecTagSpecsFromVMLabels(vmCtx, &configSpec)
+	}
+
 	return configSpec
 }
 

--- a/pkg/providers/vsphere/virtualmachine/configspec.go
+++ b/pkg/providers/vsphere/virtualmachine/configspec.go
@@ -329,9 +329,12 @@ func CreateConfigSpecForPlacement(
 	return configSpec, nil
 }
 
-// CalculateAffinityConstraints calculates the constraints based on vm object in vmCtx & creation/placement
-// workflow.
-func CalculateAffinityConstraints(vmCtx pkgctx.VirtualMachineContext, isCreateVM bool) AffinityRuleConstraints {
+// CalculateAffinityConstraints calculates the constraints based on vm object
+// in vmCtx & creation/placement workflow.
+func CalculateAffinityConstraints(
+	vmCtx pkgctx.VirtualMachineContext,
+	isCreateVM bool,
+) AffinityRuleConstraints {
 	constraints := AffinityRuleConstraints{}
 	if pkgcfg.FromContext(vmCtx).Features.VMPlacementPolicies {
 		constraints.ConfigureZoneRules = true
@@ -347,9 +350,19 @@ func CalculateAffinityConstraints(vmCtx pkgctx.VirtualMachineContext, isCreateVM
 		constraints.ConfigureHostRules = false
 	}
 
-	if isCreateVM {
-		// Zonal rules are ignored during VM Creation as DRS does not differentiate between topologies for persisted policies.
-		// Persistent policies are treated at Host Topology.
+	// ConfigureZoneRules = false when:
+	//   1. VM Creation: DRS doesn't differentiate topologies for persisted policies.
+	//   2. VKS Node: Never get zonal policies (VMs are already zone-constrained).
+	//   3. VMAffinityDuringExecution + Zone Label: Already zone-constrained
+	//
+	//   isCreateVM? → isVksNodeVM? → (VMAffinityDuringExecution + ZoneLabel)?
+	//    ↓YES (any)       ↓YES              ↓YES     		↓NO
+	//    FALSE            FALSE             FALSE    		TRUE
+	//
+	if isCreateVM ||
+		isVksNodeVM ||
+		(pkgcfg.FromContext(vmCtx).Features.VMAffinityDuringExecution &&
+			kubeutil.HasZoneLabel(vmCtx.VM.Labels)) {
 		constraints.ConfigureZoneRules = false
 	}
 

--- a/pkg/providers/vsphere/virtualmachine/configspec.go
+++ b/pkg/providers/vsphere/virtualmachine/configspec.go
@@ -12,6 +12,7 @@ import (
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/constants"
 	"github.com/vmware-tanzu/vm-operator/pkg/util"
+	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	vmopv1util "github.com/vmware-tanzu/vm-operator/pkg/util/vmopv1"
 )
@@ -152,10 +153,9 @@ func CreateConfigSpec(
 	}
 
 	// Apply placement policies and tag specs when feature is enabled
-	if pkgcfg.FromContext(vmCtx).Features.VMAffinityDuringExecution {
-		genConfigSpecAffinityPolicies(vmCtx, &configSpec)
-		genConfigSpecTagSpecsFromVMLabels(vmCtx, &configSpec)
-	}
+	affinityConstraints := CalculateAffinityConstraints(vmCtx, true)
+	genConfigSpecAffinityPolicies(vmCtx, &configSpec, affinityConstraints)
+	genConfigSpecTagSpecsFromVMLabels(vmCtx, &configSpec, affinityConstraints)
 
 	return configSpec
 }
@@ -313,10 +313,9 @@ func CreateConfigSpecForPlacement(
 	}
 
 	// Populate the affinity policy for the VM.
-	if pkgcfg.FromContext(vmCtx).Features.VMPlacementPolicies {
-		genConfigSpecAffinityPolicies(vmCtx, &configSpec)
-		genConfigSpecTagSpecsFromVMLabels(vmCtx, &configSpec)
-	}
+	affinityConstraints := CalculateAffinityConstraints(vmCtx, false)
+	genConfigSpecAffinityPolicies(vmCtx, &configSpec, affinityConstraints)
+	genConfigSpecTagSpecsFromVMLabels(vmCtx, &configSpec, affinityConstraints)
 
 	cleanupConfigSpecForPlacement(&configSpec)
 
@@ -328,6 +327,33 @@ func CreateConfigSpecForPlacement(
 	//  - whatever else I'm forgetting
 
 	return configSpec, nil
+}
+
+// CalculateAffinityConstraints calculates the constraints based on vm object in vmCtx & creation/placement
+// workflow.
+func CalculateAffinityConstraints(vmCtx pkgctx.VirtualMachineContext, isCreateVM bool) AffinityRuleConstraints {
+	constraints := AffinityRuleConstraints{}
+	if pkgcfg.FromContext(vmCtx).Features.VMPlacementPolicies {
+		constraints.ConfigureZoneRules = true
+	}
+
+	if pkgcfg.FromContext(vmCtx).Features.VMAffinityDuringExecution {
+		constraints.ConfigureHostRules = true
+	}
+
+	isVksNodeVM := kubeutil.HasCAPILabels(vmCtx.VM.Labels)
+	if isVksNodeVM {
+		// Host anti-affinity for CAPI VMs is handled via cluster modules.
+		constraints.ConfigureHostRules = false
+	}
+
+	if isCreateVM {
+		// Zonal rules are ignored during VM Creation as DRS does not differentiate between topologies for persisted policies.
+		// Persistent policies are treated at Host Topology.
+		constraints.ConfigureZoneRules = false
+	}
+
+	return constraints
 }
 
 // cleanupConfigSpecForPlacement removes fields from the placement

--- a/pkg/providers/vsphere/virtualmachine/configspec_test.go
+++ b/pkg/providers/vsphere/virtualmachine/configspec_test.go
@@ -1025,69 +1025,468 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 				})
 			})
 
-			Context("with unsupported topology key (host with affinity)", func() {
+			When("VMAffinityDuringExecution feature is enabled", func() {
 				BeforeEach(func() {
-					vmCtx.VM.Spec.Affinity = &vmopv1.AffinitySpec{
-						VMAffinity: &vmopv1.VMAffinitySpec{
-							RequiredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
-								{
-									LabelSelector: &metav1.LabelSelector{
-										MatchLabels: map[string]string{
-											"component": "web",
-										},
-										MatchExpressions: []metav1.LabelSelectorRequirement{
-											{
-												Key:      "tier",
-												Operator: metav1.LabelSelectorOpIn,
-												Values:   []string{"frontend", "backend"},
-											},
-										},
-									},
-									TopologyKey: corev1.LabelHostname,
-								},
-								{
-									LabelSelector: &metav1.LabelSelector{
-										MatchLabels: map[string]string{
-											"environment": "prod",
-										},
-									},
-									TopologyKey: corev1.LabelHostname,
-								},
-							},
-							PreferredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
-								{
-									LabelSelector: &metav1.LabelSelector{
-										MatchLabels: map[string]string{
-											"component": "web",
-										},
-										MatchExpressions: []metav1.LabelSelectorRequirement{
-											{
-												Key:      "tier",
-												Operator: metav1.LabelSelectorOpIn,
-												Values:   []string{"frontend", "backend"},
-											},
-										},
-									},
-									TopologyKey: corev1.LabelHostname,
-								},
-								{
-									LabelSelector: &metav1.LabelSelector{
-										MatchLabels: map[string]string{
-											"environment": "prod",
-										},
-									},
-									TopologyKey: corev1.LabelHostname,
-								},
-							},
-						},
-					}
+					pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
+						config.Features.VMAffinityDuringExecution = true
+					})
 				})
 
-				It("creates a minimal policy with VM tags but no anti-affinity rules", func() {
-					Expect(configSpec.VmPlacementPolicies).To(BeEmpty())
+				Context("required affinity policy with host topology key", func() {
+					BeforeEach(func() {
+						vmCtx.VM.Spec.Affinity = &vmopv1.AffinitySpec{
+							VMAffinity: &vmopv1.VMAffinitySpec{
+								RequiredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"component": "web",
+											},
+											MatchExpressions: []metav1.LabelSelectorRequirement{
+												{
+													Key:      "tier",
+													Operator: metav1.LabelSelectorOpIn,
+													Values:   []string{"frontend", "backend"},
+												},
+											},
+										},
+										TopologyKey: corev1.LabelHostname,
+									},
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"environment": "prod",
+											},
+										},
+										TopologyKey: corev1.LabelHostname,
+									},
+								},
+							},
+						}
+					})
 
-					// VM tags should still be attached (without VM Operator managed labels) even though anti-affinity policy failed.
-					assertVMTags(configSpec, []string{"vm-label1:vm-value1", "vm-label2:vm-value2"}, vmCtx.VM.Namespace)
+					It("config spec should have the expected host-level affinity policies", func() {
+						Expect(configSpec.VmPlacementPolicies).To(HaveLen(4))
+
+						pols := []vimtypes.BaseVmPlacementPolicy{
+							&vimtypes.VmVmAffinity{
+								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
+								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyHost),
+								AffinedVmsTag: vimtypes.TagId{
+									NameId: &vimtypes.TagIdNameId{
+										Tag:      "component:web",
+										Category: vmCtx.VM.Namespace,
+									},
+								},
+							},
+							&vimtypes.VmVmAffinity{
+								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
+								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyHost),
+								AffinedVmsTag: vimtypes.TagId{
+									NameId: &vimtypes.TagIdNameId{
+										Tag:      "tier:frontend",
+										Category: vmCtx.VM.Namespace,
+									},
+								},
+							},
+							&vimtypes.VmVmAffinity{
+								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
+								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyHost),
+								AffinedVmsTag: vimtypes.TagId{
+									NameId: &vimtypes.TagIdNameId{
+										Tag:      "tier:backend",
+										Category: vmCtx.VM.Namespace,
+									},
+								},
+							},
+							&vimtypes.VmVmAffinity{
+								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
+								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyHost),
+								AffinedVmsTag: vimtypes.TagId{
+									NameId: &vimtypes.TagIdNameId{
+										Tag:      "environment:prod",
+										Category: vmCtx.VM.Namespace,
+									},
+								},
+							},
+						}
+
+						Expect(configSpec.VmPlacementPolicies).To(HaveLen(4))
+						Expect(configSpec.VmPlacementPolicies).To(ConsistOf(pols))
+						assertVMTags(configSpec, []string{"vm-label1:vm-value1", "vm-label2:vm-value2"}, vmCtx.VM.Namespace)
+					})
+				})
+
+				Context("preferred affinity policy with host topology key", func() {
+					BeforeEach(func() {
+						vmCtx.VM.Spec.Affinity = &vmopv1.AffinitySpec{
+							VMAffinity: &vmopv1.VMAffinitySpec{
+								PreferredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"component": "web",
+											},
+										},
+										TopologyKey: corev1.LabelHostname,
+									},
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"environment": "prod",
+											},
+										},
+										TopologyKey: corev1.LabelHostname,
+									},
+								},
+							},
+						}
+					})
+
+					It("config spec should have the expected host-level affinity policies", func() {
+						Expect(configSpec.VmPlacementPolicies).To(HaveLen(2))
+
+						pols := []vimtypes.BaseVmPlacementPolicy{
+							&vimtypes.VmVmAffinity{
+								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessPreferredDuringPlacementPreferredDuringExecution),
+								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyHost),
+								AffinedVmsTag: vimtypes.TagId{
+									NameId: &vimtypes.TagIdNameId{
+										Tag:      "component:web",
+										Category: vmCtx.VM.Namespace,
+									},
+								},
+							},
+							&vimtypes.VmVmAffinity{
+								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessPreferredDuringPlacementPreferredDuringExecution),
+								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyHost),
+								AffinedVmsTag: vimtypes.TagId{
+									NameId: &vimtypes.TagIdNameId{
+										Tag:      "environment:prod",
+										Category: vmCtx.VM.Namespace,
+									},
+								},
+							},
+						}
+
+						Expect(configSpec.VmPlacementPolicies).To(HaveLen(2))
+						Expect(configSpec.VmPlacementPolicies).To(ConsistOf(pols))
+						assertVMTags(configSpec, []string{"vm-label1:vm-value1", "vm-label2:vm-value2"}, vmCtx.VM.Namespace)
+					})
+				})
+
+				Context("required anti-affinity policy with host topology key", func() {
+					BeforeEach(func() {
+						vmCtx.VM.Spec.Affinity = &vmopv1.AffinitySpec{
+							VMAntiAffinity: &vmopv1.VMAntiAffinitySpec{
+								RequiredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"component": "web",
+											},
+											MatchExpressions: []metav1.LabelSelectorRequirement{
+												{
+													Key:      "tier",
+													Operator: metav1.LabelSelectorOpIn,
+													Values:   []string{"frontend", "backend"},
+												},
+											},
+										},
+										TopologyKey: corev1.LabelHostname,
+									},
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"environment": "prod",
+											},
+										},
+										TopologyKey: corev1.LabelHostname,
+									},
+								},
+							},
+						}
+					})
+
+					It("creates multiple VmVmAntiAffinity policies with host topology", func() {
+						Expect(configSpec.VmPlacementPolicies).To(HaveLen(4))
+
+						expectedPolicies := []vimtypes.BaseVmPlacementPolicy{
+							&vimtypes.VmVmAntiAffinity{
+								AntiAffinedVmsTag: vimtypes.TagId{
+									NameId: &vimtypes.TagIdNameId{
+										Tag:      "component:web",
+										Category: vmCtx.VM.Namespace,
+									},
+								},
+								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
+								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyHost),
+							},
+							&vimtypes.VmVmAntiAffinity{
+								AntiAffinedVmsTag: vimtypes.TagId{
+									NameId: &vimtypes.TagIdNameId{
+										Tag:      "tier:frontend",
+										Category: vmCtx.VM.Namespace,
+									},
+								},
+								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
+								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyHost),
+							},
+							&vimtypes.VmVmAntiAffinity{
+								AntiAffinedVmsTag: vimtypes.TagId{
+									NameId: &vimtypes.TagIdNameId{
+										Tag:      "tier:backend",
+										Category: vmCtx.VM.Namespace,
+									},
+								},
+								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
+								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyHost),
+							},
+							&vimtypes.VmVmAntiAffinity{
+								AntiAffinedVmsTag: vimtypes.TagId{
+									NameId: &vimtypes.TagIdNameId{
+										Tag:      "environment:prod",
+										Category: vmCtx.VM.Namespace,
+									},
+								},
+								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
+								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyHost),
+							},
+						}
+
+						Expect(configSpec.VmPlacementPolicies).To(ConsistOf(expectedPolicies))
+						assertVMTags(configSpec, []string{"vm-label1:vm-value1", "vm-label2:vm-value2"}, vmCtx.VM.Namespace)
+					})
+				})
+
+				Context("preferred anti-affinity policy with host topology key", func() {
+					BeforeEach(func() {
+						vmCtx.VM.Spec.Affinity = &vmopv1.AffinitySpec{
+							VMAntiAffinity: &vmopv1.VMAntiAffinitySpec{
+								PreferredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"component": "web",
+											},
+										},
+										TopologyKey: corev1.LabelHostname,
+									},
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"environment": "prod",
+											},
+										},
+										TopologyKey: corev1.LabelHostname,
+									},
+								},
+							},
+						}
+					})
+
+					It("creates multiple VmVmAntiAffinity policies with host topology", func() {
+						Expect(configSpec.VmPlacementPolicies).To(HaveLen(2))
+
+						expectedPolicies := []vimtypes.BaseVmPlacementPolicy{
+							&vimtypes.VmVmAntiAffinity{
+								AntiAffinedVmsTag: vimtypes.TagId{
+									NameId: &vimtypes.TagIdNameId{
+										Tag:      "component:web",
+										Category: vmCtx.VM.Namespace,
+									},
+								},
+								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessPreferredDuringPlacementPreferredDuringExecution),
+								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyHost),
+							},
+							&vimtypes.VmVmAntiAffinity{
+								AntiAffinedVmsTag: vimtypes.TagId{
+									NameId: &vimtypes.TagIdNameId{
+										Tag:      "environment:prod",
+										Category: vmCtx.VM.Namespace,
+									},
+								},
+								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessPreferredDuringPlacementPreferredDuringExecution),
+								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyHost),
+							},
+						}
+
+						Expect(configSpec.VmPlacementPolicies).To(ConsistOf(expectedPolicies))
+						assertVMTags(configSpec, []string{"vm-label1:vm-value1", "vm-label2:vm-value2"}, vmCtx.VM.Namespace)
+					})
+				})
+
+				Context("mixed zone and host topology anti-affinity terms", func() {
+					BeforeEach(func() {
+						vmCtx.VM.Spec.Affinity = &vmopv1.AffinitySpec{
+							VMAntiAffinity: &vmopv1.VMAntiAffinitySpec{
+								RequiredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"zone-label": "zone-value",
+											},
+										},
+										TopologyKey: corev1.LabelTopologyZone,
+									},
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"host-label": "host-value",
+											},
+										},
+										TopologyKey: corev1.LabelHostname,
+									},
+								},
+							},
+						}
+					})
+
+					It("creates separate policies for zone and host topologies", func() {
+						Expect(configSpec.VmPlacementPolicies).To(HaveLen(2))
+
+						pols := []vimtypes.BaseVmPlacementPolicy{
+							&vimtypes.VmToVmGroupsAntiAffinity{
+								AntiAffinedVmGroupTags: []vimtypes.TagId{
+									{
+										NameId: &vimtypes.TagIdNameId{
+											Tag:      "zone-label:zone-value",
+											Category: vmCtx.VM.Namespace,
+										},
+									},
+								},
+								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
+								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyVSphereZone),
+							},
+							&vimtypes.VmVmAntiAffinity{
+								AntiAffinedVmsTag: vimtypes.TagId{
+									NameId: &vimtypes.TagIdNameId{
+										Tag:      "host-label:host-value",
+										Category: vmCtx.VM.Namespace,
+									},
+								},
+								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
+								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyHost),
+							},
+						}
+
+						Expect(configSpec.VmPlacementPolicies).To(HaveLen(2))
+						Expect(configSpec.VmPlacementPolicies).To(ConsistOf(pols))
+						assertVMTags(configSpec, []string{"vm-label1:vm-value1", "vm-label2:vm-value2"}, vmCtx.VM.Namespace)
+					})
+				})
+			})
+
+			When("VMAffinityDuringExecution feature is disabled", func() {
+				Context("host topology affinity terms are ignored", func() {
+					BeforeEach(func() {
+						vmCtx.VM.Spec.Affinity = &vmopv1.AffinitySpec{
+							VMAffinity: &vmopv1.VMAffinitySpec{
+								RequiredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"component": "web",
+											},
+										},
+										TopologyKey: corev1.LabelHostname,
+									},
+								},
+								PreferredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"environment": "prod",
+											},
+										},
+										TopologyKey: corev1.LabelHostname,
+									},
+								},
+							},
+						}
+					})
+
+					It("produces no placement policies", func() {
+						Expect(configSpec.VmPlacementPolicies).To(BeEmpty())
+						assertVMTags(configSpec, []string{"vm-label1:vm-value1", "vm-label2:vm-value2"}, vmCtx.VM.Namespace)
+					})
+				})
+
+				Context("host topology anti-affinity terms are ignored", func() {
+					BeforeEach(func() {
+						vmCtx.VM.Spec.Affinity = &vmopv1.AffinitySpec{
+							VMAntiAffinity: &vmopv1.VMAntiAffinitySpec{
+								RequiredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"component": "web",
+											},
+										},
+										TopologyKey: corev1.LabelHostname,
+									},
+								},
+								PreferredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"environment": "prod",
+											},
+										},
+										TopologyKey: corev1.LabelHostname,
+									},
+								},
+							},
+						}
+					})
+
+					It("produces no placement policies", func() {
+						Expect(configSpec.VmPlacementPolicies).To(BeEmpty())
+						assertVMTags(configSpec, []string{"vm-label1:vm-value1", "vm-label2:vm-value2"}, vmCtx.VM.Namespace)
+					})
+				})
+
+				Context("mixed zone and host topology terms only produce zone policies", func() {
+					BeforeEach(func() {
+						vmCtx.VM.Spec.Affinity = &vmopv1.AffinitySpec{
+							VMAntiAffinity: &vmopv1.VMAntiAffinitySpec{
+								RequiredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"zone-label": "zone-value",
+											},
+										},
+										TopologyKey: corev1.LabelTopologyZone,
+									},
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"host-label": "host-value",
+											},
+										},
+										TopologyKey: corev1.LabelHostname,
+									},
+								},
+							},
+						}
+					})
+
+					It("creates only the zone topology policy", func() {
+						Expect(configSpec.VmPlacementPolicies).To(HaveLen(1))
+
+						policy, ok := configSpec.VmPlacementPolicies[0].(*vimtypes.VmToVmGroupsAntiAffinity)
+						Expect(ok).To(BeTrue())
+						Expect(policy.PolicyTopology).To(Equal(string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyVSphereZone)))
+						Expect(policy.AntiAffinedVmGroupTags).To(ConsistOf(vimtypes.TagId{
+							NameId: &vimtypes.TagIdNameId{
+								Tag:      "zone-label:zone-value",
+								Category: vmCtx.VM.Namespace,
+							},
+						}))
+
+						assertVMTags(configSpec, []string{"vm-label1:vm-value1", "vm-label2:vm-value2"}, vmCtx.VM.Namespace)
+					})
 				})
 			})
 

--- a/pkg/providers/vsphere/virtualmachine/configspec_test.go
+++ b/pkg/providers/vsphere/virtualmachine/configspec_test.go
@@ -465,6 +465,199 @@ var _ = Describe("CreateConfigSpec", func() {
 			})
 		})
 	})
+
+	Context("AF/AAF policies", func() {
+		BeforeEach(func() {
+			pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
+				config.Features.VMAffinityDuringExecution = true
+			})
+		})
+
+		When("VM spec has affinity policies set", func() {
+			Context("required affinity policy with zone topology key", func() {
+				BeforeEach(func() {
+					vmCtx.VM.Labels = map[string]string{
+						"app":                          "db",
+						"env":                          "prod",
+						"zone":                         "us-west",
+						"vmoperator.vmware.com/paused": "true", // should be filtered out
+					}
+
+					vmCtx.VM.Spec.Affinity = &vmopv1.AffinitySpec{
+						VMAffinity: &vmopv1.VMAffinitySpec{
+							RequiredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"env": "prod",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "app",
+												Values:   []string{"db"},
+												Operator: metav1.LabelSelectorOpIn,
+											},
+										},
+									},
+									TopologyKey: corev1.LabelTopologyZone,
+								},
+							},
+						},
+					}
+				})
+
+				It("should have placement policies and tag specs", func() {
+					// Expect 2 policies: one for MatchLabels "env:prod" and one for MatchExpressions "app:db"
+					Expect(configSpec.VmPlacementPolicies).To(HaveLen(2))
+
+					// Verify both policies are VmVmAffinity
+					for _, pol := range configSpec.VmPlacementPolicies {
+						policy, ok := pol.(*vimtypes.VmVmAffinity)
+						Expect(ok).To(BeTrue())
+						Expect(policy.PolicyStrictness).To(Equal(string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution)))
+						Expect(policy.PolicyTopology).To(Equal(string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyVSphereZone)))
+						Expect(policy.AffinedVmsTag.NameId.Tag).To(BeElementOf("env:prod", "app:db"))
+						Expect(policy.AffinedVmsTag.NameId.Category).To(Equal(vmCtx.VM.Namespace))
+					}
+
+					// Only labels referenced in affinity rules should be included as tags
+					// Affinity rules reference "env" and "app" keys, so only those labels should be present
+					// "zone:us-west" should be excluded since "zone" is not referenced in any affinity rule
+					expectedTagNames := []string{"app:db", "env:prod"}
+					assertVMTags(configSpec, expectedTagNames, vmCtx.VM.Namespace)
+				})
+			})
+
+			Context("anti-affinity policy with zone topology key", func() {
+				BeforeEach(func() {
+					vmCtx.VM.Labels = map[string]string{
+						"app": "web",
+						"env": "prod",
+					}
+
+					vmCtx.VM.Spec.Affinity = &vmopv1.AffinitySpec{
+						VMAntiAffinity: &vmopv1.VMAntiAffinitySpec{
+							RequiredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "web",
+										},
+									},
+									TopologyKey: corev1.LabelTopologyZone,
+								},
+							},
+						},
+					}
+				})
+
+				It("should have anti-affinity policies and tag specs", func() {
+					Expect(configSpec.VmPlacementPolicies).To(HaveLen(1))
+					policy, ok := configSpec.VmPlacementPolicies[0].(*vimtypes.VmToVmGroupsAntiAffinity)
+					Expect(ok).To(BeTrue())
+					Expect(policy.PolicyStrictness).To(Equal(string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution)))
+					Expect(policy.PolicyTopology).To(Equal(string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyVSphereZone)))
+					Expect(policy.AntiAffinedVmGroupTags).To(HaveLen(1))
+					Expect(policy.AntiAffinedVmGroupTags[0].NameId.Tag).To(Equal("app:web"))
+					Expect(policy.AntiAffinedVmGroupTags[0].NameId.Category).To(Equal(vmCtx.VM.Namespace))
+
+					// Check TagSpecs for VM labels
+					expectedTagNames := []string{"app:web"}
+					assertVMTags(configSpec, expectedTagNames, vmCtx.VM.Namespace)
+				})
+			})
+		})
+
+		When("VM spec has no affinity policies but has labels", func() {
+			BeforeEach(func() {
+				vmCtx.VM.Labels = map[string]string{
+					"app": "standalone",
+					"env": "test",
+				}
+				vmCtx.VM.Spec.Affinity = nil
+			})
+
+			It("should not have any tag specs when no affinity rules exist", func() {
+				Expect(configSpec.VmPlacementPolicies).To(BeEmpty())
+				Expect(configSpec.TagSpecs).To(BeEmpty())
+			})
+		})
+
+		When("VM has labels but affinity only references some of them", func() {
+			BeforeEach(func() {
+				vmCtx.VM.Labels = map[string]string{
+					"app":                          "web",
+					"env":                          "prod",
+					"tier":                         "frontend",
+					"version":                      "1.0",
+					"owner":                        "team-a",
+					"vmoperator.vmware.com/paused": "true", // should be filtered out
+				}
+
+				vmCtx.VM.Spec.Affinity = &vmopv1.AffinitySpec{
+					VMAffinity: &vmopv1.VMAffinitySpec{
+						RequiredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+							{
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"app": "web",
+									},
+									MatchExpressions: []metav1.LabelSelectorRequirement{
+										{
+											Key:      "env",
+											Values:   []string{"prod", "staging"},
+											Operator: metav1.LabelSelectorOpIn,
+										},
+									},
+								},
+								TopologyKey: corev1.LabelTopologyZone,
+							},
+						},
+					},
+				}
+			})
+
+			It("should only include labels referenced in affinity rules", func() {
+				Expect(configSpec.VmPlacementPolicies).To(HaveLen(3))
+
+				// Only "app" and "env" keys are referenced in affinity rules
+				// "tier", "version", and "owner" labels should be excluded from tags
+				expectedTagNames := []string{"app:web", "env:prod"}
+				assertVMTags(configSpec, expectedTagNames, vmCtx.VM.Namespace)
+			})
+		})
+
+		When("VMAffinityDuringExecution feature flag is disabled", func() {
+			BeforeEach(func() {
+				pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
+					config.Features.VMAffinityDuringExecution = false
+				})
+
+				vmCtx.VM.Labels = map[string]string{
+					"app": "test",
+				}
+				vmCtx.VM.Spec.Affinity = &vmopv1.AffinitySpec{
+					VMAffinity: &vmopv1.VMAffinitySpec{
+						RequiredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+							{
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"app": "test",
+									},
+								},
+								TopologyKey: corev1.LabelTopologyZone,
+							},
+						},
+					},
+				}
+			})
+
+			It("should not have placement policies or tag specs", func() {
+				Expect(configSpec.VmPlacementPolicies).To(BeEmpty())
+				Expect(configSpec.TagSpecs).To(BeEmpty())
+			})
+		})
+	})
 })
 
 var _ = Describe("CreateConfigSpecForPlacement", func() {
@@ -1113,7 +1306,13 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 
 						Expect(configSpec.VmPlacementPolicies).To(HaveLen(4))
 						Expect(configSpec.VmPlacementPolicies).To(ConsistOf(pols))
-						assertVMTags(configSpec, []string{"vm-label1:vm-value1", "vm-label2:vm-value2"}, vmCtx.VM.Namespace)
+						// With VMAffinityDuringExecution enabled, only labels
+						// referenced in affinity rules are added as TagSpecs
+						// Since VM labels ("vm-label1", "vm-label2") don't
+						//  match affinity rule references
+						// ("component", "tier", "environment"),
+						// no TagSpecs should be generated
+						Expect(configSpec.TagSpecs).To(BeEmpty())
 					})
 				})
 
@@ -1171,7 +1370,12 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 
 						Expect(configSpec.VmPlacementPolicies).To(HaveLen(2))
 						Expect(configSpec.VmPlacementPolicies).To(ConsistOf(pols))
-						assertVMTags(configSpec, []string{"vm-label1:vm-value1", "vm-label2:vm-value2"}, vmCtx.VM.Namespace)
+						// With VMAffinityDuringExecution enabled, only labels
+						// referenced in affinity rules are added as TagSpecs
+						// Since VM labels ("vm-label1", "vm-label2") don't match
+						// affinity rule references ("component", "environment"),
+						// no TagSpecs should be generated
+						Expect(configSpec.TagSpecs).To(BeEmpty())
 					})
 				})
 
@@ -1255,7 +1459,12 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 						}
 
 						Expect(configSpec.VmPlacementPolicies).To(ConsistOf(expectedPolicies))
-						assertVMTags(configSpec, []string{"vm-label1:vm-value1", "vm-label2:vm-value2"}, vmCtx.VM.Namespace)
+						// With VMAffinityDuringExecution enabled, only labels
+						// referenced in affinity rules are added as TagSpecs
+						// Since VM labels ("vm-label1", "vm-label2") don't match
+						// affinity rule references ("component", "tier", "environment"),
+						// no TagSpecs should be generated
+						Expect(configSpec.TagSpecs).To(BeEmpty())
 					})
 				})
 
@@ -1312,7 +1521,12 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 						}
 
 						Expect(configSpec.VmPlacementPolicies).To(ConsistOf(expectedPolicies))
-						assertVMTags(configSpec, []string{"vm-label1:vm-value1", "vm-label2:vm-value2"}, vmCtx.VM.Namespace)
+						// With VMAffinityDuringExecution enabled, only labels
+						// referenced in affinity rules are added as TagSpecs
+						// Since VM labels ("vm-label1", "vm-label2") don't match
+						// affinity rule references ("component", "environment"),
+						// no TagSpecs should be generated
+						Expect(configSpec.TagSpecs).To(BeEmpty())
 					})
 				})
 
@@ -1372,7 +1586,12 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 
 						Expect(configSpec.VmPlacementPolicies).To(HaveLen(2))
 						Expect(configSpec.VmPlacementPolicies).To(ConsistOf(pols))
-						assertVMTags(configSpec, []string{"vm-label1:vm-value1", "vm-label2:vm-value2"}, vmCtx.VM.Namespace)
+						// With VMAffinityDuringExecution enabled, only labels
+						// referenced in affinity rules are added as TagSpecs
+						// Since VM labels ("vm-label1", "vm-label2") don't match
+						// affinity rule references ("zone-label", "host-label"),
+						// no TagSpecs should be generated
+						Expect(configSpec.TagSpecs).To(BeEmpty())
 					})
 				})
 			})

--- a/pkg/providers/vsphere/virtualmachine/configspec_test.go
+++ b/pkg/providers/vsphere/virtualmachine/configspec_test.go
@@ -963,7 +963,7 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 		})
 	})
 
-	Context("AF/AFF policies", func() {
+	Context("AF/AAF policies", func() {
 		BeforeEach(func() {
 			pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
 				config.Features.VMPlacementPolicies = true
@@ -1742,35 +1742,9 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 					})
 
 					// policies are ignored as cluster modules is used for VMs with capv labels
-					It("should ignore host affinity policies and keep zone affinity policies", func() {
-						Expect(configSpec.VmPlacementPolicies).To(HaveLen(2))
-
-						pols := []vimtypes.BaseVmPlacementPolicy{
-							&vimtypes.VmVmAffinity{
-								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
-								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyVSphereZone),
-								AffinedVmsTag: vimtypes.TagId{
-									NameId: &vimtypes.TagIdNameId{
-										Tag:      fmt.Sprintf("%s:%s", "env", "prod"),
-										Category: vmCtx.VM.Namespace,
-									},
-								},
-							},
-							&vimtypes.VmToVmGroupsAntiAffinity{
-								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
-								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyVSphereZone),
-								AntiAffinedVmGroupTags: []vimtypes.TagId{
-									{
-										NameId: &vimtypes.TagIdNameId{
-											Tag:      fmt.Sprintf("%s:%s", "env", "dev"),
-											Category: vmCtx.VM.Namespace,
-										},
-									},
-								},
-							},
-						}
-						Expect(configSpec.VmPlacementPolicies).To(ConsistOf(pols))
-						assertVMTags(configSpec, []string{"env:prod"}, vmCtx.VM.Namespace)
+					It("should ignore both host and zone affinity policies", func() {
+						Expect(configSpec.VmPlacementPolicies).To(HaveLen(0))
+						assertVMTags(configSpec, []string{}, vmCtx.VM.Namespace)
 					})
 				})
 				Context("VKS node VM with both host and zone topology keys with capw labels", func() {
@@ -1826,35 +1800,9 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 					})
 
 					// policies are ignored as cluster modules is used for VMs with capw labels
-					It("should ignore host affinity policies and keep zone affinity policies", func() {
-						Expect(configSpec.VmPlacementPolicies).To(HaveLen(2))
-
-						pols := []vimtypes.BaseVmPlacementPolicy{
-							&vimtypes.VmVmAffinity{
-								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
-								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyVSphereZone),
-								AffinedVmsTag: vimtypes.TagId{
-									NameId: &vimtypes.TagIdNameId{
-										Tag:      fmt.Sprintf("%s:%s", "env", "prod"),
-										Category: vmCtx.VM.Namespace,
-									},
-								},
-							},
-							&vimtypes.VmToVmGroupsAntiAffinity{
-								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
-								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyVSphereZone),
-								AntiAffinedVmGroupTags: []vimtypes.TagId{
-									{
-										NameId: &vimtypes.TagIdNameId{
-											Tag:      fmt.Sprintf("%s:%s", "env", "dev"),
-											Category: vmCtx.VM.Namespace,
-										},
-									},
-								},
-							},
-						}
-						Expect(configSpec.VmPlacementPolicies).To(ConsistOf(pols))
-						assertVMTags(configSpec, []string{"env:prod"}, vmCtx.VM.Namespace)
+					It("should ignore both host affinity and zone affinity policies", func() {
+						Expect(configSpec.VmPlacementPolicies).To(HaveLen(0))
+						assertVMTags(configSpec, []string{}, vmCtx.VM.Namespace)
 					})
 				})
 			})
@@ -2249,7 +2197,7 @@ var _ = Describe("CalculateAffinityConstraints", func() {
 				}
 			})
 
-			It("should disable host rules even when VMAffinityDuringExecution is enabled", func() {
+			It("should disable both host and zone rules when VMAffinityDuringExecution is enabled", func() {
 				pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
 					config.Features.VMPlacementPolicies = true
 					config.Features.VMAffinityDuringExecution = true
@@ -2257,10 +2205,10 @@ var _ = Describe("CalculateAffinityConstraints", func() {
 
 				constraints := virtualmachine.CalculateAffinityConstraints(vmCtx, false)
 				Expect(constraints.ConfigureHostRules).To(BeFalse(), "VKS node VMs should disable host rules")
-				Expect(constraints.ConfigureZoneRules).To(BeTrue(), "Zone rules should still be enabled")
+				Expect(constraints.ConfigureZoneRules).To(BeFalse(), "VKS node VMs should never get zonal policies")
 			})
 
-			It("should keep zone rules enabled when VMPlacementPolicies is enabled", func() {
+			It("should ignore zone rules even when VMPlacementPolicies is enabled", func() {
 				pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
 					config.Features.VMPlacementPolicies = true
 					config.Features.VMAffinityDuringExecution = false
@@ -2268,7 +2216,7 @@ var _ = Describe("CalculateAffinityConstraints", func() {
 
 				constraints := virtualmachine.CalculateAffinityConstraints(vmCtx, false)
 				Expect(constraints.ConfigureHostRules).To(BeFalse())
-				Expect(constraints.ConfigureZoneRules).To(BeTrue())
+				Expect(constraints.ConfigureZoneRules).To(BeFalse(), "VKS node VMs should never get zonal policies")
 			})
 		})
 
@@ -2347,73 +2295,112 @@ var _ = Describe("CalculateAffinityConstraints", func() {
 				})
 			})
 
-			It("should disable host rules but allow zone rules", func() {
+			It("should disable both host and zone rules", func() {
 				constraints := virtualmachine.CalculateAffinityConstraints(vmCtx, false)
 				Expect(constraints.ConfigureHostRules).To(BeFalse(), "VKS nodes should disable host rules")
-				Expect(constraints.ConfigureZoneRules).To(BeTrue(), "Zone rules should be enabled for placement")
+				Expect(constraints.ConfigureZoneRules).To(BeFalse(), "VKS nodes should never get zonal policies")
 			})
 		})
 
 		When("regular VM with different flag combinations", func() {
-			BeforeEach(func() {
-				vm.Labels = map[string]string{
-					"app": "test-app",
-				}
+			When("VM does not have zone label", func() {
+				BeforeEach(func() {
+					vm.Labels = map[string]string{
+						"app": "test-app",
+					}
+				})
+
+				It("should respect feature flags during placement workflow", func() {
+					testCases := []struct {
+						vmPlacement  bool
+						vmAffinity   bool
+						expectedZone bool
+						expectedHost bool
+						description  string
+					}{
+						{false, false, false, false, "no flags enabled"},
+						{true, false, true, false, "only placement enabled"},
+						{false, true, false, true, "only affinity enabled"},
+						{true, true, true, true, "both flags enabled"},
+					}
+
+					for _, tc := range testCases {
+						pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
+							config.Features.VMPlacementPolicies = tc.vmPlacement
+							config.Features.VMAffinityDuringExecution = tc.vmAffinity
+						})
+
+						constraints := virtualmachine.CalculateAffinityConstraints(vmCtx, false)
+						Expect(constraints.ConfigureHostRules).To(Equal(tc.expectedHost),
+							"Host rules mismatch for case: %s", tc.description)
+						Expect(constraints.ConfigureZoneRules).To(Equal(tc.expectedZone),
+							"Zone rules mismatch for case: %s", tc.description)
+					}
+				})
+
+				It("should disable zone rules during creation workflow regardless of flags", func() {
+					testCases := []struct {
+						vmPlacement  bool
+						vmAffinity   bool
+						expectedHost bool
+						description  string
+					}{
+						{false, false, false, "no flags enabled"},
+						{true, false, false, "only placement enabled"},
+						{false, true, true, "only affinity enabled"},
+						{true, true, true, "both flags enabled"},
+					}
+
+					for _, tc := range testCases {
+						pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
+							config.Features.VMPlacementPolicies = tc.vmPlacement
+							config.Features.VMAffinityDuringExecution = tc.vmAffinity
+						})
+
+						constraints := virtualmachine.CalculateAffinityConstraints(vmCtx, true)
+						Expect(constraints.ConfigureHostRules).To(Equal(tc.expectedHost),
+							"Host rules mismatch for case: %s", tc.description)
+						Expect(constraints.ConfigureZoneRules).To(BeFalse(),
+							"Zone rules should always be false during creation for case: %s", tc.description)
+					}
+				})
 			})
 
-			It("should respect feature flags during placement workflow", func() {
-				testCases := []struct {
-					vmPlacement  bool
-					vmAffinity   bool
-					expectedZone bool
-					expectedHost bool
-					description  string
-				}{
-					{false, false, false, false, "no flags enabled"},
-					{true, false, true, false, "only placement enabled"},
-					{false, true, false, true, "only affinity enabled"},
-					{true, true, true, true, "both flags enabled"},
-				}
+			When("VM has zone label", func() {
+				BeforeEach(func() {
+					vm.Labels = map[string]string{
+						"app":                         "test-app",
+						"topology.kubernetes.io/zone": "zone-a",
+					}
+				})
 
-				for _, tc := range testCases {
-					pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
-						config.Features.VMPlacementPolicies = tc.vmPlacement
-						config.Features.VMAffinityDuringExecution = tc.vmAffinity
-					})
+				It("should respect VMAffinityDuringExecution feature for zone-labeled VMs", func() {
+					testCases := []struct {
+						vmPlacement  bool
+						vmAffinity   bool
+						expectedZone bool
+						expectedHost bool
+						description  string
+					}{
+						{false, false, false, false, "no flags enabled"},
+						{true, false, true, false, "only placement enabled"},
+						{false, true, false, true, "only affinity enabled - zone label disables zone rules"},
+						{true, true, false, true, "both flags enabled - zone label disables zone rules"},
+					}
 
-					constraints := virtualmachine.CalculateAffinityConstraints(vmCtx, false)
-					Expect(constraints.ConfigureHostRules).To(Equal(tc.expectedHost),
-						"Host rules mismatch for case: %s", tc.description)
-					Expect(constraints.ConfigureZoneRules).To(Equal(tc.expectedZone),
-						"Zone rules mismatch for case: %s", tc.description)
-				}
-			})
+					for _, tc := range testCases {
+						pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
+							config.Features.VMPlacementPolicies = tc.vmPlacement
+							config.Features.VMAffinityDuringExecution = tc.vmAffinity
+						})
 
-			It("should disable zone rules during creation workflow regardless of flags", func() {
-				testCases := []struct {
-					vmPlacement  bool
-					vmAffinity   bool
-					expectedHost bool
-					description  string
-				}{
-					{false, false, false, "no flags enabled"},
-					{true, false, false, "only placement enabled"},
-					{false, true, true, "only affinity enabled"},
-					{true, true, true, "both flags enabled"},
-				}
-
-				for _, tc := range testCases {
-					pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
-						config.Features.VMPlacementPolicies = tc.vmPlacement
-						config.Features.VMAffinityDuringExecution = tc.vmAffinity
-					})
-
-					constraints := virtualmachine.CalculateAffinityConstraints(vmCtx, true)
-					Expect(constraints.ConfigureHostRules).To(Equal(tc.expectedHost),
-						"Host rules mismatch for case: %s", tc.description)
-					Expect(constraints.ConfigureZoneRules).To(BeFalse(),
-						"Zone rules should always be false during creation for case: %s", tc.description)
-				}
+						constraints := virtualmachine.CalculateAffinityConstraints(vmCtx, false)
+						Expect(constraints.ConfigureHostRules).To(Equal(tc.expectedHost),
+							"Host rules mismatch for case: %s", tc.description)
+						Expect(constraints.ConfigureZoneRules).To(Equal(tc.expectedZone),
+							"Zone rules mismatch for case: %s", tc.description)
+					}
+				})
 			})
 		})
 	})

--- a/pkg/providers/vsphere/virtualmachine/configspec_test.go
+++ b/pkg/providers/vsphere/virtualmachine/configspec_test.go
@@ -22,6 +22,7 @@ import (
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/constants"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/virtualmachine"
+	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
@@ -469,6 +470,7 @@ var _ = Describe("CreateConfigSpec", func() {
 	Context("AF/AAF policies", func() {
 		BeforeEach(func() {
 			pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
+				config.Features.VMPlacementPolicies = true
 				config.Features.VMAffinityDuringExecution = true
 			})
 		})
@@ -506,24 +508,9 @@ var _ = Describe("CreateConfigSpec", func() {
 					}
 				})
 
-				It("should have placement policies and tag specs", func() {
-					// Expect 2 policies: one for MatchLabels "env:prod" and one for MatchExpressions "app:db"
-					Expect(configSpec.VmPlacementPolicies).To(HaveLen(2))
-
-					// Verify both policies are VmVmAffinity
-					for _, pol := range configSpec.VmPlacementPolicies {
-						policy, ok := pol.(*vimtypes.VmVmAffinity)
-						Expect(ok).To(BeTrue())
-						Expect(policy.PolicyStrictness).To(Equal(string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution)))
-						Expect(policy.PolicyTopology).To(Equal(string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyVSphereZone)))
-						Expect(policy.AffinedVmsTag.NameId.Tag).To(BeElementOf("env:prod", "app:db"))
-						Expect(policy.AffinedVmsTag.NameId.Category).To(Equal(vmCtx.VM.Namespace))
-					}
-
-					// Only labels referenced in affinity rules should be included as tags
-					// Affinity rules reference "env" and "app" keys, so only those labels should be present
-					// "zone:us-west" should be excluded since "zone" is not referenced in any affinity rule
-					expectedTagNames := []string{"app:db", "env:prod"}
+				It("should not have placement policies and tag specs", func() {
+					Expect(configSpec.VmPlacementPolicies).To(HaveLen(0))
+					expectedTagNames := []string{}
 					assertVMTags(configSpec, expectedTagNames, vmCtx.VM.Namespace)
 				})
 			})
@@ -551,18 +538,124 @@ var _ = Describe("CreateConfigSpec", func() {
 					}
 				})
 
-				It("should have anti-affinity policies and tag specs", func() {
-					Expect(configSpec.VmPlacementPolicies).To(HaveLen(1))
-					policy, ok := configSpec.VmPlacementPolicies[0].(*vimtypes.VmToVmGroupsAntiAffinity)
-					Expect(ok).To(BeTrue())
-					Expect(policy.PolicyStrictness).To(Equal(string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution)))
-					Expect(policy.PolicyTopology).To(Equal(string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyVSphereZone)))
-					Expect(policy.AntiAffinedVmGroupTags).To(HaveLen(1))
-					Expect(policy.AntiAffinedVmGroupTags[0].NameId.Tag).To(Equal("app:web"))
-					Expect(policy.AntiAffinedVmGroupTags[0].NameId.Category).To(Equal(vmCtx.VM.Namespace))
+				It("should have not have anti-affinity policies and tag specs", func() {
+					Expect(configSpec.VmPlacementPolicies).To(HaveLen(0))
+					expectedTagNames := []string{}
+					assertVMTags(configSpec, expectedTagNames, vmCtx.VM.Namespace)
+				})
+			})
+			Context("VKS node VM with both host and zone topology keys with capw labels", func() {
+				BeforeEach(func() {
+					vmCtx.VM.Labels = map[string]string{
+						"app":                            "web",
+						"env":                            "prod",
+						kubeutil.CAPWClusterRoleLabelKey: "node",
+					}
 
-					// Check TagSpecs for VM labels
-					expectedTagNames := []string{"app:web"}
+					vmCtx.VM.Spec.Affinity = &vmopv1.AffinitySpec{
+						VMAffinity: &vmopv1.VMAffinitySpec{
+							RequiredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "web",
+										},
+									},
+									TopologyKey: corev1.LabelHostname,
+								},
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"env": "prod",
+										},
+									},
+									TopologyKey: corev1.LabelTopologyZone,
+								},
+							},
+						},
+						VMAntiAffinity: &vmopv1.VMAntiAffinitySpec{
+							RequiredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "db",
+										},
+									},
+									TopologyKey: corev1.LabelHostname,
+								},
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"env": "dev",
+										},
+									},
+									TopologyKey: corev1.LabelTopologyZone,
+								},
+							},
+						},
+					}
+				})
+				It("should ignore both host affinity policies and zone affinity policies", func() {
+					Expect(configSpec.VmPlacementPolicies).To(HaveLen(0))
+					expectedTagNames := []string{}
+					assertVMTags(configSpec, expectedTagNames, vmCtx.VM.Namespace)
+				})
+			})
+			Context("VKS node VM with both host and zone topology keys with capv labels", func() {
+				BeforeEach(func() {
+					vmCtx.VM.Labels = map[string]string{
+						"app":                            "web",
+						"env":                            "prod",
+						kubeutil.CAPVClusterRoleLabelKey: "node",
+					}
+
+					vmCtx.VM.Spec.Affinity = &vmopv1.AffinitySpec{
+						VMAffinity: &vmopv1.VMAffinitySpec{
+							RequiredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "web",
+										},
+									},
+									TopologyKey: corev1.LabelHostname,
+								},
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"env": "prod",
+										},
+									},
+									TopologyKey: corev1.LabelTopologyZone,
+								},
+							},
+						},
+						VMAntiAffinity: &vmopv1.VMAntiAffinitySpec{
+							RequiredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "db",
+										},
+									},
+									TopologyKey: corev1.LabelHostname,
+								},
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"env": "dev",
+										},
+									},
+									TopologyKey: corev1.LabelTopologyZone,
+								},
+							},
+						},
+					}
+				})
+
+				It("should ignore both host affinity policies and zone affinity policies", func() {
+					Expect(configSpec.VmPlacementPolicies).To(HaveLen(0))
+					expectedTagNames := []string{}
 					assertVMTags(configSpec, expectedTagNames, vmCtx.VM.Namespace)
 				})
 			})
@@ -610,7 +703,7 @@ var _ = Describe("CreateConfigSpec", func() {
 										},
 									},
 								},
-								TopologyKey: corev1.LabelTopologyZone,
+								TopologyKey: corev1.LabelHostname,
 							},
 						},
 					},
@@ -1139,7 +1232,8 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 					Expect(policy.PolicyStrictness).To(Equal(string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution)))
 					Expect(policy.PolicyTopology).To(Equal(string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyVSphereZone)))
 
-					assertVMTags(configSpec, []string{"vm-label1:vm-value1", "vm-label2:vm-value2"}, vmCtx.VM.Namespace)
+					// Tagspecs are empty as VM does not have relevant labels.
+					assertVMTags(configSpec, []string{}, vmCtx.VM.Namespace)
 				})
 			})
 
@@ -1214,7 +1308,8 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 					Expect(policy.PolicyStrictness).To(Equal(string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessPreferredDuringPlacementPreferredDuringExecution)))
 					Expect(policy.PolicyTopology).To(Equal(string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyVSphereZone)))
 
-					assertVMTags(configSpec, []string{"vm-label1:vm-value1", "vm-label2:vm-value2"}, vmCtx.VM.Namespace)
+					// Tagspecs are empty as VM does not have relevant labels.
+					assertVMTags(configSpec, []string{}, vmCtx.VM.Namespace)
 				})
 			})
 
@@ -1594,6 +1689,174 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 						Expect(configSpec.TagSpecs).To(BeEmpty())
 					})
 				})
+				Context("VKS node VM with both host and zone topology keys with capv labels", func() {
+					BeforeEach(func() {
+						vmCtx.VM.Labels = map[string]string{
+							"app":                            "web",
+							"env":                            "prod",
+							kubeutil.CAPVClusterRoleLabelKey: "node",
+						}
+
+						vmCtx.VM.Spec.Affinity = &vmopv1.AffinitySpec{
+							VMAffinity: &vmopv1.VMAffinitySpec{
+								RequiredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"app": "web",
+											},
+										},
+										TopologyKey: corev1.LabelHostname,
+									},
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"env": "prod",
+											},
+										},
+										TopologyKey: corev1.LabelTopologyZone,
+									},
+								},
+							},
+							VMAntiAffinity: &vmopv1.VMAntiAffinitySpec{
+								RequiredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"app": "db",
+											},
+										},
+										TopologyKey: corev1.LabelHostname,
+									},
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"env": "dev",
+											},
+										},
+										TopologyKey: corev1.LabelTopologyZone,
+									},
+								},
+							},
+						}
+					})
+
+					// policies are ignored as cluster modules is used for VMs with capv labels
+					It("should ignore host affinity policies and keep zone affinity policies", func() {
+						Expect(configSpec.VmPlacementPolicies).To(HaveLen(2))
+
+						pols := []vimtypes.BaseVmPlacementPolicy{
+							&vimtypes.VmVmAffinity{
+								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
+								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyVSphereZone),
+								AffinedVmsTag: vimtypes.TagId{
+									NameId: &vimtypes.TagIdNameId{
+										Tag:      fmt.Sprintf("%s:%s", "env", "prod"),
+										Category: vmCtx.VM.Namespace,
+									},
+								},
+							},
+							&vimtypes.VmToVmGroupsAntiAffinity{
+								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
+								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyVSphereZone),
+								AntiAffinedVmGroupTags: []vimtypes.TagId{
+									{
+										NameId: &vimtypes.TagIdNameId{
+											Tag:      fmt.Sprintf("%s:%s", "env", "dev"),
+											Category: vmCtx.VM.Namespace,
+										},
+									},
+								},
+							},
+						}
+						Expect(configSpec.VmPlacementPolicies).To(ConsistOf(pols))
+						assertVMTags(configSpec, []string{"env:prod"}, vmCtx.VM.Namespace)
+					})
+				})
+				Context("VKS node VM with both host and zone topology keys with capw labels", func() {
+					BeforeEach(func() {
+						vmCtx.VM.Labels = map[string]string{
+							"app":                            "web",
+							"env":                            "prod",
+							kubeutil.CAPWClusterRoleLabelKey: "node",
+						}
+
+						vmCtx.VM.Spec.Affinity = &vmopv1.AffinitySpec{
+							VMAffinity: &vmopv1.VMAffinitySpec{
+								RequiredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"app": "web",
+											},
+										},
+										TopologyKey: corev1.LabelHostname,
+									},
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"env": "prod",
+											},
+										},
+										TopologyKey: corev1.LabelTopologyZone,
+									},
+								},
+							},
+							VMAntiAffinity: &vmopv1.VMAntiAffinitySpec{
+								RequiredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"app": "db",
+											},
+										},
+										TopologyKey: corev1.LabelHostname,
+									},
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"env": "dev",
+											},
+										},
+										TopologyKey: corev1.LabelTopologyZone,
+									},
+								},
+							},
+						}
+					})
+
+					// policies are ignored as cluster modules is used for VMs with capw labels
+					It("should ignore host affinity policies and keep zone affinity policies", func() {
+						Expect(configSpec.VmPlacementPolicies).To(HaveLen(2))
+
+						pols := []vimtypes.BaseVmPlacementPolicy{
+							&vimtypes.VmVmAffinity{
+								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
+								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyVSphereZone),
+								AffinedVmsTag: vimtypes.TagId{
+									NameId: &vimtypes.TagIdNameId{
+										Tag:      fmt.Sprintf("%s:%s", "env", "prod"),
+										Category: vmCtx.VM.Namespace,
+									},
+								},
+							},
+							&vimtypes.VmToVmGroupsAntiAffinity{
+								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
+								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyVSphereZone),
+								AntiAffinedVmGroupTags: []vimtypes.TagId{
+									{
+										NameId: &vimtypes.TagIdNameId{
+											Tag:      fmt.Sprintf("%s:%s", "env", "dev"),
+											Category: vmCtx.VM.Namespace,
+										},
+									},
+								},
+							},
+						}
+						Expect(configSpec.VmPlacementPolicies).To(ConsistOf(pols))
+						assertVMTags(configSpec, []string{"env:prod"}, vmCtx.VM.Namespace)
+					})
+				})
 			})
 
 			When("VMAffinityDuringExecution feature is disabled", func() {
@@ -1627,7 +1890,7 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 
 					It("produces no placement policies", func() {
 						Expect(configSpec.VmPlacementPolicies).To(BeEmpty())
-						assertVMTags(configSpec, []string{"vm-label1:vm-value1", "vm-label2:vm-value2"}, vmCtx.VM.Namespace)
+						assertVMTags(configSpec, []string{}, vmCtx.VM.Namespace)
 					})
 				})
 
@@ -1661,7 +1924,9 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 
 					It("produces no placement policies", func() {
 						Expect(configSpec.VmPlacementPolicies).To(BeEmpty())
-						assertVMTags(configSpec, []string{"vm-label1:vm-value1", "vm-label2:vm-value2"}, vmCtx.VM.Namespace)
+
+						// Tagspecs are empty as VM does not have relevant labels.
+						assertVMTags(configSpec, []string{}, vmCtx.VM.Namespace)
 					})
 				})
 
@@ -1704,7 +1969,8 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 							},
 						}))
 
-						assertVMTags(configSpec, []string{"vm-label1:vm-value1", "vm-label2:vm-value2"}, vmCtx.VM.Namespace)
+						// Tagspecs are empty as VM does not have relevant labels.
+						assertVMTags(configSpec, []string{}, vmCtx.VM.Namespace)
 					})
 				})
 			})
@@ -1754,7 +2020,8 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 					Expect(policy.PolicyStrictness).To(Equal(string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessPreferredDuringPlacementPreferredDuringExecution)))
 					Expect(policy.PolicyTopology).To(Equal(string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyVSphereZone)))
 
-					assertVMTags(configSpec, []string{"vm-label1:vm-value1", "vm-label2:vm-value2"}, vmCtx.VM.Namespace)
+					// Tagspecs are empty as VM does not have relevant labels.
+					assertVMTags(configSpec, []string{}, vmCtx.VM.Namespace)
 				})
 			})
 
@@ -1812,7 +2079,8 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 					Expect(policy.PolicyStrictness).To(Equal(string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessPreferredDuringPlacementPreferredDuringExecution)))
 					Expect(policy.PolicyTopology).To(Equal(string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyVSphereZone)))
 
-					assertVMTags(configSpec, []string{"vm-label1:vm-value1", "vm-label2:vm-value2"}, vmCtx.VM.Namespace)
+					// Tagspecs are empty as VM does not have relevant labels.
+					assertVMTags(configSpec, []string{}, vmCtx.VM.Namespace)
 				})
 			})
 
@@ -1841,8 +2109,8 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 				It("creates a minimal policy with VM tags but no anti-affinity rules", func() {
 					Expect(configSpec.VmPlacementPolicies).To(BeEmpty())
 
-					// VM tags should still be attached (without VM Operator managed labels) even though selector was invalid.
-					assertVMTags(configSpec, []string{"vm-label1:vm-value1", "vm-label2:vm-value2"}, vmCtx.VM.Namespace)
+					// VM tags are empty as selector was invalid.
+					assertVMTags(configSpec, []string{}, vmCtx.VM.Namespace)
 				})
 			})
 		})
@@ -1897,6 +2165,256 @@ var _ = Describe("ConfigSpecFromVMClassDevices", func() {
 			Expect(pciBacking2.AllowedDevice[0].DeviceId).To(BeEquivalentTo(vmClassSpec.Hardware.Devices.DynamicDirectPathIODevices[0].DeviceID))
 			Expect(pciBacking2.AllowedDevice[0].VendorId).To(BeEquivalentTo(vmClassSpec.Hardware.Devices.DynamicDirectPathIODevices[0].VendorID))
 			Expect(pciBacking2.CustomLabel).To(Equal(vmClassSpec.Hardware.Devices.DynamicDirectPathIODevices[0].CustomLabel))
+		})
+	})
+})
+
+var _ = Describe("CalculateAffinityConstraints", func() {
+	var (
+		vm    *vmopv1.VirtualMachine
+		vmCtx pkgctx.VirtualMachineContext
+	)
+
+	BeforeEach(func() {
+		vm = builder.DummyVirtualMachine()
+		vm.Name = "test-vm"
+
+		vmCtx = pkgctx.VirtualMachineContext{
+			Context: pkgcfg.NewContext(),
+			Logger:  suite.GetLogger().WithValues("vmName", vm.GetName()),
+			VM:      vm,
+		}
+	})
+
+	Describe("Feature flag combinations", func() {
+		When("both flags are disabled", func() {
+			It("should disable both host and zone rules", func() {
+				pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
+					config.Features.VMPlacementPolicies = false
+					config.Features.VMAffinityDuringExecution = false
+				})
+
+				constraints := virtualmachine.CalculateAffinityConstraints(vmCtx, false)
+				Expect(constraints.ConfigureHostRules).To(BeFalse())
+				Expect(constraints.ConfigureZoneRules).To(BeFalse())
+			})
+		})
+
+		When("only VMPlacementPolicies is enabled", func() {
+			It("should enable only zone rules", func() {
+				pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
+					config.Features.VMPlacementPolicies = true
+					config.Features.VMAffinityDuringExecution = false
+				})
+
+				constraints := virtualmachine.CalculateAffinityConstraints(vmCtx, false)
+				Expect(constraints.ConfigureHostRules).To(BeFalse())
+				Expect(constraints.ConfigureZoneRules).To(BeTrue())
+			})
+		})
+
+		When("only VMAffinityDuringExecution is enabled", func() {
+			It("should enable only host rules", func() {
+				pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
+					config.Features.VMPlacementPolicies = false
+					config.Features.VMAffinityDuringExecution = true
+				})
+
+				constraints := virtualmachine.CalculateAffinityConstraints(vmCtx, false)
+				Expect(constraints.ConfigureHostRules).To(BeTrue())
+				Expect(constraints.ConfigureZoneRules).To(BeFalse())
+			})
+		})
+
+		When("both flags are enabled", func() {
+			It("should enable both host and zone rules", func() {
+				pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
+					config.Features.VMPlacementPolicies = true
+					config.Features.VMAffinityDuringExecution = true
+				})
+
+				constraints := virtualmachine.CalculateAffinityConstraints(vmCtx, false)
+				Expect(constraints.ConfigureHostRules).To(BeTrue())
+				Expect(constraints.ConfigureZoneRules).To(BeTrue())
+			})
+		})
+	})
+
+	Describe("VKS node detection", func() {
+		When("VM has CAPI labels (VKS node)", func() {
+			BeforeEach(func() {
+				// Add CAPI labels to make it a VKS node VM
+				vm.Labels = map[string]string{
+					kubeutil.CAPWClusterRoleLabelKey: "control-plane",
+				}
+			})
+
+			It("should disable host rules even when VMAffinityDuringExecution is enabled", func() {
+				pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
+					config.Features.VMPlacementPolicies = true
+					config.Features.VMAffinityDuringExecution = true
+				})
+
+				constraints := virtualmachine.CalculateAffinityConstraints(vmCtx, false)
+				Expect(constraints.ConfigureHostRules).To(BeFalse(), "VKS node VMs should disable host rules")
+				Expect(constraints.ConfigureZoneRules).To(BeTrue(), "Zone rules should still be enabled")
+			})
+
+			It("should keep zone rules enabled when VMPlacementPolicies is enabled", func() {
+				pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
+					config.Features.VMPlacementPolicies = true
+					config.Features.VMAffinityDuringExecution = false
+				})
+
+				constraints := virtualmachine.CalculateAffinityConstraints(vmCtx, false)
+				Expect(constraints.ConfigureHostRules).To(BeFalse())
+				Expect(constraints.ConfigureZoneRules).To(BeTrue())
+			})
+		})
+
+		When("VM does not have CAPI labels (regular VM)", func() {
+			BeforeEach(func() {
+				vm.Labels = map[string]string{
+					"app": "test-app",
+				}
+			})
+
+			It("should allow host rules when VMAffinityDuringExecution is enabled", func() {
+				pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
+					config.Features.VMPlacementPolicies = true
+					config.Features.VMAffinityDuringExecution = true
+				})
+
+				constraints := virtualmachine.CalculateAffinityConstraints(vmCtx, false)
+				Expect(constraints.ConfigureHostRules).To(BeTrue(), "Regular VMs should allow host rules")
+				Expect(constraints.ConfigureZoneRules).To(BeTrue())
+			})
+		})
+	})
+
+	Describe("Workflow context", func() {
+		BeforeEach(func() {
+			pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
+				config.Features.VMPlacementPolicies = true
+				config.Features.VMAffinityDuringExecution = true
+			})
+		})
+
+		When("isCreateVM is true (creation workflow)", func() {
+			It("should disable zone rules regardless of feature flags", func() {
+				constraints := virtualmachine.CalculateAffinityConstraints(vmCtx, true)
+				Expect(constraints.ConfigureHostRules).To(BeTrue(), "Host rules should still be enabled during creation")
+				Expect(constraints.ConfigureZoneRules).To(BeFalse(), "Zone rules should be disabled during VM creation")
+			})
+		})
+
+		When("isCreateVM is false (placement workflow)", func() {
+			It("should allow zone rules when VMPlacementPolicies is enabled", func() {
+				constraints := virtualmachine.CalculateAffinityConstraints(vmCtx, false)
+				Expect(constraints.ConfigureHostRules).To(BeTrue())
+				Expect(constraints.ConfigureZoneRules).To(BeTrue(), "Zone rules should be enabled during placement")
+			})
+		})
+	})
+
+	Describe("Combined scenarios", func() {
+		When("VKS node VM with creation workflow", func() {
+			BeforeEach(func() {
+				vm.Labels = map[string]string{
+					kubeutil.CAPWClusterRoleLabelKey: "worker",
+				}
+				pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
+					config.Features.VMPlacementPolicies = true
+					config.Features.VMAffinityDuringExecution = true
+				})
+			})
+
+			It("should disable both host and zone rules", func() {
+				constraints := virtualmachine.CalculateAffinityConstraints(vmCtx, true)
+				Expect(constraints.ConfigureHostRules).To(BeFalse(), "VKS nodes should disable host rules")
+				Expect(constraints.ConfigureZoneRules).To(BeFalse(), "Creation workflow should disable zone rules")
+			})
+		})
+
+		When("VKS node VM with placement workflow", func() {
+			BeforeEach(func() {
+				vm.Labels = map[string]string{
+					kubeutil.CAPWClusterRoleLabelKey: "worker",
+				}
+				pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
+					config.Features.VMPlacementPolicies = true
+					config.Features.VMAffinityDuringExecution = true
+				})
+			})
+
+			It("should disable host rules but allow zone rules", func() {
+				constraints := virtualmachine.CalculateAffinityConstraints(vmCtx, false)
+				Expect(constraints.ConfigureHostRules).To(BeFalse(), "VKS nodes should disable host rules")
+				Expect(constraints.ConfigureZoneRules).To(BeTrue(), "Zone rules should be enabled for placement")
+			})
+		})
+
+		When("regular VM with different flag combinations", func() {
+			BeforeEach(func() {
+				vm.Labels = map[string]string{
+					"app": "test-app",
+				}
+			})
+
+			It("should respect feature flags during placement workflow", func() {
+				testCases := []struct {
+					vmPlacement  bool
+					vmAffinity   bool
+					expectedZone bool
+					expectedHost bool
+					description  string
+				}{
+					{false, false, false, false, "no flags enabled"},
+					{true, false, true, false, "only placement enabled"},
+					{false, true, false, true, "only affinity enabled"},
+					{true, true, true, true, "both flags enabled"},
+				}
+
+				for _, tc := range testCases {
+					pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
+						config.Features.VMPlacementPolicies = tc.vmPlacement
+						config.Features.VMAffinityDuringExecution = tc.vmAffinity
+					})
+
+					constraints := virtualmachine.CalculateAffinityConstraints(vmCtx, false)
+					Expect(constraints.ConfigureHostRules).To(Equal(tc.expectedHost),
+						"Host rules mismatch for case: %s", tc.description)
+					Expect(constraints.ConfigureZoneRules).To(Equal(tc.expectedZone),
+						"Zone rules mismatch for case: %s", tc.description)
+				}
+			})
+
+			It("should disable zone rules during creation workflow regardless of flags", func() {
+				testCases := []struct {
+					vmPlacement  bool
+					vmAffinity   bool
+					expectedHost bool
+					description  string
+				}{
+					{false, false, false, "no flags enabled"},
+					{true, false, false, "only placement enabled"},
+					{false, true, true, "only affinity enabled"},
+					{true, true, true, "both flags enabled"},
+				}
+
+				for _, tc := range testCases {
+					pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
+						config.Features.VMPlacementPolicies = tc.vmPlacement
+						config.Features.VMAffinityDuringExecution = tc.vmAffinity
+					})
+
+					constraints := virtualmachine.CalculateAffinityConstraints(vmCtx, true)
+					Expect(constraints.ConfigureHostRules).To(Equal(tc.expectedHost),
+						"Host rules mismatch for case: %s", tc.description)
+					Expect(constraints.ConfigureZoneRules).To(BeFalse(),
+						"Zone rules should always be false during creation for case: %s", tc.description)
+				}
+			})
 		})
 	})
 })

--- a/pkg/providers/vsphere/vmprovider_vm.go
+++ b/pkg/providers/vsphere/vmprovider_vm.go
@@ -1557,11 +1557,18 @@ func (vs *vSphereVMProvider) vmCreateDoPlacement(
 
 	defer func() {
 		if retErr != nil {
-			pkgcnd.MarkError(
+			// processPlacementResult may already have set a more specific
+			// reason (e.g. ZoneMismatch); only fall back to the generic
+			// NotReady reason when the condition is not already False.
+			if !pkgcnd.IsFalse(
 				vmCtx.VM,
-				vmopv1.VirtualMachineConditionPlacementReady,
-				"NotReady",
-				retErr)
+				vmopv1.VirtualMachineConditionPlacementReady) {
+				pkgcnd.MarkError(
+					vmCtx.VM,
+					vmopv1.VirtualMachineConditionPlacementReady,
+					"NotReady",
+					retErr)
+			}
 		} else {
 			pkgcnd.MarkTrue(
 				vmCtx.VM,
@@ -1602,9 +1609,17 @@ func (vs *vSphereVMProvider) vmCreateDoPlacement(
 			return fmt.Errorf("VM is not linked to its group")
 		}
 
-		// If the VM has an explicit zone label, skip group placement
-		// and use the regular placement flow to respect the zone override.
-		if zoneName := vmCtx.VM.Labels[corev1.LabelTopologyZone]; zoneName == "" {
+		// Place the VM via its group when it has no zone label, or (with
+		// VMAffinityDuringExecution enabled) when it is a zone-labeled non-VKS
+		// VM so it can still benefit from DRS host recommendations. Zone-labeled
+		// VKS nodes, and any zone-labeled VM when the feature is disabled, use
+		// the regular placement flow to honor the zone override.
+		zoneName := vmCtx.VM.Labels[corev1.LabelTopologyZone]
+		useGroupPlacement := zoneName == "" ||
+			(pkgcfg.FromContext(vmCtx).Features.VMAffinityDuringExecution &&
+				!kubeutil.HasCAPILabels(vmCtx.VM.Labels))
+
+		if useGroupPlacement {
 			vmCtx.Logger.Info(
 				"Getting VM placement result from its group",
 				"groupName", vmCtx.VM.Spec.GroupName,
@@ -1755,6 +1770,34 @@ func processPlacementResult(
 	vcClient *vcclient.Client,
 	createArgs *VMCreateArgs,
 	result placement.Result) error {
+
+	isVksNodeVM := kubeutil.HasCAPILabels(vmCtx.VM.Labels)
+	// When VMAffinityDuringExecution is enabled, a zone-labeled non-VKS VM took
+	// part in group/DRS placement; the chosen zone must still match its pinned
+	// zone label. A mismatch means the VM would be relocated to a different
+	// zone, so block placement and surface a ZoneMismatch condition for the
+	// user to reconcile the label with the desired placement. VKS nodes and VMs
+	// without a zone label are unaffected.
+	if pkgcfg.FromContext(vmCtx).Features.VMAffinityDuringExecution {
+		if zoneLabel := vmCtx.VM.Labels[corev1.LabelTopologyZone]; zoneLabel != "" &&
+			!isVksNodeVM &&
+			result.ZoneName != "" &&
+			result.ZoneName != zoneLabel {
+
+			pkgcnd.MarkFalse(
+				vmCtx.VM,
+				vmopv1.VirtualMachineConditionPlacementReady,
+				"ZoneMismatch",
+				"placement selected zone %q which differs from the VM zone label %q",
+				result.ZoneName, zoneLabel)
+
+			return pkgerr.NoRequeueError{
+				Message: fmt.Sprintf(
+					"placement zone %q does not match VM zone label %q",
+					result.ZoneName, zoneLabel),
+			}
+		}
+	}
 
 	if result.ZoneName != "" {
 		if pkgcfg.FromContext(vmCtx).Features.FastDeploy {

--- a/pkg/providers/vsphere/vmprovider_vm_group_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_group_test.go
@@ -173,7 +173,7 @@ func vmGroupTests() {
 		Expect(pkgcond.IsTrue(&ms, vmopv1.VirtualMachineGroupMemberConditionPlacementReady)).To(BeTrue(), "No placement ready condition")
 		Expect(ms.Placement.Zone).ToNot(BeEmpty(), "Missing Placement Zone")
 		Expect(ms.Placement.Pool).ToNot(BeEmpty(), "Missing Placement Pool")
-		Expect(ms.Placement.Node).To(BeEmpty(), "Has Placement Node")
+		Expect(ms.Placement.Node).To(BeEmpty(), "Missing Placement Node")
 		if pkgcfg.FromContext(ctx).Features.FastDeploy {
 			Expect(ms.Placement.Datastores).ToNot(BeEmpty(), "Missing Placement Datastores")
 			// Verify against VirtualMachineImageCache.Status

--- a/pkg/providers/vsphere/vmprovider_vm_group_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_group_test.go
@@ -173,7 +173,7 @@ func vmGroupTests() {
 		Expect(pkgcond.IsTrue(&ms, vmopv1.VirtualMachineGroupMemberConditionPlacementReady)).To(BeTrue(), "No placement ready condition")
 		Expect(ms.Placement.Zone).ToNot(BeEmpty(), "Missing Placement Zone")
 		Expect(ms.Placement.Pool).ToNot(BeEmpty(), "Missing Placement Pool")
-		Expect(ms.Placement.Node).To(BeEmpty(), "Missing Placement Node")
+		Expect(ms.Placement.Node).ToNot(BeEmpty(), "Missing Placement Node")
 		if pkgcfg.FromContext(ctx).Features.FastDeploy {
 			Expect(ms.Placement.Datastores).ToNot(BeEmpty(), "Missing Placement Datastores")
 			// Verify against VirtualMachineImageCache.Status

--- a/pkg/providers/vsphere/vmprovider_vm_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_test.go
@@ -1661,6 +1661,121 @@ func vmTests() {
 							Expect(err.Error()).To(ContainSubstring("VM is not linked to its group"))
 						})
 					})
+					Context("when VMAffinityDuringExecution is enabled", func() {
+						JustBeforeEach(func() {
+							pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+								config.Features.VMAffinityDuringExecution = true
+							})
+						})
+
+						When("VM is a VKS node", func() {
+							JustBeforeEach(func() {
+								vm.Labels[kubeutil.CAPWClusterRoleLabelKey] = "worker"
+								Expect(ctx.Client.Update(ctx, vm)).To(Succeed())
+							})
+
+							It("should bypass group placement and honor the zone override", func() {
+								err := vmProvider.CreateOrUpdateVirtualMachine(ctx, vm)
+								Expect(err).To(HaveOccurred())
+								Expect(pkgerr.IsNoRequeueError(err)).To(BeTrue())
+								Expect(err).To(MatchError(vsphere.ErrCreate))
+
+								// Verify VM was created
+								Expect(vm.Status.UniqueID).ToNot(BeEmpty())
+							})
+						})
+
+						When("VM is not a VKS node", func() {
+							var (
+								groupZone string
+								groupHost string
+								groupPool string
+							)
+
+							setGroupPlacementReady := func(placementZone string) {
+								GinkgoHelper()
+								ccrs := ctx.GetAZClusterComputes(placementZone)
+								Expect(ccrs).ToNot(BeEmpty())
+								hosts, err := ccrs[0].Hosts(ctx)
+								Expect(err).ToNot(HaveOccurred())
+								Expect(hosts).ToNot(BeEmpty())
+								groupHost = hosts[0].Reference().Value
+
+								nsRP := ctx.GetResourcePoolForNamespace(nsInfo.Namespace, placementZone, "")
+								Expect(nsRP).ToNot(BeNil())
+								groupPool = nsRP.Reference().Value
+
+								Expect(ctx.Client.Get(
+									ctx, client.ObjectKeyFromObject(vmGroup), vmGroup)).To(Succeed())
+								vmGroup.Status.Members = []vmopv1.VirtualMachineGroupMemberStatus{
+									{
+										Name: vm.Name,
+										Kind: "VirtualMachine",
+										Conditions: []metav1.Condition{
+											{
+												Type:   vmopv1.VirtualMachineGroupMemberConditionPlacementReady,
+												Status: metav1.ConditionTrue,
+											},
+										},
+										Placement: &vmopv1.VirtualMachinePlacementStatus{
+											Zone: placementZone,
+											Node: groupHost,
+											Pool: groupPool,
+										},
+									},
+								}
+								Expect(ctx.Client.Status().Update(ctx, vmGroup)).To(Succeed())
+							}
+
+							When("group placement zone matches the VM zone label", func() {
+								JustBeforeEach(func() {
+									groupZone = zoneName
+									setGroupPlacementReady(groupZone)
+								})
+
+								It("should place the VM by group in its zone", func() {
+									err := vmProvider.CreateOrUpdateVirtualMachine(ctx, vm)
+									Expect(err).To(HaveOccurred())
+									Expect(pkgerr.IsNoRequeueError(err)).To(BeTrue())
+									Expect(err).To(MatchError(vsphere.ErrCreate))
+
+									// Verify VM was created
+									Expect(vm.Status.UniqueID).ToNot(BeEmpty())
+								})
+							})
+
+							When("group placement zone differs from the VM zone label", func() {
+								JustBeforeEach(func() {
+									Expect(len(ctx.ZoneNames)).To(BeNumerically(">", 1))
+
+									// get a random zone that is different from the VM zone
+									groupZone = zoneName
+									for groupZone == zoneName {
+										groupZone = ctx.ZoneNames[rand.Intn(len(ctx.ZoneNames))]
+									}
+									setGroupPlacementReady(groupZone)
+								})
+
+								It("should block placement with a ZoneMismatch condition", func() {
+									err := vmProvider.CreateOrUpdateVirtualMachine(ctx, vm)
+									Expect(err).To(HaveOccurred())
+									Expect(pkgerr.IsNoRequeueError(err)).To(BeTrue())
+									Expect(err.Error()).To(ContainSubstring("does not match VM zone label"))
+
+									By("VM is not created", func() {
+										Expect(vm.Status.UniqueID).To(BeEmpty())
+									})
+									By("PlacementReady is False with ZoneMismatch reason", func() {
+										c := conditions.Get(vm, vmopv1.VirtualMachineConditionPlacementReady)
+										Expect(c).ToNot(BeNil())
+										Expect(c.Status).To(Equal(metav1.ConditionFalse))
+										Expect(c.Reason).To(Equal("ZoneMismatch"))
+									})
+								})
+							})
+						})
+					})
+
 				})
 			})
 

--- a/pkg/util/kube/label.go
+++ b/pkg/util/kube/label.go
@@ -6,6 +6,8 @@ package kube
 
 import (
 	"strings"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -28,6 +30,14 @@ func HasCAPILabels(labels map[string]string) bool {
 	_, hasCAPVLabel := labels[CAPVClusterRoleLabelKey]
 
 	return hasCAPWLabel || hasCAPVLabel
+}
+
+// HasZoneLabel returns true if the VM has a label indicating it is pinned to a zone.
+func HasZoneLabel(labels map[string]string) bool {
+	labelValue, hasZoneLabel := labels[corev1.LabelTopologyZone]
+
+	return hasZoneLabel && labelValue != ""
+
 }
 
 // HasVMOperatorLabels returns true if the given labels map has a label key

--- a/pkg/util/kube/label_test.go
+++ b/pkg/util/kube/label_test.go
@@ -7,6 +7,7 @@ package kube_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 
 	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 )
@@ -32,6 +33,49 @@ var _ = Describe("Label", func() {
 		It("should return false if the VM has no Cluster API related labels", func() {
 			vmLabels := map[string]string{}
 			Expect(kubeutil.HasCAPILabels(vmLabels)).To(BeFalse())
+		})
+	})
+
+	Context("HasZoneLabel", func() {
+
+		It("should return true if the VM has a zone label", func() {
+			vmLabels := map[string]string{
+				corev1.LabelTopologyZone: "us-west-1a",
+			}
+			Expect(kubeutil.HasZoneLabel(vmLabels)).To(BeTrue())
+		})
+
+		It("should return false if the VM has a zone label with empty value", func() {
+			vmLabels := map[string]string{
+				corev1.LabelTopologyZone: "",
+			}
+			Expect(kubeutil.HasZoneLabel(vmLabels)).To(BeFalse())
+		})
+
+		It("should return true if the VM has a zone label along with other labels", func() {
+			vmLabels := map[string]string{
+				"app":                    "my-app",
+				corev1.LabelTopologyZone: "us-west-1a",
+				"version":                "1.0",
+			}
+			Expect(kubeutil.HasZoneLabel(vmLabels)).To(BeTrue())
+		})
+
+		It("should return false if the VM has no zone label", func() {
+			vmLabels := map[string]string{
+				"app":     "my-app",
+				"version": "1.0",
+			}
+			Expect(kubeutil.HasZoneLabel(vmLabels)).To(BeFalse())
+		})
+
+		It("should return false if the VM has an empty labels map", func() {
+			vmLabels := map[string]string{}
+			Expect(kubeutil.HasZoneLabel(vmLabels)).To(BeFalse())
+		})
+
+		It("should return false if the VM labels map is nil", func() {
+			Expect(kubeutil.HasZoneLabel(nil)).To(BeFalse())
 		})
 	})
 

--- a/webhooks/virtualmachine/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator.go
@@ -2860,9 +2860,20 @@ func (v validator) validateVMAffinity(
 					}
 				}
 
-				if rs.TopologyKey != corev1.LabelTopologyZone {
-					allErrs = append(allErrs, field.NotSupported(
-						p.Child("topologyKey"), rs.TopologyKey, []string{corev1.LabelTopologyZone}))
+				if pkgcfg.FromContext(ctx).Features.VMAffinityDuringExecution {
+					// When VMAffinityDuringExecution capability is enabled,
+					// either zone or host topology key is allowed for affinity required terms.
+					if rs.TopologyKey != corev1.LabelTopologyZone && rs.TopologyKey != corev1.LabelHostname {
+						allErrs = append(allErrs, field.NotSupported(
+							p.Child("topologyKey"), rs.TopologyKey, []string{corev1.LabelTopologyZone, corev1.LabelHostname}))
+					}
+				} else {
+					// Without VMAffinityDuringExecution capability enabled,
+					// only zone topology key is allowed for affinity required terms.
+					if rs.TopologyKey != corev1.LabelTopologyZone {
+						allErrs = append(allErrs, field.NotSupported(
+							p.Child("topologyKey"), rs.TopologyKey, []string{corev1.LabelTopologyZone}))
+					}
 				}
 			}
 		}

--- a/webhooks/virtualmachine/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator.go
@@ -2815,9 +2815,20 @@ func (v validator) validateVMAffinity(
 					}
 				}
 
-				if rs.TopologyKey != corev1.LabelTopologyZone {
-					allErrs = append(allErrs, field.NotSupported(
-						p.Child("topologyKey"), rs.TopologyKey, []string{corev1.LabelTopologyZone}))
+				if pkgcfg.FromContext(ctx).Features.VMAffinityDuringExecution {
+					// When VMAffinityDuringExecution capability is enabled,
+					// either zone or host topology key is allowed for affinity required terms.
+					if rs.TopologyKey != corev1.LabelTopologyZone && rs.TopologyKey != corev1.LabelHostname {
+						allErrs = append(allErrs, field.NotSupported(
+							p.Child("topologyKey"), rs.TopologyKey, []string{corev1.LabelTopologyZone, corev1.LabelHostname}))
+					}
+				} else {
+					// Without VMAffinityDuringExecution capability enabled,
+					// only zone topology key is allowed for affinity required terms.
+					if rs.TopologyKey != corev1.LabelTopologyZone {
+						allErrs = append(allErrs, field.NotSupported(
+							p.Child("topologyKey"), rs.TopologyKey, []string{corev1.LabelTopologyZone}))
+					}
 				}
 			}
 		}

--- a/webhooks/virtualmachine/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator.go
@@ -2887,16 +2887,22 @@ func (v validator) validateVMAffinity(
 					}
 				}
 
-				// For non-privileged users, only zone topology key is allowed for anti-affinity required terms.
-				if !ctx.IsPrivilegedAccount && rs.TopologyKey != corev1.LabelTopologyZone {
-					allErrs = append(allErrs, field.NotSupported(
-						p.Child("topologyKey"), rs.TopologyKey, []string{corev1.LabelTopologyZone}))
-				}
-
-				// For privileged users (mobility operator), either zone or host topology key is allowed for anti-affinity required terms.
-				if ctx.IsPrivilegedAccount && rs.TopologyKey != corev1.LabelTopologyZone && rs.TopologyKey != corev1.LabelHostname {
-					allErrs = append(allErrs, field.NotSupported(
-						p.Child("topologyKey"), rs.TopologyKey, []string{corev1.LabelTopologyZone, corev1.LabelHostname}))
+				if ctx.IsPrivilegedAccount || pkgcfg.FromContext(ctx).Features.VMAffinityDuringExecution {
+					// For privileged users or when VMAffinityRules capability
+					// is enabled, either zone or host topology key is allowed
+					// for anti-affinity required terms.
+					if rs.TopologyKey != corev1.LabelTopologyZone && rs.TopologyKey != corev1.LabelHostname {
+						allErrs = append(allErrs, field.NotSupported(
+							p.Child("topologyKey"), rs.TopologyKey, []string{corev1.LabelTopologyZone, corev1.LabelHostname}))
+					}
+				} else {
+					// For non-privileged users without VMAffinityRules
+					// capability enabled, only zone topology key is allowed
+					// for anti-affinity required terms.
+					if rs.TopologyKey != corev1.LabelTopologyZone {
+						allErrs = append(allErrs, field.NotSupported(
+							p.Child("topologyKey"), rs.TopologyKey, []string{corev1.LabelTopologyZone}))
+					}
 				}
 			}
 		}

--- a/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
@@ -3717,6 +3717,43 @@ func unitTestsValidateCreate() {
 				},
 			),
 
+			Entry("allow VM Affinity PreferredDuringSchedulingPreferredDuringExecution with Host topology key when VMAffinityDuringExecution is enabled",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+							config.Features.VMAffinityDuringExecution = true
+						})
+						ctx.vm.Spec.Affinity.VMAffinity = &vmopv1.VMAffinitySpec{
+							PreferredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+								{
+									TopologyKey: corev1.LabelHostname,
+								},
+							},
+						}
+					},
+					expectAllowed: true,
+				},
+			),
+
+			Entry("disallow VM Affinity PreferredDuringSchedulingPreferredDuringExecution with unsupported topology key even with VMAffinityDuringExecution enabled",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+							config.Features.VMAffinityDuringExecution = true
+						})
+						ctx.vm.Spec.Affinity.VMAffinity = &vmopv1.VMAffinitySpec{
+							PreferredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+								{
+									TopologyKey: "unsupported-key",
+								},
+							},
+						}
+					},
+					validate: doValidateWithMsg(
+						`spec.affinity.vmAffinity.preferredDuringSchedulingPreferredDuringExecution[0].topologyKey: Unsupported value: "unsupported-key": supported values: "topology.kubernetes.io/zone", "kubernetes.io/hostname"`),
+				},
+			),
+
 			Entry("disallow VM Affinity PreferredDuringSchedulingPreferredDuringExecution with empty topology key",
 				testParams{
 					setup: func(ctx *unitValidatingWebhookContext) {
@@ -4006,6 +4043,25 @@ func unitTestsValidateCreate() {
 					},
 					validate: doValidateWithMsg(
 						`spec.affinity.vmAntiAffinity.preferredDuringSchedulingPreferredDuringExecution[0].labelSelector.matchExpressions[0].key: Forbidden: label selector can not contain VM Operator managed labels (vmoperator.vmware.com)`),
+				},
+			),
+
+			Entry("disallow VM Anti Affinity PreferredDuringSchedulingPreferredDuringExecution with unsupported topology key when VMAffinityDuringExecution is enabled",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+							config.Features.VMAffinityDuringExecution = true
+						})
+						ctx.vm.Spec.Affinity.VMAntiAffinity = &vmopv1.VMAntiAffinitySpec{
+							PreferredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+								{
+									TopologyKey: "unsupported-key",
+								},
+							},
+						}
+					},
+					validate: doValidateWithMsg(
+						`spec.affinity.vmAntiAffinity.preferredDuringSchedulingPreferredDuringExecution[0].topologyKey: Unsupported value: "unsupported-key": supported values: "topology.kubernetes.io/zone", "kubernetes.io/hostname"`),
 				},
 			),
 		)

--- a/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
@@ -3655,7 +3655,7 @@ func unitTestsValidateCreate() {
 				},
 			),
 
-			Entry("disallow VM Anti Affinity with RequiredDuringSchedulingPreferredDuringExecution and Host topology key for non-privileged users",
+			Entry("disallow VM Anti Affinity with RequiredDuringSchedulingPreferredDuringExecution and Host topology key for non-privileged users when VMAffinityRules is enabled",
 				testParams{
 					setup: func(ctx *unitValidatingWebhookContext) {
 						ctx.IsPrivilegedAccount = false
@@ -3669,6 +3669,45 @@ func unitTestsValidateCreate() {
 					},
 					validate: doValidateWithMsg(
 						`spec.affinity.vmAntiAffinity.requiredDuringSchedulingPreferredDuringExecution[0].topologyKey: Unsupported value: "kubernetes.io/hostname": supported values: "topology.kubernetes.io/zone"`),
+				},
+			),
+
+			Entry("allow VM Anti Affinity with RequiredDuringSchedulingPreferredDuringExecution and Host topology key for non-privileged users when VMAffinityDuringExecution is enabled",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						ctx.IsPrivilegedAccount = false
+						pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+							config.Features.VMAffinityDuringExecution = true
+						})
+						ctx.vm.Spec.Affinity.VMAntiAffinity = &vmopv1.VMAntiAffinitySpec{
+							RequiredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+								{
+									TopologyKey: corev1.LabelHostname,
+								},
+							},
+						}
+					},
+					expectAllowed: true,
+				},
+			),
+
+			Entry("disallow VM Anti Affinity with RequiredDuringSchedulingPreferredDuringExecution and unsupported topology key for non-privileged users with VMAffinityDuringExecution",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						ctx.IsPrivilegedAccount = false
+						pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+							config.Features.VMAffinityDuringExecution = true
+						})
+						ctx.vm.Spec.Affinity.VMAntiAffinity = &vmopv1.VMAntiAffinitySpec{
+							RequiredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+								{
+									TopologyKey: "unsupported-key",
+								},
+							},
+						}
+					},
+					validate: doValidateWithMsg(
+						`spec.affinity.vmAntiAffinity.requiredDuringSchedulingPreferredDuringExecution[0].topologyKey: Unsupported value: "unsupported-key": supported values: "topology.kubernetes.io/zone", "kubernetes.io/hostname"`),
 				},
 			),
 

--- a/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
@@ -3623,6 +3623,141 @@ func unitTestsValidateCreate() {
 				},
 			),
 
+			Entry("disallow VM Affinity with RequiredDuringSchedulingPreferredDuringExecution and Host topology key when VMAffinityDuringExecution is disabled",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						ctx.vm.Spec.Affinity.VMAffinity = &vmopv1.VMAffinitySpec{
+							RequiredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+								{
+									TopologyKey: corev1.LabelHostname,
+								},
+							},
+						}
+					},
+					validate: doValidateWithMsg(
+						`spec.affinity.vmAffinity.requiredDuringSchedulingPreferredDuringExecution[0].topologyKey: Unsupported value: "kubernetes.io/hostname": supported values: "topology.kubernetes.io/zone"`),
+				},
+			),
+
+			Entry("allow VM Affinity with RequiredDuringSchedulingPreferredDuringExecution and Host topology key when VMAffinityDuringExecution is enabled",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+							config.Features.VMAffinityDuringExecution = true
+						})
+						ctx.vm.Spec.Affinity.VMAffinity = &vmopv1.VMAffinitySpec{
+							RequiredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+								{
+									TopologyKey: corev1.LabelHostname,
+								},
+							},
+						}
+					},
+					expectAllowed: true,
+				},
+			),
+
+			Entry("disallow VM Affinity with RequiredDuringSchedulingPreferredDuringExecution and unsupported topology key even with VMAffinityDuringExecution enabled",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+							config.Features.VMAffinityDuringExecution = true
+						})
+						ctx.vm.Spec.Affinity.VMAffinity = &vmopv1.VMAffinitySpec{
+							RequiredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+								{
+									TopologyKey: "unsupported-key",
+								},
+							},
+						}
+					},
+					validate: doValidateWithMsg(
+						`spec.affinity.vmAffinity.requiredDuringSchedulingPreferredDuringExecution[0].topologyKey: Unsupported value: "unsupported-key": supported values: "topology.kubernetes.io/zone", "kubernetes.io/hostname"`),
+				},
+			),
+
+			Entry("disallow VM Affinity with RequiredDuringSchedulingPreferredDuringExecution and unsupported operator",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						ctx.vm.Spec.Affinity.VMAffinity = &vmopv1.VMAffinitySpec{
+							RequiredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "foo",
+												Operator: metav1.LabelSelectorOpNotIn,
+												Values:   []string{"bar"},
+											},
+										},
+									},
+									TopologyKey: corev1.LabelTopologyZone,
+								},
+							},
+						}
+					},
+					validate: doValidateWithMsg(
+						`spec.affinity.vmAffinity.requiredDuringSchedulingPreferredDuringExecution[0].labelSelector.matchExpressions[0].operator: Unsupported value: "NotIn": supported values: "In"`),
+				},
+			),
+
+			Entry("disallow VM Affinity PreferredDuringSchedulingPreferredDuringExecution with Host topology key",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						ctx.vm.Spec.Affinity.VMAffinity = &vmopv1.VMAffinitySpec{
+							PreferredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+								{
+									TopologyKey: corev1.LabelHostname,
+								},
+							},
+						}
+					},
+					validate: doValidateWithMsg(
+						`spec.affinity.vmAffinity.preferredDuringSchedulingPreferredDuringExecution[0].topologyKey: Unsupported value: "kubernetes.io/hostname": supported values: "topology.kubernetes.io/zone"`),
+				},
+			),
+
+			Entry("disallow VM Affinity PreferredDuringSchedulingPreferredDuringExecution with empty topology key",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						ctx.vm.Spec.Affinity.VMAffinity = &vmopv1.VMAffinitySpec{
+							PreferredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+								{
+									TopologyKey: "",
+								},
+							},
+						}
+					},
+					validate: doValidateWithMsg(
+						`spec.affinity.vmAffinity.preferredDuringSchedulingPreferredDuringExecution[0].topologyKey: Unsupported value: "": supported values: "topology.kubernetes.io/zone"`),
+				},
+			),
+
+			Entry("disallow VM Affinity PreferredDuringSchedulingPreferredDuringExecution with unsupported operator",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						ctx.vm.Spec.Affinity.VMAffinity = &vmopv1.VMAffinitySpec{
+							PreferredDuringSchedulingPreferredDuringExecution: []vmopv1.VMAffinityTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "foo",
+												Operator: metav1.LabelSelectorOpNotIn,
+												Values:   []string{"bar"},
+											},
+										},
+									},
+									TopologyKey: corev1.LabelTopologyZone,
+								},
+							},
+						}
+					},
+					validate: doValidateWithMsg(
+						`spec.affinity.vmAffinity.preferredDuringSchedulingPreferredDuringExecution[0].labelSelector.matchExpressions[0].operator: Unsupported value: "NotIn": supported values: "In"`),
+				},
+			),
+
 			Entry("allow VM Anti Affinity with RequiredDuringSchedulingPreferredDuringExecution and Zone topology key for non-privileged users",
 				testParams{
 					setup: func(ctx *unitValidatingWebhookContext) {


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
Crossports in order:
- https://github.com/vmware-tanzu/vm-operator/pull/1501
- https://github.com/vmware-tanzu/vm-operator/pull/1503
- https://github.com/vmware-tanzu/vm-operator/pull/1567
- https://github.com/vmware-tanzu/vm-operator/pull/1515
- https://github.com/vmware-tanzu/vm-operator/pull/1574
- https://github.com/vmware-tanzu/vm-operator/pull/1570
- https://github.com/vmware-tanzu/vm-operator/pull/1637
- https://github.com/vmware-tanzu/vm-operator/pull/1643


Skipped:
- https://github.com/vmware-tanzu/vm-operator/pull/1579

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # NA

**Are there any special notes for your reviewer**:
NA

**Please add a release note if necessary**:
```release-note
NA
```