### PR TITLE
vmop-3766: Add VirtualMachineGuestOptions validation webhook

### DIFF
--- a/.sdd/memory/constitution.md
+++ b/.sdd/memory/constitution.md
@@ -1,7 +1,7 @@
 # Constitution: vm-operator Spec-Driven Development
 
 - **Repository**: [`github.com/vmware-tanzu/vm-operator`](https://github.com/vmware-tanzu/vm-operator)
-- **Last updated**: 2026-05-27
+- **Last updated**: 2026-07-30
 - **Applies to**: All feature specs under `.sdd/specs/`
 
 ---
@@ -171,7 +171,7 @@ The non-negotiables below are constitutional; for import aliases, import group o
 - Do not import packages forbidden by `.golangci.yml` `linters.settings.depguard` (`io/ioutil`, `github.com/pkg/errors`, `k8s.io/utils`, and `testing` / `github.com/onsi/ginkgo` / `github.com/onsi/gomega` outside `_test.go`).
 - `+optional` / `+required` markers on every struct field; `omitempty` JSON tags on optional fields.
 - Resource names must be DNS-subdomain safe (`^[a-z][a-z0-9-]{0,61}[a-z0-9]?$`).
-- Managed object IDs (`spec.id`) are immutable after create; enforce via webhook.
+- Managed object IDs (`spec.id`) are immutable after create. Enforce this per the CEL/Go split in the Webhooks section below: a plain `self == oldSelf` transition rule for the unconditional case, a webhook only when the immutability rule is conditional or cross-field.
 
 ## Roles referenced in specs
 

--- a/.sdd/specs/001-class-policy-resize/tasks.md
+++ b/.sdd/specs/001-class-policy-resize/tasks.md
@@ -33,14 +33,14 @@ Dependencies: none. All A-tasks may run in parallel `[P]`.
 - [x] T014 [S1.b] [PR #1667 / vmop-3748] Install the four `vim.vmware.com` CRDs (`ConfigTarget`, `VirtualMachineConfigOptions`, `VirtualMachineGuestOptions`, `VirtualMachineConfigPolicy`) via `config/crd/external-crds/` in the Supervisor chart
 - [x] T015a [S1.b] [PR #1667 / vmop-3748] Extend `config/rbac/role.yaml` with get/list/watch on `zones`
 - [x] T015b [S1.b] [PR #1695 / vmop-3740] Extend `config/rbac/role.yaml` with create/get/list/patch/update/watch on `configtargets` and `virtualmachineconfigpolicies`
-- [ ] T015c [S1.b] Extend `config/rbac/role.yaml` with create/get/list/patch/update/watch on `virtualmachineconfigoptions` and `virtualmachineguestoptions` — deferred to S6/S7 controller stories per commit `1698824b`
+- [x] T015c [S1.b] [PR #1672] Extend `config/rbac/role.yaml` with create/get/list/patch/update/watch on `virtualmachineconfigoptions` and `virtualmachineguestoptions` — landed alongside the VirtualMachineConfigOptions controller (S6) rather than as its own change; this checkbox was stale (RBAC already present before S7 started)
 
 ### Story S2 — Partner-facing integration doc (vmop-3739)
 
 - [ ] T020 [S2] Author `external/vim/doc/integration-guide.md` — pipeline diagram, role of each CRD, `ConfigTarget.status` capability surface (`maxHardwareVersion`, enriched `sriov`), per-host iteration inside the `ConfigTarget` controller, syncMode semantics, worked example of policy denial
 - [ ] T021 [S2] Link doc from public RTD site; review by PM and at least one downstream consumer team
 
-*Gate: T021 must be complete before Phase 2 code work begins.*
+*Gate (superseded): this originally required T021 complete before any Phase 2 code work began. In practice, S3/S5/S6 (and now S7) started and merged while T021 was still open, matching the Phase 2 header's actual rule ("S3/S6/S7/S8/S9 may begin after S1 is merged"). T021 remains a real, outstanding task — just not a blocking gate for the rest of Phase 2.*
 
 ---
 
@@ -88,10 +88,10 @@ Dependencies: none. All A-tasks may run in parallel `[P]`.
 
 ### Story S7 — VirtualMachineGuestOptions plumbing (vmop-3744)
 
-- [ ] T090 [S7.a] Author `webhooks/virtualmachineguestoptions/validation_webhook.go` — immutable spec.id; DNS-safe name
-- [ ] T091 [S7.a] Unit tests + RBAC + manifest registration
-- [ ] T092 [S7.b] [P] Integration tests with vcsim — `test/intg/virtualmachineguestoptions/`: two VirtualMachineConfigOptions (vmx-21, vmx-22) yield single VirtualMachineGuestOptions with two hardwareVersions listMap entries
-- [ ] T093 [S7.c] E2E test — at least one VirtualMachineGuestOptions materialised after install + zone creation
+- [x] T090 [S7.a] [vmop-3766] Author `webhooks/virtualmachineguestoptions/validation/virtualmachineguestoptions_validator.go` — immutable spec.id; metadata.name must equal the DNS-safe transform of spec.id (shared helper extracted to `pkg/util.VimGuestOptionsName`, also used by the S6 controller's fan-out); reject empty spec.id
+- [x] T091 [S7.a] [vmop-3766] Unit tests + manifest registration (`config/webhook/manifests.yaml` regenerated via `make generate-manifests`); RBAC was already present (see T015c) so no role.yaml change was needed
+- [x] T092 [S7.b] Integration tests with envtest — `webhooks/virtualmachineguestoptions/validation/virtualmachineguestoptions_validator_intg_test.go` (no separate `test/intg/` tree exists in this repo, per `testing-standards.md`). The two-hardware-versions-fan-into-one-GuestOptions scenario this task originally described is controller behavior, not webhook validation, and was already covered by S6's `controllers/virtualmachineconfigoptions/vmconfigoptions_controller_test.go` ("two VirtualMachineConfigOptions for different hardware versions report the same guest OS") — this checkbox was stale.
+- [x] T093 [S7.c] E2E test — already satisfied by S6's T086 (`test/e2e/vmservice/vmservice/configpolicy/configpolicy.go`, "Should fan out a VirtualMachineGuestOptions object for each guest OS reported by the cluster"); this checkbox was stale. No dedicated E2E test was added for the webhook's rejection paths (immutable spec.id, name/id mismatch, empty spec.id), consistent with S6's ConfigOptions webhook precedent — those rules have unit + envtest integration coverage only.
 
 ### Story S8 — VirtualMachineConfigPolicy controller (vmop-3745)
 

--- a/config/crd/external-crds/vim.vmware.com_virtualmachineguestoptions.yaml
+++ b/config/crd/external-crds/vim.vmware.com_virtualmachineguestoptions.yaml
@@ -49,6 +49,9 @@ spec:
                   ID is the desired guest ID for which to get the guest options,
                   ex.: OtherLinux64.
                 type: string
+                x-kubernetes-validations:
+                - message: id is immutable
+                  rule: self == oldSelf
             required:
             - id
             type: object

--- a/config/crd/external-crds/vim.vmware.com_virtualmachineguestoptions.yaml
+++ b/config/crd/external-crds/vim.vmware.com_virtualmachineguestoptions.yaml
@@ -52,6 +52,8 @@ spec:
                 x-kubernetes-validations:
                 - message: id is immutable
                   rule: self == oldSelf
+                - message: id must be provided
+                  rule: size(self) > 0
             required:
             - id
             type: object

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -268,6 +268,27 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /default-validate-vim-vmware-com-v1alpha1-virtualmachineguestoptions
+  failurePolicy: Fail
+  name: default.validating.virtualmachineguestoptions.v1alpha1.vim.vmware.com
+  rules:
+  - apiGroups:
+    - vim.vmware.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - virtualmachineguestoptions
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /default-validate-vmoperator-vmware-com-v1alpha6-virtualmachinepublishrequest
   failurePolicy: Fail
   name: default.validating.virtualmachinepublishrequest.v1alpha6.vmoperator.vmware.com

--- a/controllers/virtualmachineconfigoptions/vmconfigoptions_controller.go
+++ b/controllers/virtualmachineconfigoptions/vmconfigoptions_controller.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -34,6 +33,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/patch"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
 	"github.com/vmware-tanzu/vm-operator/pkg/record"
+	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
 )
 
 const (
@@ -63,13 +63,7 @@ const (
 // same name since Controller-Runtime has a global singleton registry to
 // prevent controllers with the same name, even if attached to different
 // managers.
-var (
-	SkipNameValidation *bool
-
-	// nonAlnumHyphenRE matches any character that is not a lowercase letter,
-	// digit, or hyphen.
-	nonAlnumHyphenRE = regexp.MustCompile(`[^a-z0-9-]+`)
-)
+var SkipNameValidation *bool
 
 var _ = SkipNameValidation
 
@@ -325,7 +319,7 @@ func (r *Reconciler) reconcileGuestOptions(
 	hardwareVersion string,
 	desc vimtypes.GuestOsDescriptor) error {
 
-	name := toGuestOptionsName(desc.Id)
+	name := pkgutil.VimGuestOptionsName(desc.Id)
 	hwStatus := buildHardwareVersionStatus(hardwareVersion, desc)
 
 	obj := &vimv1.VirtualMachineGuestOptions{
@@ -432,18 +426,5 @@ func buildHardwareVersionStatus(
 		s.RecommendedMem = q
 	}
 
-	return s
-}
-
-// toGuestOptionsName converts a guest OS identifier into a DNS-subdomain-safe
-// name for the corresponding VirtualMachineGuestOptions object.
-func toGuestOptionsName(guestID string) string {
-	s := strings.ToLower(guestID)
-	s = nonAlnumHyphenRE.ReplaceAllString(s, "-")
-	s = strings.Trim(s, "-")
-	if len(s) > 63 {
-		s = s[:63]
-		s = strings.TrimRight(s, "-")
-	}
 	return s
 }

--- a/external/vim/api/v1alpha1/virtualmachine_guest_options_types.go
+++ b/external/vim/api/v1alpha1/virtualmachine_guest_options_types.go
@@ -383,6 +383,7 @@ type VirtualMachineGuestOptionsHardwareVersionStatus struct {
 type VirtualMachineGuestOptionsSpec struct {
 	// +required
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="id is immutable"
+	// +kubebuilder:validation:XValidation:rule="size(self) > 0",message="id must be provided"
 
 	// ID is the desired guest ID for which to get the guest options,
 	// ex.: OtherLinux64.

--- a/external/vim/api/v1alpha1/virtualmachine_guest_options_types.go
+++ b/external/vim/api/v1alpha1/virtualmachine_guest_options_types.go
@@ -382,6 +382,7 @@ type VirtualMachineGuestOptionsHardwareVersionStatus struct {
 
 type VirtualMachineGuestOptionsSpec struct {
 	// +required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="id is immutable"
 
 	// ID is the desired guest ID for which to get the guest options,
 	// ex.: OtherLinux64.

--- a/pkg/util/vimguestoptions.go
+++ b/pkg/util/vimguestoptions.go
@@ -1,5 +1,5 @@
 // © Broadcom. All Rights Reserved.
-// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: Apache-2.0
 
 package util

--- a/pkg/util/vimguestoptions.go
+++ b/pkg/util/vimguestoptions.go
@@ -1,0 +1,28 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"regexp"
+	"strings"
+)
+
+// nonAlnumHyphenRE matches any character that is not a lowercase letter,
+// digit, or hyphen.
+var nonAlnumHyphenRE = regexp.MustCompile(`[^a-z0-9-]+`)
+
+// VimGuestOptionsName converts a guest OS identifier into the
+// DNS-subdomain-safe name used for the corresponding VirtualMachineGuestOptions
+// object's metadata.name.
+func VimGuestOptionsName(guestID string) string {
+	s := strings.ToLower(guestID)
+	s = nonAlnumHyphenRE.ReplaceAllString(s, "-")
+	s = strings.Trim(s, "-")
+	if len(s) > 63 {
+		s = s[:63]
+		s = strings.TrimRight(s, "-")
+	}
+	return s
+}

--- a/pkg/util/vimguestoptions_test.go
+++ b/pkg/util/vimguestoptions_test.go
@@ -1,5 +1,5 @@
 // © Broadcom. All Rights Reserved.
-// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: Apache-2.0
 
 package util_test

--- a/pkg/util/vimguestoptions_test.go
+++ b/pkg/util/vimguestoptions_test.go
@@ -1,0 +1,27 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package util_test
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/vmware-tanzu/vm-operator/pkg/util"
+)
+
+var _ = DescribeTable("VimGuestOptionsName",
+	func(in, out string) {
+		Expect(util.VimGuestOptionsName(in)).To(Equal(out))
+	},
+	Entry("already DNS-safe", "otherlinux64guest", "otherlinux64guest"),
+	Entry("mixed case", "otherLinux64Guest", "otherlinux64guest"),
+	Entry("spaces and punctuation", "Windows 11 (64-bit)", "windows-11-64-bit"),
+	Entry("leading and trailing invalid characters", "_Foo_", "foo"),
+	Entry("empty string", "", ""),
+	Entry("string longer than 63 characters", strings.Repeat("a", 70), strings.Repeat("a", 63)),
+	Entry("truncation lands on a hyphen", strings.Repeat("a", 62)+"-bcdef", strings.Repeat("a", 62)),
+)

--- a/test/builder/dummies.go
+++ b/test/builder/dummies.go
@@ -1018,6 +1018,23 @@ func DummyVirtualMachineConfigOptions(name, hardwareVersion string) *vimv1.Virtu
 	}
 }
 
+// DummyVirtualMachineGuestOptions returns a dummy VirtualMachineGuestOptions
+// with the given name and spec.id.
+func DummyVirtualMachineGuestOptions(name, id string) *vimv1.VirtualMachineGuestOptions {
+	return &vimv1.VirtualMachineGuestOptions{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "VirtualMachineGuestOptions",
+			APIVersion: vimv1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: vimv1.VirtualMachineGuestOptionsSpec{
+			ID: vimv1.VirtualMachineGuestOSIdentifier(id),
+		},
+	}
+}
+
 // DummyClassicVirtualMachineVolume returns a dummy VirtualMachineVolume for a classic disk.
 // Classic disks have controller placement information but no PersistentVolumeClaim source.
 func DummyClassicVirtualMachineVolume(

--- a/webhooks/virtualmachineguestoptions/validation/virtualmachineguestoptions_validator.go
+++ b/webhooks/virtualmachineguestoptions/validation/virtualmachineguestoptions_validator.go
@@ -84,7 +84,8 @@ func (v validator) ValidateDelete(_ *pkgctx.WebhookRequestContext) admission.Res
 }
 
 // ValidateUpdate validates updates to a VirtualMachineGuestOptions, enforcing
-// that spec.id is immutable.
+// that spec.id is immutable and re-running the base validations so an object
+// that predates this webhook is still caught if it is otherwise invalid.
 func (v validator) ValidateUpdate(ctx *pkgctx.WebhookRequestContext) admission.Response {
 	obj, err := v.vmGuestOptionsFromUnstructured(ctx.Obj)
 	if err != nil {
@@ -98,6 +99,8 @@ func (v validator) ValidateUpdate(ctx *pkgctx.WebhookRequestContext) admission.R
 
 	idPath := field.NewPath("spec", "id")
 	fieldErrs := validation.ValidateImmutableField(obj.Spec.ID, oldObj.Spec.ID, idPath)
+	fieldErrs = append(fieldErrs, v.validateID(string(obj.Spec.ID))...)
+	fieldErrs = append(fieldErrs, v.validateNameMatchesID(obj.Name, string(obj.Spec.ID))...)
 
 	validationErrs := make([]string, 0, len(fieldErrs))
 	for _, fieldErr := range fieldErrs {

--- a/webhooks/virtualmachineguestoptions/validation/virtualmachineguestoptions_validator.go
+++ b/webhooks/virtualmachineguestoptions/validation/virtualmachineguestoptions_validator.go
@@ -66,8 +66,7 @@ func (v validator) ValidateCreate(ctx *pkgctx.WebhookRequestContext) admission.R
 		return webhook.Errored(http.StatusBadRequest, err)
 	}
 
-	fieldErrs := v.validateID(string(obj.Spec.ID))
-	fieldErrs = append(fieldErrs, v.validateNameMatchesID(obj.Name, string(obj.Spec.ID))...)
+	fieldErrs := v.validateNameMatchesID(obj.Name, string(obj.Spec.ID))
 
 	validationErrs := make([]string, 0, len(fieldErrs))
 	for _, fieldErr := range fieldErrs {
@@ -82,17 +81,17 @@ func (v validator) ValidateDelete(_ *pkgctx.WebhookRequestContext) admission.Res
 	return admission.Allowed("")
 }
 
-// ValidateUpdate re-runs the base validations so a VirtualMachineGuestOptions
+// ValidateUpdate re-runs the base validation so a VirtualMachineGuestOptions
 // that predates this webhook is still caught if it is otherwise invalid.
-// spec.id immutability is enforced by the CRD's CEL transition rule.
+// spec.id immutability and non-emptiness are enforced by the CRD's CEL
+// rules.
 func (v validator) ValidateUpdate(ctx *pkgctx.WebhookRequestContext) admission.Response {
 	obj, err := v.vmGuestOptionsFromUnstructured(ctx.Obj)
 	if err != nil {
 		return webhook.Errored(http.StatusBadRequest, err)
 	}
 
-	fieldErrs := v.validateID(string(obj.Spec.ID))
-	fieldErrs = append(fieldErrs, v.validateNameMatchesID(obj.Name, string(obj.Spec.ID))...)
+	fieldErrs := v.validateNameMatchesID(obj.Name, string(obj.Spec.ID))
 
 	validationErrs := make([]string, 0, len(fieldErrs))
 	for _, fieldErr := range fieldErrs {
@@ -100,15 +99,6 @@ func (v validator) ValidateUpdate(ctx *pkgctx.WebhookRequestContext) admission.R
 	}
 
 	return common.BuildValidationResponse(ctx, nil, validationErrs, nil)
-}
-
-// validateID returns an error if spec.id is empty.
-func (v validator) validateID(id string) field.ErrorList {
-	if id == "" {
-		return field.ErrorList{field.Required(field.NewPath("spec", "id"), "id must be provided")}
-	}
-
-	return nil
 }
 
 // validateNameMatchesID returns an error if metadata.name does not equal the

--- a/webhooks/virtualmachineguestoptions/validation/virtualmachineguestoptions_validator.go
+++ b/webhooks/virtualmachineguestoptions/validation/virtualmachineguestoptions_validator.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"reflect"
 
-	"k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -83,23 +82,16 @@ func (v validator) ValidateDelete(_ *pkgctx.WebhookRequestContext) admission.Res
 	return admission.Allowed("")
 }
 
-// ValidateUpdate validates updates to a VirtualMachineGuestOptions, enforcing
-// that spec.id is immutable and re-running the base validations so an object
+// ValidateUpdate re-runs the base validations so a VirtualMachineGuestOptions
 // that predates this webhook is still caught if it is otherwise invalid.
+// spec.id immutability is enforced by the CRD's CEL transition rule.
 func (v validator) ValidateUpdate(ctx *pkgctx.WebhookRequestContext) admission.Response {
 	obj, err := v.vmGuestOptionsFromUnstructured(ctx.Obj)
 	if err != nil {
 		return webhook.Errored(http.StatusBadRequest, err)
 	}
 
-	oldObj, err := v.vmGuestOptionsFromUnstructured(ctx.OldObj)
-	if err != nil {
-		return webhook.Errored(http.StatusBadRequest, err)
-	}
-
-	idPath := field.NewPath("spec", "id")
-	fieldErrs := validation.ValidateImmutableField(obj.Spec.ID, oldObj.Spec.ID, idPath)
-	fieldErrs = append(fieldErrs, v.validateID(string(obj.Spec.ID))...)
+	fieldErrs := v.validateID(string(obj.Spec.ID))
 	fieldErrs = append(fieldErrs, v.validateNameMatchesID(obj.Name, string(obj.Spec.ID))...)
 
 	validationErrs := make([]string, 0, len(fieldErrs))

--- a/webhooks/virtualmachineguestoptions/validation/virtualmachineguestoptions_validator.go
+++ b/webhooks/virtualmachineguestoptions/validation/virtualmachineguestoptions_validator.go
@@ -1,0 +1,148 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package validation
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	vimv1 "github.com/vmware-tanzu/vm-operator/external/vim/api/v1alpha1"
+
+	"github.com/vmware-tanzu/vm-operator/pkg/builder"
+	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
+	"github.com/vmware-tanzu/vm-operator/webhooks/common"
+)
+
+const webHookName = "default"
+
+// +kubebuilder:webhook:verbs=create;update,path=/default-validate-vim-vmware-com-v1alpha1-virtualmachineguestoptions,mutating=false,failurePolicy=fail,groups=vim.vmware.com,resources=virtualmachineguestoptions,versions=v1alpha1,name=default.validating.virtualmachineguestoptions.v1alpha1.vim.vmware.com,sideEffects=None,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:rbac:groups=vim.vmware.com,resources=virtualmachineguestoptions,verbs=get;list
+// +kubebuilder:rbac:groups=vim.vmware.com,resources=virtualmachineguestoptions/status,verbs=get
+
+// AddToManager adds the webhook to the provided manager.
+func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) error {
+	hook, err := builder.NewValidatingWebhook(ctx, mgr, webHookName, NewValidator(mgr.GetClient()))
+	if err != nil {
+		return fmt.Errorf("failed to create VirtualMachineGuestOptions validation webhook: %w", err)
+	}
+
+	mgr.GetWebhookServer().Register(hook.Path, hook)
+
+	return nil
+}
+
+// NewValidator returns the package's Validator.
+func NewValidator(_ ctrlclient.Client) builder.Validator {
+	return validator{
+		converter: runtime.DefaultUnstructuredConverter,
+	}
+}
+
+type validator struct {
+	converter runtime.UnstructuredConverter
+}
+
+func (v validator) For() schema.GroupVersionKind {
+	return vimv1.GroupVersion.WithKind(reflect.TypeFor[vimv1.VirtualMachineGuestOptions]().Name())
+}
+
+// ValidateCreate validates a new VirtualMachineGuestOptions.
+func (v validator) ValidateCreate(ctx *pkgctx.WebhookRequestContext) admission.Response {
+	obj, err := v.vmGuestOptionsFromUnstructured(ctx.Obj)
+	if err != nil {
+		return webhook.Errored(http.StatusBadRequest, err)
+	}
+
+	fieldErrs := v.validateID(string(obj.Spec.ID))
+	fieldErrs = append(fieldErrs, v.validateNameMatchesID(obj.Name, string(obj.Spec.ID))...)
+
+	validationErrs := make([]string, 0, len(fieldErrs))
+	for _, fieldErr := range fieldErrs {
+		validationErrs = append(validationErrs, fieldErr.Error())
+	}
+
+	return common.BuildValidationResponse(ctx, nil, validationErrs, nil)
+}
+
+// ValidateDelete allows all delete requests.
+func (v validator) ValidateDelete(_ *pkgctx.WebhookRequestContext) admission.Response {
+	return admission.Allowed("")
+}
+
+// ValidateUpdate validates updates to a VirtualMachineGuestOptions, enforcing
+// that spec.id is immutable.
+func (v validator) ValidateUpdate(ctx *pkgctx.WebhookRequestContext) admission.Response {
+	obj, err := v.vmGuestOptionsFromUnstructured(ctx.Obj)
+	if err != nil {
+		return webhook.Errored(http.StatusBadRequest, err)
+	}
+
+	oldObj, err := v.vmGuestOptionsFromUnstructured(ctx.OldObj)
+	if err != nil {
+		return webhook.Errored(http.StatusBadRequest, err)
+	}
+
+	idPath := field.NewPath("spec", "id")
+	fieldErrs := validation.ValidateImmutableField(obj.Spec.ID, oldObj.Spec.ID, idPath)
+
+	validationErrs := make([]string, 0, len(fieldErrs))
+	for _, fieldErr := range fieldErrs {
+		validationErrs = append(validationErrs, fieldErr.Error())
+	}
+
+	return common.BuildValidationResponse(ctx, nil, validationErrs, nil)
+}
+
+// validateID returns an error if spec.id is empty.
+func (v validator) validateID(id string) field.ErrorList {
+	if id == "" {
+		return field.ErrorList{field.Required(field.NewPath("spec", "id"), "id must be provided")}
+	}
+
+	return nil
+}
+
+// validateNameMatchesID returns an error if metadata.name does not equal the
+// DNS-safe transform of spec.id.
+func (v validator) validateNameMatchesID(name, id string) field.ErrorList {
+	if id == "" {
+		return nil
+	}
+
+	if want := pkgutil.VimGuestOptionsName(id); name != want {
+		return field.ErrorList{field.Invalid(
+			field.NewPath("metadata", "name"),
+			name,
+			fmt.Sprintf("metadata.name must equal the DNS-safe transform of spec.id (%q)", want),
+		)}
+	}
+
+	return nil
+}
+
+// vmGuestOptionsFromUnstructured returns the VirtualMachineGuestOptions from
+// the unstructured object.
+func (v validator) vmGuestOptionsFromUnstructured(obj runtime.Unstructured) (*vimv1.VirtualMachineGuestOptions, error) {
+	vmgo := &vimv1.VirtualMachineGuestOptions{}
+
+	err := v.converter.FromUnstructured(obj.UnstructuredContent(), vmgo)
+	if err != nil {
+		return nil, err
+	}
+
+	return vmgo, nil
+}

--- a/webhooks/virtualmachineguestoptions/validation/virtualmachineguestoptions_validator_intg_test.go
+++ b/webhooks/virtualmachineguestoptions/validation/virtualmachineguestoptions_validator_intg_test.go
@@ -1,0 +1,170 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package validation_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	vimv1 "github.com/vmware-tanzu/vm-operator/external/vim/api/v1alpha1"
+
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+func intgTests() {
+	Describe(
+		"Create",
+		Label(
+			testlabels.Create,
+			testlabels.EnvTest,
+			testlabels.API,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		intgTestsValidateCreate,
+	)
+	Describe(
+		"Update",
+		Label(
+			testlabels.Update,
+			testlabels.EnvTest,
+			testlabels.API,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		intgTestsValidateUpdate,
+	)
+	Describe(
+		"Delete",
+		Label(
+			testlabels.Delete,
+			testlabels.EnvTest,
+			testlabels.API,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		intgTestsValidateDelete,
+	)
+}
+
+type intgValidatingWebhookContext struct {
+	builder.IntegrationTestContext
+
+	vmgo *vimv1.VirtualMachineGuestOptions
+}
+
+func newIntgValidatingWebhookContext() *intgValidatingWebhookContext {
+	ctx := &intgValidatingWebhookContext{
+		IntegrationTestContext: *suite.NewIntegrationTestContext(),
+	}
+
+	ctx.vmgo = builder.DummyVirtualMachineGuestOptions("otherlinux64guest", "otherLinux64Guest")
+
+	return ctx
+}
+
+func intgTestsValidateCreate() {
+	var (
+		ctx *intgValidatingWebhookContext
+	)
+
+	BeforeEach(func() {
+		ctx = newIntgValidatingWebhookContext()
+	})
+
+	AfterEach(func() {
+		_ = ctx.Client.Delete(ctx, ctx.vmgo)
+		ctx = nil
+	})
+
+	When("spec.id is provided and metadata.name matches its DNS-safe transform", func() {
+		It("should allow the request", func() {
+			Expect(ctx.Client.Create(ctx, ctx.vmgo)).To(Succeed())
+		})
+	})
+
+	When("spec.id is empty", func() {
+		BeforeEach(func() {
+			ctx.vmgo.Spec.ID = ""
+		})
+
+		It("should deny the request", func() {
+			err := ctx.Client.Create(ctx, ctx.vmgo)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("id must be provided"))
+		})
+	})
+
+	When("metadata.name does not equal the DNS-safe transform of spec.id", func() {
+		BeforeEach(func() {
+			ctx.vmgo.Name = "not-a-match"
+		})
+
+		It("should deny the request", func() {
+			err := ctx.Client.Create(ctx, ctx.vmgo)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("metadata.name must equal the DNS-safe transform of spec.id"))
+		})
+	})
+}
+
+func intgTestsValidateUpdate() {
+	var (
+		ctx *intgValidatingWebhookContext
+	)
+
+	BeforeEach(func() {
+		ctx = newIntgValidatingWebhookContext()
+		Expect(ctx.Client.Create(ctx, ctx.vmgo)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		Expect(ctx.Client.Delete(ctx, ctx.vmgo)).To(Succeed())
+		ctx = nil
+	})
+
+	When("spec.id is unchanged", func() {
+		It("should allow the update", func() {
+			Expect(ctx.Client.Update(ctx, ctx.vmgo)).To(Succeed())
+		})
+	})
+
+	When("spec.id is changed", func() {
+		BeforeEach(func() {
+			ctx.vmgo.Spec.ID = "dos"
+		})
+
+		It("should deny the update", func() {
+			err := ctx.Client.Update(ctx, ctx.vmgo)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("field is immutable"))
+		})
+	})
+}
+
+func intgTestsValidateDelete() {
+	var (
+		ctx *intgValidatingWebhookContext
+	)
+
+	BeforeEach(func() {
+		ctx = newIntgValidatingWebhookContext()
+	})
+
+	AfterEach(func() {
+		ctx = nil
+	})
+
+	When("delete is performed", func() {
+		BeforeEach(func() {
+			Expect(ctx.Client.Create(ctx, ctx.vmgo)).To(Succeed())
+		})
+
+		It("should allow the request", func() {
+			Expect(ctx.Client.Delete(ctx, ctx.vmgo)).To(Succeed())
+		})
+	})
+}

--- a/webhooks/virtualmachineguestoptions/validation/virtualmachineguestoptions_validator_intg_test.go
+++ b/webhooks/virtualmachineguestoptions/validation/virtualmachineguestoptions_validator_intg_test.go
@@ -138,9 +138,12 @@ func intgTestsValidateUpdate() {
 		})
 
 		It("should deny the update", func() {
+			// spec.id immutability is enforced by the CRD's CEL transition
+			// rule, so this rejection comes from the API server, not the
+			// webhook.
 			err := ctx.Client.Update(ctx, ctx.vmgo)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("field is immutable"))
+			Expect(err.Error()).To(ContainSubstring("id is immutable"))
 		})
 	})
 }

--- a/webhooks/virtualmachineguestoptions/validation/virtualmachineguestoptions_validator_suite_test.go
+++ b/webhooks/virtualmachineguestoptions/validation/virtualmachineguestoptions_validator_suite_test.go
@@ -1,0 +1,34 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package validation_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachineguestoptions/validation"
+)
+
+// suite is used for unit and integration testing this webhook.
+var suite = builder.NewTestSuiteForValidatingWebhookWithContext(
+	pkgcfg.WithConfig(pkgcfg.Config{
+		Features: pkgcfg.FeatureStates{
+			VirtualMachineConfigPolicy: true,
+		},
+	}),
+	validation.AddToManager,
+	validation.NewValidator,
+	"default.validating.virtualmachineguestoptions.v1alpha1.vim.vmware.com")
+
+func TestWebhook(t *testing.T) {
+	suite.Register(t, "VirtualMachineGuestOptions validation webhook suite", intgTests, unitTests)
+}
+
+var _ = BeforeSuite(suite.BeforeSuite)
+
+var _ = AfterSuite(suite.AfterSuite)

--- a/webhooks/virtualmachineguestoptions/validation/virtualmachineguestoptions_validator_unit_test.go
+++ b/webhooks/virtualmachineguestoptions/validation/virtualmachineguestoptions_validator_unit_test.go
@@ -122,9 +122,15 @@ func unitTestsValidateCreate() {
 		})
 	})
 
