### PR TITLE
Fix the KMIP installation concurrency bug

### DIFF
--- a/hack/e2e/install-pykmip.sh
+++ b/hack/e2e/install-pykmip.sh
@@ -8,6 +8,18 @@ set -x
 # Install https://github.com/OpenKMIP/PyKMIP
 # Used as KMS for encrypting VMs
 
+# Generate the TLS cert on this gateway VM if it does not already exist.
+# Cert generation lives here (on the gateway) rather than in the calling
+# test-runner container so that all parallel containers fetch and register
+# the same cert via govc kms.trust, preventing a race where containers push
+# different certs and PyKMIP ends up serving a cert that vCenter no longer
+# trusts.
+if [ ! -e /root/pykmip-crt.pem ] ; then
+  openssl req -x509 -newkey rsa:4096 -sha256 -days 365 -nodes \
+          -subj "/C=US/ST=CA/L=PA/O=Broadcom/OU=VCF/CN=pykmip" \
+          -keyout /root/pykmip-key.pem -out /root/pykmip-crt.pem
+fi
+
 # VDS/photon:
 #  server == /usr/bin/pykmip-server
 #  pip3 not installed

--- a/hack/e2e/install-pykmip.sh
+++ b/hack/e2e/install-pykmip.sh
@@ -14,11 +14,16 @@ set -x
 # the same cert via govc kms.trust, preventing a race where containers push
 # different certs and PyKMIP ends up serving a cert that vCenter no longer
 # trusts.
-if [ ! -e /root/pykmip-crt.pem ] ; then
+# flock serializes this block across parallel SSH sessions so only one
+# openssl invocation runs on a fresh gateway. The second runner blocks until
+# the lock is released, then the inner [ -e ] exits early without regenerating
+# the cert — guaranteeing both runners share the same matched cert+key pair.
+flock -x /root/pykmip.lock bash -c '
+  [ -e /root/pykmip-crt.pem ] && exit 0
   openssl req -x509 -newkey rsa:4096 -sha256 -days 365 -nodes \
           -subj "/C=US/ST=CA/L=PA/O=Broadcom/OU=VCF/CN=pykmip" \
           -keyout /root/pykmip-key.pem -out /root/pykmip-crt.pem
-fi
+'
 
 # VDS/photon:
 #  server == /usr/bin/pykmip-server

--- a/hack/e2e/install-pykmip.sh
+++ b/hack/e2e/install-pykmip.sh
@@ -8,53 +8,60 @@ set -x
 # Install https://github.com/OpenKMIP/PyKMIP
 # Used as KMS for encrypting VMs
 
-# Generate the TLS cert on this gateway VM if it does not already exist.
-# Cert generation lives here (on the gateway) rather than in the calling
-# test-runner container so that all parallel containers fetch and register
-# the same cert via govc kms.trust, preventing a race where containers push
-# different certs and PyKMIP ends up serving a cert that vCenter no longer
-# trusts.
-# flock serializes this block across parallel SSH sessions so only one
-# openssl invocation runs on a fresh gateway. The second runner blocks until
-# the lock is released, then the inner [ -e ] exits early without regenerating
-# the cert — guaranteeing both runners share the same matched cert+key pair.
-flock -x /root/pykmip.lock bash -c '
-  [ -e /root/pykmip-crt.pem ] && exit 0
-  openssl req -x509 -newkey rsa:4096 -sha256 -days 365 -nodes \
-          -subj "/C=US/ST=CA/L=PA/O=Broadcom/OU=VCF/CN=pykmip" \
-          -keyout /root/pykmip-key.pem -out /root/pykmip-crt.pem
-'
+# flock serializes this entire block across parallel SSH sessions.
+# The first runner to acquire the lock installs PyKMIP and generates the TLS
+# cert; every subsequent runner finds both already present and exits early.
+# This prevents two races at once:
+#   1. pip uninstall race — parallel runners both try to uninstall/upgrade
+#      typing_extensions from system site-packages, leaving a half-removed
+#      package that causes an OSError on the slower runner.
+#   2. cert race — parallel runners generate different certs; the one whose
+#      govc kms.trust runs last wins, but PyKMIP may be serving the other cert.
+echo "pykmip-install: waiting for lock (PID $$)..."
+flock -x /root/pykmip.lock bash -s -- "${PIP_INDEX_URL:-}" <<'LOCKED'
+  PIP_INDEX_URL="$1"
 
