### PR TITLE
🐛  delete stale vm directory and namespace mapping

### DIFF
--- a/pkg/providers/vsphere/vmlifecycle/create_fastdeploy.go
+++ b/pkg/providers/vsphere/vmlifecycle/create_fastdeploy.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"path"
 	"strings"
 	"sync"
@@ -66,29 +67,78 @@ func fastDeploy(
 
 	// Create the directory where the VM will be created.
 	var (
-		vmDirPath     string
+		vmDirPath     = vmDir
 		vmDirUUIDPath string
-		nm            *object.DatastoreNamespaceManager
+		nm            = object.NewDatastoreNamespaceManager(vimClient)
 		fm            = object.NewFileManager(vimClient)
+		tldSupported  = createArgs.Datastores[0].TopLevelDirectoryCreateSupported
+		ds            = object.NewDatastore(vimClient, createArgs.Datastores[0].MoRef)
 	)
 
-	if createArgs.Datastores[0].TopLevelDirectoryCreateSupported {
+	if err := ds.FindInventoryPath(vmCtx); err != nil {
+		return nil, fmt.Errorf("failed to find inventory path: %w", err)
+	}
+
+	_, dirExistsErr := ds.Stat(vmCtx, vmDirName)
+	if dirExistsErr == nil {
+		// A stale directory is detected.
+		if !tldSupported {
+			dsURL := createArgs.Datastores[0].URL
+			if dsURL == "" {
+				return nil, fmt.Errorf("received an empty datastore URL")
+			}
+
+			namespaceURL, err := url.Parse(dsURL)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"failed to parse datastore URL %q: %w", dsURL, err)
+			}
+
+			namespaceURL.Path = path.Join(namespaceURL.Path, vmDirName)
+			vmDirUUIDPath, err = nm.ConvertNamespacePathToUuidPath(
+				vmCtx, datacenter, namespaceURL.String())
+			if err != nil {
+				return nil, fmt.Errorf(
+					"failed to resolve namespace URL %q to UUID path: %w",
+					namespaceURL.String(), err)
+			}
+
+			vmDirUUIDName := path.Base(vmDirUUIDPath)
+			vmDirPath = strings.ReplaceAll(vmDir, vmDirName, vmDirUUIDName)
+		}
+
+		if err := fastDeployDeleteDirectory(
+			vmCtx,
+			datacenter,
+			fm,
+			vmDirPath,
+			tldSupported,
+			nm,
+			vmDirUUIDPath); err != nil {
+			return nil, fmt.Errorf(
+				"failed to delete existing directory: %w", err)
+		}
+	} else if (!errors.As(dirExistsErr, &object.DatastoreNoSuchFileError{}) &&
+		!errors.As(dirExistsErr, &object.DatastoreNoSuchDirectoryError{})) {
+		return nil, fmt.Errorf(
+			"existing directory validation failed: %w", dirExistsErr)
+	}
+
+	if tldSupported {
 		//
 		// The datastore supports TLD creation, so just use file manager.
 		//
 		if err := fm.MakeDirectory(vmCtx, vmDir, datacenter, true); err != nil {
 			return nil, fmt.Errorf("failed to create vm dir %q: %w", vmDir, err)
 		}
-		vmDirPath = vmDir
 	} else {
 		//
 		// The datastore does NOT support TLD creation, so use the datastore
 		// namespace manager to create the new directory.
 		//
-		nm = object.NewDatastoreNamespaceManager(vimClient)
 		vdp, err := nm.CreateDirectory(
 			vmCtx,
-			object.NewDatastore(vimClient, createArgs.Datastores[0].MoRef),
+			ds,
 			vmDirName,
 			"")
 		if err != nil {
@@ -142,45 +192,15 @@ func fastDeploy(
 			return
 		}
 
-		// Use a context that is not cancelled when the parent is, so cleanup
-		// runs even if the request is cancelled. Preserves the VC opID so
-		// cleanup is correlated with the failed create in VC logs.
-		ctx := context.WithoutCancel(vmCtx.Context)
-
-		// Delete the VM directory and its contents.
-		// Always use FileManager.DeleteDatastoreFile() first as it can delete
-		// non-empty directories recursively. Note that DeleteDirectory() on a
-		// non-empty directory will return an error, which is why we delete the
-		// directory contents first using DeleteDatastoreFile().
-		t, err := fm.DeleteDatastoreFile(ctx, vmDirPath, datacenter)
-		if err != nil {
-			retErr = fmt.Errorf(
-				"failed to call delete api for vm dir %q: %w,%w",
-				vmDirPath, err, retErr)
-			return
-		}
-
-		// Wait for the delete call to return.
-		if err := t.Wait(ctx); err != nil &&
-			!fault.Is(err, &vimtypes.FileNotFound{}) {
-
-			retErr = fmt.Errorf(
-				"failed to delete vm dir %q: %w,%w",
-				vmDirPath, err, retErr)
-		}
-
-		// For non-TLD datastores, also clean up the namespace mapping.
-		if !createArgs.Datastores[0].TopLevelDirectoryCreateSupported {
-			if err := nm.DeleteDirectory(
-				ctx,
-				datacenter,
-				vmDirUUIDPath); err != nil &&
-				!fault.Is(err, &vimtypes.FileNotFound{}) {
-
-				retErr = fmt.Errorf(
-					"failed to delete vm dir namespace mapping %q: %w,%w",
-					vmDirUUIDPath, err, retErr)
-			}
+		if err := fastDeployDeleteDirectory(
+			context.WithoutCancel(vmCtx.Context),
+			datacenter,
+			fm,
+			vmDirPath,
+			tldSupported,
+			nm,
+			vmDirUUIDPath); err != nil {
+			retErr = errors.Join(retErr, err)
 		}
 	}()
 
@@ -643,4 +663,50 @@ func fastDeployDirectCopyDisks(
 	}
 
 	return copyDiskErr
+}
+
+func fastDeployDeleteDirectory(
+	ctx context.Context,
+	datacenter *object.Datacenter,
+	fm *object.FileManager,
+	vmDirPath string,
+	tldSupported bool,
+	nm *object.DatastoreNamespaceManager,
+	vmDirUUIDPath string) error {
+
+	// Delete the VM directory and its contents.
+	// Always use FileManager.DeleteDatastoreFile() first as it can delete
+	// non-empty directories recursively. Note that DeleteDirectory() on a
+	// non-empty directory will return an error, which is why we delete the
+	// directory contents first using DeleteDatastoreFile().
+	t, err := fm.DeleteDatastoreFile(ctx, vmDirPath, datacenter)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to call delete api for vm dir %q: %w", vmDirPath, err)
+	}
+
+	// Wait for the delete call to return.
+	if err := t.Wait(ctx); err != nil &&
+		!fault.Is(err, &vimtypes.FileNotFound{}) {
+
+		return fmt.Errorf("failed to delete vm dir %q: %w", vmDirPath, err)
+	}
+
+	if tldSupported {
+		return nil
+	}
+
+	// For non-TLD datastore, also clean up the namespace mapping.
+	if err := nm.DeleteDirectory(
+		ctx,
+		datacenter,
+		vmDirUUIDPath); err != nil &&
+		!fault.Is(err, &vimtypes.FileNotFound{}) {
+
+		return fmt.Errorf(
+			"failed to delete vm dir namespace mapping %q: %w",
+			vmDirUUIDPath, err)
+	}
+
+	return nil
 }

