### PR TITLE
🐛 Fix placement ready condition not updating during create

### DIFF
--- a/pkg/providers/vsphere/vmprovider_vm.go
+++ b/pkg/providers/vsphere/vmprovider_vm.go
@@ -1711,18 +1711,11 @@ func (vs *vSphereVMProvider) vmCreateDoPlacement(
 
 	defer func() {
 		if retErr != nil {
-			// processPlacementResult may already have set a more specific
-			// reason (e.g. ZoneMismatch); only fall back to the generic
-			// NotReady reason when the condition is not already False.
-			if !pkgcond.IsFalse(
+			pkgcond.MarkError(
 				vmCtx.VM,
-				vmopv1.VirtualMachineConditionPlacementReady) {
-				pkgcond.MarkError(
-					vmCtx.VM,
-					vmopv1.VirtualMachineConditionPlacementReady,
-					"NotReady",
-					retErr)
-			}
+				vmopv1.VirtualMachineConditionPlacementReady,
+				"NotReady",
+				retErr)
 		} else {
 			pkgcond.MarkTrue(
 				vmCtx.VM,
@@ -1925,29 +1918,20 @@ func processPlacementResult(
 	createArgs *VMCreateArgs,
 	result placement.Result) error {
 
-	isVksNodeVM := kubeutil.HasCAPILabels(vmCtx.VM.Labels)
 	// When VMAffinityDuringExecution is enabled, a zone-labeled non-VKS VM took
 	// part in group/DRS placement; the chosen zone must still match its pinned
 	// zone label. A mismatch means the VM would be relocated to a different
 	// zone, so block placement and surface a ZoneMismatch condition for the
 	// user to reconcile the label with the desired placement. VKS nodes and VMs
 	// without a zone label are unaffected.
-	if pkgcfg.FromContext(vmCtx).Features.VMAffinityDuringExecution {
+	if pkgcfg.FromContext(vmCtx).Features.VMAffinityDuringExecution &&
+		!kubeutil.HasCAPILabels(vmCtx.VM.Labels) {
+
 		if zoneLabel := vmCtx.VM.Labels[corev1.LabelTopologyZone]; zoneLabel != "" &&
-			!isVksNodeVM &&
-			result.ZoneName != "" &&
-			result.ZoneName != zoneLabel {
-
-			pkgcond.MarkFalse(
-				vmCtx.VM,
-				vmopv1.VirtualMachineConditionPlacementReady,
-				"ZoneMismatch",
-				"placement selected zone %q which differs from the VM zone label %q",
-				result.ZoneName, zoneLabel)
-
+			result.ZoneName != "" && result.ZoneName != zoneLabel {
 			return pkgerr.NoRequeueError{
 				Message: fmt.Sprintf(
-					"placement zone %q does not match VM zone label %q",
+					"placement selected zone %q which differs from the VM zone label %q",
 					result.ZoneName, zoneLabel),
 			}
 		}

--- a/pkg/providers/vsphere/vmprovider_vm.go
+++ b/pkg/providers/vsphere/vmprovider_vm.go
@@ -1753,22 +1753,11 @@ func (vs *vSphereVMProvider) vmCreateDoPlacement(
 
 	defer func() {
 		if retErr != nil {
-			// processPlacementResult may already have set a more specific
-			// reason (e.g. ZoneMismatch); only fall back to the generic
-			// NotReady reason when the condition is not already False.
-			// Update message (which may contain updated details) only
-			// when its the same "NotReady" reason.
-			if !pkgcond.IsFalse(
+			pkgcond.MarkError(
 				vmCtx.VM,
-				vmopv1.VirtualMachineConditionPlacementReady) ||
-				pkgcond.GetReason(vmCtx.VM,
-					vmopv1.VirtualMachineConditionPlacementReady) == "NotReady" {
-				pkgcond.MarkError(
-					vmCtx.VM,
-					vmopv1.VirtualMachineConditionPlacementReady,
-					"NotReady",
-					retErr)
-			}
+				vmopv1.VirtualMachineConditionPlacementReady,
+				"NotReady",
+				retErr)
 		} else {
 			pkgcond.MarkTrue(
 				vmCtx.VM,
@@ -1822,8 +1811,7 @@ func (vs *vSphereVMProvider) vmCreateDoPlacement(
 		if useGroupPlacement {
 			vmCtx.Logger.Info(
 				"Getting VM placement result from its group",
-				"groupName", vmCtx.VM.Spec.GroupName,
-			)
+				"groupName", vmCtx.VM.Spec.GroupName)
 
 			return vs.vmCreateDoPlacementByGroup(vmCtx, vcClient, createArgs)
 		}
@@ -1971,29 +1959,20 @@ func processPlacementResult(
 	createArgs *VMCreateArgs,
 	result placement.Result) error {
 
-	isVksNodeVM := kubeutil.HasCAPILabels(vmCtx.VM.Labels)
 	// When VMAffinityDuringExecution is enabled, a zone-labeled non-VKS VM took
 	// part in group/DRS placement; the chosen zone must still match its pinned
-	// zone label. A mismatch means the VM would be relocated to a different
-	// zone, so block placement and surface a ZoneMismatch condition for the
-	// user to reconcile the label with the desired placement. VKS nodes and VMs
-	// without a zone label are unaffected.
-	if pkgcfg.FromContext(vmCtx).Features.VMAffinityDuringExecution {
+	// zone label. A mismatch means the VM would be relocated to a different zone,
+	// so block placement and surface a condition for the user to reconcile the
+	// label with the desired placement. VKS nodes and VMs without a zone label
+	// are unaffected.
+	if pkgcfg.FromContext(vmCtx).Features.VMAffinityDuringExecution &&
+		!kubeutil.HasCAPILabels(vmCtx.VM.Labels) {
+
 		if zoneLabel := vmCtx.VM.Labels[corev1.LabelTopologyZone]; zoneLabel != "" &&
-			!isVksNodeVM &&
-			result.ZoneName != "" &&
-			result.ZoneName != zoneLabel {
-
-			pkgcond.MarkFalse(
-				vmCtx.VM,
-				vmopv1.VirtualMachineConditionPlacementReady,
-				"ZoneMismatch",
-				"placement selected zone %q which differs from the VM zone label %q",
-				result.ZoneName, zoneLabel)
-
+			result.ZoneName != "" && result.ZoneName != zoneLabel {
 			return pkgerr.NoRequeueError{
 				Message: fmt.Sprintf(
-					"placement zone %q does not match VM zone label %q",
+					"placement selected zone %q which differs from the VM zone label %q",
 					result.ZoneName, zoneLabel),
 			}
 		}

--- a/pkg/providers/vsphere/vmprovider_vm_group_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_group_test.go
@@ -520,16 +520,17 @@ func vmGroupTests() {
 						err := vmProvider.CreateOrUpdateVirtualMachine(ctx, vm)
 						Expect(err).To(HaveOccurred())
 						Expect(pkgerr.IsNoRequeueError(err)).To(BeTrue())
-						Expect(err.Error()).To(ContainSubstring("does not match VM zone label"))
+						Expect(err.Error()).To(ContainSubstring("which differs from the VM zone label"))
 
 						By("VM is not created", func() {
 							Expect(vm.Status.UniqueID).To(BeEmpty())
 						})
-						By("PlacementReady is False with ZoneMismatch reason", func() {
+						By("PlacementReady is False", func() {
 							c := conditions.Get(vm, vmopv1.VirtualMachineConditionPlacementReady)
 							Expect(c).ToNot(BeNil())
 							Expect(c.Status).To(Equal(metav1.ConditionFalse))
-							Expect(c.Reason).To(Equal("ZoneMismatch"))
+							Expect(c.Reason).To(Equal("NotReady"))
+							Expect(c.Message).To(ContainSubstring("which differs from the VM zone label"))
 						})
 					})
 				})

--- a/pkg/providers/vsphere/vmprovider_vm_group_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_group_test.go
@@ -459,20 +459,23 @@ func vmGroupTests() {
 						setGroupPlacementReady(groupZone)
 					})
 
-					It("should block placement with a ZoneMismatch condition", func() {
+					It("should block placement with a NotReady condition", func() {
+						const msg = "which differs from the VM zone label"
+
 						err := vmProvider.CreateOrUpdateVirtualMachine(ctx, vm)
 						Expect(err).To(HaveOccurred())
 						Expect(pkgerr.IsNoRequeueError(err)).To(BeTrue())
-						Expect(err.Error()).To(ContainSubstring("does not match VM zone label"))
+						Expect(err.Error()).To(ContainSubstring(msg))
 
 						By("VM is not created", func() {
 							Expect(vm.Status.UniqueID).To(BeEmpty())
 						})
-						By("PlacementReady is False with ZoneMismatch reason", func() {
+						By("PlacementReady is False", func() {
 							c := conditions.Get(vm, vmopv1.VirtualMachineConditionPlacementReady)
 							Expect(c).ToNot(BeNil())
 							Expect(c.Status).To(Equal(metav1.ConditionFalse))
-							Expect(c.Reason).To(Equal("ZoneMismatch"))
+							Expect(c.Reason).To(Equal("NotReady"))
+							Expect(c.Message).To(ContainSubstring(msg))
 						})
 					})
 				})


### PR DESCRIPTION

**What does this PR do, and why is it needed?**
The condition behavior changed in cec7bc58 meant that once the placement ready condition was false, the condition would not be updated even for different reasons and/or messages. This can cause confusion.

Remove the special ZoneMismatch reason and just NotReady with a specific message.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:


```release-note
NONE
```