+	// spec.id non-emptiness is enforced by the CRD's CEL rule, not this
+	// webhook, so it cannot be exercised via a direct ValidateCreate call.
+	// See the intg suite for coverage of the CEL rejection through a real
+	// API server. An empty id short-circuits the name-match check below
+	// (there is no meaningful DNS-safe transform of ""), so the webhook
+	// itself allows this request and defers entirely to CEL.
 	When("spec.id is empty", func() {
-		It("should deny creation", func() {
-			validateCreate(createArgs{name: "", id: ""}, false, "id must be provided")
+		It("should allow creation, deferring to the CRD's CEL rule", func() {
+			validateCreate(createArgs{name: "", id: ""}, true, "")
 		})
 	})
 
@@ -187,22 +193,6 @@ func unitTestsValidateUpdate() {
 	When("spec.id is changed", func() {
 		It("should deny the update", func() {
 			validateUpdate(updateArgs{newID: "dos"}, false, "metadata.name must equal the DNS-safe transform of spec.id")
-		})
-	})
-
-	When("the object predates this webhook and was already invalid", func() {
-		It("should deny an update that leaves an empty spec.id unchanged", func() {
-			legacy := builder.DummyVirtualMachineGuestOptions("legacy-empty-id", "")
-			legacyObj, err := builder.ToUnstructured(legacy)
-			Expect(err).ToNot(HaveOccurred())
-
-			ctx = &unitValidatingWebhookContext{
-				UnitTestContextForValidatingWebhook: *suite.NewUnitTestContextForValidatingWebhook(legacyObj, legacyObj),
-			}
-
-			response := ctx.ValidateUpdate(&ctx.WebhookRequestContext)
-			Expect(response.Allowed).To(BeFalse())
-			Expect(string(response.Result.Reason)).To(ContainSubstring("id must be provided"))
 		})
 	})
 }

--- a/webhooks/virtualmachineguestoptions/validation/virtualmachineguestoptions_validator_unit_test.go
+++ b/webhooks/virtualmachineguestoptions/validation/virtualmachineguestoptions_validator_unit_test.go
@@ -177,9 +177,16 @@ func unitTestsValidateUpdate() {
 		})
 	})
 
