### PR TITLE
Reconcile VM's location when VM is moved outside of expected folder (…

### DIFF
--- a/api/v1alpha6/virtualmachine_types.go
+++ b/api/v1alpha6/virtualmachine_types.go
@@ -116,9 +116,9 @@ const (
 	// not the guest is reporting the expected IP address(es).
 	VirtualMachineGuestNetworkConfigSynced = "VirtualMachineGuestNetworkConfigSynced"
 
-	// VirtualMachineInValidLocation indicates that the VM is in the expected location in the vCenter inventory.
+	// VirtualMachineLocationValid indicates that the VM is in the expected location in the vCenter inventory.
 	// This condition is set when a VM is detected to be in the incorrect folder or resource pool based on its namespace.
-	VirtualMachineInValidLocation = "VirtualMachineInValidLocation"
+	VirtualMachineLocationValid = "VirtualMachineLocationValid"
 
 	// VirtualMachineConditionComputeConfigSynced indicates whether the VM's
 	// compute configuration (spec.resources, spec.cpuAdvanced, spec.memoryAdvanced)

--- a/pkg/providers/vsphere/vcenter/resourcepool.go
+++ b/pkg/providers/vsphere/vcenter/resourcepool.go
@@ -164,29 +164,38 @@ func findChildRP(
 	return childRP, nil
 }
 
-func IsVMInValidResourcePool(
+// GetResourcePoolProperties fetches the "parent" and "name" properties of the
+// given ResourcePool MoID and returns the populated mo.ResourcePool.
+func GetResourcePoolProperties(
 	ctx context.Context,
 	vimClient *vim25.Client,
-	currentRPMoID string,
-	expectedRootRPMoID string) (bool, error) {
+	rpMoID string) (mo.ResourcePool, error) {
 
-	// Case A: Direct match
-	if currentRPMoID == expectedRootRPMoID {
-		return true, nil
-	}
-	// Case B: Check if current pool's parent is the root
 	poolObj := object.NewResourcePool(vimClient,
-		vimtypes.ManagedObjectReference{Type: "ResourcePool", Value: currentRPMoID})
+		vimtypes.ManagedObjectReference{Type: "ResourcePool", Value: rpMoID})
 
 	var moPool mo.ResourcePool
-	err := poolObj.Properties(ctx, poolObj.Reference(), []string{"parent"}, &moPool)
-	if err != nil {
-		return false, err
+	if err := poolObj.Properties(ctx, poolObj.Reference(), []string{"parent", "name"}, &moPool); err != nil {
+		return mo.ResourcePool{}, err
 	}
 
-	if moPool.Parent != nil && moPool.Parent.Value == expectedRootRPMoID {
-		return true, nil
+	return moPool, nil
+}
+
+// GetFolderProperties fetches the "parent" and "name" properties of the given
+// Folder MoID and returns the populated mo.Folder.
+func GetFolderProperties(
+	ctx context.Context,
+	vimClient *vim25.Client,
+	folderMoID string) (mo.Folder, error) {
+
+	folderObj := object.NewFolder(vimClient,
+		vimtypes.ManagedObjectReference{Type: "Folder", Value: folderMoID})
+
+	var moFolder mo.Folder
+	if err := folderObj.Properties(ctx, folderObj.Reference(), []string{"parent", "name"}, &moFolder); err != nil {
+		return mo.Folder{}, err
 	}
 
-	return false, nil
+	return moFolder, nil
 }

--- a/pkg/providers/vsphere/vcenter/resourcepool_test.go
+++ b/pkg/providers/vsphere/vcenter/resourcepool_test.go
@@ -19,6 +19,8 @@ import (
 func resourcePoolTests() {
 	Describe("GetResourcePool", getResourcePoolTests)
 	Describe("CreateDeleteExistResourcePoolChild", createDeleteExistResourcePoolChild)
+	Describe("GetResourcePoolProperties", getParentResourcePoolTests)
+	Describe("GetFolderProperties", getParentFolderTests)
 }
 
 func getResourcePoolTests() {
@@ -201,5 +203,92 @@ func createDeleteExistResourcePoolChild() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})
+	})
+}
+
+func getParentResourcePoolTests() {
+	var (
+		ctx        *builder.TestContextForVCSim
+		nsInfo     builder.WorkloadNamespaceInfo
+		nsRP       *object.ResourcePool
+		testConfig builder.VCSimTestConfig
+
+		resourcePolicy *vmopv1.VirtualMachineSetResourcePolicy
+		childRP        *object.ResourcePool
+	)
+
+	BeforeEach(func() {
+		testConfig = builder.VCSimTestConfig{}
+		ctx = suite.NewTestContextForVCSim(testConfig)
+		nsInfo = ctx.CreateWorkloadNamespace()
+		nsRP = ctx.GetResourcePoolForNamespace(nsInfo.Namespace, "", "")
+
+		resourcePolicy, _ = ctx.CreateVirtualMachineSetResourcePolicy("child-rp", nsInfo)
+		Expect(resourcePolicy).ToNot(BeNil())
+
+		childRP = ctx.GetResourcePoolForNamespace(nsInfo.Namespace, "", resourcePolicy.Spec.ResourcePool.Name)
+		Expect(childRP).ToNot(BeNil())
+	})
+
+	AfterEach(func() {
+		ctx.AfterEach()
+		ctx = nil
+		nsRP = nil
+		childRP = nil
+		resourcePolicy = nil
+	})
+
+	It("returns the parent RP with name populated", func() {
+		moPool, err := vcenter.GetResourcePoolProperties(ctx, ctx.VCClient.Client, childRP.Reference().Value)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(moPool.Name).ToNot(BeEmpty())
+		Expect(moPool.Parent).ToNot(BeNil())
+		Expect(moPool.Parent.Value).To(Equal(nsRP.Reference().Value))
+	})
+
+	It("returns error when RP MoID does not exist", func() {
+		_, err := vcenter.GetResourcePoolProperties(ctx, ctx.VCClient.Client, "bogus-rp-id")
+		Expect(err).To(HaveOccurred())
+	})
+}
+
+func getParentFolderTests() {
+	var (
+		ctx        *builder.TestContextForVCSim
+		nsInfo     builder.WorkloadNamespaceInfo
+		testConfig builder.VCSimTestConfig
+
+		resourcePolicy *vmopv1.VirtualMachineSetResourcePolicy
+		childFolder    *object.Folder
+	)
+
+	BeforeEach(func() {
+		testConfig = builder.VCSimTestConfig{}
+		ctx = suite.NewTestContextForVCSim(testConfig)
+		nsInfo = ctx.CreateWorkloadNamespace()
+
+		resourcePolicy, childFolder = ctx.CreateVirtualMachineSetResourcePolicy("child-folder", nsInfo)
+		Expect(resourcePolicy).ToNot(BeNil())
+		Expect(childFolder).ToNot(BeNil())
+	})
+
+	AfterEach(func() {
+		ctx.AfterEach()
+		ctx = nil
+		childFolder = nil
+		resourcePolicy = nil
+	})
+
+	It("returns the parent folder with name populated", func() {
+		moFolder, err := vcenter.GetFolderProperties(ctx, ctx.VCClient.Client, childFolder.Reference().Value)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(moFolder.Name).ToNot(BeEmpty())
+		Expect(moFolder.Parent).ToNot(BeNil())
+		Expect(moFolder.Parent.Value).To(Equal(nsInfo.Folder.Reference().Value))
+	})
+
+	It("returns error when folder MoID does not exist", func() {
+		_, err := vcenter.GetFolderProperties(ctx, ctx.VCClient.Client, "bogus-folder-id")
+		Expect(err).To(HaveOccurred())
 	})
 }

