### PR TITLE
🌱 e2e: Add RegisterVM restore-to-new test & Fix Incremental Restore Resiliency

### DIFF
--- a/test/e2e/vmservice/consts/consts.go
+++ b/test/e2e/vmservice/consts/consts.go
@@ -28,6 +28,10 @@ const (
 
 	JumpboxPodVMName = "jumpbox"
 
+	// VM condition type strings used when waiting on backfill/registration lifecycle.
+	VMUnmanagedVolumesBackfilledCondition = "VirtualMachineUnmanagedVolumesBackfilled"
+	VMUnmanagedVolumesRegisteredCondition = "VirtualMachineUnmanagedVolumesRegistered"
+
 	VMGroupsCapabilityName                   = "supports_VM_service_VM_groups"
 	VirtualMachineSnapshotCapabilityName     = "supports_VM_service_VM_snapshots"
 	VMPlacementPoliciesCapabilityName        = "supports_VM_service_VM_placement_policies"

--- a/test/e2e/vmservice/lib/vmoperator/vmoperator.go
+++ b/test/e2e/vmservice/lib/vmoperator/vmoperator.go
@@ -318,6 +318,51 @@ func WaitOnVirtualMachineCondition(
 	}, config.GetIntervals("default", "wait-virtual-machine-creation")...).Should(Succeed(), "Timed out waiting for Condition: %+v on VirtualMachine: %s", expectedCondition, vmName)
 }
 
