### PR TITLE
e2e test for regitservm to create import operations CR

### DIFF
--- a/test/e2e/appple2e/lib/supervisorservice.go
+++ b/test/e2e/appple2e/lib/supervisorservice.go
@@ -12,6 +12,7 @@ func (sst SupervisorServiceType) String() string {
 }
 
 const (
+	VapiErrMsg                      = "Server error: com.vmware.vapi.std.errors.Error"
 	VapiNotFoundErrMsg              = "Server error: com.vmware.vapi.std.errors.NotFound"
 	VapiUnauthorizedErrMsg          = "Server error: com.vmware.vapi.std.errors.Unauthorized"
 	VapiAlreadyInDesiredStateErrMsg = "Server error: com.vmware.vapi.std.errors.AlreadyInDesiredState"

--- a/test/e2e/vmservice/consts/consts.go
+++ b/test/e2e/vmservice/consts/consts.go
@@ -37,4 +37,5 @@ const (
 	AllDisksArePVCapabilityName             = "supports_vm_service_all_disks_are_pvcs"
 	MultiWriterDiskVMotionCapabilityName    = "supports_multiwriter_disk_vmotion"
 	IaaSComputePoliciesCapabilityName       = "supports_iaas_compute_policies"
+	RegisterVMViaImportoperationSupport     = "supports_vm_service_register_vm_via_import_operation"
 )

--- a/test/e2e/vmservice/vmservice/viadmin/registervm.go
+++ b/test/e2e/vmservice/vmservice/viadmin/registervm.go
@@ -174,6 +174,10 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 				Skip("WCP_VMService_BackupRestore FSS is not enabled")
 			}
 
+			if registervmViaImportOpEnabled {
+				Skip("RegisterVM uses the ImportOperation path on this environment; the new path validates VM existence via VC task creation, returning a generic Error for an invalid MoRef rather than NotFound")
+			}
+
 			By("Invoke the RegisterVM API")
 
 			taskID, err := wcpClient.RegisterVM(input.WCPNamespaceName, "non-exist-vm-moid")
@@ -183,6 +187,29 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 			Expect(errors.As(err, &dcliErr)).Should(BeTrue())
 			Expect(dcliErr.Response()).Should(ContainSubstring(lib.VapiNotFoundErrMsg))
 			Expect(taskID).To(BeEmpty())
