### PR TITLE
Fix flaky webhook test, stale RBAC manifest, and e2e context nesting

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -310,19 +310,6 @@ rules:
   - update
   - watch
 - apiGroups:
-  - vim.vmware.com
-  resources:
-  - virtualmachineconfigoptions
-  verbs:
-  - get
-  - list
-- apiGroups:
-  - vim.vmware.com
-  resources:
-  - virtualmachineconfigoptions/status
-  verbs:
-  - get
-- apiGroups:
   - vmoperator.vmware.com
   resources:
   - clustervirtualmachineimages

--- a/test/e2e/vmservice/vmservice_test.go
+++ b/test/e2e/vmservice/vmservice_test.go
@@ -236,15 +236,15 @@ var _ = Describe("Testing VM Services", Label("devops"), Label("viadmin"), Label
 			})
 		})
 
-	})
-
-	Context("CONFIG-POLICY", func() {
-		configpolicy.Spec(context.TODO(), func() configpolicy.SpecInput {
-			return configpolicy.SpecInput{
-				ClusterProxy:     svClusterProxy,
-				Config:           config,
-				WCPNamespaceName: wcpNamespaceName,
-			}
+		Context("CONFIG-POLICY", func() {
+			configpolicy.Spec(context.TODO(), func() configpolicy.SpecInput {
+				return configpolicy.SpecInput{
+					ClusterProxy:     svClusterProxy,
+					Config:           config,
+					WCPNamespaceName: wcpNamespaceName,
+				}
+			})
 		})
+
 	})
 })

--- a/webhooks/virtualmachinegrouppublishrequest/validation/virtualmachinegrouppublishrequest_validator_intg_test.go
+++ b/webhooks/virtualmachinegrouppublishrequest/validation/virtualmachinegrouppublishrequest_validator_intg_test.go
@@ -59,6 +59,17 @@ func intgTests() {
 		intgTestsValidateCreate,
 	)
 	Describe(
+		"Create",
+		Label(
+			testlabels.Create,
+			testlabels.EnvTest,
+			testlabels.API,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		intgTestsValidateCreateAllowed,
+	)
+	Describe(
 		"Update",
 		Label(
 			testlabels.Update,
@@ -198,16 +209,35 @@ func intgTestsValidateCreate() {
 		})
 	})
 
