### PR TITLE
Reinstate E2E Dockerfile to condition use 7zip instead of unzip

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -68,7 +68,6 @@ LABEL branch="${BUILD_BRANCH}" \
 # consistency guarantee, causing libcap dependency conflicts.
 # To pick up OS security patches, bump the BASE_IMAGE tag instead.
 RUN tdnf install -y \
-        7zip \
         bash \
         coreutils \
         curl \
@@ -94,7 +93,16 @@ RUN curl -fsSL "${GOVC_DOWNLOAD_URL}" | tar -xz -C /usr/local/bin govc && \
 ARG PACKER_DOWNLOAD_URL=https://releases.hashicorp.com/packer/1.9.1/packer_1.9.1_linux_amd64.zip
 RUN curl -fsSL "${PACKER_DOWNLOAD_URL}" -o /tmp/packer.zip
 
-RUN 7z x /tmp/packer.zip -o/tmp/packer packer -y
+# if 7zip is available, prefer to use it
+# otherwise fallback to unzip.
+# Certain Photon5 images versions do not have it
+RUN if tdnf info 7zip > /dev/null 2>&1; then \
+        tdnf install -y 7zip && \
+        7z x /tmp/packer.zip -o/tmp/packer packer -y; \
+    else \
+        tdnf install -y unzip && \
+        unzip /tmp/packer.zip packer -d /tmp/packer; \
+    fi
 
 RUN mv /tmp/packer/packer /usr/local/bin/packer && \
     chmod 0755 /usr/local/bin/packer && \


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Modern versions of Photon5 images decommission the use of unzip package in favor of 7zip.
But there are some cases, the downloaded image from mirror might be stale without 7zip package, causing the error

```
Package '7zip' not found
```

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**: