### PR TITLE
🐛 Remove VM ownerref from detached PVCs on delete

### DIFF
--- a/.sdd/specs/002-rm-pvc-owner-ref/plan.md
+++ b/.sdd/specs/002-rm-pvc-owner-ref/plan.md
@@ -1,0 +1,118 @@
+# Implementation Plan: Remove PVC OwnerRef on Detach
+
+- **Spec**: [`spec.md`](./spec.md)
+- **Ticket**: bz-3734442
+- **Date**: 2026-07-08
+
+## Summary
+
+Before the `VirtualMachine` controller removes a VM's finalizer, it will list every `PersistentVolumeClaim` in the VM's namespace that carries an `OwnerReference` back to that VM, and — for any such PVC whose name is no longer present in `spec.volumes[].persistentVolumeClaim.claimName` — patch the PVC to strip that one `OwnerReference` entry, unless the PVC carries the `vmoperator.vmware.com/keep-owner-ref` annotation. This prevents Kubernetes' garbage collector from cascade-deleting a PVC that was detached from the VM before the VM itself was deleted, while still letting a user opt a specific PVC back into the old cascade-delete behavior.
+
+## Technical context
+
+- **Go version**: 1.26.4 (root `go.mod`)
+- **API version touched**: `v1alpha6` (current `vmopv1` alias per `.golangci.yml` `importas`) — read-only (`VirtualMachine.Spec.Volumes`); no CRD schema changes.
+- **Modules touched**: root module only (`github.com/vmware-tanzu/vm-operator`).
+- **Packages touched**:
+  - `pkg/constants/constants.go` — new `KeepOwnerRefAnnotationKey = "vmoperator.vmware.com/keep-owner-ref"` constant, following the existing `XxxAnnotationKey` convention (e.g. `NoUnmanagedVolumesRegisterAnnotationKey`).
+  - `pkg/util/kube/` — new file with the listing + patch logic (business logic, per constitution "thin controllers").
+  - `controllers/virtualmachine/virtualmachine/virtualmachine_controller.go` — call site in `ReconcileDelete`, new field-index registration in `AddToManager`, new RBAC marker.
+- **New dependencies**: none. `k8s.io/client-go/util/retry` is already an indirect dependency of `client-go` (already in `go.sum`) but is not currently imported anywhere in this repo; this plan introduces its first use for a standard `RetryOnConflict` patch loop. No `go.mod` change is required.
+
+## Constitution check
+
+| Rule | Status | Notes |
+|------|--------|-------|
+| API compatibility | OK | No API/CRD field changes; purely reads existing `spec.volumes`. |
+| Thin controllers | OK | Listing/filtering/patching logic lives in `pkg/util/kube/pvc.go`; the controller only calls one function from `ReconcileDelete`. |
+| No direct vSphere calls from controllers | OK | This is a pure Kubernetes-object operation; no provider/vSphere involvement. |
+| Field indexer for filtered List calls | OK | A new field index on `PersistentVolumeClaim` (owner-ref VM UID) is added so the list is server-side filtered, matching the existing pattern in `volumebatch_controller.go` (`spec.nodeuuid`, `spec.volumes.persistentVolumeClaim.claimName`). |
+| RBAC markers documented above Reconcile | OK | New `persistentvolumeclaims` marker added to `virtualmachine_controller.go`; `config/rbac` regenerated via `make generate-manifests`. |
+| Level-triggered / idempotent reconciliation | OK | The cleanup re-derives "detached" from current state (`spec.volumes` vs. live `OwnerReferences`) on every call; patching is a no-op if the OwnerRef is already gone. |
+| Testing standards | OK | Unit coverage in `pkg/util/kube/pvc_test.go` (external `_test` package, Ginkgo/Gomega, `testlabels`) and in `virtualmachine_controller_test.go`'s existing `ReconcileDelete` `Describe`. |
+| E2E sync with changes | Applies | This is cluster-observable VM-deletion behavior; E2E coverage required in the same PR — see "Test strategy." |
+
+No constitutional rule needs to be bent; no Complexity tracking entry is required.
+
+## Project structure
+
+```
+pkg/constants/
+  constants.go                        # MODIFIED: new KeepOwnerRefAnnotationKey constant
+
+pkg/util/kube/
+  pvc.go                              # NEW: field-index key, index registration, RemoveStaleVMOwnerRefFromPVCs
+  pvc_test.go                         # NEW: unit tests (fake client, external _test package)
+
+controllers/virtualmachine/virtualmachine/
+  virtualmachine_controller.go        # MODIFIED: AddToManager registers the new field index;
+                                       #           ReconcileDelete calls kubeutil.RemoveStaleVMOwnerRefFromPVCs
+                                       #           before RemoveFinalizer; new RBAC marker added
+  virtualmachine_controller_test.go   # MODIFIED: new ReconcileDelete scenarios (see Test strategy)
+
+config/rbac/                          # REGENERATED via `make generate-manifests`
+
+test/e2e/vmservice/virtualmachine/     # MODIFIED: new scenario for detach-then-delete (see Test strategy)
+```
+
+## API / CRD strategy
+
+Not applicable — no CRD, field, or status-condition changes. `VirtualMachineVolume` / `PersistentVolumeClaimVolumeSource` (`api/v1alpha6/virtualmachine_storage_types.go:71-245`) are read-only inputs to this feature.
+
+## Controller / webhook impact
+
+### `pkg/util/kube/pvc.go` (new)
+
+Two exported functions, following the existing filter-and-`SetOwnerReferences` pattern already used in `pkg/util/vmopv1/vmgroup.go:365-399` (`RemoveStaleGroupOwnerRef`) and the field-indexer pattern in `controllers/virtualmachine/volumebatch/volumebatch_controller.go:73-100`:
+
+- `const PVCOwnerRefVMUIDIndexKey = "metadata.ownerReferences.vmUID"` — the field-index name, exported so the controller's `AddToManager` and this package's `List` call agree on it.
+- `IndexPVCByVMOwnerRef(ctx context.Context, mgr ctrlmgr.Manager) error` — registers a field index on `corev1.PersistentVolumeClaim`, extracting the `UID` of any `OwnerReference` whose `Kind == "VirtualMachine"` and `APIVersion == vmopv1.GroupVersion.String()`. Called once from the `VirtualMachine` controller's `AddToManager`.
+- `RemoveStaleVMOwnerRefFromPVCs(ctx context.Context, c ctrlclient.Client, vm *vmopv1.VirtualMachine) error`:
+  1. `client.List` PVCs with `ctrlclient.InNamespace(vm.Namespace)` + `ctrlclient.MatchingFields{PVCOwnerRefVMUIDIndexKey: string(vm.UID)}`.
+  2. Returns immediately if the list is empty (no PVCs owned by this VM — the common case for a VM with no unmanaged disks).
+  3. Builds a `sets.Set[string]` of currently attached claim names from `vm.Spec.Volumes[].PersistentVolumeClaim.ClaimName`.
+  4. For every listed PVC **not** in that set, calls an unexported `removeVMOwnerRef` helper that:
+     - Re-`Get`s the PVC (avoids acting on a possibly-stale list entry).
+     - Checks `pkgconst.KeepOwnerRefAnnotationKey` via `_, ok := pvc.Annotations[pkgconst.KeepOwnerRefAnnotationKey]` — presence-only, value never inspected (US4). If present, returns `nil` immediately without patching.
+     - Filters `OwnerReferences` to drop the entry matching `vm.UID` (and `Kind == "VirtualMachine"`), leaving every other entry untouched (US3).
+     - No-ops (returns `nil` without a network call) if nothing changed.
+     - Otherwise patches via `ctrlclient.MergeFrom` inside `retry.RetryOnConflict` (`k8s.io/client-go/util/retry`), and treats `apierrors.IsNotFound` as success (PVC already gone).
+  5. Aggregates any real errors with `k8s.io/apimachinery/pkg/util/errors.NewAggregate` and returns them; one failing PVC does not stop the others from being processed.
+
+The annotation check happens on the freshly-`Get`'d PVC (not the stale list entry), so a user adding/removing the annotation concurrently with the delete reconcile is resolved consistently with the rest of the level-triggered design (edge case in `spec.md`).
+
+### `controllers/virtualmachine/virtualmachine/virtualmachine_controller.go`
+
+- **`AddToManager`**: add a call to `kubeutil.IndexPVCByVMOwnerRef(ctx, mgr)` alongside any existing index registrations for this controller.
+- **RBAC**: add `// +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;patch` near the existing markers (line ~302-314). The controller currently has **no** PVC permissions at all — confirmed via `grep kubebuilder:rbac` — unlike `controllers/virtualmachine/volume/volume_controller.go:227` and `volumebatch_controller.go`, which already have broader PVC verbs for a different purpose. Run `make generate-manifests` to regenerate `config/rbac/role.yaml`.
+- **`ReconcileDelete`** (currently lines 488-548): insert a call to `kubeutil.RemoveStaleVMOwnerRefFromPVCs(ctx, r.Client, ctx.VM)` immediately before the two `controllerutil.RemoveFinalizer` calls at lines 538-539, **outside/after** the `if pkgconst.SkipDeletePlatformResourceKey ... else ...` branch (lines 510-536) — i.e. it runs unconditionally whenever the finalizer is about to be removed, whether the vCenter VM was actually deleted or merely unregistered/skipped. This matches the spec's edge case that the Kubernetes-side cascade-delete risk is independent of what happened on the vSphere side. If this call returns an error, propagate it and do **not** remove the finalizer — the existing deferred-patch-and-return pattern in `Reconcile` already handles that correctly, and retrying on the next reconcile is safe (idempotent).
+
+No other controller, webhook, or provider changes. `controllers/virtualmachine/volume/volume_controller.go` and `controllers/virtualmachine/volumebatch/volumebatch_controller.go` are unaffected — their `ReconcileDelete` no-ops (relying on GC for `CnsNodeVmAttachment`/`CnsNodeVMBatchAttachment`) are correct as-is and out of scope.
+
+## Test strategy
+
+- **Unit — `pkg/util/kube/pvc_test.go`** (`Label(testlabels.Controller)`, fake `ctrlclient.Client`, external `_test` package):
+  - PVC with matching OwnerRef, name absent from `spec.volumes` → OwnerRef removed, PVC otherwise unchanged.
+  - PVC with matching OwnerRef, name present in `spec.volumes` → no patch issued.
+  - PVC with two OwnerReferences (VM + unrelated) → only the VM's entry removed (US3).
+  - No PVCs indexed for this VM → function returns `nil` without listing errors.
+  - PVC deleted between `List` and `Get` → tolerated, no error returned.
+  - Patch conflict on first attempt, succeeds on retry → end state correct, `RetryOnConflict` exercised.
+  - Detached PVC carries `pkgconst.KeepOwnerRefAnnotationKey` (US4) → OwnerRef left intact, no patch issued.
+  - Detached PVC carries the annotation with an empty-string value → still opted out (value is never inspected).
+- **Unit — `virtualmachine_controller_test.go`** (existing `ReconcileDelete` `Describe`, `testlabels.Controller` + `testlabels.EnvTest` for the integration variant):
+  - Extend with a fake-provider scenario: VM with an attached and a detached unmanaged-disk PVC; after `ReconcileDelete`, assert the detached PVC's `OwnerReferences` no longer contains the VM and the attached PVC's does.
+  - Assert the `SkipDeletePlatformResourceKey` (unregister) path also triggers OwnerRef cleanup.
+  - Extend with a third PVC that is detached but carries `pkgconst.KeepOwnerRefAnnotationKey`; assert its OwnerRef survives `ReconcileDelete` alongside the attached PVC's.
+- **Integration (envtest)**: extend the controller's existing `intgTestsReconcile` to cover the same detach/attach scenario against a real API server, confirming the patch persists, plus a detached-but-annotated PVC that keeps its OwnerRef. Note: `envtest` does not run the upstream garbage-collector controller by default, so this layer verifies the `OwnerReferences` mutation itself, not the resulting cascade-delete (or lack thereof) — that is proven at the E2E layer.
+- **E2E (mandatory per `e2e-sync-with-changes.md`)** — extend `test/e2e/vmservice/virtualmachine/`: deploy a VM Service VM from a multi-disk VMI, wait for both disks to register as PVCs with the VM's OwnerRef, remove the second disk's entry from `spec.volumes`, delete the VM, and assert: the vSphere VM is gone, the first (still-attached) PVC is garbage-collected, and the second (detached) PVC still exists with no OwnerRef to the deleted VM. Where practical, cover the opt-out annotation in the same or a sibling scenario: annotate a detached PVC with `vmoperator.vmware.com/keep-owner-ref` and assert it is garbage-collected along with the VM instead of surviving.
+
+## Rollout / migration
+
+- **No feature flag.** This is a bug fix that only ever *prevents* an erroneous deletion; it never causes a PVC to be deleted that wouldn't have been deleted before. There is no rollback scenario where reverting to the old (always-delete) behavior is preferable, so gating this behind `pkgcfg.Features.*` would add operational complexity without a corresponding safety benefit.
+- **No schema/backfill migration.** The fix only affects the OwnerRef state evaluated at the moment a VM is deleted going forward; PVCs already lost to the pre-fix cascade-delete are not recoverable and are explicitly out of scope (see spec).
+- **Partner comms**: release note should mention the corrected behavior, since a partner who was relying on "detach + delete VM" to fully clean up a disk will see a behavior change (the PVC now survives and must be deleted explicitly). The release note should also document the `vmoperator.vmware.com/keep-owner-ref` annotation as the escape hatch back to the old per-PVC behavior.
+
+## Complexity tracking
+
+Not applicable — no constitutional rule is bent by this change.

--- a/.sdd/specs/002-rm-pvc-owner-ref/spec.md
+++ b/.sdd/specs/002-rm-pvc-owner-ref/spec.md
@@ -1,0 +1,189 @@
+# Feature Specification: Remove PVC OwnerRef on Detach
+
+- **Feature branch**: [`feature/rm-pvc-owner-ref`](https://github.com/akutz/vm-operator/tree/feature/rm-pvc-owner-ref/)
+  - **Fork**: `akutz/vm-operator`
+  - **PR target**: `vmware-tanzu/vm-operator`
+- **Created**: 2026-07-08
+- **Status**: Implementation
+- **Ticket**: bz-3734442
+
+---
+
+## Summary
+
+When deleting a traditional vSphere VM, only its attached disks are deleted along with the VM. For example, imagine the following scenarios:
+
+1. User creates traditional vSphere VM with two disks at `/vmfs/volumes/my-datastore-1/my-vm/disk-1.vmdk` and `/vmfs/volumes/my-datastore-1/my-vm/disk-2.vmdk`
+2. The VM is deleted.
+3. The directory `/vmfs/volumes/my-datastore-1/my-vm/` is removed from the datastore, along with the VM's two disks.
+
+Now, a spin on the above scenario:
+
+1. User creates traditional vSphere VM with two disks at `/vmfs/volumes/my-datastore-1/my-vm/disk-1.vmdk` and `/vmfs/volumes/my-datastore-1/my-vm/disk-2.vmdk`
+2. The second disk is detached.
+3. The VM is deleted.
+4. The directory `/vmfs/volumes/my-datastore-1/my-vm/` is still present, but the only file remaining in the directory is the second disk, i.e. `/vmfs/volumes/my-datastore-1/my-vm/disk-2.vmdk`.
+
+Whenever VM Operator registers an unmanaged disk as a PVC, VM Operator ensures there is an OwnerRef set on that PVC that points back to the VM. That way if the VM is deleted, the PVC object gets cleaned up as well by Kubernetes' built-in garbage collection. However, currently this OwnerRef remains even if the PVC is later detached from the VM. This can result in the following scenario:
+
+1. User creates VM Service VM from VMI that has two disks in it.
+2. VM Operator creates the new VM and eventually registers the two, unmanaged disks as PVCs, placing OwnerRefs on each disk to ensure that when the Kubernetes VM object is deleted, the PVCs are cleaned up as well.
+3. The user detaches the second disk from the VM by removing its entry from `spec.volumes`.
+4. The user deletes the VM.
+5. VM Operator destroys the underlying vSphere VM.
+6. Because the PVCs have OwnerRefs that point to the VM that was deleted, they are both deleted as well, even the one that was detached from the VM at the time it was deleted.
+
+Because the above scenario is *not* what happens to a traditional vSphere VM, it needs to be corrected.
+
+
+---
+
+## Reconciliation pipeline
+
+1. The VM controller reconciles a VM.
+2. If the VM has a deletion timestamp, the logic reconciles a VM to-be-destroyed.
+3. Prior to removing the VM's finalizer, the logic finds all PVCs:
+    1. Are in the same namespace as the VM
+    2. Have an OwnerRef that point back to the VM
+4. For each PVC in the above list:
+    1. Check if the name of the PVC exists in the list of the currently attached volumes via `spec.volumes[].persistentVolumeClaim.claimName`.
+    2. If the PVC is not currently attached to the VM:
+        1. Check if the PVC carries the `vmoperator.vmware.com/keep-owner-ref` annotation. If present, leave the OwnerRef intact and move on to the next PVC.
+        2. Otherwise, patch the PVC object to remove the VM's OwnerRef from the PVC.
+
+A user may set the `vmoperator.vmware.com/keep-owner-ref` annotation directly on a PVC to opt that specific PVC out of this cleanup — for example, when they intend to reattach it later and still want it garbage-collected with the VM if they never do. The annotation is presence-based: its value is never inspected, only whether the key exists on the PVC at the moment this cleanup runs.
+
+This cleanup runs **once, immediately before the VM's finalizer is removed** — not the moment a volume is detached from a running VM. Removing a volume from `spec.volumes` while the VM is still alive does not, by itself, touch the PVC's OwnerRef; the OwnerRef is only re-evaluated at VM-deletion time, right before the object (and Kubernetes' built-in garbage collection) would otherwise cascade-delete every PVC that still lists the VM as an owner. This keeps the fix isolated to the one moment where an incorrect OwnerRef causes data loss, and avoids adding a per-reconcile cost to the volume controllers for a condition that only matters at deletion.
+
+### Diagram
+
+```mermaid
+flowchart TD
+    A[VM controller Reconcile] --> B{"DeletionTimestamp set?"}
+    B -- No --> Z[ReconcileNormal\nno OwnerRef changes]
+    B -- Yes --> C[ReconcileDelete]
+    C --> D{"Finalizer present?"}
+    D -- No --> Y[Nothing to do]
+    D -- Yes --> E["Delete/cleanup vCenter VM\n(VMProvider)"]
+    E --> F["List PVCs in VM's namespace\nwith an OwnerRef -> this VM"]
+    F --> G{"Any owned PVCs found?"}
+    G -- No --> K[Remove VM finalizer]
+    G -- Yes --> H[For each owned PVC]
+    H --> I{"PVC name in\nspec.volumes[].persistentVolumeClaim.claimName?"}
+    I -- "Yes (attached)" --> J["Leave OwnerRef intact\n(GC deletes PVC with VM)"]
+    I -- "No (detached)" --> O{"PVC has\nvmoperator.vmware.com/keep-owner-ref\nannotation?"}
+    O -- "Yes (opt-out)" --> J
+    O -- "No" --> L["Patch PVC:\nremove this VM's OwnerRef entry"]
+    J --> H
+    L --> H
+    H -.every PVC processed.-> K
+    K --> M[API server finishes deleting VM object]
+    M --> N["Kubernetes GC cascade-deletes\nonly the still-owned PVCs"]
+```
+
+---
+
+## User stories
+
+### US1 — DevOps user: a detached disk survives VM deletion (Priority: P1)
+
+A DevOps user removes a disk from a VM's `spec.volumes` before deleting the VM. When the VM is later deleted, the disk's PVC is not deleted along with it — matching how a traditional vSphere VM behaves when a disk is detached before the VM is destroyed.
+
+**Why P1**: This is the core bug. Without it, detaching a disk provides no real protection against data loss; the disk is still destroyed the moment the VM is deleted.
+
+**Independent test**: Create a VM with two disks registered as PVCs, remove the second disk's entry from `spec.volumes`, delete the VM, and confirm the second PVC still exists (and no longer carries the VM's OwnerRef) after the VM object is gone.
+
+**Acceptance scenarios**:
+
+1. **Given** a VM with two unmanaged-disk PVCs both OwnerRef'd to the VM, **when** the second PVC's `claimName` is removed from `spec.volumes` and the VM is subsequently deleted, **then** the second PVC still exists after the VM is removed and no longer has an OwnerRef pointing to the VM.
+2. **Given** a PVC's OwnerRef was removed because it was detached, **when** no further action is taken, **then** the PVC is otherwise unmodified (same `spec`, same data, same other OwnerReferences if any).
+3. **Given** a VM has no PVCs with an OwnerRef pointing back to it, **when** the VM is deleted, **then** the reconcile completes without listing or patching any PVCs beyond the (empty) lookup.
+
+---
+
+### US2 — DevOps user: an attached disk is still cleaned up when the VM is deleted (Priority: P1)
+
+A DevOps user deletes a VM whose disks are still attached. Those disks' PVCs are deleted along with the VM, exactly as they were before this change — this fix must not weaken existing cleanup for the common case.
+
+**Why P1**: Regression protection. The fix only has value if it is strictly additive — it must never leave behind a PVC that legitimately should be garbage-collected.
+
+**Independent test**: Create a VM with two unmanaged-disk PVCs, delete the VM without detaching anything, and confirm both PVCs are gone once Kubernetes garbage collection completes.
+
+**Acceptance scenarios**:
+
+1. **Given** a VM with N unmanaged-disk PVCs, all still listed in `spec.volumes`, **when** the VM is deleted, **then** the OwnerRef on every one of the N PVCs is left intact and all N PVCs are garbage-collected once the VM object is removed.
+2. **Given** a VM with one attached and one detached unmanaged-disk PVC, **when** the VM is deleted, **then** only the detached PVC's OwnerRef is removed; the attached PVC's OwnerRef — and its eventual cascade deletion — is unaffected.
+
+---
+
+### US3 — Platform engineer: OwnerRef removal is scoped to this VM only (Priority: P2)
+
+A PVC may end up with OwnerReferences to more than one object over its lifetime (for example, if it is re-registered, or if another controller also references it). Removing the detached VM's OwnerRef must not disturb any other entries in `OwnerReferences`, and must be safe to run repeatedly.
+
+**Why P2**: Safety guarantee. An implementation that overwrites the whole `OwnerReferences` list instead of surgically removing one entry risks corrupting unrelated ownership relationships.
+
+**Independent test**: Add a second, unrelated OwnerReference to a detached PVC alongside the VM's OwnerRef, delete the VM, and confirm only the VM's entry is gone while the unrelated entry remains.
+
+**Acceptance scenarios**:
+
+1. **Given** a detached PVC has two OwnerReferences — one to the VM and one to an unrelated object, **when** the VM is deleted, **then** only the VM's OwnerReference entry is removed from `PVC.metadata.ownerReferences`; the unrelated entry is untouched.
+2. **Given** the patch to remove a VM's OwnerRef from a PVC is retried after a transient conflict, **when** the retry succeeds, **then** the end state is identical to a single successful patch (the operation is idempotent).
+3. **Given** a PVC no longer exists by the time the reconcile attempts to patch it (already deleted independently), **when** the reconcile processes that PVC, **then** the reconcile does not fail because of that one missing PVC and continues processing the remaining PVCs.
+
+---
+
+### US4 — DevOps user: opt a specific detached PVC out of OwnerRef removal (Priority: P2)
+
+A DevOps user wants a particular PVC to remain bound to its VM's lifecycle even though it is currently detached — for example, they plan to reattach it later and, until then, still want it garbage-collected along with the VM rather than survive indefinitely as an orphan. Setting the `vmoperator.vmware.com/keep-owner-ref` annotation on that PVC opts it out of the cleanup described in US1.
+
+**Why P2**: Escape hatch. The new default (detached PVCs survive) is correct for most users, but not universally desired for every PVC; this gives users an explicit, per-PVC override.
+
+**Independent test**: Detach a PVC from a VM, add the `vmoperator.vmware.com/keep-owner-ref` annotation to the PVC, delete the VM, and confirm the PVC's OwnerRef is still present and the PVC is garbage-collected along with the VM.
+
+**Acceptance scenarios**:
+
+1. **Given** a detached PVC carries the `vmoperator.vmware.com/keep-owner-ref` annotation, **when** the VM is deleted, **then** the PVC's OwnerRef is left intact and the PVC is garbage-collected along with the VM, exactly as if it had still been attached.
+2. **Given** a detached PVC does not carry the annotation, **when** the VM is deleted, **then** behavior is unchanged from US1 — the OwnerRef is removed.
+3. **Given** the annotation is present with an empty string value (or any other value), **when** the VM is deleted, **then** the PVC is still treated as opted out — only the annotation key's presence is checked, never its value.
+4. **Given** the annotation is present on a PVC that is still attached to the VM, **when** the VM is deleted, **then** it has no observable effect, since that PVC's OwnerRef would not have been removed anyway.
+
+---
+
+## Edge cases
+
+- A PVC has more than one `OwnerReference` (e.g., the VM plus something else). Only the VM's specific entry is removed; the rest of `OwnerReferences` is preserved unchanged.
+- A PVC is concurrently deleted (e.g., by a user) between being listed and being patched. The reconcile tolerates the `NotFound` error for that PVC and continues with the rest.
+- A patch to remove the OwnerRef hits a resource-version conflict (concurrent update to the same PVC). The reconcile retries the patch rather than failing the whole VM deletion.
+- A VM is deleted while it has zero PVCs with an OwnerRef pointing back to it (e.g., a VM that never had unmanaged disks). The lookup returns an empty list and no patches are attempted.
+- A VM is deleted via the "unregister" path (`pkgconst.SkipDeletePlatformResourceKey`, which skips destroying the underlying vSphere VM). The OwnerRef cleanup still runs before the finalizer is removed, because the Kubernetes-side cascade-delete risk exists regardless of whether the vSphere VM itself is destroyed or merely unregistered.
+- A PVC also carries `spec.dataSourceRef` pointing back to the VM (a second, independent "pointer to the VM" set at PVC-registration time). `spec.dataSourceRef` is immutable once set on a `PersistentVolumeClaim`, so it cannot be cleared after creation; it does not participate in Kubernetes garbage collection and is out of scope for this change — see "Out of scope."
+- Instance-storage-backed volumes (`VirtualMachineVolume.PersistentVolumeClaim.InstanceVolumeClaim`) are not a practical concern: the validating webhook rejects any attempt by a non-privileged (SSO) user to remove, add, or modify an instance-storage volume on an existing VM (`addingModifyingInstanceVolumesNotAllowed`). For ordinary DevOps users, an instance-storage PVC's `claimName` therefore never disappears from `spec.volumes` while the VM exists, so this cleanup never treats it as detached. Only a privileged/service account could remove one and trigger OwnerRef cleanup on it; that is an accepted, narrow consequence and not a reason to special-case instance storage in this feature.
+- The `vmoperator.vmware.com/keep-owner-ref` annotation is presence-based: any value (including an empty string) opts the PVC out of removal; the value is never parsed or validated.
+- The annotation lives on the PVC, not the VM — it protects that specific PVC regardless of which VM currently owns it, and has no effect on any other PVC.
+- The annotation is evaluated fresh each time this cleanup runs (immediately before finalizer removal), not cached from an earlier reconcile. A user may add or remove it at any point before VM deletion; only its state at that moment matters.
+- Adding the annotation to a PVC that is still attached has no effect, since an attached PVC's OwnerRef is never a removal candidate in the first place.
+
+---
+
+## Out of scope
+
+- Removing a PVC's OwnerRef the moment a volume is detached from a running VM. Cleanup only happens once, at VM-deletion time, immediately before the finalizer is removed (see "Reconciliation pipeline").
+- Clearing or otherwise modifying `PVC.spec.dataSourceRef`, which also points back to the VM for unmanaged-disk PVCs but is immutable once set and does not affect Kubernetes garbage collection.
+- Any change to how the OwnerRef is *set* on PVC creation/registration (`pkg/vmconfig/volumes/unmanaged/register`), including whether it sets `Controller` or `BlockOwnerDeletion`.
+- Any change to `CnsNodeVmAttachment` / `CnsNodeVMBatchAttachment` OwnerRef or deletion behavior; those objects are intentionally left to Kubernetes garbage collection and are unaffected by this change.
+- Backfilling or correcting PVCs that were already deleted by the pre-fix cascade-delete behavior before this change ships.
+
+---
+
+## Review & acceptance checklist
+
+- [ ] Both user stories (detached-disk survives, attached-disk still cleaned up) have at least two Given/When/Then scenarios.
+- [ ] Each scenario is independently testable.
+- [ ] The reconciliation pipeline states exactly when the OwnerRef check runs (once, before finalizer removal) and not on every detach.
+- [ ] Partial-owner-reference removal (multiple OwnerReferences on one PVC) is specified.
+- [ ] Failure modes (PVC not found, patch conflict) are specified and do not block VM deletion.
+- [ ] The `dataSourceRef` distinction is called out explicitly as out of scope (immutable once set).
+- [ ] The instance-storage interaction is resolved (webhook already prevents non-privileged removal) rather than left open.
+- [ ] The `vmoperator.vmware.com/keep-owner-ref` opt-out annotation is specified, including its presence-based (value-agnostic), PVC-scoped, evaluated-at-cleanup-time semantics.
+- [ ] Out-of-scope items are listed.
+

--- a/controllers/virtualmachine/virtualmachine/virtualmachine_controller.go
+++ b/controllers/virtualmachine/virtualmachine/virtualmachine_controller.go
@@ -80,6 +80,13 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		return err
 	}
 
