### PR TITLE
Fix VC credential extraction for VPC testbed shape

### DIFF
--- a/hack/e2e/collect-support-bundle.sh
+++ b/hack/e2e/collect-support-bundle.sh
@@ -87,13 +87,28 @@ _jq() { jq -r "$@" "${TESTBED_INFO_JSON}"; }
 
 # ---------------------------------------------------------------------------
 # Parse vCenter credentials
-# Supports both VDS (.vc[] array) and VPC (.vc{} object) testbed shapes.
+# Supports both VDS (.vc[] array) and VPC (.vc{} object, keyed by runid)
+# testbed shapes; .vc[0] only works for the array shape, so pick the first
+# entry regardless of which shape is present.
 # vimUsername/vimPassword are SSO credentials required by the namespace-management
 # API; root is a local vCenter account that lacks namespace-management privileges.
+# Some testbed shapes (e.g. VPC) label the same SSO account plain
+# username/password instead of vimUsername/vimPassword, so fall back to those.
 # ---------------------------------------------------------------------------
-VC_IP="$(_jq '.vc[0].ip4 // .vc[0].ip // empty')"
-VC_VIM_USER="$(_jq '.vc[0].vimUsername // empty')"
-VC_VIM_PWD="$(_jq '.vc[0].vimPassword // empty')"
+IFS=$'\t' read -r VC_IP VC_VIM_USER VC_VIM_PWD < <(_jq '
+    def firstvc:
+      if (.vc | type) == "array" then .vc[0]
+      else (.vc | to_entries | sort_by(.key | tonumber) | .[0].value)
+      end;
+    # username/password fall back to the plain (non-"root") account when
+    # vimUsername/vimPassword are absent; never fall back to root itself.
+    def ssouser: firstvc.vimUsername // (if firstvc.username == "root" then empty else firstvc.username end);
+    [
+      firstvc.ip4 // firstvc.ip // "",
+      ssouser // "",
+      (if firstvc.vimUsername then firstvc.vimPassword else (if firstvc.username == "root" then empty else firstvc.password end) end) // ""
+    ] | @tsv
+')
 
 if [[ -z "${VC_IP}" || -z "${VC_VIM_USER}" || -z "${VC_VIM_PWD}" ]]; then
     _err "Could not extract VC IP or vim credentials from testbedInfo.json"


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

`collect-support-bundle.sh` always indexed `.vc` as an array (`.vc[0]`), but VPC-smoke testbeds represent `.vc` as an object keyed by runid (e.g. `{"1": {...}}`). Indexing an object with a number makes `jq` throw `Cannot index object with number`, which is not caught by the `//` default operator, so `VC_IP`/`VC_VIM_USER`/`VC_VIM_PWD` always came back empty and the script exited with `Could not extract VC IP or vim credentials` on every VPC-smoke run — meaning the WCP support bundle has never actually been collected for VPC testbeds.

This also fixes a related credential-shape gap discovered while reproducing the failure: VPC testbeds label the SSO account as plain `username`/`password` rather than `vimUsername`/`vimPassword`. The fix falls back to those fields when `vimUsername`/`vimPassword` are absent, but explicitly excludes the `root` account from that fallback (per the script's own comment, root lacks namespace-management privileges).

Confirmed against the real `testbed_blob` payload from a live UTS run (`collect-support-bundle-vpc-smoke`, VCF_Smoke pipeline, run_id 1077860 / build 17470), which reproduced the exact reported jq error.

**Which issue(s) is/are addressed by this PR?**:

Fixes #

**Are there any special notes for your reviewer**:

Related but independent: my other open branch/PR (`topic/fa000323/fail-open-support-bundle`) changes this same script's *failure mode* when testbed data is missing (fail open / exit 0 instead of exit 1). This PR fixes the underlying *data-shape* bug so the credentials are actually extracted when a VPC testbed genuinely exists. They're complementary and don't conflict, but review independently.

<details>
<summary><strong>Proof of testing</strong> — jq-filter unit tests + end-to-end script runs across every testbed shape</summary>

Test fixtures and the exact jq filter extracted verbatim from the script (`hack/e2e/collect-support-bundle.sh` lines 96-107):

```
def firstvc:
  if (.vc | type) == "array" then .vc[0]
  else (.vc | to_entries | sort_by(.key | tonumber) | .[0].value)
  end;
def ssouser: firstvc.vimUsername // (if firstvc.username == "root" then empty else firstvc.username end);
[
  firstvc.ip4 // firstvc.ip // "",
  ssouser // "",
  (if firstvc.vimUsername then firstvc.vimPassword else (if firstvc.username == "root" then empty else firstvc.password end) end) // ""
] | @tsv
```

_Layer 1 — jq filter run in isolation against each fixture (`jq -r "<filter>" <fixture>`), output is the raw `ip \t user \t pass` tuple:_

| Fixture | `.vc` shape | Command output | Assertion |
|---|---|---|---|
| `real-vpc.json` — actual `deliverable_blob` pulled from UTS `test_blob/6a60a5477221200142b6234f` (run 1077860, the failing run) | VPC object `{"1": {...}}`, no `vimUsername`/`vimPassword` | `<redacted-ip>	<redacted-user>	<redacted-password>` (real values redacted from this description; verified non-empty and matching the blob's own `.ip`/`.username`/`.password` fields exactly) | **PASS** — IP + real SSO creds extracted from the exact blob that used to error |
| `vds-array.json` — synthetic, mirrors the pre-existing supported shape | VDS array `[{...}]` with `vimUsername`/`vimPassword` | `10.1.2.3	administrator@vsphere.local	secretpw2` | **PASS** — no regression on the shape the script already handled |
| `vpc-vim-present.json` — synthetic, `vimUsername`/`vimPassword` *and* `username: "root"` both present | VPC object | `10.0.0.9	vimuser@vsphere.local	vimpw` | **PASS** — `vimUsername`/`vimPassword` correctly take priority over the `username`/`password` fallback |
| `vpc-root-only.json` — synthetic, only `username: "root"`/`password` present | VPC object | `10.0.0.5			` (empty user/pass) | **PASS** — fallback never resolves to the `root` account |
| `no-vc.json` — synthetic, no `.vc` key at all | n/a | `jq: error (at no-vc.json:1): null (null) has no keys` (exit 5) | **PASS** — errors as expected; caught below by the script's existing guard |

_Layer 2 — full script run end-to-end (`bash hack/e2e/collect-support-bundle.sh --testbed-info-json <fixture> --output-dir <dir>`), IPs swapped to `127.0.0.1` so the subsequent (unrelated) vCenter-auth call resolves locally instead of hitting a real host:_

```
$ bash hack/e2e/collect-support-bundle.sh --testbed-info-json real-vpc-local.json --output-dir out1
[collect-support-bundle.sh] Collecting WCP support bundle from VC 127.0.0.1...
[collect-support-bundle.sh] WARNING: Could not authenticate to vCenter REST API on 127.0.0.1 (HTTP 000); skipping WCP bundle
$ echo $?
0
```
**PASS** — script now reaches VC IP extraction and proceeds past it (the `Could not extract VC IP or vim credentials` guard no longer fires); the subsequent auth warning/exit 0 is the script's pre-existing, unrelated "VC unreachable" path, expected here since `127.0.0.1` isn't a real vCenter.

```
$ bash hack/e2e/collect-support-bundle.sh --testbed-info-json no-vc-local.json --output-dir out2
jq: error (at no-vc-local.json:1): null (null) has no keys
[collect-support-bundle.sh] ERROR: Could not extract VC IP or vim credentials from testbedInfo.json
$ echo $?
1
```
**PASS** — genuinely malformed input (no `.vc` at all) still fails safe with the original error message and exit code 1, unaffected by the fix.

Summary: **8/8 assertions passed** (5 jq-filter unit tests + 3 end-to-end checks: extraction succeeds, original error string is gone, and the genuine-failure path still exits 1).

</details>

**Please add a release note if necessary**:

```release-note
Fix WCP support bundle collection for VPC testbeds, where vCenter credentials were never correctly extracted from the testbed data blob.
```

