### PR TITLE
Honor a pre-set NETWORK env var in e2e testbed setup

### DIFF
--- a/hack/e2e/setup-testbed-env.sh
+++ b/hack/e2e/setup-testbed-env.sh
@@ -293,13 +293,17 @@ _export_common_vars() {
     _export GOVC_PASSWORD "${vc_vim_password}"
     _export VCSA_PASSWORD "${vc_vim_password}"
 
+    # Honour a NETWORK value the caller already exported (e.g. the UTS
+    # pipeline job spec) instead of overwriting it with the auto-detected
+    # value below, which falls back to "vds" whenever the testbed JSON
+    # doesn't carry a recognized topology field.
     local networking_type
     networking_type=$(jq -r '
         .deliverable_blob.networking //
         .networking //
         (if .TESTBED_TOPOLOGY == "NIMBUS_NSXT" then "nsx" else "vds" end)
     ' <<< "${testbed_data}")
-    _export NETWORK "${networking_type}"
+    _export NETWORK "${NETWORK:-${networking_type}}"
 
     # Honour values already set in the environment; fall back to safe defaults.
     _export TEST_SKIP  "${TEST_SKIP:-}"


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

`hack/e2e/setup-testbed-env.sh` always overwrote the `NETWORK` env var with a value it auto-detected from the testbed JSON blob, even if the caller (e.g. a CI/UTS pipeline job) had already exported `NETWORK` explicitly. The auto-detection heuristic falls back to `"vds"` whenever the testbed JSON doesn't carry one of the recognized topology fields (`.deliverable_blob.networking`, `.networking`, or `.TESTBED_TOPOLOGY == "NIMBUS_NSXT"`).

This was found while triaging the first e2e run against a real NSX testbed: the run's testbed JSON didn't match any of those fields, so `NETWORK` silently defaulted to `vds`, and every test that reads `config.InfraConfig.NetworkingTopology` (`GetVirtualMachineNetworkProviderIP` and friends in `test/e2e/vmservice/lib/vmoperator/vmoperator.go`) took the VDS code path against an NSX cluster and failed with `no NetworkInterfaces found in namespace ...`.

This change makes `NETWORK` caller-overridable: if it's already set in the environment, that value is kept; otherwise it falls back to the existing auto-detected value. A companion change to the UTS pipeline config now explicitly passes `NETWORK=nsx` for the NSX/VPC e2e jobs so they no longer depend on the JSON-based auto-detection at all.

**Which issue(s) is/are addressed by this PR?**:

Fixes #

**Are there any special notes for your reviewer**:

No behavior change for existing VDS/callers that don't set `NETWORK` — the auto-detected value is used exactly as before. Only affects callers that explicitly export `NETWORK`.

**Please add a release note if necessary**:

```release-note
NONE
```