### PR TITLE
test: Fix flaky ISO CD-ROM disconnect assertion in e2e

### DIFF
--- a/test/e2e/vmservice/vmservice/virtualmachine/virtualmachinelcm.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/virtualmachinelcm.go
@@ -749,11 +749,19 @@ func VMSpec(ctx context.Context, inputGetter func() VMSpecInput) {
 		Expect(cdromFileName).To(Equal(clItem.Status.FileInfo[0].StorageURI))
 
 		By("Verifying CD-ROM can be disconnected from the VM")
+		// Use a host-forced (allowGuestControl=false) disconnect here: the guest
+		// is still sitting at the ISO's boot/installer screen with no VMware
+		// Tools running, so a guest-mediated disconnect (allowGuestControl=true)
+		// cannot get a guest ack and fails with msg.disk.onlineConnectFail. This
+		// step is only exercising the k8s-to-vSphere connection-state plumbing,
+		// not a guest-cooperative eject, so the host-forced path is the correct
+		// one to assert against.
 		//nolint:staticcheck // VirtualMachineYaml (v1alpha3) still exposes deprecated Cdrom for this spec path.
 		vmParameters.Cdrom[0].Connected = false
+		vmParameters.Cdrom[0].AllowGuestControl = false
 		vmYaml = manifestbuilders.GetVirtualMachineYamlA3(vmParameters)
 		Expect(clusterProxy.ApplyWithArgs(ctx, vmYaml)).To(Succeed(), "failed to apply updated VM YAML with CD-ROM disconnected %s", string(vmYaml))
-		verifyCdromConnectionState(ctx, vmMoRef, propCollector, false, true)
+		verifyCdromConnectionState(ctx, vmMoRef, propCollector, false, false)
 
 		By("Verifying CD-ROM can be reconnected to the VM with allowGuestControl disabled")
 		//nolint:staticcheck // VirtualMachineYaml (v1alpha3) still exposes deprecated Cdrom for this spec path.


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

The `VM-LCM` "Should create expected resources for a VirtualMachine
deployed from ISO" e2e spec disconnects the attached ISO CD-ROM with
`allowGuestControl=true` immediately after the VM powers on. At that
point the guest is still sitting at the live-installer ISO's boot
screen with no VMware Tools running, so the guest-mediated (online)
disconnect vCenter attempts on our behalf can never get a guest ack.
This run failed reliably (not just intermittently) with:

```
Timed out after 60.000s.
VM CD-ROM did not have expected connection state
```

The controller-manager logs show vm-operator issued the correct
`ReconfigVM_Task` device-edit, but vCenter's task itself failed after
~4 minutes with `msg.disk.onlineConnectFail` / "Connection control
operation failed for disk 'ide0:0'." This isn't a vm-operator
reconciler bug and isn't a timing race that a longer `Eventually`
would fix — it's a guest-cooperation requirement that a freshly
booted, Tools-less installer ISO can never satisfy.

The disconnect step only needs to exercise the k8s-to-vSphere
connection-state plumbing, not a guest-cooperative eject (the
reconnect step immediately below it already uses the host-forced
path via `allowGuestControl=false`). This PR switches the disconnect
step to the same host-forced path so it no longer depends on guest
cooperation that isn't available in this scenario.

**Which issue(s) is/are addressed by this PR?**

Fixes #

**Are there any special notes for your reviewer**:

No product code changes — this is a test-only fix. Root-caused from a
UTS e2e failure by inspecting both the e2e-runner log and the
vm-operator controller-manager log for the affected VM/timeframe.

**Please add a release note if necessary**:

```release-note
NONE
```

**Testing Done**
```
Ran 1 of 136 Specs in 272.873 seconds
SUCCESS! -- 1 Passed | 0 Failed | 5 Pending | 130 Skipped
PASS
```