### PR TITLE
🐛 Fix image name resolution in boot disk storage policy test

### DIFF
--- a/test/e2e/vmservice/vmservice/virtualmachine/virtualmachinelcm.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/virtualmachinelcm.go
@@ -475,7 +475,7 @@ func VMSpec(ctx context.Context, inputGetter func() VMSpecInput) {
 		vmParameters := manifestbuilders.VirtualMachineYaml{
 			Namespace:        input.WCPNamespaceName,
 			Name:             vmName,
-			ImageName:        linuxImageDisplayName,
+			ImageName:        linuxVMIName,
 			VMClassName:      clusterResources.VMClassName,
 			StorageClassName: clusterResources.StorageClassName,
 			ResourcePolicy:   clusterResources.VMResourcePolicyName,


### PR DESCRIPTION
The test "Should verify boot disk storage policy matches VM spec.storageClass after power-on" was using linuxImageDisplayName (the human-readable display name, e.g. "photon-5.0") instead of linuxVMIName (the resolved Kubernetes CR name, e.g. "vmi-abc123") when building the VM YAML.

This caused the mutating webhook's ResolveImageName function to search by status.name across both namespace-scoped and cluster-scoped VirtualMachineImages, finding one match in each scope. The webhook correctly rejects this ambiguous reference with "multiple VM images exist for 'photon-5.0' in namespace and cluster scope".

By using the resolved CR name (linuxVMIName), the webhook takes the direct lookup path (HasPrefix "vmi-") and skips the scope-search entirely, avoiding the ambiguity. This aligns with every other It block in the same test file which all correctly use linuxVMIName.

Changes:
- Use linuxVMIName instead of linuxImageDisplayName in VM YAML builder

Test changes:
- None (this fixes the broken test without requiring test infrastructure changes)

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note

```