### PR TITLE
Fix the vm-location e2e test failure wrt zone mismatch in vds-ssv setup

### DIFF
--- a/test/e2e/vmservice/lib/vmoperator/vmoperator.go
+++ b/test/e2e/vmservice/lib/vmoperator/vmoperator.go
@@ -422,6 +422,17 @@ func GetVirtualMachineMOID(ctx context.Context, client ctrlclient.Client, ns, vm
 	return vm.Status.UniqueID
 }
 
+// GetVirtualMachineZone returns the zone the VirtualMachine was placed in.
+// It fails the spec if the VM has no zone set on its status, since the
+// namespace resource pool is per-zone and cannot be resolved without it.
+func GetVirtualMachineZone(ctx context.Context, client ctrlclient.Client, ns, vmName string) string {
+	vm, err := utils.GetVirtualMachine(ctx, client, ns, vmName)
+	Expect(err).ShouldNot(HaveOccurred())
+	Expect(vm.Status.Zone).ShouldNot(BeEmpty(), "VM %s/%s has no status.zone", ns, vmName)
+
+	return vm.Status.Zone
+}
+
 func GetVirtualMachineIP(ctx context.Context, client ctrlclient.Client, ns, vmName string) string {
 	vm, err := utils.GetVirtualMachine(ctx, client, ns, vmName)
 	Expect(err).ShouldNot(HaveOccurred())

--- a/test/e2e/vmservice/lib/vmoperator/vmoperator.go
+++ b/test/e2e/vmservice/lib/vmoperator/vmoperator.go
@@ -423,8 +423,9 @@ func GetVirtualMachineMOID(ctx context.Context, client ctrlclient.Client, ns, vm
 }
 
 // GetVirtualMachineZone returns the zone the VirtualMachine was placed in.
-// It fails the spec if the VM has no zone set on its status, since the
-// namespace resource pool is per-zone and cannot be resolved without it.
+// It does a single read with no retry and fails the spec if status.zone is
+// empty, since the namespace resource pool is per-zone and cannot be resolved
+// without it. Call it only after the VM has been placed.
 func GetVirtualMachineZone(ctx context.Context, client ctrlclient.Client, ns, vmName string) string {
 	vm, err := utils.GetVirtualMachine(ctx, client, ns, vmName)
 	Expect(err).ShouldNot(HaveOccurred())

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
@@ -146,33 +146,24 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 	// is per-zone, so zone must match the VM's status.zone or the resolved RP
 	// belongs to a different zone.
 	getNsRPAndFolder := func(namespace, zone string) (rpMoID, folderMoID string) {
-		zoneList := &topologyv1.ZoneList{}
-		Expect(svClusterClient.List(ctx, zoneList, ctrlclient.InNamespace(namespace))).
-			To(Succeed(), "failed to list Zones for namespace %s", namespace)
-
-		for _, z := range zoneList.Items {
-			if z.Name == zone && len(z.Spec.ManagedVMs.PoolMoIDs) > 0 {
-				e2eframework.Logf("resolved namespace RP from Zone %s: %s / %s",
-					z.Name, z.Spec.ManagedVMs.PoolMoIDs[0], z.Spec.ManagedVMs.FolderMoID)
-				return z.Spec.ManagedVMs.PoolMoIDs[0], z.Spec.ManagedVMs.FolderMoID
-			}
+		z := &topologyv1.Zone{}
+		err := svClusterClient.Get(ctx, ctrlclient.ObjectKey{Namespace: namespace, Name: zone}, z)
+		if err == nil && len(z.Spec.ManagedVMs.PoolMoIDs) > 0 {
+			e2eframework.Logf("resolved namespace RP from Zone %s: %s / %s",
+				z.Name, z.Spec.ManagedVMs.PoolMoIDs[0], z.Spec.ManagedVMs.FolderMoID)
+			return z.Spec.ManagedVMs.PoolMoIDs[0], z.Spec.ManagedVMs.FolderMoID
 		}
+		Expect(ctrlclient.IgnoreNotFound(err)).To(Succeed(), "failed to get Zone %s/%s", namespace, zone)
 
 		// Fallback for older, non-zonal configs, where status.zone is the AZ name.
-		azList := &topologyv1.AvailabilityZoneList{}
-		Expect(svClusterClient.List(ctx, azList)).
-			To(Succeed(), "failed to list AvailabilityZones")
-		Expect(azList.Items).ToNot(BeEmpty(), "expected at least one AvailabilityZone")
+		az := &topologyv1.AvailabilityZone{}
+		Expect(svClusterClient.Get(ctx, ctrlclient.ObjectKey{Name: zone}, az)).
+			To(Succeed(), "failed to get AvailabilityZone %s", zone)
 
-		for _, az := range azList.Items {
-			if az.Name != zone {
-				continue
-			}
-			if nsInfo, ok := az.Spec.Namespaces[namespace]; ok && nsInfo.PoolMoId != "" {
-				e2eframework.Logf("resolved namespace RP from AvailabilityZone %s: %s / %s",
-					az.Name, nsInfo.PoolMoId, nsInfo.FolderMoId)
-				return nsInfo.PoolMoId, nsInfo.FolderMoId
-			}
+		if nsInfo, ok := az.Spec.Namespaces[namespace]; ok && nsInfo.PoolMoId != "" {
+			e2eframework.Logf("resolved namespace RP from AvailabilityZone %s: %s / %s",
+				az.Name, nsInfo.PoolMoId, nsInfo.FolderMoId)
+			return nsInfo.PoolMoId, nsInfo.FolderMoId
 		}
 
 		Fail(fmt.Sprintf(

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
@@ -141,28 +141,42 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 	})
 
 	// getNsRPAndFolder returns the namespace RP MoID and folder MoID for the
-	// WCP namespace.  It mirrors the lookup order in topology.GetNamespaceFolderAndRPMoID:
-	// Zone.Spec.ManagedVMs first, then AvailabilityZone.Spec.Namespaces as fallback.
-	getNsRPAndFolder := func(namespace string) (rpMoID, folderMoID string) {
+	// WCP namespace in the given zone. It mirrors topology.GetNamespaceFolderAndRPMoID,
+	// which the controller uses to compute the VM's expected location:
+	// Zone.Spec.ManagedVMs for the VM's own zone first, then the matching
+	// AvailabilityZone.Spec.Namespaces as fallback.
+	//
+	// On a multi-zone Supervisor the namespace RP is per-zone (each zone has its
+	// own resource pool), so the Zone selected MUST match the VM's status.zone.
+	// Returning an arbitrary zone's RP relocates the VM into a different zone's
+	// pool, which the controller correctly reports as a ResourcePoolMismatch and
+	// never reconciles back to LocationValid=True. The folder, in contrast, is
+	// shared across zones for a namespace, but it is resolved from the same
+	// zone-scoped entry here for consistency with the controller.
+	getNsRPAndFolder := func(namespace, zone string) (rpMoID, folderMoID string) {
 		zoneList := &topologyv1.ZoneList{}
 		Expect(svClusterClient.List(ctx, zoneList, ctrlclient.InNamespace(namespace))).
 			To(Succeed(), "failed to list Zones for namespace %s", namespace)
 
 		for _, z := range zoneList.Items {
-			if len(z.Spec.ManagedVMs.PoolMoIDs) > 0 {
+			if z.Name == zone && len(z.Spec.ManagedVMs.PoolMoIDs) > 0 {
 				e2eframework.Logf("resolved namespace RP from Zone %s: %s / %s",
 					z.Name, z.Spec.ManagedVMs.PoolMoIDs[0], z.Spec.ManagedVMs.FolderMoID)
 				return z.Spec.ManagedVMs.PoolMoIDs[0], z.Spec.ManagedVMs.FolderMoID
 			}
 		}
 
-		// Fallback: AvailabilityZone.Spec.Namespaces (older cluster configurations).
+		// Fallback: AvailabilityZone.Spec.Namespaces (older, non-zonal configurations).
+		// There the VM's status.zone is the AvailabilityZone name.
 		azList := &topologyv1.AvailabilityZoneList{}
 		Expect(svClusterClient.List(ctx, azList)).
 			To(Succeed(), "failed to list AvailabilityZones")
 		Expect(azList.Items).ToNot(BeEmpty(), "expected at least one AvailabilityZone")
 
 		for _, az := range azList.Items {
+			if az.Name != zone {
+				continue
+			}
 			if nsInfo, ok := az.Spec.Namespaces[namespace]; ok && nsInfo.PoolMoId != "" {
 				e2eframework.Logf("resolved namespace RP from AvailabilityZone %s: %s / %s",
 					az.Name, nsInfo.PoolMoId, nsInfo.FolderMoId)
@@ -170,7 +184,9 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 			}
 		}
 
-		Fail("could not determine namespace RP and folder MoIDs for namespace " + namespace)
+		Fail(fmt.Sprintf(
+			"could not determine namespace RP and folder MoIDs for namespace %s in zone %s",
+			namespace, zone))
 		return "", ""
 	}
 
@@ -244,7 +260,7 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		Expect(task.Wait(ctx)).To(Succeed(), "Relocate task failed for VM %s", vmMoID)
 	}
 
-	When("VM is created in the correct namespace RP and folder", Label("core-functional","experimental"), func() {
+	When("VM is created in the correct namespace RP and folder", Label("core-functional", "experimental"), func() {
 		It("sets VirtualMachineLocationValid condition to True", func() {
 			createVM()
 
@@ -256,7 +272,7 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		})
 	})
 
-	When("VM is moved outside the namespace RP hierarchy", Label("core-functional","experimental"), func() {
+	When("VM is moved outside the namespace RP hierarchy", Label("core-functional", "experimental"), func() {
 		It("sets condition False, then recovers to True when VM is returned to the correct location", func() {
 			By("Creating VM and waiting for it to reach Running state")
 			createVM()
@@ -271,8 +287,9 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 			vmMoID := vmoperator.GetVirtualMachineMOID(ctx, svClusterClient, input.WCPNamespaceName, vmName)
 			Expect(vmMoID).ToNot(BeEmpty(), "VM must have a UniqueID before relocation")
 
-			By("Retrieving the correct namespace RP and folder MoIDs")
-			nsRPMoID, nsFolderMoID := getNsRPAndFolder(input.WCPNamespaceName)
+			By("Retrieving the correct namespace RP and folder MoIDs for the VM's zone")
+			vmZone := vmoperator.GetVirtualMachineZone(ctx, svClusterClient, input.WCPNamespaceName, vmName)
+			nsRPMoID, nsFolderMoID := getNsRPAndFolder(input.WCPNamespaceName, vmZone)
 
 			By("Retrieving the cluster root RP to use as an invalid location")
 			// 1. Resolve the specific Cluster MoID for the active Supervisor context
@@ -315,7 +332,7 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		})
 	})
 
-	When("VM is moved outside the namespace Folder hierarchy", Label("core-functional","experimental"), func() {
+	When("VM is moved outside the namespace Folder hierarchy", Label("core-functional", "experimental"), func() {
 		It("sets condition False, then recovers to True when VM is returned to the correct location", func() {
 			By("Creating VM and waiting for it to reach Running state")
 			createVM()
@@ -330,8 +347,9 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 			vmMoID := vmoperator.GetVirtualMachineMOID(ctx, svClusterClient, input.WCPNamespaceName, vmName)
 			Expect(vmMoID).ToNot(BeEmpty(), "VM must have a UniqueID before relocation")
 
-			By("Retrieving the correct namespace folder MoID")
-			_, nsFolderMoID := getNsRPAndFolder(input.WCPNamespaceName)
+			By("Retrieving the correct namespace folder MoID for the VM's zone")
+			vmZone := vmoperator.GetVirtualMachineZone(ctx, svClusterClient, input.WCPNamespaceName, vmName)
+			_, nsFolderMoID := getNsRPAndFolder(input.WCPNamespaceName, vmZone)
 
 			By("Retrieving another Supervisor Namespace's folder as the invalid folder location")
 			// A different namespace's folder always lies outside the 2-level hierarchy

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
@@ -140,19 +140,11 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		vcenter.LogoutVimClient(vCenterAdminClient)
 	})
 
-	// getNsRPAndFolder returns the namespace RP MoID and folder MoID for the
-	// WCP namespace in the given zone. It mirrors topology.GetNamespaceFolderAndRPMoID,
-	// which the controller uses to compute the VM's expected location:
-	// Zone.Spec.ManagedVMs for the VM's own zone first, then the matching
-	// AvailabilityZone.Spec.Namespaces as fallback.
-	//
-	// On a multi-zone Supervisor the namespace RP is per-zone (each zone has its
-	// own resource pool), so the Zone selected MUST match the VM's status.zone.
-	// Returning an arbitrary zone's RP relocates the VM into a different zone's
-	// pool, which the controller correctly reports as a ResourcePoolMismatch and
-	// never reconciles back to LocationValid=True. The folder, in contrast, is
-	// shared across zones for a namespace, but it is resolved from the same
-	// zone-scoped entry here for consistency with the controller.
+	// getNsRPAndFolder returns the namespace RP and folder MoIDs for the given
+	// zone, mirroring the controller's topology.GetNamespaceFolderAndRPMoID:
+	// the namespaced Zone first, then the AvailabilityZone as fallback. The RP
+	// is per-zone, so zone must match the VM's status.zone or the resolved RP
+	// belongs to a different zone.
 	getNsRPAndFolder := func(namespace, zone string) (rpMoID, folderMoID string) {
 		zoneList := &topologyv1.ZoneList{}
 		Expect(svClusterClient.List(ctx, zoneList, ctrlclient.InNamespace(namespace))).
@@ -166,8 +158,7 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 			}
 		}
 
-		// Fallback: AvailabilityZone.Spec.Namespaces (older, non-zonal configurations).
-		// There the VM's status.zone is the AvailabilityZone name.
+		// Fallback for older, non-zonal configs, where status.zone is the AZ name.
 		azList := &topologyv1.AvailabilityZoneList{}
 		Expect(svClusterClient.List(ctx, azList)).
 			To(Succeed(), "failed to list AvailabilityZones")

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
@@ -17,6 +17,7 @@ import (
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/mo"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	e2eframework "k8s.io/kubernetes/test/e2e/framework"
 	capiutil "sigs.k8s.io/cluster-api/util"
@@ -146,16 +147,22 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 	// is per-zone, so zone must match the VM's status.zone or the resolved RP
 	// belongs to a different zone.
 	getNsRPAndFolder := func(namespace, zone string) (rpMoID, folderMoID string) {
+		// A found Zone is authoritative: assert it carries a pool rather than
+		// falling through to the AvailabilityZone path, which would otherwise
+		// surface a misleading "AvailabilityZone not found" error.
 		z := &topologyv1.Zone{}
 		err := svClusterClient.Get(ctx, ctrlclient.ObjectKey{Namespace: namespace, Name: zone}, z)
-		if err == nil && len(z.Spec.ManagedVMs.PoolMoIDs) > 0 {
+		if err == nil {
+			Expect(z.Spec.ManagedVMs.PoolMoIDs).ToNot(BeEmpty(),
+				"Zone %s/%s has no ManagedVMs.PoolMoIDs", namespace, zone)
 			e2eframework.Logf("resolved namespace RP from Zone %s: %s / %s",
 				z.Name, z.Spec.ManagedVMs.PoolMoIDs[0], z.Spec.ManagedVMs.FolderMoID)
 			return z.Spec.ManagedVMs.PoolMoIDs[0], z.Spec.ManagedVMs.FolderMoID
 		}
-		Expect(ctrlclient.IgnoreNotFound(err)).To(Succeed(), "failed to get Zone %s/%s", namespace, zone)
+		Expect(apierrors.IsNotFound(err)).To(BeTrue(), "failed to get Zone %s/%s", namespace, zone)
 
-		// Fallback for older, non-zonal configs, where status.zone is the AZ name.
+		// Fallback for older, non-zonal configs (no Zone object), where the VM's
+		// status.zone is the cluster-scoped AvailabilityZone name.
 		az := &topologyv1.AvailabilityZone{}
 		Expect(svClusterClient.Get(ctx, ctrlclient.ObjectKey{Name: zone}, az)).
 			To(Succeed(), "failed to get AvailabilityZone %s", zone)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

- Fixes a flaky failure in the vm-location E2E specs (VM-LOCATION … moved outside the namespace RP hierarchy) on multi-zone Supervisors.
- The test helper getNsRPAndFolder returned the RP/folder of the first Zone in the namespace's ZoneList (always zone-1, since client.List sorts by name) rather than the zone the VM was actually scheduled into. On a multi-zone Supervisor the namespace resource pool is per-zone (each zone has its own resgroup), while the folder is shared across zones. So when the scheduler placed the VM in zone-2/zone-3, the spec "restored" it to zone-1's RP — a location the controller correctly rejects — and VirtualMachineLocationValid never returned to True, timing out after 300s
```
[38;5;9mâ€¢ [FAILED] [398.771 seconds][0m
[0mTesting VM Services [38;5;243mVIRTUAL-MACHINE [0mVM-LOCATION [38;5;243mwhen VM is moved outside the namespace RP hierarchy [38;5;9m[1m[It] sets condition False, then recovers to True when VM is returned to the correct location[0m [38;5;204m[devops, viadmin, virtualmachine, vmservice, core-functional, experimental][0m
[38;5;243m/vm-operator/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go:260[0m

  [38;5;9m[FAILED] Timed out after 300.009s.
  Timed out waiting for Condition: {Type:VirtualMachineLocationValid Status:True ObservedGeneration:0 LastTransitionTime:0001-01-01 00:00:00 +0000 UTC Reason: Message:} on VirtualMachine: vm-location-lwh9
  The function passed to Eventually failed at /vm-operator/test/e2e/vmservice/lib/vmoperator/vmoperator.go:313 with:
  Expected
      <v1.ConditionStatus>: False
  to equal
      <v1.ConditionStatus>: True[0m
```
- This made the spec flaky: it passed only when placement happened to land the VM in zone-1, and failed otherwise. The Folder spec was unaffected because folders are zone-independent.

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #
vmop-3844

**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->
vm-operator-e2e-experimental-vds-ssv and  vm-operator-e2e-experimental-vds ran vm-location tests successfully

**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note

```