+	// Index PersistentVolumeClaims by any VirtualMachine OwnerReference's
+	// UID so ReconcileDelete can efficiently find the PVCs owned by a VM
+	// being deleted.
+	if err := kubeutil.IndexPVCByVMOwnerRef(ctx, mgr); err != nil {
+		return err
+	}
+
 	r := NewReconciler(
 		ctx,
 		mgr.GetClient(),
@@ -313,6 +320,7 @@ type Reconciler struct {
 // +kubebuilder:rbac:groups="events.k8s.io",resources=events,verbs=create;update;patch
 // +kubebuilder:rbac:groups="",resources=resourcequotas;namespaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups=encryption.vmware.com,resources=encryptionclasses,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;patch
 
 // Reconcile the object.
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
@@ -535,6 +543,17 @@ func (r *Reconciler) ReconcileDelete(ctx *pkgctx.VirtualMachineContext) (reterr 
 			if err := r.VMProvider.DeleteVirtualMachine(ctx, ctx.VM); err != nil {
 				return err
 			}
+		}
+
+		// Remove this VM's OwnerRef from any PVC that is no longer attached
+		// to it. Without this, Kubernetes garbage collection would delete
+		// every PVC still OwnerRef'd to the VM once the finalizer below is
+		// removed, even PVCs whose disks were detached from the VM prior to
+		// deletion. This runs regardless of whether the underlying vCenter
+		// VM was deleted or merely unregistered above, since the Kubernetes
+		// cascade-delete risk exists either way.
+		if err := kubeutil.RemoveStaleVMOwnerRefFromPVCs(ctx, r.Client, ctx.VM); err != nil {
+			return fmt.Errorf("failed to remove stale pvc owner refs: %w", err)
 		}
 
 		controllerutil.RemoveFinalizer(ctx.VM, finalizerName)

--- a/controllers/virtualmachine/virtualmachine/virtualmachine_controller.go
+++ b/controllers/virtualmachine/virtualmachine/virtualmachine_controller.go
@@ -88,6 +88,13 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		return err
 	}
 
+	// Index PersistentVolumeClaims by any VirtualMachine OwnerReference's
+	// UID so ReconcileDelete can efficiently find the PVCs owned by a VM
+	// being deleted.
+	if err := kubeutil.IndexPVCByVMOwnerRef(ctx, mgr); err != nil {
+		return err
+	}
+
 	r := NewReconciler(
 		ctx,
 		mgr.GetClient(),
@@ -334,6 +341,7 @@ type Reconciler struct {
 // +kubebuilder:rbac:groups="events.k8s.io",resources=events,verbs=create;update;patch
 // +kubebuilder:rbac:groups="",resources=resourcequotas;namespaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups=encryption.vmware.com,resources=encryptionclasses,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;patch
 
 // Reconcile the object.
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
@@ -556,6 +564,17 @@ func (r *Reconciler) ReconcileDelete(ctx *pkgctx.VirtualMachineContext) (reterr 
 			if err := r.VMProvider.DeleteVirtualMachine(ctx, ctx.VM); err != nil {
 				return err
 			}
+		}
+
+		// Remove this VM's OwnerRef from any PVC that is no longer attached
+		// to it. Without this, Kubernetes garbage collection would delete
+		// every PVC still OwnerRef'd to the VM once the finalizer below is
+		// removed, even PVCs whose disks were detached from the VM prior to
+		// deletion. This runs regardless of whether the underlying vCenter
+		// VM was deleted or merely unregistered above, since the Kubernetes
+		// cascade-delete risk exists either way.
+		if err := kubeutil.RemoveStaleVMOwnerRefFromPVCs(ctx, r.Client, ctx.VM); err != nil {
+			return fmt.Errorf("failed to remove stale pvc owner refs: %w", err)
 		}
 
 		controllerutil.RemoveFinalizer(ctx.VM, finalizerName)

--- a/controllers/virtualmachine/virtualmachine/virtualmachine_controller_intg_test.go
+++ b/controllers/virtualmachine/virtualmachine/virtualmachine_controller_intg_test.go
@@ -17,7 +17,9 @@ import (
 	"github.com/google/uuid"
 	"github.com/vmware/govmomi/object"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2/textlogger"
@@ -499,6 +501,82 @@ func intgTestsReconcile() {
 				Eventually(func(g Gomega) {
 					g.Expect(getVirtualMachine(ctx, vmKey)).To(BeNil())
 				}).Should(Succeed())
+			})
+		})
+
+		It("Removes the VM's OwnerRef from a detached PVC but not an attached one", func() {
+			vm.Spec.Volumes = []vmopv1.VirtualMachineVolume{
+				builder.DummyPVCVolume("disk-1", "attached-pvc"),
+			}
+			Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
+			// Wait for initial reconcile.
+			waitForVirtualMachineFinalizer(ctx, vmKey)
+
+			createdVM := getVirtualMachine(ctx, vmKey)
+			Expect(createdVM).ToNot(BeNil())
+			Expect(createdVM.UID).ToNot(BeEmpty())
+
+			ownerRef := metav1.OwnerReference{
+				APIVersion: vmopv1.GroupVersion.String(),
+				Kind:       "VirtualMachine",
+				Name:       createdVM.Name,
+				UID:        createdVM.UID,
+			}
+
+			newPVC := func(name string, annotations map[string]string) *corev1.PersistentVolumeClaim {
+				return &corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            name,
+						Namespace:       vm.Namespace,
+						Annotations:     annotations,
+						OwnerReferences: []metav1.OwnerReference{ownerRef},
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				}
+			}
+
+			attachedPVC := newPVC("attached-pvc", nil)
+			detachedPVC := newPVC("detached-pvc", nil)
+			detachedKeptPVC := newPVC("detached-kept-pvc", map[string]string{
+				pkgconst.KeepOwnerRefAnnotationKey: "",
+			})
+			Expect(ctx.Client.Create(ctx, attachedPVC)).To(Succeed())
+			Expect(ctx.Client.Create(ctx, detachedPVC)).To(Succeed())
+			Expect(ctx.Client.Create(ctx, detachedKeptPVC)).To(Succeed())
+
+			Expect(ctx.Client.Delete(ctx, vm)).To(Succeed())
+
+			By("VirtualMachine should be deleted", func() {
+				Eventually(func(g Gomega) {
+					g.Expect(getVirtualMachine(ctx, vmKey)).To(BeNil())
+				}).Should(Succeed())
+			})
+
+			By("detached PVC's OwnerRef is removed", func() {
+				Eventually(func(g Gomega) {
+					got := &corev1.PersistentVolumeClaim{}
+					g.Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(detachedPVC), got)).To(Succeed())
+					g.Expect(got.OwnerReferences).To(BeEmpty())
+				}).Should(Succeed())
+			})
+
+			By("attached PVC keeps its OwnerRef", func() {
+				got := &corev1.PersistentVolumeClaim{}
+				Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(attachedPVC), got)).To(Succeed())
+				Expect(got.OwnerReferences).To(ConsistOf(ownerRef))
+			})
+
+			By("detached PVC with the keep-owner-ref annotation keeps its OwnerRef", func() {
+				got := &corev1.PersistentVolumeClaim{}
+				Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(detachedKeptPVC), got)).To(Succeed())
+				Expect(got.OwnerReferences).To(ConsistOf(ownerRef))
 			})
 		})
 

--- a/controllers/virtualmachine/virtualmachine/virtualmachine_controller_intg_test.go
+++ b/controllers/virtualmachine/virtualmachine/virtualmachine_controller_intg_test.go
@@ -19,6 +19,7 @@ import (
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2/textlogger"
@@ -583,6 +584,82 @@ func intgTestsReconcile() {
 				Eventually(func(g Gomega) {
 					g.Expect(getVirtualMachine(ctx, vmKey)).To(BeNil())
 				}).Should(Succeed())
+			})
+		})
+
+		It("Removes the VM's OwnerRef from a detached PVC but not an attached one", func() {
+			vm.Spec.Volumes = []vmopv1.VirtualMachineVolume{
+				builder.DummyPVCVolume("disk-1", "attached-pvc"),
+			}
+			Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
+			// Wait for initial reconcile.
+			waitForVirtualMachineFinalizer(ctx, vmKey)
+
+			createdVM := getVirtualMachine(ctx, vmKey)
+			Expect(createdVM).ToNot(BeNil())
+			Expect(createdVM.UID).ToNot(BeEmpty())
+
+			ownerRef := metav1.OwnerReference{
+				APIVersion: vmopv1.GroupVersion.String(),
+				Kind:       "VirtualMachine",
+				Name:       createdVM.Name,
+				UID:        createdVM.UID,
+			}
+
+			newPVC := func(name string, annotations map[string]string) *corev1.PersistentVolumeClaim {
+				return &corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            name,
+						Namespace:       vm.Namespace,
+						Annotations:     annotations,
+						OwnerReferences: []metav1.OwnerReference{ownerRef},
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				}
+			}
+
+			attachedPVC := newPVC("attached-pvc", nil)
+			detachedPVC := newPVC("detached-pvc", nil)
+			detachedKeptPVC := newPVC("detached-kept-pvc", map[string]string{
+				pkgconst.KeepOwnerRefAnnotationKey: "",
+			})
+			Expect(ctx.Client.Create(ctx, attachedPVC)).To(Succeed())
+			Expect(ctx.Client.Create(ctx, detachedPVC)).To(Succeed())
+			Expect(ctx.Client.Create(ctx, detachedKeptPVC)).To(Succeed())
+
+			Expect(ctx.Client.Delete(ctx, vm)).To(Succeed())
+
+			By("VirtualMachine should be deleted", func() {
+				Eventually(func(g Gomega) {
+					g.Expect(getVirtualMachine(ctx, vmKey)).To(BeNil())
+				}).Should(Succeed())
+			})
+
+			By("detached PVC's OwnerRef is removed", func() {
+				Eventually(func(g Gomega) {
+					got := &corev1.PersistentVolumeClaim{}
+					g.Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(detachedPVC), got)).To(Succeed())
+					g.Expect(got.OwnerReferences).To(BeEmpty())
+				}).Should(Succeed())
+			})
+
+			By("attached PVC keeps its OwnerRef", func() {
+				got := &corev1.PersistentVolumeClaim{}
+				Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(attachedPVC), got)).To(Succeed())
+				Expect(got.OwnerReferences).To(ConsistOf(ownerRef))
+			})
+
+			By("detached PVC with the keep-owner-ref annotation keeps its OwnerRef", func() {
+				got := &corev1.PersistentVolumeClaim{}
+				Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(detachedKeptPVC), got)).To(Succeed())
+				Expect(got.OwnerReferences).To(ConsistOf(ownerRef))
 			})
 		})
 

--- a/controllers/virtualmachine/virtualmachine/virtualmachine_controller_unit_test.go
+++ b/controllers/virtualmachine/virtualmachine/virtualmachine_controller_unit_test.go
@@ -13,9 +13,11 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 
@@ -30,6 +32,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
 	providerfake "github.com/vmware-tanzu/vm-operator/pkg/providers/fake"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
