### PR TITLE
Widen VM group boot-delay E2E tolerance to 15s

### DIFF
--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_group.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_group.go
@@ -304,11 +304,15 @@ func VMGroupSpec(ctx context.Context, inputGetter func() VMGroupSpecInput) {
 				By(fmt.Sprintf("VM boot timing: VM1: %v, VM2: %v (delay from VM1: %v), VM3: %v (delay from VM2: %v)",
 					vm1BootTime, vm2BootTime, vm2DelayFromVM1, vm3BootTime, vm3DelayFromVM2))
 
-				// Allow some tolerance (±10 seconds) for VM controller to reconcile and actually power on the VMs.
-				Expect(vm2DelayFromVM1).To(BeNumerically(">=", 20*time.Second), "VM2 boot delay should be at least 20s from VM1")
-				Expect(vm2DelayFromVM1).To(BeNumerically("<=", 40*time.Second), "VM2 boot delay should be at most 40s from VM1")
-				Expect(vm3DelayFromVM2).To(BeNumerically(">=", 50*time.Second), "VM3 boot delay should be at least 50s from VM2")
-				Expect(vm3DelayFromVM2).To(BeNumerically("<=", 70*time.Second), "VM3 boot delay should be at most 70s from VM2")
+				// Allow some tolerance (±15 seconds) for VM controller to reconcile and actually power on the VMs.
+				// The measured delay is the gap between vCenter runtime.bootTime values, which reflects
+				// per-VM PowerOn task latency (placement, datastore, VMX startup) in addition to the
+				// configured PowerOnDelay, so it can legitimately land further from the configured value
+				// than the delay enforced between PowerOn requests.
+				Expect(vm2DelayFromVM1).To(BeNumerically(">=", 15*time.Second), "VM2 boot delay should be at least 15s from VM1")
+				Expect(vm2DelayFromVM1).To(BeNumerically("<=", 45*time.Second), "VM2 boot delay should be at most 45s from VM1")
+				Expect(vm3DelayFromVM2).To(BeNumerically(">=", 45*time.Second), "VM3 boot delay should be at least 45s from VM2")
+				Expect(vm3DelayFromVM2).To(BeNumerically("<=", 75*time.Second), "VM3 boot delay should be at most 75s from VM2")
 			})
 
 			By("Creating a new standalone VM4 with spec.groupName unset and spec.powerState set to PoweredOn")


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

The flat-group `VirtualMachineGroup` boot-order E2E test
(`test/e2e/vmservice/vmservice/virtualmachine/vm_group.go`) asserts that VM2
and VM3 boot times land within a ±10s window of their configured
`PowerOnDelay` (30s and 1m respectively), measured via vCenter
`runtime.bootTime`.

That window is tighter than what the controller actually guarantees:
`PowerOnDelay` is enforced between PowerOn *requests* issued by the
`VirtualMachineGroup` controller, but the test measures the gap between
`bootTime` values, which additionally includes per-VM PowerOn task latency
(placement, datastore, VMX startup). This caused a flaky smoke-test failure
in CI (`uts_container/1067871`), where VM2 booted only 17s after VM1 — 3s
short of the 20s floor — despite no regression in the delay-reconciliation
logic (`controllers/virtualmachinegroup/virtualmachinegroup_controller.go`).

This PR widens the tolerance to ±15s for both the VM2 and VM3 assertions to
absorb that task-latency variance, and adds a comment explaining why the
window exists. Test-only change; no product code touched.

**Which issue(s) is/are addressed by this PR?**

Fixes #

**Are there any special notes for your reviewer**:

Root-caused via the CI log at uts_container/1067871 — single failing spec
out of 150 (rest passed/skipped/pending). No code changes to
`controllers/virtualmachinegroup` or `pkg/providers/vsphere` were needed;
this is a test-tolerance-only fix.

**Please add a release note if necessary**:

```release-note
NONE
```

**Proof of testing**
```
Ran 3 of 151 Specs in 960.431 seconds
SUCCESS! -- 3 Passed | 0 Failed | 4 Pending | 144 Skipped
PASS
```