### PR TITLE
✨ Distroless: Adopt minimal Photon bottom-up image build without rpm packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,47 @@
 ARG BASE_IMAGE=mirror.gcr.io/library/photon:5.0
 
-# Copy the controller-manager into a thin image
-FROM ${BASE_IMAGE}
-
 ## --------------------------------------
-## Cleanup (Distroless image)
+## Build a minimal root filesystem (bottom-up)
 ## --------------------------------------
 
-RUN tdnf makecache && tdnf -y update && \
-    rm /etc/tdnf/protected.d/tdnf.conf && tdnf -y autoremove photon-repos tdnf && \
-    rm -rf /var/cache/tdnf /usr/lib/{rpm,tdnf} /usr/lib/sysimage/{rpm,tdnf} /etc/{rpm,tdnf}
+FROM ${BASE_IMAGE} AS installer
+
+RUN mkdir -p /installroot
+
+# For distroless, we just need the files from filesystem,
+# ca-certificates-pki, glibc, and glibc-libs, which are
+# pre-installed on most curated base images including
+# internal+external Photon builds. 
+# glibc/glibc-libs are required because manager is 
+# built internally with CGO_ENABLED=1 and
+# GOEXPERIMENT=boringcrypto for FIPS compliance
+# so it is dynamically linked against libc, not static.
+# Copy their files straight out of the live root
+# filesystem using tdnf's own package queries, which
+# needs no extra package and no network access.
+
+RUN set -eo pipefail; \
+    for pkg in filesystem ca-certificates-pki glibc glibc-libs; do \
+            tdnf --disablerepo="*" list installed "$pkg" >/dev/null 2>&1 \
+                # if any missing package, fail the build
+                || { echo "missing package: $pkg" >&2; exit 1; }; \
+            tdnf --disablerepo="*" repoquery --installed --list "$pkg" \
+                | while read -r f; do if [ -e "$f" ]; then echo "$f"; fi; done \
+                | cpio -pdm /installroot; \
+    done
+
+## --------------------------------------
+## Copy the controller-manager into a thin image
+## --------------------------------------
+
+FROM scratch
 
 ## --------------------------------------
 ## Environment variables
 ## --------------------------------------
 
+ARG TARGETOS
+ARG TARGETARCH
 ENV GOOS=${TARGETOS}
 ENV GOARCH=${TARGETARCH}
 
@@ -42,11 +69,20 @@ LABEL branch="${BUILD_BRANCH}" \
 
 
 ## --------------------------------------
+## Minimal root filesystem (CA bundle + glibc, no tdnf/rpm/shell)
+## --------------------------------------
+
+COPY --from=installer /installroot /
+
+
+## --------------------------------------
 ## Copy the binaries from the builder
 ## --------------------------------------
 
 WORKDIR /
 COPY ./bin/manager .
 COPY ./bin/web-console-validator .
-USER nobody
+# No /etc/passwd on the image
+# we need to use UID instead of nobody
+USER 65534:65534
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Re-adopts the bottom-up minimal Photon rootfs build for the manager image (originally #1715), this time relying on the four local pre-installed packages needed for the distroless: `filesystem`, `ca-certificates-pki`, `glibc` and `glibc-libs` (the last two packages are needed when building with `CGO_ENABLED=1`):

- The installer stage no longer needs network access or the rpm package to download packages since they are core packages shipped and pre-installed on every base image of this Dockerfile is built against (public and internal Photon5 images); their files are now copied straight out of the live root filesystem via tdnf's own installed-package queries (`tdnf list installed`, `tdnf repoquery --installed --list`) piped through `cpio -p`.
- The build fails clearly (clear message + exit 1) if any of the four packages is ever missing from the base image, which is very unlikely since these packages are the foundation of any Photon5 image itself.
In the previous approach used on #1715,  we used `tdnf --downloadonly` and it could silently skip a package already at its latest version, non-deterministically leaving `/installroot` incomplete depending on upstream package freshness at build time.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # vmop-3901


**Are there any special notes for your reviewer**:

Tested the build against external version and multiple versions of internal Photon5 images.  Internal builds passed and a testbed was created and verified - all testing is documented on ticket.

**Please add a release note if necessary**:

```release-note
Docker images contain the very minimum for controller execution and no longer contains bash or any other libraries (with the exception of glibc and glibc-libs).
```