### PR TITLE
Bound async create's getCreateArgs to stop lock leaks

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -174,6 +174,20 @@ type Config struct {
 	// Please note, this field has no effect if a CRD is being installed for the
 	// first time.
 	CRDCleanupEnabled bool
+
+	// AsyncCreateGetArgsTimeout bounds how long the synchronous,
+	// prerequisite-gathering phase of a non-blocking VM create (the call to
+	// getCreateArgs, which is made before the actual create is handed off to
+	// a background goroutine) is allowed to run.
+	//
+	// This phase can make both vCenter and Kubernetes API calls. Without a
+	// deadline, a stalled dependency (e.g. an overloaded API server) blocks
+	// the reconcile goroutine forever, which in turn permanently leaks the
+	// in-memory currentlyReconciling lock for that VM, wedging it in progress
+	// indefinitely.
+	//
+	// Defaults to 2 minutes.
+	AsyncCreateGetArgsTimeout time.Duration
 }
 
 // GetMaxDeployThreadsOnProvider returns MaxDeployThreadsOnProvider if it is >0

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -64,5 +64,6 @@ func Default() Config {
 		WebhookSecretNamespace:       defaultPrefix + "system",
 		WebhookSecretVolumeMountPath: "/etc/vmware/wcp/webhook-certs",
 		CRDCleanupEnabled:            false,
+		AsyncCreateGetArgsTimeout:    2 * time.Minute,
 	}
 }

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -34,6 +34,7 @@ func FromEnv() Config {
 	setString(env.FastDeployMode, &config.FastDeployMode)
 	setString(env.VCCredsSecretName, &config.VCCredsSecretName)
 	setBool(env.CRDCleanupEnabled, &config.CRDCleanupEnabled)
+	setDuration(env.AsyncCreateGetArgsTimeout, &config.AsyncCreateGetArgsTimeout)
 
 	setDuration(env.InstanceStoragePVPlacementFailedTTL, &config.InstanceStorage.PVPlacementFailedTTL)
 	setFloat64(env.InstanceStorageJitterMaxFactor, &config.InstanceStorage.JitterMaxFactor)

--- a/pkg/config/env/env.go
+++ b/pkg/config/env/env.go
@@ -51,6 +51,7 @@ const (
 	WebhookSecretName
 	WebhookSecretNamespace
 	CRDCleanupEnabled
+	AsyncCreateGetArgsTimeout
 	FSSInstanceStorage
 	FSSK8sWorkloadMgmtAPI
 	FSSPodVMOnStretchedSupervisor
@@ -169,6 +170,8 @@ func (n VarName) String() string {
 		return "WEBHOOK_SECRET_NAMESPACE"
 	case CRDCleanupEnabled:
 		return "CRD_CLEANUP_ENABLED"
+	case AsyncCreateGetArgsTimeout:
+		return "ASYNC_CREATE_GET_ARGS_TIMEOUT"
 
 	//
 	// Features/Capabilities

--- a/pkg/config/env_test.go
+++ b/pkg/config/env_test.go
@@ -112,6 +112,7 @@ var _ = Describe(
 					Expect(os.Setenv("DEPLOYMENT_NAME", "129")).To(Succeed())
 					Expect(os.Setenv("SIGUSR2_RESTART_ENABLED", "true")).To(Succeed())
 					Expect(os.Setenv("CRD_CLEANUP_ENABLED", "true")).To(Succeed())
+					Expect(os.Setenv("ASYNC_CREATE_GET_ARGS_TIMEOUT", "130h")).To(Succeed())
 				})
 				It("Should return a default config overridden by the environment", func() {
 					Expect(config).To(BeComparableTo(pkgcfg.Config{
@@ -150,6 +151,7 @@ var _ = Describe(
 						WebhookSecretNamespace:       "124",
 						WebhookSecretVolumeMountPath: pkgcfg.Default().WebhookSecretVolumeMountPath,
 						CRDCleanupEnabled:            true,
+						AsyncCreateGetArgsTimeout:    130 * time.Hour,
 						Features: pkgcfg.FeatureStates{
 							InstanceStorage:           false,
 							K8sWorkloadMgmtAPI:        true,

--- a/pkg/providers/vsphere/vmprovider_vm.go
+++ b/pkg/providers/vsphere/vmprovider_vm.go
@@ -291,14 +291,39 @@ func (vs *vSphereVMProvider) createOrUpdateVirtualMachine(
 		}
 	}()
 
-	createArgs, err := vs.getCreateArgs(vmCtx, client)
+	// Bound the synchronous, prerequisite-gathering phase of the non-blocking
+	// create with a deadline. getCreateArgs makes both vCenter and
+	// Kubernetes API calls; without a deadline, a stalled dependency (e.g. an
+	// overloaded API server) blocks this reconcile goroutine forever, which
+	// permanently leaks the currentlyReconciling lock for this VM.
+	//
+	// A separate VirtualMachineContext value is used here -- rather than
+	// mutating vmCtx.Context in place -- so the timeout does not leak into
+	// copyOfCtx/the goroutine spawned below. Since defer cancel() fires the
+	// instant this function returns (right after the "go" statement), if the
+	// goroutine's context inherited this deadline it would be canceled
+	// microseconds after the async create started.
+	getArgsCtx, cancel := context.WithTimeout(
+		ctx, pkgcfg.FromContext(vmCtx).AsyncCreateGetArgsTimeout)
+	defer cancel()
+
+	getArgsVMCtx := vmCtx
+	getArgsVMCtx.Context = getArgsCtx
+
+	createArgs, err := vs.getCreateArgs(getArgsVMCtx, client)
 	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return nil, fmt.Errorf("timed out gathering create args: %w", err)
+		}
 		return nil, err
 	}
 
 	// Create a copy of the context and replace its VM with a copy to
 	// ensure modifications in the goroutine below are not impacted or
 	// impact the operations above us in the call stack.
+	//
+	// copyOfCtx is derived from vmCtx (not getArgsVMCtx), so it retains the
+	// original, un-timed-out context for the async create goroutine.
 	copyOfCtx := vmCtx
 	copyOfCtx.VM = vmCtx.VM.DeepCopy()
 

--- a/pkg/providers/vsphere/vmprovider_vm_create_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_create_test.go
@@ -7,6 +7,7 @@ package vsphere_test
 import (
 	"context"
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -14,6 +15,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"github.com/vmware/govmomi/simulator"
 	"github.com/vmware/govmomi/vim25/mo"
@@ -285,6 +287,78 @@ func vmCreateTests() {
 					g.Expect(c.Reason).To(Equal("Error"))
 					g.Expect(c.Message).To(Equal("deploy error: ServerFaultCode: InvalidRequest"))
 				}).Should(Succeed())
+			})
+		})
+
+		// Regression coverage for the currentlyReconciling lock leaking
+		// forever when the synchronous, prerequisite-gathering phase of a
+		// non-blocking create (getCreateArgs) hangs, e.g. because a
+		// Kubernetes API call it depends on stalls.
+		When("gathering the create pre-reqs hangs past the configured timeout", func() {
+			var unblock chan struct{}
+
+			BeforeEach(func() {
+				unblock = make(chan struct{})
+
+				pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
+					config.AsyncCreateGetArgsTimeout = 200 * time.Millisecond
+				})
+			})
+
+			JustBeforeEach(func() {
+				// Simulate a stalled Kubernetes API server by blocking the
+				// Get call for the VM Class -- one of the first k8s calls
+				// made from getCreateArgs -- until either the context's
+				// deadline fires or the test unblocks it.
+				interceptedClient := interceptor.NewClient(
+					ctx.Client.(client.WithWatch),
+					interceptor.Funcs{
+						Get: func(
+							getCtx context.Context,
+							c client.WithWatch,
+							key client.ObjectKey,
+							obj client.Object,
+							opts ...client.GetOption) error {
+							if _, ok := obj.(*vmopv1.VirtualMachineClass); ok {
+								select {
+								case <-getCtx.Done():
+									return getCtx.Err()
+								case <-unblock:
+								}
+							}
+
+							return c.Get(getCtx, key, obj, opts...)
+						},
+					})
+
+				vmProvider = vsphere.NewVSphereVMProviderFromClient(
+					ctx, interceptedClient, ctx.Recorder)
+			})
+
+			AfterEach(func() {
+				close(unblock)
+			})
+
+			It("returns within the configured timeout and releases the create lock", func() {
+				timeout := pkgcfg.FromContext(ctx).AsyncCreateGetArgsTimeout
+
+				start := time.Now()
+				_, err := vmProvider.CreateOrUpdateVirtualMachineAsync(ctx, vm)
+				elapsed := time.Since(start)
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("timed out gathering create args"))
+
+				// The call must return promptly -- bounded by the configured
+				// timeout -- rather than hanging indefinitely.
+				Expect(elapsed).To(BeNumerically("<", timeout+30*time.Second))
+
+				// The critical assertion: currentlyReconciling must have been
+				// released. If the lock leaked, this second call for the
+				// same VM would be rejected with ErrReconcileInProgress
+				// forever instead of retrying the timed-out work.
+				_, err2 := vmProvider.CreateOrUpdateVirtualMachineAsync(ctx, vm)
+				Expect(err2).ToNot(MatchError(providers.ErrReconcileInProgress))
 			})
 		})
 	})


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Fixes a bug where a VirtualMachine's non-blocking ("async") create can get
permanently stuck holding the in-process `currentlyReconciling` lock, making
the VM unrecoverable — every subsequent create/update/delete attempt for it
bounces off `ErrReconcileInProgress` forever, even after the underlying
platform issue that triggered the stall has cleared.

