### PR TITLE
🌱 Promote VM suspend E2E test out of experimental

### DIFF
--- a/test/e2e/vmservice/vmservice/virtualmachine/virtualmachinelcm.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/virtualmachinelcm.go
@@ -386,7 +386,7 @@ func VMSpec(ctx context.Context, inputGetter func() VMSpecInput) {
 		vmoperator.WaitForVirtualMachinePowerState(ctx, config, svClusterClient, input.WCPNamespaceName, vmName, "PoweredOff")
 	})
 
-	Context("when suspending a VM", Label("core-functional", "experimental"), func() {
+	Context("when suspending a VM", Label("core-functional"), func() {
 		BeforeEach(func() {
 			By("Creating a powered on VirtualMachine to suspend")
 			vmParameters := manifestbuilders.VirtualMachineYaml{


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

Removes the experimental label from the "when suspending a VM" E2E test context in virtualmachinelcm.go, keeping only core-functional. This test has run succesfully on the UTS experimental run on hardware and no longer needs to be gated behind the experimental label.

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #
vmop-3579

**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note

```