### PR TITLE
🌱 Return NoRequeueError for more PVC errors

### DIFF
--- a/pkg/providers/vsphere/storage/storage.go
+++ b/pkg/providers/vsphere/storage/storage.go
@@ -9,10 +9,12 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+	pkgerr "github.com/vmware-tanzu/vm-operator/pkg/errors"
 	pkglog "github.com/vmware-tanzu/vm-operator/pkg/log"
 	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 )
@@ -92,8 +94,9 @@ func getVMStorageClassNamesAndPVCs(
 			pvc := &corev1.PersistentVolumeClaim{}
 			pvcKey := ctrlclient.ObjectKey{Name: claim.ClaimName, Namespace: vm.Namespace}
 			if err := client.Get(ctx, pvcKey, pvc); err != nil {
-				// TODO: If later we won't actually do placement, IMO this shouldn't be fatal. Need
-				// to rework the code a bit so this isn't as clunky.
+				if apierrors.IsNotFound(err) {
+					err = pkgerr.NoRequeueErrorf("%s", err.Error())
+				}
 				return nil, nil, err
 			}
 

--- a/pkg/providers/vsphere/storage/storage_test.go
+++ b/pkg/providers/vsphere/storage/storage_test.go
@@ -19,15 +19,16 @@ import (
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/storage"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 var _ = Describe("GetVMStorageData", func() {
 
 	var (
-		initObjects []client.Object
-		client      client.Client
+		initObjects  []client.Object
+		client       client.Client
+		storageClass *storagev1.StorageClass
+		pvc          *corev1.PersistentVolumeClaim
 
 		vmCtx pkgctx.VirtualMachineContext
 	)
@@ -39,6 +40,25 @@ var _ = Describe("GetVMStorageData", func() {
 			Logger:  logf.Log,
 			VM:      vm,
 		}
+
+		storageClass = &storagev1.StorageClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "my-class",
+			},
+			Parameters: map[string]string{
+				"storagePolicyID": "id1",
+			},
+		}
+
+		pvc = &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pvc1",
+				Namespace: vmCtx.VM.Namespace,
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				StorageClassName: new(storageClass.Name),
+			},
+		}
 	})
 
 	JustBeforeEach(func() {
@@ -49,51 +69,56 @@ var _ = Describe("GetVMStorageData", func() {
 		initObjects = nil
 	})
 
+	Context("VM StorageClass does not exist", func() {
+		BeforeEach(func() {
+			vmCtx.VM.Spec.StorageClass = storageClass.Name
+		})
+
+		It("returns error", func() {
+			_, err := storage.GetVMStorageData(vmCtx, client)
+			Expect(err).To(MatchError(`storageclasses.storage.k8s.io "my-class" not found`))
+		})
+	})
+
 	Context("VM with PVC", func() {
 		BeforeEach(func() {
-			storageClass := &storagev1.StorageClass{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "my-class",
-				},
-				Parameters: map[string]string{
-					"storagePolicyID": "id1",
-				},
-			}
 			initObjects = append(initObjects, storageClass)
-
-			pvc1 := &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pvc1",
-					Namespace: vmCtx.VM.Namespace,
-				},
-				Spec: corev1.PersistentVolumeClaimSpec{
-					StorageClassName: ptr.To(storageClass.Name),
-				},
-			}
-			initObjects = append(initObjects, pvc1)
 
 			vmCtx.VM.Spec.Volumes = append(vmCtx.VM.Spec.Volumes, vmopv1.VirtualMachineVolume{
 				Name: "volume1",
 				VirtualMachineVolumeSource: vmopv1.VirtualMachineVolumeSource{
 					PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
 						PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
-							ClaimName: pvc1.Name,
+							ClaimName: pvc.Name,
 						},
 					},
 				},
 			})
 		})
 
-		It("returns success", func() {
-			data, err := storage.GetVMStorageData(vmCtx, client)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(data).ToNot(BeNil())
-			Expect(data.StorageClasses).To(HaveLen(1))
-			Expect(data.StorageClasses).To(HaveKey("my-class"))
-			Expect(data.StorageClassToPolicyID).To(HaveLen(1))
-			Expect(data.StorageClassToPolicyID).To(HaveKeyWithValue("my-class", "id1"))
-			Expect(data.PVCs).To(HaveLen(1))
-			Expect(data.PVCs[0].Name).To(Equal("pvc1"))
+		When("PVC does not exist", func() {
+			It("returns error", func() {
+				_, err := storage.GetVMStorageData(vmCtx, client)
+				Expect(err).To(MatchError(`persistentvolumeclaims "pvc1" not found`))
+			})
+		})
+
+		When("PVC exists", func() {
+			BeforeEach(func() {
+				initObjects = append(initObjects, pvc)
+			})
+
+			It("returns success", func() {
+				data, err := storage.GetVMStorageData(vmCtx, client)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(data).ToNot(BeNil())
+				Expect(data.StorageClasses).To(HaveLen(1))
+				Expect(data.StorageClasses).To(HaveKey("my-class"))
+				Expect(data.StorageClassToPolicyID).To(HaveLen(1))
+				Expect(data.StorageClassToPolicyID).To(HaveKeyWithValue("my-class", "id1"))
+				Expect(data.PVCs).To(HaveLen(1))
+				Expect(data.PVCs[0].Name).To(Equal("pvc1"))
+			})
 		})
 	})
 })

--- a/pkg/providers/vsphere/vmprovider_vm.go
+++ b/pkg/providers/vsphere/vmprovider_vm.go
@@ -2330,7 +2330,7 @@ func (vs *vSphereVMProvider) vmCreateGetPrereqs(
 	// is no point in continuing if the above checks aren't met since we are missing data
 	// required to create the VM.
 	if len(prereqErrs) > 0 {
-		return nil, apierrorsutil.NewAggregate(prereqErrs)
+		return nil, errors.Join(prereqErrs...)
 	}
 
 	if !vmopv1util.IsClasslessVM(*vmCtx.VM) {

--- a/pkg/util/kube/storage.go
+++ b/pkg/util/kube/storage.go
@@ -25,6 +25,7 @@ import (
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 	infrav1 "github.com/vmware-tanzu/vm-operator/external/infra/api/v1alpha1"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
+	pkgerr "github.com/vmware-tanzu/vm-operator/pkg/errors"
 	pkglog "github.com/vmware-tanzu/vm-operator/pkg/log"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/internal"
 )
@@ -115,7 +116,7 @@ func GetPVCZoneConstraints(
 
 			if isImmediate {
 				// Must wait for this PVC to get bound so we know its accessible zones.
-				return nil, fmt.Errorf("PVC %s is not bound", pvc.Name)
+				return nil, pkgerr.NoRequeueErrorf("PVC %s is not bound", pvc.Name)
 			}
 
 			z = getPVCRequestedZones(pvc)


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

After 5e54618 in which the VM controller watches PVCs and will reconcile VMs when a PVC it references is updated, we can return NoRequeueErrors for when the PVC doesn't exist or is not bound, and the watch will take care of reconciling the VM.

ResultFromError() uses errors.As() to determine the wrapped error so we cannot use k8s Aggregate since it does not implement As(), so switch to use errors.Join().

Remove a stale TODO comment about not doing placement: this is called during VM create, and with other changes we basically always do some form of placement.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:

```release-note
NONE
```