+	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
@@ -82,6 +85,21 @@ func unitTestsReconcile() {
 
 	JustBeforeEach(func() {
 		ctx = suite.NewUnitTestContextForController(initObjects...)
+
+		// ReconcileDelete looks up PVCs by VM OwnerRef via a field index that
+		// is normally registered by AddToManager. The fake client used here
+		// does not go through AddToManager, so register the same index
+		// directly.
+		ctx.Client = fake.NewClientBuilder().
+			WithScheme(ctx.Client.Scheme()).
+			WithObjects(initObjects...).
+			WithStatusSubresource(builder.KnownObjectTypes()...).
+			WithIndex(
+				&corev1.PersistentVolumeClaim{},
+				kubeutil.PVCOwnerRefVMUIDIndexKey,
+				kubeutil.PVCOwnerRefVMUIDIndexerFunc).
+			Build()
+
 		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
 			config.MaxDeployThreadsOnProvider = 16
 		})
@@ -466,6 +484,91 @@ func unitTestsReconcile() {
 
 			Expect(reconciler.ReconcileDelete(vmCtx)).Should(Succeed())
 			Expect(fakeProbeManager.IsRemoveFromProberManagerCalled).Should(BeTrue())
+		})
+
+		When("the VM owns PVCs", func() {
+			var (
+				attachedPVC     *corev1.PersistentVolumeClaim
+				detachedPVC     *corev1.PersistentVolumeClaim
+				detachedKeptPVC *corev1.PersistentVolumeClaim
+			)
+
+			ownerRefFor := func(vm *vmopv1.VirtualMachine) metav1.OwnerReference {
+				return metav1.OwnerReference{
+					APIVersion: vmopv1.GroupVersion.String(),
+					Kind:       "VirtualMachine",
+					Name:       vm.Name,
+					UID:        vm.UID,
+				}
+			}
+
+			BeforeEach(func() {
+				vm.UID = "dummy-vm-uid"
+				vm.Spec.Volumes = []vmopv1.VirtualMachineVolume{
+					builder.DummyPVCVolume("disk-1", "attached-pvc"),
+				}
+
+				attachedPVC = &corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "attached-pvc",
+						Namespace: vm.Namespace,
+					},
+				}
+				detachedPVC = &corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "detached-pvc",
+						Namespace: vm.Namespace,
+					},
+				}
+				detachedKeptPVC = &corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "detached-kept-pvc",
+						Namespace: vm.Namespace,
+						Annotations: map[string]string{
+							pkgconst.KeepOwnerRefAnnotationKey: "",
+						},
+					},
+				}
+			})
+
+			JustBeforeEach(func() {
+				attachedPVC.OwnerReferences = []metav1.OwnerReference{ownerRefFor(vm)}
+				detachedPVC.OwnerReferences = []metav1.OwnerReference{ownerRefFor(vm)}
+				detachedKeptPVC.OwnerReferences = []metav1.OwnerReference{ownerRefFor(vm)}
+				Expect(ctx.Client.Create(ctx, attachedPVC)).To(Succeed())
+				Expect(ctx.Client.Create(ctx, detachedPVC)).To(Succeed())
+				Expect(ctx.Client.Create(ctx, detachedKeptPVC)).To(Succeed())
+			})
+
+			It("removes the VM's OwnerRef only from the detached PVC without the keep-owner-ref annotation", func() {
+				Expect(reconciler.ReconcileDelete(vmCtx)).To(Succeed())
+
+				gotAttached := &corev1.PersistentVolumeClaim{}
+				Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(attachedPVC), gotAttached)).To(Succeed())
+				Expect(gotAttached.OwnerReferences).To(ConsistOf(ownerRefFor(vm)))
+
+				gotDetached := &corev1.PersistentVolumeClaim{}
+				Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(detachedPVC), gotDetached)).To(Succeed())
+				Expect(gotDetached.OwnerReferences).To(BeEmpty())
+
+				gotDetachedKept := &corev1.PersistentVolumeClaim{}
+				Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(detachedKeptPVC), gotDetachedKept)).To(Succeed())
+				Expect(gotDetachedKept.OwnerReferences).To(ConsistOf(ownerRefFor(vm)))
+			})
+
+			When("the VM is being unregistered rather than deleted", func() {
+				JustBeforeEach(func() {
+					vm.Annotations[pkgconst.SkipDeletePlatformResourceKey] = ""
+				})
+
+				It("still removes the OwnerRef from the detached PVC", func() {
+					Expect(reconciler.ReconcileDelete(vmCtx)).To(Succeed())
+
+					gotDetached := &corev1.PersistentVolumeClaim{}
+					Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(detachedPVC), gotDetached)).To(Succeed())
+					Expect(gotDetached.OwnerReferences).To(BeEmpty())
+				})
+			})
 		})
 
 		When("VM has skip-platform-delete annotation", func() {

--- a/docs/concepts/workloads/vm.md
+++ b/docs/concepts/workloads/vm.md
@@ -1434,22 +1434,21 @@ For volumes that were automatically created from VM images:
 
 2. **Removing Additional Image Disks**: Additional disks from the image can be removed from `spec.volumes`, but:
     - The automatically created PVC has an owner reference to the VM
-    - When the VM is deleted, all owned PVCs are automatically deleted
     - If you remove the volume from `spec.volumes` but keep the VM, the PVC remains but is no longer attached
+    - When the VM is later deleted, VM Operator removes its owner reference from any PVC that is no longer attached, immediately before the VM's finalizer is removed. A detached PVC therefore **survives** VM deletion instead of being cascade-deleted, matching how a traditional vSphere VM behaves — only disks still attached at delete time are destroyed with the VM. See [Preventing Owner Reference Removal](#preventing-owner-reference-removal) to opt a specific PVC out of this behavior.
 
-3. **Reclaiming Storage**: To properly clean up a removed image-based volume:
+3. **Reclaiming Storage**: To properly clean up a removed image-based volume that survived VM deletion:
    ```bash
-   # First, remove from spec.volumes (as shown above)
-   # Then delete the PVC
    kubectl delete pvc disk-<uuid> -n <namespace>
    ```
 
 !!! note "PVC Ownership"
     PVCs created automatically for image disks have `ownerReferences` pointing to the VM. This means:
 
-    - Deleting the VM will cascade delete all owned PVCs
-    - Removing the volume from `spec.volumes` does NOT delete the PVC automatically
-    - To prevent accidental data loss, you must explicitly delete the PVC
+    - Deleting the VM cascade-deletes only the PVCs that are **still attached** (listed in `spec.volumes`) at the time of deletion
+    - A PVC that was detached from `spec.volumes` before the VM was deleted has its owner reference removed and survives the VM's deletion, unless it carries the `vmoperator.vmware.com/keep-owner-ref` annotation
+    - Removing the volume from `spec.volumes` does NOT delete the PVC automatically, whether or not the VM is later deleted
+    - To prevent accidental data loss, an attached PVC — or a detached PVC that has survived VM deletion and is no longer needed — must be deleted explicitly
 
 ##### Detach vs. Delete
 
@@ -1465,6 +1464,9 @@ To detach a volume temporarily (keeping the data for potential reattachment):
 1. Remove the volume from `spec.volumes`
 2. Keep the PVC in the namespace
 3. Later, add the volume back to `spec.volumes` with the same PVC claim name
+
+!!! note "Detaching Before VM Deletion"
+    If a volume is detached and the VM is later deleted, VM Operator automatically removes the VM's owner reference from the detached PVC immediately before the VM's finalizer is removed. The PVC is therefore **not** cascade-deleted along with the VM. To restore the old cascade-delete behavior for a specific PVC, annotate it with `vmoperator.vmware.com/keep-owner-ref` — see [Preventing Owner Reference Removal](#preventing-owner-reference-removal).
 
 ##### Volume Removal Prerequisites
 
@@ -1599,9 +1601,25 @@ When the system automatically creates PVCs for disks that come from VM images, t
 
 ##### Ownership and Lifecycle
 
-- **Owner References**: Automatically created PVCs have an owner reference pointing to the `VirtualMachine`. When the VM is deleted, the PVCs are automatically deleted as well.
+- **Owner References**: Automatically created PVCs have an owner reference pointing to the `VirtualMachine`. When the VM is deleted, PVCs that are still attached (listed in `spec.volumes`) are automatically deleted along with it. A PVC that was detached before the VM was deleted has its owner reference removed immediately before the VM's finalizer is removed, so it survives instead of being cascade-deleted — see [Preventing Owner Reference Removal](#preventing-owner-reference-removal) to opt a specific PVC out of this behavior.
 - **Naming Convention**: PVCs are created with generated names following the pattern `disk-<uuid>`. This ensures uniqueness across the namespace.
-- **DataSource Reference**: Each PVC includes a `dataSourceRef` field pointing back to the VM, indicating the PVC was created through the automatic registration process.
+- **DataSource Reference**: Each PVC includes a `dataSourceRef` field pointing back to the VM, indicating the PVC was created through the automatic registration process. Unlike the owner reference, `dataSourceRef` is immutable once set and is never removed, even after the disk is detached or the VM is deleted.
+
+##### Preventing Owner Reference Removal
+
+By default, once a PVC is no longer attached to a VM — its entry has been removed from `spec.volumes` — VM Operator removes the VM's owner reference from that PVC the next time the VM is deleted, immediately before the VM's finalizer is removed. This lets a detached PVC survive VM deletion instead of being cascade-deleted, matching how a traditional vSphere VM behaves: only disks still attached at delete time are destroyed with the VM.
+
+To opt a specific PVC out of this behavior — for example, if you intend to reattach it later and still want it cleaned up automatically should you never get around to it — annotate the PVC with:
+
+```yaml
+metadata:
+  annotations:
+    vmoperator.vmware.com/keep-owner-ref: ""
+```
+
+- Only the presence of the annotation key is checked; its value is never inspected, so any value (including an empty string) opts the PVC out.
+- The annotation is evaluated only at the moment the VM is deleted, against whichever PVCs are detached at that time. It has no effect on a PVC that is still attached, since an attached PVC's owner reference is never removed in the first place.
+- The annotation lives on the PVC, not the VM, and only affects that specific PVC.
 
 ##### Storage Class and Policies
 

--- a/docs/concepts/workloads/vm.md
+++ b/docs/concepts/workloads/vm.md
@@ -1467,22 +1467,21 @@ For volumes that were automatically created from VM images:
 
 2. **Removing Additional Image Disks**: Additional disks from the image can be removed from `spec.volumes`, but:
     - The automatically created PVC has an owner reference to the VM
-    - When the VM is deleted, all owned PVCs are automatically deleted
     - If you remove the volume from `spec.volumes` but keep the VM, the PVC remains but is no longer attached
+    - When the VM is later deleted, VM Operator removes its owner reference from any PVC that is no longer attached, immediately before the VM's finalizer is removed. A detached PVC therefore **survives** VM deletion instead of being cascade-deleted, matching how a traditional vSphere VM behaves — only disks still attached at delete time are destroyed with the VM. See [Preventing Owner Reference Removal](#preventing-owner-reference-removal) to opt a specific PVC out of this behavior.
 
-3. **Reclaiming Storage**: To properly clean up a removed image-based volume:
+3. **Reclaiming Storage**: To properly clean up a removed image-based volume that survived VM deletion:
    ```bash
-   # First, remove from spec.volumes (as shown above)
-   # Then delete the PVC
    kubectl delete pvc disk-<uuid> -n <namespace>
    ```
 
 !!! note "PVC Ownership"
     PVCs created automatically for image disks have `ownerReferences` pointing to the VM. This means:
 
-    - Deleting the VM will cascade delete all owned PVCs
-    - Removing the volume from `spec.volumes` does NOT delete the PVC automatically
-    - To prevent accidental data loss, you must explicitly delete the PVC
+    - Deleting the VM cascade-deletes only the PVCs that are **still attached** (listed in `spec.volumes`) at the time of deletion
+    - A PVC that was detached from `spec.volumes` before the VM was deleted has its owner reference removed and survives the VM's deletion, unless it carries the `vmoperator.vmware.com/keep-owner-ref` annotation
+    - Removing the volume from `spec.volumes` does NOT delete the PVC automatically, whether or not the VM is later deleted
+    - To prevent accidental data loss, an attached PVC — or a detached PVC that has survived VM deletion and is no longer needed — must be deleted explicitly
 
 ##### Detach vs. Delete
 
@@ -1498,6 +1497,9 @@ To detach a volume temporarily (keeping the data for potential reattachment):
 1. Remove the volume from `spec.volumes`
 2. Keep the PVC in the namespace
 3. Later, add the volume back to `spec.volumes` with the same PVC claim name
+
+!!! note "Detaching Before VM Deletion"
+    If a volume is detached and the VM is later deleted, VM Operator automatically removes the VM's owner reference from the detached PVC immediately before the VM's finalizer is removed. The PVC is therefore **not** cascade-deleted along with the VM. To restore the old cascade-delete behavior for a specific PVC, annotate it with `vmoperator.vmware.com/keep-owner-ref` — see [Preventing Owner Reference Removal](#preventing-owner-reference-removal).
 
 ##### Volume Removal Prerequisites
 
@@ -1632,9 +1634,25 @@ When the system automatically creates PVCs for disks that come from VM images, t
 
 ##### Ownership and Lifecycle
 
-- **Owner References**: Automatically created PVCs have an owner reference pointing to the `VirtualMachine`. When the VM is deleted, the PVCs are automatically deleted as well.
+- **Owner References**: Automatically created PVCs have an owner reference pointing to the `VirtualMachine`. When the VM is deleted, PVCs that are still attached (listed in `spec.volumes`) are automatically deleted along with it. A PVC that was detached before the VM was deleted has its owner reference removed immediately before the VM's finalizer is removed, so it survives instead of being cascade-deleted — see [Preventing Owner Reference Removal](#preventing-owner-reference-removal) to opt a specific PVC out of this behavior.
 - **Naming Convention**: PVCs are created with generated names following the pattern `disk-<uuid>`. This ensures uniqueness across the namespace.
-- **DataSource Reference**: Each PVC includes a `dataSourceRef` field pointing back to the VM, indicating the PVC was created through the automatic registration process.
+- **DataSource Reference**: Each PVC includes a `dataSourceRef` field pointing back to the VM, indicating the PVC was created through the automatic registration process. Unlike the owner reference, `dataSourceRef` is immutable once set and is never removed, even after the disk is detached or the VM is deleted.
+
+##### Preventing Owner Reference Removal
+
+By default, once a PVC is no longer attached to a VM — its entry has been removed from `spec.volumes` — VM Operator removes the VM's owner reference from that PVC the next time the VM is deleted, immediately before the VM's finalizer is removed. This lets a detached PVC survive VM deletion instead of being cascade-deleted, matching how a traditional vSphere VM behaves: only disks still attached at delete time are destroyed with the VM.
+
+To opt a specific PVC out of this behavior — for example, if you intend to reattach it later and still want it cleaned up automatically should you never get around to it — annotate the PVC with:
+
+```yaml
+metadata:
+  annotations:
+    vmoperator.vmware.com/keep-owner-ref: ""
+```
+
+- Only the presence of the annotation key is checked; its value is never inspected, so any value (including an empty string) opts the PVC out.
+- The annotation is evaluated only at the moment the VM is deleted, against whichever PVCs are detached at that time. It has no effect on a PVC that is still attached, since an attached PVC's owner reference is never removed in the first place.
+- The annotation lives on the PVC, not the VM, and only affects that specific PVC.
 
 ##### Storage Class and Policies
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -261,4 +261,11 @@ const (
 	// PVCEncryptionClassNameAnnotation specifies the name of an EncryptionClass
 	// on a PVC.
 	PVCEncryptionClassNameAnnotation = "csi.vsphere.encryption-class"
+
+	// KeepOwnerRefAnnotationKey is the annotation that, when present on a
+	// PersistentVolumeClaim, opts it out of having a VirtualMachine's
+	// OwnerReference removed when the PVC is no longer attached to that VM
+	// at the time the VM is deleted. Presence of the key is sufficient; the
+	// value is never inspected.
+	KeepOwnerRefAnnotationKey = "vmoperator.vmware.com/keep-owner-ref"
 )

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -257,4 +257,11 @@ const (
 	// PVCEncryptionClassNameAnnotation specifies the name of an EncryptionClass
 	// on a PVC.
 	PVCEncryptionClassNameAnnotation = "csi.vsphere.encryption-class"
+
+	// KeepOwnerRefAnnotationKey is the annotation that, when present on a
+	// PersistentVolumeClaim, opts it out of having a VirtualMachine's
+	// OwnerReference removed when the PVC is no longer attached to that VM
+	// at the time the VM is deleted. Presence of the key is sufficient; the
+	// value is never inspected.
+	KeepOwnerRefAnnotationKey = "vmoperator.vmware.com/keep-owner-ref"
 )

--- a/pkg/util/kube/pvc.go
+++ b/pkg/util/kube/pvc.go
@@ -1,0 +1,180 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package kube
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apierrorsutil "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/util/retry"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+	pkgconst "github.com/vmware-tanzu/vm-operator/pkg/constants"
+)
+
+const (
+	// PVCOwnerRefVMUIDIndexKey is the field-index key used to efficiently
+	// list PersistentVolumeClaims by the UID of any VirtualMachine
+	// OwnerReference they carry. See IndexPVCByVMOwnerRef.
+	PVCOwnerRefVMUIDIndexKey = "metadata.ownerReferences.vmUID"
+
+	vmKind = "VirtualMachine"
+)
+
+// apiGroupNamePrefix is used when matching just the API group of a VM Op
+// object.
+const apiGroupNamePrefix = vmopv1.GroupName + "/"
+
+// PVCOwnerRefVMUIDIndexerFunc extracts the UIDs of any VirtualMachine
+// OwnerReferences from a PersistentVolumeClaim. It is used to populate the
+// field index registered by IndexPVCByVMOwnerRef.
+func PVCOwnerRefVMUIDIndexerFunc(obj ctrlclient.Object) []string {
+	pvc, ok := obj.(*corev1.PersistentVolumeClaim)
+	if !ok {
+		return nil
+	}
+
+	var uids []string
+	for _, ref := range pvc.OwnerReferences {
+
+		if ref.Kind == vmKind &&
+			strings.HasPrefix(ref.APIVersion, apiGroupNamePrefix) {
+
+			uids = append(uids, string(ref.UID))
+		}
+	}
+
+	return uids
+}
+
+// IndexPVCByVMOwnerRef registers a field index on PersistentVolumeClaim,
+// keyed by PVCOwnerRefVMUIDIndexKey, so RemoveStaleVMOwnerRefFromPVCs can
+// efficiently list the PVCs owned by a given VirtualMachine instead of
+// scanning every PVC in the namespace.
+func IndexPVCByVMOwnerRef(ctx context.Context, mgr manager.Manager) error {
+	return mgr.GetFieldIndexer().IndexField(
+		ctx,
+		&corev1.PersistentVolumeClaim{},
+		PVCOwnerRefVMUIDIndexKey,
+		PVCOwnerRefVMUIDIndexerFunc)
+}
+
+// RemoveStaleVMOwnerRefFromPVCs finds every PersistentVolumeClaim in vm's
+// namespace whose OwnerReferences includes vm, and removes that specific
+// OwnerReference entry from any such PVC whose name is no longer present in
+// vm.Spec.Volumes[].PersistentVolumeClaim.ClaimName. This prevents
+// Kubernetes' garbage collector from cascade-deleting a PVC that was
+// detached from the VM before the VM itself was deleted.
+//
+// A PVC that carries the pkgconst.KeepOwnerRefAnnotationKey annotation is
+// skipped regardless of its attachment state, letting a user opt a specific
+// PVC back into the old cascade-delete behavior.
+//
+// The field index registered by IndexPVCByVMOwnerRef must already be present
+// on the client/manager for this to find any candidate PVCs.
+func RemoveStaleVMOwnerRefFromPVCs(
+	ctx context.Context,
+	c ctrlclient.Client,
+	vm *vmopv1.VirtualMachine) error {
+
+	var pvcList corev1.PersistentVolumeClaimList
+	if err := c.List(
+		ctx,
+		&pvcList,
+		ctrlclient.InNamespace(vm.Namespace),
+		ctrlclient.MatchingFields{PVCOwnerRefVMUIDIndexKey: string(vm.UID)}); err != nil {
+
+		return fmt.Errorf(
+			"failed to list pvcs owned by vm %s/%s: %w",
+			vm.Namespace, vm.Name, err)
+	}
+
+	if len(pvcList.Items) == 0 {
+		return nil
+	}
+
+	attachedClaimNames := sets.New[string]()
+	for _, vol := range vm.Spec.Volumes {
+		if pvc := vol.PersistentVolumeClaim; pvc != nil && pvc.ClaimName != "" {
+			attachedClaimNames.Insert(pvc.ClaimName)
+		}
+	}
+
+	var errs []error
+	for i := range pvcList.Items {
+		pvc := &pvcList.Items[i]
+
+		if attachedClaimNames.Has(pvc.Name) {
+			continue
+		}
+
+		key := ctrlclient.ObjectKeyFromObject(pvc)
+		if err := removeVMOwnerRefFromPVC(ctx, c, key, vm); err != nil {
+			errs = append(errs, fmt.Errorf(
+				"failed to remove owner ref from pvc %s/%s: %w",
+				pvc.Namespace, pvc.Name, err))
+		}
+	}
+
+	return apierrorsutil.NewAggregate(errs)
+}
+
+// removeVMOwnerRefFromPVC removes the OwnerReference matching vm from the
+// PersistentVolumeClaim identified by key, retrying on write conflicts. All
+// other OwnerReferences on the PVC are left untouched. A PVC that no longer
+// exists, or that no longer carries the OwnerReference, is a no-op success.
+func removeVMOwnerRefFromPVC(
+	ctx context.Context,
+	c ctrlclient.Client,
+	key ctrlclient.ObjectKey,
+	vm *vmopv1.VirtualMachine) error {
+
+	expOwnerRef := metav1.OwnerReference{
+		APIVersion: vmopv1.GroupVersion.String(),
+		Kind:       vmKind,
+		Name:       vm.Name,
+		UID:        vm.UID,
+	}
+
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		pvc := &corev1.PersistentVolumeClaim{}
+		if err := c.Get(ctx, key, pvc); err != nil {
+			return ctrlclient.IgnoreNotFound(err)
+		}
+
+		if _, ok := pvc.Annotations[pkgconst.KeepOwnerRefAnnotationKey]; ok {
+			return nil
+		}
+
+		filteredRefs := make([]metav1.OwnerReference, 0, len(pvc.OwnerReferences))
+		changed := false
+		for _, ref := range pvc.OwnerReferences {
+			if strings.HasPrefix(ref.APIVersion, apiGroupNamePrefix) &&
+				ref.Kind == expOwnerRef.Kind &&
+				ref.Name == expOwnerRef.Name &&
+				ref.UID == expOwnerRef.UID {
+
+				changed = true
+				continue
+			}
+			filteredRefs = append(filteredRefs, ref)
+		}
+
+		if !changed {
+			return nil
+		}
+
+		objPatch := ctrlclient.MergeFrom(pvc.DeepCopy())
+		pvc.OwnerReferences = filteredRefs
+		return c.Patch(ctx, pvc, objPatch)
+	})
+}

--- a/pkg/util/kube/pvc.go
+++ b/pkg/util/kube/pvc.go
@@ -6,22 +6,41 @@ package kube
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apierrorsutil "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/util/retry"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+	pkgconst "github.com/vmware-tanzu/vm-operator/pkg/constants"
 )
 
 const (
 	// VMSpecVolumesPVCsIndexKey is the field-index key used to efficiently
 	// determine PVCs that are referenced in a VM Spec.
 	VMSpecVolumesPVCsIndexKey = "spec.volumes.persistentVolumeClaim.claimName"
+
+	// PVCOwnerRefVMUIDIndexKey is the field-index key used to efficiently
+	// list PersistentVolumeClaims by the UID of any VirtualMachine
+	// OwnerReference they carry. See IndexPVCByVMOwnerRef.
+	PVCOwnerRefVMUIDIndexKey = "metadata.ownerReferences.vmUID"
+
+	vmKind = "VirtualMachine"
+
+	// apiGroupNamePrefix is used when matching just the API group of a VM Op
+// object.
+ apiGroupNamePrefix = vmopv1.GroupName + "/"
 )
 
 // VMSpecVolumesPVCsIndexerFunc returns the list of the PVC names that are referenced
 // in the VM Spec.