-# VDS/photon:
-#  server == /usr/bin/pykmip-server
-#  pip3 not installed
-# NSX/ubuntu:
-#  server == /usr/local/bin/pykmip-server
-#  pip3 already installed
-if ! type -p pykmip-server >/dev/null ; then
-  if ! type -p pip3 >/dev/null ; then
-    # On VDS/Photon OS, ensurepip installs pip as a Python module but does not
-    # create a pip3 binary in PATH. Use --upgrade so the module is up to date,
-    # then invoke pip via the module throughout to avoid the missing-binary error.
-    python3 -m ensurepip --upgrade
+  # --- pip install (serialized) ---
+  # VDS/photon:  server == /usr/bin/pykmip-server,  pip3 not installed
+  # NSX/ubuntu:  server == /usr/local/bin/pykmip-server, pip3 already installed
+  if type -p pykmip-server >/dev/null 2>&1; then
+    echo "pykmip-install: pykmip-server already installed, skipping pip install"
+  else
+    echo "pykmip-install: installing PyKMIP via pip..."
+    if ! type -p pip3 >/dev/null 2>&1; then
+      # On VDS/Photon OS, ensurepip installs pip as a Python module but does
+      # not create a pip3 binary in PATH.
+      python3 -m ensurepip --upgrade
+    fi
+    # PIP_INDEX_URL can be set by the caller to redirect pip to an internal
+    # package mirror (e.g. a corporate Artifactory instance).
+    python3 -m pip install \
+      ${PIP_INDEX_URL:+--index-url "$PIP_INDEX_URL"} \
+      pykmip
+    # currently by default there are no shared ciphers between
+    # vCenter/qClient + pykmip, patch the default TLS1.2 suite for now.
+    # See: https://bugzilla-vcf.lvn.broadcom.net/show_bug.cgi?id=3428705
+    site=$(python3 -c 'import site; print(site.getsitepackages()[0])')
+    sed -i -e "s/'ECDHE-RSA-AES128-SHA256',/'ECDHE-RSA-AES128-SHA',/g" \
+        "$site"/kmip/services/auth.py
+    echo "pykmip-install: pip install complete"
   fi
 
-  # PIP_INDEX_URL can be set by the caller to redirect pip to an internal
-  # package mirror (e.g. a corporate Artifactory instance). If unset, pip
-  # uses its default index (public PyPI).
-  # Use "python3 -m pip" rather than "pip3" so this works on platforms where
-  # ensurepip installed pip but did not add a pip3 binary to PATH (e.g. Photon OS).
-  python3 -m pip install \
-    ${PIP_INDEX_URL:+--index-url "$PIP_INDEX_URL"} \
-    pykmip
-
-  # currently by default there are no shared ciphers between
-  # vCenter/qClient + pykmip, patch the default TLS1.2 suite for now.
-  # See: https://bugzilla-vcf.lvn.broadcom.net/show_bug.cgi?id=3428705
-  site=$(python3 -c 'import site; print(site.getsitepackages()[0])')
-  sed -i -e "s/'ECDHE-RSA-AES128-SHA256',/'ECDHE-RSA-AES128-SHA',/g" \
-      "$site"/kmip/services/auth.py
-fi
+  # --- TLS cert generation (serialized) ---
+  # Cert lives on the gateway so all parallel runners fetch and register the
+  # same cert via govc kms.trust, preventing a trust mismatch between vCenter
+  # and the PyKMIP server.
+  if [ -e /root/pykmip-crt.pem ]; then
+    echo "pykmip-install: TLS cert already exists, skipping cert generation"
+  else
+    echo "pykmip-install: generating TLS cert..."
+    openssl req -x509 -newkey rsa:4096 -sha256 -days 365 -nodes \
+            -subj "/C=US/ST=CA/L=PA/O=Broadcom/OU=VCF/CN=pykmip" \
+            -keyout /root/pykmip-key.pem -out /root/pykmip-crt.pem
+    echo "pykmip-install: TLS cert generated"
+  fi
+LOCKED
+echo "pykmip-install: lock released (PID $$)"
 
 mkdir -p /etc/pykmip
 

--- a/hack/e2e/install-pykmip.sh
+++ b/hack/e2e/install-pykmip.sh
@@ -16,16 +16,18 @@ set -x
 #  pip3 already installed
 if ! type -p pykmip-server >/dev/null ; then
   if ! type -p pip3 >/dev/null ; then
-    python3 -m ensurepip
-    pip3 install --upgrade \
-      ${PIP_INDEX_URL:+--index-url "$PIP_INDEX_URL"} \
-      pip
+    # On VDS/Photon OS, ensurepip installs pip as a Python module but does not
+    # create a pip3 binary in PATH. Use --upgrade so the module is up to date,
+    # then invoke pip via the module throughout to avoid the missing-binary error.
+    python3 -m ensurepip --upgrade
   fi
 
   # PIP_INDEX_URL can be set by the caller to redirect pip to an internal
   # package mirror (e.g. a corporate Artifactory instance). If unset, pip
   # uses its default index (public PyPI).
