### PR TITLE
❇️  Distro-less: Adopt minimal Photon bottom-up image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,38 @@
 ARG BASE_IMAGE=mirror.gcr.io/library/photon:5.0
 
-# Copy the controller-manager into a thin image
-FROM ${BASE_IMAGE}
-
 ## --------------------------------------
-## Cleanup (Distroless image)
+## Build a minimal root filesystem (bottom-up)
 ## --------------------------------------
 
-RUN tdnf makecache && tdnf -y update && \
-    rm /etc/tdnf/protected.d/tdnf.conf && tdnf -y autoremove photon-repos tdnf && \
-    rm -rf /var/cache/tdnf /usr/lib/{rpm,tdnf} /usr/lib/sysimage/{rpm,tdnf} /etc/{rpm,tdnf}
+FROM ${BASE_IMAGE} AS installer
+
+# Install just the FHS layout and the CA trust bundle by extracting the RPM
+# payloads directly (--nodeps --downloadonly + rpm2cpio). A normal `tdnf
+# install ca-certificates` pulls in bash/coreutils/glibc via the package's
+# postinstall scriptlet; ca-certificates-pki ships the pre-built bundle with
+# no scriptlet and no dependencies, which is all the static manager binary
+# needs for its system cert pool.
+RUN tdnf makecache && \
+    tdnf install -y rpm && \
+    mkdir /download && \
+    tdnf install -y --nodeps --downloadonly --downloaddir=/download \
+        --releasever=5.0 filesystem ca-certificates-pki && \
+    mkdir /installroot && \
+    cd /installroot && \
+    for f in /download/*.rpm; do rpm2cpio "$f" | cpio -idmu; done
+
+## --------------------------------------
+## Copy the controller-manager into a thin image
+## --------------------------------------
+
+FROM scratch
 
 ## --------------------------------------
 ## Environment variables
 ## --------------------------------------
 
+ARG TARGETOS
+ARG TARGETARCH
 ENV GOOS=${TARGETOS}
 ENV GOARCH=${TARGETARCH}
 
@@ -42,11 +60,20 @@ LABEL branch="${BUILD_BRANCH}" \
 
 
 ## --------------------------------------
+## Minimal root filesystem (CA bundle only, no tdnf/rpm/shell)
+## --------------------------------------
+
+COPY --from=installer /installroot /
+
+
+## --------------------------------------
 ## Copy the binaries from the builder
 ## --------------------------------------
 
 WORKDIR /
 COPY ./bin/manager .
 COPY ./bin/web-console-validator .
-USER nobody
+# No /etc/passwd on the image
+# we need to use UID instead of nobody
+USER 65534
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Replace the top-down cleanup (install tdnf/rpm into the final image, then autoremove and delete the caches) with a two-stage bottom-up build. An "installer" stage extracts only the filesystem and ca-certificates-pki RPM payloads directly via rpm2cpio, bypassing tdnf's dependency resolution and postinstall scriptlets, which otherwise pull in bash/coreutils/glibc for no benefit to a static binary. The final stage is FROM scratch and never contains tdnf, rpm, or a shell.

manager is built with CGO_ENABLED=0 and static linking, so the only runtime dependency is the CA trust bundle for crypto/x509's system cert pool; ca-certificates-pki ships that pre-built bundle with no scriptlet and no extra packages.

USER nobody is replaced with USER 65534 since a scratch image has no /etc/passwd to resolve the name against; this matches the numeric runAsUser/runAsGroup already pinned in
config/default/manager_security_context_patch.yaml, so no other manifest changes are required.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # vmop-3901


**Are there any special notes for your reviewer**:

This builds on the previous "distroless-style" Top Down approach implemented by #1616: with this PR, the Docker image no longer contains bash or any other lingering libraries.


**Please add a release note if necessary**:

```release-note
Docker images no longer contains bash or any other libraries.
```