### PR TITLE
e2e: Retry and validate WCP support bundle download

### DIFF
--- a/hack/e2e/collect-support-bundle.sh
+++ b/hack/e2e/collect-support-bundle.sh
@@ -201,7 +201,7 @@ if [[ -n "${SUPERVISOR_ID}" || -n "${CLUSTER_ID}" ]]; then
 
         _log "Downloading WCP support bundle from ${BUNDLE_URL}..."
         WCP_BUNDLE_PAYLOAD="{\"wcp-support-bundle-token\": \"${BUNDLE_TOKEN}\"}"
-        _bundle_http=$(curl -sk --max-time 600 -X POST \
+        _bundle_http=$(curl -sk --max-time 900 -X POST \
             -H 'Content-Type: application/json' \
             -d "${WCP_BUNDLE_PAYLOAD}" \
             "${BUNDLE_URL}" \
@@ -209,16 +209,28 @@ if [[ -n "${SUPERVISOR_ID}" || -n "${CLUSTER_ID}" ]]; then
             -w '%{http_code}')
         _curl_rc=$?
 
-        if [[ ${_curl_rc} -ne 0 ]]; then
+        # A structurally-valid tar is the authoritative success signal: bundle
+        # generation on VC can take long enough that curl's own --max-time
+        # elapses while tearing down the connection just after the body was
+        # fully written, yielding a nonzero curl exit (e.g. 28, "Operation
+        # timeout") and a printed HTTP code even though the file on disk is
+        # complete. Checking tar integrity first (rather than gating on curl's
+        # exit code) avoids discarding and needlessly re-generating a bundle
+        # that actually downloaded fine.
+        if tar -tf "${BUNDLE_OUT}" >/dev/null 2>&1; then
+            if [[ ${_curl_rc} -ne 0 ]]; then
+                _log "WCP support bundle downloaded and verified on attempt ${attempt}/${MAX_ATTEMPTS} (curl reported exit ${_curl_rc} but content is a valid tar)"
+            else
+                _log "WCP support bundle downloaded and verified on attempt ${attempt}/${MAX_ATTEMPTS}"
+            fi
+            DOWNLOAD_OK=true
+            break
+        elif [[ ${_curl_rc} -ne 0 ]]; then
             _warn "Attempt ${attempt}/${MAX_ATTEMPTS}: WCP support bundle download failed (curl exit ${_curl_rc})"
         elif [[ "${_bundle_http}" != "20"* ]]; then
             _warn "Attempt ${attempt}/${MAX_ATTEMPTS}: WCP support bundle download failed (HTTP ${_bundle_http})"
-        elif ! tar -tf "${BUNDLE_OUT}" >/dev/null 2>&1; then
-            _warn "Attempt ${attempt}/${MAX_ATTEMPTS}: downloaded WCP support bundle is truncated or not a valid tar"
         else
-            _log "WCP support bundle downloaded and verified on attempt ${attempt}/${MAX_ATTEMPTS}"
-            DOWNLOAD_OK=true
-            break
+            _warn "Attempt ${attempt}/${MAX_ATTEMPTS}: downloaded WCP support bundle is truncated or not a valid tar"
         fi
 
         rm -f "${BUNDLE_OUT}"

--- a/hack/e2e/collect-support-bundle.sh
+++ b/hack/e2e/collect-support-bundle.sh
@@ -133,8 +133,8 @@ if [[ "${_vc_session_http}" != "20"* || -z "${VC_SESSION}" || "${VC_SESSION}" ==
     exit 0
 fi
 
-BUNDLE_URL=""
-BUNDLE_TOKEN=""
+SUPERVISOR_ID=""
+CLUSTER_ID=""
 
 # ---------------------------------------------------------------------------
 # v2 API: supervisors endpoint (vSphere 8.0+)
@@ -143,47 +143,91 @@ SUPERVISOR_ID=$(curl -sk --max-time 30 -H "vmware-api-session-id: ${VC_SESSION}"
     "https://${VC_IP}/api/vcenter/namespace-management/supervisors" \
     | jq -r 'if type == "array" then .[0].supervisor // empty else empty end')
 
-if [[ -n "${SUPERVISOR_ID}" ]]; then
-    _log "Getting WCP bundle for supervisor ${SUPERVISOR_ID} (v2 API)..."
-    BUNDLE_INFO=$(curl -sk --max-time 30 -X POST \
-        -H "vmware-api-session-id: ${VC_SESSION}" \
-        "https://${VC_IP}/api/vcenter/namespace-management/supervisors/${SUPERVISOR_ID}/support-bundles")
-    BUNDLE_URL=$(echo "${BUNDLE_INFO}" | jq -r '.url // empty')
-    BUNDLE_TOKEN=$(echo "${BUNDLE_INFO}" | jq -r '.support_bundle_token.token // empty')
-else
+if [[ -z "${SUPERVISOR_ID}" ]]; then
     # ---------------------------------------------------------------------------
     # v1 fallback: clusters endpoint (pre-8.0)
     # ---------------------------------------------------------------------------
     CLUSTER_ID=$(curl -sk --max-time 30 -H "vmware-api-session-id: ${VC_SESSION}" \
         "https://${VC_IP}/api/vcenter/namespace-management/clusters" \
         | jq -r 'if type == "array" then .[0].cluster // empty else empty end')
-    if [[ -n "${CLUSTER_ID}" ]]; then
-        _log "Getting WCP bundle for cluster ${CLUSTER_ID} (v1 API)..."
-        BUNDLE_INFO=$(curl -sk --max-time 30 -X POST \
-            -H "vmware-api-session-id: ${VC_SESSION}" \
-            "https://${VC_IP}/api/vcenter/namespace-management/clusters/${CLUSTER_ID}/support-bundle" \
-            || echo '{}')
-        BUNDLE_URL=$(echo "${BUNDLE_INFO}" | jq -r '.url // empty')
-        BUNDLE_TOKEN=$(echo "${BUNDLE_INFO}" | jq -r '.wcp_support_bundle_token.token // empty')
-    else
-        _warn "No supervisor or cluster found on VC ${VC_IP}; skipping WCP bundle"
-    fi
+fi
+
+if [[ -z "${SUPERVISOR_ID}" && -z "${CLUSTER_ID}" ]]; then
+    _warn "No supervisor or cluster found on VC ${VC_IP}; skipping WCP bundle"
 fi
 
 # ---------------------------------------------------------------------------
-# Download the bundle
+# Request and download the bundle, with retries.
+#
+# The support-bundle token is single-use (VC discards it once a download is
+# attempted), so a retry must re-request a fresh bundle/token — it cannot
+# just re-download the previous URL. Each attempt is validated for both a
+# successful HTTP status and a structurally-intact tar before being accepted;
+# a truncated download (e.g. VC's own bundle-generation timing out mid-stream)
+# is otherwise silently treated as success because curl only reports failure
+# on transport-level errors, not on a short/incomplete 2xx response body.
 # ---------------------------------------------------------------------------
-if [[ -n "${BUNDLE_URL}" && -n "${BUNDLE_TOKEN}" ]]; then
-    _log "Downloading WCP support bundle from ${BUNDLE_URL}..."
-    WCP_BUNDLE_PAYLOAD="{\"wcp-support-bundle-token\": \"${BUNDLE_TOKEN}\"}"
-    curl -sk --max-time 600 -X POST \
-        -H 'Content-Type: application/json' \
-        -d "${WCP_BUNDLE_PAYLOAD}" \
-        "${BUNDLE_URL}" \
-        -o "${OUTPUT_DIR}/wcp-support-bundle.tar" \
-        || _warn "WCP support bundle download failed"
-else
-    _warn "Could not obtain WCP support bundle URL or token"
+BUNDLE_OUT="${OUTPUT_DIR}/wcp-support-bundle.tar"
+MAX_ATTEMPTS=3
+DOWNLOAD_OK=false
+
+if [[ -n "${SUPERVISOR_ID}" || -n "${CLUSTER_ID}" ]]; then
+    for attempt in $(seq 1 "${MAX_ATTEMPTS}"); do
+        BUNDLE_URL=""
+        BUNDLE_TOKEN=""
+
+        if [[ -n "${SUPERVISOR_ID}" ]]; then
+            _log "Getting WCP bundle for supervisor ${SUPERVISOR_ID} (v2 API), attempt ${attempt}/${MAX_ATTEMPTS}..."
+            BUNDLE_INFO=$(curl -sk --max-time 30 -X POST \
+                -H "vmware-api-session-id: ${VC_SESSION}" \
+                "https://${VC_IP}/api/vcenter/namespace-management/supervisors/${SUPERVISOR_ID}/support-bundles")
+            BUNDLE_URL=$(echo "${BUNDLE_INFO}" | jq -r '.url // empty')
+            BUNDLE_TOKEN=$(echo "${BUNDLE_INFO}" | jq -r '.support_bundle_token.token // empty')
+        else
+            _log "Getting WCP bundle for cluster ${CLUSTER_ID} (v1 API), attempt ${attempt}/${MAX_ATTEMPTS}..."
+            BUNDLE_INFO=$(curl -sk --max-time 30 -X POST \
+                -H "vmware-api-session-id: ${VC_SESSION}" \
+                "https://${VC_IP}/api/vcenter/namespace-management/clusters/${CLUSTER_ID}/support-bundle" \
+                || echo '{}')
+            BUNDLE_URL=$(echo "${BUNDLE_INFO}" | jq -r '.url // empty')
+            BUNDLE_TOKEN=$(echo "${BUNDLE_INFO}" | jq -r '.wcp_support_bundle_token.token // empty')
+        fi
+
+        if [[ -z "${BUNDLE_URL}" || -z "${BUNDLE_TOKEN}" ]]; then
+            _warn "Attempt ${attempt}/${MAX_ATTEMPTS}: could not obtain WCP support bundle URL or token"
+            sleep 5
+            continue
+        fi
+
+        _log "Downloading WCP support bundle from ${BUNDLE_URL}..."
+        WCP_BUNDLE_PAYLOAD="{\"wcp-support-bundle-token\": \"${BUNDLE_TOKEN}\"}"
+        _bundle_http=$(curl -sk --max-time 600 -X POST \
+            -H 'Content-Type: application/json' \
+            -d "${WCP_BUNDLE_PAYLOAD}" \
+            "${BUNDLE_URL}" \
+            -o "${BUNDLE_OUT}" \
+            -w '%{http_code}')
+        _curl_rc=$?
+
+        if [[ ${_curl_rc} -ne 0 ]]; then
+            _warn "Attempt ${attempt}/${MAX_ATTEMPTS}: WCP support bundle download failed (curl exit ${_curl_rc})"
+        elif [[ "${_bundle_http}" != "20"* ]]; then
+            _warn "Attempt ${attempt}/${MAX_ATTEMPTS}: WCP support bundle download failed (HTTP ${_bundle_http})"
+        elif ! tar -tf "${BUNDLE_OUT}" >/dev/null 2>&1; then
+            _warn "Attempt ${attempt}/${MAX_ATTEMPTS}: downloaded WCP support bundle is truncated or not a valid tar"
+        else
+            _log "WCP support bundle downloaded and verified on attempt ${attempt}/${MAX_ATTEMPTS}"
+            DOWNLOAD_OK=true
+            break
+        fi
+
+        rm -f "${BUNDLE_OUT}"
+        [[ ${attempt} -lt ${MAX_ATTEMPTS} ]] && sleep 15
+    done
+
+    if [[ "${DOWNLOAD_OK}" != true ]]; then
+        _warn "WCP support bundle download did not succeed after ${MAX_ATTEMPTS} attempts; leaving ${OUTPUT_DIR} without a bundle"
+    fi
 fi
 
 curl -sk -X DELETE \


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

`hack/e2e/collect-support-bundle.sh` downloads the WCP support bundle
with a single `curl` call that only reports failure on transport-level
errors (connection refused, DNS failure, timeout) — never on an HTTP
error status or a truncated response body. When VC's own support-bundle
generation endpoint fails or times out mid-stream while still returning
a 2xx response, the script silently accepts the truncated tar as a
successful download and always exits 0 regardless, so the truncation
goes unnoticed until someone actually opens the resulting bundle. This
was observed while triaging VCF_Smoke build 17579 (vmop-3977): the
support bundle for the failing testbed was truncated at the source, and
`container-collect-support-bundle.log` showed the collector's own
`WARNING: WCP support bundle download failed` line going unheeded.

This PR wraps the bundle request + download in a retry loop (3
attempts, 15s backoff). The support-bundle token is single-use, so each
retry re-requests a fresh bundle/token rather than re-fetching the same
stale URL. Each attempt is validated on `tar -tf` structural integrity
first (the authoritative signal — see "Proof of testing" below for why),
falling back to curl exit code / HTTP status only to explain a failed
attempt; a truncated/invalid download now triggers a retry instead of
being treated as success. `--max-time` is also raised from 600s to 900s
to give real multi-node bundle generation more headroom. The script
remains a best-effort diagnostic step — it still exits 0 after
exhausting all retries so a bad bundle never fails the e2e/teardown
pipeline, but the diagnostic artifact itself is now much more likely to
actually be usable when someone needs it.

**Which issue(s) is/are addressed by this PR?**

Fixes #

**Are there any special notes for your reviewer**:

No behavior change to the e2e/teardown pipeline's pass/fail outcome —
this only hardens the *diagnostic* bundle-collection step so it
produces a valid artifact more reliably. Related to vmop-3977.

**Proof of testing**:

Ran the script locally against a live testbed (`testbedInfo.json` for
UTS container 1102642, a 4-ESX WCP cluster, VC `10.161.3.90`), calling
it the same way CI does:

```
hack/e2e/collect-support-bundle.sh \
  --testbed-info-json ./testbedInfo.json \
  --output-dir ./out
```

- **First run** (before the `--max-time`/validation-order fix below)
  reproduced the original failure mode live: attempt 1's download hit
  `curl` exit 28 (timeout at 600s) while VC was still generating the
  bundle; attempts 2 and 3 then failed to get a fresh URL/token because
  VC's namespace-management API returned
  `"A download operation is already in progress for cluster ... domain-c9"`
  (confirmed directly via a manual `curl` to the
  `.../clusters/domain-c9/support-bundle` endpoint) — i.e. the prior
  in-flight generation was still holding VC's per-cluster lock. This is
  the same failure signature seen in the original incident, reproduced
  against a real testbed rather than inferred from logs.
- Manually re-requested a bundle once the lock cleared and timed a raw
  download: it completed in just under 600s with `HTTP 200` and a
  **structurally valid** tar (`tar -tf` succeeded, listing
  `kube_instance_detail.txt`, `master-vm-56.tgz`,
  `vc-support.tar.gz.FRAG-*`) — but curl still returned exit 28,
  because the connection teardown crossed the `--max-time` boundary a
  moment after the body was fully written. This showed the original
  fix's validation order (gating on curl's exit code before checking
  the tar) would have discarded a perfectly good download and forced an
  unnecessary retry — so `tar -tf` is now checked first, with curl
  exit/HTTP status used only to explain a *genuine* failure, and
  `--max-time` raised to 900s.
- **Final run** with both fixes applied: single attempt, clean exit 0,
  `WCP support bundle downloaded and verified on attempt 1/3`, producing
  a complete 124MB tar (8 `vc-support.tar.gz.FRAG-*` fragments, up from
  1 partial fragment in the original truncated 45MB bundle) that passed
  `tar -tf` validation. Wall-clock time for the full script (session
  auth → cluster lookup → bundle request → download → validation →
  session logout): 11m50s, consistent with the ~10-minute generation
  time observed manually.

**Please add a release note if necessary**:

```release-note
NONE
```