-func VMSpecVolumesPVCsIndexerFunc(obj client.Object) []string {
+func VMSpecVolumesPVCsIndexerFunc(obj ctrlclient.Object) []string {
 	vm, ok := obj.(*vmopv1.VirtualMachine)
 	if !ok {
 		return nil
@@ -45,4 +64,149 @@ func IndexVMSpecVolumesPVCs(ctx context.Context, mgr manager.Manager) error {
 		&vmopv1.VirtualMachine{},
 		VMSpecVolumesPVCsIndexKey,
 		VMSpecVolumesPVCsIndexerFunc)
+}
+
+// PVCOwnerRefVMUIDIndexerFunc extracts the UIDs of any VirtualMachine
+// OwnerReferences from a PersistentVolumeClaim. It is used to populate the
+// field index registered by IndexPVCByVMOwnerRef.
+func PVCOwnerRefVMUIDIndexerFunc(obj ctrlclient.Object) []string {
+	pvc, ok := obj.(*corev1.PersistentVolumeClaim)
+	if !ok {
+		return nil
+	}
+
+	var uids []string
+	for _, ref := range pvc.OwnerReferences {
+
+		if ref.Kind == vmKind &&
+			strings.HasPrefix(ref.APIVersion, apiGroupNamePrefix) {
+
+			uids = append(uids, string(ref.UID))
+		}
+	}
+
+	return uids
+}
+
+// IndexPVCByVMOwnerRef registers a field index on PersistentVolumeClaim,
+// keyed by PVCOwnerRefVMUIDIndexKey, so RemoveStaleVMOwnerRefFromPVCs can
+// efficiently list the PVCs owned by a given VirtualMachine instead of
+// scanning every PVC in the namespace.
+func IndexPVCByVMOwnerRef(ctx context.Context, mgr manager.Manager) error {
+	return mgr.GetFieldIndexer().IndexField(
+		ctx,
+		&corev1.PersistentVolumeClaim{},
+		PVCOwnerRefVMUIDIndexKey,
+		PVCOwnerRefVMUIDIndexerFunc)
+}
+
+// RemoveStaleVMOwnerRefFromPVCs finds every PersistentVolumeClaim in vm's
+// namespace whose OwnerReferences includes vm, and removes that specific
+// OwnerReference entry from any such PVC whose name is no longer present in
+// vm.Spec.Volumes[].PersistentVolumeClaim.ClaimName. This prevents
+// Kubernetes' garbage collector from cascade-deleting a PVC that was
+// detached from the VM before the VM itself was deleted.
+//
+// A PVC that carries the pkgconst.KeepOwnerRefAnnotationKey annotation is
+// skipped regardless of its attachment state, letting a user opt a specific
+// PVC back into the old cascade-delete behavior.
+//
+// The field index registered by IndexPVCByVMOwnerRef must already be present
+// on the client/manager for this to find any candidate PVCs.
+func RemoveStaleVMOwnerRefFromPVCs(
+	ctx context.Context,
+	c ctrlclient.Client,
+	vm *vmopv1.VirtualMachine) error {
+
+	var pvcList corev1.PersistentVolumeClaimList
+	if err := c.List(
+		ctx,
+		&pvcList,
+		ctrlclient.InNamespace(vm.Namespace),
+		ctrlclient.MatchingFields{PVCOwnerRefVMUIDIndexKey: string(vm.UID)}); err != nil {
+
+		return fmt.Errorf(
+			"failed to list pvcs owned by vm %s/%s: %w",
+			vm.Namespace, vm.Name, err)
+	}
+
+	if len(pvcList.Items) == 0 {
+		return nil
+	}
+
+	attachedClaimNames := sets.New[string]()
+	for _, vol := range vm.Spec.Volumes {
+		if pvc := vol.PersistentVolumeClaim; pvc != nil && pvc.ClaimName != "" {
+			attachedClaimNames.Insert(pvc.ClaimName)
+		}
+	}
+
+	var errs []error
+	for i := range pvcList.Items {
+		pvc := &pvcList.Items[i]
+
+		if attachedClaimNames.Has(pvc.Name) {
+			continue
+		}
+
+		key := ctrlclient.ObjectKeyFromObject(pvc)
+		if err := removeVMOwnerRefFromPVC(ctx, c, key, vm); err != nil {
+			errs = append(errs, fmt.Errorf(
+				"failed to remove owner ref from pvc %s/%s: %w",
+				pvc.Namespace, pvc.Name, err))
+		}
+	}
+
+	return apierrorsutil.NewAggregate(errs)
+}
+
+// removeVMOwnerRefFromPVC removes the OwnerReference matching vm from the
+// PersistentVolumeClaim identified by key, retrying on write conflicts. All
+// other OwnerReferences on the PVC are left untouched. A PVC that no longer
+// exists, or that no longer carries the OwnerReference, is a no-op success.
+func removeVMOwnerRefFromPVC(
+	ctx context.Context,
+	c ctrlclient.Client,
+	key ctrlclient.ObjectKey,
+	vm *vmopv1.VirtualMachine) error {
+
+	expOwnerRef := metav1.OwnerReference{
+		APIVersion: vmopv1.GroupVersion.String(),
+		Kind:       vmKind,
+		Name:       vm.Name,
+		UID:        vm.UID,
+	}
+
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		pvc := &corev1.PersistentVolumeClaim{}
+		if err := c.Get(ctx, key, pvc); err != nil {
+			return ctrlclient.IgnoreNotFound(err)
+		}
+
+		if _, ok := pvc.Annotations[pkgconst.KeepOwnerRefAnnotationKey]; ok {
+			return nil
+		}
+
+		filteredRefs := make([]metav1.OwnerReference, 0, len(pvc.OwnerReferences))
+		changed := false
+		for _, ref := range pvc.OwnerReferences {
+			if strings.HasPrefix(ref.APIVersion, apiGroupNamePrefix) &&
+				ref.Kind == expOwnerRef.Kind &&
+				ref.Name == expOwnerRef.Name &&
+				ref.UID == expOwnerRef.UID {
+
+				changed = true
+				continue
+			}
+			filteredRefs = append(filteredRefs, ref)
+		}
+
+		if !changed {
+			return nil
+		}
+
+		objPatch := ctrlclient.MergeFrom(pvc.DeepCopy())
+		pvc.OwnerReferences = filteredRefs
+		return c.Patch(ctx, pvc, objPatch)
+	})
 }

