### PR TITLE
✨ Use spec.VMName for indexed snapshot lookup for a VM

### DIFF
--- a/controllers/virtualmachinesnapshot/virtualmachinesnapshot_controller.go
+++ b/controllers/virtualmachinesnapshot/virtualmachinesnapshot_controller.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -54,6 +55,16 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 
 		controllerNameShort = fmt.Sprintf("%s-controller", strings.ToLower(controlledTypeName))
 	)
+
+	// Index by Spec.VMName so per-VM snapshot lookups scale with matches,
+	// not with the total snapshots in a namespace.
+	if err := mgr.GetFieldIndexer().IndexField(
+		ctx,
+		&vmopv1.VirtualMachineSnapshot{},
+		kubeutil.VMSnapshotVMNameFieldIndex,
+		kubeutil.VMSnapshotVMNameIndexerFunc); err != nil {
+		return err
+	}
 
 	r := NewReconciler(
 		ctx,
@@ -164,11 +175,14 @@ func (r *Reconciler) ReconcileNormal(ctx *pkgctx.VirtualMachineSnapshotContext) 
 	}
 
 	vmSnapshot := ctx.VirtualMachineSnapshot
-	ctx.Logger.Info("Fetching VirtualMachine from snapshot object")
 
 	if vmSnapshot.Spec.VMName == "" {
 		return ctrl.Result{}, errors.New("vmName is required")
 	}
+
+	ensureVMNameLabel(vmSnapshot)
+
+	ctx.Logger.Info("Fetching VirtualMachine from snapshot object")
 
 	vm := &vmopv1.VirtualMachine{}
 	objKey := client.ObjectKey{Name: vmSnapshot.Spec.VMName, Namespace: vmSnapshot.Namespace}
@@ -179,7 +193,7 @@ func (r *Reconciler) ReconcileNormal(ctx *pkgctx.VirtualMachineSnapshotContext) 
 	ctx.VM = vm
 
 	// The snapshot must be owned by a VM.  Set an owner reference to the VM.
-	if err := controllerutil.SetOwnerReference(ctx.VM, ctx.VirtualMachineSnapshot, r.Scheme()); err != nil {
+	if err := controllerutil.SetOwnerReference(ctx.VM, vmSnapshot, r.Scheme()); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to set owner reference to snapshot: %w", err)
 	}
 
@@ -300,6 +314,13 @@ func (r *Reconciler) syncVMSSnapshotTreeStatus(ctx *pkgctx.VirtualMachineSnapsho
 		return err
 	}
 	return r.Client.Status().Patch(ctx, ctx.VM, mergePatch)
+}
+
+// ensureVMNameLabel keeps the VM name label in sync with Spec.VMName.
+// Spec.VMName is immutable once set, so this can never introduce a value
+// that later needs to change.
+func ensureVMNameLabel(vmSnapshot *vmopv1.VirtualMachineSnapshot) {
+	metav1.SetMetaDataLabel(&vmSnapshot.ObjectMeta, vmopv1.VMNameForSnapshotLabel, vmSnapshot.Spec.VMName)
 }
 
 // ensureCSIVolumeSyncAnnotation ensures the annotation is set to request

--- a/controllers/virtualmachinesnapshot/virtualmachinesnapshot_controller_unit_test.go
+++ b/controllers/virtualmachinesnapshot/virtualmachinesnapshot_controller_unit_test.go
@@ -303,6 +303,25 @@ func unitTestsReconcile() {
 			})
 		})
 
