### PR TITLE
🐛 Cap per-subtest syndrome at 1024 chars in E2E callback

### DIFF
--- a/hack/e2e/run-e2e.sh
+++ b/hack/e2e/run-e2e.sh
@@ -56,7 +56,10 @@ fi
 # and the latter two to "SKIPPED" so the callback payload distinguishes
 # "never attempted" from "test logic decided to skip". Failed specs also get
 # a "syndrome" carrying Failure.Message, the callback API's field for a short
-# failure synopsis.
+# failure synopsis. Failure.Message is Gomega's full failure output (often an
+# object diff or YAML dump running well past 1024 characters), so it is
+# truncated to the same 1024-character cap the callback API enforces on
+# "syndrome" fields — otherwise the callback POST is rejected outright.
 parse_json_report() {
     local json_file="${1}"
     jq '[.[0].SpecReports[] |
@@ -76,7 +79,7 @@ parse_json_report() {
                 end
             )
         } + (if .State == "failed" and (.Failure.Message // "") != ""
-             then {syndrome: .Failure.Message}
+             then {syndrome: (.Failure.Message[0:1024])}
              else {} end)
     ]' "${json_file}"
 }


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

`parse_json_report()` in `hack/e2e/run-e2e.sh` copied Gomega's `Failure.Message` verbatim into each failed subtest's `syndrome` field. Gomega failure output (object diffs, YAML dumps) routinely exceeds 1024 characters, so the UTS callback API rejects the whole payload with `data/syndrome must NOT have more than 1024 characters` once a run has enough failures. The top-level aggregated syndrome in `report_result()` already truncates to 1024 chars; this applies the same cap per-subtest so a single verbose failure message can't sink the entire callback POST.

Example failure observed in CI:

```
{"error":"validation failed: data/syndrome must NOT have more than 1024 characters", ...}
```

**Which issue(s) is/are addressed by this PR?**

Fixes #

**Are there any special notes for your reviewer**:

Split out of #1728, which was mixing this callback fix in with an unrelated `collect-support-bundle.sh` change. This PR is scoped to just the syndrome-truncation bug.

**Please add a release note if necessary**:

```release-note
NONE
```