### PR TITLE
🌱 Report E2E setup failures to the callback URL too

### DIFF
--- a/hack/e2e/callback.sh
+++ b/hack/e2e/callback.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# callback.sh - Shared helper for reporting E2E pipeline results to a generic
+# HTTP callback URL.
+#
+# wait-for-artifact-dir.sh, setup-testbed-env.sh, and run-e2e.sh are chained
+# with "&&" in the E2E container's entrypoint, so a failure in any one of the
+# earlier steps stops the chain before run-e2e.sh (previously the only
+# script that ever POSTed a result) gets a chance to run. Sourcing this file
+# lets every step in the chain report its own "Failed" + syndrome instead of
+# leaving the callback endpoint with nothing but the container's bare
+# non-zero exit code.
+#
+# Usage:
+#   source "$(dirname "${BASH_SOURCE[0]}")/callback.sh"
+#   report_callback "Failed" "SSH to vCenter failed after 6 attempts"
+#   report_callback "Passed" "" "${subtest_details_json}"
+#
+# Set TEST_CALLBACK_URL in the environment to enable reporting; when unset,
+# report_callback is a no-op (safe for local runs).
+
+# report_callback posts {result, subtest_details, syndrome} to
+# TEST_CALLBACK_URL. "syndrome" and "subtest_details" are optional:
+# "syndrome" is omitted from the payload when empty, and "subtest_details"
+# defaults to "[]". The callback API caps "syndrome" at 1024 characters.
+report_callback() {
+    local result="${1}"
+    local syndrome="${2:-}"
+    local subtest_details="${3:-[]}"
+
+    if [ -z "${TEST_CALLBACK_URL:-}" ]; then
+        return 0
+    fi
+
+    syndrome=$(printf '%s' "${syndrome}" | cut -c1-1024)
+
+    local count
+    count=$(printf '%s' "${subtest_details}" | jq 'length' 2>/dev/null || echo 0)
+    echo "[callback] Reporting result '${result}' with ${count} subtests to callback URL..."
+
+    local payload
+    payload=$(jq -n \
+        --arg result "${result}" \
+        --arg syndrome "${syndrome}" \
+        --argjson subtests "${subtest_details}" \
+        '{result: $result, subtest_details: $subtests}
+         + (if $syndrome != "" then {syndrome: $syndrome} else {} end)')
+
+    curl --silent --show-error --max-time 30 \
+        -X POST "${TEST_CALLBACK_URL}" \
+        -H "Content-Type: application/json" \
+        -d "${payload}" || echo "[callback] WARNING: callback POST failed (ignored)"
+}

--- a/hack/e2e/run-e2e.sh
+++ b/hack/e2e/run-e2e.sh
@@ -36,6 +36,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# shellcheck source=./callback.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/callback.sh"
+
 # parse_json_report reads a Ginkgo JSON report (written by --json-report) and
 # emits a JSON array of per-test results suitable for the subtest_details field
 # of a test callback payload. Each element has "testcasename" and "result".
@@ -71,11 +74,10 @@ parse_json_report() {
     ]' "${json_file}"
 }
 
