### PR TITLE
🐛 Fix VirtualMachineService Endpoints on VM relabel

### DIFF
--- a/controllers/virtualmachineservice/virtualmachineservice_controller.go
+++ b/controllers/virtualmachineservice/virtualmachineservice_controller.go
@@ -7,6 +7,7 @@ package virtualmachineservice
 import (
 	"context"
 	"fmt"
+	"maps"
 	"reflect"
 	"strings"
 
@@ -16,10 +17,12 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -72,7 +75,7 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		Watches(&corev1.Endpoints{},
 			handler.EnqueueRequestForOwner(mgr.GetScheme(), mgr.GetRESTMapper(), &vmopv1.VirtualMachineService{})).
 		Watches(&vmopv1.VirtualMachine{},
-			handler.EnqueueRequestsFromMapFunc(r.virtualMachineToVirtualMachineServiceMapper())).
+			r.virtualMachineToVirtualMachineServiceHandler()).
 		Complete(r)
 }
 
@@ -294,28 +297,168 @@ func (r *ReconcileVirtualMachineService) reconcileVMService(ctx *pkgctx.VirtualM
 	return nil
 }
 
-// virtualMachineToVirtualMachineServiceMapper returns a mapper function that returns reconcile requests for
-// VirtualMachineServices that select a given VM via label selectors.
-// TODO: The VM's labels could have been changed so this should also return VirtualMachineServices that the
-// VM is currently an Endpoint for, because otherwise the VM won't be removed in a timely manner.
-func (r *ReconcileVirtualMachineService) virtualMachineToVirtualMachineServiceMapper() func(_ context.Context, o client.Object) []reconcile.Request {
-	return func(_ context.Context, o client.Object) []reconcile.Request {
-		vm := o.(*vmopv1.VirtualMachine)
+// virtualMachineToVirtualMachineServiceHandler returns an event handler that
+// enqueues the VirtualMachineServices whose label selector matches a given
+// VirtualMachine.
+//
+// On update, a VM's labels may have changed such that it now matches a
+// different set of VirtualMachineServices than it did before. To ensure a VM is
+// promptly removed from the Endpoints of a VirtualMachineService it no longer
+// matches, the update handler enqueues the union of the VirtualMachineServices
+// that matched the VM's previous labels and those that match its current
+// labels. This mirrors how the core Kubernetes endpoints controller reacts to
+// Pod updates (it computes the service memberships of both the old and new Pod
+// and reconciles the combined set).
+//
+// Recomputing service memberships on every VirtualMachine event would be
+// wasteful because a VM is updated for many reasons unrelated to its Endpoints.
+// The update handler therefore skips the lookup entirely unless a change
+// relevant to the Endpoints occurred; see virtualMachineEndpointsChanged.
+func (r *ReconcileVirtualMachineService) virtualMachineToVirtualMachineServiceHandler() handler.EventHandler {
+	return handler.Funcs{
+		CreateFunc: func(ctx context.Context, e event.CreateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+			if vm, ok := e.Object.(*vmopv1.VirtualMachine); ok {
+				r.enqueueVirtualMachineServicesSelectingVM(ctx, vm, q)
+			}
+		},
+		UpdateFunc: func(ctx context.Context, e event.UpdateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+			oldVM, ok := e.ObjectOld.(*vmopv1.VirtualMachine)
+			if !ok {
+				return
+			}
+			newVM, ok := e.ObjectNew.(*vmopv1.VirtualMachine)
+			if !ok {
+				return
+			}
 
-		reconcileRequests, err := r.getVirtualMachineServicesSelectingVirtualMachine(context.Background(), vm)
-		if err != nil {
-			return nil
+			changed, labelsChanged := virtualMachineEndpointsChanged(oldVM, newVM)
+			if !changed {
+				return
+			}
+
+			// When the labels have changed, reconcile the services that the VM
+			// previously selected so the VM is removed from services it no longer
+			// selects, in addition to the services it now selects.
+			if labelsChanged {
+				r.enqueueVirtualMachineServicesSelectingLabelSets(ctx, newVM.Namespace, q, oldVM.Labels, newVM.Labels)
+			} else {
+				r.enqueueVirtualMachineServicesSelectingVM(ctx, newVM, q)
+			}
+		},
+		DeleteFunc: func(ctx context.Context, e event.DeleteEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+			if vm, ok := e.Object.(*vmopv1.VirtualMachine); ok {
+				r.enqueueVirtualMachineServicesSelectingVM(ctx, vm, q)
+			}
+		},
+		GenericFunc: func(ctx context.Context, e event.GenericEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+			if vm, ok := e.Object.(*vmopv1.VirtualMachine); ok {
+				r.enqueueVirtualMachineServicesSelectingVM(ctx, vm, q)
+			}
+		},
+	}
+}
+
+// enqueueVirtualMachineServicesSelectingVM enqueues a reconcile request for
+// every VirtualMachineService whose label selector matches the given
+// VirtualMachine's labels.
+func (r *ReconcileVirtualMachineService) enqueueVirtualMachineServicesSelectingVM(
+	ctx context.Context,
+	vm *vmopv1.VirtualMachine,
+	q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+
+	if len(vm.Labels) != 0 {
+		r.enqueueVirtualMachineServicesSelectingLabelSets(ctx, vm.Namespace, q, vm.Labels)
+	}
+}
+
+// enqueueVirtualMachineServicesSelectingLabelSets lists the
+// VirtualMachineServices in ns once and enqueues a reconcile request for each
+// whose selector matches any of the given label sets.
+func (r *ReconcileVirtualMachineService) enqueueVirtualMachineServicesSelectingLabelSets(
+	ctx context.Context,
+	ns string,
+	q workqueue.TypedRateLimitingInterface[reconcile.Request],
+	labelSets ...map[string]string) {
+
+	vmServiceList := &vmopv1.VirtualMachineServiceList{}
+	if err := r.List(ctx, vmServiceList, client.InNamespace(ns)); err != nil {
+		pkglog.FromContextOrDefault(ctx).Error(err, "Failed to list VirtualMachineServices")
+		return
+	}
+
+	for _, vmService := range vmServiceList.Items {
+		if len(vmService.Spec.Selector) == 0 {
+			continue
 		}
 
-		if len(reconcileRequests) != 0 && r.log.V(4).Enabled() {
-			logger := r.log.WithValues("VirtualMachine", client.ObjectKey{Namespace: vm.Namespace, Name: vm.Name})
-			for _, r := range reconcileRequests {
-				logger.V(4).Info("Generating reconcile request for VM Service due to event on VM", "VirtualMachineService", r.NamespacedName)
+		selector := labels.SelectorFromValidatedSet(vmService.Spec.Selector)
+		for _, l := range labelSets {
+			if len(l) != 0 && selector.Matches(labels.Set(l)) {
+				q.Add(reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&vmService)})
+				break
 			}
 		}
-
-		return reconcileRequests
 	}
+}
+
+// virtualMachineEndpointsChanged returns true if the difference between the old
+// and new VirtualMachine could affect the Endpoints of any VirtualMachineService.
+// The second bool return is true if the labels has changed, since that requires
+// reconciling the services that might no longer select the VM.
+func virtualMachineEndpointsChanged(oldVM, newVM *vmopv1.VirtualMachine) (bool, bool) {
+	// VM's changed labels may select different services.
+	if !maps.Equal(oldVM.Labels, newVM.Labels) {
+		return true, true
+	}
+
+	// VM's being deleted are not included in the ready Endpoints.
+	if oldVM.DeletionTimestamp.IsZero() != newVM.DeletionTimestamp.IsZero() {
+		return true, false
+	}
+
+	// We don't have the Service at this point so we don't know which IP families
+	// it cares about, but IPs changing is not an expected common occurrence so
+	// reconcile if either changes.
+	oldIP4, oldIP6 := virtualMachinePrimaryIPs(oldVM)
+	newIP4, newIP6 := virtualMachinePrimaryIPs(newVM)
+	if oldIP4 != newIP4 || oldIP6 != newIP6 {
+		return true, false
+	}
+
+	// The Ready condition mirrors probe results but is not cleared when the
+	// probe itself is removed, so a probe being added or removed must be
+	// compared directly rather than relying solely on the condition.
+	if virtualMachineHasReadinessProbe(oldVM) != virtualMachineHasReadinessProbe(newVM) {
+		return true, false
+	}
+
+	// The VM's Readiness probe (if it had/has one) will update the ready condition.
+	return virtualMachineReadyStatus(oldVM) != virtualMachineReadyStatus(newVM), false
+}
+
+// virtualMachineHasReadinessProbe returns whether the VM has a configured
+// readiness probe that generateSubsetsForService uses to gate readiness.
+func virtualMachineHasReadinessProbe(vm *vmopv1.VirtualMachine) bool {
+	probe := vm.Spec.ReadinessProbe
+	return probe != nil && (probe.TCPSocket != nil || probe.GuestHeartbeat != nil || len(probe.GuestInfo) != 0)
+}
+
+// virtualMachinePrimaryIPs returns the VM's primary IPv4 and IPv6 addresses.
+func virtualMachinePrimaryIPs(vm *vmopv1.VirtualMachine) (ip4, ip6 string) {
+	if vm.Status.Network != nil {
+		ip4 = vm.Status.Network.PrimaryIP4
+		ip6 = vm.Status.Network.PrimaryIP6
+	}
+	return ip4, ip6
+}
+
+// virtualMachineReadyStatus returns the status of the VM's Ready condition, or
+// the empty string if the condition is not present.
+func virtualMachineReadyStatus(vm *vmopv1.VirtualMachine) metav1.ConditionStatus {
+	if c := pkgcond.Get(vm, vmopv1.ReadyConditionType); c != nil {
+		return c.Status
+	}
+	return ""
 }
 
 // Set labels and annotations on the Service from the VirtualMachineService. Some load balancer
@@ -545,37 +688,6 @@ func (r *ReconcileVirtualMachineService) getVMsReferencedByServiceEndpoints(
 	return vmToSubsetsMap
 }
 
-func (r *ReconcileVirtualMachineService) getVirtualMachineServicesSelectingVirtualMachine(
-	ctx context.Context,
-	lookupVM *vmopv1.VirtualMachine) ([]reconcile.Request, error) {
-
-	if len(lookupVM.Labels) == 0 {
-		return nil, nil
-	}
-
-	vmServiceList := &vmopv1.VirtualMachineServiceList{}
-	err := r.List(ctx, vmServiceList, client.InNamespace(lookupVM.Namespace))
-	if err != nil {
-		return nil, err
-	}
-
-	var matchingVMServices []reconcile.Request
-	vmLabels := labels.Set(lookupVM.Labels)
-
-	for _, vmService := range vmServiceList.Items {
-		if len(vmService.Spec.Selector) != 0 {
-			sel := labels.SelectorFromValidatedSet(vmService.Spec.Selector)
-			if sel.Matches(vmLabels) {
-				matchingVMServices = append(matchingVMServices, reconcile.Request{
-					NamespacedName: client.ObjectKey{Namespace: vmService.Namespace, Name: vmService.Name},
-				})
-			}
-		}
-	}
-
-	return matchingVMServices, nil
-}
-
 // createOrUpdateEndpoints updates the Endpoints for VirtualMachineService.
 func (r *ReconcileVirtualMachineService) createOrUpdateEndpoints(ctx *pkgctx.VirtualMachineServiceContext, service *corev1.Service) error {
 	ctx.Logger.V(5).Info("Updating VirtualMachineService Endpoints")
@@ -662,19 +774,22 @@ func (r *ReconcileVirtualMachineService) generateSubsetsForService(
 		vm := vmList.Items[i]
 		logger := ctx.Logger.WithValues("virtualMachine", vm.NamespacedName())
 
+		// NOTE: Anything that is changed here may need to be reflected in
+		// virtualMachineEndpointsChanged(), so that the service is timely
+		// reconciled when the VM changes.
+
 		if !vm.DeletionTimestamp.IsZero() {
 			logger.Info("Skipping VM marked for deletion")
 			continue
 		}
 
 		var vmIPs []string
-		if vm.Status.Network != nil {
-			if vm.Status.Network.PrimaryIP4 != "" && allowedFamilies[corev1.IPv4Protocol] {
-				vmIPs = append(vmIPs, vm.Status.Network.PrimaryIP4)
-			}
-			if vm.Status.Network.PrimaryIP6 != "" && allowedFamilies[corev1.IPv6Protocol] {
-				vmIPs = append(vmIPs, vm.Status.Network.PrimaryIP6)
-			}
+		ipV4, ipV6 := virtualMachinePrimaryIPs(&vm)
+		if ipV4 != "" && allowedFamilies[corev1.IPv4Protocol] {
+			vmIPs = append(vmIPs, ipV4)
+		}
+		if ipV6 != "" && allowedFamilies[corev1.IPv6Protocol] {
+			vmIPs = append(vmIPs, ipV6)
 		}
 
 		if len(vmIPs) == 0 {
@@ -692,7 +807,7 @@ func (r *ReconcileVirtualMachineService) generateSubsetsForService(
 		// Otherwise, a VM that does not have a ReadinessProbe is implicitly ready.
 		ready := true
 
-		if probe := vm.Spec.ReadinessProbe; probe != nil && (probe.TCPSocket != nil || probe.GuestHeartbeat != nil || len(probe.GuestInfo) != 0) {
+		if virtualMachineHasReadinessProbe(&vm) {
 			if condition := pkgcond.Get(&vm, vmopv1.ReadyConditionType); condition == nil {
 				if vmInSubsetsMap == nil {
 					vmInSubsetsMap = r.getVMsReferencedByServiceEndpoints(ctx, service)

--- a/controllers/virtualmachineservice/virtualmachineservice_controller_intg_test.go
+++ b/controllers/virtualmachineservice/virtualmachineservice_controller_intg_test.go
@@ -408,21 +408,52 @@ func intgTestsReconcile() {
 
 					svcKey := client.ObjectKeyFromObject(vmService)
 					svc := &corev1.Service{}
-				Consistently(func(g Gomega) {
-					err := ctx.Client.Get(ctx, svcKey, svc)
-					g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
-				}, "3s").Should(Succeed())
+					Consistently(func(g Gomega) {
+						err := ctx.Client.Get(ctx, svcKey, svc)
+						g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+					}, "3s").Should(Succeed())
 				})
 			})
 		})
 
-		Context("Reconciles after VirtualMachineService after VMs labels no longer match", func() {
+		Context("Reconciles after a VM's Endpoints-relevant fields change", func() {
 			BeforeEach(func() {
 				vmServiceName = "test-vm-service-unmatched-vm"
 			})
 
-			// The VM mapping function needs to be fixed for this to work.
-			XIt("Simulate workflow", func() {
+			// Each By below exercises one of the conditions checked by
+			// virtualMachineEndpointsChanged(): label changes, deletion,
+			// primary IP changes, readiness probe presence, and the Ready
+			// condition status.
+			It("Simulate workflow", func() {
+				vmService := &vmopv1.VirtualMachineService{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      vmServiceName,
+						Namespace: ctx.Namespace,
+					},
+					Spec: vmopv1.VirtualMachineServiceSpec{
+						Type:       vmopv1.VirtualMachineServiceTypeLoadBalancer,
+						Ports:      []vmopv1.VirtualMachineServicePort{vmServicePort},
+						Selector:   selector,
+						IPFamilies: []corev1.IPFamily{corev1.IPv4Protocol},
+					},
+				}
+
+				objKey := client.ObjectKeyFromObject(vmService)
+
+				By("Create VirtualMachineService", func() {
+					Expect(ctx.Client.Create(ctx, vmService)).To(Succeed())
+				})
+
+				By("Underlying Service and Endpoints should be created", func() {
+					Eventually(func(g Gomega) {
+						service := &corev1.Service{}
+						g.Expect(ctx.Client.Get(ctx, objKey, service)).To(Succeed())
+						endpoints := &corev1.Endpoints{}
+						g.Expect(ctx.Client.Get(ctx, objKey, endpoints)).To(Succeed())
+					}).Should(Succeed())
+				})
+
 				readyVM := &vmopv1.VirtualMachine{}
 				By("Create ready VM with selected labels", func() {
 					readyVM = &vmopv1.VirtualMachine{
@@ -444,25 +475,6 @@ func intgTestsReconcile() {
 					Expect(ctx.Client.Status().Update(ctx, readyVM)).To(Succeed())
 				})
 
-				vmService := &vmopv1.VirtualMachineService{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      vmServiceName,
-						Namespace: ctx.Namespace,
-					},
-					Spec: vmopv1.VirtualMachineServiceSpec{
-						Type:       vmopv1.VirtualMachineServiceTypeLoadBalancer,
-						Ports:      []vmopv1.VirtualMachineServicePort{vmServicePort},
-						Selector:   selector,
-						IPFamilies: []corev1.IPFamily{corev1.IPv4Protocol},
-					},
-				}
-
-				objKey := client.ObjectKey{Namespace: vmService.Namespace, Name: vmService.Name}
-
-				By("Create VirtualMachineService", func() {
-					Expect(ctx.Client.Create(ctx, vmService)).To(Succeed())
-				})
-
 				By("Ready VM should be added to Endpoints", func() {
 					endpoints := &corev1.Endpoints{}
 					Eventually(func(g Gomega) {
@@ -474,10 +486,8 @@ func intgTestsReconcile() {
 					Expect(subsets).To(HaveLen(1))
 
 					subset := subsets[0]
-					Expect(subset.Addresses).To(HaveLen(1))
-
-					address := subset.Addresses[0]
-					Expect(address.IP).To(Equal(readyVM.Status.Network.PrimaryIP4))
+					Expect(subset.Addresses).To(ConsistOf(HaveField("IP", readyVM.Status.Network.PrimaryIP4)))
+					Expect(subset.NotReadyAddresses).To(BeEmpty())
 
 					Expect(subset.Ports).To(HaveLen(1))
 					port := subset.Ports[0]
@@ -486,17 +496,115 @@ func intgTestsReconcile() {
 					Expect(port.Protocol).To(BeEquivalentTo(corev1.ProtocolTCP))
 				})
 
-				By("Change VM Labels so it no longer matches selector", func() {
+				By("VM's labels no longer matching the selector removes it from Endpoints", func() {
 					readyVM.Labels = map[string]string{"some-other": "label"}
 					Expect(ctx.Client.Update(ctx, readyVM)).To(Succeed())
-				})
 
-				By("VM should be removed from Endpoints", func() {
-					endpoints := &corev1.Endpoints{}
 					Eventually(func(g Gomega) {
+						endpoints := &corev1.Endpoints{}
 						g.Expect(ctx.Client.Get(ctx, objKey, endpoints)).To(Succeed())
 						g.Expect(endpoints.Subsets).To(BeEmpty())
 					}).Should(Succeed())
+				})
+
+				By("VM's labels matching the selector again adds it back to Endpoints", func() {
+					readyVM.Labels = vmLabels
+					Expect(ctx.Client.Update(ctx, readyVM)).To(Succeed())
+
+					Eventually(func(g Gomega) {
+						endpoints := &corev1.Endpoints{}
+						g.Expect(ctx.Client.Get(ctx, objKey, endpoints)).To(Succeed())
+						g.Expect(endpoints.Subsets).To(HaveLen(1))
+						g.Expect(endpoints.Subsets[0].Addresses).To(ConsistOf(HaveField("IP", vmIP1)))
+					}).Should(Succeed())
+				})
+
+				By("VM's primary IP changing updates its Endpoints address", func() {
+					Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(readyVM), readyVM)).To(Succeed())
+					readyVM.Status.Network.PrimaryIP4 = vmIP2
+					Expect(ctx.Client.Status().Update(ctx, readyVM)).To(Succeed())
+
+					Eventually(func(g Gomega) {
+						endpoints := &corev1.Endpoints{}
+						g.Expect(ctx.Client.Get(ctx, objKey, endpoints)).To(Succeed())
+						g.Expect(endpoints.Subsets).To(HaveLen(1))
+						g.Expect(endpoints.Subsets[0].Addresses).To(ConsistOf(HaveField("IP", vmIP2)))
+					}).Should(Succeed())
+				})
+
+				By("VM's Ready condition becoming False moves it to NotReadyAddresses", func() {
+					conditions.MarkFalse(readyVM, vmopv1.ReadyConditionType, "not_ready", "VM should be not ready")
+					Expect(ctx.Client.Status().Update(ctx, readyVM)).To(Succeed())
+
+					Eventually(func(g Gomega) {
+						endpoints := &corev1.Endpoints{}
+						g.Expect(ctx.Client.Get(ctx, objKey, endpoints)).To(Succeed())
+						g.Expect(endpoints.Subsets).To(HaveLen(1))
+						g.Expect(endpoints.Subsets[0].Addresses).To(BeEmpty())
+						g.Expect(endpoints.Subsets[0].NotReadyAddresses).To(ConsistOf(HaveField("IP", vmIP2)))
+					}).Should(Succeed())
+				})
+
+				By("Removing the VM's readiness probe marks it ready regardless of the Ready condition", func() {
+					readyVM.Spec.ReadinessProbe = nil
+					Expect(ctx.Client.Update(ctx, readyVM)).To(Succeed())
+
+					Eventually(func(g Gomega) {
+						endpoints := &corev1.Endpoints{}
+						g.Expect(ctx.Client.Get(ctx, objKey, endpoints)).To(Succeed())
+						g.Expect(endpoints.Subsets).To(HaveLen(1))
+						g.Expect(endpoints.Subsets[0].Addresses).To(ConsistOf(HaveField("IP", vmIP2)))
+						g.Expect(endpoints.Subsets[0].NotReadyAddresses).To(BeEmpty())
+					}).Should(Succeed())
+				})
+
+				By("Adding a readiness probe back marks the VM not ready again", func() {
+					Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(readyVM), readyVM)).To(Succeed())
+					readyVM.Spec.ReadinessProbe = &vmopv1.VirtualMachineReadinessProbeSpec{
+						GuestHeartbeat: &vmopv1.GuestHeartbeatAction{},
+					}
+					Expect(ctx.Client.Update(ctx, readyVM)).To(Succeed())
+
+					Eventually(func(g Gomega) {
+						endpoints := &corev1.Endpoints{}
+						g.Expect(ctx.Client.Get(ctx, objKey, endpoints)).To(Succeed())
+						g.Expect(endpoints.Subsets).To(HaveLen(1))
+						g.Expect(endpoints.Subsets[0].Addresses).To(BeEmpty())
+						g.Expect(endpoints.Subsets[0].NotReadyAddresses).To(ConsistOf(HaveField("IP", vmIP2)))
+					}).Should(Succeed())
+				})
+
+				By("VM's Ready condition becoming True adds it back to Addresses", func() {
+					conditions.MarkTrue(readyVM, vmopv1.ReadyConditionType)
+					Expect(ctx.Client.Status().Update(ctx, readyVM)).To(Succeed())
+
+					Eventually(func(g Gomega) {
+						endpoints := &corev1.Endpoints{}
+						g.Expect(ctx.Client.Get(ctx, objKey, endpoints)).To(Succeed())
+						g.Expect(endpoints.Subsets).To(HaveLen(1))
+						g.Expect(endpoints.Subsets[0].Addresses).To(ConsistOf(HaveField("IP", vmIP2)))
+						g.Expect(endpoints.Subsets[0].NotReadyAddresses).To(BeEmpty())
+					}).Should(Succeed())
+				})
+
+				By("VM being marked for deletion removes it from Endpoints", func() {
+					// Add a finalizer so the VM is only marked for deletion (its
+					// DeletionTimestamp is set) rather than immediately removed,
+					// mirroring how the VirtualMachine controller's finalizer
+					// behaves in practice.
+					readyVM.Finalizers = append(readyVM.Finalizers, "dummy.test.finalizer")
+					Expect(ctx.Client.Update(ctx, readyVM)).To(Succeed())
+					Expect(ctx.Client.Delete(ctx, readyVM)).To(Succeed())
+
+					Eventually(func(g Gomega) {
+						endpoints := &corev1.Endpoints{}
+						g.Expect(ctx.Client.Get(ctx, objKey, endpoints)).To(Succeed())
+						g.Expect(endpoints.Subsets).To(BeEmpty())
+					}).Should(Succeed())
+
+					Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(readyVM), readyVM)).To(Succeed())
+					readyVM.Finalizers = nil
+					Expect(ctx.Client.Update(ctx, readyVM)).To(Succeed())
 				})
 			})
 		})

--- a/controllers/virtualmachineservice/virtualmachineservice_controller_unit_test.go
+++ b/controllers/virtualmachineservice/virtualmachineservice_controller_unit_test.go
@@ -26,7 +26,6 @@ import (
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
@@ -186,7 +185,7 @@ func unitTestsReconcile() {
 				Expect(ownerRefs).To(HaveLen(1))
 				ownerRef := ownerRefs[0]
 				Expect(ownerRef.Name).To(Equal(vmService.Name))
-				Expect(ownerRef.Controller).To(Equal(ptr.To(true)))
+				Expect(ownerRef.Controller).To(HaveValue(BeTrue()))
 			})
 
 			It("With Expected Spec", func() {
@@ -656,7 +655,7 @@ func unitTestsReconcile() {
 				Expect(ownerRefs).To(HaveLen(1))
 				ownerRef := ownerRefs[0]
 				Expect(ownerRef.Name).To(Equal(vmService.Name))
-				Expect(ownerRef.Controller).To(Equal(ptr.To(true)))
+				Expect(ownerRef.Controller).To(HaveValue(BeTrue()))
 			})
 
 			It("With Expected Annotations and Labels", func() {

--- a/test/e2e/vmservice/config/wcp.yaml
+++ b/test/e2e/vmservice/config/wcp.yaml
@@ -80,6 +80,7 @@ intervals:
   default/wait-virtual-machine-moid: ["5m", "10s"]
   default/wait-virtual-machine-restart-mode-update: ["2m", "10s"]
   default/wait-virtual-machine-vmip: ["5m", "10s"]
+  default/wait-virtual-machine-service-endpoints: ["2m", "5s"]
   default/wait-virtual-machine-image-creation: ["10m", "5s"]
   default/consistent-virtual-machine-condition: ["30s", "5s"]
   default/wait-virtual-machine-annotation-update: ["30s", "5s"]

--- a/test/e2e/vmservice/lib/vmoperator/vmoperator.go
+++ b/test/e2e/vmservice/lib/vmoperator/vmoperator.go
@@ -17,6 +17,7 @@ import (
 	"github.com/vmware/govmomi/vim25"
 	"k8s.io/apimachinery/pkg/api/meta"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -200,6 +201,45 @@ func WaitForVirtualMachineIP(ctx context.Context, config *config.E2EConfig, svCl
 			vm.Status.Network.PrimaryIP4 != "" &&
 			net.ParseIP(vm.Status.Network.PrimaryIP4).To4() != nil
 	}, config.GetIntervals("default", "wait-virtual-machine-vmip")...).Should(BeTrue())
+}
+
+// GetVirtualMachineServiceEndpointsTargetRefNames returns the set of VM names
+// referenced via TargetRef by the named VirtualMachineService's Endpoints,
+// across both ready and not-ready addresses.
+func GetVirtualMachineServiceEndpointsTargetRefNames(ctx context.Context, client ctrlclient.Client, ns, name string) (sets.Set[string], error) {
+	endpoints := &corev1.Endpoints{}
+	if err := client.Get(ctx, ctrlclient.ObjectKey{Namespace: ns, Name: name}, endpoints); err != nil {
+		return nil, err
+	}
+
+	names := sets.New[string]()
+	for _, subset := range endpoints.Subsets {
+		for _, addr := range subset.Addresses {
+			if addr.TargetRef != nil {
+				names.Insert(addr.TargetRef.Name)
+			}
+		}
+		for _, addr := range subset.NotReadyAddresses {
+			if addr.TargetRef != nil {
+				names.Insert(addr.TargetRef.Name)
+			}
+		}
+	}
+
+	return names, nil
+}
+
+// WaitForVirtualMachineServiceEndpointsVMs waits until the named
+// VirtualMachineService's Endpoints reference exactly the given set of VMs
+// via TargetRef, no more and no less.
+func WaitForVirtualMachineServiceEndpointsVMs(ctx context.Context, config *config.E2EConfig, client ctrlclient.Client, ns, name string, expectedVMNames []string) {
+	By(fmt.Sprintf("Verify VirtualMachineService '%s/%s' Endpoints reference exactly VMs %v", ns, name, expectedVMNames))
+	Eventually(func(g Gomega) {
+		names, err := GetVirtualMachineServiceEndpointsTargetRefNames(ctx, client, ns, name)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(names.UnsortedList()).To(ConsistOf(expectedVMNames))
+	}, config.GetIntervals("default", "wait-virtual-machine-service-endpoints")...).Should(Succeed(),
+		"Timed out waiting for VirtualMachineService %s/%s Endpoints to reference exactly VMs %v", ns, name, expectedVMNames)
 }
 
 // Utility function to check Virtual Machine Status MoID.

--- a/test/e2e/vmservice/vmservice/virtualmachineservice/virtualmachineservice.go
+++ b/test/e2e/vmservice/vmservice/virtualmachineservice/virtualmachineservice.go
@@ -1,0 +1,182 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package virtualmachineservice
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	capiutil "sigs.k8s.io/cluster-api/util"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+
+	"github.com/vmware-tanzu/vm-operator/test/e2e/framework"
+	"github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/common"
+	e2eConfig "github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/config"
+	"github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/consts"
+	"github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/lib/vmoperator"
+	"github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/skipper"
+	"github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/vmservice"
+	"github.com/vmware-tanzu/vm-operator/test/e2e/wcpframework"
+)
+
+const (
+	virtualMachineKind        = "VirtualMachine"
+	virtualMachineServiceKind = "VirtualMachineService"
+)
+
+type SpecInput struct {
+	Config           *e2eConfig.E2EConfig
+	ClusterProxy     wcpframework.WCPClusterProxyInterface
+	ArtifactFolder   string
+	WCPNamespaceName string
+}
+
+func VirtualMachineServiceSpec(ctx context.Context, inputGetter func() SpecInput) {
+	const specName = "virtual-machine-service"
+
+	var (
+		input            SpecInput
+		config           *e2eConfig.E2EConfig
+		clusterProxy     *common.VMServiceClusterProxy
+		svClusterClient  ctrlclient.Client
+		clusterResources *e2eConfig.Resources
+
+		linuxImageDisplayName string
+		linuxVMIName          string
+
+		selectorKey   string
+		vmServiceName string
+		vmNames       []string
+	)
+
+	BeforeEach(func() {
+		input = inputGetter()
+		Expect(input.Config).ToNot(BeNil(), "Invalid argument. input.Config can't be nil when calling %s spec", specName)
+		Expect(input.Config.InfraConfig).ToNot(BeNil(), "Invalid argument. input.Config.InfraConfig can't be nil when calling %s spec", specName)
+		skipper.SkipUnlessInfraIs(input.Config.InfraConfig.InfraName, consts.WCP)
+
+		Expect(input.ClusterProxy).ToNot(BeNil(), "Invalid argument. input.ClusterProxy can't be nil when calling %s spec", specName)
+		Expect(input.WCPNamespaceName).ToNot(BeEmpty(), "Invalid argument. input.WCPNamespaceName can't be empty when calling %s spec", specName)
+		Expect(os.MkdirAll(input.ArtifactFolder, 0755)).To(Succeed(), "Invalid argument. input.ArtifactFolder can't be created for %s spec", specName)
+
+		config = input.Config
+		clusterResources = config.InfraConfig.ManagementClusterConfig.Resources
+		clusterProxy = input.ClusterProxy.(*common.VMServiceClusterProxy)
+		svClusterClient = clusterProxy.GetClient()
+		cancelPodWatches := framework.WatchPodLogsAndEventsInNamespaces(ctx, []string{config.GetVariable("VMOPNamespace")}, clusterProxy.GetClientSet(), filepath.Join(input.ArtifactFolder, specName))
+		DeferCleanup(cancelPodWatches)
+
+		linuxImageDisplayName = vmservice.GetDefaultImageDisplayName(clusterResources)
+		linuxVMIName = vmoperator.WaitForVirtualMachineImageName(ctx, &config.Config, svClusterClient, input.WCPNamespaceName, linuxImageDisplayName)
+
+		suffix := capiutil.RandomString(4)
+		vmServiceName = fmt.Sprintf("%s-%s", specName, suffix)
+		selectorKey = fmt.Sprintf("%s-selector", vmServiceName)
+		vmNames = []string{fmt.Sprintf("%s-vm1", vmServiceName), fmt.Sprintf("%s-vm2", vmServiceName)}
+	})
+
+	AfterEach(func() {
+		if CurrentSpecReport().Failed() {
+			vmoperator.DescribeResourceIfExists(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), input.WCPNamespaceName, vmServiceName, virtualMachineServiceKind)
+			for _, vmName := range vmNames {
+				vmoperator.DescribeResourceIfExists(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), input.WCPNamespaceName, vmName, virtualMachineKind)
+			}
+		}
+
+		Expect(ctrlclient.IgnoreNotFound(svClusterClient.Delete(ctx, &vmopv1.VirtualMachineService{
+			ObjectMeta: metav1.ObjectMeta{Name: vmServiceName, Namespace: input.WCPNamespaceName},
+		}))).To(Succeed(), "failed to delete VirtualMachineService")
+
+		for _, vmName := range vmNames {
+			Expect(ctrlclient.IgnoreNotFound(svClusterClient.Delete(ctx, &vmopv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{Name: vmName, Namespace: input.WCPNamespaceName},
+			}))).To(Succeed(), "failed to delete VirtualMachine %q", vmName)
+		}
+
+		for _, vmName := range vmNames {
+			vmoperator.WaitForVirtualMachineToBeDeleted(ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
+		}
+	})
+
+	It("Should remove a VM from VirtualMachineService Endpoints once it no longer matches the selector", Label("core-functional", "experimental"), func() {
+		By("Creating a VirtualMachineService selecting VMs with a unique label")
+		vmService := &vmopv1.VirtualMachineService{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      vmServiceName,
+				Namespace: input.WCPNamespaceName,
+			},
+			Spec: vmopv1.VirtualMachineServiceSpec{
+				Type: vmopv1.VirtualMachineServiceTypeClusterIP,
+				Selector: map[string]string{
+					selectorKey: "true",
+				},
+				Ports: []vmopv1.VirtualMachineServicePort{
+					{
+						Name:       "ssh",
+						Protocol:   "TCP",
+						Port:       22,
+						TargetPort: 22,
+					},
+				},
+			},
+		}
+		Expect(svClusterClient.Create(ctx, vmService)).To(Succeed(), "failed to create VirtualMachineService %q", vmServiceName)
+
+		By("Creating 2 VMs labeled to match the VirtualMachineService selector")
+		for _, vmName := range vmNames {
+			vm := &vmopv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      vmName,
+					Namespace: input.WCPNamespaceName,
+					Labels:    map[string]string{selectorKey: "true"},
+				},
+				Spec: vmopv1.VirtualMachineSpec{
+					ImageName:    linuxVMIName,
+					ClassName:    clusterResources.VMClassName,
+					StorageClass: clusterResources.StorageClassName,
+					PowerState:   vmopv1.VirtualMachinePowerStateOn,
+				},
+			}
+			Expect(svClusterClient.Create(ctx, vm)).To(Succeed(), "failed to create VirtualMachine %q", vmName)
+		}
+
+		By("Waiting for both VMs to be created, powered on, and have an IP assigned")
+		for _, vmName := range vmNames {
+			vmoperator.WaitForVirtualMachineCreation(ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
+		}
+
+		By("Waiting for the VirtualMachineService Endpoints to reference both VMs")
+		vmoperator.WaitForVirtualMachineServiceEndpointsVMs(ctx, config, svClusterClient, input.WCPNamespaceName, vmServiceName, vmNames)
+
+		By("Removing the selector label from the first VM")
+		Eventually(func(g Gomega) {
+			vm := &vmopv1.VirtualMachine{}
+			err := svClusterClient.Get(ctx, ctrlclient.ObjectKey{Namespace: input.WCPNamespaceName, Name: vmNames[0]}, vm)
+			g.Expect(err).NotTo(HaveOccurred(), "failed to get VirtualMachine %q", vmNames[0])
+			delete(vm.Labels, selectorKey)
+			g.Expect(svClusterClient.Update(ctx, vm)).To(Succeed(), "failed to update VirtualMachine %q", vmNames[0])
+		}, config.GetIntervals("default", "wait-virtual-machine-annotation-update")...).Should(Succeed(),
+			"Timed out removing selector label from VirtualMachine %q", vmNames[0])
+
+		By("Verifying the first VM is promptly removed from the VirtualMachineService Endpoints, leaving only the second VM")
+		vmoperator.WaitForVirtualMachineServiceEndpointsVMs(ctx, config, svClusterClient, input.WCPNamespaceName, vmServiceName, vmNames[1:])
+
+		By("Deleting the second VM")
+		Expect(svClusterClient.Delete(ctx, &vmopv1.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{Name: vmNames[1], Namespace: input.WCPNamespaceName},
+		})).To(Succeed(), "failed to delete VirtualMachine %q", vmNames[1])
+
+		By("Verifying the second VM is promptly removed from the VirtualMachineService Endpoints, leaving none")
+		vmoperator.WaitForVirtualMachineServiceEndpointsVMs(ctx, config, svClusterClient, input.WCPNamespaceName, vmServiceName, []string{})
+	})
+}

--- a/test/e2e/vmservice/vmservice_test.go
+++ b/test/e2e/vmservice/vmservice_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/vmservice/devops"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/vmservice/viadmin"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/vmservice/virtualmachine"
+	"github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/vmservice/virtualmachineservice"
 )
 
 var _ = Describe("Testing VM Services", Label("devops"), Label("viadmin"), Label("virtualmachine"), Label("vmservice"), func() {
@@ -268,6 +269,17 @@ var _ = Describe("Testing VM Services", Label("devops"), Label("viadmin"), Label
 					WCPNamespaceName: wcpNamespaceName,
 				}
 			})
+		})
+	})
+
+	Context("VIRTUAL-MACHINE-SERVICE", func() {
+		virtualmachineservice.VirtualMachineServiceSpec(context.TODO(), func() virtualmachineservice.SpecInput {
+			return virtualmachineservice.SpecInput{
+				ClusterProxy:     svClusterProxy,
+				Config:           config,
+				ArtifactFolder:   artifactFolder,
+				WCPNamespaceName: wcpNamespaceName,
+			}
 		})
 	})
 })


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

