### PR TITLE
🐛 Watch PVCs in VM controller

### DIFF
--- a/controllers/virtualmachine/virtualmachine/virtualmachine_controller.go
+++ b/controllers/virtualmachine/virtualmachine/virtualmachine_controller.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -75,6 +76,12 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 
 		controllerNameShort = fmt.Sprintf("%s-controller", strings.ToLower(controlledTypeName))
 	)
+
+	// Set up field index for VirtualMachine by ClaimName to efficiently query VMs
+	// referencing a PVC. This index is also used by the batch controller.
+	if err := kubeutil.IndexVMSpecVolumesPVCs(ctx, mgr); err != nil {
+		return err
+	}
 
 	proberManager, err := prober.AddToManager(ctx, mgr, ctx.VMProvider)
 	if err != nil {
@@ -220,6 +227,14 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 			)
 		}
 	}
+
+	builder = builder.WatchesRawSource(source.Kind(
+		mgr.GetCache(),
+		&corev1.PersistentVolumeClaim{},
+		handler.TypedEnqueueRequestsFromMapFunc(
+			vmopv1util.PVCToVirtualMachineVolumeClaimNameMapper(ctx, r.Client),
+		),
+	))
 
 	// Watch CnsNodeVMBatchAttachment in order to account for the volume
 	// registration race outlined/fixed in

--- a/controllers/virtualmachine/virtualmachine/virtualmachine_controller_intg_test.go
+++ b/controllers/virtualmachine/virtualmachine/virtualmachine_controller_intg_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/vmware/govmomi/object"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -484,6 +485,89 @@ func intgTestsReconcile() {
 					vm := getVirtualMachine(ctx, vmKey)
 					g.Expect(vm).NotTo(BeNil())
 					g.Expect(vm.Status.InstanceUUID).To(Equal(instanceUUID))
+				}).Should(Succeed())
+			})
+		})
+
+		It("Reconciles after PVC referenced by a volume is updated", func() {
+			const (
+				pvcName       = "dummy-pvc"
+				annotationKey = "dummy-annotation"
+			)
+
+			vm.Spec.Volumes = []vmopv1.VirtualMachineVolume{
+				{
+					Name: "my-volume",
+					VirtualMachineVolumeSource: vmopv1.VirtualMachineVolumeSource{
+						PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
+							PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: pvcName,
+							},
+						},
+					},
+				},
+			}
+
+			// Reflect the PVC's current annotation value onto the VM's
+			// status on every reconcile. Reconciles unrelated to the PVC
+			// (e.g. the VM's own create/requeue lifecycle churn) are
+			// harmless no-ops here since they just re-copy whatever the PVC
+			// currently holds -- unlike a call counter, there's nothing to
+			// race against or wait to "settle." What proves the PVC watch
+			// works is that this value can only ever advance to what the
+			// PVC is annotated with *after* the update below, and nothing
+			// else in this test can produce a reconcile at that point.
+			providerfake.SetCreateOrUpdateFunction(
+				ctx,
+				intgFakeVMProvider,
+				func(_ context.Context, vm *vmopv1.VirtualMachine) error {
+					conditions.MarkTrue(vm, vmopv1.VirtualMachineConditionCreated)
+
+					pvc := &corev1.PersistentVolumeClaim{}
+					pvcKey := client.ObjectKey{Namespace: vm.Namespace, Name: pvcName}
+					if err := ctx.Client.Get(ctx, pvcKey, pvc); err == nil {
+						vm.Status.InstanceUUID = pvc.Annotations[annotationKey]
+					}
+					return nil
+				},
+			)
+
+			Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
+			// Wait for initial reconcile.
+			waitForVirtualMachineFinalizer(ctx, vmKey)
+
+			By("VirtualMachine should be reconciled", func() {
+				Eventually(func(g Gomega) {
+					vm := getVirtualMachine(ctx, vmKey)
+					g.Expect(vm).NotTo(BeNil())
+					g.Expect(conditions.IsTrue(vm, vmopv1.VirtualMachineConditionCreated)).To(BeTrue())
+				}).Should(Succeed())
+			})
+
+			pvc := builder.DummyPersistentVolumeClaim()
+			pvc.Name = pvcName
+			pvc.Namespace = vm.Namespace
+			pvc.Annotations = map[string]string{annotationKey: "before-update"}
+			Expect(ctx.Client.Create(ctx, pvc)).To(Succeed())
+
+			By("VirtualMachine should be reconciled due to PVC creation", func() {
+				Eventually(func(g Gomega) {
+					vm := getVirtualMachine(ctx, vmKey)
+					g.Expect(vm).NotTo(BeNil())
+					g.Expect(vm.Status.InstanceUUID).To(Equal("before-update"))
+				}).Should(Succeed())
+			})
+
+			By("Update the PVC", func() {
+				pvc.Annotations[annotationKey] = "after-update"
+				Expect(ctx.Client.Update(ctx, pvc)).To(Succeed())
+			})
+
+			By("VirtualMachine should be reconciled due to PVC update", func() {
+				Eventually(func(g Gomega) {
+					vm := getVirtualMachine(ctx, vmKey)
+					g.Expect(vm).NotTo(BeNil())
+					g.Expect(vm.Status.InstanceUUID).To(Equal("after-update"))
 				}).Should(Succeed())
 			})
 		})

