### PR TITLE
✨ Add SDD spec, research, and plan for auto-ISO

### DIFF
--- a/.sdd/specs/003-auto-iso/plan.md
+++ b/.sdd/specs/003-auto-iso/plan.md
@@ -1,0 +1,1024 @@
+# Implementation Plan: Automated Deployment from ISO Image
+
+- **Spec**: `spec.md` in this directory
+- **Research**: `research.md` in this directory
+- **Created**: 2026-07-10
+- **Status**: Draft
+- **Related epic**: vmop-TBD
+
+---
+
+## Summary
+
+This plan translates the auto-ISO spec into a constitutionally-compliant technical
+approach. The feature adds `spec.bootstrap.iso` to the VirtualMachine API, enabling
+automated OS installation from an ISO image via a shared framework — a virtual USB
+keyboard that sends scan codes to the VM's boot loader, and an ephemeral HTTP server
+Pod on the Supervisor that serves user-supplied bootstrap assets (kickstart files,
+autoinstall configs, Windows answer files, provisioning scripts) — plus per-OS-family
+wiring documented in `research.md`.
+
+The mechanism is directly analogous to the vSphere Packer ISO builder
+(`packer-plugin-vsphere/builder/vsphere/iso`), which solves the same problem. The key
+insight from studying that code: the vSphere `PutUsbScanCodes` API
+(`govmomi.VirtualMachine.PutUsbScanCodes`) replaces VNC and is all that is needed to
+type into a VM console without direct network access to the guest.
+
+This plan is organized in two parts:
+
+1. **The framework** — the OS-agnostic pieces every automation technology depends on
+   (API, feature flag, keyboard driver, HTTP server, template variables, bootstrap
+   integration, webhook validation, conditions, E2E harness).
+2. **End-to-end walkthroughs** for the three P0/P1 user stories named in `spec.md` —
+   Ubuntu (Autoinstall), RHEL (Kickstart), and Windows (Unattend) — showing how the
+   framework's pieces compose for each, using the syntax researched in `research.md`.
+
+Debian/Preseed is covered in `research.md` (Finding 2) but is not a named user story
+in `spec.md`; it is expected to fall out of the same framework as Ubuntu/RHEL once
+the netcfg-style command renderer described below exists, and is not walked
+end-to-end in this plan.
+
+---
+
+## Technical context
+
+- **Go version**: matches root `go.mod` (see `go.mod` in repository root).
+- **API version(s) touched**: `v1alpha6` (new field), `v1alpha5` (stub for
+  conversion).
+- **Modules touched**: root module only (`github.com/vmware-tanzu/vm-operator`).
+- **New dependencies**: none expected; `govmomi`'s `PutUsbScanCodes` and
+  `UsbScanCodeSpec` types are already vendored at a sufficient version (see
+  "Current State").
+
+---
+
+## Current State
+
+The following is already implemented or available:
+
+- **CD-ROM device support** — `api/v1alpha6/virtualmachine_hardware_types.go` defines
+  `VirtualMachineCdromSpec` and `VirtualMachineHardwareSpec.Cdrom`; the reconciler
+  lives in `pkg/vmconfig/cdrom/`. Every OS family in this plan attaches exactly one
+  CD-ROM entry (the OS installation ISO) — none of the end-to-end flows below need
+  `spec.hardware.cdrom`'s existing support for multiple entries.
+- **ISO content library item type** — `ContentLibraryItemTypeIso = "ISO"` exists in
+  both `external/image-registry-operator/api/v1alpha1/` and `v1alpha2/`.
+  `VirtualMachineImageTypeLabel` is defined in `api/v1alpha6/virtualmachineimage_types.go`.
+- **`PutUsbScanCodes` API** — `govmomi v0.55.0-alpha` exposes
+  `object.VirtualMachine.PutUsbScanCodes(ctx, types.UsbScanCodeSpec)`.
+  Types `UsbScanCodeSpec`, `UsbScanCodeSpecKeyEvent`, and `UsbScanCodeSpecModifierType`
+  are all available in `vim25/types`.
+- **Template rendering infrastructure** — `GetTemplateRenderFunc` in
+  `pkg/providers/vsphere/vmlifecycle/bootstrap_templatedata.go` already provides a
+  full `text/template` function map with network helpers (firstIP, subnetMask, etc.)
+  for all API versions v1alpha1–v1alpha6.
+- **Bootstrap integration point** — `DoBootstrap` in
+  `pkg/providers/vsphere/vmlifecycle/bootstrap.go` is the single dispatch point for
+  all bootstrap providers; adding an ISO case fits naturally here.
+- **Feature flag infrastructure** — `pkg/config/` and `pkg/config/env/` already
+  support adding a new FSS (feature state switch) toggle.
+
+---
+
+## Constitution check
+
+| Rule | Status | Notes |
+|------|--------|-------|
+| Controllers are thin; business logic in `pkg/` | OK | All ISO logic in `pkg/providers/vsphere/vmlifecycle/`, `pkg/util/vsphere/keyboard/`, `pkg/util/kube/isohttp/` |
+| No direct vSphere API calls from controllers | OK | `PutUsbScanCodes` called from the provider layer only |
+| `status.observedGeneration` and `Ready` condition | OK | New `VirtualMachineBootstrapISOSynced` condition added |
+| `+optional` / `+required` markers on all fields | Must verify when typing new API structs |
+| Finalizer pattern for cleanup | HTTP server Pod/Service owned by VM via owner reference — GC handles cleanup |
+| `make generate-go` run after API changes | Required; blocks code phase |
+| E2E coverage ships with behavior | OK — see "Test strategy" |
+| Markdown: no hard line wrapping | OK — this document uses soft wrap |
+
+---
+
+## The framework
+
+These phases are OS-agnostic. Every end-to-end walkthrough below is built entirely
+out of these pieces — no per-OS controller or webhook code is introduced.
+
+### Phase 1 — API (US1, P0)
+
+**Files touched:**
+- `api/v1alpha6/virtualmachine_bootstrap_types.go`
+- `api/v1alpha6/virtualmachine_types.go` (new condition constants)
+- `api/v1alpha6/zz_generated.deepcopy.go` (regenerated)
+- `api/v1alpha5/virtualmachine_bootstrap_types.go` (stub for conversion)
+- Corresponding `zz_generated.conversion.go` files
+
+**New types** in `api/v1alpha6/virtualmachine_bootstrap_types.go`:
+
+```go
+// VirtualMachineBootstrapISOSpec describes the ISO-based automated
+// installation configuration used to bootstrap the VM.
+type VirtualMachineBootstrapISOSpec struct {
+    // +optional
+    // +listType=atomic
+
+    // Commands is an ordered list of boot commands sent to the VM via the
+    // virtual USB keyboard immediately after power-on.
+    //
+    // Each element may contain:
+    //   - Literal printable ASCII characters (typed one at a time).
+    //   - Special key tokens: <esc>, <enter>, <tab>, <bs>, <del>,
+    //     <spacebar>, <f1>-<f12>, <up>, <down>, <left>, <right>.
+    //   - Wait tokens: <wait> (1s), <wait5> (5s), <wait10> (10s), or an
+    //     arbitrary Go duration, e.g. <wait3m30s>.
+    //   - Modifier hold/release: <leftShiftOn>x<leftShiftOff>.
+    //   - Go text/template expressions evaluated against the VM's intended
+    //     network config -- see the template variable reference in spec.md.
+    //
+    // Used by every guest OS family this bootstrap provider supports,
+    // including Windows -- see plan.md's per-OS end-to-end sections for
+    // worked examples of the token sequence each one needs.
+    Commands []string `json:"commands,omitempty"`
+
+    // +optional
+    // +listType=map
+    // +listMapKey=name
+
+    // Assets is a list of references to keys in Secret resources in the same
+    // namespace. Each referenced key's value is served as a file by an
+    // ephemeral HTTP server that VM Operator creates and tears down for this
+    // VM, reachable from the VM during installation.
+    //
+    // The served URL path is /<secretName>/<key>. The address of the HTTP
+    // server is available in Commands via the {{V1Alpha6_BootstrapService}}
+    // template function.
+    Assets []VirtualMachineBootstrapISOAsset `json:"assets,omitempty"`
+}
+
+// VirtualMachineBootstrapISOAsset references a single key in a Secret
+// resource that is served by the ephemeral bootstrap HTTP server.
+type VirtualMachineBootstrapISOAsset struct {
+    // +required
+    // +kubebuilder:validation:MinLength=1
+
+    // Name is the name of the Secret resource in the same namespace as the VM.
+    Name string `json:"name"`
+
+    // +required
+    // +kubebuilder:validation:MinLength=1
+
+    // Key is the key within the Secret whose value is the file content to serve.
+    Key string `json:"key"`
+}
+```
+
+**Add to `VirtualMachineBootstrapSpec`:**
+
+```go
+// +optional
+
+// ISO may be used to automate the installation of a VM from an ISO image.
+//
+// Boot commands are sent via the virtual USB keyboard to the VM console
+// immediately after power-on. User-supplied assets (kickstart files,
+// autoinstall configs, Windows answer files, etc.) are served from an
+// ephemeral HTTP server Pod on the Supervisor, reachable from the VM's
+// workload network.
+//
+// Please note this bootstrap provider may not be used in conjunction with
+// CloudInit, LinuxPrep, Sysprep, or VAppConfig.
+ISO *VirtualMachineBootstrapISOSpec `json:"iso,omitempty"`
+```
+
+**New condition constants** in `api/v1alpha6/virtualmachine_types.go`:
+
+```go
+// VirtualMachineBootstrapISOSynced indicates that the ISO bootstrap
+// process (boot commands and/or ephemeral HTTP server) has been applied.
+VirtualMachineBootstrapISOSynced = "VirtualMachineBootstrapISOSynced"
+```
+
+**After types are written:** run `make generate-go` to regenerate deepcopy and
+conversion.
+
+---
+
+### Phase 2 — Feature Flag
+
+**Files touched:**
+- `pkg/config/config.go` (add `AutoISO bool` to `FeatureStates`)
+- `pkg/config/env/env.go` (add `FSSAutoISO`)
+- `pkg/config/env.go` (wire env var -> feature flag)
+
+The feature flag is `WCP_Auto_ISO`. All controller and bootstrap logic that touches
+the ISO path must gate on `pkgcfg.FromContext(ctx).Features.AutoISO`.
+
+---
+
+### Phase 3 — USB Keyboard Driver
+
+**New package:** `pkg/util/vsphere/keyboard/`
+
+This is a direct port and adaptation of Packer's
+`builder/vsphere/common/bootcommand/usb_driver.go` and
+`builder/vsphere/driver/vm_keyboard.go`. The abstraction boundary:
+
+- `pkg/util/vsphere/keyboard/hid.go` — USB HID scan code table mapping printable
+  ASCII characters, special keys (esc, enter, tab, backspace, delete, function
+  keys, arrow keys), and modifier keys to `int32` USB HID codes. Encoding:
+  `hidCode << 16 | 7` (same as Packer).
+
+- `pkg/util/vsphere/keyboard/command.go` — boot command string parser:
+
+  ```go
+  // Token types: Literal, Wait, SpecialKey, ModifierOn, ModifierOff
+  type Token struct { ... }
+
+  // ParseCommands parses a slice of boot command strings into an ordered
+  // slice of Tokens, resolving template expressions first.
+  func ParseCommands(commands []string, render func(string) string) ([]Token, error)
+  ```
+
+- `pkg/util/vsphere/keyboard/send.go` — sends tokens to a govmomi VM:
+
+  ```go
+  // SendCommands sends the parsed boot command tokens to the VM via the
+  // virtual USB keyboard. Waits are honored via ctx (cancellable).
+  // Returns an error if any PutUsbScanCodes call fails or ctx is cancelled.
+  func SendCommands(ctx context.Context, vm *object.VirtualMachine, tokens []Token) error
+  ```
+
+  The function batches consecutive non-wait keystrokes into a single
+  `PutUsbScanCodes` call (Packer sends one call per key, which is fine, but
+  batching reduces API call count). Wait tokens use `time.Sleep` gated by
+  `ctx.Done()`.
+
+**Key implementation details from Packer analysis:**
+- HID code encoding: `scancode << 16 | 7` (the `7` is the USB usage page for
+  keyboard).
+- Modifiers are set per-keystroke via `UsbScanCodeSpecModifierType`.
+- `<leftShiftOn>/<leftShiftOff>` hold the shift modifier across subsequent
+  keystrokes; needed for symbols like `!`, `@`, `#` etc. on US keyboards.
+- The default inter-key delay (Packer: 100ms via `PACKER_KEY_INTERVAL`) is not
+  needed if we batch; the vSphere API processes all events in the spec
+  atomically.
+
+**Network-parameter renderer split (from `research.md` Finding 1/2/3/4):** the
+template helpers that render network parameters into `Commands` must support two
+distinct grammars, not one:
+
+- **dracut-style** (`ip=...`, `ifname=...`) — used by Ubuntu (Finding 3) and RHEL
+  (Finding 4).
+- **netcfg-style** (`netcfg/get_ipaddress=...`, ...) — used by Debian (Finding 2),
+  not walked end-to-end in this plan but kept in mind so the renderer interface
+  does not silently assume dracut syntax is universal.
+
+Windows does not use this renderer at all — see the Windows end-to-end section.
+
+---
+
+### Phase 4 — Ephemeral HTTP Server
+
+**New package:** `pkg/util/kube/isohttp/`
+
+The ephemeral HTTP server serves bootstrap assets to the VM during OS installation.
+VM Operator owns the entire lifecycle of the Pod and the Service that fronts it —
+there is no user-facing field naming or otherwise configuring the Service; it is an
+implementation detail of how `Assets` get to the VM, not part of the API contract.
+
+#### 4a. Pod / Service lifecycle
+
+The package manages:
+
+1. **Secret validation** — verify that every `spec.bootstrap.iso.assets[*].{name,key}`
+   exists and is readable.
+2. **Pod creation** — creates a Pod in the same namespace as the VM:
+   - Mounts each referenced Secret as a volume.
+   - Runs a minimal HTTP server container (see §4b).
+   - Name derived deterministically from the VM (e.g. `<vm-name>-iso-bootstrap`),
+     so `EnsureReady` can `CreateOrPatch` idempotently without persisting a
+     separate generated name anywhere.
+   - Labels: `vmoperator.vmware.com/iso-bootstrap-vm: <vm-name>`.
+   - Owner reference: the VirtualMachine resource (so GC fires on VM deletion).
+3. **Service creation** — creates a Service under the same deterministic name
+   (`<vm-name>-iso-bootstrap`), of type `LoadBalancer` (preferred for NSX-T
+   Supervisor) or `NodePort` (VDS fallback), targeting the Pod:
+   - Annotation `vmoperator.vmware.com/iso-bootstrap-vm: <vm-name>`.
+   - Owner reference: the VirtualMachine resource.
+   - `EnsureReady` is a `CreateOrPatch` keyed on the deterministic name — safe
+     to call every reconcile without an annotation to remember what was
+     created (the boot-command idempotency annotation described in Phase 6 is
+     still required, since sending commands twice is not safe — that guard is
+     about `Commands`, not about the Service).
+4. **Address discovery** — wait for `service.status.loadBalancer.ingress[0].ip`
+   (LoadBalancer) or use `nodeIP:nodePort` (NodePort) to obtain the address/port
+   substituted into `{{V1Alpha6_BootstrapService}}` (see Phase 5).
+5. **Teardown** — delete the Pod and Service VM Operator created for this VM
+   when the VM condition `VirtualMachineBootstrapISOSynced` is set to True or
+   after a configurable timeout (default: 60 minutes).
+
+URL path convention: `http://<service-address>:<service-port>/<secretName>/<key>`.
+
+```go
+// Manager creates and tears down the ephemeral HTTP server for ISO bootstrap.
+// The Pod and Service names are derived from the VM's name; callers never
+// supply or see the name -- it is purely an implementation detail.
+type Manager struct { ... }
+
+func NewManager(k8sClient ctrlclient.Client, vm *vmopv1.VirtualMachine) *Manager
+func (m *Manager) EnsureReady(ctx context.Context) (ip string, port int, err error)
+func (m *Manager) Teardown(ctx context.Context) error
+```
+
+#### 4b. HTTP server container image
+
+The Pod runs a dedicated minimal image (e.g., `vmop-iso-httpserver:VERSION`) that:
+- Accepts a root directory as an argument.
+- Serves files with content-type `application/octet-stream`.
+- Logs requests.
+- Is under 10 MB.
+
+The image name is configurable via an operator config environment variable
+(`VSPHERE_ISO_HTTP_SERVER_IMAGE`), defaulting to the image shipped with the
+operator release.
+
+The HTTP server source lives at `cmd/iso-httpserver/` in this repo, similar to
+other vmop cmd binaries.
+
+#### 4c. Networking constraint
+
+The VM must be able to reach the Pod's Service IP. In the Supervisor:
+
+- **NSX-T deployments**: Use `type: LoadBalancer`. NSX-T allocates an IP on the
+  workload segment. This is the preferred path.
+- **VDS deployments**: Use `type: NodePort`. The NodePort is reachable via the ESXi
+  host's management VMkernel NIC, which is usually on the same routable network as
+  the VM gateway. The VM's boot command would use the node IP.
+
+The `isohttp.Manager.EnsureReady` selects the service type based on the cluster
+capability (detected via the existing Supervisor capabilities API at
+`external/capabilities/`).
+
+#### 4d. Per-technology serving quirks
+
+`research.md` calls out that not every automation technology wants a single
+file at a single URL:
+
+- **Ubuntu Autoinstall** (`ds=nocloud-net;s=<url>/`) needs `user-data` **and**
+  `meta-data` to resolve under the same URL prefix. `Manager` must special-case
+  this: when the VM's asset list contains both a `user-data` and a `meta-data`
+  key under one Secret, serve them at `/<secretName>/user-data` and
+  `/<secretName>/meta-data` (a real subpath, not the flat `/<secretName>/<key>`
+  layout) so the trailing-slash `ds=nocloud-net;s=` convention resolves both
+  files without extra installer-side configuration.
+- **Kickstart** and **Windows** (the answer file, fetched via `curl.exe` in the
+  boot-command sequence) both use the flat `/<secretName>/<key>` convention
+  as-is; no special-casing required.
+
+---
+
+### Phase 5 — Template Variables for ISO Boot Commands
+
+**File:** `pkg/providers/vsphere/vmlifecycle/bootstrap_templatedata.go`
+
+`Commands` (and the Windows answer-file content, per its end-to-end section) are
+rendered through the exact same `GetTemplateRenderFunc`/`renderTemplate` machinery
+already used to template vAppConfig properties today — there is no separate,
+ISO-specific function map. Network/hostname values come entirely from the
+existing `v1a6TemplateFunctions` function map and the `templateData.V1alpha6`
+struct field (`VM`/`Net`) that `GetTemplateRenderFunc` already builds; ISO
+bootstrap adds exactly **one** new function, `V1Alpha6_BootstrapService`.
+
+Functions already available today (`pkg/providers/vsphere/constants/constants.go`,
+`v1a6TemplateFunctions`) and reused as-is by ISO `Commands`:
+
+| Template call | Returns |
+|---|---|
+| `{{V1alpha6_FirstIP}}` | First IP address (CIDR notation) of the first NIC |
+| `{{V1alpha6_FirstNicMacAddr}}` | MAC address of the first NIC |
+| `{{V1alpha6_FirstIPFromNIC <index>}}` | First IP address (CIDR notation) of the `<index>`th NIC |
+| `{{V1alpha6_IPsFromNIC <index>}}` | All IP addresses of the `<index>`th NIC |
+| `{{V1alpha6_FormatIP <ip> <mask>}}` | Reformats `<ip>` with `<mask>` (a dotted mask or `/N` prefix); `<mask>=""` strips to a bare address |
+| `{{V1alpha6_IP <ip>}}` | Formats a bare `<ip>` with its address family's default netmask CIDR |
+| `{{V1alpha6_SubnetMask <cidr>}}` | Dotted-decimal subnet mask derived from a CIDR string |
+| `{{V1alpha6_FormatNameservers <count> <delimiter>}}` | Joins up to `<count>` nameservers with `<delimiter>` |
+
+Hostname and gateway are not functions at all — they are plain dot-notation field
+access against the down-converted VM object already exposed as `.V1alpha6.VM`,
+exactly as `spec.md`'s own worked example uses them:
+
+| Template expression | Returns |
+|---|---|
+| `{{(index .V1alpha6.VM.Status.Network.Config.Interfaces 0).Gateway4}}` | IPv4 gateway of the first NIC |
+| `{{.V1alpha6.VM.Status.Network.Config.DNS.HostName}}` | VM hostname |
+
+**New for this feature:**
+
+| Template call | Returns |
+|---|---|
+| `{{V1Alpha6_BootstrapService}}` | `<address>:<port>` of the ephemeral bootstrap HTTP Service VM Operator created for this VM (Phase 4) |
+
+`V1Alpha6_BootstrapService` follows the same per-API-version naming convention as
+the existing `V1alpha6_*` functions, but unlike them it cannot be computed purely
+from `BootstrapArgs`/network status at `GetTemplateRenderFunc` construction time —
+its value only exists once `isohttp.Manager.EnsureReady` (Phase 4) has created the
+Pod/Service and resolved an address. `BootstrapISO` (Phase 6) therefore calls
+`EnsureReady` *before* building the render func, and passes the resolved
+address/port into `v1a6TemplateFunctions` (or a small ISO-only wrapper around it)
+as an additional closure parameter, the same way `networkStatusV1A6`/
+`networkDevicesStatusV1A6` are threaded in today. The function's name constant
+(`constants.V1alpha6BootstrapService = "V1Alpha6_BootstrapService"`) is added
+alongside the existing `V1alpha6First*`/`V1alpha6Format*` constants in
+`pkg/providers/vsphere/constants/constants.go`.
+
+There is no separate `http_ip`/`http_port` pair — `spec.md`'s Ubuntu example uses
+`{{V1Alpha6_BootstrapService}}` as a single combined value everywhere, including
+inside the Windows answer-file XML (Phase 4's HTTP server exposes one address and
+one port; splitting them into two template calls would be a distinction without a
+consumer).
+
+---
+
+### Phase 6 — Bootstrap Integration
+
+**File:** `pkg/providers/vsphere/vmlifecycle/bootstrap_iso.go` (new)
+
+```go
+// BootstrapISO performs the ISO automated installation bootstrap for a VM.
+// It creates the ephemeral HTTP server, renders boot commands with network
+// template variables, and sends the resulting keystrokes to the VM via the
+// virtual USB keyboard.
+func BootstrapISO(
+    vmCtx pkgctx.VirtualMachineContext,
+    vcVM *object.VirtualMachine,
+    k8sClient ctrlclient.Client,
+    bootstrapArgs BootstrapArgs,
+) error
+```
+
+Integration into `DoBootstrap` in `bootstrap.go`:
+
+```go
+case bootstrap.ISO != nil:
+    return BootstrapISO(vmCtx, vcVM, k8sClient, bootstrapArgs)
+```
+
+`BootstrapISO` is shared by every OS family, Windows included; it does not branch
+on guest OS at all. Every family renders and sends `spec.bootstrap.iso.commands`
+through the identical Phase 3 keyboard driver — only the *content* of `Commands`
+differs per OS (dracut/netcfg parameters and an installer-file pointer for
+Debian/Ubuntu/RHEL; `Shift+F10`/`netsh`/`curl.exe`/`setup.exe` for Windows). See
+each OS's end-to-end section for the concrete token sequences.
+
+**State tracking** — to ensure boot commands are sent exactly once (level-triggered
+reconciliation requires idempotency guards):
+
+- Hash of `spec.bootstrap.iso` stored in `vmoperator.vmware.com/bootstrap-iso-hash`
+  annotation (same pattern as `BootstrapHashConfigSpecAnnotationKey` used by other
+  bootstrap providers).
+- No separate annotation is needed to track the Pod/Service created for this VM —
+  their names are derived deterministically from the VM's own name (Phase 4a), so
+  `EnsureReady` can always be called without first looking up what was created.
+- If annotation hash matches current spec hash, skip sending boot commands again
+  (idempotent). `EnsureReady`/`Teardown` for the Pod/Service are themselves
+  idempotent via `CreateOrPatch` and do not need the hash guard.
+
+**Return value:** `ErrBootstrapISO = pkgerr.NoRequeueNoErr("bootstrapped vm from iso")`
+after successfully sending commands (same pattern as `ErrBootstrapReconfigure`).
+
+---
+
+### Phase 7 — Webhook Validation
+
+**File:** `webhooks/virtualmachine/v1alpha6/` (validation webhook)
+
+Rules to enforce:
+
+1. `spec.bootstrap.iso` is mutually exclusive with CloudInit, LinuxPrep, Sysprep,
+   and VAppConfig.
+2. When `spec.bootstrap.iso` is non-nil, at least one entry in
+   `spec.hardware.cdrom` must reference an ISO-type image.
+3. `spec.bootstrap.iso.assets[*].name` must be a valid DNS subdomain name
+   (standard Kubernetes Secret name validation).
+4. `spec.bootstrap.iso.commands` may not be changed while the VM is powered on
+   and the bootstrap annotation is set (immutable after first boot).
+
+Because the Pod and Service that host `Assets` are created and named entirely
+by VM Operator (Phase 4), there is no user-facing field to validate for them —
+no name collision is possible across VMs, since each VM's Service name is
+derived from that VM's own name.
+
+---
+
+### Phase 8 — Conditions & Status
+
+When ISO bootstrap is in progress or complete, reflect status via conditions:
+
+| Condition | True | False/Reason |
+|---|---|---|
+| `VirtualMachineBootstrapISOSynced` | Commands sent, HTTP server created | `HTTPServerNotReady`, `KeyboardSendFailed`, `AssetNotFound` |
+
+The HTTP server Pod readiness is surfaced via the `VirtualMachineBootstrapReady`
+condition (already exists) with a reason like `ISOHTTPServerPending`.
+
+---
+
+### Phase 9 — E2E Tests
+
+Per `e2e-sync-with-changes.md`, E2E coverage ships with the behavior. Target tests in
+`test/e2e/vmservice/virtualmachine/`:
+
+- `iso_bootstrap_test.go` — deploy a VM from a known ISO (e.g., a minimal custom
+  ISO that immediately writes a file and powers off), verify the VM completes
+  installation.
+
+E2E tests require a pre-uploaded ISO image in the Content Library, which must be
+documented in `test/e2e/README.md`.
+
+---
+
+## End-to-end: Ubuntu Server (Autoinstall) — US2, P0
+
+Walks the framework phases above end to end for the Ubuntu case, matching
+`research.md` Finding 3.
+
+1. **User applies the VM manifest.** `spec.bootstrap.iso.assets` references a
+   Secret with two keys, `user-data` (the `autoinstall:` document) and
+   `meta-data` (may be empty). `spec.bootstrap.iso.commands` contains the
+   boot-command sequence below. `spec.hardware.cdrom` references the Ubuntu
+   Server ISO's `VirtualMachineImage`. This is the exact shape of `spec.md`'s
+   worked example — there is no Service to name; VM Operator creates and
+   tears down its own.
+2. **Pre-power-on** (Phase 6/7): the CD-ROM reconciler (`pkg/vmconfig/cdrom/`)
+   attaches and connects the ISO. The webhook (Phase 7) confirms the CD-ROM is
+   ISO-typed and no conflicting bootstrap provider is set.
+3. **Pre-power-on** (Phase 4): `isohttp.Manager.EnsureReady` creates the Pod +
+   Service (named deterministically from the VM), mounts the Secret, and —
+   per Phase 4d — serves `user-data` and `meta-data` under one URL prefix
+   `/<secretName>/`.
+4. **Power on.** The VM boots the Ubuntu Server ISO's GRUB2 menu.
+5. **`BootstrapISO` (Phase 6) renders and sends `Commands`**, matching
+   `spec.md`'s worked example (enter GRUB's command-line mode with `c`, then
+   type the `linux`/`initrd`/`boot` sequence directly, rather than editing the
+   default menu entry in place):
+
+   ```text
+   <esc><wait>
+   ifname=bootnet:{{V1alpha6_FirstNicMacAddr}};ip={{(V1alpha6_FormatIP V1alpha6_FirstIP "")}}:{{(index .V1alpha6.VM.Status.Network.Config.Interfaces 0).Gateway4}}:{{(V1alpha6_SubnetMask V1alpha6_FirstIP)}}:{{.V1alpha6.VM.Status.Network.Config.DNS.HostName}}:bootnet
+   <wait3s>c<wait3s>
+   linux /casper/vmlinuz --- autoinstall ds="nocloud-net;seedfrom=http://{{V1Alpha6_BootstrapService}}/"
+   <enter><wait>
+   initrd /casper/initrd
+   <enter><wait>
+   boot
+   <enter>
+   ```
+
+   - The `ifname=`/`ip=` tokens (dracut-style, Phase 3) bring up static
+     networking on the bootloader's own kernel before `c` is even pressed —
+     GRUB2 itself runs with a Linux kernel already loaded into memory at this
+     point on Ubuntu's ISO, so the networking parameters are typed as part of
+     the *default* menu entry's implicit boot line before dropping to the
+     GRUB command line to override `linux`/`initrd`/`boot` explicitly.
+   - `<wait3s>c<wait3s>` drops into GRUB's command-line mode.
+   - `{{V1Alpha6_BootstrapService}}` resolves to the address/port of the
+     ephemeral Service Phase 4 created and resolved in step 3 above.
+6. **Subiquity fetches `user-data`/`meta-data`, installs unattended.** The
+   autoinstall document's `late-commands` may `curl` further provisioning
+   scripts from the same HTTP endpoint, addressed the same way via
+   `{{V1Alpha6_BootstrapService}}` if the script itself is templated before
+   being placed in the Secret (Finding 3's chaining pattern).
+7. **Post-install** (Phase 8): once `status.network.primaryIP` is populated,
+   `VirtualMachineBootstrapISOSynced` flips True and `isohttp.Manager.Teardown`
+   removes the Pod/Service (subject to Open Issue OI-5 below).
+8. **E2E** (Phase 9): `iso_bootstrap_test.go` gains an Ubuntu-specific scenario
+   asserting the VM reaches `Ready` and its guest hostname matches
+   `.V1alpha6.VM.Status.Network.Config.DNS.HostName`.
+
+---
+
+## End-to-end: RHEL / Rocky / AlmaLinux (Kickstart) — US4, P1
+
+Walks the framework phases above end to end for the RHEL-family case, matching
+`research.md` Finding 4. Steps 1-4 and 7-8 are structurally identical to the
+Ubuntu flow above; only step 5's command syntax and step 3's serving convention
+differ.
+
+1. **User applies the VM manifest.** `spec.bootstrap.iso.assets` references a
+   Secret with a single key holding the kickstart file. `spec.hardware.cdrom`
+   references the RHEL/Rocky/AlmaLinux ISO's `VirtualMachineImage`.
+2. **Pre-power-on**: identical to Ubuntu step 2.
+3. **Pre-power-on** (Phase 4): `isohttp.Manager.EnsureReady` serves the
+   kickstart file at the flat `/<secretName>/<key>` path — no special-casing
+   needed (Phase 4d).
+4. **Power on.** The VM boots the RHEL-family ISO's GRUB2 menu (same boot
+   loader as Ubuntu — Anaconda ships on the same GRUB2 base).
+5. **`BootstrapISO` renders and sends `Commands`** via the same dracut-style
+   renderer used for Ubuntu (Phase 3), since Anaconda's initramfs is dracut
+   itself:
+
+   ```text
+   <wait10>e
+   <end> ifname=bootnet:{{V1alpha6_FirstNicMacAddr}} ip={{(V1alpha6_FormatIP V1alpha6_FirstIP "")}}::{{(index .V1alpha6.VM.Status.Network.Config.Interfaces 0).Gateway4}}:{{(V1alpha6_SubnetMask V1alpha6_FirstIP)}}:{{.V1alpha6.VM.Status.Network.Config.DNS.HostName}}:bootnet:none inst.ks=http://{{V1Alpha6_BootstrapService}}/<secretName>/<key>
+   <f10>
+   ```
+
+   - `inst.ks=` replaces Ubuntu's `autoinstall ds=nocloud-net;seedfrom=` —
+     Anaconda fetches the kickstart file directly (no separate
+     `user-data`/`meta-data` split), and the flat asset-serving convention
+     already works unmodified.
+   - `{{V1Alpha6_BootstrapService}}` resolves the same way it does for
+     Ubuntu — the address/port of the ephemeral Service VM Operator created
+     for this VM.
+6. **Anaconda fetches the kickstart file, installs unattended.** The kickstart
+   file's `%post` section may `curl` further provisioning scripts from the
+   same HTTP endpoint (Finding 4's chaining pattern).
+7. **Post-install**: identical to Ubuntu step 7.
+8. **E2E**: `iso_bootstrap_test.go` gains a RHEL-family scenario. Because
+   Rocky/Alma/RHEL/CentOS Stream all share Anaconda unmodified, one test
+   parametrized over the ISO image is sufficient rather than one test per
+   distribution (`research.md` Finding 4, "Note on downstream RHEL
+   derivatives").
+
+---
+
+## End-to-end: Windows Server (Unattend) — US3, P0
+
+Windows does not have a GRUB-equivalent boot-command line, so it cannot use the
+exact `ip=`/`inst.ks=`/`ds=nocloud-net;seedfrom=` idiom the three Linux flows
+share. This plan nonetheless keeps Windows on the **same architecture** as
+Linux — the Phase 3 keyboard driver types a boot-time command sequence that
+fetches the answer file from the Phase 4 HTTP server over the network — rather
+than pre-baking the answer file onto a second, synthesized CD-ROM
+(`research.md` Finding 5, Option A vs. Option B). No new "synthesize an ISO
+from templated text" capability is introduced anywhere in this plan; Windows
+reuses Phase 3 and Phase 4 exactly as built for Debian/Ubuntu/RHEL.
+
+The trade-off, made explicitly: Windows inherits the same boot-command timing
+risk (OI-4, "Possible Issues" item 2) that Debian/Ubuntu/RHEL already accept,
+in exchange for one shared mechanism across every OS family instead of two.
+
+### Steps
+
+1. **User applies the VM manifest.** `spec.bootstrap.iso.assets` references a
+   Secret whose key is named `autounattend.xml` (the Windows answer file), plus
+   optionally further keys for `RunSynchronousCommand` payloads (e.g. a
+   PowerShell provisioning script). `spec.bootstrap.iso.commands` contains the
+   boot-command sequence below. `spec.hardware.cdrom` references the Windows
+   Server installation ISO — a single entry, exactly like the Linux flows;
+   Windows does not need a second `cdrom` entry.
+2. **Pre-power-on** (Phase 4): `isohttp.Manager.EnsureReady` creates the Pod +
+   Service and serves `autounattend.xml` (and any further provisioning script)
+   at `/<secretName>/<key>`, same as every other OS family.
+3. **Power on.** Windows Setup boots to its first screen ("language and other
+   preferences").
+4. **`BootstrapISO` (Phase 6) renders and sends `Commands`** via a
+   Windows-specific token sequence (not the dracut-style renderer — Windows
+   has no kernel command line to append to):
+
+   ```text
+   <waitNNs>
+   <leftShiftOn>f10<leftShiftOff>
+   wpeutil initializenetwork
+   <enter><wait>
+   netsh interface ip set address name="Ethernet" static {{(V1alpha6_FormatIP V1alpha6_FirstIP "")}} {{(V1alpha6_SubnetMask V1alpha6_FirstIP)}} {{(index .V1alpha6.VM.Status.Network.Config.Interfaces 0).Gateway4}}
+   <enter><wait>
+   curl.exe -o X:\autounattend.xml http://{{V1Alpha6_BootstrapService}}/<secretName>/autounattend.xml
+   <enter><wait>
+   X:\sources\setup.exe /unattend:X:\autounattend.xml
+   <enter>
+   ```
+
+   - `<waitNNs>` is the calibrated, ISO-version-dependent delay for Setup's
+     first screen to render — the same class of risk `spec.md`'s own Windows
+     sketch and OI-4/"Possible Issues" item 2 already call out for every OS
+     family.
+   - `<leftShiftOn>f10<leftShiftOff>` (Shift+F10) opens a command prompt
+     inside the running WinPE environment.
+   - `wpeutil initializenetwork` brings up the NIC driver stack before
+     `netsh` can configure an address on it.
+   - `netsh interface ip set address ...` brings up static networking —
+     the Windows analogue of the Linux `ip=`/`netcfg` kernel parameters,
+     using the same `V1alpha6_FormatIP`/`V1alpha6_SubnetMask`/gateway
+     template calls as the Linux flows (Phase 5).
+   - `curl.exe` is the literal stand-in for the URL-fetch step every Linux
+     installer does natively — `setup.exe /unattend:<path>` only accepts a
+     local filesystem path, so the answer file must be downloaded to WinPE's
+     `X:` RAM disk first. `{{V1Alpha6_BootstrapService}}` resolves the same
+     way it does for the Linux flows (Phase 5).
+   - `X:\sources\setup.exe /unattend:X:\autounattend.xml` launches Setup
+     fully unattended from that point on.
+5. **Setup applies networking and runs `RunSynchronousCommand` entries** from
+   the answer file itself — the `windowsPE` pass, `Microsoft-Windows-TCPIP`
+   component can additionally set a static address for Setup's *own* later
+   phases if `netsh` from step 4 is not sufficient, and
+   `Microsoft-Windows-Setup` component `RunSynchronousCommand` entries pull
+   any further provisioning payload from the same HTTP endpoint (e.g.
+   `cmd /c curl.exe -o C:\provision.ps1 http://{{V1Alpha6_BootstrapService}}/<secretName>/provision.ps1`)
+   — the direct analogue of Debian's `preseed/run` and Kickstart's `%post`.
+   `oobeSystem` pass `FirstLogonCommands` handles anything that must run
+   after first boot rather than during Setup.
+6. **Post-install** (Phase 8): once `status.network.primaryIP` is populated
+   (or, alternatively, once the answer file's last `RunSynchronousCommand`
+   signals completion — see OI-5), `VirtualMachineBootstrapISOSynced` flips
+   True and `isohttp.Manager.Teardown` removes the Pod/Service.
+7. **E2E** (Phase 9): `iso_bootstrap_test.go` gains a Windows scenario. Because
+   this path shares the Phase 3 keyboard driver and Phase 4 HTTP server with
+   every other OS family, no Windows-specific test infrastructure is needed
+   beyond a Windows Server ISO and the boot-command sequence above; flakiness
+   from `<waitNNs>` calibration is tracked the same way it already is for
+   Ubuntu/RHEL (OI-1, "Possible Issues" item 2), not as a Windows-only risk.
+
+### Alternative (attached-media autodetection, not pursued for v1)
+
+`research.md` Finding 5, Option B describes attaching a second, synthesized
+CD-ROM containing `autounattend.xml`, which Windows Setup auto-discovers with
+zero keystrokes. It would remove the boot-command timing risk entirely for
+Windows, but at the cost of a second bootstrap mechanism (ISO synthesis)
+alongside the HTTP-serving one every other OS family uses, and of `spec.hardware.cdrom`
+needing a second entry only for this one OS family. Not built in this plan;
+revisit only if Option A's boot-command timing proves unworkable in practice.
+
+---
+
+## Sequence Diagram (Linux path — Ubuntu/RHEL)
+
+```
+User kubectl apply VM (spec.bootstrap.iso set, Commands present)
+  |
+VM Controller reconcile
+  |
+[Pre-power-on] cdrom reconciler ensures CD-ROM attached and connected
+  |
+[Pre-power-on] isohttp.Manager.EnsureReady
+  -> create Pod + Service (named deterministically from the VM) in namespace
+  -> wait for Service external/cluster IP
+  |
+[Power on] VM powered on with CD-ROM as boot device
+  |
+DoBootstrap -> BootstrapISO:
+  1. Build render func: existing V1alpha6_* network functions (vAppConfig's
+     v1a6TemplateFunctions) plus the new V1Alpha6_BootstrapService, backed
+     by the address/port isohttp.Manager.EnsureReady just resolved
+  2. Parse boot command tokens (dracut-style renderer)
+  3. Call vcVM.PutUsbScanCodes (govmomi) for each keystroke batch
+     -- <waitN> tokens call time.Sleep(N) with ctx cancellation
+  4. Store hash annotation
+  5. Return ErrBootstrapISO (no-requeue, not an error)
+  |
+VM installs OS, pulls assets from http://<service-address>:<service-port>/<secret>/<key>
+  |
+VM reports IP via VMware Tools / guest info
+  |
+[Post-install] status.network.primaryIP populated
+  -> VirtualMachineBootstrapISOSynced condition set to True
+  -> isohttp.Manager.Teardown (delete Pod + Service)
+  |
+CD-ROM disconnected (user sets spec.hardware.cdrom[*].connected = false)
+VM reboots from disk
+```
+
+## Sequence Diagram (Windows path)
+
+```
+User kubectl apply VM (spec.bootstrap.iso set, Commands present,
+                       assets include autounattend.xml)
+  |
+VM Controller reconcile
+  |
+[Pre-power-on] cdrom reconciler ensures the Windows install ISO is attached
+  and connected (a single cdrom entry, same as every other OS family)
+  |
+[Pre-power-on] isohttp.Manager.EnsureReady
+  -> create Pod + Service (named deterministically from the VM) in namespace
+  -> wait for Service external/cluster IP
+  |
+[Power on] VM powered on with CD-ROM as boot device
+  |
+DoBootstrap -> BootstrapISO (no Windows-specific branch -- same call as Linux):
+  1. Build render func (V1alpha6_* network functions + V1Alpha6_BootstrapService)
+  2. Parse boot command tokens (Windows-specific token sequence, not the
+     dracut-style renderer)
+  3. Call vcVM.PutUsbScanCodes (govmomi) for each keystroke batch:
+     Shift+F10 -> wpeutil initializenetwork -> netsh (static IP) ->
+     curl.exe (fetch autounattend.xml to X:\) -> setup.exe /unattend:X:\...
+  4. Store hash annotation
+  5. Return ErrBootstrapISO (no-requeue, not an error)
+  |
+Setup runs windowsPE-pass RunSynchronousCommand entries, pulls further
+  provisioning assets from http://<service-address>:<service-port>/<secret>/<key>
+  |
+VM reports IP via VMware Tools / guest info
+  |
+[Post-install] status.network.primaryIP populated
+  -> VirtualMachineBootstrapISOSynced condition set to True
+  -> isohttp.Manager.Teardown (delete Pod + Service)
+  |
+CD-ROM disconnected (user sets spec.hardware.cdrom[*].connected = false)
+VM reboots from disk
+```
+
+---
+
+## Open Issues
+
+### OI-1: Boot command execution blocking the reconcile loop
+
+Sending boot commands blocks the reconcile goroutine for the total duration of all
+`<waitN>` tokens in the command list. For a typical Ubuntu autoinstall sequence this
+is 10-30 seconds. Risks:
+
+- Controller-manager liveness probe timeout if many VMs bootstrap simultaneously.
+- Goroutine starvation under load.
+
+This applies to all four OS families, Windows included — every one of them sends
+boot commands through the same Phase 3 keyboard driver.
+
+**Proposed mitigation (v1):** Run `BootstrapISO` in a dedicated long-running
+goroutine managed by the controller, signalling completion back via a channel
+source (using the existing `pkg/util/kube/cource` pattern). Annotate the VM with
+`vmoperator.vmware.com/bootstrap-iso-phase: sending-commands` before starting and
+`complete` when done.
+
+**Simpler alternative (v1 fallback):** Cap total wait time at 120 seconds. If the
+sum of all `<waitN>` tokens exceeds this, return an error. Document the limitation.
+This is acceptable for the initial MVP.
+
+### OI-2: HTTP server Pod networking on VDS
+
+On VDS (non-NSX-T) Supervisors, `LoadBalancer` Services are not available. The
+`NodePort` fallback requires the VM to route traffic to an ESXi node IP. Depending
+on the workload network topology, the ESXi management VMkernel NIC may not be
+reachable from the workload network segment.
+
+**Proposed mitigation:** Require NSX-T for the initial implementation. Document that
+VDS Supervisor deployments are not supported for automated ISO bootstrap in the
+first release. VDS support is a P2 follow-up.
+
+### OI-3: HTTP server container image in air-gapped environments
+
+The `vmop-iso-httpserver` image must be available in the local registry used by the
+Supervisor cluster. In air-gapped environments, the image must be pre-seeded.
+
+**Proposed mitigation:** Document the image as a required artifact alongside the
+operator image. Use the existing vmop image distribution pipeline to ship it. Make
+the image name configurable via operator env var with a sensible default.
+
+### OI-4: Windows automated bootstrap reliability
+
+Automating the Windows setup screen via boot-command keystrokes is not
+deterministic without VNC — there is no reliable way to know when the first
+screen appears, and `Shift-F10` timing is undocumented. This plan deliberately
+accepts that risk for Windows (`research.md` Finding 5, Option A) rather than
+engineering around it with a synthesized second CD-ROM (Option B), so that
+Windows shares one mechanism with Debian/Ubuntu/RHEL instead of introducing a
+second one. Concretely, this is the same class of risk already recorded in
+"Possible Issues" item 2 for the other three OS families — Windows does not get
+a worse reliability story than they already have, but it does not get a better
+one either.
+
+**Status: open, accepted trade-off.** No mitigation beyond calibrated
+`<waitNNs>` tokens is planned for v1. If Windows boot-command timing proves
+materially less reliable in practice than the Linux flows (e.g. because Setup's
+screen-render time varies more across hardware/ISO versions than GRUB2's does),
+revisit `research.md` Finding 5 Option B (synthesized second CD-ROM) as a
+follow-up rather than a v1 requirement.
+
+### OI-5: Detecting installation completion
+
+The current plan tears down the HTTP server when `status.network.primaryIP` is
+populated (VMware Tools reports an IP). This heuristic is imperfect — the OS could
+report an IP before the installer has finished, for either the Linux or Windows
+path.
+
+**Alternative approaches:**
+- Tear down after a configurable timeout (simpler, explicit).
+- Expose a user-controlled field `spec.bootstrap.iso.autoCleanup: false` to let the
+  user tear down manually.
+- Tear down on next reconcile after the VM is powered off and back on (post-install
+  reboot cycle).
+- Windows-specific: have the last `RunSynchronousCommand`/`FirstLogonCommands`
+  entry in the answer file signal completion explicitly (e.g., write a marker file
+  the controller can poll for via guest info), since Setup's own lifecycle events
+  are more observable than a Linux installer's.
+
+**Recommended for v1:** Configurable timeout (default 60 minutes) with manual
+override via annotation.
+
+### OI-6: `V1Alpha6_BootstrapService` is visible outside the ISO path
+
+Phase 5 adds `V1Alpha6_BootstrapService` to the same shared `v1a6TemplateFunctions`
+map used to render vAppConfig properties, since that is the existing, correct home
+for every other `V1alpha6_*` function. That also means the function is callable
+from a vAppConfig template on a VM that is **not** using `spec.bootstrap.iso` at
+all — `GetTemplateRenderFunc` does not know ahead of time which bootstrap provider
+is active. Calling it outside an ISO-bootstrap reconcile has no address to
+resolve, since `isohttp.Manager.EnsureReady` never ran.
+
+**Proposed mitigation:** only register `V1Alpha6_BootstrapService` in the `FuncMap`
+when `BootstrapISO` (Phase 6) builds its own render func — i.e., `DoBootstrap`'s
+vAppConfig path continues to call `GetTemplateRenderFunc` exactly as it does
+today (function absent), while `BootstrapISO` calls a small wrapper that takes
+`GetTemplateRenderFunc`'s existing `v1a6TemplateFunctions` output and adds the one
+new entry on top, scoped to that single render call. This avoids a version bump
+or a parallel function-map builder while keeping the function absent (and
+therefore a clear "undefined function" template error, not a confusing empty
+string) anywhere it cannot mean anything.
+
+---
+
+## Possible Issues
+
+1. **`PutUsbScanCodes` requires the VM to be powered on and have a USB controller.**
+   The VM must have a USB HID keyboard device. By default, vSphere VMs created via
+   `CreateVM_Task` may not have a virtual keyboard attached if not explicitly
+   specified in the ConfigSpec. The cdrom reconciler or the ISO bootstrap path must
+   verify a virtual keyboard exists and add one if needed. Applies to all four OS
+   families, Windows included.
+
+2. **Bootloader/setup-screen race condition.** Boot commands are sent after
+   `boot_wait` (a configurable initial delay). If the ISO's BIOS/UEFI POST (or,
+   for Windows, Setup's own load time) takes longer than expected, the first
+   keystrokes may be dropped. The end-to-end examples above use explicit
+   `<waitN>` tokens to handle this, but the user must calibrate these for their
+   specific ISO. Document that the initial `<wait>` duration may need tuning —
+   see OI-4 for why this risk is accepted rather than engineered around for
+   Windows specifically.
+
+3. **Non-US keyboard layout.** The HID scan code table is based on a US QWERTY
+   layout. Users running VMs with non-US keyboard layouts configured in the VM's
+   BIOS may receive wrong characters. Document this limitation. Applies to all
+   four OS families, Windows included.
+
+4. **Secret permissions.** The VM controller must have `get` and `watch` RBAC on
+   Secrets in the VM's namespace to read bootstrap assets. The existing RBAC markers
+   may need updating.
+
+5. **Pod security context.** The ephemeral HTTP server Pod must comply with the
+   namespace's Pod Security Admission policy. Use a non-root user, read-only
+   filesystem, and drop all capabilities.
+
+6. **Content library ISO VirtualMachineImage creation.** The image-registry-operator
+   only surfaces OVF-type content library items as VirtualMachineImages today. This
+   must be extended to include ISO-type items. This work is likely in the
+   image-registry-operator, not vm-operator. If it is not done, ISO images will not
+   appear as VirtualMachineImage resources and `spec.hardware.cdrom[*].image` cannot
+   reference them. This is a **hard dependency** that may block the feature.
+
+7. **Content library storage URI for CD-ROM backing.** The vSphere CD-ROM device
+   requires a datastore path (`[datastore] path/to/file.iso`) as its backing. The
+   existing `cdrom_reconciler.go` must resolve the VirtualMachineImage's content
+   library item to a datastore path via the `content/library/item/storage` vSphere
+   REST API. Verify this path is already wired up in the CD-ROM reconciler; every
+   OS family in this plan, Windows included, attaches only its own installation
+   ISO this way, so there is no second CD-ROM-backing case to handle.
+
+---
+
+## Module Impact
+
+Only the root module (`github.com/vmware-tanzu/vm-operator`) is impacted. No
+sub-modules require changes. CRD manifests must be regenerated via
+`make generate-manifests`.
+
+---
+
+## Test strategy
+
+- **Unit** (`testlabels.Controller`): `pkg/util/vsphere/keyboard/` token parsing and
+  HID encoding, including the Windows-specific token sequence (`Shift+F10`,
+  literal command strings, `<waitNNs>`) alongside the dracut/netcfg-style
+  renderers; `pkg/util/kube/isohttp/` Pod/Service spec construction, including
+  that the Pod/Service name is derived deterministically from the VM name and
+  `EnsureReady` is idempotent across repeated calls (fake client).
+- **Integration** (`testlabels.EnvTest` / `testlabels.VCSim`): `BootstrapISO`
+  dispatch from `DoBootstrap` against vcsim, including the annotation-hash
+  idempotency guard — one code path exercised identically for every OS family,
+  Windows included, since there is no Windows-specific branch to test separately.
+- **E2E** (mandatory, `test/e2e/vmservice/virtualmachine/iso_bootstrap_test.go`):
+  one scenario per end-to-end walkthrough above — Ubuntu Autoinstall, RHEL-family
+  Kickstart (parametrized across Rocky/Alma/RHEL where feasible), and Windows
+  Unattend. Per `e2e-sync-with-changes.md`, this ships in the same PR as each user
+  story's code.
+
+---
+
+## Rollout / migration
+
+- **Feature flag**: `pkgcfg.Features.AutoISO`, wired to `WCP_Auto_ISO`, default
+  `false`.
+- **Schema upgrade**: none — `spec.bootstrap.iso` is a net-new, additive field on
+  `v1alpha6`; `v1alpha5` carries a stub for round-trip conversion.
+- **Partner comms**: Content Library ISO-type-item support (Possible Issue 6) is a
+  cross-repo dependency (image-registry-operator) that must ship before or
+  alongside this feature; call this out explicitly to partner teams before GA.
+- **Sequencing**: ship US1 (API) + framework Phases 1-2 first, then US2 (Ubuntu)
+  end to end, then US4 (RHEL family) end to end, then US3 (Windows) last. Windows
+  needs no new framework phases — it reuses Phase 3/4 exactly as built for
+  Linux — but is sequenced last so its boot-command timing (OI-4) can be
+  calibrated against a working reference (the already-shipped Linux flows)
+  rather than in isolation.
+
+---
+
+## Complexity tracking
+
+| Violation | Why needed | Simpler alternative rejected because |
+|-----------|------------|--------------------------------------|
+| Two network-parameter renderers (dracut-style, netcfg-style) instead of one | Debian's `netcfg` component does not accept dracut's `ip=` grammar (`research.md` Finding 1 vs. Finding 2) | A single renderer would either break Debian or require Debian to be excluded from the shared framework entirely |

--- a/.sdd/specs/003-auto-iso/research.md
+++ b/.sdd/specs/003-auto-iso/research.md
@@ -1,0 +1,399 @@
+# Research: Unattended OS Installation from ISO on vSphere
+
+- **Feature**: `specs/003-auto-iso/`
+- **Related**: `spec.md`, `plan.md` in this directory
+- **Epic**: vmop-TBD
+
+---
+
+## Problem statement
+
+`spec.md` and `plan.md` establish the mechanism for reaching a guest that has no
+network yet: a virtual USB keyboard (`PutUsbScanCodes`) sends keystrokes into
+the boot loader, and an ephemeral HTTP server on the Supervisor serves
+user-supplied assets (kickstart files, preseed files, autoinstall
+configs, Windows answer files, provisioning scripts). This document is the
+per-OS-family investigation of **what those keystrokes actually need to say**
+for each unattended-install technology VM Operator must support. Every
+family reduces to the same three steps named in the spec:
+
+1. **Boot the ISO** far enough to reach an editable boot-command line (or, for
+   Windows, the point where a command prompt is reachable).
+2. **Pause the boot process** and inject enough configuration that the
+   installer's *early* environment — which normally has no network at all —
+   can reach the HTTP server.
+3. **Point the installer at the external script/assets** so the rest of the
+   installation proceeds unattended, driven entirely from the network.
+
+The four technologies differ in *where* the pause happens and *what syntax*
+step 2 and step 3 use, but not in the shape of the problem.
+
+---
+
+## Finding 1: the three Linux families share one enabling mechanism — kernel command-line networking
+
+Preseed, Autoinstall, and Kickstart are three different installers
+(debian-installer, Subiquity, Anaconda) with three different automation
+file formats, but all three boot a Linux kernel via GRUB2 (or isolinux on
+legacy BIOS media) and all three accept **extra kernel command-line
+parameters** typed in at the boot menu. That command line is the only
+"early" configuration surface available before the installer's own
+environment starts — which is exactly the surface the virtual USB keyboard
+can reach.
+
+### Pausing the boot loader
+
+For all three Linux families, the mechanic is the same:
+
+1. Wait for the GRUB2 (or isolinux) menu to render (`<wait>`/`<waitNNs>`
+   tokens calibrated to the ISO's POST + menu-render time — see
+   `plan.md` "Possible Issues" item 2).
+2. Highlight the default/first entry (already highlighted on most ISOs) and
+   press `e` (GRUB2) or `Tab` (isolinux/syslinux) to edit the boot command
+   line in place.
+3. Navigate to the `linux`/`linuxefi` line and append the extra parameters
+   (a trailing space plus the new tokens).
+4. Press `Ctrl+X` (GRUB2) or `Enter` (isolinux) to boot with the edited line.
+
+### Early networking on the kernel command line
+
+Debian's own installer (`netcfg`) and the dracut-based initramfs used by
+both Ubuntu's casper/live-boot image and RHEL's Anaconda accept network
+configuration directly as kernel parameters, so the installer's *first*
+network-dependent action (fetching the preseed/autoinstall/kickstart file
+over HTTP) already has a working interface. The dracut `ip=` grammar
+(cited in `spec.md` References, "Configure Linux networking via kernel
+parameters") is:
+
+```text
+ip=<client-IP>:<peer>:<gateway-IP>:<netmask>:<hostname>:<iface>:<autoconf>
+```
+
+- `<client-IP>` — the VM's intended static IPv4 address.
+- `<peer>` — NFS-root peer address; empty for our use case.
+- `<gateway-IP>` — the network's IPv4 gateway.
+- `<netmask>` — dotted-decimal subnet mask (not CIDR).
+- `<hostname>` — the VM's intended hostname.
+- `<iface>` — the kernel network interface name (`eth0`/`ens192` for
+  legacy naming, or resolved via `ifname=<name>:<mac>` when the guest uses
+  predictable interface names and the MAC is known ahead of boot).
+- `<autoconf>` — `none`/`off` for static addressing.
+
+This is exactly the shape already sketched in `spec.md`'s example
+`commands` list (`ifname=bootnet:{{...MacAddr}};ip={{...}}:...`). Because
+Debian's `netcfg` component does **not** consume dracut's `ip=` syntax
+(see Finding 2), this single grammar covers Ubuntu and RHEL but not Debian.
+
+---
+
+## Finding 2: Debian / Preseed
+
+- **Installer**: debian-installer (`d-i`), a debconf-driven installer — not
+  dracut-based.
+- **Upstream reference**: <https://wiki.debian.org/DebianInstaller/Preseed>
+
+### Step 2 — early network configuration
+
+`d-i`'s `netcfg` component owns network configuration and is driven by
+debconf keys, not dracut's `ip=` syntax. The keys can be preseeded directly
+on the kernel command line as `path=value` pairs, which is what makes
+"chicken-and-egg" bootstrapping possible — the values needed to bring up
+the network are themselves supplied before the network exists:
+
+```text
+netcfg/disable_autoconfig=true
+netcfg/choose_interface=<iface>
+netcfg/get_ipaddress=<client-IP>
+netcfg/get_netmask=<netmask>
+netcfg/get_gateway=<gateway-IP>
+netcfg/get_nameservers=<dns-IP>
+netcfg/confirm_static=true
+```
+
+`netcfg/disable_autoconfig=true` is required — otherwise `netcfg` attempts
+DHCP first and only falls back to the static values on failure/timeout,
+adding non-deterministic delay.
+
+### Step 3 — pointing at the external preseed file and assets
+
+Debian supports fetching the *rest* of the preseed answers from the network
+once step 2 has brought up an interface, via the `url=` / `auto=true`
+boot parameters:
+
+```text
+auto=true priority=critical url=http://<http-ip>:<http-port>/<secret>/<key>
+```
+
+- `auto=true` selects the "auto" preseed profile (aggressive defaults,
+  minimal prompting for anything not covered by the preseed file).
+- `priority=critical` suppresses any question whose priority is below
+  critical, which is what makes the install silent even for questions the
+  preseed file does not answer.
+- `url=` is expanded by `d-i` internally to
+  `http://<url>/preseed.cfg` unless the value already ends in a
+  filename with an extension; supplying the full path (as VM Operator's
+  asset-serving convention `/<secretName>/<key>` does) avoids ambiguity.
+
+The preseed file itself (served from the Secret-backed HTTP endpoint) can
+in turn use the `preseed/include` or `d-i preseed/run` directives to chain
+to further post-install shell scripts hosted at the same endpoint — this is
+the standard Debian pattern for "run an arbitrary provisioning script after
+the base install completes."
+
+### Combined command line
+
+```text
+auto=true priority=critical netcfg/disable_autoconfig=true \
+  netcfg/get_ipaddress=<client-IP> netcfg/get_netmask=<netmask> \
+  netcfg/get_gateway=<gateway-IP> netcfg/get_nameservers=<dns-IP> \
+  netcfg/confirm_static=true \
+  url=http://<http-ip>:<http-port>/<secret>/<key>
+```
+
+---
+
+## Finding 3: Ubuntu / Autoinstall
+
+- **Installer**: Subiquity, driven by an `autoinstall` config consumed via
+  `cloud-init`'s `NoCloud` datasource.
+- **Upstream reference**:
+  <https://canonical-subiquity.readthedocs-hosted.com/en/latest/intro-to-autoinstall.html>
+
+### Step 2 — early network configuration
+
+Ubuntu Server's live-installer initramfs (casper) is dracut-compatible for
+early networking, so the `ip=` grammar from Finding 1 applies directly.
+This is the mechanism the `spec.md` example already models with
+`ifname=...;ip=...`.
+
+### Step 3 — pointing at the external autoinstall config and assets
+
+`cloud-init`'s `NoCloud` datasource is selected and pointed at an HTTP
+endpoint via the `ds=nocloud-net` kernel parameter:
+
+```text
+autoinstall ds=nocloud-net;s=http://<http-ip>:<http-port>/<secret>/
+```
+
+- `autoinstall` tells Subiquity to run non-interactively once it locates a
+  valid autoinstall config (as opposed to merely finding cloud-init
+  user-data, which cloud-init consumes on every boot regardless).
+- `ds=nocloud-net;s=<url>` — the trailing slash is significant; cloud-init
+  appends `user-data` and `meta-data` to `<url>` and fetches both over
+  HTTP. The served `user-data` file's top-level key is `autoinstall:`.
+  `meta-data` may be an empty file — cloud-init requires it to exist but
+  does not require content for this use case.
+- Because VM Operator's asset convention serves individual Secret keys at
+  `/<secretName>/<key>` rather than a directory, the HTTP server package
+  (`pkg/util/kube/isohttp/`, `plan.md` Phase 4) needs a small
+  accommodation for Ubuntu specifically: either (a) serve a synthetic
+  directory listing so `.../<secretName>/user-data` and
+  `.../<secretName>/meta-data` both resolve, or (b) require the user to
+  supply both keys (`user-data`, `meta-data`) under one Secret and have
+  the HTTP handler special-case the `nocloud-net` layout. Track as an
+  open item feeding into `plan.md` Phase 4.
+- The autoinstall config's own `late-commands` (or `user-data`'s
+  `runcmd`) can `curl`/`wget` additional provisioning scripts from the
+  same HTTP endpoint, mirroring the Debian `preseed/run` chaining pattern.
+
+### Combined command line
+
+```text
+autoinstall ds=nocloud-net;s=http://<http-ip>:<http-port>/<secret>/ \
+  ifname=bootnet:<mac> \
+  ip=<client-IP>::<gateway-IP>:<netmask>:<hostname>:bootnet:none
+```
+
+---
+
+## Finding 4: RHEL / Kickstart
+
+- **Installer**: Anaconda, dracut-based initramfs.
+- **Upstream reference**:
+  <https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/7/html/installation_guide/sect-kickstart-howto>
+
+### Step 2 — early network configuration
+
+Anaconda's initramfs is dracut itself, so the `ip=` grammar from Finding 1
+applies unmodified — this is the same reference already cited in
+`spec.md` ("RHEL boot commands ... including networking").
+
+### Step 3 — pointing at the external kickstart file and assets
+
+```text
+inst.ks=http://<http-ip>:<http-port>/<secret>/<key>
+```
+
+- `inst.ks=` (the modern prefix; bare `ks=` remains a supported alias on
+  RHEL 7) fetches the kickstart file over HTTP once the interface from
+  step 2 is up.
+- `inst.ks.device=<iface>` can be set explicitly when Anaconda's automatic
+  "which NIC has a route to the kickstart URL" heuristic is ambiguous
+  (more than one NIC configured) — not needed for VM Operator's
+  single-NIC bootstrap network case, but worth documenting for the
+  multi-NIC edge case.
+- The kickstart file's own `%post --nochroot` (or plain `%post`) section
+  is the standard place to `curl` further provisioning assets from the
+  same HTTP endpoint — the same chaining pattern as Debian/Ubuntu.
+
+### Combined command line
+
+```text
+inst.ks=http://<http-ip>:<http-port>/<secret>/<key> \
+  ip=<client-IP>::<gateway-IP>:<netmask>:<hostname>:<iface>:none
+```
+
+### Note on downstream RHEL derivatives
+
+Rocky Linux, AlmaLinux, and CentOS Stream all ship Anaconda unmodified from
+RHEL, so this section applies to all of them without changes beyond the
+`inst.ks=` parameter name (stable across RHEL 8/9). `spec.md` User Story
+US4 ("Rocky, RHEL, other Linux distributions") is fully covered by this
+finding — no per-distribution branching is required in
+`pkg/util/vsphere/keyboard/` beyond the network-parameter templating
+already shared with Ubuntu.
+
+---
+
+## Finding 5: Windows / Unattend — a structurally different mechanism
+
+- **Upstream reference**:
+  <https://learn.microsoft.com/en-us/windows-hardware/customize/desktop/unattend/>
+
+Windows Setup has no GRUB-equivalent boot-command line, and its automation
+file (`autounattend.xml`, an "unattend" answer file) is **not** referenced
+via a kernel/boot parameter. This means the "pause the boot process, type
+a URL" pattern used by the three Linux families does not transfer
+directly, and the choice of mechanism materially changes the reliability
+story flagged in `plan.md` OI-4.
+
+### Option A — boot-command keystrokes into a WinPE command prompt, fetching the answer file over HTTP (recommended)
+
+This is the direct Windows analogue of the pattern the three Linux families
+already use: type a boot-time command that fetches the automation file
+from the network, rather than pre-baking it onto attached media. It keeps
+Windows on the same architecture as Linux — the Phase 3 keyboard driver is
+the only mechanism used across all four OS families, and `Assets` are
+always reached over HTTP, never via a synthesized ISO.
+
+1. Wait for the Windows Setup "language and other preferences" screen —
+   this wait has no reliable signal to key off of (`plan.md` OI-4);
+   it must be a calibrated `<waitNNs>`.
+2. Send `<leftShiftOn>f10<leftShiftOff>` (Shift+F10) to open a command
+   prompt inside the WinPE environment Setup is running in.
+3. Bring up static networking from the command prompt:
+
+   ```text
+   wpeutil initializenetwork
+   netsh interface ip set address name="Ethernet" static <client-IP> <netmask> <gateway-IP>
+   ```
+
+   (`spec.md`'s example already sketches this `netsh` invocation.)
+4. Fetch the answer file from the HTTP endpoint and launch Setup with it,
+   e.g.:
+
+   ```text
+   curl.exe -o X:\autounattend.xml http://<http-ip>:<http-port>/<secret>/<key>
+   X:\sources\setup.exe /unattend:X:\autounattend.xml
+   ```
+
+   (`X:` is WinPE's conventional RAM-disk drive letter for the running
+   Setup environment.) `setup.exe /unattend:<path>` requires a local
+   filesystem path, not a URL — the `curl.exe` step is what stands in for
+   the URL fetch a Linux installer does natively via `url=`/
+   `ds=nocloud-net;seedfrom=`/`inst.ks=`.
+5. Further provisioning assets/scripts referenced from the answer file
+   (`RunSynchronousCommand` during `windowsPE`, or `FirstLogonCommands` in
+   `oobeSystem` for post-first-boot steps) are pulled from the same HTTP
+   endpoint the same way — the direct analogue of Debian's `preseed/run`
+   and Kickstart's `%post`.
+
+This path inherits the same timing risk `plan.md` OI-4 already calls out
+for the boot-command mechanism in general — there is no deterministic
+signal for "the setup screen is now showing," so `<waitNNs>` values are
+ISO-version- and hardware-speed-dependent and must be recalibrated
+whenever the Windows ISO changes. That risk is judged acceptable here
+because it is the same risk already accepted for Ubuntu/RHEL/Debian
+(`plan.md` "Possible Issues" item 2) — Windows does not get a materially
+different reliability story than the rest of the framework, and the whole
+feature stays on one mechanism instead of two.
+
+### Option B — attached-media autodetection (not pursued for v1)
+
+Windows Setup automatically scans every attached removable volume (floppy,
+USB, or a second CD/DVD drive) for a file literally named
+`autounattend.xml` at its root, **before any user interaction**, and
+applies it with zero keystrokes if found. This is the mechanism the
+existing Packer vSphere-ISO builder relies on for Windows: the Windows
+installation ISO is attached as one CD-ROM device, and a small second ISO
+(or floppy image) built from the answer file is attached as a second
+CD-ROM device.
+
+This sidesteps the boot-command timing problem entirely — there is nothing
+to time, because Setup checks for the file on its own before rendering the
+first screen — but it requires the ISO-bootstrap path to gain a wholly new
+capability (synthesizing a small ISO/floppy image from templated text) that
+the HTTP-serving design in `plan.md` Phase 4 does not otherwise need, and it
+departs from the "fetch assets over HTTP" shape shared by every other OS
+family. Recorded here as a known alternative — e.g., if Option A's boot-
+command timing proves unworkable in practice for a given Windows ISO — but
+not the direction this plan takes for v1.
+
+### Recommendation
+
+Prefer Option A: it keeps Windows on the same boot-command + HTTP-serving
+architecture as Debian/Ubuntu/RHEL, using the Phase 3 keyboard driver and
+Phase 4 HTTP server exactly as built for Linux, with no new "synthesize an
+ISO" capability. The cost is that Windows inherits the same boot-command
+timing risk (OI-4) the other three families already accept.
+
+---
+
+## Comparison summary
+
+| | Debian (Preseed) | Ubuntu (Autoinstall) | RHEL (Kickstart) | Windows (Unattend) |
+|---|---|---|---|---|
+| Installer | debian-installer | Subiquity + cloud-init | Anaconda | Windows Setup |
+| Boot loader | GRUB2 / isolinux | GRUB2 | GRUB2 / isolinux | Windows Boot Manager |
+| Pause mechanic | Edit kernel cmdline (`e`/`Tab`) | Edit kernel cmdline (`e`) | Edit kernel cmdline (`e`/`Tab`) | Shift+F10 |
+| Early network syntax | `netcfg/get_*=` debconf keys | dracut `ip=` | dracut `ip=` | `netsh` from a WinPE command prompt |
+| Automation-file pointer | `auto=true priority=critical url=` | `autoinstall ds=nocloud-net;s=` | `inst.ks=` | `curl.exe` fetch + `setup.exe /unattend:<local path>` |
+| Post-install script chaining | `preseed/include`, `preseed/run` | `late-commands` / `runcmd` | `%post` | `RunSynchronousCommand` / `FirstLogonCommands` |
+
+---
+
+## Open items feeding back into `plan.md`
+
+1. **Ubuntu `nocloud-net` needs two files at one URL** (`user-data` +
+   `meta-data`), which does not map cleanly onto the
+   one-Secret-key-per-asset serving convention in `plan.md` Phase 4. Needs
+   a decision before Phase 4 is implemented for US2.
+2. **Windows uses the same boot-command path as Linux, on purpose.** Finding
+   5's Option A keeps Windows on the shared Phase 3 keyboard driver and
+   Phase 4 HTTP server rather than introducing a second, ISO-synthesis-based
+   mechanism (Option B). This means OI-4's boot-command timing risk applies
+   to Windows exactly as it does to Debian/Ubuntu/RHEL — it is accepted, not
+   engineered away, in exchange for one shared mechanism across all four OS
+   families.
+3. **Debian's `netcfg` keys vs. dracut's `ip=`** means
+   `pkg/util/vsphere/keyboard`'s command templating cannot share one
+   "network parameters" template across all Linux families — it needs at
+   least two renderers (netcfg-style vs. dracut-style), selected by the
+   image's installer family. `spec.md`/`plan.md` do not yet name this
+   distinction explicitly.
+
+---
+
+## References
+
+- Debian Preseed: <https://wiki.debian.org/DebianInstaller/Preseed>
+- Ubuntu Autoinstall: <https://canonical-subiquity.readthedocs-hosted.com/en/latest/intro-to-autoinstall.html>
+- RHEL Kickstart: <https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/7/html/installation_guide/sect-kickstart-howto>
+- Windows unattended setup / answer files: <https://learn.microsoft.com/en-us/windows-hardware/customize/desktop/unattend/>
+- dracut kernel command line (`ip=` grammar): referenced in `spec.md` as
+  "RHEL boot commands" / "Ubuntu boot commands"
+- Configure Linux networking via kernel parameters: referenced in
+  `spec.md` ("Configure Linux networking via kernel parameters")
+- `spec.md` (this feature) — boot-command and asset-serving API shape
+- `plan.md` (this feature) — USB keyboard driver (Phase 3), ephemeral HTTP
+  server (Phase 4), Windows reliability risk (OI-4)

--- a/.sdd/specs/003-auto-iso/spec.md
+++ b/.sdd/specs/003-auto-iso/spec.md
@@ -1,0 +1,185 @@
+# Feature Specification: Automated Deployment from ISO image
+
+- **Feature branch**: [`feature/auto-iso`](https://github.com/akutz/vm-operator/tree/feature/auto-iso/)
+  - **Fork**: `akutz/vm-operator`
+  - **PR target**: `vmware-tanzu/vm-operator`
+- **Created**: 2026-06-29
+- **Status**: In Progress (Architecture phase; code not yet started)
+- **Epic**: vmop-TBD
+- **Wiki parent**: VM Service: Auto ISO
+- **Spike (done)**: vmop-TBD
+
+---
+
+## Summary
+
+A previous effort resulted in the ability to boot and manually configure a VM Service VM from an ISO image. This new effort aims to automate this process. The two, primary impediments to achieve this are:
+
+1. The client must be able to configure the VM to use a temporary network so it can access assets over the network that inform the guest how to perform the unattended installation. Typically a Packer workflow would use VNC to send commands into the guest since it would be running locally. While it *is* possible to run VNC for ESXi-hosted VMs, it is more challenging due to firewalls and being disabled by default.
+2. The endpoint hosting the assets mentioned in step one must be accessible by the VM. Typically a Packer workflow would start an HTTP server local to where the `packer` command is running, but this would not be accessible by the VM Service VM.
+
+In other words:
+
+1. How does VM Operator configure a VM's guest such that it can access the network before the OS is even installed?
+2. How does VM Operator make assets available via the network to the VM's guest OS's installation process?
+
+It turns out there is already a [Packer builder for deploying a vSphere VM from ISO](https://developer.hashicorp.com/packer/integrations/vmware/vsphere/latest/components/builder/vsphere-iso) ([GitHub](https://github.com/vmware/packer-plugin-vsphere/tree/main/builder/vsphere/iso)). This builder uses the a virtual USB keyboard to send keyscan codes to communicate to the VM's guest in place of VNC. For Linux, tt should therefore be
+possible to:
+
+1. Update the VM API so that `spec.bootstrap.iso` enables automated installation from an ISO image, ex.:
+
+    ```yaml
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: my-vm-1-boot-disk
+      namespace: my-namespace-1
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      volumeMode: Block
+      resources:
+        requests:
+          storage: 20Gi
+      storageClassName: my-storage-class-1
+
+    ---
+
+    apiVersion: vmoperator.vmware.com/v1alpha6
+    kind: VirtualMachine
+    metadata:
+      name: my-vm-1
+      namespace: my-namespace-1
+    spec:
+      className: best-effort-small
+      imageName: ubuntu-24.04-iso
+      storageClassName: my-storage-class-1
+      guestID: ubuntu64Guest
+      bootstrap:
+        iso:
+          commands:
+          # Configure the Linux kernel with networking. There should be specific
+          # parameters, ex. {{V1alpha6_FirstNicMacAddr}}, that are pre-defined
+          # and map to values from the VM's intended network config,
+          # ex. `status.network.config`.
+          - "<esc><wait> "
+          - "ifname=bootnet:{{V1alpha6_FirstNicMacAddr}};ip={{(V1alpha6_FormatIP V1alpha6_FirstIP \"\")}}:{{(index .V1alpha6.VM.Status.Network.Config.Interfaces 0).Gateway4}}:{{(V1alpha6_SubnetMask V1alpha6_FirstIP)}}:{{.V1alpha6.VM.Status.Network.Config.DNS.HostName}}:bootnet "
+          
+          # This waits for 3 seconds, sends the "c" key, and then waits for
+          # another 3 seconds. In the GRUB boot loader, this is used to enter
+          # command line mode.
+          - "<wait3s>c<wait3s>"
+          
+          # This types a command to load the Linux kernel from the specified
+          # path with the 'autoinstall' option and the value of the
+          # 'data_source_command' local variable.
+          # The 'autoinstall' option is used to automate the installation
+          # process.
+          # The '{{V1Alpha6_BootstrapService}}' function resolves to the
+          # IP_ADDR:PORT of the ephemeral bootstrap HTTP service that VM
+          # Operator automatically creates and tears down for this VM.
+          - "linux /casper/vmlinuz --- autoinstall ds=\"nocloud-net;seedfrom=http://{{V1Alpha6_BootstrapService}}/\""
+          
+          # This sends the "enter" key and then waits. This is typically used to
+          # execute the command and give the system time to process it.
+          - "<enter><wait>"
+          
+          # This types a command to load the initial RAM disk from the specified
+          # path.
+          - "initrd /casper/initrd"
+          
+          # This sends the "enter" key and then waits. This is typically used to
+          # execute the command and give the system time to process it.
+          - "<enter><wait>",
+          
+          # This types the "boot" command. This starts the boot process using
+          # the loaded kernel and initial RAM disk.
+          - "boot"
+          
+          # This sends the "enter" key. This is typically used to execute the
+          # command.
+          - "<enter>"
+    
+          assets:
+          # The client has already uploaded the bootstrap assets to a Secret
+          # resource named my-vm-1-bootstrap-data where each asset is a file
+          # accessible at key-1 and key-2. This Secret will be mounted to a Pod
+          # on Supervisor and the keys in the Secret will be accessible via the
+          # network when the Pod starts a web server pointed at the path where
+          # the Secret is mounted.
+          - name: my-vm-1-bootstrap-data
+            key: key-1
+          - name: my-vm-1-bootstrap-data
+            key: key-2
+      volumes:
+      - name: boot-disk
+        persistentVolumeClaim:
+          claimName: my-vm-1-boot-disk
+    ```
+
+2. Use a virtual USB keyboard to send scan codes that configure the [Linux kernel parameters](https://linuxlink.timesys.com/docs/static_ip) so any Linux installer can access the network.
+3. Place any bootstrap assets into a `Secret` resource that is then made available on the same network as the VM via a PodVM with the `Secret` mounted as a volume and surfaced via a web server, ex. `python3 -m http.server`.
+4. Use the virtual USB keyboard again to send scan codes from the `spec.bootstrap.iso.commands` property that indicates how to automate the installation.
+
+For Windows systems it would be similar, the boot commands may differ, ex.:
+
+1. Wait `X` amount of time to assume the system is at the first screen of the setup process
+2. Use the virtual keyboard to send the `Shift-F10` key to access the command line.
+3. Use `netsh` to then configure the network, ex.: `netsh interface ipv4 set address name="Ethernet" static {{(V1alpha6_FormatIP V1alpha6_FirstIP \"\")}} {{(V1alpha6_SubnetMask V1alpha6_FirstIP)}} {{(index .V1alpha6.VM.Status.Network.Config.Interfaces 0).Gateway4}}`.
+
+
+---
+
+## Reconciliation pipeline (big picture)
+
+
+
+---
+
+## User stories
+
+### US1 — API changes (Priority: P0)
+
+### US2 - Support Ubuntu Server 26.04 LTS (Priority: P0)
+
+### US3 - Support Windows Server 2025 (Priority: P0)
+
+### US4 - Support Ubuntu, Photon, Rocky, RHEL, other Linux distributions (Priority: P1)
+
+---
+
+## Edge cases
+
+
+---
+
+## Out of scope
+
+- Support for non-Windows and non-Linux guest operating systems.
+
+---
+
+## Review & acceptance checklist
+
+- [ ] All user stories have at least two Given/When/Then scenarios.
+- [ ] Each scenario is independently testable.
+- [ ] ExtraConfig Allow/Deny precedence is stated.
+- [ ] Out-of-scope items are listed.
+
+---
+
+## References
+
+* WIKI page 1872226468
+* [William's manual testing](https://github.com/warroyo/packer-supervisor-examples/tree/main/manual-testing)
+* [Ubuntu boot commands](https://manpages.ubuntu.com/manpages/xenial/en/man7/dracut.cmdline.7.html) (including networking)
+* [RHEL boot commands](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/networking_guide/sec-configuring_ip_networking_from_the_kernel_command_line) (including networking)
+* [Packer template](https://github.com/haproxytech/vmware-haproxy/blob/main/packer.json#L58-L63) to build a HAProxy VM using the existing VMware ISO builder
+* Configure [Linux networking via kernel parameters](https://linuxlink.timesys.com/docs/static_ip)
+* Use virtual USB keyboard to send keystrokes to remote VM:
+    * [Example 1](https://github.com/hashicorp/packer-plugin-vsphere/blob/main/builder/vsphere/common/step_boot_command.go)
+    * [Example 2](https://github.com/hashicorp/packer-plugin-vsphere/blob/main/builder/vsphere/driver/vm_keyboard.go)
+* Packer examples for vSphere:
+    * [Base](https://github.com/vmware/packer-examples-for-vsphere/tree/develop/builds)
+    * [Linux](https://github.com/vmware/packer-examples-for-vsphere/tree/develop/builds/linux)
+    * [Windows](https://github.com/vmware/packer-examples-for-vsphere/tree/develop/builds/windows)


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

Capture Spec-Driven Development artifacts for automating OS installation from an ISO image on vSphere. The feature lets a VM Service VM configure temporary networking and pull unattended-install assets over the network before the guest OS exists, using a virtual USB keyboard (PutUsbScanCodes) in place of VNC and an ephemeral HTTP server that VM Operator creates and tears down per VM to host user-supplied bootstrap assets.

- spec.md: API shape (spec.bootstrap.iso), user stories for Ubuntu Server, Windows Server, and other Linux distributions.
- research.md: per-installer investigation of Preseed, Autoinstall, Kickstart, and Windows Unattend, including the boot-command and network-parameter syntax each one needs. Windows is kept on the same boot-command-plus-HTTP-fetch mechanism as Linux (curl.exe and setup.exe /unattend:) rather than a synthesized second CD-ROM.
- plan.md: the shared framework (API, feature flag, USB keyboard driver, ephemeral HTTP server, template variables reused from the existing vAppConfig render functions, bootstrap integration, webhook validation, conditions, E2E) plus end-to-end walkthroughs for Ubuntu Autoinstall, RHEL Kickstart, and Windows Unattend.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
SDD spec and plan for auto-ISO support
```