### PR TITLE
🐛 Fix SRP Docker bridge network detection in api-docs build

### DIFF
--- a/api-docs/Makefile
+++ b/api-docs/Makefile
@@ -7,7 +7,7 @@
 # go directive in go.mod. If either is updated, verify the other still matches
 # or the vendor/docs-generation step will fail with a version mismatch.
 API_DOCS_IMAGE ?= wcp-docker-local.packages.vcfd.broadcom.net/tools/api-docs:4d81416
-DOCKER_RUN := docker run --platform=linux/amd64 \
+DOCKER_RUN := docker run --platform=linux/amd64 --network=host \
   -v $(CURDIR):$(CURDIR) -w $(CURDIR) --rm $(API_DOCS_IMAGE)
 
 # Prefer native binaries when present on PATH (faster for local dev).


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Disabling Docker's default bridge network on the api-docs Dockerfile so the security assessment can be performed.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

Required for SRP.


**Please add a release note if necessary**:

```release-note

```