### PR TITLE
🌱 Disable ginkgo color logging in CI env

### DIFF
--- a/hack/e2e/run-e2e.sh
+++ b/hack/e2e/run-e2e.sh
@@ -135,6 +135,9 @@ REPORT_DIR="${ARTIFACT_FOLDER}"
 # before the container scheduler force-kills the process.
 GINKGO_TIMEOUT="${GINKGO_TIMEOUT:-2h}"
 
+# Disable color output in CI env.
+export GINKGO_NO_COLOR=${TEST_CALLBACK_URL:+TRUE}
+
 # Define the flag prefix based on mode
 # Prebuilt binaries require the "--ginkgo." prefix for ginkgo-specific flags
 PREFIX=""


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Set GINKGO_TIMEOUT=TRUE so we don't get the annoying color escape codes in CI logs

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

**Please add a release note if necessary**:

```release-note
NONE
```