### PR TITLE
Remove the experimental label  from vm-location tests

### DIFF
--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
@@ -244,7 +244,7 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		Expect(task.Wait(ctx)).To(Succeed(), "Relocate task failed for VM %s", vmMoID)
 	}
 
-	When("VM is created in the correct namespace RP and folder", Label("core-functional","experimental"), func() {
+	When("VM is created in the correct namespace RP and folder", Label("core-functional"), func() {
 		It("sets VirtualMachineLocationValid condition to True", func() {
 			createVM()
 
@@ -256,7 +256,7 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		})
 	})
 
-	When("VM is moved outside the namespace RP hierarchy", Label("core-functional","experimental"), func() {
+	When("VM is moved outside the namespace RP hierarchy", Label("core-functional"), func() {
 		It("sets condition False, then recovers to True when VM is returned to the correct location", func() {
 			By("Creating VM and waiting for it to reach Running state")
 			createVM()
@@ -315,7 +315,7 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		})
 	})
 
-	When("VM is moved outside the namespace Folder hierarchy", Label("core-functional","experimental"), func() {
+	When("VM is moved outside the namespace Folder hierarchy", Label("core-functional"), func() {
 		It("sets condition False, then recovers to True when VM is returned to the correct location", func() {
 			By("Creating VM and waiting for it to reach Running state")
 			createVM()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

Removes the experimental label from three VirtualMachineLocation E2E specs in vm_location.go:

1. VM is created in the correct namespace RP and folder
2. VM is moved outside the namespace RP hierarchy
3. VM is moved outside the namespace Folder hierarchy

These carried experimental because they hadn't yet been validated against a real WCP/vSphere testbed. They've now run successfully on hardware, so promote them into the standard core-functional

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #

vmop-3844


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note

```