+// WaitForBootDiskPVC waits for the VirtualMachineUnmanagedVolumesBackfilled and
+// VirtualMachineUnmanagedVolumesRegistered conditions to become true, then polls
+// spec.volumes until the boot disk (ControllerBusNumber 0, UnitNumber 0) has a
+// non-empty PersistentVolumeClaim.ClaimName. Returns the boot-disk volume name.
+// Only call this when the AllDisksArePVCs capability is enabled.
+func WaitForBootDiskPVC(
+	ctx context.Context,
+	config *config.E2EConfig,
+	client ctrlclient.Client,
+	ns, vmName string,
+) string {
+	By("Waiting on virtual machine conditions to become true")
+	for _, condition := range []metav1.Condition{
+		{Type: "VirtualMachineUnmanagedVolumesBackfilled", Status: metav1.ConditionTrue},
+		{Type: "VirtualMachineUnmanagedVolumesRegistered", Status: metav1.ConditionTrue},
+	} {
+		WaitOnVirtualMachineCondition(ctx, config, client, ns, vmName, condition)
+	}
+
+	By("Waiting for the boot disk to be promoted to a PVC")
+	var bootDiskVolName string
+	Eventually(func(g Gomega) bool {
+		vm, err := utils.GetVirtualMachineA5(ctx, client, ns, vmName)
+		if err != nil {
+			e2eframework.Logf("retry due to: %v", err)
+			return false
+		}
+		for _, vol := range vm.Spec.Volumes {
+			if vol.ControllerBusNumber != nil && *vol.ControllerBusNumber == 0 &&
+				vol.UnitNumber != nil && *vol.UnitNumber == 0 {
+				g.Expect(vol.PersistentVolumeClaim).ToNot(BeNil(),
+					"Expected boot disk to have a PersistentVolumeClaim")
+				g.Expect(vol.PersistentVolumeClaim.ClaimName).ToNot(BeEmpty(),
+					"Expected boot disk PVC to have a claim name")
+				bootDiskVolName = vol.Name
+				return true
+			}
+		}
+		return false
+	}, config.GetIntervals("default", "wait-virtual-machine-condition-update")...).
+		Should(BeTrue(), "Timed out waiting for boot disk to be found in spec.volumes")
+
+	return bootDiskVolName
+}
+
 // Utility function to ensure that a VirtualMachine is deleted.
 func WaitForVirtualMachineToBeDeleted(ctx context.Context, config *config.E2EConfig, client ctrlclient.Client, ns, vmName string) {
 	Eventually(func(g Gomega) {

--- a/test/e2e/vmservice/lib/vmoperator/vmoperator.go
+++ b/test/e2e/vmservice/lib/vmoperator/vmoperator.go
@@ -328,19 +328,24 @@ func WaitForBootDiskPVC(
 	config *config.E2EConfig,
 	client ctrlclient.Client,
 	ns, vmName string,
-) string {
+) (string, *vmopv1.VirtualMachine) {
 	By("Waiting on virtual machine conditions to become true")
 	for _, condition := range []metav1.Condition{
-		{Type: "VirtualMachineUnmanagedVolumesBackfilled", Status: metav1.ConditionTrue},
-		{Type: "VirtualMachineUnmanagedVolumesRegistered", Status: metav1.ConditionTrue},
+		{Type: consts.VMUnmanagedVolumesBackfilledCondition, Status: metav1.ConditionTrue},
+		{Type: consts.VMUnmanagedVolumesRegisteredCondition, Status: metav1.ConditionTrue},
 	} {
 		WaitOnVirtualMachineCondition(ctx, config, client, ns, vmName, condition)
 	}
 
 	By("Waiting for the boot disk to be promoted to a PVC")
-	var bootDiskVolName string
+	var (
+		bootDiskVolName string
+		vm              *vmopv1.VirtualMachine
+	)
+
 	Eventually(func(g Gomega) bool {
-		vm, err := utils.GetVirtualMachineA5(ctx, client, ns, vmName)
+		var err error
+		vm, err = utils.GetVirtualMachine(ctx, client, ns, vmName)
 		if err != nil {
 			e2eframework.Logf("retry due to: %v", err)
 			return false
@@ -360,7 +365,7 @@ func WaitForBootDiskPVC(
 	}, config.GetIntervals("default", "wait-virtual-machine-condition-update")...).
 		Should(BeTrue(), "Timed out waiting for boot disk to be found in spec.volumes")
 
-	return bootDiskVolName
+	return bootDiskVolName, vm
 }
 
 // Utility function to ensure that a VirtualMachine is deleted.

--- a/test/e2e/vmservice/lib/vmoperator/vmoperator.go
+++ b/test/e2e/vmservice/lib/vmoperator/vmoperator.go
@@ -318,6 +318,21 @@ func WaitOnVirtualMachineCondition(
 	}, config.GetIntervals("default", "wait-virtual-machine-creation")...).Should(Succeed(), "Timed out waiting for Condition: %+v on VirtualMachine: %s", expectedCondition, vmName)
 }
 
+// findBootDiskVolume returns the volume at ControllerBusNumber 0, UnitNumber 0
+// (the boot disk), or nil if spec.volumes has no such entry.
+// Note: This assumes there is only a single boot disk. Reconsider if/when
+// multiple boot disks are supported.
+func findBootDiskVolume(volumes []vmopv1.VirtualMachineVolume) *vmopv1.VirtualMachineVolume {
+	for i := range volumes {
+		vol := &volumes[i]
+		if vol.ControllerBusNumber != nil && *vol.ControllerBusNumber == 0 &&
+			vol.UnitNumber != nil && *vol.UnitNumber == 0 {
+			return vol
+		}
+	}
+	return nil
+}
+
 // WaitForBootDiskPVC waits for the VirtualMachineUnmanagedVolumesBackfilled and
 // VirtualMachineUnmanagedVolumesRegistered conditions to become true, then polls
 // spec.volumes until the boot disk (ControllerBusNumber 0, UnitNumber 0) has a
@@ -330,10 +345,18 @@ func WaitForBootDiskPVC(
 	ns, vmName string,
 ) (string, *vmopv1.VirtualMachine) {
 	By("Waiting on virtual machine conditions to become true")
-	for _, condition := range []metav1.Condition{
-		{Type: consts.VMUnmanagedVolumesBackfilledCondition, Status: metav1.ConditionTrue},
-		{Type: consts.VMUnmanagedVolumesRegisteredCondition, Status: metav1.ConditionTrue},
-	} {
+
+	conditions := []metav1.Condition{
+		{
+			Type:   consts.VMUnmanagedVolumesBackfilledCondition,
+			Status: metav1.ConditionTrue,
+		},
+		{
+			Type:   consts.VMUnmanagedVolumesRegisteredCondition,
+			Status: metav1.ConditionTrue,
+		},
+	}
+	for _, condition := range conditions {
 		WaitOnVirtualMachineCondition(ctx, config, client, ns, vmName, condition)
 	}
 
@@ -342,28 +365,20 @@ func WaitForBootDiskPVC(
 		bootDiskVolName string
 		vm              *vmopv1.VirtualMachine
 	)
-
-	Eventually(func(g Gomega) bool {
+	Eventually(func(g Gomega) {
 		var err error
 		vm, err = utils.GetVirtualMachine(ctx, client, ns, vmName)
-		if err != nil {
-			e2eframework.Logf("retry due to: %v", err)
-			return false
-		}
-		for _, vol := range vm.Spec.Volumes {
-			if vol.ControllerBusNumber != nil && *vol.ControllerBusNumber == 0 &&
-				vol.UnitNumber != nil && *vol.UnitNumber == 0 {
-				g.Expect(vol.PersistentVolumeClaim).ToNot(BeNil(),
-					"Expected boot disk to have a PersistentVolumeClaim")
-				g.Expect(vol.PersistentVolumeClaim.ClaimName).ToNot(BeEmpty(),
-					"Expected boot disk PVC to have a claim name")
-				bootDiskVolName = vol.Name
-				return true
-			}
-		}
-		return false
+		g.Expect(err).NotTo(HaveOccurred(), "failed to get VirtualMachine %s/%s", ns, vmName)
+
+		bootDiskVol := findBootDiskVolume(vm.Spec.Volumes)
+		g.Expect(bootDiskVol).ToNot(BeNil(), "boot disk volume not found in spec.volumes")
+		g.Expect(bootDiskVol.PersistentVolumeClaim).ToNot(BeNil(),
+			"Expected boot disk to have a PersistentVolumeClaim")
+		g.Expect(bootDiskVol.PersistentVolumeClaim.ClaimName).ToNot(BeEmpty(),
+			"Expected boot disk PVC to have a claim name")
+		bootDiskVolName = bootDiskVol.Name
 	}, config.GetIntervals("default", "wait-virtual-machine-condition-update")...).
-		Should(BeTrue(), "Timed out waiting for boot disk to be found in spec.volumes")
+		Should(Succeed(), "Timed out waiting for boot disk to be found in spec.volumes")
 
 	return bootDiskVolName, vm
 }

--- a/test/e2e/vmservice/vmservice/util.go
+++ b/test/e2e/vmservice/vmservice/util.go
@@ -836,10 +836,23 @@ func waitForBackupToComplete(
 ) {
 	By("Waiting for backup to complete for all PVCs")
 
+	// Wait until the backfill reconciler has added the OS disk PVC to spec.volumes.
+	vmoperator.WaitOnVirtualMachineCondition(ctx, config, clusterProxy.GetClient(),
+		vm.Namespace, vm.Name, metav1.Condition{
+			Type:   "VirtualMachineUnmanagedVolumesRegistered",
+			Status: metav1.ConditionTrue,
+		})
+
+	v1a2VM := &vmopv1a2.VirtualMachine{}
+	Expect(clusterProxy.GetClient().Get(ctx, ctrlclient.ObjectKey{
+		Namespace: vm.Namespace,
+		Name:      vm.Name,
+	}, v1a2VM)).To(Succeed(), "failed to re-fetch VM at v1alpha2 after backfill condition")
+
 	// Get list of PVC names from VM spec
 	expectedPVCNames := make(map[string]struct{})
 
-	for _, vol := range vm.Spec.Volumes {
+	for _, vol := range v1a2VM.Spec.Volumes {
 		if vol.PersistentVolumeClaim != nil {
 			expectedPVCNames[vol.PersistentVolumeClaim.ClaimName] = struct{}{}
 		}

--- a/test/e2e/vmservice/vmservice/util.go
+++ b/test/e2e/vmservice/vmservice/util.go
@@ -815,20 +815,8 @@ func decodeGzipBase64(encoded string) (string, error) {
 
 // WaitForBackupToComplete waits for the VM backup process to complete by verifying
 // that all PVCs in the VM spec have corresponding entries in the backup data stored
-// in the VM's ExtraConfig. This is exported for use in tests that perform in-place restores.
-func WaitForBackupToComplete(
-	ctx context.Context,
-	vm *vmopv1.VirtualMachine,
-	clusterProxy *common.VMServiceClusterProxy,
-	config *config.E2EConfig,
-) {
-	waitForBackupToComplete(ctx, vm, clusterProxy, config)
-}
-
-// waitForBackupToComplete waits for the VM backup process to complete by verifying
-// that all PVCs in the VM spec have corresponding entries in the backup data stored
 // in the VM's ExtraConfig.
-func waitForBackupToComplete(
+func WaitForBackupToComplete(
 	ctx context.Context,
 	vm *vmopv1.VirtualMachine,
 	clusterProxy *common.VMServiceClusterProxy,
@@ -1028,7 +1016,7 @@ func DeleteVMResource(
 	Expect(err).ToNot(HaveOccurred())
 
 	// Wait for backup to complete before powering off and deleting the VM
-	waitForBackupToComplete(ctx, vm, clusterProxy, config)
+	WaitForBackupToComplete(ctx, vm, clusterProxy, config)
 
 	// When AllDisksArePVCs is enabled, the CSI driver takes a VM snapshot
 	// while registering the boot VMDK as an FCD. If that snapshot is still

--- a/test/e2e/vmservice/vmservice/util.go
+++ b/test/e2e/vmservice/vmservice/util.go
@@ -836,43 +836,16 @@ func waitForBackupToComplete(
 ) {
 	By("Waiting for backup to complete for all PVCs")
 
-	conditions := []metav1.Condition{
-		{
-			Type:   "VirtualMachineUnmanagedVolumesBackfilled",
-			Status: metav1.ConditionTrue,
-		},
-		{
-			Type:   "VirtualMachineUnmanagedVolumesRegistered",
-			Status: metav1.ConditionTrue,
-		},
+	// If AllDisksArePVC is not enabled, then we end up waiting forever.
+	asyncSVFSSEnabled, err := utils.CheckSupervisorCapabilitiesCRDSupport(ctx, clusterProxy.GetClient())
+	Expect(err).ToNot(HaveOccurred())
+	if utils.IsSupervisorCapabilityEnabled(ctx, clusterProxy.GetClientSet(), clusterProxy.GetDynamicClient(),
+		consts.AllDisksArePVCapabilityName, asyncSVFSSEnabled) {
+		vmoperator.WaitForBootDiskPVC(ctx, config, clusterProxy.GetClient(), vm.Namespace, vm.Name)
+		Expect(clusterProxy.GetClient().Get(ctx,
+			ctrlclient.ObjectKey{Namespace: vm.Namespace, Name: vm.Name}, vm)).
+			To(Succeed(), "failed to re-fetch VM after boot disk backfill")
 	}
-	for _, condition := range conditions {
-		vmoperator.WaitOnVirtualMachineCondition(ctx, config, clusterProxy.GetClient(), vm.Namespace, vm.Name, condition)
-	}
-
-	volumeNames := make([]string, 0)
-	Eventually(func(g Gomega) bool {
-		vm, err := utils.GetVirtualMachineA5(ctx, clusterProxy.GetClient(), vm.Namespace, vm.Name)
-		if err != nil {
-			framework.Logf("retry due to: %v", err)
-			return false
-		}
-
-		for _, vol := range vm.Spec.Volumes {
-			volumeNames = append(volumeNames, vol.Name)
-			if vol.ControllerBusNumber != nil && *vol.ControllerBusNumber == 0 &&
-				vol.UnitNumber != nil && *vol.UnitNumber == 0 {
-				g.Expect(vol.PersistentVolumeClaim).ToNot(BeNil(),
-					"Expected boot disk to have a PersistentVolumeClaim")
-				g.Expect(vol.PersistentVolumeClaim.ClaimName).ToNot(BeEmpty(),
-					"Expected boot disk PVC to have a claim name")
-				return true
-			}
-		}
-
-		return false
-	}, config.GetIntervals("default", "wait-virtual-machine-condition-update")...).
-		Should(BeTrue(), "Timed out waiting for boot disk to be found in spec.volumes")
 
 	// Get list of PVC names from VM spec
 	expectedPVCNames := make(map[string]struct{})

--- a/test/e2e/vmservice/vmservice/util.go
+++ b/test/e2e/vmservice/vmservice/util.go
@@ -843,16 +843,15 @@ func waitForBackupToComplete(
 			Status: metav1.ConditionTrue,
 		})
 
-	v1a2VM := &vmopv1a2.VirtualMachine{}
 	Expect(clusterProxy.GetClient().Get(ctx, ctrlclient.ObjectKey{
 		Namespace: vm.Namespace,
 		Name:      vm.Name,
-	}, v1a2VM)).To(Succeed(), "failed to re-fetch VM at v1alpha2 after backfill condition")
+	}, vm)).To(Succeed(), "failed to re-fetch VM at v1alpha2 after backfill condition")
 
 	// Get list of PVC names from VM spec
 	expectedPVCNames := make(map[string]struct{})
 
-	for _, vol := range v1a2VM.Spec.Volumes {
+	for _, vol := range vm.Spec.Volumes {
 		if vol.PersistentVolumeClaim != nil {
 			expectedPVCNames[vol.PersistentVolumeClaim.ClaimName] = struct{}{}
 		}

--- a/test/e2e/vmservice/vmservice/util.go
+++ b/test/e2e/vmservice/vmservice/util.go
@@ -836,17 +836,43 @@ func waitForBackupToComplete(
 ) {
 	By("Waiting for backup to complete for all PVCs")
 
-	// Wait until the backfill reconciler has added the OS disk PVC to spec.volumes.
-	vmoperator.WaitOnVirtualMachineCondition(ctx, config, clusterProxy.GetClient(),
-		vm.Namespace, vm.Name, metav1.Condition{
+	conditions := []metav1.Condition{
+		{
+			Type:   "VirtualMachineUnmanagedVolumesBackfilled",
+			Status: metav1.ConditionTrue,
+		},
+		{
 			Type:   "VirtualMachineUnmanagedVolumesRegistered",
 			Status: metav1.ConditionTrue,
-		})
+		},
+	}
+	for _, condition := range conditions {
+		vmoperator.WaitOnVirtualMachineCondition(ctx, config, clusterProxy.GetClient(), vm.Namespace, vm.Name, condition)
+	}
 
-	Expect(clusterProxy.GetClient().Get(ctx, ctrlclient.ObjectKey{
-		Namespace: vm.Namespace,
-		Name:      vm.Name,
-	}, vm)).To(Succeed(), "failed to re-fetch VM at v1alpha2 after backfill condition")
+	volumeNames := make([]string, 0)
+	Eventually(func(g Gomega) bool {
+		vm, err := utils.GetVirtualMachineA5(ctx, clusterProxy.GetClient(), vm.Namespace, vm.Name)
+		if err != nil {
+			framework.Logf("retry due to: %v", err)
+			return false
+		}
+
+		for _, vol := range vm.Spec.Volumes {
+			volumeNames = append(volumeNames, vol.Name)
+			if vol.ControllerBusNumber != nil && *vol.ControllerBusNumber == 0 &&
+				vol.UnitNumber != nil && *vol.UnitNumber == 0 {
+				g.Expect(vol.PersistentVolumeClaim).ToNot(BeNil(),
+					"Expected boot disk to have a PersistentVolumeClaim")
+				g.Expect(vol.PersistentVolumeClaim.ClaimName).ToNot(BeEmpty(),
+					"Expected boot disk PVC to have a claim name")
+				return true
+			}
+		}
+
+		return false
+	}, config.GetIntervals("default", "wait-virtual-machine-condition-update")...).
+		Should(BeTrue(), "Timed out waiting for boot disk to be found in spec.volumes")
 
 	// Get list of PVC names from VM spec
 	expectedPVCNames := make(map[string]struct{})

--- a/test/e2e/vmservice/vmservice/util.go
+++ b/test/e2e/vmservice/vmservice/util.go
@@ -1005,14 +1005,11 @@ func DeleteVMResource(
 	clusterProxy *common.VMServiceClusterProxy,
 	config *config.E2EConfig,
 	svClusterClient ctrlclient.Client) string {
-	By("Get VM before powering off")
-
-	var (
-		err error
-	)
-
-	// Wait for backup to complete before powering off and deleting the VM
+	// Wait for backup to complete before powering off and deleting the VM.
+	// Capture the MoID now while the VM CR still exists; it is returned to
+	// the caller so RegisterVM can re-register the vSphere VM after deletion.
 	vm := WaitForBackupToComplete(ctx, vmName, vmNamespace, clusterProxy, config)
+	vmMoID := vm.Status.UniqueID
 
 	// When AllDisksArePVCs is enabled, the CSI driver takes a VM snapshot
 	// while registering the boot VMDK as an FCD. If that snapshot is still
@@ -1050,25 +1047,21 @@ func DeleteVMResource(
 	// The finalizer should be removed after the VM is being deleted to avoid
 	// its being added again during the normal reconciliation by the controller.
 	By("Remove the VMOP finalizer to ensure deletion of K8s VM")
-	Eventually(func() bool {
+	Eventually(func(g Gomega) {
+		var err error
 		vm, err = utils.GetVirtualMachine(ctx, svClusterClient, vmNamespace, vmName)
-		if err != nil {
-			// If VM is already deleted, nothing to do.
-			return apierrors.IsNotFound(err)
+		if apierrors.IsNotFound(err) {
+			return
 		}
-
-		if vm.DeletionTimestamp.IsZero() {
-			err = fmt.Errorf("VM %s/%s does not have deletion timestamp set", vmNamespace, vmName)
-			return false
-		}
-
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(vm.DeletionTimestamp.IsZero()).To(BeFalse(),
+			"VM %s/%s does not have deletion timestamp set", vmNamespace, vmName)
 		controllerutil.RemoveFinalizer(vm, VMFinalizerName)
 		// Also remove the deprecated finalizer if it exists to ensure backward compatibility.
 		controllerutil.RemoveFinalizer(vm, VMFinalizerNameDeprecated)
-		err = svClusterClient.Update(ctx, vm)
-
-		return err == nil
-	}, 30*time.Second, 3*time.Second).Should(BeTrue(), "failed to remove finalizer from VM '%s/%s', most recent error: %v", vmNamespace, vmName, err)
+		g.Expect(svClusterClient.Update(ctx, vm)).To(Succeed())
+	}, 30*time.Second, 3*time.Second).Should(Succeed(),
+		"failed to remove finalizer from VM '%s/%s'", vmNamespace, vmName)
 
 	vmoperator.WaitForVirtualMachineToBeDeleted(ctx, config, svClusterClient, vmNamespace, vmName)
 
@@ -1077,7 +1070,7 @@ func DeleteVMResource(
 		Expect(clusterProxy.DeleteWithArgs(ctx, bootstrapResourceYAML)).To(Succeed(), "failed to delete VM bootstrap resource")
 	}
 
-	return vm.Status.UniqueID
+	return vmMoID
 }
 
 // InvokeRegisterVM invokes the RegisterVM API.

--- a/test/e2e/vmservice/vmservice/util.go
+++ b/test/e2e/vmservice/vmservice/util.go
@@ -818,22 +818,15 @@ func decodeGzipBase64(encoded string) (string, error) {
 // in the VM's ExtraConfig.
 func WaitForBackupToComplete(
 	ctx context.Context,
-	vm *vmopv1.VirtualMachine,
+	vmName string,
+	vmNamespace string,
 	clusterProxy *common.VMServiceClusterProxy,
 	config *config.E2EConfig,
-) {
+) *vmopv1.VirtualMachine {
 	By("Waiting for backup to complete for all PVCs")
 
-	// If AllDisksArePVC is not enabled, then we end up waiting forever.
-	asyncSVFSSEnabled, err := utils.CheckSupervisorCapabilitiesCRDSupport(ctx, clusterProxy.GetClient())
-	Expect(err).ToNot(HaveOccurred())
-	if utils.IsSupervisorCapabilityEnabled(ctx, clusterProxy.GetClientSet(), clusterProxy.GetDynamicClient(),
-		consts.AllDisksArePVCapabilityName, asyncSVFSSEnabled) {
-		vmoperator.WaitForBootDiskPVC(ctx, config, clusterProxy.GetClient(), vm.Namespace, vm.Name)
-		Expect(clusterProxy.GetClient().Get(ctx,
-			ctrlclient.ObjectKey{Namespace: vm.Namespace, Name: vm.Name}, vm)).
-			To(Succeed(), "failed to re-fetch VM after boot disk backfill")
-	}
+	var vm *vmopv1.VirtualMachine
+	_, vm = vmoperator.WaitForBootDiskPVC(ctx, config, clusterProxy.GetClient(), vmNamespace, vmName)
 
 	// Get list of PVC names from VM spec
 	expectedPVCNames := make(map[string]struct{})
@@ -847,7 +840,7 @@ func WaitForBackupToComplete(
 	// If there are no PVCs, no need to wait
 	if len(expectedPVCNames) == 0 {
 		framework.Logf("No PVCs found in VM spec, skipping backup wait")
-		return
+		return vm
 	}
 
 	framework.Logf("Expected PVCs to be backed up: %v", strings.Join(slices.Collect(maps.Keys(expectedPVCNames)), ", "))
@@ -918,6 +911,8 @@ func WaitForBackupToComplete(
 
 		return true
 	}, config.GetIntervals("default", "wait-backup-to-complete")...).Should(BeTrue(), "backup did not complete for all PVCs")
+
+	return vm
 }
 
 // UnregisterPVCVolumes unregisters all PVCs in the provided list using CnsUnregisterVolume.
@@ -1012,11 +1007,12 @@ func DeleteVMResource(
 	svClusterClient ctrlclient.Client) string {
 	By("Get VM before powering off")
 
-	vm, err := utils.GetVirtualMachine(ctx, svClusterClient, vmNamespace, vmName)
-	Expect(err).ToNot(HaveOccurred())
+	var (
+		err error
+	)
 
 	// Wait for backup to complete before powering off and deleting the VM
-	WaitForBackupToComplete(ctx, vm, clusterProxy, config)
+	vm := WaitForBackupToComplete(ctx, vmName, vmNamespace, clusterProxy, config)
 
 	// When AllDisksArePVCs is enabled, the CSI driver takes a VM snapshot
 	// while registering the boot VMDK as an FCD. If that snapshot is still
@@ -1031,8 +1027,7 @@ func DeleteVMResource(
 	vmoperator.WaitForVirtualMachinePowerState(ctx, config, svClusterClient, vmNamespace, vmName, string(vmopv1.VirtualMachinePowerStateOff))
 
 	By("Add the pause annotation to VM")
-	vm, err = utils.GetVirtualMachine(ctx, svClusterClient, vmNamespace, vmName)
-	Expect(err).ToNot(HaveOccurred())
+
 	base := vm.DeepCopy()
 	metav1.SetMetaDataAnnotation(&vm.ObjectMeta, vmopv1.PauseAnnotation, trueString)
 	Expect(svClusterClient.Patch(ctx, vm, ctrlclient.MergeFrom(base))).To(Succeed())

--- a/test/e2e/vmservice/vmservice/viadmin/registervm.go
+++ b/test/e2e/vmservice/vmservice/viadmin/registervm.go
@@ -26,19 +26,16 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/govmomi/vslm"
 
-	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
-	backupapi "github.com/vmware-tanzu/vm-operator/pkg/backup/api"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	e2eframework "k8s.io/kubernetes/test/e2e/framework"
 	capiutil "sigs.k8s.io/cluster-api/util"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	e2eframework "k8s.io/kubernetes/test/e2e/framework"
-
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+	backupapi "github.com/vmware-tanzu/vm-operator/pkg/backup/api"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/appple2e/lib"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/infrastructure/vsphere/dcli"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/infrastructure/vsphere/testbed"
@@ -311,11 +308,9 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 			vmoperator.WaitForVirtualMachineCreation(ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
 			vmoperator.WaitForVirtualMachineMOID(ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
 
-			existingVM, err := utils.GetVirtualMachine(ctx, svClusterClient, input.WCPNamespaceName, vmName)
-			Expect(err).ToNot(HaveOccurred())
-
-			// Wait for backup to complete before reading the backup data
-			vmservice.WaitForBackupToComplete(ctx, existingVM, clusterProxy, config)
+			// Wait for backup to complete before reading the backup data.
+			// Use the returned VM to avoid a redundant Get call.
+			existingVM := vmservice.WaitForBackupToComplete(ctx, vmName, input.WCPNamespaceName, clusterProxy, config)
 
 			vmMoRef := types.ManagedObjectReference{Type: "VirtualMachine", Value: existingVM.Status.UniqueID}
 			vmObj := object.NewVirtualMachine(vCenterClient, vmMoRef)
@@ -450,19 +445,17 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 			// is processed; if removable is missing the disk may be misclassified
 			// during a restore pass.
 			By("Set all PVC volumes as removable=true before backup is captured")
-			vmA5, err := utils.GetVirtualMachine(ctx, svClusterClient, input.WCPNamespaceName, vmName)
+			vmPatch, err := utils.GetVirtualMachine(ctx, svClusterClient, input.WCPNamespaceName, vmName)
 			Expect(err).ToNot(HaveOccurred())
-			baseRemovable := vmA5.DeepCopy()
-			for i := range vmA5.Spec.Volumes {
-				vmA5.Spec.Volumes[i].Removable = ptr.To(true)
+			baseRemovable := vmPatch.DeepCopy()
+			for i := range vmPatch.Spec.Volumes {
+				vmPatch.Spec.Volumes[i].Removable = ptr.To(true)
 			}
-			Expect(svClusterClient.Patch(ctx, vmA5, ctrlclient.MergeFrom(baseRemovable))).To(Succeed())
+			Expect(svClusterClient.Patch(ctx, vmPatch, ctrlclient.MergeFrom(baseRemovable))).To(Succeed())
 
-			existingVM, err := utils.GetVirtualMachine(ctx, svClusterClient, input.WCPNamespaceName, vmName)
-			Expect(err).ToNot(HaveOccurred())
-
-			// Wait for backup to complete before reading the backup data
-			vmservice.WaitForBackupToComplete(ctx, existingVM, clusterProxy, config)
+			// Wait for backup to complete before reading the backup data.
+			// Use the returned VM to avoid a redundant Get call.
+			existingVM := vmservice.WaitForBackupToComplete(ctx, vmName, input.WCPNamespaceName, clusterProxy, config)
 
 			vmMoRef := types.ManagedObjectReference{Type: "VirtualMachine", Value: existingVM.Status.UniqueID}
 			vmObj := object.NewVirtualMachine(vCenterClient, vmMoRef)
@@ -495,12 +488,11 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 			testutils.AssertCreatePVC(svClusterClientSet, pvcNameB, input.WCPNamespaceName, resources.StorageClassName)
 			DeferCleanup(deletePVCOrIgnore, ctx, svClusterClient, input.WCPNamespaceName, pvcNameB)
 
-			// Use v1alpha3 here to make sure this doesn't blow up in product branches older than v1a5.
 			By(fmt.Sprintf("Updating the VM with two PVCs: '%v'", vmParameters.PVCNames))
 
 			vm, err := utils.GetVirtualMachine(ctx, svClusterClient, input.WCPNamespaceName, vmName)
 			Expect(err).ToNot(HaveOccurred())
-			baseA3 := vm.DeepCopy()
+			base := vm.DeepCopy()
 			vm.Spec.Volumes = append(vm.Spec.Volumes, vmopv1.VirtualMachineVolume{
 				Name: pvcNameB,
 				VirtualMachineVolumeSource: vmopv1.VirtualMachineVolumeSource{
@@ -511,7 +503,7 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 					},
 				},
 			})
-			Expect(svClusterClient.Patch(ctx, vm, ctrlclient.MergeFrom(baseA3))).To(Succeed())
+			Expect(svClusterClient.Patch(ctx, vm, ctrlclient.MergeFrom(base))).To(Succeed())
 
 			vmoperator.WaitForPVCAttachment(ctx, config, svClusterClient, input.WCPNamespaceName, vmName, pvcNameB)
 			// Both PVC A and B are now attached to VM.
@@ -522,20 +514,17 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 
 			By("Add the pause annotation and set all volumes as removable")
 
-			vm, err = utils.GetVirtualMachine(ctx, svClusterClient, input.WCPNamespaceName, vmName)
-			Expect(err).ToNot(HaveOccurred())
-
 			// RegisterVM restores from the backup yaml (pvcA only), requiring pvcB
 			// removal; the validating webhook blocks that unless Removable=true on
 			// every volume.
-			vmA5, err = utils.GetVirtualMachine(ctx, svClusterClient, input.WCPNamespaceName, vmName)
+			vm, err = utils.GetVirtualMachine(ctx, svClusterClient, input.WCPNamespaceName, vmName)
 			Expect(err).ToNot(HaveOccurred())
-			basePause := vmA5.DeepCopy()
-			metav1.SetMetaDataAnnotation(&vmA5.ObjectMeta, vmopv1.PauseAnnotation, trueString)
-			for i := range vmA5.Spec.Volumes {
-				vmA5.Spec.Volumes[i].Removable = ptr.To(true)
+			basePause := vm.DeepCopy()
+			metav1.SetMetaDataAnnotation(&vm.ObjectMeta, vmopv1.PauseAnnotation, trueString)
+			for i := range vm.Spec.Volumes {
+				vm.Spec.Volumes[i].Removable = ptr.To(true)
 			}
-			Expect(svClusterClient.Patch(ctx, vmA5, ctrlclient.MergeFrom(basePause))).To(Succeed())
+			Expect(svClusterClient.Patch(ctx, vm, ctrlclient.MergeFrom(basePause))).To(Succeed())
 
 			// Collect all PVC names from the VM spec
 			var pvcNames []string
@@ -672,11 +661,10 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 			DeferCleanup(deleteRegisteredVMAndPVCs, ctx, svClusterClient, clusterProxy, input.WCPNamespaceName, vmName, vmYaml)
 
 			vmoperator.WaitForVirtualMachineCreation(ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
-			existingVM, err := utils.GetVirtualMachine(ctx, svClusterClient, input.WCPNamespaceName, vmName)
-			Expect(err).ToNot(HaveOccurred())
 
-			// Wait for backup to complete before reading the backup data
-			vmservice.WaitForBackupToComplete(ctx, existingVM, clusterProxy, config)
+			// Wait for backup to complete before reading the backup data.
+			// Use the returned VM to avoid a redundant Get call.
+			existingVM := vmservice.WaitForBackupToComplete(ctx, vmName, input.WCPNamespaceName, clusterProxy, config)
 
 			// Delete the VM Service VM CR, keeping the vCenter VM in inventory.
 			vmMoID := vmservice.DeleteVMResource(ctx, existingVM.Name, existingVM.Namespace, nil, clusterProxy, config, svClusterClient)
@@ -911,11 +899,9 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 			vmoperator.WaitForVirtualMachineMOID(ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
 			vmoperator.WaitForPVCAttachment(ctx, config, svClusterClient, input.WCPNamespaceName, vmName, pvcNameA)
 
-			existingVM, err := utils.GetVirtualMachine(ctx, svClusterClient, vmNamespace, vmName)
-			Expect(err).ToNot(HaveOccurred())
-
-			// Wait for backup to complete before powering off the VM
-			vmservice.WaitForBackupToComplete(ctx, existingVM, clusterProxy, config)
+			// Wait for backup to complete before powering off the VM.
+			// Use the returned VM to avoid a redundant Get call.
+			existingVM := vmservice.WaitForBackupToComplete(ctx, vmName, vmNamespace, clusterProxy, config)
 
 			vmMoID := existingVM.Status.UniqueID
 
@@ -1153,20 +1139,19 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 			vmYaml := manifestbuilders.GetVirtualMachineYamlA2(vmParameters)
 			Expect(clusterProxy.CreateWithArgs(ctx, vmYaml)).To(Succeed(), "failed to create Linux VM:\n%s", string(vmYaml))
 
-			vCenterClient := vcenter.NewVimClientFromKubeconfig(ctx, clusterProxy.GetKubeconfigPath())
-			defer vcenter.LogoutVimClient(vCenterClient)
-
 			vmoperator.WaitForVirtualMachineCreation(ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
 			vmoperator.WaitForVirtualMachineMOID(ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
 			vmoperator.WaitOnVirtualMachineCondition(ctx, config, svClusterClient, input.WCPNamespaceName, vmName,
 				metav1.Condition{
-					Type:   "VirtualMachineUnmanagedVolumesRegistered",
+					Type:   consts.VMUnmanagedVolumesBackfilledCondition,
 					Status: metav1.ConditionTrue,
 				})
 
 			existingVM, err := utils.GetVirtualMachine(ctx, svClusterClient, input.WCPNamespaceName, vmName)
-			expectedVolCount := len(existingVM.Spec.Volumes)
 			Expect(err).ToNot(HaveOccurred())
+			Expect(existingVM).ToNot(BeNil())
+
+			expectedVolCount := len(existingVM.Spec.Volumes)
 			vmMoID := vmservice.DeleteVMResource(ctx, existingVM.Name, existingVM.Namespace, nil, clusterProxy, config, svClusterClient)
 			taskInfo, err := vmservice.InvokeRegisterVM(ctx, vmMoID, input.WCPNamespaceName, clusterProxy, wcpClient)
 

--- a/test/e2e/vmservice/vmservice/viadmin/registervm.go
+++ b/test/e2e/vmservice/vmservice/viadmin/registervm.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	capiutil "sigs.k8s.io/cluster-api/util"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	e2eframework "k8s.io/kubernetes/test/e2e/framework"
 
@@ -1113,6 +1114,101 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 
 			// We can't use len(existingVM.Spec.Volumes) here because we are only restoring one disk.
 			vmservice.VerifyPostRegisterVM(ctx, existingVM.Name, existingVM.Namespace, nil, 1, clusterProxy, config, svClusterClient, wcpClient)
+		})
+	})
+
+	Context("RegisterVM - Restore to new", func() {
+		It("Should register VM when no pre-existing VM CR exists", func() {
+			if !vmServiceBackupRestoreEnabled {
+				Skip("WCP_VMService_BackupRestore FSS is not enabled")
+			}
+
+			vCenterClient := vcenter.NewVimClientFromKubeconfig(ctx, clusterProxy.GetKubeconfigPath())
+			defer vcenter.LogoutVimClient(vCenterClient)
+
+			vmName := fmt.Sprintf("%s-%s", specName, capiutil.RandomString(4))
+			secretName := vmName + "-cloud-config-data"
+			secret := manifestbuilders.Secret{
+				Namespace: input.WCPNamespaceName,
+				Name:      secretName,
+			}
+			secretYaml := manifestbuilders.GetSecretYamlCloudConfig(secret)
+			Expect(clusterProxy.CreateWithArgs(ctx, secretYaml)).To(Succeed(), "failed to create the Secret with cloud-config data")
+
+			resources := config.InfraConfig.ManagementClusterConfig.Resources
+			vmParameters := manifestbuilders.VirtualMachineYaml{
+				Namespace:        input.WCPNamespaceName,
+				Name:             vmName,
+				VMClassName:      resources.VMClassName,
+				StorageClassName: resources.StorageClassName,
+				ResourcePolicy:   resources.VMResourcePolicyName,
+				ImageName:        linuxVMIName,
+				Bootstrap: manifestbuilders.Bootstrap{
+					CloudInit: &manifestbuilders.CloudInit{
+						RawCloudConfig: &manifestbuilders.KeySelector{
+							Key:  "user-data",
+							Name: secretName,
+						},
+					},
+				},
+				PowerState: "PoweredOn",
+			}
+			vmYaml := manifestbuilders.GetVirtualMachineYamlA2(vmParameters)
+			Expect(clusterProxy.CreateWithArgs(ctx, vmYaml)).To(Succeed(), "failed to create Linux VM:\n%s", string(vmYaml))
+
+			vmoperator.WaitForVirtualMachineCreation(ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
+			vmoperator.WaitForVirtualMachineMOID(ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
+
+			existingVM, err := utils.GetVirtualMachine(ctx, svClusterClient, input.WCPNamespaceName, vmName)
+			Expect(err).ToNot(HaveOccurred())
+
+			vmMoRef := types.ManagedObjectReference{Type: "VirtualMachine", Value: existingVM.Status.UniqueID}
+
+			By("Wait for VM resource YAML to be saved in ExtraConfig")
+			var vmMO mo.VirtualMachine
+			propCollector := property.DefaultCollector(vCenterClient)
+			Eventually(func(g Gomega) {
+				g.Expect(propCollector.RetrieveOne(ctx, vmMoRef, []string{"config.extraConfig"}, &vmMO)).To(Succeed())
+				g.Expect(vmMO.Config).ToNot(BeNil())
+				ecList := object.OptionValueList(vmMO.Config.ExtraConfig)
+				resourceYAML, _ := ecList.GetString(backupapi.VMResourceYAMLExtraConfigKey)
+				g.Expect(resourceYAML).ToNot(BeEmpty())
+			}, config.GetIntervals("default", "wait-backup-to-complete")...).
+				Should(Succeed(), "Timed out waiting for VM resource YAML in ExtraConfig")
+
+			By("Power off the VM")
+			vmoperator.UpdateVirtualMachinePowerState(ctx, config, svClusterClient, input.WCPNamespaceName, vmName, "PoweredOff")
+			vmoperator.WaitForVirtualMachinePowerState(ctx, config, svClusterClient, input.WCPNamespaceName, vmName, "PoweredOff")
+
+			By("Add the pause annotation to stop reconciliation")
+			vm, err := utils.GetVirtualMachine(ctx, svClusterClient, input.WCPNamespaceName, vmName)
+			Expect(err).ToNot(HaveOccurred())
+			base := vm.DeepCopy()
+			if vm.Annotations == nil {
+				vm.Annotations = make(map[string]string)
+			}
+			vm.Annotations[vmopv1a3.PauseAnnotation] = trueString
+			Expect(svClusterClient.Patch(ctx, vm, ctrlclient.MergeFrom(base))).To(Succeed())
+
+			By("Remove the VMOP finalizer and delete the VM CR")
+			vm, err = utils.GetVirtualMachine(ctx, svClusterClient, input.WCPNamespaceName, vmName)
+			Expect(err).ToNot(HaveOccurred())
+			controllerutil.RemoveFinalizer(vm, vmservice.VMFinalizerName)
+			controllerutil.RemoveFinalizer(vm, vmservice.VMFinalizerNameDeprecated)
+			Expect(svClusterClient.Update(ctx, vm)).To(Succeed())
+			Expect(svClusterClient.Delete(ctx, vm)).To(Succeed())
+			vmoperator.WaitForVirtualMachineToBeDeleted(ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
+
+			taskInfo, err := vmservice.InvokeRegisterVM(ctx, existingVM.Status.UniqueID, input.WCPNamespaceName, clusterProxy, wcpClient)
+
+			By("Verify task state is success")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(taskInfo).ToNot(BeNil())
+			Expect(taskInfo.Error).To(BeNil())
+			Expect(taskInfo.State).To(Equal(types.TaskInfoStateSuccess))
+
+			vmservice.VerifyPostRegisterVM(ctx, vmName, input.WCPNamespaceName, nil, len(existingVM.Spec.Volumes), clusterProxy, config, svClusterClient, wcpClient)
+			Expect(clusterProxy.DeleteWithArgs(ctx, vmYaml)).To(Succeed(), "failed to delete virtualmachine")
 		})
 	})
 }

--- a/test/e2e/vmservice/vmservice/viadmin/registervm.go
+++ b/test/e2e/vmservice/vmservice/viadmin/registervm.go
@@ -1158,6 +1158,14 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 
 			vmoperator.WaitForVirtualMachineCreation(ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
 			vmoperator.WaitForVirtualMachineMOID(ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
+			// With AllDisksArePVCs enabled, the CSI driver takes a snapshot while
+			// registering the boot VMDK as an FCD. If that snapshot is still active
+			// when the backup runs, ExtraConfig records the delta filename
+			// (e.g. "_3.vmdk"). After consolidation the disk reverts to the base
+			// name, so RegisterVM's filename lookup would fail. Wait until every
+			// CnsRegisterVolume is registered (snapshot consolidated) before
+			// reading the backup.
+			vmoperator.WaitForVMCnsRegisterVolumesRegistered(ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
 
 			existingVM, err := utils.GetVirtualMachine(ctx, svClusterClient, input.WCPNamespaceName, vmName)
 			Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/vmservice/vmservice/viadmin/registervm.go
+++ b/test/e2e/vmservice/vmservice/viadmin/registervm.go
@@ -1118,7 +1118,7 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 	})
 
 	Context("RegisterVM - Restore to new", func() {
-		It("Should register VM when no pre-existing VM CR exists", func() {
+		It("Should register VM when no pre-existing VM CR exists", Label("experimental"), func() {
 			if !vmServiceBackupRestoreEnabled {
 				Skip("WCP_VMService_BackupRestore FSS is not enabled")
 			}
@@ -1165,6 +1165,7 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 				})
 
 			existingVM, err := utils.GetVirtualMachine(ctx, svClusterClient, input.WCPNamespaceName, vmName)
+			expectedVolCount := len(existingVM.Spec.Volumes)
 			Expect(err).ToNot(HaveOccurred())
 			vmMoID := vmservice.DeleteVMResource(ctx, existingVM.Name, existingVM.Namespace, nil, clusterProxy, config, svClusterClient)
 			taskInfo, err := vmservice.InvokeRegisterVM(ctx, vmMoID, input.WCPNamespaceName, clusterProxy, wcpClient)
@@ -1175,7 +1176,7 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 			Expect(taskInfo.Error).To(BeNil())
 			Expect(taskInfo.State).To(Equal(types.TaskInfoStateSuccess))
 
-			vmservice.VerifyPostRegisterVM(ctx, vmName, input.WCPNamespaceName, nil, len(existingVM.Spec.Volumes), clusterProxy, config, svClusterClient, wcpClient)
+			vmservice.VerifyPostRegisterVM(ctx, vmName, input.WCPNamespaceName, nil, expectedVolCount, clusterProxy, config, svClusterClient, wcpClient)
 			Expect(clusterProxy.DeleteWithArgs(ctx, vmYaml)).To(Succeed(), "failed to delete virtualmachine")
 		})
 	})

--- a/test/e2e/vmservice/vmservice/viadmin/registervm.go
+++ b/test/e2e/vmservice/vmservice/viadmin/registervm.go
@@ -1123,9 +1123,6 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 				Skip("WCP_VMService_BackupRestore FSS is not enabled")
 			}
 
-			vCenterClient := vcenter.NewVimClientFromKubeconfig(ctx, clusterProxy.GetKubeconfigPath())
-			defer vcenter.LogoutVimClient(vCenterClient)
-
 			vmName := fmt.Sprintf("%s-%s", specName, capiutil.RandomString(4))
 			secretName := vmName + "-cloud-config-data"
 			secret := manifestbuilders.Secret{
@@ -1156,58 +1153,21 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 			vmYaml := manifestbuilders.GetVirtualMachineYamlA2(vmParameters)
 			Expect(clusterProxy.CreateWithArgs(ctx, vmYaml)).To(Succeed(), "failed to create Linux VM:\n%s", string(vmYaml))
 
+			vCenterClient := vcenter.NewVimClientFromKubeconfig(ctx, clusterProxy.GetKubeconfigPath())
+			defer vcenter.LogoutVimClient(vCenterClient)
+
 			vmoperator.WaitForVirtualMachineCreation(ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
 			vmoperator.WaitForVirtualMachineMOID(ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
-			// With AllDisksArePVCs enabled, the CSI driver takes a snapshot while
-			// registering the boot VMDK as an FCD. If that snapshot is still active
-			// when the backup runs, ExtraConfig records the delta filename
-			// (e.g. "_3.vmdk"). After consolidation the disk reverts to the base
-			// name, so RegisterVM's filename lookup would fail. Wait until every
-			// CnsRegisterVolume is registered (snapshot consolidated) before
-			// reading the backup.
-			vmoperator.WaitForVMCnsRegisterVolumesRegistered(ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
+			vmoperator.WaitOnVirtualMachineCondition(ctx, config, svClusterClient, input.WCPNamespaceName, vmName,
+				metav1.Condition{
+					Type:   "VirtualMachineUnmanagedVolumesRegistered",
+					Status: metav1.ConditionTrue,
+				})
 
 			existingVM, err := utils.GetVirtualMachine(ctx, svClusterClient, input.WCPNamespaceName, vmName)
 			Expect(err).ToNot(HaveOccurred())
-
-			vmMoRef := types.ManagedObjectReference{Type: "VirtualMachine", Value: existingVM.Status.UniqueID}
-
-			By("Wait for VM resource YAML to be saved in ExtraConfig")
-			var vmMO mo.VirtualMachine
-			propCollector := property.DefaultCollector(vCenterClient)
-			Eventually(func(g Gomega) {
-				g.Expect(propCollector.RetrieveOne(ctx, vmMoRef, []string{"config.extraConfig"}, &vmMO)).To(Succeed())
-				g.Expect(vmMO.Config).ToNot(BeNil())
-				ecList := object.OptionValueList(vmMO.Config.ExtraConfig)
-				resourceYAML, _ := ecList.GetString(backupapi.VMResourceYAMLExtraConfigKey)
-				g.Expect(resourceYAML).ToNot(BeEmpty())
-			}, config.GetIntervals("default", "wait-backup-to-complete")...).
-				Should(Succeed(), "Timed out waiting for VM resource YAML in ExtraConfig")
-
-			By("Power off the VM")
-			vmoperator.UpdateVirtualMachinePowerState(ctx, config, svClusterClient, input.WCPNamespaceName, vmName, "PoweredOff")
-			vmoperator.WaitForVirtualMachinePowerState(ctx, config, svClusterClient, input.WCPNamespaceName, vmName, "PoweredOff")
-
-			By("Add the pause annotation to stop reconciliation")
-			vm, err := utils.GetVirtualMachine(ctx, svClusterClient, input.WCPNamespaceName, vmName)
-			Expect(err).ToNot(HaveOccurred())
-			base := vm.DeepCopy()
-			if vm.Annotations == nil {
-				vm.Annotations = make(map[string]string)
-			}
-			vm.Annotations[vmopv1a3.PauseAnnotation] = trueString
-			Expect(svClusterClient.Patch(ctx, vm, ctrlclient.MergeFrom(base))).To(Succeed())
-
-			By("Remove the VMOP finalizer and delete the VM CR")
-			vm, err = utils.GetVirtualMachine(ctx, svClusterClient, input.WCPNamespaceName, vmName)
-			Expect(err).ToNot(HaveOccurred())
-			controllerutil.RemoveFinalizer(vm, vmservice.VMFinalizerName)
-			controllerutil.RemoveFinalizer(vm, vmservice.VMFinalizerNameDeprecated)
-			Expect(svClusterClient.Update(ctx, vm)).To(Succeed())
-			Expect(svClusterClient.Delete(ctx, vm)).To(Succeed())
-			vmoperator.WaitForVirtualMachineToBeDeleted(ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
-
-			taskInfo, err := vmservice.InvokeRegisterVM(ctx, existingVM.Status.UniqueID, input.WCPNamespaceName, clusterProxy, wcpClient)
+			vmMoID := vmservice.DeleteVMResource(ctx, existingVM.Name, existingVM.Namespace, nil, clusterProxy, config, svClusterClient)
+			taskInfo, err := vmservice.InvokeRegisterVM(ctx, vmMoID, input.WCPNamespaceName, clusterProxy, wcpClient)
 
 			By("Verify task state is success")
 			Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_hardware.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_hardware.go
@@ -13,7 +13,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/mo"
@@ -30,6 +29,7 @@ import (
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 	mopv1a2 "github.com/vmware-tanzu/vm-operator/external/mobility-operator/api/v1alpha2"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/framework"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/infrastructure/vsphere/testbed"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/infrastructure/vsphere/vcenter"
@@ -132,11 +132,11 @@ func getBackfilledVolumes(
 	// Wait for both conditions
 	conditions := []metav1.Condition{
 		{
-			Type:   "VirtualMachineUnmanagedVolumesBackfilled",
+			Type:   consts.VMUnmanagedVolumesBackfilledCondition,
 			Status: metav1.ConditionTrue,
 		},
 		{
-			Type:   "VirtualMachineUnmanagedVolumesRegistered",
+			Type:   consts.VMUnmanagedVolumesRegisteredCondition,
 			Status: metav1.ConditionTrue,
 		},
 	}
@@ -1820,10 +1820,7 @@ func VMHardwareSpec(ctx context.Context, inputGetter func() VMHardwareSpecInput)
 
 				waitForVMAndBatchAttach(ctx, config, svClusterClient, vmSvcNamespace, vmName, []string{})
 
-				bootDiskVolName := vmoperator.WaitForBootDiskPVC(ctx, config, svClusterClient, vmSvcNamespace, vmName)
-
-				currentVM, err := utils.GetVirtualMachineA5(ctx, svClusterClient, vmSvcNamespace, vmName)
-				Expect(err).ToNot(HaveOccurred(), "failed to get VM after boot disk backfill")
+				bootDiskVolName, currentVM := vmoperator.WaitForBootDiskPVC(ctx, config, svClusterClient, vmSvcNamespace, vmName)
 				volumeNames := make([]string, 0, len(currentVM.Spec.Volumes))
 				for _, vol := range currentVM.Spec.Volumes {
 					volumeNames = append(volumeNames, vol.Name)
@@ -2127,11 +2124,11 @@ func VMHardwareSpec(ctx context.Context, inputGetter func() VMHardwareSpecInput)
 
 				conditions := []metav1.Condition{
 					{
-						Type:   "VirtualMachineUnmanagedVolumesBackfilled",
+						Type:   consts.VMUnmanagedVolumesBackfilledCondition,
 						Status: metav1.ConditionTrue,
 					},
 					{
-						Type:   "VirtualMachineUnmanagedVolumesRegistered",
+						Type:   consts.VMUnmanagedVolumesRegisteredCondition,
 						Status: metav1.ConditionTrue,
 					},
 				}
@@ -2273,11 +2270,11 @@ func VMHardwareSpec(ctx context.Context, inputGetter func() VMHardwareSpecInput)
 
 				conditions := []metav1.Condition{
 					{
-						Type:   "VirtualMachineUnmanagedVolumesBackfilled",
+						Type:   consts.VMUnmanagedVolumesBackfilledCondition,
 						Status: metav1.ConditionTrue,
 					},
 					{
-						Type:   "VirtualMachineUnmanagedVolumesRegistered",
+						Type:   consts.VMUnmanagedVolumesRegisteredCondition,
 						Status: metav1.ConditionTrue,
 					},
 				}

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_hardware.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_hardware.go
@@ -1820,52 +1820,14 @@ func VMHardwareSpec(ctx context.Context, inputGetter func() VMHardwareSpecInput)
 
 				waitForVMAndBatchAttach(ctx, config, svClusterClient, vmSvcNamespace, vmName, []string{})
 
-				By("Waiting on virtual machine conditions to become true")
+				bootDiskVolName := vmoperator.WaitForBootDiskPVC(ctx, config, svClusterClient, vmSvcNamespace, vmName)
 
-				conditions := []metav1.Condition{
-					{
-						Type:   "VirtualMachineUnmanagedVolumesBackfilled",
-						Status: metav1.ConditionTrue,
-					},
-					{
-						Type:   "VirtualMachineUnmanagedVolumesRegistered",
-						Status: metav1.ConditionTrue,
-					},
+				currentVM, err := utils.GetVirtualMachineA5(ctx, svClusterClient, vmSvcNamespace, vmName)
+				Expect(err).ToNot(HaveOccurred(), "failed to get VM after boot disk backfill")
+				volumeNames := make([]string, 0, len(currentVM.Spec.Volumes))
+				for _, vol := range currentVM.Spec.Volumes {
+					volumeNames = append(volumeNames, vol.Name)
 				}
-				for _, condition := range conditions {
-					vmoperator.WaitOnVirtualMachineCondition(ctx, config, svClusterClient, vmSvcNamespace, vmName, condition)
-				}
-
-				volumeNames := make([]string, 0)
-
-				By("Waiting for the boot disk to be promoted to a PVC")
-
-				var bootDiskVolName string
-
-				Eventually(func(g Gomega) bool {
-					vm, err := utils.GetVirtualMachine(ctx, svClusterClient, vmSvcNamespace, vmName)
-					if err != nil {
-						e2eframework.Logf("retry due to: %v", err)
-						return false
-					}
-
-					for _, vol := range vm.Spec.Volumes {
-						volumeNames = append(volumeNames, vol.Name)
-						if vol.ControllerBusNumber != nil && *vol.ControllerBusNumber == 0 &&
-							vol.UnitNumber != nil && *vol.UnitNumber == 0 {
-							g.Expect(vol.PersistentVolumeClaim).ToNot(BeNil(),
-								"Expected boot disk to have a PersistentVolumeClaim")
-							g.Expect(vol.PersistentVolumeClaim.ClaimName).ToNot(BeEmpty(),
-								"Expected boot disk PVC to have a claim name")
-							bootDiskVolName = vol.Name
-
-							return true
-						}
-					}
-
-					return false
-				}, config.GetIntervals("default", "wait-virtual-machine-condition-update")...).
-					Should(BeTrue(), "Timed out waiting for boot disk to be found in spec.volumes")
 
 				By("Verify volumes in batch attachment CRD")
 				csi.WaitForBatchAttachVolumesToBeAttached(ctx, config, svClusterClient, vmSvcNamespace, vmName, volumeNames)


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

1. Adds a new E2E test for the RegisterVM *restore-to-new* scenario: a vCenter VM whose Kubernetes CR has been deleted (simulating a post-disaster state) is re-registered via the RegisterVM API, creating a fresh CR from the backup YAML stored in ExtraConfig. 
2. There is a flakiness in our e2e test when we don't wait on backfill to complete. So OS disk is not present in spec at the time of backup and but is expected after InvokeRegisterVM restore.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #

Added new tests for more coverage.
Waits on Backfill condition to be true.

**Are there any special notes for your reviewer**:

Incremental Restore - Ran the test multiple times to ensure there is no flakiness. 
Restore To new - Ran VDS, Stretched, didn't see the failure. 

https://uts.lvn.broadcom.net/dashboard/pipeline/detail/6a58759e7221200142432012/


```
./e2e-tests -e2e.e2e-config=test/e2e/vmservice/config/wcp.yaml --ginkgo.focus="Boot disk PVC lifecycle operations should succeed|VI-ADMIN-RegisterVM" --ginkgo.v

STDOUT: [SynchronizedAfterSuite] PASSED [102.027 seconds]
------------------------------

Ran 9 of 149 Specs in 1664.114 seconds
SUCCESS! -- 9 Passed | 0 Failed | 4 Pending | 136 Skipped
PASS
```

**Please add a release note if necessary**:


```release-note

```