+	// spec.id immutability is enforced by the CRD's CEL transition rule, not
+	// this webhook, so it cannot be exercised via a direct ValidateUpdate
+	// call. See the intg suite for coverage of the CEL rejection through a
+	// real API server. What remains testable here is the base
+	// re-validation this webhook still performs on update: a changed id
+	// whose DNS-safe transform no longer matches metadata.name is denied on
+	// that basis.
 	When("spec.id is changed", func() {
 		It("should deny the update", func() {
-			validateUpdate(updateArgs{newID: "dos"}, false, "field is immutable")
+			validateUpdate(updateArgs{newID: "dos"}, false, "metadata.name must equal the DNS-safe transform of spec.id")
 		})
 	})
 

--- a/webhooks/virtualmachineguestoptions/validation/virtualmachineguestoptions_validator_unit_test.go
+++ b/webhooks/virtualmachineguestoptions/validation/virtualmachineguestoptions_validator_unit_test.go
@@ -182,6 +182,22 @@ func unitTestsValidateUpdate() {
 			validateUpdate(updateArgs{newID: "dos"}, false, "field is immutable")
 		})
 	})
+
+	When("the object predates this webhook and was already invalid", func() {
+		It("should deny an update that leaves an empty spec.id unchanged", func() {
+			legacy := builder.DummyVirtualMachineGuestOptions("legacy-empty-id", "")
+			legacyObj, err := builder.ToUnstructured(legacy)
+			Expect(err).ToNot(HaveOccurred())
+
+			ctx = &unitValidatingWebhookContext{
+				UnitTestContextForValidatingWebhook: *suite.NewUnitTestContextForValidatingWebhook(legacyObj, legacyObj),
+			}
+
+			response := ctx.ValidateUpdate(&ctx.WebhookRequestContext)
+			Expect(response.Allowed).To(BeFalse())
+			Expect(string(response.Result.Reason)).To(ContainSubstring("id must be provided"))
+		})
+	})
 }
 
 func unitTestsValidateDelete() {

--- a/webhooks/virtualmachineguestoptions/validation/virtualmachineguestoptions_validator_unit_test.go
+++ b/webhooks/virtualmachineguestoptions/validation/virtualmachineguestoptions_validator_unit_test.go
@@ -1,0 +1,206 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package validation_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	vimv1 "github.com/vmware-tanzu/vm-operator/external/vim/api/v1alpha1"
+
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+func unitTests() {
+	Describe(
+		"Create",
+		Label(
+			testlabels.Create,
+			testlabels.API,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		unitTestsValidateCreate,
+	)
+	Describe(
+		"Update",
+		Label(
+			testlabels.Update,
+			testlabels.API,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		unitTestsValidateUpdate,
+	)
+	Describe(
+		"Delete",
+		Label(
+			testlabels.Delete,
+			testlabels.API,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		unitTestsValidateDelete,
+	)
+}
+
+type unitValidatingWebhookContext struct {
+	builder.UnitTestContextForValidatingWebhook
+
+	vmgo    *vimv1.VirtualMachineGuestOptions
+	oldVMGO *vimv1.VirtualMachineGuestOptions
+}
+
+func newUnitTestContextForValidatingWebhook(isUpdate bool) *unitValidatingWebhookContext {
+	vmgo := builder.DummyVirtualMachineGuestOptions("otherlinux64guest", "otherLinux64Guest")
+	obj, err := builder.ToUnstructured(vmgo)
+	Expect(err).ToNot(HaveOccurred())
+
+	var (
+		oldVMGO *vimv1.VirtualMachineGuestOptions
+		oldObj  *unstructured.Unstructured
+	)
+
+	if isUpdate {
+		oldVMGO = vmgo.DeepCopy()
+		oldObj, err = builder.ToUnstructured(oldVMGO)
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	return &unitValidatingWebhookContext{
+		UnitTestContextForValidatingWebhook: *suite.NewUnitTestContextForValidatingWebhook(obj, oldObj),
+		vmgo:                                vmgo,
+		oldVMGO:                             oldVMGO,
+	}
+}
+
+func unitTestsValidateCreate() {
+	var (
+		ctx *unitValidatingWebhookContext
+	)
+
+	type createArgs struct {
+		name string
+		id   string
+	}
+
+	validateCreate := func(args createArgs, expectedAllowed bool, expectedReason string) {
+		vmgo := builder.DummyVirtualMachineGuestOptions(args.name, args.id)
+		obj, err := builder.ToUnstructured(vmgo)
+		Expect(err).ToNot(HaveOccurred())
+
+		ctx.Obj = obj
+
+		response := ctx.ValidateCreate(&ctx.WebhookRequestContext)
+		Expect(response.Allowed).To(Equal(expectedAllowed))
+
+		if !expectedAllowed {
+			Expect(string(response.Result.Reason)).To(ContainSubstring(expectedReason))
+		}
+	}
+
+	BeforeEach(func() {
+		ctx = newUnitTestContextForValidatingWebhook(false)
+	})
+
+	AfterEach(func() {
+		ctx = nil
+	})
+
+	When("spec.id is provided and metadata.name matches its DNS-safe transform", func() {
+		It("should allow creation", func() {
+			validateCreate(createArgs{name: "otherlinux64guest", id: "otherLinux64Guest"}, true, "")
+		})
+
+		It("should allow creation when the id needs no transformation", func() {
+			validateCreate(createArgs{name: "dos", id: "dos"}, true, "")
+		})
+	})
+
+	When("spec.id is empty", func() {
+		It("should deny creation", func() {
+			validateCreate(createArgs{name: "", id: ""}, false, "id must be provided")
+		})
+	})
+
+	When("metadata.name does not equal the DNS-safe transform of spec.id", func() {
+		It("should deny creation", func() {
+			validateCreate(
+				createArgs{name: "not-a-match", id: "otherLinux64Guest"},
+				false,
+				"metadata.name must equal the DNS-safe transform of spec.id",
+			)
+		})
+	})
+}
+
+func unitTestsValidateUpdate() {
+	var (
+		ctx *unitValidatingWebhookContext
+	)
+
+	type updateArgs struct {
+		newID string
+	}
+
+	validateUpdate := func(args updateArgs, expectedAllowed bool, expectedReason string) {
+		vmgo := builder.DummyVirtualMachineGuestOptions("otherlinux64guest", args.newID)
+		obj, err := builder.ToUnstructured(vmgo)
+		Expect(err).ToNot(HaveOccurred())
+
+		ctx.Obj = obj
+
+		response := ctx.ValidateUpdate(&ctx.WebhookRequestContext)
+		Expect(response.Allowed).To(Equal(expectedAllowed))
+
+		if !expectedAllowed {
+			Expect(string(response.Result.Reason)).To(ContainSubstring(expectedReason))
+		}
+	}
+
+	BeforeEach(func() {
+		ctx = newUnitTestContextForValidatingWebhook(true)
+	})
+
+	AfterEach(func() {
+		ctx = nil
+	})
+
+	When("spec.id is unchanged", func() {
+		It("should allow the update", func() {
+			validateUpdate(updateArgs{newID: "otherLinux64Guest"}, true, "")
+		})
+	})
+
+	When("spec.id is changed", func() {
+		It("should deny the update", func() {
+			validateUpdate(updateArgs{newID: "dos"}, false, "field is immutable")
+		})
+	})
+}
+
+func unitTestsValidateDelete() {
+	var (
+		ctx *unitValidatingWebhookContext
+	)
+
+	BeforeEach(func() {
+		ctx = newUnitTestContextForValidatingWebhook(false)
+	})
+
+	AfterEach(func() {
+		ctx = nil
+	})
+
+	When("delete is performed", func() {
+		It("should always allow", func() {
+			response := ctx.ValidateDelete(&ctx.WebhookRequestContext)
+			Expect(response.Allowed).To(BeTrue())
+		})
+	})
+}

--- a/webhooks/virtualmachineguestoptions/webhooks.go
+++ b/webhooks/virtualmachineguestoptions/webhooks.go
@@ -1,0 +1,17 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package virtualmachineguestoptions
+
+import (
+	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
+
+	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachineguestoptions/validation"
+)
+
+// AddToManager adds the webhook to the provided manager.
+func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) error {
+	return validation.AddToManager(ctx, mgr)
+}

--- a/webhooks/webhooks.go
+++ b/webhooks/webhooks.go
@@ -20,6 +20,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachineconfigoptions"
 	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachinegroup"
 	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachinegrouppublishrequest"
+	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachineguestoptions"
 	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachinepublishrequest"
 	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachinereplicaset"
 	"github.com/vmware-tanzu/vm-operator/webhooks/virtualmachineservice"
@@ -86,6 +87,9 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) err
 		}
 		if err := configtarget.AddToManager(ctx, mgr); err != nil {
 			return fmt.Errorf("failed to initialize ConfigTarget webhooks: %w", err)
+		}
+		if err := virtualmachineguestoptions.AddToManager(ctx, mgr); err != nil {
+			return fmt.Errorf("failed to initialize VirtualMachineGuestOptions webhooks: %w", err)
 		}
 	}
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Adds the admission webhook for `VirtualMachineGuestOptions` (vmop-3766, Story S7 of vmop-3331):

- Rejects `spec.id` mutation after create (immutable) — enforced via a CEL rule on the CRD, see below.
- Rejects `spec.id` that is empty — also enforced via CEL.
- Rejects `metadata.name` that does not equal the DNS-safe transform of `spec.id` — enforced by this webhook.

The DNS-safe transform was previously private to the `VirtualMachineConfigOptions` controller, which fans out `VirtualMachineGuestOptions` objects and needs the same logic to name them. This PR extracts it to `pkg/util.VimGuestOptionsName` so the controller and the new webhook share one implementation instead of drifting.

RBAC for `virtualmachineguestoptions` was already present in `config/rbac/role.yaml` (landed with the `VirtualMachineConfigOptions` controller in PR #1672), so no RBAC change was needed; only the webhook admission path and its generated `config/webhook/manifests.yaml` entry are new.

While auditing `.sdd/specs/001-class-policy-resize/tasks.md` before starting, three checkboxes were found stale and corrected in the same change: T015c (RBAC already landed), T092 and T093 (already satisfied by Story S6's controller and E2E tests), and the Phase 1→2 gate note (which no longer matched what actually happened, since S3/S5/S6 already started and merged before the gate's stated condition was met).

**Constitution amendment (added after review):**

A review comment on this PR (@hpannem) asked whether `spec.id` immutability could use a `+kubebuilder:validation:XValidation` CEL rule instead of a Go webhook check. Investigating that surfaced a direct conflict in `.sdd/memory/constitution.md`:

- The Coding style section said: "Managed object IDs (`spec.id`) are immutable after create; enforce via webhook."
- The Webhooks section said: "CEL validation is preferred for simple structural rules; Go validation for complex, cross-field, or vSphere-data-dependent rules."

Plain, unconditional scalar immutability (no ratchet, no cross-field condition — unlike, e.g., `VirtualMachine.spec.minHardwareVersion`, which *is* Go because it's a ratcheted, power-state-conditional rule) is exactly what the second rule calls simple. This PR amends line 174 to defer to that general CEL/Go test instead of hardcoding the mechanism, and applies the result to `VirtualMachineGuestOptions`'s `spec.id`: immutability and non-emptiness both moved to CEL transition/validation rules on the CRD. `metadata.name` matching the DNS-safe transform of `spec.id` stays in this webhook, since that transform (lowercase, regex-collapse non-DNS-safe runs to a hyphen, trim, truncate to 63 chars) isn't expressible in CEL.

**Note on scope**: the sibling `configtarget` and `virtualmachineconfigoptions` webhooks have the exact same shape of checks (simple scalar immutability/format/name-match) and were already merged (#1711, #1672) before this constitution amendment landed. Retrofitting them to CEL — and, since CEL ends up covering their *entire* validators, removing both webhooks outright — is a separate follow-up PR rather than bundled into this one, to keep this PR's diff scoped to what its review comment was actually about.

**Which issue(s) is/are addressed by this PR?**

Fixes #

**Are there any special notes for your reviewer**:

- No new E2E test was added. The webhook's remaining admission-rejection path (name/id mismatch) has unit + envtest integration coverage; the CEL-enforced immutability and non-emptiness checks have envtest coverage exercising a real API server. `VirtualMachineGuestOptions` materialization is already covered by the existing E2E spec in `test/e2e/vmservice/vmservice/configpolicy/configpolicy.go` ("Should fan out a VirtualMachineGuestOptions object for each guest OS reported by the cluster").
- `config/webhook/manifests.yaml` was regenerated via `make generate-manifests`; `config/rbac/role.yaml` was unchanged by that run, confirming RBAC was already correct.
- `config/crd/external-crds/vim.vmware.com_virtualmachineguestoptions.yaml` was regenerated to add the two CEL rules.
- Verified via the intg/envtest suite that CEL fires before the webhook is even invoked for the immutability and empty-id rejections (no webhook `validation denied` log line on those specs).

**Please add a release note if necessary**:

```release-note
Add a validation webhook for VirtualMachineGuestOptions enforcing metadata.name matching the DNS-safe transform of spec.id. spec.id immutability and non-emptiness are enforced by the CRD's own CEL validation rules.
```
