### PR TITLE
🌱 Tighten E2E poll interval for VM wait helpers

### DIFF
--- a/test/e2e/vmservice/config/kind.yaml
+++ b/test/e2e/vmservice/config/kind.yaml
@@ -37,13 +37,13 @@ variables:
 intervals:
   # Please keep the wait-virtual-machine values in sync between the different
   # configuration files.
-  default/wait-virtual-machine-creation: ["5m", "10s"]
-  default/wait-virtual-machine-deletion: ["5m", "10s"]
-  default/wait-virtual-machine-condition-update: ["5m", "10s"]
-  default/wait-virtual-machine-powerstate: ["5m", "10s"]
-  default/wait-virtual-machine-resize: ["5m", "10s"]
-  default/wait-virtual-machine-moid: ["5m", "10s"]
-  default/wait-virtual-machine-vmip: ["5m", "10s"]
+  default/wait-virtual-machine-creation: ["5m", "3s"]
+  default/wait-virtual-machine-deletion: ["5m", "3s"]
+  default/wait-virtual-machine-condition-update: ["5m", "3s"]
+  default/wait-virtual-machine-powerstate: ["5m", "3s"]
+  default/wait-virtual-machine-resize: ["5m", "3s"]
+  default/wait-virtual-machine-moid: ["5m", "3s"]
+  default/wait-virtual-machine-vmip: ["5m", "3s"]
   default/wait-virtual-machine-image-creation: ["20s", "2s"]
   default/consistent-virtual-machine-condition: ["30s", "5s"]
   default/wait-virtual-machine-annotation-update: ["30s", "5s"]

--- a/test/e2e/vmservice/config/wcp.yaml
+++ b/test/e2e/vmservice/config/wcp.yaml
@@ -72,14 +72,14 @@ variables:
 intervals:
   # Please keep the wait-virtual-machine values in sync between the different
   # configuration files.
-  default/wait-virtual-machine-creation: ["5m", "10s"]
-  default/wait-virtual-machine-deletion: ["5m", "10s"]
-  default/wait-virtual-machine-condition-update: ["5m", "10s"]
-  default/wait-virtual-machine-powerstate: ["5m", "10s"]
-  default/wait-virtual-machine-resize: ["5m", "10s"]
-  default/wait-virtual-machine-moid: ["5m", "10s"]
-  default/wait-virtual-machine-restart-mode-update: ["2m", "10s"]
-  default/wait-virtual-machine-vmip: ["5m", "10s"]
+  default/wait-virtual-machine-creation: ["5m", "3s"]
+  default/wait-virtual-machine-deletion: ["5m", "3s"]
+  default/wait-virtual-machine-condition-update: ["5m", "3s"]
+  default/wait-virtual-machine-powerstate: ["5m", "3s"]
+  default/wait-virtual-machine-resize: ["5m", "3s"]
+  default/wait-virtual-machine-moid: ["5m", "3s"]
+  default/wait-virtual-machine-restart-mode-update: ["2m", "3s"]
+  default/wait-virtual-machine-vmip: ["5m", "3s"]
   default/wait-virtual-machine-service-endpoints: ["2m", "5s"]
   default/wait-virtual-machine-image-creation: ["10m", "5s"]
   default/consistent-virtual-machine-condition: ["30s", "5s"]


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Analysis of an e2e-smoke run showed ~359s (20.7%) of total spec runtime sitting inside Eventually-based waits for VM power-state and creation, with event-timeline deltas landing on multiples of 10s - the signature of the condition becoming true mid-interval but only being checked every 10s.

Tighten the poll interval from 10s to 3s for the default/wait-virtual-machine-* family in wcp.yaml and kind.yaml (creation, deletion, condition-update, powerstate, resize, moid, restart-mode-update, vmip), keeping the existing timeout ceilings unchanged. Each poll is a single cheap k8s GET, so this is low risk and should reclaim a meaningful fraction of the polling-boundary waste.

Basic smoke test passes

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # vmop-3998

**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:


```release-note
NONE
```