### PR TITLE
Nest CONFIG-POLICY context under VIRTUAL-MACHINE in e2e suite

### DIFF
--- a/test/e2e/vmservice/vmservice_test.go
+++ b/test/e2e/vmservice/vmservice_test.go
@@ -236,15 +236,15 @@ var _ = Describe("Testing VM Services", Label("devops"), Label("viadmin"), Label
 			})
 		})
 
-	})
-
-	Context("CONFIG-POLICY", func() {
-		configpolicy.Spec(context.TODO(), func() configpolicy.SpecInput {
-			return configpolicy.SpecInput{
-				ClusterProxy:     svClusterProxy,
-				Config:           config,
-				WCPNamespaceName: wcpNamespaceName,
-			}
+		Context("CONFIG-POLICY", func() {
+			configpolicy.Spec(context.TODO(), func() configpolicy.SpecInput {
+				return configpolicy.SpecInput{
+					ClusterProxy:     svClusterProxy,
+					Config:           config,
+					WCPNamespaceName: wcpNamespaceName,
+				}
+			})
 		})
+
 	})
 })


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

In `test/e2e/vmservice/vmservice_test.go`, the `CONFIG-POLICY` Context
(which exercises `configpolicy.Spec`, testing
`VirtualMachineConfigPolicy`/`ConfigTarget` behavior scoped to a
VirtualMachine) was declared as a sibling of the `VIRTUAL-MACHINE`
Context rather than nested inside it, unlike `VM-LCM`, `VM-HARDWARE`,
`VM-NETWORKING`, and the other VM-scoped specs that live under
`VIRTUAL-MACHINE`.

This moves `CONFIG-POLICY` inside `VIRTUAL-MACHINE` alongside the
other VM-scoped Contexts, matching where it belongs.

**Which issue(s) is/are addressed by this PR?**

Fixes #

**Are there any special notes for your reviewer**:

Pure test-structure change (Ginkgo `Context` nesting) — no product or
test-logic changes. Verified `go vet` passes on the `test/e2e` module
after the change; running the suite itself requires a live WCP
Supervisor + vSphere testbed, which wasn't available to verify here.

This session was not linked to a Jira ticket; happy to file one (as
`vmop-xxx`) if preferred before merge.

**Please add a release note if necessary**:

```release-note
NONE
```