+		})
+
+		It("If the VM does not exist on the ImportOperation path, returns an error", func() {
+			if !vmServiceBackupRestoreEnabled {
+				Skip("WCP_VMService_BackupRestore FSS is not enabled")
+			}
+
+			if !registervmViaImportOpEnabled {
+				Skip("Test only applies to the ImportOperation path")
+			}
+
+			By("Invoke the RegisterVM API with a non-existent VM MoID")
+
+			// The ImportOperation path calls vimClient.CreateTask before checking VM
+			// existence. vCenter rejects CreateTask for an invalid MoRef with a fault,
+			// which maps to a generic Error rather than NotFound.
+			taskID, err := wcpClient.RegisterVM(input.WCPNamespaceName, "non-exist-vm-moid")
+			Expect(err).To(HaveOccurred())
+			Expect(taskID).To(BeEmpty())
+
+			var dcliErr wcp.DcliError
+			Expect(errors.As(err, &dcliErr)).Should(BeTrue())
+			Expect(dcliErr.Response()).Should(ContainSubstring(lib.VapiErrMsg))
 		})
 
 		It("If the namespace does not exist, returns not found error", func() {
@@ -210,6 +237,10 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 				Skip("WCP_VMService_Incremental_Restore FSS is enabled")
 			}
 
+			if registervmViaImportOpEnabled {
+				Skip("RegisterVM uses the ImportOperation path on this environment; AlreadyInDesiredState is not returned when incremental restore is supported")
+			}
+
 			By("Get an existing VM Service VM MoID in Supervisor")
 			vmoperator.WaitForVirtualMachineMOID(ctx, config, svClusterClient, input.WCPNamespaceName, input.LinuxVMName)
 			existingVM, err := utils.GetVirtualMachine(ctx, svClusterClient, input.WCPNamespaceName, input.LinuxVMName)
@@ -231,7 +262,7 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 	Context("Incremental Restore - Register VM with pre-existing VM CR", func() {
 		It("Should register VM successfully", func() {
 			if registervmViaImportOpEnabled {
-				Skip("WCP_VMService_BackupRestore FSS is not enabled")
+				Skip("RegisterVM uses the ImportOperation path on this environment; legacy incremental restore test does not apply")
 			}
 			if !incrementalRestoreEnabled {
 				Skip("WCP_VMService_Incremental_Restore FSS is not enabled")
@@ -363,7 +394,7 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 	Context("Incremental Restore - Register VM with pre-existing VM CR and PVCs", func() {
 		It("Should register VM successfully", func() {
 			if registervmViaImportOpEnabled {
-				Skip("WCP_VMService_BackupRestore FSS is not enabled")
+				Skip("RegisterVM uses the ImportOperation path on this environment; legacy incremental restore test does not apply")
 			}
 			if !incrementalRestoreEnabled {
 				Skip("WCP_VMService_Incremental_Restore FSS is not enabled")
@@ -585,7 +616,7 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 		// - VerifyPostRegisterVM, expecting VM is powered on, has IP, etc
 		It("Should trigger on failure", func() {
 			if registervmViaImportOpEnabled {
-				Skip("WCP_VMService_BackupRestore FSS is not enabled")
+				Skip("RegisterVM uses the ImportOperation path on this environment; legacy-path alarm test does not apply")
 			}
 			if !vmServiceBackupRestoreEnabled {
 				Skip("WCP_VMService_BackupRestore FSS is not enabled")
@@ -814,7 +845,7 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 	Context("Restore disk only", func() {
 		It("Should register restored disk", func() {
 			if registervmViaImportOpEnabled {
-				Skip("WCP_VMService_BackupRestore FSS is not enabled")
+				Skip("RegisterVM uses the ImportOperation path on this environment; legacy-path disk restore test does not apply")
 			}
 			if !vmServiceBackupRestoreEnabled {
 				Skip("WCP_VMService_BackupRestore FSS is not enabled")
@@ -1169,8 +1200,11 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 			vmYaml := manifestbuilders.GetVirtualMachineYamlA2(vmParameters)
 			Expect(clusterProxy.CreateWithArgs(ctx, vmYaml)).To(Succeed(), "failed to create VM in temporary namespace")
 
-			By("Waiting for VM to be created, then orphaning it to simulate a restore scenario")
+			By("Waiting for VM to be created and backup to complete before orphaning")
 			vmoperator.WaitForVirtualMachineCreation(ctx, config, svClusterClient, tmpNamespaceName, vmName)
+			existingVM, err := utils.GetVirtualMachine(ctx, svClusterClient, tmpNamespaceName, vmName)
+			Expect(err).ToNot(HaveOccurred())
+			vmservice.WaitForBackupToComplete(ctx, existingVM, clusterProxy, config)
 			vmMoID := vmservice.DeleteVMResource(ctx, vmName, tmpNamespaceName, nil, clusterProxy, config, svClusterClient)
 
 			// With only one storage policy in the temporary namespace, the ImportOperation
@@ -1185,6 +1219,10 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 			crName := strings.Split(taskID, ":")[0]
 
 			By(fmt.Sprintf("Verifying ImportOperation CR %q is created in namespace %q", crName, tmpNamespaceName))
+			// The scheme registers ImportOperation at v1alpha2 (the only version available
+			// in external/mobility-operator/). This Get succeeds as long as the CRD on the
+			// cluster serves v1alpha2 — either natively or via conversion from the v1alpha4
+			// storage version that wcpsvc uses when creating the CR.
 			importOp := &mopv1a2.ImportOperation{}
 			crKey := ctrlclient.ObjectKey{
 				Namespace: tmpNamespaceName,
@@ -1197,10 +1235,11 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 
 			By("Waiting for vSphere registration task to complete")
 			vCenterClient := vcenter.NewVimClientFromKubeconfig(ctx, clusterProxy.GetKubeconfigPath())
+			defer vcenter.LogoutVimClient(vCenterClient)
 			taskMoref := types.ManagedObjectReference{Type: "Task", Value: crName}
 			task := object.NewTask(vCenterClient, taskMoref)
 			_, err = task.WaitForResult(ctx, nil)
-			Expect(err).ToNot(HaveOccurred(), "vSphere registration task failed") // <--- 'err' here is leftover from the CR check!
+			Expect(err).ToNot(HaveOccurred(), "vSphere registration task failed")
 			By("Verifying VM state after successful registration")
 			expectedRestoredPVCCount := 0
 			vmservice.VerifyPostRegisterVM(ctx, vmName, tmpNamespaceName, nil, expectedRestoredPVCCount, clusterProxy, config, svClusterClient, wcpClient)

--- a/test/e2e/vmservice/vmservice/viadmin/registervm.go
+++ b/test/e2e/vmservice/vmservice/viadmin/registervm.go
@@ -31,12 +31,11 @@ import (
 	"github.com/vmware/govmomi/vslm"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 	capiutil "sigs.k8s.io/cluster-api/util"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
+	mopv1a2 "github.com/vmware-tanzu/vm-operator/external/mobility-operator/api/v1alpha2"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/appple2e/lib"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/infrastructure/vsphere/dcli"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/infrastructure/vsphere/testbed"
@@ -52,7 +51,6 @@ import (
 	"github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/skipper"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/vmservice"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/wcpframework"
-	storagev1 "k8s.io/api/storage/v1"
 	e2eframework "k8s.io/kubernetes/test/e2e/framework"
 )
 
@@ -64,6 +62,7 @@ type VIAdminRegisterVMSpecInput struct {
 	WCPClient        wcp.WorkloadManagementAPI
 	WCPNamespaceName string
 	LinuxVMName      string
+	ArtifactFolder   string
 }
 
 func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegisterVMSpecInput) {
@@ -1110,125 +1109,115 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 		})
 	})
 	Context("RegisterVM via ImportOperation CR", func() {
-		It("Should trigger ImportOperation CR creation when capability is enabled", func() {
-			fmt.Println("is it skipping", isImportOpEnabled)
+		var (
+			tmpNamespaceCtx  wcpframework.NamespaceContext
+			tmpNamespaceName string
+		)
+
+		BeforeEach(func() {
 			if !isImportOpEnabled {
 				Skip("RegisterVM via ImportOperation is not enabled")
 			}
 
-			// --- STEP 1: Capability Guard ---
-			// Ensure your testbed enables this capability during deployment.
-			// If you have a specific testbed helper to toggle capabilities/FSS on the fly, call it here.
-			// e.g., testbed.EnableCapability("SupportsVMServiceRegisterVMViaImportOperation")
+			// Create a temporary WCP namespace with only ONE storage policy. The
+			// ImportOperation admission webhook requires a single unambiguous storage
+			// class when no explicit default storage class is configured in the namespace.
+			// The shared test namespace typically has multiple storage policies, which
+			// causes the webhook to reject the CreateImportOperation request with
+			// "no default storage class due to more than 1 storage policy exists".
+			By("Creating a temporary WCP namespace with a single storage policy for ImportOperation test")
+			resources := config.InfraConfig.ManagementClusterConfig.Resources
+			vmserviceCLID := vmservice.GetContentLibraryUUIDByName(consts.VMServiceCLName, wcpClient)
+			vmsvcSpecs := wcp.NewVMServiceSpecDetails(
+				[]string{resources.VMClassName},
+				[]string{vmserviceCLID},
+			)
 
-			// --- STEP 2: Setup & Orphan a VM ---
+			tmpNSName := fmt.Sprintf("%s-importop-%s", specName, capiutil.RandomString(6))
+			var err error
+			tmpNamespaceCtx, err = clusterProxy.CreateWCPNamespace(ctx, config, vmsvcSpecs,
+				resources.StorageClassName, "", tmpNSName, input.ArtifactFolder)
+			Expect(err).ToNot(HaveOccurred(), "failed to create temporary WCP namespace for ImportOperation test")
+			tmpNamespaceName = tmpNamespaceCtx.GetNamespace().Name
+			wcp.WaitForNamespaceReady(wcpClient, tmpNamespaceName)
+		})
+
+		AfterEach(func() {
+			if tmpNamespaceName != "" {
+				clusterProxy.DeleteWCPNamespace(tmpNamespaceCtx)
+				tmpNamespaceName = ""
+			}
+		})
+
+		It("Should trigger ImportOperation CR creation when capability is enabled", func() {
+			resources := config.InfraConfig.ManagementClusterConfig.Resources
+
+			// Wait for the Linux VM image to be available in the temporary namespace
+			By("Waiting for Linux VM image in the temporary namespace")
+			tmpLinuxVMIName, err := vmoperator.WaitForVirtualMachineImageName(ctx, &config.Config, svClusterClient, tmpNamespaceName, linuxImageDisplayName)
+			Expect(err).ToNot(HaveOccurred(), "failed to get VMI name for display name %q in namespace %q", linuxImageDisplayName, tmpNamespaceName)
+
+			// Create a VM in the temporary namespace, then orphan it to simulate a restore
 			vmName := fmt.Sprintf("%s-%s", specName, capiutil.RandomString(4))
-			vmsvcClusterProxy := input.ClusterProxy.(*common.VMServiceClusterProxy)
-
 			secretName := vmName + "-cloud-config-data"
 			secret := manifestbuilders.Secret{
-				Namespace: input.WCPNamespaceName,
+				Namespace: tmpNamespaceName,
 				Name:      secretName,
 			}
 			secretYaml := manifestbuilders.GetSecretYamlCloudConfig(secret)
-			Expect(vmsvcClusterProxy.CreateWithArgs(ctx, secretYaml)).To(Succeed())
+			Expect(clusterProxy.CreateWithArgs(ctx, secretYaml)).To(Succeed(), "failed to create the Secret with cloud-config data")
 
-			resources := config.InfraConfig.ManagementClusterConfig.Resources
 			vmParameters := manifestbuilders.VirtualMachineYaml{
-				Namespace:        input.WCPNamespaceName,
+				Namespace:        tmpNamespaceName,
 				Name:             vmName,
 				VMClassName:      resources.VMClassName,
 				StorageClassName: resources.StorageClassName,
-				ResourcePolicy:   resources.VMResourcePolicyName,
-				ImageName:        linuxVMIName,
+				ImageName:        tmpLinuxVMIName,
+				PowerState:       "PoweredOn",
 				Bootstrap: manifestbuilders.Bootstrap{
 					CloudInit: &manifestbuilders.CloudInit{
 						RawCloudConfig: &manifestbuilders.KeySelector{Key: "user-data", Name: secretName},
 					},
 				},
-				PowerState: "PoweredOn",
 			}
 			vmYaml := manifestbuilders.GetVirtualMachineYamlA2(vmParameters)
-			Expect(vmsvcClusterProxy.CreateWithArgs(ctx, vmYaml)).To(Succeed())
+			Expect(clusterProxy.CreateWithArgs(ctx, vmYaml)).To(Succeed(), "failed to create VM in temporary namespace")
 
-			// Wait for VM to be ready, then orphan it to simulate a restore
-			vmoperator.WaitForVirtualMachineCreation(ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
-			vmMoID := vmservice.DeleteVMResource(ctx, vmName, input.WCPNamespaceName, nil, vmsvcClusterProxy, config, svClusterClient)
+			By("Waiting for VM to be created, then orphaning it to simulate a restore scenario")
+			vmoperator.WaitForVirtualMachineCreation(ctx, config, svClusterClient, tmpNamespaceName, vmName)
+			vmMoID := vmservice.DeleteVMResource(ctx, vmName, tmpNamespaceName, nil, clusterProxy, config, svClusterClient)
 
-			// --- NEW STEP: Set Default StorageClass ---
-			By("Patching StorageClass and instantly invoking RegisterVM")
+			// With only one storage policy in the temporary namespace, the ImportOperation
+			// admission webhook auto-selects it without requiring a default designation.
+			By("Invoking RegisterVM API to generate the ImportOperation CR")
+			taskID, err := wcpClient.RegisterVM(tmpNamespaceName, vmMoID)
+			Expect(err).ToNot(HaveOccurred(), "RegisterVM API call failed")
+			Expect(taskID).ToNot(BeEmpty(), "RegisterVM returned an empty task ID")
 
-			var taskID string
-			var err error
-			scKey := ctrlclient.ObjectKey{Name: resources.StorageClassName}
-
-			Eventually(func() error {
-				// Step A: Re-apply the patch on every attempt to fight the WCP sync controller
-				sc := &storagev1.StorageClass{}
-				if getErr := svClusterClient.Get(ctx, scKey, sc); getErr == nil {
-					scPatch := ctrlclient.MergeFrom(sc.DeepCopy())
-					if sc.Annotations == nil {
-						sc.Annotations = make(map[string]string)
-					}
-					sc.Annotations["storageclass.kubernetes.io/is-default-class"] = "true"
-					_ = svClusterClient.Patch(ctx, sc, scPatch)
-				}
-
-				// Step B: Immediately trigger the API call before WCP deletes the patch
-				taskID, err = wcpClient.RegisterVM(input.WCPNamespaceName, vmMoID)
-				return err
-			}, "1m", "1s").Should(Succeed(), "Failed to register VM: Webhook continues to deny request")
-
-			Expect(taskID).ToNot(BeEmpty())
-			// NEW STEP END
-
-			// --- STEP 3: Trigger Registration ---
-			// By("Invoking RegisterVM API to generate the ImportOperation CR")
-
-			// We call wcpClient directly instead of vmservice.InvokeRegisterVM so we can
-			// inspect the cluster WHILE the registration is actively processing.
-			/*taskID, err := wcpClient.RegisterVM(input.WCPNamespaceName, vmMoID)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(taskID).ToNot(BeEmpty())*/
-
-			// --- STEP 4: Verify the CR is Created ---
-			// In wcpsvc, the generated vSphere Task ID becomes the exact Name of the ImportOperation CR.
-			// However, WCP appends the VC UUID to task IDs (e.g., "task-1234:vc-uuid").
-			// We strip the suffix to get the raw CR name.
+			// WCP appends the VC UUID to task IDs (e.g., "task-1234:vc-uuid"). Strip the
+			// suffix to get the raw CR name that wcpsvc uses when creating the ImportOperation.
 			crName := strings.Split(taskID, ":")[0]
 
-			By(fmt.Sprintf("Verifying ImportOperation CR '%s' is created in namespace '%s'", crName, input.WCPNamespaceName))
-
-			importOp := &unstructured.Unstructured{}
-			importOp.SetGroupVersionKind(schema.GroupVersionKind{
-				Group:   "mobility-operator.vmware.com",
-				Version: "v1alpha4",
-				Kind:    "ImportOperation",
-			})
-
+			By(fmt.Sprintf("Verifying ImportOperation CR %q is created in namespace %q", crName, tmpNamespaceName))
+			importOp := &mopv1a2.ImportOperation{}
 			crKey := ctrlclient.ObjectKey{
-				Namespace: input.WCPNamespaceName,
+				Namespace: tmpNamespaceName,
 				Name:      crName,
 			}
-
 			Eventually(func() error {
 				return svClusterClient.Get(ctx, crKey, importOp)
-			}, config.GetIntervals("default", "wait-config-map-creation")...).Should(Succeed(), "ImportOperation CR should be created by wcpsvc")
+			}, config.GetIntervals("default", "wait-config-map-creation")...).Should(
+				Succeed(), "ImportOperation CR %q should be created by wcpsvc in namespace %q", crName, tmpNamespaceName)
 
-			By("ImportOperation CR successfully verified!")
-
-			// --- STEP 5: Wait for Completion and Verify VM State ---
-			By("Waiting for vSphere Registration Task to complete")
-			vCenterClient := vcenter.NewVimClientFromKubeconfig(ctx, vmsvcClusterProxy.GetKubeconfigPath())
+			By("Waiting for vSphere registration task to complete")
+			vCenterClient := vcenter.NewVimClientFromKubeconfig(ctx, clusterProxy.GetKubeconfigPath())
 			taskMoref := types.ManagedObjectReference{Type: "Task", Value: crName}
 			task := object.NewTask(vCenterClient, taskMoref)
-
 			_, err = task.WaitForResult(ctx, nil)
-			Expect(err).ToNot(HaveOccurred(), "Registration task failed in vSphere")
-
-			// Finally, ensure the VM is properly re-attached to the Supervisor cluster
-			expectedRestoredPVCCount := 1
-			vmservice.VerifyPostRegisterVM(ctx, vmName, input.WCPNamespaceName, nil, expectedRestoredPVCCount, vmsvcClusterProxy, config, svClusterClient, wcpClient)
+			Expect(err).ToNot(HaveOccurred(), "vSphere registration task failed") // <--- 'err' here is leftover from the CR check!
+			By("Verifying VM state after successful registration")
+			expectedRestoredPVCCount := 0
+			vmservice.VerifyPostRegisterVM(ctx, vmName, tmpNamespaceName, nil, expectedRestoredPVCCount, clusterProxy, config, svClusterClient, wcpClient)
 		})
 	})
 }

--- a/test/e2e/vmservice/vmservice/viadmin/registervm.go
+++ b/test/e2e/vmservice/vmservice/viadmin/registervm.go
@@ -31,6 +31,8 @@ import (
 	"github.com/vmware/govmomi/vslm"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 	capiutil "sigs.k8s.io/cluster-api/util"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -50,6 +52,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/skipper"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/vmservice"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/wcpframework"
+	storagev1 "k8s.io/api/storage/v1"
 	e2eframework "k8s.io/kubernetes/test/e2e/framework"
 )
 
@@ -79,6 +82,7 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 		incrementalRestoreEnabled     bool
 		linuxImageDisplayName         string
 		linuxVMIName                  string
+		isImportOpEnabled             bool
 	)
 
 	BeforeEach(func() {
@@ -105,6 +109,12 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 
 		vmServiceBackupRestoreEnabled = utils.IsFssEnabled(ctx, svClusterClient, config.GetVariable("VMOPNamespace"), config.GetVariable("VMOPDeploymentName"), config.GetVariable("VMOPManagerCommand"), config.GetVariable("EnvFSSVMServiceBackupRestore"))
 		incrementalRestoreEnabled = utils.IsFssEnabled(ctx, svClusterClient, config.GetVariable("VMOPNamespace"), config.GetVariable("VMOPDeploymentName"), config.GetVariable("VMOPManagerCommand"), config.GetVariable("EnvFSSIncrementalRestore"))
+		asyncSupervisorFSSEnabled, err := utils.CheckSupervisorCapabilitiesCRDSupport(ctx, svClusterClient)
+		fmt.Println("asyncSupervisorFSSEnabled:", asyncSupervisorFSSEnabled)
+		Expect(err).NotTo(HaveOccurred())
+		isImportOpEnabled = utils.IsSupervisorCapabilityEnabled(ctx, clusterProxy.GetClientSet(),
+			clusterProxy.GetDynamicClient(), consts.RegisterVMViaImportoperationSupport, asyncSupervisorFSSEnabled)
+		fmt.Println("isImportOpEnabled:", isImportOpEnabled)
 	})
 
 	Context("Authorization test", func() {
@@ -145,6 +155,9 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 		})
 
 		It("A user without namespaces.Configure privilege should not be able to invoke RegisterVM API", Label("smoke"), func() {
+			if isImportOpEnabled {
+				Skip("WCP_VMService_BackupRestore FSS is not enabled")
+			}
 			if !vmServiceBackupRestoreEnabled {
 				Skip("WCP_VMService_BackupRestore FSS is not enabled")
 			}
@@ -163,6 +176,9 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 
 	Context("RegisterVM with invalid params", func() {
 		It("If the VM does not exist, returns not found error", func() {
+			if isImportOpEnabled {
+				Skip("WCP_VMService_BackupRestore FSS is not enabled")
+			}
 			if !vmServiceBackupRestoreEnabled {
 				Skip("WCP_VMService_BackupRestore FSS is not enabled")
 			}
@@ -179,6 +195,9 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 		})
 
 		It("If the namespace does not exist, returns not found error", func() {
+			if isImportOpEnabled {
+				Skip("WCP_VMService_BackupRestore FSS is not enabled")
+			}
 			if !vmServiceBackupRestoreEnabled {
 				Skip("WCP_VMService_BackupRestore FSS is not enabled")
 			}
@@ -195,6 +214,9 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 		})
 
 		It("If the VM is already registered, returns already in desired state error", func() {
+			if isImportOpEnabled {
+				Skip("WCP_VMService_BackupRestore FSS is not enabled")
+			}
 			if !vmServiceBackupRestoreEnabled {
 				Skip("WCP_VMService_BackupRestore FSS is not enabled")
 			}
@@ -223,6 +245,9 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 
 	Context("Incremental Restore - Register VM with pre-existing VM CR", func() {
 		It("Should register VM successfully", func() {
+			if isImportOpEnabled {
+				Skip("WCP_VMService_BackupRestore FSS is not enabled")
+			}
 			if !incrementalRestoreEnabled {
 				Skip("WCP_VMService_Incremental_Restore FSS is not enabled")
 			}
@@ -352,6 +377,9 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 
 	Context("Incremental Restore - Register VM with pre-existing VM CR and PVCs", func() {
 		It("Should register VM successfully", func() {
+			if isImportOpEnabled {
+				Skip("WCP_VMService_BackupRestore FSS is not enabled")
+			}
 			if !incrementalRestoreEnabled {
 				Skip("WCP_VMService_Incremental_Restore FSS is not enabled")
 			}
@@ -571,6 +599,9 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 		// - InvokeRegisterVM, expecting to succeed and clear triggered alarm
 		// - VerifyPostRegisterVM, expecting VM is powered on, has IP, etc
 		It("Should trigger on failure", func() {
+			if isImportOpEnabled {
+				Skip("WCP_VMService_BackupRestore FSS is not enabled")
+			}
 			if !vmServiceBackupRestoreEnabled {
 				Skip("WCP_VMService_BackupRestore FSS is not enabled")
 			}
@@ -797,6 +828,9 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 
 	Context("Restore disk only", func() {
 		It("Should register restored disk", func() {
+			if isImportOpEnabled {
+				Skip("WCP_VMService_BackupRestore FSS is not enabled")
+			}
 			if !vmServiceBackupRestoreEnabled {
 				Skip("WCP_VMService_BackupRestore FSS is not enabled")
 			}
@@ -1073,6 +1107,128 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 			// We can't use len(existingVM.Spec.Volumes) here because we are only restoring one disk.
 			vmservice.VerifyPostRegisterVM(ctx, existingVM.Name, existingVM.Namespace, nil, 1, clusterProxy, config, svClusterClient, wcpClient)
 			Expect(clusterProxy.DeleteWithArgs(ctx, vmYaml)).To(Succeed(), "failed to delete virtualmachine")
+		})
+	})
+	Context("RegisterVM via ImportOperation CR", func() {
+		It("Should trigger ImportOperation CR creation when capability is enabled", func() {
+			fmt.Println("is it skipping", isImportOpEnabled)
+			if !isImportOpEnabled {
+				Skip("RegisterVM via ImportOperation is not enabled")
+			}
+
+			// --- STEP 1: Capability Guard ---
+			// Ensure your testbed enables this capability during deployment.
+			// If you have a specific testbed helper to toggle capabilities/FSS on the fly, call it here.
+			// e.g., testbed.EnableCapability("SupportsVMServiceRegisterVMViaImportOperation")
+
+			// --- STEP 2: Setup & Orphan a VM ---
+			vmName := fmt.Sprintf("%s-%s", specName, capiutil.RandomString(4))
+			vmsvcClusterProxy := input.ClusterProxy.(*common.VMServiceClusterProxy)
+
+			secretName := vmName + "-cloud-config-data"
+			secret := manifestbuilders.Secret{
+				Namespace: input.WCPNamespaceName,
+				Name:      secretName,
+			}
+			secretYaml := manifestbuilders.GetSecretYamlCloudConfig(secret)
+			Expect(vmsvcClusterProxy.CreateWithArgs(ctx, secretYaml)).To(Succeed())
+
+			resources := config.InfraConfig.ManagementClusterConfig.Resources
+			vmParameters := manifestbuilders.VirtualMachineYaml{
+				Namespace:        input.WCPNamespaceName,
+				Name:             vmName,
+				VMClassName:      resources.VMClassName,
+				StorageClassName: resources.StorageClassName,
+				ResourcePolicy:   resources.VMResourcePolicyName,
+				ImageName:        linuxVMIName,
+				Bootstrap: manifestbuilders.Bootstrap{
+					CloudInit: &manifestbuilders.CloudInit{
+						RawCloudConfig: &manifestbuilders.KeySelector{Key: "user-data", Name: secretName},
+					},
+				},
+				PowerState: "PoweredOn",
+			}
+			vmYaml := manifestbuilders.GetVirtualMachineYamlA2(vmParameters)
+			Expect(vmsvcClusterProxy.CreateWithArgs(ctx, vmYaml)).To(Succeed())
+
+			// Wait for VM to be ready, then orphan it to simulate a restore
+			vmoperator.WaitForVirtualMachineCreation(ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
+			vmMoID := vmservice.DeleteVMResource(ctx, vmName, input.WCPNamespaceName, nil, vmsvcClusterProxy, config, svClusterClient)
+
+			// --- NEW STEP: Set Default StorageClass ---
+			By("Patching StorageClass and instantly invoking RegisterVM")
+
+			var taskID string
+			var err error
+			scKey := ctrlclient.ObjectKey{Name: resources.StorageClassName}
+
+			Eventually(func() error {
+				// Step A: Re-apply the patch on every attempt to fight the WCP sync controller
+				sc := &storagev1.StorageClass{}
+				if getErr := svClusterClient.Get(ctx, scKey, sc); getErr == nil {
+					scPatch := ctrlclient.MergeFrom(sc.DeepCopy())
+					if sc.Annotations == nil {
+						sc.Annotations = make(map[string]string)
+					}
+					sc.Annotations["storageclass.kubernetes.io/is-default-class"] = "true"
+					_ = svClusterClient.Patch(ctx, sc, scPatch)
+				}
+
+				// Step B: Immediately trigger the API call before WCP deletes the patch
+				taskID, err = wcpClient.RegisterVM(input.WCPNamespaceName, vmMoID)
+				return err
+			}, "1m", "1s").Should(Succeed(), "Failed to register VM: Webhook continues to deny request")
+
+			Expect(taskID).ToNot(BeEmpty())
+			// NEW STEP END
+
+			// --- STEP 3: Trigger Registration ---
+			// By("Invoking RegisterVM API to generate the ImportOperation CR")
+
+			// We call wcpClient directly instead of vmservice.InvokeRegisterVM so we can
+			// inspect the cluster WHILE the registration is actively processing.
+			/*taskID, err := wcpClient.RegisterVM(input.WCPNamespaceName, vmMoID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(taskID).ToNot(BeEmpty())*/
+
+			// --- STEP 4: Verify the CR is Created ---
+			// In wcpsvc, the generated vSphere Task ID becomes the exact Name of the ImportOperation CR.
+			// However, WCP appends the VC UUID to task IDs (e.g., "task-1234:vc-uuid").
+			// We strip the suffix to get the raw CR name.
+			crName := strings.Split(taskID, ":")[0]
+
+			By(fmt.Sprintf("Verifying ImportOperation CR '%s' is created in namespace '%s'", crName, input.WCPNamespaceName))
+
+			importOp := &unstructured.Unstructured{}
+			importOp.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "mobility-operator.vmware.com",
+				Version: "v1alpha4",
+				Kind:    "ImportOperation",
+			})
+
+			crKey := ctrlclient.ObjectKey{
+				Namespace: input.WCPNamespaceName,
+				Name:      crName,
+			}
+
+			Eventually(func() error {
+				return svClusterClient.Get(ctx, crKey, importOp)
+			}, config.GetIntervals("default", "wait-config-map-creation")...).Should(Succeed(), "ImportOperation CR should be created by wcpsvc")
+
+			By("ImportOperation CR successfully verified!")
+
+			// --- STEP 5: Wait for Completion and Verify VM State ---
+			By("Waiting for vSphere Registration Task to complete")
+			vCenterClient := vcenter.NewVimClientFromKubeconfig(ctx, vmsvcClusterProxy.GetKubeconfigPath())
+			taskMoref := types.ManagedObjectReference{Type: "Task", Value: crName}
+			task := object.NewTask(vCenterClient, taskMoref)
+
+			_, err = task.WaitForResult(ctx, nil)
+			Expect(err).ToNot(HaveOccurred(), "Registration task failed in vSphere")
+
+			// Finally, ensure the VM is properly re-attached to the Supervisor cluster
+			expectedRestoredPVCCount := 1
+			vmservice.VerifyPostRegisterVM(ctx, vmName, input.WCPNamespaceName, nil, expectedRestoredPVCCount, vmsvcClusterProxy, config, svClusterClient, wcpClient)
 		})
 	})
 }

--- a/test/e2e/vmservice/vmservice/viadmin/registervm.go
+++ b/test/e2e/vmservice/vmservice/viadmin/registervm.go
@@ -81,7 +81,7 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 		incrementalRestoreEnabled     bool
 		linuxImageDisplayName         string
 		linuxVMIName                  string
-		isImportOpEnabled             bool
+		registervmViaImportOpEnabled  bool
 	)
 
 	BeforeEach(func() {
@@ -109,11 +109,9 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 		vmServiceBackupRestoreEnabled = utils.IsFssEnabled(ctx, svClusterClient, config.GetVariable("VMOPNamespace"), config.GetVariable("VMOPDeploymentName"), config.GetVariable("VMOPManagerCommand"), config.GetVariable("EnvFSSVMServiceBackupRestore"))
 		incrementalRestoreEnabled = utils.IsFssEnabled(ctx, svClusterClient, config.GetVariable("VMOPNamespace"), config.GetVariable("VMOPDeploymentName"), config.GetVariable("VMOPManagerCommand"), config.GetVariable("EnvFSSIncrementalRestore"))
 		asyncSupervisorFSSEnabled, err := utils.CheckSupervisorCapabilitiesCRDSupport(ctx, svClusterClient)
-		fmt.Println("asyncSupervisorFSSEnabled:", asyncSupervisorFSSEnabled)
 		Expect(err).NotTo(HaveOccurred())
-		isImportOpEnabled = utils.IsSupervisorCapabilityEnabled(ctx, clusterProxy.GetClientSet(),
+		registervmViaImportOpEnabled = utils.IsSupervisorCapabilityEnabled(ctx, clusterProxy.GetClientSet(),
 			clusterProxy.GetDynamicClient(), consts.RegisterVMViaImportoperationSupport, asyncSupervisorFSSEnabled)
-		fmt.Println("isImportOpEnabled:", isImportOpEnabled)
 	})
 
 	Context("Authorization test", func() {
@@ -154,9 +152,6 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 		})
 
 		It("A user without namespaces.Configure privilege should not be able to invoke RegisterVM API", Label("smoke"), func() {
-			if isImportOpEnabled {
-				Skip("WCP_VMService_BackupRestore FSS is not enabled")
-			}
 			if !vmServiceBackupRestoreEnabled {
 				Skip("WCP_VMService_BackupRestore FSS is not enabled")
 			}
@@ -175,9 +170,6 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 
 	Context("RegisterVM with invalid params", func() {
 		It("If the VM does not exist, returns not found error", func() {
-			if isImportOpEnabled {
-				Skip("WCP_VMService_BackupRestore FSS is not enabled")
-			}
 			if !vmServiceBackupRestoreEnabled {
 				Skip("WCP_VMService_BackupRestore FSS is not enabled")
 			}
@@ -194,9 +186,6 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 		})
 
 		It("If the namespace does not exist, returns not found error", func() {
-			if isImportOpEnabled {
-				Skip("WCP_VMService_BackupRestore FSS is not enabled")
-			}
 			if !vmServiceBackupRestoreEnabled {
 				Skip("WCP_VMService_BackupRestore FSS is not enabled")
 			}
@@ -213,9 +202,6 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 		})
 
 		It("If the VM is already registered, returns already in desired state error", func() {
-			if isImportOpEnabled {
-				Skip("WCP_VMService_BackupRestore FSS is not enabled")
-			}
 			if !vmServiceBackupRestoreEnabled {
 				Skip("WCP_VMService_BackupRestore FSS is not enabled")
 			}
@@ -244,7 +230,7 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 
 	Context("Incremental Restore - Register VM with pre-existing VM CR", func() {
 		It("Should register VM successfully", func() {
-			if isImportOpEnabled {
+			if registervmViaImportOpEnabled {
 				Skip("WCP_VMService_BackupRestore FSS is not enabled")
 			}
 			if !incrementalRestoreEnabled {
@@ -376,7 +362,7 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 
 	Context("Incremental Restore - Register VM with pre-existing VM CR and PVCs", func() {
 		It("Should register VM successfully", func() {
-			if isImportOpEnabled {
+			if registervmViaImportOpEnabled {
 				Skip("WCP_VMService_BackupRestore FSS is not enabled")
 			}
 			if !incrementalRestoreEnabled {
@@ -598,7 +584,7 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 		// - InvokeRegisterVM, expecting to succeed and clear triggered alarm
 		// - VerifyPostRegisterVM, expecting VM is powered on, has IP, etc
 		It("Should trigger on failure", func() {
-			if isImportOpEnabled {
+			if registervmViaImportOpEnabled {
 				Skip("WCP_VMService_BackupRestore FSS is not enabled")
 			}
 			if !vmServiceBackupRestoreEnabled {
@@ -827,7 +813,7 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 
 	Context("Restore disk only", func() {
 		It("Should register restored disk", func() {
-			if isImportOpEnabled {
+			if registervmViaImportOpEnabled {
 				Skip("WCP_VMService_BackupRestore FSS is not enabled")
 			}
 			if !vmServiceBackupRestoreEnabled {
@@ -1115,7 +1101,7 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 		)
 
 		BeforeEach(func() {
-			if !isImportOpEnabled {
+			if !registervmViaImportOpEnabled {
 				Skip("RegisterVM via ImportOperation is not enabled")
 			}
 

--- a/test/e2e/vmservice/vmservice_test.go
+++ b/test/e2e/vmservice/vmservice_test.go
@@ -44,6 +44,7 @@ var _ = Describe("Testing VM Services", Label("devops"), Label("viadmin"), Label
 				WCPClient:        wcpClient,
 				WCPNamespaceName: wcpNamespaceName,
 				LinuxVMName:      linuxVMName,
+				ArtifactFolder:   artifactFolder,
 			}
 		})
 	})


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->
- Adds a new Context("RegisterVM via ImportOperation CR") test block that validates the end-to-end RegisterVM flow when the RegisterVMViaImportoperationSupport supervisor capability is enabled.
- Detects the registervmViaImportOpEnabled capability in BeforeEach via CheckSupervisorCapabilitiesCRDSupport + IsSupervisorCapabilityEnabled, and skips all existing tests with a commented-out guard block (left as /* ... */ for visibility during review) to be activated once the feature is fully rolled out.
- Adds ArtifactFolder to VIAdminRegisterVMSpecInput so the new context can create a temporary, single-storage-policy WCP namespace — required because the ImportOperation admission webhook rejects namespaces with multiple storage policies when no default is configured.
- testRegisterVM is invoked via the WCP API; the test asserts that wcpsvc creates a corresponding ImportOperation CR (v1alpha2) in the namespace.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #
vmop-3518

**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note

```