### PR TITLE
:bug: Wait for disks to be registered before snapshot creation

### DIFF
--- a/api/v1alpha5/virtualmachinesnapshot_types.go
+++ b/api/v1alpha5/virtualmachinesnapshot_types.go
@@ -102,6 +102,11 @@ const (
 	// VirtualMachineSnapshotCreationFailedReason documents that the virtual machine
 	// snapshot creation has failed.
 	VirtualMachineSnapshotCreationFailedReason = "VirtualMachineSnapshotCreationFailed"
+
+	// VirtualMachineSnapshotWaitingForDiskRegistrationReason documents that the
+	// virtual machine snapshot is waiting for all unmanaged disk registrations
+	// to complete before the snapshot can be triggered.
+	VirtualMachineSnapshotWaitingForDiskRegistrationReason = "VirtualMachineSnapshotWaitingForDiskRegistration"
 )
 
 const (

--- a/api/v1alpha6/virtualmachinesnapshot_types.go
+++ b/api/v1alpha6/virtualmachinesnapshot_types.go
@@ -102,6 +102,11 @@ const (
 	// VirtualMachineSnapshotCreationFailedReason documents that the virtual machine
 	// snapshot creation has failed.
 	VirtualMachineSnapshotCreationFailedReason = "VirtualMachineSnapshotCreationFailed"
+
+	// VirtualMachineSnapshotWaitingForDiskRegistrationReason documents that the
+	// virtual machine snapshot is waiting for all unmanaged disk registrations
+	// to complete before the snapshot can be triggered.
+	VirtualMachineSnapshotWaitingForDiskRegistrationReason = "VirtualMachineSnapshotWaitingForDiskRegistration"
 )
 
 const (

--- a/controllers/virtualmachinesnapshot/virtualmachinesnapshot_controller.go
+++ b/controllers/virtualmachinesnapshot/virtualmachinesnapshot_controller.go
@@ -325,7 +325,17 @@ func reconcileSnapshotReadyCondition(vmSnapshot *vmopv1.VirtualMachineSnapshot) 
 
 	created := pkgcond.IsTrue(vmSnapshot, vmopv1.VirtualMachineSnapshotCreatedCondition)
 	synced := pkgcond.IsTrue(vmSnapshot, vmopv1.VirtualMachineSnapshotCSIVolumeSyncedCondition)
+	createdReason := pkgcond.GetReason(vmSnapshot, vmopv1.VirtualMachineSnapshotCreatedCondition)
 	switch {
+	case !created && createdReason == vmopv1.VirtualMachineSnapshotWaitingForDiskRegistrationReason:
+		// Propagate the specific disk-registration-waiting reason to the Ready
+		// condition so it is visible without inspecting the Created condition.
+		pkgcond.MarkFalse(
+			vmSnapshot,
+			vmopv1.VirtualMachineSnapshotReadyCondition,
+			vmopv1.VirtualMachineSnapshotWaitingForDiskRegistrationReason,
+			"Snapshot is not ready because disk registration hasn't been completed",
+		)
 	case !created:
 		pkgcond.MarkFalse(
 			vmSnapshot,

--- a/controllers/virtualmachinesnapshot/virtualmachinesnapshot_controller_unit_test.go
+++ b/controllers/virtualmachinesnapshot/virtualmachinesnapshot_controller_unit_test.go
@@ -327,6 +327,30 @@ func unitTestsReconcile() {
 			})
 		})
 
+		When("snapshot's created condition is false with WaitingForDiskRegistration reason", func() {
+			BeforeEach(func() {
+				conditions.MarkFalse(vmSnapshot,
+					vmopv1.VirtualMachineSnapshotCreatedCondition,
+					vmopv1.VirtualMachineSnapshotWaitingForDiskRegistrationReason,
+					"waiting for disk registration")
+				vm.Status.UniqueID = dummyVMUUID
+				initObjects = nil
+				initObjects = append(initObjects, vm, vmSnapshot)
+			})
+
+			It("sets ready condition to WaitingForDiskRegistration", func() {
+				Expect(err).ToNot(HaveOccurred())
+				vmSnapshotObj := &vmopv1.VirtualMachineSnapshot{}
+				Expect(ctx.Client.Get(ctx, snapshotObjKey, vmSnapshotObj)).To(Succeed())
+
+				Expect(conditions.IsFalse(vmSnapshotObj,
+					vmopv1.VirtualMachineSnapshotReadyCondition)).To(BeTrue())
+				Expect(conditions.GetReason(vmSnapshotObj,
+					vmopv1.VirtualMachineSnapshotReadyCondition)).
+					To(Equal(vmopv1.VirtualMachineSnapshotWaitingForDiskRegistrationReason))
+			})
+		})
+
 		When("snapshot's created condition is true", func() {
 			BeforeEach(func() {
 				conditions.MarkTrue(vmSnapshot, vmopv1.VirtualMachineSnapshotCreatedCondition)

--- a/pkg/providers/vsphere/vmprovider_vm.go
+++ b/pkg/providers/vsphere/vmprovider_vm.go
@@ -1083,6 +1083,19 @@ func (vs *vSphereVMProvider) updateVirtualMachine(
 	//
 	if err := vs.reconcileConfig(vmCtx, vcVM, vcClient); err != nil {
 		if pkgerr.IsNoRequeueError(err) {
+			// When disk registration is pending and VMSnapshots are enabled,
+			// annotate any queued snapshots so they don't appear stuck with
+			// empty conditions. ReconcileCurrentSnapshot is skipped on this
+			// path, so we set the condition here before exiting early.
+			if pkgcfg.FromContext(vmCtx).Features.VMSnapshots &&
+				pkgcfg.FromContext(vmCtx).Features.AllDisksArePVCs &&
+				!pkgcond.IsTrue(vmCtx.VM, vmconfunmanagedvolsreg.Condition) {
+				if setErr := ReconcileSnapshotWaitForCRVCondition(
+					vmCtx, vs.k8sClient); setErr != nil {
+					reconcileErr = getReconcileErr(
+						"snapshot wait-for-crv condition", reconcileErr, setErr)
+				}
+			}
 			return errOrReconcileErr(reconcileErr, err)
 		}
 		reconcileErr = getReconcileErr("config", reconcileErr, err)

--- a/pkg/providers/vsphere/vmprovider_vm_unmanaged_volumes_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_unmanaged_volumes_test.go
@@ -46,7 +46,6 @@ import (
 // vmUnmanagedVolumesTests provides comprehensive test coverage for the
 // AllDisksArePVCs feature in the vSphere provider.
 func vmUnmanagedVolumesTests() {
-
 	var (
 		parentCtx   context.Context
 		initObjects []client.Object
@@ -113,8 +112,8 @@ func vmUnmanagedVolumesTests() {
 		// versions.
 		ctx.SimulatorContext().For("/pbm").Map.Handler = func(
 			simCtx *simulator.Context,
-			m *simulator.Method) (mo.Reference, vimtypes.BaseMethodFault) {
-
+			m *simulator.Method,
+		) (mo.Reference, vimtypes.BaseMethodFault) {
 			if m.Name == "PbmQueryAssociatedProfiles" {
 				req, ok := m.Body.(*pbmtypes.PbmQueryAssociatedProfiles)
 				if !ok {
@@ -168,7 +167,6 @@ func vmUnmanagedVolumesTests() {
 	})
 
 	When("VM has unmanaged disks from vSphere", func() {
-
 		It("should backfill unmanaged disk into spec.volumes", func() {
 			Expect(createOrUpdateVM(ctx, vmProvider, vm)).
 				To(MatchError(vsphere.ErrRegisterVolumes))
@@ -255,10 +253,14 @@ func vmUnmanagedVolumesTests() {
 				Expect(ctx.Client.Update(ctx, vm)).To(Succeed())
 			}
 
+			// Simulate CNS marking the CRV as registered before the final reconcile.
+			crv.Status.Registered = true
+			Expect(ctx.Client.Status().Update(ctx, crv)).To(Succeed())
+
 			// Trigger another reconciliation
 			Expect(createOrUpdateVM(ctx, vmProvider, vm)).To(Succeed())
 
-			// Verify CnsRegisterVolume was deleted
+			// CRV was cleaned up since it's now registered
 			Expect(client.IgnoreNotFound(ctx.Client.Get(ctx, client.ObjectKey{
 				Namespace: vm.Namespace,
 				Name:      claimName,
@@ -270,7 +272,6 @@ func vmUnmanagedVolumesTests() {
 	})
 
 	When("VM has PVC with datasource ref w disk from VMI", func() {
-
 		var vmic vmopv1.VirtualMachineImageCache
 
 		BeforeEach(func() {
@@ -481,10 +482,14 @@ func vmUnmanagedVolumesTests() {
 			vm.Status.Volumes[0].Attached = true
 			Expect(ctx.Client.Status().Update(ctx, vm)).To(Succeed())
 
+			// Simulate CNS marking the CRV as registered before the final reconcile.
+			crv.Status.Registered = true
+			Expect(ctx.Client.Status().Update(ctx, crv)).To(Succeed())
+
 			// Trigger another reconciliation
 			Expect(createOrUpdateVM(ctx, vmProvider, vm)).To(Succeed())
 
-			// Verify CnsRegisterVolume was deleted
+			// CRV was cleaned up since it's now registered
 			Expect(client.IgnoreNotFound(ctx.Client.Get(ctx, client.ObjectKey{
 				Namespace: vm.Namespace,
 				Name:      claimName,
@@ -531,8 +536,8 @@ type fakeProfileManager struct {
 }
 
 func (m *fakeProfileManager) PbmQueryAssociatedProfiles(
-	req *pbmtypes.PbmQueryAssociatedProfiles) soap.HasFault {
-
+	req *pbmtypes.PbmQueryAssociatedProfiles,
+) soap.HasFault {
 	body := new(pbmmethods.PbmQueryAssociatedProfilesBody)
 	body.Res = new(pbmtypes.PbmQueryAssociatedProfilesResponse)
 	body.Res.Returnval = m.Result

--- a/pkg/providers/vsphere/vmprovider_vmsnapshot.go
+++ b/pkg/providers/vsphere/vmprovider_vmsnapshot.go
@@ -200,6 +200,33 @@ func markSnapshotFailed(vmCtx pkgctx.VirtualMachineContext,
 	return nil
 }
 
+// markSnapshotWaitingForDiskRegistration sets a condition on a snapshot to
+// indicate it is blocked waiting for unmanaged disk CnsRegisterVolume objects
+// to complete registration before the snapshot can be triggered.
+func markSnapshotWaitingForDiskRegistration(
+	vmCtx pkgctx.VirtualMachineContext,
+	k8sClient ctrlclient.Client,
+	vmSnapshot *vmopv1.VirtualMachineSnapshot) error {
+
+	if pkgcond.GetReason(vmSnapshot, vmopv1.VirtualMachineSnapshotCreatedCondition) ==
+		vmopv1.VirtualMachineSnapshotWaitingForDiskRegistrationReason {
+		return nil
+	}
+
+	patch := ctrlclient.MergeFrom(vmSnapshot.DeepCopy())
+	pkgcond.MarkFalse(
+		vmSnapshot,
+		vmopv1.VirtualMachineSnapshotCreatedCondition,
+		vmopv1.VirtualMachineSnapshotWaitingForDiskRegistrationReason,
+		"Snapshot cannot be created until all unmanaged disk registrations complete")
+	if err := k8sClient.Status().Patch(vmCtx, vmSnapshot, patch); err != nil {
+		return fmt.Errorf("failed to patch snapshot status: %w", err)
+	}
+	vmCtx.Logger.V(4).Info("Marked snapshot as waiting for disk registration",
+		"snapshotName", vmSnapshot.Name)
+	return nil
+}
+
 // getVirtualMachineSnapshotsForVM finds all VirtualMachineSnapshot objects that reference this VM.
 func getVirtualMachineSnapshotsForVM(
 	vmCtx pkgctx.VirtualMachineContext,
@@ -799,6 +826,32 @@ func synthesizeVMSpecForSnapshot(
 	}
 }
 
+// ReconcileSnapshotWaitForCRVCondition sets the WaitingForDiskRegistration
+// condition on every pending snapshot for the VM. It is called from the VM
+// reconcile loop when reconcileConfig exits early due to pending
+// CnsRegisterVolume objects, so that snapshots do not appear stuck with empty
+// conditions.
+func ReconcileSnapshotWaitForCRVCondition(
+	vmCtx pkgctx.VirtualMachineContext,
+	k8sClient ctrlclient.Client) error {
+
+	vmSnapshots, err := getVirtualMachineSnapshotsForVM(vmCtx, k8sClient)
+	if err != nil {
+		return err
+	}
+
+	for i := range vmSnapshots {
+		snapshot := &vmSnapshots[i]
+		if pkgcond.IsTrue(snapshot, vmopv1.VirtualMachineSnapshotCreatedCondition) {
+			continue
+		}
+		if err := markSnapshotWaitingForDiskRegistration(vmCtx, k8sClient, snapshot); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // ReconcileCurrentSnapshot reconciles the current snapshot owned by the VM.
 func ReconcileCurrentSnapshot(
 	vmCtx pkgctx.VirtualMachineContext,
@@ -836,7 +889,7 @@ func ReconcileCurrentSnapshot(
 		}
 	}
 
-	// When AllDisksArePVCs is enabled, wait for VM's disks to be registered.
+	// When AllDisksArePVCs is enabled, wait for VM's disks to be backfilled.
 	// This is because vSphere cannot register disks as PVCs if there's disk
 	// delta caused by snapshot creation.
 	if pkgcfg.FromContext(vmCtx).Features.AllDisksArePVCs {
@@ -844,12 +897,6 @@ func ReconcileCurrentSnapshot(
 		if !pkgcond.IsTrue(vmCtx.VM, vmconfunmanagedvolsfil.Condition) {
 			logger.Info("Skipping snapshot as required condition is not ready",
 				"condition", vmconfunmanagedvolsfil.Condition)
-			return nil
-		}
-
-		if !pkgcond.IsTrue(vmCtx.VM, vmconfunmanagedvolsreg.Condition) {
-			logger.Info("Skipping snapshot as required condition is not ready",
-				"condition", vmconfunmanagedvolsreg.Condition)
 			return nil
 		}
 	}
@@ -927,6 +974,36 @@ func ReconcileCurrentSnapshot(
 
 		logger.V(4).Info("Snapshot is in progress, waiting for completion")
 		return nil
+	}
+
+	// When AllDisksArePVCs is enabled, wait for all unmanaged disk registrations
+	// to complete before triggering the snapshot. Taking a snapshot while a
+	// CnsRegisterVolume is in-flight races with CNS: vSphere converts the disk
+	// to a read-only snapshot base, causing CNS to reject the CRV with
+	// vmodl.fault.InvalidArgument and leaving the snapshot permanently stuck.
+	//
+	// We rely solely on the condition here. The register reconciler (step 10)
+	// always runs before this function (step 12) in the same reconcile cycle,
+	// so the condition on vmCtx.VM is already up-to-date. The hasPendingCRVs
+	// check in the register reconciler keeps the condition False when a CRV
+	// exists but its disk has been filtered out by FilterOutLinkedClones (e.g.
+	// after a snapshot converted the backing to a delta chain). Checking
+	// VolumeTypeClassic entries directly would block snapshots permanently on
+	// VMs where promoteDiskMode is disabled, because those disks are always
+	// linked clones and their Classic status entries are never cleaned up.
+	if pkgcfg.FromContext(vmCtx).Features.AllDisksArePVCs {
+		if !pkgcond.IsTrue(vmCtx.VM, vmconfunmanagedvolsreg.Condition) {
+			logger.Info("Waiting for disk registration before creating snapshot",
+				"vmCondition", vmconfunmanagedvolsreg.Condition,
+				"vmConditionReason", pkgcond.GetReason(vmCtx.VM, vmconfunmanagedvolsreg.Condition))
+
+			if err := markSnapshotWaitingForDiskRegistration(
+				vmCtx, k8sClient, snapshotToProcess); err != nil {
+				return fmt.Errorf("failed to mark snapshot %q waiting for disk registration: %w",
+					snapshotToProcess.Name, err)
+			}
+			return nil
+		}
 	}
 
 	// Mark the snapshot as in progress before starting the operation to

--- a/pkg/providers/vsphere/vmprovider_vmsnapshot_test.go
+++ b/pkg/providers/vsphere/vmprovider_vmsnapshot_test.go
@@ -425,9 +425,9 @@ var _ = Describe(
 
 			When("snapshot has empty VM name", func() {
 				It("should skip snapshot with empty VM name and process the next one", func() {
-					// Create snapshot1 CR with spec.VMName set to empty and owner reference set to the VM.
-					snapshot1 = builder.DummyVirtualMachineSnapshot(vm.Namespace, "snapshot-1", vm.Name)
-					snapshot1.Spec.VMName = ""
+					// Create snapshot1 with empty vmName so both Spec.VMName and
+					// VMNameForSnapshotLabel are empty — label filter excludes it.
+					snapshot1 = builder.DummyVirtualMachineSnapshot(vm.Namespace, "snapshot-1", "")
 					Expect(controllerutil.SetOwnerReference(vm, snapshot1, ctx.Scheme)).To(Succeed())
 					Expect(ctx.Client.Create(ctx, snapshot1)).To(Succeed())
 
@@ -449,9 +449,9 @@ var _ = Describe(
 
 			When("snapshot references different VM", func() {
 				It("should skip snapshot for different VM and process the next one", func() {
-					// Create snapshot1 CR with spec.VMName set to a different VM name than owner reference VM.
-					snapshot1 = builder.DummyVirtualMachineSnapshot(vm.Namespace, "snapshot-1", vm.Name)
-					snapshot1.Spec.VMName = "different-vm"
+					// Create snapshot1 with "different-vm" so both Spec.VMName and
+					// VMNameForSnapshotLabel point to a different VM — label filter excludes it.
+					snapshot1 = builder.DummyVirtualMachineSnapshot(vm.Namespace, "snapshot-1", "different-vm")
 					Expect(controllerutil.SetOwnerReference(vm, snapshot1, ctx.Scheme)).To(Succeed())
 					Expect(ctx.Client.Create(ctx, snapshot1)).To(Succeed())
 
@@ -550,7 +550,7 @@ var _ = Describe(
 					// Reconcile the snapshot.
 					Expect(vsphere.ReconcileCurrentSnapshot(vmCtx, ctx.Client, vcVM)).To(Succeed())
 
-					// Snapshot should not be processed.
+					// Snapshot should not be processed (backfill not ready).
 					verifyK8sVMSnapshot(snapshot1.Name, snapshot1.Namespace, false)
 					verifyNoVcVMSnapshot()
 
@@ -565,6 +565,16 @@ var _ = Describe(
 					verifyK8sVMSnapshot(snapshot1.Name, snapshot1.Namespace, false)
 					verifyNoVcVMSnapshot()
 
+					// Snapshot should have WaitingForDiskRegistration condition set.
+					updatedSnapshot := &vmopv1.VirtualMachineSnapshot{}
+					Expect(ctx.Client.Get(ctx, ctrlclient.ObjectKey{
+						Name:      snapshot1.Name,
+						Namespace: snapshot1.Namespace,
+					}, updatedSnapshot)).To(Succeed())
+					Expect(conditions.GetReason(updatedSnapshot,
+						vmopv1.VirtualMachineSnapshotCreatedCondition)).To(Equal(
+						vmopv1.VirtualMachineSnapshotWaitingForDiskRegistrationReason))
+
 					// Update the VM's disk registration condition to true.
 					conditions.MarkTrue(vm, vmconfunmanagedvolsreg.Condition)
 					Expect(ctx.Client.Status().Update(ctx, vm)).To(Succeed())
@@ -574,6 +584,38 @@ var _ = Describe(
 
 					// Snapshot should be created.
 					verifyK8sVMSnapshot(snapshot1.Name, snapshot1.Namespace, true)
+				})
+
+				It("should set WaitingForDiskRegistration on all pending snapshots when registration is pending", func() {
+					// Both backfill and registration conditions are not set (pending).
+					conditions.MarkTrue(vm, vmconfunmanagedvolsfil.Condition)
+					conditions.MarkFalse(vm, vmconfunmanagedvolsreg.Condition,
+						"PendingRegistration", "CnsRegisterVolume objects are being processed")
+					Expect(ctx.Client.Status().Update(ctx, vm)).To(Succeed())
+
+					// Create two snapshot CRs.
+					snapshot1 = builder.DummyVirtualMachineSnapshot(vm.Namespace, "snapshot-1", vm.Name)
+					Expect(controllerutil.SetOwnerReference(vm, snapshot1, ctx.Scheme)).To(Succeed())
+					Expect(ctx.Client.Create(ctx, snapshot1)).To(Succeed())
+
+					snapshot2 = builder.DummyVirtualMachineSnapshot(vm.Namespace, "snapshot-2", vm.Name)
+					Expect(controllerutil.SetOwnerReference(vm, snapshot2, ctx.Scheme)).To(Succeed())
+					Expect(ctx.Client.Create(ctx, snapshot2)).To(Succeed())
+
+					// ReconcileSnapshotWaitForCRVCondition mirrors what vmprovider_vm.go
+					// calls when reconcileConfig exits early due to pending CRVs.
+					Expect(vsphere.ReconcileSnapshotWaitForCRVCondition(vmCtx, ctx.Client)).To(Succeed())
+
+					// Both snapshots should have WaitingForDiskRegistration condition.
+					for _, name := range []string{snapshot1.Name, snapshot2.Name} {
+						s := &vmopv1.VirtualMachineSnapshot{}
+						Expect(ctx.Client.Get(ctx, ctrlclient.ObjectKey{
+							Name: name, Namespace: vm.Namespace,
+						}, s)).To(Succeed())
+						Expect(conditions.GetReason(s,
+							vmopv1.VirtualMachineSnapshotCreatedCondition)).To(Equal(
+							vmopv1.VirtualMachineSnapshotWaitingForDiskRegistrationReason))
+					}
 				})
 			})
 		})

--- a/pkg/vmconfig/volumes/unmanaged/register/unmanagedvolumes_register.go
+++ b/pkg/vmconfig/volumes/unmanaged/register/unmanagedvolumes_register.go
@@ -198,17 +198,34 @@ func (r reconciler) Reconcile(
 	}
 
 	// Clean up CnsRegisterVolume objects that are complete (PVC is bound).
-	if err := cleanupCompletedCnsRegisterVolumesForVM(
+	hasPendingCRVs, err := cleanupCompletedCnsRegisterVolumesForVM(
 		ctx,
 		k8sClient,
-		vm); err != nil {
-
+		vm)
+	if err != nil {
 		pkgcond.MarkError(
 			vm,
 			Condition,
 			"ErrCleanup",
 			err)
 		return err
+	}
+
+	// If CRVs exist but are not yet registered (e.g. the disk was filtered out
+	// of info.Disks after a snapshot converted its backing to a delta chain),
+	// the PVC-based pending check above would have returned false while the CRV
+	// is still waiting for CNS to process it. Hold the condition False so that
+	// operations that gate on it (e.g. snapshot creation) continue to wait.
+	// We do NOT return ErrPendingRegister here — that would block the entire VM
+	// reconcile (including power state). The condition being False is sufficient
+	// to guard individual operations that care about registration state.
+	if hasPendingCRVs {
+		pkgcond.MarkFalse(
+			vm,
+			Condition,
+			"PendingRegistration",
+			"")
+		return nil
 	}
 
 	// Clean up the VM status.
@@ -900,10 +917,12 @@ func ensureCnsRegisterVolumeForDisk(
 
 // cleanupCompletedCnsRegisterVolumesForVM cleans up CnsRegisterVolume objects
 // for a VM where the CnsRegisterVolume has been successfully registered.
+// It returns true if any CRVs for the VM still have Status.Registered=false,
+// indicating that CNS has not yet completed processing them.
 func cleanupCompletedCnsRegisterVolumesForVM(
 	ctx context.Context,
 	k8sClient ctrlclient.Client,
-	vm *vmopv1.VirtualMachine) error {
+	vm *vmopv1.VirtualMachine) (bool, error) {
 
 	// List all CnsRegisterVolume objects for this VM.
 	crvList := &cnsv1alpha1.CnsRegisterVolumeList{}
@@ -915,7 +934,7 @@ func cleanupCompletedCnsRegisterVolumesForVM(
 			pkgconst.CreatedByLabel: vm.Name,
 		}); err != nil {
 
-		return fmt.Errorf(
+		return false, fmt.Errorf(
 			"failed to list CnsRegisterVolume objects for VM %s: %w",
 			vm.NamespacedName(), err)
 	}
@@ -934,13 +953,25 @@ func cleanupCompletedCnsRegisterVolumesForVM(
 	// In that case, the CRV never gets to registered, and we will
 	// never clean that up. However, that is an extremely rare case
 	// for which we would want the reconcile to fail.
-	var errs []error
+	var (
+		errs       []error
+		hasPending bool
+	)
 	for _, crv := range crvList.Items {
 		if !crv.Status.Registered {
-			logger.V(4).Info(
-				"Skipping deletion of CnsRegisterVolume - not yet registered",
-				"crv", crv.Name,
-				"crvStatusError", crv.Status.Error)
+			if crv.Status.Error != "" {
+				// The CRV has a permanent error (e.g. CNS rejected it with
+				// vmodl.fault.InvalidArgument after a snapshot race). It will
+				// not self-resolve; manual intervention is required.
+				logger.Error(nil, "CnsRegisterVolume has a permanent error",
+					"crv", crv.Name,
+					"error", crv.Status.Error)
+			} else {
+				logger.V(4).Info(
+					"Skipping deletion of CnsRegisterVolume - not yet registered",
+					"crv", crv.Name)
+			}
+			hasPending = true
 			continue
 		}
 
@@ -956,7 +987,7 @@ func cleanupCompletedCnsRegisterVolumesForVM(
 		}
 	}
 
-	return errors.Join(errs...)
+	return hasPending, errors.Join(errs...)
 }
 
 // cleanupVolumeStatus remove any status entries for classic disks that have

--- a/pkg/vmconfig/volumes/unmanaged/register/unmanagedvolumes_register_test.go
+++ b/pkg/vmconfig/volumes/unmanaged/register/unmanagedvolumes_register_test.go
@@ -1689,13 +1689,8 @@ var _ = Describe("Reconcile", func() {
 					Expect(k8sClient.Status().Update(ctx, pvc)).To(Succeed())
 
 					// Simulate CSI marking CRV as registered (this happens after PVC is bound)
-					// Re-fetch the CRV to get the latest version before updating status
-					Expect(k8sClient.Get(ctx, ctrlclient.ObjectKey{
-						Namespace: vm.Namespace,
-						Name:      claimName,
-					}, crv)).To(Succeed())
 					crv.Status.Registered = true
-					Expect(k8sClient.Update(ctx, crv)).To(Succeed())
+					Expect(k8sClient.Status().Update(ctx, crv)).To(Succeed())
 
 					// Verify the status was not yet pruned.
 					Expect(vm.Status.Volumes).To(HaveLen(1))

--- a/test/builder/dummies.go
+++ b/test/builder/dummies.go
@@ -682,6 +682,9 @@ func DummyVirtualMachineSnapshot(namespace, name, vmName string) *vmopv1.Virtual
 				"vmoperator.vmware.com/virtualmachinesnapshot",
 			},
 			Annotations: map[string]string{},
+			Labels: map[string]string{
+				vmopv1.VMNameForSnapshotLabel: vmName,
+			},
 		},
 		Spec: vmopv1.VirtualMachineSnapshotSpec{
 			VMName: vmName,

--- a/test/builder/fake.go
+++ b/test/builder/fake.go
@@ -39,8 +39,8 @@ func NewFakeClient(objs ...client.Object) client.Client {
 
 func NewFakeClientWithInterceptors(
 	funcs interceptor.Funcs,
-	objs ...client.Object) client.Client {
-
+	objs ...client.Object,
+) client.Client {
 	scheme := NewScheme()
 	return fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -70,6 +70,7 @@ func KnownObjectTypes() []client.Object {
 		&vmopv1a1.WebConsoleRequest{},
 		&cnsv1alpha1.CnsNodeVmAttachment{},
 		&cnsv1alpha1.CnsNodeVMBatchAttachment{},
+		&cnsv1alpha1.CnsRegisterVolume{},
 		&spqv1.StoragePolicyQuota{},
 		&spqv1.StoragePolicyUsage{},
 		&spqv1.StorageQuota{},

--- a/webhooks/virtualmachinesnapshot/mutation/virtualmachinesnapshot_mutator_unit_test.go
+++ b/webhooks/virtualmachinesnapshot/mutation/virtualmachinesnapshot_mutator_unit_test.go
@@ -39,6 +39,9 @@ type unitMutationWebhookContext struct {
 
 func newUnitTestContextForMutatingWebhook() *unitMutationWebhookContext {
 	vmSnapshot := builder.DummyVirtualMachineSnapshot("dummy-ns", "dummy-vm-snapshot", "dummy-vm")
+	// Clear out the label that's set by default so we can test a clean object mutation
+	vmSnapshot.Labels = nil
+
 	obj, err := builder.ToUnstructured(vmSnapshot)
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

If we invoke VM snapshot API after the CnsRegisterVolume resource for an unmanaged disk has been created, but before CSI has had a chance to register the disk, then CRV will fail in a terminal way because CreateVolume call will refuse to reject a disk that is not the running point.

This change fixes this behavior by waiting for all disks to be registered before a VM snapshot is triggered.  A potential side effect is that a VM snapshot can not be taken if disk registration is broken. But that would have been the same behavior today anyway.

Testing Done:
- Unit tests
- Ran the failing end to end tests from our reco job a few times to make sure they pass


**Please add a release note if necessary**:

```release-note
 Wait for disks to be registered before snapshot creation
```