+		When("object is missing the VM name label", func() {
+			BeforeEach(func() {
+				vmSnapshot.Labels = nil
+				vm.Status.UniqueID = dummyVMUUID
+				initObjects = nil
+				initObjects = append(initObjects, vm, vmSnapshot)
+			})
+
+			It("backfills the label and continues reconciling in the same pass", func() {
+				Expect(err).NotTo(HaveOccurred())
+				vmSnapshotObj := &vmopv1.VirtualMachineSnapshot{}
+				Expect(ctx.Client.Get(ctx, snapshotObjKey, vmSnapshotObj)).To(Succeed())
+				Expect(vmSnapshotObj.Labels).To(HaveKeyWithValue(
+					vmopv1.VMNameForSnapshotLabel, vmSnapshot.Spec.VMName))
+				// A populated status confirms the reconcile did not stop early.
+				Expect(vmSnapshotObj.Status.Storage).ToNot(BeNil())
+			})
+		})
+
 		When("snapshot's created condition is not set", func() {
 			BeforeEach(func() {
 				vm.Status.UniqueID = dummyVMUUID

--- a/pkg/providers/vsphere/vmprovider_vmsnapshot.go
+++ b/pkg/providers/vsphere/vmprovider_vmsnapshot.go
@@ -227,30 +227,27 @@ func markSnapshotWaitingForDiskRegistration(
 	return nil
 }
 
-// getVirtualMachineSnapshotsForVM finds all VirtualMachineSnapshot objects that reference this VM.
+// getVirtualMachineSnapshotsForVM returns all VirtualMachineSnapshot objects
+// for this VM. The lookup is indexed so it scales with matching snapshots,
+// not with every snapshot in the namespace.
 func getVirtualMachineSnapshotsForVM(
 	vmCtx pkgctx.VirtualMachineContext,
 	k8sClient ctrlclient.Client) ([]vmopv1.VirtualMachineSnapshot, error) {
 
-	// List all VirtualMachineSnapshot objects in the VM's namespace
 	var snapshotList vmopv1.VirtualMachineSnapshotList
-	if err := k8sClient.List(vmCtx, &snapshotList, ctrlclient.InNamespace(vmCtx.VM.Namespace)); err != nil {
+	if err := k8sClient.List(
+		vmCtx,
+		&snapshotList,
+		ctrlclient.InNamespace(vmCtx.VM.Namespace),
+		ctrlclient.MatchingFields{kubeutil.VMSnapshotVMNameFieldIndex: vmCtx.VM.Name},
+	); err != nil {
 		return nil, fmt.Errorf("failed to list VirtualMachineSnapshot objects: %w", err)
 	}
 
-	// Filter snapshots that reference this VM. We do this by checking
-	// the VMName, and by filtering the snapshots owned by this VM.
-	var vmSnapshots []vmopv1.VirtualMachineSnapshot
-	for _, snapshot := range snapshotList.Items {
-		if snapshot.Spec.VMName == vmCtx.VM.Name {
-			vmSnapshots = append(vmSnapshots, snapshot)
-		}
-	}
-
 	vmCtx.Logger.V(4).Info("Current count of VirtualMachineSnapshot objects for VM",
-		"count", len(vmSnapshots))
+		"count", len(snapshotList.Items))
 
-	return vmSnapshots, nil
+	return snapshotList.Items, nil
 }
 
 func (vs *vSphereVMProvider) reconcileSnapshotRevert(

--- a/pkg/providers/vsphere/vmprovider_vmsnapshot_test.go
+++ b/pkg/providers/vsphere/vmprovider_vmsnapshot_test.go
@@ -617,6 +617,45 @@ var _ = Describe(
 							vmopv1.VirtualMachineSnapshotWaitingForDiskRegistrationReason))
 					}
 				})
+
+				// Selection must key off Spec.VMName, not the label, since the
+				// label can be absent or stale independently of the VM it names.
+				DescribeTable("selecting which snapshot to mark WaitingForDiskRegistration",
+					func(labelBelongsToThisVM, specBelongsToThisVM, wantTouched bool) {
+						resolve := func(belongsToThisVM bool) string {
+							if belongsToThisVM {
+								return vm.Name
+							}
+							return "other-vm"
+						}
+
+						conditions.MarkTrue(vm, vmconfunmanagedvolsfil.Condition)
+						conditions.MarkFalse(vm, vmconfunmanagedvolsreg.Condition,
+							"PendingRegistration", "CnsRegisterVolume objects are being processed")
+						Expect(ctx.Client.Status().Update(ctx, vm)).To(Succeed())
+
+						snapshot1 = builder.DummyVirtualMachineSnapshot(
+							vm.Namespace, "snapshot-1", resolve(specBelongsToThisVM))
+						metav1.SetMetaDataLabel(&snapshot1.ObjectMeta,
+							vmopv1.VMNameForSnapshotLabel, resolve(labelBelongsToThisVM))
+						Expect(ctx.Client.Create(ctx, snapshot1)).To(Succeed())
+
+						Expect(vsphere.ReconcileSnapshotWaitForCRVCondition(vmCtx, ctx.Client)).To(Succeed())
+
+						got := &vmopv1.VirtualMachineSnapshot{}
+						Expect(ctx.Client.Get(ctx, ctrlclient.ObjectKey{
+							Name: snapshot1.Name, Namespace: vm.Namespace,
+						}, got)).To(Succeed())
+
+						touched := conditions.GetReason(got, vmopv1.VirtualMachineSnapshotCreatedCondition) ==
+							vmopv1.VirtualMachineSnapshotWaitingForDiskRegistrationReason
+						Expect(touched).To(Equal(wantTouched))
+					},
+					Entry("label and Spec.VMName both belong to this VM", true, true, true),
+					Entry("label and Spec.VMName both belong to a different VM", false, false, false),
+					Entry("Spec.VMName belongs to this VM but the label is stale/wrong", false, true, true),
+					Entry("label belongs to this VM but Spec.VMName belongs elsewhere", true, false, false),
+				)
 			})
 		})
 	})

