### PR TITLE
Fix VC client session logout race and stale VM dir on retry

### DIFF
--- a/controllers/virtualmachineimagecache/virtualmachineimagecache_controller.go
+++ b/controllers/virtualmachineimagecache/virtualmachineimagecache_controller.go
@@ -195,10 +195,11 @@ func (r *reconciler) ReconcileNormal(
 	ctx = logr.NewContext(ctx, logger)
 
 	// Get a vSphere client.
-	c, err := r.VMProvider.VSphereClient(ctx)
+	c, release, err := r.VMProvider.VSphereClient(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get vSphere client: %w", err)
 	}
+	defer release()
 
 	// Get the content library provider.
 	var clProv clprov.Provider

--- a/pkg/providers/fake/fake_vm_provider.go
+++ b/pkg/providers/fake/fake_vm_provider.go
@@ -437,15 +437,17 @@ func (s *VMProvider) GetStoragePolicyStatus(
 	return infrav1.StoragePolicyStatus{}, nil
 }
 
-func (s *VMProvider) VSphereClient(ctx context.Context) (*vsclient.Client, error) {
+func (s *VMProvider) VSphereClient(
+	ctx context.Context) (*vsclient.Client, func(), error) {
 	_ = pkgcfg.FromContext(ctx)
 
 	s.Lock()
 	defer s.Unlock()
 	if fn := s.VSphereClientFn; fn != nil {
-		return fn(ctx)
+		c, err := fn(ctx)
+		return c, func() {}, err
 	}
-	return nil, nil
+	return nil, func() {}, nil
 }
 
 func (s *VMProvider) DeleteSnapshot(

--- a/pkg/providers/vm_provider_interface.go
+++ b/pkg/providers/vm_provider_interface.go
@@ -81,8 +81,10 @@ type VirtualMachineProviderInterface interface {
 	// storage policy.
 	GetStoragePolicyStatus(ctx context.Context, profileID string) (infrav1.StoragePolicyStatus, error)
 
-	// VSphereClient returns the provider's vSphere client.
-	VSphereClient(context.Context) (*client.Client, error)
+	// VSphereClient returns the provider's vSphere client along with a
+	// release func the caller MUST call (typically via defer) once it is
+	// done using the client.
+	VSphereClient(context.Context) (*client.Client, func(), error)
 
 	// DeleteSnapshot deletes a snapshot from a virtual machine.
 	DeleteSnapshot(ctx context.Context, vmSnapshot *vmopv1.VirtualMachineSnapshot,

--- a/pkg/providers/vsphere/vmlifecycle/create_fastdeploy.go
+++ b/pkg/providers/vsphere/vmlifecycle/create_fastdeploy.go
@@ -25,7 +25,74 @@ import (
 	pkglog "github.com/vmware-tanzu/vm-operator/pkg/log"
 	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
+	pkgdatastore "github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/datastore"
 )
+
+// deleteVMDir deletes dirPath via fm and, if nm is non-nil, clears its
+// namespace mapping at dsPath.
+func deleteVMDir(
+	ctx context.Context,
+	fm *object.FileManager,
+	datacenter *object.Datacenter,
+	dirPath string,
+	nm *object.DatastoreNamespaceManager,
+	dsPath string) error {
+
+	t, err := fm.DeleteDatastoreFile(ctx, dirPath, datacenter)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to call delete api for dir %q: %w",
+			dirPath, err)
+	}
+
+	taskWaitErr := t.Wait(ctx)
+	if taskWaitErr != nil {
+		if fault.Is(taskWaitErr, &vimtypes.FileNotFound{}) {
+			taskWaitErr = nil
+		} else {
+			taskWaitErr = fmt.Errorf(
+				"failed to delete dir %q: %w",
+				dirPath, taskWaitErr)
+		}
+	}
+
+	if nm == nil {
+		return taskWaitErr
+	}
+
+	if dsPath == "" {
+		return errors.Join(
+			taskWaitErr,
+			fmt.Errorf("datastore path cannot be empty"))
+	}
+
+	if err := nm.DeleteDirectory(ctx, datacenter, dsPath); err != nil &&
+		!fault.Is(err, &vimtypes.FileNotFound{}) {
+
+		return errors.Join(taskWaitErr, fmt.Errorf(
+			"failed to delete dir namespace mapping %q: %w",
+			dsPath, err))
+	}
+
+	return taskWaitErr
+}
+
+// staleVMDirExists reports whether vmDirName already exists on ds.
+func staleVMDirExists(
+	ctx context.Context,
+	ds *object.Datastore,
+	vmDirName string) (bool, error) {
+
+	if _, err := ds.Stat(ctx, vmDirName); err != nil {
+		if pkgdatastore.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf(
+			"failed to stat vm dir %q: %w", vmDirName, err)
+	}
+
+	return true, nil
+}
 
 //nolint:gocyclo
 func fastDeploy(
@@ -66,11 +133,50 @@ func fastDeploy(
 
 	// Create the directory where the VM will be created.
 	var (
-		vmDirPath     string
+		vmDirPath     = vmDir
 		vmDirUUIDPath string
 		nm            *object.DatastoreNamespaceManager
 		fm            = object.NewFileManager(vimClient)
 	)
+
+	ds := object.NewDatastore(vimClient, createArgs.Datastores[0].MoRef)
+
+	// Register cleanup defer before any directory creation, so it also
+	// cleans up a stale directory detected just below.
+	defer func() {
+		if retErr == nil {
+			// Do not delete the VM directory if this function
+			// succeeded.
+			return
+		}
+
+		// Use a context that is not cancelled when the parent is, so
+		// cleanup runs even if the request is cancelled. Preserves the
+		// VC opID so cleanup is correlated with the failed create in VC
+		// logs.
+		ctx := context.WithoutCancel(vmCtx.Context)
+
+		// Delete the VM directory and its contents, and, for non-TLD
+		// datastores, its namespace mapping too.
+		if err := deleteVMDir(
+			ctx, fm, datacenter, vmDirPath, nm,
+			vmDirUUIDPath); err != nil {
+
+			retErr = errors.Join(retErr, err)
+		}
+	}()
+
+	exists, err := staleVMDirExists(vmCtx, ds, vmDirName)
+	if err != nil {
+		return nil, err
+	}
+	if exists {
+		// The deferred cleanup above deletes the stale directory before
+		// this error reaches the caller.
+		return nil, fmt.Errorf(
+			"found stale vm dir %q from a prior create attempt",
+			vmDir)
+	}
 
 	if createArgs.Datastores[0].TopLevelDirectoryCreateSupported {
 		//
@@ -79,21 +185,20 @@ func fastDeploy(
 		if err := fm.MakeDirectory(vmCtx, vmDir, datacenter, true); err != nil {
 			return nil, fmt.Errorf("failed to create vm dir %q: %w", vmDir, err)
 		}
-		vmDirPath = vmDir
 	} else {
 		//
 		// The datastore does NOT support TLD creation, so use the datastore
 		// namespace manager to create the new directory.
 		//
-		nm = object.NewDatastoreNamespaceManager(vimClient)
-		vdp, err := nm.CreateDirectory(
-			vmCtx,
-			object.NewDatastore(vimClient, createArgs.Datastores[0].MoRef),
-			vmDirName,
-			"")
+		dnm := object.NewDatastoreNamespaceManager(vimClient)
+		vdp, err := dnm.CreateDirectory(vmCtx, ds, vmDirName, "")
 		if err != nil {
 			return nil, fmt.Errorf("failed to create vm dir: %w", err)
 		}
+
+		// Set nm only now that CreateDirectory succeeded, so it and
+		// vmDirUUIDPath stay consistent for the defer above.
+		nm = dnm
 
 		// The vmDirUUIDPath value will look something like the following:
 		//
@@ -134,55 +239,6 @@ func fastDeploy(
 	logger.Info("Updated vm dir paths",
 		"vmDirPath", vmDirPath,
 		"vmPathName", createArgs.ConfigSpec.Files.VmPathName)
-
-	// Register cleanup defer immediately after directory creation.
-	defer func() {
-		if retErr == nil {
-			// Do not delete the VM directory if this function succeeded.
-			return
-		}
-
-		// Use a context that is not cancelled when the parent is, so cleanup
-		// runs even if the request is cancelled. Preserves the VC opID so
-		// cleanup is correlated with the failed create in VC logs.
-		ctx := context.WithoutCancel(vmCtx.Context)
-
-		// Delete the VM directory and its contents.
-		// Always use FileManager.DeleteDatastoreFile() first as it can delete
-		// non-empty directories recursively. Note that DeleteDirectory() on a
-		// non-empty directory will return an error, which is why we delete the
-		// directory contents first using DeleteDatastoreFile().
-		t, err := fm.DeleteDatastoreFile(ctx, vmDirPath, datacenter)
-		if err != nil {
-			retErr = fmt.Errorf(
-				"failed to call delete api for vm dir %q: %w,%w",
-				vmDirPath, err, retErr)
-			return
-		}
-
-		// Wait for the delete call to return.
-		if err := t.Wait(ctx); err != nil &&
-			!fault.Is(err, &vimtypes.FileNotFound{}) {
-
-			retErr = fmt.Errorf(
-				"failed to delete vm dir %q: %w,%w",
-				vmDirPath, err, retErr)
-		}
-
-		// For non-TLD datastores, also clean up the namespace mapping.
-		if !createArgs.Datastores[0].TopLevelDirectoryCreateSupported {
-			if err := nm.DeleteDirectory(
-				ctx,
-				datacenter,
-				vmDirUUIDPath); err != nil &&
-				!fault.Is(err, &vimtypes.FileNotFound{}) {
-
-				retErr = fmt.Errorf(
-					"failed to delete vm dir namespace mapping %q: %w,%w",
-					vmDirUUIDPath, err, retErr)
-			}
-		}
-	}()
 
 	var (
 		disks                      []*vimtypes.VirtualDisk

--- a/pkg/providers/vsphere/vmprovider.go
+++ b/pkg/providers/vsphere/vmprovider.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -23,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apierrorsutil "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/waitgroup"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/yaml"
@@ -64,7 +66,39 @@ type vSphereVMProvider struct {
 	minCPUFreq        uint64
 
 	vcClientLock sync.Mutex
-	vcClient     *vcclient.Client
+	vcClientGen  *vcClientGeneration
+}
+
+// vcClientGeneration pairs a vSphere client with a count of callers
+// currently using it, so a superseded client is not logged out while it
+// may still be in active use.
+type vcClientGeneration struct {
+	client *vcclient.Client
+	wg     waitgroup.SafeWaitGroup
+}
+
+// vcClientRelease guards a single release of an acquired vcClientGeneration
+// reference. The returned func is safe to call more than once; only the
+// first call has an effect. If a caller loses the returned func without
+// calling it, a cleanup runs as a backstop so the generation's WaitGroup is
+// not held indefinitely.
+type vcClientRelease struct {
+	once  sync.Once
+	done  func()
+	clean runtime.Cleanup
+}
+
+func (r *vcClientRelease) release() {
+	r.once.Do(func() {
+		r.clean.Stop()
+		r.done()
+	})
+}
+
+func newVcClientRelease(done func()) func() {
+	r := &vcClientRelease{done: done}
+	r.clean = runtime.AddCleanup(r, func(fn func()) { fn() }, done)
+	return r.release
 }
 
 func NewVSphereVMProviderFromClient(
@@ -105,77 +139,100 @@ func getExtraConfig(ctx context.Context) map[string]string {
 	return ec
 }
 
-func (vs *vSphereVMProvider) getVcClient(ctx context.Context) (*vcclient.Client, error) {
+// getVcClient returns the current vSphere client along with a release func
+// that the caller MUST call (typically via defer) once it is done using the
+// client. Until release is called, the client is guaranteed not to be
+// logged out from under the caller.
+func (vs *vSphereVMProvider) getVcClient(
+	ctx context.Context) (*vcclient.Client, func(), error) {
 	vs.vcClientLock.Lock()
 	defer vs.vcClientLock.Unlock()
 
-	if vs.vcClient != nil {
-		return vs.vcClient, nil
+	if gen := vs.vcClientGen; gen != nil {
+		if err := gen.wg.Add(1); err != nil {
+			return nil, nil, fmt.Errorf("failed to acquire vc client: %w", err)
+		}
+		return gen.client, newVcClientRelease(gen.wg.Done), nil
 	}
 
 	config, err := vcconfig.GetProviderConfig(ctx, vs.k8sClient)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	vcClient, err := vcclient.NewClient(ctx, config)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	vs.vcClient = vcClient
+	gen := &vcClientGeneration{client: vcClient}
+	vs.vcClientGen = gen
 
-	return vcClient, nil
+	if err := gen.wg.Add(1); err != nil {
+		return nil, nil, fmt.Errorf("failed to acquire vc client: %w", err)
+	}
+
+	return gen.client, newVcClientRelease(gen.wg.Done), nil
 }
 
-func (vs *vSphereVMProvider) UpdateVcPNID(ctx context.Context, vcPNID, vcPort string) error {
-	updated, err := vcconfig.UpdateVcInConfigMap(ctx, vs.k8sClient, vcPNID, vcPort)
+// rotateVcClientGen retires the current client generation, if one exists and
+// isStale returns true for it, so the next call to getVcClient creates a new
+// client. It then waits, without blocking the caller, for existing callers
+// of the retired generation to finish before logging it out.
+func (vs *vSphereVMProvider) rotateVcClientGen(
+	ctx context.Context, isStale func(*vcClientGeneration) bool) {
+
+	oldGen := func() *vcClientGeneration {
+		vs.vcClientLock.Lock()
+		defer vs.vcClientLock.Unlock()
+
+		gen := vs.vcClientGen
+		if gen == nil || !isStale(gen) {
+			return nil
+		}
+
+		vs.vcClientGen = nil
+		return gen
+	}()
+
+	if oldGen == nil {
+		return
+	}
+
+	// Use a context that is not cancelled when ctx is, so the logout
+	// below still runs even though this call returns immediately and
+	// ctx may be cancelled long before the old generation's existing
+	// callers finish using it.
+	logoutCtx := context.WithoutCancel(ctx)
+	go func() {
+		oldGen.wg.Wait()
+		oldGen.client.Logout(logoutCtx)
+	}()
+}
+
+func (vs *vSphereVMProvider) UpdateVcPNID(
+	ctx context.Context, vcPNID, vcPort string) error {
+	updated, err := vcconfig.UpdateVcInConfigMap(
+		ctx, vs.k8sClient, vcPNID, vcPort)
 	if err != nil || !updated {
 		return err
 	}
 
-	oldVcClient := func() *vcclient.Client {
-		vs.vcClientLock.Lock()
-		defer vs.vcClientLock.Unlock()
-
-		if vcClient := vs.vcClient; vcClient != nil {
-			// Clear and logout existing clean so new client will be created next call to getVcClient().
-			vs.vcClient = nil
-			return vcClient
-		}
-
-		return nil
-	}()
-
-	if oldVcClient != nil {
-		oldVcClient.Logout(ctx)
-	}
+	vs.rotateVcClientGen(ctx, func(*vcClientGeneration) bool { return true })
 
 	return nil
 }
 
-func (vs *vSphereVMProvider) UpdateVcCreds(ctx context.Context, data map[string][]byte) error {
+func (vs *vSphereVMProvider) UpdateVcCreds(
+	ctx context.Context, data map[string][]byte) error {
 	newVcCreds, err := vccreds.ExtractVCCredentials(data)
 	if err != nil {
 		return err
 	}
 
-	oldVcClient := func() *vcclient.Client {
-		vs.vcClientLock.Lock()
-		defer vs.vcClientLock.Unlock()
-
-		if vcClient := vs.vcClient; vcClient != nil && vcClient.Config().VcCreds != newVcCreds {
-			// Clear and logout existing clean so new client will be created next call to getVcClient().
-			vs.vcClient = nil
-			return vcClient
-		}
-
-		return nil
-	}()
-
-	if oldVcClient != nil {
-		oldVcClient.Logout(ctx)
-	}
+	vs.rotateVcClientGen(ctx, func(gen *vcClientGeneration) bool {
+		return gen.client.Config().VcCreds != newVcCreds
+	})
 
 	return nil
 }
@@ -366,10 +423,11 @@ func (vs *vSphereVMProvider) syncVirtualMachineImageFastDeployVM(
 	vmi ctrlclient.Object,
 	vmMoID string) error {
 
-	vcClient, err := vs.getVcClient(ctx)
+	vcClient, release, err := vs.getVcClient(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get a vc client for image vm: %w", err)
 	}
+	defer release()
 
 	vm := object.NewVirtualMachine(
 		vcClient.VimClient(),
@@ -420,10 +478,11 @@ func (vs *vSphereVMProvider) syncVirtualMachineImage(
 func (vs *vSphereVMProvider) getOvfEnvelope(
 	ctx context.Context, itemID string) (*ovf.Envelope, error) {
 
-	client, err := vs.getVcClient(ctx)
+	client, release, err := vs.getVcClient(ctx)
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 
 	p := contentlibrary.NewProvider(ctx, client.RestClient())
 	return p.RetrieveOvfEnvelopeByLibraryItemID(ctx, itemID)
@@ -437,10 +496,11 @@ func (vs *vSphereVMProvider) GetItemFromLibraryByName(ctx context.Context,
 	pkglog.FromContextOrDefault(ctx).V(4).Info("Get item from ContentLibrary",
 		"UUID", contentLibrary, "item name", itemName)
 
-	client, err := vs.getVcClient(ctx)
+	client, release, err := vs.getVcClient(ctx)
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 
 	contentLibraryProvider := contentlibrary.NewProvider(ctx, client.RestClient())
 	return contentLibraryProvider.GetLibraryItem(ctx, contentLibrary, itemName, false)
@@ -450,10 +510,11 @@ func (vs *vSphereVMProvider) GetItemFromInventoryByName(
 	ctx context.Context,
 	contentLibrary, itemName string) (object.Reference, error) {
 
-	client, err := vs.getVcClient(ctx)
+	client, release, err := vs.getVcClient(ctx)
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 
 	c := client.VimClient()
 
@@ -499,10 +560,11 @@ func (vs *vSphereVMProvider) ContainsExtraConfigEntry(
 func (vs *vSphereVMProvider) UpdateContentLibraryItem(ctx context.Context, itemID, newName string, newDescription *string) error {
 	pkglog.FromContextOrDefault(ctx).V(4).Info("Update Content Library Item", "itemID", itemID)
 
-	client, err := vs.getVcClient(ctx)
+	client, release, err := vs.getVcClient(ctx)
 	if err != nil {
 		return err
 	}
+	defer release()
 
 	contentLibraryProvider := contentlibrary.NewProvider(ctx, client.RestClient())
 	return contentLibraryProvider.UpdateLibraryItem(ctx, itemID, newName, newDescription)
@@ -566,10 +628,11 @@ func (vs *vSphereVMProvider) computeCPUMinFrequency(ctx context.Context) (uint64
 		return 0, err
 	}
 
-	client, err := vs.getVcClient(ctx)
+	client, release, err := vs.getVcClient(ctx)
 	if err != nil {
 		return 0, err
 	}
+	defer release()
 
 	var errs []error
 
@@ -600,10 +663,11 @@ func (vs *vSphereVMProvider) GetTasksByActID(ctx context.Context, vm *vmopv1.Vir
 	ctx = pkgctx.WithVCOpID(ctx, vm, "getTasksByActID")
 	logger := pkglog.FromContextOrDefault(ctx)
 
-	vcClient, err := vs.getVcClient(ctx)
+	vcClient, release, err := vs.getVcClient(ctx)
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 
 	taskManager := task.NewManager(vcClient.VimClient())
 	filterSpec := vimtypes.TaskFilterSpec{}
@@ -662,10 +726,11 @@ func (vs *vSphereVMProvider) DoesProfileSupportEncryption(
 	ctx context.Context,
 	profileID string) (bool, error) {
 
-	c, err := vs.getVcClient(ctx)
+	c, release, err := vs.getVcClient(ctx)
 	if err != nil {
 		return false, err
 	}
+	defer release()
 
 	return c.PbmClient().SupportsEncryption(ctx, profileID)
 }
@@ -673,10 +738,11 @@ func (vs *vSphereVMProvider) DoesProfileSupportEncryption(
 func (vs *vSphereVMProvider) GetStoragePolicyStatus(
 	ctx context.Context, profileID string) (infrav1.StoragePolicyStatus, error) {
 
-	c, err := vs.getVcClient(ctx)
+	c, release, err := vs.getVcClient(ctx)
 	if err != nil {
 		return infrav1.StoragePolicyStatus{}, err
 	}
+	defer release()
 
 	return storutil.GetStoragePolicyStatus(
 		ctx,
@@ -687,13 +753,13 @@ func (vs *vSphereVMProvider) GetStoragePolicyStatus(
 }
 
 func (vs *vSphereVMProvider) VSphereClient(
-	ctx context.Context) (*vsclient.Client, error) {
+	ctx context.Context) (*vsclient.Client, func(), error) {
 
-	c, err := vs.getVcClient(ctx)
+	c, release, err := vs.getVcClient(ctx)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return c.Client, nil
+	return c.Client, release, nil
 }
 
 // GetVirtualMachineConfigTarget returns the vSphere cluster's
@@ -702,10 +768,11 @@ func (vs *vSphereVMProvider) VSphereClient(
 func (vs *vSphereVMProvider) GetVirtualMachineConfigTarget(
 	ctx context.Context,
 	clusterMoID string) (*vimtypes.ConfigTarget, []vimtypes.VirtualMachineConfigOptionDescriptor, error) {
-	vcClient, err := vs.getVcClient(ctx)
+	vcClient, release, err := vs.getVcClient(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
+	defer release()
 
 	ccr := object.NewClusterComputeResource(vcClient.VimClient(),
 		vimtypes.ManagedObjectReference{Type: "ClusterComputeResource", Value: clusterMoID})

--- a/pkg/providers/vsphere/vmprovider_resourcepolicy.go
+++ b/pkg/providers/vsphere/vmprovider_resourcepolicy.go
@@ -27,10 +27,11 @@ func (vs *vSphereVMProvider) CreateOrUpdateVirtualMachineSetResourcePolicy(
 		return err
 	}
 
-	client, err := vs.getVcClient(ctx)
+	client, release, err := vs.getVcClient(ctx)
 	if err != nil {
 		return err
 	}
+	defer release()
 
 	vimClient := client.VimClient()
 	var errs []error
@@ -90,10 +91,11 @@ func (vs *vSphereVMProvider) DeleteVirtualMachineSetResourcePolicy(
 		return err
 	}
 
-	client, err := vs.getVcClient(ctx)
+	client, release, err := vs.getVcClient(ctx)
 	if err != nil {
 		return err
 	}
+	defer release()
 
 	vimClient := client.VimClient()
 	var errs []error

--- a/pkg/providers/vsphere/vmprovider_update_creds_test.go
+++ b/pkg/providers/vsphere/vmprovider_update_creds_test.go
@@ -40,8 +40,9 @@ var _ = Describe("UpdateVcCreds", func() {
 	When("New Credentials", func() {
 
 		It("VC Client is logged out", func() {
-			vcClient, err := vmProvider.VSphereClient(ctx)
+			vcClient, release, err := vmProvider.VSphereClient(ctx)
 			Expect(err).NotTo(HaveOccurred())
+			defer release()
 			Expect(vcClient).NotTo(BeNil())
 			session, err := vcClient.RestClient().Session(ctx)
 			Expect(err).NotTo(HaveOccurred())
@@ -63,8 +64,9 @@ var _ = Describe("UpdateVcCreds", func() {
 	When("Same Credentials", func() {
 
 		It("VC Client is not logged out", func() {
-			vcClient, err := vmProvider.VSphereClient(ctx)
+			vcClient, release, err := vmProvider.VSphereClient(ctx)
 			Expect(err).NotTo(HaveOccurred())
+			defer release()
 			Expect(vcClient).NotTo(BeNil())
 			session, err := vcClient.RestClient().Session(ctx)
 			Expect(err).NotTo(HaveOccurred())
@@ -76,8 +78,9 @@ var _ = Describe("UpdateVcCreds", func() {
 			}
 			Expect(vmProvider.UpdateVcCreds(ctx, data)).To(Succeed())
 			By("VC Client is the same", func() {
-				vcClient2, err := vmProvider.VSphereClient(ctx)
+				vcClient2, release2, err := vmProvider.VSphereClient(ctx)
 				Expect(err).NotTo(HaveOccurred())
+				defer release2()
 				Expect(vcClient2).To(BeIdenticalTo(vcClient))
 
 				session, err := vcClient.RestClient().Session(ctx)

--- a/pkg/providers/vsphere/vmprovider_vm.go
+++ b/pkg/providers/vsphere/vmprovider_vm.go
@@ -191,10 +191,20 @@ func (vs *vSphereVMProvider) createOrUpdateVirtualMachine(
 	)
 	ctx = vmCtx.Context
 
-	client, err := vs.getVcClient(ctx)
+	client, release, err := vs.getVcClient(ctx)
 	if err != nil {
 		return nil, err
 	}
+	// releaseClient tracks whether this function must release the vc client
+	// itself on return, or whether that responsibility has been handed off
+	// to the async create goroutine below (which releases it when the
+	// goroutine, and thus its use of client, is actually done).
+	releaseClient := true
+	defer func() {
+		if releaseClient {
+			release()
+		}
+	}()
 
 	// Set the VC UUID annotation on the VM before attempting creation or
 	// update. Among other things, the annotation facilitates differential
@@ -302,16 +312,20 @@ func (vs *vSphereVMProvider) createOrUpdateVirtualMachine(
 	copyOfCtx := vmCtx
 	copyOfCtx.VM = vmCtx.VM.DeepCopy()
 
-	// Start a goroutine to create the VM in the background.
+	// Start a goroutine to create the VM in the background. The goroutine
+	// takes over responsibility for releasing the vc client, since it, not
+	// this function, is what actually finishes using client.
 	chanErr := make(chan error)
 	go vs.createVirtualMachineAsync(
 		copyOfCtx,
 		client,
 		createArgs,
 		chanErr,
-		cleanupFn)
+		cleanupFn,
+		release)
 
 	asyncCreateStarted = true
+	releaseClient = false
 
 	// Return with the error channel. The VM will be re-enqueued once the create
 	// completes with success or failure.
@@ -341,10 +355,11 @@ func (vs *vSphereVMProvider) CleanupVirtualMachine(
 	)
 	ctx = vmCtx.Context
 
-	client, err := vs.getVcClient(ctx)
+	client, release, err := vs.getVcClient(ctx)
 	if err != nil {
 		return err
 	}
+	defer release()
 
 	vcVM, err := vs.getVM(vmCtx, client, false)
 	if err != nil {
@@ -385,10 +400,11 @@ func (vs *vSphereVMProvider) DeleteVirtualMachine(
 	)
 	ctx = vmCtx.Context
 
-	client, err := vs.getVcClient(ctx)
+	client, release, err := vs.getVcClient(ctx)
 	if err != nil {
 		return err
 	}
+	defer release()
 
 	vcVM, err := vs.getVM(vmCtx, client, false)
 	if err != nil {
@@ -486,10 +502,11 @@ func (vs *vSphereVMProvider) PublishVirtualMachine(
 		vmCtx.Context = ctx
 	}
 
-	client, err := vs.getVcClient(ctx)
+	client, release, err := vs.getVcClient(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to get vCenter client: %w", err)
 	}
+	defer release()
 
 	if pkgcfg.FromContext(ctx).Features.InventoryContentLibrary {
 		v1a2contentLibrary := &imgregv1.ContentLibrary{}
@@ -540,10 +557,11 @@ func (vs *vSphereVMProvider) GetVirtualMachineGuestHeartbeat(
 	)
 	ctx = vmCtx.Context
 
-	client, err := vs.getVcClient(ctx)
+	client, release, err := vs.getVcClient(ctx)
 	if err != nil {
 		return "", err
 	}
+	defer release()
 
 	vcVM, err := vs.getVM(vmCtx, client, true)
 	if err != nil {
@@ -569,10 +587,11 @@ func (vs *vSphereVMProvider) GetVirtualMachineProperties(
 	)
 	ctx = vmCtx.Context
 
-	client, err := vs.getVcClient(vmCtx)
+	client, release, err := vs.getVcClient(vmCtx)
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 
 	vcVM, err := vs.getVM(vmCtx, client, true)
 	if err != nil {
@@ -628,10 +647,11 @@ func (vs *vSphereVMProvider) GetVirtualMachineFiles(
 	)
 	ctx = vmCtx.Context
 
-	client, err := vs.getVcClient(ctx)
+	client, release, err := vs.getVcClient(ctx)
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 
 	vcVM, err := vs.getVM(vmCtx, client, true)
 	if err != nil {
@@ -662,10 +682,11 @@ func (vs *vSphereVMProvider) GetVirtualMachineWebMKSTicket(
 	)
 	ctx = vmCtx.Context
 
-	client, err := vs.getVcClient(ctx)
+	client, release, err := vs.getVcClient(ctx)
 	if err != nil {
 		return "", err
 	}
+	defer release()
 
 	vcVM, err := vs.getVM(vmCtx, client, true)
 	if err != nil {
@@ -690,10 +711,11 @@ func (vs *vSphereVMProvider) GetVirtualMachineHardwareVersion(
 	)
 	ctx = vmCtx.Context
 
-	client, err := vs.getVcClient(ctx)
+	client, release, err := vs.getVcClient(ctx)
 	if err != nil {
 		return 0, err
 	}
+	defer release()
 
 	vcVM, err := vs.getVM(vmCtx, client, true)
 	if err != nil {
@@ -883,11 +905,13 @@ func (vs *vSphereVMProvider) createVirtualMachineAsync(
 	vcClient *vcclient.Client,
 	args *VMCreateArgs,
 	chanErr chan error,
-	cleanupFn func()) {
+	cleanupFn func(),
+	release func()) {
 
 	defer func() {
 		close(chanErr)
 		cleanupFn()
+		release()
 	}()
 
 	moRef, vimErr := vmlifecycle.CreateVirtualMachine(
@@ -2012,7 +2036,7 @@ func (vs *vSphereVMProvider) vmCreateGetSourceFilePaths(
 	}
 
 	var (
-		datacenterID = vs.vcClient.Datacenter().Reference().Value
+		datacenterID = vcClient.Datacenter().Reference().Value
 		datastoreID  = createArgs.Datastores[0].MoRef.Value
 		itemID       = createArgs.ImageStatus.ProviderItemID
 		itemVersion  = createArgs.ImageStatus.ProviderContentVersion
@@ -2960,11 +2984,12 @@ func (vs *vSphereVMProvider) getConfigSpecFromVM(
 	vmiCache vmopv1.VirtualMachineImageCache,
 	vmClass vmopv1.VirtualMachineClass) (vimtypes.VirtualMachineConfigSpec, error) {
 
-	vcClient, err := vs.getVcClient(vmCtx)
+	vcClient, release, err := vs.getVcClient(vmCtx)
 	if err != nil {
 		return vimtypes.VirtualMachineConfigSpec{},
 			fmt.Errorf("failed to get vc client: %w", err)
 	}
+	defer release()
 
 	vm := object.NewVirtualMachine(
 		vcClient.VimClient(),

--- a/pkg/providers/vsphere/vmprovider_vmgroup.go
+++ b/pkg/providers/vsphere/vmprovider_vmgroup.go
@@ -54,10 +54,11 @@ func (vs *vSphereVMProvider) PlaceVirtualMachineGroup(
 
 	ctx = pkgctx.WithVCOpID(ctx, group, "groupPlacement")
 
-	vcClient, err := vs.getVcClient(ctx)
+	vcClient, release, err := vs.getVcClient(ctx)
 	if err != nil {
 		return err
 	}
+	defer release()
 
 	placementArgs, err := vs.vmGroupGetVMPlacementArgs(ctx, vcClient, groupPlacements)
 	if err != nil {

--- a/pkg/providers/vsphere/vmprovider_vmsnapshot.go
+++ b/pkg/providers/vsphere/vmprovider_vmsnapshot.go
@@ -55,10 +55,11 @@ func (vs *vSphereVMProvider) DeleteSnapshot(
 	)
 	ctx = vmCtx.Context
 
-	client, err := vs.getVcClient(ctx)
+	client, release, err := vs.getVcClient(ctx)
 	if err != nil {
 		return false, err
 	}
+	defer release()
 
 	vcVM, err := vs.getVM(vmCtx, client, false)
 	if err != nil {
@@ -96,10 +97,11 @@ func (vs *vSphereVMProvider) GetSnapshotSize(
 	)
 	ctx = vmCtx.Context
 
-	client, err := vs.getVcClient(ctx)
+	client, release, err := vs.getVcClient(ctx)
 	if err != nil {
 		return 0, err
 	}
+	defer release()
 
 	vcVM, err := vs.getVM(vmCtx, client, true)
 	if err != nil {
@@ -134,10 +136,11 @@ func (vs *vSphereVMProvider) SyncVMSnapshotTreeStatus(
 	)
 	ctx = vmCtx.Context
 
-	client, err := vs.getVcClient(ctx)
+	client, release, err := vs.getVcClient(ctx)
 	if err != nil {
 		return err
 	}
+	defer release()
 
 	vcVM, err := vs.getVM(vmCtx, client, true)
 	if err != nil {

--- a/pkg/util/vsphere/datastore/datastore.go
+++ b/pkg/util/vsphere/datastore/datastore.go
@@ -6,6 +6,7 @@ package datastore
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/vmware/govmomi/find"
@@ -38,4 +39,11 @@ func GetDatastoreURLFromDatastorePath(
 	}
 
 	return datastore.NewURL(dsPath.Path).String(), nil
+}
+
+// IsNotFound returns true if err is a Datastore.Stat() not-found error.
+func IsNotFound(err error) bool {
+	var noSuchFile object.DatastoreNoSuchFileError
+	var noSuchDir object.DatastoreNoSuchDirectoryError
+	return errors.As(err, &noSuchFile) || errors.As(err, &noSuchDir)
 }

--- a/services/vm-watcher/vm_watcher_service.go
+++ b/services/vm-watcher/vm_watcher_service.go
@@ -239,10 +239,11 @@ func (s Service) waitForChanges(ctx context.Context) error {
 		chanSource = cource.FromContextWithBuffer(ctx, "VirtualMachine", 100)
 	)
 
-	vcClient, err := s.provider.VSphereClient(ctx)
+	vcClient, release, err := s.provider.VSphereClient(ctx)
 	if err != nil {
 		return err
 	}
+	defer release()
 	logger.Info("Got vsphere client")
 
 	moRefWithIDs, err := s.vmFolderMoRefWithIDs(ctx, vcClient)


### PR DESCRIPTION
## What does this PR do, and why is it needed?

A `VirtualMachine` create could get stuck permanently retrying
`failed to create vm dir: ... already exists` after a routine rotation
of the VC service-account credentials Secret raced with an in-flight
create.

**Root cause:** `vSphereVMProvider.UpdateVcCreds`/`UpdateVcPNID` swapped
the cached vSphere client and immediately called `Logout()` on the old
one, even though reconciles that had already acquired that client via
`getVcClient` could still be using it mid-transaction. When a
credentials rotation landed between two calls on the same client (a VM
directory create followed by `CreateVM`), the session was killed out
from under the in-flight create. The subsequent failure-cleanup then
reused that same now-dead client and failed too, leaving the VM
directory orphaned. Because the directory path is deterministic
(derived from the VM's own object UID), every retry thereafter collided
with the same leftover directory forever.

**Commit 1** fixes the root cause: the client is now tracked as a
generation paired with a `WaitGroup` of outstanding callers.
`getVcClient` hands out a release func callers must call once done.
`UpdateVcCreds`/`UpdateVcPNID` swap in a new generation immediately for
future callers, but wait for the old generation's outstanding callers
to finish before logging it out. The async VM-create path hands its
release func to the background goroutine, since that goroutine (not
the spawning call) is what actually finishes using the client.
`VSphereClient`'s public signature changes to propagate the same
protection to its two callers (the VM watcher service and the image
cache controller), since both were also observed hitting this exact
race in the original incident.

**Commit 2** adds defense in depth, independent of the above: on a
`FileAlreadyExists` fault while creating a VM's own directory, clean up
the stale leftover and let the normal reconcile-retry path proceed,
instead of colliding with it indefinitely. This covers other causes of
a partial create that commit 1 doesn't address (e.g. a pod restart
mid-create, or an independent failure in the two-step namespace
cleanup).

**Which issue(s) is/are addressed by this PR?**

Fixes #

**Are there any special notes for your reviewer**:

- This is a draft — tests have intentionally not been added/updated yet.
- One existing test, `vmprovider_update_creds_test.go`'s "VC Client is
  logged out" case, asserts the old client's session is `nil`
  *immediately* after `UpdateVcCreds` returns. That's asserting the
  exact synchronous-logout behavior this PR removes, so it will need
  its assertions updated (not just the compile-fix already applied) in
  a follow-up test pass.
- In commit 2, I couldn't verify against a live vCenter or a raw fault
  payload exactly what format `FileAlreadyExists.File` comes back in
  (a fully-qualified `"[datastore] path"` string vs. a bare name).
  vcsim's `DatastoreNamespaceManager.CreateDirectory` simulator doesn't
  reproduce the random-UUID-remapping behavior observed in the real
  incident, so it couldn't settle this either. Handled both possible
  formats defensively rather than assuming one; flagging for review.

**Please add a release note if necessary**:

```release-note
Fix a race where a vSphere credentials/PNID update could log out a
vCenter session still in use by an in-flight VirtualMachine create,
which could permanently orphan the VM's directory and get it stuck
retrying "already exists" indefinitely.
```