### PR TITLE
🌱 Add support for standard switches on VDS

### DIFF
--- a/pkg/providers/vsphere/network/devices.go
+++ b/pkg/providers/vsphere/network/devices.go
@@ -163,9 +163,18 @@ func findMatchingEthCardNetOpNetIf(
 			}
 		}
 
-		dvpg, ok := ethCard.Backing.(*vimtypes.VirtualEthernetCardDistributedVirtualPortBackingInfo)
-		if ok && dvpg.Port.PortgroupKey == netIf.Status.NetworkID {
-			return i
+		switch b := ethCard.Backing.(type) {
+		case *vimtypes.VirtualEthernetCardDistributedVirtualPortBackingInfo:
+			if b.Port.PortgroupKey == netIf.Status.NetworkID {
+				return i
+			}
+		case *vimtypes.VirtualEthernetCardNetworkBackingInfo:
+			// The server resolves and reports back the Network MoRef for a
+			// standard portgroup backing even though it is not required
+			// when configuring the device.
+			if b.Network != nil && b.Network.Value == netIf.Status.NetworkID {
+				return i
+			}
 		}
 	}
 

--- a/pkg/providers/vsphere/network/network_test.go
+++ b/pkg/providers/vsphere/network/network_test.go
@@ -5,6 +5,7 @@
 package network_test
 
 import (
+	"context"
 	"strings"
 	"time"
 
@@ -57,6 +58,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 
 	var (
 		testConfig builder.VCSimTestConfig
+		parentCtx  context.Context
 		ctx        *builder.TestContextForVCSim
 
 		vmCtx       pkgctx.VirtualMachineContext
@@ -70,7 +72,9 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 
 	BeforeEach(func() {
 		network.RetryTimeout = 1 * time.Millisecond
+
 		testConfig = builder.VCSimTestConfig{}
+		parentCtx = pkgcfg.NewContextWithDefaultConfig()
 
 		vm = &vmopv1.VirtualMachine{
 			ObjectMeta: metav1.ObjectMeta{
@@ -85,7 +89,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 	})
 
 	JustBeforeEach(func() {
-		ctx = suite.NewTestContextForVCSim(testConfig, initObjects...)
+		ctx = builder.NewTestContextForVCSim(parentCtx, testConfig, initObjects...)
 
 		vmCtx = pkgctx.VirtualMachineContext{
 			Context: ctx,
@@ -113,6 +117,7 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 		const networkName = "DC0_DVPG0"
 
 		BeforeEach(func() {
+			testConfig.NumNetworks = 0
 			testConfig.WithNetworkEnv = builder.NetworkEnvNamed
 		})
 
@@ -138,7 +143,9 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 					Expect(err).ToNot(HaveOccurred())
 					backingInfo, ok := backing.(*vimtypes.VirtualEthernetCardDistributedVirtualPortBackingInfo)
 					Expect(ok).To(BeTrue())
-					Expect(backingInfo.Port.PortgroupKey).To(Equal(ctx.GetNetwork(0).Backing.Reference().Value))
+					dvpg, err := ctx.Finder.Network(ctx, networkName)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(backingInfo.Port.PortgroupKey).To(Equal(dvpg.Reference().Value))
 				})
 
 				Expect(result.DHCP4).To(BeFalse())
@@ -409,6 +416,111 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 					Expect(ipConfig.IPCIDR).To(Equal("fd1a:6c85:79fe:7c98::f/56"))
 					Expect(ipConfig.IsIPv4).To(BeFalse())
 					Expect(ipConfig.Gateway).To(Equal("fd1a:6c85:79fe:7c98:0000:0000:0000:0001"))
+				})
+			})
+		})
+
+		Context("Standard Portgroup", func() {
+			BeforeEach(func() {
+				testConfig.WithNetworkEnv = ""
+				testConfig.WithNetworkConfig = []builder.VCSimNetworkConfig{
+					{Provider: pkgcfg.NetworkProviderTypeVDS, StandardPortGroup: true},
+				}
+
+				pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
+					config.Features.PerNamespaceNetworkProvider = true
+				})
+
+				networkSpec.Interfaces = []vmopv1.VirtualMachineNetworkInterfaceSpec{
+					{
+						Name: interfaceName,
+						Network: &common.PartialObjectRef{
+							TypeMeta: netOPNetworkTypeMeta,
+							Name:     networkName,
+						},
+					},
+				}
+			})
+
+			simulateReady := func() {
+				netInterface := &netopv1alpha1.NetworkInterface{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      network.NetOPCRName(vm.Name, networkName, interfaceName, false),
+						Namespace: vm.Namespace,
+					},
+				}
+				Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(netInterface), netInterface)).To(Succeed())
+				Expect(netInterface.Spec.NetworkName).To(Equal(networkName))
+
+				netInterface.Status.NetworkID = ctx.GetNetwork(0).Backing.Reference().Value
+				netInterface.Status.Conditions = []netopv1alpha1.NetworkInterfaceCondition{
+					{
+						Type:   netopv1alpha1.NetworkInterfaceReady,
+						Status: corev1.ConditionTrue,
+					},
+				}
+				Expect(ctx.Client.Status().Update(ctx, netInterface)).To(Succeed())
+			}
+
+			When("PerNamespaceNetworkProvider is enabled", func() {
+				It("resolves to a standard Network backing", func() {
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
+					Expect(results.Results).To(BeEmpty())
+
+					By("simulate successful NetOP reconcile", simulateReady)
+
+					results, err = network.CreateAndWaitForNetworkInterfaces(
+						vmCtx,
+						ctx.Client,
+						ctx.VCClient.Client,
+						ctx.Finder,
+						nil,
+						networkSpec)
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(results.Results).To(HaveLen(1))
+					result := results.Results[0]
+					Expect(result.NetworkID).To(Equal(ctx.GetNetwork(0).Backing.Reference().Value))
+					Expect(result.Backing).ToNot(BeNil())
+
+					backing, err := result.Backing.EthernetCardBackingInfo(ctx)
+					Expect(err).ToNot(HaveOccurred())
+					backingInfo, ok := backing.(*vimtypes.VirtualEthernetCardNetworkBackingInfo)
+					Expect(ok).To(BeTrue())
+
+					expectedBacking, err := ctx.GetNetwork(0).Backing.EthernetCardBackingInfo(ctx)
+					Expect(err).ToNot(HaveOccurred())
+					expectedBackingInfo, ok := expectedBacking.(*vimtypes.VirtualEthernetCardNetworkBackingInfo)
+					Expect(ok).To(BeTrue())
+					Expect(backingInfo.DeviceName).To(Equal(expectedBackingInfo.DeviceName))
+				})
+			})
+
+			When("PerNamespaceNetworkProvider is disabled", func() {
+				BeforeEach(func() {
+					pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
+						config.Features.PerNamespaceNetworkProvider = false
+					})
+				})
+
+				It("returns an error", func() {
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
+					Expect(results.Results).To(BeEmpty())
+
+					By("simulate successful NetOP reconcile", simulateReady)
+
+					results, err = network.CreateAndWaitForNetworkInterfaces(
+						vmCtx,
+						ctx.Client,
+						ctx.VCClient.Client,
+						ctx.Finder,
+						nil,
+						networkSpec)
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(MatchError(network.ErrNetworkInterfaceBackingNotSupported))
+					Expect(results.Results).To(BeEmpty())
 				})
 			})
 		})
