### PR TITLE
[x-port] [9.1.1] 🐛 Fix zonal affinity policies for capv nodes 

### DIFF
--- a/pkg/providers/vsphere/virtualmachine/configspec.go
+++ b/pkg/providers/vsphere/virtualmachine/configspec.go
@@ -331,38 +331,58 @@ func CreateConfigSpecForPlacement(
 
 // CalculateAffinityConstraints calculates the constraints based on vm object
 // in vmCtx & creation/placement workflow.
+//
+// ConfigureZoneRules is true when the VMPlacementPolicies capability is
+// enabled, except:
+//   - It is disabled during VM Create configspec creation, As DRS only evaluates
+//     zonal policies during placement. Therefore, when the VM is being created,
+//     we want to omit zonal policies from the ConfigSpec
+//   - It is disabled for a VKS node VM (CAPI labels) with a zone label set,
+//     i.e. an explicit zone is already specified by the VM.
+//   - It is disabled when VMAffinityDuringExecution is enabled and the VM has a zone
+//     label set, i.e. an explicit zone is already specified by the VM.
+//
+// ConfigureHostRules is true when the VMAffinityDuringExecution capability
+// is enabled, except for a VKS node VM (CAPI labels), since its host
+// anti-affinity is handled via cluster modules instead.
 func CalculateAffinityConstraints(
 	vmCtx pkgctx.VirtualMachineContext,
 	isCreateVM bool,
 ) AffinityRuleConstraints {
 	constraints := AffinityRuleConstraints{}
+
+	// set base condition for zonal rules based on capability.
 	if pkgcfg.FromContext(vmCtx).Features.VMPlacementPolicies {
 		constraints.ConfigureZoneRules = true
 	}
 
+	// set base condition for host rules based on capability.
 	if pkgcfg.FromContext(vmCtx).Features.VMAffinityDuringExecution {
 		constraints.ConfigureHostRules = true
 	}
 
+	// conditionals are broken down for readability.
+	// Host anti-affinity for CAPI VMs is handled via cluster modules.
 	isVksNodeVM := kubeutil.HasCAPILabels(vmCtx.VM.Labels)
 	if isVksNodeVM {
-		// Host anti-affinity for CAPI VMs is handled via cluster modules.
 		constraints.ConfigureHostRules = false
 	}
 
-	// ConfigureZoneRules = false when:
-	//   1. VM Creation: DRS doesn't differentiate topologies for persisted policies.
-	//   2. VKS Node: Never get zonal policies (VMs are already zone-constrained).
-	//   3. VMAffinityDuringExecution + Zone Label: Already zone-constrained
-	//
-	//   isCreateVM? → isVksNodeVM? → (VMAffinityDuringExecution + ZoneLabel)?
-	//    ↓YES (any)       ↓YES              ↓YES     		↓NO
-	//    FALSE            FALSE             FALSE    		TRUE
-	//
-	if isCreateVM ||
-		isVksNodeVM ||
-		(pkgcfg.FromContext(vmCtx).Features.VMAffinityDuringExecution &&
-			kubeutil.HasZoneLabel(vmCtx.VM.Labels)) {
+	// Drs interprets all persisted policies at host level, hence avoid configuring zonal policies during create.
+	// zonal policies are only considered at placement time.
+	if isCreateVM {
+		constraints.ConfigureZoneRules = false
+	}
+
+	// for vks nodes with zone labels or failure domains set, do not configure zonal affinity rules.
+	// zones are assigned from the zone label.
+	if isVksNodeVM && kubeutil.HasZoneLabel(vmCtx.VM.Labels) {
+		constraints.ConfigureZoneRules = false
+	}
+
+	// for vms with preferred zones, & VMAffinityDuringExecution capability, do not configure zonal rules.
+	// zones are assigned from the zone label.
+	if pkgcfg.FromContext(vmCtx).Features.VMAffinityDuringExecution && kubeutil.HasZoneLabel(vmCtx.VM.Labels) {
 		constraints.ConfigureZoneRules = false
 	}
 

--- a/pkg/providers/vsphere/virtualmachine/configspec_test.go
+++ b/pkg/providers/vsphere/virtualmachine/configspec_test.go
@@ -1741,10 +1741,38 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 						}
 					})
 