--- a/controllers/virtualmachine/volumebatch/volumebatch_controller.go
+++ b/controllers/virtualmachine/volumebatch/volumebatch_controller.go
@@ -81,25 +81,6 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		return err
 	}
 
-	// Set up field index for VirtualMachine by ClaimName to efficiently query VMs
-	// referencing a PVC.
-	if err := mgr.GetFieldIndexer().IndexField(
-		ctx,
-		&vmopv1.VirtualMachine{},
-		"spec.volumes.persistentVolumeClaim.claimName",
-		func(rawObj client.Object) []string {
-			vm := rawObj.(*vmopv1.VirtualMachine)
-			pvcs := make([]string, 0, len(vm.Spec.Volumes))
-			for _, volume := range vm.Spec.Volumes {
-				if pvc := volume.PersistentVolumeClaim; pvc != nil && pvc.ClaimName != "" {
-					pvcs = append(pvcs, pvc.ClaimName)
-				}
-			}
-			return pvcs
-		}); err != nil {
-		return err
-	}
-
 	r := NewReconciler(
 		ctx,
 		mgr.GetClient(),

--- a/controllers/virtualmachine/volumebatch/volumebatch_controller.go
+++ b/controllers/virtualmachine/volumebatch/volumebatch_controller.go
@@ -165,26 +165,7 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		pkgcfg.FromContext(ctx).Features.InstanceStorage {
 
 		// Watch for changes for PersistentVolumeClaim, and enqueue
-		// VirtualMachine which is the owner of PersistentVolumeClaim.
-		if err := c.Watch(source.Kind(
-			mgr.GetCache(),
-			&corev1.PersistentVolumeClaim{},
-			handler.TypedEnqueueRequestForOwner[*corev1.PersistentVolumeClaim](
-				mgr.GetScheme(),
-				mgr.GetRESTMapper(),
-				&vmopv1.VirtualMachine{},
-			),
-		)); err != nil {
-			return fmt.Errorf(
-				"failed to start VirtualMachine watch "+
-					"for PersistentVolumeClaim: %w", err)
-		}
-
-		// Watch for changes for PersistentVolumeClaim, and enqueue
 		// VirtualMachine that reference the PVC in their Spec.Volumes.
-		//
-		// TODO(BMV): This should cover every case that the above OwnerRef
-		// mapper does, and that can be removed later.
 		if err := c.Watch(source.Kind(
 			mgr.GetCache(),
 			&corev1.PersistentVolumeClaim{},

--- a/controllers/virtualmachine/volumebatch/volumebatch_controller_suite_test.go
+++ b/controllers/virtualmachine/volumebatch/volumebatch_controller_suite_test.go
@@ -15,6 +15,7 @@ import (
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	providerfake "github.com/vmware-tanzu/vm-operator/pkg/providers/fake"
+	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
@@ -22,11 +23,21 @@ var intgFakeVMProvider = providerfake.NewVMProvider()
 
 var suite = builder.NewTestSuiteForControllerWithContext(
 	pkgcfg.NewContextWithDefaultConfig(),
-	volumebatch.AddToManager,
+	addToMgr,
 	func(ctx *pkgctx.ControllerManagerContext, _ ctrlmgr.Manager) error {
 		ctx.VMProvider = intgFakeVMProvider
 		return nil
 	})
+
+func addToMgr(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) error {
+	// TODO(BMV): Here until we centralize all indexer func registration. In production,
+	// this is done in the VirtualMachine controller.
+	if err := kubeutil.IndexVMSpecVolumesPVCs(ctx, mgr); err != nil {
+		return err
+	}
+
+	return volumebatch.AddToManager(ctx, mgr)
+}
 
 func TestBatchVolume(t *testing.T) {
 	suite.Register(t, "Volume batch controller suite", intgTests, unitTests)

--- a/pkg/util/kube/pvc.go
+++ b/pkg/util/kube/pvc.go
@@ -1,0 +1,48 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package kube
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+)
+
+const (
+	// VMSpecVolumesPVCsIndexKey is the field-index key used to efficiently
+	// determine PVCs that are referenced in a VM Spec.
+	VMSpecVolumesPVCsIndexKey = "spec.volumes.persistentVolumeClaim.claimName"
+)
+
+// VMSpecVolumesPVCsIndexerFunc returns the list of the PVC names that are referenced
+// in the VM Spec.
+func VMSpecVolumesPVCsIndexerFunc(obj client.Object) []string {
+	vm, ok := obj.(*vmopv1.VirtualMachine)
+	if !ok {
+		return nil
+	}
+
+	pvcs := make([]string, 0, len(vm.Spec.Volumes))
+	for _, volume := range vm.Spec.Volumes {
+		if pvc := volume.PersistentVolumeClaim; pvc != nil && pvc.ClaimName != "" {
+			pvcs = append(pvcs, pvc.ClaimName)
+		}
+	}
+	return pvcs
+}
+
+// IndexVMSpecVolumesPVCs registers a field indexer on the VirtualMachine keyed by
+// VMSpecVolumesPVCsIndexKey to efficiently list the VirtualMachines that reference
+// a PVC.
+func IndexVMSpecVolumesPVCs(ctx context.Context, mgr manager.Manager) error {
+	return mgr.GetFieldIndexer().IndexField(
+		ctx,
+		&vmopv1.VirtualMachine{},
+		VMSpecVolumesPVCsIndexKey,
+		VMSpecVolumesPVCsIndexerFunc)
+}

--- a/pkg/util/kube/pvc_test.go
+++ b/pkg/util/kube/pvc_test.go
@@ -1,0 +1,106 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package kube_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
+)
+
+var _ = Describe("VMSpecVolumesPVCsIndexerFunc", func() {
+	When("the object is not a VirtualMachine", func() {
+		It("should return nil", func() {
+			obj := &corev1.Pod{}
+			Expect(kubeutil.VMSpecVolumesPVCsIndexerFunc(obj)).To(BeNil())
+		})
+	})
+
+	When("the object is a VirtualMachine", func() {
+		var vm *vmopv1.VirtualMachine
+
+		BeforeEach(func() {
+			vm = &vmopv1.VirtualMachine{}
+		})
+
+		When("there are no volumes", func() {
+			It("should return an empty slice", func() {
+				Expect(kubeutil.VMSpecVolumesPVCsIndexerFunc(vm)).To(BeEmpty())
+			})
+		})
+
+		When("there are non-PVC volumes", func() {
+			BeforeEach(func() {
+				vm.Spec.Volumes = []vmopv1.VirtualMachineVolume{
+					{
+						Name:                       "vol1",
+						VirtualMachineVolumeSource: vmopv1.VirtualMachineVolumeSource{},
+					},
+				}
+			})
+			It("should return an empty slice", func() {
+				Expect(kubeutil.VMSpecVolumesPVCsIndexerFunc(vm)).To(BeEmpty())
+			})
+		})
+
+		When("there is a PVC volume with an empty claim name", func() {
+			BeforeEach(func() {
+				vm.Spec.Volumes = []vmopv1.VirtualMachineVolume{
+					{
+						Name: "vol1",
+						VirtualMachineVolumeSource: vmopv1.VirtualMachineVolumeSource{
+							PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
+								PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: "",
+								},
+							},
+						},
+					},
+				}
+			})
+			It("should return an empty slice", func() {
+				Expect(kubeutil.VMSpecVolumesPVCsIndexerFunc(vm)).To(BeEmpty())
+			})
+		})
+
+		When("there are one or more PVC volumes with claim names", func() {
+			BeforeEach(func() {
+				vm.Spec.Volumes = []vmopv1.VirtualMachineVolume{
+					{
+						Name: "vol1",
+						VirtualMachineVolumeSource: vmopv1.VirtualMachineVolumeSource{
+							PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
+								PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: "pvc1",
+								},
+							},
+						},
+					},
+					{
+						Name:                       "vol2",
+						VirtualMachineVolumeSource: vmopv1.VirtualMachineVolumeSource{},
+					},
+					{
+						Name: "vol3",
+						VirtualMachineVolumeSource: vmopv1.VirtualMachineVolumeSource{
+							PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
+								PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: "pvc2",
+								},
+							},
+						},
+					},
+				}
+			})
+			It("should return the claim names in spec order", func() {
+				Expect(kubeutil.VMSpecVolumesPVCsIndexerFunc(vm)).To(Equal([]string{"pvc1", "pvc2"}))
+			})
+		})
+	})
+})