-	When("spec is filled properly with resources created", func() {
-		BeforeEach(func() {
-			setDefaultSpecValues(ctx)
-			Expect(setCreateRequiredResources(ctx)).To(Succeed())
-		})
-		It("should allow", func() {
-			Expect(createErr).ToNot(HaveOccurred())
-		})
+}
+
+// intgTestsValidateCreateAllowed exercises the happy path as a standalone
+// test outside intgTestsValidateCreate's shared JustBeforeEach, so the
+// Create call can be retried below.
+func intgTestsValidateCreateAllowed() {
+	var ctx *intgValidatingWebhookContext
+
+	BeforeEach(func() {
+		ctx = newIntgValidatingWebhookContext(false)
+		setDefaultSpecValues(ctx)
+		Expect(setCreateRequiredResources(ctx)).To(Succeed())
+	})
+	AfterEach(func() {
+		ctx.AfterEach()
+		ctx = nil
 	})
 
+	It("should allow", func() {
+		// The source VirtualMachineGroup and target ContentLibrary were just
+		// created above, and the validating webhook checks for their existence
+		// via the manager's cached client. Retry the Create until the cache has
+		// observed those objects, since the informer watch may lag behind the
+		// direct write, otherwise the webhook can transiently deny with "Not
+		// found" errors.
+		Eventually(func() error {
+			return ctx.Client.Create(ctx.Context, ctx.vmGroupPubReq)
+		}).Should(Succeed())
+	})
 }
 
 func intgTestsValidateUpdate() {


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This PR bundles three independent fixes for `main`:

1. **Flaky `VirtualMachineGroupPublishRequest` webhook integration test**
   (observed in CI:
   https://github.com/vmware-tanzu/vm-operator/actions/runs/29034428151/job/86175561802).

   The `Create when spec is filled properly with resources created
   should allow` test creates its prerequisite `VirtualMachineGroup`
   (source) and `ContentLibrary` (target) objects and then immediately
   creates the `VirtualMachineGroupPublishRequest`, expecting the
   webhook to allow it. The validating webhook looks up those objects
   via the manager's cached client, whose informer cache is populated
   asynchronously via watch. Under load, the cache can lag behind the
   just-completed direct writes, so the webhook transiently denies the
   request with a spurious "Not found" error and the test fails.

   This mirrors an existing pattern already used by the sibling
   `VirtualMachinePublishRequest` validating webhook test
   (`webhooks/virtualmachinepublishrequest/validation/..._intg_test.go`),
   which wraps its happy-path `Create` call in `Eventually(...)` to
   retry until the cache is consistent. The happy-path assertion is
   moved out of `intgTestsValidateCreate` (which shares a single
   `JustBeforeEach` invoking `Create` exactly once, used by all the
   negative-path specs) into its own test function, so the `Create`
   call can be safely retried without double-creating the object.

   Verified locally: ran the validation webhook suite (including with
   `--race`) repeatedly with no failures.

2. **Stale generated RBAC manifest** (observed in CI:
   https://github.com/vmware-tanzu/vm-operator/actions/runs/29044960664/job/86211274364).

   `config/rbac/role.yaml` carried a stale, redundant `ClusterRole`
   rule for `vim.vmware.com/virtualmachineconfigoptions` (and its
   `/status` subresource) with verbs (`get;list` / `get`) that are a
   strict subset of the verbs already granted by the combined
   `configtargets`/`virtualmachineconfigoptions` rule immediately
   above it (`create;delete;get;list;patch;update;watch` /
   `get;patch;update`). A fresh `controller-gen` run no longer emits
   the redundant rule, so `make generate-manifests` produces a diff
   and `make verify-codegen` fails on `main`.

   This just runs `make generate-manifests` and commits the result. No
   RBAC verbs are actually removed for the manager's ServiceAccount —
   the broader rule already covers everything the dropped entries
   granted.

   Verified locally: reproduced the exact same diff CI reports by
   running `make generate-manifests` from a clean checkout of `main`
   (`18fe73a6c6a685c6472f5b53be6e1d755d3a0172`).

3. **`CONFIG-POLICY` e2e context nesting**
   (`test/e2e/vmservice/vmservice_test.go`).

   The `CONFIG-POLICY` Context (which exercises `configpolicy.Spec`,
   testing `VirtualMachineConfigPolicy`/`ConfigTarget` behavior scoped
   to a VirtualMachine) was declared as a sibling of the
   `VIRTUAL-MACHINE` Context rather than nested inside it, unlike
   `VM-LCM`, `VM-HARDWARE`, `VM-NETWORKING`, and the other VM-scoped
   specs that live under `VIRTUAL-MACHINE`. Moved it inside
   `VIRTUAL-MACHINE` alongside the other VM-scoped Contexts.

   Pure test-structure change (Ginkgo `Context` nesting) — no product
   or test-logic changes. Verified `go vet` passes on the `test/e2e`
   module after the change; running the suite itself requires a live
   WCP Supervisor + vSphere testbed, which wasn't available to verify
   here.

All three are independent of each other and of the change set;
they're bundled here per request rather than in an unrelated fourth
CI failure (a data race inside the vendored
`github.com/vmware/govmomi/simulator` package in `TestZoneController`,
which is out of scope since it's not vm-operator's own code).

**Which issue(s) is/are addressed by this PR?**

Fixes #

**Are there any special notes for your reviewer**:

This session was not linked to a Jira ticket; happy to file one (as
`vmop-xxx`) if preferred before merge.

**Please add a release note if necessary**:

```release-note
NONE
```