### PR TITLE
🌱 Add E2E coverage for VM suspend/resume across suspend modes

### DIFF
--- a/test/e2e/vmservice/vmservice/virtualmachine/virtualmachinelcm.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/virtualmachinelcm.go
@@ -48,6 +48,7 @@ import (
 const (
 	poweredOnState  = "PoweredOn"
 	poweredOffState = "PoweredOff"
+	suspendedState  = "Suspended"
 )
 
 type VMSpecInput struct {
@@ -383,6 +384,38 @@ func VMSpec(ctx context.Context, inputGetter func() VMSpecInput) {
 		e2eframework.Logf("Updating the VM's PowerState to '%v'", vmParameters.PowerState)
 		Expect(clusterProxy.ApplyWithArgs(ctx, vmYaml)).To(Succeed(), "failed to power-off virtualmachine", string(vmYaml))
 		vmoperator.WaitForVirtualMachinePowerState(ctx, config, svClusterClient, input.WCPNamespaceName, vmName, "PoweredOff")
+	})
+
+	Context("when suspending a VM", Label("core-functional", "experimental"), func() {
+		BeforeEach(func() {
+			By("Creating a powered on VirtualMachine to suspend")
+			vmParameters := manifestbuilders.VirtualMachineYaml{
+				Namespace:        input.WCPNamespaceName,
+				Name:             vmName,
+				ImageName:        linuxVMIName,
+				VMClassName:      clusterResources.VMClassName,
+				StorageClassName: clusterResources.StorageClassName,
+				ResourcePolicy:   clusterResources.VMResourcePolicyName,
+				PowerState:       poweredOnState,
+			}
+			vmYaml = manifestbuilders.GetVirtualMachineYamlA6(vmParameters)
+			Expect(clusterProxy.CreateWithArgs(ctx, vmYaml)).To(Succeed(), "failed to create virtualmachine:\n %s", string(vmYaml))
+			vmoperator.WaitForVirtualMachineCreation(ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
+			vmoperator.WaitForVirtualMachinePowerState(ctx, config, svClusterClient, input.WCPNamespaceName, vmName, poweredOnState)
+
+			// Wait for the guest to obtain an IP so that VMware Tools is running
+			// and can service graceful (Soft / TrySoft) suspend requests.
+			vmoperator.WaitForVirtualMachineIP(ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
+		})
+
+		DescribeTable("Should suspend and resume a VM using the configured suspend mode",
+			func(suspendMode vmopv1.VirtualMachinePowerOpMode) {
+				suspendAndResumeVirtualMachine(ctx, config, svClusterClient, input.WCPNamespaceName, vmName, suspendMode)
+			},
+			Entry("using Hard suspend mode", vmopv1.VirtualMachinePowerOpModeHard),
+			Entry("using Soft suspend mode", vmopv1.VirtualMachinePowerOpModeSoft),
+			Entry("using TrySoft suspend mode", vmopv1.VirtualMachinePowerOpModeTrySoft),
+		)
 	})
 
 	It("Should create expected resources for a VirtualMachine on Namespaces recreated with identical names", func() {
@@ -1329,4 +1362,35 @@ func verifyCdromConnectionState(
 	}, 1*time.Minute, 5*time.Second).Should(Succeed(), "VM CD-ROM did not have expected connection state")
 
 	return cdrom
+}
+
+// suspendAndResumeVirtualMachine suspends the VM by patching its
+// spec.suspendMode and spec.powerState to Suspended, waits for it to reach the
+// suspended power state, then resumes it by patching spec.powerState back to
+// PoweredOn and waits for it to power on again.
+func suspendAndResumeVirtualMachine(
+	ctx context.Context,
+	config *e2eConfig.E2EConfig,
+	client ctrlclient.Client,
+	ns, vmName string,
+	suspendMode vmopv1.VirtualMachinePowerOpMode) {
+
+	By(fmt.Sprintf("Suspending the VirtualMachine using %q suspend mode", suspendMode))
+	vm, err := utils.GetVirtualMachine(ctx, client, ns, vmName)
+	Expect(err).NotTo(HaveOccurred())
+	vmPatch := vm.DeepCopy()
+	vmPatch.Spec.PowerState = vmopv1.VirtualMachinePowerStateSuspended
+	vmPatch.Spec.SuspendMode = suspendMode
+	Expect(client.Patch(ctx, vmPatch, ctrlclient.MergeFrom(vm))).To(Succeed(),
+		"failed to patch VM %s to suspended power state", vmName)
+	vmoperator.WaitForVirtualMachinePowerState(ctx, config, client, ns, vmName, suspendedState)
+
+	By("Resuming the VirtualMachine by powering it back on")
+	vm, err = utils.GetVirtualMachine(ctx, client, ns, vmName)
+	Expect(err).NotTo(HaveOccurred())
+	vmPatch = vm.DeepCopy()
+	vmPatch.Spec.PowerState = vmopv1.VirtualMachinePowerStateOn
+	Expect(client.Patch(ctx, vmPatch, ctrlclient.MergeFrom(vm))).To(Succeed(),
+		"failed to patch VM %s to powered on power state", vmName)
+	vmoperator.WaitForVirtualMachinePowerState(ctx, config, client, ns, vmName, poweredOnState)
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

- Adds E2E coverage for the Suspended VM power state, which previously had no test coverage in the VM lifecycle suite (virtualmachinelcm.go).
- Adds a new Context("when suspending a VM", ...) inside VMSpec that:
- Creates a powered-on VM and waits for it to obtain a guest IP (so VMware Tools is available for graceful suspend paths).
- Exercises suspend → verify Suspended → resume → verify PoweredOn via a DescribeTable with one Entry per supported spec.suspendMode (Hard, Soft, TrySoft).

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # vmop-3579


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note

```