### PR TITLE
🌱 docs: Add CLAUDE.md proxy files for Claude Code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,39 @@
+# VM Operator — Claude Code Guidelines
+
+This project follows Spec-Driven Development (SDD). The authoritative guidelines live in `.sdd/memory/`. This file is a Claude Code proxy that maps those rules into the contexts where they apply, following the same pattern as `.cursor/rules/*.mdc`.
+
+> **Do not duplicate guidance here.** Update `.sdd/memory/*.md` instead; this file and the `.cursor` rules will stay current automatically via the `@` imports below.
+
+---
+
+## Always-active rules
+
+@.sdd/memory/constitution.md
+
+@.sdd/memory/commit-message-standards.md
+
+@.sdd/memory/pull-request-standards.md
+
+@.sdd/memory/e2e-sync-with-changes.md
+
+---
+
+## Go source files
+
+Applies when editing any `**/*.go` file that is not a test file.
+
+@.sdd/memory/architectural-standards.md
+
+---
+
+## Controller and provider files
+
+Applies when editing `controllers/**/*.go`, `pkg/providers/**/*.go`, `services/**/*.go`, and related packages.
+
+@.sdd/memory/operator-best-practices.md
+
+---
+
+## Test files (`**/*_test.go`)
+
+@.sdd/memory/testing-standards.md

--- a/test/e2e/CLAUDE.md
+++ b/test/e2e/CLAUDE.md
@@ -1,0 +1,5 @@
+# VM Operator — E2E Test Guidelines
+
+Loaded automatically by Claude Code when editing files under `test/e2e/`. For the always-active E2E sync rule (add/update/delete E2E tests alongside product changes) see the root `CLAUDE.md`.
+
+@../../.sdd/memory/e2e-testing.md


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Claude Code does not honor `.cursor/rules/*.mdc` files. This PR adds `CLAUDE.md` files that follow the same thin-proxy pattern already established by the Cursor rules: each file imports the authoritative `.sdd/memory/*.md` docs via `@` imports rather than duplicating content.

Two files are added:
- `CLAUDE.md` (root) — always loaded by Claude Code; covers the constitution, commit/PR standards, E2E-sync, architectural standards, operator best practices, and testing standards.
- `test/e2e/CLAUDE.md` — automatically loaded when Claude Code edits files under `test/e2e/`; adds E2E-specific testing guidance on top of the root file.

The `.sdd/memory/` files remain the single source of truth, consistent with the constitutional requirement:
> *AI-assistant-specific rule files MUST be proxies that link back into `.sdd/memory/*.md`. Do not duplicate guidance across the two trees.*

**Which issue(s) is/are addressed by this PR?** *(optional)*:

N/A

**Are there any special notes for your reviewer**:

No logic changes — documentation/tooling files only.

**Please add a release note if necessary**:

```release-note
NONE
```