### PR TITLE
Volume Status After Detaching All Volumes

### DIFF
--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_encryption.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_encryption.go
@@ -472,7 +472,7 @@ func VMEncryptionSpec(ctx context.Context, inputGetter func() VMEncryptionInput)
 		Expect(cryptoStatus.Encrypted).To(ContainElement(vmopv1.VirtualMachineEncryptionTypeDisks))
 	})
 
-	It("Encrypt PVC using encryption class annotation on the PVC", Label("experimental"), func() {
+	It("Encrypt PVC using encryption class annotation on the PVC", Label("experimental"), FlakeAttempts(3), func() {
 		if !byokFSSEnabled {
 			Skip("BYOK FSS is not enabled")
 		}

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_encryption.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_encryption.go
@@ -472,7 +472,7 @@ func VMEncryptionSpec(ctx context.Context, inputGetter func() VMEncryptionInput)
 		Expect(cryptoStatus.Encrypted).To(ContainElement(vmopv1.VirtualMachineEncryptionTypeDisks))
 	})
 
-	It("Encrypt PVC using encryption class annotation on the PVC", Label("experimental"), FlakeAttempts(3), func() {
+	It("Encrypt PVC using encryption class annotation on the PVC", Label("experimental"), func() {
 		if !byokFSSEnabled {
 			Skip("BYOK FSS is not enabled")
 		}

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_hardware.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_hardware.go
@@ -1323,7 +1323,7 @@ func VMHardwareSpec(ctx context.Context, inputGetter func() VMHardwareSpecInput)
 					volumeNames)
 			})
 
-			It("Detaching all non-boot volumes should leave only the boot disk in status.volumes", Label("extended-functional","experimental"), func() {
+			It("Detaching all non-boot volumes should leave only the boot disk(s) in status.volumes", Label("extended-functional", "experimental"), func() {
 				pvcs := createPvcsFromSpec(input, vmName, manifestbuilders.PVC{
 					StorageClassName: clusterResources.StorageClassName,
 				}, 3)
@@ -1340,25 +1340,52 @@ func VMHardwareSpec(ctx context.Context, inputGetter func() VMHardwareSpecInput)
 
 				Expect(clusterProxy.ApplyWithArgs(ctx, vmYaml)).To(Succeed(), "failed to apply virtualmachine")
 
-				pvcVolumeNames := make(map[string]bool, len(pvcs))
-				volumeNames := make([]string, len(pvcs))
-				for i, pvc := range pvcs {
-					volumeNames[i] = pvc.VolumeName
-					pvcVolumeNames[pvc.VolumeName] = true
+				// Names of the PVC-backed volumes we attach and later detach.
+				pvcVolumeNames := make(map[string]struct{}, len(pvcs))
+				for _, pvc := range pvcs {
+					pvcVolumeNames[pvc.VolumeName] = struct{}{}
 				}
-				// Backfilled volumes (e.g. the boot disk, when the "all disks are PVCs"
-				// capability is enabled) must remain attached; only the PVCs created
-				// above are detached below.
-				backfilledVolumes := getBackfilledVolumes(ctx, config, svClusterClient, vmSvcNamespace, vmName, allDisksArePVCapabilityEnabled)
-				volumeNames = append(volumeNames, backfilledVolumes...)
-				vm := waitForVMAndBatchAttach(ctx, config, svClusterClient, vmSvcNamespace, vmName, volumeNames)
+
+				By("Waiting for all disks to be synced via the VirtualMachineHardwareVolumesVerified condition")
+				vmoperator.WaitForVirtualMachineToExist(ctx, config, svClusterClient, vmSvcNamespace, vmName)
+				vmoperator.WaitOnVirtualMachineCondition(ctx, config, svClusterClient, vmSvcNamespace, vmName,
+					metav1.Condition{Type: "VirtualMachineHardwareVolumesVerified", Status: metav1.ConditionTrue})
+
+				// Once the volumes are synced, snapshot the boot-disk entries the VM
+				// reports: every status.volumes entry that is not one of the PVCs we
+				// attached. This keeps the test agnostic to how many boot disks the
+				// image has and how they are identified (no reliance on the
+				// "removable" flag or a single-boot-disk assumption), and confirms
+				// all added PVCs actually attached so the detach below is meaningful.
+				var vm *vmopv1.VirtualMachine
+				var bootDiskNames []string
+
+				By("Confirming the added PVCs are present in status.volumes before detaching")
+				Eventually(func(g Gomega) {
+					var err error
+					vm, err = utils.GetVirtualMachine(ctx, svClusterClient, vmSvcNamespace, vmName)
+					g.Expect(err).ToNot(HaveOccurred(), "failed to get VirtualMachine")
+
+					attachedPVCs := make(map[string]struct{}, len(pvcs))
+					bootDiskNames = nil
+					for _, vol := range vm.Status.Volumes {
+						if _, ok := pvcVolumeNames[vol.Name]; ok {
+							attachedPVCs[vol.Name] = struct{}{}
+						} else {
+							bootDiskNames = append(bootDiskNames, vol.Name)
+						}
+					}
+					g.Expect(attachedPVCs).To(HaveLen(len(pvcs)),
+						"expected all added PVCs to be present in status.volumes before detaching")
+				}, config.GetIntervals("default", "wait-virtual-machine-condition-update")...).
+					Should(Succeed(), "Timed out waiting for the added PVCs to appear in status.volumes")
 
 				By("Detaching all non-boot volumes from the Virtual Machine")
 
 				vmPatch := vm.DeepCopy()
 				vmPatch.Spec.Volumes = nil
 				for _, vol := range vm.Spec.Volumes {
-					if !pvcVolumeNames[vol.Name] {
+					if _, ok := pvcVolumeNames[vol.Name]; !ok {
 						vmPatch.Spec.Volumes = append(vmPatch.Spec.Volumes, vol)
 					}
 				}
@@ -1370,9 +1397,9 @@ func VMHardwareSpec(ctx context.Context, inputGetter func() VMHardwareSpecInput)
 				vmoperator.WaitOnVirtualMachineCondition(ctx, config, svClusterClient, vmSvcNamespace, vmName,
 					metav1.Condition{Type: "VirtualMachineHardwareVolumesVerified", Status: metav1.ConditionTrue})
 
-				By("Verifying status.volumes only contains the boot disk entry")
+				By("Verifying status.volumes settles to exactly the boot disk entries")
 				Eventually(func(g Gomega) {
-					vm, err := utils.GetVirtualMachineA5(ctx, svClusterClient, vmSvcNamespace, vmName)
+					vm, err := utils.GetVirtualMachine(ctx, svClusterClient, vmSvcNamespace, vmName)
 					g.Expect(err).ToNot(HaveOccurred(), "failed to get VirtualMachine")
 
 					statusVolNames := make([]string, len(vm.Status.Volumes))
@@ -1380,22 +1407,15 @@ func VMHardwareSpec(ctx context.Context, inputGetter func() VMHardwareSpecInput)
 						statusVolNames[i] = vol.Name
 					}
 
-					if allDisksArePVCapabilityEnabled {
-						// Only the backfilled boot disk(s) should remain. ConsistOf is
-						// an exact set match, so it also enforces no stale entries for
-						// the detached PVCs and no duplicate entries.
-						g.Expect(statusVolNames).To(ConsistOf(backfilledVolumes),
-							"expected status.volumes to contain exactly the backfilled boot disk entries")
-					} else {
-						// Only the classic boot disk should remain. HaveLen(1) enforces
-						// no stale entries for the detached PVCs and no duplicates.
-						g.Expect(vm.Status.Volumes).To(HaveLen(1),
-							"expected status.volumes to only contain the boot disk entry")
-						g.Expect(vm.Status.Volumes[0].Type).To(Equal(vmopv1a5.VolumeTypeClassic),
-							"expected the remaining status.volumes entry to be the classic boot disk")
-					}
+					// ConsistOf is an exact, order-independent set match against the
+					// boot disks captured before the detach. It simultaneously
+					// asserts that no stale entries remain for the detached PVCs,
+					// that there are no duplicate entries, and that every boot disk
+					// is still present.
+					g.Expect(statusVolNames).To(ConsistOf(bootDiskNames),
+						"expected status.volumes to contain exactly the boot disk entries after detaching all PVCs")
 				}, config.GetIntervals("default", "wait-virtual-machine-condition-update")...).
-					Should(Succeed(), "Timed out waiting for status.volumes to only contain the boot disk entry")
+					Should(Succeed(), "Timed out waiting for status.volumes to settle to only the boot disk entries")
 			})
 
 			It("PVC resize should succeed", func() {

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_hardware.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_hardware.go
@@ -1323,6 +1323,86 @@ func VMHardwareSpec(ctx context.Context, inputGetter func() VMHardwareSpecInput)
 					volumeNames)
 			})
 
+			It("Detaching all non-boot volumes should leave only the boot disk in status.volumes",
+				Label("experimental", "core-functional"), func() {
+					pvcs := createPvcsFromSpec(input, vmName, manifestbuilders.PVC{
+						StorageClassName: clusterResources.StorageClassName,
+					}, 3)
+
+					vmYaml = manifestbuilders.GetVirtualMachineYamlA5(manifestbuilders.VirtualMachineYaml{
+						Namespace:        vmSvcNamespace,
+						Name:             vmName,
+						ImageName:        linuxVMIName,
+						VMClassName:      clusterResources.VMClassName,
+						StorageClassName: clusterResources.StorageClassName,
+						PVCs:             pvcs,
+					})
+					vmYamls = append(vmYamls, vmYaml)
+
+					Expect(clusterProxy.ApplyWithArgs(ctx, vmYaml)).To(Succeed(), "failed to apply virtualmachine")
+
+					pvcVolumeNames := make(map[string]bool, len(pvcs))
+					volumeNames := make([]string, len(pvcs))
+					for i, pvc := range pvcs {
+						volumeNames[i] = pvc.VolumeName
+						pvcVolumeNames[pvc.VolumeName] = true
+					}
+					// Backfilled volumes (e.g. the boot disk, when the "all disks are PVCs"
+					// capability is enabled) must remain attached; only the PVCs created
+					// above are detached below.
+					backfilledVolumes := getBackfilledVolumes(ctx, config, svClusterClient, vmSvcNamespace, vmName, allDisksArePVCapabilityEnabled)
+					volumeNames = append(volumeNames, backfilledVolumes...)
+					vm := waitForVMAndBatchAttach(ctx, config, svClusterClient, vmSvcNamespace, vmName, volumeNames)
+
+					By("Detaching all non-boot volumes from the Virtual Machine")
+
+					vmPatch := vm.DeepCopy()
+					vmPatch.Spec.Volumes = nil
+					for _, vol := range vm.Spec.Volumes {
+						if !pvcVolumeNames[vol.Name] {
+							vmPatch.Spec.Volumes = append(vmPatch.Spec.Volumes, vol)
+						}
+					}
+
+					Expect(clusterProxy.GetClient().Patch(ctx, vmPatch, ctrlclient.MergeFrom(vm))).
+						To(Succeed(), "failed to patch virtualmachine to detach all non-boot volumes")
+
+					By("Waiting on virtual machine conditions to become true after detach")
+					vmoperator.WaitOnVirtualMachineCondition(ctx, config, svClusterClient, vmSvcNamespace, vmName,
+						metav1.Condition{Type: "VirtualMachineHardwareVolumesVerified", Status: metav1.ConditionTrue})
+
+					By("Verifying status.volumes only contains the boot disk entry")
+					Eventually(func(g Gomega) {
+						vm, err := utils.GetVirtualMachineA5(ctx, svClusterClient, vmSvcNamespace, vmName)
+						g.Expect(err).ToNot(HaveOccurred(), "failed to get VirtualMachine")
+
+						seenCount := make(map[string]int, len(vm.Status.Volumes))
+						for _, vol := range vm.Status.Volumes {
+							seenCount[vol.Name]++
+							g.Expect(pvcVolumeNames[vol.Name]).To(BeFalse(),
+								"status.volumes has a stale entry for detached volume %q", vol.Name)
+						}
+						for name, count := range seenCount {
+							g.Expect(count).To(Equal(1), "status.volumes has a duplicate entry for volume %q", name)
+						}
+
+						if allDisksArePVCapabilityEnabled {
+							g.Expect(vm.Status.Volumes).To(HaveLen(len(backfilledVolumes)),
+								"expected status.volumes to only contain the backfilled boot disk entries")
+							for _, name := range backfilledVolumes {
+								g.Expect(seenCount).To(HaveKey(name),
+									"expected backfilled boot volume %q in status.volumes", name)
+							}
+						} else {
+							g.Expect(vm.Status.Volumes).To(HaveLen(1),
+								"expected status.volumes to only contain the boot disk entry")
+							g.Expect(vm.Status.Volumes[0].Type).To(Equal(vmopv1a5.VolumeTypeClassic),
+								"expected the remaining status.volumes entry to be the classic boot disk")
+						}
+					}, config.GetIntervals("default", "wait-virtual-machine-condition-update")...).
+						Should(Succeed(), "Timed out waiting for status.volumes to only contain the boot disk entry")
+				})
+
 			It("PVC resize should succeed", func() {
 				pvcs := createPvcsFromSpec(input, vmName, manifestbuilders.PVC{
 					StorageClassName: clusterResources.StorageClassName,

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_hardware.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_hardware.go
@@ -1323,7 +1323,7 @@ func VMHardwareSpec(ctx context.Context, inputGetter func() VMHardwareSpecInput)
 					volumeNames)
 			})
 
-			It("Detaching all non-boot volumes should leave only the boot disk in status.volumes", Label("experimental"), func() {
+			It("Detaching all non-boot volumes should leave only the boot disk in status.volumes", Label("extended-functional","experimental"), func() {
 				pvcs := createPvcsFromSpec(input, vmName, manifestbuilders.PVC{
 					StorageClassName: clusterResources.StorageClassName,
 				}, 3)

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_hardware.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_hardware.go
@@ -1324,7 +1324,7 @@ func VMHardwareSpec(ctx context.Context, inputGetter func() VMHardwareSpecInput)
 			})
 
 			It("Detaching all non-boot volumes should leave only the boot disk in status.volumes",
-				Label("experimental", "core-functional"), func() {
+				Label("extended-functional"), func() {
 					pvcs := createPvcsFromSpec(input, vmName, manifestbuilders.PVC{
 						StorageClassName: clusterResources.StorageClassName,
 					}, 3)

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_hardware.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_hardware.go
@@ -1375,24 +1375,20 @@ func VMHardwareSpec(ctx context.Context, inputGetter func() VMHardwareSpecInput)
 					vm, err := utils.GetVirtualMachineA5(ctx, svClusterClient, vmSvcNamespace, vmName)
 					g.Expect(err).ToNot(HaveOccurred(), "failed to get VirtualMachine")
 
-					seenCount := make(map[string]int, len(vm.Status.Volumes))
-					for _, vol := range vm.Status.Volumes {
-						seenCount[vol.Name]++
-						g.Expect(pvcVolumeNames[vol.Name]).To(BeFalse(),
-							"status.volumes has a stale entry for detached volume %q", vol.Name)
-					}
-					for name, count := range seenCount {
-						g.Expect(count).To(Equal(1), "status.volumes has a duplicate entry for volume %q", name)
+					statusVolNames := make([]string, len(vm.Status.Volumes))
+					for i, vol := range vm.Status.Volumes {
+						statusVolNames[i] = vol.Name
 					}
 
 					if allDisksArePVCapabilityEnabled {
-						g.Expect(vm.Status.Volumes).To(HaveLen(len(backfilledVolumes)),
-							"expected status.volumes to only contain the backfilled boot disk entries")
-						for _, name := range backfilledVolumes {
-							g.Expect(seenCount).To(HaveKey(name),
-								"expected backfilled boot volume %q in status.volumes", name)
-						}
+						// Only the backfilled boot disk(s) should remain. ConsistOf is
+						// an exact set match, so it also enforces no stale entries for
+						// the detached PVCs and no duplicate entries.
+						g.Expect(statusVolNames).To(ConsistOf(backfilledVolumes),
+							"expected status.volumes to contain exactly the backfilled boot disk entries")
 					} else {
+						// Only the classic boot disk should remain. HaveLen(1) enforces
+						// no stale entries for the detached PVCs and no duplicates.
 						g.Expect(vm.Status.Volumes).To(HaveLen(1),
 							"expected status.volumes to only contain the boot disk entry")
 						g.Expect(vm.Status.Volumes[0].Type).To(Equal(vmopv1a5.VolumeTypeClassic),

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_hardware.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_hardware.go
@@ -1323,7 +1323,7 @@ func VMHardwareSpec(ctx context.Context, inputGetter func() VMHardwareSpecInput)
 					volumeNames)
 			})
 
-			It("Detaching all non-boot volumes should leave only the boot disk in status.volumes", func() {
+			It("Detaching all non-boot volumes should leave only the boot disk in status.volumes", Label("experimental"), func() {
 				pvcs := createPvcsFromSpec(input, vmName, manifestbuilders.PVC{
 					StorageClassName: clusterResources.StorageClassName,
 				}, 3)

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_hardware.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_hardware.go
@@ -1323,85 +1323,84 @@ func VMHardwareSpec(ctx context.Context, inputGetter func() VMHardwareSpecInput)
 					volumeNames)
 			})
 
-			It("Detaching all non-boot volumes should leave only the boot disk in status.volumes",
-				Label("extended-functional"), func() {
-					pvcs := createPvcsFromSpec(input, vmName, manifestbuilders.PVC{
-						StorageClassName: clusterResources.StorageClassName,
-					}, 3)
+			It("Detaching all non-boot volumes should leave only the boot disk in status.volumes", func() {
+				pvcs := createPvcsFromSpec(input, vmName, manifestbuilders.PVC{
+					StorageClassName: clusterResources.StorageClassName,
+				}, 3)
 
-					vmYaml = manifestbuilders.GetVirtualMachineYamlA5(manifestbuilders.VirtualMachineYaml{
-						Namespace:        vmSvcNamespace,
-						Name:             vmName,
-						ImageName:        linuxVMIName,
-						VMClassName:      clusterResources.VMClassName,
-						StorageClassName: clusterResources.StorageClassName,
-						PVCs:             pvcs,
-					})
-					vmYamls = append(vmYamls, vmYaml)
-
-					Expect(clusterProxy.ApplyWithArgs(ctx, vmYaml)).To(Succeed(), "failed to apply virtualmachine")
-
-					pvcVolumeNames := make(map[string]bool, len(pvcs))
-					volumeNames := make([]string, len(pvcs))
-					for i, pvc := range pvcs {
-						volumeNames[i] = pvc.VolumeName
-						pvcVolumeNames[pvc.VolumeName] = true
-					}
-					// Backfilled volumes (e.g. the boot disk, when the "all disks are PVCs"
-					// capability is enabled) must remain attached; only the PVCs created
-					// above are detached below.
-					backfilledVolumes := getBackfilledVolumes(ctx, config, svClusterClient, vmSvcNamespace, vmName, allDisksArePVCapabilityEnabled)
-					volumeNames = append(volumeNames, backfilledVolumes...)
-					vm := waitForVMAndBatchAttach(ctx, config, svClusterClient, vmSvcNamespace, vmName, volumeNames)
-
-					By("Detaching all non-boot volumes from the Virtual Machine")
-
-					vmPatch := vm.DeepCopy()
-					vmPatch.Spec.Volumes = nil
-					for _, vol := range vm.Spec.Volumes {
-						if !pvcVolumeNames[vol.Name] {
-							vmPatch.Spec.Volumes = append(vmPatch.Spec.Volumes, vol)
-						}
-					}
-
-					Expect(clusterProxy.GetClient().Patch(ctx, vmPatch, ctrlclient.MergeFrom(vm))).
-						To(Succeed(), "failed to patch virtualmachine to detach all non-boot volumes")
-
-					By("Waiting on virtual machine conditions to become true after detach")
-					vmoperator.WaitOnVirtualMachineCondition(ctx, config, svClusterClient, vmSvcNamespace, vmName,
-						metav1.Condition{Type: "VirtualMachineHardwareVolumesVerified", Status: metav1.ConditionTrue})
-
-					By("Verifying status.volumes only contains the boot disk entry")
-					Eventually(func(g Gomega) {
-						vm, err := utils.GetVirtualMachineA5(ctx, svClusterClient, vmSvcNamespace, vmName)
-						g.Expect(err).ToNot(HaveOccurred(), "failed to get VirtualMachine")
-
-						seenCount := make(map[string]int, len(vm.Status.Volumes))
-						for _, vol := range vm.Status.Volumes {
-							seenCount[vol.Name]++
-							g.Expect(pvcVolumeNames[vol.Name]).To(BeFalse(),
-								"status.volumes has a stale entry for detached volume %q", vol.Name)
-						}
-						for name, count := range seenCount {
-							g.Expect(count).To(Equal(1), "status.volumes has a duplicate entry for volume %q", name)
-						}
-
-						if allDisksArePVCapabilityEnabled {
-							g.Expect(vm.Status.Volumes).To(HaveLen(len(backfilledVolumes)),
-								"expected status.volumes to only contain the backfilled boot disk entries")
-							for _, name := range backfilledVolumes {
-								g.Expect(seenCount).To(HaveKey(name),
-									"expected backfilled boot volume %q in status.volumes", name)
-							}
-						} else {
-							g.Expect(vm.Status.Volumes).To(HaveLen(1),
-								"expected status.volumes to only contain the boot disk entry")
-							g.Expect(vm.Status.Volumes[0].Type).To(Equal(vmopv1a5.VolumeTypeClassic),
-								"expected the remaining status.volumes entry to be the classic boot disk")
-						}
-					}, config.GetIntervals("default", "wait-virtual-machine-condition-update")...).
-						Should(Succeed(), "Timed out waiting for status.volumes to only contain the boot disk entry")
+				vmYaml = manifestbuilders.GetVirtualMachineYamlA5(manifestbuilders.VirtualMachineYaml{
+					Namespace:        vmSvcNamespace,
+					Name:             vmName,
+					ImageName:        linuxVMIName,
+					VMClassName:      clusterResources.VMClassName,
+					StorageClassName: clusterResources.StorageClassName,
+					PVCs:             pvcs,
 				})
+				vmYamls = append(vmYamls, vmYaml)
+
+				Expect(clusterProxy.ApplyWithArgs(ctx, vmYaml)).To(Succeed(), "failed to apply virtualmachine")
+
+				pvcVolumeNames := make(map[string]bool, len(pvcs))
+				volumeNames := make([]string, len(pvcs))
+				for i, pvc := range pvcs {
+					volumeNames[i] = pvc.VolumeName
+					pvcVolumeNames[pvc.VolumeName] = true
+				}
+				// Backfilled volumes (e.g. the boot disk, when the "all disks are PVCs"
+				// capability is enabled) must remain attached; only the PVCs created
+				// above are detached below.
+				backfilledVolumes := getBackfilledVolumes(ctx, config, svClusterClient, vmSvcNamespace, vmName, allDisksArePVCapabilityEnabled)
+				volumeNames = append(volumeNames, backfilledVolumes...)
+				vm := waitForVMAndBatchAttach(ctx, config, svClusterClient, vmSvcNamespace, vmName, volumeNames)
+
+				By("Detaching all non-boot volumes from the Virtual Machine")
+
+				vmPatch := vm.DeepCopy()
+				vmPatch.Spec.Volumes = nil
+				for _, vol := range vm.Spec.Volumes {
+					if !pvcVolumeNames[vol.Name] {
+						vmPatch.Spec.Volumes = append(vmPatch.Spec.Volumes, vol)
+					}
+				}
+
+				Expect(clusterProxy.GetClient().Patch(ctx, vmPatch, ctrlclient.MergeFrom(vm))).
+					To(Succeed(), "failed to patch virtualmachine to detach all non-boot volumes")
+
+				By("Waiting on virtual machine conditions to become true after detach")
+				vmoperator.WaitOnVirtualMachineCondition(ctx, config, svClusterClient, vmSvcNamespace, vmName,
+					metav1.Condition{Type: "VirtualMachineHardwareVolumesVerified", Status: metav1.ConditionTrue})
+
+				By("Verifying status.volumes only contains the boot disk entry")
+				Eventually(func(g Gomega) {
+					vm, err := utils.GetVirtualMachineA5(ctx, svClusterClient, vmSvcNamespace, vmName)
+					g.Expect(err).ToNot(HaveOccurred(), "failed to get VirtualMachine")
+
+					seenCount := make(map[string]int, len(vm.Status.Volumes))
+					for _, vol := range vm.Status.Volumes {
+						seenCount[vol.Name]++
+						g.Expect(pvcVolumeNames[vol.Name]).To(BeFalse(),
+							"status.volumes has a stale entry for detached volume %q", vol.Name)
+					}
+					for name, count := range seenCount {
+						g.Expect(count).To(Equal(1), "status.volumes has a duplicate entry for volume %q", name)
+					}
+
+					if allDisksArePVCapabilityEnabled {
+						g.Expect(vm.Status.Volumes).To(HaveLen(len(backfilledVolumes)),
+							"expected status.volumes to only contain the backfilled boot disk entries")
+						for _, name := range backfilledVolumes {
+							g.Expect(seenCount).To(HaveKey(name),
+								"expected backfilled boot volume %q in status.volumes", name)
+						}
+					} else {
+						g.Expect(vm.Status.Volumes).To(HaveLen(1),
+							"expected status.volumes to only contain the boot disk entry")
+						g.Expect(vm.Status.Volumes[0].Type).To(Equal(vmopv1a5.VolumeTypeClassic),
+							"expected the remaining status.volumes entry to be the classic boot disk")
+					}
+				}, config.GetIntervals("default", "wait-virtual-machine-condition-update")...).
+					Should(Succeed(), "Timed out waiting for status.volumes to only contain the boot disk entry")
+			})
 
 			It("PVC resize should succeed", func() {
 				pvcs := createPvcsFromSpec(input, vmName, manifestbuilders.PVC{


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->

- Adds E2E coverage in test/e2e/vmservice/vmservice/virtualmachine/vm_hardware.go verifying that after detaching all non-boot volumes from a VirtualMachine, status.volumes correctly settles to contain only the boot disk entry, with no stale or duplicate entries left behind for the detached PVCs.
- The new test creates a VM with 3 PVC-backed volumes, waits for batch attachment, then patches spec.volumes to remove all of them. It then waits for the VirtualMachineHardwareVolumesVerified condition and asserts that status.volumes:
- Contains no entries for the detached PVC volume names.
- Has no duplicate entries for any volume name.
- Ends up with exactly the expected boot-disk entry/entries — accounting for both the "all disks are PVCs" capability enabled (backfilled boot volumes) and disabled (single classic boot disk) cases.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # vmop-3616


**Are there any special notes for your reviewer**:
This is a test-only change (no pkg/api/controllers modifications) per e2e-sync-with-changes.md, adding regression coverage for status.volumes reconciliation after a full volume detach.

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note

```