--- a/pkg/util/kube/pvc_test.go
+++ b/pkg/util/kube/pvc_test.go
@@ -1,0 +1,320 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package kube_test
+
+import (
+	"context"
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+	pkgconst "github.com/vmware-tanzu/vm-operator/pkg/constants"
+	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+var _ = Describe("RemoveStaleVMOwnerRefFromPVCs", func() {
+
+	const namespace = "my-namespace"
+
+	var (
+		ctx         context.Context
+		k8sClient   ctrlclient.Client
+		vm          *vmopv1.VirtualMachine
+		initObjects []ctrlclient.Object
+		withFuncs   interceptor.Funcs
+		reterr      error
+	)
+
+	ownerRefFor := func(vm *vmopv1.VirtualMachine) metav1.OwnerReference {
+		return metav1.OwnerReference{
+			APIVersion: vmopv1.GroupVersion.String(),
+			Kind:       "VirtualMachine",
+			Name:       vm.Name,
+			UID:        vm.UID,
+		}
+	}
+
+	getPVC := func(name string) *corev1.PersistentVolumeClaim {
+		pvc := &corev1.PersistentVolumeClaim{}
+		ExpectWithOffset(1, k8sClient.Get(
+			ctx,
+			ctrlclient.ObjectKey{Namespace: namespace, Name: name},
+			pvc)).To(Succeed())
+		return pvc
+	}
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		withFuncs = interceptor.Funcs{}
+		initObjects = nil
+
+		vm = builder.DummyBasicVirtualMachine("my-vm", namespace)
+		vm.UID = "my-vm-uid"
+		vm.Spec.Volumes = []vmopv1.VirtualMachineVolume{
+			builder.DummyPVCVolume("disk-1", "attached-pvc"),
+		}
+	})
+
+	JustBeforeEach(func() {
+		k8sClient = fake.NewClientBuilder().
+			WithScheme(builder.NewScheme()).
+			WithObjects(initObjects...).
+			WithInterceptorFuncs(withFuncs).
+			WithIndex(
+				&corev1.PersistentVolumeClaim{},
+				kubeutil.PVCOwnerRefVMUIDIndexKey,
+				kubeutil.PVCOwnerRefVMUIDIndexerFunc).
+			Build()
+
+		reterr = kubeutil.RemoveStaleVMOwnerRefFromPVCs(ctx, k8sClient, vm)
+	})
+
+	When("a PVC is still attached to the VM", func() {
+		BeforeEach(func() {
+			initObjects = []ctrlclient.Object{
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "attached-pvc",
+						Namespace:       namespace,
+						OwnerReferences: []metav1.OwnerReference{ownerRefFor(vm)},
+					},
+				},
+			}
+		})
+
+		It("leaves the OwnerRef intact", func() {
+			Expect(reterr).ToNot(HaveOccurred())
+			pvc := getPVC("attached-pvc")
+			Expect(pvc.OwnerReferences).To(ConsistOf(ownerRefFor(vm)))
+		})
+	})
+
+	When("a PVC has been detached from the VM", func() {
+		BeforeEach(func() {
+			initObjects = []ctrlclient.Object{
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "detached-pvc",
+						Namespace:       namespace,
+						OwnerReferences: []metav1.OwnerReference{ownerRefFor(vm)},
+					},
+				},
+			}
+		})
+
+		It("removes the VM's OwnerRef", func() {
+			Expect(reterr).ToNot(HaveOccurred())
+			pvc := getPVC("detached-pvc")
+			Expect(pvc.OwnerReferences).To(BeEmpty())
+		})
+	})
+
+	When("a detached PVC carries the keep-owner-ref annotation", func() {
+		BeforeEach(func() {
+			initObjects = []ctrlclient.Object{
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "detached-pvc",
+						Namespace:       namespace,
+						OwnerReferences: []metav1.OwnerReference{ownerRefFor(vm)},
+						Annotations: map[string]string{
+							pkgconst.KeepOwnerRefAnnotationKey: "",
+						},
+					},
+				},
+			}
+		})
+
+		It("leaves the OwnerRef intact", func() {
+			Expect(reterr).ToNot(HaveOccurred())
+			pvc := getPVC("detached-pvc")
+			Expect(pvc.OwnerReferences).To(ConsistOf(ownerRefFor(vm)))
+		})
+	})
+
+	When("a detached PVC carries the keep-owner-ref annotation with a non-empty value", func() {
+		BeforeEach(func() {
+			initObjects = []ctrlclient.Object{
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "detached-pvc",
+						Namespace:       namespace,
+						OwnerReferences: []metav1.OwnerReference{ownerRefFor(vm)},
+						Annotations: map[string]string{
+							pkgconst.KeepOwnerRefAnnotationKey: "anything",
+						},
+					},
+				},
+			}
+		})
+
+		It("still leaves the OwnerRef intact, since only the key's presence is checked", func() {
+			Expect(reterr).ToNot(HaveOccurred())
+			pvc := getPVC("detached-pvc")
+			Expect(pvc.OwnerReferences).To(ConsistOf(ownerRefFor(vm)))
+		})
+	})
+
+	When("a detached PVC has an additional, unrelated OwnerRef", func() {
+		var otherRef metav1.OwnerReference
+
+		BeforeEach(func() {
+			otherRef = metav1.OwnerReference{
+				APIVersion: "v1",
+				Kind:       "ConfigMap",
+				Name:       "some-other-owner",
+				UID:        "some-other-uid",
+			}
+			initObjects = []ctrlclient.Object{
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "detached-pvc-multi-owner",
+						Namespace: namespace,
+						OwnerReferences: []metav1.OwnerReference{
+							ownerRefFor(vm),
+							otherRef,
+						},
+					},
+				},
+			}
+		})
+
+		It("removes only the VM's OwnerRef entry", func() {
+			Expect(reterr).ToNot(HaveOccurred())
+			pvc := getPVC("detached-pvc-multi-owner")
+			Expect(pvc.OwnerReferences).To(ConsistOf(otherRef))
+		})
+	})
+
+	When("no PVCs are owned by the VM", func() {
+		BeforeEach(func() {
+			initObjects = nil
+		})
+
+		It("returns without error", func() {
+			Expect(reterr).ToNot(HaveOccurred())
+		})
+	})
+
+	When("a detached PVC is deleted between listing and patching", func() {
+		BeforeEach(func() {
+			initObjects = []ctrlclient.Object{
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "detached-pvc",
+						Namespace:       namespace,
+						OwnerReferences: []metav1.OwnerReference{ownerRefFor(vm)},
+					},
+				},
+			}
+			withFuncs.Get = func(
+				ctx context.Context,
+				c ctrlclient.WithWatch,
+				key ctrlclient.ObjectKey,
+				obj ctrlclient.Object,
+				opts ...ctrlclient.GetOption) error {
+
+				if key.Name == "detached-pvc" {
+					return apierrors.NewNotFound(
+						corev1.Resource("persistentvolumeclaims"), key.Name)
+				}
+				return c.Get(ctx, key, obj, opts...)
+			}
+		})
+
+		It("does not fail", func() {
+			Expect(reterr).ToNot(HaveOccurred())
+		})
+	})
+
+	When("the patch conflicts once and then succeeds on retry", func() {
+		var attempts int
+
+		BeforeEach(func() {
+			attempts = 0
+			initObjects = []ctrlclient.Object{
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "detached-pvc",
+						Namespace:       namespace,
+						OwnerReferences: []metav1.OwnerReference{ownerRefFor(vm)},
+					},
+				},
+			}
+			withFuncs.Patch = func(
+				ctx context.Context,
+				c ctrlclient.WithWatch,
+				obj ctrlclient.Object,
+				patch ctrlclient.Patch,
+				opts ...ctrlclient.PatchOption) error {
+
+				attempts++
+				if attempts == 1 {
+					return apierrors.NewConflict(
+						corev1.Resource("persistentvolumeclaims"), obj.GetName(), errors.New("conflict"))
+				}
+				return c.Patch(ctx, obj, patch, opts...)
+			}
+		})
+
+		It("retries and succeeds", func() {
+			Expect(reterr).ToNot(HaveOccurred())
+			Expect(attempts).To(BeNumerically(">=", 2))
+			pvc := getPVC("detached-pvc")
+			Expect(pvc.OwnerReferences).To(BeEmpty())
+		})
+	})
+
+	When("removing the OwnerRef from one of several detached PVCs fails permanently", func() {
+		BeforeEach(func() {
+			initObjects = []ctrlclient.Object{
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "detached-pvc-1",
+						Namespace:       namespace,
+						OwnerReferences: []metav1.OwnerReference{ownerRefFor(vm)},
+					},
+				},
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "detached-pvc-2",
+						Namespace:       namespace,
+						OwnerReferences: []metav1.OwnerReference{ownerRefFor(vm)},
+					},
+				},
+			}
+			withFuncs.Patch = func(
+				ctx context.Context,
+				c ctrlclient.WithWatch,
+				obj ctrlclient.Object,
+				patch ctrlclient.Patch,
+				opts ...ctrlclient.PatchOption) error {
+
+				if obj.GetName() == "detached-pvc-1" {
+					return apierrors.NewInternalError(errors.New("boom"))
+				}
+				return c.Patch(ctx, obj, patch, opts...)
+			}
+		})
+
+		It("returns an error but still processes the other PVC", func() {
+			Expect(reterr).To(HaveOccurred())
+			Expect(reterr.Error()).To(ContainSubstring("detached-pvc-1"))
+
+			pvc2 := getPVC("detached-pvc-2")
+			Expect(pvc2.OwnerReferences).To(BeEmpty())
+		})
+	})
+})

--- a/pkg/util/kube/pvc_test.go
+++ b/pkg/util/kube/pvc_test.go
@@ -5,13 +5,23 @@
 package kube_test
 
 import (
+	"context"
+	"errors"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+	pkgconst "github.com/vmware-tanzu/vm-operator/pkg/constants"
 	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 var _ = Describe("VMSpecVolumesPVCsIndexerFunc", func() {
@@ -101,6 +111,301 @@ var _ = Describe("VMSpecVolumesPVCsIndexerFunc", func() {
 			It("should return the claim names in spec order", func() {
 				Expect(kubeutil.VMSpecVolumesPVCsIndexerFunc(vm)).To(Equal([]string{"pvc1", "pvc2"}))
 			})
+		})
+	})
+})
+
+var _ = Describe("RemoveStaleVMOwnerRefFromPVCs", func() {
+
+	const namespace = "my-namespace"
+
+	var (
+		ctx         context.Context
+		k8sClient   ctrlclient.Client
+		vm          *vmopv1.VirtualMachine
+		initObjects []ctrlclient.Object
+		withFuncs   interceptor.Funcs
+		reterr      error
+	)
+
+	ownerRefFor := func(vm *vmopv1.VirtualMachine) metav1.OwnerReference {
+		return metav1.OwnerReference{
+			APIVersion: vmopv1.GroupVersion.String(),
+			Kind:       "VirtualMachine",
+			Name:       vm.Name,
+			UID:        vm.UID,
+		}
+	}
+
+	getPVC := func(name string) *corev1.PersistentVolumeClaim {
+		pvc := &corev1.PersistentVolumeClaim{}
+		ExpectWithOffset(1, k8sClient.Get(
+			ctx,
+			ctrlclient.ObjectKey{Namespace: namespace, Name: name},
+			pvc)).To(Succeed())
+		return pvc
+	}
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		withFuncs = interceptor.Funcs{}
+		initObjects = nil
+
+		vm = builder.DummyBasicVirtualMachine("my-vm", namespace)
+		vm.UID = "my-vm-uid"
+		vm.Spec.Volumes = []vmopv1.VirtualMachineVolume{
+			builder.DummyPVCVolume("disk-1", "attached-pvc"),
+		}
+	})
+
+	JustBeforeEach(func() {
+		k8sClient = fake.NewClientBuilder().
+			WithScheme(builder.NewScheme()).
+			WithObjects(initObjects...).
+			WithInterceptorFuncs(withFuncs).
+			WithIndex(
+				&corev1.PersistentVolumeClaim{},
+				kubeutil.PVCOwnerRefVMUIDIndexKey,
+				kubeutil.PVCOwnerRefVMUIDIndexerFunc).
+			Build()
+
+		reterr = kubeutil.RemoveStaleVMOwnerRefFromPVCs(ctx, k8sClient, vm)
+	})
+
+	When("a PVC is still attached to the VM", func() {
+		BeforeEach(func() {
+			initObjects = []ctrlclient.Object{
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "attached-pvc",
+						Namespace:       namespace,
+						OwnerReferences: []metav1.OwnerReference{ownerRefFor(vm)},
+					},
+				},
+			}
+		})
+
+		It("leaves the OwnerRef intact", func() {
+			Expect(reterr).ToNot(HaveOccurred())
+			pvc := getPVC("attached-pvc")
+			Expect(pvc.OwnerReferences).To(ConsistOf(ownerRefFor(vm)))
+		})
+	})
+
+	When("a PVC has been detached from the VM", func() {
+		BeforeEach(func() {
+			initObjects = []ctrlclient.Object{
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "detached-pvc",
+						Namespace:       namespace,
+						OwnerReferences: []metav1.OwnerReference{ownerRefFor(vm)},
+					},
+				},
+			}
+		})
+
+		It("removes the VM's OwnerRef", func() {
+			Expect(reterr).ToNot(HaveOccurred())
+			pvc := getPVC("detached-pvc")
+			Expect(pvc.OwnerReferences).To(BeEmpty())
+		})
+	})
+
+	When("a detached PVC carries the keep-owner-ref annotation", func() {
+		BeforeEach(func() {
+			initObjects = []ctrlclient.Object{
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "detached-pvc",
+						Namespace:       namespace,
+						OwnerReferences: []metav1.OwnerReference{ownerRefFor(vm)},
+						Annotations: map[string]string{
+							pkgconst.KeepOwnerRefAnnotationKey: "",
+						},
+					},
+				},
+			}
+		})
+
+		It("leaves the OwnerRef intact", func() {
+			Expect(reterr).ToNot(HaveOccurred())
+			pvc := getPVC("detached-pvc")
+			Expect(pvc.OwnerReferences).To(ConsistOf(ownerRefFor(vm)))
+		})
+	})
+
+	When("a detached PVC carries the keep-owner-ref annotation with a non-empty value", func() {
+		BeforeEach(func() {
+			initObjects = []ctrlclient.Object{
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "detached-pvc",
+						Namespace:       namespace,
+						OwnerReferences: []metav1.OwnerReference{ownerRefFor(vm)},
+						Annotations: map[string]string{
+							pkgconst.KeepOwnerRefAnnotationKey: "anything",
+						},
+					},
+				},
+			}
+		})
+
+		It("still leaves the OwnerRef intact, since only the key's presence is checked", func() {
+			Expect(reterr).ToNot(HaveOccurred())
+			pvc := getPVC("detached-pvc")
+			Expect(pvc.OwnerReferences).To(ConsistOf(ownerRefFor(vm)))
+		})
+	})
+
+	When("a detached PVC has an additional, unrelated OwnerRef", func() {
+		var otherRef metav1.OwnerReference
+
+		BeforeEach(func() {
+			otherRef = metav1.OwnerReference{
+				APIVersion: "v1",
+				Kind:       "ConfigMap",
+				Name:       "some-other-owner",
+				UID:        "some-other-uid",
+			}
+			initObjects = []ctrlclient.Object{
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "detached-pvc-multi-owner",
+						Namespace: namespace,
+						OwnerReferences: []metav1.OwnerReference{
+							ownerRefFor(vm),
+							otherRef,
+						},
+					},
+				},
+			}
+		})
+
+		It("removes only the VM's OwnerRef entry", func() {
+			Expect(reterr).ToNot(HaveOccurred())
+			pvc := getPVC("detached-pvc-multi-owner")
+			Expect(pvc.OwnerReferences).To(ConsistOf(otherRef))
+		})
+	})
+
+	When("no PVCs are owned by the VM", func() {
+		BeforeEach(func() {
+			initObjects = nil
+		})
+
+		It("returns without error", func() {
+			Expect(reterr).ToNot(HaveOccurred())
+		})
+	})
+
+	When("a detached PVC is deleted between listing and patching", func() {
+		BeforeEach(func() {
+			initObjects = []ctrlclient.Object{
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "detached-pvc",
+						Namespace:       namespace,
+						OwnerReferences: []metav1.OwnerReference{ownerRefFor(vm)},
+					},
+				},
+			}
+			withFuncs.Get = func(
+				ctx context.Context,
+				c ctrlclient.WithWatch,
+				key ctrlclient.ObjectKey,
+				obj ctrlclient.Object,
+				opts ...ctrlclient.GetOption) error {
+
+				if key.Name == "detached-pvc" {
+					return apierrors.NewNotFound(
+						corev1.Resource("persistentvolumeclaims"), key.Name)
+				}
+				return c.Get(ctx, key, obj, opts...)
+			}
+		})
+
+		It("does not fail", func() {
+			Expect(reterr).ToNot(HaveOccurred())
+		})
+	})
+
+	When("the patch conflicts once and then succeeds on retry", func() {
+		var attempts int
+
+		BeforeEach(func() {
+			attempts = 0
+			initObjects = []ctrlclient.Object{
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "detached-pvc",
+						Namespace:       namespace,
+						OwnerReferences: []metav1.OwnerReference{ownerRefFor(vm)},
+					},
+				},
+			}
+			withFuncs.Patch = func(
+				ctx context.Context,
+				c ctrlclient.WithWatch,
+				obj ctrlclient.Object,
+				patch ctrlclient.Patch,
+				opts ...ctrlclient.PatchOption) error {
+
+				attempts++
+				if attempts == 1 {
+					return apierrors.NewConflict(
+						corev1.Resource("persistentvolumeclaims"), obj.GetName(), errors.New("conflict"))
+				}
+				return c.Patch(ctx, obj, patch, opts...)
+			}
+		})
+
+		It("retries and succeeds", func() {
+			Expect(reterr).ToNot(HaveOccurred())
+			Expect(attempts).To(BeNumerically(">=", 2))
+			pvc := getPVC("detached-pvc")
+			Expect(pvc.OwnerReferences).To(BeEmpty())
+		})
+	})
+
+	When("removing the OwnerRef from one of several detached PVCs fails permanently", func() {
+		BeforeEach(func() {
+			initObjects = []ctrlclient.Object{
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "detached-pvc-1",
+						Namespace:       namespace,
+						OwnerReferences: []metav1.OwnerReference{ownerRefFor(vm)},
+					},
+				},
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "detached-pvc-2",
+						Namespace:       namespace,
+						OwnerReferences: []metav1.OwnerReference{ownerRefFor(vm)},
+					},
+				},
+			}
+			withFuncs.Patch = func(
+				ctx context.Context,
+				c ctrlclient.WithWatch,
+				obj ctrlclient.Object,
+				patch ctrlclient.Patch,
+				opts ...ctrlclient.PatchOption) error {
+
+				if obj.GetName() == "detached-pvc-1" {
+					return apierrors.NewInternalError(errors.New("boom"))
+				}
+				return c.Patch(ctx, obj, patch, opts...)
+			}
+		})
+
+		It("returns an error but still processes the other PVC", func() {
+			Expect(reterr).To(HaveOccurred())
+			Expect(reterr.Error()).To(ContainSubstring("detached-pvc-1"))
+
+			pvc2 := getPVC("detached-pvc-2")
+			Expect(pvc2.OwnerReferences).To(BeEmpty())
 		})
 	})
 })

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_hardware.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_hardware.go
@@ -21,6 +21,7 @@ import (
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -30,6 +31,7 @@ import (
 
 	vmopv1a5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	mopv1a2 "github.com/vmware-tanzu/vm-operator/external/mobility-operator/api/v1alpha2"
+	pkgconst "github.com/vmware-tanzu/vm-operator/pkg/constants"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/framework"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/infrastructure/vsphere/testbed"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/infrastructure/vsphere/vcenter"
@@ -2233,6 +2235,263 @@ func VMHardwareSpec(ctx context.Context, inputGetter func() VMHardwareSpecInput)
 							"Expected PVC %s to be bound", volName)
 					}
 				}