--- a/pkg/util/vmopv1/vm.go
+++ b/pkg/util/vmopv1/vm.go
@@ -528,12 +528,15 @@ func PVCToVirtualMachineVolumeClaimNameMapper(
 			WithValues("name", pvc.Name, "namespace", pvc.Namespace)
 		logger.V(4).Info("Reconciling VMs by ClaimName due to PVC event")
 
+		// TODO(BMV): Can't use VMSpecVolumesPVCsIndexKey due to import cycles.
+		const key = "spec.volumes.persistentVolumeClaim.claimName"
+
 		list := &vmopv1.VirtualMachineList{}
 		err := k8sClient.List(
 			ctx,
 			list,
 			client.InNamespace(pvc.Namespace),
-			client.MatchingFields{"spec.volumes.persistentVolumeClaim.claimName": pvc.Name})
+			client.MatchingFields{key: pvc.Name})
 		if err != nil {
 			logger.Error(err, "Failed to list VirtualMachines by ClaimName for PVC")
 			return nil

--- a/pkg/util/vmopv1/vm_test.go
+++ b/pkg/util/vmopv1/vm_test.go
@@ -31,6 +31,7 @@ import (
 	cnsv1alpha1 "github.com/vmware-tanzu/vm-operator/external/vsphere-csi-driver/api/v1alpha1"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgconst "github.com/vmware-tanzu/vm-operator/pkg/constants"
+	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
 	spqutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube/spq"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
@@ -1277,7 +1278,6 @@ var _ = Describe("CnsNodeVMBatchAttachmentToVirtualMachineMapper", func() {
 var _ = Describe("PVCToVirtualMachineVolumeClaimNameMapper", func() {
 	const (
 		namespaceName = "fake"
-		fieldName     = "spec.volumes.persistentVolumeClaim.claimName"
 	)
 
 	var (
@@ -1363,17 +1363,8 @@ var _ = Describe("PVCToVirtualMachineVolumeClaimNameMapper", func() {
 			WithObjects(withObjs...).
 			WithIndex(
 				&vmopv1.VirtualMachine{},
-				fieldName,
-				func(rawObj ctrlclient.Object) []string {
-					vm := rawObj.(*vmopv1.VirtualMachine)
-					pvcs := make([]string, 0, len(vm.Spec.Volumes))
-					for _, volume := range vm.Spec.Volumes {
-						if pvc := volume.PersistentVolumeClaim; pvc != nil && pvc.ClaimName != "" {
-							pvcs = append(pvcs, pvc.ClaimName)
-						}
-					}
-					return pvcs
-				},
+				kubeutil.VMSpecVolumesPVCsIndexKey,
+				kubeutil.VMSpecVolumesPVCsIndexerFunc,
 			).
 			Build()
 	})


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

The VM controller should watch PVCs and reconcile the VM when a PVC that is referenced in the VM Spec.Volumes is changed. This is needed for more timely reconciliation of VM creation it a PVC is not bound.

The volume batch controller already had this watch, so reorganize a bit to better share that. While here, remove an old TODO in the batch controller to stop enqueuing based on the PVC OwnerRef the mapper covers what we need (and outside of PVCs created for CNS registration, PVCs generally won't have the VM as a owner anyways).

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # vmop-3933

**Are there any special notes for your reviewer**:

smoke, vm-hardware passed

**Please add a release note if necessary**:

```release-note
VirtualMachine controller now watches PVCs and will reconcile a VM when one of the PVCs referenced in its VM Spec.Volume changes.
```