### PR TITLE
🐛  Relax error when finding VM without InstanceUUID or MoID

### DIFF
--- a/pkg/providers/vsphere/vcenter/getvm.go
+++ b/pkg/providers/vsphere/vcenter/getvm.go
@@ -26,8 +26,7 @@ func GetVirtualMachine(
 	vimClient *vim25.Client,
 	datacenter *object.Datacenter) (*object.VirtualMachine, error) {
 
-	moID := vmCtx.VM.Status.UniqueID
-	if moID != "" {
+	if moID := vmCtx.VM.Status.UniqueID; moID != "" {
 		if vm, err := findVMByMoID(vmCtx, vimClient, moID); err == nil {
 			return vm, nil
 		} else if !errors.Is(err, errVMNotFound) {
@@ -52,12 +51,6 @@ func GetVirtualMachine(
 		} else if !errors.Is(err, errVMNotFound) {
 			return nil, err
 		}
-	}
-
-	if moID == "" && instanceUUID == "" {
-		// This shouldn't happen, but we cannot determine if this VM exists or not so
-		// must return an error.
-		return nil, fmt.Errorf("neither MoID or InstanceUUID set on VM")
 	}
 
 	return nil, nil

--- a/pkg/providers/vsphere/vcenter/getvm_test.go
+++ b/pkg/providers/vsphere/vcenter/getvm_test.go
@@ -156,17 +156,4 @@ func getVM() {
 			Expect(vm).To(BeNil())
 		})
 	})
-
-	Context("VM does not have IDs set", func() {
-		BeforeEach(func() {
-			vmCtx.VM.Spec.InstanceUUID = ""
-			vmCtx.VM.Status.UniqueID = ""
-		})
-
-		It("returns error", func() {
-			vm, err := vcenter.GetVirtualMachine(vmCtx, ctx.VCClient.Client, ctx.Datacenter)
-			Expect(err).To(MatchError("neither MoID or InstanceUUID set on VM"))
-			Expect(vm).To(BeNil())
-		})
-	})
 }


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

For new VMs the Spec.InstanceUUID will be mutated in during create. For created brownfield VMs, the Spec.InstanceUUID is backfilled from the actual VC VM. Relax the condition for when the VM does not have an InstanceUUID or MoID to cover the rare gap of the VM not getting created in the first place prior to upgrade.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:


```release-note
NONE
```