### PR TITLE
🐛 Reject bus-sharing SCSI controllers/volumes on snapshotted VMs

### DIFF
--- a/pkg/providers/vsphere/resources/resources_suite_test.go
+++ b/pkg/providers/vsphere/resources/resources_suite_test.go
@@ -1,0 +1,19 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package resources_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	_ "github.com/vmware-tanzu/vm-operator/test/builder/log"
+)
+
+func TestResources(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "vSphere Resources Suite")
+}

--- a/pkg/providers/vsphere/resources/vm.go
+++ b/pkg/providers/vsphere/resources/vm.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/vmware/govmomi/fault"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/mo"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
@@ -91,10 +92,37 @@ func (vm *VirtualMachine) Reconfigure(
 
 	taskInfo, err := reconfigureTask.WaitForResult(ctx, nil)
 	if err != nil {
+		// When a task fails, WaitForResult returns an error that contains the
+		// LocalizedMessage, but taskInfo.Error contains the full fault details.
+		// Extract a comprehensive error message that includes both the
+		// localized message and all fault messages.
+		if errMsg := taskutil.ErrorMessageFromTaskInfo(taskInfo); errMsg != "" {
+			err = fmt.Errorf("%s: %w", errMsg, err)
+		}
+
+		if IsSharedBusControllerNotSupportedFault(err) {
+			return taskInfo, pkgerr.NoRequeueErrorf(
+				"reconfigure VM task failed: %s: adding a bus-sharing SCSI controller is not supported while the VM has a snapshot",
+				err)
+		}
+
 		return taskInfo, fmt.Errorf("reconfigure VM task failed: %w", err)
 	}
 
 	return taskInfo, nil
+}
+
+// IsSharedBusControllerNotSupportedFault returns true if err is, or wraps,
+// vim.fault.SharedBusControllerNotSupported. vSphere never allows a
+// bus-sharing (Physical/Virtual) SCSI controller to be added to a VM that
+// has a snapshot, and the reverse -- taking a snapshot of a VM with such a
+// controller -- is also unsupported. This is a VM-wide, disk-mode-agnostic
+// restriction, distinct from the disk-level MultiWriter flag (see
+// vmopv1util.GetControllerSharingMode). Once a VM is in this state,
+// retrying the same reconfigure will fail identically forever, so callers
+// should stop requeuing instead of retrying in a tight loop.
+func IsSharedBusControllerNotSupportedFault(err error) bool {
+	return fault.Is(err, &vimtypes.SharedBusControllerNotSupported{})
 }
 
 func (vm *VirtualMachine) GetProperties(ctx context.Context, properties []string) (*mo.VirtualMachine, error) {

--- a/pkg/providers/vsphere/resources/vm_test.go
+++ b/pkg/providers/vsphere/resources/vm_test.go
@@ -1,0 +1,58 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package resources_test
+
+import (
+	"errors"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/vmware/govmomi/task"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+
+	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/resources"
+)
+
+var _ = Describe("IsSharedBusControllerNotSupportedFault", func() {
+
+	sharedBusFaultErr := func() error {
+		return task.Error{
+			LocalizedMethodFault: &vimtypes.LocalizedMethodFault{
+				Fault: &vimtypes.SharedBusControllerNotSupported{
+					DeviceNotSupported: vimtypes.DeviceNotSupported{
+						Device: "key-1000",
+					},
+				},
+				LocalizedMessage: "Device 'key-1000' is a SCSI controller engaged in bus-sharing.",
+			},
+		}
+	}
+
+	DescribeTable("classifies errors",
+		func(err error, expected bool) {
+			Expect(resources.IsSharedBusControllerNotSupportedFault(err)).To(Equal(expected))
+		},
+
+		Entry("nil error", nil, false),
+		Entry("unrelated plain error", errors.New("boom"), false),
+		Entry(
+			"unrelated vSphere fault",
+			task.Error{
+				LocalizedMethodFault: &vimtypes.LocalizedMethodFault{
+					Fault: &vimtypes.InvalidDeviceSpec{},
+				},
+			},
+			false,
+		),
+		Entry("SharedBusControllerNotSupported fault", sharedBusFaultErr(), true),
+		Entry(
+			"SharedBusControllerNotSupported fault wrapped with fmt.Errorf",
+			fmt.Errorf("reconfigure VM task failed: %w", sharedBusFaultErr()),
+			true,
+		),
+	)
+})

--- a/webhooks/virtualmachine/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator.go
@@ -1915,6 +1915,37 @@ func (v validator) validateSharedVolumesOrControllers(
 		(controllerSharingMode == vmopv1.VirtualControllerSharingModePhysical ||
 			controllerSharingMode == vmopv1.VirtualControllerSharingModeVirtual)
 
+	if vm.Status.CurrentSnapshot != nil {
+		// A MultiWriter disk only conflicts with a snapshot when the disk
+		// uses a dependent mode (Persistent/NonPersistent): a snapshot's
+		// redo log can't be shared across concurrent writers. Independent
+		// disks (e.g. OracleRAC volumes, which are always
+		// IndependentPersistent) are excluded from VM snapshots entirely,
+		// so this restriction does not apply to them.
+		independentDiskMode := vol.DiskMode == vmopv1.VolumeDiskModeIndependentPersistent ||
+			vol.DiskMode == vmopv1.VolumeDiskModeIndependentNonPersistent
+		if volShared && !independentDiskMode {
+			allErrs = append(allErrs, field.Invalid(
+				volPath.Child("sharingMode"),
+				vol.SharingMode,
+				"MultiWriter disk sharing is not supported for a dependent-mode volume on a VM that has a snapshot"))
+		}
+
+		// Bus-sharing (Physical/Virtual) SCSI controllers are a VM-wide
+		// restriction: vSphere never allows a bus-sharing controller to be
+		// added to a VM that has a snapshot, regardless of disk mode. The
+		// ReconfigVM_Task fails with vim.fault.SharedBusControllerNotSupported
+		// and vm-operator has no way to recover other than the snapshot
+		// being removed.
+		if controllerShared {
+			allErrs = append(allErrs, field.Invalid(
+				volPath.Child("controllerBusNumber"),
+				fmt.Sprintf("%s:%d", vol.ControllerType, *vol.ControllerBusNumber),
+				fmt.Sprintf("Controller with sharing mode %s is not supported for a VM that has a snapshot",
+					controllerSharingMode)))
+		}
+	}
+
 	// MultiWriter volumes or shared controllers (Physical/Virtual) cannot be encrypted.
 	if pvcEncrypted {
 		if volShared {

--- a/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
@@ -10515,6 +10515,118 @@ func commonCreateAndUpdateValidations(
 				},
 			),
 
+			Entry("should deny a dependent-mode MultiWriter volume on a VM that has a snapshot",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						ctx.vm.Status.CurrentSnapshot = &vmopv1.VirtualMachineSnapshotReference{
+							Name: "snap-1",
+						}
+						ctx.vm.Spec.Volumes = []vmopv1.VirtualMachineVolume{
+							{
+								Name: "test-volume",
+								VirtualMachineVolumeSource: vmopv1.VirtualMachineVolumeSource{
+									PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
+										PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+											ClaimName: nonEncryptedPVCName,
+										},
+									},
+								},
+								SharingMode: vmopv1.VolumeSharingModeMultiWriter,
+								DiskMode:    vmopv1.VolumeDiskModePersistent,
+							},
+						}
+					},
+					validate: doValidateWithMsg(
+						"MultiWriter disk sharing is not supported for a dependent-mode volume on a VM that has a snapshot",
+					),
+				},
+			),
+
+			Entry("should allow an independent-mode MultiWriter volume (e.g. OracleRAC) on a VM that has a snapshot",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						ctx.vm.Status.CurrentSnapshot = &vmopv1.VirtualMachineSnapshotReference{
+							Name: "snap-1",
+						}
+						ctx.vm.Spec.Volumes = []vmopv1.VirtualMachineVolume{
+							{
+								Name: "test-volume",
+								VirtualMachineVolumeSource: vmopv1.VirtualMachineVolumeSource{
+									PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
+										PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+											ClaimName: nonEncryptedPVCName,
+										},
+									},
+								},
+								ApplicationType: vmopv1.VolumeApplicationTypeOracleRAC,
+								SharingMode:     vmopv1.VolumeSharingModeMultiWriter,
+								DiskMode:        vmopv1.VolumeDiskModeIndependentPersistent,
+							},
+						}
+					},
+					expectAllowed: true,
+				},
+			),
+
+			Entry("should deny a Physical sharing-mode controller volume on a VM that has a snapshot",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						ctx.vm.Status.CurrentSnapshot = &vmopv1.VirtualMachineSnapshotReference{
+							Name: "snap-1",
+						}
+						ctx.vm.Spec.Hardware.SCSIControllers = []vmopv1.SCSIControllerSpec{
+							{
+								BusNumber:   0,
+								Type:        vmopv1.SCSIControllerTypeParaVirtualSCSI,
+								SharingMode: vmopv1.VirtualControllerSharingModePhysical,
+							},
+						}
+						ctx.vm.Spec.Volumes = []vmopv1.VirtualMachineVolume{
+							{
+								Name: "test-volume",
+								VirtualMachineVolumeSource: vmopv1.VirtualMachineVolumeSource{
+									PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
+										PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+											ClaimName: nonEncryptedPVCName,
+										},
+									},
+								},
+								ControllerType:      vmopv1.VirtualControllerTypeSCSI,
+								ControllerBusNumber: ptr.To(int32(0)),
+								UnitNumber:          ptr.To(int32(0)),
+							},
+						}
+					},
+					validate: doValidateWithMsg(
+						"Controller with sharing mode Physical is not supported for a VM that has a snapshot",
+					),
+				},
+			),
+
+			Entry("should allow a non-shared volume on a VM that has a snapshot",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						ctx.vm.Status.CurrentSnapshot = &vmopv1.VirtualMachineSnapshotReference{
+							Name: "snap-1",
+						}
+						ctx.vm.Spec.Volumes = []vmopv1.VirtualMachineVolume{
+							{
+								Name: "test-volume",
+								VirtualMachineVolumeSource: vmopv1.VirtualMachineVolumeSource{
+									PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
+										PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+											ClaimName: nonEncryptedPVCName,
+										},
+									},
+								},
+								SharingMode: vmopv1.VolumeSharingModeNone,
+							},
+						}
+					},
+					expectAllowed: true,
+				},
+			),
+
 			Entry("should deny encrypted PVC with Physical controller sharing",
 				testParams{
 					setup: func(ctx *unitValidatingWebhookContext) {

--- a/webhooks/virtualmachinesnapshot/validation/virtualmachinesnapshot_validator.go
+++ b/webhooks/virtualmachinesnapshot/validation/virtualmachinesnapshot_validator.go
@@ -32,6 +32,7 @@ const (
 
 const (
 	errUnsupportedVMControllerSharingModeFmt = "controller type %s bus %d is using unsupported sharingMode for snapshot: %s"
+	errUnsupportedVMVolumeSharingModeFmt     = "volume %s is using unsupported sharingMode for snapshot: %s"
 )
 
 // +kubebuilder:webhook:verbs=create;update,path=/default-validate-vmoperator-vmware-com-v1alpha6-virtualmachinesnapshot,mutating=false,failurePolicy=fail,groups=vmoperator.vmware.com,resources=virtualmachinesnapshots,versions=v1alpha6,name=default.validating.virtualmachinesnapshot.v1alpha6.vmoperator.vmware.com,sideEffects=None,admissionReviewVersions=v1;v1beta1
@@ -187,6 +188,37 @@ func (v validator) validateVMControllerSharingMode(
 	return allErrs
 }
 
+// validateVMVolumeSharingMode checks if the referenced VM has a
+// dependent-mode volume (Persistent/NonPersistent) with sharingMode
+// MultiWriter. vSphere does not support snapshotting a VM with such a
+// volume, because the snapshot's redo log can't be shared across
+// concurrent writers. Independent-mode MultiWriter volumes (e.g. OracleRAC,
+// which is always IndependentPersistent) are excluded from VM snapshots
+// entirely, so this restriction does not apply to them.
+func (v validator) validateVMVolumeSharingMode(
+	vm vmopv1.VirtualMachine,
+	vmNameField *field.Path) field.ErrorList {
+
+	var allErrs field.ErrorList
+
+	for _, vol := range vm.Spec.Volumes {
+		independentDiskMode := vol.DiskMode == vmopv1.VolumeDiskModeIndependentPersistent ||
+			vol.DiskMode == vmopv1.VolumeDiskModeIndependentNonPersistent
+
+		if vol.SharingMode == vmopv1.VolumeSharingModeMultiWriter && !independentDiskMode {
+			allErrs = append(allErrs,
+				field.NotSupported(vmNameField,
+					fmt.Sprintf(errUnsupportedVMVolumeSharingModeFmt,
+						vol.Name,
+						vol.SharingMode), []string{string(vmopv1.VolumeSharingModeNone)},
+				),
+			)
+		}
+	}
+
+	return allErrs
+}
+
 func (v validator) validateVMFields(
 	ctx *pkgctx.WebhookRequestContext,
 	vmName, namespace string,
@@ -220,6 +252,13 @@ func (v validator) validateVMFields(
 	// Check if the reference VM has controllers with unsupported sharingMode.
 	fieldErrs = append(fieldErrs,
 		v.validateVMControllerSharingMode(
+			vm,
+			vmNameField)...,
+	)
+
+	// Check if the reference VM has volumes with unsupported sharingMode.
+	fieldErrs = append(fieldErrs,
+		v.validateVMVolumeSharingMode(
 			vm,
 			vmNameField)...,
 	)

--- a/webhooks/virtualmachinesnapshot/validation/virtualmachinesnapshot_validator_unit_test.go
+++ b/webhooks/virtualmachinesnapshot/validation/virtualmachinesnapshot_validator_unit_test.go
@@ -92,6 +92,7 @@ func unitTestsValidateCreate() {
 		mismatchedVMNameLabel bool
 		createVKSNode         bool
 		hardware              *vmopv1.VirtualMachineHardwareSpec
+		volumes               []vmopv1.VirtualMachineVolume
 	}
 
 	validateCreate := func(args createArgs, expectedAllowed bool, expectedReason string, expectedErr error) {
@@ -104,7 +105,7 @@ func unitTestsValidateCreate() {
 		}
 
 		// Create a VM with CAPI labels to simulate a VKS/TKG node
-		if args.hardware != nil || args.createVKSNode {
+		if args.hardware != nil || args.createVKSNode || args.volumes != nil {
 			vm := builder.DummyBasicVirtualMachine(ctx.vmSnapshot.Spec.VMName, ctx.vmSnapshot.Namespace)
 			if args.createVKSNode {
 				vm.Labels = map[string]string{
@@ -112,6 +113,7 @@ func unitTestsValidateCreate() {
 				}
 			}
 			vm.Spec.Hardware = args.hardware
+			vm.Spec.Volumes = args.volumes
 			Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
 		}
 
@@ -205,6 +207,47 @@ func unitTestsValidateCreate() {
 							BusNumber:   0,
 							SharingMode: vmopv1.VirtualControllerSharingModeNone,
 						},
+					},
+				},
+			},
+			true,
+			nil,
+			nil,
+		),
+		Entry("should deny snapshot if a volume has MultiWriter sharing mode",
+			createArgs{
+				volumes: []vmopv1.VirtualMachineVolume{
+					{
+						Name:        "test-volume",
+						SharingMode: vmopv1.VolumeSharingModeMultiWriter,
+					},
+				},
+			},
+			false,
+			field.NotSupported(vmNameField, "volume test-volume is using unsupported sharingMode for snapshot: MultiWriter", []string{string(vmopv1.VolumeSharingModeNone)}).Error(),
+			nil,
+		),
+		Entry("should allow snapshot if a volume has none sharing mode",
+			createArgs{
+				volumes: []vmopv1.VirtualMachineVolume{
+					{
+						Name:        "test-volume",
+						SharingMode: vmopv1.VolumeSharingModeNone,
+					},
+				},
+			},
+			true,
+			nil,
+			nil,
+		),
+		Entry("should allow snapshot if an independent-mode volume (e.g. OracleRAC) has MultiWriter sharing mode",
+			createArgs{
+				volumes: []vmopv1.VirtualMachineVolume{
+					{
+						Name:            "test-volume",
+						ApplicationType: vmopv1.VolumeApplicationTypeOracleRAC,
+						SharingMode:     vmopv1.VolumeSharingModeMultiWriter,
+						DiskMode:        vmopv1.VolumeDiskModeIndependentPersistent,
 					},
 				},
 			},


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

vSphere never allows a bus-sharing (Physical/Virtual) SCSI controller to be added to a VM that has a snapshot, and the reverse -- taking a snapshot of a VM with such a controller -- is also unsupported (`vim.fault.SharedBusControllerNotSupported`).

Without this check, adding a `MicrosoftWSFC` volume (which requires a Physical-sharing controller) to a VM that already has a snapshot was admitted by the `VirtualMachine` webhook. vm-operator then retried the failing `ReconfigVM_Task` in a tight loop forever, leaving the VM stuck in `PoweredOff`/`poweredOffReconfigure` indefinitely, with only a spammy `UpdateFailure` event and generic hardware-mismatch conditions to show for it.

This PR:
- **`webhooks/virtualmachine`**: rejects adding a bus-sharing controller, or a `MultiWriter` volume on a *dependent-mode* disk, to a VM that already has a snapshot. Independent-mode `MultiWriter` volumes (e.g. `OracleRAC`, which is always `IndependentPersistent`) are excluded from VM snapshots entirely by vSphere and are correctly still allowed.
- **`webhooks/virtualmachinesnapshot`**: the existing controller-sharing-mode check only inspected `spec.hardware.scsiControllers`; extends it to also reject creating a snapshot when a volume itself has a dependent-mode `MultiWriter` sharing mode.
- **`pkg/providers/vsphere/resources`**: classifies `vim.fault.SharedBusControllerNotSupported` using the same `fault.Is` idiom already used for `NotAuthenticated`/`InvalidLogin` in `pkg/util/vsphere/client`, and returns it as a `NoRequeueError` so the controller stops retrying a reconfigure that will fail identically forever. Also builds the full task error message via `taskutil.ErrorMessageFromTaskInfo` for all reconfigure failures, matching the existing pattern already used in `Customize()`.

**Which issue(s) is/are addressed by this PR?**


**Are there any special notes for your reviewer**:

This intentionally does *not* change how the reconfigure failure is surfaced as a Kubernetes Event/condition beyond stopping the retry storm -- the existing `HardwareControllersMismatch`/`HardwareVolumesMismatch` conditions are generic and don't distinguish a terminal failure from an in-progress reconcile, which is a separate, larger product decision (new condition reason/event semantics) intentionally left out of scope here.

**Please add a release note if necessary**:

```release-note
Reject admission of a bus-sharing SCSI controller or a dependent-mode MultiWriter volume on a VirtualMachine or VirtualMachineSnapshot that would conflict with an existing snapshot, and stop retrying a ReconfigVM_Task that vCenter permanently rejects for this reason (vim.fault.SharedBusControllerNotSupported).
```