-# report_result POSTs the overall pass/fail and per-test breakdown to a generic
-# callback URL when one is configured in the environment. The variable name is
-# intentionally generic so that this public script does not reference any
-# specific CI system. Set TEST_CALLBACK_URL in the environment to enable
-# reporting; when unset the function is a no-op (safe for local runs).
+# report_result reports the overall pass/fail and per-test breakdown via
+# report_callback (see callback.sh). Set TEST_CALLBACK_URL in the environment
+# to enable reporting; when unset the callback is a no-op (safe for local
+# runs).
 report_result() {
     local exit_code="${1}"
     local json_report="${2:-}"
@@ -97,32 +99,16 @@ report_result() {
         subtest_details=$(parse_json_report "${json_report}") || subtest_details="[]"
     fi
 
-    local count
-    count=$(printf '%s' "${subtest_details}" | jq 'length')
-    echo "[run-e2e] Reporting result '${result}' with ${count} subtests to callback URL..."
-
     # Build a top-level syndrome from the failed subtests' own syndromes, so
     # the overall result carries a short synopsis instead of a bare Failed.
-    # The callback API caps "syndrome" at 1024 characters.
     local syndrome=""
     if [ "${result}" = "Failed" ]; then
         syndrome=$(printf '%s' "${subtest_details}" | jq -r '
             [.[] | select(.result == "FAIL") | (.testcasename + ": " + (.syndrome // "no failure message"))] | join("; ")
-        ' | cut -c1-1024)
+        ')
     fi
 
-    local payload
-    payload=$(jq -n \
-        --arg result "${result}" \
-        --arg syndrome "${syndrome}" \
-        --argjson subtests "${subtest_details}" \
-        '{result: $result, subtest_details: $subtests}
-         + (if $syndrome != "" then {syndrome: $syndrome} else {} end)')
-
-    curl --silent --show-error --max-time 30 \
-        -X POST "${TEST_CALLBACK_URL}" \
-        -H "Content-Type: application/json" \
-        -d "${payload}" || echo "[run-e2e] WARNING: callback POST failed (ignored)"
+    report_callback "${result}" "${syndrome}" "${subtest_details}"
 }
 
 # Inputs from Environment

--- a/hack/e2e/run-e2e.sh
+++ b/hack/e2e/run-e2e.sh
@@ -36,8 +36,15 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# shellcheck source=./callback.sh
-source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/callback.sh"
+# Source callback.sh for report_callback. Guarded (rather than an
+# unconditional source) so a missing sibling file can't take down the whole
+# script before any test output is produced; report_result below already
+# no-ops when report_callback isn't defined.
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -f "${_SCRIPT_DIR}/callback.sh" ]; then
+    # shellcheck source=./callback.sh
+    source "${_SCRIPT_DIR}/callback.sh"
+fi
 
 # parse_json_report reads a Ginkgo JSON report (written by --json-report) and
 # emits a JSON array of per-test results suitable for the subtest_details field
@@ -108,7 +115,11 @@ report_result() {
         ')
     fi
 
-    report_callback "${result}" "${syndrome}" "${subtest_details}"
+    if declare -F report_callback >/dev/null 2>&1; then
+        report_callback "${result}" "${syndrome}" "${subtest_details}"
+    else
+        echo "[run-e2e] WARNING: report_callback unavailable (callback.sh not found); skipping callback" >&2
+    fi
 }
 
 # Inputs from Environment

--- a/hack/e2e/setup-testbed-env.sh
+++ b/hack/e2e/setup-testbed-env.sh
@@ -63,7 +63,55 @@ _KUBECTL_VSPHERE_RETRY_INITIAL_DELAY=5 # seconds; doubles each attempt (~2.5 min
 # ---------------------------------------------------------------------------
 _log()  { printf '%s\n'          "$*" >&2; }
 _warn() { printf 'Warning: %s\n' "$*" >&2; }
-_err()  { printf 'Error: %s\n'   "$*" >&2; }
+# _err records its message in _LAST_ERR (used as the callback syndrome if
+# setup fails) in addition to printing it.
+_LAST_ERR=""
+_err()  { _LAST_ERR="$*"; printf 'Error: %s\n' "$*" >&2; }
+
+# _find_sibling_script_dir <marker_file>
+#
+# Resolves the directory containing this script by checking BASH_SOURCE[0] /
+# $0 first (works when executed or sourced from a known path), falling back
+# to a pwd-relative search for callers that source this file via a dynamic
+# path (e.g. "source ./hack/e2e/setup-testbed-env.sh" from the repo root).
+_find_sibling_script_dir() {
+    local -r marker="$1"
+    local d=""
+    if [[ -n "${BASH_VERSION:-}" ]]; then
+        d="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    elif [[ -n "${ZSH_VERSION:-}" ]]; then
+        d="$(cd "$(dirname "$0")" && pwd)"
+    fi
+    if [[ -z "${d}" || ! -f "${d}/${marker}" ]]; then
+        local _d
+        for _d in "$(pwd)/hack/e2e" "$(pwd)"; do
+            if [[ -f "${_d}/${marker}" ]]; then
+                d="${_d}"
+                break
+            fi
+        done
+    fi
+    printf '%s' "${d}"
+}
+
+# Source callback.sh so a fatal setup failure can report itself via
+# report_callback before returning. Best-effort: if it can't be found, the
+# entry point below simply skips reporting.
+_CALLBACK_SCRIPT_DIR="$(_find_sibling_script_dir "callback.sh")"
+if [[ -n "${_CALLBACK_SCRIPT_DIR}" ]]; then
+    # shellcheck source=./callback.sh
+    source "${_CALLBACK_SCRIPT_DIR}/callback.sh"
+fi
+
+# _report_setup_failure reports the most recent _err message as a "Failed"
+# callback. Setup failures happen before run-e2e.sh ever runs (the two are
+# chained with "&&" in the E2E container's entrypoint), so without this the
+# callback URL would never hear anything but the container's bare exit code.
+_report_setup_failure() {
+    if declare -F report_callback >/dev/null 2>&1; then
+        report_callback "Failed" "${_LAST_ERR}"
+    fi
+}
 
 # _retry_with_backoff <max_attempts> <initial_delay_seconds> <description> <cmd> [args...]
 #
@@ -638,22 +686,9 @@ EOF
 
     if [[ "${enable_e2e}" == "true" ]]; then
         # Resolve the directory containing this script so we can find siblings
-        # (proxy.sh, kms.sh).  Cascade: bash BASH_SOURCE[0] → zsh $0 → cwd search.
-        local script_dir=""
-        if [[ -n "${BASH_VERSION:-}" ]]; then
-            script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-        elif [[ -n "${ZSH_VERSION:-}" ]]; then
-            script_dir="$(cd "$(dirname "$0")" && pwd)"
-        fi
-        if [[ -z "${script_dir:-}" || ! -f "${script_dir}/proxy.sh" ]]; then
-            local _d
-            for _d in "$(pwd)/hack/e2e" "$(pwd)"; do
-                if [[ -f "${_d}/proxy.sh" ]]; then
-                    script_dir="${_d}"
-                    break
-                fi
-            done
-        fi
+        # (proxy.sh, kms.sh).
+        local script_dir
+        script_dir="$(_find_sibling_script_dir "proxy.sh")"
         _setup_e2e "${script_dir}"
     fi
 
@@ -693,7 +728,7 @@ EOF
 # being sourced or executed directly.
 # ---------------------------------------------------------------------------
 if [[ "${_SOURCED}" == "true" ]]; then
-    _main "$@" || return $?
+    _main "$@" || { _report_setup_failure; return $?; }
 else
-    _main "$@"
+    _main "$@" || { _report_setup_failure; exit $?; }
 fi

--- a/hack/e2e/wait-for-artifact-dir.sh
+++ b/hack/e2e/wait-for-artifact-dir.sh
@@ -17,8 +17,19 @@ set -ex
 TIMEOUT_SECONDS=600
 POLL_INTERVAL=5
 
+# Source callback.sh so a failure here can report itself before this step's
+# non-zero exit stops the "&&"-chained entrypoint (wait-for-artifact-dir.sh
+# && setup-testbed-env.sh && run-e2e.sh) short of run-e2e.sh, which is
+# otherwise the only script that ever POSTs to TEST_CALLBACK_URL.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -f "${SCRIPT_DIR}/callback.sh" ]]; then
+    # shellcheck source=./callback.sh
+    source "${SCRIPT_DIR}/callback.sh"
+fi
+
 if [[ -z "$RESULTSDIR" ]]; then
     echo "[wait-for-artifact-dir] ERROR: RESULTSDIR environment variable is not set"
+    declare -F report_callback >/dev/null 2>&1 && report_callback "Failed" "RESULTSDIR environment variable is not set"
     exit 1
 fi
 
@@ -29,6 +40,7 @@ elapsed=0
 while [[ ! -d "$RESULTSDIR" ]]; do
     if [[ $elapsed -ge $TIMEOUT_SECONDS ]]; then
         echo "[wait-for-artifact-dir] ERROR: Timed out after ${TIMEOUT_SECONDS}s waiting for $RESULTSDIR"
+        declare -F report_callback >/dev/null 2>&1 && report_callback "Failed" "Timed out after ${TIMEOUT_SECONDS}s waiting for artifact directory ${RESULTSDIR}"
         exit 1
     fi
     sleep $POLL_INTERVAL


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

The E2E container's entrypoint chains `wait-for-artifact-dir.sh && setup-testbed-env.sh && run-e2e.sh` with `&&`, but only `run-e2e.sh` ever POSTed a result to `TEST_CALLBACK_URL`. When one of the earlier two steps failed (e.g. exhausting SSH retries to vCenter during testbed setup), the chain stopped before `run-e2e.sh` ran, so the callback endpoint only ever saw a bare non-zero container exit — no result, no syndrome explaining why.

This extracts the callback POST logic into a shared `hack/e2e/callback.sh` helper (`report_callback`) and sources it from all three scripts, so each one reports `Failed` with a syndrome describing its own failure instead of leaving that reporting solely to `run-e2e.sh`.

**Which issue(s) is/are addressed by this PR?**:

Fixes #

**Are there any special notes for your reviewer**:

No product/API behavior changes — this only touches E2E CI orchestration scripts under `hack/e2e/`. Verified locally by stubbing `curl` and simulating failures at each of the three entrypoint stages (missing testbed file, unset `RESULTSDIR`, artifact-dir timeout) and confirming each POSTs a `{result: "Failed", syndrome: "..."}` payload.

**Please add a release note if necessary**:

```release-note
NONE
```