--- a/pkg/util/kube/vmsnapshot.go
+++ b/pkg/util/kube/vmsnapshot.go
@@ -20,6 +20,22 @@ import (
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 )
 
+// VMSnapshotVMNameFieldIndex is the field index key for looking up
+// VirtualMachineSnapshot objects by Spec.VMName.
+const VMSnapshotVMNameFieldIndex = "spec.vmName"
+
+// VMSnapshotVMNameIndexerFunc extracts the value indexed by
+// VMSnapshotVMNameFieldIndex from a VirtualMachineSnapshot object. Shared
+// between the field indexer registration and any fake client used in tests,
+// so the two can never drift apart.
+func VMSnapshotVMNameIndexerFunc(rawObj ctrlclient.Object) []string {
+	vmSnapshot := rawObj.(*vmopv1.VirtualMachineSnapshot)
+	if vmSnapshot.Spec.VMName == "" {
+		return nil
+	}
+	return []string{vmSnapshot.Spec.VMName}
+}
+
 // CalculateReservedForSnapshotPerStorageClass calculates the reserved capacity for a snapshot.
 // And return the requested capacity categorized by each storage class.
 // 1. Space required for classic disks.

--- a/test/builder/fake.go
+++ b/test/builder/fake.go
@@ -32,6 +32,7 @@ import (
 	vmopv1a1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 	"github.com/vmware-tanzu/vm-operator/pkg/record"
+	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 )
 
 func NewFakeClient(objs ...client.Object) client.Client {
@@ -48,6 +49,10 @@ func NewFakeClientWithInterceptors(
 		WithInterceptorFuncs(funcs).
 		WithObjects(objs...).
 		WithStatusSubresource(KnownObjectTypes()...).
+		WithIndex(
+			&vmopv1.VirtualMachineSnapshot{},
+			kubeutil.VMSnapshotVMNameFieldIndex,
+			kubeutil.VMSnapshotVMNameIndexerFunc).
 		Build()
 }
 

--- a/webhooks/virtualmachinesnapshot/mutation/virtualmachinesnapshot_mutator.go
+++ b/webhooks/virtualmachinesnapshot/mutation/virtualmachinesnapshot_mutator.go
@@ -54,7 +54,7 @@ type mutator struct {
 }
 
 func (m mutator) Mutate(ctx *pkgctx.WebhookRequestContext) admission.Response {
-	if ctx.Op != admissionv1.Create {
+	if ctx.Op != admissionv1.Create && ctx.Op != admissionv1.Update {
 		return admission.Allowed("")
 	}
 
@@ -63,7 +63,8 @@ func (m mutator) Mutate(ctx *pkgctx.WebhookRequestContext) admission.Response {
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
 
-	// Always set the VM name label on create
+	// Fills in the label for snapshots that predate it or were created while
+	// this webhook was unavailable.
 	if wasMutated := SetVMNameLabel(modified); !wasMutated {
 		return admission.Allowed("")
 	}

--- a/webhooks/virtualmachinesnapshot/mutation/virtualmachinesnapshot_mutator_unit_test.go
+++ b/webhooks/virtualmachinesnapshot/mutation/virtualmachinesnapshot_mutator_unit_test.go
@@ -5,6 +5,8 @@
 package mutation_test
 
 import (
+	"encoding/json"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -119,11 +121,32 @@ func unitTestsMutating() {
 	})
 
 	Describe("VirtualMachineSnapshotMutator should admit update operations", func() {
-		Context("when updating snapshot", func() {
-			It("should not mutate during update operations", func() {
-				// Set up a snapshot without the VM name label
+		Context("when updating a snapshot that is missing the VM name label", func() {
+			It("should backfill the VM name label", func() {
+				// Simulate a snapshot that predates this label.
 				ctx.vmSnapshot.Labels = map[string]string{
 					"app": "test",
+				}
+				obj, err := builder.ToUnstructured(ctx.vmSnapshot)
+				Expect(err).ToNot(HaveOccurred())
+				ctx.WebhookRequestContext.Obj = obj
+
+				rawObj, err := json.Marshal(ctx.vmSnapshot)
+				Expect(err).ToNot(HaveOccurred())
+				ctx.WebhookRequestContext.RawObj = rawObj
+
+				ctx.WebhookRequestContext.Op = admissionv1.Update
+				response := ctx.Mutate(&ctx.WebhookRequestContext)
+				Expect(response.Allowed).To(BeTrue())
+
+				Expect(response.Patches).ToNot(BeEmpty())
+			})
+		})
+
+		Context("when updating a snapshot that already has the VM name label", func() {
+			It("should not mutate", func() {
+				ctx.vmSnapshot.Labels = map[string]string{
+					vmopv1.VMNameForSnapshotLabel: "dummy-vm",
 				}
 				obj, err := builder.ToUnstructured(ctx.vmSnapshot)
 				Expect(err).ToNot(HaveOccurred())
@@ -133,8 +156,7 @@ func unitTestsMutating() {
 				response := ctx.Mutate(&ctx.WebhookRequestContext)
 				Expect(response.Allowed).To(BeTrue())
 
-				// Should not have any patches since we only update
-				// the object in Create operations.
+				// Already labeled, so there is nothing to backfill.
 				Expect(response.Patches).To(BeEmpty())
 			})
 		})

--- a/webhooks/virtualmachinesnapshot/validation/virtualmachinesnapshot_validator.go
+++ b/webhooks/virtualmachinesnapshot/validation/virtualmachinesnapshot_validator.go
@@ -80,6 +80,7 @@ func (v validator) ValidateCreate(ctx *pkgctx.WebhookRequestContext) admission.R
 	if vmSnapshot.Spec.VMName == "" {
 		fieldErrs = append(fieldErrs, field.Required(vmNameField, "vmName must be provided"))
 	} else {
+		fieldErrs = append(fieldErrs, vmNameLabelMismatchErr(vmSnapshot)...)
 		fieldErrs = append(fieldErrs,
 			v.validateVMFields(
 				ctx,
@@ -119,7 +120,7 @@ func (v validator) ValidateUpdate(ctx *pkgctx.WebhookRequestContext) admission.R
 	fieldErrs = append(fieldErrs, validation.ValidateImmutableField(vmSnapshot.Spec.Memory, oldVMSnapshot.Spec.Memory, field.NewPath("spec", "memory"))...)
 	fieldErrs = append(fieldErrs, validation.ValidateImmutableField(vmSnapshot.Spec.Quiesce, oldVMSnapshot.Spec.Quiesce, field.NewPath("spec", "quiesce"))...)
 	fieldErrs = append(fieldErrs, validation.ValidateImmutableField(vmSnapshot.Spec.VMName, oldVMSnapshot.Spec.VMName, field.NewPath("spec", "vmName"))...)
-	fieldErrs = append(fieldErrs, v.validateImmutableVMNameLabel(ctx, vmSnapshot, oldVMSnapshot)...)
+	fieldErrs = append(fieldErrs, vmNameLabelMismatchErr(vmSnapshot)...)
 
 	validationErrs := make([]string, 0, len(fieldErrs))
 	for _, fieldErr := range fieldErrs {
@@ -129,25 +130,22 @@ func (v validator) ValidateUpdate(ctx *pkgctx.WebhookRequestContext) admission.R
 	return common.BuildValidationResponse(ctx, nil, validationErrs, nil)
 }
 
-// validateImmutableVMNameLabel validates that the label on the
-// VirtualMachineSnapshot resource pointing to the VM can never be
-// changed. This label is set by the mutation webhook during creation
-// of the snapshot resource. This validation is only applicable during
-// an update operation.
-func (v validator) validateImmutableVMNameLabel(
-	_ *pkgctx.WebhookRequestContext,
-	vmSnapshot, oldVMSnapshot *vmopv1.VirtualMachineSnapshot) field.ErrorList {
+// vmNameLabelMismatchErr rejects a VMNameForSnapshotLabel that disagrees
+// with spec.vmName. Returns nil if the label is absent or matches. Since
+// spec.vmName is itself immutable, this is sufficient to keep the label
+// correct on both create and update without a separate lock-once-set check.
+func vmNameLabelMismatchErr(vmSnapshot *vmopv1.VirtualMachineSnapshot) field.ErrorList {
+	label, ok := vmSnapshot.Labels[vmopv1.VMNameForSnapshotLabel]
+	if !ok || label == vmSnapshot.Spec.VMName {
+		return nil
+	}
 
-	var allErrs field.ErrorList
-	vmNameLabelPath := field.NewPath("metadata", "labels").Key(vmopv1.VMNameForSnapshotLabel)
-
-	// Since this gets called only during an Update, the mutation
-	// webhook is always guaranteed to have set the Labels.
-	newVMNameLabel := vmSnapshot.Labels[vmopv1.VMNameForSnapshotLabel]
-	oldVMNameLabel := oldVMSnapshot.Labels[vmopv1.VMNameForSnapshotLabel]
-
-	return append(allErrs,
-		validation.ValidateImmutableField(newVMNameLabel, oldVMNameLabel, vmNameLabelPath)...)
+	return field.ErrorList{
+		field.Invalid(
+			field.NewPath("metadata", "labels").Key(vmopv1.VMNameForSnapshotLabel),
+			label,
+			fmt.Sprintf("must match spec.vmName %q", vmSnapshot.Spec.VMName)),
+	}
 }
 
 // validateVMNotVKSNode checks if the referenced VM is a VKS/TKG node and

--- a/webhooks/virtualmachinesnapshot/validation/virtualmachinesnapshot_validator_intg_test.go
+++ b/webhooks/virtualmachinesnapshot/validation/virtualmachinesnapshot_validator_intg_test.go
@@ -120,18 +120,16 @@ func intgTestsValidateUpdate() {
 	})
 
 	When("trying to update VM name label", func() {
-		It("should reject attempt to change VM name label", func() {
+		It("should reject a value that disagrees with spec.vmName", func() {
 			ctx.vmSnapshot.Labels[vmopv1.VMNameForSnapshotLabel] = "different-vm-name"
 			err := ctx.Client.Update(ctx, ctx.vmSnapshot)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("field is immutable"))
+			Expect(err.Error()).To(ContainSubstring("must match spec.vmName"))
 		})
 
-		It("should reject attempt to remove VM name label", func() {
+		It("should allow removing the VM name label", func() {
 			delete(ctx.vmSnapshot.Labels, vmopv1.VMNameForSnapshotLabel)
-			err := ctx.Client.Update(ctx, ctx.vmSnapshot)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("field is immutable"))
+			Expect(ctx.Client.Update(ctx, ctx.vmSnapshot)).To(Succeed())
 		})
 	})
 }

--- a/webhooks/virtualmachinesnapshot/validation/virtualmachinesnapshot_validator_unit_test.go
+++ b/webhooks/virtualmachinesnapshot/validation/virtualmachinesnapshot_validator_unit_test.go
@@ -88,14 +88,19 @@ func unitTestsValidateCreate() {
 	)
 
 	type createArgs struct {
-		emptyVMName   bool
-		createVKSNode bool
-		hardware      *vmopv1.VirtualMachineHardwareSpec
+		emptyVMName           bool
+		mismatchedVMNameLabel bool
+		createVKSNode         bool
+		hardware              *vmopv1.VirtualMachineHardwareSpec
 	}
 
 	validateCreate := func(args createArgs, expectedAllowed bool, expectedReason string, expectedErr error) {
 		if args.emptyVMName {
 			ctx.vmSnapshot.Spec.VMName = ""
+		}
+
+		if args.mismatchedVMNameLabel {
+			metav1.SetMetaDataLabel(&ctx.vmSnapshot.ObjectMeta, vmopv1.VMNameForSnapshotLabel, "some-other-vm")
 		}
 
 		// Create a VM with CAPI labels to simulate a VKS/TKG node
@@ -144,6 +149,15 @@ func unitTestsValidateCreate() {
 			createArgs{emptyVMName: true},
 			false,
 			field.Required(vmNameField, "vmName must be provided").Error(),
+			nil,
+		),
+		Entry("should deny VMNameForSnapshotLabel that does not match spec.vmName",
+			createArgs{mismatchedVMNameLabel: true},
+			false,
+			field.Invalid(
+				field.NewPath("metadata", "labels").Key(vmopv1.VMNameForSnapshotLabel),
+				"some-other-vm",
+				`must match spec.vmName "dummy-vm"`).Error(),
 			nil,
 		),
 		Entry("should deny snapshot for VKS/TKG node",
@@ -212,6 +226,7 @@ func unitTestsValidateUpdate() {
 		updateQuiesce     bool
 		updateVMRef       bool
 		updateVMNameLabel bool
+		oldLabelMissing   bool
 	}
 
 	validateUpdate := func(args updateArgs, expectedAllowed bool, expectedReason string, expectedErr error) {
@@ -229,6 +244,10 @@ func unitTestsValidateUpdate() {
 			ctx.vmSnapshot.Spec.VMName = "another-vm"
 		}
 
+		if args.oldLabelMissing {
+			delete(ctx.oldVMSnapshot.Labels, vmopv1.VMNameForSnapshotLabel)
+		}
+
 		if args.updateVMNameLabel {
 			// Try to change the VM name label to a different value
 			metav1.SetMetaDataLabel(&ctx.vmSnapshot.ObjectMeta, vmopv1.VMNameForSnapshotLabel, "different-vm-name")
@@ -243,7 +262,7 @@ func unitTestsValidateUpdate() {
 		response := ctx.ValidateUpdate(&ctx.WebhookRequestContext)
 		Expect(response.Allowed).To(Equal(expectedAllowed))
 		if expectedReason != "" {
-			Expect(string(response.Result.Reason)).To(HaveSuffix(expectedReason))
+			Expect(string(response.Result.Reason)).To(ContainSubstring(expectedReason))
 		}
 		if expectedErr != nil {
 			Expect(response.Result.Message).To(Equal(expectedErr.Error()))
@@ -284,10 +303,22 @@ func unitTestsValidateUpdate() {
 			"field is immutable",
 			nil,
 		),
-		Entry("should not allow updating VM name label",
+		Entry("should not allow updating VM name label to a value that disagrees with spec.vmName",
 			updateArgs{updateVMNameLabel: true},
 			false,
-			"field is immutable",
+			`must match spec.vmName "dummy-vm"`,
+			nil,
+		),
+		Entry("should allow backfilling the VM name label when the old object was missing it",
+			updateArgs{oldLabelMissing: true},
+			true,
+			"",
+			nil,
+		),
+		Entry("should not allow backfilling the VM name label to a value that disagrees with spec.vmName",
+			updateArgs{oldLabelMissing: true, updateVMNameLabel: true},
+			false,
+			`must match spec.vmName "dummy-vm"`,
 			nil,
 		),
 	)


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

`getVirtualMachineSnapshotsForVM` listed every VirtualMachineSnapshot in a VM's namespace and filtered in memory by Spec.VMName, an O(n) scan that grows with namespace-wide snapshot count. Register a field index on spec.vmName and query it with MatchingFields instead, so the lookup scales with matching snapshots rather than every snapshot in the namespace. The index key and extractor func live in pkg/util/kube so the controller's registration and the fake test client's index can't drift apart.

The `VMNameForSnapshotLabel` label is also kept in sync with `spec.vmName` end to end:

- The controller unconditionally re-asserts the label every
  reconcile, correcting a missing or stale value instead of only
  backfilling an absent one.
- The mutation webhook now backfills the label on update as well
  as create.
- The validator's lock-once-set check is replaced with a "label
  must match spec.vmName if present" rule on both create and
  update, since spec.vmName is already immutable. This allows
  correcting a bad label instead of freezing it forever, at the
  cost of also allowing the label to be removed (the controller
  re-adds it on the next reconcile).

vmop-3927.

**Please add a release note if necessary**:

```release-note
Use VMNameForSnapshotLabel for indexed snapshot lookup
```