### PR TITLE
Fix vm-location e2e test failure

### DIFF
--- a/test/e2e/vmservice/vmservice_test.go
+++ b/test/e2e/vmservice/vmservice_test.go
@@ -249,10 +249,11 @@ var _ = Describe("Testing VM Services", Label("devops"), Label("viadmin"), Label
 		Context("VM-LOCATION", func() {
 			virtualmachine.VMLocationSpec(context.TODO(), func() virtualmachine.VMLocationSpecInput {
 				return virtualmachine.VMLocationSpecInput{
-					ClusterProxy:   svClusterProxy,
-					Config:         config,
-					WCPClient:      wcpClient,
-					ArtifactFolder: artifactFolder,
+					ClusterProxy:     svClusterProxy,
+					Config:           config,
+					WCPClient:        wcpClient,
+					ArtifactFolder:   artifactFolder,
+					WCPNamespaceName: wcpNamespaceName,
 				}
 			})
 		})


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

- Restores the WCPNamespaceName field on the VM-LOCATION spec input in test/e2e/vmservice/vmservice_test.go.
- When the VM-LOCATION E2E spec was added, its input correctly passed WCPNamespaceName: wcpNamespaceName. The merge for [https://github.com/vmware-tanzu/vm-operator/pull/1688](url) mis-reconstructed this block and dropped that line from the VM-LOCATION input while adding the new VM-EXTRACONFIG context, leaving the field unset (defaulting to ""). Since it's an omitted struct field, nothing caught it at compile time.
- As a result, all three VM-LOCATION specs fail in their BeforeEach guard:
`Invalid argument. input.WCPNamespaceName can't be empty when calling`

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # vmop-3844


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note

```