-					// policies are ignored as cluster modules is used for VMs with capv labels
-					It("should ignore both host and zone affinity policies", func() {
-						Expect(configSpec.VmPlacementPolicies).To(HaveLen(0))
-						assertVMTags(configSpec, []string{}, vmCtx.VM.Namespace)
+					// Host affinity is ignored as cluster modules is used for VMs with
+					// capv labels, but zone affinity still applies since the VM has no
+					// zone label pinning it to a zone already.
+					It("should ignore host affinity policies but keep zone affinity policies", func() {
+						pols := []vimtypes.BaseVmPlacementPolicy{
+							&vimtypes.VmVmAffinity{
+								AffinedVmsTag: vimtypes.TagId{
+									NameId: &vimtypes.TagIdNameId{
+										Tag:      "env:prod",
+										Category: vmCtx.VM.Namespace,
+									},
+								},
+								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
+								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyVSphereZone),
+							},
+							&vimtypes.VmToVmGroupsAntiAffinity{
+								AntiAffinedVmGroupTags: []vimtypes.TagId{
+									{
+										NameId: &vimtypes.TagIdNameId{
+											Tag:      "env:dev",
+											Category: vmCtx.VM.Namespace,
+										},
+									},
+								},
+								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
+								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyVSphereZone),
+							},
+						}
+
+						Expect(configSpec.VmPlacementPolicies).To(HaveLen(2))
+						Expect(configSpec.VmPlacementPolicies).To(ConsistOf(pols))
+						assertVMTags(configSpec, []string{"env:prod"}, vmCtx.VM.Namespace)
 					})
 				})
 				Context("VKS node VM with both host and zone topology keys with capw labels", func() {
@@ -1799,10 +1827,38 @@ var _ = Describe("CreateConfigSpecForPlacement", func() {
 						}
 					})
 
-					// policies are ignored as cluster modules is used for VMs with capw labels
-					It("should ignore both host affinity and zone affinity policies", func() {
-						Expect(configSpec.VmPlacementPolicies).To(HaveLen(0))
-						assertVMTags(configSpec, []string{}, vmCtx.VM.Namespace)
+					// Host affinity is ignored as cluster modules is used for VMs with
+					// capw labels, but zone affinity still applies since the VM has no
+					// zone label pinning it to a zone already.
+					It("should ignore host affinity policies but keep zone affinity policies", func() {
+						pols := []vimtypes.BaseVmPlacementPolicy{
+							&vimtypes.VmVmAffinity{
+								AffinedVmsTag: vimtypes.TagId{
+									NameId: &vimtypes.TagIdNameId{
+										Tag:      "env:prod",
+										Category: vmCtx.VM.Namespace,
+									},
+								},
+								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
+								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyVSphereZone),
+							},
+							&vimtypes.VmToVmGroupsAntiAffinity{
+								AntiAffinedVmGroupTags: []vimtypes.TagId{
+									{
+										NameId: &vimtypes.TagIdNameId{
+											Tag:      "env:dev",
+											Category: vmCtx.VM.Namespace,
+										},
+									},
+								},
+								PolicyStrictness: string(vimtypes.VmPlacementPolicyVmPlacementPolicyStrictnessRequiredDuringPlacementPreferredDuringExecution),
+								PolicyTopology:   string(vimtypes.VmPlacementPolicyVmPlacementPolicyTopologyVSphereZone),
+							},
+						}
+
+						Expect(configSpec.VmPlacementPolicies).To(HaveLen(2))
+						Expect(configSpec.VmPlacementPolicies).To(ConsistOf(pols))
+						assertVMTags(configSpec, []string{"env:prod"}, vmCtx.VM.Namespace)
 					})
 				})
 			})
@@ -2197,7 +2253,7 @@ var _ = Describe("CalculateAffinityConstraints", func() {
 				}
 			})
 
