### PR TITLE
:sparkles: Part 1: Moving conversion webhooks out of api/ module

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -96,6 +96,8 @@ linters:
           pkg: sigs.k8s.io/controller-runtime/pkg/client
         - alias: ctrlmgr
           pkg: sigs.k8s.io/controller-runtime/pkg/manager
+        - alias: whconversion
+          pkg: sigs.k8s.io/controller-runtime/pkg/webhook/conversion
 
         - alias: vim25
           pkg: github.com/vmware/govmomi/vim25

--- a/.sdd/specs/002-move-conversion-to-a-separate-module/plan.md
+++ b/.sdd/specs/002-move-conversion-to-a-separate-module/plan.md
@@ -1,0 +1,300 @@
+# Plan: Move Conversion to a Separate Module
+
+## Goal
+
+Remove `sigs.k8s.io/controller-runtime` from `api/go.mod` and `api/test/go.mod` by moving all conversion method implementations out of the `api/` sub-tree and into the root module's existing `webhooks/conversion/` packages. No new Go module is required.
+
+## Background
+
+The `api/` module currently imports `sigs.k8s.io/controller-runtime v0.19.0` solely for `pkg/conversion`, which provides two interfaces:
+
+- `conversion.Hub` — a marker interface with a `Hub()` method
+- `conversion.Convertible` — requires `ConvertTo(Hub) error` and `ConvertFrom(Hub) error`
+
+Every spoke type (v1alpha1–v1alpha5) implements `Convertible` via methods in `*_conversion.go` files, and hub types (v1alpha6) implement `Hub` via trivial marker methods. This forces controller-runtime — and its large transitive closure — into the dependency graph of anyone who imports `api/`.
+
+Controller-runtime v0.24.0, already used by the root module, shipped the APIs from upstream PR [kubernetes-sigs/controller-runtime#3335](https://github.com/kubernetes-sigs/controller-runtime/pull/3335): `NewHubSpokeConverter`, `NewSpokeConverter`, and `WithConverter` in `pkg/webhook/conversion`. These allow conversion logic to live anywhere — the types themselves no longer need to implement `Convertible`. This is the mechanism we exploit.
+
+Reference implementation: [kubernetes-sigs/cluster-api#13762](https://github.com/kubernetes-sigs/cluster-api/pull/13762), which moves conversion into the root module's `webhooks/conversion/` packages — no new sub-module inside `api/`.
+
+---
+
+## Atomicity Constraint
+
+Tasks 1, 2, 3a, 3b, and 3c are **not independent** and must land in a single compilable changeset:
+
+- **Task 3a cannot precede 3b.** Deleting `webhooks/conversion/v1alpha1/`–`v1alpha5/` while `webhooks/conversion/webhooks.go` still imports them produces a compile error. 3a and 3b are atomic.
+- **Task 1 cannot precede 3c.** After Task 1 removes `ConvertTo`/`ConvertFrom` from spoke types, controller-runtime's `IsConvertible()` check during `Complete()` finds hub types without their convertible spokes and returns a `PartialImplementationError`. Task 3c (adding `WithConverter`) must land in the same commit as Task 1.
+- **Task 2 must complete before 3c.** The `WithConverter(<var>)` calls reference package-level variables defined in Task 2.
+
+---
+
+## Target Architecture
+
+```
+api/                         — type definitions only
+  go.mod: k8s.io/api, k8s.io/apimachinery  (no controller-runtime)
+  v1alphaN/*_conversion.go:  Convert_xxx_To_yyy() functions remain;
+                              ConvertTo/ConvertFrom methods removed;
+                              Hub()/List Hub() markers removed from v1alpha6;
+                              empty files deleted after removal
+
+webhooks/conversion/         — conversion logic moves here (root module)
+  v1alpha6/webhooks.go:      registers all conversion webhooks with
+                              .WithConverter(<var>).Complete()
+  v1alpha6/convert_xxx.go:   package-level converter var + version-suffixed
+                              or shared converter functions per spoke version
+  v1alpha6/convert_xxx_test.go: conversion round-trip tests (moved from api/test/)
+  v1alpha1..v1alpha5/:        deleted (no longer needed)
+
+api/test/                    — fuzz harness redesigned without Convertible
+  go.mod: controller-runtime removed after harness redesign
+  v1alphaN/*_conversion_test.go: ConvertTo/ConvertFrom call sites replaced
+                              with direct Convert_xxx_To_yyy calls; tests
+                              that verify the full round-trip pipeline move
+                              to webhooks/conversion/v1alpha6/
+```
+
+---
+
+## Spoke Version Matrix
+
+`NewHubSpokeConverter` validates at `Complete()` time that every version registered in the scheme for a given `GroupKind` has a spoke converter. Getting this wrong causes the manager to fail to start. The following matrix, derived from the current `*_conversion.go` files, is the authoritative reference for Task 3.
+
+| Kind | v1alpha1 | v1alpha2 | v1alpha3 | v1alpha4 | v1alpha5 |
+|---|:---:|:---:|:---:|:---:|:---:|
+| VirtualMachine | ✓ | ✓ | ✓ | ✓ | ✓ |
+| VirtualMachineClass | ✓ | ✓ | ✓ | ✓ | ✓ |
+| VirtualMachineImage | ✓ | ✓ | ✓ | ✓ | ✓ |
+| ClusterVirtualMachineImage | ✓ | ✓ | ✓ | ✓ | ✓ |
+| VirtualMachinePublishRequest | ✓ | ✓ | ✓ | ✓ | ✓ |
+| VirtualMachineService | ✓ | ✓ | ✓ | ✓ | ✓ |
+| VirtualMachineSetResourcePolicy | ✓ | ✓ | ✓ | ✓ | ✓ |
+| VirtualMachineGroup | ✗ | ✓ | ✓ | ✓ | ✓ |
+| VirtualMachineWebConsoleRequest | ✗ | ✓ | ✓ | ✓ | ✓ |
+| VirtualMachineImageCache | ✗ | ✗ | ✓ | ✓ | ✓ |
+| VirtualMachineReplicaSet | ✗ | ✗ | ✓ | ✓ | ✓ |
+| VirtualMachineClassInstance | ✗ | ✗ | ✗ | ✓ | ✓ |
+| VirtualMachineSnapshot | ✗ | ✗ | ✗ | ✗ | ✓ |
+| VirtualMachineGroupPublishRequest | ✗ | ✗ | ✗ | ✗ | ✓ |
+
+---
+
+## Task 1 — Strip controller-runtime from `api/`
+
+### 1a. Spoke versions (v1alpha1–v1alpha5)
+
+For every file matching `api/v1alphaN/*_conversion.go`:
+
+1. Remove the `ctrlconversion "sigs.k8s.io/controller-runtime/pkg/conversion"` import.
+2. Delete all `ConvertTo(dstRaw ctrlconversion.Hub) error` method implementations.
+3. Delete all `ConvertFrom(srcRaw ctrlconversion.Hub) error` method implementations.
+4. Move the `restore_*` helper functions used by ConvertTo/ConvertFrom to `webhooks/conversion/v1alpha6/` (Task 2), applying the naming rules in that task.
+5. Remove the `"slices"` import from `api/v1alpha1/`, `api/v1alpha2/`, `api/v1alpha3/`, and `api/v1alpha4/` `virtualmachine_conversion.go`. In every case `"slices"` is used only inside `restore_v1alpha6_VirtualMachinePolicies`, which moves to the root module in step 4. `api/v1alpha5/virtualmachine_conversion.go` does not import `"slices"` and is unaffected.
+
+### 1b. Hub version (v1alpha6)
+
+For every file matching `api/v1alpha6/*_conversion.go`, delete **all** `Hub()` marker methods. Note that each file declares `Hub()` on both the singular type **and** the corresponding List type (e.g., `func (*VirtualMachine) Hub() {}` and `func (*VirtualMachineList) Hub() {}`). Both must be removed.
+
+After deletion, any file that contains only a copyright header and `package v1alpha6` declaration must be **deleted entirely** rather than left as an empty shell.
+
+### 1c. Update `api/go.mod`
+
+Remove `sigs.k8s.io/controller-runtime` and all indirect dependencies it was pulling in that are no longer reachable. Run `go mod tidy` inside `api/` to verify and clean `go.sum`.
+
+---
+
+## Task 2 — Implement converter functions in the root module
+
+### 2a. Add import alias to `.golangci.yml`
+
+The new converter files import `sigs.k8s.io/controller-runtime/pkg/webhook/conversion`. This package has no alias in `.golangci.yml` `linters.settings.importas.alias` yet. Add the entry before writing any code, as the `importas` linter enforces it on all source files:
+
+```yaml
+- pkg: sigs.k8s.io/controller-runtime/pkg/webhook/conversion
+  alias: whconversion
+```
+
+### 2b. Naming convention for moved restore helpers
+
+There are **24 distinct `restore_` function names** that appear in two or more spoke versions and will collide if moved into the same package unchanged. Derive the full list before starting by running:
+
+```
+grep -rh "^func restore_" api/v1alpha*/ --include="*.go" | sed 's/(.*$//' | sort | uniq -c | sort -rn
+```
+
+For each colliding name, compare the function bodies across versions:
+
+- **Identical body across all versions** (e.g., `restore_v1alpha6_VirtualMachineResources` is `dst.Spec.Resources = src.Spec.Resources` in all five versions) → use a **single shared helper** with no version suffix in `webhooks/conversion/v1alpha6/`. This avoids needless code explosion.
+- **Divergent body** across versions (e.g., `restore_v1alpha6_VirtualMachineAdvanced` has a different set of fields restored in v1alpha2 vs v1alpha3 vs v1alpha4 vs v1alpha5) → rename each with a **version suffix** when moved: `restoreV1Alpha2VirtualMachineAdvanced`, `restoreV1Alpha3VirtualMachineAdvanced`, etc.
+
+### 2c. Converter file pattern
+
+Create one file per resource kind inside `webhooks/conversion/v1alpha6/`, named `convert_<kind>.go`. Each file defines:
+
+1. A **package-level variable** of type `func(*runtime.Scheme) (whconversion.Converter, error)` — the return type of `NewHubSpokeConverter` — assembling all spoke converters for that resource kind per the matrix above.
+2. The **typed converter functions** for every applicable spoke version (one hub-to-spoke and one spoke-to-hub per version), calling the existing `Convert_xxx_To_yyy` functions from `api/`.
+
+**Simple type (no marshal/restore logic):**
+
+```go
+// webhooks/conversion/v1alpha6/convert_virtualmachineclass.go
+
+var VirtualMachineClass = whconversion.NewHubSpokeConverter(
+    &vmopv1.VirtualMachineClass{},
+    whconversion.NewSpokeConverter(&vmopv1a1.VirtualMachineClass{}, convertVMClassHubToV1Alpha1, convertVMClassV1Alpha1ToHub),
+    whconversion.NewSpokeConverter(&vmopv1a2.VirtualMachineClass{}, convertVMClassHubToV1Alpha2, convertVMClassV1Alpha2ToHub),
+    whconversion.NewSpokeConverter(&vmopv1a3.VirtualMachineClass{}, convertVMClassHubToV1Alpha3, convertVMClassV1Alpha3ToHub),
+    whconversion.NewSpokeConverter(&vmopv1a4.VirtualMachineClass{}, convertVMClassHubToV1Alpha4, convertVMClassV1Alpha4ToHub),
+    whconversion.NewSpokeConverter(&vmopv1a5.VirtualMachineClass{}, convertVMClassHubToV1Alpha5, convertVMClassV1Alpha5ToHub),
+)
+
+func convertVMClassHubToV1Alpha2(_ context.Context, hub *vmopv1.VirtualMachineClass, spoke *vmopv1a2.VirtualMachineClass) error {
+    return vmopv1a2.Convert_v1alpha6_VirtualMachineClass_To_v1alpha2_VirtualMachineClass(hub, spoke, nil)
+}
+
+func convertVMClassV1Alpha2ToHub(_ context.Context, spoke *vmopv1a2.VirtualMachineClass, hub *vmopv1.VirtualMachineClass) error {
+    return vmopv1a2.Convert_v1alpha2_VirtualMachineClass_To_v1alpha6_VirtualMachineClass(spoke, hub, nil)
+}
+// ... repeat for other versions
+```
+
+**Complex type (with marshal/restore logic):**
+
+The spoke-to-hub direction handles `UnmarshalData` and restore (equivalent to the existing `ConvertTo`). The hub-to-spoke direction handles `MarshalData` (equivalent to `ConvertFrom`). `dst.Status = restored.Status` at the end of spoke-to-hub is taken verbatim from the existing `ConvertTo` implementations (confirmed at `api/v1alpha2/virtualmachine_conversion.go:591` and `api/v1alpha3/virtualmachine_conversion.go:529`).
+
+```go
+// webhooks/conversion/v1alpha6/convert_virtualmachine.go
+
+var VirtualMachine = whconversion.NewHubSpokeConverter(
+    &vmopv1.VirtualMachine{},
+    whconversion.NewSpokeConverter(&vmopv1a1.VirtualMachine{}, convertVMHubToV1Alpha1, convertVMV1Alpha1ToHub),
+    whconversion.NewSpokeConverter(&vmopv1a2.VirtualMachine{}, convertVMHubToV1Alpha2, convertVMV1Alpha2ToHub),
+    // ... v1alpha3, v1alpha4, v1alpha5
+)
+
+// convertVMHubToV1Alpha2 is the ConvertFrom equivalent: hub → spoke.
+func convertVMHubToV1Alpha2(_ context.Context, hub *vmopv1.VirtualMachine, spoke *vmopv1a2.VirtualMachine) error {
+    if err := vmopv1a2.Convert_v1alpha6_VirtualMachine_To_v1alpha2_VirtualMachine(hub, spoke, nil); err != nil {
+        return err
+    }
+    return utilconversion.MarshalData(hub, spoke)
+}
+
+// convertVMV1Alpha2ToHub is the ConvertTo equivalent: spoke → hub.
+func convertVMV1Alpha2ToHub(_ context.Context, spoke *vmopv1a2.VirtualMachine, hub *vmopv1.VirtualMachine) error {
+    if err := vmopv1a2.Convert_v1alpha2_VirtualMachine_To_v1alpha6_VirtualMachine(spoke, hub, nil); err != nil {
+        return err
+    }
+    restored := &vmopv1.VirtualMachine{}
+    if ok, err := utilconversion.UnmarshalData(spoke, restored); err != nil || !ok {
+        return err
+    }
+    restoreV1Alpha2VirtualMachineImage(hub, restored)
+    // ... all restore calls, version-suffixed or shared per naming rules
+    hub.Status = restored.Status  // taken verbatim from existing ConvertTo
+    return nil
+}
+```
+
+### 2d. Note on list types
+
+`NewHubSpokeConverter` uses `scheme.ObjectKinds()` and filters by `GroupKind()`. A `VirtualMachineList` has `Kind = "VirtualMachineList"`, giving it a different `GroupKind` from `VirtualMachine`, so list types are not enumerated and require no separate spoke converters.
+
+---
+
+## Task 3 — Consolidate webhook conversion registrations
+
+### 3a+3b. Delete per-spoke webhook directories and update the top-level aggregator (atomic)
+
+Delete `webhooks/conversion/v1alpha1/` through `webhooks/conversion/v1alpha5/` **in the same change** as removing their `AddToManager` calls from `webhooks/conversion/webhooks.go`. These two steps must be done together to avoid a compile error from dangling imports.
+
+### 3c. Update `webhooks/conversion/v1alpha6/webhooks.go`
+
+For each resource kind, switch from `.Complete()` to `.WithConverter(<var>).Complete()`, referencing the package-level variable from Task 2. The spoke version coverage is encoded in the variable definition, so the registration file needs no per-kind version logic.
+
+**Before:**
+
+```go
+ctrl.NewWebhookManagedBy(mgr, &vmopv1.VirtualMachine{}).Complete()
+```
+
+**After:**
+
+```go
+ctrl.NewWebhookManagedBy(mgr, &vmopv1.VirtualMachine{}).
+    WithConverter(VirtualMachine).
+    Complete()
+```
+
+**Feature-gated type — `VirtualMachineClassInstance`:** The existing `pkgcfg.FromContext(ctx).Features.ImmutableClasses` guard around the `VirtualMachineClassInstance` registration **must be preserved**. The `.WithConverter(VirtualMachineClassInstance).Complete()` call must remain inside that guard, matching the behavior of the v1alpha4 and v1alpha5 per-spoke webhooks it replaces. `VirtualMachineClassInstance` is unconditionally registered in the scheme, so omitting the gate would silently enable a conversion handler for a feature-gated type.
+
+---
+
+## Task 4 — Migrate `api/test/` conversion tests
+
+### 4a. Affected files
+
+The following 17 test files in `api/test/` import `sigs.k8s.io/controller-runtime/pkg/conversion` and call `.ConvertTo()`/`.ConvertFrom()` directly on typed spoke objects (108 call sites total):
+
+```
+api/test/v1alpha1/virtualmachine_conversion_test.go
+api/test/v1alpha1/virtualmachineclass_conversion_test.go
+api/test/v1alpha1/virtualmachineimage_conversion_test.go
+api/test/v1alpha1/virtualmachinepublishrequest_conversion_test.go
+api/test/v1alpha1/virtualmachineservice_conversion_test.go
+api/test/v1alpha2/virtualmachine_conversion_test.go
+api/test/v1alpha2/virtualmachineclass_conversion_test.go
+api/test/v1alpha2/virtualmachinepublishrequest_conversion_test.go
+api/test/v1alpha2/virtualmachineservice_conversion_test.go
+api/test/v1alpha3/virtualmachine_conversion_test.go
+api/test/v1alpha3/virtualmachinepublishrequest_conversion_test.go
+api/test/v1alpha3/virtualmachineservice_conversion_test.go
+api/test/v1alpha4/virtualmachine_conversion_test.go
+api/test/v1alpha4/virtualmachinepublishrequest_conversion_test.go
+api/test/v1alpha4/virtualmachineservice_conversion_test.go
+api/test/v1alpha5/virtualmachine_conversion_test.go
+api/test/v1alpha5/virtualmachineservice_conversion_test.go
+```
+
+### 4b. Migration approach per test type
+
+**Tests that verify the full round-trip pipeline** (calling `spoke.ConvertTo(hub)` / `spoke.ConvertFrom(hub)` to exercise the MarshalData/UnmarshalData/restore connector layer) → **move to the root module** as `webhooks/conversion/v1alpha6/convert_<kind>_test.go`. In the root module, these tests call the new typed wrapper functions (`convertVMV1Alpha2ToHub`, `convertVMHubToV1Alpha2`, etc.) directly. This migration also satisfies Finding 7 — it is the mechanism for testing the connector layer.
+
+**Tests that verify only field-level conversion** (calling `spoke.ConvertTo(hub)` only to exercise a `Convert_xxx_To_yyy` function, with no assertion on MarshalData behavior) → **adapt in-place** inside `api/test/`. Replace `spoke.ConvertTo(&hub)` with the direct call `vmopv1aN.Convert_v1alphaN_Type_To_v1alpha6_Type(spoke, hub, nil)`, and `spoke.ConvertFrom(hub)` with `vmopv1aN.Convert_v1alpha6_Type_To_v1alphaN_Type(hub, spoke, nil)`. Remove the `ctrlconversion` import from those files after replacement.
+
+An implementer should classify each call site by inspection before making changes. The majority of the `virtualmachine_conversion_test.go` sites are round-trip tests and belong in the root module; the `virtualmachineclass_conversion_test.go` and similar simpler-type tests are likely field-level only.
+
+### 4c. Redesign the fuzz harness
+
+`api/test/utilconversion/fuzztests/conversion_fuzz.go` is built entirely around `ctrlconversion.Convertible`. Replace the interface-parameterized `FuzzTestFuncInput` with a typed function-pair struct:
+
+```go
+type FuzzTestFuncInput[Hub, Spoke any] struct {
+    Hub        Hub
+    Spoke      Spoke
+    SpokeToHub func(spoke Spoke, hub Hub) error
+    HubToSpoke func(hub Hub, spoke Spoke) error
+    ...
+}
+```
+
+Each per-spoke fuzz caller passes the corresponding `Convert_xxx_To_yyy` pair from `api/v1alphaN/` directly. The `conversion_test.go` suite files in `api/test/v1alphaN/` are updated to match.
+
+### 4d. Clean up `api/test/go.mod`
+
+After steps 4a–4c, `sigs.k8s.io/controller-runtime` is no longer imported anywhere in `api/test/`. Run `go mod tidy` inside `api/test/` to remove it and clean `go.sum`. This completes the goal of removing controller-runtime from the entire `api/` sub-tree.
+
+---
+
+## What Does NOT Change
+
+| Artifact | Reason |
+|---|---|
+| `Convert_vNalphaX_Type_To_vMalphaY_Type()` functions in `api/` | Only depend on `k8s.io/apimachinery`; stay exactly as-is |
+| `zz_generated.conversion.go` files in `api/` | Auto-generated, no controller-runtime imports |
+| `api/utilconversion/` package | No controller-runtime dependency; stays in `api/` |
+| Scheme registration (`RegisterConversions`) | Stays in `api/`; only uses `k8s.io/apimachinery/pkg/runtime` |
+| Root `go.mod` | No new dependencies; root module already imports both `api/` and `controller-runtime v0.24.0` |
+| Webhook TLS, certificate management, routing | Unchanged |
+| E2E tests | Conversion is an internal implementation detail; observable behavior is identical |

--- a/.sdd/specs/002-move-conversion-to-a-separate-module/tasks.md
+++ b/.sdd/specs/002-move-conversion-to-a-separate-module/tasks.md
@@ -1,0 +1,317 @@
+# Tasks: Move Conversion to a Separate Module
+
+Reference: [`plan.md`](./plan.md) — read it before implementing any story here. The plan contains the full converter matrix, naming rules for colliding restore helpers, code patterns for simple vs. complex types, and the atomicity constraint that governs Change 2.
+
+## Story ordering
+
+```
+Change 1 (additive)  →  Change 2 (atomic removal)  →  Change 3 (test cleanup)
+```
+
+Each change is a single compilable, reviewable PR. Changes 2 and 3 have hard compile-time dependencies on the previous change and must not be merged out of order.
+
+---
+
+## Change 1 — Implement converter functions in the root module
+
+**Summary:** Create the new converter infrastructure inside the root module without touching `api/`. This change is purely additive: the root module compiles before and after; the `api/` sub-module is completely unchanged.
+
+### Why this change can land independently
+
+After this change, `api/v1alpha1`–`v1alpha5` spoke types still implement `ctrlconversion.Convertible` (their `ConvertTo`/`ConvertFrom` methods are still present). The new converter variables in `webhooks/conversion/v1alpha6/` are defined and tested but not yet wired into the webhook registrar. The binary behaviour is identical to `main`.
+
+### Sub-tasks
+
+#### 1.1 — Add `whconversion` import alias to `.golangci.yml`
+
+**Files touched:** `.golangci.yml`
+
+Add the following entry under `linters.settings.importas.alias` before writing any code that imports the package, so that the `importas` linter enforces the alias from the first commit:
+
+```yaml
+- pkg: sigs.k8s.io/controller-runtime/pkg/webhook/conversion
+  alias: whconversion
+```
+
+**Acceptance criteria:**
+- The alias entry is present in `.golangci.yml`.
+- `make lint-go` passes on a no-change tree (verifies the entry is syntactically valid).
+
+#### 1.2 — Create `convert_<kind>.go` files in `webhooks/conversion/v1alpha6/`
+
+**Files touched (new):**
+```
+webhooks/conversion/v1alpha6/convert_virtualmachine.go
+webhooks/conversion/v1alpha6/convert_virtualmachineclass.go
+webhooks/conversion/v1alpha6/convert_virtualmachineimage.go
+webhooks/conversion/v1alpha6/convert_clustervirtualmachineimage.go
+webhooks/conversion/v1alpha6/convert_virtualmachinepublishrequest.go
+webhooks/conversion/v1alpha6/convert_virtualmachineservice.go
+webhooks/conversion/v1alpha6/convert_virtualmachinesetresourcepolicy.go
+webhooks/conversion/v1alpha6/convert_virtualmachinegroup.go
+webhooks/conversion/v1alpha6/convert_virtualmachinewebconsolerequest.go
+webhooks/conversion/v1alpha6/convert_virtualmachineimagecache.go
+webhooks/conversion/v1alpha6/convert_virtualmachinereplicaset.go
+webhooks/conversion/v1alpha6/convert_virtualmachineclassinstance.go
+webhooks/conversion/v1alpha6/convert_virtualmachinesnapshot.go
+webhooks/conversion/v1alpha6/convert_virtualmachinegrouppublishrequest.go
+```
+
+For each file, follow the patterns in `plan.md` § "Task 2 — Implement converter functions":
+
+- Declare a **package-level exported variable** whose type satisfies `whconversion.Converter`. Use `whconversion.NewHubSpokeConverter` with one `whconversion.NewSpokeConverter` per version row in the matrix (see `plan.md` § "Spoke Version Matrix").
+- Declare **typed converter functions** (one hub-to-spoke and one spoke-to-hub per applicable version). For simple types (no MarshalData), call the `Convert_xxx_To_yyy` function from the respective `api/v1alphaN/` package directly. For complex types (`VirtualMachine`, and any other type that currently uses `MarshalData`/`UnmarshalData`), follow the `convertVMHubToV1AlphaN` / `convertVMV1AlphaNToHub` pattern shown in `plan.md`.
+- Move all `restore_*` helpers from `api/v1alphaN/virtualmachine_conversion.go` into the appropriate file here, applying the naming rules from `plan.md` § "Task 2b": identical-body helpers across all versions become a single shared helper; helpers with divergent bodies are renamed with a version suffix (e.g., `restoreV1Alpha2VirtualMachineAdvanced`). Derive the full set of 24 colliding names by running `grep -rh "^func restore_" api/v1alpha*/ --include="*.go" | sed 's/(.*$//' | sort | uniq -c | sort -rn` before starting.
+
+**Acceptance criteria:**
+- All 14 converter files exist.
+- Each exported converter variable references the correct set of spoke versions per the matrix in `plan.md`.
+- All `restore_*` helpers have been moved and renamed per the collision rules; no two functions in the package share the same name.
+- `go build ./webhooks/...` passes.
+- `make lint-go` passes (no import alias violations, no unused imports).
+- The `api/` sub-module is **not modified**.
+
+#### 1.3 — Create converter tests in `webhooks/conversion/v1alpha6/`
+
+**Files touched (new):**
+```
+webhooks/conversion/v1alpha6/convert_virtualmachine_test.go
+webhooks/conversion/v1alpha6/convert_virtualmachineclass_test.go
+```
+(At minimum these two; add more for other complex kinds as appropriate.)
+
+These test files live in the root module and can import both `api/v1alphaN` types and the typed converter functions from the same package (`webhooks/conversion/v1alpha6`). They replace the full round-trip tests that currently live in `api/test/v1alphaN/` and will be removed in Change 3.
+
+Each test file should include:
+- A spoke-to-hub round-trip test: build a spoke object with all fields populated, call `convertVM<Kind>V1AlphaNToHub`, verify hub fields match expectations, call `convertVM<Kind>HubToV1AlphaN`, verify the spoke round-trips correctly.
+- A test that verifies `MarshalData`/`UnmarshalData` preserves hub-only fields that have no counterpart in the spoke schema.
+
+Follow the Ginkgo/Gomega testing conventions in `.sdd/memory/testing-standards.md` (external `_test` package, `Label()` decorators from `pkg/constants/testlabels`).
+
+**Acceptance criteria:**
+- Tests exist for at least `VirtualMachine` (complex, has restore logic) and `VirtualMachineClass` (simple, no restore logic).
+- `go test ./webhooks/conversion/v1alpha6/...` passes.
+- Tests use `testlabels.API` label (no `testlabels.EnvTest` — these are pure unit tests).
+
+---
+
+## Change 2 — Remove conversion interfaces from `api/` (atomic)
+
+**Summary:** Strip `ConvertTo`/`ConvertFrom` methods and `Hub()` markers from `api/`, delete the now-redundant per-spoke webhook packages, wire up `WithConverter`, and remove controller-runtime from `api/go.mod`.
+
+**Prerequisite:** Change 1 must be merged. The converter variables and typed functions defined in Change 1 are what make `webhooks/conversion/v1alpha6/webhooks.go` compilable after the old per-spoke webhooks are deleted.
+
+### Why this is atomic
+
+After the `ConvertTo`/`ConvertFrom` methods are removed from spoke types, controller-runtime's `IsConvertible()` check at `Complete()` time returns `PartialImplementationError` for any hub type that does not have `WithConverter` registered. All sub-tasks below must therefore land in a single commit (or squashed PR) to avoid a startup-time panic in any intermediate state.
+
+### Sub-tasks
+
+#### 2.1 — Remove `ConvertTo`/`ConvertFrom` methods from spoke types (v1alpha1–v1alpha5)
+
+**Files touched:**
+All `api/v1alphaN/*_conversion.go` files for N ∈ {1, 2, 3, 4, 5}.
+
+Steps per file:
+1. Delete the `ConvertTo(dstRaw ctrlconversion.Hub) error` method body.
+2. Delete the `ConvertFrom(srcRaw ctrlconversion.Hub) error` method body.
+3. Remove the `ctrlconversion "sigs.k8s.io/controller-runtime/pkg/conversion"` import.
+4. The `restore_*` helpers were moved to `webhooks/conversion/v1alpha6/` in Change 1 sub-task 1.2; delete the originals from `api/v1alphaN/` now.
+5. Remove the `"slices"` import from `api/v1alpha1/`, `api/v1alpha2/`, `api/v1alpha3/`, and `api/v1alpha4/` `virtualmachine_conversion.go`. (`api/v1alpha5/virtualmachine_conversion.go` does not import `"slices"` and is unaffected.)
+
+**Acceptance criteria:**
+- No `ConvertTo`/`ConvertFrom` methods remain in any file under `api/v1alpha1/` through `api/v1alpha5/`.
+- No `ctrlconversion` import remains in any `api/v1alphaN/*_conversion.go` file.
+- No `"slices"` import remains in `api/v1alpha1–4/virtualmachine_conversion.go`.
+- No `restore_*` function remains under `api/` (all moved to `webhooks/conversion/v1alpha6/` in Change 1).
+
+#### 2.2 — Remove `Hub()` markers from v1alpha6 and delete empty files
+
+**Files touched:**
+All `api/v1alpha6/*_conversion.go` files.
+
+Steps:
+1. Delete every `func (*TypeName) Hub() {}` and `func (*TypeNameList) Hub() {}` declaration from each file. Both the singular type and the corresponding List type have a `Hub()` method — remove both.
+2. After deletion, any file that contains only the copyright header and a bare `package v1alpha6` declaration **must be deleted entirely**.
+
+**Acceptance criteria:**
+- No `Hub()` method remains under `api/v1alpha6/`.
+- No file under `api/v1alpha6/` contains only a copyright header and package declaration.
+
+#### 2.3 — Update `api/go.mod`
+
+**Files touched:** `api/go.mod`, `api/go.sum`
+
+Remove `sigs.k8s.io/controller-runtime` from `api/go.mod`. Run `go mod tidy` inside `api/` to remove the entry and clean up `go.sum`.
+
+**Acceptance criteria:**
+- `api/go.mod` contains no reference to `sigs.k8s.io/controller-runtime`.
+- `go build ./...` inside `api/` passes.
+- `go mod tidy` inside `api/` produces no diff.
+
+#### 2.4 — Delete per-spoke webhook packages (v1alpha1–v1alpha5) and update the aggregator (atomic with 2.4)
+
+**Files touched:**
+```
+webhooks/conversion/v1alpha1/   — delete entire directory
+webhooks/conversion/v1alpha2/   — delete entire directory
+webhooks/conversion/v1alpha3/   — delete entire directory
+webhooks/conversion/v1alpha4/   — delete entire directory
+webhooks/conversion/v1alpha5/   — delete entire directory
+webhooks/conversion/webhooks.go — remove AddToManager calls for v1alpha1–5
+```
+
+Delete the five directories and remove their `AddToManager` invocations from `webhooks/conversion/webhooks.go` in the same operation. Leaving dangling imports in `webhooks.go` while the directories are gone produces a compile error.
+
+**Acceptance criteria:**
+- Directories `webhooks/conversion/v1alpha1/` through `webhooks/conversion/v1alpha5/` no longer exist.
+- `webhooks/conversion/webhooks.go` no longer imports or calls any per-spoke `AddToManager`.
+- `go build ./webhooks/...` passes after this sub-task.
+
+#### 2.5 — Wire `WithConverter` into `webhooks/conversion/v1alpha6/webhooks.go`
+
+**Files touched:** `webhooks/conversion/v1alpha6/webhooks.go`
+
+For each resource kind registration in the file, switch from `.Complete()` to `.WithConverter(<var>).Complete()`, where `<var>` is the package-level converter variable defined in Change 1 sub-task 1.2.
+
+**Special case — `VirtualMachineClassInstance`:** The existing `pkgcfg.FromContext(ctx).Features.ImmutableClasses` guard around the `VirtualMachineClassInstance` registration **must be preserved**. The new form is:
+
+```go
+if pkgcfg.FromContext(ctx).Features.ImmutableClasses {
+    if err := ctrl.NewWebhookManagedBy(mgr, &vmopv1.VirtualMachineClassInstance{}).
+        WithConverter(VirtualMachineClassInstance).
+        Complete(); err != nil {
+        return err
+    }
+}
+```
+
+**Acceptance criteria:**
+- Every `ctrl.NewWebhookManagedBy(mgr, &vmopv1.<Kind>{}).Complete()` call in the file is replaced with `.WithConverter(<var>).Complete()`.
+- The `ImmutableClasses` feature gate wraps `VirtualMachineClassInstance` registration exactly as it did before.
+- `go build ./...` passes for the root module.
+- `make lint-go` passes.
+
+### Change 2 overall acceptance criteria
+
+- `api/go.mod` has no dependency on `sigs.k8s.io/controller-runtime`.
+- `go build ./...` passes for the root module.
+- `go build ./...` passes inside `api/`.
+- `make lint-go` passes for the root module.
+- `make test` (unit tests, no vcsim/envtest required) passes for the root module.
+- The manager binary starts without errors when conversion webhooks are enabled.
+
+---
+
+## Change 3 — Migrate `api/test/` conversion tests
+
+**Summary:** Fix the 17 `api/test/` files that call `.ConvertTo()`/`.ConvertFrom()` (now removed), redesign the fuzz harness, and remove controller-runtime from `api/test/go.mod`.
+
+**Prerequisite:** Change 2 must be merged. The `ConvertTo`/`ConvertFrom` methods no longer exist on spoke types; any `api/test/` file that calls them fails to compile.
+
+### Affected files
+
+```
+api/test/v1alpha1/virtualmachine_conversion_test.go
+api/test/v1alpha1/virtualmachineclass_conversion_test.go
+api/test/v1alpha1/virtualmachineimage_conversion_test.go
+api/test/v1alpha1/virtualmachinepublishrequest_conversion_test.go
+api/test/v1alpha1/virtualmachineservice_conversion_test.go
+api/test/v1alpha2/virtualmachine_conversion_test.go
+api/test/v1alpha2/virtualmachineclass_conversion_test.go
+api/test/v1alpha2/virtualmachinepublishrequest_conversion_test.go
+api/test/v1alpha2/virtualmachineservice_conversion_test.go
+api/test/v1alpha3/virtualmachine_conversion_test.go
+api/test/v1alpha3/virtualmachinepublishrequest_conversion_test.go
+api/test/v1alpha3/virtualmachineservice_conversion_test.go
+api/test/v1alpha4/virtualmachine_conversion_test.go
+api/test/v1alpha4/virtualmachinepublishrequest_conversion_test.go
+api/test/v1alpha4/virtualmachineservice_conversion_test.go
+api/test/v1alpha5/virtualmachine_conversion_test.go
+api/test/v1alpha5/virtualmachineservice_conversion_test.go
+```
+
+### Sub-tasks
+
+#### 3.1 — Migrate full round-trip tests to the root module
+
+**Files touched (in root module, new or extended):**
+```
+webhooks/conversion/v1alpha6/convert_virtualmachine_test.go   (extend, or create if not done in Change 1)
+webhooks/conversion/v1alpha6/convert_virtualmachinepublishrequest_test.go
+webhooks/conversion/v1alpha6/convert_virtualmachineservice_test.go
+```
+(and any other kind whose `api/test/` file exercises `MarshalData`/`UnmarshalData` or restore logic)
+
+**Files touched (in api/test/, deleted or gutted):**
+The corresponding `*_conversion_test.go` files that exercised the full pipeline are deleted after their coverage is replicated in the root module tests above.
+
+**Decision rule:** A test exercises the *full round-trip pipeline* if it calls `spoke.ConvertTo(hub)` or `spoke.ConvertFrom(hub)` and then makes assertions about fields that are preserved only via `MarshalData`/`UnmarshalData` (i.e., hub-only fields with no spoke counterpart). Such tests cannot be adapted in-place after `ConvertTo`/`ConvertFrom` are removed; they must move to the root module where the typed wrapper functions are available.
+
+**Acceptance criteria:**
+- Every test that previously relied on `MarshalData`/`UnmarshalData` round-trip semantics now exists in `webhooks/conversion/v1alpha6/` and passes.
+- No round-trip assertion is silently dropped.
+
+#### 3.2 — Adapt field-level tests in-place
+
+**Files touched (in api/test/, modified):**
+Any `*_conversion_test.go` file whose tests only verify that specific fields map correctly between spoke and hub (i.e., they call `spoke.ConvertTo(&hub)` purely to exercise a `Convert_xxx_To_yyy` function, with no assertion dependent on `MarshalData`).
+
+For each such call site, replace:
+- `spoke.ConvertTo(&hub)` → `vmopv1aN.Convert_v1alphaN_Type_To_v1alpha6_Type(spoke, &hub, nil)`
+- `spoke.ConvertFrom(hub)` → `vmopv1aN.Convert_v1alpha6_Type_To_v1alphaN_Type(hub, spoke, nil)`
+
+Remove the `ctrlconversion` import from any file where all call sites have been replaced.
+
+**Acceptance criteria:**
+- No `ctrlconversion` import remains in any `api/test/v1alphaN/` file.
+- No `.ConvertTo(` or `.ConvertFrom(` call remains in any file under `api/test/`.
+- `go build ./...` inside `api/test/` passes.
+
+#### 3.3 — Redesign the fuzz harness
+
+**Files touched:**
+```
+api/test/utilconversion/fuzztests/conversion_fuzz.go
+api/test/v1alphaN/conversion_test.go  (per-spoke callers of the fuzz harness)
+```
+
+Replace the `ctrlconversion.Convertible`-parameterized `FuzzTestFuncInput` struct with a generic function-pair struct:
+
+```go
+type FuzzTestFuncInput[Hub, Spoke any] struct {
+    Hub        Hub
+    Spoke      Spoke
+    SpokeToHub func(spoke Spoke, hub Hub) error
+    HubToSpoke func(hub Hub, spoke Spoke) error
+    // ... existing fields (SkipImmutableFieldValidation etc.) unchanged
+}
+```
+
+Update `SpokeHubSpoke` and `HubSpokeHub` to call `input.SpokeToHub` / `input.HubToSpoke` instead of `.ConvertTo()` / `.ConvertFrom()`.
+
+Update every per-spoke `conversion_test.go` file in `api/test/v1alphaN/` to pass the appropriate `Convert_xxx_To_yyy` pair from `api/v1alphaN/` as the function arguments.
+
+**Acceptance criteria:**
+- `FuzzTestFuncInput` uses no types from `sigs.k8s.io/controller-runtime`.
+- `SpokeHubSpoke` and `HubSpokeHub` use the typed function pair, not interface method calls.
+- All per-spoke fuzz test callers compile and pass.
+
+#### 3.4 — Remove controller-runtime from `api/test/go.mod`
+
+**Files touched:** `api/test/go.mod`, `api/test/go.sum`
+
+Run `go mod tidy` inside `api/test/`. After sub-tasks 3.1–3.3, `sigs.k8s.io/controller-runtime` should no longer be reachable from any import in the module.
+
+**Acceptance criteria:**
+- `api/test/go.mod` contains no reference to `sigs.k8s.io/controller-runtime`.
+- `go mod tidy` inside `api/test/` produces no diff.
+- `go test ./...` inside `api/test/` passes.
+
+### Change 3 overall acceptance criteria
+
+- No file under `api/test/` imports `sigs.k8s.io/controller-runtime`.
+- `api/test/go.mod` has no dependency on `sigs.k8s.io/controller-runtime`.
+- `go test ./...` inside `api/test/` passes.
+- `go test ./webhooks/conversion/v1alpha6/...` passes in the root module (round-trip coverage moved here in sub-task 3.1).
+- `make lint-go` passes for the root module.

--- a/webhooks/conversion/v1alpha6/conversion_suite_test.go
+++ b/webhooks/conversion/v1alpha6/conversion_suite_test.go
@@ -1,0 +1,17 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha6_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConversion(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Conversion Suite")
+}

--- a/webhooks/conversion/v1alpha6/convert_virtualmachine.go
+++ b/webhooks/conversion/v1alpha6/convert_virtualmachine.go
@@ -1,0 +1,837 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha6
+
+import (
+	"context"
+	"reflect"
+	"slices"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	whconversion "sigs.k8s.io/controller-runtime/pkg/webhook/conversion"
+
+
+	"github.com/vmware-tanzu/vm-operator/api/utilconversion"
+	vmopv1a1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1a2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	vmopv1a3 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	vmopv1a4 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	vmopv1a5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+	vmopv1common "github.com/vmware-tanzu/vm-operator/api/v1alpha6/common"
+)
+
+// VirtualMachine is the converter for VirtualMachine across all spoke versions.
+var VirtualMachine = whconversion.NewHubSpokeConverter(
+	&vmopv1.VirtualMachine{},
+	whconversion.NewSpokeConverter(&vmopv1a1.VirtualMachine{}, convertVMHubToV1Alpha1, convertVMV1Alpha1ToHub),
+	whconversion.NewSpokeConverter(&vmopv1a2.VirtualMachine{}, convertVMHubToV1Alpha2, convertVMV1Alpha2ToHub),
+	whconversion.NewSpokeConverter(&vmopv1a3.VirtualMachine{}, convertVMHubToV1Alpha3, convertVMV1Alpha3ToHub),
+	whconversion.NewSpokeConverter(&vmopv1a4.VirtualMachine{}, convertVMHubToV1Alpha4, convertVMV1Alpha4ToHub),
+	whconversion.NewSpokeConverter(&vmopv1a5.VirtualMachine{}, convertVMHubToV1Alpha5, convertVMV1Alpha5ToHub),
+)
+
+// ============================================================
+// Shared restore helpers (body identical across all versions)
+// ============================================================
+
+func restoreVirtualMachineResources(dst, src *vmopv1.VirtualMachine) {
+	dst.Spec.Resources = src.Spec.Resources
+}
+
+func restoreVirtualMachineCPUAdvanced(dst, src *vmopv1.VirtualMachine) {
+	dst.Spec.CPUAdvanced = src.Spec.CPUAdvanced
+}
+
+func restoreVirtualMachineMemoryAdvanced(dst, src *vmopv1.VirtualMachine) {
+	dst.Spec.MemoryAdvanced = src.Spec.MemoryAdvanced
+}
+
+func restoreVirtualMachineBootOptions(dst, src *vmopv1.VirtualMachine) {
+	dst.Spec.BootOptions = src.Spec.BootOptions
+}
+
+func restoreVirtualMachinePromoteDisksMode(dst, src *vmopv1.VirtualMachine) {
+	dst.Spec.PromoteDisksMode = src.Spec.PromoteDisksMode
+}
+
+func restoreVirtualMachineInstanceUUID(dst, src *vmopv1.VirtualMachine) {
+	dst.Spec.InstanceUUID = src.Spec.InstanceUUID
+}
+
+func restoreVirtualMachineBiosUUID(dst, src *vmopv1.VirtualMachine) {
+	dst.Spec.BiosUUID = src.Spec.BiosUUID
+}
+
+func restoreVirtualMachineGuestID(dst, src *vmopv1.VirtualMachine) {
+	dst.Spec.GuestID = src.Spec.GuestID
+}
+
+func restoreVirtualMachineCryptoVTPM(dst, src *vmopv1.VirtualMachine) {
+	if dst.Spec.Crypto != nil && src.Spec.Crypto != nil {
+		dst.Spec.Crypto.VTPMMode = src.Spec.Crypto.VTPMMode
+	}
+}
+
+func restoreVirtualMachineCurrentSnapshotName(dst, src *vmopv1.VirtualMachine) {
+	dst.Spec.CurrentSnapshotName = src.Spec.CurrentSnapshotName
+}
+
+func restoreVirtualMachineVolumeAttributesClassName(dst, src *vmopv1.VirtualMachine) {
+	if src.Spec.VolumeAttributesClassName != "" {
+		dst.Spec.VolumeAttributesClassName = src.Spec.VolumeAttributesClassName
+	}
+}
+
+func restoreVirtualMachineNetworkVLANs(dst, src *vmopv1.VirtualMachine) {
+	if src.Spec.Network == nil || len(src.Spec.Network.VLANs) == 0 {
+		return
+	}
+	if dst.Spec.Network == nil {
+		dst.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
+	}
+	dst.Spec.Network.VLANs = src.Spec.Network.VLANs
+}
+
+func restoreVirtualMachinePolicies(dst, src *vmopv1.VirtualMachine) {
+	dst.Spec.Policies = slices.Clone(src.Spec.Policies)
+}
+
+func restoreVirtualMachineBootstrapDisabled(dst, src *vmopv1.VirtualMachine) {
+	if bs := src.Spec.Bootstrap; bs != nil {
+		if bs.Disabled {
+			if dst.Spec.Bootstrap == nil {
+				dst.Spec.Bootstrap = &vmopv1.VirtualMachineBootstrapSpec{}
+			}
+			dst.Spec.Bootstrap.Disabled = true
+		}
+	}
+}
+
+func restoreVirtualMachineBootstrapCloudInitInstanceID(dst, src *vmopv1.VirtualMachine) {
+	var iid string
+	if bs := src.Spec.Bootstrap; bs != nil {
+		if ci := bs.CloudInit; ci != nil {
+			iid = ci.InstanceID
+		}
+	}
+	if iid == "" {
+		return
+	}
+	if dst.Spec.Bootstrap == nil {
+		dst.Spec.Bootstrap = &vmopv1.VirtualMachineBootstrapSpec{}
+	}
+	if dst.Spec.Bootstrap.CloudInit == nil {
+		dst.Spec.Bootstrap.CloudInit = &vmopv1.VirtualMachineBootstrapCloudInitSpec{}
+	}
+	dst.Spec.Bootstrap.CloudInit.InstanceID = iid
+}
+
+func restoreVirtualMachineBootstrapCloudInitWaitOnNetwork(dst, src *vmopv1.VirtualMachine) {
+	if bs := src.Spec.Bootstrap; bs != nil {
+		if ci := bs.CloudInit; ci != nil {
+			if ci.WaitOnNetwork4 != nil || ci.WaitOnNetwork6 != nil {
+				if dst.Spec.Bootstrap != nil && dst.Spec.Bootstrap.CloudInit != nil {
+					dst.Spec.Bootstrap.CloudInit.WaitOnNetwork4 = ci.WaitOnNetwork4
+					dst.Spec.Bootstrap.CloudInit.WaitOnNetwork6 = ci.WaitOnNetwork6
+				}
+			}
+		}
+	}
+}
+
+func restoreVirtualMachineBootstrapLinuxPrep(dst, src *vmopv1.VirtualMachine) {
+	if bs := src.Spec.Bootstrap; bs != nil {
+		if lp := bs.LinuxPrep; lp != nil {
+			if dst.Spec.Bootstrap != nil && dst.Spec.Bootstrap.LinuxPrep != nil {
+				dst.Spec.Bootstrap.LinuxPrep.ExpirePasswordAfterNextLogin = lp.ExpirePasswordAfterNextLogin
+				dst.Spec.Bootstrap.LinuxPrep.Password = lp.Password
+				dst.Spec.Bootstrap.LinuxPrep.ScriptText = lp.ScriptText
+				dst.Spec.Bootstrap.LinuxPrep.CustomizeAtNextPowerOn = lp.CustomizeAtNextPowerOn
+			}
+		}
+	}
+}
+
+func restoreVirtualMachineBootstrapSysprep(dst, src *vmopv1.VirtualMachine) {
+	if bs := src.Spec.Bootstrap; bs != nil {
+		if sp := bs.Sysprep; sp != nil {
+			if dst.Spec.Bootstrap != nil && dst.Spec.Bootstrap.Sysprep != nil {
+				if sp.Sysprep != nil && dst.Spec.Bootstrap.Sysprep.Sysprep != nil {
+					dst.Spec.Bootstrap.Sysprep.Sysprep.ExpirePasswordAfterNextLogin = sp.Sysprep.ExpirePasswordAfterNextLogin
+					dst.Spec.Bootstrap.Sysprep.Sysprep.ScriptText = sp.Sysprep.ScriptText
+				}
+				dst.Spec.Bootstrap.Sysprep.CustomizeAtNextPowerOn = sp.CustomizeAtNextPowerOn
+			}
+		}
+	}
+}
+
+// restoreVirtualMachineImage is shared across all versions.
+func restoreVirtualMachineImage(dst, src *vmopv1.VirtualMachine) {
+	dst.Spec.Image = src.Spec.Image
+	dst.Spec.ImageName = src.Spec.ImageName
+}
+
+// restoreVirtualMachineHardwareShared restores hardware fields for v2-v5.
+// v1alpha1 has a simpler variant (see restoreV1Alpha1VirtualMachineHardware).
+func restoreVirtualMachineHardwareShared(dst, src *vmopv1.VirtualMachine) {
+	if src.Spec.Hardware == nil {
+		return
+	}
+	var cdromChanges []vmopv1.VirtualMachineCdromSpec
+	if dst.Spec.Hardware != nil && len(dst.Spec.Hardware.Cdrom) > 0 {
+		cdromChanges = dst.Spec.Hardware.Cdrom
+	}
+	dst.Spec.Hardware = src.Spec.Hardware.DeepCopy()
+	dst.Spec.Hardware.Cdrom = cdromChanges
+	for i := range dst.Spec.Hardware.Cdrom {
+		dstCdrom := &dst.Spec.Hardware.Cdrom[i]
+		for _, srcCdrom := range src.Spec.Hardware.Cdrom {
+			if srcCdrom.Name == dstCdrom.Name {
+				dstCdrom.ControllerBusNumber = srcCdrom.ControllerBusNumber
+				dstCdrom.ControllerType = srcCdrom.ControllerType
+				dstCdrom.UnitNumber = srcCdrom.UnitNumber
+				break
+			}
+		}
+	}
+}
+
+// restoreVirtualMachineAffinity is shared across v2-v5.
+func restoreVirtualMachineAffinity(dst, src *vmopv1.VirtualMachine) {
+	if src.Spec.Affinity == nil {
+		dst.Spec.Affinity = nil
+	} else {
+		dst.Spec.Affinity = src.Spec.Affinity.DeepCopy()
+	}
+}
+
+// ============================================================
+// Version-specific restore helpers for VirtualMachineAdvanced
+// ============================================================
+
+// restoreV1Alpha1VirtualMachineAdvanced restores Advanced fields for v1alpha1.
+// v1alpha1 additionally restores DefaultVolumeProvisioningMode.
+func restoreV1Alpha1VirtualMachineAdvanced(dst, src *vmopv1.VirtualMachine) {
+	adv := src.Spec.Advanced
+	if adv == nil {
+		return
+	}
+	if dst.Spec.Advanced == nil {
+		dst.Spec.Advanced = &vmopv1.VirtualMachineAdvancedSpec{}
+	}
+	dst.Spec.Advanced.DefaultVolumeProvisioningMode = adv.DefaultVolumeProvisioningMode
+	dst.Spec.Advanced.PreferHTEnabled = adv.PreferHTEnabled
+	dst.Spec.Advanced.HugePages1GEnabled = adv.HugePages1GEnabled
+	dst.Spec.Advanced.TimeTrackerLowLatencyEnabled = adv.TimeTrackerLowLatencyEnabled
+	dst.Spec.Advanced.CPUAffinityExclusiveNoStatsEnabled = adv.CPUAffinityExclusiveNoStatsEnabled
+	dst.Spec.Advanced.VMXSwapEnabled = adv.VMXSwapEnabled
+	dst.Spec.Advanced.PNUMANodeAffinity = adv.PNUMANodeAffinity
+	dst.Spec.Advanced.ExtraConfig = adv.ExtraConfig
+}
+
+// restoreV1Alpha2VirtualMachineAdvanced restores Advanced fields for v1alpha2-v5
+// (no DefaultVolumeProvisioningMode).
+func restoreV1Alpha2VirtualMachineAdvanced(dst, src *vmopv1.VirtualMachine) {
+	adv := src.Spec.Advanced
+	if adv == nil {
+		return
+	}
+	if dst.Spec.Advanced == nil {
+		dst.Spec.Advanced = &vmopv1.VirtualMachineAdvancedSpec{}
+	}
+	dst.Spec.Advanced.PreferHTEnabled = adv.PreferHTEnabled
+	dst.Spec.Advanced.HugePages1GEnabled = adv.HugePages1GEnabled
+	dst.Spec.Advanced.TimeTrackerLowLatencyEnabled = adv.TimeTrackerLowLatencyEnabled
+	dst.Spec.Advanced.CPUAffinityExclusiveNoStatsEnabled = adv.CPUAffinityExclusiveNoStatsEnabled
+	dst.Spec.Advanced.VMXSwapEnabled = adv.VMXSwapEnabled
+	dst.Spec.Advanced.PNUMANodeAffinity = adv.PNUMANodeAffinity
+	dst.Spec.Advanced.ExtraConfig = adv.ExtraConfig
+}
+
+// ============================================================
+// Version-specific restore helpers for VirtualMachineVolumes
+// ============================================================
+
+// restoreV1Alpha1VirtualMachineVolumes restores volume fields for v1alpha1.
+// v1alpha1 additionally filters out boot-disk-size volumes.
+func restoreV1Alpha1VirtualMachineVolumes(dst, src *vmopv1.VirtualMachine) {
+	srcVolMap := map[string]*vmopv1.VirtualMachineVolume{}
+	for i := range src.Spec.Volumes {
+		vol := &src.Spec.Volumes[i]
+		srcVolMap[vol.Name] = vol
+	}
+	var vols []vmopv1.VirtualMachineVolume
+	for _, v := range dst.Spec.Volumes {
+		if srcVol, ok := srcVolMap[v.Name]; ok {
+			v.ApplicationType = srcVol.ApplicationType
+			v.ControllerBusNumber = srcVol.ControllerBusNumber
+			v.ControllerType = srcVol.ControllerType
+			v.DiskMode = srcVol.DiskMode
+			v.SharingMode = srcVol.SharingMode
+			v.UnitNumber = srcVol.UnitNumber
+			v.Removable = srcVol.Removable
+		}
+		if v.PersistentVolumeClaim != nil ||
+			(v.ControllerType != "" &&
+				v.ControllerBusNumber != nil &&
+				v.UnitNumber != nil) {
+			vols = append(vols, v)
+		}
+	}
+	if len(vols) == 0 {
+		vols = nil
+	}
+	dst.Spec.Volumes = vols
+}
+
+// restoreVirtualMachineVolumes restores volume fields for v2-v5.
+func restoreVirtualMachineVolumes(dst, src *vmopv1.VirtualMachine) {
+	srcVolMap := map[string]*vmopv1.VirtualMachineVolume{}
+	for i := range src.Spec.Volumes {
+		vol := &src.Spec.Volumes[i]
+		srcVolMap[vol.Name] = vol
+	}
+	for i := range dst.Spec.Volumes {
+		dstVol := &dst.Spec.Volumes[i]
+		if srcVol, ok := srcVolMap[dstVol.Name]; ok {
+			dstVol.ApplicationType = srcVol.ApplicationType
+			dstVol.ControllerBusNumber = srcVol.ControllerBusNumber
+			dstVol.ControllerType = srcVol.ControllerType
+			dstVol.DiskMode = srcVol.DiskMode
+			dstVol.SharingMode = srcVol.SharingMode
+			dstVol.UnitNumber = srcVol.UnitNumber
+			dstVol.Removable = srcVol.Removable
+		}
+	}
+}
+
+// ============================================================
+// Version-specific restore for network interfaces (v2-v5 shared)
+// ============================================================
+
+func restoreVirtualMachineNetworkInterfaces(dst, src *vmopv1.VirtualMachine) {
+	if src.Spec.Network == nil || len(src.Spec.Network.Interfaces) == 0 {
+		return
+	}
+	if dst.Spec.Network == nil || len(dst.Spec.Network.Interfaces) == 0 {
+		return
+	}
+	srcByName := make(map[string]*vmopv1.VirtualMachineNetworkInterfaceSpec, len(src.Spec.Network.Interfaces))
+	for i := range src.Spec.Network.Interfaces {
+		srcByName[src.Spec.Network.Interfaces[i].Name] = &src.Spec.Network.Interfaces[i]
+	}
+	for i := range dst.Spec.Network.Interfaces {
+		srcIface, ok := srcByName[dst.Spec.Network.Interfaces[i].Name]
+		if !ok {
+			continue
+		}
+		dstIface := &dst.Spec.Network.Interfaces[i]
+		dstIface.IPAMModes = append([]corev1.IPFamily(nil), srcIface.IPAMModes...)
+		dstIface.Type = srcIface.Type
+		dstIface.VNUMANodeID = srcIface.VNUMANodeID
+		dstIface.VMXNet3 = srcIface.VMXNet3
+		dstIface.AdvancedProperties = srcIface.AdvancedProperties
+		if dstIface.DHCP4 == nil && srcIface.DHCP4 != nil && !*srcIface.DHCP4 {
+			dstIface.DHCP4 = srcIface.DHCP4
+		}
+		if dstIface.DHCP6 == nil && srcIface.DHCP6 != nil && !*srcIface.DHCP6 {
+			dstIface.DHCP6 = srcIface.DHCP6
+		}
+	}
+}
+
+// ============================================================
+// v1alpha1-specific restore helpers
+// ============================================================
+
+func restoreV1Alpha1VirtualMachineHardware(dst, src *vmopv1.VirtualMachine) {
+	if src.Spec.Hardware != nil {
+		dst.Spec.Hardware = src.Spec.Hardware.DeepCopy()
+	} else {
+		dst.Spec.Hardware = nil
+	}
+}
+
+func restoreV1Alpha1VirtualMachineBootstrapSpec(dst, src *vmopv1.VirtualMachine) {
+	srcBootstrap := src.Spec.Bootstrap
+	if srcBootstrap == nil {
+		return
+	}
+
+	dstBootstrap := dst.Spec.Bootstrap
+	if dstBootstrap == nil {
+		if reflect.DeepEqual(&srcBootstrap, &vmopv1.VirtualMachineBootstrapSpec{}) {
+			dst.Spec.Bootstrap = &vmopv1.VirtualMachineBootstrapSpec{}
+			return
+		}
+		if srcBootstrap.LinuxPrep != nil || srcBootstrap.Disabled {
+			dst.Spec.Bootstrap = &vmopv1.VirtualMachineBootstrapSpec{
+				LinuxPrep: srcBootstrap.LinuxPrep,
+				Disabled:  srcBootstrap.Disabled,
+			}
+		}
+		return
+	}
+
+	mergeSecretKeySelector := func(dstSel, srcSel *vmopv1common.SecretKeySelector) *vmopv1common.SecretKeySelector {
+		if dstSel == nil || srcSel == nil {
+			return dstSel
+		}
+		newSel := *srcSel
+		newSel.Name = dstSel.Name
+		return &newSel
+	}
+
+	if dstCloudInit := dstBootstrap.CloudInit; dstCloudInit != nil {
+		if srcCloudInit := srcBootstrap.CloudInit; srcCloudInit != nil {
+			dstCloudInit.CloudConfig = srcCloudInit.CloudConfig
+			dstCloudInit.RawCloudConfig = mergeSecretKeySelector(dstCloudInit.RawCloudConfig, srcCloudInit.RawCloudConfig)
+			dstCloudInit.SSHAuthorizedKeys = srcCloudInit.SSHAuthorizedKeys
+			dstCloudInit.UseGlobalNameserversAsDefault = srcCloudInit.UseGlobalNameserversAsDefault
+			dstCloudInit.UseGlobalSearchDomainsAsDefault = srcCloudInit.UseGlobalSearchDomainsAsDefault
+			dstCloudInit.WaitOnNetwork4 = srcCloudInit.WaitOnNetwork4
+			dstCloudInit.WaitOnNetwork6 = srcCloudInit.WaitOnNetwork6
+		}
+	}
+
+	if dstLinuxPrep := dstBootstrap.LinuxPrep; dstLinuxPrep != nil {
+		if srcLinuxPrep := srcBootstrap.LinuxPrep; srcLinuxPrep != nil {
+			dstLinuxPrep.HardwareClockIsUTC = srcLinuxPrep.HardwareClockIsUTC
+			dstLinuxPrep.TimeZone = srcLinuxPrep.TimeZone
+			dstLinuxPrep.ExpirePasswordAfterNextLogin = srcLinuxPrep.ExpirePasswordAfterNextLogin
+			dstLinuxPrep.Password = srcLinuxPrep.Password
+			dstLinuxPrep.ScriptText = srcLinuxPrep.ScriptText
+			dstLinuxPrep.CustomizeAtNextPowerOn = srcLinuxPrep.CustomizeAtNextPowerOn
+		}
+	}
+
+	if dstSysPrep := dstBootstrap.Sysprep; dstSysPrep != nil {
+		if srcSysPrep := srcBootstrap.Sysprep; srcSysPrep != nil {
+			dstSysPrep.Sysprep = srcSysPrep.Sysprep
+			dstSysPrep.RawSysprep = mergeSecretKeySelector(dstSysPrep.RawSysprep, srcSysPrep.RawSysprep)
+			dstSysPrep.CustomizeAtNextPowerOn = srcSysPrep.CustomizeAtNextPowerOn
+			if dstBootstrap.VAppConfig == nil && srcBootstrap.VAppConfig != nil {
+				dstBootstrap.VAppConfig = &vmopv1.VirtualMachineBootstrapVAppConfigSpec{}
+			}
+		}
+	}
+
+	if dstVAppConfig := dstBootstrap.VAppConfig; dstVAppConfig != nil {
+		if srcVAppConfig := srcBootstrap.VAppConfig; srcVAppConfig != nil {
+			dstVAppConfig.Properties = srcVAppConfig.Properties
+			dstVAppConfig.RawProperties = srcVAppConfig.RawProperties
+		}
+	}
+
+	dstBootstrap.Disabled = srcBootstrap.Disabled
+}
+
+func restoreV1Alpha1VirtualMachineNetworkSpec(dst, src *vmopv1.VirtualMachine) {
+	srcNetwork := src.Spec.Network
+	if srcNetwork == nil {
+		return
+	}
+	if dst.Spec.Network == nil {
+		dst.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
+	}
+	dstNetwork := dst.Spec.Network
+	dstNetwork.DomainName = srcNetwork.DomainName
+	dstNetwork.HostName = srcNetwork.HostName
+	dstNetwork.Disabled = srcNetwork.Disabled
+	dstNetwork.Nameservers = srcNetwork.Nameservers
+	dstNetwork.SearchDomains = srcNetwork.SearchDomains
+	dstNetwork.VLANs = srcNetwork.VLANs
+	if len(dstNetwork.Interfaces) == 0 {
+		return
+	}
+	dstNetwork.Interfaces = srcNetwork.Interfaces
+}
+
+func restoreV1Alpha1VirtualMachineReadinessProbeSpec(dst, src *vmopv1.VirtualMachine) {
+	if src.Spec.ReadinessProbe != nil {
+		if dst.Spec.ReadinessProbe == nil {
+			dst.Spec.ReadinessProbe = &vmopv1.VirtualMachineReadinessProbeSpec{}
+		}
+		dst.Spec.ReadinessProbe.GuestInfo = src.Spec.ReadinessProbe.GuestInfo
+	}
+}
+
+func restoreV1Alpha1VirtualMachineCryptoSpec(dst, src *vmopv1.VirtualMachine) {
+	dst.Spec.Crypto = src.Spec.Crypto
+}
+
+func restoreV1Alpha1VirtualMachineGroupName(dst, src *vmopv1.VirtualMachine) {
+	dst.Spec.GroupName = src.Spec.GroupName
+}
+
+func restoreV1Alpha1VirtualMachineAffinitySpec(dst, src *vmopv1.VirtualMachine) {
+	dst.Spec.Affinity = src.Spec.Affinity
+}
+
+func convertV1Alpha1PreReqsReadyConditionToV1Alpha6Conditions(dst *vmopv1.VirtualMachine) []metav1.Condition {
+	var preReqCond, vmClassCond, vmImageCond, vmSetResourcePolicyCond, vmBootstrapCond *metav1.Condition
+	var preReqCondIdx int
+
+	for i := range dst.Status.Conditions {
+		c := &dst.Status.Conditions[i]
+		switch c.Type {
+		case string(vmopv1a1.VirtualMachinePrereqReadyCondition):
+			preReqCond = c
+			preReqCondIdx = i
+		case vmopv1.VirtualMachineConditionClassReady:
+			vmClassCond = c
+		case vmopv1.VirtualMachineConditionImageReady:
+			vmImageCond = c
+		case vmopv1.VirtualMachineConditionVMSetResourcePolicyReady:
+			vmSetResourcePolicyCond = c
+		case vmopv1.VirtualMachineConditionBootstrapReady:
+			vmBootstrapCond = c
+		}
+	}
+
+	if preReqCond == nil {
+		return dst.Status.Conditions
+	}
+
+	dst.Status.Conditions = append(dst.Status.Conditions[:preReqCondIdx], dst.Status.Conditions[preReqCondIdx+1:]...)
+
+	if vmClassCond != nil || vmImageCond != nil || vmSetResourcePolicyCond != nil || vmBootstrapCond != nil {
+		return dst.Status.Conditions
+	}
+
+	var conditions []metav1.Condition
+	if preReqCond.Status == metav1.ConditionTrue {
+		conditions = append(conditions, metav1.Condition{
+			Type:               vmopv1.VirtualMachineConditionClassReady,
+			Status:             metav1.ConditionTrue,
+			LastTransitionTime: preReqCond.LastTransitionTime,
+			Reason:             string(metav1.ConditionTrue),
+		})
+		conditions = append(conditions, metav1.Condition{
+			Type:               vmopv1.VirtualMachineConditionImageReady,
+			Status:             metav1.ConditionTrue,
+			LastTransitionTime: preReqCond.LastTransitionTime,
+			Reason:             string(metav1.ConditionTrue),
+		})
+		if dst.Spec.Reserved != nil && dst.Spec.Reserved.ResourcePolicyName != "" {
+			conditions = append(conditions, metav1.Condition{
+				Type:               vmopv1.VirtualMachineConditionVMSetResourcePolicyReady,
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: preReqCond.LastTransitionTime,
+				Reason:             string(metav1.ConditionTrue),
+			})
+		}
+		if dst.Spec.Bootstrap != nil {
+			conditions = append(conditions, metav1.Condition{
+				Type:               vmopv1.VirtualMachineConditionBootstrapReady,
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: preReqCond.LastTransitionTime,
+				Reason:             string(metav1.ConditionTrue),
+			})
+		}
+	} else if preReqCond.Status == metav1.ConditionFalse {
+		if preReqCond.Reason == string(vmopv1a1.VirtualMachineClassNotFoundReason) ||
+			preReqCond.Reason == string(vmopv1a1.VirtualMachineClassBindingNotFoundReason) {
+			conditions = append(conditions, metav1.Condition{
+				Type:               vmopv1.VirtualMachineConditionClassReady,
+				Status:             metav1.ConditionFalse,
+				LastTransitionTime: preReqCond.LastTransitionTime,
+				Reason:             preReqCond.Reason,
+			})
+			conditions = append(conditions, metav1.Condition{
+				Type:               vmopv1.VirtualMachineConditionImageReady,
+				Status:             metav1.ConditionUnknown,
+				LastTransitionTime: preReqCond.LastTransitionTime,
+				Reason:             string(metav1.ConditionUnknown),
+			})
+		} else if preReqCond.Reason == string(vmopv1a1.VirtualMachineImageNotFoundReason) ||
+			preReqCond.Reason == string(vmopv1a1.VirtualMachineImageNotReadyReason) ||
+			preReqCond.Reason == string(vmopv1a1.ContentSourceBindingNotFoundReason) ||
+			preReqCond.Reason == string(vmopv1a1.ContentLibraryProviderNotFoundReason) {
+			conditions = append(conditions, metav1.Condition{
+				Type:               vmopv1.VirtualMachineConditionClassReady,
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: preReqCond.LastTransitionTime,
+				Reason:             string(metav1.ConditionTrue),
+			})
+			conditions = append(conditions, metav1.Condition{
+				Type:               vmopv1.VirtualMachineConditionImageReady,
+				Status:             metav1.ConditionFalse,
+				LastTransitionTime: preReqCond.LastTransitionTime,
+				Reason:             preReqCond.Reason,
+			})
+		}
+		if dst.Spec.Reserved != nil && dst.Spec.Reserved.ResourcePolicyName != "" {
+			conditions = append(conditions, metav1.Condition{
+				Type:               vmopv1.VirtualMachineConditionVMSetResourcePolicyReady,
+				Status:             metav1.ConditionUnknown,
+				LastTransitionTime: preReqCond.LastTransitionTime,
+				Reason:             string(metav1.ConditionUnknown),
+			})
+		}
+		if dst.Spec.Bootstrap != nil {
+			conditions = append(conditions, metav1.Condition{
+				Type:               vmopv1.VirtualMachineConditionBootstrapReady,
+				Status:             metav1.ConditionUnknown,
+				LastTransitionTime: preReqCond.LastTransitionTime,
+				Reason:             string(metav1.ConditionUnknown),
+			})
+		}
+	}
+
+	return append(dst.Status.Conditions, conditions...)
+}
+
+// restoreV1Alpha2VirtualMachineSpecNetworkDomainName restores the DomainName
+// from the hub if the down-conversion lost it (v1alpha2 stores it in sysprep).
+func restoreV1Alpha2VirtualMachineSpecNetworkDomainName(dst, src *vmopv1.VirtualMachine) {
+	var dstDN, srcDN string
+	if net := dst.Spec.Network; net != nil {
+		dstDN = net.DomainName
+	}
+	if net := src.Spec.Network; net != nil {
+		srcDN = net.DomainName
+	}
+	if dstDN == "" && srcDN != dstDN {
+		if dst.Spec.Network == nil {
+			dst.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
+		}
+		dst.Spec.Network.DomainName = srcDN
+	}
+}
+
+// ============================================================
+// v1alpha1 converter functions
+// ============================================================
+
+func convertVMHubToV1Alpha1(_ context.Context, hub *vmopv1.VirtualMachine, spoke *vmopv1a1.VirtualMachine) error {
+	if err := vmopv1a1.Convert_v1alpha6_VirtualMachine_To_v1alpha1_VirtualMachine(hub, spoke, nil); err != nil {
+		return err
+	}
+	return utilconversion.MarshalData(hub, spoke)
+}
+
+func convertVMV1Alpha1ToHub(_ context.Context, spoke *vmopv1a1.VirtualMachine, hub *vmopv1.VirtualMachine) error {
+	if err := vmopv1a1.Convert_v1alpha1_VirtualMachine_To_v1alpha6_VirtualMachine(spoke, hub, nil); err != nil {
+		return err
+	}
+
+	restored := &vmopv1.VirtualMachine{}
+	ok, err := utilconversion.UnmarshalData(spoke, restored)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		hub.Status.Conditions = convertV1Alpha1PreReqsReadyConditionToV1Alpha6Conditions(hub)
+		return nil
+	}
+
+	restoreVirtualMachineImage(hub, restored)
+	restoreV1Alpha1VirtualMachineBootstrapSpec(hub, restored)
+	restoreV1Alpha1VirtualMachineNetworkSpec(hub, restored)
+	restoreV1Alpha1VirtualMachineReadinessProbeSpec(hub, restored)
+	restoreVirtualMachineBiosUUID(hub, restored)
+	restoreVirtualMachineBootstrapCloudInitInstanceID(hub, restored)
+	restoreVirtualMachineInstanceUUID(hub, restored)
+	restoreVirtualMachineGuestID(hub, restored)
+	restoreV1Alpha1VirtualMachineCryptoSpec(hub, restored)
+	restoreVirtualMachinePromoteDisksMode(hub, restored)
+	restoreVirtualMachineBootOptions(hub, restored)
+	restoreV1Alpha1VirtualMachineAffinitySpec(hub, restored)
+	restoreV1Alpha1VirtualMachineGroupName(hub, restored)
+	restoreV1Alpha1VirtualMachineVolumes(hub, restored)
+	restoreV1Alpha1VirtualMachineHardware(hub, restored)
+	restoreVirtualMachinePolicies(hub, restored)
+	restoreVirtualMachineVolumeAttributesClassName(hub, restored)
+	restoreV1Alpha1VirtualMachineAdvanced(hub, restored)
+	restoreVirtualMachineCurrentSnapshotName(hub, restored)
+	restoreVirtualMachineResources(hub, restored)
+	restoreVirtualMachineCPUAdvanced(hub, restored)
+	restoreVirtualMachineMemoryAdvanced(hub, restored)
+
+	hub.Status = restored.Status
+	return nil
+}
+
+// ============================================================
+// v1alpha2 converter functions
+// ============================================================
+
+func convertVMHubToV1Alpha2(_ context.Context, hub *vmopv1.VirtualMachine, spoke *vmopv1a2.VirtualMachine) error {
+	if err := vmopv1a2.Convert_v1alpha6_VirtualMachine_To_v1alpha2_VirtualMachine(hub, spoke, nil); err != nil {
+		return err
+	}
+	return utilconversion.MarshalData(hub, spoke)
+}
+
+func convertVMV1Alpha2ToHub(_ context.Context, spoke *vmopv1a2.VirtualMachine, hub *vmopv1.VirtualMachine) error {
+	if err := vmopv1a2.Convert_v1alpha2_VirtualMachine_To_v1alpha6_VirtualMachine(spoke, hub, nil); err != nil {
+		return err
+	}
+
+	restored := &vmopv1.VirtualMachine{}
+	ok, err := utilconversion.UnmarshalData(spoke, restored)
+	if err != nil || !ok {
+		return err
+	}
+
+	restoreVirtualMachineImage(hub, restored)
+	restoreVirtualMachineInstanceUUID(hub, restored)
+	restoreVirtualMachineBiosUUID(hub, restored)
+	restoreVirtualMachineBootstrapCloudInitInstanceID(hub, restored)
+	restoreVirtualMachineBootstrapCloudInitWaitOnNetwork(hub, restored)
+	restoreVirtualMachineBootstrapLinuxPrep(hub, restored)
+	restoreVirtualMachineBootstrapSysprep(hub, restored)
+	restoreVirtualMachineBootstrapDisabled(hub, restored)
+	restoreV1Alpha2VirtualMachineSpecNetworkDomainName(hub, restored)
+	restoreVirtualMachineGuestID(hub, restored)
+	restoreVirtualMachinePromoteDisksMode(hub, restored)
+	restoreVirtualMachineBootOptions(hub, restored)
+	restoreVirtualMachineVolumes(hub, restored)
+	restoreVirtualMachineHardwareShared(hub, restored)
+	restoreVirtualMachinePolicies(hub, restored)
+	restoreVirtualMachineCryptoVTPM(hub, restored)
+	restoreVirtualMachineAffinity(hub, restored)
+	restoreVirtualMachineVolumeAttributesClassName(hub, restored)
+	restoreVirtualMachineNetworkVLANs(hub, restored)
+	restoreV1Alpha2VirtualMachineAdvanced(hub, restored)
+	restoreVirtualMachineNetworkInterfaces(hub, restored)
+	restoreVirtualMachineCurrentSnapshotName(hub, restored)
+	restoreVirtualMachineResources(hub, restored)
+	restoreVirtualMachineCPUAdvanced(hub, restored)
+	restoreVirtualMachineMemoryAdvanced(hub, restored)
+
+	hub.Status = restored.Status
+	return nil
+}
+
+// ============================================================
+// v1alpha3 converter functions
+// ============================================================
+
+func convertVMHubToV1Alpha3(_ context.Context, hub *vmopv1.VirtualMachine, spoke *vmopv1a3.VirtualMachine) error {
+	if err := vmopv1a3.Convert_v1alpha6_VirtualMachine_To_v1alpha3_VirtualMachine(hub, spoke, nil); err != nil {
+		return err
+	}
+	return utilconversion.MarshalData(hub, spoke)
+}
+
+func convertVMV1Alpha3ToHub(_ context.Context, spoke *vmopv1a3.VirtualMachine, hub *vmopv1.VirtualMachine) error {
+	if err := vmopv1a3.Convert_v1alpha3_VirtualMachine_To_v1alpha6_VirtualMachine(spoke, hub, nil); err != nil {
+		return err
+	}
+
+	restored := &vmopv1.VirtualMachine{}
+	ok, err := utilconversion.UnmarshalData(spoke, restored)
+	if err != nil || !ok {
+		return err
+	}
+
+	restoreVirtualMachineBootstrapCloudInitWaitOnNetwork(hub, restored)
+	restoreVirtualMachineBootstrapLinuxPrep(hub, restored)
+	restoreVirtualMachineBootstrapSysprep(hub, restored)
+	restoreVirtualMachineBootstrapDisabled(hub, restored)
+	restoreVirtualMachinePromoteDisksMode(hub, restored)
+	restoreVirtualMachineBootOptions(hub, restored)
+	restoreVirtualMachineVolumes(hub, restored)
+	restoreVirtualMachineHardwareShared(hub, restored)
+	restoreVirtualMachinePolicies(hub, restored)
+	restoreVirtualMachineCryptoVTPM(hub, restored)
+	restoreVirtualMachineAffinity(hub, restored)
+	restoreVirtualMachineVolumeAttributesClassName(hub, restored)
+	restoreVirtualMachineNetworkVLANs(hub, restored)
+	restoreV1Alpha2VirtualMachineAdvanced(hub, restored)
+	restoreVirtualMachineNetworkInterfaces(hub, restored)
+	restoreVirtualMachineCurrentSnapshotName(hub, restored)
+	restoreVirtualMachineResources(hub, restored)
+	restoreVirtualMachineCPUAdvanced(hub, restored)
+	restoreVirtualMachineMemoryAdvanced(hub, restored)
+
+	hub.Status = restored.Status
+	return nil
+}
+
+// ============================================================
+// v1alpha4 converter functions
+// ============================================================
+
+func convertVMHubToV1Alpha4(_ context.Context, hub *vmopv1.VirtualMachine, spoke *vmopv1a4.VirtualMachine) error {
+	if err := vmopv1a4.Convert_v1alpha6_VirtualMachine_To_v1alpha4_VirtualMachine(hub, spoke, nil); err != nil {
+		return err
+	}
+	return utilconversion.MarshalData(hub, spoke)
+}
+
+func convertVMV1Alpha4ToHub(_ context.Context, spoke *vmopv1a4.VirtualMachine, hub *vmopv1.VirtualMachine) error {
+	if err := vmopv1a4.Convert_v1alpha4_VirtualMachine_To_v1alpha6_VirtualMachine(spoke, hub, nil); err != nil {
+		return err
+	}
+
+	restored := &vmopv1.VirtualMachine{}
+	ok, err := utilconversion.UnmarshalData(spoke, restored)
+	if err != nil || !ok {
+		return err
+	}
+
+	restoreVirtualMachineHardwareShared(hub, restored)
+	restoreVirtualMachinePolicies(hub, restored)
+	restoreVirtualMachineBootOptions(hub, restored)
+	restoreVirtualMachineCryptoVTPM(hub, restored)
+	restoreVirtualMachineBootstrapCloudInitWaitOnNetwork(hub, restored)
+	restoreVirtualMachineBootstrapLinuxPrep(hub, restored)
+	restoreVirtualMachineBootstrapSysprep(hub, restored)
+	restoreVirtualMachineBootstrapDisabled(hub, restored)
+	restoreVirtualMachineAffinity(hub, restored)
+	restoreVirtualMachineVolumes(hub, restored)
+	restoreVirtualMachineVolumeAttributesClassName(hub, restored)
+	restoreVirtualMachineNetworkVLANs(hub, restored)
+	restoreV1Alpha2VirtualMachineAdvanced(hub, restored)
+	restoreVirtualMachineNetworkInterfaces(hub, restored)
+	restoreVirtualMachineCurrentSnapshotName(hub, restored)
+	restoreVirtualMachineResources(hub, restored)
+	restoreVirtualMachineCPUAdvanced(hub, restored)
+	restoreVirtualMachineMemoryAdvanced(hub, restored)
+
+	hub.Status = restored.Status
+	return nil
+}
+
+// ============================================================
+// v1alpha5 converter functions
+// ============================================================
+
+func convertVMHubToV1Alpha5(_ context.Context, hub *vmopv1.VirtualMachine, spoke *vmopv1a5.VirtualMachine) error {
+	if err := vmopv1a5.Convert_v1alpha6_VirtualMachine_To_v1alpha5_VirtualMachine(hub, spoke, nil); err != nil {
+		return err
+	}
+	return utilconversion.MarshalData(hub, spoke)
+}
+
+func convertVMV1Alpha5ToHub(_ context.Context, spoke *vmopv1a5.VirtualMachine, hub *vmopv1.VirtualMachine) error {
+	if err := vmopv1a5.Convert_v1alpha5_VirtualMachine_To_v1alpha6_VirtualMachine(spoke, hub, nil); err != nil {
+		return err
+	}
+
+	restored := &vmopv1.VirtualMachine{}
+	ok, err := utilconversion.UnmarshalData(spoke, restored)
+	if err != nil || !ok {
+		return err
+	}
+
+	restoreVirtualMachineBootstrapDisabled(hub, restored)
+	restoreVirtualMachineVolumeAttributesClassName(hub, restored)
+	restoreVirtualMachineNetworkVLANs(hub, restored)
+	restoreV1Alpha2VirtualMachineAdvanced(hub, restored)
+	restoreVirtualMachineNetworkInterfaces(hub, restored)
+	restoreVirtualMachineResources(hub, restored)
+	restoreVirtualMachineCPUAdvanced(hub, restored)
+	restoreVirtualMachineMemoryAdvanced(hub, restored)
+
+	hub.Status = restored.Status
+	return nil
+}

--- a/webhooks/conversion/v1alpha6/convert_virtualmachineclass.go
+++ b/webhooks/conversion/v1alpha6/convert_virtualmachineclass.go
@@ -1,0 +1,68 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha6
+
+import (
+	"context"
+
+	whconversion "sigs.k8s.io/controller-runtime/pkg/webhook/conversion"
+
+	vmopv1a1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1a2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	vmopv1a3 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	vmopv1a4 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	vmopv1a5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+)
+
+// VirtualMachineClass is the converter for VirtualMachineClass across all spoke versions.
+var VirtualMachineClass = whconversion.NewHubSpokeConverter(
+	&vmopv1.VirtualMachineClass{},
+	whconversion.NewSpokeConverter(&vmopv1a1.VirtualMachineClass{}, convertVMClassHubToV1Alpha1, convertVMClassV1Alpha1ToHub),
+	whconversion.NewSpokeConverter(&vmopv1a2.VirtualMachineClass{}, convertVMClassHubToV1Alpha2, convertVMClassV1Alpha2ToHub),
+	whconversion.NewSpokeConverter(&vmopv1a3.VirtualMachineClass{}, convertVMClassHubToV1Alpha3, convertVMClassV1Alpha3ToHub),
+	whconversion.NewSpokeConverter(&vmopv1a4.VirtualMachineClass{}, convertVMClassHubToV1Alpha4, convertVMClassV1Alpha4ToHub),
+	whconversion.NewSpokeConverter(&vmopv1a5.VirtualMachineClass{}, convertVMClassHubToV1Alpha5, convertVMClassV1Alpha5ToHub),
+)
+
+func convertVMClassHubToV1Alpha1(_ context.Context, hub *vmopv1.VirtualMachineClass, spoke *vmopv1a1.VirtualMachineClass) error {
+	return vmopv1a1.Convert_v1alpha6_VirtualMachineClass_To_v1alpha1_VirtualMachineClass(hub, spoke, nil)
+}
+
+func convertVMClassV1Alpha1ToHub(_ context.Context, spoke *vmopv1a1.VirtualMachineClass, hub *vmopv1.VirtualMachineClass) error {
+	return vmopv1a1.Convert_v1alpha1_VirtualMachineClass_To_v1alpha6_VirtualMachineClass(spoke, hub, nil)
+}
+
+func convertVMClassHubToV1Alpha2(_ context.Context, hub *vmopv1.VirtualMachineClass, spoke *vmopv1a2.VirtualMachineClass) error {
+	return vmopv1a2.Convert_v1alpha6_VirtualMachineClass_To_v1alpha2_VirtualMachineClass(hub, spoke, nil)
+}
+
+func convertVMClassV1Alpha2ToHub(_ context.Context, spoke *vmopv1a2.VirtualMachineClass, hub *vmopv1.VirtualMachineClass) error {
+	return vmopv1a2.Convert_v1alpha2_VirtualMachineClass_To_v1alpha6_VirtualMachineClass(spoke, hub, nil)
+}
+
+func convertVMClassHubToV1Alpha3(_ context.Context, hub *vmopv1.VirtualMachineClass, spoke *vmopv1a3.VirtualMachineClass) error {
+	return vmopv1a3.Convert_v1alpha6_VirtualMachineClass_To_v1alpha3_VirtualMachineClass(hub, spoke, nil)
+}
+
+func convertVMClassV1Alpha3ToHub(_ context.Context, spoke *vmopv1a3.VirtualMachineClass, hub *vmopv1.VirtualMachineClass) error {
+	return vmopv1a3.Convert_v1alpha3_VirtualMachineClass_To_v1alpha6_VirtualMachineClass(spoke, hub, nil)
+}
+
+func convertVMClassHubToV1Alpha4(_ context.Context, hub *vmopv1.VirtualMachineClass, spoke *vmopv1a4.VirtualMachineClass) error {
+	return vmopv1a4.Convert_v1alpha6_VirtualMachineClass_To_v1alpha4_VirtualMachineClass(hub, spoke, nil)
+}
+
+func convertVMClassV1Alpha4ToHub(_ context.Context, spoke *vmopv1a4.VirtualMachineClass, hub *vmopv1.VirtualMachineClass) error {
+	return vmopv1a4.Convert_v1alpha4_VirtualMachineClass_To_v1alpha6_VirtualMachineClass(spoke, hub, nil)
+}
+
+func convertVMClassHubToV1Alpha5(_ context.Context, hub *vmopv1.VirtualMachineClass, spoke *vmopv1a5.VirtualMachineClass) error {
+	return vmopv1a5.Convert_v1alpha6_VirtualMachineClass_To_v1alpha5_VirtualMachineClass(hub, spoke, nil)
+}
+
+func convertVMClassV1Alpha5ToHub(_ context.Context, spoke *vmopv1a5.VirtualMachineClass, hub *vmopv1.VirtualMachineClass) error {
+	return vmopv1a5.Convert_v1alpha5_VirtualMachineClass_To_v1alpha6_VirtualMachineClass(spoke, hub, nil)
+}

--- a/webhooks/conversion/v1alpha6/convert_virtualmachineclass_test.go
+++ b/webhooks/conversion/v1alpha6/convert_virtualmachineclass_test.go
@@ -1,0 +1,89 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha6_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	vmopv1a1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1a2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	vmopv1a3 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	vmopv1a4 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	vmopv1a5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
+	. "github.com/vmware-tanzu/vm-operator/webhooks/conversion/v1alpha6"
+)
+
+var _ = Describe("VirtualMachineClass conversion",
+	Label(testlabels.API, testlabels.Webhook),
+	func() {
+		var (
+			ctx    context.Context
+			scheme *runtime.Scheme
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			scheme = runtime.NewScheme()
+			Expect(vmopv1.AddToScheme(scheme)).To(Succeed())
+			Expect(vmopv1a1.AddToScheme(scheme)).To(Succeed())
+			Expect(vmopv1a2.AddToScheme(scheme)).To(Succeed())
+			Expect(vmopv1a3.AddToScheme(scheme)).To(Succeed())
+			Expect(vmopv1a4.AddToScheme(scheme)).To(Succeed())
+			Expect(vmopv1a5.AddToScheme(scheme)).To(Succeed())
+		})
+
+		Describe("v1alpha2 spoke", func() {
+			It("round-trips hub→spoke→hub without loss", func() {
+				converter, err := VirtualMachineClass(scheme)
+				Expect(err).NotTo(HaveOccurred())
+
+				hub := &vmopv1.VirtualMachineClass{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "vmoperator.vmware.com/v1alpha6",
+						Kind:       "VirtualMachineClass",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-class",
+					},
+					Spec: vmopv1.VirtualMachineClassSpec{
+						Hardware: vmopv1.VirtualMachineClassHardware{
+							Cpus:   4,
+							Memory: resource.MustParse("8Gi"),
+						},
+					},
+				}
+
+				spoke := &vmopv1a2.VirtualMachineClass{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "vmoperator.vmware.com/v1alpha2",
+						Kind:       "VirtualMachineClass",
+					},
+				}
+
+				Expect(converter.ConvertObject(ctx, hub, spoke)).To(Succeed())
+				Expect(spoke.Name).To(Equal(hub.Name))
+				Expect(spoke.Spec.Hardware.Cpus).To(Equal(int64(4)))
+
+				hub2 := &vmopv1.VirtualMachineClass{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "vmoperator.vmware.com/v1alpha6",
+						Kind:       "VirtualMachineClass",
+					},
+				}
+				Expect(converter.ConvertObject(ctx, spoke, hub2)).To(Succeed())
+				Expect(hub2.Name).To(Equal(hub.Name))
+				Expect(hub2.Spec.Hardware.Cpus).To(Equal(hub.Spec.Hardware.Cpus))
+			})
+		})
+	})

