### PR TITLE
🌱  Add triage-prod-vmsvc-reco Claude Code skill

### DIFF
--- a/.cursor/skills/triage-prod-vmsvc-reco/SKILL.md
+++ b/.cursor/skills/triage-prod-vmsvc-reco/SKILL.md
@@ -1,0 +1,347 @@
+---
+name: triage-prod-vmsvc-reco
+description: >-
+  Triage VM Service E2E pipeline failures end-to-end: collect gce2e logs,
+  parse JUnit timings against wcp.yaml timeouts, categorize failures, decide
+  whether to dig into operator logs / support bundle / ESX logs, and escalate
+  when out of scope. Use when the user asks to investigate, triage, or root-cause
+  any prod-vmsvc-reco-* pipeline build failure.
+args: |
+  Jenkins pipeline URL (e.g., https://jenkins-vcfwcp.devops.broadcom.net/job/prod-vmsvc-reco-main/2207/)
+disable-model-invocation: true
+---
+
+# VM Service E2E — Failure Triage
+
+## Overview
+
+Always work **data-first**. Present a high-level summary first, then wait for the user to pick which failure(s) to investigate. Never auto-advance to deep log analysis without user direction.
+
+```
+Pipeline build URL
+    │
+    ▼
+Step 1 — Classify the build (INFRA vs PRODUCT)
+    │
+    ├── INFRA failure → Step 7 (Escalation)
+    │
+    └── PRODUCT: gce2e failure
+            │
+            ▼
+        Step 2 — Run fetch-gce2e-logs.py
+            │   Downloads: JUnit XML + per-suite vm-operator logs
+            │
+            ▼
+        Step 3 — Present HIGH-LEVEL SUMMARY  ◄── STOP HERE
+            │   • Compact table: #, test, suite, category, time vs timeout
+            │   • 2-3 line error snippet per failure (from JUnit message)
+            │   • Group INFRA flakes separately from PRODUCT failures
+            │   • Ask the user: "Which failure(s) should I investigate?"
+            │
+            │   ── WAIT FOR USER DIRECTION ──
+            │
+            ▼ (only after user picks)
+        Step 4 — Deep dive: timeline analysis on operator log
+            │   Targeted to the specific failure(s) the user asked about
+            │
+            ▼
+        Step 5 — Decision: support bundle needed?
+            │   See matrix below
+            │
+            ├── Not needed → write RCA
+            │
+            └── Needed → Step 6 (fetch-bundle.py)
+                            │
+                            └── ESX logs needed? → Step 7 (Escalation)
+```
+
+---
+
+## Step 1 — Classify the build
+
+```bash
+# Get the pipeline category from triage report or Jenkins console
+curl -sf "https://jenkins-vcfwcp.devops.broadcom.net/job/<JOB>/<BUILD>/consoleText" \
+  --globoff | grep -E "FAILURE|gce2e|OVA|Import|checkout|testbed" | head -20
+```
+
+| Signal in console | Category | Next step |
+|-------------------|----------|-----------|
+| `run-guest-clusters-end-to-end-tests #NNN` found | PRODUCT: gce2e | → Step 2 |
+| `OVA\|transferring file\|InternalServerError` | INFRA: OVA Import | → Step 7 |
+| `Maximum checkout retry\|checkout` | INFRA: Git Checkout | → Step 7 |
+| `Deploy Testbed stage failed` | INFRA: Testbed Creation | → Step 7 |
+| `WCP Sanity Tests failed` | INFRA: WCP Sanity | → Step 7 |
+
+---
+
+## Step 2 — Collect gce2e artifacts
+
+The skill ships `scripts/fetch-gce2e-logs.py`. It:
+1. Finds the gce2e build number from the pipeline console.
+2. Downloads the JUnit XML and parses every failing test with its **actual elapsed time**.
+3. Looks up the configured timeout for each test from `wcp.yaml`.
+4. Downloads the **targeted vm-operator log per test suite** (already archived by gce2e — no support bundle needed at this stage).
+5. Prints a structured triage summary.
+
+```bash
+python3 .cursor/skills/triage-vm-service-e2e/scripts/fetch-gce2e-logs.py \
+    https://jenkins-vcfwcp.devops.broadcom.net/job/<JOB>/<BUILD#> \
+    --out /tmp/gce2e-debug
+```
+
+Output directory structure:
+```
+/tmp/gce2e-debug/
+  junit_vmservice.xml
+  v1alpha5-vmsnapshot/logs-vmware-system-vmop-*.log
+  vm-encryption/logs-vmware-system-vmop-*.log
+  vm-lcm/logs-vmware-system-vmop-*.log
+  vm-hardware/logs-vmware-system-vmop-*.log
+  vm-guest-customization/logs-vmware-system-vmop-*.log
+  ...
+```
+
+---
+
+## Step 3 — Present high-level summary  ⚑ STOP HERE
+
+After the script completes, emit a summary in this exact format, then **stop and ask the user which failure(s) to investigate**. Do not proceed to Step 4 until the user responds.
+
+### 3a — Output format
+
+**Header line** (one line):
+```
+Pipeline: <job-name> #<build>   Topologies: VDS · NSX · NSX-VPC · ...   Total failures: N
+```
+
+**Failure table** (one row per failing test):
+
+| # | Test (shortened) | Suite | Cat | Actual / Timeout | Error snippet |
+|---|-----------------|-------|-----|-----------------|---------------|
+| 1 | `successfully create…snapshots` | `v1alpha5-vmsnapshot` | ⏱ TIMEOUT | 10m02s / 10m | `Timed out waiting for VirtualMachineSnapshot…conditions: []` |
+| 2 | … | | | | |
+
+Rules for the table:
+- Shorten test names to the last 60 characters if needed (they're long Ginkgo paths).
+- **Error snippet**: first 120 chars of the JUnit `<failure>` message, newlines replaced by `↵`.
+- Group rows: PRODUCT failures first, then INFRA flakes (mark INFRA rows with 🔧).
+- If multiple topologies failed on the same test, collapse to one row and note topologies: `VDS · NSX-VPC`.
+
+**Category key** (print inline under the table):
+- ⏱ TIMEOUT — elapsed ≈ configured timeout; condition never became True
+- ❌ ASSERTION — wrong value returned; check test logic / operator state
+- 🔧 INFRA — SSH / OVA / testbed error; likely infra flake, escalate
+- 🔴 HANG — elapsed >> timeout; missing hard timeout guard
+
+### 3b — Cross-topology pattern check
+
+After the table, print one sentence stating whether the same test failed across ≥2 topologies (strong signal of a product bug, not a testbed flake).
+
+### 3c — Stop and ask
+
+End with exactly:
+```
+Which failure(s) should I investigate? (e.g. "all", "#1", "#1 and #3", or "skip INFRA")
+```
+
+**Do not read any operator logs, do not grep any files, do not open any source files until the user replies to this prompt.**
+
+---
+
+## Step 4 — Deep dive: timeline analysis on operator log  (on user request)
+
+Run this step **only** for the specific failure number(s) the user named. Use the operator log downloaded in Step 2 — no support bundle required yet.
+
+**Timeout config reference** (from `test/e2e/vmservice/config/wcp.yaml`):
+
+| Operation | Interval key | Timeout | Poll |
+|-----------|-------------|---------|------|
+| VM snapshot ready | `wait-virtual-machine-snapshot-condition` | **10m** | 5s |
+| VM created | `wait-virtual-machine-creation` | **5m** | 10s |
+| VM power state | `wait-virtual-machine-powerstate` | **5m** | 10s |
+| VM condition update | `wait-virtual-machine-condition-update` | **5m** | 10s |
+| VM IP address | `wait-virtual-machine-vmip` | **5m** | 10s |
+| VM image creation | `wait-virtual-machine-image-creation` | **10m** | 5s |
+| SSH / login retry | `login-retry-timeout` | **5m** | 10s |
+| PVC attachment | `wait-pvc-attachment` | **5m** | 10s |
+| VM group condition | `wait-virtual-machine-group-condition-update` | **6m** | 5s |
+| CNS batch attach | `wait-virtual-machine-cns-node-batch-attachment-creation` | **10m** | 5s |
+| Backup complete | `wait-backup-to-complete` | **10m** | 5s |
+| Jumpbox SSH ready | `wait-jumpbox-sshpass-ready` | **30m** | 10s |
+
+```bash
+VMOP_LOG="/tmp/gce2e-debug/<suite>/logs-vmware-system-vmop-*.log"
+
+# 1. Find all errors for the failing VM (name comes from test / JUnit message)
+rg "terminal error|Reconciler error" "$VMOP_LOG" | head -40
+
+# 2. Build a timeline for a specific VM
+VM="vm-snapshot-abc1"
+rg "\"$VM\"" "$VMOP_LOG" | head -40
+
+# 3. Find the first reconcile timestamp vs. the error timestamp
+# → calculate: create → first reconcile → condition stuck → timeout
+rg "\"$VM\"" "$VMOP_LOG" | awk '{print $1, $0}' | sort | head -20
+
+# 4. Check for the specific stuck condition
+rg "conditions.*\[\]|hasPendingCRVs|ErrPendingBackfill|SubnetPort|OpaqueNetwork" "$VMOP_LOG" | head -20
+```
+
+**Pinpointing which phase caused the timeout:**
+
+| Elapsed before error | Likely bottleneck phase |
+|----------------------|------------------------|
+| < 30s | Immediate rejection (bad spec, missing resource, API error) |
+| 30s – 2m | Early reconcile block (storage policy, NSX SubnetPort not ready) |
+| 2m – (timeout − 10s) | Condition set but then reverted (race), or VM stuck in vSphere task |
+| ≈ configured timeout | Condition never set at all; operator loop not triggering |
+
+---
+
+## Step 5 — Support bundle decision matrix
+
+| Operator log shows | Support bundle needed? | ESX logs? |
+|--------------------|------------------------|-----------|
+| `terminal error: network interface is not ready` | ✅ YES — need NSX pod logs | ❌ No |
+| `Timed out … conditions: []` + no operator errors | ✅ YES — condition never set | ❌ No |
+| `ErrPendingBackfill` / `missing controller bus number` | ✅ YES — CSI / backfill state | ❌ No |
+| `OpaqueNetworkBackingInfoImpl` / `InvalidArgument` | ❌ No — test/product bug | ❌ No |
+| `409 conflict` / `resourceVersion` | ❌ No — test uses Update not Patch | ❌ No |
+| `ManagedEntityStatus: red != green` | ❌ No — check KMS / encryption state | ❌ No |
+| `vSphere MethodFault` / `InvalidArgument(path)` | ✅ YES | ⚠️ Maybe |
+| `disk … is not restored` / VSLM error | ✅ YES — snapshot delta race | ❌ No |
+| OVA import / `transferring file` error | 🚫 ESCALATE — infra issue | 🚫 ESCALATE |
+| `esx\|kernel\|storage IO` error in VC logs | 🚫 ESCALATE — needs ESX team | ✅ If escalating |
+
+**When ESX logs ARE needed** (rare):
+- vSAN I/O errors during OVA transfer
+- ESX kernel panic affecting VM power-on
+- Storage controller bus-number issues not explained by operator log
+
+ESX logs are in `esx-host-*.tar.gz` inside the support bundle (large — extract only if justified).
+
+---
+
+## Step 6 — Support bundle download (only when Step 5 says YES)
+
+```bash
+python3 .cursor/skills/triage-vm-service-e2e/scripts/fetch-bundle.py \
+    https://jenkins-vcfwcp.devops.broadcom.net/job/<JOB>/<BUILD#> \
+    --out /tmp/wcp-sb
+```
+
+The script outputs ready-to-paste shell variables:
+```
+SB="/tmp/wcp-sb/wcp-agent-<hash>-<ts>/"
+VMOP_LOG="$SB/var/log/pods/vmware-system-vmop-.../manager/0.log"
+NSX_POD="$SB/var/log/pods/vmware-system-nsx-operator-.../"
+```
+
+**Search patterns after pasting the vars:**
+
+```bash
+# Decompress rotated logs
+gunzip "$SB/var/log/pods/vmware-system-vmop-"*/manager/*.log.*.gz 2>/dev/null || true
+
+# SNAP / EXACT_TIMEOUT — snapshot condition never set
+rg "VirtualMachineSnapshot|hasPendingCRVs|snapshot" "$VMOP_LOG" | head -40
+
+# HW — backfill / SubnetPort
+rg "terminal error|ErrPendingBackfill|SubnetPort|bus number" "$VMOP_LOG" | head -40
+
+# LCM — NIC backing
+rg "OpaqueNetwork|InvalidArgument|deployOVF" "$VMOP_LOG" | head -30
+
+# NSX SubnetPort
+rg "SubnetPortNotReady|empty NSX resource" "$NSX_POD"/*/0.log | head -20
+```
+
+**Key log signals:**
+
+| Signal | Meaning |
+|--------|---------|
+| `terminal error: network interface is not ready` | NSX SubnetPort not realized; reconcile exits, no requeue |
+| `ErrPendingBackfill` / `Backfilled unmanaged volume` | Backfill ran once; condition not yet True |
+| `PolicyEvaluation … not ready` | Storage policy gate blocking reconcile |
+| `VM has task` + taskID | vSphere task in flight, reconcile skipped |
+| `noRequeueReason="backed up vm"` | Backup reconcile path — main reconcile not running |
+| `hasPendingCRVs=true` | CnsRegisterVolume still in flight; snapshot must wait |
+
+---
+
+## Step 7 — Escalation / Human intervention required
+
+Call out the following explicitly. **Do not dig deeper in support bundle or code for these.**
+
+| Signal | Category | Action |
+|--------|----------|--------|
+| `Error transferring file *.ova` | INFRA: OVA Import | File Nimbus/testbed bug; check if content library vSAN is healthy |
+| `Maximum checkout retry` | INFRA: Git | Check GitHub Enterprise / network; pipeline team |
+| `Deploy Testbed stage failed` | INFRA: Testbed | Nimbus scheduling/capacity issue; pipeline team |
+| `test ran >> configured timeout` (HANG) | Test bug | Add hard timeout + `Skip` guard in `BeforeAll`; missing timeout is a P0 pipeline blocker |
+| NSX `SubnetPort` never realized after support bundle analysis | Product / NSX team | File bug with NSX operator team; include SubnetPort YAML + NSX operator logs |
+| KMS / encryption status `red` | Product / KMS config | Verify KMS cluster is reachable from testbed; check `wait-kms-cluster-ready` |
+| ESX kernel panic / storage I/O | Infra / ESX team | Include esx-host logs; escalate to storage/ESX team |
+
+---
+
+## Step 8 — Topology-specific notes
+
+| Check | VDS | NSX | NSX-VPC |
+|-------|-----|-----|---------|
+| `VirtualMachineUnmanagedVolumesBackfilled` fails | rare | 100% | 100% |
+| `OpaqueNetworkBackingInfoImpl` rejection | no | yes | yes |
+| `terminal error: network interface not ready` | no | possible | yes |
+| VM-VPC webhook errors | no | no | yes |
+| OvfEnv cloud-init SSH race | yes (no retry) | no | no |
+
+If a failure is topology-specific:
+1. Confirm topology from the job name (`prod-vmsvc-reco-vds`, `prod-vmsvc-reco-nsx`, `prod-vmsvc-reco-nsx-vpc`).
+2. Check if a `skipper.SkipUnless…` / `skipper.SkipIf…` guard is needed in the test.
+3. Apply fixes to both `vm-operator/test/e2e/vmservice/` and `vks-gce2e/test/vmservicee2e/` if the file exists in both.
+
+---
+
+## Step 9 — Write RCA and action items
+
+After identifying root cause:
+
+1. **Code fix**: patch test or operator as needed; see type-specific notes below.
+2. **Test guard**: add `skipper` call if feature/topology is unsupported.
+3. **RCA write-up**: update `triage-report-<date>.md` — add error evidence, log excerpts, affected builds, fix.
+4. **Action item**: add to Action Items table with priority (🔴/🟡/🟢), owner, and due date.
+
+---
+
+## Appendix — Type-specific fix pointers
+
+### SNAP (`VirtualMachineSnapshot` conditions=[] timeout)
+- Source: `vm_snapshot.go`
+- Check `BeforeAll` for indefinitely blocking `WaitOnVirtualMachineCondition` → add ≤ 10-min hard timeout + `Skip`.
+- Check `WaitForVMCnsRegisterVolumesRegistered` is called before any snapshot (VSLM `RegisterDisk` fails if CRV in flight).
+- Snapshot delta leaves a child disk that makes `RegisterDisk` reject with `InvalidArgument("path")`.
+
+### HW (`VirtualMachineUnmanagedVolumesBackfilled` timeout)
+- Source: `vm_hardware.go` — `Multiple VMs sharing MultiWriter PVCs`
+- `ErrPendingBackfill` exits reconcile **without requeue** — condition stuck until next spec change.
+- NSX: `terminal error: network interface not ready` → NSX SubnetPort never realized.
+- Code: `pkg/*/unmanagedvolumes_backfill.go` — condition set True only when `updatedSpec=false`.
+
+### LCM (`OpaqueNetworkBackingInfoImpl` / VM creation timeout)
+- Source: `virtualmachinelcm.go`
+- `fast-deploy: "false"` annotation forces OVF/VDCS path → VDCS rejects NSX NIC backing.
+- Add `skipper.SkipIfNetworkingIsVPC(...)` or supply VPC-compatible NIC spec.
+
+### GCUST (`VM-GUEST-CUSTOMIZATION` SSH failure)
+- VDS: `VerifyLoginAndRunCmdsInVDSSetup` has no retry — wrap in `Eventually(..., login-retry-timeout...)`.
+- `disk is not restored`: call `WaitForVMCnsRegisterVolumesRegistered` before `DeleteVMResource`.
+
+### ENCRYPT (`VM-ENCRYPTION` assertion fail — `red != green`)
+- KMS status check fails; verify KMS cluster is reachable from testbed.
+- Re-encryption tests: use `wait-encrypted-virtual-machine-powerstate` (`["10m","10s"]`), not the default 5m.
+
+### VIADM (`VI-ADMIN-RegisterVM` 409 conflict)
+- Use `Patch` with `MergeFrom(base)` instead of `Update`.
+- Remove `Eventually` wrapper hiding the 409 — `Patch` is idempotent.
+

--- a/.cursor/skills/triage-prod-vmsvc-reco/evals/trigger_eval.json
+++ b/.cursor/skills/triage-prod-vmsvc-reco/evals/trigger_eval.json
@@ -1,0 +1,41 @@
+{
+  "triggers": [
+    "triage this prod-vmsvc-reco-main pipeline",
+    "prod-vmsvc-reco-main",
+    "triage-vm-service-e2e",
+    "jenkins-vcfwcp",
+    "triage this pipeline",
+    "investigate the pipeline failure",
+    "why did the pipeline fail",
+    "what failed in the pipeline",
+    "root cause the pipeline failure",
+    "prod-vmsvc-reco-nsx failed",
+    "prod-vmsvc-reco-vds failed",
+    "prod-vmsvc-reco-nsx-vpc failed",
+    "prod-vmsvc-reco-vds-ssv failed",
+    "pipeline is failing on prod-vmsvc-reco",
+    "triage prod-vmsvc-reco-nsx",
+    "triage prod-vmsvc-reco-vds",
+    "triage prod-vmsvc-reco-nsx-vpc",
+    "triage prod-vmsvc-reco-vds-ssv",
+    "can you triage this jenkins pipeline",
+    "jenkins build failed, please triage",
+    "look into this jenkins failure",
+    "what caused the vmsvc reco pipeline to fail",
+    "investigate this jenkins build",
+    "prod-vmsvc-reco pipeline failure",
+    "all downstream jobs failed",
+    "nimbus infra failure in pipeline",
+    "testbed deploy failed in pipeline",
+    "gce2e test failure",
+    "vm service e2e pipeline triage",
+    "please triage jenkins-vcfwcp.devops.broadcom.net/job/prod-vmsvc-reco"
+  ],
+  "non_triggers": [
+    "how do I write a unit test",
+    "what is a CnsRegisterVolume",
+    "show me the controller code",
+    "fix this Go compilation error",
+    "help me understand the reconciler loop"
+  ]
+}

--- a/.cursor/skills/triage-prod-vmsvc-reco/scripts/fetch-bundle.py
+++ b/.cursor/skills/triage-prod-vmsvc-reco/scripts/fetch-bundle.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""
+fetch-bundle.py — Download and extract a WCP support bundle from Jenkins.
+
+Downloads the wcp-support-*.tar artifact for a given build, extracts only the
+master-vm-*.tgz (Supervisor VM logs + pod logs), and prints shell variables
+pointing at the vm-operator, NSX-operator, and CSI pod-log directories.
+
+Works without any third-party dependencies (stdlib only).
+Compatible with Cursor agent and Claude Code.
+
+Usage
+-----
+  python3 fetch-bundle.py <jenkins-build-url> [--out DIR]
+
+Examples
+--------
+  # VDS build
+  python3 fetch-bundle.py \
+      https://jenkins-vcfwcp.devops.broadcom.net/job/prod-vmsvc-reco-vds/1917
+
+  # NSX-VPC build, custom output dir
+  python3 fetch-bundle.py \
+      https://jenkins-vcfwcp.devops.broadcom.net/job/prod-vmsvc-reco-nsx-vpc/1317 \
+      --out /tmp/wcp-sb-vpc
+
+Authentication
+--------------
+  No auth needed for this Jenkins instance (public read access).
+  If a 401 is returned, set JENKINS_USER and JENKINS_TOKEN in the environment:
+
+      export JENKINS_USER=myuser
+      export JENKINS_TOKEN=my-api-token
+      python3 fetch-bundle.py ...
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+
+
+# ─── Jenkins URL helpers ───────────────────────────────────────────────────────
+
+_API_SUFFIX  = "/api/json?tree=artifacts[fileName,relativePath]"
+_ART_SUFFIX  = "/artifact/{rel}"
+
+
+def _curl_base() -> list[str]:
+    """Build base curl command with optional auth and silent flags."""
+    cmd = ["curl", "-sf", "--max-time", "600", "--globoff"]
+    user  = os.environ.get("JENKINS_USER", "")
+    token = os.environ.get("JENKINS_TOKEN", "")
+    if user and token:
+        cmd += ["-u", f"{user}:{token}"]
+    return cmd
+
+
+def _fetch_json(url: str) -> dict:
+    """Fetch a JSON endpoint via curl (uses system keychain for TLS)."""
+    result = subprocess.run([*_curl_base(), url], capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"ERROR: curl failed (exit {result.returncode}) for {url}", file=sys.stderr)
+        if "401" in result.stderr or "403" in result.stderr:
+            print("  Set JENKINS_USER + JENKINS_TOKEN env vars for auth.", file=sys.stderr)
+        raise SystemExit(1)
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as e:
+        print(f"ERROR: Invalid JSON from {url}: {e}", file=sys.stderr)
+        raise SystemExit(1)
+
+
+def _find_bundle_artifact(build_url: str) -> str:
+    """Return the relativePath of the wcp-support-*.tar artifact."""
+    data = _fetch_json(build_url + _API_SUFFIX)
+    for art in data.get("artifacts", []):
+        name = art["fileName"]
+        if name.startswith("wcp-support-") and name.endswith(".tar"):
+            return art["relativePath"]
+    available = [a["fileName"] for a in data.get("artifacts", [])]
+    print(f"ERROR: No wcp-support-*.tar in artifacts: {available}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+# ─── Download + extract ────────────────────────────────────────────────────────
+
+def _download(url: str, dest: Path) -> None:
+    """Download url to dest using curl with a progress bar."""
+    filename = url.rsplit("/", 1)[-1]
+    print(f"Downloading {filename} ...", flush=True)
+    cmd = [
+        *_curl_base(),
+        "--progress-bar",    # show % progress bar
+        "-o", str(dest),
+        url,
+    ]
+    # Remove -s (silent) so progress bar shows, keep -f (fail on 4xx/5xx)
+    cmd = [c for c in cmd if c != "-sf"]
+    cmd.insert(1, "-f")
+    result = subprocess.run(cmd)
+    if result.returncode != 0:
+        print(f"\nERROR: curl download failed (exit {result.returncode})", file=sys.stderr)
+        raise SystemExit(1)
+
+
+def _find_master_vm_name(tar_path: Path) -> str:
+    """Find the master-vm-*.tgz member name inside the outer tar."""
+    with tarfile.open(tar_path, "r:") as t:
+        names = [m.name for m in t.getmembers()
+                 if m.name.startswith("master-vm-") and m.name.endswith(".tgz")]
+    if not names:
+        print("ERROR: No master-vm-*.tgz found inside the bundle.", file=sys.stderr)
+        print("  Members:", file=sys.stderr)
+        with tarfile.open(tar_path, "r:") as t:
+            for m in t.getmembers()[:20]:
+                print(f"    {m.name}", file=sys.stderr)
+        raise SystemExit(1)
+    return names[0]
+
+
+def _extract_master(tar_path: Path, master_name: str, out_dir: Path) -> Path:
+    """Extract master-vm-*.tgz from the outer tar into out_dir."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    print(f"Extracting {master_name} ...", flush=True)
+
+    with tarfile.open(tar_path, "r:") as outer:
+        fobj = outer.extractfile(master_name)
+        if fobj is None:
+            print(f"ERROR: Cannot extract {master_name}", file=sys.stderr)
+            raise SystemExit(1)
+        with tarfile.open(fileobj=fobj, mode="r:gz") as inner:
+            inner.extractall(out_dir)
+
+    agents = sorted(out_dir.glob("wcp-agent-*"))
+    if not agents:
+        print(f"ERROR: No wcp-agent-* directory found in {out_dir}", file=sys.stderr)
+        raise SystemExit(1)
+    return agents[-1]
+
+
+# ─── Pretty-print env vars ─────────────────────────────────────────────────────
+
+def _first_log(pod_dir: Path, container: str = "manager") -> Path | None:
+    """Return the first *.log file in <pod_dir>/<container>/."""
+    container_dir = pod_dir / container
+    if not container_dir.exists():
+        # Try any container dir
+        subdirs = [d for d in pod_dir.iterdir() if d.is_dir()]
+        if subdirs:
+            container_dir = subdirs[0]
+        else:
+            return None
+    logs = sorted(container_dir.glob("*.log"))
+    return logs[0] if logs else None
+
+
+def _print_env(agent_dir: Path) -> None:
+    """Print copy-paste shell variables for the triage debugging workflow."""
+    pods = agent_dir / "var" / "log" / "pods"
+    if not pods.exists():
+        print(f"WARNING: {pods} does not exist", file=sys.stderr)
+        return
+
+    pod_dirs = sorted(pods.iterdir())
+
+    vmop = next((p for p in pod_dirs if "vmware-system-vmop" in p.name), None)
+    nsx  = next((p for p in pod_dirs if "vmware-system-nsx-operator" in p.name), None)
+    csi  = next((p for p in pod_dirs if "vmware-system-csi" in p.name), None)
+
+    print("\n" + "─" * 60)
+    print("# Paste into your shell to start debugging:\n")
+    print(f'SB="{agent_dir}"')
+
+    if vmop:
+        log = _first_log(vmop)
+        # Decompress any rotated .log.gz files if present
+        gz_files = list((vmop / "manager" if (vmop / "manager").exists() else vmop).glob("*.log.*.gz"))
+        if gz_files:
+            print(f'# Rotated logs found — decompress with:')
+            print(f'#   gunzip "{vmop}/manager/"*.log.*.gz 2>/dev/null || true')
+        print(f'VMOP_LOG="{log}"' if log else f'VMOP_POD="{vmop}"')
+    else:
+        print("# WARNING: No vmware-system-vmop pod log found")
+
+    if nsx:
+        print(f'NSX_POD="{nsx}"')
+    if csi:
+        print(f'CSI_POD="{csi}"')
+
+    print()
+    print("# ── Suggested searches ───────────────────────────────")
+    if vmop and _first_log(vmop):
+        print(f'# SNAP: rg "VirtualMachineSnapshot|hasPendingCRVs|snapshot" "$VMOP_LOG" | head -40')
+        print(f'# HW:   rg "terminal error|ErrPendingBackfill|UnmanagedVolumes" "$VMOP_LOG" | head -40')
+        print(f'# LCM:  rg "OpaqueNetwork|InvalidArgument|deployOVF" "$VMOP_LOG" | head -40')
+    if nsx:
+        print(f'# NSX:  rg "SubnetPortNotReady|empty NSX resource" "$NSX_POD"/*/0.log | head -20')
+    print("─" * 60)
+
+
+# ─── Main ──────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument(
+        "build_url",
+        help="Jenkins build URL, e.g. https://.../job/prod-vmsvc-reco-vds/1917",
+    )
+    ap.add_argument(
+        "--out",
+        default="/tmp/wcp-sb",
+        metavar="DIR",
+        help="Directory to extract into (default: /tmp/wcp-sb)",
+    )
+    ap.add_argument(
+        "--keep-tar",
+        action="store_true",
+        help="Keep the downloaded .tar file instead of deleting it after extraction",
+    )
+    args = ap.parse_args()
+
+    build_url = args.build_url.rstrip("/")
+    out_dir   = Path(args.out)
+
+    # 1. Find the artifact
+    rel_path     = _find_bundle_artifact(build_url)
+    artifact_url = build_url + _ART_SUFFIX.format(rel=rel_path)
+    print(f"Found:  {rel_path}")
+
+    # 2. Download to a temp file
+    with tempfile.NamedTemporaryFile(suffix=".tar", delete=False,
+                                     dir=out_dir.parent if out_dir.parent.exists() else None) as tmp:
+        tmp_path = Path(tmp.name)
+
+    try:
+        _download(artifact_url, tmp_path)
+
+        # 3. Find master-vm-*.tgz inside
+        master_name = _find_master_vm_name(tmp_path)
+
+        # 4. Extract master-vm-*.tgz into out_dir
+        agent_dir = _extract_master(tmp_path, master_name, out_dir)
+
+    finally:
+        if not args.keep_tar:
+            tmp_path.unlink(missing_ok=True)
+
+    print(f"\nExtracted to: {agent_dir}")
+    _print_env(agent_dir)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/.cursor/skills/triage-prod-vmsvc-reco/scripts/fetch-gce2e-logs.py
+++ b/.cursor/skills/triage-prod-vmsvc-reco/scripts/fetch-gce2e-logs.py
@@ -1,0 +1,513 @@
+#!/usr/bin/env python3
+"""
+fetch-gce2e-logs.py — Collect gce2e failure data for a pipeline build.
+
+Given a prod-vmsvc-reco-* Jenkins build URL, this script:
+  1. Reads the pipeline console to find the downstream gce2e build number.
+  2. Downloads the JUnit XML and parses every failing test with its actual time.
+  3. Looks up the configured timeout for each failure from wcp.yaml.
+  4. Downloads the targeted vm-operator log for each failing test suite.
+  5. Prints a structured triage summary including:
+     - Failure category (EXACT_TIMEOUT / ASSERTION_FAIL / INFRA_ERROR)
+     - The relevant wcp.yaml interval key and configured timeout
+     - Recommendation: operator-log-only vs full-support-bundle vs escalate
+
+Usage
+-----
+  python3 fetch-gce2e-logs.py <pipeline-build-url> [--out DIR] [--wcp-yaml PATH]
+
+Examples
+--------
+  python3 fetch-gce2e-logs.py \
+      https://jenkins-vcfwcp.devops.broadcom.net/job/prod-vmsvc-reco-vds/1917
+
+  python3 fetch-gce2e-logs.py \
+      https://jenkins-vcfwcp.devops.broadcom.net/job/prod-vmsvc-reco-nsx-vpc/1317 \
+      --out /tmp/gce2e-debug --wcp-yaml ~/Documents/personal/vm-operator/test/e2e/vmservice/config/wcp.yaml
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+# ─── WCP.YAML built-in defaults (from test/e2e/vmservice/config/wcp.yaml) ────
+
+WCP_INTERVALS: dict[str, tuple[str, str]] = {
+    "wait-virtual-machine-creation":                 ("5m",  "10s"),
+    "wait-virtual-machine-deletion":                 ("5m",  "10s"),
+    "wait-virtual-machine-condition-update":         ("5m",  "10s"),
+    "wait-virtual-machine-powerstate":               ("5m",  "10s"),
+    "wait-virtual-machine-resize":                   ("5m",  "10s"),
+    "wait-virtual-machine-moid":                     ("5m",  "10s"),
+    "wait-virtual-machine-restart-mode-update":      ("2m",  "10s"),
+    "wait-virtual-machine-vmip":                     ("5m",  "10s"),
+    "wait-virtual-machine-image-creation":           ("10m", "5s"),
+    "consistent-virtual-machine-condition":          ("30s", "5s"),
+    "wait-virtual-machine-annotation-update":        ("30s", "5s"),
+    "wait-virtual-machine-group-deletion":           ("60s", "5s"),
+    "wait-virtual-machine-group-condition-update":   ("6m",  "5s"),
+    "wait-virtual-machine-snapshot-condition":       ("10m", "5s"),
+    "wait-virtual-machine-snapshot-deletion":        ("60s", "2s"),
+    "wait-virtual-machine-snapshot-quota-usage":     ("60s", "5s"),
+    "wait-virtual-machine-snapshot-related-resource":("60s", "5s"),
+    "wait-virtual-machine-snapshot-revert":          ("5m",  "5s"),
+    "wait-virtual-machine-snapshot-update":          ("5m",  "5s"),
+    "wait-virtual-machine-web-console-request-creation": ("30s", "5s"),
+    "wait-virtual-machine-cns-node-batch-attachment-creation": ("10m", "5s"),
+    "wait-virtual-machine-cns-node-batch-attachment-deletion": ("5m", "5s"),
+    "wait-content-library-name":                     ("2m",  "5s"),
+    "wait-storage-class-ready":                      ("5m",  "15s"),
+    "wait-namespace-ready":                          ("5m",  "10s"),
+    "wait-kms-cluster-ready":                        ("2m",  "5s"),
+    "wait-backup-to-complete":                       ("10m", "5s"),
+    "wait-virtual-machine-compute-policy-status-update": ("5m", "10s"),
+    "wait-policy-evaluation-creation":               ("3m",  "10s"),
+    "wait-policy-evaluation-compliant":              ("2m",  "10s"),
+    "wait-policy-evaluation-update":                 ("3m",  "10s"),
+    "wait-config-map-creation":                      ("3m",  "10s"),
+    "wait-secret-creation":                          ("3m",  "10s"),
+    "wait-pod-ready":                                ("2m",  "10s"),
+    "login-retry-timeout":                           ("5m",  "10s"),
+    "wait-subnet-creation":                          ("2m",  "10s"),
+    "wait-subnet-deletion":                          ("6m",  "10s"),
+    "wait-security-policy-creation":                 ("2m",  "10s"),
+    "wait-pvc-attachment":                           ("5m",  "10s"),
+    "wait-pvc-deletion":                             ("2m",  "5s"),
+    "wait-jumpbox-sshpass-ready":                    ("30m", "10s"),
+}
+
+
+def _parse_duration(s: str) -> float:
+    """Convert wcp.yaml duration string like '10m' or '30s' to seconds."""
+    s = s.strip()
+    if s.endswith("m"):
+        return float(s[:-1]) * 60
+    if s.endswith("s"):
+        return float(s[:-1])
+    return float(s)
+
+
+def _load_wcp_yaml(path: Path) -> dict[str, tuple[str, str]]:
+    """Load wcp.yaml intervals section; fall back to built-in defaults."""
+    if not path.exists():
+        return WCP_INTERVALS
+
+    result = dict(WCP_INTERVALS)
+    try:
+        import yaml  # type: ignore
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        for key, val in (data or {}).get("intervals", {}).items():
+            short_key = key.split("/", 1)[-1]
+            if isinstance(val, list) and len(val) == 2:
+                result[short_key] = (str(val[0]), str(val[1]))
+    except Exception:
+        pass
+    return result
+
+
+# ─── Timeout inference: test name → interval key ─────────────────────────────
+
+_TIMEOUT_HINTS: list[tuple[str, str]] = [
+    # pattern in test name (lowercase)        →  interval key
+    ("snapshot",                              "wait-virtual-machine-snapshot-condition"),
+    ("powerstate",                            "wait-virtual-machine-powerstate"),
+    ("powered on",                            "wait-virtual-machine-powerstate"),
+    ("power on",                              "wait-virtual-machine-powerstate"),
+    ("create.*vm|vm.*create|single virtual",  "wait-virtual-machine-creation"),
+    ("vmip|ip address",                       "wait-virtual-machine-vmip"),
+    ("hardware version|multiwriter",          "wait-virtual-machine-condition-update"),
+    ("backfilled|unmanagedvolume",            "wait-virtual-machine-condition-update"),
+    ("customization|ovfenv|linuxprep",        "login-retry-timeout"),
+    ("ssh|helloworld",                        "login-retry-timeout"),
+    ("resize",                                "wait-virtual-machine-resize"),
+    ("moid",                                  "wait-virtual-machine-moid"),
+    ("publish",                               "wait-virtual-machine-publish-request-condition"),
+    ("backup",                                "wait-backup-to-complete"),
+    ("encryption|encrypted|encrypt",         "wait-virtual-machine-powerstate"),
+    ("pvc|cns|storage",                       "wait-pvc-attachment"),
+    ("image",                                 "wait-virtual-machine-image-creation"),
+]
+
+
+def _infer_interval(test_name: str) -> str | None:
+    name_lower = test_name.lower()
+    for pattern, key in _TIMEOUT_HINTS:
+        if re.search(pattern, name_lower):
+            return key
+    return None
+
+
+# ─── Failure classification ────────────────────────────────────────────────────
+
+def _classify_failure(message: str, actual_s: float,
+                      interval: tuple[str, str] | None) -> tuple[str, str]:
+    """
+    Return (category, recommendation) where category is one of:
+      EXACT_TIMEOUT      — hit the configured Eventually() timeout
+      ASSERTION_FAIL     — returned wrong value (assertion mismatch)
+      INFRA_ERROR        — infra-level error (OVA, SSH, MethodFault, etc.)
+      HANG               — no configured timeout but very long run
+    """
+    msg = message.lower() if message else ""
+
+    # Hard infra signals
+    if any(x in msg for x in ["methodfault", "ova", "import", "transferring file",
+                               "internalservererror", "gitclone", "checkout"]):
+        return ("INFRA_ERROR",
+                "ESCALATE — Infrastructure failure; requires Nimbus/testbed team intervention. "
+                "Check Nimbus log URI. No support bundle needed.")
+
+    if "ssh" in msg or "exit error" in msg or "/helloworld" in msg:
+        return ("INFRA_ERROR",
+                "ESCALATE — SSH/cloud-init race condition. May be a flake or need test fix (add retry). "
+                "No support bundle needed for initial triage.")
+
+    if "timed out" in msg or "timeout" in msg:
+        if interval:
+            configured_s = _parse_duration(interval[0])
+            delta = abs(actual_s - configured_s)
+            if delta <= 15:
+                return ("EXACT_TIMEOUT",
+                        "Deep dive — vm-operator log (already in gce2e artifacts). "
+                        "Check what condition is stuck. Support bundle only if operator log is unclear.")
+            if actual_s > configured_s * 1.5:
+                return ("HANG",
+                        "ESCALATE — test ran much longer than configured timeout. "
+                        "Possible missing hard timeout guard in BeforeAll. "
+                        "Check if pipeline was blocked for 21+ hours.")
+        return ("EXACT_TIMEOUT",
+                "Deep dive — vm-operator log (already in gce2e artifacts).")
+
+    if any(x in msg for x in ["expected\n", "to equal", "to be true", "to be false",
+                               "managedentitystatus", "red", "green"]):
+        return ("ASSERTION_FAIL",
+                "Check test source + vm-operator log. Usually a product state mismatch. "
+                "Support bundle only if operator log shows no reconcile errors.")
+
+    if "nil pointer" in msg or "panic" in msg:
+        return ("ASSERTION_FAIL",
+                "Nil pointer / panic in test or operator. Check operator log for stack trace. "
+                "Support bundle if panic is in operator process.")
+
+    if "409" in msg or "conflict" in msg:
+        return ("ASSERTION_FAIL",
+                "Resource conflict (409). Test is using Update instead of Patch. "
+                "No support bundle needed — fix test code.")
+
+    return ("UNKNOWN", "Inspect operator log. Support bundle if condition stuck.")
+
+
+# ─── HTTP helper (curl-based for internal TLS) ───────────────────────────────
+
+def _curl(*args: str, output_file: str | None = None) -> str:
+    cmd = ["curl", "-sf", "--max-time", "120", "--globoff"]
+    user  = os.environ.get("JENKINS_USER", "")
+    token = os.environ.get("JENKINS_TOKEN", "")
+    if user and token:
+        cmd += ["-u", f"{user}:{token}"]
+    cmd.extend(args)
+    if output_file:
+        cmd += ["-o", output_file]
+        r = subprocess.run(cmd)
+        if r.returncode != 0:
+            raise RuntimeError(f"curl failed: {' '.join(args)}")
+        return ""
+    r = subprocess.run(cmd, capture_output=True, text=True)
+    if r.returncode != 0:
+        raise RuntimeError(f"curl failed (exit {r.returncode}): {' '.join(args)}\n{r.stderr}")
+    return r.stdout
+
+
+def _fetch_json(url: str) -> dict:
+    return json.loads(_curl(url))
+
+
+# ─── Jenkins helpers ──────────────────────────────────────────────────────────
+
+_GCE2E_BUILD_RE = re.compile(
+    r"run-guest-clusters-end-to-end-tests\s+#(\d+)"
+)
+_NIMBUS_LOG_RE = re.compile(r"resultsDir\s+([^\s\"']+)")
+
+
+def _find_gce2e_build(console: str) -> str | None:
+    matches = _GCE2E_BUILD_RE.findall(console)
+    return matches[-1] if matches else None
+
+
+def _find_nimbus_log_uri(console: str) -> str | None:
+    """Return the Nimbus log directory path from the pipeline console."""
+    m = re.search(r"resultsDir\s+['\"]?(/cpbu/logs/[^\s\"']+)['\"]?", console)
+    if m:
+        base = m.group(1)
+        # Convert to HTTP URL format
+        return base.replace(
+            "/cpbu/logs/user-logs/wcp-butler",
+            "https://uts-logs.lvn.broadcom.net/user-logs/wcp-butler"
+        )
+    return None
+
+
+# ─── JUnit parsing ────────────────────────────────────────────────────────────
+
+class TestFailure:
+    def __init__(self, classname: str, name: str, time_s: float,
+                 message: str, suite_tag: str):
+        self.classname  = classname
+        self.name       = name
+        self.time_s     = time_s
+        self.message    = message
+        self.suite_tag  = suite_tag
+
+
+def _parse_junit(xml_text: str) -> list[TestFailure]:
+    root = ET.fromstring(xml_text)
+    failures: list[TestFailure] = []
+    for tc in root.iter("testcase"):
+        fail_nodes = list(tc.iter("failure")) + list(tc.iter("error"))
+        if not fail_nodes:
+            continue
+        name      = tc.get("name", "")
+        classname = tc.get("classname", "")
+        time_s    = float(tc.get("time", "0"))
+        message   = (fail_nodes[0].text or "").strip()[:400]
+        suite_tag = _test_to_suite_tag(name)
+        failures.append(TestFailure(classname, name, time_s, message, suite_tag))
+    return failures
+
+
+_TEST_SUITE_MAP: list[tuple[str, str]] = [
+    # pattern in test name (lowercase)   →  gce2e artifact test_logs dir
+    ("vm-snapshot|vmsnapshot|snapshot",    "v1alpha5-vmsnapshot"),
+    ("vm-encryption|encrypt",             "vm-encryption"),
+    ("vm-lcm|vm-lifecycle|lifecycle",     "vm-lcm"),
+    ("vm-hardware|multiwriter|hardware",  "vm-hardware"),
+    ("vm-guest-customization|ovfenv|linuxprep|customiz", "vm-guest-customization"),
+    ("vi-admin|registervm|register",      "vm-networking"),
+    ("vm-group",                          "vm-group"),
+    ("vm-longevity",                      "vm-longevity"),
+    ("vm-networking",                     "vm-networking"),
+    ("vm-web-console",                    "vm-web-console"),
+    ("vmpub|publish",                     "vmpub"),
+]
+
+
+def _test_to_suite_tag(name: str) -> str:
+    lower = name.lower()
+    for pattern, tag in _TEST_SUITE_MAP:
+        if re.search(pattern, lower):
+            return tag
+    return "unknown"
+
+
+# ─── gce2e artifact downloader ───────────────────────────────────────────────
+
+_GCE2E_BASE = "https://jenkins-vcfwcp.devops.broadcom.net/job/run-guest-clusters-end-to-end-tests"
+_JUNIT_REL  = "test_logs/junit_vmservice.xml"
+_VMOP_LOG_PATTERN = re.compile(r"logs-vmware-system-vmop-controller-manager.*manager\.log")
+
+
+def _download_gce2e_artifacts(gce2e_build: str, out_dir: Path) -> dict[str, Path]:
+    """
+    Download JUnit XML and per-suite vm-operator logs from the gce2e build.
+    Returns {artifact_relative_path: local_path}.
+    """
+    base = f"{_GCE2E_BASE}/{gce2e_build}"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # 1. artifact list
+    artifacts_data = _fetch_json(f"{base}/api/json?tree=artifacts[fileName,relativePath]")
+    artifacts = artifacts_data.get("artifacts", [])
+
+    downloaded: dict[str, Path] = {}
+
+    # 2. JUnit XML
+    junit_path = out_dir / "junit_vmservice.xml"
+    print(f"  Downloading junit_vmservice.xml ...", flush=True)
+    _curl(f"{base}/artifact/{_JUNIT_REL}", output_file=str(junit_path))
+    downloaded[_JUNIT_REL] = junit_path
+
+    # 3. Per-suite vm-operator logs
+    for art in artifacts:
+        rel = art["relativePath"]
+        if "test_logs" in rel and _VMOP_LOG_PATTERN.search(art["fileName"]):
+            # e.g. test/vmservicee2e/test_logs/v1alpha5-vmsnapshot/logs-vmware-system-vmop-*.log
+            parts = rel.split("/")
+            suite = parts[3] if len(parts) >= 4 else "unknown"
+            dest  = out_dir / suite / art["fileName"]
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            print(f"  Downloading {suite}/{art['fileName']} ...", flush=True)
+            _curl(f"{base}/artifact/{rel}", output_file=str(dest))
+            downloaded[rel] = dest
+
+    return downloaded
+
+
+# ─── Main output ──────────────────────────────────────────────────────────────
+
+def _format_duration(s: float) -> str:
+    if s >= 60:
+        return f"{s / 60:.1f}m"
+    return f"{s:.0f}s"
+
+
+def _print_triage(failures: list[TestFailure],
+                  intervals: dict[str, tuple[str, str]],
+                  downloaded: dict[str, Path],
+                  gce2e_url: str,
+                  nimbus_log_uri: str | None) -> None:
+    sep = "─" * 70
+
+    print(f"\n{sep}")
+    print(f"gce2e build: {gce2e_url}")
+    if nimbus_log_uri:
+        print(f"Nimbus logs: {nimbus_log_uri}")
+    print(f"\n{len(failures)} failing test(s)\n")
+
+    for i, f in enumerate(failures, 1):
+        interval_key = _infer_interval(f.name)
+        interval     = intervals.get(interval_key, None) if interval_key else None
+        cat, rec     = _classify_failure(f.message, f.time_s, interval)
+
+        # vm-operator log for this suite
+        vmop_log: Path | None = None
+        for rel, path in downloaded.items():
+            if f.suite_tag in rel and "manager.log" in rel:
+                vmop_log = path
+                break
+
+        print(f"[{i}] {f.name[:80]}")
+        print(f"     Suite tag   : {f.suite_tag}")
+        print(f"     Actual time : {_format_duration(f.time_s)}")
+
+        if interval_key and interval:
+            configured_s = _parse_duration(interval[0])
+            print(f"     wcp.yaml    : {interval_key}: {interval[0]} poll={interval[1]}"
+                  f"  (={configured_s:.0f}s)")
+        elif interval_key:
+            print(f"     wcp.yaml    : {interval_key} (not found in config)")
+
+        cat_icon = {"EXACT_TIMEOUT": "⏱", "ASSERTION_FAIL": "❌",
+                    "INFRA_ERROR": "🔧", "HANG": "🔴", "UNKNOWN": "❓"}.get(cat, "?")
+        print(f"     Category    : {cat_icon} {cat}")
+        print(f"     Recommend   : {rec}")
+
+        if vmop_log:
+            print(f"     vm-op log   : {vmop_log}")
+
+        # Error snippet
+        if f.message:
+            snippet = f.message[:200].replace("\n", " ↵ ")
+            print(f"     Error msg   : {snippet}")
+        print()
+
+    print(sep)
+
+    # Quick search hints
+    print("\n# Next steps — copy-paste into your shell:\n")
+    for i, f in enumerate(failures, 1):
+        vmop_log = next(
+            (p for rel, p in downloaded.items()
+             if f.suite_tag in rel and "manager.log" in rel),
+            None
+        )
+        if vmop_log:
+            # Extract VM name hint from test name (short random suffix)
+            cat, _ = _classify_failure(f.message, f.time_s, None)
+            if cat == "EXACT_TIMEOUT":
+                print(f"# [{i}] {f.suite_tag} — scan operator log for stuck condition:")
+                print(f'rg "terminal error|Reconciler error|conditions: \\[\\]" "{vmop_log}" | tail -30')
+                print()
+            elif cat == "ASSERTION_FAIL":
+                print(f"# [{i}] {f.suite_tag} — check operator log for mismatch signal:")
+                print(f'rg "Reconciler error|terminal error" "{vmop_log}" | tail -20')
+                print()
+
+    print(sep)
+    print("\n# Support bundle decision guide:")
+    print("  EXACT_TIMEOUT → download support bundle (fetch-bundle.py) only if operator log is unclear")
+    print("  ASSERTION_FAIL → check test source code first; support bundle rarely needed")
+    print("  INFRA_ERROR    → ESCALATE; do NOT dig into support bundle")
+    print("  HANG           → ESCALATE; confirm with pipeline team about missing BeforeAll guard")
+
+
+# ─── Main ──────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument(
+        "build_url",
+        help="Pipeline Jenkins build URL, e.g. https://.../job/prod-vmsvc-reco-vds/1917",
+    )
+    ap.add_argument(
+        "--out",
+        default="/tmp/gce2e-debug",
+        metavar="DIR",
+        help="Directory to store downloaded artifacts (default: /tmp/gce2e-debug)",
+    )
+    ap.add_argument(
+        "--wcp-yaml",
+        default=str(Path.home() / "Documents/personal/vm-operator/test/e2e/vmservice/config/wcp.yaml"),
+        metavar="PATH",
+        help="Path to wcp.yaml for timeout lookup",
+    )
+    args = ap.parse_args()
+
+    build_url = args.build_url.rstrip("/")
+    out_dir   = Path(args.out)
+    wcp_path  = Path(args.wcp_yaml).expanduser()
+
+    # 1. Load timeout config
+    intervals = _load_wcp_yaml(wcp_path)
+    print(f"Loaded {len(intervals)} intervals from wcp.yaml", flush=True)
+
+    # 2. Fetch pipeline console to find gce2e build number
+    print(f"Fetching pipeline console for {build_url} ...", flush=True)
+    console = _curl(f"{build_url}/consoleText")
+    nimbus_uri = _find_nimbus_log_uri(console)
+
+    gce2e_build = _find_gce2e_build(console)
+    if not gce2e_build:
+        print("ERROR: No run-guest-clusters-end-to-end-tests build found in console.", file=sys.stderr)
+        print("  This build may be INFRA-only (testbed creation / Git checkout failure).", file=sys.stderr)
+        if nimbus_uri:
+            print(f"  Nimbus log: {nimbus_uri}", file=sys.stderr)
+        raise SystemExit(1)
+
+    gce2e_url = f"{_GCE2E_BASE}/{gce2e_build}"
+    print(f"Found gce2e build: {gce2e_url}", flush=True)
+
+    # 3. Download JUnit + per-suite operator logs
+    print(f"Downloading gce2e artifacts → {out_dir}", flush=True)
+    downloaded = _download_gce2e_artifacts(gce2e_build, out_dir)
+
+    # 4. Parse JUnit
+    junit_path = out_dir / "junit_vmservice.xml"
+    if not junit_path.exists():
+        print("ERROR: junit_vmservice.xml not found.", file=sys.stderr)
+        raise SystemExit(1)
+
+    failures = _parse_junit(junit_path.read_text())
+    if not failures:
+        print("No test failures found in JUnit XML — all tests passed.")
+        raise SystemExit(0)
+
+    # 5. Print triage summary
+    _print_triage(failures, intervals, downloaded, gce2e_url, nimbus_uri)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Adds the `triage-prod-vmsvc-reco` Claude Code skill to the repo so any team member can run it directly from the project.

The skill automates prod-vmsvc-reco-* pipeline triage in two phases:
1. **Summary phase** — fetches gce2e JUnit XML + per-suite vm-operator logs, classifies every failure (⏱ TIMEOUT / ❌ ASSERTION / 🔧 INFRA), collapses cross-topology duplicates into a single table, then stops and asks which failure(s) to investigate.
2. **Deep-dive phase** — timeline analysis on the operator log, support bundle download, and RCA write-up, triggered only for the failure(s) the engineer picks.

**Usage:**

```
/triage-prod-vmsvc-reco https://jenkins-vcfwcp.devops.broadcom.net/job/prod-vmsvc-reco-main/<BUILD>/
```

**Example output** (prod-vmsvc-reco-main #2207, ~$0.50 in Claude API usage):

```
Pipeline: prod-vmsvc-reco-main #2207
Topologies: VDS · VDS-SSV · NSX-VPC   Total gce2e failures: 17

PRODUCT failures (cross-topology):
#1  v1alpha5-vmsnapshot  ⏱ TIMEOUT  ~10m55s / 10m  VDS · VDS-SSV · NSX-VPC
    "Timed out waiting for VirtualMachineSnapshot to be ready, current conditions: []"
#2  v1alpha5-vmsnapshot  ⏱ TIMEOUT  ~10m50s / 10m  VDS · VDS-SSV · NSX-VPC
    "Timed out waiting for VirtualMachineSnapshot to be ready, current conditions: []"
#3  vm-encryption        ❌ ASSERT   4m36s / 5m     VDS only
    "PersistentVolumeClaims not all in phase Bound within 3m0s"

INFRA flakes (Nimbus — no tests ran):
NSX #1121, NSX-VPC #1318 → result:INVALID-I, failed_component:nimbus

Cross-topology verdict: snapshot timeout (#1, #2) hit all 3 testbeds — product bug, not flake.
NSX-VPC had broad testbed instability (Subnet creation, web-console API) unrelated to product.

Which failure(s) should I investigate?
```

**Files:**
- `SKILL.md` — two-phase workflow definition
- `scripts/fetch-gce2e-logs.py` — downloads JUnit XML + targeted vm-operator logs per suite
- `scripts/fetch-bundle.py` — downloads WCP support bundle when operator log is insufficient
- `evals/trigger_eval.json` — eval harness trigger config

**Are there any special notes for your reviewer**:

Skills live in `.cursor/skills/` and are only invoked by engineers running Claude Code locally — no runtime dependency on production code.

**Please add a release note if necessary**:

```release-note
NONE
```