@@ -1843,15 +1955,18 @@ var _ = Describe("CreateNetworkDevices", Label(testlabels.VCSim), func() {
 	})
 
 	Context("Named Network", func() {
-		const namedNetwork = "DC0_DVPG0"
+		// Use network vcsim automatically creates.
+		const networkName = "DC0_DVPG0"
 
 		BeforeEach(func() {
+			testConfig.NumNetworks = 0
 			testConfig.WithNetworkEnv = builder.NetworkEnvNamed
+
 			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{
 				Interfaces: []vmopv1.VirtualMachineNetworkInterfaceSpec{
 					{
 						Name:    interfaceName0,
-						Network: &common.PartialObjectRef{Name: namedNetwork},
+						Network: &common.PartialObjectRef{Name: networkName},
 					},
 				},
 			}
@@ -1867,7 +1982,9 @@ var _ = Describe("CreateNetworkDevices", Label(testlabels.VCSim), func() {
 			Expect(err).ToNot(HaveOccurred())
 			backingInfo, ok := backing.(*vimtypes.VirtualEthernetCardDistributedVirtualPortBackingInfo)
 			Expect(ok).To(BeTrue())
-			Expect(backingInfo.Port.PortgroupKey).To(Equal(ctx.GetNetwork(0).Backing.Reference().Value))
+			dvpg, err := ctx.Finder.Network(ctx, networkName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(backingInfo.Port.PortgroupKey).To(Equal(dvpg.Reference().Value))
 		})
 
 		Context("Named Network with MAC address", func() {

--- a/pkg/providers/vsphere/vmprovider_vm_network_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_network_test.go
@@ -181,6 +181,7 @@ func vmNetworkTests() {
 
 	When("multiple NICs are specified", func() {
 		BeforeEach(func() {
+			testConfig.NumNetworks = 0
 			testConfig.WithNetworkEnv = builder.NetworkEnvNamed
 
 			vm.Spec.Network.Interfaces = []vmopv1.VirtualMachineNetworkInterfaceSpec{
@@ -440,15 +441,19 @@ func vmNetworkTests() {
 						lp, err := netsetutil.TypeToNetworkProvider(netCfg[1].Provider)
 						Expect(err).ToNot(HaveOccurred())
 
-						ns := &netopv1alpha1.NetworkSettings{
-							ObjectMeta: metav1.ObjectMeta{
-								Name:      "default",
-								Namespace: nsInfo.Namespace,
-							},
-							Provider:       p,
-							LegacyProvider: lp,
-						}
-						Expect(ctx.Client.Create(ctx, ns)).To(Succeed())
+						By("Set legacy network provider", func() {
+							ns := &netopv1alpha1.NetworkSettings{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      "default",
+									Namespace: vm.Namespace,
+								},
+							}
+							Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(ns), ns)).To(Succeed())
+							Expect(ns.Provider).To(Equal(p))
+							Expect(ns.LegacyProvider).To(BeEmpty())
+							ns.LegacyProvider = lp
+							Expect(ctx.Client.Update(ctx, ns)).To(Succeed())
+						})
 					})
 
 					It("configures both NICs when powered off, does not reconfigure when powered on", func() {
@@ -669,19 +674,35 @@ func vmNetworkTests() {
 
 		Context("simulate vm power on/off", func() {
 			DescribeTableSubtree("with adding/removing network interfaces ",
-				func(networkEnv builder.NetworkEnv, bootstrap string) {
+				func(networkEnv builder.NetworkEnv, bootstrap string, standardPortGroup bool) {
 					var np fakeNetworkProvider
 
 					BeforeEach(func() {
-						testConfig.WithNetworkEnv = networkEnv
+						var providerType pkgcfg.NetworkProviderType
 
 						switch networkEnv {
 						case builder.NetworkEnvVDS:
-							np = vdsNetworkProvider{}
+							providerType = pkgcfg.NetworkProviderTypeVDS
+							np = vdsNetworkProvider{isStandardPG: standardPortGroup}
 						case builder.NetworkEnvNSXT:
+							providerType = pkgcfg.NetworkProviderTypeNSXT
 							np = nsxtNetworkProvider{}
 						case builder.NetworkEnvVPC:
+							providerType = pkgcfg.NetworkProviderTypeVPC
 							np = vpcNetworkProvider{}
+						}
+
+						if standardPortGroup {
+							// Standard PG are only supported with PerNS network providers.
+							pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
+								config.Features.PerNamespaceNetworkProvider = true
+							})
+						}
+
+						testConfig.NumNetworks = 0
+						testConfig.WithNetworkConfig = []builder.VCSimNetworkConfig{
+							{Provider: providerType, StandardPortGroup: standardPortGroup},
+							{Provider: providerType, StandardPortGroup: standardPortGroup},
 						}
 					})
 
@@ -829,25 +850,43 @@ func vmNetworkTests() {
 						})
 					})
 				},
-				Entry("VDS with CloudInit", builder.NetworkEnvVDS, bsCloudInit),
-				Entry("NSX-T with CloudInit", builder.NetworkEnvNSXT, bsCloudInit),
-				Entry("VPC with Sysprep", builder.NetworkEnvVPC, bsSysprep),
+				Entry("VDS with CloudInit", builder.NetworkEnvVDS, bsCloudInit, false),
+				Entry("VDS Standard Portgroup with CloudInit", builder.NetworkEnvVDS, bsCloudInit, true),
+				Entry("NSX-T with CloudInit", builder.NetworkEnvNSXT, bsCloudInit, false),
+				Entry("VPC with Sysprep", builder.NetworkEnvVPC, bsSysprep, false),
 			)
 
 			DescribeTableSubtree("with modifying network interface",
-				func(networkEnv builder.NetworkEnv, bootstrap string) {
+				func(networkEnv builder.NetworkEnv, bootstrap string, standardPortGroup bool) {
 					var np fakeNetworkProvider
 
 					BeforeEach(func() {
-						testConfig.WithNetworkEnv = networkEnv
+						var providerType pkgcfg.NetworkProviderType
 
 						switch networkEnv {
 						case builder.NetworkEnvVDS:
-							np = vdsNetworkProvider{}
+							providerType = pkgcfg.NetworkProviderTypeVDS
+							np = vdsNetworkProvider{isStandardPG: standardPortGroup}
 						case builder.NetworkEnvNSXT:
+							providerType = pkgcfg.NetworkProviderTypeNSXT
 							np = nsxtNetworkProvider{}
 						case builder.NetworkEnvVPC:
+							providerType = pkgcfg.NetworkProviderTypeVPC
 							np = vpcNetworkProvider{}
+						}
+
+						if standardPortGroup {
+							// Standard PG are only supported with PerNS network providers.
+							pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
+								config.Features.PerNamespaceNetworkProvider = true
+							})
+						}
+
+						testConfig.NumNetworks = 0
+						testConfig.WithNetworkConfig = []builder.VCSimNetworkConfig{
+							{Provider: providerType, StandardPortGroup: standardPortGroup},
+							{Provider: providerType, StandardPortGroup: standardPortGroup},
+							{Provider: providerType, StandardPortGroup: standardPortGroup},
 						}
 
 						// We assert the device type is preserved when editing an interface spec.
@@ -1084,10 +1123,11 @@ func vmNetworkTests() {
 						})
 					})
 				},
-				Entry("VDS with CloudInit", builder.NetworkEnvVDS, bsCloudInit),
-				Entry("VPC with CloudInit", builder.NetworkEnvVPC, bsCloudInit),
-				Entry("VDS with LinuxPrep", builder.NetworkEnvVDS, bsLinuxPrep),
-				Entry("NSX-T with Sysprep", builder.NetworkEnvNSXT, bsSysprep),
+				Entry("VDS with CloudInit", builder.NetworkEnvVDS, bsCloudInit, false),
+				Entry("VDS Standard Portgroup with CloudInit", builder.NetworkEnvVDS, bsCloudInit, true),
+				Entry("VPC with CloudInit", builder.NetworkEnvVPC, bsCloudInit, false),
+				Entry("VDS with LinuxPrep", builder.NetworkEnvVDS, bsLinuxPrep, false),
+				Entry("NSX-T with Sysprep", builder.NetworkEnvNSXT, bsSysprep, false),
 			)
 		})
 	})
@@ -1127,7 +1167,9 @@ func idxFromInterfaceName(s string) int {
 	return int(i)
 }
 
-type vdsNetworkProvider struct{}
+type vdsNetworkProvider struct {
+	isStandardPG bool
+}
 
 func (vdsNetworkProvider) getTypeMeta() metav1.TypeMeta {
 	return metav1.TypeMeta{
@@ -1183,12 +1225,22 @@ func (v vdsNetworkProvider) assertEthernetCard(
 	interfaceName, networkName := interfaceSpec.Name, interfaceSpec.Network.Name
 
 	ethCard := dev.(vimtypes.BaseVirtualEthernetCard).GetVirtualEthernetCard()
-	backingInfo, ok := ethCard.Backing.(*vimtypes.VirtualEthernetCardDistributedVirtualPortBackingInfo)
-	Expect(ok).Should(BeTrue())
-	ExpectWithOffset(1, backingInfo.Port.PortgroupKey).To(Equal(ctx.GetNetwork(networkIdx).Backing.Reference().Value))
+	if v.isStandardPG {
+		backingInfo, ok := ethCard.Backing.(*vimtypes.VirtualEthernetCardNetworkBackingInfo)
+		Expect(ok).Should(BeTrue())
+		expectedBacking, err := ctx.GetNetwork(networkIdx).Backing.EthernetCardBackingInfo(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		expectedBackingInfo, ok := expectedBacking.(*vimtypes.VirtualEthernetCardNetworkBackingInfo)
+		Expect(ok).Should(BeTrue())
+		Expect(backingInfo.DeviceName).To(Equal(expectedBackingInfo.DeviceName))
+	} else {
+		backingInfo, ok := ethCard.Backing.(*vimtypes.VirtualEthernetCardDistributedVirtualPortBackingInfo)
+		Expect(ok).Should(BeTrue())
+		Expect(backingInfo.Port.PortgroupKey).To(Equal(ctx.GetNetwork(networkIdx).Backing.Reference().Value))
+	}
+
 	Expect(ethCard.MacAddress).ToNot(BeEmpty())
 	Expect(ethCard.ExternalId).To(Equal(extID(networkName, interfaceName)))
-
 }
 
 func (v vdsNetworkProvider) assertNetworkInterfacesDNE(

--- a/test/builder/vcsim_test_context.go
+++ b/test/builder/vcsim_test_context.go
@@ -61,6 +61,8 @@ import (
 	//nolint:godot
 	// _ "github.com/vmware/govmomi/pbm/simulator"
 
+	netopv1alpha1 "github.com/vmware-tanzu/net-operator-api/api/v1alpha1"
+
 	byokv1 "github.com/vmware-tanzu/vm-operator/external/byok/api/v1alpha1"
 	infrav1 "github.com/vmware-tanzu/vm-operator/external/infra/api/v1alpha1"
 	spqv1 "github.com/vmware-tanzu/vm-operator/external/storage-policy-quota/api/v1alpha2"
@@ -74,6 +76,7 @@ import (
 	pkgmgr "github.com/vmware-tanzu/vm-operator/pkg/manager"
 	"github.com/vmware-tanzu/vm-operator/pkg/record"
 	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
+	netsetutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube/networksettings"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	pkgclient "github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/client"
@@ -158,6 +161,11 @@ type VCSimTestConfig struct {
 // to configure on vcsim.
 type VCSimNetworkConfig struct {
 	Provider pkgcfg.NetworkProviderType
+
+	// StandardPortGroup, when true, backs this network with a standard
+	// (non-distributed) vSphere Network instead of a DVPG. Only valid
+	// when Provider is NetworkProviderTypeVDS.
+	StandardPortGroup bool
 }
 
 type TestContextForVCSim struct {
@@ -269,6 +277,10 @@ func NewTestContextForVCSim(
 	config VCSimTestConfig,
 	initObjects ...ctrlclient.Object) *TestContextForVCSim {
 
+	if _, err := logr.FromContext(parentCtx); err != nil {
+		parentCtx = logr.NewContext(parentCtx, logf.Log)
+	}
+
 	ctx := newTestContextForVCSim(parentCtx, config, initObjects)
 
 	ctx.setupEnv(config)
@@ -336,9 +348,9 @@ func (s *TestSuite) NewTestContextForVCSim(
 	initObjects ...ctrlclient.Object) *TestContextForVCSim {
 
 	ctx := pkgcfg.NewContextWithDefaultConfig()
-	ctx = logr.NewContext(ctx, logf.Log)
 	ctx = ctxop.WithContext(ctx)
 	ctx = ovfcache.WithContext(ctx)
+
 	return NewTestContextForVCSim(ctx, config, initObjects...)
 }
 
@@ -346,10 +358,6 @@ func (s *TestSuite) NewTestContextForVCSimWithParentContext(
 	ctx context.Context,
 	config VCSimTestConfig,
 	initObjects ...ctrlclient.Object) *TestContextForVCSim {
-
-	if _, err := logr.FromContext(ctx); err != nil {
-		ctx = logr.NewContext(ctx, logf.Log)
-	}
 
 	return NewTestContextForVCSim(ctx, config, initObjects...)
 }
@@ -571,6 +579,22 @@ func (c *TestContextForVCSim) CreateWorkloadNamespace() WorkloadNamespaceInfo {
 			&encryptionClass2KeyID)
 	}
 
+	if pkgcfg.FromContext(c).Features.PerNamespaceNetworkProvider {
+		if len(c.networkConfig) > 0 {
+			p, err := netsetutil.TypeToNetworkProvider(c.networkConfig[0].Provider)
+			Expect(err).ToNot(HaveOccurred())
+
+			netset := &netopv1alpha1.NetworkSettings{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "default",
+					Namespace: ns.Name,
+				},
+				Provider: p,
+			}
+			Expect(c.Client.Create(c, netset)).To(Succeed())
+		}
+	}
+
 	// Make trip through the Finder to populate InventoryPath.
 	objRef, err := c.Finder.ObjectReference(c, nsFolder.Reference())
 	Expect(err).ToNot(HaveOccurred())
@@ -676,13 +700,23 @@ func (c *TestContextForVCSim) setupVCSim(config VCSimTestConfig) {
 	}
 
 	for i, cfg := range c.networkConfig {
+		if cfg.Provider == pkgcfg.NetworkProviderTypeNamed {
+			continue
+		}
+
 		network := VCSimNetwork{
 			Provider: cfg.Provider,
 		}
 
-		networkRef, err := c.Finder.Network(c, fmt.Sprintf("DC0_DVPG%d", i))
-		Expect(err).ToNot(HaveOccurred())
-		network.Backing = networkRef
+		switch {
+		case cfg.StandardPortGroup:
+			Expect(cfg.Provider).To(Equal(pkgcfg.NetworkProviderTypeVDS))
+			network.Backing = c.createStandardPortGroup(fmt.Sprintf("VMOP VM Network %d", i))
+		default:
+			var err error
+			network.Backing, err = c.Finder.Network(c, fmt.Sprintf("DC0_DVPG%d", i))
+			Expect(err).ToNot(HaveOccurred())
+		}
 
 		switch cfg.Provider {
 		case pkgcfg.NetworkProviderTypeVDS:
@@ -696,7 +730,7 @@ func (c *TestContextForVCSim) setupVCSim(config VCSimTestConfig) {
 			}
 
 			task, err := object.NewDistributedVirtualPortgroup(
-				c.VCClient.Client, networkRef.Reference()).Reconfigure(c, dvpgSpec)
+				c.VCClient.Client, network.Backing.Reference()).Reconfigure(c, dvpgSpec)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(task.Wait(c)).To(Succeed())
 		}
@@ -714,6 +748,28 @@ func (c *TestContextForVCSim) setupVCSim(config VCSimTestConfig) {
 	if p, ok := simulator.DefaultLogin.Password(); ok {
 		c.VCClientConfig.Password = p
 	}
+}
+
+// createStandardPortGroup creates an additional standard (non-distributed)
+// portgroup on the first host's default vSwitch. vcsim always creates one
+// standard "VM Network" per Datacenter already; this is used to create
+// additional standard networks beyond that default.
+func (c *TestContextForVCSim) createStandardPortGroup(name string) object.NetworkReference {
+	hosts, err := c.Finder.HostSystemList(c, "*")
+	Expect(err).ToNot(HaveOccurred())
+	Expect(hosts).ToNot(BeEmpty())
+
+	netSys, err := hosts[0].ConfigManager().NetworkSystem(c)
+	Expect(err).ToNot(HaveOccurred())
+
+	Expect(netSys.AddPortGroup(c, vimtypes.HostPortGroupSpec{
+		Name:        name,
+		VswitchName: "vSwitch0",
+	})).To(Succeed())
+
+	networkRef, err := c.Finder.Network(c, name)
+	Expect(err).ToNot(HaveOccurred())
+	return networkRef
 }
 
 //nolint:gocyclo


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This is only supported on VDS, and determined by the MoID type that is in the NetworkInterface networkID field.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

vmop-3717

**Please add a release note if necessary**:


```release-note
NONE
```