Root cause: `createOrUpdateVirtualMachine`'s non-blocking path takes the
`currentlyReconciling` lock synchronously, then calls `getCreateArgs`
(vCenter + Kubernetes API calls) *before* ever spawning the background
create goroutine. Neither call has a context deadline, so a stalled
dependency (e.g. an overloaded API server) blocks the reconcile goroutine
indefinitely. Since the deferred cleanup that releases the lock only runs
when the function actually returns, a stuck `getCreateArgs` call means the
lock is held forever, regardless of how long the underlying stall itself
lasts.

This was root-caused from a real incident using a full support-bundle
investigation (vCenter task logs, Kubernetes object state, and etcd logs
showing a control-plane overload window) rather than from code inspection
alone — see the analysis for the precise evidence chain if useful for
review context.

Fix: wrap only the `getCreateArgs` call with a new, configurable
`pkgcfg.AsyncCreateGetArgsTimeout` (default 2 minutes). A separate
`VirtualMachineContext` value carries the bounded context so the timeout
cannot leak into the context handed to the create goroutine spawned
afterward — that goroutine keeps the original, un-timed-out context. On
timeout, the function returns a plain wrapped error (not a `RequeueError`),
so it flows through the controller's normal rate-limited backoff instead of
adding retry pressure onto an already-struggling control plane.