--- a/webhooks/conversion/v1alpha6/convert_virtualmachineclassinstance.go
+++ b/webhooks/conversion/v1alpha6/convert_virtualmachineclassinstance.go
@@ -1,0 +1,38 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha6
+
+import (
+	"context"
+
+	whconversion "sigs.k8s.io/controller-runtime/pkg/webhook/conversion"
+
+	vmopv1a4 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	vmopv1a5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+)
+
+// VirtualMachineClassInstance is the converter for VirtualMachineClassInstance across all spoke versions.
+var VirtualMachineClassInstance = whconversion.NewHubSpokeConverter(
+	&vmopv1.VirtualMachineClassInstance{},
+	whconversion.NewSpokeConverter(&vmopv1a4.VirtualMachineClassInstance{}, convertVMClassInstanceHubToV1Alpha4, convertVMClassInstanceV1Alpha4ToHub),
+	whconversion.NewSpokeConverter(&vmopv1a5.VirtualMachineClassInstance{}, convertVMClassInstanceHubToV1Alpha5, convertVMClassInstanceV1Alpha5ToHub),
+)
+
+func convertVMClassInstanceHubToV1Alpha4(_ context.Context, hub *vmopv1.VirtualMachineClassInstance, spoke *vmopv1a4.VirtualMachineClassInstance) error {
+	return vmopv1a4.Convert_v1alpha6_VirtualMachineClassInstance_To_v1alpha4_VirtualMachineClassInstance(hub, spoke, nil)
+}
+
+func convertVMClassInstanceV1Alpha4ToHub(_ context.Context, spoke *vmopv1a4.VirtualMachineClassInstance, hub *vmopv1.VirtualMachineClassInstance) error {
+	return vmopv1a4.Convert_v1alpha4_VirtualMachineClassInstance_To_v1alpha6_VirtualMachineClassInstance(spoke, hub, nil)
+}
+
+func convertVMClassInstanceHubToV1Alpha5(_ context.Context, hub *vmopv1.VirtualMachineClassInstance, spoke *vmopv1a5.VirtualMachineClassInstance) error {
+	return vmopv1a5.Convert_v1alpha6_VirtualMachineClassInstance_To_v1alpha5_VirtualMachineClassInstance(hub, spoke, nil)
+}
+
+func convertVMClassInstanceV1Alpha5ToHub(_ context.Context, spoke *vmopv1a5.VirtualMachineClassInstance, hub *vmopv1.VirtualMachineClassInstance) error {
+	return vmopv1a5.Convert_v1alpha5_VirtualMachineClassInstance_To_v1alpha6_VirtualMachineClassInstance(spoke, hub, nil)
+}

