### PR TITLE
🐛 Fix VM group placements for preferred zones if affinity capability was set.

### DIFF
--- a/pkg/providers/vsphere/placement/group_placement.go
+++ b/pkg/providers/vsphere/placement/group_placement.go
@@ -16,15 +16,23 @@ import (
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 )
 
+// GroupPlacement places the given group members together via a single
+// DRS PlaceVmsXCluster call.
+//
+// preferredZoneName should be set by the caller only when every VM being
+// placed in this call already has the same, non-empty
+// topology.kubernetes.io/zone label. If any member has no zone label, or
+// members disagree on zone, the caller must pass an empty string so
+// candidates span all zone.
 func GroupPlacement(
 	ctx context.Context,
 	client ctrlclient.Client,
 	vcClient *vim25.Client,
 	finder *find.Finder,
-	namespace, childRPName string,
+	namespace, childRPName, preferredZoneName string,
 	configSpecs []vimtypes.VirtualMachineConfigSpec) (map[string]Result, error) {
 
-	candidates, err := getPlacementCandidates(ctx, client, vcClient, "", namespace, childRPName)
+	candidates, err := getPlacementCandidates(ctx, client, vcClient, preferredZoneName, namespace, childRPName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get placement candidates: %w", err)
 	}

--- a/pkg/providers/vsphere/vmprovider_vmgroup.go
+++ b/pkg/providers/vsphere/vmprovider_vmgroup.go
@@ -11,6 +11,8 @@ import (
 
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 
+	corev1 "k8s.io/api/core/v1"
+
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 	pkgcond "github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
@@ -27,6 +29,11 @@ import (
 type vmGroupPlacementArgs struct {
 	configSpecs           []vimtypes.VirtualMachineConfigSpec
 	childResourcePoolName string
+	// preferredZoneName is set only when every VM being placed in this
+	// batch already has the same, non-empty topology.kubernetes.io/zone
+	// label. It is empty if any VM lacks the label or members disagree on
+	// zone, so that placement candidates span all zones as before.
+	preferredZoneName string
 }
 
 const (
@@ -82,12 +89,21 @@ func (vs *vSphereVMProvider) vmGroupGetVMPlacementArgs(
 	firstVM := true
 	var errs []error
 
+	// preferredZones collects every distinct zone label seen across all VMs
+	// in groupPlacements, including "" for VMs with no zone label. If
+	// exactly one distinct value is found and it's non-empty, every VM
+	// agrees on that zone, so it's used to constrain placement candidates
+	// below; otherwise candidates span all zones, as today.
+	preferredZones := map[string]struct{}{}
+
 	for _, grpPlacement := range groupPlacements {
 		for _, vm := range grpPlacement.VMMembers {
 			logger := pkglog.FromContextOrDefault(ctx).WithValues(
 				"childGroupName", grpPlacement.VMGroup.Name,
 				"vm", vm.Name,
 			)
+
+			preferredZones[vm.Labels[corev1.LabelTopologyZone]] = struct{}{}
 
 			vmCtx := pkgctx.VirtualMachineContext{
 				Context: ctx,
@@ -136,6 +152,17 @@ func (vs *vSphereVMProvider) vmGroupGetVMPlacementArgs(
 
 	if len(errs) > 0 {
 		return nil, fmt.Errorf("%w: %w", ErrVMGroupPlacementConfigSpec, errors.Join(errs...))
+	}
+
+	// set placementArgs.preferredZoneName only if every VM agreed on the
+	// same single, non-empty zone.
+	if len(preferredZones) == 1 {
+		for zoneName := range preferredZones {
+			if zoneName != "" {
+				placementArgs.preferredZoneName = zoneName
+			}
+			break
+		}
 	}
 
 	return placementArgs, nil
@@ -240,6 +267,7 @@ func (vs *vSphereVMProvider) vmGroupDoPlacement(
 		vcClient.Finder(),
 		namespace,
 		placementArgs.childResourcePoolName,
+		placementArgs.preferredZoneName,
 		placementArgs.configSpecs,
 	)
 }

--- a/pkg/providers/vsphere/vmprovider_vmgroup_test.go
+++ b/pkg/providers/vsphere/vmprovider_vmgroup_test.go
@@ -273,6 +273,79 @@ var _ = Describe(
 			})
 		})
 
+		Context("Group placement with VMs specifying a preferred zone", func() {
+			It("should constrain placement to the shared zone when all members agree", func() {
+				Expect(len(ctx.ZoneNames)).To(BeNumerically(">", 1))
+				zoneName := ctx.ZoneNames[0]
+				vm1.Labels[corev1.LabelTopologyZone] = zoneName
+				vm2.Labels[corev1.LabelTopologyZone] = zoneName
+
+				groupPlacements := []providers.VMGroupPlacement{
+					{
+						VMGroup: vmGroup,
+						VMMembers: []*vmopv1.VirtualMachine{
+							vm1,
+							vm2,
+						},
+					},
+				}
+
+				err := vmProvider.PlaceVirtualMachineGroup(ctx, vmGroup, groupPlacements)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(vmGroup.Status.Members).To(HaveLen(2))
+				assertMemberStatusForVM(vm1, vmGroup.Status.Members[0])
+				assertMemberStatusForVM(vm2, vmGroup.Status.Members[1])
+
+				Expect(vmGroup.Status.Members[0].Placement.Zone).To(Equal(zoneName))
+				Expect(vmGroup.Status.Members[1].Placement.Zone).To(Equal(zoneName))
+			})
+
+			It("should not constrain placement to a single zone when members disagree", func() {
+				Expect(len(ctx.ZoneNames)).To(BeNumerically(">", 1))
+				vm1.Labels[corev1.LabelTopologyZone] = ctx.ZoneNames[0]
+				vm2.Labels[corev1.LabelTopologyZone] = ctx.ZoneNames[1]
+
+				groupPlacements := []providers.VMGroupPlacement{
+					{
+						VMGroup: vmGroup,
+						VMMembers: []*vmopv1.VirtualMachine{
+							vm1,
+							vm2,
+						},
+					},
+				}
+
+				err := vmProvider.PlaceVirtualMachineGroup(ctx, vmGroup, groupPlacements)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(vmGroup.Status.Members).To(HaveLen(2))
+				assertMemberStatusForVM(vm1, vmGroup.Status.Members[0])
+				assertMemberStatusForVM(vm2, vmGroup.Status.Members[1])
+			})
+
+			It("should not constrain placement to a single zone when one member has no zone label", func() {
+				Expect(len(ctx.ZoneNames)).To(BeNumerically(">", 1))
+				// vm1 has a zone label, vm2 has none: not every member agrees
+				// on a zone, so placement must remain unconstrained.
+				vm1.Labels[corev1.LabelTopologyZone] = ctx.ZoneNames[0]
+
+				groupPlacements := []providers.VMGroupPlacement{
+					{
+						VMGroup: vmGroup,
+						VMMembers: []*vmopv1.VirtualMachine{
+							vm1,
+							vm2,
+						},
+					},
+				}
+
+				err := vmProvider.PlaceVirtualMachineGroup(ctx, vmGroup, groupPlacements)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(vmGroup.Status.Members).To(HaveLen(2))
+				assertMemberStatusForVM(vm1, vmGroup.Status.Members[0])
+				assertMemberStatusForVM(vm2, vmGroup.Status.Members[1])
+			})
+		})
+
 		Context("VSpherePolicies is enabled", func() {
 			JustBeforeEach(func() {
 				pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_group.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_group.go
@@ -994,6 +994,21 @@ func VMGroupSpec(ctx context.Context, inputGetter func() VMGroupSpecInput) {
 			return host
 		}
 
+		getVMZoneFunc := func(vmName string) string {
+			GinkgoHelper()
+
+			var zone string
+			Eventually(func(g Gomega) {
+				vm, err := utils.GetVirtualMachine(ctx, svClusterClient, tmpNamespaceName, vmName)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(vm.Status.Zone).ToNot(BeEmpty())
+				zone = vm.Status.Zone
+
+			}, config.GetIntervals("default", "wait-virtual-machine-creation")...).Should(Succeed())
+
+			return zone
+		}
+
 		powerOnVMFunc := func(vmName string) {
 			GinkgoHelper()
 
@@ -1065,24 +1080,24 @@ func VMGroupSpec(ctx context.Context, inputGetter func() VMGroupSpecInput) {
 				}
 			}
 
-		vmParameters := manifestbuilders.VirtualMachineYaml{
-			Namespace:        tmpNamespaceName,
-			Name:             vmName,
-			GroupName:        vmgRootName,
-			Labels:           labels,
-			ImageName:        tmpNamespaceVMIName,
-			VMClassName:      clusterResources.VMClassName,
-			StorageClassName: clusterResources.StorageClassName,
-			PowerState:       string(vmopv1a5.VirtualMachinePowerStateOff),
-			Affinity: &vmopv1a5.AffinitySpec{
-				VMAffinity:     affinityLabelSelector,
-				VMAntiAffinity: antiAffinityLabelSelector,
-			},
+			vmParameters := manifestbuilders.VirtualMachineYaml{
+				Namespace:        tmpNamespaceName,
+				Name:             vmName,
+				GroupName:        vmgRootName,
+				Labels:           labels,
+				ImageName:        tmpNamespaceVMIName,
+				VMClassName:      clusterResources.VMClassName,
+				StorageClassName: clusterResources.StorageClassName,
+				PowerState:       string(vmopv1a5.VirtualMachinePowerStateOff),
+				Affinity: &vmopv1a5.AffinitySpec{
+					VMAffinity:     affinityLabelSelector,
+					VMAntiAffinity: antiAffinityLabelSelector,
+				},
+			}
+			vmYAML := manifestbuilders.GetVirtualMachineYamlA5(vmParameters)
+			e2eframework.Logf("VM YAML:\n%s", string(vmYAML))
+			Expect(clusterProxy.ApplyWithArgs(ctx, vmYAML)).To(Succeed(), "failed to create vm %s:\n %s", vmName, string(vmYAML))
 		}
-		vmYAML := manifestbuilders.GetVirtualMachineYamlA5(vmParameters)
-		e2eframework.Logf("VM YAML:\n%s", string(vmYAML))
-		Expect(clusterProxy.ApplyWithArgs(ctx, vmYAML)).To(Succeed(), "failed to create vm %s:\n %s", vmName, string(vmYAML))
-	}
 
 		verifyAffinity := func(vmHosts map[string]string, affinedVms []string) {
 			GinkgoHelper()
@@ -1358,6 +1373,144 @@ func VMGroupSpec(ctx context.Context, inputGetter func() VMGroupSpecInput) {
 				runVmVmAffinityAtHostTopoTest(requiredDuringSchedulingPreferredDuringExecution,
 					[]string{vm1Name, vm2Name},
 					[]string{vm3Name, vm4Name})
+			})
+
+			It("Should create VMs in the same zone with required host AF and AAF, repeated 5 times", func() {
+				const iterations = 5
+
+				By("Determining a zone bound to the temporary namespace")
+				namespaceZones, err := utils.ListZonesByNamespace(ctx, input.ClusterProxy.GetClient(), tmpNamespaceName)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(namespaceZones.Items).ToNot(BeEmpty())
+				preferredZone := namespaceZones.Items[0].Name
+
+				By("Resolving the tiny-core-linux-complex-hw VMI in the temporary namespace")
+				tinyImageVMIName, err := vmoperator.WaitForVirtualMachineImageName(ctx, &config.Config, svClusterClient, tmpNamespaceName, "tiny-core-linux-complex-hw")
+				Expect(err).NotTo(HaveOccurred(), "failed to get VMI name for display name %q in namespace %q", "tiny-core-linux-complex-hw", tmpNamespaceName)
+
+				createCacheVMFunc := func(vmName, groupName, appLabel string, antiAffinity bool) {
+					GinkgoHelper()
+
+					term := vmopv1a5.VMAffinityTerm{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"app": appLabel,
+							},
+						},
+						TopologyKey: "kubernetes.io/hostname",
+					}
+
+					affinity := &vmopv1a5.AffinitySpec{}
+					if antiAffinity {
+						affinity.VMAntiAffinity = &vmopv1a5.VMAntiAffinitySpec{
+							RequiredDuringSchedulingPreferredDuringExecution: []vmopv1a5.VMAffinityTerm{term},
+						}
+					} else {
+						affinity.VMAffinity = &vmopv1a5.VMAffinitySpec{
+							RequiredDuringSchedulingPreferredDuringExecution: []vmopv1a5.VMAffinityTerm{term},
+						}
+					}
+
+					vmParameters := manifestbuilders.VirtualMachineYaml{
+						Namespace: tmpNamespaceName,
+						Name:      vmName,
+						GroupName: groupName,
+						Labels: map[string]string{
+							"topology.kubernetes.io/zone": preferredZone,
+							"app":                         appLabel,
+						},
+						ImageName:        tinyImageVMIName,
+						VMClassName:      clusterResources.VMClassName,
+						StorageClassName: clusterResources.StorageClassName,
+						PowerState:       string(vmopv1a5.VirtualMachinePowerStateOff),
+						Affinity:         affinity,
+					}
+					vmYAML := manifestbuilders.GetVirtualMachineYamlA5(vmParameters)
+					e2eframework.Logf("VM YAML:\n%s", string(vmYAML))
+					Expect(clusterProxy.ApplyWithArgs(ctx, vmYAML)).To(Succeed(), "failed to create vm %s:\n %s", vmName, string(vmYAML))
+				}
+
+				aafGroupName := fmt.Sprintf("%s-aaf", vmgRootName)
+				afGroupName := fmt.Sprintf("%s-af", vmgRootName)
+				aafVM1 := fmt.Sprintf("%s-aaf-vm1", vmgRootName)
+				aafVM2 := fmt.Sprintf("%s-aaf-vm2", vmgRootName)
+				afVM1 := fmt.Sprintf("%s-af-vm1", vmgRootName)
+				afVM2 := fmt.Sprintf("%s-af-vm2", vmgRootName)
+				allVMNames := []string{aafVM1, aafVM2, afVM1, afVM2}
+				vmMemberNames = allVMNames
+
+				for i := range iterations {
+					By(fmt.Sprintf("Iteration %d: creating both VirtualMachineGroups (AAF and AF) and their VMs", i))
+
+					aafGroupParameters := manifestbuilders.VirtualMachineGroupYaml{
+						Namespace: tmpNamespaceName,
+						Name:      aafGroupName,
+						BootOrder: []manifestbuilders.BootOrder{
+							{
+								Members: []vmopv1a5.GroupMember{
+									{Kind: vmKind, Name: aafVM1},
+									{Kind: vmKind, Name: aafVM2},
+								},
+							},
+						},
+					}
+					aafGroupYaml := manifestbuilders.GetVirtualMachineGroupWithBootOrderYaml(aafGroupParameters)
+					e2eframework.Logf("VirtualMachineGroup YAML:\n%s", string(aafGroupYaml))
+					Expect(clusterProxy.CreateWithArgs(ctx, aafGroupYaml)).To(Succeed())
+
+					afGroupParameters := manifestbuilders.VirtualMachineGroupYaml{
+						Namespace: tmpNamespaceName,
+						Name:      afGroupName,
+						BootOrder: []manifestbuilders.BootOrder{
+							{
+								Members: []vmopv1a5.GroupMember{
+									{Kind: vmKind, Name: afVM1},
+									{Kind: vmKind, Name: afVM2},
+								},
+							},
+						},
+					}
+					afGroupYaml := manifestbuilders.GetVirtualMachineGroupWithBootOrderYaml(afGroupParameters)
+					e2eframework.Logf("VirtualMachineGroup YAML:\n%s", string(afGroupYaml))
+					Expect(clusterProxy.CreateWithArgs(ctx, afGroupYaml)).To(Succeed())
+
+					createCacheVMFunc(aafVM1, aafGroupName, "cache-cluster-aaf", true)
+					createCacheVMFunc(aafVM2, aafGroupName, "cache-cluster-aaf", true)
+					createCacheVMFunc(afVM1, afGroupName, "cache-cluster-af", false)
+					createCacheVMFunc(afVM2, afGroupName, "cache-cluster-af", false)
+
+					By(fmt.Sprintf("Iteration %d: waiting for all VMs to be created in vSphere (powered off)", i))
+					for _, vmName := range allVMNames {
+						vmoperator.WaitForVirtualMachineConditionCreated(ctx, config, svClusterClient, tmpNamespaceName, vmName)
+					}
+
+					By(fmt.Sprintf("Iteration %d: verifying zone placement and host affinity/anti-affinity", i))
+					for _, vmName := range allVMNames {
+						vmZone := getVMZoneFunc(vmName)
+						Expect(vmZone).To(Equal(preferredZone), "iteration %d: vm %s zone mismatch", i, vmName)
+					}
+
+					aafHost1 := getVMHostFunc(aafVM1)
+					aafHost2 := getVMHostFunc(aafVM2)
+					Expect(aafHost1).ToNot(BeEmpty())
+					Expect(aafHost2).ToNot(BeEmpty())
+					Expect(aafHost1).ToNot(Equal(aafHost2), "iteration %d: AAF VMs %s and %s are on the same host", i, aafVM1, aafVM2)
+
+					afHost1 := getVMHostFunc(afVM1)
+					afHost2 := getVMHostFunc(afVM2)
+					Expect(afHost1).ToNot(BeEmpty())
+					Expect(afHost2).ToNot(BeEmpty())
+					Expect(afHost1).To(Equal(afHost2), "iteration %d: AF VMs %s and %s are on different hosts", i, afVM1, afVM2)
+
+					By(fmt.Sprintf("Iteration %d: deleting both VirtualMachineGroups", i))
+					Expect(clusterProxy.DeleteWithArgs(ctx, aafGroupYaml)).To(Succeed())
+					Expect(clusterProxy.DeleteWithArgs(ctx, afGroupYaml)).To(Succeed())
+					vmoperator.WaitForVirtualMachineGroupToBeDeleted(ctx, config, svClusterClient, tmpNamespaceName, aafGroupName)
+					vmoperator.WaitForVirtualMachineGroupToBeDeleted(ctx, config, svClusterClient, tmpNamespaceName, afGroupName)
+					for _, vmName := range allVMNames {
+						vmoperator.WaitForVirtualMachineToBeDeleted(ctx, config, svClusterClient, tmpNamespaceName, vmName)
+					}
+				}
 			})
 		})
 	})


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Preferred zones were ignored during group placement. If the recommended host was in a different zone than the preferred zone, deployment failed.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

Validated deployment succeeded. Added relevant E2E test cases.
Verified on 3 zone, 3 host per zone supervisor :
1. VMGroup with preferred zone, af/aaf policies are respected.
2. VMGroup without preferred zone, af/aff policies are respected.
3. VKS Cluster deployed w/wo failure domains, verified scale up/down of worker nodes, verified new nodepool addition/deletion. 
```release-note
NA
```