--- a/pkg/providers/vsphere/vmlifecycle/create_fastdeploy.go
+++ b/pkg/providers/vsphere/vmlifecycle/create_fastdeploy.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"path"
 	"strings"
 	"sync"
@@ -68,11 +69,27 @@ func fastDeploy(
 	var (
 		vmDirPath     string
 		vmDirUUIDPath string
-		nm            *object.DatastoreNamespaceManager
+		nm            = object.NewDatastoreNamespaceManager(vimClient)
 		fm            = object.NewFileManager(vimClient)
+		tldSupported  = createArgs.Datastores[0].TopLevelDirectoryCreateSupported
+		ds            = object.NewDatastore(vimClient, createArgs.Datastores[0].MoRef)
 	)
 
-	if createArgs.Datastores[0].TopLevelDirectoryCreateSupported {
+	if err := fastDeployStaleDirectory(
+		vmCtx,
+		logger,
+		datacenter,
+		ds,
+		fm,
+		nm,
+		vmDir,
+		tldSupported,
+		createArgs.Datastores[0].URL); err != nil {
+
+		return nil, fmt.Errorf("failed to delete existing directory: %w", err)
+	}
+
+	if tldSupported {
 		//
 		// The datastore supports TLD creation, so just use file manager.
 		//
@@ -85,10 +102,9 @@ func fastDeploy(
 		// The datastore does NOT support TLD creation, so use the datastore
 		// namespace manager to create the new directory.
 		//
-		nm = object.NewDatastoreNamespaceManager(vimClient)
 		vdp, err := nm.CreateDirectory(
 			vmCtx,
-			object.NewDatastore(vimClient, createArgs.Datastores[0].MoRef),
+			ds,
 			vmDirName,
 			"")
 		if err != nil {
@@ -142,45 +158,17 @@ func fastDeploy(
 			return
 		}
 
-		// Use a context that is not cancelled when the parent is, so cleanup
-		// runs even if the request is cancelled. Preserves the VC opID so
-		// cleanup is correlated with the failed create in VC logs.
-		ctx := context.WithoutCancel(vmCtx.Context)
+		if err := fastDeployDeleteDirectory(
+			context.WithoutCancel(vmCtx.Context),
+			logger,
+			datacenter,
+			fm,
+			vmDirPath,
+			tldSupported,
+			nm,
+			vmDirUUIDPath); err != nil {
 
-		// Delete the VM directory and its contents.
-		// Always use FileManager.DeleteDatastoreFile() first as it can delete
-		// non-empty directories recursively. Note that DeleteDirectory() on a
-		// non-empty directory will return an error, which is why we delete the
-		// directory contents first using DeleteDatastoreFile().
-		t, err := fm.DeleteDatastoreFile(ctx, vmDirPath, datacenter)
-		if err != nil {
-			retErr = fmt.Errorf(
-				"failed to call delete api for vm dir %q: %w,%w",
-				vmDirPath, err, retErr)
-			return
-		}
-
-		// Wait for the delete call to return.
-		if err := t.Wait(ctx); err != nil &&
-			!fault.Is(err, &vimtypes.FileNotFound{}) {
-
-			retErr = fmt.Errorf(
-				"failed to delete vm dir %q: %w,%w",
-				vmDirPath, err, retErr)
-		}
-
-		// For non-TLD datastores, also clean up the namespace mapping.
-		if !createArgs.Datastores[0].TopLevelDirectoryCreateSupported {
-			if err := nm.DeleteDirectory(
-				ctx,
-				datacenter,
-				vmDirUUIDPath); err != nil &&
-				!fault.Is(err, &vimtypes.FileNotFound{}) {
-
-				retErr = fmt.Errorf(
-					"failed to delete vm dir namespace mapping %q: %w,%w",
-					vmDirUUIDPath, err, retErr)
-			}
+			retErr = errors.Join(retErr, err)
 		}
 	}()
 
@@ -643,4 +631,127 @@ func fastDeployDirectCopyDisks(
 	}
 
 	return copyDiskErr
+}
+
+func fastDeployDeleteDirectory(
+	ctx context.Context,
+	logger logr.Logger,
+	datacenter *object.Datacenter,
+	fm *object.FileManager,
+	vmDirPath string,
+	tldSupported bool,
+	nm *object.DatastoreNamespaceManager,
+	vmDirUUIDPath string) error {
+
+	logger.Info("Deleting VM directory", "vmDirPath", vmDirPath)
+
+	// Delete the VM directory and its contents.
+	// Always use FileManager.DeleteDatastoreFile() first as it can delete
+	// non-empty directories recursively. Note that DeleteDirectory() on a
+	// non-empty directory will return an error, which is why we delete the
+	// directory contents first using DeleteDatastoreFile().
+	t, err := fm.DeleteDatastoreFile(ctx, vmDirPath, datacenter)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to call delete api for vm dir %q: %w", vmDirPath, err)
+	}
+	logger.Info("Waiting VM directory deletion", "vmDirPath", vmDirPath)
+
+	// Wait for the delete call to return.
+	if err := t.Wait(ctx); err != nil &&
+		!fault.Is(err, &vimtypes.FileNotFound{}) {
+
+		return fmt.Errorf("failed to delete vm dir %q: %w", vmDirPath, err)
+	}
+	logger.Info("Deleted VM directory", "vmDirPath", vmDirPath)
+
+	if tldSupported {
+		return nil
+	}
+
+	// For non-TLD datastore, also clean up the namespace mapping.
+	logger.Info("Deleting namespace mapping", "vmDirUUIDPath", vmDirUUIDPath)
+	if err := nm.DeleteDirectory(
+		ctx,
+		datacenter,
+		vmDirUUIDPath); err != nil &&
+		!fault.Is(err, &vimtypes.FileNotFound{}) {
+
+		return fmt.Errorf(
+			"failed to delete vm dir namespace mapping %q: %w",
+			vmDirUUIDPath, err)
+	}
+	logger.Info("Deleted namespace mapping", "vmDirUUIDPath", vmDirUUIDPath)
+
+	return nil
+}
+
+func fastDeployStaleDirectory(
+	ctx context.Context,
+	logger logr.Logger,
+	datacenter *object.Datacenter,
+	ds *object.Datastore,
+	fm *object.FileManager,
+	nm *object.DatastoreNamespaceManager,
+	vmDirPath string,
+	tldSupported bool,
+	datastoreURL string,
+) error {
+
+	var dp object.DatastorePath
+	if !dp.FromString(vmDirPath) {
+		return fmt.Errorf("invalid datastore path: %s", vmDirPath)
+	}
+
+	if err := ds.FindInventoryPath(ctx); err != nil {
+		return fmt.Errorf("failed to find inventory path: %w", err)
+	}
+
+	vmDirName := dp.Path
+	_, dirExistsErr := ds.Stat(ctx, vmDirName)
+	if dirExistsErr != nil {
+		if errors.As(dirExistsErr, &object.DatastoreNoSuchFileError{}) ||
+			errors.As(dirExistsErr, &object.DatastoreNoSuchDirectoryError{}) {
+			return nil
+		}
+
+		return fmt.Errorf(
+			"existing directory validation failed: %w", dirExistsErr)
+	}
+	logger.Info("Found stale VM directory", "vmDirPath", vmDirPath)
+
+	var (
+		pathToDelete = vmDirPath
+		uuidPath     string
+	)
+
+	if !tldSupported {
+		if datastoreURL == "" {
+			return fmt.Errorf("received an empty datastore URL")
+		}
+
+		namespaceURL, err := url.Parse(datastoreURL)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to parse datastore URL %q: %w", datastoreURL, err)
+		}
+
+		namespaceURL.Path = path.Join(namespaceURL.Path, vmDirName)
+		namespaceURL.Scheme = ""
+		uuidPath, err = nm.ConvertNamespacePathToUuidPath(
+			ctx,
+			datacenter,
+			namespaceURL.String())
+		if err != nil {
+			return fmt.Errorf(
+				"failed to resolve namespace URL %q to UUID path: %w",
+				namespaceURL.String(), err)
+		}
+
+		uuidName := path.Base(uuidPath)
+		pathToDelete = strings.ReplaceAll(vmDirPath, vmDirName, uuidName)
+	}
+
+	return fastDeployDeleteDirectory(
+		ctx, logger, datacenter, fm, pathToDelete, tldSupported, nm, uuidPath)
 }

--- a/pkg/providers/vsphere/vmlifecycle/create_fastdeploy_test.go
+++ b/pkg/providers/vsphere/vmlifecycle/create_fastdeploy_test.go
@@ -7,31 +7,30 @@ package vmlifecycle_test
 import (
 	"errors"
 	"fmt"
-	"os"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
+	"github.com/vmware/govmomi/object"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
-
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/vmlifecycle"
-	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 var _ = Describe("createFastDeploy", func() {
-
 	var (
-		ctx   *builder.TestContextForVCSim
-		vmCtx pkgctx.VirtualMachineContext
-		vm    *vmopv1.VirtualMachine
+		ctx        *builder.TestContextForVCSim
+		fm         *object.FileManager
+		vm         *vmopv1.VirtualMachine
+		ds         *object.Datastore
+		vmCtx      pkgctx.VirtualMachineContext
+		vmDirName  string
+		vmDirPath  string
+		configSpec vimtypes.VirtualMachineConfigSpec
+		createArgs *vmlifecycle.CreateArgs
 	)
 
 	BeforeEach(func() {
@@ -44,189 +43,173 @@ var _ = Describe("createFastDeploy", func() {
 		})
 
 		vm = builder.DummyVirtualMachine()
-		vm.Name = "fastdeploy-cleanup-test"
-		vm.UID = types.UID("cleanup-test-uid-12345")
+		vm.Name = "fastdeploy-stale-dir-test"
+		vm.UID = "stale-dir-test-uid-12345"
 		vm.Namespace = pkgcfg.FromContext(ctx).PodNamespace
+
+		fm = object.NewFileManager(ctx.VCClient.Client)
+		ds = object.NewDatastore(ctx.VCClient.Client, ctx.Datastore.Reference())
+		Expect(ds.FindInventoryPath(ctx)).To(Succeed(),
+			"failed to set InventoryPath and DatacenterPath for datastore object")
 
 		vmCtx = pkgctx.VirtualMachineContext{
 			Context: ctx,
 			Logger:  suite.GetLogger().WithValues("vmName", vm.Name),
 			VM:      vm,
 		}
+
+		vmDirName = string(vm.UID)
+		vmDirPath = fmt.Sprintf("[%s] %s", ctx.Datastore.Name(), vmDirName)
 	})
 
 	AfterEach(func() {
 		ctx.AfterEach()
 		ctx = nil
+		fm = nil
+		vm = nil
+		ds = nil
+		createArgs = nil
 	})
 
-	Context("when directory is created successfully", func() {
-		// Note: We only test TLD-supported datastores here. Testing non-TLD datastores
-		// (vSAN) is limited because vcsim may not enforce the "non-empty directory"
-		// restriction that real vSphere/vSAN does, so we cannot validate the two-step
-		// cleanup approach (DeleteDatastoreFile + DeleteDirectory) in the simulator.
-		Context("with TLD-supported datastore (using FileManager.MakeDirectory)", func() {
-			It("should cleanup directory when error occurs after directory creation", func() {
-				// Similar test but for TLD-supported datastores
-				// This uses FileManager.MakeDirectory instead of CreateDirectory
+	JustBeforeEach(func() {
+		configSpec = vimtypes.VirtualMachineConfigSpec{
+			Name: vm.Name,
+			Files: &vimtypes.VirtualMachineFileInfo{
+				VmPathName: fmt.Sprintf("%s/%s.vmx", vmDirPath, vm.Name),
+			},
+		}
 
-				vmicName := pkgutil.VMIName(ctx.ContentLibraryItem1ID)
-				vmic := vmopv1.VirtualMachineImageCache{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: pkgcfg.FromContext(ctx).PodNamespace,
-						Name:      vmicName,
-					},
-					Status: vmopv1.VirtualMachineImageCacheStatus{
-						OVF: &vmopv1.VirtualMachineImageCacheOVFStatus{
-							ConfigMapName:   vmicName,
-							ProviderVersion: ctx.ContentLibraryItem1Version,
-						},
-						Conditions: []metav1.Condition{
-							{
-								Type:   vmopv1.VirtualMachineImageCacheConditionHardwareReady,
-								Status: metav1.ConditionTrue,
-							},
-							{
-								Type:   vmopv1.VirtualMachineImageCacheConditionFilesReady,
-								Status: metav1.ConditionTrue,
-							},
-						},
-						Locations: []vmopv1.VirtualMachineImageCacheLocationStatus{
-							{
-								DatacenterID: ctx.Datacenter.Reference().Value,
-								DatastoreID:  ctx.Datastore.Reference().Value,
-								ProfileID:    ctx.StorageProfileID,
-								Files: []vmopv1.VirtualMachineImageCacheFileStatus{
-									{
-										ID:       ctx.ContentLibraryItem1Disk1Path,
-										Type:     vmopv1.VirtualMachineImageCacheFileTypeDisk,
-										DiskType: vmopv1.VolumeTypeClassic,
-									},
-									{
-										ID:   ctx.ContentLibraryItem1NVRAMPath,
-										Type: vmopv1.VirtualMachineImageCacheFileTypeOther,
-									},
-								},
-								Conditions: []metav1.Condition{
-									{
-										Type:   vmopv1.ReadyConditionType,
-										Status: metav1.ConditionTrue,
-									},
-								},
-							},
-						},
-					},
-				}
+		dcFolders, err := ctx.Datacenter.Folders(ctx)
+		Expect(err).ToNot(HaveOccurred(), "failed to fetch datacenter folder properties")
+		pools, err := ctx.Finder.ResourcePoolList(ctx, "*")
+		Expect(err).ToNot(HaveOccurred(), "failed to list resource pools")
+		Expect(pools).ToNot(BeEmpty(), "no resource pools found in the test environment")
+		defaultPool := pools[0]
 
-				vmicm := corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: vmic.Namespace,
-						Name:      vmic.Name,
-					},
-					Data: map[string]string{
-						"value": `<?xml version="1.0" encoding="UTF-8"?>
-<Envelope xmlns="http://schemas.dmtf.org/ovf/envelope/1">
-  <References>
-    <File ovf:href="disk.vmdk" ovf:id="file1"/>
-  </References>
-  <DiskSection>
-    <Info>Virtual disk information</Info>
-    <Disk ovf:capacity="1024" ovf:diskId="vmdisk1" ovf:fileRef="file1"/>
-  </DiskSection>
-  <VirtualSystem>
-    <Name>test-vm</Name>
-    <VirtualHardwareSection>
-      <System>
-        <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
-        <vssd:InstanceID>0</vssd:InstanceID>
-        <vssd:VirtualSystemIdentifier>test-vm</vssd:VirtualSystemIdentifier>
-        <vssd:VirtualSystemType>vmx-11</vssd:VirtualSystemType>
-      </System>
-    </VirtualHardwareSection>
-  </VirtualSystem>
-</Envelope>`,
-					},
-				}
+		createArgs = &vmlifecycle.CreateArgs{
+			ConfigSpec:        configSpec,
+			UseContentLibrary: true,
+			Datastores: []vmlifecycle.DatastoreRef{
+				{
+					MoRef:                            ctx.Datastore.Reference(),
+					TopLevelDirectoryCreateSupported: true,
+				},
+			},
+			DatacenterMoID:   ctx.Datacenter.Reference().Value,
+			DiskPaths:        []string{ctx.ContentLibraryItem1Disk1Path}, // Only 1 disk
+			FilePaths:        []string{ctx.ContentLibraryItem1NVRAMPath},
+			ProviderItemID:   ctx.ContentLibraryItem1ID,
+			FolderMoID:       dcFolders.VmFolder.Reference().Value,
+			ResourcePoolMoID: defaultPool.Reference().Value,
+		}
+	})
 
-				Expect(ctx.Client.Create(ctx, &vmic)).To(Succeed())
-				Expect(ctx.Client.Create(ctx, &vmicm)).To(Succeed())
-				Expect(ctx.Client.Status().Update(ctx, &vmic)).To(Succeed())
+	When("no issues with fast deploy vm creation", func() {
+		It("should succeed", func() {
+			_, err := vmlifecycle.CreateVirtualMachine(
+				vmCtx,
+				ctx.Client,
+				ctx.RestClient,
+				ctx.VCClient.Client,
+				ctx.Finder,
+				createArgs)
+			Expect(err).ToNot(HaveOccurred(), "failed to create a new VM")
 
-				vmDirName := string(vm.UID)
-				vmDirPath := fmt.Sprintf("[%s] %s", ctx.Datastore.Name(), vmDirName)
-
-				// Verify directory doesn't exist initially
-				// DatastoreFileExists returns nil when file exists, os.ErrNotExist when it doesn't
-				err := pkgutil.DatastoreFileExists(ctx, ctx.VCClient.Client, vmDirPath, ctx.Datacenter)
-				Expect(errors.Is(err, os.ErrNotExist)).To(BeTrue(), "Directory should not exist before creation")
-
-				// Create ConfigSpec with 2 disks (mismatch)
-				configSpec := vimtypes.VirtualMachineConfigSpec{
-					Name: vm.Name,
-					Files: &vimtypes.VirtualMachineFileInfo{
-						VmPathName: fmt.Sprintf("[%s] %s/%s.vmx", ctx.Datastore.Name(), vmDirName, vm.Name),
-					},
-					DeviceChange: []vimtypes.BaseVirtualDeviceConfigSpec{
-						&vimtypes.VirtualDeviceConfigSpec{
-							Operation: vimtypes.VirtualDeviceConfigSpecOperationAdd,
-							Device: &vimtypes.VirtualDisk{
-								VirtualDevice: vimtypes.VirtualDevice{
-									Backing: &vimtypes.VirtualDiskFlatVer2BackingInfo{
-										VirtualDeviceFileBackingInfo: vimtypes.VirtualDeviceFileBackingInfo{
-											FileName: fmt.Sprintf("[%s] %s/disk-0.vmdk", ctx.Datastore.Name(), vmDirName),
-										},
-									},
-								},
-								CapacityInKB: 1024,
-							},
-						},
-						&vimtypes.VirtualDeviceConfigSpec{
-							Operation: vimtypes.VirtualDeviceConfigSpecOperationAdd,
-							Device: &vimtypes.VirtualDisk{
-								VirtualDevice: vimtypes.VirtualDevice{
-									Backing: &vimtypes.VirtualDiskFlatVer2BackingInfo{
-										VirtualDeviceFileBackingInfo: vimtypes.VirtualDeviceFileBackingInfo{
-											FileName: fmt.Sprintf("[%s] %s/disk-1.vmdk", ctx.Datastore.Name(), vmDirName),
-										},
-									},
-								},
-								CapacityInKB: 1024,
-							},
-						},
-					},
-				}
-
-				createArgs := &vmlifecycle.CreateArgs{
-					ConfigSpec:        configSpec,
-					UseContentLibrary: true,
-					Datastores: []vmlifecycle.DatastoreRef{
-						{
-							MoRef:                            ctx.Datastore.Reference(),
-							TopLevelDirectoryCreateSupported: true, // TLD-supported
-						},
-					},
-					DatacenterMoID: ctx.Datacenter.Reference().Value,
-					DiskPaths:      []string{ctx.ContentLibraryItem1Disk1Path}, // Only 1 disk
-					FilePaths:      []string{ctx.ContentLibraryItem1NVRAMPath},
-					ProviderItemID: ctx.ContentLibraryItem1ID,
-				}
-
-				// Attempt creation - should fail with "failed to find cached"
-				_, err = vmlifecycle.CreateVirtualMachine(
-					vmCtx,
-					ctx.Client,
-					ctx.RestClient,
-					ctx.VCClient.Client,
-					ctx.Finder,
-					createArgs)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("failed to find cached"))
-
-				// Verify directory was cleaned up
-				// DatastoreFileExists returns nil when file exists, os.ErrNotExist when it doesn't
-				err = pkgutil.DatastoreFileExists(ctx, ctx.VCClient.Client, vmDirPath, ctx.Datacenter)
-				Expect(errors.Is(err, os.ErrNotExist)).To(BeTrue(), "Directory should be cleaned up after error (should not exist)")
-			})
+			_, dirExistsErr := ds.Stat(vmCtx, vmDirName)
+			Expect(dirExistsErr).To(BeNil(), "the directory should exist")
 		})
 	})
+
+	createWithStaleDirectory := func() {
+		By("create a new directory")
+		err := fm.MakeDirectory(ctx, vmDirPath, ctx.Datacenter, true)
+		Expect(err).To(BeNil(), "creating a new directory failed")
+
+		By("verify directory exists initially")
+		_, dirExistsErr := ds.Stat(vmCtx, vmDirName)
+		Expect(dirExistsErr).To(BeNil(), "the directory should exist")
+
+		By("create a new VM with stale directory")
+		_, err = vmlifecycle.CreateVirtualMachine(
+			vmCtx,
+			ctx.Client,
+			ctx.RestClient,
+			ctx.VCClient.Client,
+			ctx.Finder,
+			createArgs)
+		Expect(err).ToNot(HaveOccurred(), "should be able to create a new VM")
+	}
+
+	When("there is a stale vm directory with fast deploy vm creation (root directory)", func() {
+		It("should delete the stale directory and then succeed", func() {
+			createWithStaleDirectory()
+		})
+	})
+
+	When("there is a stale vm directory with fast deploy vm creation (nested directory)", func() {
+		BeforeEach(func() {
+			vmDirName = "parent-dir/" + vmDirName
+			vmDirPath = fmt.Sprintf("[%s] %s", ctx.Datastore.Name(), vmDirName)
+		})
+
+		It("should delete the stale directory and then succeed", func() {
+			createWithStaleDirectory()
+		})
+	})
+
+	When("there is issue with vm creation", func() {
+		It("should cleanup the newly created vm directory", func() {
+
+			By("verify no directory exists initially")
+			_, dirExistsErr := ds.Stat(vmCtx, vmDirName)
+			Expect(errors.As(dirExistsErr, &object.DatastoreNoSuchFileError{})).To(
+				BeTrue(), "the directory should not exist")
+
+			// Set ConfigSpec with mismatch disks to force vm creation failure after directory creation
+			createArgs.ConfigSpec.DeviceChange = []vimtypes.BaseVirtualDeviceConfigSpec{
+				&vimtypes.VirtualDeviceConfigSpec{
+					Operation: vimtypes.VirtualDeviceConfigSpecOperationAdd,
+					Device: &vimtypes.VirtualDisk{
+						VirtualDevice: vimtypes.VirtualDevice{
+							Backing: &vimtypes.VirtualDiskFlatVer2BackingInfo{
+								VirtualDeviceFileBackingInfo: vimtypes.VirtualDeviceFileBackingInfo{
+									FileName: fmt.Sprintf("[%s] %s/disk-0.vmdk", ctx.Datastore.Name(), vmDirName),
+								},
+							},
+						},
+						CapacityInKB: 1024,
+					},
+				},
+				&vimtypes.VirtualDeviceConfigSpec{
+					Operation: vimtypes.VirtualDeviceConfigSpecOperationAdd,
+					Device: &vimtypes.VirtualDisk{
+						VirtualDevice: vimtypes.VirtualDevice{
+							Backing: &vimtypes.VirtualDiskFlatVer2BackingInfo{
+								VirtualDeviceFileBackingInfo: vimtypes.VirtualDeviceFileBackingInfo{
+									FileName: fmt.Sprintf("[%s] %s/disk-1.vmdk", ctx.Datastore.Name(), vmDirName),
+								},
+							},
+						},
+						CapacityInKB: 1024,
+					},
+				},
+			}
+
+			By("create a VM with mismatch disks")
+			_, err := vmlifecycle.CreateVirtualMachine(
+				vmCtx,
+				ctx.Client,
+				ctx.RestClient,
+				ctx.VCClient.Client,
+				ctx.Finder,
+				createArgs)
+			Expect(err).To(HaveOccurred(), "should fail to create a new VM")
+
+			By("verify no directory exists after")
+			_, dirExistsErr = ds.Stat(vmCtx, vmDirName)
+			Expect(errors.As(dirExistsErr, &object.DatastoreNoSuchFileError{})).To(
+				BeTrue(), "the directory should not exist after cleanup")
+		})
+	})
+
 })


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Implement an upfront pre-flight sweep to identify and delete stale
datastore folders and vCenter namespace catalog mappings from previous
aborted runs.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:
Testing Done:

`--------- TLD -----------

- Defer Cleanup Logs

  I0813 05:07:22.870133       1 create_fastdeploy.go:648] "Deleting VM directory"              
  logger="virtualmachine-controller.fastDeploy" VirtualMachine="vmtest/fastdeploy-test-vm"     
  reconcileID="4d6d0eb7-31b1-42a0-9e92-a44297631b82" vmDirPath="[sharedVmfs-0]                 
  40a16e20-963a-4dfa-b5d3-97b7e5dddb4a"                                                        
                                                                                               
  I0813 05:07:22.887545       1 create_fastdeploy.go:660] "Waiting VM directory deletion"      
  logger="virtualmachine-controller.fastDeploy" VirtualMachine="vmtest/fastdeploy-test-vm"     
  reconcileID="4d6d0eb7-31b1-42a0-9e92-a44297631b82" vmDirPath="[sharedVmfs-0]                 
  40a16e20-963a-4dfa-b5d3-97b7e5dddb4a"                                                        
                                                                                               
  I0813 05:07:22.986726       1 create_fastdeploy.go:668] "Deleted VM directory"               
  logger="virtualmachine-controller.fastDeploy" VirtualMachine="vmtest/fastdeploy-test-vm"     
  reconcileID="4d6d0eb7-31b1-42a0-9e92-a44297631b82" vmDirPath="[sharedVmfs-0]                 
  40a16e20-963a-4dfa-b5d3-97b7e5dddb4a"                                                        
                                            
- Stale Cleanup Logs

  I0813 08:49:24.667791       1 create_fastdeploy.go:44] "Got vm dir" logger="virtualmachine-controller.fastDeploy" VirtualMachine="vmtest/stale-test-vm"                                            
  reconcileID="a32fe4ee-02b6-4c12-b841-7748f3630f13" vmDir="[sharedVmfs-0] ff3e05f3-bca9-4ccd-a2c7-a7f84d7b0436"                                                                                     
  I0813 08:49:24.667857       1 create_fastdeploy.go:51] "Got vm dir name" logger="virtualmachine-controller.fastDeploy" VirtualMachine="vmtest/stale-test-vm"                                       
  reconcileID="a32fe4ee-02b6-4c12-b841-7748f3630f13" vmDirName="ff3e05f3-bca9-4ccd-a2c7-a7f84d7b0436"                                                                                                
  I0813 08:49:24.737866       1 create_fastdeploy.go:720] "Found stale VM directory" logger="virtualmachine-controller.fastDeploy" VirtualMachine="vmtest/stale-test-vm"                             
  reconcileID="a32fe4ee-02b6-4c12-b841-7748f3630f13" vmDirPath="[sharedVmfs-0] ff3e05f3-bca9-4ccd-a2c7-a7f84d7b0436"                                                                                 
  I0813 08:49:24.737966       1 create_fastdeploy.go:645] "Deleting VM directory" logger="virtualmachine-controller.fastDeploy" VirtualMachine="vmtest/stale-test-vm"                                
  reconcileID="a32fe4ee-02b6-4c12-b841-7748f3630f13" vmDirPath="[sharedVmfs-0] ff3e05f3-bca9-4ccd-a2c7-a7f84d7b0436"                                                                                 
  I0813 08:49:24.752226       1 create_fastdeploy.go:657] "Waiting VM directory deletion" logger="virtualmachine-controller.fastDeploy" VirtualMachine="vmtest/stale-test-vm"                        
  reconcileID="a32fe4ee-02b6-4c12-b841-7748f3630f13" vmDirPath="[sharedVmfs-0] ff3e05f3-bca9-4ccd-a2c7-a7f84d7b0436"                                                                                 
  I0813 08:49:24.816366       1 create_fastdeploy.go:665] "Deleted VM directory" logger="virtualmachine-controller.fastDeploy" VirtualMachine="vmtest/stale-test-vm"                                 
  reconcileID="a32fe4ee-02b6-4c12-b841-7748f3630f13" vmDirPath="[sharedVmfs-0] ff3e05f3-bca9-4ccd-a2c7-a7f84d7b0436"                                                                                 
  I0813 08:49:24.841073       1 create_fastdeploy.go:150] "Updated vm dir paths" logger="virtualmachine-controller.fastDeploy" VirtualMachine="vmtest/stale-test-vm"                                 
  reconcileID="a32fe4ee-02b6-4c12-b841-7748f3630f13" vmDirPath="[sharedVmfs-0] ff3e05f3-bca9-4ccd-a2c7-a7f84d7b0436" vmPathName="[sharedVmfs-0]                                                      
  ff3e05f3-bca9-4ccd-a2c7-a7f84d7b0436/stale-test-vm.vmx" 


------- non-TLD------------
- Defer Cleanup Logs

  I0813 10:41:27.288025       1 create_fastdeploy.go:651] "Deleting VM directory" logger="virtualmachine-controller.fastDeploy" VirtualMachine="vmtest/stale-test-vm"  
  reconcileID="074f342f-685b-4237-b0b2-c9c2645217b0" vmDirPath="[vsanDatastore] 559f7d6a-240b-0d2f-72f8-02007a7b7370"                                                  
  I0813 10:41:27.296335       1 create_fastdeploy.go:663] "Waiting VM directory deletion" logger="virtualmachine-controller.fastDeploy"                                
  VirtualMachine="vmtest/stale-test-vm" reconcileID="074f342f-685b-4237-b0b2-c9c2645217b0" vmDirPath="[vsanDatastore] 559f7d6a-240b-0d2f-72f8-02007a7b7370"            
  I0813 10:41:27.953680       1 create_fastdeploy.go:671] "Deleted VM directory" logger="virtualmachine-controller.fastDeploy" VirtualMachine="vmtest/stale-test-vm"   
  reconcileID="074f342f-685b-4237-b0b2-c9c2645217b0" vmDirPath="[vsanDatastore] 559f7d6a-240b-0d2f-72f8-02007a7b7370"                                                  
  I0813 10:41:27.953727       1 create_fastdeploy.go:678] "Deleting namespace mapping" logger="virtualmachine-controller.fastDeploy"                                   
  VirtualMachine="vmtest/stale-test-vm" reconcileID="074f342f-685b-4237-b0b2-c9c2645217b0"                                                                             
  vmDirUUIDPath="/vmfs/volumes/vsan:52a389ef91023900-569608edb88147ea/559f7d6a-240b-0d2f-72f8-02007a7b7370"                                                            
  I0813 10:41:28.017679       1 create_fastdeploy.go:689] "Deleted namespace mapping" logger="virtualmachine-controller.fastDeploy"                                    
  VirtualMachine="vmtest/stale-test-vm" reconcileID="074f342f-685b-4237-b0b2-c9c2645217b0"                                                                             
  vmDirUUIDPath="/vmfs/volumes/vsan:52a389ef91023900-569608edb88147ea/559f7d6a-240b-0d2f-72f8-02007a7b7370"


- Stale Cleanup Logs
  I0813 13:28:50.849862       1 create_fastdeploy.go:726] "Found stale VM directory" logger="virtualmachine-controller.fastDeploy"                      
  VirtualMachine="vmtest/stale-test-vm" reconcileID="e0402e16-d579-4e11-8753-52118e5c7e6a" vmDirPath="[vsanDatastore]                                   
  c95f9dde-53ec-4565-8163-294eefb0c16e"                                                                                                                 
  I0813 13:28:50.868205       1 create_fastdeploy.go:651] "Deleting VM directory" logger="virtualmachine-controller.fastDeploy"                         
  VirtualMachine="vmtest/stale-test-vm" reconcileID="e0402e16-d579-4e11-8753-52118e5c7e6a" vmDirPath="[vsanDatastore]                                   
  8fc67d6a-50a9-67a8-be94-02007a7b7370"                                                                                                                 
  I0813 13:28:50.876216       1 create_fastdeploy.go:663] "Waiting VM directory deletion" logger="virtualmachine-controller.fastDeploy"                 
  VirtualMachine="vmtest/stale-test-vm" reconcileID="e0402e16-d579-4e11-8753-52118e5c7e6a" vmDirPath="[vsanDatastore]                                   
  8fc67d6a-50a9-67a8-be94-02007a7b7370"                                                                                                                 
  I0813 13:28:52.418812       1 create_fastdeploy.go:671] "Deleted VM directory" logger="virtualmachine-controller.fastDeploy"                          
  VirtualMachine="vmtest/stale-test-vm" reconcileID="e0402e16-d579-4e11-8753-52118e5c7e6a" vmDirPath="[vsanDatastore]                                   
  8fc67d6a-50a9-67a8-be94-02007a7b7370"                                                                                                                 
  I0813 13:28:52.418860       1 create_fastdeploy.go:678] "Deleting namespace mapping" logger="virtualmachine-controller.fastDeploy"                    
  VirtualMachine="vmtest/stale-test-vm" reconcileID="e0402e16-d579-4e11-8753-52118e5c7e6a"                                                              
  vmDirUUIDPath="/vmfs/volumes/vsan:52a389ef91023900-569608edb88147ea/8fc67d6a-50a9-67a8-be94-02007a7b7370"                                             
  I0813 13:28:52.468348       1 create_fastdeploy.go:689] "Deleted namespace mapping" logger="virtualmachine-controller.fastDeploy"                     
  VirtualMachine="vmtest/stale-test-vm" reconcileID="e0402e16-d579-4e11-8753-52118e5c7e6a"                                                              
  vmDirUUIDPath="/vmfs/volumes/vsan:52a389ef91023900-569608edb88147ea/8fc67d6a-50a9-67a8-be94-02007a7b7370" `


**Please add a release note if necessary**:

```release-note
NONE
```