--- a/webhooks/conversion/v1alpha6/convert_virtualmachinegroup.go
+++ b/webhooks/conversion/v1alpha6/convert_virtualmachinegroup.go
@@ -1,0 +1,58 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha6
+
+import (
+	"context"
+
+	whconversion "sigs.k8s.io/controller-runtime/pkg/webhook/conversion"
+
+	vmopv1a2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	vmopv1a3 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	vmopv1a4 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	vmopv1a5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+)
+
+// VirtualMachineGroup is the converter for VirtualMachineGroup across all spoke versions.
+var VirtualMachineGroup = whconversion.NewHubSpokeConverter(
+	&vmopv1.VirtualMachineGroup{},
+	whconversion.NewSpokeConverter(&vmopv1a2.VirtualMachineGroup{}, convertVMGroupHubToV1Alpha2, convertVMGroupV1Alpha2ToHub),
+	whconversion.NewSpokeConverter(&vmopv1a3.VirtualMachineGroup{}, convertVMGroupHubToV1Alpha3, convertVMGroupV1Alpha3ToHub),
+	whconversion.NewSpokeConverter(&vmopv1a4.VirtualMachineGroup{}, convertVMGroupHubToV1Alpha4, convertVMGroupV1Alpha4ToHub),
+	whconversion.NewSpokeConverter(&vmopv1a5.VirtualMachineGroup{}, convertVMGroupHubToV1Alpha5, convertVMGroupV1Alpha5ToHub),
+)
+
+func convertVMGroupHubToV1Alpha2(_ context.Context, hub *vmopv1.VirtualMachineGroup, spoke *vmopv1a2.VirtualMachineGroup) error {
+	return vmopv1a2.Convert_v1alpha6_VirtualMachineGroup_To_v1alpha2_VirtualMachineGroup(hub, spoke, nil)
+}
+
+func convertVMGroupV1Alpha2ToHub(_ context.Context, spoke *vmopv1a2.VirtualMachineGroup, hub *vmopv1.VirtualMachineGroup) error {
+	return vmopv1a2.Convert_v1alpha2_VirtualMachineGroup_To_v1alpha6_VirtualMachineGroup(spoke, hub, nil)
+}
+
+func convertVMGroupHubToV1Alpha3(_ context.Context, hub *vmopv1.VirtualMachineGroup, spoke *vmopv1a3.VirtualMachineGroup) error {
+	return vmopv1a3.Convert_v1alpha6_VirtualMachineGroup_To_v1alpha3_VirtualMachineGroup(hub, spoke, nil)
+}
+
+func convertVMGroupV1Alpha3ToHub(_ context.Context, spoke *vmopv1a3.VirtualMachineGroup, hub *vmopv1.VirtualMachineGroup) error {
+	return vmopv1a3.Convert_v1alpha3_VirtualMachineGroup_To_v1alpha6_VirtualMachineGroup(spoke, hub, nil)
+}
+
+func convertVMGroupHubToV1Alpha4(_ context.Context, hub *vmopv1.VirtualMachineGroup, spoke *vmopv1a4.VirtualMachineGroup) error {
+	return vmopv1a4.Convert_v1alpha6_VirtualMachineGroup_To_v1alpha4_VirtualMachineGroup(hub, spoke, nil)
+}
+
+func convertVMGroupV1Alpha4ToHub(_ context.Context, spoke *vmopv1a4.VirtualMachineGroup, hub *vmopv1.VirtualMachineGroup) error {
+	return vmopv1a4.Convert_v1alpha4_VirtualMachineGroup_To_v1alpha6_VirtualMachineGroup(spoke, hub, nil)
+}
+
+func convertVMGroupHubToV1Alpha5(_ context.Context, hub *vmopv1.VirtualMachineGroup, spoke *vmopv1a5.VirtualMachineGroup) error {
+	return vmopv1a5.Convert_v1alpha6_VirtualMachineGroup_To_v1alpha5_VirtualMachineGroup(hub, spoke, nil)
+}
+
+func convertVMGroupV1Alpha5ToHub(_ context.Context, spoke *vmopv1a5.VirtualMachineGroup, hub *vmopv1.VirtualMachineGroup) error {
+	return vmopv1a5.Convert_v1alpha5_VirtualMachineGroup_To_v1alpha6_VirtualMachineGroup(spoke, hub, nil)
+}