**Scope note:** the analogous call inside the spawned goroutine
(`createVirtualMachineAsync` → `vmlifecycle.CreateVirtualMachine`, the
actual vCenter create/clone) is deliberately left unbounded in this change.
The incident that surfaced this bug never reached that goroutine, so it's
not addressed here, and a single timeout value there risks aborting
legitimate multi-minute template clones/deploys — the right bound likely
differs per deploy mode (fast deploy vs. clone vs. content library) and
deserves its own follow-up rather than a value bolted onto this fix.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #

**Are there any special notes for your reviewer**:

- The critical test assertion is in `vmprovider_vm_create_test.go`,
  `"gathering the create pre-reqs hangs past the configured timeout"`: it
  blocks a `VirtualMachineClass` `Get` call past the configured timeout via
  `interceptor.NewClient`, then asserts (a) the call returns promptly with a
  "timed out gathering create args" error, and (b) — the assertion that
  actually catches the regression — a *second* call for the same VM does
  **not** get `ErrReconcileInProgress`, proving the lock was actually
  released rather than just observing an error come back.
- Please double check the context-scoping logic in
  `createOrUpdateVirtualMachine`: the timeout-bound context is applied to a
  copy (`getArgsVMCtx`) of the `VirtualMachineContext`, not to `vmCtx`
  in place, specifically so it doesn't leak into `copyOfCtx` and get handed
  to the async create goroutine (which would otherwise have its context
  cancelled microseconds after starting, since `defer cancel()` fires as
  soon as this function returns).

**Please add a release note if necessary**:

```release-note
Fix a bug where a VirtualMachine could get permanently stuck in a
"reconcile already in progress" state if a dependency stalled during
the prerequisite-gathering phase of a non-blocking VM create.
```