+			})
+
+			It("Detaching an unmanaged disk before VM deletion preserves its PVC", Label("experimental"), func() {
+				if !allDisksArePVCapabilityEnabled {
+					Skip("AllDisksArePVCs capability is not enabled")
+				}
+
+				const (
+					removedDiskCapacity = 5 * 1024 * 1024 // 5MB, OwnerRef expected to be removed
+					keptDiskCapacity    = 6 * 1024 * 1024 // 6MB, OwnerRef expected to be kept via annotation
+				)
+
+				addUnmanagedDisk := func(
+					ctx context.Context,
+					brownfieldVM *object.VirtualMachine,
+					scsiControllerKey int32,
+					datastoreRef vimtypes.ManagedObjectReference,
+					unitNumber int32,
+					capacity int64,
+				) error {
+					disk := &vimtypes.VirtualDisk{
+						VirtualDevice: vimtypes.VirtualDevice{
+							Backing: &vimtypes.VirtualDiskFlatVer2BackingInfo{
+								DiskMode:        string(vimtypes.VirtualDiskModePersistent),
+								ThinProvisioned: new(true),
+								VirtualDeviceFileBackingInfo: vimtypes.VirtualDeviceFileBackingInfo{
+									Datastore: &datastoreRef,
+								},
+							},
+							ControllerKey: scsiControllerKey,
+							UnitNumber:    vimtypes.NewInt32(unitNumber),
+						},
+						CapacityInBytes: capacity,
+					}
+
+					reconfigTask, err := brownfieldVM.Reconfigure(ctx, vimtypes.VirtualMachineConfigSpec{
+						DeviceChange: []vimtypes.BaseVirtualDeviceConfigSpec{
+							&vimtypes.VirtualDeviceConfigSpec{
+								Operation:     vimtypes.VirtualDeviceConfigSpecOperationAdd,
+								FileOperation: vimtypes.VirtualDeviceConfigSpecFileOperationCreate,
+								Device:        disk,
+							},
+						},
+					})
+					if err != nil {
+						return fmt.Errorf("failed to reconfigure VM with new disk: %w", err)
+					}
+					if err := reconfigTask.Wait(ctx); err != nil {
+						return fmt.Errorf("failed to wait for VM reconfiguration: %w", err)
+					}
+					return nil
+				}
+
+				By("Creating a brownfield VM by deploying from content library template using govmomi")
+
+				result := ImportBrownfieldVM(ImportBrownfieldVMInput{
+					Ctx:                ctx,
+					Config:             config,
+					VCenterAdminClient: vCenterAdminClient,
+					SVClusterClient:    svClusterClient,
+					Namespace:          vmSvcNamespace,
+					ClusterMoID:        clusterMoID,
+					BrownfieldVMName:   brownfieldVMName,
+					StorageClassName:   clusterResources.StorageClassName,
+					VMClassName:        clusterResources.VMClassName,
+					ImportOpName:       fmt.Sprintf("import-%s", vmName),
+					BeforePowerOn: func(ctx context.Context, brownfieldVM *object.VirtualMachine) error {
+						By("Adding two extra unmanaged disks to the brownfield VM before power-on and import")
+
+						var moVM mo.VirtualMachine
+						if err := brownfieldVM.Properties(ctx, brownfieldVM.Reference(),
+							[]string{"config.hardware.device", "datastore"}, &moVM); err != nil {
+							return fmt.Errorf("failed to get VM properties: %w", err)
+						}
+
+						if len(moVM.Datastore) == 0 {
+							return fmt.Errorf("VM has no datastores")
+						}
+						datastoreRef := moVM.Datastore[0]
+
+						var scsiControllerKey int32
+						for _, dev := range moVM.Config.Hardware.Device {
+							if scsi, ok := dev.(vimtypes.BaseVirtualSCSIController); ok {
+								scsiControllerKey = scsi.GetVirtualSCSIController().Key
+								break
+							}
+						}
+						if scsiControllerKey == 0 {
+							return fmt.Errorf("VM has no SCSI controller")
+						}
+
+						if err := addUnmanagedDisk(ctx, brownfieldVM, scsiControllerKey, datastoreRef, 1, removedDiskCapacity); err != nil {
+							return err
+						}
+						if err := addUnmanagedDisk(ctx, brownfieldVM, scsiControllerKey, datastoreRef, 2, keptDiskCapacity); err != nil {
+							return err
+						}
+						e2eframework.Logf("Successfully added two unmanaged disks to brownfield VM")
+						return nil
+					},
+				})
+				brownfieldVMMoID = result.BrownfieldVMMoID
+				importedVMName := result.ImportedVMName
+
+				importOperation = &mopv1a2.ImportOperation{}
+				_ = svClusterClient.Get(ctx, ctrlclient.ObjectKey{
+					Namespace: vmSvcNamespace,
+					Name:      fmt.Sprintf("import-%s", vmName),
+				}, importOperation)
+
+				vmYaml := manifestbuilders.GetVirtualMachineYamlA5(manifestbuilders.VirtualMachineYaml{
+					Namespace: vmSvcNamespace,
+					Name:      importedVMName,
+				})
+				vmYamls = append(vmYamls, vmYaml)
+
+				vmoperator.WaitForVirtualMachinePowerState(ctx, config, svClusterClient, vmSvcNamespace, importedVMName, "PoweredOn")
+
+				By("Waiting for the unmanaged disks to be backfilled and registered as PVCs")
+
+				conditions := []metav1.Condition{
+					{Type: "VirtualMachineUnmanagedVolumesBackfilled", Status: metav1.ConditionTrue},
+					{Type: "VirtualMachineUnmanagedVolumesRegistered", Status: metav1.ConditionTrue},
+				}
+				for _, condition := range conditions {
+					vmoperator.WaitOnVirtualMachineCondition(ctx, config, svClusterClient, vmSvcNamespace, importedVMName, condition)
+				}
+
+				By("Finding the PVCs that back the two added disks")
+
+				var (
+					removedPVCName string
+					keptPVCName    string
+					vmUID          types.UID
+				)
+
+				findVolumeByCapacity := func(vm *vmopv1a5.VirtualMachine, capacity int64) string {
+					for _, vol := range vm.Status.Volumes {
+						if vol.Limit == nil {
+							continue
+						}
+						if limit, ok := vol.Limit.AsInt64(); ok && limit == capacity {
+							return vol.Name
+						}
+					}
+					return ""
+				}
+
+				Eventually(func(g Gomega) {
+					vm, err := utils.GetVirtualMachineA5(ctx, svClusterClient, vmSvcNamespace, importedVMName)
+					g.Expect(err).ToNot(HaveOccurred())
+					vmUID = vm.UID
+
+					removedPVCName = findVolumeByCapacity(vm, removedDiskCapacity)
+					keptPVCName = findVolumeByCapacity(vm, keptDiskCapacity)
+					g.Expect(removedPVCName).ToNot(BeEmpty(), "Expected to find the 5MB disk among registered volumes")
+					g.Expect(keptPVCName).ToNot(BeEmpty(), "Expected to find the 6MB disk among registered volumes")
+				}, config.GetIntervals("default", "wait-virtual-machine-condition-update")...).
+					Should(Succeed(), "Timed out waiting for the added disks to be registered as PVCs")
+
+				getPVC := func(name string) *corev1.PersistentVolumeClaim {
+					pvc := &corev1.PersistentVolumeClaim{}
+					Expect(svClusterClient.Get(ctx, ctrlclient.ObjectKey{
+						Namespace: vmSvcNamespace,
+						Name:      name,
+					}, pvc)).To(Succeed(), "Failed to get registered PVC %s", name)
+					return pvc
+				}
+
+				hasVMOwnerRef := func(pvc *corev1.PersistentVolumeClaim) bool {
+					for _, ref := range pvc.OwnerReferences {
+						if ref.Kind == "VirtualMachine" && ref.UID == vmUID {
+							return true
+						}
+					}
+					return false
+				}
+
+				removedPVC := getPVC(removedPVCName)
+				Expect(hasVMOwnerRef(removedPVC)).To(BeTrue(), "Expected PVC %s to have an OwnerRef to VM %s", removedPVCName, importedVMName)
+
+				keptPVC := getPVC(keptPVCName)
+				Expect(hasVMOwnerRef(keptPVC)).To(BeTrue(), "Expected PVC %s to have an OwnerRef to VM %s", keptPVCName, importedVMName)
+
+				By("Annotating one of the PVCs with vmoperator.vmware.com/keep-owner-ref")
+
+				keptPVCPatch := keptPVC.DeepCopy()
+				if keptPVCPatch.Annotations == nil {
+					keptPVCPatch.Annotations = map[string]string{}
+				}
+				keptPVCPatch.Annotations[pkgconst.KeepOwnerRefAnnotationKey] = ""
+				Expect(svClusterClient.Patch(ctx, keptPVCPatch, ctrlclient.MergeFrom(keptPVC))).
+					To(Succeed(), "Failed to annotate PVC %s", keptPVCName)
+
+				By("Detaching both disks via the VirtualMachine spec, keeping the underlying files (simulating a user detach)")
+
+				vm, err := utils.GetVirtualMachineA5(ctx, svClusterClient, vmSvcNamespace, importedVMName)
+				Expect(err).ToNot(HaveOccurred(), "failed to get VirtualMachine")
+
+				vmPatch := vm.DeepCopy()
+				vmPatch.Spec.Volumes = nil
+				for _, vol := range vm.Spec.Volumes {
+					if vol.Name != removedPVCName && vol.Name != keptPVCName {
+						vmPatch.Spec.Volumes = append(vmPatch.Spec.Volumes, vol)
+					}
+				}
+
+				Expect(clusterProxy.GetClient().Patch(ctx, vmPatch, ctrlclient.MergeFrom(vm))).
+					To(Succeed(), "failed to patch virtualmachine to detach the two disks")
+
+				By("Waiting for the VirtualMachine to no longer report the detached disks as attached")
+
+				Eventually(func(g Gomega) {
+					vm, err := utils.GetVirtualMachineA5(ctx, svClusterClient, vmSvcNamespace, importedVMName)
+					g.Expect(err).ToNot(HaveOccurred())
+
+					for _, vol := range vm.Status.Volumes {
+						g.Expect(vol.Name).ToNot(Equal(removedPVCName),
+							"Expected disk %s to no longer be attached to the VM", removedPVCName)
+						g.Expect(vol.Name).ToNot(Equal(keptPVCName),
+							"Expected disk %s to no longer be attached to the VM", keptPVCName)
+					}
+				}, config.GetIntervals("default", "wait-virtual-machine-condition-update")...).
+					Should(Succeed(), "Timed out waiting for the VM to drop the detached disks from status.volumes")
+
+				By("Deleting the VirtualMachine")
+				Expect(clusterProxy.DeleteWithArgs(ctx, vmYaml)).To(Succeed(), "failed to delete virtualmachine")
+
+				Eventually(func(g Gomega) {
+					_, err := utils.GetVirtualMachineA5(ctx, svClusterClient, vmSvcNamespace, importedVMName)
+					g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+				}, config.GetIntervals("default", "wait-virtual-machine-creation")...).
+					Should(Succeed(), "Timed out waiting for the VirtualMachine to be deleted")
+
+				By("Verifying the non-annotated detached PVC survives with its OwnerRef removed")
+
+				Eventually(func(g Gomega) {
+					got := getPVC(removedPVCName)
+					g.Expect(hasVMOwnerRef(got)).To(BeFalse(), "Expected VM OwnerRef to be removed from PVC %s", removedPVCName)
+				}, config.GetIntervals("default", "wait-virtual-machine-condition-update")...).
+					Should(Succeed())
+
+				By("Verifying the annotated detached PVC keeps its OwnerRef and is garbage collected")
+
+				Eventually(func(g Gomega) {
+					got := &corev1.PersistentVolumeClaim{}
+					err := svClusterClient.Get(ctx, ctrlclient.ObjectKey{
+						Namespace: vmSvcNamespace,
+						Name:      keptPVCName,
+					}, got)
+					g.Expect(apierrors.IsNotFound(err)).To(BeTrue(),
+						"Expected annotated PVC %s to be garbage collected once its owning VM was deleted", keptPVCName)
+				}, config.GetIntervals("default", "wait-virtual-machine-condition-update")...).
+					Should(Succeed())
+
+				By("Cleaning up the orphaned PVC")
+				_ = svClusterClient.Delete(ctx, removedPVC)
 			})
 
 			It("Import brownfield VM with shared SCSI controller and shared disk should succeed", Label("experimental"), func() {

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_hardware.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_hardware.go
@@ -20,6 +20,7 @@ import (
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -29,6 +30,7 @@ import (
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 	mopv1a2 "github.com/vmware-tanzu/vm-operator/external/mobility-operator/api/v1alpha2"
+	pkgconst "github.com/vmware-tanzu/vm-operator/pkg/constants"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/framework"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/infrastructure/vsphere/testbed"
@@ -2243,6 +2245,280 @@ func VMHardwareSpec(ctx context.Context, inputGetter func() VMHardwareSpecInput)
 							"Expected PVC %s to be bound", volName)
 					}
 				}
+			})
+
+			It("Detaching an unmanaged disk before VM deletion preserves its PVC", Label("experimental"), func() {
+				if !allDisksArePVCapabilityEnabled {
+					Skip("AllDisksArePVCs capability is not enabled")
+				}
+
+				const (
+					removedDiskCapacity = 5 * 1024 * 1024 // 5MB, OwnerRef expected to be removed
+					keptDiskCapacity    = 6 * 1024 * 1024 // 6MB, OwnerRef expected to be kept via annotation
+				)
+
+				addUnmanagedDisk := func(
+					ctx context.Context,
+					brownfieldVM *object.VirtualMachine,
+					scsiControllerKey int32,
+					datastoreRef vimtypes.ManagedObjectReference,
+					unitNumber int32,
+					capacity int64,
+				) error {
+					disk := &vimtypes.VirtualDisk{
+						VirtualDevice: vimtypes.VirtualDevice{
+							Backing: &vimtypes.VirtualDiskFlatVer2BackingInfo{
+								DiskMode:        string(vimtypes.VirtualDiskModePersistent),
+								ThinProvisioned: new(true),
+								VirtualDeviceFileBackingInfo: vimtypes.VirtualDeviceFileBackingInfo{
+									Datastore: &datastoreRef,
+								},
+							},
+							ControllerKey: scsiControllerKey,
+							UnitNumber:    vimtypes.NewInt32(unitNumber),
+						},
+						CapacityInBytes: capacity,
+					}
+
+					reconfigTask, err := brownfieldVM.Reconfigure(ctx, vimtypes.VirtualMachineConfigSpec{
+						DeviceChange: []vimtypes.BaseVirtualDeviceConfigSpec{
+							&vimtypes.VirtualDeviceConfigSpec{
+								Operation:     vimtypes.VirtualDeviceConfigSpecOperationAdd,
+								FileOperation: vimtypes.VirtualDeviceConfigSpecFileOperationCreate,
+								Device:        disk,
+							},
+						},
+					})
+					if err != nil {
+						return fmt.Errorf("failed to reconfigure VM with new disk: %w", err)
+					}
+					if err := reconfigTask.Wait(ctx); err != nil {
+						return fmt.Errorf("failed to wait for VM reconfiguration: %w", err)
+					}
+					return nil
+				}
+
+				By("Creating a brownfield VM by deploying from content library template using govmomi")
+
+				result := ImportBrownfieldVM(ImportBrownfieldVMInput{
+					Ctx:                ctx,
+					Config:             config,
+					VCenterAdminClient: vCenterAdminClient,
+					SVClusterClient:    svClusterClient,
+					Namespace:          vmSvcNamespace,
+					ClusterMoID:        clusterMoID,
+					BrownfieldVMName:   brownfieldVMName,
+					StorageClassName:   clusterResources.StorageClassName,
+					VMClassName:        clusterResources.VMClassName,
+					ImportOpName:       fmt.Sprintf("import-%s", vmName),
+					BeforePowerOn: func(ctx context.Context, brownfieldVM *object.VirtualMachine) error {
+						By("Adding two extra unmanaged disks to the brownfield VM before power-on and import")
+
+						var moVM mo.VirtualMachine
+						if err := brownfieldVM.Properties(ctx, brownfieldVM.Reference(),
+							[]string{"config.hardware.device", "datastore"}, &moVM); err != nil {
+							return fmt.Errorf("failed to get VM properties: %w", err)
+						}
+
+						if len(moVM.Datastore) == 0 {
+							return fmt.Errorf("VM has no datastores")
+						}
+						datastoreRef := moVM.Datastore[0]
+
+						var scsiControllerKey int32
+						for _, dev := range moVM.Config.Hardware.Device {
+							if scsi, ok := dev.(vimtypes.BaseVirtualSCSIController); ok {
+								scsiControllerKey = scsi.GetVirtualSCSIController().Key
+								break
+							}
+						}
+						if scsiControllerKey == 0 {
+							return fmt.Errorf("VM has no SCSI controller")
+						}
+
+						if err := addUnmanagedDisk(ctx, brownfieldVM, scsiControllerKey, datastoreRef, 1, removedDiskCapacity); err != nil {
+							return err
+						}
+						if err := addUnmanagedDisk(ctx, brownfieldVM, scsiControllerKey, datastoreRef, 2, keptDiskCapacity); err != nil {
+							return err
+						}
+						e2eframework.Logf("Successfully added two unmanaged disks to brownfield VM")
+						return nil
+					},
+				})
+				brownfieldVMMoID = result.BrownfieldVMMoID
+				importedVMName := result.ImportedVMName
+
+				importOperation = &mopv1a2.ImportOperation{}
+				_ = svClusterClient.Get(ctx, ctrlclient.ObjectKey{
+					Namespace: vmSvcNamespace,
+					Name:      fmt.Sprintf("import-%s", vmName),
+				}, importOperation)
+
+				vmYaml := manifestbuilders.GetVirtualMachineYamlA5(manifestbuilders.VirtualMachineYaml{
+					Namespace: vmSvcNamespace,
+					Name:      importedVMName,
+				})
+				vmYamls = append(vmYamls, vmYaml)
+
+				vmoperator.WaitForVirtualMachinePowerState(ctx, config, svClusterClient, vmSvcNamespace, importedVMName, "PoweredOn")
+
+				By("Waiting for the unmanaged disks to be backfilled and registered as PVCs")
+
+				conditions := []metav1.Condition{
+					{Type: "VirtualMachineUnmanagedVolumesBackfilled", Status: metav1.ConditionTrue},
+					{Type: "VirtualMachineUnmanagedVolumesRegistered", Status: metav1.ConditionTrue},
+				}
+				for _, condition := range conditions {
+					vmoperator.WaitOnVirtualMachineCondition(ctx, config, svClusterClient, vmSvcNamespace, importedVMName, condition)
+				}
+
+				By("Finding the PVCs that back the two added disks")
+
+				var (
+					removedPVCName string
+					keptPVCName    string
+					vmUID          types.UID
+				)
+
+				findVolumeByCapacity := func(vm *vmopv1.VirtualMachine, capacity int64) string {
+					for _, vol := range vm.Status.Volumes {
+						if vol.Limit == nil {
+							continue
+						}
+						if limit, ok := vol.Limit.AsInt64(); ok && limit == capacity {
+							return vol.Name
+						}
+					}
+					return ""
+				}
+
+				Eventually(func(g Gomega) {
+					vm, err := utils.GetVirtualMachine(ctx, svClusterClient, vmSvcNamespace, importedVMName)
+					g.Expect(err).ToNot(HaveOccurred())
+					vmUID = vm.UID
+
+					removedPVCName = findVolumeByCapacity(vm, removedDiskCapacity)
+					keptPVCName = findVolumeByCapacity(vm, keptDiskCapacity)
+					g.Expect(removedPVCName).ToNot(BeEmpty(), "Expected to find the 5MB disk among registered volumes")
+					g.Expect(keptPVCName).ToNot(BeEmpty(), "Expected to find the 6MB disk among registered volumes")
+				}, config.GetIntervals("default", "wait-virtual-machine-condition-update")...).
+					Should(Succeed(), "Timed out waiting for the added disks to be registered as PVCs")
+
+				getPVC := func(name string) *corev1.PersistentVolumeClaim {
+					pvc := &corev1.PersistentVolumeClaim{}
+					Expect(svClusterClient.Get(ctx, ctrlclient.ObjectKey{
+						Namespace: vmSvcNamespace,
+						Name:      name,
+					}, pvc)).To(Succeed(), "Failed to get registered PVC %s", name)
+					return pvc
+				}
+
+				hasVMOwnerRef := func(pvc *corev1.PersistentVolumeClaim) bool {
+					for _, ref := range pvc.OwnerReferences {
+						if ref.Kind == "VirtualMachine" && ref.UID == vmUID {
+							return true
+						}
+					}
+					return false
+				}
+
+				removedPVC := getPVC(removedPVCName)
+				Expect(hasVMOwnerRef(removedPVC)).To(BeTrue(), "Expected PVC %s to have an OwnerRef to VM %s", removedPVCName, importedVMName)
+
+				DeferCleanup(func() {
+					By("Cleaning up the orphaned PVC")
+					_ = svClusterClient.Delete(ctx, removedPVC)
+				})
+
+				keptPVC := getPVC(keptPVCName)
+				Expect(hasVMOwnerRef(keptPVC)).To(BeTrue(), "Expected PVC %s to have an OwnerRef to VM %s", keptPVCName, importedVMName)
+
+				By("Annotating one of the PVCs with vmoperator.vmware.com/keep-owner-ref")
+
+				keptPVCPatch := keptPVC.DeepCopy()
+				if keptPVCPatch.Annotations == nil {
+					keptPVCPatch.Annotations = map[string]string{}
+				}
+				keptPVCPatch.Annotations[pkgconst.KeepOwnerRefAnnotationKey] = ""
+				Expect(svClusterClient.Patch(ctx, keptPVCPatch, ctrlclient.MergeFrom(keptPVC))).
+					To(Succeed(), "Failed to annotate PVC %s", keptPVCName)
+
+				By("Marking the two backfilled volumes as removable")
+
+				vm, err := utils.GetVirtualMachine(ctx, svClusterClient, vmSvcNamespace, importedVMName)
+				Expect(err).ToNot(HaveOccurred(), "failed to get VirtualMachine")
+
+				removablePatch := vm.DeepCopy()
+				for i, vol := range removablePatch.Spec.Volumes {
+					if vol.Name == removedPVCName || vol.Name == keptPVCName {
+						removablePatch.Spec.Volumes[i].Removable = ptr.To(true)
+					}
+				}
+
+				Expect(clusterProxy.GetClient().Patch(ctx, removablePatch, ctrlclient.MergeFrom(vm))).
+					To(Succeed(), "failed to mark the two disks as removable")
+
+				By("Detaching both disks via the VirtualMachine spec, keeping the underlying files (simulating a user detach)")
+
+				vm, err = utils.GetVirtualMachine(ctx, svClusterClient, vmSvcNamespace, importedVMName)
+				Expect(err).ToNot(HaveOccurred(), "failed to get VirtualMachine")
+
+				vmPatch := vm.DeepCopy()
+				vmPatch.Spec.Volumes = nil
+				for _, vol := range vm.Spec.Volumes {
+					if vol.Name != removedPVCName && vol.Name != keptPVCName {
+						vmPatch.Spec.Volumes = append(vmPatch.Spec.Volumes, vol)
+					}
+				}
+
+				Expect(clusterProxy.GetClient().Patch(ctx, vmPatch, ctrlclient.MergeFrom(vm))).
+					To(Succeed(), "failed to patch virtualmachine to detach the two disks")
+
+				By("Waiting for the VirtualMachine to no longer report the detached disks as attached")
+
+				Eventually(func(g Gomega) {
+					vm, err := utils.GetVirtualMachine(ctx, svClusterClient, vmSvcNamespace, importedVMName)
+					g.Expect(err).ToNot(HaveOccurred())
+
+					for _, vol := range vm.Status.Volumes {
+						g.Expect(vol.Name).ToNot(Equal(removedPVCName),
+							"Expected disk %s to no longer be attached to the VM", removedPVCName)
+						g.Expect(vol.Name).ToNot(Equal(keptPVCName),
+							"Expected disk %s to no longer be attached to the VM", keptPVCName)
+					}
+				}, config.GetIntervals("default", "wait-virtual-machine-condition-update")...).
+					Should(Succeed(), "Timed out waiting for the VM to drop the detached disks from status.volumes")
+
+				By("Deleting the VirtualMachine")
+				Expect(clusterProxy.DeleteWithArgs(ctx, vmYaml)).To(Succeed(), "failed to delete virtualmachine")
+
+				Eventually(func(g Gomega) {
+					_, err := utils.GetVirtualMachine(ctx, svClusterClient, vmSvcNamespace, importedVMName)
+					g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+				}, config.GetIntervals("default", "wait-virtual-machine-creation")...).
+					Should(Succeed(), "Timed out waiting for the VirtualMachine to be deleted")
+
+				By("Verifying the non-annotated detached PVC survives with its OwnerRef removed")
+
+				Eventually(func(g Gomega) {
+					got := getPVC(removedPVCName)
+					g.Expect(hasVMOwnerRef(got)).To(BeFalse(), "Expected VM OwnerRef to be removed from PVC %s", removedPVCName)
+				}, config.GetIntervals("default", "wait-virtual-machine-condition-update")...).
+					Should(Succeed())
+
+				By("Verifying the annotated detached PVC keeps its OwnerRef and is garbage collected")
+
+				Eventually(func(g Gomega) {
+					got := &corev1.PersistentVolumeClaim{}
+					err := svClusterClient.Get(ctx, ctrlclient.ObjectKey{
+						Namespace: vmSvcNamespace,
+						Name:      keptPVCName,
+					}, got)
+					g.Expect(apierrors.IsNotFound(err)).To(BeTrue(),
+						"Expected annotated PVC %s to be garbage collected once its owning VM was deleted", keptPVCName)
+				}, config.GetIntervals("default", "wait-virtual-machine-condition-update")...).
+					Should(Succeed())
 			})
 
 			It("Import brownfield VM with shared SCSI controller and shared disk should succeed", Label("experimental"), func() {


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

Today, VM Operator sets an OwnerRef on every PVC it registers for an unmanaged disk, but never clears it. If a disk is detached from a VM before the VM is deleted, Kubernetes garbage collection still cascade-deletes that PVC along with the VM -- unlike a traditional vSphere VM, which only removes disks still attached at delete time.

Add pkg/util/kube/pvc.go's RemoveStaleVMOwnerRefFromPVCs, called from the VirtualMachine controller's ReconcileDelete immediately before the finalizer is removed. It lists PVCs owned by the VM via a new field index on PVC OwnerReferences, and for each PVC no longer listed in spec.volumes, surgically removes just that VM's OwnerReference entry -- leaving any other OwnerReferences and the rest of the PVC untouched.

A PVC can opt out of this cleanup via the new, presence-based vmoperator.vmware.com/keep-owner-ref annotation, for callers that still want a detached PVC garbage-collected along with its VM.

Add unit coverage in pkg/util/kube/pvc_test.go and the VirtualMachine controller's existing unit/envtest suites, plus an experimental E2E scenario in vm_hardware.go that hot-detaches unmanaged disks via govmomi and verifies both the default removal and the annotation opt-out. The E2E scenario is labeled "experimental" and has not yet been validated against real infrastructure.

Also add the spec (spec.md) and implementation plan (plan.md) under .sdd/specs/002-rm-pvc-owner-ref/, and a new persistentvolumeclaims RBAC marker the VirtualMachine controller previously lacked.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Remove VM owner ref on detached PVCs by default.
```

<!-- readthedocs-preview vm-operator start -->
----
📚 Documentation preview 📚: https://vm-operator--1716.org.readthedocs.build/en/1716/

<!-- readthedocs-preview vm-operator end -->