### PR TITLE
✨ ConfigTarget: validation webhook + manifest wiring

### DIFF
--- a/.sdd/specs/001-class-policy-resize/plan.md
+++ b/.sdd/specs/001-class-policy-resize/plan.md
@@ -84,9 +84,9 @@ controllers/
 
 webhooks/
 ├── configtarget/
-│   ├── webhooks.go                      NEW — thin wrapper delegating to validation subpackage (DONE, PR #1711 / vmop-3757)
+│   ├── webhooks.go                      NEW
 │   └── validation/
-│       └── configtarget_validator.go   NEW — immutable spec.id; valid cluster MoID format for metadata.name (DONE, PR #1711 / vmop-3757)
+│       └── configtarget_validator.go   NEW — immutable spec.id; valid cluster MoID format for metadata.name
 ├── virtualmachineconfigoptions/
 │   └── validation_webhook.go           NEW
 ├── virtualmachineconfigpolicy/

--- a/.sdd/specs/001-class-policy-resize/plan.md
+++ b/.sdd/specs/001-class-policy-resize/plan.md
@@ -84,7 +84,9 @@ controllers/
 
 webhooks/
 ├── configtarget/
-│   └── validation_webhook.go           NEW
+│   ├── webhooks.go                      NEW — thin wrapper delegating to validation subpackage (DONE, PR #1711 / vmop-3757)
+│   └── validation/
+│       └── configtarget_validator.go   NEW — immutable spec.id; valid cluster MoID format for metadata.name (DONE, PR #1711 / vmop-3757)
 ├── virtualmachineconfigoptions/
 │   └── validation_webhook.go           NEW
 ├── virtualmachineconfigpolicy/

--- a/.sdd/specs/001-class-policy-resize/tasks.md
+++ b/.sdd/specs/001-class-policy-resize/tasks.md
@@ -57,16 +57,17 @@ Dependencies: none. All A-tasks may run in parallel `[P]`.
 
 ### Story S5 — ConfigTarget controller (vmop-3742)
 
-- [ ] T060 [S5.a] Author `webhooks/configtarget/validation_webhook.go` — immutable spec.id; valid cluster MoID format for metadata.name
-- [ ] T061 [S5.a] Register ConfigTarget validation webhook in `webhooks/` suite files
+- [x] T060 [S5.a] [PR #1711 / vmop-3757] Author `webhooks/configtarget/validation/configtarget_validator.go` — immutable spec.id; valid cluster MoID format for metadata.name
+- [ ] T061 [S5.a] [PR #1711 / vmop-3757 — webhook half only] Register ConfigTarget webhook in `controllers/controllers.go` and `webhooks/` suite files
 - [x] T061a [S5.a] Register ConfigTarget controller in `controllers/controllers.go`, gated on `Features.VirtualMachineConfigPolicy`
-- [ ] T062 [S5.a] Unit tests — `webhooks/configtarget/validation_webhook_test.go`
+- [x] T062 [S5.a] [PR #1711 / vmop-3757] Unit and integration tests — `webhooks/configtarget/validation/configtarget_validator_unit_test.go`, `configtarget_validator_intg_test.go`
 - [x] T063 [S5.b] Author `controllers/configtarget/configtarget_controller.go` — cluster-scope path: QueryConfigTarget + QueryConfigOptionDescriptor; populate status; fan out VirtualMachineConfigOptions
 - [x] T064 [S5.b] Add `GetVirtualMachineConfigTarget` (QueryConfigTarget + QueryConfigOptionDescriptor) — implemented directly on `pkg/providers/vsphere/vmprovider.go` (see note below) instead of a new `environment_browser.go` file
 - [x] T065 [S5.b] Unit tests — `controllers/configtarget/configtarget_controller_test.go` (includes vcsim-backed integration coverage in the same file)
 
 > **Implementation note (T063–T065):** `metadata.name` (not `spec.id`) is the cluster MoID key. This is confirmed correct, not just a convention choice: `spec.md`'s acceptance criteria key every `ConfigTarget` lookup off `metadata.name` (`spec.id` is referenced only as an immutability constraint), and the merged Zone controller (vmop-3740, PR #1695) sets `spec.id.ID` to the same value as `metadata.name` on every `ConfigTarget` it creates — so the two fields are always identical in practice. `GetVirtualMachineConfigTarget` was placed directly on `vSphereVMProvider` in `vmprovider.go` — consistent with other single-purpose vSphere queries in that file (`DoesProfileSupportEncryption`, `GetStoragePolicyStatus`) — rather than the `pkg/providers/vsphere/environment_browser.go` sketched in the plan; that file can still be introduced later once `QueryConfigOptionEx` (S6) and the per-host iteration (S5.c) grow the surface area.
 >
+
 - [ ] T066 [S5.c / vmop-3759] Extend controller with the per-host iteration — enumerate cluster hosts via `ClusterComputeResource.host`; for each host, run one `PropertyCollector` RPC for `config.defaultHardwareVersion`, `capability.supportedHardwareVersions`, `config.pciPassthruInfo` (filtered to `sriovCapable=true`), and `hardware.dvxClasses` (where `sriovNic=true`); aggregate `max(defaultHardwareVersion)` into `ConfigTarget.status.maxHardwareVersion`; build per-(host, NIC) `VirtualMachineSriovInfo` entries and write them to `ConfigTarget.status.sriov`. Treat per-host RPC failure as a warning event; do not block the rest of the iteration.
 - [ ] T066a [S5.c / vmop-3797] Add `ConfigTargetStatus.MaxHardwareVersion` to `external/vim/api/v1alpha1/config_target_types.go`; extend `VirtualMachineSriovInfo` in `external/vim/api/v1alpha1/config_target_devices_types.go` with `HostMoID` (required), `Active`, `MaxVFs`, `NumVFs`, `DVXClass`, `DVXCheckpointSupported`, `DVXSWDMATracingSupported`; add `+listType=map` with `+listMapKey=hostMoID` and `+listMapKey=pciDevice.id` to `status.sriov`; regenerate `zz_generated.deepcopy.go` and `vim.vmware.com_configtargets.yaml`. T066 cannot be merged before T066a.
 - [ ] T067 [S5.c] Unit tests for the per-host iteration — `max(defaultHardwareVersion)` aggregation across mixed hosts; SR-IOV entries carry `hostMoID`; DVX class enrichment correlates correctly; partial-failure (one host RPC fails) leaves the other hosts' data intact and triggers a re-queue.

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -116,6 +116,27 @@ metadata:
 webhooks:
 - admissionReviewVersions:
   - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /default-validate-vim-vmware-com-v1alpha1-configtarget
+  failurePolicy: Fail
+  name: default.validating.configtarget.v1alpha1.vim.vmware.com
+  rules:
+  - apiGroups:
+    - vim.vmware.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - configtargets
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
   clientConfig:
     service:
       name: webhook-service

--- a/webhooks/configtarget/validation/configtarget_validator.go
+++ b/webhooks/configtarget/validation/configtarget_validator.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
-	"regexp"
 
 	"k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -30,10 +29,6 @@ import (
 const (
 	webHookName = "default"
 )
-
-// clusterMoIDPattern matches the managed object ID vCenter assigns to a
-// ClusterComputeResource, e.g. domain-c21.
-var clusterMoIDPattern = regexp.MustCompile(`^domain-c[0-9]+$`)
 
 // +kubebuilder:webhook:verbs=create;update,path=/default-validate-vim-vmware-com-v1alpha1-configtarget,mutating=false,failurePolicy=fail,groups=vim.vmware.com,resources=configtargets,versions=v1alpha1,name=default.validating.configtarget.v1alpha1.vim.vmware.com,sideEffects=None,admissionReviewVersions=v1;v1beta1
 // +kubebuilder:rbac:groups=vim.vmware.com,resources=configtargets,verbs=get;list
@@ -71,7 +66,7 @@ func (v validator) ValidateCreate(ctx *pkgctx.WebhookRequestContext) admission.R
 		return webhook.Errored(http.StatusBadRequest, err)
 	}
 
-	fieldErrs := append(v.validateName(configTarget), v.validateSpec(configTarget)...)
+	fieldErrs := v.validateSpec(configTarget)
 
 	validationErrs := make([]string, 0, len(fieldErrs))
 	for _, fieldErr := range fieldErrs {
@@ -106,22 +101,9 @@ func (v validator) ValidateUpdate(ctx *pkgctx.WebhookRequestContext) admission.R
 	return common.BuildValidationResponse(ctx, nil, validationErrs, nil)
 }
 
-// validateName returns an error if metadata.name is not a valid vSphere
-// cluster managed object ID.
-func (v validator) validateName(configTarget *vimv1.ConfigTarget) field.ErrorList {
-	if clusterMoIDPattern.MatchString(configTarget.Name) {
-		return nil
-	}
-
-	return field.ErrorList{
-		field.Invalid(
-			field.NewPath("metadata", "name"),
-			configTarget.Name,
-			"must be a valid vSphere cluster managed object ID, e.g. domain-c21"),
-	}
-}
-
-// validateSpec returns an error if spec.id is empty.
+// validateSpec returns an error if spec.id is empty. The CRD's +required
+// marker on this field only enforces the JSON key's presence, not a
+// non-empty value, since ID has no omitempty tag.
 func (v validator) validateSpec(configTarget *vimv1.ConfigTarget) field.ErrorList {
 	if configTarget.Spec.ID.ID != "" {
 		return nil

--- a/webhooks/configtarget/validation/configtarget_validator.go
+++ b/webhooks/configtarget/validation/configtarget_validator.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"regexp"
 
 	"k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -29,6 +30,15 @@ import (
 const (
 	webHookName = "default"
 )
+
+// clusterMoIDPattern matches the conventional form of the managed object ID
+// vCenter assigns to a ClusterComputeResource, e.g. domain-c21. The vSphere
+// API documents ManagedObjectReference values as opaque strings, but this
+// prefix has been stable across vSphere releases, is how the Zone
+// controller derives ConfigTarget's name (controllers/infra/zone), and is
+// required by this webhook's task spec
+// (.sdd/specs/001-class-policy-resize/tasks.md, T060).
+var clusterMoIDPattern = regexp.MustCompile(`^domain-c[0-9]+$`)
 
 // +kubebuilder:webhook:verbs=create;update,path=/default-validate-vim-vmware-com-v1alpha1-configtarget,mutating=false,failurePolicy=fail,groups=vim.vmware.com,resources=configtargets,versions=v1alpha1,name=default.validating.configtarget.v1alpha1.vim.vmware.com,sideEffects=None,admissionReviewVersions=v1;v1beta1
 // +kubebuilder:rbac:groups=vim.vmware.com,resources=configtargets,verbs=get;list
@@ -66,7 +76,7 @@ func (v validator) ValidateCreate(ctx *pkgctx.WebhookRequestContext) admission.R
 		return webhook.Errored(http.StatusBadRequest, err)
 	}
 
-	fieldErrs := v.validateSpec(configTarget)
+	fieldErrs := append(v.validateName(configTarget), v.validateSpec(configTarget)...)
 
 	validationErrs := make([]string, 0, len(fieldErrs))
 	for _, fieldErr := range fieldErrs {
@@ -91,7 +101,7 @@ func (v validator) ValidateUpdate(ctx *pkgctx.WebhookRequestContext) admission.R
 		return webhook.Errored(http.StatusBadRequest, err)
 	}
 
-	fieldErrs := v.validateAllowedChanges(configTarget, oldConfigTarget)
+	fieldErrs := append(v.validateSpec(configTarget), v.validateAllowedChanges(configTarget, oldConfigTarget)...)
 
 	validationErrs := make([]string, 0, len(fieldErrs))
 	for _, fieldErr := range fieldErrs {
@@ -99,6 +109,21 @@ func (v validator) ValidateUpdate(ctx *pkgctx.WebhookRequestContext) admission.R
 	}
 
 	return common.BuildValidationResponse(ctx, nil, validationErrs, nil)
+}
+
+// validateName returns an error if metadata.name is not a valid vSphere
+// cluster managed object ID.
+func (v validator) validateName(configTarget *vimv1.ConfigTarget) field.ErrorList {
+	if clusterMoIDPattern.MatchString(configTarget.Name) {
+		return nil
+	}
+
+	return field.ErrorList{
+		field.Invalid(
+			field.NewPath("metadata", "name"),
+			configTarget.Name,
+			"must be a valid vSphere cluster managed object ID, e.g. domain-c21"),
+	}
 }
 
 // validateSpec returns an error if spec.id is empty. The CRD's +required

--- a/webhooks/configtarget/validation/configtarget_validator.go
+++ b/webhooks/configtarget/validation/configtarget_validator.go
@@ -1,0 +1,152 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package validation
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"regexp"
+
+	"k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	vimv1 "github.com/vmware-tanzu/vm-operator/external/vim/api/v1alpha1"
+
+	"github.com/vmware-tanzu/vm-operator/pkg/builder"
+	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/webhooks/common"
+)
+
+const (
+	webHookName = "default"
+)
+
+// clusterMoIDPattern matches the managed object ID vCenter assigns to a
+// ClusterComputeResource, e.g. domain-c21.
+var clusterMoIDPattern = regexp.MustCompile(`^domain-c[0-9]+$`)
+
+// +kubebuilder:webhook:verbs=create;update,path=/default-validate-vim-vmware-com-v1alpha1-configtarget,mutating=false,failurePolicy=fail,groups=vim.vmware.com,resources=configtargets,versions=v1alpha1,name=default.validating.configtarget.v1alpha1.vim.vmware.com,sideEffects=None,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:rbac:groups=vim.vmware.com,resources=configtargets,verbs=get;list
+
+// AddToManager adds the webhook to the provided manager.
+func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) error {
+	hook, err := builder.NewValidatingWebhook(ctx, mgr, webHookName, NewValidator(mgr.GetClient()))
+	if err != nil {
+		return fmt.Errorf("failed to create ConfigTarget validation webhook: %w", err)
+	}
+
+	mgr.GetWebhookServer().Register(hook.Path, hook)
+
+	return nil
+}
+
+// NewValidator returns the package's Validator.
+func NewValidator(_ client.Client) builder.Validator {
+	return validator{
+		converter: runtime.DefaultUnstructuredConverter,
+	}
+}
+
+type validator struct {
+	converter runtime.UnstructuredConverter
+}
+
+func (v validator) For() schema.GroupVersionKind {
+	return vimv1.GroupVersion.WithKind(reflect.TypeFor[vimv1.ConfigTarget]().Name())
+}
+
+func (v validator) ValidateCreate(ctx *pkgctx.WebhookRequestContext) admission.Response {
+	configTarget, err := v.configTargetFromUnstructured(ctx.Obj)
+	if err != nil {
+		return webhook.Errored(http.StatusBadRequest, err)
+	}
+
+	fieldErrs := append(v.validateName(configTarget), v.validateSpec(configTarget)...)
+
+	validationErrs := make([]string, 0, len(fieldErrs))
+	for _, fieldErr := range fieldErrs {
+		validationErrs = append(validationErrs, fieldErr.Error())
+	}
+
+	return common.BuildValidationResponse(ctx, nil, validationErrs, nil)
+}
+
+func (v validator) ValidateDelete(*pkgctx.WebhookRequestContext) admission.Response {
+	return admission.Allowed("")
+}
+
+func (v validator) ValidateUpdate(ctx *pkgctx.WebhookRequestContext) admission.Response {
+	configTarget, err := v.configTargetFromUnstructured(ctx.Obj)
+	if err != nil {
+		return webhook.Errored(http.StatusBadRequest, err)
+	}
+
+	oldConfigTarget, err := v.configTargetFromUnstructured(ctx.OldObj)
+	if err != nil {
+		return webhook.Errored(http.StatusBadRequest, err)
+	}
+
+	fieldErrs := v.validateAllowedChanges(configTarget, oldConfigTarget)
+
+	validationErrs := make([]string, 0, len(fieldErrs))
+	for _, fieldErr := range fieldErrs {
+		validationErrs = append(validationErrs, fieldErr.Error())
+	}
+
+	return common.BuildValidationResponse(ctx, nil, validationErrs, nil)
+}
+
+// validateName returns an error if metadata.name is not a valid vSphere
+// cluster managed object ID.
+func (v validator) validateName(configTarget *vimv1.ConfigTarget) field.ErrorList {
+	if clusterMoIDPattern.MatchString(configTarget.Name) {
+		return nil
+	}
+
+	return field.ErrorList{
+		field.Invalid(
+			field.NewPath("metadata", "name"),
+			configTarget.Name,
+			"must be a valid vSphere cluster managed object ID, e.g. domain-c21"),
+	}
+}
+
+// validateSpec returns an error if spec.id is empty.
+func (v validator) validateSpec(configTarget *vimv1.ConfigTarget) field.ErrorList {
+	if configTarget.Spec.ID.ID != "" {
+		return nil
+	}
+
+	return field.ErrorList{
+		field.Required(field.NewPath("spec", "id", "id"), ""),
+	}
+}
+
+// validateAllowedChanges returns an error if any immutable fields have been
+// modified.
+func (v validator) validateAllowedChanges(configTarget, oldConfigTarget *vimv1.ConfigTarget) field.ErrorList {
+	return validation.ValidateImmutableField(
+		configTarget.Spec.ID, oldConfigTarget.Spec.ID, field.NewPath("spec", "id"))
+}
+
+// configTargetFromUnstructured returns the ConfigTarget from the unstructured object.
+func (v validator) configTargetFromUnstructured(obj runtime.Unstructured) (*vimv1.ConfigTarget, error) {
+	configTarget := &vimv1.ConfigTarget{}
+
+	err := v.converter.FromUnstructured(obj.UnstructuredContent(), configTarget)
+	if err != nil {
+		return nil, err
+	}
+
+	return configTarget, nil
+}

--- a/webhooks/configtarget/validation/configtarget_validator_intg_test.go
+++ b/webhooks/configtarget/validation/configtarget_validator_intg_test.go
@@ -1,0 +1,167 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package validation_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	vimv1 "github.com/vmware-tanzu/vm-operator/external/vim/api/v1alpha1"
+
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+func intgTests() {
+	Describe(
+		"Create",
+		Label(
+			testlabels.Create,
+			testlabels.EnvTest,
+			testlabels.API,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		intgTestsValidateCreate,
+	)
+	Describe(
+		"Update",
+		Label(
+			testlabels.Update,
+			testlabels.EnvTest,
+			testlabels.API,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		intgTestsValidateUpdate,
+	)
+	Describe(
+		"Delete",
+		Label(
+			testlabels.Delete,
+			testlabels.EnvTest,
+			testlabels.API,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		intgTestsValidateDelete,
+	)
+}
+
+type intgValidatingWebhookContext struct {
+	builder.IntegrationTestContext
+
+	configTarget *vimv1.ConfigTarget
+}
+
+func newIntgValidatingWebhookContext() *intgValidatingWebhookContext {
+	ctx := &intgValidatingWebhookContext{
+		IntegrationTestContext: *suite.NewIntegrationTestContext(),
+	}
+
+	ctx.configTarget = dummyConfigTarget()
+
+	return ctx
+}
+
+func intgTestsValidateCreate() {
+	var (
+		ctx *intgValidatingWebhookContext
+	)
+
+	validateCreate := func(expectedAllowed bool, expectedReason string) {
+		configTarget := ctx.configTarget.DeepCopy()
+
+		if !expectedAllowed {
+			configTarget.Spec.ID.ID = ""
+		}
+
+		err := ctx.Client.Create(ctx, configTarget)
+		if expectedAllowed {
+			Expect(err).ToNot(HaveOccurred())
+		} else {
+			Expect(err).To(HaveOccurred())
+		}
+
+		if expectedReason != "" {
+			Expect(err.Error()).To(ContainSubstring(expectedReason))
+		}
+	}
+
+	BeforeEach(func() {
+		ctx = newIntgValidatingWebhookContext()
+	})
+	AfterEach(func() {
+		Expect(ctrlclient.IgnoreNotFound(ctx.Client.Delete(ctx, ctx.configTarget))).To(Succeed())
+		ctx = nil
+	})
+
+	idPath := field.NewPath("spec", "id", "id")
+	DescribeTable("create table", validateCreate,
+		Entry("should work", true, ""),
+		Entry("should not work for an empty spec.id", false, field.Required(idPath, "").Error()),
+	)
+}
+
+func intgTestsValidateUpdate() {
+	var (
+		err error
+		ctx *intgValidatingWebhookContext
+	)
+
+	BeforeEach(func() {
+		ctx = newIntgValidatingWebhookContext()
+		err = ctx.Client.Create(ctx, ctx.configTarget)
+		Expect(err).ToNot(HaveOccurred())
+	})
+	JustBeforeEach(func() {
+		err = ctx.Client.Update(suite, ctx.configTarget)
+	})
+	AfterEach(func() {
+		Expect(ctrlclient.IgnoreNotFound(ctx.Client.Delete(ctx, ctx.configTarget))).To(Succeed())
+
+		err = nil
+		ctx = nil
+	})
+
+	When("update is performed with a changed spec.id", func() {
+		BeforeEach(func() {
+			ctx.configTarget.Spec.ID = vimv1.ManagedObjectID{ID: "domain-c22"}
+		})
+		It("should deny the request", func() {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("field is immutable"))
+		})
+	})
+}
+
+func intgTestsValidateDelete() {
+	var (
+		err error
+		ctx *intgValidatingWebhookContext
+	)
+
+	BeforeEach(func() {
+		ctx = newIntgValidatingWebhookContext()
+		err = ctx.Client.Create(ctx, ctx.configTarget)
+		Expect(err).ToNot(HaveOccurred())
+	})
+	JustBeforeEach(func() {
+		err = ctx.Client.Delete(suite, ctx.configTarget)
+	})
+	AfterEach(func() {
+		err = nil
+		ctx = nil
+	})
+
+	When("delete is performed", func() {
+		It("should allow the request", func() {
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+}

--- a/webhooks/configtarget/validation/configtarget_validator_intg_test.go
+++ b/webhooks/configtarget/validation/configtarget_validator_intg_test.go
@@ -129,6 +129,12 @@ func intgTestsValidateUpdate() {
 		ctx = nil
 	})
 
+	When("update is performed without changing spec.id", func() {
+		It("should allow the request", func() {
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
 	When("update is performed with a changed spec.id", func() {
 		BeforeEach(func() {
 			ctx.configTarget.Spec.ID = vimv1.ManagedObjectID{ID: "domain-c22"}

--- a/webhooks/configtarget/validation/configtarget_validator_intg_test.go
+++ b/webhooks/configtarget/validation/configtarget_validator_intg_test.go
@@ -74,10 +74,19 @@ func intgTestsValidateCreate() {
 		ctx *intgValidatingWebhookContext
 	)
 
-	validateCreate := func(expectedAllowed bool, expectedReason string) {
+	type createArgs struct {
+		invalidName bool
+		emptyID     bool
+	}
+
+	validateCreate := func(args createArgs, expectedAllowed bool, expectedReason string) {
 		configTarget := ctx.configTarget.DeepCopy()
 
-		if !expectedAllowed {
+		if args.invalidName {
+			configTarget.Name = "not-a-cluster-moid"
+		}
+
+		if args.emptyID {
 			configTarget.Spec.ID.ID = ""
 		}
 
@@ -101,10 +110,14 @@ func intgTestsValidateCreate() {
 		ctx = nil
 	})
 
+	namePath := field.NewPath("metadata", "name")
 	idPath := field.NewPath("spec", "id", "id")
 	DescribeTable("create table", validateCreate,
-		Entry("should work", true, ""),
-		Entry("should not work for an empty spec.id", false, field.Required(idPath, "").Error()),
+		Entry("should work", createArgs{}, true, ""),
+		Entry("should not work for an invalid cluster moid name", createArgs{invalidName: true}, false,
+			field.Invalid(namePath, "not-a-cluster-moid", "must be a valid vSphere cluster managed object ID, e.g. domain-c21").Error()),
+		Entry("should not work for an empty spec.id", createArgs{emptyID: true}, false,
+			field.Required(idPath, "").Error()),
 	)
 }
 

--- a/webhooks/configtarget/validation/configtarget_validator_suite_test.go
+++ b/webhooks/configtarget/validation/configtarget_validator_suite_test.go
@@ -1,0 +1,35 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package validation_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+	"github.com/vmware-tanzu/vm-operator/webhooks/configtarget/validation"
+)
+
+// suite is used for unit and integration testing this webhook.
+var suite = builder.NewTestSuiteForValidatingWebhookWithContext(
+	pkgcfg.WithConfig(
+		pkgcfg.Config{
+			Features: pkgcfg.FeatureStates{
+				VirtualMachineConfigPolicy: true,
+			},
+		}),
+	validation.AddToManager,
+	validation.NewValidator,
+	"default.validating.configtarget.v1alpha1.vim.vmware.com")
+
+func TestWebhook(t *testing.T) {
+	suite.Register(t, "Validation webhook suite", intgTests, unitTests)
+}
+
+var _ = BeforeSuite(suite.BeforeSuite)
+
+var _ = AfterSuite(suite.AfterSuite)

--- a/webhooks/configtarget/validation/configtarget_validator_unit_test.go
+++ b/webhooks/configtarget/validation/configtarget_validator_unit_test.go
@@ -1,0 +1,235 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package validation_test
+
+import (
+	"fmt"
+	"sync/atomic"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	vimv1 "github.com/vmware-tanzu/vm-operator/external/vim/api/v1alpha1"
+
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+// configTargetCounter ensures each dummyConfigTarget has a unique name, since
+// ConfigTarget is cluster-scoped and the integration tests share a single
+// envtest API server across parallel specs.
+var configTargetCounter atomic.Int64
+
+func unitTests() {
+	Describe(
+		"Create",
+		Label(
+			testlabels.Create,
+			testlabels.API,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		unitTestsValidateCreate,
+	)
+	Describe(
+		"Update",
+		Label(
+			testlabels.Update,
+			testlabels.API,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		unitTestsValidateUpdate,
+	)
+	Describe(
+		"Delete",
+		Label(
+			testlabels.Delete,
+			testlabels.API,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		unitTestsValidateDelete,
+	)
+}
+
+type unitValidatingWebhookContext struct {
+	builder.UnitTestContextForValidatingWebhook
+
+	configTarget    *vimv1.ConfigTarget
+	oldConfigTarget *vimv1.ConfigTarget
+}
+
+func dummyConfigTarget() *vimv1.ConfigTarget {
+	name := fmt.Sprintf("domain-c%d", configTargetCounter.Add(1))
+
+	return &vimv1.ConfigTarget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: vimv1.ConfigTargetSpec{
+			ID: vimv1.ManagedObjectID{ID: name},
+		},
+	}
+}
+
+func newUnitTestContextForValidatingWebhook(isUpdate bool) *unitValidatingWebhookContext {
+	configTarget := dummyConfigTarget()
+	obj, err := builder.ToUnstructured(configTarget)
+	Expect(err).ToNot(HaveOccurred())
+
+	var (
+		oldConfigTarget *vimv1.ConfigTarget
+		oldObj          *unstructured.Unstructured
+	)
+
+	if isUpdate {
+		oldConfigTarget = configTarget.DeepCopy()
+		oldObj, err = builder.ToUnstructured(oldConfigTarget)
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	return &unitValidatingWebhookContext{
+		UnitTestContextForValidatingWebhook: *suite.NewUnitTestContextForValidatingWebhook(obj, oldObj),
+		configTarget:                        configTarget,
+		oldConfigTarget:                     oldConfigTarget,
+	}
+}
+
+func unitTestsValidateCreate() {
+	var (
+		ctx *unitValidatingWebhookContext
+	)
+
+	type createArgs struct {
+		invalidName bool
+		emptyID     bool
+	}
+
+	validateCreate := func(args createArgs, expectedAllowed bool, expectedReason string) {
+		var err error
+
+		if args.invalidName {
+			ctx.configTarget.Name = "not-a-cluster-moid"
+		}
+
+		if args.emptyID {
+			ctx.configTarget.Spec.ID.ID = ""
+		}
+
+		ctx.WebhookRequestContext.Obj, err = builder.ToUnstructured(ctx.configTarget)
+		Expect(err).ToNot(HaveOccurred())
+
+		response := ctx.ValidateCreate(&ctx.WebhookRequestContext)
+		Expect(response.Allowed).To(Equal(expectedAllowed))
+
+		if expectedReason != "" {
+			Expect(string(response.Result.Reason)).To(Equal(expectedReason))
+		}
+	}
+
+	BeforeEach(func() {
+		ctx = newUnitTestContextForValidatingWebhook(false)
+	})
+	AfterEach(func() {
+		ctx = nil
+	})
+
+	namePath := field.NewPath("metadata", "name")
+	idPath := field.NewPath("spec", "id", "id")
+	DescribeTable("create table", validateCreate,
+		Entry("should allow valid", createArgs{}, true, ""),
+		Entry("should deny an invalid cluster moid name", createArgs{invalidName: true}, false,
+			field.Invalid(namePath, "not-a-cluster-moid", "must be a valid vSphere cluster managed object ID, e.g. domain-c21").Error()),
+		Entry("should deny an empty spec.id", createArgs{emptyID: true}, false,
+			field.Required(idPath, "").Error()),
+	)
+}
+
+func unitTestsValidateUpdate() {
+	var (
+		ctx *unitValidatingWebhookContext
+	)
+
+	type updateArgs struct {
+		changeID bool
+	}
+
+	validateUpdate := func(args updateArgs, expectedAllowed bool, expectedReason string) {
+		var err error
+
+		if args.changeID {
+			ctx.configTarget.Spec.ID = vimv1.ManagedObjectID{ID: "domain-c22"}
+		}
+
+		ctx.WebhookRequestContext.Obj, err = builder.ToUnstructured(ctx.configTarget)
+		Expect(err).ToNot(HaveOccurred())
+
+		response := ctx.ValidateUpdate(&ctx.WebhookRequestContext)
+		Expect(response.Allowed).To(Equal(expectedAllowed))
+
+		if expectedReason != "" {
+			Expect(string(response.Result.Reason)).To(ContainSubstring(expectedReason))
+		}
+	}
+
+	BeforeEach(func() {
+		ctx = newUnitTestContextForValidatingWebhook(true)
+	})
+	AfterEach(func() {
+		ctx = nil
+	})
+
+	immutableFieldMsg := "field is immutable"
+	DescribeTable("update table", validateUpdate,
+		Entry("should allow", updateArgs{}, true, ""),
+		Entry("should deny spec.id mutation", updateArgs{changeID: true}, false, immutableFieldMsg),
+	)
+
+	When("the update is performed while object deletion", func() {
+		var response admission.Response
+
+		JustBeforeEach(func() {
+			t := metav1.Now()
+			ctx.WebhookRequestContext.Obj.SetDeletionTimestamp(&t)
+			response = ctx.ValidateUpdate(&ctx.WebhookRequestContext)
+		})
+
+		It("should allow the request", func() {
+			Expect(response.Allowed).To(BeTrue())
+			Expect(response.Result).ToNot(BeNil())
+		})
+	})
+}
+
+func unitTestsValidateDelete() {
+	var (
+		ctx      *unitValidatingWebhookContext
+		response admission.Response
+	)
+
+	BeforeEach(func() {
+		ctx = newUnitTestContextForValidatingWebhook(false)
+	})
+	AfterEach(func() {
+		ctx = nil
+	})
+
+	When("the delete is performed", func() {
+		JustBeforeEach(func() {
+			response = ctx.ValidateDelete(&ctx.WebhookRequestContext)
+		})
+
+		It("should allow the request", func() {
+			Expect(response.Allowed).To(BeTrue())
+			Expect(response.Result).ToNot(BeNil())
+		})
+	})
+}

--- a/webhooks/configtarget/validation/configtarget_validator_unit_test.go
+++ b/webhooks/configtarget/validation/configtarget_validator_unit_test.go
@@ -19,6 +19,7 @@ import (
 	vimv1 "github.com/vmware-tanzu/vm-operator/external/vim/api/v1alpha1"
 
 	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
@@ -109,11 +110,16 @@ func unitTestsValidateCreate() {
 	)
 
 	type createArgs struct {
-		id *string
+		name *string
+		id   *string
 	}
 
 	validateCreate := func(args createArgs, expectedAllowed bool, expectedReason string) {
 		var err error
+
+		if args.name != nil {
+			ctx.configTarget.Name = *args.name
+		}
 
 		if args.id != nil {
 			ctx.configTarget.Spec.ID.ID = *args.id
@@ -137,9 +143,13 @@ func unitTestsValidateCreate() {
 		ctx = nil
 	})
 
+	namePath := field.NewPath("metadata", "name")
 	idPath := field.NewPath("spec", "id", "id")
 	DescribeTable("create table", validateCreate,
 		Entry("should allow valid", createArgs{}, true, ""),
+		Entry("should deny an invalid cluster moid name",
+			createArgs{name: ptr.To("not-a-cluster-moid")}, false, //nolint:modernize // not the zero value; new(string) would change the assertion
+			field.Invalid(namePath, "not-a-cluster-moid", "must be a valid vSphere cluster managed object ID, e.g. domain-c21").Error()),
 		Entry("should deny an empty spec.id", createArgs{id: new(string)}, false,
 			field.Required(idPath, "").Error()),
 	)
@@ -151,14 +161,14 @@ func unitTestsValidateUpdate() {
 	)
 
 	type updateArgs struct {
-		id vimv1.ManagedObjectID
+		id *vimv1.ManagedObjectID
 	}
 
-	validateUpdate := func(args updateArgs, expectedAllowed bool, expectedReason string) {
+	validateUpdate := func(args updateArgs, expectedAllowed bool, expectedReasons ...string) {
 		var err error
 
-		if args.id != (vimv1.ManagedObjectID{}) {
-			ctx.configTarget.Spec.ID = args.id
+		if args.id != nil {
+			ctx.configTarget.Spec.ID = *args.id
 		}
 
 		ctx.WebhookRequestContext.Obj, err = builder.ToUnstructured(ctx.configTarget)
@@ -167,10 +177,13 @@ func unitTestsValidateUpdate() {
 		response := ctx.ValidateUpdate(&ctx.WebhookRequestContext)
 		Expect(response.Allowed).To(Equal(expectedAllowed))
 
-		if expectedReason != "" {
+		for _, expectedReason := range expectedReasons {
 			Expect(string(response.Result.Reason)).To(ContainSubstring(expectedReason))
 		}
 	}
+
+	immutableFieldMsg := "field is immutable"
+	requiredIDMsg := field.Required(field.NewPath("spec", "id", "id"), "").Error()
 
 	BeforeEach(func() {
 		ctx = newUnitTestContextForValidatingWebhook(true)
@@ -179,11 +192,12 @@ func unitTestsValidateUpdate() {
 		ctx = nil
 	})
 
-	immutableFieldMsg := "field is immutable"
 	DescribeTable("update table", validateUpdate,
-		Entry("should allow when spec.id is unchanged", updateArgs{}, true, ""),
+		Entry("should allow when spec.id is unchanged", updateArgs{}, true),
 		Entry("should deny when spec.id changes to domain-c22",
-			updateArgs{id: vimv1.ManagedObjectID{ID: "domain-c22"}}, false, immutableFieldMsg),
+			updateArgs{id: &vimv1.ManagedObjectID{ID: "domain-c22"}}, false, immutableFieldMsg),
+		Entry("should deny with both errors when spec.id is cleared",
+			updateArgs{id: &vimv1.ManagedObjectID{}}, false, immutableFieldMsg, requiredIDMsg),
 	)
 
 	When("the update is performed while object deletion", func() {

--- a/webhooks/configtarget/validation/configtarget_validator_unit_test.go
+++ b/webhooks/configtarget/validation/configtarget_validator_unit_test.go
@@ -109,19 +109,14 @@ func unitTestsValidateCreate() {
 	)
 
 	type createArgs struct {
-		invalidName bool
-		emptyID     bool
+		id *string
 	}
 
 	validateCreate := func(args createArgs, expectedAllowed bool, expectedReason string) {
 		var err error
 
-		if args.invalidName {
-			ctx.configTarget.Name = "not-a-cluster-moid"
-		}
-
-		if args.emptyID {
-			ctx.configTarget.Spec.ID.ID = ""
+		if args.id != nil {
+			ctx.configTarget.Spec.ID.ID = *args.id
 		}
 
 		ctx.WebhookRequestContext.Obj, err = builder.ToUnstructured(ctx.configTarget)
@@ -142,13 +137,10 @@ func unitTestsValidateCreate() {
 		ctx = nil
 	})
 
-	namePath := field.NewPath("metadata", "name")
 	idPath := field.NewPath("spec", "id", "id")
 	DescribeTable("create table", validateCreate,
 		Entry("should allow valid", createArgs{}, true, ""),
-		Entry("should deny an invalid cluster moid name", createArgs{invalidName: true}, false,
-			field.Invalid(namePath, "not-a-cluster-moid", "must be a valid vSphere cluster managed object ID, e.g. domain-c21").Error()),
-		Entry("should deny an empty spec.id", createArgs{emptyID: true}, false,
+		Entry("should deny an empty spec.id", createArgs{id: new(string)}, false,
 			field.Required(idPath, "").Error()),
 	)
 }
@@ -159,14 +151,14 @@ func unitTestsValidateUpdate() {
 	)
 
 	type updateArgs struct {
-		changeID bool
+		id vimv1.ManagedObjectID
 	}
 
 	validateUpdate := func(args updateArgs, expectedAllowed bool, expectedReason string) {
 		var err error
 
-		if args.changeID {
-			ctx.configTarget.Spec.ID = vimv1.ManagedObjectID{ID: "domain-c22"}
+		if args.id != (vimv1.ManagedObjectID{}) {
+			ctx.configTarget.Spec.ID = args.id
 		}
 
 		ctx.WebhookRequestContext.Obj, err = builder.ToUnstructured(ctx.configTarget)
@@ -189,8 +181,9 @@ func unitTestsValidateUpdate() {
 
 	immutableFieldMsg := "field is immutable"
 	DescribeTable("update table", validateUpdate,
-		Entry("should allow", updateArgs{}, true, ""),
-		Entry("should deny spec.id mutation", updateArgs{changeID: true}, false, immutableFieldMsg),
+		Entry("should allow when spec.id is unchanged", updateArgs{}, true, ""),
+		Entry("should deny when spec.id changes to domain-c22",
+			updateArgs{id: vimv1.ManagedObjectID{ID: "domain-c22"}}, false, immutableFieldMsg),
 	)
 
 	When("the update is performed while object deletion", func() {

--- a/webhooks/configtarget/webhooks.go
+++ b/webhooks/configtarget/webhooks.go
@@ -1,0 +1,17 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package configtarget
+
+import (
+	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
+
+	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/webhooks/configtarget/validation"
+)
+
+// AddToManager adds the ConfigTarget webhooks to the provided manager.
+func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) error {
+	return validation.AddToManager(ctx, mgr)
+}

--- a/webhooks/webhooks.go
+++ b/webhooks/webhooks.go
@@ -11,6 +11,7 @@ import (
 
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/webhooks/configtarget"
 	"github.com/vmware-tanzu/vm-operator/webhooks/conversion"
 	"github.com/vmware-tanzu/vm-operator/webhooks/persistentvolumeclaim"
 	"github.com/vmware-tanzu/vm-operator/webhooks/unifiedstoragequota"
@@ -82,6 +83,9 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) err
 	if pkgcfg.FromContext(ctx).Features.VirtualMachineConfigPolicy {
 		if err := virtualmachineconfigoptions.AddToManager(ctx, mgr); err != nil {
 			return fmt.Errorf("failed to initialize VirtualMachineConfigOptions webhooks: %w", err)
+		}
+		if err := configtarget.AddToManager(ctx, mgr); err != nil {
+			return fmt.Errorf("failed to initialize ConfigTarget webhooks: %w", err)
 		}
 	}
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Adds the validating webhook for the cluster-scoped `ConfigTarget` CRD
(`vim.vmware.com/v1alpha1`), gated by the `VirtualMachineConfigPolicy`
capability, consistent with how `pkg/manager` already gates the
`ConfigTarget` scheme registration.

The webhook enforces:
* `spec.id` is immutable after create.
* `metadata.name` must be a valid vSphere cluster managed object ID
  (e.g. `domain-c21`).
* `spec.id` must not be empty.

New package: `webhooks/configtarget/validation`, following the same
shape as `webhooks/virtualmachinesetresourcepolicy` (webhook +
validator + unit/integration/suite tests). Wired into
`webhooks/webhooks.go` behind `Features.VirtualMachineConfigPolicy`.
Ran `make generate-manifests` to regenerate
`config/webhook/manifests.yaml` with the new webhook entry.

RBAC: `configtargets` already has `get`/`list` (added earlier by the
Zone controller for `create`/`patch`/`update`/`watch`), so
`config/rbac/role.yaml` did not change after regenerating manifests
with this webhook's `get;list` marker.

**Scope note:** the parent story's "wire the ClusterRole for
configtargets, virtualmachineconfigoptions, and hostsystems" and
"register the ConfigTarget controller in controllers/controllers.go"
items are intentionally left out of this PR. The `ConfigTarget`
reconciler and the `HostSystem` CRD (a stated dependency, S4.a) don't
exist on this branch yet and are tracked separately under
vmop-3758/vmop-3759/vmop-3760/vmop-3761. Adding write RBAC for
resources with no owning controller yet, or RBAC for a CRD that
doesn't exist, would be premature; that wiring belongs with the
controller's own PR.

**Which issue(s) is/are addressed by this PR?**:

Fixes vmop-3757

**Are there any special notes for your reviewer**:

- Unit and integration tests both pass locally (`go test ./webhooks/configtarget/...`), gating the ConfigTarget scheme registration on `Features.VirtualMachineConfigPolicy` the same way `webhooks/virtualmachinegroup` gates on `Features.VMGroups`.
- `ConfigTarget` is cluster-scoped, so integration test object names are made unique per spec via an atomic counter to avoid collisions on the shared envtest API server.

**Please add a release note if necessary**:

```release-note
Add a validating webhook for the ConfigTarget resource.
```