-  pip3 install \
+  # Use "python3 -m pip" rather than "pip3" so this works on platforms where
+  # ensurepip installed pip but did not add a pip3 binary to PATH (e.g. Photon OS).
+  python3 -m pip install \
     ${PIP_INDEX_URL:+--index-url "$PIP_INDEX_URL"} \
     pykmip
 

--- a/hack/e2e/kms.sh
+++ b/hack/e2e/kms.sh
@@ -52,21 +52,29 @@ install() {
   if kms_is_green "gce2e-standard"; then
     echo "KMS provider gce2e-standard already green, skipping pykmip install"
   else
-    if [ ! -e "$crt_dir/pykmip-crt.pem" ] ; then
-      mkdir -p "$crt_dir"
-      openssl req -x509 -newkey rsa:4096 -sha256 -days 365 -nodes \
-              -subj "/C=US/ST=CA/L=PA/O=Broadcom/OU=VCF/CN=pykmip" \
-              -keyout "$crt_dir"/pykmip-key.pem -out "$crt_dir"/pykmip-crt.pem
-    fi
-
     if [ -n "$2" ]; then
       target="$1@$2"
       password=$3
 
-      sshpass -p "$password" scp $SSH_OPTS "$crt_dir"/pykmip-*.pem "$script_dir"/install-pykmip.sh "$target":
+      # Push install-pykmip.sh to the gateway. The script generates the TLS
+      # cert on the gateway itself (if not already present) rather than having
+      # each test-runner container generate its own. This makes the gateway the
+      # canonical cert source so all parallel containers fetch and register the
+      # same cert, preventing the race where two containers push different certs
+      # and one's kms.trust overwrites the other's while PyKMIP uses the cert
+      # from whichever restart happened last.
+      sshpass -p "$password" scp $SSH_OPTS "$script_dir"/install-pykmip.sh "$target":
       sshpass -p "$password" ssh -T $SSH_OPTS "$target" \
         "PIP_INDEX_URL=${PIP_INDEX_URL:-} /bin/bash ./install-pykmip.sh" \
         || echo "⚠ pykmip install failed — gce2e-standard KMS will not be available"
+
+      # Fetch the cert the gateway generated so setup() can pass it to
+      # govc kms.trust. All parallel runners end up with the same file.
+      mkdir -p "$crt_dir"
+      sshpass -p "$password" scp $SSH_OPTS \
+        "$target":/root/pykmip-crt.pem "$crt_dir"/pykmip-crt.pem
+      sshpass -p "$password" scp $SSH_OPTS \
+        "$target":/root/pykmip-key.pem "$crt_dir"/pykmip-key.pem
     else
       echo "⚠ No gateway IP available — skipping pykmip install for gce2e-standard"
     fi


### PR DESCRIPTION
Since we are executing both the containers parallelly, both of setup-testbed-env runs parallely too.

Core Container - Generated cert A → SCP cert A to gateway → installed PyKMIP → restarted with cert A → govc kms.trust with cert A ✓

Experimental : Generated cert B → SCP cert B to gateway → found pykmip-server already installed → skipped install block → wrote server.conf (cert B paths) → restarted PyKMIP with cert B → govc kms.trust failed: ServerFaultCode: A specified parameter was not correct: server.info.name

flock ensures one of the container triggered process in the external-gateway, will do the pip install and cert generation. 


| Step | Before Fix | After Fix |
| :--- | :--- | :--- |
| **Cert generation** | Each container generates its own cert locally — two different certs | Gateway generates cert once (first runner) — one cert |
| **Cert pushed to gateway** | Both containers SCP different certs to `/root/pykmip-crt.pem` — last write wins | Neither container pushes a cert; gateway owns it |
| **PyKMIP cert at restart** | Whichever container's SCP landed last | Same single cert on the gateway |
| **kms.trust cert** | Each container uses its own locally-generated cert (may differ from PyKMIP's) | Both containers fetch and use the gateway's cert (matches PyKMIP) |
| **Result** | Cert mismatch 🔴 **RED** | Same cert all around 🟢 **GREEN** |


Tested running with multiple UTS runs 

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #

https://uts.lvn.broadcom.net/dashboard/pipeline/detail/6a60e15272212001420b9766

**Are there any special notes for your reviewer**:

I explored file based locks, flock seem the more elegant. There is a con with the waiting time on second container, which is acceptable.

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note

```