--- a/webhooks/conversion/v1alpha6/convert_virtualmachinegrouppublishrequest.go
+++ b/webhooks/conversion/v1alpha6/convert_virtualmachinegrouppublishrequest.go
@@ -1,0 +1,28 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha6
+
+import (
+	"context"
+
+	whconversion "sigs.k8s.io/controller-runtime/pkg/webhook/conversion"
+
+	vmopv1a5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+)
+
+// VirtualMachineGroupPublishRequest is the converter for VirtualMachineGroupPublishRequest across all spoke versions.
+var VirtualMachineGroupPublishRequest = whconversion.NewHubSpokeConverter(
+	&vmopv1.VirtualMachineGroupPublishRequest{},
+	whconversion.NewSpokeConverter(&vmopv1a5.VirtualMachineGroupPublishRequest{}, convertVMGroupPublishRequestHubToV1Alpha5, convertVMGroupPublishRequestV1Alpha5ToHub),
+)
+
+func convertVMGroupPublishRequestHubToV1Alpha5(_ context.Context, hub *vmopv1.VirtualMachineGroupPublishRequest, spoke *vmopv1a5.VirtualMachineGroupPublishRequest) error {
+	return vmopv1a5.Convert_v1alpha6_VirtualMachineGroupPublishRequest_To_v1alpha5_VirtualMachineGroupPublishRequest(hub, spoke, nil)
+}
+
+func convertVMGroupPublishRequestV1Alpha5ToHub(_ context.Context, spoke *vmopv1a5.VirtualMachineGroupPublishRequest, hub *vmopv1.VirtualMachineGroupPublishRequest) error {
+	return vmopv1a5.Convert_v1alpha5_VirtualMachineGroupPublishRequest_To_v1alpha6_VirtualMachineGroupPublishRequest(spoke, hub, nil)
+}

