### PR TITLE
✨ vmop-3743: Add VirtualMachineConfigOptions controller

### DIFF
--- a/.sdd/memory/constitution.md
+++ b/.sdd/memory/constitution.md
@@ -86,7 +86,7 @@ The non-negotiables below are constitutional; for the canonical reconcile-loop t
 - Controllers are **thin**: reconcile loops live in `controllers/`; all business logic lives in `pkg/`.
 - No controller may call vSphere APIs directly; use the provider abstraction under `pkg/providers/vsphere/`.
 - Controllers must track `status.observedGeneration` and set a `Ready` condition.
-- Fan-out to child objects uses `controllerutil.CreateOrPatch`; ownership is set via `controllerutil.SetControllerReference` unless the object is cluster-scoped, in which case use labels for ownership tracing.
+- Fan-out to child objects uses `controllerutil.CreateOrPatch` by default; ownership is set via `controllerutil.SetControllerReference` unless the object is cluster-scoped, in which case use labels for ownership tracing. When multiple parents fan-in write to the same *list-typed* field on a shared child (e.g., owner references, a status list each parent upserts an entry into), patch with `client.MergeFromWithOptimisticLock` instead and skip the write when nothing changed — a plain merge patch replaces list fields wholesale with no conflict detection and can silently drop a writer's contribution, whereas the optimistic lock makes a concurrent write fail with a conflict that the next reconcile retries. Disjoint fields or a shared map keyed per writer are unaffected. See [`operator-best-practices.md`](./operator-best-practices.md#fan-out-to-child-objects-patch-vs-createorupdate).
 - Controllers for API groups other than `vmoperator.vmware.com` should not be placed directly in the `controllers/` directory.
 
 ## Webhooks

