### PR TITLE
Remove Guest Customisation test for Legacy Ubuntu OvfEnv images.

### DIFF
--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_guestcustomization.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_guestcustomization.go
@@ -433,53 +433,6 @@ func VMGOSCSpec(ctx context.Context, inputGetter func() VMGOSCSpecInput) {
 		})
 	})
 
-	// TODO: Remove this as OvfEnv is deprecated.
-	Context("OvfEnv", func() {
-		// VMs with OvfEnv transport do not support restore due to the defer-cloud-init configuration.
-		// Once a VM is booted, the defer-cloud-init is not re-applied hence causing the race between
-		// vmtools and cloud-init to configure networking during the second boot from the restore.
-		// Therefore, VerifyRegisterVM is not called for these images using OvfEnv transport.
-		BeforeEach(func() {
-			vmParameters.Transport = ovfEnvTransport
-
-			if os.Getenv("RUN_CANONICAL_TEST") == "true" {
-				Skip("These tests will be skipped for Canonical OVA testing.")
-			}
-		})
-
-		XIt("should successfully apply customization from a ConfigMap and get a valid IP assigned to ubuntu-20.04", func() {
-			// Create and apply ConfigMap yaml.
-			createAndVerifyConfigMap(ctx, ovfEnvTransport)
-			// This ubuntu 20.04 image is supported in marketplace
-			vmImageName := ubuntuMarketplaceImage
-			imageName := vmoperator.WaitForVirtualMachineImageName(ctx, &config.Config, svClusterClient, input.WCPNamespaceName, vmImageName)
-
-			vmParameters.ImageName = imageName
-			vmParameters.ConfigMapName = configMapName
-			CreateAndVerifyVM(ctx, vmParameters)
-			vmIp := vmoperator.GetVirtualMachineIP(ctx, svClusterClient, input.WCPNamespaceName, vmName)
-			cmds := []string{"cat /helloworld"}
-			expectedOutput := []string{"Hello World"}
-			verifyLoginAndRunCmds(ctx, vmIp, cmds, expectedOutput)
-		})
-
-		XIt("should successfully apply customization from a Secret and get a valid IP assigned to centos-stream-8", func() {
-			// Create and apply Secret yaml.
-			CreateAndVerifySecret(ctx, ovfEnvTransport)
-			// This centos stream 8 image is supported in marketplace
-			vmImageName := centosMarketplaceImage
-			imageName := vmoperator.WaitForVirtualMachineImageName(ctx, &config.Config, svClusterClient, input.WCPNamespaceName, vmImageName)
-
-			vmParameters.ImageName = imageName
-			vmParameters.SecretName = secretName
-			CreateAndVerifyVM(ctx, vmParameters)
-			vmIp := vmoperator.GetVirtualMachineIP(ctx, svClusterClient, input.WCPNamespaceName, vmName)
-			cmds := []string{"cat /helloworld"}
-			expectedOutput := []string{"Hello World"}
-			verifyLoginAndRunCmds(ctx, vmIp, cmds, expectedOutput)
-		})
-	})
-
 	Context("vAppConfig", func() {
 		BeforeEach(func() {
 			skipper.SkipUnlessV1a2FSSEnabled(ctx, svClusterClient, config)

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_guestcustomization.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_guestcustomization.go
@@ -447,7 +447,7 @@ func VMGOSCSpec(ctx context.Context, inputGetter func() VMGOSCSpecInput) {
 			}
 		})
 
-		It("should successfully apply customization from a ConfigMap and get a valid IP assigned to ubuntu-20.04", func() {
+		XIt("should successfully apply customization from a ConfigMap and get a valid IP assigned to ubuntu-20.04", func() {
 			// Create and apply ConfigMap yaml.
 			createAndVerifyConfigMap(ctx, ovfEnvTransport)
 			// This ubuntu 20.04 image is supported in marketplace

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_guestcustomization.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_guestcustomization.go
@@ -44,13 +44,11 @@ type VMGOSCSpecInput struct {
 }
 
 const (
-	specName               = "vm-guest-customization"
-	inlineCloudInit        = "inlineCloudInit"
-	cloudInitTransport     = "CloudInit"
-	ovfEnvTransport        = "OvfEnv"
-	vAppConfigTransport    = "vAppConfig"
-	ubuntuMarketplaceImage = "ubuntu-20.04-vmservice-v1alpha1.20210528"
-	centosMarketplaceImage = "centos-stream-8-vmservice-v1alpha1.20210528"
+	specName            = "vm-guest-customization"
+	inlineCloudInit     = "inlineCloudInit"
+	cloudInitTransport  = "CloudInit"
+	ovfEnvTransport     = "OvfEnv"
+	vAppConfigTransport = "vAppConfig"
 )
 
 var (


### PR DESCRIPTION
Removed the unsupported OvfEnv v1alpha1 image tests for ubuntu-20.04 and centos-stream-8

```
vmoperator [ /vm-operator ]$ ./e2e-tests  -e2e.e2e-config=test/e2e/vmservice/config/wcp.yaml  --ginkgo.focus="OvfEnv"  --ginkgo.dry-run  --ginkgo.v
Running Suite: VM Service E2E suite - /vm-operator
==================================================
Random Seed: 1784182448

Will run 0 of 134 specs
SSSSSSSSSSSSSSSSS
P [PENDING]
Testing VM Services VI-ADMIN-VM-CLASS When testing VMClasses workflow with invalid params Invalid vGPU Profile [devops, viadmin, virtualmachine, vmservice]
/vm-operator/test/e2e/vmservice/vmservice/viadmin/virtualmachineclasses.go:253
------------------------------
P [PENDING]
Testing VM Services VI-ADMIN-VM-CLASS When testing VMClasses workflow with invalid params Invalid DDPIO Device [devops, viadmin, virtualmachine, vmservice]
/vm-operator/test/e2e/vmservice/vmservice/viadmin/virtualmachineclasses.go:264
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
P [PENDING]
Testing VM Services VIRTUAL-MACHINE VM-GUEST-CUSTOMIZATION Sysprep when raw Sysprep data is used should successfully deploy VM and be able to register VM from backup [devops, viadmin, virtualmachine, vmservice]
/vm-operator/test/e2e/vmservice/vmservice/virtualmachine/vm_guestcustomization.go:638
------------------------------
P [PENDING]
Testing VM Services VIRTUAL-MACHINE VM-GUEST-CUSTOMIZATION Sysprep when Inline Sysprep is used should successfully deploy VM and be able to register VM from backup [devops, viadmin, virtualmachine, vmservice]
/vm-operator/test/e2e/vmservice/vmservice/virtualmachine/vm_guestcustomization.go:655
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 0 of 134 Specs in 0.002 seconds
SUCCESS! -- 0 Passed | 0 Failed | 4 Pending | 130 Skipped
```
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Initially marked TODO to delete.
```