--- a/webhooks/conversion/v1alpha6/convert_virtualmachineimage.go
+++ b/webhooks/conversion/v1alpha6/convert_virtualmachineimage.go
@@ -1,0 +1,311 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha6
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	whconversion "sigs.k8s.io/controller-runtime/pkg/webhook/conversion"
+
+
+	vmopv1a1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1a2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	vmopv1a3 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	vmopv1a4 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	vmopv1a5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+	vmopv1common "github.com/vmware-tanzu/vm-operator/api/v1alpha6/common"
+)
+
+// VirtualMachineImage is the converter for VirtualMachineImage across all spoke versions.
+var VirtualMachineImage = whconversion.NewHubSpokeConverter(
+	&vmopv1.VirtualMachineImage{},
+	whconversion.NewSpokeConverter(&vmopv1a1.VirtualMachineImage{}, convertVMImageHubToV1Alpha1, convertVMImageV1Alpha1ToHub),
+	whconversion.NewSpokeConverter(&vmopv1a2.VirtualMachineImage{}, convertVMImageHubToV1Alpha2, convertVMImageV1Alpha2ToHub),
+	whconversion.NewSpokeConverter(&vmopv1a3.VirtualMachineImage{}, convertVMImageHubToV1Alpha3, convertVMImageV1Alpha3ToHub),
+	whconversion.NewSpokeConverter(&vmopv1a4.VirtualMachineImage{}, convertVMImageHubToV1Alpha4, convertVMImageV1Alpha4ToHub),
+	whconversion.NewSpokeConverter(&vmopv1a5.VirtualMachineImage{}, convertVMImageHubToV1Alpha5, convertVMImageV1Alpha5ToHub),
+)
+
+// ClusterVirtualMachineImage is the converter for ClusterVirtualMachineImage across all spoke versions.
+var ClusterVirtualMachineImage = whconversion.NewHubSpokeConverter(
+	&vmopv1.ClusterVirtualMachineImage{},
+	whconversion.NewSpokeConverter(&vmopv1a1.ClusterVirtualMachineImage{}, convertClusterVMImageHubToV1Alpha1, convertClusterVMImageV1Alpha1ToHub),
+	whconversion.NewSpokeConverter(&vmopv1a2.ClusterVirtualMachineImage{}, convertClusterVMImageHubToV1Alpha2, convertClusterVMImageV1Alpha2ToHub),
+	whconversion.NewSpokeConverter(&vmopv1a3.ClusterVirtualMachineImage{}, convertClusterVMImageHubToV1Alpha3, convertClusterVMImageV1Alpha3ToHub),
+	whconversion.NewSpokeConverter(&vmopv1a4.ClusterVirtualMachineImage{}, convertClusterVMImageHubToV1Alpha4, convertClusterVMImageV1Alpha4ToHub),
+	whconversion.NewSpokeConverter(&vmopv1a5.ClusterVirtualMachineImage{}, convertClusterVMImageHubToV1Alpha5, convertClusterVMImageV1Alpha5ToHub),
+)
+
+// readVMIContentLibRefAnnotation reads the VMIContentLibRefAnnotation from a
+// metav1.Object and unmarshals it into a TypedLocalObjectReference.
+func readVMIContentLibRefAnnotation(from metav1.Object) (objRef *corev1.TypedLocalObjectReference) {
+	if data, ok := from.GetAnnotations()[vmopv1.VMIContentLibRefAnnotation]; ok {
+		objRef = &corev1.TypedLocalObjectReference{}
+		_ = json.Unmarshal([]byte(data), objRef)
+	}
+	return
+}
+
+// convertV1Alpha1OVFEnvToV1Alpha6OVFProperties converts v1alpha1 OvfProperty map
+// to v1alpha6 OVFProperty slice. This replicates the unexported helper in api/v1alpha1.
+func convertV1Alpha1OVFEnvToV1Alpha6OVFProperties(in map[string]vmopv1a1.OvfProperty, out *[]vmopv1.OVFProperty) {
+	if in != nil {
+		*out = make([]vmopv1.OVFProperty, 0, len(in))
+		for _, v := range in {
+			*out = append(*out, vmopv1.OVFProperty{
+				Key:     v.Key,
+				Type:    v.Type,
+				Default: v.Default,
+			})
+		}
+	}
+}
+
+// convertV1Alpha6OVFPropertiesToV1Alpha1OVFEnv converts v1alpha6 OVFProperty slice
+// to v1alpha1 OvfProperty map. This replicates the unexported helper in api/v1alpha1.
+func convertV1Alpha6OVFPropertiesToV1Alpha1OVFEnv(in []vmopv1.OVFProperty, out *map[string]vmopv1a1.OvfProperty) {
+	if in != nil {
+		*out = make(map[string]vmopv1a1.OvfProperty)
+		for _, p := range in {
+			(*out)[p.Key] = vmopv1a1.OvfProperty{
+				Key:         p.Key,
+				Type:        p.Type,
+				Default:     p.Default,
+				Description: "",
+				Label:       "",
+			}
+		}
+	}
+}
+
+// convertV1Alpha1VMISpecToV1Alpha6Status moves fields from the v1alpha1 ImageSpec
+// into the v1alpha6 ImageStatus (they were reorganized between versions).
+func convertV1Alpha1VMISpecToV1Alpha6Status(in *vmopv1a1.VirtualMachineImageSpec, out *vmopv1.VirtualMachineImageStatus) error {
+	out.ProviderItemID = in.ImageID
+	if in.HardwareVersion != 0 {
+		out.HardwareVersion = &in.HardwareVersion
+	}
+
+	if err := vmopv1a1.Convert_v1alpha1_VirtualMachineImageOSInfo_To_v1alpha6_VirtualMachineImageOSInfo(&in.OSInfo, &out.OSInfo, nil); err != nil {
+		return err
+	}
+
+	convertV1Alpha1OVFEnvToV1Alpha6OVFProperties(in.OVFEnv, &out.OVFProperties)
+
+	if err := vmopv1a1.Convert_v1alpha1_VirtualMachineImageProductInfo_To_v1alpha6_VirtualMachineImageProductInfo(&in.ProductInfo, &out.ProductInfo, nil); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// convertV1Alpha6StatusToV1Alpha1VMISpec moves fields from v1alpha6 ImageStatus
+// back into v1alpha1 ImageSpec.
+func convertV1Alpha6StatusToV1Alpha1VMISpec(in *vmopv1.VirtualMachineImageStatus, out *vmopv1a1.VirtualMachineImageSpec) error {
+	out.ImageID = in.ProviderItemID
+	if in.HardwareVersion != nil {
+		out.HardwareVersion = *in.HardwareVersion
+	}
+
+	if err := vmopv1a1.Convert_v1alpha6_VirtualMachineImageOSInfo_To_v1alpha1_VirtualMachineImageOSInfo(&in.OSInfo, &out.OSInfo, nil); err != nil {
+		return err
+	}
+
+	convertV1Alpha6OVFPropertiesToV1Alpha1OVFEnv(in.OVFProperties, &out.OVFEnv)
+
+	if err := vmopv1a1.Convert_v1alpha6_VirtualMachineImageProductInfo_To_v1alpha1_VirtualMachineImageProductInfo(&in.ProductInfo, &out.ProductInfo, nil); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// convertV1Alpha6VMwareSystemPropertiesToV1Alpha1Annotations copies vmware-system
+// KeyValuePairs from the hub status into the spoke annotation map.
+func convertV1Alpha6VMwareSystemPropertiesToV1Alpha1Annotations(
+	in *[]vmopv1common.KeyValuePair, out *map[string]string) error {
+
+	if in != nil && len(*in) > 0 {
+		if *out == nil {
+			*out = make(map[string]string)
+		}
+		for _, pair := range *in {
+			(*out)[pair.Key] = pair.Value
+		}
+	}
+	return nil
+}
+
+// convertV1Alpha1AnnotationsToV1Alpha6VMwareSystemProperties copies vmware-system
+// annotations from the spoke into the hub's VMwareSystemProperties status field,
+// then removes them from the hub's annotation map.
+func convertV1Alpha1AnnotationsToV1Alpha6VMwareSystemProperties(
+	in *map[string]string, dstAnnotations *map[string]string, dstSystemProperties *[]vmopv1common.KeyValuePair) error {
+
+	if *in == nil {
+		return nil
+	}
+	for k, v := range *in {
+		if strings.HasPrefix(k, "vmware-system") {
+			*dstSystemProperties = append(*dstSystemProperties, vmopv1common.KeyValuePair{
+				Key:   k,
+				Value: v,
+			})
+		}
+	}
+	if *dstAnnotations != nil {
+		for k := range *dstAnnotations {
+			if strings.HasPrefix(k, "vmware-system") {
+				delete(*dstAnnotations, k)
+			}
+		}
+	}
+	return nil
+}
+
+// ============================================================
+// v1alpha1 — complex conversion (spec/status rearrangement)
+// ============================================================
+
+func convertVMImageHubToV1Alpha1(_ context.Context, hub *vmopv1.VirtualMachineImage, spoke *vmopv1a1.VirtualMachineImage) error {
+	if err := vmopv1a1.Convert_v1alpha6_VirtualMachineImage_To_v1alpha1_VirtualMachineImage(hub, spoke, nil); err != nil {
+		return err
+	}
+	if err := convertV1Alpha6StatusToV1Alpha1VMISpec(&hub.Status, &spoke.Spec); err != nil {
+		return err
+	}
+	if err := convertV1Alpha6VMwareSystemPropertiesToV1Alpha1Annotations(
+		&hub.Status.VMwareSystemProperties, &spoke.Annotations); err != nil {
+		return err
+	}
+	if spoke.Spec.ProviderRef.Name != "" {
+		// The Namespace isn't a field in the hub LocalObjectRef so backfill it here.
+		spoke.Spec.ProviderRef.Namespace = hub.Namespace
+	}
+	spoke.Status.ContentLibraryRef = readVMIContentLibRefAnnotation(hub)
+	return nil
+}
+
+func convertVMImageV1Alpha1ToHub(_ context.Context, spoke *vmopv1a1.VirtualMachineImage, hub *vmopv1.VirtualMachineImage) error {
+	if err := vmopv1a1.Convert_v1alpha1_VirtualMachineImage_To_v1alpha6_VirtualMachineImage(spoke, hub, nil); err != nil {
+		return err
+	}
+	if err := convertV1Alpha1VMISpecToV1Alpha6Status(&spoke.Spec, &hub.Status); err != nil {
+		return err
+	}
+	return convertV1Alpha1AnnotationsToV1Alpha6VMwareSystemProperties(
+		&spoke.Annotations, &hub.Annotations, &hub.Status.VMwareSystemProperties)
+}
+
+func convertClusterVMImageHubToV1Alpha1(_ context.Context, hub *vmopv1.ClusterVirtualMachineImage, spoke *vmopv1a1.ClusterVirtualMachineImage) error {
+	if err := vmopv1a1.Convert_v1alpha6_ClusterVirtualMachineImage_To_v1alpha1_ClusterVirtualMachineImage(hub, spoke, nil); err != nil {
+		return err
+	}
+	if err := convertV1Alpha6StatusToV1Alpha1VMISpec(&hub.Status, &spoke.Spec); err != nil {
+		return err
+	}
+	if err := convertV1Alpha6VMwareSystemPropertiesToV1Alpha1Annotations(
+		&hub.Status.VMwareSystemProperties, &spoke.Annotations); err != nil {
+		return err
+	}
+	spoke.Status.ContentLibraryRef = readVMIContentLibRefAnnotation(hub)
+	return nil
+}
+
+func convertClusterVMImageV1Alpha1ToHub(_ context.Context, spoke *vmopv1a1.ClusterVirtualMachineImage, hub *vmopv1.ClusterVirtualMachineImage) error {
+	if err := vmopv1a1.Convert_v1alpha1_ClusterVirtualMachineImage_To_v1alpha6_ClusterVirtualMachineImage(spoke, hub, nil); err != nil {
+		return err
+	}
+	if err := convertV1Alpha1VMISpecToV1Alpha6Status(&spoke.Spec, &hub.Status); err != nil {
+		return err
+	}
+	return convertV1Alpha1AnnotationsToV1Alpha6VMwareSystemProperties(
+		&spoke.Annotations, &hub.Annotations, &hub.Status.VMwareSystemProperties)
+}
+
+// ============================================================
+// v1alpha2 — simple conversion
+// ============================================================
+
+func convertVMImageHubToV1Alpha2(_ context.Context, hub *vmopv1.VirtualMachineImage, spoke *vmopv1a2.VirtualMachineImage) error {
+	return vmopv1a2.Convert_v1alpha6_VirtualMachineImage_To_v1alpha2_VirtualMachineImage(hub, spoke, nil)
+}
+
+func convertVMImageV1Alpha2ToHub(_ context.Context, spoke *vmopv1a2.VirtualMachineImage, hub *vmopv1.VirtualMachineImage) error {
+	return vmopv1a2.Convert_v1alpha2_VirtualMachineImage_To_v1alpha6_VirtualMachineImage(spoke, hub, nil)
+}
+
+func convertClusterVMImageHubToV1Alpha2(_ context.Context, hub *vmopv1.ClusterVirtualMachineImage, spoke *vmopv1a2.ClusterVirtualMachineImage) error {
+	return vmopv1a2.Convert_v1alpha6_ClusterVirtualMachineImage_To_v1alpha2_ClusterVirtualMachineImage(hub, spoke, nil)
+}
+
+func convertClusterVMImageV1Alpha2ToHub(_ context.Context, spoke *vmopv1a2.ClusterVirtualMachineImage, hub *vmopv1.ClusterVirtualMachineImage) error {
+	return vmopv1a2.Convert_v1alpha2_ClusterVirtualMachineImage_To_v1alpha6_ClusterVirtualMachineImage(spoke, hub, nil)
+}
+
+// ============================================================
+// v1alpha3 — simple conversion
+// ============================================================
+
+func convertVMImageHubToV1Alpha3(_ context.Context, hub *vmopv1.VirtualMachineImage, spoke *vmopv1a3.VirtualMachineImage) error {
+	return vmopv1a3.Convert_v1alpha6_VirtualMachineImage_To_v1alpha3_VirtualMachineImage(hub, spoke, nil)
+}
+
+func convertVMImageV1Alpha3ToHub(_ context.Context, spoke *vmopv1a3.VirtualMachineImage, hub *vmopv1.VirtualMachineImage) error {
+	return vmopv1a3.Convert_v1alpha3_VirtualMachineImage_To_v1alpha6_VirtualMachineImage(spoke, hub, nil)
+}
+
+func convertClusterVMImageHubToV1Alpha3(_ context.Context, hub *vmopv1.ClusterVirtualMachineImage, spoke *vmopv1a3.ClusterVirtualMachineImage) error {
+	return vmopv1a3.Convert_v1alpha6_ClusterVirtualMachineImage_To_v1alpha3_ClusterVirtualMachineImage(hub, spoke, nil)
+}
+
+func convertClusterVMImageV1Alpha3ToHub(_ context.Context, spoke *vmopv1a3.ClusterVirtualMachineImage, hub *vmopv1.ClusterVirtualMachineImage) error {
+	return vmopv1a3.Convert_v1alpha3_ClusterVirtualMachineImage_To_v1alpha6_ClusterVirtualMachineImage(spoke, hub, nil)
+}
+
+// ============================================================
+// v1alpha4 — simple conversion
+// ============================================================
+
+func convertVMImageHubToV1Alpha4(_ context.Context, hub *vmopv1.VirtualMachineImage, spoke *vmopv1a4.VirtualMachineImage) error {
+	return vmopv1a4.Convert_v1alpha6_VirtualMachineImage_To_v1alpha4_VirtualMachineImage(hub, spoke, nil)
+}
+
+func convertVMImageV1Alpha4ToHub(_ context.Context, spoke *vmopv1a4.VirtualMachineImage, hub *vmopv1.VirtualMachineImage) error {
+	return vmopv1a4.Convert_v1alpha4_VirtualMachineImage_To_v1alpha6_VirtualMachineImage(spoke, hub, nil)
+}
+
+func convertClusterVMImageHubToV1Alpha4(_ context.Context, hub *vmopv1.ClusterVirtualMachineImage, spoke *vmopv1a4.ClusterVirtualMachineImage) error {
+	return vmopv1a4.Convert_v1alpha6_ClusterVirtualMachineImage_To_v1alpha4_ClusterVirtualMachineImage(hub, spoke, nil)
+}
+
+func convertClusterVMImageV1Alpha4ToHub(_ context.Context, spoke *vmopv1a4.ClusterVirtualMachineImage, hub *vmopv1.ClusterVirtualMachineImage) error {
+	return vmopv1a4.Convert_v1alpha4_ClusterVirtualMachineImage_To_v1alpha6_ClusterVirtualMachineImage(spoke, hub, nil)
+}
+
+// ============================================================
+// v1alpha5 — simple conversion
+// ============================================================
+
+func convertVMImageHubToV1Alpha5(_ context.Context, hub *vmopv1.VirtualMachineImage, spoke *vmopv1a5.VirtualMachineImage) error {
+	return vmopv1a5.Convert_v1alpha6_VirtualMachineImage_To_v1alpha5_VirtualMachineImage(hub, spoke, nil)
+}
+
+func convertVMImageV1Alpha5ToHub(_ context.Context, spoke *vmopv1a5.VirtualMachineImage, hub *vmopv1.VirtualMachineImage) error {
+	return vmopv1a5.Convert_v1alpha5_VirtualMachineImage_To_v1alpha6_VirtualMachineImage(spoke, hub, nil)
+}
+
+func convertClusterVMImageHubToV1Alpha5(_ context.Context, hub *vmopv1.ClusterVirtualMachineImage, spoke *vmopv1a5.ClusterVirtualMachineImage) error {
+	return vmopv1a5.Convert_v1alpha6_ClusterVirtualMachineImage_To_v1alpha5_ClusterVirtualMachineImage(hub, spoke, nil)
+}
+
+func convertClusterVMImageV1Alpha5ToHub(_ context.Context, spoke *vmopv1a5.ClusterVirtualMachineImage, hub *vmopv1.ClusterVirtualMachineImage) error {
+	return vmopv1a5.Convert_v1alpha5_ClusterVirtualMachineImage_To_v1alpha6_ClusterVirtualMachineImage(spoke, hub, nil)
+}

--- a/webhooks/conversion/v1alpha6/convert_virtualmachineimagecache.go
+++ b/webhooks/conversion/v1alpha6/convert_virtualmachineimagecache.go
@@ -1,0 +1,73 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha6
+
+import (
+	"context"
+
+	whconversion "sigs.k8s.io/controller-runtime/pkg/webhook/conversion"
+
+	"github.com/vmware-tanzu/vm-operator/api/utilconversion"
+	vmopv1a3 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	vmopv1a4 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	vmopv1a5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+)
+
+// VirtualMachineImageCache is the converter for VirtualMachineImageCache across all spoke versions.
+var VirtualMachineImageCache = whconversion.NewHubSpokeConverter(
+	&vmopv1.VirtualMachineImageCache{},
+	whconversion.NewSpokeConverter(&vmopv1a3.VirtualMachineImageCache{}, convertVMImageCacheHubToV1Alpha3, convertVMImageCacheV1Alpha3ToHub),
+	whconversion.NewSpokeConverter(&vmopv1a4.VirtualMachineImageCache{}, convertVMImageCacheHubToV1Alpha4, convertVMImageCacheV1Alpha4ToHub),
+	whconversion.NewSpokeConverter(&vmopv1a5.VirtualMachineImageCache{}, convertVMImageCacheHubToV1Alpha5, convertVMImageCacheV1Alpha5ToHub),
+)
+
+func convertVMImageCacheHubToV1Alpha3(_ context.Context, hub *vmopv1.VirtualMachineImageCache, spoke *vmopv1a3.VirtualMachineImageCache) error {
+	if err := vmopv1a3.Convert_v1alpha6_VirtualMachineImageCache_To_v1alpha3_VirtualMachineImageCache(hub, spoke, nil); err != nil {
+		return err
+	}
+	return utilconversion.MarshalData(hub, spoke)
+}
+
+func convertVMImageCacheV1Alpha3ToHub(_ context.Context, spoke *vmopv1a3.VirtualMachineImageCache, hub *vmopv1.VirtualMachineImageCache) error {
+	if err := vmopv1a3.Convert_v1alpha3_VirtualMachineImageCache_To_v1alpha6_VirtualMachineImageCache(spoke, hub, nil); err != nil {
+		return err
+	}
+	restored := &vmopv1.VirtualMachineImageCache{}
+	ok, err := utilconversion.UnmarshalData(spoke, restored)
+	if err != nil || !ok {
+		return err
+	}
+	hub.Status = restored.Status
+	return nil
+}
+
+func convertVMImageCacheHubToV1Alpha4(_ context.Context, hub *vmopv1.VirtualMachineImageCache, spoke *vmopv1a4.VirtualMachineImageCache) error {
+	if err := vmopv1a4.Convert_v1alpha6_VirtualMachineImageCache_To_v1alpha4_VirtualMachineImageCache(hub, spoke, nil); err != nil {
+		return err
+	}
+	return utilconversion.MarshalData(hub, spoke)
+}
+
+func convertVMImageCacheV1Alpha4ToHub(_ context.Context, spoke *vmopv1a4.VirtualMachineImageCache, hub *vmopv1.VirtualMachineImageCache) error {
+	if err := vmopv1a4.Convert_v1alpha4_VirtualMachineImageCache_To_v1alpha6_VirtualMachineImageCache(spoke, hub, nil); err != nil {
+		return err
+	}
+	restored := &vmopv1.VirtualMachineImageCache{}
+	ok, err := utilconversion.UnmarshalData(spoke, restored)
+	if err != nil || !ok {
+		return err
+	}
+	hub.Status = restored.Status
+	return nil
+}
+
+func convertVMImageCacheHubToV1Alpha5(_ context.Context, hub *vmopv1.VirtualMachineImageCache, spoke *vmopv1a5.VirtualMachineImageCache) error {
+	return vmopv1a5.Convert_v1alpha6_VirtualMachineImageCache_To_v1alpha5_VirtualMachineImageCache(hub, spoke, nil)
+}
+
+func convertVMImageCacheV1Alpha5ToHub(_ context.Context, spoke *vmopv1a5.VirtualMachineImageCache, hub *vmopv1.VirtualMachineImageCache) error {
+	return vmopv1a5.Convert_v1alpha5_VirtualMachineImageCache_To_v1alpha6_VirtualMachineImageCache(spoke, hub, nil)
+}

--- a/webhooks/conversion/v1alpha6/convert_virtualmachinepublishrequest.go
+++ b/webhooks/conversion/v1alpha6/convert_virtualmachinepublishrequest.go
@@ -1,0 +1,123 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha6
+
+import (
+	"context"
+
+	whconversion "sigs.k8s.io/controller-runtime/pkg/webhook/conversion"
+
+	"github.com/vmware-tanzu/vm-operator/api/utilconversion"
+	vmopv1a1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1a2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	vmopv1a3 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	vmopv1a4 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	vmopv1a5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+)
+
+// VirtualMachinePublishRequest is the converter for VirtualMachinePublishRequest across all spoke versions.
+var VirtualMachinePublishRequest = whconversion.NewHubSpokeConverter(
+	&vmopv1.VirtualMachinePublishRequest{},
+	whconversion.NewSpokeConverter(&vmopv1a1.VirtualMachinePublishRequest{}, convertVMPublishRequestHubToV1Alpha1, convertVMPublishRequestV1Alpha1ToHub),
+	whconversion.NewSpokeConverter(&vmopv1a2.VirtualMachinePublishRequest{}, convertVMPublishRequestHubToV1Alpha2, convertVMPublishRequestV1Alpha2ToHub),
+	whconversion.NewSpokeConverter(&vmopv1a3.VirtualMachinePublishRequest{}, convertVMPublishRequestHubToV1Alpha3, convertVMPublishRequestV1Alpha3ToHub),
+	whconversion.NewSpokeConverter(&vmopv1a4.VirtualMachinePublishRequest{}, convertVMPublishRequestHubToV1Alpha4, convertVMPublishRequestV1Alpha4ToHub),
+	whconversion.NewSpokeConverter(&vmopv1a5.VirtualMachinePublishRequest{}, convertVMPublishRequestHubToV1Alpha5, convertVMPublishRequestV1Alpha5ToHub),
+)
+
+func convertVMPublishRequestHubToV1Alpha1(_ context.Context, hub *vmopv1.VirtualMachinePublishRequest, spoke *vmopv1a1.VirtualMachinePublishRequest) error {
+	if err := vmopv1a1.Convert_v1alpha6_VirtualMachinePublishRequest_To_v1alpha1_VirtualMachinePublishRequest(hub, spoke, nil); err != nil {
+		return err
+	}
+	return utilconversion.MarshalData(hub, spoke)
+}
+
+func convertVMPublishRequestV1Alpha1ToHub(_ context.Context, spoke *vmopv1a1.VirtualMachinePublishRequest, hub *vmopv1.VirtualMachinePublishRequest) error {
+	if err := vmopv1a1.Convert_v1alpha1_VirtualMachinePublishRequest_To_v1alpha6_VirtualMachinePublishRequest(spoke, hub, nil); err != nil {
+		return err
+	}
+	restored := &vmopv1.VirtualMachinePublishRequest{}
+	ok, err := utilconversion.UnmarshalData(spoke, restored)
+	if err != nil || !ok {
+		return err
+	}
+	hub.Spec.BackoffLimit = restored.Spec.BackoffLimit
+	return nil
+}
+
+func convertVMPublishRequestHubToV1Alpha2(_ context.Context, hub *vmopv1.VirtualMachinePublishRequest, spoke *vmopv1a2.VirtualMachinePublishRequest) error {
+	if err := vmopv1a2.Convert_v1alpha6_VirtualMachinePublishRequest_To_v1alpha2_VirtualMachinePublishRequest(hub, spoke, nil); err != nil {
+		return err
+	}
+	return utilconversion.MarshalData(hub, spoke)
+}
+
+func convertVMPublishRequestV1Alpha2ToHub(_ context.Context, spoke *vmopv1a2.VirtualMachinePublishRequest, hub *vmopv1.VirtualMachinePublishRequest) error {
+	if err := vmopv1a2.Convert_v1alpha2_VirtualMachinePublishRequest_To_v1alpha6_VirtualMachinePublishRequest(spoke, hub, nil); err != nil {
+		return err
+	}
+	restored := &vmopv1.VirtualMachinePublishRequest{}
+	ok, err := utilconversion.UnmarshalData(spoke, restored)
+	if err != nil || !ok {
+		return err
+	}
+	hub.Spec.BackoffLimit = restored.Spec.BackoffLimit
+	return nil
+}
+
+func convertVMPublishRequestHubToV1Alpha3(_ context.Context, hub *vmopv1.VirtualMachinePublishRequest, spoke *vmopv1a3.VirtualMachinePublishRequest) error {
+	if err := vmopv1a3.Convert_v1alpha6_VirtualMachinePublishRequest_To_v1alpha3_VirtualMachinePublishRequest(hub, spoke, nil); err != nil {
+		return err
+	}
+	return utilconversion.MarshalData(hub, spoke)
+}
+
+func convertVMPublishRequestV1Alpha3ToHub(_ context.Context, spoke *vmopv1a3.VirtualMachinePublishRequest, hub *vmopv1.VirtualMachinePublishRequest) error {
+	if err := vmopv1a3.Convert_v1alpha3_VirtualMachinePublishRequest_To_v1alpha6_VirtualMachinePublishRequest(spoke, hub, nil); err != nil {
+		return err
+	}
+	restored := &vmopv1.VirtualMachinePublishRequest{}
+	ok, err := utilconversion.UnmarshalData(spoke, restored)
+	if err != nil || !ok {
+		return err
+	}
+	hub.Spec.BackoffLimit = restored.Spec.BackoffLimit
+	return nil
+}
+
+func convertVMPublishRequestHubToV1Alpha4(_ context.Context, hub *vmopv1.VirtualMachinePublishRequest, spoke *vmopv1a4.VirtualMachinePublishRequest) error {
+	if err := vmopv1a4.Convert_v1alpha6_VirtualMachinePublishRequest_To_v1alpha4_VirtualMachinePublishRequest(hub, spoke, nil); err != nil {
+		return err
+	}
+	return utilconversion.MarshalData(hub, spoke)
+}
+
+func convertVMPublishRequestV1Alpha4ToHub(_ context.Context, spoke *vmopv1a4.VirtualMachinePublishRequest, hub *vmopv1.VirtualMachinePublishRequest) error {
+	if err := vmopv1a4.Convert_v1alpha4_VirtualMachinePublishRequest_To_v1alpha6_VirtualMachinePublishRequest(spoke, hub, nil); err != nil {
+		return err
+	}
+	restored := &vmopv1.VirtualMachinePublishRequest{}
+	ok, err := utilconversion.UnmarshalData(spoke, restored)
+	if err != nil || !ok {
+		return err
+	}
+	hub.Spec.BackoffLimit = restored.Spec.BackoffLimit
+	return nil
+}
+
+func convertVMPublishRequestHubToV1Alpha5(_ context.Context, hub *vmopv1.VirtualMachinePublishRequest, spoke *vmopv1a5.VirtualMachinePublishRequest) error {
+	if err := vmopv1a5.Convert_v1alpha6_VirtualMachinePublishRequest_To_v1alpha5_VirtualMachinePublishRequest(hub, spoke, nil); err != nil {
+		return err
+	}
+	return utilconversion.MarshalData(hub, spoke)
+}
+
+func convertVMPublishRequestV1Alpha5ToHub(_ context.Context, spoke *vmopv1a5.VirtualMachinePublishRequest, hub *vmopv1.VirtualMachinePublishRequest) error {
+	if err := vmopv1a5.Convert_v1alpha5_VirtualMachinePublishRequest_To_v1alpha6_VirtualMachinePublishRequest(spoke, hub, nil); err != nil {
+		return err
+	}
+	return nil
+}

--- a/webhooks/conversion/v1alpha6/convert_virtualmachinereplicaset.go
+++ b/webhooks/conversion/v1alpha6/convert_virtualmachinereplicaset.go
@@ -1,0 +1,73 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha6
+
+import (
+	"context"
+
+	whconversion "sigs.k8s.io/controller-runtime/pkg/webhook/conversion"
+
+	"github.com/vmware-tanzu/vm-operator/api/utilconversion"
+	vmopv1a3 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	vmopv1a4 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	vmopv1a5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+)
+
+// VirtualMachineReplicaSet is the converter for VirtualMachineReplicaSet across all spoke versions.
+var VirtualMachineReplicaSet = whconversion.NewHubSpokeConverter(
+	&vmopv1.VirtualMachineReplicaSet{},
+	whconversion.NewSpokeConverter(&vmopv1a3.VirtualMachineReplicaSet{}, convertVMReplicaSetHubToV1Alpha3, convertVMReplicaSetV1Alpha3ToHub),
+	whconversion.NewSpokeConverter(&vmopv1a4.VirtualMachineReplicaSet{}, convertVMReplicaSetHubToV1Alpha4, convertVMReplicaSetV1Alpha4ToHub),
+	whconversion.NewSpokeConverter(&vmopv1a5.VirtualMachineReplicaSet{}, convertVMReplicaSetHubToV1Alpha5, convertVMReplicaSetV1Alpha5ToHub),
+)
+
+func convertVMReplicaSetHubToV1Alpha3(_ context.Context, hub *vmopv1.VirtualMachineReplicaSet, spoke *vmopv1a3.VirtualMachineReplicaSet) error {
+	if err := vmopv1a3.Convert_v1alpha6_VirtualMachineReplicaSet_To_v1alpha3_VirtualMachineReplicaSet(hub, spoke, nil); err != nil {
+		return err
+	}
+	return utilconversion.MarshalData(hub, spoke)
+}
+
+func convertVMReplicaSetV1Alpha3ToHub(_ context.Context, spoke *vmopv1a3.VirtualMachineReplicaSet, hub *vmopv1.VirtualMachineReplicaSet) error {
+	if err := vmopv1a3.Convert_v1alpha3_VirtualMachineReplicaSet_To_v1alpha6_VirtualMachineReplicaSet(spoke, hub, nil); err != nil {
+		return err
+	}
+	restored := &vmopv1.VirtualMachineReplicaSet{}
+	ok, err := utilconversion.UnmarshalData(spoke, restored)
+	if err != nil || !ok {
+		return err
+	}
+	hub.Status = restored.Status
+	return nil
+}
+
+func convertVMReplicaSetHubToV1Alpha4(_ context.Context, hub *vmopv1.VirtualMachineReplicaSet, spoke *vmopv1a4.VirtualMachineReplicaSet) error {
+	if err := vmopv1a4.Convert_v1alpha6_VirtualMachineReplicaSet_To_v1alpha4_VirtualMachineReplicaSet(hub, spoke, nil); err != nil {
+		return err
+	}
+	return utilconversion.MarshalData(hub, spoke)
+}
+
+func convertVMReplicaSetV1Alpha4ToHub(_ context.Context, spoke *vmopv1a4.VirtualMachineReplicaSet, hub *vmopv1.VirtualMachineReplicaSet) error {
+	if err := vmopv1a4.Convert_v1alpha4_VirtualMachineReplicaSet_To_v1alpha6_VirtualMachineReplicaSet(spoke, hub, nil); err != nil {
+		return err
+	}
+	restored := &vmopv1.VirtualMachineReplicaSet{}
+	ok, err := utilconversion.UnmarshalData(spoke, restored)
+	if err != nil || !ok {
+		return err
+	}
+	hub.Status = restored.Status
+	return nil
+}
+
+func convertVMReplicaSetHubToV1Alpha5(_ context.Context, hub *vmopv1.VirtualMachineReplicaSet, spoke *vmopv1a5.VirtualMachineReplicaSet) error {
+	return vmopv1a5.Convert_v1alpha6_VirtualMachineReplicaSet_To_v1alpha5_VirtualMachineReplicaSet(hub, spoke, nil)
+}
+
+func convertVMReplicaSetV1Alpha5ToHub(_ context.Context, spoke *vmopv1a5.VirtualMachineReplicaSet, hub *vmopv1.VirtualMachineReplicaSet) error {
+	return vmopv1a5.Convert_v1alpha5_VirtualMachineReplicaSet_To_v1alpha6_VirtualMachineReplicaSet(spoke, hub, nil)
+}

--- a/webhooks/conversion/v1alpha6/convert_virtualmachineservice.go
+++ b/webhooks/conversion/v1alpha6/convert_virtualmachineservice.go
@@ -1,0 +1,139 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha6
+
+import (
+	"context"
+
+	whconversion "sigs.k8s.io/controller-runtime/pkg/webhook/conversion"
+
+	"github.com/vmware-tanzu/vm-operator/api/utilconversion"
+	vmopv1a1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1a2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	vmopv1a3 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	vmopv1a4 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	vmopv1a5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+)
+
+// VirtualMachineService is the converter for VirtualMachineService across all spoke versions.
+var VirtualMachineService = whconversion.NewHubSpokeConverter(
+	&vmopv1.VirtualMachineService{},
+	whconversion.NewSpokeConverter(&vmopv1a1.VirtualMachineService{}, convertVMServiceHubToV1Alpha1, convertVMServiceV1Alpha1ToHub),
+	whconversion.NewSpokeConverter(&vmopv1a2.VirtualMachineService{}, convertVMServiceHubToV1Alpha2, convertVMServiceV1Alpha2ToHub),
+	whconversion.NewSpokeConverter(&vmopv1a3.VirtualMachineService{}, convertVMServiceHubToV1Alpha3, convertVMServiceV1Alpha3ToHub),
+	whconversion.NewSpokeConverter(&vmopv1a4.VirtualMachineService{}, convertVMServiceHubToV1Alpha4, convertVMServiceV1Alpha4ToHub),
+	whconversion.NewSpokeConverter(&vmopv1a5.VirtualMachineService{}, convertVMServiceHubToV1Alpha5, convertVMServiceV1Alpha5ToHub),
+)
+
+func restoreVirtualMachineServiceIPFamilies(dst, restored *vmopv1.VirtualMachineService) {
+	dst.Spec.IPFamilies = restored.Spec.IPFamilies
+	dst.Spec.IPFamilyPolicy = restored.Spec.IPFamilyPolicy
+}
+
+func convertVMServiceHubToV1Alpha1(_ context.Context, hub *vmopv1.VirtualMachineService, spoke *vmopv1a1.VirtualMachineService) error {
+	if err := vmopv1a1.Convert_v1alpha6_VirtualMachineService_To_v1alpha1_VirtualMachineService(hub, spoke, nil); err != nil {
+		return err
+	}
+	return utilconversion.MarshalData(hub, spoke)
+}
+
+func convertVMServiceV1Alpha1ToHub(_ context.Context, spoke *vmopv1a1.VirtualMachineService, hub *vmopv1.VirtualMachineService) error {
+	if err := vmopv1a1.Convert_v1alpha1_VirtualMachineService_To_v1alpha6_VirtualMachineService(spoke, hub, nil); err != nil {
+		return err
+	}
+	restored := &vmopv1.VirtualMachineService{}
+	ok, err := utilconversion.UnmarshalData(spoke, restored)
+	if err != nil || !ok {
+		return err
+	}
+	restoreVirtualMachineServiceIPFamilies(hub, restored)
+	hub.Status = restored.Status
+	return nil
+}
+
+func convertVMServiceHubToV1Alpha2(_ context.Context, hub *vmopv1.VirtualMachineService, spoke *vmopv1a2.VirtualMachineService) error {
+	if err := vmopv1a2.Convert_v1alpha6_VirtualMachineService_To_v1alpha2_VirtualMachineService(hub, spoke, nil); err != nil {
+		return err
+	}
+	return utilconversion.MarshalData(hub, spoke)
+}
+
+func convertVMServiceV1Alpha2ToHub(_ context.Context, spoke *vmopv1a2.VirtualMachineService, hub *vmopv1.VirtualMachineService) error {
+	if err := vmopv1a2.Convert_v1alpha2_VirtualMachineService_To_v1alpha6_VirtualMachineService(spoke, hub, nil); err != nil {
+		return err
+	}
+	restored := &vmopv1.VirtualMachineService{}
+	ok, err := utilconversion.UnmarshalData(spoke, restored)
+	if err != nil || !ok {
+		return err
+	}
+	restoreVirtualMachineServiceIPFamilies(hub, restored)
+	hub.Status = restored.Status
+	return nil
+}
+
+func convertVMServiceHubToV1Alpha3(_ context.Context, hub *vmopv1.VirtualMachineService, spoke *vmopv1a3.VirtualMachineService) error {
+	if err := vmopv1a3.Convert_v1alpha6_VirtualMachineService_To_v1alpha3_VirtualMachineService(hub, spoke, nil); err != nil {
+		return err
+	}
+	return utilconversion.MarshalData(hub, spoke)
+}
+
+func convertVMServiceV1Alpha3ToHub(_ context.Context, spoke *vmopv1a3.VirtualMachineService, hub *vmopv1.VirtualMachineService) error {
+	if err := vmopv1a3.Convert_v1alpha3_VirtualMachineService_To_v1alpha6_VirtualMachineService(spoke, hub, nil); err != nil {
+		return err
+	}
+	restored := &vmopv1.VirtualMachineService{}
+	ok, err := utilconversion.UnmarshalData(spoke, restored)
+	if err != nil || !ok {
+		return err
+	}
+	restoreVirtualMachineServiceIPFamilies(hub, restored)
+	hub.Status = restored.Status
+	return nil
+}
+
+func convertVMServiceHubToV1Alpha4(_ context.Context, hub *vmopv1.VirtualMachineService, spoke *vmopv1a4.VirtualMachineService) error {
+	if err := vmopv1a4.Convert_v1alpha6_VirtualMachineService_To_v1alpha4_VirtualMachineService(hub, spoke, nil); err != nil {
+		return err
+	}
+	return utilconversion.MarshalData(hub, spoke)
+}
+
+func convertVMServiceV1Alpha4ToHub(_ context.Context, spoke *vmopv1a4.VirtualMachineService, hub *vmopv1.VirtualMachineService) error {
+	if err := vmopv1a4.Convert_v1alpha4_VirtualMachineService_To_v1alpha6_VirtualMachineService(spoke, hub, nil); err != nil {
+		return err
+	}
+	restored := &vmopv1.VirtualMachineService{}
+	ok, err := utilconversion.UnmarshalData(spoke, restored)
+	if err != nil || !ok {
+		return err
+	}
+	restoreVirtualMachineServiceIPFamilies(hub, restored)
+	hub.Status = restored.Status
+	return nil
+}
+
+func convertVMServiceHubToV1Alpha5(_ context.Context, hub *vmopv1.VirtualMachineService, spoke *vmopv1a5.VirtualMachineService) error {
+	if err := vmopv1a5.Convert_v1alpha6_VirtualMachineService_To_v1alpha5_VirtualMachineService(hub, spoke, nil); err != nil {
+		return err
+	}
+	return utilconversion.MarshalData(hub, spoke)
+}
+
+func convertVMServiceV1Alpha5ToHub(_ context.Context, spoke *vmopv1a5.VirtualMachineService, hub *vmopv1.VirtualMachineService) error {
+	if err := vmopv1a5.Convert_v1alpha5_VirtualMachineService_To_v1alpha6_VirtualMachineService(spoke, hub, nil); err != nil {
+		return err
+	}
+	restored := &vmopv1.VirtualMachineService{}
+	ok, err := utilconversion.UnmarshalData(spoke, restored)
+	if err != nil || !ok {
+		return err
+	}
+	restoreVirtualMachineServiceIPFamilies(hub, restored)
+	hub.Status = restored.Status
+	return nil
+}

--- a/webhooks/conversion/v1alpha6/convert_virtualmachinesetresourcepolicy.go
+++ b/webhooks/conversion/v1alpha6/convert_virtualmachinesetresourcepolicy.go
@@ -1,0 +1,68 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha6
+
+import (
+	"context"
+
+	whconversion "sigs.k8s.io/controller-runtime/pkg/webhook/conversion"
+
+	vmopv1a1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmopv1a2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	vmopv1a3 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	vmopv1a4 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	vmopv1a5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+)
+
+// VirtualMachineSetResourcePolicy is the converter for VirtualMachineSetResourcePolicy across all spoke versions.
+var VirtualMachineSetResourcePolicy = whconversion.NewHubSpokeConverter(
+	&vmopv1.VirtualMachineSetResourcePolicy{},
+	whconversion.NewSpokeConverter(&vmopv1a1.VirtualMachineSetResourcePolicy{}, convertVMSetResourcePolicyHubToV1Alpha1, convertVMSetResourcePolicyV1Alpha1ToHub),
+	whconversion.NewSpokeConverter(&vmopv1a2.VirtualMachineSetResourcePolicy{}, convertVMSetResourcePolicyHubToV1Alpha2, convertVMSetResourcePolicyV1Alpha2ToHub),
+	whconversion.NewSpokeConverter(&vmopv1a3.VirtualMachineSetResourcePolicy{}, convertVMSetResourcePolicyHubToV1Alpha3, convertVMSetResourcePolicyV1Alpha3ToHub),
+	whconversion.NewSpokeConverter(&vmopv1a4.VirtualMachineSetResourcePolicy{}, convertVMSetResourcePolicyHubToV1Alpha4, convertVMSetResourcePolicyV1Alpha4ToHub),
+	whconversion.NewSpokeConverter(&vmopv1a5.VirtualMachineSetResourcePolicy{}, convertVMSetResourcePolicyHubToV1Alpha5, convertVMSetResourcePolicyV1Alpha5ToHub),
+)
+
+func convertVMSetResourcePolicyHubToV1Alpha1(_ context.Context, hub *vmopv1.VirtualMachineSetResourcePolicy, spoke *vmopv1a1.VirtualMachineSetResourcePolicy) error {
+	return vmopv1a1.Convert_v1alpha6_VirtualMachineSetResourcePolicy_To_v1alpha1_VirtualMachineSetResourcePolicy(hub, spoke, nil)
+}
+
+func convertVMSetResourcePolicyV1Alpha1ToHub(_ context.Context, spoke *vmopv1a1.VirtualMachineSetResourcePolicy, hub *vmopv1.VirtualMachineSetResourcePolicy) error {
+	return vmopv1a1.Convert_v1alpha1_VirtualMachineSetResourcePolicy_To_v1alpha6_VirtualMachineSetResourcePolicy(spoke, hub, nil)
+}
+
+func convertVMSetResourcePolicyHubToV1Alpha2(_ context.Context, hub *vmopv1.VirtualMachineSetResourcePolicy, spoke *vmopv1a2.VirtualMachineSetResourcePolicy) error {
+	return vmopv1a2.Convert_v1alpha6_VirtualMachineSetResourcePolicy_To_v1alpha2_VirtualMachineSetResourcePolicy(hub, spoke, nil)
+}
+
+func convertVMSetResourcePolicyV1Alpha2ToHub(_ context.Context, spoke *vmopv1a2.VirtualMachineSetResourcePolicy, hub *vmopv1.VirtualMachineSetResourcePolicy) error {
+	return vmopv1a2.Convert_v1alpha2_VirtualMachineSetResourcePolicy_To_v1alpha6_VirtualMachineSetResourcePolicy(spoke, hub, nil)
+}
+
+func convertVMSetResourcePolicyHubToV1Alpha3(_ context.Context, hub *vmopv1.VirtualMachineSetResourcePolicy, spoke *vmopv1a3.VirtualMachineSetResourcePolicy) error {
+	return vmopv1a3.Convert_v1alpha6_VirtualMachineSetResourcePolicy_To_v1alpha3_VirtualMachineSetResourcePolicy(hub, spoke, nil)
+}
+
+func convertVMSetResourcePolicyV1Alpha3ToHub(_ context.Context, spoke *vmopv1a3.VirtualMachineSetResourcePolicy, hub *vmopv1.VirtualMachineSetResourcePolicy) error {
+	return vmopv1a3.Convert_v1alpha3_VirtualMachineSetResourcePolicy_To_v1alpha6_VirtualMachineSetResourcePolicy(spoke, hub, nil)
+}
+
+func convertVMSetResourcePolicyHubToV1Alpha4(_ context.Context, hub *vmopv1.VirtualMachineSetResourcePolicy, spoke *vmopv1a4.VirtualMachineSetResourcePolicy) error {
+	return vmopv1a4.Convert_v1alpha6_VirtualMachineSetResourcePolicy_To_v1alpha4_VirtualMachineSetResourcePolicy(hub, spoke, nil)
+}
+
+func convertVMSetResourcePolicyV1Alpha4ToHub(_ context.Context, spoke *vmopv1a4.VirtualMachineSetResourcePolicy, hub *vmopv1.VirtualMachineSetResourcePolicy) error {
+	return vmopv1a4.Convert_v1alpha4_VirtualMachineSetResourcePolicy_To_v1alpha6_VirtualMachineSetResourcePolicy(spoke, hub, nil)
+}
+
+func convertVMSetResourcePolicyHubToV1Alpha5(_ context.Context, hub *vmopv1.VirtualMachineSetResourcePolicy, spoke *vmopv1a5.VirtualMachineSetResourcePolicy) error {
+	return vmopv1a5.Convert_v1alpha6_VirtualMachineSetResourcePolicy_To_v1alpha5_VirtualMachineSetResourcePolicy(hub, spoke, nil)
+}
+
+func convertVMSetResourcePolicyV1Alpha5ToHub(_ context.Context, spoke *vmopv1a5.VirtualMachineSetResourcePolicy, hub *vmopv1.VirtualMachineSetResourcePolicy) error {
+	return vmopv1a5.Convert_v1alpha5_VirtualMachineSetResourcePolicy_To_v1alpha6_VirtualMachineSetResourcePolicy(spoke, hub, nil)
+}

--- a/webhooks/conversion/v1alpha6/convert_virtualmachinesnapshot.go
+++ b/webhooks/conversion/v1alpha6/convert_virtualmachinesnapshot.go
@@ -1,0 +1,28 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha6
+
+import (
+	"context"
+
+	whconversion "sigs.k8s.io/controller-runtime/pkg/webhook/conversion"
+
+	vmopv1a5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+)
+
+// VirtualMachineSnapshot is the converter for VirtualMachineSnapshot across all spoke versions.
+var VirtualMachineSnapshot = whconversion.NewHubSpokeConverter(
+	&vmopv1.VirtualMachineSnapshot{},
+	whconversion.NewSpokeConverter(&vmopv1a5.VirtualMachineSnapshot{}, convertVMSnapshotHubToV1Alpha5, convertVMSnapshotV1Alpha5ToHub),
+)
+
+func convertVMSnapshotHubToV1Alpha5(_ context.Context, hub *vmopv1.VirtualMachineSnapshot, spoke *vmopv1a5.VirtualMachineSnapshot) error {
+	return vmopv1a5.Convert_v1alpha6_VirtualMachineSnapshot_To_v1alpha5_VirtualMachineSnapshot(hub, spoke, nil)
+}
+
+func convertVMSnapshotV1Alpha5ToHub(_ context.Context, spoke *vmopv1a5.VirtualMachineSnapshot, hub *vmopv1.VirtualMachineSnapshot) error {
+	return vmopv1a5.Convert_v1alpha5_VirtualMachineSnapshot_To_v1alpha6_VirtualMachineSnapshot(spoke, hub, nil)
+}

--- a/webhooks/conversion/v1alpha6/convert_virtualmachinewebconsolerequest.go
+++ b/webhooks/conversion/v1alpha6/convert_virtualmachinewebconsolerequest.go
@@ -1,0 +1,58 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha6
+
+import (
+	"context"
+
+	whconversion "sigs.k8s.io/controller-runtime/pkg/webhook/conversion"
+
+	vmopv1a2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	vmopv1a3 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	vmopv1a4 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	vmopv1a5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+)
+
+// VirtualMachineWebConsoleRequest is the converter for VirtualMachineWebConsoleRequest across all spoke versions.
+var VirtualMachineWebConsoleRequest = whconversion.NewHubSpokeConverter(
+	&vmopv1.VirtualMachineWebConsoleRequest{},
+	whconversion.NewSpokeConverter(&vmopv1a2.VirtualMachineWebConsoleRequest{}, convertVMWebConsoleRequestHubToV1Alpha2, convertVMWebConsoleRequestV1Alpha2ToHub),
+	whconversion.NewSpokeConverter(&vmopv1a3.VirtualMachineWebConsoleRequest{}, convertVMWebConsoleRequestHubToV1Alpha3, convertVMWebConsoleRequestV1Alpha3ToHub),
+	whconversion.NewSpokeConverter(&vmopv1a4.VirtualMachineWebConsoleRequest{}, convertVMWebConsoleRequestHubToV1Alpha4, convertVMWebConsoleRequestV1Alpha4ToHub),
+	whconversion.NewSpokeConverter(&vmopv1a5.VirtualMachineWebConsoleRequest{}, convertVMWebConsoleRequestHubToV1Alpha5, convertVMWebConsoleRequestV1Alpha5ToHub),
+)
+
+func convertVMWebConsoleRequestHubToV1Alpha2(_ context.Context, hub *vmopv1.VirtualMachineWebConsoleRequest, spoke *vmopv1a2.VirtualMachineWebConsoleRequest) error {
+	return vmopv1a2.Convert_v1alpha6_VirtualMachineWebConsoleRequest_To_v1alpha2_VirtualMachineWebConsoleRequest(hub, spoke, nil)
+}
+
+func convertVMWebConsoleRequestV1Alpha2ToHub(_ context.Context, spoke *vmopv1a2.VirtualMachineWebConsoleRequest, hub *vmopv1.VirtualMachineWebConsoleRequest) error {
+	return vmopv1a2.Convert_v1alpha2_VirtualMachineWebConsoleRequest_To_v1alpha6_VirtualMachineWebConsoleRequest(spoke, hub, nil)
+}
+
+func convertVMWebConsoleRequestHubToV1Alpha3(_ context.Context, hub *vmopv1.VirtualMachineWebConsoleRequest, spoke *vmopv1a3.VirtualMachineWebConsoleRequest) error {
+	return vmopv1a3.Convert_v1alpha6_VirtualMachineWebConsoleRequest_To_v1alpha3_VirtualMachineWebConsoleRequest(hub, spoke, nil)
+}
+
+func convertVMWebConsoleRequestV1Alpha3ToHub(_ context.Context, spoke *vmopv1a3.VirtualMachineWebConsoleRequest, hub *vmopv1.VirtualMachineWebConsoleRequest) error {
+	return vmopv1a3.Convert_v1alpha3_VirtualMachineWebConsoleRequest_To_v1alpha6_VirtualMachineWebConsoleRequest(spoke, hub, nil)
+}
+
+func convertVMWebConsoleRequestHubToV1Alpha4(_ context.Context, hub *vmopv1.VirtualMachineWebConsoleRequest, spoke *vmopv1a4.VirtualMachineWebConsoleRequest) error {
+	return vmopv1a4.Convert_v1alpha6_VirtualMachineWebConsoleRequest_To_v1alpha4_VirtualMachineWebConsoleRequest(hub, spoke, nil)
+}
+
+func convertVMWebConsoleRequestV1Alpha4ToHub(_ context.Context, spoke *vmopv1a4.VirtualMachineWebConsoleRequest, hub *vmopv1.VirtualMachineWebConsoleRequest) error {
+	return vmopv1a4.Convert_v1alpha4_VirtualMachineWebConsoleRequest_To_v1alpha6_VirtualMachineWebConsoleRequest(spoke, hub, nil)
+}
+
+func convertVMWebConsoleRequestHubToV1Alpha5(_ context.Context, hub *vmopv1.VirtualMachineWebConsoleRequest, spoke *vmopv1a5.VirtualMachineWebConsoleRequest) error {
+	return vmopv1a5.Convert_v1alpha6_VirtualMachineWebConsoleRequest_To_v1alpha5_VirtualMachineWebConsoleRequest(hub, spoke, nil)
+}
+
+func convertVMWebConsoleRequestV1Alpha5ToHub(_ context.Context, spoke *vmopv1a5.VirtualMachineWebConsoleRequest, hub *vmopv1.VirtualMachineWebConsoleRequest) error {
+	return vmopv1a5.Convert_v1alpha5_VirtualMachineWebConsoleRequest_To_v1alpha6_VirtualMachineWebConsoleRequest(spoke, hub, nil)
+}


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This is the first change in two-change series to move the conversion webhooks out of the api/ module.

Conversion webhooks have a dependency on controller-runtime and therefore having them in the api/ module adds a transitive dependency on controller-runtime.

We have a lot of consumers of the api/ directory.  Most notably WCP service in vCenter.  We have already seen challenges in updating the api/ module there since that can potentially bring in a new version of controller-runtime - which can bring in breaking changes.

This change has no impact on the webhooks.  It is simply moving the conversion (Hub -> Spoke and vice-versa) for all types in the webhooks/conversion package.  A subsequent commit will actually register the webhooks from this new directory structure to the controller manager.

The plan.md contains a detailed plan for this change.


**Are there any special notes for your reviewer**:

I have split the change in two to make it easier to review.

**Please add a release note if necessary**:


```release-note
NONE
```