When a label is removed from a VirtualMachine, we need to reconcile all the VirtualMachineServices that the old VM matched, to ensure that it is removed from those Services' Endpoints. This has been a long standing issue that while, uncommon, we should just fix. It originally wasn't a high priority issue since TKG/VKS will always select all the worker VMs, and that label will not change for the life of the VM.

Replace the mapper with an event handler whose UpdateFunc, on a label change, enqueues the union of VirtualMachineServices selecting the VM's old and new labels, mirroring how the core Kubernetes endpoints controller reacts to Pod updates. Introduce virtualMachineEndpointsChanged() that for an updated VM, determines if the change requires service reconciliation.

Add an E2E test that creates a VirtualMachineService and two matching VMs, then asserts that removing the selector label from one VM promptly removes it from the Service's Endpoints.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # vmop-3978


**Are there any special notes for your reviewer**:

```
     Testing VM Services VIRTUAL-MACHINE-SERVICE Should remove a VM from VirtualMachineService Endpoints once it no longer matches the selector [devops, viadmin, virtualmachine, vmservice, core-functional, experimental]                                                                           
     ...work/vm-operator/test/e2e/vmservice/vmservice/virtualmachineservice/virtualmachineservice.go:114                                                                                                                                                                            
       STEP: Creating a VirtualMachineService selecting VMs with a unique label @ 07/22/26 11:54:56.868                                                                                                                                                                                               
       STEP: Creating 2 VMs labeled to match the VirtualMachineService selector @ 07/22/26 11:54:57.054                                                                                                                                                                                               
       STEP: Waiting for both VMs to be created, powered on, and have an IP assigned @ 07/22/26 11:54:58.085                                                                                                                                                                                          
       STEP: Verify that a single VirtualMachine 'test-bmv-ns/virtual-machine-service-kntn-vm1' is created @ 07/22/26 11:54:58.085                                                                                                                                                                    
       STEP: Verifying the existence of VM CR in etcd @ 07/22/26 11:54:58.085                                                                                                                                                                                                                         
       STEP: Waiting for vSphere VM to be created @ 07/22/26 11:54:58.207                                                                                                                                                                                                                             
       STEP: Waiting for VM power state to reach PoweredOn @ 07/22/26 11:55:08.622                                                                                                                                                                                                                    
       STEP: Verify that an IP (ipv4) is allocated to the VirtualMachine 'test-bmv-ns/virtual-machine-service-kntn-vm1' @ 07/22/26 11:55:29.074                                                                                                                                                       
       STEP: Verify that a single VirtualMachine 'test-bmv-ns/virtual-machine-service-kntn-vm2' is created @ 07/22/26 11:56:29.763                                                                                                                                                                    
       STEP: Verifying the existence of VM CR in etcd @ 07/22/26 11:56:29.763                                                                                                                                                                                                                         
       STEP: Waiting for vSphere VM to be created @ 07/22/26 11:56:29.82                                                                                                                                                                                                                              
       STEP: Waiting for VM power state to reach PoweredOn @ 07/22/26 11:56:29.89                                                                                                                                                                                                                     
       STEP: Verify that an IP (ipv4) is allocated to the VirtualMachine 'test-bmv-ns/virtual-machine-service-kntn-vm2' @ 07/22/26 11:56:29.953                                                                                                                                                       
       STEP: Waiting for the VirtualMachineService Endpoints to reference both VMs @ 07/22/26 11:56:30.015                                                                                                                                                                                            
       STEP: Verify VirtualMachineService 'test-bmv-ns/virtual-machine-service-kntn' Endpoints reference exactly VMs [virtual-machine-service-kntn-vm1 virtual-machine-service-kntn-vm2] @ 07/22/26 11:56:30.015                                                                                      
       I0722 11:56:30.077406   58886 warning_handler.go:64] "v1 Endpoints is deprecated in v1.33+; use discovery.k8s.io/v1 EndpointSlice"                                                                                                                                                             
       STEP: Removing the selector label from the first VM @ 07/22/26 11:56:30.077                                                                                                                                                                                                                    
       STEP: Verifying the first VM is promptly removed from the VirtualMachineService Endpoints, leaving only the second VM @ 07/22/26 11:56:30.336                                                                                                                                                  
       STEP: Verify VirtualMachineService 'test-bmv-ns/virtual-machine-service-kntn' Endpoints reference exactly VMs [virtual-machine-service-kntn-vm2] @ 07/22/26 11:56:30.336                                                                                                                       
       I0722 11:56:30.403129   58886 warning_handler.go:64] "v1 Endpoints is deprecated in v1.33+; use discovery.k8s.io/v1 EndpointSlice"                                                                                                                                                             
       I0722 11:56:35.454390   58886 warning_handler.go:64] "v1 Endpoints is deprecated in v1.33+; use discovery.k8s.io/v1 EndpointSlice"                                                                                                                                                             
     • [119.709 seconds]    
```

**Please add a release note if necessary**:


```release-note
When a VirtualMachine labels changes, the VirtualMachineServices that it previously did match selectors with need to be reconciled
```