-			It("should disable both host and zone rules when VMAffinityDuringExecution is enabled", func() {
+			It("should disable host rules but allow zone rules when it has no zone label", func() {
 				pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
 					config.Features.VMPlacementPolicies = true
 					config.Features.VMAffinityDuringExecution = true
@@ -2205,10 +2261,10 @@ var _ = Describe("CalculateAffinityConstraints", func() {
 
 				constraints := virtualmachine.CalculateAffinityConstraints(vmCtx, false)
 				Expect(constraints.ConfigureHostRules).To(BeFalse(), "VKS node VMs should disable host rules")
-				Expect(constraints.ConfigureZoneRules).To(BeFalse(), "VKS node VMs should never get zonal policies")
+				Expect(constraints.ConfigureZoneRules).To(BeTrue(), "VKS node VMs without a zone label are not yet zone-constrained")
 			})
 
-			It("should ignore zone rules even when VMPlacementPolicies is enabled", func() {
+			It("should allow zone rules when VMPlacementPolicies is enabled and VMAffinityDuringExecution is disabled", func() {
 				pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
 					config.Features.VMPlacementPolicies = true
 					config.Features.VMAffinityDuringExecution = false
@@ -2216,7 +2272,35 @@ var _ = Describe("CalculateAffinityConstraints", func() {
 
 				constraints := virtualmachine.CalculateAffinityConstraints(vmCtx, false)
 				Expect(constraints.ConfigureHostRules).To(BeFalse())
-				Expect(constraints.ConfigureZoneRules).To(BeFalse(), "VKS node VMs should never get zonal policies")
+				Expect(constraints.ConfigureZoneRules).To(BeTrue(), "VKS node VMs without a zone label are not yet zone-constrained")
+			})
+
+			When("the VM also has a zone label", func() {
+				BeforeEach(func() {
+					vm.Labels[corev1.LabelTopologyZone] = "zone-a"
+				})
+
+				It("should disable both host and zone rules when VMAffinityDuringExecution is enabled", func() {
+					pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
+						config.Features.VMPlacementPolicies = true
+						config.Features.VMAffinityDuringExecution = true
+					})
+
+					constraints := virtualmachine.CalculateAffinityConstraints(vmCtx, false)
+					Expect(constraints.ConfigureHostRules).To(BeFalse(), "VKS node VMs should disable host rules")
+					Expect(constraints.ConfigureZoneRules).To(BeFalse(), "zone-labeled VKS node VMs are already zone-constrained")
+				})
+
+				It("should disable zone rules even when VMAffinityDuringExecution is disabled", func() {
+					pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
+						config.Features.VMPlacementPolicies = true
+						config.Features.VMAffinityDuringExecution = false
+					})
+
+					constraints := virtualmachine.CalculateAffinityConstraints(vmCtx, false)
+					Expect(constraints.ConfigureHostRules).To(BeFalse())
+					Expect(constraints.ConfigureZoneRules).To(BeFalse(), "zone-labeled VKS node VMs are already zone-constrained")
+				})
 			})
 		})
 
@@ -2295,10 +2379,22 @@ var _ = Describe("CalculateAffinityConstraints", func() {
 				})
 			})
 
-			It("should disable both host and zone rules", func() {
+			It("should disable host rules but allow zone rules when it has no zone label", func() {
 				constraints := virtualmachine.CalculateAffinityConstraints(vmCtx, false)
 				Expect(constraints.ConfigureHostRules).To(BeFalse(), "VKS nodes should disable host rules")
-				Expect(constraints.ConfigureZoneRules).To(BeFalse(), "VKS nodes should never get zonal policies")
+				Expect(constraints.ConfigureZoneRules).To(BeTrue(), "VKS nodes without a zone label are not yet zone-constrained")
+			})
+
+			When("the VM also has a zone label", func() {
+				BeforeEach(func() {
+					vm.Labels[corev1.LabelTopologyZone] = "zone-a"
+				})
+
+				It("should disable both host and zone rules", func() {
+					constraints := virtualmachine.CalculateAffinityConstraints(vmCtx, false)
+					Expect(constraints.ConfigureHostRules).To(BeFalse(), "VKS nodes should disable host rules")
+					Expect(constraints.ConfigureZoneRules).To(BeFalse(), "zone-labeled VKS nodes are already zone-constrained")
+				})
 			})
 		})
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
Crossport of
- https://github.com/vmware-tanzu/vm-operator/pull/1706

Fixes zonal affinity policies for capv nodes during VM placement.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #

Testing: E2E success

**Are there any special notes for your reviewer**:

**Please add a release note if necessary**:
```release-note
NA
```