### PR TITLE
🌱 Bump go to version 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/vm-operator
 
-go 1.26.4
+go 1.26.5
 
 replace (
 	github.com/vmware-tanzu/vm-operator/api => ./api

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/vm-operator/hack/tools
 
-go 1.26.4
+go 1.26.5
 
 // The version of Ginkgo must match the one from ../../go.mod.
 require github.com/onsi/ginkgo/v2 v2.28.1

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/vm-operator/test/e2e
 
-go 1.26.4
+go 1.26.5
 
 replace (
 	github.com/onsi/ginkgo/v2 => github.com/onsi/ginkgo/v2 v2.28.1


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Update Go to 1.26.5 which addresses CVE-2026-39822 and CVE-2026-42505.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # vmop-3742323 and vmop-3742326


**Are there any special notes for your reviewer**:

**Please add a release note if necessary**:

```release-note
Go 1.26.5
```