### PR TITLE
Fix e2e Dockerfile to use 7zip for zip extraction

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -68,6 +68,7 @@ LABEL branch="${BUILD_BRANCH}" \
 # consistency guarantee, causing libcap dependency conflicts.
 # To pick up OS security patches, bump the BASE_IMAGE tag instead.
 RUN tdnf install -y \
+        7zip \
         bash \
         coreutils \
         curl \
@@ -93,17 +94,7 @@ RUN curl -fsSL "${GOVC_DOWNLOAD_URL}" | tar -xz -C /usr/local/bin govc && \
 ARG PACKER_DOWNLOAD_URL=https://releases.hashicorp.com/packer/1.9.1/packer_1.9.1_linux_amd64.zip
 RUN curl -fsSL "${PACKER_DOWNLOAD_URL}" -o /tmp/packer.zip
 
-# if 7zip is available, prefer to use it
-# otherwise fallback to unzip. Remove after using it
-RUN if tdnf info 7zip > /dev/null 2>&1; then \
-        tdnf install -y 7zip && \
-        7z x /tmp/packer.zip -o/tmp/packer packer -y && \
-        tdnf remove -y 7zip; \
-    else \
-        tdnf install -y unzip && \
-        unzip /tmp/packer.zip packer -d /tmp/packer && \
-        tdnf remove -y unzip; \
-    fi
+RUN 7z x /tmp/packer.zip -o/tmp/packer packer -y
 
 RUN mv /tmp/packer/packer /usr/local/bin/packer && \
     chmod 0755 /usr/local/bin/packer && \

--- a/hack/e2e/setup-testbed-env.sh
+++ b/hack/e2e/setup-testbed-env.sh
@@ -384,7 +384,16 @@ _setup_kubectl_vsphere() {
 
     mkdir -p "${extract_dir}"
     local unzip_out
-    if ! unzip_out=$(unzip -o vsphere-plugin.zip -d "${extract_dir}" 2>&1); then
+    if command -v 7z &>/dev/null; then
+        unzip_out=$(7z x vsphere-plugin.zip -o"${extract_dir}" -y 2>&1)
+    elif command -v unzip &>/dev/null; then
+        unzip_out=$(unzip -o vsphere-plugin.zip -d "${extract_dir}" 2>&1)
+    else
+        rm -f vsphere-plugin.zip
+        _err "Failed to unzip kubectl-vsphere plugin: neither 7z nor unzip is available"
+        return 1
+    fi
+    if [[ ${?} -ne 0 ]]; then
         local zip_size
         zip_size=$(wc -c < vsphere-plugin.zip 2>/dev/null || echo "unknown")
         rm -f vsphere-plugin.zip


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

The e2e Docker image was failing to install `kubectl-vsphere` at runtime because `unzip` was not available. The prior Dockerfile logic installed `unzip` (or `7zip`) transiently to extract the packer binary, then removed it — leaving no zip extraction tool available when `setup-testbed-env.sh` later needs to unzip the `kubectl-vsphere` plugin.

This PR:
- Installs `7zip` permanently in the e2e Docker image (Photon 5 prefers `7zip` over `unzip`)
- Removes the conditional install/remove dance for packer extraction, replacing it with a direct `7z x` call
- Updates `setup-testbed-env.sh` to prefer `7z` when available and fall back to `unzip`, so the script works both inside the Docker image and on macOS

Fixes the runtime error:
```
Error: Failed to unzip kubectl-vsphere plugin: ./hack/e2e/setup-testbed-env.sh: line 387: unzip: command not found
```

**Which issue(s) is/are addressed by this PR?** *(optional)*:

Fixes #


**Are there any special notes for your reviewer**:

This builds on the approach introduced in 8cc69df (prefer 7zip over unzip in Dockerfile), completing it by also updating the runtime script and making 7zip a permanent install rather than a transient one.

**Please add a release note if necessary**:

```release-note
NONE
```