### PR TITLE
Regenerate manager RBAC role manifest

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -310,19 +310,6 @@ rules:
   - update
   - watch
 - apiGroups:
-  - vim.vmware.com
-  resources:
-  - virtualmachineconfigoptions
-  verbs:
-  - get
-  - list
-- apiGroups:
-  - vim.vmware.com
-  resources:
-  - virtualmachineconfigoptions/status
-  verbs:
-  - get
-- apiGroups:
   - vmoperator.vmware.com
   resources:
   - clustervirtualmachineimages


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

`verify-codegen` is currently failing on `main` (observed in CI:
https://github.com/vmware-tanzu/vm-operator/actions/runs/29044960664/job/86211274364).

`config/rbac/role.yaml` carries a stale, redundant `ClusterRole` rule
for `vim.vmware.com/virtualmachineconfigoptions` (and its `/status`
subresource) with verbs (`get;list` / `get`) that are a strict subset
of the verbs already granted by the combined
`configtargets`/`virtualmachineconfigoptions` rule immediately above
it (`create;delete;get;list;patch;update;watch` /
`get;patch;update`). A fresh `controller-gen` run no longer emits the
redundant rule, so `make generate-manifests` now produces a diff and
`make verify-codegen` fails.

This PR just runs `make generate-manifests` and commits the result.
No RBAC verbs are actually removed for the manager's ServiceAccount —
the broader rule already covers everything the dropped entries
granted.

Verified locally: reproduced the exact same diff CI reports by running
`make generate-manifests` from a clean checkout of `main`
(`18fe73a6c6a685c6472f5b53be6e1d755d3a0172`).

**Which issue(s) is/are addressed by this PR?**

Fixes #

**Are there any special notes for your reviewer**:

This session was not linked to a Jira ticket; happy to file one (as
`vmop-xxx`) if preferred before merge.

**Please add a release note if necessary**:

```release-note
NONE
```