### PR TITLE
[x-port] [9.1.1] Fix VM group placements for preferred zones if affinity capability was set

### DIFF
--- a/pkg/providers/vsphere/placement/group_placement.go
+++ b/pkg/providers/vsphere/placement/group_placement.go
@@ -16,15 +16,23 @@ import (
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 )
 
+// GroupPlacement places the given group members together via a single
+// DRS PlaceVmsXCluster call.
+//
+// preferredZoneName should be set by the caller only when every VM being
+// placed in this call already has the same, non-empty
+// topology.kubernetes.io/zone label. If any member has no zone label, or
+// members disagree on zone, the caller must pass an empty string so
+// candidates span all zone.
 func GroupPlacement(
 	ctx context.Context,
 	client ctrlclient.Client,
 	vcClient *vim25.Client,
 	finder *find.Finder,
-	namespace, childRPName string,
+	namespace, childRPName, preferredZoneName string,
 	configSpecs []vimtypes.VirtualMachineConfigSpec) (map[string]Result, error) {
 
-	candidates, err := getPlacementCandidates(ctx, client, vcClient, "", namespace, childRPName)
+	candidates, err := getPlacementCandidates(ctx, client, vcClient, preferredZoneName, namespace, childRPName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get placement candidates: %w", err)
 	}

--- a/pkg/providers/vsphere/vmprovider_vm_group.go
+++ b/pkg/providers/vsphere/vmprovider_vm_group.go
@@ -11,6 +11,8 @@ import (
 
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 
+	corev1 "k8s.io/api/core/v1"
+
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	pkgcond "github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
@@ -27,6 +29,11 @@ import (
 type vmGroupPlacementArgs struct {
 	configSpecs           []vimtypes.VirtualMachineConfigSpec
 	childResourcePoolName string
+	// preferredZoneName is set only when every VM being placed in this
+	// batch already has the same, non-empty topology.kubernetes.io/zone
+	// label. It is empty if any VM lacks the label or members disagree on
+	// zone, so that placement candidates span all zones as before.
+	preferredZoneName string
 }
 
 const (
@@ -82,12 +89,21 @@ func (vs *vSphereVMProvider) vmGroupGetVMPlacementArgs(
 	firstVM := true
 	var errs []error
 
+	// preferredZones collects every distinct zone label seen across all VMs
+	// in groupPlacements, including "" for VMs with no zone label. If
+	// exactly one distinct value is found and it's non-empty, every VM
+	// agrees on that zone, so it's used to constrain placement candidates
+	// below; otherwise candidates span all zones, as today.
+	preferredZones := map[string]struct{}{}
+
 	for _, grpPlacement := range groupPlacements {
 		for _, vm := range grpPlacement.VMMembers {
 			logger := pkglog.FromContextOrDefault(ctx).WithValues(
 				"childGroupName", grpPlacement.VMGroup.Name,
 				"vm", vm.Name,
 			)
+
+			preferredZones[vm.Labels[corev1.LabelTopologyZone]] = struct{}{}
 
 			vmCtx := pkgctx.VirtualMachineContext{
 				Context: ctx,
@@ -136,6 +152,17 @@ func (vs *vSphereVMProvider) vmGroupGetVMPlacementArgs(
 
 	if len(errs) > 0 {
 		return nil, fmt.Errorf("%w: %w", ErrVMGroupPlacementConfigSpec, errors.Join(errs...))
+	}
+
+	// set placementArgs.preferredZoneName only if every VM agreed on the
+	// same single, non-empty zone.
+	if len(preferredZones) == 1 {
+		for zoneName := range preferredZones {
+			if zoneName != "" {
+				placementArgs.preferredZoneName = zoneName
+			}
+			break
+		}
 	}
 
 	return placementArgs, nil
@@ -240,6 +267,7 @@ func (vs *vSphereVMProvider) vmGroupDoPlacement(
 		vcClient.Finder(),
 		namespace,
 		placementArgs.childResourcePoolName,
+		placementArgs.preferredZoneName,
 		placementArgs.configSpecs,
 	)
 }

--- a/pkg/providers/vsphere/vmprovider_vm_group_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_group_test.go
@@ -269,6 +269,79 @@ func vmGroupTests() {
 		})
 	})
 
+	Context("Group placement with VMs specifying a preferred zone", func() {
+		It("should constrain placement to the shared zone when all members agree", func() {
+			Expect(len(ctx.ZoneNames)).To(BeNumerically(">", 1))
+			zoneName := ctx.ZoneNames[0]
+			vm1.Labels[corev1.LabelTopologyZone] = zoneName
+			vm2.Labels[corev1.LabelTopologyZone] = zoneName
+
+			groupPlacements := []providers.VMGroupPlacement{
+				{
+					VMGroup: vmGroup,
+					VMMembers: []*vmopv1.VirtualMachine{
+						vm1,
+						vm2,
+					},
+				},
+			}
+
+			err := vmProvider.PlaceVirtualMachineGroup(ctx, vmGroup, groupPlacements)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vmGroup.Status.Members).To(HaveLen(2))
+			assertMemberStatusForVM(vm1, vmGroup.Status.Members[0])
+			assertMemberStatusForVM(vm2, vmGroup.Status.Members[1])
+
+			Expect(vmGroup.Status.Members[0].Placement.Zone).To(Equal(zoneName))
+			Expect(vmGroup.Status.Members[1].Placement.Zone).To(Equal(zoneName))
+		})
+
+		It("should not constrain placement to a single zone when members disagree", func() {
+			Expect(len(ctx.ZoneNames)).To(BeNumerically(">", 1))
+			vm1.Labels[corev1.LabelTopologyZone] = ctx.ZoneNames[0]
+			vm2.Labels[corev1.LabelTopologyZone] = ctx.ZoneNames[1]
+
+			groupPlacements := []providers.VMGroupPlacement{
+				{
+					VMGroup: vmGroup,
+					VMMembers: []*vmopv1.VirtualMachine{
+						vm1,
+						vm2,
+					},
+				},
+			}
+
+			err := vmProvider.PlaceVirtualMachineGroup(ctx, vmGroup, groupPlacements)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vmGroup.Status.Members).To(HaveLen(2))
+			assertMemberStatusForVM(vm1, vmGroup.Status.Members[0])
+			assertMemberStatusForVM(vm2, vmGroup.Status.Members[1])
+		})
+
+		It("should not constrain placement to a single zone when one member has no zone label", func() {
+			Expect(len(ctx.ZoneNames)).To(BeNumerically(">", 1))
+			// vm1 has a zone label, vm2 has none: not every member agrees
+			// on a zone, so placement must remain unconstrained.
+			vm1.Labels[corev1.LabelTopologyZone] = ctx.ZoneNames[0]
+
+			groupPlacements := []providers.VMGroupPlacement{
+				{
+					VMGroup: vmGroup,
+					VMMembers: []*vmopv1.VirtualMachine{
+						vm1,
+						vm2,
+					},
+				},
+			}
+
+			err := vmProvider.PlaceVirtualMachineGroup(ctx, vmGroup, groupPlacements)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vmGroup.Status.Members).To(HaveLen(2))
+			assertMemberStatusForVM(vm1, vmGroup.Status.Members[0])
+			assertMemberStatusForVM(vm2, vmGroup.Status.Members[1])
+		})
+	})
+
 	Context("VSpherePolicies is enabled", func() {
 		JustBeforeEach(func() {
 			pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Crossport of 
- https://github.com/vmware-tanzu/vm-operator/pull/1701

Preferred zones were ignored during group placement. If the recommended host was in a different zone than the preferred zone, deployment failed.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

Validated deployment succeeded. Added relevant E2E test cases.
Verified on 3 zone, 3 host per zone supervisor :
1. VMGroup with preferred zone, af/aaf policies are respected.
2. VMGroup without preferred zone, af/aff policies are respected.
3. VKS Cluster deployed w/wo failure domains, verified scale up/down of worker nodes, verified new nodepool addition/deletion. 
```release-note
NA
```