### PR TITLE
🌱 Update E2E Dockerfile to prefer to use 7zip with fallback of unzip

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -78,7 +78,6 @@ RUN tdnf install -y \
         sshpass \
         make \
         sudo \
-        unzip \
         && \
     rm -rf /var/cache/tdnf
 
@@ -91,11 +90,22 @@ RUN curl -fsSL "${GOVC_DOWNLOAD_URL}" | tar -xz -C /usr/local/bin govc && \
     chmod +x /usr/local/bin/govc
 
 # packer — required by vmserviceapp E2E tests.
-# unzip is installed only for this extraction step and removed immediately after.
 ARG PACKER_DOWNLOAD_URL=https://releases.hashicorp.com/packer/1.9.1/packer_1.9.1_linux_amd64.zip
-RUN curl -fsSL "${PACKER_DOWNLOAD_URL}" -o /tmp/packer.zip && \
-    unzip /tmp/packer.zip -d /tmp/packer && \
-    mv /tmp/packer/packer /usr/local/bin/packer && \
+RUN curl -fsSL "${PACKER_DOWNLOAD_URL}" -o /tmp/packer.zip
+
+# if 7zip is available, prefer to use it
+# otherwise fallback to unzip. Remove after using it
+RUN if tdnf info 7zip > /dev/null 2>&1; then \
+        tdnf install -y 7zip && \
+        7z x /tmp/packer.zip -o/tmp/packer packer -y && \
+        tdnf remove -y 7zip; \
+    else \
+        tdnf install -y unzip && \
+        unzip /tmp/packer.zip packer -d /tmp/packer && \
+        tdnf remove -y unzip; \
+    fi
+
+RUN mv /tmp/packer/packer /usr/local/bin/packer && \
     chmod 0755 /usr/local/bin/packer && \
     rm -rf /tmp/packer.zip /tmp/packer && \
     rm -rf /var/cache/tdnf

--- a/test/e2e/vmservice/vmservice/viadmin/registervm.go
+++ b/test/e2e/vmservice/vmservice/viadmin/registervm.go
@@ -402,7 +402,7 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 			// Set Removable=true on every volume before backup is captured so the
 			// backup YAML reflects the correct value. The CSI CnsRegisterVolume
 			// controller reads spec.volumes[*].removable when a newly registered FCD
-			// is processed; if removable is missing the disk may be mis-classified
+			// is processed; if removable is missing the disk may be misclassified
 			// during a restore pass.
 			By("Set all PVC volumes as removable=true before backup is captured")
 			vmA5, err := utils.GetVirtualMachineA5(ctx, svClusterClient, input.WCPNamespaceName, vmName)


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Modern versions of Photon5 images decommission the use of unzip package in favor of 7zip.
This patch makes the E2E Dockerfile to use 7zip with fallback to unzip
(and it removes the uncompressing tool after using it).

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #

**Are there any special notes for your reviewer**:

Public Photon5 image still contains unzip package but modern private Photon5 images have decommissioned unzip package.

**Please add a release note if necessary**:

```release-note
7zip package is used for e2e Dockerfile.
```