### PR TITLE
Remove experimental label from vm_publishrequest tests

### DIFF
--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_publishrequest.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_publishrequest.go
@@ -302,7 +302,7 @@ func VMPublishRequestSpec(ctx context.Context, inputGetter func() VMPublishReque
 				vmoperator.VerifyVirtualMachinePublishRequestCondition(ctx, config, svClusterClient, input.WCPNamespaceName, vmPublishRequestName, vmPubCondition)
 			})
 
-			It("should preserve vAppConfig properties on a VM deployed from the published image", Label("extended-functional", "experimental"), func() {
+			It("should preserve vAppConfig properties on a VM deployed from the published image", Label("extended-functional"), func() {
 				skipper.SkipUnlessV1a2FSSEnabled(ctx, svClusterClient, config)
 
 				By("Attaching the target content library to the namespace as writable")
@@ -546,7 +546,7 @@ func VMPublishRequestSpec(ctx context.Context, inputGetter func() VMPublishReque
 				}
 			})
 
-			It("should compute the requestedCapacity annotation from the VM's actual used storage, not its provisioned disk size", Label("extended-functional", "experimental"), func() {
+			It("should compute the requestedCapacity annotation from the VM's actual used storage, not its provisioned disk size", Label("extended-functional"), func() {
 				// Labeling the target ContentLibrary opts the publish request into the async
 				// storage-quota check, normally driven by an external VCFA component. This lets
 				// us exercise the controller's capacity estimation (see checkContentLibraryQuota)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

Removes the experimental label from two VirtualMachinePublishRequest E2E specs in vm_publishrequest.go:
1. should preserve vAppConfig properties on a VM deployed from the published image
2. should compute the requestedCapacity annotation from the VM's actual used storage, not its provisioned disk size

Both specs carried experimental because they hadn't yet been validated against a real WCP/vSphere testbed. They've now run successfully on hardware, so promote them into the standard extended-functional CI runs per the project's E2E labeling convention.

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # vmop-3613


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note

```