--- a/pkg/providers/vsphere/vmprovider_vm.go
+++ b/pkg/providers/vsphere/vmprovider_vm.go
@@ -944,6 +944,7 @@ var VMUpdatePropertiesSelector = []string{
 	"runtime",
 	"snapshot",
 	"summary",
+	"parent",
 }
 
 func getReconcileErr(msg string, reconcileErr, err error) error {
@@ -964,11 +965,11 @@ func errOrReconcileErr(reconcileErr, err error) error {
 // updateVirtualMachine performs the following operations in the stated order:
 //
 //  1. Fetch properties
-//  2. Reconcile location
-//  3. Fetch recent tasks
-//  4. Fetch attached tags
-//  5. Fetch volume info
-//  6. Reconcile status
+//  2. Fetch recent tasks
+//  3. Fetch attached tags
+//  4. Fetch volume info
+//  5. Reconcile status
+//  6. Reconcile location
 //  7. Reconcile schema upgrade
 //  8. Reconcile backup state
 //  9. Reconcile snapshot revert
@@ -997,17 +998,7 @@ func (vs *vSphereVMProvider) updateVirtualMachine(
 	}
 
 	//
-	// 2. Reconcile location
-	//
-	if err := vs.reconcileLocation(vmCtx, vcClient); err != nil {
-		if pkgerr.IsNoRequeueError(err) {
-			return errOrReconcileErr(reconcileErr, err)
-		}
-		reconcileErr = getReconcileErr("location", reconcileErr, err)
-	}
-
-	//
-	// 3. Get the recent tasks.
+	// 2. Get the recent tasks.
 	//
 	ctxWithRecentTaskInfo, err := vs.getRecentTaskInfo(vmCtx, vcClient)
 	if err != nil {
@@ -1016,7 +1007,7 @@ func (vs *vSphereVMProvider) updateVirtualMachine(
 	vmCtx.Context = ctxWithRecentTaskInfo
 
 	//
-	// 4. Get the attached tags.
+	// 3. Get the attached tags.
 	//
 	ctxWithAttachedTags, err := vs.getTags(vmCtx, vcClient)
 	if err != nil {
@@ -1025,7 +1016,7 @@ func (vs *vSphereVMProvider) updateVirtualMachine(
 	vmCtx.Context = ctxWithAttachedTags
 
 	//
-	// 5. Get the volume info.
+	// 4. Get the volume info.
 	//
 	ctxWithVolumeInfo, err := vs.getVolumeInfo(vmCtx, vcClient)
 	if err != nil {
@@ -1034,13 +1025,23 @@ func (vs *vSphereVMProvider) updateVirtualMachine(
 	vmCtx.Context = ctxWithVolumeInfo
 
 	//
-	// 6. Reconcile status
+	// 5. Reconcile status
 	//
 	if err := vs.reconcileStatus(vmCtx, vcVM); err != nil {
 		if pkgerr.IsNoRequeueError(err) {
 			return errOrReconcileErr(reconcileErr, err)
 		}
 		reconcileErr = getReconcileErr("status", reconcileErr, err)
+	}
+
+	//
+	// 6. Reconcile location
+	//
+	if err := vs.reconcileLocation(vmCtx, vcClient); err != nil {
+		if pkgerr.IsNoRequeueError(err) {
+			return errOrReconcileErr(reconcileErr, err)
+		}
+		reconcileErr = getReconcileErr("location", reconcileErr, err)
 	}
 
 	//
@@ -1134,21 +1135,27 @@ func (vs *vSphereVMProvider) updateVirtualMachine(
 	return reconcileErr
 }
 
+// reconcileLocation validates that the VM is within its expected namespace
+// ResourcePool and Folder hierarchy. If the VM is found outside this hierarchy,
+// all further reconciliation is blocked until the VM is returned to the correct
+// location. This prevents unintended changes to VMs that have been manually
+// moved in the vCenter inventory.
 func (vs *vSphereVMProvider) reconcileLocation(vmCtx pkgctx.VirtualMachineContext, vcClient *vcclient.Client) error {
-	logger := pkglog.FromContextOrDefault(vmCtx)
+	vmCtx.Logger.V(4).Info("Reconciling VirtualMachine location")
 	if vmCtx.MoVM.ResourcePool == nil {
-		return fmt.Errorf("VM %s is not assigned to any resource pools", vmCtx.VM.Name)
+		return fmt.Errorf("VM is not assigned to any resource pools")
+	}
+	if vmCtx.MoVM.Parent == nil {
+		return fmt.Errorf("VM has no parent folder")
 	}
 
-	// If the VM doesn't have a topology zone label, skip location validation.
-	// This can happen in unit tests or when the zone is being determined.
-	// Similar to how vmlifecycle/update_status.go handles missing zone labels.
-	zoneName := vmCtx.VM.Labels[corev1.LabelTopologyZone]
+	zoneName := vmCtx.VM.Status.Zone
 	if zoneName == "" {
+		vmCtx.Logger.Info("VM has no zone set; skipping location validation")
 		return nil
 	}
 
-	_, expectedRootRPMoID, err := topology.GetNamespaceFolderAndRPMoID(
+	expectedFolder, expectedRootRPMoID, err := topology.GetNamespaceFolderAndRPMoID(
 		vmCtx,
 		vs.k8sClient,
 		zoneName,
@@ -1158,35 +1165,103 @@ func (vs *vSphereVMProvider) reconcileLocation(vmCtx pkgctx.VirtualMachineContex
 		return fmt.Errorf("failed to get expected namespace resource pool: %w", err)
 	}
 
-	// Check if the VM is in the Root RP or a Child RP
-	isValid, err := vcenter.IsVMInValidResourcePool(
-		vmCtx,
-		vcClient.VimClient(),
-		vmCtx.MoVM.ResourcePool.Value,
-		expectedRootRPMoID,
-	)
+	isVMInValidRP, err := validateVMResourcePool(vmCtx, expectedRootRPMoID, vcClient)
 	if err != nil {
-		logger.Error(err, "failed to validate VM resource pool")
-		return err
+		return fmt.Errorf("failed to validate VM resource pool: %w", err)
+	}
+	isVMInValidFolder, err := validateVMFolder(vmCtx, expectedFolder, vcClient)
+	if err != nil {
+		return fmt.Errorf("failed to validate VM folder: %w", err)
 	}
 
-	// Handle Mismatch
-	if !isValid {
+	// If the VM is outside its expected RP or Folder hierarchy, block all further
+	// reconciliation by returning a NoRequeueError. The VM will not be reconciled
+	// again until its inventory location changes.
+	if !isVMInValidRP || !isVMInValidFolder {
+		var reason string
+		switch {
+		case !isVMInValidRP && !isVMInValidFolder:
+			reason = "ResourcePoolAndFolderMismatch"
+		case !isVMInValidRP:
+			reason = "ResourcePoolMismatch"
+		default:
+			reason = "FolderMismatch"
+		}
 		pkgcond.MarkFalse(
 			vmCtx.VM,
-			vmopv1.VirtualMachineInValidLocation,
-			"LocationMismatch",
-			"VM is in an invalid Resource Pool. Move the VM back to the Resource Pool hierarchy for namespace %s to resume reconciliation.",
-			vmCtx.VM.Namespace,
+			vmopv1.VirtualMachineLocationValid,
+			reason,
+			"VM was moved to an unexpected ResourcePool or Folder",
 		)
 
 		return pkgerr.NoRequeueError{Message: fmt.Sprintf(
-			"reconciliation paused for the VM %s because it is moved to invalid Resource Pool. Expected Resource Pool MoRef: %s, Current Resource Pool MoRef: %s",
-			vmCtx.VM.Name, expectedRootRPMoID, vmCtx.MoVM.ResourcePool.Value)}
+			"VM %s/%s relocated outside expected hierarchy: "+
+				"expected RP %s got %s, expected folder %s got %s",
+			vmCtx.VM.Namespace, vmCtx.VM.Name,
+			expectedRootRPMoID, vmCtx.MoVM.ResourcePool.Value,
+			expectedFolder, vmCtx.MoVM.Parent.Value,
+		)}
 	}
 
-	pkgcond.MarkTrue(vmCtx.VM, vmopv1.VirtualMachineInValidLocation)
+	pkgcond.MarkTrue(vmCtx.VM, vmopv1.VirtualMachineLocationValid)
 	return nil
+}
+
+// validateVMResourcePool checks that the VM resides within the expected
+// namespace ResourcePool hierarchy. It accepts the VM being directly in the
+// namespace RP or in an immediate child RP (e.g. a VKS workload pool). Only
+// one level of depth is validated: deeper nesting is not a supported
+// configuration and would not be detected as valid here.
+func validateVMResourcePool(
+	vmCtx pkgctx.VirtualMachineContext,
+	expectedRootRPMoID string,
+	vcClient *vcclient.Client) (bool, error) {
+
+	if vmCtx.MoVM.ResourcePool.Value == expectedRootRPMoID {
+		return true, nil
+	}
+
+	moPool, err := vcenter.GetResourcePoolProperties(
+		vmCtx,
+		vcClient.VimClient(),
+		vmCtx.MoVM.ResourcePool.Value,
+	)
+	if err != nil {
+		return false, err
+	}
+	if moPool.Parent != nil && moPool.Parent.Value == expectedRootRPMoID {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// validateVMFolder checks that the VM resides within the expected namespace
+// Folder hierarchy. It accepts the VM being directly in the namespace Folder
+// or in an immediate child Folder (e.g. a VKS workload folder). Only one
+// level of depth is validated: deeper nesting is not a supported configuration
+// and would not be detected as valid here.
+func validateVMFolder(
+	vmCtx pkgctx.VirtualMachineContext,
+	expectedFolder string,
+	vcClient *vcclient.Client) (bool, error) {
+
+	if vmCtx.MoVM.Parent.Value == expectedFolder {
+		return true, nil
+	}
+	moFolder, err := vcenter.GetFolderProperties(
+		vmCtx,
+		vcClient.VimClient(),
+		vmCtx.MoVM.Parent.Value,
+	)
+	if err != nil {
+		return false, err
+	}
+	// Accept VMs in an immediate child of the namespace folder (e.g. VKS node folders).
+	if moFolder.Parent != nil && moFolder.Parent.Value == expectedFolder {
+		return true, nil
+	}
+	return false, nil
 }
 
 func (vs *vSphereVMProvider) reconcileStatus(

--- a/pkg/providers/vsphere/vmprovider_vm_configspec_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_configspec_test.go
@@ -205,14 +205,18 @@ func vmConfigSpecTests() {
 			instanceUUID = o.Config.InstanceUuid
 			vm.Spec.InstanceUUID = instanceUUID
 
-			// Move the imported VM into the namespace's resource pool so
-			// that reconcileLocation accepts the VM as living in an
+			// Move the imported VM into the namespace's resource pool and folder
+			// so that reconcileLocation accepts the VM as living in an
 			// authorized location for this namespace.
 			nsRP := ctx.GetResourcePoolForNamespace(nsInfo.Namespace, "", "")
 			nsRPRef := nsRP.Reference()
+			nsFolderRef := nsInfo.Folder.Reference()
 			relocateTask, err := vcVM.Relocate(
 				ctx,
-				vimtypes.VirtualMachineRelocateSpec{Pool: &nsRPRef},
+				vimtypes.VirtualMachineRelocateSpec{
+					Pool:   &nsRPRef,
+					Folder: &nsFolderRef,
+				},
 				vimtypes.VirtualMachineMovePriorityDefaultPriority)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(relocateTask.Wait(ctx)).To(Succeed())

--- a/pkg/providers/vsphere/vmprovider_vm_crypto_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_crypto_test.go
@@ -163,14 +163,18 @@ func vmCryptoTests() {
 		Expect(vcVM.Properties(ctx, vcVM.Reference(), nil, &o)).To(Succeed())
 		vm.Spec.InstanceUUID = o.Config.InstanceUuid
 
-		// Move the imported VM into the namespace's resource pool so that
-		// reconcileLocation accepts the VM as living in an authorized
+		// Move the imported VM into the namespace's resource pool and folder
+		// so that reconcileLocation accepts the VM as living in an authorized
 		// location for this namespace.
 		nsRP := ctx.GetResourcePoolForNamespace(nsInfo.Namespace, zoneName, "")
 		nsRPRef := nsRP.Reference()
+		nsFolderRef := nsInfo.Folder.Reference()
 		relocateTask, err := vcVM.Relocate(
 			ctx,
-			vimtypes.VirtualMachineRelocateSpec{Pool: &nsRPRef},
+			vimtypes.VirtualMachineRelocateSpec{
+				Pool:   &nsRPRef,
+				Folder: &nsFolderRef,
+			},
 			vimtypes.VirtualMachineMovePriorityDefaultPriority)
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 		ExpectWithOffset(1, relocateTask.Wait(ctx)).To(Succeed())

--- a/pkg/providers/vsphere/vmprovider_vm_location_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_location_test.go
@@ -1,0 +1,346 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package vsphere_test
+
+import (
+	"context"
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
+	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
+	pkgerr "github.com/vmware-tanzu/vm-operator/pkg/errors"
+	"github.com/vmware-tanzu/vm-operator/pkg/providers"
+	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+func vmLocationTests() {
+	var (
+		parentCtx   context.Context
+		initObjects []client.Object
+		testConfig  builder.VCSimTestConfig
+		ctx         *builder.TestContextForVCSim
+		vmProvider  providers.VirtualMachineProviderInterface
+		nsInfo      builder.WorkloadNamespaceInfo
+
+		vm      *vmopv1.VirtualMachine
+		vmClass *vmopv1.VirtualMachineClass
+	)
+
+	BeforeEach(func() {
+		parentCtx = pkgcfg.NewContextWithDefaultConfig()
+		parentCtx = ctxop.WithContext(parentCtx)
+		parentCtx = ovfcache.WithContext(parentCtx)
+		parentCtx = cource.WithContext(parentCtx)
+		pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
+			config.AsyncCreateEnabled = false
+			config.AsyncSignalEnabled = false
+		})
+		testConfig = builder.VCSimTestConfig{
+			WithContentLibrary: true,
+		}
+
+		vmClass = builder.DummyVirtualMachineClassGenName()
+		vm = builder.DummyBasicVirtualMachine("test-vm", "")
+		if vm.Spec.Network == nil {
+			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
+		}
+		vm.Spec.Network.Disabled = true
+	})
+
+	JustBeforeEach(func() {
+		ctx = suite.NewTestContextForVCSimWithParentContext(
+			parentCtx, testConfig, initObjects...)
+		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+			config.MaxDeployThreadsOnProvider = 1
+		})
+		vmProvider = vsphere.NewVSphereVMProviderFromClient(
+			ctx, ctx.Client, ctx.Recorder)
+		nsInfo = ctx.CreateWorkloadNamespace()
+
+		vmClass.Namespace = nsInfo.Namespace
+		Expect(ctx.Client.Create(ctx, vmClass)).To(Succeed())
+
+		clusterVMI1 := &vmopv1.ClusterVirtualMachineImage{}
+		Expect(ctx.Client.Get(
+			ctx, client.ObjectKey{Name: ctx.ContentLibraryItem1Name},
+			clusterVMI1)).To(Succeed())
+
+		vm.Namespace = nsInfo.Namespace
+		vm.Spec.ClassName = vmClass.Name
+		vm.Spec.ImageName = clusterVMI1.Name
+		vm.Spec.Image.Kind = cvmiKind
+		vm.Spec.Image.Name = clusterVMI1.Name
+		vm.Spec.StorageClass = ctx.StorageClassName
+
+		Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
+
+		zoneName := ctx.GetFirstZoneName()
+		vm.Labels[corev1.LabelTopologyZone] = zoneName
+		Expect(ctx.Client.Update(ctx, vm)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		vmClass = nil
+		vm = nil
+
+		ctx.AfterEach()
+		ctx = nil
+		initObjects = nil
+		vmProvider = nil
+		nsInfo = builder.WorkloadNamespaceInfo{}
+	})
+
+	// callProviderOnce calls the provider exactly once and returns the raw error.
+	// The caller is responsible for interpreting the error.
+	callProviderOnce := func() error {
+		opctx := ctxop.WithContext(ctx)
+		return vmProvider.CreateOrUpdateVirtualMachine(opctx, vm)
+	}
+
+	When("VM is in the correct namespace RP and folder", func() {
+		It("sets VirtualMachineLocationValid condition to True", func() {
+			Expect(createOrUpdateVM(ctx, vmProvider, vm)).To(Succeed())
+			Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineLocationValid)).To(BeTrue())
+		})
+	})
+
+	When("VM is in a direct child RP of the namespace RP", func() {
+		It("sets VirtualMachineLocationValid condition to True", func() {
+			vcVM, err := createOrUpdateAndGetVcVM(ctx, vmProvider, vm)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create a child RP under the namespace RP.
+			rp, _ := ctx.CreateVirtualMachineSetResourcePolicy("child-rp-policy", nsInfo)
+			Expect(rp).ToNot(BeNil())
+
+			childRP := ctx.GetResourcePoolForNamespace(nsInfo.Namespace, "", rp.Spec.ResourcePool.Name)
+			Expect(childRP).ToNot(BeNil())
+
+			// Move VM into the child RP, keep it in the namespace folder.
+			task, err := vcVM.Relocate(ctx, vimtypes.VirtualMachineRelocateSpec{
+				Pool:   ptr.To(childRP.Reference()),
+				Folder: ptr.To(nsInfo.Folder.Reference()),
+			}, vimtypes.VirtualMachineMovePriorityDefaultPriority)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(task.Wait(ctx)).To(Succeed())
+
+			Expect(createOrUpdateVM(ctx, vmProvider, vm)).To(Succeed())
+			Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineLocationValid)).To(BeTrue())
+		})
+	})
+
+	When("VM is in a direct child folder of the namespace folder", func() {
+		It("sets VirtualMachineLocationValid condition to True", func() {
+			vcVM, err := createOrUpdateAndGetVcVM(ctx, vmProvider, vm)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create a child folder under the namespace folder.
+			_, childFolder := ctx.CreateVirtualMachineSetResourcePolicy("child-folder-policy", nsInfo)
+			Expect(childFolder).ToNot(BeNil())
+
+			nsRP := ctx.GetResourcePoolForNamespace(nsInfo.Namespace, "", "")
+
+			// Move VM into the child folder, keep it in the namespace RP.
+			task, err := vcVM.Relocate(ctx, vimtypes.VirtualMachineRelocateSpec{
+				Pool:   ptr.To(nsRP.Reference()),
+				Folder: ptr.To(childFolder.Reference()),
+			}, vimtypes.VirtualMachineMovePriorityDefaultPriority)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(task.Wait(ctx)).To(Succeed())
+
+			Expect(createOrUpdateVM(ctx, vmProvider, vm)).To(Succeed())
+			Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineLocationValid)).To(BeTrue())
+		})
+	})
+
+	When("VM is moved to an invalid resource pool", func() {
+		It("sets VirtualMachineLocationValid condition to False and returns NoRequeueError", func() {
+			vcVM, err := createOrUpdateAndGetVcVM(ctx, vmProvider, vm)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Move VM to the cluster root RP — outside the namespace RP hierarchy.
+			clusterRP, err := ctx.GetFirstClusterFromFirstZone().ResourcePool(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			task, err := vcVM.Relocate(ctx, vimtypes.VirtualMachineRelocateSpec{
+				Pool:   ptr.To(clusterRP.Reference()),
+				Folder: ptr.To(nsInfo.Folder.Reference()),
+			}, vimtypes.VirtualMachineMovePriorityDefaultPriority)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(task.Wait(ctx)).To(Succeed())
+
+			err = callProviderOnce()
+			Expect(err).To(HaveOccurred())
+			var noRequeueErr pkgerr.NoRequeueError
+			Expect(errors.As(err, &noRequeueErr)).To(BeTrue())
+
+			cond := conditions.Get(vm, vmopv1.VirtualMachineLocationValid)
+			Expect(cond).ToNot(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Reason).To(Equal("ResourcePoolMismatch"))
+		})
+	})
+
+	When("VM is moved to an invalid folder", func() {
+		It("sets VirtualMachineLocationValid condition to False and returns NoRequeueError", func() {
+			vcVM, err := createOrUpdateAndGetVcVM(ctx, vmProvider, vm)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Move VM to the datacenter VM folder — outside the namespace folder.
+			dcFolder, err := ctx.Finder.DefaultFolder(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			nsRP := ctx.GetResourcePoolForNamespace(nsInfo.Namespace, "", "")
+			task, err := vcVM.Relocate(ctx, vimtypes.VirtualMachineRelocateSpec{
+				Pool:   ptr.To(nsRP.Reference()),
+				Folder: ptr.To(dcFolder.Reference()),
+			}, vimtypes.VirtualMachineMovePriorityDefaultPriority)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(task.Wait(ctx)).To(Succeed())
+
+			err = callProviderOnce()
+			Expect(err).To(HaveOccurred())
+			var noRequeueErr pkgerr.NoRequeueError
+			Expect(errors.As(err, &noRequeueErr)).To(BeTrue())
+
+			cond := conditions.Get(vm, vmopv1.VirtualMachineLocationValid)
+			Expect(cond).ToNot(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Reason).To(Equal("FolderMismatch"))
+		})
+	})
+
+	When("VM is moved to both an invalid resource pool and an invalid folder", func() {
+		It("sets VirtualMachineLocationValid condition to False with ResourcePoolAndFolderMismatch reason", func() {
+			vcVM, err := createOrUpdateAndGetVcVM(ctx, vmProvider, vm)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Move VM to the cluster root RP (outside namespace RP) and to the
+			// datacenter root folder (outside namespace folder) simultaneously.
+			clusterRP, err := ctx.GetFirstClusterFromFirstZone().ResourcePool(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			dcFolder, err := ctx.Finder.DefaultFolder(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			task, err := vcVM.Relocate(ctx, vimtypes.VirtualMachineRelocateSpec{
+				Pool:   ptr.To(clusterRP.Reference()),
+				Folder: ptr.To(dcFolder.Reference()),
+			}, vimtypes.VirtualMachineMovePriorityDefaultPriority)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(task.Wait(ctx)).To(Succeed())
+
+			err = callProviderOnce()
+			Expect(err).To(HaveOccurred())
+			var noRequeueErr pkgerr.NoRequeueError
+			Expect(errors.As(err, &noRequeueErr)).To(BeTrue())
+
+			cond := conditions.Get(vm, vmopv1.VirtualMachineLocationValid)
+			Expect(cond).ToNot(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Reason).To(Equal("ResourcePoolAndFolderMismatch"))
+		})
+	})
+
+	When("VM is in an invalid location on consecutive reconciles", func() {
+		Context("condition idempotency (False)", func() {
+			It("does not change LastTransitionTime on the second reconcile", func() {
+				vcVM, err := createOrUpdateAndGetVcVM(ctx, vmProvider, vm)
+				Expect(err).ToNot(HaveOccurred())
+
+				clusterRP, err := ctx.GetFirstClusterFromFirstZone().ResourcePool(ctx)
+				Expect(err).ToNot(HaveOccurred())
+
+				task, err := vcVM.Relocate(ctx, vimtypes.VirtualMachineRelocateSpec{
+					Pool:   ptr.To(clusterRP.Reference()),
+					Folder: ptr.To(nsInfo.Folder.Reference()),
+				}, vimtypes.VirtualMachineMovePriorityDefaultPriority)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(task.Wait(ctx)).To(Succeed())
+
+				// First call sets condition to False.
+				Expect(callProviderOnce()).Error().To(HaveOccurred())
+				cond1 := conditions.Get(vm, vmopv1.VirtualMachineLocationValid)
+				Expect(cond1).ToNot(BeNil())
+				Expect(cond1.Status).To(Equal(metav1.ConditionFalse))
+				ltt1 := cond1.LastTransitionTime
+
+				// Second call: condition is already False — must not touch LastTransitionTime.
+				Expect(callProviderOnce()).Error().To(HaveOccurred())
+				cond2 := conditions.Get(vm, vmopv1.VirtualMachineLocationValid)
+				Expect(cond2).ToNot(BeNil())
+				Expect(cond2.LastTransitionTime).To(Equal(ltt1))
+			})
+		})
+
+		Context("condition idempotency (True)", func() {
+			It("does not change LastTransitionTime on the second reconcile", func() {
+				Expect(createOrUpdateVM(ctx, vmProvider, vm)).To(Succeed())
+
+				cond1 := conditions.Get(vm, vmopv1.VirtualMachineLocationValid)
+				Expect(cond1).ToNot(BeNil())
+				Expect(cond1.Status).To(Equal(metav1.ConditionTrue))
+				ltt1 := cond1.LastTransitionTime
+
+				// Second full reconcile: condition is already True — must not touch LastTransitionTime.
+				Expect(createOrUpdateVM(ctx, vmProvider, vm)).To(Succeed())
+				cond2 := conditions.Get(vm, vmopv1.VirtualMachineLocationValid)
+				Expect(cond2).ToNot(BeNil())
+				Expect(cond2.LastTransitionTime).To(Equal(ltt1))
+			})
+		})
+	})
+
+	When("VM is moved back to the correct location after being in an invalid resource pool", func() {
+		It("resets VirtualMachineLocationValid condition to True", func() {
+			vcVM, err := createOrUpdateAndGetVcVM(ctx, vmProvider, vm)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineLocationValid)).To(BeTrue())
+
+			// Move VM to the cluster root RP — outside the namespace RP hierarchy.
+			clusterRP, err := ctx.GetFirstClusterFromFirstZone().ResourcePool(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			task, err := vcVM.Relocate(ctx, vimtypes.VirtualMachineRelocateSpec{
+				Pool:   ptr.To(clusterRP.Reference()),
+				Folder: ptr.To(nsInfo.Folder.Reference()),
+			}, vimtypes.VirtualMachineMovePriorityDefaultPriority)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(task.Wait(ctx)).To(Succeed())
+
+			// Condition should become False while VM is in an invalid location.
+			Expect(callProviderOnce()).Error().To(HaveOccurred())
+			Expect(conditions.IsFalse(vm, vmopv1.VirtualMachineLocationValid)).To(BeTrue())
+
+			// Move VM back to the namespace RP and folder.
+			nsRP := ctx.GetResourcePoolForNamespace(nsInfo.Namespace, "", "")
+			Expect(nsRP).ToNot(BeNil())
+			task, err = vcVM.Relocate(ctx, vimtypes.VirtualMachineRelocateSpec{
+				Pool:   ptr.To(nsRP.Reference()),
+				Folder: ptr.To(nsInfo.Folder.Reference()),
+			}, vimtypes.VirtualMachineMovePriorityDefaultPriority)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(task.Wait(ctx)).To(Succeed())
+
+			// Condition should be reset to True after the VM is back in the correct location.
+			Expect(createOrUpdateVM(ctx, vmProvider, vm)).To(Succeed())
+			Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineLocationValid)).To(BeTrue())
+		})
+	})
+}

--- a/pkg/providers/vsphere/vmprovider_vm_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_test.go
@@ -51,6 +51,7 @@ var _ = Describe("VirtualMachine", Label(testlabels.VCSim), func() {
 	Describe("VKS", Label(testlabels.VKS), vmVKSTests)
 	Describe("WebConsole", vmWebConsoleTests)
 	Describe("Zone", vmZoneTests)
+	Describe("Location", vmLocationTests)
 })
 
 // getVMHomeDisk gets the VM's "home" disk. It makes some assumptions about the backing and disk name.

--- a/test/e2e/infrastructure/vsphere/vcenter/roles.go
+++ b/test/e2e/infrastructure/vsphere/vcenter/roles.go
@@ -77,6 +77,47 @@ func UpdateRole(ctx context.Context, vimClient *vim25.Client, roleID int32, role
 	return nil
 }
 
+// EnsureRolePrivileges makes sure the role with the given id grants at least the specified
+// privileges, without removing any privileges it already has. It is a no-op if the role
+// already grants every requested privilege.
+func EnsureRolePrivileges(ctx context.Context, vimClient *vim25.Client, roleID int32, privilegeIDs []string) error {
+	authzManager := object.NewAuthorizationManager(vimClient)
+
+	roleList, err := authzManager.RoleList(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list roles: %w", err)
+	}
+
+	role := roleList.ById(roleID)
+	if role == nil {
+		return fmt.Errorf("role %d not found", roleID)
+	}
+
+	have := make(map[string]struct{}, len(role.Privilege))
+	for _, p := range role.Privilege {
+		have[p] = struct{}{}
+	}
+
+	merged := role.Privilege
+	changed := false
+	for _, p := range privilegeIDs {
+		if _, ok := have[p]; !ok {
+			merged = append(merged, p)
+			changed = true
+		}
+	}
+
+	if !changed {
+		return nil
+	}
+
+	if err := authzManager.UpdateRole(ctx, roleID, role.Name, merged); err != nil {
+		return fmt.Errorf("failed to update role %d (%s): %w", roleID, role.Name, err)
+	}
+
+	return nil
+}
+
 // RemoveRole removes the role with specified id in VC.
 func RemoveRole(ctx context.Context, vimClient *vim25.Client, roleID int32) error {
 	authzManager := object.NewAuthorizationManager(vimClient)

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
@@ -179,6 +179,38 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		return "", ""
 	}
 
+	// getOtherNamespaceFolder returns the folder MoID and name of a Supervisor Namespace other
+	// than the given one. WCP grants the VM-Service-VM-Management role directly on every
+	// namespace's own folder, so a different namespace's folder is a location that is both
+	// outside the given namespace's folder hierarchy and already permitted for the test's
+	// vCenter account -- unlike an arbitrary vCenter folder (e.g. the Datacenter's root VM
+	// folder), which WCP never grants permissions on.
+	getOtherNamespaceFolder := func(namespace string) (folderMoID, otherNamespace string) {
+		zoneList := &topologyv1.ZoneList{}
+		Expect(svClusterClient.List(ctx, zoneList)).To(Succeed(), "failed to list Zones")
+
+		for _, z := range zoneList.Items {
+			if z.Namespace != namespace && len(z.Spec.ManagedVMs.PoolMoIDs) > 0 {
+				return z.Spec.ManagedVMs.FolderMoID, z.Namespace
+			}
+		}
+
+		// Fallback: AvailabilityZone.Spec.Namespaces (older cluster configurations).
+		azList := &topologyv1.AvailabilityZoneList{}
+		Expect(svClusterClient.List(ctx, azList)).
+			To(Succeed(), "failed to list AvailabilityZones")
+
+		for _, az := range azList.Items {
+			for ns, nsInfo := range az.Spec.Namespaces {
+				if ns != namespace && nsInfo.PoolMoId != "" {
+					return nsInfo.FolderMoId, ns
+				}
+			}
+		}
+
+		return "", ""
+	}
+
 	// createVM deploys a VM and waits for it to reach Running state.
 	createVM := func() {
 		vmParameters := manifestbuilders.VirtualMachineYaml{
@@ -306,27 +338,22 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 			By("Retrieving the correct namespace folder MoID")
 			_, nsFolderMoID := getNsRPAndFolder(input.WCPNamespaceName)
 
-			By("Retrieving the parent of the namespace folder as the invalid folder location")
-			// The namespace folder's parent (the DC's root VM folder) is always a
-			// Folder-typed MoRef and always lies outside the 2-level hierarchy that
-			// validateVMFolder checks, so it reliably triggers the LocationMismatch.
-			pc := property.DefaultCollector(vCenterAdminClient)
-			var nsFolderMo mo.Folder
-			Expect(pc.RetrieveOne(ctx,
-				vimtypes.ManagedObjectReference{Type: "Folder", Value: nsFolderMoID},
-				[]string{"parent"},
-				&nsFolderMo,
-			)).To(Succeed(), "failed to fetch namespace folder's parent")
-			Expect(nsFolderMo.Parent).ToNot(BeNil(), "namespace folder has no parent")
-			Expect(nsFolderMo.Parent.Type).To(Equal("Folder"),
-				"namespace folder's parent must be a Folder (got %s %s)",
-				nsFolderMo.Parent.Type, nsFolderMo.Parent.Value)
-			invalidFolderMoID := nsFolderMo.Parent.Value
+			By("Retrieving another Supervisor Namespace's folder as the invalid folder location")
+			// A different namespace's folder always lies outside the 2-level hierarchy
+			// that validateVMFolder checks, so it reliably triggers the LocationMismatch.
+			// Unlike the Datacenter's root VM folder, WCP grants the VM-Service-VM-Management
+			// role directly on every namespace's own folder, so this location is one the
+			// test's vCenter account is already permitted to move VMs into.
+			invalidFolderMoID, otherNamespace := getOtherNamespaceFolder(input.WCPNamespaceName)
+			if invalidFolderMoID == "" {
+				Skip("no other Supervisor Namespace found on this vCenter; " +
+					"cannot exercise cross-namespace folder isolation")
+			}
 			Expect(invalidFolderMoID).ToNot(Equal(nsFolderMoID),
-				"namespace folder's parent unexpectedly equals the namespace folder itself")
-			e2eframework.Logf("invalid folder MoID (parent of namespace folder): %s", invalidFolderMoID)
+				"other namespace's folder unexpectedly equals the namespace folder itself")
+			e2eframework.Logf("invalid folder MoID (folder of namespace %s): %s", otherNamespace, invalidFolderMoID)
 
-			By("Moving VM into the DC root VM folder via MoveIntoFolder (direct inventory move)")
+			By("Moving VM into the other namespace's folder via MoveIntoFolder (direct inventory move)")
 			// Use Folder.MoveInto rather than Relocate.Folder: in WCP, the
 			// Relocate API honors Pool changes but silently ignores the Folder
 			// field because WCP controls namespace folder placement.
@@ -341,6 +368,7 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 			Expect(moveTask.Wait(ctx)).To(Succeed(), "MoveIntoFolder task failed for VM %s", vmMoID)
 
 			By("Verifying the VM actually moved to the invalid folder")
+			pc := property.DefaultCollector(vCenterAdminClient)
 			var vmMoAfterMove mo.VirtualMachine
 			Expect(pc.RetrieveOne(ctx,
 				vimtypes.ManagedObjectReference{Type: "VirtualMachine", Value: vmMoID},
@@ -350,7 +378,7 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 			e2eframework.Logf("VM parent after MoveIntoFolder: type=%s value=%s (expected=%s)",
 				vmMoAfterMove.Parent.Type, vmMoAfterMove.Parent.Value, invalidFolderMoID)
 			Expect(vmMoAfterMove.Parent.Value).To(Equal(invalidFolderMoID),
-				"VM did not move to the DC root VM folder; actual parent: %s", vmMoAfterMove.Parent.Value)
+				"VM did not move to the other namespace's folder; actual parent: %s", vmMoAfterMove.Parent.Value)
 
 			By("Waiting for VirtualMachineLocationValid condition to become False")
 			vmoperator.WaitOnVirtualMachineCondition(ctx, config, svClusterClient,

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
@@ -14,8 +14,8 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/property"
-	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/mo"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	e2eframework "k8s.io/kubernetes/test/e2e/framework"
@@ -170,7 +170,7 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 			StorageClassName: clusterResources.StorageClassName,
 			PowerState:       "PoweredOn",
 		}
-		vmYaml := manifestbuilders.GetVirtualMachineYamlA6(vmParameters)
+		vmYaml := manifestbuilders.GetVirtualMachineYamlA5(vmParameters)
 		e2eframework.Logf("Creating VirtualMachine %s", vmName)
 		Expect(clusterProxy.CreateWithArgs(ctx, vmYaml)).To(Succeed(),
 			"failed to create VM %s", vmName)
@@ -198,7 +198,7 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		Expect(task.Wait(ctx)).To(Succeed(), "Relocate task failed for VM %s", vmMoID)
 	}
 
-	When("VM is created in the correct namespace RP and folder", Label("vmrelocation"), func() {
+	When("VM is created in the correct namespace RP and folder", Label("vmrelocation", "experimental"), func() {
 		It("sets VirtualMachineLocationValid condition to True", func() {
 			createVM()
 
@@ -210,7 +210,7 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		})
 	})
 
-	When("VM is moved outside the namespace RP hierarchy", Label("vmrelocation"), func() {
+	When("VM is moved outside the namespace RP hierarchy", Label("vmrelocation", "experimental"), func() {
 		It("sets condition False, then recovers to True when VM is returned to the correct location", func() {
 			By("Creating VM and waiting for it to reach Running state")
 			createVM()
@@ -269,7 +269,7 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		})
 	})
 
-	When("VM is moved outside the namespace Folder hierarchy", Label("vmrelocation"), func() {
+	When("VM is moved outside the namespace Folder hierarchy", Label("vmrelocation", "experimental"), func() {
 		It("sets condition False, then recovers to True when VM is returned to the correct location", func() {
 			By("Creating VM and waiting for it to reach Running state")
 			createVM()

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
@@ -53,6 +53,10 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 	const (
 		specName = "vm-location"
 		vmKind   = "VirtualMachine"
+
+		// vmServiceVMMgmtRoleID is the hardcoded vCenter role ID for the VM-Service-VM-Management role.
+		vmServiceVMMgmtRoleID   = int32(1039)
+		vmServiceVMMgmtRoleName = "VM-Service-VM-Management"
 	)
 
 	var (
@@ -102,6 +106,21 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		var err error
 		vCenterAdminClient, err = vcenter.NewVimClient(vCenterHostname, testbed.AdminUsername, testbed.AdminPassword)
 		Expect(err).ToNot(HaveOccurred(), "Failed to create vCenter admin client")
+
+		// WCP grants the VM-Service-VM-Management role to the Administrators group directly on the
+		// namespace RP/folder, which overrides the inherited vCenter Administrator role for those
+		// objects. That role does not always include the privileges the specs below need to
+		// relocate a VM between resource pools and move it in/out of the namespace folder, so
+		// ensure they are present here.
+		Expect(vcenter.EnsureRolePrivileges(ctx, vCenterAdminClient, vmServiceVMMgmtRoleID,
+			[]string{
+				"Folder.Move",
+				"Resource.AssignVMToPool",
+				"Resource.ColdMigrate",
+				"Resource.HotMigrate",
+				"VirtualMachine.Inventory.Move",
+			})).To(Succeed(),
+			"failed to ensure %s role has the privileges required for VM relocation", vmServiceVMMgmtRoleName)
 
 		linuxImageDisplayName := vmservice.GetDefaultImageDisplayName(clusterResources)
 		linuxVMIName, err = vmoperator.WaitForVirtualMachineImageName(

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
@@ -249,7 +249,7 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		Expect(task.Wait(ctx)).To(Succeed(), "Relocate task failed for VM %s", vmMoID)
 	}
 
-	When("VM is created in the correct namespace RP and folder", Label("experimental"), func() {
+	When("VM is created in the correct namespace RP and folder", Label("core-functional","experimental"), func() {
 		It("sets VirtualMachineLocationValid condition to True", func() {
 			createVM()
 
@@ -261,7 +261,7 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		})
 	})
 
-	When("VM is moved outside the namespace RP hierarchy", Label("experimental"), func() {
+	When("VM is moved outside the namespace RP hierarchy", Label("core-functional","experimental"), func() {
 		It("sets condition False, then recovers to True when VM is returned to the correct location", func() {
 			By("Creating VM and waiting for it to reach Running state")
 			createVM()
@@ -320,7 +320,7 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		})
 	})
 
-	When("VM is moved outside the namespace Folder hierarchy", Label("experimental"), func() {
+	When("VM is moved outside the namespace Folder hierarchy", Label("core-functional","experimental"), func() {
 		It("sets condition False, then recovers to True when VM is returned to the correct location", func() {
 			By("Creating VM and waiting for it to reach Running state")
 			createVM()

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
@@ -198,7 +198,7 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		Expect(task.Wait(ctx)).To(Succeed(), "Relocate task failed for VM %s", vmMoID)
 	}
 
-	When("VM is created in the correct namespace RP and folder", Label("vmrelocation", "experimental"), func() {
+	When("VM is created in the correct namespace RP and folder", Label("vmrelocation"), func() {
 		It("sets VirtualMachineLocationValid condition to True", func() {
 			createVM()
 
@@ -210,7 +210,7 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		})
 	})
 
-	When("VM is moved outside the namespace RP hierarchy", Label("vmrelocation", "experimental"), func() {
+	When("VM is moved outside the namespace RP hierarchy", Label("vmrelocation"), func() {
 		It("sets condition False, then recovers to True when VM is returned to the correct location", func() {
 			By("Creating VM and waiting for it to reach Running state")
 			createVM()
@@ -269,7 +269,7 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		})
 	})
 
-	When("VM is moved outside the namespace Folder hierarchy", Label("vmrelocation", "experimental"), func() {
+	When("VM is moved outside the namespace Folder hierarchy", Label("vmrelocation"), func() {
 		It("sets condition False, then recovers to True when VM is returned to the correct location", func() {
 			By("Creating VM and waiting for it to reach Running state")
 			createVM()

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
@@ -249,7 +249,7 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		Expect(task.Wait(ctx)).To(Succeed(), "Relocate task failed for VM %s", vmMoID)
 	}
 
-	When("VM is created in the correct namespace RP and folder", Label("vmrelocation"), func() {
+	When("VM is created in the correct namespace RP and folder", Label("experimental"), func() {
 		It("sets VirtualMachineLocationValid condition to True", func() {
 			createVM()
 
@@ -261,7 +261,7 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		})
 	})
 
-	When("VM is moved outside the namespace RP hierarchy", Label("vmrelocation"), func() {
+	When("VM is moved outside the namespace RP hierarchy", Label("experimental"), func() {
 		It("sets condition False, then recovers to True when VM is returned to the correct location", func() {
 			By("Creating VM and waiting for it to reach Running state")
 			createVM()
@@ -320,7 +320,7 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		})
 	})
 
-	When("VM is moved outside the namespace Folder hierarchy", Label("vmrelocation"), func() {
+	When("VM is moved outside the namespace Folder hierarchy", Label("experimental"), func() {
 		It("sets condition False, then recovers to True when VM is returned to the correct location", func() {
 			By("Creating VM and waiting for it to reach Running state")
 			createVM()

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
@@ -1,0 +1,361 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package virtualmachine
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	e2eframework "k8s.io/kubernetes/test/e2e/framework"
+	capiutil "sigs.k8s.io/cluster-api/util"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+	topologyv1 "github.com/vmware-tanzu/vm-operator/external/tanzu-topology/api/v1alpha1"
+	"github.com/vmware-tanzu/vm-operator/test/e2e/framework"
+	"github.com/vmware-tanzu/vm-operator/test/e2e/infrastructure/vsphere/testbed"
+	"github.com/vmware-tanzu/vm-operator/test/e2e/infrastructure/vsphere/vcenter"
+	"github.com/vmware-tanzu/vm-operator/test/e2e/infrastructure/vsphere/wcp"
+	"github.com/vmware-tanzu/vm-operator/test/e2e/manifestbuilders"
+	"github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/common"
+	e2eConfig "github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/config"
+	"github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/consts"
+	"github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/lib/vmoperator"
+	"github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/skipper"
+	"github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/vmservice"
+	"github.com/vmware-tanzu/vm-operator/test/e2e/wcpframework"
+)
+
+// VMLocationSpecInput is the input to VMLocationSpec.
+type VMLocationSpecInput struct {
+	ClusterProxy     wcpframework.WCPClusterProxyInterface
+	Config           *e2eConfig.E2EConfig
+	WCPClient        wcp.WorkloadManagementAPI
+	ArtifactFolder   string
+	WCPNamespaceName string
+}
+
+// VMLocationSpec validates that the VirtualMachineLocationValid condition is set correctly
+// when a VM is created in, moved out of, or returned to the expected vCenter inventory location.
+func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput) {
+	const (
+		specName = "vm-location"
+		vmKind   = "VirtualMachine"
+	)
+
+	var (
+		input              VMLocationSpecInput
+		config             *e2eConfig.E2EConfig
+		clusterProxy       *common.VMServiceClusterProxy
+		svClusterClient    ctrlclient.Client
+		vCenterAdminClient *vim25.Client
+		clusterResources   *e2eConfig.Resources
+
+		vmName       string
+		linuxVMIName string
+	)
+
+	BeforeEach(func() {
+		input = inputGetter()
+		Expect(input.Config).ToNot(BeNil(),
+			"Invalid argument. input.E2EConfig can't be nil when calling %s spec", specName)
+		Expect(input.Config.InfraConfig).ToNot(BeNil(),
+			"Invalid argument. input.E2EConfig.InfraConfig can't be nil when calling %s spec", specName)
+		skipper.SkipUnlessInfraIs(input.Config.InfraConfig.InfraName, consts.WCP)
+
+		Expect(input.ClusterProxy).ToNot(BeNil(),
+			"Invalid argument. input.ClusterProxy can't be nil when calling %s spec", specName)
+		Expect(input.WCPNamespaceName).ToNot(BeEmpty(),
+			"Invalid argument. input.WCPNamespaceName can't be empty when calling %s spec", specName)
+		Expect(os.MkdirAll(input.ArtifactFolder, 0755)).To(Succeed(),
+			"Invalid argument. input.ArtifactFolder can't be created for %s spec", specName)
+
+		config = input.Config
+		clusterResources = config.InfraConfig.ManagementClusterConfig.Resources
+		clusterProxy = input.ClusterProxy.(*common.VMServiceClusterProxy)
+
+		cancelPodWatches := framework.WatchPodLogsAndEventsInNamespaces(
+			ctx,
+			[]string{config.GetVariable("VMOPNamespace")},
+			clusterProxy.GetClientSet(),
+			filepath.Join(input.ArtifactFolder, specName),
+		)
+		DeferCleanup(cancelPodWatches)
+
+		svClusterClient = clusterProxy.GetClient()
+
+		kubeconfigPath := clusterProxy.GetKubeconfigPath()
+		vCenterHostname := vcenter.GetVCPNIDFromKubeconfigFile(ctx, kubeconfigPath)
+
+		var err error
+		vCenterAdminClient, err = vcenter.NewVimClient(vCenterHostname, testbed.AdminUsername, testbed.AdminPassword)
+		Expect(err).ToNot(HaveOccurred(), "Failed to create vCenter admin client")
+
+		linuxImageDisplayName := vmservice.GetDefaultImageDisplayName(clusterResources)
+		linuxVMIName, err = vmoperator.WaitForVirtualMachineImageName(
+			ctx, &config.Config, svClusterClient,
+			input.WCPNamespaceName, linuxImageDisplayName)
+		Expect(err).NotTo(HaveOccurred(),
+			"failed to get VMI name for display name %q in namespace %q",
+			linuxImageDisplayName, input.WCPNamespaceName)
+
+		vmName = fmt.Sprintf("%s-%s", specName, capiutil.RandomString(4))
+	})
+
+	AfterEach(func() {
+		if CurrentSpecReport().Failed() {
+			vmoperator.DescribeResourceIfExists(
+				ctx, svClusterClient,
+				clusterProxy.GetKubeconfigPath(),
+				input.WCPNamespaceName, vmName, vmKind)
+		}
+
+		vmoperator.VerifyVMDeleted(ctx, svClusterClient, config, input.WCPNamespaceName, vmName)
+		vcenter.LogoutVimClient(vCenterAdminClient)
+	})
+
+	// getNsRPAndFolder returns the namespace RP MoID and folder MoID for the
+	// WCP namespace.  It mirrors the lookup order in topology.GetNamespaceFolderAndRPMoID:
+	// Zone.Spec.ManagedVMs first, then AvailabilityZone.Spec.Namespaces as fallback.
+	getNsRPAndFolder := func(namespace string) (rpMoID, folderMoID string) {
+		zoneList := &topologyv1.ZoneList{}
+		Expect(svClusterClient.List(ctx, zoneList, ctrlclient.InNamespace(namespace))).
+			To(Succeed(), "failed to list Zones for namespace %s", namespace)
+
+		for _, z := range zoneList.Items {
+			if len(z.Spec.ManagedVMs.PoolMoIDs) > 0 {
+				e2eframework.Logf("resolved namespace RP from Zone %s: %s / %s",
+					z.Name, z.Spec.ManagedVMs.PoolMoIDs[0], z.Spec.ManagedVMs.FolderMoID)
+				return z.Spec.ManagedVMs.PoolMoIDs[0], z.Spec.ManagedVMs.FolderMoID
+			}
+		}
+
+		// Fallback: AvailabilityZone.Spec.Namespaces (older cluster configurations).
+		azList := &topologyv1.AvailabilityZoneList{}
+		Expect(svClusterClient.List(ctx, azList)).
+			To(Succeed(), "failed to list AvailabilityZones")
+		Expect(azList.Items).ToNot(BeEmpty(), "expected at least one AvailabilityZone")
+
+		for _, az := range azList.Items {
+			if nsInfo, ok := az.Spec.Namespaces[namespace]; ok && nsInfo.PoolMoId != "" {
+				e2eframework.Logf("resolved namespace RP from AvailabilityZone %s: %s / %s",
+					az.Name, nsInfo.PoolMoId, nsInfo.FolderMoId)
+				return nsInfo.PoolMoId, nsInfo.FolderMoId
+			}
+		}
+
+		Fail("could not determine namespace RP and folder MoIDs for namespace " + namespace)
+		return "", ""
+	}
+
+	// createVM deploys a VM and waits for it to reach Running state.
+	createVM := func() {
+		vmParameters := manifestbuilders.VirtualMachineYaml{
+			Namespace:        input.WCPNamespaceName,
+			Name:             vmName,
+			ImageName:        linuxVMIName,
+			VMClassName:      clusterResources.VMClassName,
+			StorageClassName: clusterResources.StorageClassName,
+			PowerState:       "PoweredOn",
+		}
+		vmYaml := manifestbuilders.GetVirtualMachineYamlA6(vmParameters)
+		e2eframework.Logf("Creating VirtualMachine %s", vmName)
+		Expect(clusterProxy.CreateWithArgs(ctx, vmYaml)).To(Succeed(),
+			"failed to create VM %s", vmName)
+		vmoperator.WaitForVirtualMachineCreation(ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
+	}
+
+	// relocateVM moves the VM to the given resource pool and/or folder MoID.
+	// Pass an empty string to leave that field unchanged.
+	relocateVM := func(vmMoID, poolMoID, folderMoID string) {
+		vmObj := object.NewVirtualMachine(vCenterAdminClient, vimtypes.ManagedObjectReference{
+			Type:  "VirtualMachine",
+			Value: vmMoID,
+		})
+		spec := vimtypes.VirtualMachineRelocateSpec{}
+		if poolMoID != "" {
+			ref := vimtypes.ManagedObjectReference{Type: "ResourcePool", Value: poolMoID}
+			spec.Pool = &ref
+		}
+		if folderMoID != "" {
+			ref := vimtypes.ManagedObjectReference{Type: "Folder", Value: folderMoID}
+			spec.Folder = &ref
+		}
+		task, err := vmObj.Relocate(ctx, spec, vimtypes.VirtualMachineMovePriorityDefaultPriority)
+		Expect(err).ToNot(HaveOccurred(), "failed to start Relocate task for VM %s", vmMoID)
+		Expect(task.Wait(ctx)).To(Succeed(), "Relocate task failed for VM %s", vmMoID)
+	}
+
+	When("VM is created in the correct namespace RP and folder", Label("vmrelocation"), func() {
+		It("sets VirtualMachineLocationValid condition to True", func() {
+			createVM()
+
+			vmoperator.WaitOnVirtualMachineCondition(ctx, config, svClusterClient,
+				input.WCPNamespaceName, vmName, metav1.Condition{
+					Type:   vmopv1.VirtualMachineLocationValid,
+					Status: metav1.ConditionTrue,
+				})
+		})
+	})
+
+	When("VM is moved outside the namespace RP hierarchy", Label("vmrelocation"), func() {
+		It("sets condition False, then recovers to True when VM is returned to the correct location", func() {
+			By("Creating VM and waiting for it to reach Running state")
+			createVM()
+
+			By("Waiting for VirtualMachineLocationValid=True after initial creation")
+			vmoperator.WaitOnVirtualMachineCondition(ctx, config, svClusterClient,
+				input.WCPNamespaceName, vmName, metav1.Condition{
+					Type:   vmopv1.VirtualMachineLocationValid,
+					Status: metav1.ConditionTrue,
+				})
+
+			vmMoID := vmoperator.GetVirtualMachineMOID(ctx, svClusterClient, input.WCPNamespaceName, vmName)
+			Expect(vmMoID).ToNot(BeEmpty(), "VM must have a UniqueID before relocation")
+
+			By("Retrieving the correct namespace RP and folder MoIDs")
+			nsRPMoID, nsFolderMoID := getNsRPAndFolder(input.WCPNamespaceName)
+
+			By("Retrieving the cluster root RP to use as an invalid location")
+			// 1. Resolve the specific Cluster MoID for the active Supervisor context
+			kubeconfigPath := clusterProxy.GetKubeconfigPath()
+			clusterMoID := vcenter.GetClusterMoIDFromKubeconfigFile(ctx, kubeconfigPath)
+
+			// 2. Create an explicit ManagedObjectReference using the real Cluster ID
+			clusterMoRef := vimtypes.ManagedObjectReference{
+				Type:  "ClusterComputeResource",
+				Value: clusterMoID,
+			}
+			clusterRef := object.NewClusterComputeResource(vCenterAdminClient, clusterMoRef)
+
+			// 3. Extract the root Resource Pool from the verified cluster
+			clusterRP, err := clusterRef.ResourcePool(ctx)
+			Expect(err).ToNot(HaveOccurred(), "Failed to get the root Resource Pool for cluster %s", clusterMoID)
+			clusterRPRef := clusterRP.Reference()
+			e2eframework.Logf("cluster root RP MoID: %s", clusterRPRef.Value)
+
+			By("Relocating VM to the cluster root RP (outside the namespace RP hierarchy)")
+			relocateVM(vmMoID, clusterRPRef.Value, "")
+
+			By("Waiting for VirtualMachineLocationValid condition to become False")
+			vmoperator.WaitOnVirtualMachineCondition(ctx, config, svClusterClient,
+				input.WCPNamespaceName, vmName, metav1.Condition{
+					Type:   vmopv1.VirtualMachineLocationValid,
+					Status: metav1.ConditionFalse,
+					Reason: "ResourcePoolMismatch",
+				})
+
+			By("Relocating VM back to the correct namespace RP and folder")
+			relocateVM(vmMoID, nsRPMoID, nsFolderMoID)
+
+			By("Waiting for VirtualMachineLocationValid condition to return to True")
+			vmoperator.WaitOnVirtualMachineCondition(ctx, config, svClusterClient,
+				input.WCPNamespaceName, vmName, metav1.Condition{
+					Type:   vmopv1.VirtualMachineLocationValid,
+					Status: metav1.ConditionTrue,
+				})
+		})
+	})
+
+	When("VM is moved outside the namespace Folder hierarchy", Label("vmrelocation"), func() {
+		It("sets condition False, then recovers to True when VM is returned to the correct location", func() {
+			By("Creating VM and waiting for it to reach Running state")
+			createVM()
+
+			By("Waiting for VirtualMachineLocationValid=True after initial creation")
+			vmoperator.WaitOnVirtualMachineCondition(ctx, config, svClusterClient,
+				input.WCPNamespaceName, vmName, metav1.Condition{
+					Type:   vmopv1.VirtualMachineLocationValid,
+					Status: metav1.ConditionTrue,
+				})
+
+			vmMoID := vmoperator.GetVirtualMachineMOID(ctx, svClusterClient, input.WCPNamespaceName, vmName)
+			Expect(vmMoID).ToNot(BeEmpty(), "VM must have a UniqueID before relocation")
+
+			By("Retrieving the correct namespace folder MoID")
+			_, nsFolderMoID := getNsRPAndFolder(input.WCPNamespaceName)
+
+			By("Retrieving the parent of the namespace folder as the invalid folder location")
+			// The namespace folder's parent (the DC's root VM folder) is always a
+			// Folder-typed MoRef and always lies outside the 2-level hierarchy that
+			// validateVMFolder checks, so it reliably triggers the LocationMismatch.
+			pc := property.DefaultCollector(vCenterAdminClient)
+			var nsFolderMo mo.Folder
+			Expect(pc.RetrieveOne(ctx,
+				vimtypes.ManagedObjectReference{Type: "Folder", Value: nsFolderMoID},
+				[]string{"parent"},
+				&nsFolderMo,
+			)).To(Succeed(), "failed to fetch namespace folder's parent")
+			Expect(nsFolderMo.Parent).ToNot(BeNil(), "namespace folder has no parent")
+			Expect(nsFolderMo.Parent.Type).To(Equal("Folder"),
+				"namespace folder's parent must be a Folder (got %s %s)",
+				nsFolderMo.Parent.Type, nsFolderMo.Parent.Value)
+			invalidFolderMoID := nsFolderMo.Parent.Value
+			Expect(invalidFolderMoID).ToNot(Equal(nsFolderMoID),
+				"namespace folder's parent unexpectedly equals the namespace folder itself")
+			e2eframework.Logf("invalid folder MoID (parent of namespace folder): %s", invalidFolderMoID)
+
+			By("Moving VM into the DC root VM folder via MoveIntoFolder (direct inventory move)")
+			// Use Folder.MoveInto rather than Relocate.Folder: in WCP, the
+			// Relocate API honors Pool changes but silently ignores the Folder
+			// field because WCP controls namespace folder placement.
+			// MoveIntoFolder_Task is a pure vCenter inventory move that bypasses
+			// this restriction and actually changes the VM's parent in vCenter.
+			invalidFolderObj := object.NewFolder(vCenterAdminClient,
+				vimtypes.ManagedObjectReference{Type: "Folder", Value: invalidFolderMoID})
+			moveTask, err := invalidFolderObj.MoveInto(ctx, []vimtypes.ManagedObjectReference{
+				{Type: "VirtualMachine", Value: vmMoID},
+			})
+			Expect(err).ToNot(HaveOccurred(), "failed to start MoveIntoFolder task")
+			Expect(moveTask.Wait(ctx)).To(Succeed(), "MoveIntoFolder task failed for VM %s", vmMoID)
+
+			By("Verifying the VM actually moved to the invalid folder")
+			var vmMoAfterMove mo.VirtualMachine
+			Expect(pc.RetrieveOne(ctx,
+				vimtypes.ManagedObjectReference{Type: "VirtualMachine", Value: vmMoID},
+				[]string{"parent"},
+				&vmMoAfterMove,
+			)).To(Succeed(), "failed to fetch VM parent after move")
+			e2eframework.Logf("VM parent after MoveIntoFolder: type=%s value=%s (expected=%s)",
+				vmMoAfterMove.Parent.Type, vmMoAfterMove.Parent.Value, invalidFolderMoID)
+			Expect(vmMoAfterMove.Parent.Value).To(Equal(invalidFolderMoID),
+				"VM did not move to the DC root VM folder; actual parent: %s", vmMoAfterMove.Parent.Value)
+
+			By("Waiting for VirtualMachineLocationValid condition to become False")
+			vmoperator.WaitOnVirtualMachineCondition(ctx, config, svClusterClient,
+				input.WCPNamespaceName, vmName, metav1.Condition{
+					Type:   vmopv1.VirtualMachineLocationValid,
+					Status: metav1.ConditionFalse,
+					Reason: "FolderMismatch",
+				})
+
+			By("Moving VM back into the namespace folder")
+			nsFolderObj := object.NewFolder(vCenterAdminClient,
+				vimtypes.ManagedObjectReference{Type: "Folder", Value: nsFolderMoID})
+			recoverTask, recoverErr := nsFolderObj.MoveInto(ctx, []vimtypes.ManagedObjectReference{
+				{Type: "VirtualMachine", Value: vmMoID},
+			})
+			Expect(recoverErr).ToNot(HaveOccurred(), "failed to start MoveIntoFolder recovery task")
+			Expect(recoverTask.Wait(ctx)).To(Succeed(), "MoveIntoFolder recovery task failed for VM %s", vmMoID)
+
+			By("Waiting for VirtualMachineLocationValid condition to return to True")
+			vmoperator.WaitOnVirtualMachineCondition(ctx, config, svClusterClient,
+				input.WCPNamespaceName, vmName, metav1.Condition{
+					Type:   vmopv1.VirtualMachineLocationValid,
+					Status: metav1.ConditionTrue,
+				})
+		})
+	})
+}

--- a/test/e2e/vmservice/vmservice_test.go
+++ b/test/e2e/vmservice/vmservice_test.go
@@ -246,5 +246,17 @@ var _ = Describe("Testing VM Services", Label("devops"), Label("viadmin"), Label
 			})
 		})
 
+		Context("VM-LOCATION", func() {
+			virtualmachine.VMLocationSpec(context.TODO(), func() virtualmachine.VMLocationSpecInput {
+				return virtualmachine.VMLocationSpecInput{
+					ClusterProxy:     svClusterProxy,
+					Config:           config,
+					WCPClient:        wcpClient,
+					ArtifactFolder:   artifactFolder,
+					WCPNamespaceName: wcpNamespaceName,
+				}
+			})
+		})
+
 	})
 })


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

- validateVMFolder: A new method added to assess if the VM's active folder is the designated namespace folder or a valid child folder associated with a VirtualMachineSetResourcePolicy.
- validateVMResourcePool: Refactored to tightly restrict valid locations to explicit VKS child resource pools derived from active namespace resource policies.
- Integrated an API helper (vcenter.GetParentFolder) to navigate and verify the structural vSphere inventory folder paths.
- Refactored the reconcileLocation workflow in vmprovider_vm.go to evaluate both the resource pool (isVMInValidRP) and the inventory folder (isVMInValidFolder).
- Unit Tests and e2e tests are added

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # vmop-3844


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

successfull Uts


The same review was merged  to main and the reverted because of pipeline failure
https://github.com/vmware-tanzu/vm-operator/pull/1630
https://github.com/vmware-tanzu/vm-operator/pull/1690

In this PR the e2e test is updated and ensured that it passes. Rest of the core changes remains same.

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note

```