### PR TITLE
e2e: retry SetupClusterRoleBindings on transient API server errors

### DIFF
--- a/test/e2e/vmservice/vmservice/util.go
+++ b/test/e2e/vmservice/vmservice/util.go
@@ -33,6 +33,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"k8s.io/kubernetes/test/e2e/framework"
 
@@ -1737,6 +1738,35 @@ func kubeCreateAlreadyExists(stderr []byte) bool {
 	return strings.Contains(s, "AlreadyExists") || strings.Contains(s, "already exists")
 }
 
+// runKubectlCreateWithRetry runs a kubectl create Command, retrying with exponential backoff
+// on transient failures (e.g. a dropped connection to the supervisor API server). Without this,
+// a single blip during SetupClusterRoleBindings aborts SynchronizedBeforeSuite and fails the
+// entire e2e run before a single spec has executed, forcing a full pipeline-level retry instead
+// of a cheap in-process one. Stops retrying as soon as the command succeeds or fails with
+// AlreadyExists, since the caller treats that as a non-fatal, already-satisfied outcome.
+func runKubectlCreateWithRetry(ctx context.Context, cmd *e2eframework.Command) (stdout, stderr []byte, err error) {
+	backoff := wait.Backoff{
+		Steps:    5,
+		Duration: 5 * time.Second,
+		Factor:   2,
+		Jitter:   0.1,
+	}
+
+	if pollErr := wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (bool, error) {
+		stdout, stderr, err = cmd.Run(ctx)
+		if err == nil || kubeCreateAlreadyExists(stderr) {
+			return true, nil
+		}
+		framework.Logf("kubectl create failed, retrying: %v\nstderr: %s", err, string(stderr))
+		return false, nil
+	}); pollErr != nil && err == nil {
+		// The command never got to run at all (e.g. context canceled before the first attempt).
+		err = pollErr
+	}
+
+	return stdout, stderr, err
+}
+
 // SetupClusterRoleBindings creates the necessary cluster role bindings for vm-operator e2e tests.
 // This replaces the Python logic from roles_helper.py that was called by gce2e_prerequisite.py.
 // It SSHes into the supervisor control plane as root to run kubectl with admin.conf, exactly as
@@ -1818,7 +1848,7 @@ func SetupClusterRoleBindings(clusterProxy *common.VMServiceClusterProxy) error 
 			e2eframework.WithArgs(createRoleArgs...),
 		)
 
-		_, stderr, err := createRoleCmd.Run(ctx)
+		_, stderr, err := runKubectlCreateWithRetry(ctx, createRoleCmd)
 		if err != nil {
 			if kubeCreateAlreadyExists(stderr) {
 				framework.Logf("Info: cluster role %q already exists, skipping create", role.Name)
@@ -1840,7 +1870,7 @@ func SetupClusterRoleBindings(clusterProxy *common.VMServiceClusterProxy) error 
 			e2eframework.WithArgs(createBindingArgs...),
 		)
 
-		_, stderr, err = createBindingCmd.Run(ctx)
+		_, stderr, err = runKubectlCreateWithRetry(ctx, createBindingCmd)
 		if err != nil {
 			if kubeCreateAlreadyExists(stderr) {
 				framework.Logf("Info: cluster role binding %q already exists, skipping create", role.Name)

--- a/test/e2e/vmservice/vmservice/util.go
+++ b/test/e2e/vmservice/vmservice/util.go
@@ -1744,7 +1744,7 @@ func kubeCreateAlreadyExists(stderr []byte) bool {
 // entire e2e run before a single spec has executed, forcing a full pipeline-level retry instead
 // of a cheap in-process one. Stops retrying as soon as the command succeeds or fails with
 // AlreadyExists, since the caller treats that as a non-fatal, already-satisfied outcome.
-func runKubectlCreateWithRetry(ctx context.Context, cmd *e2eframework.Command) (stdout, stderr []byte, err error) {
+func runKubectlCreateWithRetry(ctx context.Context, cmd *e2eframework.Command) (stderr []byte, err error) {
 	backoff := wait.Backoff{
 		Steps:    5,
 		Duration: 5 * time.Second,
@@ -1753,7 +1753,7 @@ func runKubectlCreateWithRetry(ctx context.Context, cmd *e2eframework.Command) (
 	}
 
 	if pollErr := wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (bool, error) {
-		stdout, stderr, err = cmd.Run(ctx)
+		_, stderr, err = cmd.Run(ctx)
 		if err == nil || kubeCreateAlreadyExists(stderr) {
 			return true, nil
 		}
@@ -1764,7 +1764,7 @@ func runKubectlCreateWithRetry(ctx context.Context, cmd *e2eframework.Command) (
 		err = pollErr
 	}
 
-	return stdout, stderr, err
+	return stderr, err
 }
 
 // SetupClusterRoleBindings creates the necessary cluster role bindings for vm-operator e2e tests.
@@ -1848,7 +1848,7 @@ func SetupClusterRoleBindings(clusterProxy *common.VMServiceClusterProxy) error 
 			e2eframework.WithArgs(createRoleArgs...),
 		)
 
-		_, stderr, err := runKubectlCreateWithRetry(ctx, createRoleCmd)
+		stderr, err := runKubectlCreateWithRetry(ctx, createRoleCmd)
 		if err != nil {
 			if kubeCreateAlreadyExists(stderr) {
 				framework.Logf("Info: cluster role %q already exists, skipping create", role.Name)
@@ -1870,7 +1870,7 @@ func SetupClusterRoleBindings(clusterProxy *common.VMServiceClusterProxy) error 
 			e2eframework.WithArgs(createBindingArgs...),
 		)
 
-		_, stderr, err = runKubectlCreateWithRetry(ctx, createBindingCmd)
+		stderr, err = runKubectlCreateWithRetry(ctx, createBindingCmd)
 		if err != nil {
 			if kubeCreateAlreadyExists(stderr) {
 				framework.Logf("Info: cluster role binding %q already exists, skipping create", role.Name)


### PR DESCRIPTION
## What this fixes

Observed in UTS CI: a `vm-operator-e2e-smoke-vds` run failed at `[SynchronizedBeforeSuite]` with:

```
failed to create cluster role gce2e-crds: exit status 1, stderr: Unable to connect to the server: http2: client connection lost
```

0 of 151 specs ran. The connection to the supervisor API server was healthy moments earlier in the same setup sequence (an admin binding check had just succeeded) -- this was a transient blip, not a broken handoff. This same pipeline run retried the entire e2e container 3 more times (4 attempts total) and failed identically every time, so it's a real, if intermittent, condition -- not something that self-heals on the existing pipeline-level retry.

`SetupClusterRoleBindings` issued each `kubectl create clusterrole`/`clusterrolebinding` as a single one-shot call with no retry, so any transient error during that ~1-2s window hard-fails `SynchronizedBeforeSuite` and the entire run, before a single spec executes -- the only recovery path is re-running the whole (40+ minute) e2e container from scratch.

## The fix

Wrap the two required (non-best-effort) `kubectl create` calls in a small retry helper, `runKubectlCreateWithRetry`, using `wait.ExponentialBackoffWithContext` -- the same retry shape already established by `clusterProxy.Apply` elsewhere in this framework (5 steps, 5s initial backoff, factor 2, jitter 0.1). It stops immediately on success or on an `AlreadyExists` failure, which the caller already treats as a non-fatal, already-satisfied outcome, so behavior is unchanged on the happy path.

## Testing

`go build ./...` and `go vet ./...` pass for `test/e2e`. `gofmt -l` clean on the changed file.