### PR TITLE
🐛 Fix imageNames empty strings race in VMGPR

### DIFF
--- a/controllers/virtualmachinegrouppublishrequest/virtualmachinegrouppublishrequest_controller.go
+++ b/controllers/virtualmachinegrouppublishrequest/virtualmachinegrouppublishrequest_controller.go
@@ -227,7 +227,7 @@ func (r *Reconciler) getVMPublishRequests(
 	for _, req := range reqs.Items {
 		if metav1.IsControlledBy(&req, ctx.VMGroupPublishRequest) {
 			existReqsMap[req.Spec.Source.Name] = req
-			if req.Status.Ready {
+			if req.Status.Ready && req.Status.ImageName != "" {
 				completedReqsSet.Insert(req.Spec.Source.Name)
 			} else {
 				pendingReqsSet.Insert(req.Spec.Source.Name)

--- a/controllers/virtualmachinegrouppublishrequest/virtualmachinegrouppublishrequest_controller_intg_test.go
+++ b/controllers/virtualmachinegrouppublishrequest/virtualmachinegrouppublishrequest_controller_intg_test.go
@@ -91,6 +91,7 @@ func intgTestsReconcile() {
 	setVMPubReqCompleted := func(vmPubReq *vmopv1.VirtualMachinePublishRequest) {
 		_, err := controllerutil.CreateOrPatch(ctx, ctx.Client, vmPubReq, func() error {
 			vmPubReq.Status.Ready = true
+			vmPubReq.Status.ImageName = vmPubReq.Spec.Target.Item.Name
 			return nil
 		})
 		Expect(err).ToNot(HaveOccurred())

--- a/controllers/virtualmachinegrouppublishrequest/virtualmachinegrouppublishrequest_controller_unit_test.go
+++ b/controllers/virtualmachinegrouppublishrequest/virtualmachinegrouppublishrequest_controller_unit_test.go
@@ -177,6 +177,24 @@ func unitTestsReconcile() {
 			})
 		})
 
+		When("a vm publish request has Ready=true but empty ImageName", func() {
+			It("should count it as pending, not completed", func() {
+				// First reconcile creates the vm publish requests.
+				Expect(reconciler.ReconcileNormal(vmpGroupPubReqCtx)).To(Succeed())
+				reqs := getVMPublishRequests(vmGroupPubReq, reconciler, len(vmGroupPubReq.Spec.VirtualMachines))
+
+				// Simulate race condition: Ready=true but ImageName not yet populated.
+				reqs[0].Status.Ready = true
+				reqs[0].Status.ImageName = ""
+				Expect(ctx.Client.Status().Update(ctx, &reqs[0])).To(Succeed())
+
+				// Second reconcile: request with Ready=true but no ImageName should
+				// still count as pending, not completed.
+				Expect(reconciler.ReconcileNormal(vmpGroupPubReqCtx)).To(Succeed())
+				verifyFalseCondition(Default, vmGroupPubReq, len(vmGroupPubReq.Spec.VirtualMachines))
+			})
+		})
+
 		When("vm group publish request is completed", func() {
 			BeforeEach(func() {
 				conditions.MarkTrue(vmGroupPubReq, vmopv1.VirtualMachineGroupPublishRequestConditionComplete)


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

The VirtualMachineGroupPublishRequest (VMGPR) controller was triggered to reconcile by the first of the child
VirtualMachinePublishRequest's (VMPR) patch operations, which writes status.conditions with Ready=true.
Because the parent reads child objects via apiReader, it could observe the child after that first patch but before the child controller had committed the the ImageName on a subsequent patch operation.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # vmop-3627179

**Are there any special notes for your reviewer**:

**Please add a release note if necessary**:

```release-note
Addresses race condition on Virtual Machine Group Publish Request can read child objects with empty strings on imageNames
```