--- a/.sdd/memory/operator-best-practices.md
+++ b/.sdd/memory/operator-best-practices.md
@@ -181,6 +181,47 @@ func relatedToMyResourceMapper(c client.Client) func(context.Context, client.Obj
 }
 ```
 
+## Fan-out to Child Objects (patch vs. CreateOrUpdate)
+
+`controllerutil.CreateOrPatch` uses a JSON merge patch: map fields merge
+key-by-key, but **list fields are replaced wholesale** and there is **no
+`resourceVersion` precondition**. Fine for disjoint fields or a shared map
+keyed per writer; unsafe for a shared list.
+
+When multiple parents fan-in write to the same *list*-typed field (owner
+references, or a status list each parent upserts an entry into), a plain merge
+patch can silently drop a concurrent writer's entry with no error to trigger a
+retry. Patch with an optimistic lock, and skip the write when nothing changed:
+
+```go
+base := obj.DeepCopy()
+// mutate obj toward desired ...
+if !apiequality.Semantic.DeepEqual(base.Spec, obj.Spec) ||
+    !apiequality.Semantic.DeepEqual(base.OwnerReferences, obj.OwnerReferences) {
+    // MergeFromWithOptimisticLock sends base's resourceVersion, so a racing
+    // writer's patch fails with a conflict instead of overwriting. Reconcile
+    // is idempotent, so just return the error and let the requeue retry.
+    if err := c.Patch(ctx, obj, client.MergeFromWithOptions(base, client.MergeFromWithOptimisticLock{})); err != nil {
+        return err
+    }
+}
+```
+
+- **Compare with `apiequality.Semantic.DeepEqual`** (`k8s.io/apimachinery/pkg/api/equality`),
+  not `reflect.DeepEqual` — plain reflection false-diffs on types like
+  `resource.Quantity` that carry an unexported lazy-formatted-string cache, so a
+  freshly-built value and its round-tripped-through-the-API-server equivalent
+  compare unequal even when identical. That silently defeats the skip-if-unchanged
+  guard below.
+- **Skip unchanged writes** so an idle reconcile does not bump
+  `resourceVersion` and re-trigger watchers. (`CreateOrUpdate`'s `Update` gets
+  the same conflict guarantee but writes the whole object; prefer the patch.)
+- **Status is a subresource:** persist it separately via `c.Status().Patch(...)`
+  (same optimistic lock, same skip guard) after the object exists.
+- **In tests**, register the type with `WithStatusSubresource` (all VM Operator
+  types already are — `test/builder/fake.go` `KnownObjectTypes`) so the fake
+  client enforces the spec/status split and catches a missing status write.
+
 ## VM Update Reconcile Order
 
 The `updateVirtualMachine` method in the vSphere provider follows a strict, intentional ordering. Each step depends on the state established by prior steps. Do NOT reorder these without understanding the dependencies:
@@ -206,6 +247,50 @@ Key ordering rationale:
 - **Snapshot create last**: Captures the final converged state after all changes.
 
 Each step uses `getReconcileErr` to accumulate errors while continuing through subsequent steps where possible. A `NoRequeueError` from any step short-circuits the remaining steps via `errOrReconcileErr`.
+
+## VC Operation IDs (WithVCOpID)
+
+Any code path that calls into vCenter — govmomi, the property collector, or a
+package-level helper in `pkg/providers/vsphere/*.go` that takes a
+`*vim25.Client` directly — MUST wrap the context with `pkgctx.WithVCOpID`
+before making that call, so the operation can be correlated with VC-side
+logs.
+
+**Set it inside the provider method, not in the calling controller.** When a
+controller reaches vCenter through the `VMProvider` interface (the normal
+case), the wrapping belongs at the top of the concrete
+`pkg/providers/vsphere/*.go` method that actually talks to VC — the
+controller just calls the interface method with a plain `ctx`:
+
+```go
+// pkg/providers/vsphere/vmprovider.go
+func (vs *vSphereVMProvider) QueryConfigOptionEx(
+    ctx context.Context,
+    clusterMoID string,
+    hardwareVersion string) (*vimtypes.VirtualMachineConfigOption, error) {
+
+    ctx = pkgctx.WithVCOpID(ctx, nil, "queryConfigOptionEx")
+
+    client, err := vs.getVcClient(ctx)
+    ...
+}
+```
+
+- The object parameter is nil-safe — pass the Kubernetes object being
+  reconciled when the provider method has one in scope (e.g.
+  `pkgctx.WithVCOpID(ctx, vm, "properties")`), or `nil` when the method only
+  takes primitive args (e.g. a `clusterMoID` string) and has no object to
+  fold into the op ID.
+- `operation` is a short, camelCase label naming the specific VC call/step
+  (e.g. `"properties"`, `"createOrUpdateVM"`, `"queryConfigOptionEx"`), not a
+  generic term like `"reconcile"`. The resulting string is
+  `vmoperator-<objName>-<operation>-<reconcileID>`.
+- Usually one op ID per provider method is enough: set it once near the top of
+  the `pkg/providers/vsphere/*.go` method that reaches vCenter rather than
+  labeling every individual govmomi/property-collector call it makes. This is a
+  default to steer toward when nothing else dictates otherwise, not a hard rule
+  — if a method does genuinely distinct operations worth telling apart in
+  VC-side logs, giving them their own op IDs is fine.
 
 ## Requeue and Error Semantics (pkgerr)
 

--- a/.sdd/specs/001-class-policy-resize/tasks.md
+++ b/.sdd/specs/001-class-policy-resize/tasks.md
@@ -80,11 +80,11 @@ Dependencies: none. All A-tasks may run in parallel `[P]`.
 
 - [x] T080 [S6.a] [PR #1671 / vmop-3762] Author `webhooks/virtualmachineconfigoptions/validation/virtualmachineconfigoptions_validator.go` — immutable spec.hardwareVersion; format ^vmx-\d+$; metadata.name must equal spec.hardwareVersion
 - [x] T081 [S6.a] [PR #1671 / vmop-3762] Unit tests (13 specs) + integration test stubs — `webhooks/virtualmachineconfigoptions/validation/`
-- [ ] T082 [S6.b] Author `controllers/virtualmachineconfigoptions/vmconfigoptions_controller.go` — QueryConfigOptionEx; map vim.vm.ConfigOption → status; fan out VirtualMachineGuestOptions per guest OS; update listMap entry keyed by hardwareVersion
-- [ ] T083 [S6.b] Add `pkg/providers/vsphere/environment_browser.go` QueryConfigOptionEx wrapper (extend T064)
-- [ ] T084 [S6.b] Unit tests — `controllers/virtualmachineconfigoptions/vmconfigoptions_controller_test.go`
-- [ ] T085 [S6.c] [P] Integration tests with vcsim — `test/intg/virtualmachineconfigoptions/vmconfigoptions_intg_test.go`: happy path on multiple HW versions; idempotent re-reconcile updates one listMap entry; golden-file assertion against testdata/configoption-vmx-22.yaml
-- [ ] T086 [S6.d] E2E test — `test/e2e/vmservice/vmservice/configpolicy/vmconfigoptions.go`: at least one HW version reconciled on test cluster. Deferred until the VirtualMachineConfigOptions controller (T082-T084) is implemented; webhook validation for hardwareVersion is already covered by the envtest integration suite in `webhooks/virtualmachineconfigoptions/validation/`
+- [x] T082 [S6.b] [PR #1672] Author `controllers/virtualmachineconfigoptions/vmconfigoptions_controller.go` — QueryConfigOptionEx; map vim.vm.ConfigOption → status; fan out VirtualMachineGuestOptions per guest OS; update listMap entry keyed by hardwareVersion
+- [x] T083 [S6.b] [PR #1672] Add `pkg/providers/vsphere/environment_browser.go` — `QueryConfigOptionEx` wrapper, consistent with T064's note that single-purpose EnvironmentBrowser queries can live in a dedicated file once the surface area grows
+- [x] T084 [S6.b] [PR #1672] Unit tests — `controllers/virtualmachineconfigoptions/vmconfigoptions_controller_test.go` (envtest-backed suite; 5 specs, 75.5% coverage)
+- [x] T085 [S6.c] [PR #1672] Integration coverage — folded into `controllers/virtualmachineconfigoptions/vmconfigoptions_controller_test.go` per `testing-standards.md` (no separate `test/intg` tree exists in this repo; unit/integration tests are differentiated by Ginkgo `Label()`, not by file path). Covers happy path and idempotent re-reconcile; no golden-file fixture was added.
+- [x] T086 [S6.d] [PR #1672] E2E test — `test/e2e/vmservice/vmservice/configpolicy/configpolicy.go`: `VirtualMachineConfigOptions.status.guestOSIdentifiers` populated and `Ready=True`, and a `VirtualMachineGuestOptions` fanned out per reported guest OS (folded into the shared Spec function established by S3/S5, not a standalone `vmconfigoptions_test.go`)
 
 ### Story S7 — VirtualMachineGuestOptions plumbing (vmop-3744)
 

--- a/config/crd/external-crds/vim.vmware.com_virtualmachineguestoptions.yaml
+++ b/config/crd/external-crds/vim.vmware.com_virtualmachineguestoptions.yaml
@@ -293,7 +293,7 @@ spec:
                         RecommendedEthernetCard is the recommended default ethernet adapter type
                         for this guest.
                       enum:
-                      - VirtualE1000e
+                      - VirtualE1000
                       - VirtualE1000e
                       - VirtualPCNet32
                       - VirtualSriovEthernetCard
@@ -390,7 +390,7 @@ spec:
                           EthernetCardType identifies the concrete type of a virtual Ethernet
                           card in a virtual machine.
                         enum:
-                        - VirtualE1000e
+                        - VirtualE1000
                         - VirtualE1000e
                         - VirtualPCNet32
                         - VirtualSriovEthernetCard
@@ -636,7 +636,7 @@ spec:
                           EthernetCardType identifies the concrete type of a virtual Ethernet
                           card in a virtual machine.
                         enum:
-                        - VirtualE1000e
+                        - VirtualE1000
                         - VirtualE1000e
                         - VirtualPCNet32
                         - VirtualSriovEthernetCard

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -281,6 +281,7 @@ rules:
   resources:
   - configtargets
   - virtualmachineconfigoptions
+  - virtualmachineguestoptions
   verbs:
   - create
   - delete
@@ -294,6 +295,7 @@ rules:
   resources:
   - configtargets/status
   - virtualmachineconfigoptions/status
+  - virtualmachineguestoptions/status
   verbs:
   - get
   - patch

--- a/controllers/configtarget/configtarget_controller.go
+++ b/controllers/configtarget/configtarget_controller.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/vmware/govmomi/fault"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -247,7 +248,12 @@ func populateStatus(obj *vimv1.ConfigTarget, ct *vimtypes.ConfigTarget) {
 // SetControllerReference, because the same hardware-version-keyed
 // VirtualMachineConfigOptions object may be legitimately co-owned by
 // multiple ConfigTarget objects from different clusters that happen to
-// support the same hardware version.
+// support the same hardware version. That fan-in means more than one
+// reconcile can write to the same object's owner references, so the patch
+// uses client.MergeFromWithOptimisticLock: the API server rejects a
+// concurrent write with a conflict error -- no custom retry loop is needed
+// to detect that; the error is simply returned, and controller-runtime's own
+// requeue re-fetches and re-applies on the next attempt.
 func (r *Reconciler) reconcileConfigOptions(
 	ctx context.Context,
 	obj *vimv1.ConfigTarget,
@@ -260,17 +266,42 @@ func (r *Reconciler) reconcileConfigOptions(
 		}
 
 		liveKeys.Insert(d.Key)
+		key := d.Key
 
 		vmco := &vimv1.VirtualMachineConfigOptions{
-			ObjectMeta: metav1.ObjectMeta{Name: d.Key},
+			ObjectMeta: metav1.ObjectMeta{Name: key},
 		}
 
-		_, err := controllerutil.CreateOrPatch(ctx, r.Client, vmco, func() error {
-			vmco.Spec.HardwareVersion = d.Key
-			return controllerutil.SetOwnerReference(obj, vmco, r.Scheme())
-		})
-		if err != nil {
-			return fmt.Errorf("failed to create or patch VirtualMachineConfigOptions %q: %w", d.Key, err)
+		if err := r.Get(ctx, client.ObjectKey{Name: key}, vmco); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return fmt.Errorf("failed to get VirtualMachineConfigOptions %q: %w", key, err)
+			}
+			vmco.Spec.HardwareVersion = key
+			if err := controllerutil.SetOwnerReference(obj, vmco, r.Scheme()); err != nil {
+				return fmt.Errorf("failed to set owner reference on VirtualMachineConfigOptions %q: %w", key, err)
+			}
+			if err := r.Create(ctx, vmco); err != nil {
+				return fmt.Errorf("failed to create VirtualMachineConfigOptions %q: %w", key, err)
+			}
+			continue
+		}
+
+		// The same hardware-version-keyed object can be co-owned by
+		// multiple ConfigTargets, so each writer upserts its own owner
+		// reference into a shared list. The optimistic lock makes a racing
+		// writer's patch fail with a conflict instead of dropping an owner
+		// reference; skip the write when nothing changed.
+		base := vmco.DeepCopy()
+		vmco.Spec.HardwareVersion = key
+		if err := controllerutil.SetOwnerReference(obj, vmco, r.Scheme()); err != nil {
+			return fmt.Errorf("failed to set owner reference on VirtualMachineConfigOptions %q: %w", key, err)
+		}
+		if apiequality.Semantic.DeepEqual(base.Spec, vmco.Spec) &&
+			apiequality.Semantic.DeepEqual(base.OwnerReferences, vmco.OwnerReferences) {
+			continue
+		}
+		if err := r.Patch(ctx, vmco, client.MergeFromWithOptions(base, client.MergeFromWithOptimisticLock{})); err != nil {
+			return fmt.Errorf("failed to patch VirtualMachineConfigOptions %q: %w", key, err)
 		}
 	}
 

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -15,6 +15,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/controllers/storage"
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachine"
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachineclass"
+	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachineconfigoptions"
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachinegroup"
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachinegrouppublishrequest"
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachineimagecache"
@@ -93,8 +94,13 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 	}
 
 	if pkgcfg.FromContext(ctx).Features.VirtualMachineConfigPolicy {
+		// ConfigTarget fans out VirtualMachineConfigOptions, so it's
+		// registered first.
 		if err := configtarget.AddToManager(ctx, mgr); err != nil {
 			return fmt.Errorf("failed to initialize ConfigTarget controller: %w", err)
+		}
+		if err := virtualmachineconfigoptions.AddToManager(ctx, mgr); err != nil {
+			return fmt.Errorf("failed to initialize VirtualMachineConfigOptions controller: %w", err)
 		}
 	}
 

--- a/controllers/virtualmachineconfigoptions/vmconfigoptions_controller.go
+++ b/controllers/virtualmachineconfigoptions/vmconfigoptions_controller.go
@@ -1,0 +1,449 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package virtualmachineconfigoptions
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	vimv1 "github.com/vmware-tanzu/vm-operator/external/vim/api/v1alpha1"
+	pkgcond "github.com/vmware-tanzu/vm-operator/pkg/conditions"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
+	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+	pkglog "github.com/vmware-tanzu/vm-operator/pkg/log"
+	"github.com/vmware-tanzu/vm-operator/pkg/patch"
+	"github.com/vmware-tanzu/vm-operator/pkg/providers"
+	"github.com/vmware-tanzu/vm-operator/pkg/record"
+)
+
+const (
+	// Finalizer is the finalizer placed on VirtualMachineConfigOptions objects
+	// by VM Operator.
+	Finalizer = "vmoperator.vmware.com/virtualmachineconfigoptions"
+
+	// ConfigTargetKind is the owner-reference Kind used to identify a
+	// ConfigTarget among a VirtualMachineConfigOptions' owner references.
+	ConfigTargetKind = "ConfigTarget"
+
+	// ConfigTargetNotFoundReason is the Ready condition reason used while a
+	// VirtualMachineConfigOptions has no ConfigTarget owner reference yet.
+	ConfigTargetNotFoundReason = "ConfigTargetNotFound"
+
+	// QueryFailedReason is the Ready condition reason used when resolving the
+	// owning cluster or querying QueryConfigOptionEx fails.
+	QueryFailedReason = "QueryFailed"
+
+	// NotFoundReason is the Ready condition reason used when
+	// QueryConfigOptionEx reports no config option for the requested
+	// hardware version.
+	NotFoundReason = "NotFound"
+)
+
+// SkipNameValidation is used for testing to allow multiple controllers with the
+// same name since Controller-Runtime has a global singleton registry to
+// prevent controllers with the same name, even if attached to different
+// managers.
+var (
+	SkipNameValidation *bool
+
+	// nonAlnumHyphenRE matches any character that is not a lowercase letter,
+	// digit, or hyphen.
+	nonAlnumHyphenRE = regexp.MustCompile(`[^a-z0-9-]+`)
+)
+
+var _ = SkipNameValidation
+
+// AddToManager adds this package's controller to the provided manager.
+func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) error {
+	var (
+		controlledType     = &vimv1.VirtualMachineConfigOptions{}
+		controlledTypeName = reflect.TypeOf(controlledType).Elem().Name()
+
+		controllerNameShort = fmt.Sprintf("%s-controller", strings.ToLower(controlledTypeName))
+	)
+
+	r := NewReconciler(
+		ctx,
+		mgr.GetClient(),
+		ctrl.Log.WithName("controllers").WithName(controlledTypeName),
+		record.New(mgr.GetEventRecorder(controllerNameShort)),
+		ctx.VMProvider,
+	)
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(controlledType).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: ctx.GetMaxConcurrentReconciles(controllerNameShort, 1),
+			SkipNameValidation:      SkipNameValidation,
+			LogConstructor:          pkglog.ControllerLogConstructor(controllerNameShort, controlledType, mgr.GetScheme()),
+		}).
+		Complete(r)
+}
+
+// NewReconciler returns a new Reconciler for VirtualMachineConfigOptions.
+func NewReconciler(
+	ctx context.Context,
+	c client.Client,
+	logger logr.Logger,
+	recorder record.Recorder,
+	vmProvider providers.VirtualMachineProviderInterface) *Reconciler {
+
+	return &Reconciler{
+		Context:    ctx,
+		Client:     c,
+		Logger:     logger,
+		Recorder:   recorder,
+		VMProvider: vmProvider,
+	}
+}
+
+// Reconciler reconciles a VirtualMachineConfigOptions object.
+type Reconciler struct {
+	client.Client
+	Context    context.Context
+	Logger     logr.Logger
+	Recorder   record.Recorder
+	VMProvider providers.VirtualMachineProviderInterface
+}
+
+// +kubebuilder:rbac:groups=vim.vmware.com,resources=virtualmachineconfigoptions,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=vim.vmware.com,resources=virtualmachineconfigoptions/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=vim.vmware.com,resources=configtargets,verbs=get;list;watch
+// +kubebuilder:rbac:groups=vim.vmware.com,resources=virtualmachineguestoptions,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=vim.vmware.com,resources=virtualmachineguestoptions/status,verbs=get;update;patch
+
+func (r *Reconciler) Reconcile(
+	ctx context.Context,
+	req ctrl.Request) (_ ctrl.Result, reterr error) {
+
+	ctx = pkgcfg.JoinContext(ctx, r.Context)
+
+	var obj vimv1.VirtualMachineConfigOptions
+	if err := r.Get(ctx, req.NamespacedName, &obj); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	patchHelper, err := patch.NewHelper(&obj, r.Client)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to init patch helper for %s: %w", req, err)
+	}
+	defer func() {
+		if err := patchHelper.Patch(ctx, &obj); err != nil {
+			if reterr == nil {
+				reterr = err
+			} else {
+				reterr = fmt.Errorf("%w,%w", err, reterr)
+			}
+		}
+	}()
+
+	if !obj.DeletionTimestamp.IsZero() {
+		return r.ReconcileDelete(ctx, &obj)
+	}
+	return r.ReconcileNormal(ctx, &obj)
+}
+
+// ReconcileDelete handles deletion of a VirtualMachineConfigOptions object.
+func (r *Reconciler) ReconcileDelete(
+	ctx context.Context,
+	obj *vimv1.VirtualMachineConfigOptions) (ctrl.Result, error) {
+
+	controllerutil.RemoveFinalizer(obj, Finalizer)
+	return ctrl.Result{}, nil
+}
+
+// ReconcileNormal reconciles a VirtualMachineConfigOptions object during normal
+// (non-delete) operations.
+func (r *Reconciler) ReconcileNormal(
+	ctx context.Context,
+	obj *vimv1.VirtualMachineConfigOptions) (ctrl.Result, error) {
+
+	if controllerutil.AddFinalizer(obj, Finalizer) {
+		// Return immediately to persist the finalizer before proceeding.
+		return ctrl.Result{}, nil
+	}
+
+	clusterMoID, err := r.findClusterMoID(ctx, obj)
+	if err != nil {
+		pkgcond.MarkError(obj, vimv1.ReadyConditionType, QueryFailedReason, err)
+		return ctrl.Result{}, err
+	}
+	if clusterMoID == "" {
+		// No ConfigTarget owner found yet; surface it on the Ready condition
+		// and requeue after a short delay.
+		pkgcond.MarkFalse(obj, vimv1.ReadyConditionType, ConfigTargetNotFoundReason,
+			"no %s owner reference found yet", ConfigTargetKind)
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+	}
+
+	configOption, err := r.VMProvider.QueryConfigOptionEx(ctx, clusterMoID, obj.Spec.HardwareVersion)
+	if err != nil {
+		pkgcond.MarkError(obj, vimv1.ReadyConditionType, QueryFailedReason, err)
+		return ctrl.Result{}, fmt.Errorf("failed to query config option ex: %w", err)
+	}
+
+	if configOption == nil {
+		pkgcond.MarkFalse(obj, vimv1.ReadyConditionType, NotFoundReason,
+			"config option not found for hardware version %s", obj.Spec.HardwareVersion)
+		obj.Status.ObservedGeneration = obj.Generation
+		return ctrl.Result{}, nil
+	}
+
+	applyStatus(obj, configOption)
+
+	if err := r.fanOutGuestOptions(ctx, obj.Spec.HardwareVersion, configOption.GuestOSDescriptor); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	pkgcond.MarkTrue(obj, vimv1.ReadyConditionType)
+	obj.Status.ObservedGeneration = obj.Generation
+	return ctrl.Result{}, nil
+}
+
+// findClusterMoID looks up a cluster managed object ID from the owner
+// references of the given VirtualMachineConfigOptions. It returns an empty
+// string (with no error) when no ConfigTarget owner is found.
+//
+// A hardware-version-keyed VirtualMachineConfigOptions may legitimately be
+// co-owned by more than one ConfigTarget (see
+// controllers/configtarget's reconcileConfigOptions), since multiple
+// clusters can report supporting the same hardware version. vSphere's own
+// EnvironmentBrowser.QueryConfigOptionEx does not aggregate across hosts in
+// this situation either: it resolves to exactly one host's real, internally
+// consistent ConfigOption, chosen deterministically as the host running the
+// lowest product version among those supporting the requested key. We have
+// no comparable per-cluster signal to replicate that "most conservative"
+// selection today (that would need something like each ConfigTarget's ESXi
+// version, which this design deliberately does not expose -- see the
+// retired HostSystem CRD). So, among co-owners, this picks the
+// lexicographically smallest cluster MoID: an arbitrary but stable and
+// reproducible tie-break, not a proxy for "most conservative".
+//
+// TODO(vmop-3964): Replace this tie-break with a real conservative-selection
+// signal (e.g. minimum ESXi build across co-owning ConfigTargets) and record
+// the selected cluster in VirtualMachineConfigOptions.Status for debugging.
+func (r *Reconciler) findClusterMoID(
+	ctx context.Context,
+	obj *vimv1.VirtualMachineConfigOptions) (string, error) {
+
+	clusterMoIDs := make([]string, 0, len(obj.OwnerReferences))
+	for _, ref := range obj.OwnerReferences {
+		if ref.Kind != ConfigTargetKind {
+			continue
+		}
+		var ct vimv1.ConfigTarget
+		if err := r.Client.Get(ctx, client.ObjectKey{Name: ref.Name}, &ct); err != nil {
+			return "", fmt.Errorf("failed to get ConfigTarget %s: %w", ref.Name, err)
+		}
+		clusterMoIDs = append(clusterMoIDs, ct.Spec.ID.ID)
+	}
+
+	if len(clusterMoIDs) == 0 {
+		return "", nil
+	}
+
+	sort.Strings(clusterMoIDs)
+	return clusterMoIDs[0], nil
+}
+
+// applyStatus maps configOption fields onto obj.Status. It has no side
+// effects beyond obj itself -- fanning out child VirtualMachineGuestOptions
+// objects is the separate fanOutGuestOptions method.
+func applyStatus(
+	obj *vimv1.VirtualMachineConfigOptions,
+	configOption *vimtypes.VirtualMachineConfigOption) {
+
+	obj.Status.Description = configOption.Description
+	obj.Status.GuestOSDefaultIndex = configOption.GuestOSDefaultIndex
+	obj.Status.SupportedMonitorTypes = configOption.SupportedMonitorType
+	obj.Status.SupportedOvfEnvironmentTransports = configOption.SupportedOvfEnvironmentTransport
+	obj.Status.SupportedOvfInstallTransports = configOption.SupportedOvfInstallTransport
+
+	guestIDs := make([]vimv1.VirtualMachineGuestOSIdentifier, 0, len(configOption.GuestOSDescriptor))
+	for _, desc := range configOption.GuestOSDescriptor {
+		guestIDs = append(guestIDs, vimv1.VirtualMachineGuestOSIdentifier(desc.Id))
+	}
+	obj.Status.GuestOSIdentifiers = guestIDs
+}
+
+// fanOutGuestOptions creates or updates a VirtualMachineGuestOptions object
+// for each guest OS descriptor. Every descriptor is attempted even if an
+// earlier one fails -- each is an independent, idempotent upsert, so a
+// failure on one must not block progress on the others. Errors from all
+// descriptors are joined and returned together; any descriptor left
+// unconverged this pass is retried, along with the rest, on the next
+// reconcile triggered by that error.
+func (r *Reconciler) fanOutGuestOptions(
+	ctx context.Context,
+	hardwareVersion string,
+	descriptors []vimtypes.GuestOsDescriptor) error {
+
+	var errs []error
+	for i := range descriptors {
+		if err := r.reconcileGuestOptions(ctx, hardwareVersion, descriptors[i]); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// reconcileGuestOptions creates or updates the VirtualMachineGuestOptions
+// object for the given guest OS descriptor.
+//
+// This object is shared: every VirtualMachineConfigOptions (one per hardware
+// version) that reports support for this guest OS upserts its own entry into
+// Status.HardwareVersions. That fan-in means more than one hardware version's
+// reconcile can race to update the same object. Writes therefore use
+// client.MergeFromWithOptimisticLock, so a concurrent writer's patch fails
+// with a conflict instead of silently dropping an entry; the error is simply
+// returned, and controller-runtime's own requeue re-fetches and re-applies on
+// the next attempt. Status is a subresource, so it is persisted separately via
+// Status().Patch. Each write is skipped when nothing changed, to avoid bumping
+// ResourceVersion and re-triggering watchers on an otherwise idle reconcile.
+func (r *Reconciler) reconcileGuestOptions(
+	ctx context.Context,
+	hardwareVersion string,
+	desc vimtypes.GuestOsDescriptor) error {
+
+	name := toGuestOptionsName(desc.Id)
+	hwStatus := buildHardwareVersionStatus(hardwareVersion, desc)
+
+	obj := &vimv1.VirtualMachineGuestOptions{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	}
+
+	if err := r.Get(ctx, client.ObjectKey{Name: name}, obj); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to get VirtualMachineGuestOptions %s: %w", name, err)
+		}
+		obj.Spec.ID = vimv1.VirtualMachineGuestOSIdentifier(desc.Id)
+		if err := r.Create(ctx, obj); err != nil {
+			return fmt.Errorf("failed to create VirtualMachineGuestOptions %s: %w", name, err)
+		}
+		obj.Status.FullName = desc.FullName
+		obj.Status.Family.FromVimType(desc.Family)
+		obj.Status.HardwareVersions = upsertHardwareVersionStatus(obj.Status.HardwareVersions, hwStatus)
+		if err := r.Status().Update(ctx, obj); err != nil {
+			return fmt.Errorf("failed to update status for VirtualMachineGuestOptions %s: %w", name, err)
+		}
+		return nil
+	}
+
+	// Patch the spec toward desired, skipping the write when nothing changed
+	// so an idle reconcile does not bump ResourceVersion and re-trigger
+	// watchers.
+	specBase := obj.DeepCopy()
+	obj.Spec.ID = vimv1.VirtualMachineGuestOSIdentifier(desc.Id)
+	if !apiequality.Semantic.DeepEqual(specBase.Spec, obj.Spec) {
+		if err := r.Patch(ctx, obj, client.MergeFromWithOptions(specBase, client.MergeFromWithOptimisticLock{})); err != nil {
+			return fmt.Errorf("failed to patch VirtualMachineGuestOptions %s: %w", name, err)
+		}
+	}
+
+	// Upsert this hardware version's entry into the shared status list. The
+	// optimistic lock makes a racing writer's patch fail with a conflict
+	// rather than silently dropping an entry; skip the write when nothing
+	// changed.
+	statusBase := obj.DeepCopy()
+	obj.Status.FullName = desc.FullName
+	obj.Status.Family.FromVimType(desc.Family)
+	obj.Status.HardwareVersions = upsertHardwareVersionStatus(obj.Status.HardwareVersions, hwStatus)
+	if !apiequality.Semantic.DeepEqual(statusBase.Status, obj.Status) {
+		if err := r.Status().Patch(ctx, obj, client.MergeFromWithOptions(statusBase, client.MergeFromWithOptimisticLock{})); err != nil {
+			return fmt.Errorf("failed to patch status for VirtualMachineGuestOptions %s: %w", name, err)
+		}
+	}
+
+	return nil
+}
+
+// upsertHardwareVersionStatus returns versions with hwStatus inserted,
+// replacing any existing entry for the same hardware version.
+func upsertHardwareVersionStatus(
+	versions []vimv1.VirtualMachineGuestOptionsHardwareVersionStatus,
+	hwStatus vimv1.VirtualMachineGuestOptionsHardwareVersionStatus,
+) []vimv1.VirtualMachineGuestOptionsHardwareVersionStatus {
+
+	for i := range versions {
+		if versions[i].HardwareVersion == hwStatus.HardwareVersion {
+			versions[i] = hwStatus
+			return versions
+		}
+	}
+	return append(versions, hwStatus)
+}
+
+// buildHardwareVersionStatus builds a
+// VirtualMachineGuestOptionsHardwareVersionStatus from a GuestOsDescriptor.
+func buildHardwareVersionStatus(
+	hardwareVersion string,
+	desc vimtypes.GuestOsDescriptor) vimv1.VirtualMachineGuestOptionsHardwareVersionStatus {
+
+	s := vimv1.VirtualMachineGuestOptionsHardwareVersionStatus{
+		HardwareVersion:             hardwareVersion,
+		SupportedMaxCPUs:            desc.SupportedMaxCPUs,
+		NumSupportedPhysicalSockets: desc.NumSupportedPhysicalSockets,
+		NumSupportedCoresPerSocket:  desc.NumSupportedCoresPerSocket,
+		RecommendedColorDepth:       desc.RecommendedColorDepth,
+		SupportedNumDisks:           desc.SupportedNumDisks,
+		RecommendedDiskController:   vimv1.VirtualControllerType(desc.RecommendedDiskController),
+		RecommendedSCSIController:   vimv1.VirtualControllerType(desc.RecommendedSCSIController),
+		RecommendedCdromController:  vimv1.VirtualControllerType(desc.RecommendedCdromController),
+		RecommendedEthernetCard:     vimv1.EthernetCardType(desc.RecommendedEthernetCard),
+		SupportsWakeOnLan:           desc.SupportsWakeOnLan,
+		SmcRequired:                 desc.SmcRequired,
+		SmcRecommended:              desc.SmcRecommended,
+		UsbRecommended:              desc.UsbRecommended,
+		SupportsVMI:                 desc.SupportsVMI,
+		SupportedForCreate:          desc.SupportedForCreate,
+	}
+	s.SupportLevel.FromVimType(desc.SupportLevel)
+
+	if desc.SupportedMaxMemMB > 0 {
+		q := resource.NewQuantity(int64(desc.SupportedMaxMemMB)*1024*1024, resource.BinarySI)
+		s.SupportedMaxMem = q
+	}
+	if desc.SupportedMinMemMB > 0 {
+		q := resource.NewQuantity(int64(desc.SupportedMinMemMB)*1024*1024, resource.BinarySI)
+		s.SupportedMinMem = q
+	}
+	if desc.RecommendedMemMB > 0 {
+		q := resource.NewQuantity(int64(desc.RecommendedMemMB)*1024*1024, resource.BinarySI)
+		s.RecommendedMem = q
+	}
+
+	return s
+}
+
+// toGuestOptionsName converts a guest OS identifier into a DNS-subdomain-safe
+// name for the corresponding VirtualMachineGuestOptions object.
+func toGuestOptionsName(guestID string) string {
+	s := strings.ToLower(guestID)
+	s = nonAlnumHyphenRE.ReplaceAllString(s, "-")
+	s = strings.Trim(s, "-")
+	if len(s) > 63 {
+		s = s[:63]
+		s = strings.TrimRight(s, "-")
+	}
+	return s
+}

--- a/controllers/virtualmachineconfigoptions/vmconfigoptions_controller_suite_test.go
+++ b/controllers/virtualmachineconfigoptions/vmconfigoptions_controller_suite_test.go
@@ -1,0 +1,41 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package virtualmachineconfigoptions_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+
+	vmconfigoptions "github.com/vmware-tanzu/vm-operator/controllers/virtualmachineconfigoptions"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
+	"github.com/vmware-tanzu/vm-operator/pkg/manager"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+var suite = builder.NewTestSuiteForControllerWithContext(
+	cource.WithContext(
+		pkgcfg.UpdateContext(
+			pkgcfg.NewContextWithDefaultConfig(),
+			func(config *pkgcfg.Config) {
+				config.Features.VirtualMachineConfigPolicy = true
+			},
+		),
+	),
+	vmconfigoptions.AddToManager,
+	manager.InitializeProvidersNoopFn)
+
+func TestVirtualMachineConfigOptions(t *testing.T) {
+	suite.Register(t, "VirtualMachineConfigOptions controller suite", intgTests, unitTests)
+}
+
+var _ = BeforeSuite(func() {
+	vmconfigoptions.SkipNameValidation = ptr.To(true)
+	suite.BeforeSuite()
+})
+
+var _ = AfterSuite(suite.AfterSuite)

--- a/controllers/virtualmachineconfigoptions/vmconfigoptions_controller_test.go
+++ b/controllers/virtualmachineconfigoptions/vmconfigoptions_controller_test.go
@@ -1,0 +1,687 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package virtualmachineconfigoptions_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	vmconfigoptions "github.com/vmware-tanzu/vm-operator/controllers/virtualmachineconfigoptions"
+	vimv1 "github.com/vmware-tanzu/vm-operator/external/vim/api/v1alpha1"
+	pkgcond "github.com/vmware-tanzu/vm-operator/pkg/conditions"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
+	providerfake "github.com/vmware-tanzu/vm-operator/pkg/providers/fake"
+	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+func intgTests() {}
+
+func unitTests() {
+	Describe(
+		"Reconcile",
+		Label(
+			testlabels.Controller,
+			testlabels.API,
+		),
+		unitTestsReconcile,
+	)
+
+	Describe(
+		"Reconcile against vcsim",
+		Label(
+			testlabels.Controller,
+			testlabels.API,
+			testlabels.EnvTest,
+			testlabels.VCSim,
+		),
+		vcsimTestsReconcile,
+	)
+}
+
+func unitTestsReconcile() {
+	const (
+		objName         = "vmx-22-config"
+		clusterMoID     = "domain-c1234"
+		hardwareVersion = "vmx-22"
+	)
+
+	var (
+		initObjects    []client.Object
+		ctx            *builder.UnitTestContextForController
+		reconciler     *vmconfigoptions.Reconciler
+		fakeVMProvider *providerfake.VMProvider
+
+		configOptions *vimv1.VirtualMachineConfigOptions
+		configTarget  *vimv1.ConfigTarget
+		objKey        types.NamespacedName
+	)
+
+	BeforeEach(func() {
+		initObjects = nil
+
+		configTarget = &vimv1.ConfigTarget{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cluster-config-target",
+			},
+			Spec: vimv1.ConfigTargetSpec{
+				ID: vimv1.ManagedObjectID{
+					ID: clusterMoID,
+				},
+			},
+		}
+
+		configOptions = &vimv1.VirtualMachineConfigOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: objName,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: vimv1.GroupVersion.String(),
+						Kind:       vmconfigoptions.ConfigTargetKind,
+						Name:       configTarget.Name,
+						UID:        configTarget.UID,
+					},
+				},
+			},
+			Spec: vimv1.VirtualMachineConfigOptionsSpec{
+				HardwareVersion: hardwareVersion,
+			},
+		}
+
+		objKey = types.NamespacedName{Name: objName}
+	})
+
+	JustBeforeEach(func() {
+		ctx = suite.NewUnitTestContextForController(initObjects...)
+		fakeVMProvider = ctx.VMProvider.(*providerfake.VMProvider)
+		reconciler = vmconfigoptions.NewReconciler(
+			ctx,
+			ctx.Client,
+			ctx.Logger,
+			ctx.Recorder,
+			ctx.VMProvider,
+		)
+	})
+
+	AfterEach(func() {
+		ctx.AfterEach()
+		ctx = nil
+		reconciler = nil
+		fakeVMProvider = nil
+	})
+
+	doReconcile := func() (reconcile.Result, error) {
+		return reconciler.Reconcile(cource.WithContext(ctx), reconcile.Request{NamespacedName: objKey})
+	}
+
+	Context("Reconcile", func() {
+		When("VirtualMachineConfigOptions does not exist", func() {
+			It("should not error", func() {
+				_, err := doReconcile()
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		When("VirtualMachineConfigOptions has no owner references", func() {
+			BeforeEach(func() {
+				configOptions.OwnerReferences = nil
+				initObjects = append(initObjects, configOptions)
+			})
+
+			It("should requeue with a delay and mark Ready=False with ConfigTargetNotFound", func() {
+				// First reconcile adds the finalizer and returns early.
+				_, err := doReconcile()
+				Expect(err).ToNot(HaveOccurred())
+				// Second reconcile finds no ConfigTarget owner and requeues.
+				result, err := doReconcile()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result.RequeueAfter).To(BeNumerically(">", 0))
+
+				current := &vimv1.VirtualMachineConfigOptions{}
+				Expect(ctx.Client.Get(ctx, objKey, current)).To(Succeed())
+				Expect(pkgcond.IsFalse(current, vimv1.ReadyConditionType)).To(BeTrue())
+				Expect(pkgcond.GetReason(current, vimv1.ReadyConditionType)).To(Equal(vmconfigoptions.ConfigTargetNotFoundReason))
+			})
+		})
+
+		When("VirtualMachineConfigOptions and ConfigTarget exist", func() {
+			BeforeEach(func() {
+				initObjects = append(initObjects, configTarget, configOptions)
+			})
+
+			When("QueryConfigOptionEx returns an error", func() {
+				JustBeforeEach(func() {
+					fakeVMProvider.QueryConfigOptionExFn = func(_ context.Context, _, _ string) (*vimtypes.VirtualMachineConfigOption, error) {
+						return nil, errors.New("vc unavailable")
+					}
+				})
+
+				It("should mark Ready=False with QueryFailed reason and return error", func() {
+					// First reconcile adds finalizer; second surfaces the error.
+					_, _ = doReconcile()
+					_, err := doReconcile()
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("vc unavailable"))
+
+					current := &vimv1.VirtualMachineConfigOptions{}
+					Expect(ctx.Client.Get(ctx, objKey, current)).To(Succeed())
+					Expect(pkgcond.IsFalse(current, vimv1.ReadyConditionType)).To(BeTrue())
+					Expect(pkgcond.GetReason(current, vimv1.ReadyConditionType)).To(Equal(vmconfigoptions.QueryFailedReason))
+				})
+			})
+
+			When("reconcile succeeds", func() {
+				JustBeforeEach(func() {
+					fakeVMProvider.QueryConfigOptionExFn = func(_ context.Context, _, _ string) (*vimtypes.VirtualMachineConfigOption, error) {
+						return &vimtypes.VirtualMachineConfigOption{
+							Description:                      "Test config option",
+							GuestOSDefaultIndex:              1,
+							SupportedMonitorType:             []string{"debug", "release"},
+							SupportedOvfEnvironmentTransport: []string{"com.vmware.guestInfo"},
+							SupportedOvfInstallTransport:     []string{"iso"},
+							GuestOSDescriptor: []vimtypes.GuestOsDescriptor{
+								{
+									Id:                          "otherLinux64Guest",
+									FullName:                    "Other Linux (64-bit)",
+									Family:                      "linuxGuest",
+									SupportedMaxCPUs:            64,
+									SupportedMaxMemMB:           8192,
+									SupportedMinMemMB:           512,
+									RecommendedMemMB:            2048,
+									NumSupportedPhysicalSockets: 4,
+									NumSupportedCoresPerSocket:  8,
+									RecommendedColorDepth:       24,
+									SupportedNumDisks:           16,
+									RecommendedDiskController:   "ParaVirtualSCSIController",
+									RecommendedSCSIController:   "VirtualLsiLogicController",
+									RecommendedCdromController:  "VirtualIDEController",
+									RecommendedEthernetCard:     "VirtualVmxnet3",
+									SupportsWakeOnLan:           true,
+									SmcRequired:                 true,
+									SmcRecommended:              true,
+									UsbRecommended:              true,
+									SupportsVMI:                 true,
+									SupportedForCreate:          true,
+									SupportLevel:                "deprecated",
+								},
+								{
+									Id:               "windows9Server64Guest",
+									FullName:         "Microsoft Windows Server 2016 (64-bit)",
+									Family:           "windowsGuest",
+									SupportedMaxCPUs: 128,
+								},
+							},
+						}, nil
+					}
+				})
+
+				It("should populate status.guestOSIdentifiers and mark Ready=True", func() {
+					// First reconcile adds finalizer.
+					_, err := doReconcile()
+					Expect(err).ToNot(HaveOccurred())
+					// Second reconcile performs the full reconciliation.
+					_, err = doReconcile()
+					Expect(err).ToNot(HaveOccurred())
+
+					current := &vimv1.VirtualMachineConfigOptions{}
+					Expect(ctx.Client.Get(ctx, objKey, current)).To(Succeed())
+					Expect(pkgcond.IsTrue(current, vimv1.ReadyConditionType)).To(BeTrue())
+					Expect(current.Status.GuestOSIdentifiers).To(HaveLen(2))
+					Expect(current.Status.GuestOSIdentifiers).To(ContainElements(
+						vimv1.VirtualMachineGuestOSIdentifier("otherLinux64Guest"),
+						vimv1.VirtualMachineGuestOSIdentifier("windows9Server64Guest"),
+					))
+					Expect(current.Status.Description).To(Equal("Test config option"))
+					Expect(current.Status.ObservedGeneration).To(Equal(current.Generation))
+				})
+
+				It("should populate status.guestOSDefaultIndex and the supported transport/monitor lists", func() {
+					_, err := doReconcile()
+					Expect(err).ToNot(HaveOccurred())
+					_, err = doReconcile()
+					Expect(err).ToNot(HaveOccurred())
+
+					current := &vimv1.VirtualMachineConfigOptions{}
+					Expect(ctx.Client.Get(ctx, objKey, current)).To(Succeed())
+					Expect(current.Status.GuestOSDefaultIndex).To(Equal(int32(1)))
+					Expect(current.Status.SupportedMonitorTypes).To(Equal([]string{"debug", "release"}))
+					Expect(current.Status.SupportedOvfEnvironmentTransports).To(Equal([]string{"com.vmware.guestInfo"}))
+					Expect(current.Status.SupportedOvfInstallTransports).To(Equal([]string{"iso"}))
+				})
+
+				It("should map SupportLevel and Family from their vSphere wire values", func() {
+					_, err := doReconcile()
+					Expect(err).ToNot(HaveOccurred())
+					_, err = doReconcile()
+					Expect(err).ToNot(HaveOccurred())
+
+					guestOptions := &vimv1.VirtualMachineGuestOptions{}
+					Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: "otherlinux64guest"}, guestOptions)).To(Succeed())
+					Expect(guestOptions.Status.Family).To(Equal(vimv1.VirtualMachineGuestOSFamilyLinux))
+					Expect(guestOptions.Status.HardwareVersions).To(HaveLen(1))
+					Expect(guestOptions.Status.HardwareVersions[0].SupportLevel).To(Equal(vimv1.SupportLevelDeprecated))
+				})
+
+				It("should populate the remaining hardware-version status fields", func() {
+					_, err := doReconcile()
+					Expect(err).ToNot(HaveOccurred())
+					_, err = doReconcile()
+					Expect(err).ToNot(HaveOccurred())
+
+					guestOptions := &vimv1.VirtualMachineGuestOptions{}
+					Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: "otherlinux64guest"}, guestOptions)).To(Succeed())
+					Expect(guestOptions.Status.HardwareVersions).To(HaveLen(1))
+					hwStatus := guestOptions.Status.HardwareVersions[0]
+
+					Expect(hwStatus.SupportedMaxCPUs).To(Equal(int32(64)))
+					Expect(hwStatus.NumSupportedPhysicalSockets).To(Equal(int32(4)))
+					Expect(hwStatus.NumSupportedCoresPerSocket).To(Equal(int32(8)))
+					Expect(hwStatus.RecommendedColorDepth).To(Equal(int32(24)))
+					Expect(hwStatus.SupportedNumDisks).To(Equal(int32(16)))
+					Expect(hwStatus.RecommendedDiskController).To(Equal(vimv1.VirtualControllerType("ParaVirtualSCSIController")))
+					Expect(hwStatus.RecommendedSCSIController).To(Equal(vimv1.VirtualControllerType("VirtualLsiLogicController")))
+					Expect(hwStatus.RecommendedCdromController).To(Equal(vimv1.VirtualControllerType("VirtualIDEController")))
+					Expect(hwStatus.RecommendedEthernetCard).To(Equal(vimv1.EthernetCardType("VirtualVmxnet3")))
+					Expect(hwStatus.SupportsWakeOnLan).To(BeTrue())
+					Expect(hwStatus.SmcRequired).To(BeTrue())
+					Expect(hwStatus.SmcRecommended).To(BeTrue())
+					Expect(hwStatus.UsbRecommended).To(BeTrue())
+					Expect(hwStatus.SupportsVMI).To(BeTrue())
+					Expect(hwStatus.SupportedForCreate).To(BeTrue())
+				})
+			})
+
+			When("QueryConfigOptionEx reports no config option for the requested hardware version", func() {
+				JustBeforeEach(func() {
+					fakeVMProvider.QueryConfigOptionExFn = func(_ context.Context, _, _ string) (*vimtypes.VirtualMachineConfigOption, error) {
+						return nil, nil
+					}
+				})
+
+				It("should mark Ready=False with NotFound reason", func() {
+					// First reconcile adds finalizer.
+					_, err := doReconcile()
+					Expect(err).ToNot(HaveOccurred())
+					// Second reconcile queries the provider and finds nothing.
+					_, err = doReconcile()
+					Expect(err).ToNot(HaveOccurred())
+
+					current := &vimv1.VirtualMachineConfigOptions{}
+					Expect(ctx.Client.Get(ctx, objKey, current)).To(Succeed())
+					Expect(pkgcond.IsFalse(current, vimv1.ReadyConditionType)).To(BeTrue())
+					Expect(pkgcond.GetReason(current, vimv1.ReadyConditionType)).To(Equal(vmconfigoptions.NotFoundReason))
+					Expect(current.Status.ObservedGeneration).To(Equal(current.Generation))
+				})
+			})
+
+		})
+
+		When("a ConfigTarget owner reference names a ConfigTarget that no longer exists", func() {
+			BeforeEach(func() {
+				configOptions.OwnerReferences = []metav1.OwnerReference{
+					{
+						APIVersion: vimv1.GroupVersion.String(),
+						Kind:       vmconfigoptions.ConfigTargetKind,
+						Name:       "deleted-config-target",
+						UID:        "deleted-uid",
+					},
+				}
+				// Note: configTarget itself is intentionally not added to
+				// initObjects, since the owner reference must point to a
+				// ConfigTarget that no longer exists in the cluster.
+				initObjects = append(initObjects, configOptions)
+			})
+
+			It("should mark Ready=False with QueryFailed reason and return an error", func() {
+				// First reconcile adds finalizer.
+				_, err := doReconcile()
+				Expect(err).ToNot(HaveOccurred())
+				// Second reconcile fails to resolve the owning ConfigTarget.
+				_, err = doReconcile()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to get ConfigTarget"))
+
+				current := &vimv1.VirtualMachineConfigOptions{}
+				Expect(ctx.Client.Get(ctx, objKey, current)).To(Succeed())
+				Expect(pkgcond.IsFalse(current, vimv1.ReadyConditionType)).To(BeTrue())
+				Expect(pkgcond.GetReason(current, vimv1.ReadyConditionType)).To(Equal(vmconfigoptions.QueryFailedReason))
+			})
+		})
+
+		When("two VirtualMachineConfigOptions for different hardware versions report the same guest OS", func() {
+			const otherHardwareVersion = "vmx-21"
+
+			var otherConfigOptions *vimv1.VirtualMachineConfigOptions
+
+			BeforeEach(func() {
+				otherConfigOptions = &vimv1.VirtualMachineConfigOptions{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "vmx-21-config",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: vimv1.GroupVersion.String(),
+								Kind:       vmconfigoptions.ConfigTargetKind,
+								Name:       configTarget.Name,
+								UID:        configTarget.UID,
+							},
+						},
+					},
+					Spec: vimv1.VirtualMachineConfigOptionsSpec{
+						HardwareVersion: otherHardwareVersion,
+					},
+				}
+				initObjects = append(initObjects, configTarget, configOptions, otherConfigOptions)
+			})
+
+			JustBeforeEach(func() {
+				fakeVMProvider.QueryConfigOptionExFn = func(_ context.Context, _, _ string) (*vimtypes.VirtualMachineConfigOption, error) {
+					return &vimtypes.VirtualMachineConfigOption{
+						GuestOSDescriptor: []vimtypes.GuestOsDescriptor{
+							{
+								Id:       "otherLinux64Guest",
+								FullName: "Other Linux (64-bit)",
+								Family:   "linuxGuest",
+							},
+						},
+					}, nil
+				}
+			})
+
+			It("should accumulate a distinct status.hardwareVersions entry per hardware version", func() {
+				otherObjKey := types.NamespacedName{Name: otherConfigOptions.Name}
+				doReconcileOther := func() (reconcile.Result, error) {
+					return reconciler.Reconcile(cource.WithContext(ctx), reconcile.Request{NamespacedName: otherObjKey})
+				}
+
+				// First reconcile of each adds its finalizer; second performs
+				// the full reconciliation and fan-out.
+				_, err := doReconcile()
+				Expect(err).ToNot(HaveOccurred())
+				_, err = doReconcile()
+				Expect(err).ToNot(HaveOccurred())
+				_, err = doReconcileOther()
+				Expect(err).ToNot(HaveOccurred())
+				_, err = doReconcileOther()
+				Expect(err).ToNot(HaveOccurred())
+
+				guestOptions := &vimv1.VirtualMachineGuestOptions{}
+				Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: "otherlinux64guest"}, guestOptions)).To(Succeed())
+				Expect(guestOptions.Status.HardwareVersions).To(HaveLen(2))
+
+				var hardwareVersions []string
+				for _, hv := range guestOptions.Status.HardwareVersions {
+					hardwareVersions = append(hardwareVersions, hv.HardwareVersion)
+				}
+				Expect(hardwareVersions).To(ContainElements(hardwareVersion, otherHardwareVersion))
+			})
+		})
+
+		When("a guest OS identifier is not DNS-subdomain-safe", func() {
+			const longGuestID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-tobetrimmed"
+
+			BeforeEach(func() {
+				initObjects = append(initObjects, configTarget, configOptions)
+			})
+
+			JustBeforeEach(func() {
+				fakeVMProvider.QueryConfigOptionExFn = func(_ context.Context, _, _ string) (*vimtypes.VirtualMachineConfigOption, error) {
+					return &vimtypes.VirtualMachineConfigOption{
+						GuestOSDescriptor: []vimtypes.GuestOsDescriptor{
+							{
+								Id:       "Other_Linux!!64Guest",
+								FullName: "Other Linux (64-bit), sanitized",
+								Family:   "linuxGuest",
+							},
+							{
+								Id:       longGuestID,
+								FullName: "Guest with an over-length identifier",
+								Family:   "linuxGuest",
+							},
+						},
+					}, nil
+				}
+			})
+
+			It("should replace non-alphanumeric-hyphen characters and truncate to 63 characters", func() {
+				_, err := doReconcile()
+				Expect(err).ToNot(HaveOccurred())
+				_, err = doReconcile()
+				Expect(err).ToNot(HaveOccurred())
+
+				sanitized := &vimv1.VirtualMachineGuestOptions{}
+				Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: "other-linux-64guest"}, sanitized)).To(Succeed())
+				Expect(sanitized.Spec.ID).To(Equal(vimv1.VirtualMachineGuestOSIdentifier("Other_Linux!!64Guest")))
+
+				Expect(len(longGuestID)).To(BeNumerically(">", 63))
+				truncatedName := strings.Repeat("a", 62)
+				Expect(len(truncatedName)).To(BeNumerically("<=", 63))
+				truncated := &vimv1.VirtualMachineGuestOptions{}
+				Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: truncatedName}, truncated)).To(Succeed())
+				Expect(truncated.Spec.ID).To(Equal(vimv1.VirtualMachineGuestOSIdentifier(longGuestID)))
+			})
+		})
+		When("VirtualMachineConfigOptions is co-owned by multiple ConfigTargets", func() {
+			const (
+				higherClusterMoID = "domain-c9999"
+				lowerClusterMoID  = "domain-c0001"
+			)
+
+			var (
+				configTargetHigher *vimv1.ConfigTarget
+				configTargetLower  *vimv1.ConfigTarget
+				queriedClusterMoID string
+			)
+
+			BeforeEach(func() {
+				configTargetHigher = &vimv1.ConfigTarget{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster-config-target-higher"},
+					Spec:       vimv1.ConfigTargetSpec{ID: vimv1.ManagedObjectID{ID: higherClusterMoID}},
+				}
+				configTargetLower = &vimv1.ConfigTarget{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster-config-target-lower"},
+					Spec:       vimv1.ConfigTargetSpec{ID: vimv1.ManagedObjectID{ID: lowerClusterMoID}},
+				}
+
+				// Order the owner references so the lexicographically lowest
+				// cluster MoID (lowerClusterMoID) is listed last, proving
+				// selection isn't just "the first owner ref".
+				configOptions.OwnerReferences = []metav1.OwnerReference{
+					{
+						APIVersion: vimv1.GroupVersion.String(),
+						Kind:       vmconfigoptions.ConfigTargetKind,
+						Name:       configTarget.Name,
+						UID:        configTarget.UID,
+					},
+					{
+						APIVersion: vimv1.GroupVersion.String(),
+						Kind:       vmconfigoptions.ConfigTargetKind,
+						Name:       configTargetHigher.Name,
+						UID:        configTargetHigher.UID,
+					},
+					{
+						APIVersion: vimv1.GroupVersion.String(),
+						Kind:       vmconfigoptions.ConfigTargetKind,
+						Name:       configTargetLower.Name,
+						UID:        configTargetLower.UID,
+					},
+				}
+
+				initObjects = append(initObjects, configTarget, configOptions, configTargetHigher, configTargetLower)
+
+				queriedClusterMoID = ""
+			})
+
+			JustBeforeEach(func() {
+				fakeVMProvider.QueryConfigOptionExFn = func(_ context.Context, clusterMoID, _ string) (*vimtypes.VirtualMachineConfigOption, error) {
+					queriedClusterMoID = clusterMoID
+					return &vimtypes.VirtualMachineConfigOption{}, nil
+				}
+			})
+
+			It("deterministically queries the lexicographically lowest cluster MoID", func() {
+				// First reconcile adds finalizer.
+				_, err := doReconcile()
+				Expect(err).ToNot(HaveOccurred())
+				// Second reconcile queries the vSphere provider.
+				_, err = doReconcile()
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(queriedClusterMoID).To(Equal(lowerClusterMoID))
+			})
+		})
+
+		When("ReconcileDelete", func() {
+			BeforeEach(func() {
+				configOptions.Finalizers = []string{vmconfigoptions.Finalizer}
+				initObjects = append(initObjects, configTarget, configOptions)
+			})
+
+			It("should remove the finalizer", func() {
+				// Trigger deletion after context is ready; fake client sets DeletionTimestamp.
+				Expect(ctx.Client.Delete(cource.WithContext(ctx), configOptions)).To(Succeed())
+
+				_, err := doReconcile()
+				Expect(err).ToNot(HaveOccurred())
+
+				// After the finalizer is removed the fake client may garbage-collect
+				// the object immediately, so accept both NotFound and an object with
+				// no finalizer.
+				current := &vimv1.VirtualMachineConfigOptions{}
+				getErr := ctx.Client.Get(ctx, objKey, current)
+				if getErr == nil {
+					Expect(current.Finalizers).ToNot(ContainElement(vmconfigoptions.Finalizer))
+				} else {
+					Expect(getErr).To(MatchError(ContainSubstring("not found")))
+				}
+			})
+		})
+	})
+}
+
+// vcsimTestsReconcile exercises the reconciler against a real vcsim-backed
+// vSphere provider so the QueryConfigOptionEx wrapper's govmomi call path
+// (PropertyCollector RetrieveOne for the EnvironmentBrowser MoRef, then the
+// SOAP QueryConfigOptionEx RPC) is exercised end-to-end, not just mocked away
+// via the fake provider used by unitTestsReconcile above.
+func vcsimTestsReconcile() {
+	var (
+		vcsimCtx      *builder.TestContextForVCSim
+		reconciler    *vmconfigoptions.Reconciler
+		configTarget  *vimv1.ConfigTarget
+		configOptions *vimv1.VirtualMachineConfigOptions
+		objReq        ctrl.Request
+	)
+
+	BeforeEach(func() {
+		vcsimCtx = suite.NewTestContextForVCSim(builder.VCSimTestConfig{})
+
+		provider := vsphere.NewVSphereVMProviderFromClient(vcsimCtx, vcsimCtx.Client, vcsimCtx.Recorder)
+
+		reconciler = vmconfigoptions.NewReconciler(
+			vcsimCtx,
+			vcsimCtx.Client,
+			ctrl.Log.WithName("virtualmachineconfigoptions"),
+			vcsimCtx.Recorder,
+			provider)
+
+		ccr := vcsimCtx.GetFirstClusterFromFirstZone()
+		Expect(ccr).ToNot(BeNil())
+
+		configTarget = &vimv1.ConfigTarget{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: ccr.Reference().Value,
+			},
+			Spec: vimv1.ConfigTargetSpec{
+				ID: vimv1.ManagedObjectID{ID: ccr.Reference().Value},
+			},
+		}
+		Expect(vcsimCtx.Client.Create(vcsimCtx, configTarget)).To(Succeed())
+
+		configOptions = &vimv1.VirtualMachineConfigOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "vmx-19",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: vimv1.GroupVersion.String(),
+						Kind:       vmconfigoptions.ConfigTargetKind,
+						Name:       configTarget.Name,
+						UID:        configTarget.UID,
+					},
+				},
+			},
+			Spec: vimv1.VirtualMachineConfigOptionsSpec{
+				HardwareVersion: "vmx-19",
+			},
+		}
+		Expect(vcsimCtx.Client.Create(vcsimCtx, configOptions)).To(Succeed())
+
+		objReq = ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: configOptions.Name},
+		}
+	})
+
+	AfterEach(func() {
+		vcsimCtx.AfterEach()
+	})
+
+	When("the owning ConfigTarget names a real vcsim cluster", func() {
+		It("populates status from the real EnvironmentBrowser result and marks Ready=True", func() {
+			// First reconcile adds the finalizer.
+			_, err := reconciler.Reconcile(vcsimCtx, objReq)
+			Expect(err).ToNot(HaveOccurred())
+			// Second reconcile queries the real EnvironmentBrowser via vcsim.
+			_, err = reconciler.Reconcile(vcsimCtx, objReq)
+			Expect(err).ToNot(HaveOccurred())
+
+			var current vimv1.VirtualMachineConfigOptions
+			Expect(vcsimCtx.Client.Get(vcsimCtx, client.ObjectKeyFromObject(configOptions), &current)).To(Succeed())
+			Expect(pkgcond.IsTrue(&current, vimv1.ReadyConditionType)).To(BeTrue())
+			Expect(current.Status.ObservedGeneration).To(Equal(current.Generation))
+			Expect(current.Status.GuestOSIdentifiers).ToNot(BeEmpty())
+
+			var guestOptionsList vimv1.VirtualMachineGuestOptionsList
+			Expect(vcsimCtx.Client.List(vcsimCtx, &guestOptionsList)).To(Succeed())
+			Expect(guestOptionsList.Items).ToNot(BeEmpty())
+
+			// Every guest OS identifier reported in status should have a
+			// corresponding VirtualMachineGuestOptions with a matching
+			// hardware-version status entry -- this is the actual fan-out,
+			// not just "something got created".
+			for _, guestID := range current.Status.GuestOSIdentifiers {
+				var match *vimv1.VirtualMachineGuestOptions
+				for i := range guestOptionsList.Items {
+					if guestOptionsList.Items[i].Spec.ID == guestID {
+						match = &guestOptionsList.Items[i]
+						break
+					}
+				}
+				Expect(match).ToNot(BeNil(), "expected a VirtualMachineGuestOptions for guest ID %q", guestID)
+				Expect(match.Status.Family).ToNot(BeEmpty())
+
+				var hwEntry *vimv1.VirtualMachineGuestOptionsHardwareVersionStatus
+				for i := range match.Status.HardwareVersions {
+					if match.Status.HardwareVersions[i].HardwareVersion == configOptions.Spec.HardwareVersion {
+						hwEntry = &match.Status.HardwareVersions[i]
+						break
+					}
+				}
+				Expect(hwEntry).ToNot(BeNil(), "expected a %q hardwareVersions entry for guest ID %q",
+					configOptions.Spec.HardwareVersion, guestID)
+			}
+		})
+	})
+}

--- a/external/vim/api/v1alpha1/enum_types.go
+++ b/external/vim/api/v1alpha1/enum_types.go
@@ -52,6 +52,49 @@ const (
 	SupportLevelUnsupported SupportLevel = "Unsupported"
 )
 
+// ToVimType returns the Vim identifier for the SupportLevel.
+func (t SupportLevel) ToVimType() string {
+	switch t {
+	case SupportLevelDeprecated:
+		return "deprecated"
+	case SupportLevelExperimental:
+		return "experimental"
+	case SupportLevelLegacy:
+		return "legacy"
+	case SupportLevelSupported:
+		return "supported"
+	case SupportLevelTechPreview:
+		return "techPreview"
+	case SupportLevelTerminated:
+		return "terminated"
+	case SupportLevelUnsupported:
+		return "unsupported"
+	}
+	return string(t)
+}
+
+// FromVimType returns the SupportLevel from the Vim identifier.
+func (t *SupportLevel) FromVimType(s string) {
+	switch s {
+	case "deprecated":
+		*t = SupportLevelDeprecated
+	case "experimental":
+		*t = SupportLevelExperimental
+	case "legacy":
+		*t = SupportLevelLegacy
+	case "supported":
+		*t = SupportLevelSupported
+	case "techPreview":
+		*t = SupportLevelTechPreview
+	case "terminated":
+		*t = SupportLevelTerminated
+	case "unsupported":
+		*t = SupportLevelUnsupported
+	default:
+		*t = SupportLevel(s)
+	}
+}
+
 // HostDateTimeInfoProtocol describes types of time synchronization protocols.
 // It corresponds to vim.host.DateTimeInfo.Protocol.
 type HostDateTimeInfoProtocol string

--- a/external/vim/api/v1alpha1/enum_types_test.go
+++ b/external/vim/api/v1alpha1/enum_types_test.go
@@ -1,0 +1,92 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1_test
+
+import (
+	"testing"
+
+	v1alpha1 "github.com/vmware-tanzu/vm-operator/external/vim/api/v1alpha1"
+)
+
+func TestSupportLevelVimTypeRoundTrip(t *testing.T) {
+	levels := []v1alpha1.SupportLevel{
+		v1alpha1.SupportLevelDeprecated,
+		v1alpha1.SupportLevelExperimental,
+		v1alpha1.SupportLevelLegacy,
+		v1alpha1.SupportLevelSupported,
+		v1alpha1.SupportLevelTechPreview,
+		v1alpha1.SupportLevelTerminated,
+		v1alpha1.SupportLevelUnsupported,
+	}
+
+	for _, want := range levels {
+		vimType := want.ToVimType()
+
+		var got v1alpha1.SupportLevel
+		got.FromVimType(vimType)
+
+		if got != want {
+			t.Errorf("FromVimType(%q) = %q, want %q", vimType, got, want)
+		}
+	}
+}
+
+func TestSupportLevelFromVimTypeKnownValues(t *testing.T) {
+	// These are the literal wire values vim.vm.GuestOsDescriptor.SupportLevel
+	// sends, which are lowercase/camelCase, not the PascalCase values used by
+	// this type's own constants.
+	cases := map[string]v1alpha1.SupportLevel{
+		"deprecated":   v1alpha1.SupportLevelDeprecated,
+		"experimental": v1alpha1.SupportLevelExperimental,
+		"legacy":       v1alpha1.SupportLevelLegacy,
+		"supported":    v1alpha1.SupportLevelSupported,
+		"techPreview":  v1alpha1.SupportLevelTechPreview,
+		"terminated":   v1alpha1.SupportLevelTerminated,
+		"unsupported":  v1alpha1.SupportLevelUnsupported,
+	}
+
+	for raw, want := range cases {
+		var got v1alpha1.SupportLevel
+		got.FromVimType(raw)
+
+		if got != want {
+			t.Errorf("FromVimType(%q) = %q, want %q", raw, got, want)
+		}
+	}
+}
+
+func TestVirtualMachineGuestOSFamilyFromVimTypeKnownValues(t *testing.T) {
+	cases := map[string]v1alpha1.VirtualMachineGuestOSFamily{
+		"darwinGuestFamily": v1alpha1.VirtualMachineGuestOSFamilyDarwin,
+		"linuxGuest":        v1alpha1.VirtualMachineGuestOSFamilyLinux,
+		"netwareGuest":      v1alpha1.VirtualMachineGuestOSFamilyNetware,
+		"otherGuestFamily":  v1alpha1.VirtualMachineGuestOSFamilyOther,
+		"solarisGuest":      v1alpha1.VirtualMachineGuestOSFamilySolaris,
+		"windowsGuest":      v1alpha1.VirtualMachineGuestOSFamilyWindows,
+	}
+
+	for raw, want := range cases {
+		var got v1alpha1.VirtualMachineGuestOSFamily
+		got.FromVimType(raw)
+
+		// Regression test: FromVimType previously overwrote the matched
+		// value with the raw, unmapped string unconditionally after the
+		// switch statement, so every known value round-tripped back out as
+		// itself, and none of them ever resolved to their PascalCase
+		// constant.
+		if got != want {
+			t.Errorf("FromVimType(%q) = %q, want %q", raw, got, want)
+		}
+	}
+}
+
+func TestVirtualMachineGuestOSFamilyFromVimTypeUnknownValue(t *testing.T) {
+	var got v1alpha1.VirtualMachineGuestOSFamily
+	got.FromVimType("someFutureGuestFamily")
+
+	if want := v1alpha1.VirtualMachineGuestOSFamily("someFutureGuestFamily"); got != want {
+		t.Errorf("FromVimType(unknown) = %q, want %q", got, want)
+	}
+}

--- a/external/vim/api/v1alpha1/guest_enum_types.go
+++ b/external/vim/api/v1alpha1/guest_enum_types.go
@@ -66,8 +66,9 @@ func (t *VirtualMachineGuestOSFamily) FromVimType(s string) {
 		*t = VirtualMachineGuestOSFamilySolaris
 	case "windowsGuest":
 		*t = VirtualMachineGuestOSFamilyWindows
+	default:
+		*t = VirtualMachineGuestOSFamily(s)
 	}
-	*t = VirtualMachineGuestOSFamily(s)
 }
 
 // VirtualMachineGuestOSIdentifier identifies a guest operating system.

--- a/external/vim/api/v1alpha1/virtual_device_ethernet_types.go
+++ b/external/vim/api/v1alpha1/virtual_device_ethernet_types.go
@@ -4,7 +4,7 @@
 
 package v1alpha1
 
-// +kubebuilder:validation:Enum=VirtualE1000e;VirtualE1000e;VirtualPCNet32;VirtualSriovEthernetCard;VirtualVmxnet;VirtualVmxnet2;VirtualVmxnet3;VirtualVmxnet3Vrdma
+// +kubebuilder:validation:Enum=VirtualE1000;VirtualE1000e;VirtualPCNet32;VirtualSriovEthernetCard;VirtualVmxnet;VirtualVmxnet2;VirtualVmxnet3;VirtualVmxnet3Vrdma
 
 // EthernetCardType identifies the concrete type of a virtual Ethernet
 // card in a virtual machine.

--- a/pkg/providers/fake/fake_vm_provider.go
+++ b/pkg/providers/fake/fake_vm_provider.go
@@ -69,6 +69,7 @@ type funcs struct {
 	SyncVMSnapshotTreeStatusFn func(ctx context.Context, vm *vmopv1.VirtualMachine) error
 
 	GetVirtualMachineConfigTargetFn func(ctx context.Context, clusterMoID string) (*vimtypes.ConfigTarget, []vimtypes.VirtualMachineConfigOptionDescriptor, error)
+	QueryConfigOptionExFn           func(ctx context.Context, clusterMoID, hardwareVersion string) (*vimtypes.VirtualMachineConfigOption, error)
 }
 
 type VMProvider struct {
@@ -502,6 +503,15 @@ func (s *VMProvider) GetVirtualMachineConfigTarget(
 	}
 
 	return &vimtypes.ConfigTarget{}, nil, nil
+}
+
+func (s *VMProvider) QueryConfigOptionEx(ctx context.Context, clusterMoID, hardwareVersion string) (*vimtypes.VirtualMachineConfigOption, error) {
+	s.Lock()
+	defer s.Unlock()
+	if s.QueryConfigOptionExFn != nil {
+		return s.QueryConfigOptionExFn(ctx, clusterMoID, hardwareVersion)
+	}
+	return nil, nil
 }
 
 func NewVMProvider() *VMProvider {

--- a/pkg/providers/vm_provider_interface.go
+++ b/pkg/providers/vm_provider_interface.go
@@ -96,4 +96,11 @@ type VirtualMachineProviderInterface interface {
 	// EnvironmentBrowser QueryConfigTarget and QueryConfigOptionDescriptor
 	// results for the cluster identified by clusterMoID.
 	GetVirtualMachineConfigTarget(ctx context.Context, clusterMoID string) (*vimtypes.ConfigTarget, []vimtypes.VirtualMachineConfigOptionDescriptor, error)
+
+	// QueryConfigOptionEx returns the VirtualMachineConfigOption for a given
+	// cluster and hardware version. The clusterMoID is the managed object ID of
+	// the vSphere cluster (e.g. "domain-c1234"). The hardwareVersion is the
+	// desired hardware version string (e.g. "vmx-22"). Returns nil without error
+	// when no config option is found.
+	QueryConfigOptionEx(ctx context.Context, clusterMoID, hardwareVersion string) (*vimtypes.VirtualMachineConfigOption, error)
 }

--- a/pkg/providers/vsphere/environment_browser.go
+++ b/pkg/providers/vsphere/environment_browser.go
@@ -1,0 +1,52 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package vsphere
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/mo"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+)
+
+// QueryConfigOptionEx retrieves the VirtualMachineConfigOption for the given
+// hardware version from the EnvironmentBrowser of the cluster identified by
+// clusterMoID.
+func QueryConfigOptionEx(
+	ctx context.Context,
+	vimClient *vim25.Client,
+	clusterMoID string,
+	hardwareVersion string) (*vimtypes.VirtualMachineConfigOption, error) {
+
+	ccrRef := vimtypes.ManagedObjectReference{
+		Type:  "ClusterComputeResource",
+		Value: clusterMoID,
+	}
+
+	var cr mo.ClusterComputeResource
+	pc := property.DefaultCollector(vimClient)
+	if err := pc.RetrieveOne(ctx, ccrRef, []string{"environmentBrowser"}, &cr); err != nil {
+		return nil, fmt.Errorf("failed to retrieve EnvironmentBrowser for cluster %s: %w",
+			clusterMoID, err)
+	}
+
+	if cr.EnvironmentBrowser == nil {
+		return nil, fmt.Errorf("cluster %s has no EnvironmentBrowser", clusterMoID)
+	}
+
+	eb := object.NewEnvironmentBrowser(vimClient, *cr.EnvironmentBrowser)
+	spec := &vimtypes.EnvironmentBrowserConfigOptionQuerySpec{
+		Key: hardwareVersion,
+	}
+	opt, err := eb.QueryConfigOption(ctx, spec)
+	if err != nil {
+		return nil, fmt.Errorf("QueryConfigOptionEx for %s failed: %w", hardwareVersion, err)
+	}
+	return opt, nil
+}

--- a/pkg/providers/vsphere/vmprovider.go
+++ b/pkg/providers/vsphere/vmprovider.go
@@ -739,3 +739,18 @@ func (vs *vSphereVMProvider) GetVirtualMachineConfigTarget(
 
 	return configTarget, configOptionDescriptors, nil
 }
+
+// QueryConfigOptionEx implements VirtualMachineProviderInterface.
+func (vs *vSphereVMProvider) QueryConfigOptionEx(
+	ctx context.Context,
+	clusterMoID string,
+	hardwareVersion string) (*vimtypes.VirtualMachineConfigOption, error) {
+
+	ctx = pkgctx.WithVCOpID(ctx, nil, "queryConfigOptionEx")
+
+	client, err := vs.getVcClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get vSphere client for QueryConfigOptionEx: %w", err)
+	}
+	return QueryConfigOptionEx(ctx, client.VimClient(), clusterMoID, hardwareVersion)
+}

--- a/test/builder/fake.go
+++ b/test/builder/fake.go
@@ -90,6 +90,7 @@ func KnownObjectTypes() []client.Object {
 		&vimv1.ConfigTarget{},
 		&vimv1.VirtualMachineConfigOptions{},
 		&vimv1.VirtualMachineConfigPolicy{},
+		&vimv1.VirtualMachineGuestOptions{},
 	}
 }
 

--- a/test/e2e/vmservice/config/wcp.yaml
+++ b/test/e2e/vmservice/config/wcp.yaml
@@ -109,6 +109,12 @@ intervals:
   default/wait-policy-evaluation-compliant: ["2m", "10s"]
   default/wait-policy-evaluation-update: ["3m", "10s"]
 
+  default/wait-config-target-condition-update: ["5m", "10s"]
+  default/wait-vm-config-options-creation: ["5m", "10s"]
+  default/wait-vm-config-options-condition-update: ["5m", "10s"]
+  default/wait-vm-guest-options-condition-update: ["5m", "10s"]
+  default/wait-vm-config-options-deletion: ["5m", "10s"]
+
   default/wait-config-map-creation: ["3m", "10s"]
   default/wait-secret-creation: ["3m", "10s"]
   default/wait-pod-ready: ["2m", "10s"]

--- a/test/e2e/vmservice/vmservice/configpolicy/configpolicy.go
+++ b/test/e2e/vmservice/vmservice/configpolicy/configpolicy.go
@@ -142,7 +142,7 @@ func Spec(ctx context.Context, inputGetter func() SpecInput) {
 							"ConfigTarget %q status.numCPUs should be populated from QueryConfigTarget", name)
 						g.Expect(ct.Status.MaxCPUsPerVM).To(BeNumerically(">", 0),
 							"ConfigTarget %q status.maxCPUsPerVM should be populated from QueryConfigTarget", name)
-					}).Should(Succeed())
+					}, input.Config.GetIntervals("default", "wait-config-target-condition-update")...).Should(Succeed())
 				}
 			})
 
@@ -164,7 +164,106 @@ func Spec(ctx context.Context, inputGetter func() SpecInput) {
 						g.Expect(vco.Spec.HardwareVersion).To(Equal(vco.Name),
 							"VirtualMachineConfigOptions %q spec.hardwareVersion should equal its metadata.name", vco.Name)
 					}
-				}).Should(Succeed())
+				}, input.Config.GetIntervals("default", "wait-vm-config-options-creation")...).Should(Succeed())
+			})
+
+		It("Should populate status.guestOSIdentifiers on each VirtualMachineConfigOptions",
+			Label("core-functional", "experimental"),
+			func() {
+				var vcoList vimv1.VirtualMachineConfigOptionsList
+				Expect(svClusterClient.List(ctx, &vcoList)).To(Succeed())
+				Expect(vcoList.Items).ToNot(BeEmpty(), "expected at least one VirtualMachineConfigOptions in the cluster")
+
+				for i := range vcoList.Items {
+					name := vcoList.Items[i].Name
+
+					Eventually(func(g Gomega) {
+						vco := &vimv1.VirtualMachineConfigOptions{}
+						g.Expect(svClusterClient.Get(ctx, ctrlclient.ObjectKey{Name: name}, vco)).To(Succeed())
+
+						cond := apimeta.FindStatusCondition(vco.Status.Conditions, vimv1.ReadyConditionType)
+						g.Expect(cond).ToNot(BeNil(), "VirtualMachineConfigOptions %q should have a Ready condition", name)
+						g.Expect(cond.Status).To(Equal(metav1.ConditionTrue), "VirtualMachineConfigOptions %q should be Ready", name)
+						g.Expect(vco.Status.ObservedGeneration).To(Equal(vco.Generation),
+							"VirtualMachineConfigOptions %q status.observedGeneration should match metadata.generation", name)
+
+						g.Expect(vco.Status.Description).ToNot(BeEmpty(),
+							"VirtualMachineConfigOptions %q status.description should be populated from QueryConfigOptionEx", name)
+
+						g.Expect(vco.Status.GuestOSIdentifiers).ToNot(BeEmpty(),
+							"VirtualMachineConfigOptions %q status.guestOSIdentifiers should be populated from QueryConfigOptionEx", name)
+						g.Expect(int(vco.Status.GuestOSDefaultIndex)).To(BeNumerically(">=", 0),
+							"VirtualMachineConfigOptions %q status.guestOSDefaultIndex should be a valid index", name)
+						g.Expect(int(vco.Status.GuestOSDefaultIndex)).To(BeNumerically("<", len(vco.Status.GuestOSIdentifiers)),
+							"VirtualMachineConfigOptions %q status.guestOSDefaultIndex should index into status.guestOSIdentifiers", name)
+
+						// "otherGuest" and "otherLinuxGuest" are the generic
+						// catch-all guest identifiers that every vSphere
+						// release has supported since the earliest hardware
+						// versions vm-operator targets; asserting on them
+						// (rather than a testbed-specific guest list) keeps
+						// this check meaningful without being brittle to
+						// whichever real cluster CI happens to run against.
+						g.Expect(vco.Status.GuestOSIdentifiers).To(ContainElement(
+							vimv1.VirtualMachineGuestOSIdentifier("otherGuest")),
+							"VirtualMachineConfigOptions %q status.guestOSIdentifiers should include the universal 'otherGuest' fallback", name)
+					}, input.Config.GetIntervals("default", "wait-vm-config-options-condition-update")...).Should(Succeed())
+				}
+			})
+
+		It("Should fan out a VirtualMachineGuestOptions object for each guest OS reported by the cluster",
+			Label("core-functional", "experimental"),
+			func() {
+				Eventually(func(g Gomega) {
+					var vcoList vimv1.VirtualMachineConfigOptionsList
+					g.Expect(svClusterClient.List(ctx, &vcoList)).To(Succeed())
+					g.Expect(vcoList.Items).ToNot(BeEmpty(), "expected at least one VirtualMachineConfigOptions in the cluster")
+
+					var totalGuestIDs int
+					for i := range vcoList.Items {
+						totalGuestIDs += len(vcoList.Items[i].Status.GuestOSIdentifiers)
+					}
+					g.Expect(totalGuestIDs).To(BeNumerically(">", 0),
+						"expected at least one VirtualMachineConfigOptions with a populated status.guestOSIdentifiers")
+
+					var vgoList vimv1.VirtualMachineGuestOptionsList
+					g.Expect(svClusterClient.List(ctx, &vgoList)).To(Succeed())
+					g.Expect(vgoList.Items).ToNot(BeEmpty(),
+						"expected at least one VirtualMachineGuestOptions fanned out from a VirtualMachineConfigOptions")
+
+					for i := range vcoList.Items {
+						vco := &vcoList.Items[i]
+
+						for _, guestID := range vco.Status.GuestOSIdentifiers {
+							var match *vimv1.VirtualMachineGuestOptions
+							for j := range vgoList.Items {
+								if vgoList.Items[j].Spec.ID == guestID {
+									match = &vgoList.Items[j]
+									break
+								}
+							}
+							g.Expect(match).ToNot(BeNil(),
+								"expected a VirtualMachineGuestOptions with spec.id %q reported by VirtualMachineConfigOptions %q",
+								guestID, vco.Name)
+
+							g.Expect(match.Status.FullName).ToNot(BeEmpty(),
+								"VirtualMachineGuestOptions %q status.fullName should be populated", match.Name)
+							g.Expect(match.Status.Family).ToNot(BeEmpty(),
+								"VirtualMachineGuestOptions %q status.family should be populated", match.Name)
+
+							var hwEntry *vimv1.VirtualMachineGuestOptionsHardwareVersionStatus
+							for k := range match.Status.HardwareVersions {
+								if match.Status.HardwareVersions[k].HardwareVersion == vco.Spec.HardwareVersion {
+									hwEntry = &match.Status.HardwareVersions[k]
+									break
+								}
+							}
+							g.Expect(hwEntry).ToNot(BeNil(),
+								"VirtualMachineGuestOptions %q should have a status.hardwareVersions entry for %q",
+								match.Name, vco.Spec.HardwareVersion)
+						}
+					}
+				}, input.Config.GetIntervals("default", "wait-vm-guest-options-condition-update")...).Should(Succeed())
 			})
 
 		It("Should garbage-collect a stale VirtualMachineConfigOptions no longer reported by the cluster",
@@ -209,7 +308,7 @@ func Spec(ctx context.Context, inputGetter func() SpecInput) {
 					err := svClusterClient.Get(ctx, ctrlclient.ObjectKeyFromObject(stale), &vimv1.VirtualMachineConfigOptions{})
 					g.Expect(apierrors.IsNotFound(err)).To(BeTrue(),
 						"stale VirtualMachineConfigOptions %q should have been garbage-collected", stale.Name)
-				}).Should(Succeed())
+				}, input.Config.GetIntervals("default", "wait-vm-config-options-deletion")...).Should(Succeed())
 			})
 	})
 }

--- a/webhooks/virtualmachineconfigoptions/webhooks.go
+++ b/webhooks/virtualmachineconfigoptions/webhooks.go
@@ -11,7 +11,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachineconfigoptions/validation"
 )
 
-// AddToManager registers all VirtualMachineConfigOptions webhooks.
+// AddToManager adds the webhook to the provided manager.
 func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) error {
 	return validation.AddToManager(ctx, mgr)
 }


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Implements Story S6 (vmop-3743) from the 001-class-policy-resize spec: the `VirtualMachineConfigOptions` controller. This is a self-contained vertical slice (product code + unit tests + E2E tests) for the ConfigTarget → VirtualMachineConfigOptions pipeline stage. The admission webhook for this CRD is delivered separately in PR #1671 (vmop-3762) and is not part of this PR.

**Controller** (`controllers/virtualmachineconfigoptions/`):
- Watches cluster-scoped `VirtualMachineConfigOptions` objects
- Resolves the owning `ConfigTarget` via owner references to obtain the cluster MoID
- Calls `QueryConfigOptionEx` on the vSphere provider to retrieve hardware version capabilities from the cluster's `EnvironmentBrowser`
- Maps the result into `status` (description, guest OS identifiers, default index, hardware options, etc.)
- Fans out one `VirtualMachineGuestOptions` child object per guest OS descriptor, upserting the per-hardware-version status entry
- Tracks `status.observedGeneration` and sets a `Ready` condition; requeues with `RequeueAfter: 10s` when no ConfigTarget owner is found yet

**vSphere provider plumbing** (`pkg/providers/vsphere/environment_browser.go`):
- Wraps govmomi `EnvironmentBrowser.QueryConfigOption` using a `ClusterComputeResource` property fetch to resolve the browser reference

**RBAC**: `+kubebuilder:rbac` markers in the controller; `config/rbac/role.yaml` regenerated via `make generate-manifests`.

**Test coverage**:
- Controller unit tests (envtest-backed, ~75% coverage) plus a vcsim-backed test exercising the real `QueryConfigOptionEx` govmomi call path against a simulated vSphere backend.
- Rebased onto main to pick up the ConfigTarget controller (S5, PR #1704) and Zone fan-out (S3, PR #1695), which unblocked real E2E coverage. Extended the existing `test/e2e/vmservice/vmservice/configpolicy/configpolicy.go` spec (rather than the disconnected placeholder suite that previously lived here) with assertions that `VirtualMachineConfigOptions.status.guestOSIdentifiers` is populated and `Ready=True`, and that a `VirtualMachineGuestOptions` is fanned out per reported guest OS.

**Known limitation — multi-cluster `VirtualMachineConfigOptions` co-ownership (temporary, tracked in vmop-3797):**

`VirtualMachineConfigOptions` is keyed purely by hardware-version string (`metadata.name = vmx-N`), so it can legitimately be co-owned by multiple `ConfigTarget`s (clusters) that report supporting the same version — this is intentional, already-merged design from the `ConfigTarget` controller (S5). When co-owned, `findClusterMoID` currently queries `QueryConfigOptionEx` against **the lexicographically lowest cluster MoID** among the co-owners. This is an arbitrary-but-stable tie-break, not a considered "most correct" choice — it exists only to make the selection deterministic and reproducible across reconciles (the previous behavior picked whichever owner reference happened to be first, which is not guaranteed stable by Kubernetes).

Traced vSphere's own `EnvironmentBrowser.QueryConfigOptionEx` (vpxd source) to see how it resolves the analogous problem across multiple hosts in one cluster: it does **not** aggregate — it deterministically defers to the host running the **lowest product/ESXi version** among hosts supporting the requested key, on the theory that hardware-version capability is monotonic with product version. We don't yet have a comparable per-cluster signal (ESXi/product version) to replicate that "most conservative" selection at the cluster level — `ConfigTarget.status` doesn't expose it today, and this design deliberately avoids per-host granularity (the retired `HostSystem` CRD). Note `ConfigTargetStatus.MaxHardwareVersion` (vmop-3797) is **not** a valid stand-in for this: it's each cluster's own ceiling, not its product/patch vintage, and since co-owners by definition already support the shared key being queried, picking by lowest `MaxHardwareVersion` can select the *newer*-patched cluster rather than the more conservative one -- the opposite of what we want. A real fix needs an actual product-version-like signal, which doesn't exist yet.

Confirmed via ESXi release notes and the vSphere API's guest-OS-identifier changelog that this isn't a hypothetical edge case: at least two documented instances in the 8.x line alone (API 8.0.0.1 added 10 new guest OS identifiers to unchanged hardware version vmx-20; API 8.0.3.0 added another to unchanged vmx-21) show new guest OS support landing on an *already-shipped* hardware version via a patch, independent of any hardware-version bump. Multi-cluster Supervisor environments commonly patch clusters on staggered schedules, so two co-owning clusters disagreeing on `QueryConfigOptionEx`'s answer for the same key is a real, recurring condition, not a corner case.

Severity is currently limited to discovery/informational surfaces: `spec.md`'s admission-enforcement acceptance criteria (US5/S9) only reference `ConfigTarget.status.maxHardwareVersion`, never `VirtualMachineConfigOptions`/`VirtualMachineGuestOptions`, so today's arbitrary-cluster selection can't produce an incorrect admission decision — only a potentially inconsistent read for `kubectl get`/partner tooling. That should be re-escalated if any future story starts reading these objects for enforcement rather than discovery.

Filed a follow-up comment on vmop-3797 flagging that its `MaxHardwareVersion` addition is not sufficient to fix this by itself, and that revisiting this selection logic depends on a real per-cluster product-version signal that doesn't exist yet.

**Which issue(s) is/are addressed by this PR?**

Fixes #


**Are there any special notes for your reviewer**:

- This PR depends on PR #1671 (vmop-3762) for the `VirtualMachineConfigOptions` admission webhook; that PR is not required to merge first, but review of RBAC/scheme overlap between the two may be easier once both are visible.
- The `test/builder/fake.go` change registers `vimv1` types (`ConfigTarget`, `VirtualMachineGuestOptions`) into the unit-test scheme, in addition to `VirtualMachineConfigOptions` already registered by #1671, which is needed for the controller's fake-client unit tests.
- `make generate-manifests` fails locally because the `hack/tools` module requires Go 1.26.4 but the runner has 1.26.2; the existing `controller-gen` (`v0.19.0`) and `setup-envtest`-provisioned `etcd`/`kube-apiserver` binaries were used instead to fully validate the build, lint, and envtest suite locally.
- New E2E assertions carry the `experimental` label per `e2e-sync-with-changes.md` until validated on a real WCP cluster.
- See the "Known limitation" section above for the temporary multi-cluster co-ownership tie-break; tracked for follow-up in vmop-3797.

**Please add a release note if necessary**:

```release-note
Add VirtualMachineConfigOptions controller
```

**E2E Test Results**
```
Ran 7 of 138 Specs in 227.930 seconds
SUCCESS! -- 7 Passed | 0 Failed | 5 Pending | 126 Skipped
PASS
```