### PR TITLE
Add VirtualMachineConfigPolicy sync controller

### DIFF
--- a/.sdd/specs/001-class-policy-resize/tasks.md
+++ b/.sdd/specs/001-class-policy-resize/tasks.md
@@ -98,11 +98,21 @@ Dependencies: none. All A-tasks may run in parallel `[P]`.
 - [ ] T100 [S8.a] Author `webhooks/virtualmachineconfigpolicy/defaulting_webhook.go` — default syncMode=ConfigTarget, createMode/updateMode/powerOnMode=Allow, vmClassMode=AsPolicy
 - [ ] T101 [S8.a] Author `webhooks/virtualmachineconfigpolicy/validation_webhook.go` — spec.zone references existing Zone; extraConfig allowed/denied entries have non-empty key and valid type enum
 - [ ] T102 [S8.a] Unit tests — `webhooks/virtualmachineconfigpolicy/`
-- [ ] T103 [S8.b] Author `controllers/virtualmachineconfigpolicy/vmconfigpolicy_controller.go` — syncMode=ConfigTarget: copy ConfigTarget.status → policy spec; syncMode=Disabled: set Ready=True, skip sync; never overwrite extraConfig/latencySensitivityLevels/txRxThreadModels
-- [ ] T104 [S8.b] Author `pkg/vmconfig/policy/policy_reconciler.go` — ConfigTarget→policy sync field mapping logic (separate from controller for unit testability)
-- [ ] T105 [S8.b] Unit tests — `pkg/vmconfig/policy/policy_reconciler_test.go`
-- [ ] T106 [S8.c] [P] Integration tests with vcsim — `test/intg/virtualmachineconfigpolicy/`: syncMode=ConfigTarget happy path; syncMode=Disabled skip; missing ConfigTarget → condition; multi-cluster zone selects correct ConfigTarget
-- [ ] T107 [S8.d] E2E test — policy spec filled from real cluster capabilities after Zone creation
+- [x] T103 [S8.b] [vmop-3745] Author `controllers/virtualmachineconfigpolicy/vmconfigpolicy_controller.go` — syncMode=ConfigTarget: copy ConfigTarget.status → policy spec; syncMode=Disabled: set Ready=True (reason SyncDisabled), skip sync; never overwrite extraConfig/latencySensitivityLevels/txRxThreadModels. spec.zone not resolving to a live Zone surfaces Ready=False/ZoneNotFound rather than blocking other policies, per spec.md's edge-case note — the complement to the validation webhook's create/update-time check.
+- [x] T104 [S8.b] [vmop-3745] Author `pkg/util/configpolicysync/configpolicysync.go` — ConfigTarget→policy sync field mapping logic (separate from controller for unit testability). Multi-cluster zones merge by intersection (min of numeric maxima, AND of boolean flags, common ConfigTargetDevices entries), per vmop-3746's acceptance criteria.
+- [x] T105 [S8.b] [vmop-3745] Unit tests — `pkg/util/configpolicysync/configpolicysync_test.go`; `controllers/virtualmachineconfigpolicy/vmconfigpolicy_controller_test.go` covers the controller's Disabled/ZoneNotFound/ConfigTargetNotFound/toggle/hot-loop-regression paths with a fake client.
+- [x] T106 [S8.c] [vmop-3745] Integration tests — co-located in `controllers/virtualmachineconfigpolicy/vmconfigpolicy_controller_test.go` as a second `Describe` (Label `EnvTest`+`VCSim`, per `testing-standards.md`'s single-file-per-package convention, not a `test/intg/` tree): syncMode=ConfigTarget happy path against a real vcsim-derived ConfigTarget; missing ConfigTarget → condition.
+- [x] T107 [S8.d] [vmop-3745] E2E test — extended `test/e2e/vmservice/vmservice/configpolicy/configpolicy.go`'s existing `Spec()`: policy spec (numCPUCores, memory) filled from the zone's real ConfigTarget after Zone creation; toggling syncMode=Disabled stops spec changes. Labeled `experimental` pending validation on real hardware, per `e2e-testing.md`.
+
+  > Implementation note: T104's path was changed from `pkg/vmconfig/policy/`
+  > to `pkg/util/configpolicysync/` — `pkg/vmconfig/policy/` already exists
+  > and implements unrelated per-VM tag/PolicyEvaluation reconciliation
+  > (`Reconcile(ctx, k8sClient, vimClient, vm)`), and `pkg/util/configpolicy`
+  > is reserved for the enforcement-side matching logic PR #1738 introduces
+  > for Story S9. T106's vcsim coverage is folded into the controller's own
+  > test file rather than a `test/intg/` directory, matching
+  > `testing-standards.md` and the `configtarget` controller's precedent
+  > (`controllers/configtarget/configtarget_controller_test.go`).
 
 ### Story S9 — VM admission webhook enforcement (vmop-3746)
 

--- a/.sdd/specs/001-class-policy-resize/tasks.md
+++ b/.sdd/specs/001-class-policy-resize/tasks.md
@@ -104,15 +104,7 @@ Dependencies: none. All A-tasks may run in parallel `[P]`.
 - [x] T106 [S8.c] [vmop-3745] Integration tests — co-located in `controllers/virtualmachineconfigpolicy/vmconfigpolicy_controller_test.go` as a second `Describe` (Label `EnvTest`+`VCSim`, per `testing-standards.md`'s single-file-per-package convention, not a `test/intg/` tree): syncMode=ConfigTarget happy path against a real vcsim-derived ConfigTarget; missing ConfigTarget → condition.
 - [x] T107 [S8.d] [vmop-3745] E2E test — extended `test/e2e/vmservice/vmservice/configpolicy/configpolicy.go`'s existing `Spec()`: policy spec (numCPUCores, memory) filled from the zone's real ConfigTarget after Zone creation; toggling syncMode=Disabled stops spec changes. Labeled `experimental` pending validation on real hardware, per `e2e-testing.md`.
 
-  > Implementation note: T104's path was changed from `pkg/vmconfig/policy/`
-  > to `pkg/util/configpolicysync/` — `pkg/vmconfig/policy/` already exists
-  > and implements unrelated per-VM tag/PolicyEvaluation reconciliation
-  > (`Reconcile(ctx, k8sClient, vimClient, vm)`), and `pkg/util/configpolicy`
-  > is reserved for the enforcement-side matching logic PR #1738 introduces
-  > for Story S9. T106's vcsim coverage is folded into the controller's own
-  > test file rather than a `test/intg/` directory, matching
-  > `testing-standards.md` and the `configtarget` controller's precedent
-  > (`controllers/configtarget/configtarget_controller_test.go`).
+  > Implementation note: T104's path was changed from `pkg/vmconfig/policy/` to `pkg/util/configpolicysync/` — `pkg/vmconfig/policy/` already exists and implements unrelated per-VM tag/PolicyEvaluation reconciliation (`Reconcile(ctx, k8sClient, vimClient, vm)`), and `pkg/util/configpolicy` is reserved for the enforcement-side matching logic PR #1738 introduces for Story S9. T106's vcsim coverage is folded into the controller's own test file rather than a `test/intg/` directory, matching `testing-standards.md` and the `configtarget` controller's precedent (`controllers/configtarget/configtarget_controller_test.go`).
 
 ### Story S9 — VM admission webhook enforcement (vmop-3746)
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -282,6 +282,7 @@ rules:
   resources:
   - configtargets
   - virtualmachineconfigoptions
+  - virtualmachineconfigpolicies
   - virtualmachineguestoptions
   verbs:
   - create
@@ -296,22 +297,12 @@ rules:
   resources:
   - configtargets/status
   - virtualmachineconfigoptions/status
+  - virtualmachineconfigpolicies/status
   - virtualmachineguestoptions/status
   verbs:
   - get
   - patch
   - update
-- apiGroups:
-  - vim.vmware.com
-  resources:
-  - virtualmachineconfigpolicies
-  verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
-  - watch
 - apiGroups:
   - vmoperator.vmware.com
   resources:

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachine"
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachineclass"
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachineconfigoptions"
+	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachineconfigpolicy"
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachinegroup"
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachinegrouppublishrequest"
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachineimagecache"
@@ -101,6 +102,9 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		}
 		if err := virtualmachineconfigoptions.AddToManager(ctx, mgr); err != nil {
 			return fmt.Errorf("failed to initialize VirtualMachineConfigOptions controller: %w", err)
+		}
+		if err := virtualmachineconfigpolicy.AddToManager(ctx, mgr); err != nil {
+			return fmt.Errorf("failed to initialize VirtualMachineConfigPolicy controller: %w", err)
 		}
 	}
 

--- a/controllers/virtualmachineconfigpolicy/vmconfigpolicy_controller.go
+++ b/controllers/virtualmachineconfigpolicy/vmconfigpolicy_controller.go
@@ -62,8 +62,17 @@ const (
 	ZoneNotFoundReason = "ZoneNotFound"
 
 	// ConfigTargetNotFoundReason is the Ready condition reason used when
-	// none of the zone's cluster MoIDs resolve to an existing ConfigTarget.
+	// the zone has no cluster MoIDs to sync from.
 	ConfigTargetNotFoundReason = "ConfigTargetNotFound"
+
+	// ConfigTargetNotReadyReason is the Ready condition reason used when
+	// one or more of the zone's cluster MoIDs do not resolve to a Ready
+	// ConfigTarget. spec is left untouched in this case: a ConfigTarget
+	// with Ready!=True has not finished populating its status, and merging
+	// its zero-valued fields would publish a false capability denial rather
+	// than "unknown," since a zero maximum on a numeric field means "not
+	// supported" per VirtualMachineConfigPolicySpec's doc comments.
+	ConfigTargetNotReadyReason = "ConfigTargetNotReady"
 )
 
 // SkipNameValidation is used for testing to allow multiple controllers with the
@@ -294,6 +303,7 @@ func (r *Reconciler) ReconcileNormal(
 		if apierrors.IsNotFound(err) {
 			pkgcond.MarkFalse(obj, vimv1.ReadyConditionType, ZoneNotFoundReason,
 				"zone %q not found", obj.Spec.Zone)
+			obj.Status.ObservedGeneration = obj.Generation
 
 			return nil
 		}
@@ -303,15 +313,30 @@ func (r *Reconciler) ReconcileNormal(
 		return fmt.Errorf("failed to get zone %q: %w", obj.Spec.Zone, err)
 	}
 
-	targets, err := r.getConfigTargets(ctx, zone.Spec.ManagedVMs.ClusterMoIDs)
+	if len(zone.Spec.ManagedVMs.ClusterMoIDs) == 0 {
+		pkgcond.MarkFalse(obj, vimv1.ReadyConditionType, ConfigTargetNotFoundReason,
+			"zone %q has no cluster to sync from", zone.Name)
+		obj.Status.ObservedGeneration = obj.Generation
+
+		return nil
+	}
+
+	targets, notReady, err := r.getConfigTargets(ctx, zone.Spec.ManagedVMs.ClusterMoIDs)
 	if err != nil {
-		pkgcond.MarkError(obj, vimv1.ReadyConditionType, ConfigTargetNotFoundReason, err)
+		pkgcond.MarkError(obj, vimv1.ReadyConditionType, ConfigTargetNotReadyReason, err)
 		return fmt.Errorf("failed to get config targets for zone %q: %w", zone.Name, err)
 	}
 
-	if len(targets) == 0 {
-		pkgcond.MarkFalse(obj, vimv1.ReadyConditionType, ConfigTargetNotFoundReason,
-			"no ConfigTarget found for zone %q", zone.Name)
+	if len(notReady) > 0 {
+		// Require every cluster behind the zone to have a Ready
+		// ConfigTarget before syncing: merging a subset would compute an
+		// intersection over fewer clusters than the zone actually spans,
+		// which is a strictly wider (more permissive) result than the true
+		// intersection -- the opposite of the safe direction for data that
+		// feeds capability enforcement.
+		pkgcond.MarkFalse(obj, vimv1.ReadyConditionType, ConfigTargetNotReadyReason,
+			"ConfigTarget(s) not ready for cluster(s) %v", notReady)
+		obj.Status.ObservedGeneration = obj.Generation
 
 		return nil
 	}
@@ -331,31 +356,41 @@ func (r *Reconciler) ReconcileNormal(
 }
 
 // getConfigTargets returns the ConfigTarget status of every clusterMoID that
-// resolves to an existing ConfigTarget. A clusterMoID with no matching
-// ConfigTarget is skipped rather than treated as an error: today a zone
-// maps to a single vSphere cluster in practice, and per
-// external/vim/doc/controller-workflows.md the remaining entries exist for
-// infrastructure mobility / cluster decommissioning, so a stale MoID should
-// not block a sync that the live cluster(s) can otherwise satisfy.
+// resolves to a Ready ConfigTarget, and the subset of clusterMoIDs that do
+// not (missing, or present but Ready!=True). Every clusterMoID behind the
+// zone must be Ready before the caller may sync: a ConfigTarget that has not
+// finished populating its status still reports zero-valued numeric fields,
+// and a zero maximum is a real capability denial per
+// VirtualMachineConfigPolicySpec's field docs, not "no data yet." Merging a
+// not-yet-Ready target's status, or silently dropping a missing one from a
+// multi-cluster zone's intersection, would therefore compute a result no
+// narrower than -- and possibly wider (more permissive) than -- the true
+// intersection across every cluster the zone spans.
 func (r *Reconciler) getConfigTargets(
 	ctx context.Context,
-	clusterMoIDs []string) ([]vimv1.ConfigTargetStatus, error) {
-	targets := make([]vimv1.ConfigTargetStatus, 0, len(clusterMoIDs))
+	clusterMoIDs []string) (targets []vimv1.ConfigTargetStatus, notReady []string, err error) {
+	targets = make([]vimv1.ConfigTargetStatus, 0, len(clusterMoIDs))
 
 	for _, clusterMoID := range clusterMoIDs {
 		var ct vimv1.ConfigTarget
 
-		err := r.Get(ctx, client.ObjectKey{Name: clusterMoID}, &ct)
-		if err != nil {
-			if apierrors.IsNotFound(err) {
+		getErr := r.Get(ctx, client.ObjectKey{Name: clusterMoID}, &ct)
+		if getErr != nil {
+			if apierrors.IsNotFound(getErr) {
+				notReady = append(notReady, clusterMoID)
 				continue
 			}
 
-			return nil, fmt.Errorf("failed to get ConfigTarget %q: %w", clusterMoID, err)
+			return nil, nil, fmt.Errorf("failed to get ConfigTarget %q: %w", clusterMoID, getErr)
+		}
+
+		if !pkgcond.IsTrue(&ct, vimv1.ReadyConditionType) {
+			notReady = append(notReady, clusterMoID)
+			continue
 		}
 
 		targets = append(targets, ct.Status)
 	}
 
-	return targets, nil
+	return targets, notReady, nil
 }

--- a/controllers/virtualmachineconfigpolicy/vmconfigpolicy_controller.go
+++ b/controllers/virtualmachineconfigpolicy/vmconfigpolicy_controller.go
@@ -17,8 +17,11 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	topologyv1 "github.com/vmware-tanzu/vm-operator/external/tanzu-topology/api/v1alpha1"
 	vimv1 "github.com/vmware-tanzu/vm-operator/external/vim/api/v1alpha1"
 	pkgcond "github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
@@ -28,6 +31,20 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/record"
 	"github.com/vmware-tanzu/vm-operator/pkg/topology"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/configpolicysync"
+)
+
+const (
+	// zoneByClusterMoIDIndex is the field index key used to look up Zones by
+	// one of the cluster MoIDs in spec.managedVMs.clusterMoIDs, so a
+	// ConfigTarget watch event can find every Zone whose sync result depends
+	// on that ConfigTarget.
+	zoneByClusterMoIDIndex = "spec.managedVMs.clusterMoIDs"
+
+	// policyByZoneIndex is the field index key used to look up
+	// VirtualMachineConfigPolicy objects by spec.zone, so a Zone (directly)
+	// or ConfigTarget (via zoneByClusterMoIDIndex) watch event can find
+	// every policy that references it.
+	policyByZoneIndex = "spec.zone"
 )
 
 const (
@@ -70,14 +87,116 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		ctrl.Log.WithName("controllers").WithName(controlledTypeName),
 		record.New(mgr.GetEventRecorder(controllerNameShort)))
 
+	err := mgr.GetFieldIndexer().IndexField(
+		ctx,
+		&vimv1.VirtualMachineConfigPolicy{},
+		policyByZoneIndex,
+		func(rawObj client.Object) []string {
+			policy := rawObj.(*vimv1.VirtualMachineConfigPolicy) //nolint:forcetypeassert
+			if policy.Spec.Zone == "" {
+				return nil
+			}
+
+			return []string{policy.Spec.Zone}
+		})
+	if err != nil {
+		return fmt.Errorf("failed to index VirtualMachineConfigPolicy by spec.zone: %w", err)
+	}
+
+	err = mgr.GetFieldIndexer().IndexField(
+		ctx,
+		&topologyv1.Zone{},
+		zoneByClusterMoIDIndex,
+		func(rawObj client.Object) []string {
+			zone := rawObj.(*topologyv1.Zone) //nolint:forcetypeassert
+			return zone.Spec.ManagedVMs.ClusterMoIDs
+		})
+	if err != nil {
+		return fmt.Errorf("failed to index Zone by spec.managedVMs.clusterMoIDs: %w", err)
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(controlledType).
+		Watches(
+			&topologyv1.Zone{},
+			handler.EnqueueRequestsFromMapFunc(zoneToPolicyMapper(r.Client))).
+		Watches(
+			&vimv1.ConfigTarget{},
+			handler.EnqueueRequestsFromMapFunc(configTargetToPolicyMapper(r.Client))).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: ctx.GetMaxConcurrentReconciles(controllerNameShort, 0),
 			SkipNameValidation:      SkipNameValidation,
 			LogConstructor:          pkglog.ControllerLogConstructor(controllerNameShort, controlledType, mgr.GetScheme()),
 		}).
 		Complete(r)
+}
+
+// zoneToPolicyMapper returns reconcile requests for every
+// VirtualMachineConfigPolicy in the Zone's namespace whose spec.zone
+// references it, so a Zone change (e.g. its cluster MoIDs) is reflected on
+// the next reconcile.
+func zoneToPolicyMapper(c client.Client) handler.MapFunc {
+	return func(ctx context.Context, o client.Object) []reconcile.Request {
+		zone, ok := o.(*topologyv1.Zone)
+		if !ok {
+			return nil
+		}
+
+		return policiesReferencingZone(ctx, c, zone.Namespace, zone.Name)
+	}
+}
+
+// configTargetToPolicyMapper returns reconcile requests for every
+// VirtualMachineConfigPolicy whose zone lists the ConfigTarget's cluster
+// MoID (the ConfigTarget's name) among spec.managedVMs.clusterMoIDs, so a
+// ConfigTarget status change is reflected within one reconcile, per the
+// spec's requirement that config policy stays in sync with the ConfigTarget.
+func configTargetToPolicyMapper(c client.Client) handler.MapFunc {
+	return func(ctx context.Context, o client.Object) []reconcile.Request {
+		ct, ok := o.(*vimv1.ConfigTarget)
+		if !ok {
+			return nil
+		}
+
+		var zones topologyv1.ZoneList
+
+		err := c.List(ctx, &zones, client.MatchingFields{zoneByClusterMoIDIndex: ct.Name})
+		if err != nil {
+			return nil
+		}
+
+		var requests []reconcile.Request
+
+		for i := range zones.Items {
+			zone := &zones.Items[i]
+			requests = append(requests, policiesReferencingZone(ctx, c, zone.Namespace, zone.Name)...)
+		}
+
+		return requests
+	}
+}
+
+// policiesReferencingZone lists every VirtualMachineConfigPolicy in
+// namespace whose spec.zone equals zoneName.
+func policiesReferencingZone(
+	ctx context.Context,
+	c client.Client,
+	namespace, zoneName string) []reconcile.Request {
+	var policies vimv1.VirtualMachineConfigPolicyList
+
+	err := c.List(ctx, &policies,
+		client.InNamespace(namespace),
+		client.MatchingFields{policyByZoneIndex: zoneName})
+	if err != nil {
+		return nil
+	}
+
+	requests := make([]reconcile.Request, len(policies.Items))
+	for i := range policies.Items {
+		requests[i] = reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&policies.Items[i])}
+	}
+
+	return requests
 }
 
 func NewReconciler(

--- a/controllers/virtualmachineconfigpolicy/vmconfigpolicy_controller.go
+++ b/controllers/virtualmachineconfigpolicy/vmconfigpolicy_controller.go
@@ -1,0 +1,242 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package virtualmachineconfigpolicy
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/go-logr/logr"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	vimv1 "github.com/vmware-tanzu/vm-operator/external/vim/api/v1alpha1"
+	pkgcond "github.com/vmware-tanzu/vm-operator/pkg/conditions"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
+	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+	pkglog "github.com/vmware-tanzu/vm-operator/pkg/log"
+	"github.com/vmware-tanzu/vm-operator/pkg/patch"
+	"github.com/vmware-tanzu/vm-operator/pkg/record"
+	"github.com/vmware-tanzu/vm-operator/pkg/topology"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/configpolicysync"
+)
+
+const (
+	// SyncDisabledReason is the Ready condition reason used when
+	// spec.syncMode=Disabled, so reconciliation intentionally does not
+	// touch spec.
+	SyncDisabledReason = "SyncDisabled"
+
+	// ZoneNotFoundReason is the Ready condition reason used when
+	// spec.zone does not resolve to an existing Zone. This is the
+	// controller-side complement to the admission webhook's spec.zone
+	// check: the webhook rejects a policy created or updated with a bad
+	// reference; this handles a Zone deleted after the policy already
+	// exists.
+	ZoneNotFoundReason = "ZoneNotFound"
+
+	// ConfigTargetNotFoundReason is the Ready condition reason used when
+	// none of the zone's cluster MoIDs resolve to an existing ConfigTarget.
+	ConfigTargetNotFoundReason = "ConfigTargetNotFound"
+)
+
+// SkipNameValidation is used for testing to allow multiple controllers with the
+// same name since Controller-Runtime has a global singleton registry to
+// prevent controllers with the same name, even if attached to different
+// managers.
+var SkipNameValidation *bool
+
+// AddToManager adds this package's controller to the provided manager.
+func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) error {
+	var (
+		controlledType     = &vimv1.VirtualMachineConfigPolicy{}
+		controlledTypeName = reflect.TypeFor[vimv1.VirtualMachineConfigPolicy]().Name()
+
+		controllerNameShort = fmt.Sprintf("%s-controller", strings.ToLower(controlledTypeName))
+	)
+
+	r := NewReconciler(
+		ctx,
+		mgr.GetClient(),
+		ctrl.Log.WithName("controllers").WithName(controlledTypeName),
+		record.New(mgr.GetEventRecorder(controllerNameShort)))
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(controlledType).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: ctx.GetMaxConcurrentReconciles(controllerNameShort, 0),
+			SkipNameValidation:      SkipNameValidation,
+			LogConstructor:          pkglog.ControllerLogConstructor(controllerNameShort, controlledType, mgr.GetScheme()),
+		}).
+		Complete(r)
+}
+
+func NewReconciler(
+	ctx context.Context,
+	client client.Client,
+	logger logr.Logger,
+	recorder record.Recorder) *Reconciler {
+	return &Reconciler{
+		Context:  ctx,
+		Client:   client,
+		Logger:   logger,
+		Recorder: recorder,
+	}
+}
+
+// Reconciler reconciles a VirtualMachineConfigPolicy's spec with the
+// capabilities reported by the ConfigTarget(s) behind its zone.
+type Reconciler struct {
+	client.Client
+
+	Context  context.Context
+	Logger   logr.Logger
+	Recorder record.Recorder
+}
+
+// +kubebuilder:rbac:groups=vim.vmware.com,resources=virtualmachineconfigpolicies,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=vim.vmware.com,resources=virtualmachineconfigpolicies/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=vim.vmware.com,resources=configtargets,verbs=get;list;watch
+
+func (r *Reconciler) Reconcile(
+	ctx context.Context,
+	req ctrl.Request) (_ ctrl.Result, reterr error) {
+	ctx = pkgcfg.JoinContext(ctx, r.Context)
+
+	logger := pkglog.FromContextOrDefault(ctx)
+	logger = logger.WithName(req.String())
+	ctx = logr.NewContext(ctx, logger)
+
+	var obj vimv1.VirtualMachineConfigPolicy
+
+	err := r.Get(ctx, req.NamespacedName, &obj)
+	if err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	base := obj.DeepCopy()
+
+	patchHelper, err := patch.NewHelper(&obj, r.Client)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to init patch helper for %s: %w", req, err)
+	}
+
+	defer func() {
+		err := patchHelper.Patch(ctx, &obj)
+		if err != nil {
+			if reterr == nil {
+				reterr = err
+			}
+
+			logger.Error(err, "patch failed")
+		}
+	}()
+
+	if !obj.DeletionTimestamp.IsZero() {
+		return ctrl.Result{}, nil
+	}
+
+	return ctrl.Result{}, r.ReconcileNormal(ctx, base, &obj)
+}
+
+// ReconcileNormal reconciles obj's spec against the ConfigTarget(s) behind
+// its zone when spec.syncMode=ConfigTarget, and otherwise leaves spec
+// untouched. base is obj's state as read, before this reconcile's changes;
+// it is used to detect a no-op spec write so an unchanged sync does not
+// bump resourceVersion and re-trigger this controller's own watch.
+func (r *Reconciler) ReconcileNormal(
+	ctx context.Context,
+	base *vimv1.VirtualMachineConfigPolicy,
+	obj *vimv1.VirtualMachineConfigPolicy) error {
+	logger := pkglog.FromContextOrDefault(ctx)
+
+	if obj.Spec.SyncMode == vimv1.VirtualMachineConfigPolicySyncModeDisabled {
+		pkgcond.Set(obj, &metav1.Condition{
+			Type:   vimv1.ReadyConditionType,
+			Status: metav1.ConditionTrue,
+			Reason: SyncDisabledReason,
+		})
+		obj.Status.ObservedGeneration = obj.Generation
+
+		return nil
+	}
+
+	zone, err := topology.GetZone(ctx, r.Client, obj.Spec.Zone, obj.Namespace)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			pkgcond.MarkFalse(obj, vimv1.ReadyConditionType, ZoneNotFoundReason,
+				"zone %q not found", obj.Spec.Zone)
+
+			return nil
+		}
+
+		pkgcond.MarkError(obj, vimv1.ReadyConditionType, ZoneNotFoundReason, err)
+
+		return fmt.Errorf("failed to get zone %q: %w", obj.Spec.Zone, err)
+	}
+
+	targets, err := r.getConfigTargets(ctx, zone.Spec.ManagedVMs.ClusterMoIDs)
+	if err != nil {
+		pkgcond.MarkError(obj, vimv1.ReadyConditionType, ConfigTargetNotFoundReason, err)
+		return fmt.Errorf("failed to get config targets for zone %q: %w", zone.Name, err)
+	}
+
+	if len(targets) == 0 {
+		pkgcond.MarkFalse(obj, vimv1.ReadyConditionType, ConfigTargetNotFoundReason,
+			"no ConfigTarget found for zone %q", zone.Name)
+
+		return nil
+	}
+
+	mergedSpec := configpolicysync.Merge(obj.Spec, targets...)
+
+	if !apiequality.Semantic.DeepEqual(base.Spec, mergedSpec) {
+		obj.Spec = mergedSpec
+	}
+
+	obj.Status.ObservedGeneration = obj.Generation
+	pkgcond.MarkTrue(obj, vimv1.ReadyConditionType)
+
+	logger.V(4).Info("Reconciled VirtualMachineConfigPolicy", "zone", zone.Name, "clusters", len(targets))
+
+	return nil
+}
+
+// getConfigTargets returns the ConfigTarget status of every clusterMoID that
+// resolves to an existing ConfigTarget. A clusterMoID with no matching
+// ConfigTarget is skipped rather than treated as an error: today a zone
+// maps to a single vSphere cluster in practice, and per
+// external/vim/doc/controller-workflows.md the remaining entries exist for
+// infrastructure mobility / cluster decommissioning, so a stale MoID should
+// not block a sync that the live cluster(s) can otherwise satisfy.
+func (r *Reconciler) getConfigTargets(
+	ctx context.Context,
+	clusterMoIDs []string) ([]vimv1.ConfigTargetStatus, error) {
+	targets := make([]vimv1.ConfigTargetStatus, 0, len(clusterMoIDs))
+
+	for _, clusterMoID := range clusterMoIDs {
+		var ct vimv1.ConfigTarget
+
+		err := r.Get(ctx, client.ObjectKey{Name: clusterMoID}, &ct)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+
+			return nil, fmt.Errorf("failed to get ConfigTarget %q: %w", clusterMoID, err)
+		}
+
+		targets = append(targets, ct.Status)
+	}
+
+	return targets, nil
+}

--- a/controllers/virtualmachineconfigpolicy/vmconfigpolicy_controller.go
+++ b/controllers/virtualmachineconfigpolicy/vmconfigpolicy_controller.go
@@ -76,9 +76,12 @@ const (
 
 	// InvalidRangeReason is the Ready condition reason used when a
 	// cluster's reported capability has narrowed below an existing,
-	// tenant-managed Min on one of the policy's range fields. spec is
-	// left untouched: applying the sync would otherwise publish a
-	// Min > Max range, which is meaningless to whatever enforces it.
+	// tenant-managed Min on one or more of the policy's range fields.
+	// configpolicysync.Merge leaves each such field unchanged rather than
+	// publishing a Min > Max range for it, but every other
+	// ConfigTarget-derived field -- including other range fields -- still
+	// converges normally, so this reason does not mean spec as a whole is
+	// untouched.
 	InvalidRangeReason = "InvalidRange"
 )
 
@@ -109,7 +112,16 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		policyByZoneIndex,
 		func(rawObj client.Object) []string {
 			policy := rawObj.(*vimv1.VirtualMachineConfigPolicy) //nolint:forcetypeassert
-			if policy.Spec.Zone == "" {
+
+			// A Disabled policy never syncs, so it has no reason to be
+			// woken by a Zone/ConfigTarget event -- omitting it here keeps
+			// zoneToPolicyMapper/configTargetToPolicyMapper's List calls
+			// from enqueuing (and patching status.observedGeneration on)
+			// every Disabled policy in the namespace on every capability
+			// change. A policy transitioning to/from Disabled still
+			// reconciles immediately via For(controlledType) on its own
+			// update, so nothing is lost.
+			if policy.Spec.Zone == "" || policy.Spec.SyncMode == vimv1.VirtualMachineConfigPolicySyncModeDisabled {
 				return nil
 			}
 
@@ -350,18 +362,22 @@ func (r *Reconciler) ReconcileNormal(
 	}
 
 	mergedSpec, err := configpolicysync.Merge(obj.Spec, targets...)
-	if err != nil {
-		pkgcond.MarkFalse(obj, vimv1.ReadyConditionType, InvalidRangeReason, "%v", err)
-		obj.Status.ObservedGeneration = obj.Generation
-
-		return nil
-	}
 
 	if !apiequality.Semantic.DeepEqual(base.Spec, mergedSpec) {
 		obj.Spec = mergedSpec
 	}
 
 	obj.Status.ObservedGeneration = obj.Generation
+
+	if err != nil {
+		// Merge still converged every field it could; only the field(s)
+		// named in err were left unchanged. Apply the spec above as usual
+		// and only use Ready=False to surface the conflict.
+		pkgcond.MarkFalse(obj, vimv1.ReadyConditionType, InvalidRangeReason, "%v", err)
+
+		return nil
+	}
+
 	pkgcond.MarkTrue(obj, vimv1.ReadyConditionType)
 
 	logger.V(4).Info("Reconciled VirtualMachineConfigPolicy", "zone", zone.Name, "clusters", len(targets))

--- a/controllers/virtualmachineconfigpolicy/vmconfigpolicy_controller.go
+++ b/controllers/virtualmachineconfigpolicy/vmconfigpolicy_controller.go
@@ -208,6 +208,7 @@ func policiesReferencingZone(
 	return requests
 }
 
+// NewReconciler returns a new Reconciler for VirtualMachineConfigPolicy.
 func NewReconciler(
 	ctx context.Context,
 	client client.Client,

--- a/controllers/virtualmachineconfigpolicy/vmconfigpolicy_controller.go
+++ b/controllers/virtualmachineconfigpolicy/vmconfigpolicy_controller.go
@@ -73,6 +73,13 @@ const (
 	// than "unknown," since a zero maximum on a numeric field means "not
 	// supported" per VirtualMachineConfigPolicySpec's doc comments.
 	ConfigTargetNotReadyReason = "ConfigTargetNotReady"
+
+	// InvalidRangeReason is the Ready condition reason used when a
+	// cluster's reported capability has narrowed below an existing,
+	// tenant-managed Min on one of the policy's range fields. spec is
+	// left untouched: applying the sync would otherwise publish a
+	// Min > Max range, which is meaningless to whatever enforces it.
+	InvalidRangeReason = "InvalidRange"
 )
 
 // SkipNameValidation is used for testing to allow multiple controllers with the
@@ -342,7 +349,13 @@ func (r *Reconciler) ReconcileNormal(
 		return nil
 	}
 
-	mergedSpec := configpolicysync.Merge(obj.Spec, targets...)
+	mergedSpec, err := configpolicysync.Merge(obj.Spec, targets...)
+	if err != nil {
+		pkgcond.MarkFalse(obj, vimv1.ReadyConditionType, InvalidRangeReason, "%v", err)
+		obj.Status.ObservedGeneration = obj.Generation
+
+		return nil
+	}
 
 	if !apiequality.Semantic.DeepEqual(base.Spec, mergedSpec) {
 		obj.Spec = mergedSpec

--- a/controllers/virtualmachineconfigpolicy/vmconfigpolicy_controller_suite_test.go
+++ b/controllers/virtualmachineconfigpolicy/vmconfigpolicy_controller_suite_test.go
@@ -1,0 +1,31 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package virtualmachineconfigpolicy_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachineconfigpolicy"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+var suite = builder.NewTestSuite()
+
+func TestVirtualMachineConfigPolicyController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "VirtualMachineConfigPolicy Controller Test Suite")
+}
+
+var _ = BeforeSuite(func() {
+	virtualmachineconfigpolicy.SkipNameValidation = ptr.To(true)
+
+	suite.BeforeSuite()
+})
+
+var _ = AfterSuite(suite.AfterSuite)

--- a/controllers/virtualmachineconfigpolicy/vmconfigpolicy_controller_test.go
+++ b/controllers/virtualmachineconfigpolicy/vmconfigpolicy_controller_test.go
@@ -304,7 +304,7 @@ func unitTests() {
 			withObjs = []ctrlclient.Object{zone, obj, configTarget(testClusterMoID, 4, "64Gi")}
 		})
 
-		It("sets Ready=False with reason InvalidRange and does not modify spec", func() {
+		It("sets Ready=False with reason InvalidRange, leaves only the conflicting field unchanged", func() {
 			_, err := reconciler.Reconcile(ctx, objReq)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -313,6 +313,12 @@ func unitTests() {
 			Expect(pkgcond.GetReason(got, vimv1.ReadyConditionType)).To(Equal(virtualmachineconfigpolicy.InvalidRangeReason))
 			Expect(got.Spec.NumCPUCores.Min).To(Equal(int32(8)))
 			Expect(got.Spec.NumCPUCores.Max).To(Equal(int32(64)), "must not publish a Min > Max range")
+
+			// The rest of the policy must still converge -- one field's
+			// conflict must not freeze the whole sync.
+			Expect(got.Spec.Memory.Max.Equal(resource.MustParse("64Gi"))).To(BeTrue())
+			Expect(got.Spec.SEVSupported).To(BeTrue())
+			Expect(got.Status.ObservedGeneration).To(Equal(got.Generation))
 		})
 	})
 
@@ -617,6 +623,54 @@ var _ = Describe("VirtualMachineConfigPolicy Controller watches, against a real 
 					g.Expect(got.Spec.NumCPUCores.Max).To(Equal(int32(8)))
 				}, 10*time.Second, 100*time.Millisecond).
 					Should(Succeed(), "the ConfigTarget watch must enqueue the policy once the ConfigTarget is marked Ready")
+			})
+		})
+
+		When("a Disabled policy's ConfigTarget becomes Ready", func() {
+			var (
+				policy *vimv1.VirtualMachineConfigPolicy
+				ct     *vimv1.ConfigTarget
+			)
+
+			BeforeEach(func() {
+				ct = &vimv1.ConfigTarget{
+					ObjectMeta: metav1.ObjectMeta{Name: clusterMoID},
+					Spec:       vimv1.ConfigTargetSpec{ID: vimv1.ManagedObjectID{ID: clusterMoID}},
+				}
+				Expect(vcSimCtx.Client.Create(vcSimCtx, ct)).To(Succeed())
+
+				policy = &vimv1.VirtualMachineConfigPolicy{
+					ObjectMeta: metav1.ObjectMeta{Name: zoneName, Namespace: vcSimCtx.NSInfo.Namespace},
+					Spec: vimv1.VirtualMachineConfigPolicySpec{
+						Zone:     zoneName,
+						SyncMode: vimv1.VirtualMachineConfigPolicySyncModeDisabled,
+					},
+				}
+				Expect(vcSimCtx.Client.Create(vcSimCtx, policy)).To(Succeed())
+			})
+
+			It("is never enqueued by the ConfigTarget watch", func() {
+				Eventually(func(g Gomega) {
+					var got vimv1.VirtualMachineConfigPolicy
+					g.Expect(vcSimCtx.Client.Get(vcSimCtx, ctrlclient.ObjectKeyFromObject(policy), &got)).To(Succeed())
+					g.Expect(pkgcond.GetReason(&got, vimv1.ReadyConditionType)).
+						To(Equal(virtualmachineconfigpolicy.SyncDisabledReason))
+				}, 10*time.Second, 100*time.Millisecond).
+					Should(Succeed(), "the policy's own creation event must still reconcile it once")
+
+				var before vimv1.VirtualMachineConfigPolicy
+				Expect(vcSimCtx.Client.Get(vcSimCtx, ctrlclient.ObjectKeyFromObject(policy), &before)).To(Succeed())
+
+				ct.Status = vimv1.ConfigTargetStatus{NumCPUCores: 8}
+				pkgcond.MarkTrue(ct, vimv1.ReadyConditionType)
+				Expect(vcSimCtx.Client.Status().Update(vcSimCtx, ct)).To(Succeed())
+
+				Consistently(func(g Gomega) {
+					var got vimv1.VirtualMachineConfigPolicy
+					g.Expect(vcSimCtx.Client.Get(vcSimCtx, ctrlclient.ObjectKeyFromObject(policy), &got)).To(Succeed())
+					g.Expect(got.ResourceVersion).To(Equal(before.ResourceVersion),
+						"a Disabled policy must not be woken (and re-patched) by a ConfigTarget it never syncs from")
+				}, 3*time.Second, 250*time.Millisecond).Should(Succeed())
 			})
 		})
 	})

--- a/controllers/virtualmachineconfigpolicy/vmconfigpolicy_controller_test.go
+++ b/controllers/virtualmachineconfigpolicy/vmconfigpolicy_controller_test.go
@@ -1,0 +1,391 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package virtualmachineconfigpolicy_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/events"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachineconfigpolicy"
+	topologyv1 "github.com/vmware-tanzu/vm-operator/external/tanzu-topology/api/v1alpha1"
+	vimv1 "github.com/vmware-tanzu/vm-operator/external/vim/api/v1alpha1"
+	pkgcond "github.com/vmware-tanzu/vm-operator/pkg/conditions"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
+	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
+	"github.com/vmware-tanzu/vm-operator/pkg/record"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/configtarget"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
+)
+
+const (
+	testNamespace   = "dummy-ns"
+	testZoneName    = "zone-1"
+	testClusterMoID = "domain-c9"
+)
+
+var _ = Describe("VirtualMachineConfigPolicy Controller", Label(testlabels.Controller, testlabels.API), unitTests)
+
+func unitTests() {
+	var (
+		ctx        context.Context
+		k8sClient  ctrlclient.Client
+		reconciler *virtualmachineconfigpolicy.Reconciler
+		obj        *vimv1.VirtualMachineConfigPolicy
+		zone       *topologyv1.Zone
+		objReq     ctrl.Request
+
+		withObjs []ctrlclient.Object
+	)
+
+	BeforeEach(func() {
+		ctx = pkgcfg.NewContextWithDefaultConfig()
+
+		zone = &topologyv1.Zone{
+			ObjectMeta: metav1.ObjectMeta{Name: testZoneName, Namespace: testNamespace},
+			Spec: topologyv1.ZoneSpec{
+				ManagedVMs: topologyv1.VSphereEntityInfo{
+					ClusterMoIDs: []string{testClusterMoID},
+				},
+			},
+		}
+
+		obj = &vimv1.VirtualMachineConfigPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: testZoneName, Namespace: testNamespace},
+			Spec: vimv1.VirtualMachineConfigPolicySpec{
+				Zone:       testZoneName,
+				SyncMode:   vimv1.VirtualMachineConfigPolicySyncModeConfigTarget,
+				CreateMode: vimv1.VirtualMachineConfigPolicyModeDeny,
+			},
+		}
+		objReq = ctrl.Request{NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testZoneName}}
+
+		withObjs = []ctrlclient.Object{zone, obj}
+	})
+
+	JustBeforeEach(func() {
+		scheme := runtime.NewScheme()
+		Expect(clientgoscheme.AddToScheme(scheme)).To(Succeed())
+		Expect(vimv1.AddToScheme(scheme)).To(Succeed())
+		Expect(topologyv1.AddToScheme(scheme)).To(Succeed())
+
+		k8sClient = fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&vimv1.VirtualMachineConfigPolicy{}).
+			WithObjects(withObjs...).
+			Build()
+
+		reconciler = virtualmachineconfigpolicy.NewReconciler(
+			ctx,
+			k8sClient,
+			log.Log.WithName("virtualmachineconfigpolicy"),
+			record.New(events.NewFakeRecorder(100)))
+	})
+
+	getPolicy := func() *vimv1.VirtualMachineConfigPolicy {
+		var got vimv1.VirtualMachineConfigPolicy
+		Expect(k8sClient.Get(ctx, ctrlclient.ObjectKeyFromObject(obj), &got)).To(Succeed())
+
+		return &got
+	}
+
+	configTarget := func(clusterMoID string, numCPUCores int32, maxMem string) *vimv1.ConfigTarget {
+		return &vimv1.ConfigTarget{
+			ObjectMeta: metav1.ObjectMeta{Name: clusterMoID},
+			Spec:       vimv1.ConfigTargetSpec{ID: vimv1.ManagedObjectID{ID: clusterMoID}},
+			Status: vimv1.ConfigTargetStatus{
+				NumCPUCores:     numCPUCores,
+				SupportedMaxMem: resourceQuantityPtr(maxMem),
+				SEVSupported:    true,
+			},
+		}
+	}
+
+	When("the VirtualMachineConfigPolicy does not exist", func() {
+		BeforeEach(func() {
+			withObjs = []ctrlclient.Object{zone}
+		})
+
+		It("returns without error", func() {
+			result, err := reconciler.Reconcile(ctx, objReq)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(ctrl.Result{}))
+		})
+	})
+
+	When("spec.syncMode is Disabled", func() {
+		BeforeEach(func() {
+			obj.Spec.SyncMode = vimv1.VirtualMachineConfigPolicySyncModeDisabled
+			obj.Spec.NumCPUCores = &vimv1.IntRange{Min: 1, Max: 2}
+			withObjs = []ctrlclient.Object{zone, obj}
+		})
+
+		It("sets Ready=True with reason SyncDisabled and does not modify spec", func() {
+			_, err := reconciler.Reconcile(ctx, objReq)
+			Expect(err).ToNot(HaveOccurred())
+
+			got := getPolicy()
+			Expect(pkgcond.IsTrue(got, vimv1.ReadyConditionType)).To(BeTrue())
+			Expect(pkgcond.GetReason(got, vimv1.ReadyConditionType)).To(Equal(virtualmachineconfigpolicy.SyncDisabledReason))
+			Expect(got.Spec.NumCPUCores).To(Equal(&vimv1.IntRange{Min: 1, Max: 2}))
+		})
+	})
+
+	When("spec.zone references a non-existent Zone", func() {
+		BeforeEach(func() {
+			obj.Spec.Zone = "does-not-exist"
+			withObjs = []ctrlclient.Object{zone, obj}
+		})
+
+		It("sets Ready=False with reason ZoneNotFound", func() {
+			_, err := reconciler.Reconcile(ctx, objReq)
+			Expect(err).ToNot(HaveOccurred())
+
+			got := getPolicy()
+			Expect(pkgcond.IsFalse(got, vimv1.ReadyConditionType)).To(BeTrue())
+			Expect(pkgcond.GetReason(got, vimv1.ReadyConditionType)).To(Equal(virtualmachineconfigpolicy.ZoneNotFoundReason))
+		})
+	})
+
+	When("the zone's cluster has no matching ConfigTarget", func() {
+		It("sets Ready=False with reason ConfigTargetNotFound", func() {
+			_, err := reconciler.Reconcile(ctx, objReq)
+			Expect(err).ToNot(HaveOccurred())
+
+			got := getPolicy()
+			Expect(pkgcond.IsFalse(got, vimv1.ReadyConditionType)).To(BeTrue())
+			Expect(pkgcond.GetReason(got, vimv1.ReadyConditionType)).To(Equal(virtualmachineconfigpolicy.ConfigTargetNotFoundReason))
+		})
+	})
+
+	When("a single ConfigTarget exists for the zone's cluster", func() {
+		BeforeEach(func() {
+			withObjs = []ctrlclient.Object{zone, obj, configTarget(testClusterMoID, 8, "64Gi")}
+		})
+
+		It("copies its capacity limits into spec and sets Ready=True", func() {
+			_, err := reconciler.Reconcile(ctx, objReq)
+			Expect(err).ToNot(HaveOccurred())
+
+			got := getPolicy()
+			Expect(pkgcond.IsTrue(got, vimv1.ReadyConditionType)).To(BeTrue())
+			Expect(got.Spec.NumCPUCores).ToNot(BeNil())
+			Expect(got.Spec.NumCPUCores.Max).To(Equal(int32(8)))
+			Expect(got.Spec.Memory.Max.Equal(resource.MustParse("64Gi"))).To(BeTrue())
+			Expect(got.Spec.SEVSupported).To(BeTrue())
+			Expect(got.Status.ObservedGeneration).To(Equal(got.Generation))
+
+			// Non-ConfigTarget-derived fields are untouched.
+			Expect(got.Spec.CreateMode).To(Equal(vimv1.VirtualMachineConfigPolicyModeDeny))
+		})
+
+		It("does not bump resourceVersion on a second reconcile against an unchanged ConfigTarget", func() {
+			_, err := reconciler.Reconcile(ctx, objReq)
+			Expect(err).ToNot(HaveOccurred())
+
+			rv1 := getPolicy().ResourceVersion
+
+			_, err = reconciler.Reconcile(ctx, objReq)
+			Expect(err).ToNot(HaveOccurred())
+
+			rv2 := getPolicy().ResourceVersion
+			Expect(rv2).To(Equal(rv1), "reconciling an unchanged ConfigTarget must not re-patch spec")
+		})
+	})
+
+	When("two ConfigTargets exist for a multi-cluster zone", func() {
+		const secondClusterMoID = "domain-c10"
+
+		BeforeEach(func() {
+			zone.Spec.ManagedVMs.ClusterMoIDs = []string{testClusterMoID, secondClusterMoID}
+			withObjs = []ctrlclient.Object{
+				zone, obj,
+				configTarget(testClusterMoID, 8, "64Gi"),
+				configTarget(secondClusterMoID, 4, "128Gi"),
+			}
+		})
+
+		It("intersects to the minimum of the per-cluster maxima", func() {
+			_, err := reconciler.Reconcile(ctx, objReq)
+			Expect(err).ToNot(HaveOccurred())
+
+			got := getPolicy()
+			Expect(pkgcond.IsTrue(got, vimv1.ReadyConditionType)).To(BeTrue())
+			Expect(got.Spec.NumCPUCores.Max).To(Equal(int32(4)))
+			Expect(got.Spec.Memory.Max.Equal(resource.MustParse("64Gi"))).To(BeTrue())
+		})
+	})
+
+	When("toggling syncMode between ConfigTarget and Disabled", func() {
+		BeforeEach(func() {
+			withObjs = []ctrlclient.Object{zone, obj, configTarget(testClusterMoID, 8, "64Gi")}
+		})
+
+		It("converges correctly in both directions", func() {
+			_, err := reconciler.Reconcile(ctx, objReq)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getPolicy().Spec.NumCPUCores.Max).To(Equal(int32(8)))
+
+			toDisable := getPolicy()
+			toDisable.Spec.SyncMode = vimv1.VirtualMachineConfigPolicySyncModeDisabled
+			toDisable.Spec.NumCPUCores.Max = 999
+			Expect(k8sClient.Update(ctx, toDisable)).To(Succeed())
+
+			_, err = reconciler.Reconcile(ctx, objReq)
+			Expect(err).ToNot(HaveOccurred())
+
+			disabled := getPolicy()
+			Expect(pkgcond.GetReason(disabled, vimv1.ReadyConditionType)).To(Equal(virtualmachineconfigpolicy.SyncDisabledReason))
+			Expect(disabled.Spec.NumCPUCores.Max).To(Equal(int32(999)), "spec must not change while sync is disabled")
+
+			toEnable := getPolicy()
+			toEnable.Spec.SyncMode = vimv1.VirtualMachineConfigPolicySyncModeConfigTarget
+			Expect(k8sClient.Update(ctx, toEnable)).To(Succeed())
+
+			_, err = reconciler.Reconcile(ctx, objReq)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getPolicy().Spec.NumCPUCores.Max).To(Equal(int32(8)), "re-enabling sync converges spec back to ConfigTarget's value")
+		})
+	})
+
+	When("the policy has extraConfig and other non-ConfigTarget-derived fields set", func() {
+		BeforeEach(func() {
+			obj.Spec.ExtraConfig = &vimv1.VirtualMachineConfigPolicyExtraConfigSpec{
+				Denied: []vimv1.VirtualMachineConfigPolicyExtraConfigKey{
+					{Type: vimv1.MatchTypeFixed, Key: "some.key"},
+				},
+			}
+			obj.Spec.LatencySensitivityLevels = []vimv1.LatencySensitivityLevel{vimv1.LatencySensitivityLevelHigh}
+			withObjs = []ctrlclient.Object{zone, obj, configTarget(testClusterMoID, 8, "64Gi")}
+		})
+
+		It("preserves them across a sync", func() {
+			_, err := reconciler.Reconcile(ctx, objReq)
+			Expect(err).ToNot(HaveOccurred())
+
+			got := getPolicy()
+			Expect(got.Spec.ExtraConfig).To(Equal(obj.Spec.ExtraConfig))
+			Expect(got.Spec.LatencySensitivityLevels).To(Equal(obj.Spec.LatencySensitivityLevels))
+		})
+	})
+}
+
+func resourceQuantityPtr(s string) *resource.Quantity {
+	q := resource.MustParse(s)
+	return &q
+}
+
+var _ = Describe("VirtualMachineConfigPolicy Controller against vcsim",
+	Label(testlabels.Controller, testlabels.API, testlabels.EnvTest, testlabels.VCSim),
+	vcsimTests)
+
+func vcsimTests() {
+	var (
+		vcsimCtx    *builder.TestContextForVCSim
+		reconciler  *virtualmachineconfigpolicy.Reconciler
+		nsInfo      builder.WorkloadNamespaceInfo
+		zoneName    string
+		clusterMoID string
+	)
+
+	BeforeEach(func() {
+		vcsimCtx = suite.NewTestContextForVCSim(builder.VCSimTestConfig{})
+		nsInfo = vcsimCtx.CreateWorkloadNamespace()
+		zoneName = vcsimCtx.GetFirstZoneName()
+
+		ccr := vcsimCtx.GetFirstClusterFromFirstZone()
+		Expect(ccr).ToNot(BeNil())
+		clusterMoID = ccr.Reference().Value
+
+		reconciler = virtualmachineconfigpolicy.NewReconciler(
+			vcsimCtx,
+			vcsimCtx.Client,
+			log.Log.WithName("virtualmachineconfigpolicy"),
+			vcsimCtx.Recorder)
+	})
+
+	AfterEach(func() {
+		vcsimCtx.AfterEach()
+	})
+
+	populateRealConfigTarget := func() {
+		provider := vsphere.NewVSphereVMProviderFromClient(vcsimCtx, vcsimCtx.Client, vcsimCtx.Recorder)
+
+		ct := &vimv1.ConfigTarget{
+			ObjectMeta: metav1.ObjectMeta{Name: clusterMoID},
+			Spec:       vimv1.ConfigTargetSpec{ID: vimv1.ManagedObjectID{ID: clusterMoID}},
+		}
+		Expect(vcsimCtx.Client.Create(vcsimCtx, ct)).To(Succeed())
+
+		configTargetResult, descriptors, err := provider.GetVirtualMachineConfigTarget(vcsimCtx, clusterMoID)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(vcsimCtx.Client.Get(vcsimCtx, ctrlclient.ObjectKeyFromObject(ct), ct)).To(Succeed())
+		configtarget.PopulateStatus(ct, configTargetResult, descriptors)
+		Expect(vcsimCtx.Client.Status().Update(vcsimCtx, ct)).To(Succeed())
+	}
+
+	When("a real, populated ConfigTarget exists for the zone's cluster", func() {
+		var policy *vimv1.VirtualMachineConfigPolicy
+
+		BeforeEach(func() {
+			populateRealConfigTarget()
+
+			policy = &vimv1.VirtualMachineConfigPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: zoneName, Namespace: nsInfo.Namespace},
+				Spec:       vimv1.VirtualMachineConfigPolicySpec{Zone: zoneName},
+			}
+			Expect(vcsimCtx.Client.Create(vcsimCtx, policy)).To(Succeed())
+		})
+
+		It("populates spec from the real cluster's capabilities and sets Ready=True", func() {
+			req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: policy.Namespace, Name: policy.Name}}
+			_, err := reconciler.Reconcile(vcsimCtx, req)
+			Expect(err).ToNot(HaveOccurred())
+
+			var got vimv1.VirtualMachineConfigPolicy
+			Expect(vcsimCtx.Client.Get(vcsimCtx, ctrlclient.ObjectKeyFromObject(policy), &got)).To(Succeed())
+			Expect(pkgcond.IsTrue(&got, vimv1.ReadyConditionType)).To(BeTrue())
+			Expect(got.Spec.NumCPUCores).ToNot(BeNil())
+			Expect(got.Spec.NumCPUCores.Max).To(BeNumerically(">", 0))
+		})
+	})
+
+	When("no ConfigTarget exists yet for the zone's cluster", func() {
+		var policy *vimv1.VirtualMachineConfigPolicy
+
+		BeforeEach(func() {
+			policy = &vimv1.VirtualMachineConfigPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: zoneName, Namespace: nsInfo.Namespace},
+				Spec:       vimv1.VirtualMachineConfigPolicySpec{Zone: zoneName},
+			}
+			Expect(vcsimCtx.Client.Create(vcsimCtx, policy)).To(Succeed())
+		})
+
+		It("sets Ready=False with reason ConfigTargetNotFound", func() {
+			req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: policy.Namespace, Name: policy.Name}}
+			_, err := reconciler.Reconcile(vcsimCtx, req)
+			Expect(err).ToNot(HaveOccurred())
+
+			var got vimv1.VirtualMachineConfigPolicy
+			Expect(vcsimCtx.Client.Get(vcsimCtx, ctrlclient.ObjectKeyFromObject(policy), &got)).To(Succeed())
+			Expect(pkgcond.IsFalse(&got, vimv1.ReadyConditionType)).To(BeTrue())
+			Expect(pkgcond.GetReason(&got, vimv1.ReadyConditionType)).To(Equal(virtualmachineconfigpolicy.ConfigTargetNotFoundReason))
+		})
+	})
+}

--- a/controllers/virtualmachineconfigpolicy/vmconfigpolicy_controller_test.go
+++ b/controllers/virtualmachineconfigpolicy/vmconfigpolicy_controller_test.go
@@ -281,6 +281,41 @@ func unitTests() {
 		})
 	})
 
+	When("a cluster's reported capability has shrunk since the last sync", func() {
+		BeforeEach(func() {
+			obj.Spec.NumCPUCores = &vimv1.IntRange{Min: 2, Max: 64}
+			withObjs = []ctrlclient.Object{zone, obj, configTarget(testClusterMoID, 32, "64Gi")}
+		})
+
+		It("narrows Max down instead of leaving it pinned to the old, wider value", func() {
+			_, err := reconciler.Reconcile(ctx, objReq)
+			Expect(err).ToNot(HaveOccurred())
+
+			got := getPolicy()
+			Expect(pkgcond.IsTrue(got, vimv1.ReadyConditionType)).To(BeTrue())
+			Expect(got.Spec.NumCPUCores.Max).To(Equal(int32(32)))
+			Expect(got.Spec.NumCPUCores.Min).To(Equal(int32(2)), "tenant-managed Min must survive a shrink")
+		})
+	})
+
+	When("a cluster's reported capability has shrunk below an existing tenant-managed Min", func() {
+		BeforeEach(func() {
+			obj.Spec.NumCPUCores = &vimv1.IntRange{Min: 8, Max: 64}
+			withObjs = []ctrlclient.Object{zone, obj, configTarget(testClusterMoID, 4, "64Gi")}
+		})
+
+		It("sets Ready=False with reason InvalidRange and does not modify spec", func() {
+			_, err := reconciler.Reconcile(ctx, objReq)
+			Expect(err).ToNot(HaveOccurred())
+
+			got := getPolicy()
+			Expect(pkgcond.IsFalse(got, vimv1.ReadyConditionType)).To(BeTrue())
+			Expect(pkgcond.GetReason(got, vimv1.ReadyConditionType)).To(Equal(virtualmachineconfigpolicy.InvalidRangeReason))
+			Expect(got.Spec.NumCPUCores.Min).To(Equal(int32(8)))
+			Expect(got.Spec.NumCPUCores.Max).To(Equal(int32(64)), "must not publish a Min > Max range")
+		})
+	})
+
 	When("two ConfigTargets exist for a multi-cluster zone", func() {
 		const secondClusterMoID = "domain-c10"
 

--- a/controllers/virtualmachineconfigpolicy/vmconfigpolicy_controller_test.go
+++ b/controllers/virtualmachineconfigpolicy/vmconfigpolicy_controller_test.go
@@ -364,6 +364,23 @@ func vcsimTests() {
 			Expect(got.Spec.NumCPUCores).ToNot(BeNil())
 			Expect(got.Spec.NumCPUCores.Max).To(BeNumerically(">", 0))
 		})
+
+		It("does not bump resourceVersion on a second reconcile against a real, unchanged ConfigTarget", func() {
+			req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: policy.Namespace, Name: policy.Name}}
+
+			_, err := reconciler.Reconcile(vcsimCtx, req)
+			Expect(err).ToNot(HaveOccurred())
+
+			var got vimv1.VirtualMachineConfigPolicy
+			Expect(vcsimCtx.Client.Get(vcsimCtx, ctrlclient.ObjectKeyFromObject(policy), &got)).To(Succeed())
+			rv1 := got.ResourceVersion
+
+			_, err = reconciler.Reconcile(vcsimCtx, req)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(vcsimCtx.Client.Get(vcsimCtx, ctrlclient.ObjectKeyFromObject(policy), &got)).To(Succeed())
+			Expect(got.ResourceVersion).To(Equal(rv1))
+		})
 	})
 
 	When("no ConfigTarget exists yet for the zone's cluster", func() {

--- a/controllers/virtualmachineconfigpolicy/vmconfigpolicy_controller_test.go
+++ b/controllers/virtualmachineconfigpolicy/vmconfigpolicy_controller_test.go
@@ -6,6 +6,7 @@ package virtualmachineconfigpolicy_test
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -20,20 +21,16 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
 
-	configtargetctrl "github.com/vmware-tanzu/vm-operator/controllers/configtarget"
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachineconfigpolicy"
 	topologyv1 "github.com/vmware-tanzu/vm-operator/external/tanzu-topology/api/v1alpha1"
 	vimv1 "github.com/vmware-tanzu/vm-operator/external/vim/api/v1alpha1"
 	pkgcond "github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
-	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
-	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
+	"github.com/vmware-tanzu/vm-operator/pkg/manager"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
 	"github.com/vmware-tanzu/vm-operator/pkg/record"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/configtarget"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
@@ -491,6 +488,17 @@ func vcsimTests() {
 // end: a direct-Reconcile test cannot tell an intentional watch from a
 // missing one, since it never goes through the manager's watch wiring at
 // all.
+//
+// This suite deliberately does NOT run the real configtarget controller or
+// a real vSphere provider: that combination makes the ConfigTarget's Ready
+// transition depend on a live (albeit vcsim-backed) govmomi round trip whose
+// duration is not bounded under CI/local resource contention, which made an
+// earlier version of this test flaky (timing out anywhere from a few
+// seconds to several minutes). Driving the ConfigTarget's status by hand
+// keeps the test deterministic while still exercising exactly what this
+// Describe exists to prove: that a ConfigTarget status change reaches the
+// policy purely through AddToManager's watch wiring, with no manual
+// reconcile call.
 var _ = Describe("VirtualMachineConfigPolicy Controller watches, against a real manager",
 	Label(testlabels.Controller, testlabels.API, testlabels.EnvTest, testlabels.VCSim),
 	func() {
@@ -506,24 +514,12 @@ var _ = Describe("VirtualMachineConfigPolicy Controller watches, against a real 
 			ctx = pkgcfg.UpdateContext(ctx, func(config *pkgcfg.Config) {
 				config.Features.VirtualMachineConfigPolicy = true
 			})
-			ctx = ctxop.WithContext(ctx)
-			ctx = ovfcache.WithContext(ctx)
 
 			vcSimCtx = builder.NewIntegrationTestContextForVCSim(
 				ctx,
 				builder.VCSimTestConfig{},
-				func(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) error {
-					err := configtargetctrl.AddToManager(ctx, mgr)
-					if err != nil {
-						return err
-					}
-
-					return virtualmachineconfigpolicy.AddToManager(ctx, mgr)
-				},
-				func(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) error {
-					ctx.VMProvider = vsphere.NewVSphereVMProviderFromClient(ctx, mgr.GetClient(), ctx.Recorder)
-					return nil
-				},
+				virtualmachineconfigpolicy.AddToManager,
+				manager.InitializeProvidersNoopFn,
 				nil)
 			Expect(vcSimCtx).ToNot(BeNil())
 
@@ -541,10 +537,13 @@ var _ = Describe("VirtualMachineConfigPolicy Controller watches, against a real 
 		})
 
 		When("a policy is created before its ConfigTarget becomes Ready", func() {
-			var policy *vimv1.VirtualMachineConfigPolicy
+			var (
+				policy *vimv1.VirtualMachineConfigPolicy
+				ct     *vimv1.ConfigTarget
+			)
 
 			BeforeEach(func() {
-				ct := &vimv1.ConfigTarget{
+				ct = &vimv1.ConfigTarget{
 					ObjectMeta: metav1.ObjectMeta{Name: clusterMoID},
 					Spec:       vimv1.ConfigTargetSpec{ID: vimv1.ManagedObjectID{ID: clusterMoID}},
 				}
@@ -557,22 +556,32 @@ var _ = Describe("VirtualMachineConfigPolicy Controller watches, against a real 
 				Expect(vcSimCtx.Client.Create(vcSimCtx, policy)).To(Succeed())
 			})
 
-			It("converges once the real configtarget controller marks the ConfigTarget Ready, with no manual reconcile", func() {
+			It("converges once the ConfigTarget is marked Ready, with no manual reconcile", func() {
+				// This suite does not go through TestSuite.Register, so the
+				// package-wide 10s/100ms Gomega defaults it would otherwise
+				// set are not in effect here -- use an explicit interval
+				// instead of Gomega's 1s/10ms fallback.
 				Eventually(func(g Gomega) {
 					var got vimv1.VirtualMachineConfigPolicy
 					g.Expect(vcSimCtx.Client.Get(vcSimCtx, ctrlclient.ObjectKeyFromObject(policy), &got)).To(Succeed())
 					g.Expect(pkgcond.IsFalse(&got, vimv1.ReadyConditionType)).To(BeTrue())
 					g.Expect(pkgcond.GetReason(&got, vimv1.ReadyConditionType)).
 						To(Equal(virtualmachineconfigpolicy.ConfigTargetNotReadyReason))
-				}).Should(Succeed(), "policy must observe the not-yet-Ready ConfigTarget before it converges")
+				}, 10*time.Second, 100*time.Millisecond).
+					Should(Succeed(), "policy must observe the not-yet-Ready ConfigTarget before it converges")
+
+				ct.Status = vimv1.ConfigTargetStatus{NumCPUCores: 8}
+				pkgcond.MarkTrue(ct, vimv1.ReadyConditionType)
+				Expect(vcSimCtx.Client.Status().Update(vcSimCtx, ct)).To(Succeed())
 
 				Eventually(func(g Gomega) {
 					var got vimv1.VirtualMachineConfigPolicy
 					g.Expect(vcSimCtx.Client.Get(vcSimCtx, ctrlclient.ObjectKeyFromObject(policy), &got)).To(Succeed())
 					g.Expect(pkgcond.IsTrue(&got, vimv1.ReadyConditionType)).To(BeTrue())
 					g.Expect(got.Spec.NumCPUCores).ToNot(BeNil())
-					g.Expect(got.Spec.NumCPUCores.Max).To(BeNumerically(">", 0))
-				}).Should(Succeed(), "the ConfigTarget watch must enqueue the policy once the real configtarget controller marks it Ready")
+					g.Expect(got.Spec.NumCPUCores.Max).To(Equal(int32(8)))
+				}, 10*time.Second, 100*time.Millisecond).
+					Should(Succeed(), "the ConfigTarget watch must enqueue the policy once the ConfigTarget is marked Ready")
 			})
 		})
 	})

--- a/controllers/virtualmachineconfigpolicy/vmconfigpolicy_controller_test.go
+++ b/controllers/virtualmachineconfigpolicy/vmconfigpolicy_controller_test.go
@@ -20,15 +20,20 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
 
+	configtargetctrl "github.com/vmware-tanzu/vm-operator/controllers/configtarget"
 	"github.com/vmware-tanzu/vm-operator/controllers/virtualmachineconfigpolicy"
 	topologyv1 "github.com/vmware-tanzu/vm-operator/external/tanzu-topology/api/v1alpha1"
 	vimv1 "github.com/vmware-tanzu/vm-operator/external/vim/api/v1alpha1"
 	pkgcond "github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
+	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
 	"github.com/vmware-tanzu/vm-operator/pkg/record"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/configtarget"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
@@ -105,7 +110,7 @@ func unitTests() {
 	}
 
 	configTarget := func(clusterMoID string, numCPUCores int32, maxMem string) *vimv1.ConfigTarget {
-		return &vimv1.ConfigTarget{
+		ct := &vimv1.ConfigTarget{
 			ObjectMeta: metav1.ObjectMeta{Name: clusterMoID},
 			Spec:       vimv1.ConfigTargetSpec{ID: vimv1.ManagedObjectID{ID: clusterMoID}},
 			Status: vimv1.ConfigTargetStatus{
@@ -113,6 +118,21 @@ func unitTests() {
 				SupportedMaxMem: resourceQuantityPtr(maxMem),
 				SEVSupported:    true,
 			},
+		}
+		pkgcond.MarkTrue(ct, vimv1.ReadyConditionType)
+
+		return ct
+	}
+
+	// notReadyConfigTarget returns a ConfigTarget that exists but has not
+	// finished populating its status (Ready!=True) -- e.g. the configtarget
+	// controller has not reconciled it yet. Its numeric fields are left at
+	// their Go zero value, which the sync must not treat as "the cluster
+	// supports nothing."
+	notReadyConfigTarget := func(clusterMoID string) *vimv1.ConfigTarget {
+		return &vimv1.ConfigTarget{
+			ObjectMeta: metav1.ObjectMeta{Name: clusterMoID},
+			Spec:       vimv1.ConfigTargetSpec{ID: vimv1.ManagedObjectID{ID: clusterMoID}},
 		}
 	}
 
@@ -162,7 +182,11 @@ func unitTests() {
 		})
 	})
 
-	When("the zone's cluster has no matching ConfigTarget", func() {
+	When("the zone has no cluster to sync from", func() {
+		BeforeEach(func() {
+			zone.Spec.ManagedVMs.ClusterMoIDs = nil
+		})
+
 		It("sets Ready=False with reason ConfigTargetNotFound", func() {
 			_, err := reconciler.Reconcile(ctx, objReq)
 			Expect(err).ToNot(HaveOccurred())
@@ -170,6 +194,58 @@ func unitTests() {
 			got := getPolicy()
 			Expect(pkgcond.IsFalse(got, vimv1.ReadyConditionType)).To(BeTrue())
 			Expect(pkgcond.GetReason(got, vimv1.ReadyConditionType)).To(Equal(virtualmachineconfigpolicy.ConfigTargetNotFoundReason))
+			Expect(got.Status.ObservedGeneration).To(Equal(got.Generation))
+		})
+	})
+
+	When("the zone's cluster has no matching ConfigTarget", func() {
+		It("sets Ready=False with reason ConfigTargetNotReady and does not touch spec", func() {
+			_, err := reconciler.Reconcile(ctx, objReq)
+			Expect(err).ToNot(HaveOccurred())
+
+			got := getPolicy()
+			Expect(pkgcond.IsFalse(got, vimv1.ReadyConditionType)).To(BeTrue())
+			Expect(pkgcond.GetReason(got, vimv1.ReadyConditionType)).To(Equal(virtualmachineconfigpolicy.ConfigTargetNotReadyReason))
+			Expect(got.Status.ObservedGeneration).To(Equal(got.Generation))
+		})
+	})
+
+	When("the zone's ConfigTarget exists but has not finished populating its status", func() {
+		BeforeEach(func() {
+			withObjs = []ctrlclient.Object{zone, obj, notReadyConfigTarget(testClusterMoID)}
+		})
+
+		It("sets Ready=False with reason ConfigTargetNotReady and does not merge its zero-valued fields", func() {
+			_, err := reconciler.Reconcile(ctx, objReq)
+			Expect(err).ToNot(HaveOccurred())
+
+			got := getPolicy()
+			Expect(pkgcond.IsFalse(got, vimv1.ReadyConditionType)).To(BeTrue())
+			Expect(pkgcond.GetReason(got, vimv1.ReadyConditionType)).To(Equal(virtualmachineconfigpolicy.ConfigTargetNotReadyReason))
+			Expect(got.Spec.NumCPUCores).To(BeNil(), "a not-yet-Ready ConfigTarget's zero fields must not be published as capability denials")
+		})
+	})
+
+	When("a multi-cluster zone has one Ready ConfigTarget and one not yet Ready", func() {
+		const secondClusterMoID = "domain-c10"
+
+		BeforeEach(func() {
+			zone.Spec.ManagedVMs.ClusterMoIDs = []string{testClusterMoID, secondClusterMoID}
+			withObjs = []ctrlclient.Object{
+				zone, obj,
+				configTarget(testClusterMoID, 8, "64Gi"),
+				notReadyConfigTarget(secondClusterMoID),
+			}
+		})
+
+		It("does not sync from the single Ready target -- that would be wider than the true intersection", func() {
+			_, err := reconciler.Reconcile(ctx, objReq)
+			Expect(err).ToNot(HaveOccurred())
+
+			got := getPolicy()
+			Expect(pkgcond.IsFalse(got, vimv1.ReadyConditionType)).To(BeTrue())
+			Expect(pkgcond.GetReason(got, vimv1.ReadyConditionType)).To(Equal(virtualmachineconfigpolicy.ConfigTargetNotReadyReason))
+			Expect(got.Spec.NumCPUCores).To(BeNil())
 		})
 	})
 
@@ -337,6 +413,7 @@ func vcsimTests() {
 
 		Expect(vcsimCtx.Client.Get(vcsimCtx, ctrlclient.ObjectKeyFromObject(ct), ct)).To(Succeed())
 		configtarget.PopulateStatus(ct, configTargetResult, descriptors)
+		pkgcond.MarkTrue(ct, vimv1.ReadyConditionType)
 		Expect(vcsimCtx.Client.Status().Update(vcsimCtx, ct)).To(Succeed())
 	}
 
@@ -394,7 +471,7 @@ func vcsimTests() {
 			Expect(vcsimCtx.Client.Create(vcsimCtx, policy)).To(Succeed())
 		})
 
-		It("sets Ready=False with reason ConfigTargetNotFound", func() {
+		It("sets Ready=False with reason ConfigTargetNotReady", func() {
 			req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: policy.Namespace, Name: policy.Name}}
 			_, err := reconciler.Reconcile(vcsimCtx, req)
 			Expect(err).ToNot(HaveOccurred())
@@ -402,7 +479,100 @@ func vcsimTests() {
 			var got vimv1.VirtualMachineConfigPolicy
 			Expect(vcsimCtx.Client.Get(vcsimCtx, ctrlclient.ObjectKeyFromObject(policy), &got)).To(Succeed())
 			Expect(pkgcond.IsFalse(&got, vimv1.ReadyConditionType)).To(BeTrue())
-			Expect(pkgcond.GetReason(&got, vimv1.ReadyConditionType)).To(Equal(virtualmachineconfigpolicy.ConfigTargetNotFoundReason))
+			Expect(pkgcond.GetReason(&got, vimv1.ReadyConditionType)).To(Equal(virtualmachineconfigpolicy.ConfigTargetNotReadyReason))
 		})
 	})
 }
+
+// The Describe below runs against a real controller-runtime manager (via
+// builder.NewIntegrationTestContextForVCSim), unlike the two above which
+// call reconciler.Reconcile() directly. It exists specifically to exercise
+// AddToManager's ConfigTarget/Zone watches and field-indexed mappers end to
+// end: a direct-Reconcile test cannot tell an intentional watch from a
+// missing one, since it never goes through the manager's watch wiring at
+// all.
+var _ = Describe("VirtualMachineConfigPolicy Controller watches, against a real manager",
+	Label(testlabels.Controller, testlabels.API, testlabels.EnvTest, testlabels.VCSim),
+	func() {
+		var (
+			ctx         context.Context
+			vcSimCtx    *builder.IntegrationTestContextForVCSim
+			zoneName    string
+			clusterMoID string
+		)
+
+		BeforeEach(func() {
+			ctx = pkgcfg.NewContextWithDefaultConfig()
+			ctx = pkgcfg.UpdateContext(ctx, func(config *pkgcfg.Config) {
+				config.Features.VirtualMachineConfigPolicy = true
+			})
+			ctx = ctxop.WithContext(ctx)
+			ctx = ovfcache.WithContext(ctx)
+
+			vcSimCtx = builder.NewIntegrationTestContextForVCSim(
+				ctx,
+				builder.VCSimTestConfig{},
+				func(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) error {
+					err := configtargetctrl.AddToManager(ctx, mgr)
+					if err != nil {
+						return err
+					}
+
+					return virtualmachineconfigpolicy.AddToManager(ctx, mgr)
+				},
+				func(ctx *pkgctx.ControllerManagerContext, mgr ctrlmgr.Manager) error {
+					ctx.VMProvider = vsphere.NewVSphereVMProviderFromClient(ctx, mgr.GetClient(), ctx.Recorder)
+					return nil
+				},
+				nil)
+			Expect(vcSimCtx).ToNot(BeNil())
+
+			vcSimCtx.BeforeEach()
+
+			zoneName = vcSimCtx.GetFirstZoneName()
+
+			ccr := vcSimCtx.GetFirstClusterFromFirstZone()
+			Expect(ccr).ToNot(BeNil())
+			clusterMoID = ccr.Reference().Value
+		})
+
+		AfterEach(func() {
+			vcSimCtx.AfterEach()
+		})
+
+		When("a policy is created before its ConfigTarget becomes Ready", func() {
+			var policy *vimv1.VirtualMachineConfigPolicy
+
+			BeforeEach(func() {
+				ct := &vimv1.ConfigTarget{
+					ObjectMeta: metav1.ObjectMeta{Name: clusterMoID},
+					Spec:       vimv1.ConfigTargetSpec{ID: vimv1.ManagedObjectID{ID: clusterMoID}},
+				}
+				Expect(vcSimCtx.Client.Create(vcSimCtx, ct)).To(Succeed())
+
+				policy = &vimv1.VirtualMachineConfigPolicy{
+					ObjectMeta: metav1.ObjectMeta{Name: zoneName, Namespace: vcSimCtx.NSInfo.Namespace},
+					Spec:       vimv1.VirtualMachineConfigPolicySpec{Zone: zoneName},
+				}
+				Expect(vcSimCtx.Client.Create(vcSimCtx, policy)).To(Succeed())
+			})
+
+			It("converges once the real configtarget controller marks the ConfigTarget Ready, with no manual reconcile", func() {
+				Eventually(func(g Gomega) {
+					var got vimv1.VirtualMachineConfigPolicy
+					g.Expect(vcSimCtx.Client.Get(vcSimCtx, ctrlclient.ObjectKeyFromObject(policy), &got)).To(Succeed())
+					g.Expect(pkgcond.IsFalse(&got, vimv1.ReadyConditionType)).To(BeTrue())
+					g.Expect(pkgcond.GetReason(&got, vimv1.ReadyConditionType)).
+						To(Equal(virtualmachineconfigpolicy.ConfigTargetNotReadyReason))
+				}).Should(Succeed(), "policy must observe the not-yet-Ready ConfigTarget before it converges")
+
+				Eventually(func(g Gomega) {
+					var got vimv1.VirtualMachineConfigPolicy
+					g.Expect(vcSimCtx.Client.Get(vcSimCtx, ctrlclient.ObjectKeyFromObject(policy), &got)).To(Succeed())
+					g.Expect(pkgcond.IsTrue(&got, vimv1.ReadyConditionType)).To(BeTrue())
+					g.Expect(got.Spec.NumCPUCores).ToNot(BeNil())
+					g.Expect(got.Spec.NumCPUCores.Max).To(BeNumerically(">", 0))
+				}).Should(Succeed(), "the ConfigTarget watch must enqueue the policy once the real configtarget controller marks it Ready")
+			})
+		})
+	})

--- a/pkg/util/configpolicysync/configpolicysync.go
+++ b/pkg/util/configpolicysync/configpolicysync.go
@@ -1,0 +1,229 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package configpolicysync maps one or more vim.vmware.com ConfigTarget
+// statuses onto the fields of a VirtualMachineConfigPolicy spec that
+// syncMode=ConfigTarget derives from vSphere cluster capabilities.
+//
+// A zone with more than one relevant cluster (multi-cluster zone) merges by
+// intersection: the result is only what every target's cluster supports --
+// the minimum of numeric maxima, the logical AND of boolean support flags,
+// and, for ConfigTargetDevices, only the device descriptors that appear,
+// value-for-value, on every target.
+//
+// Fields the policy spec owns independently of any ConfigTarget --
+// createMode, updateMode, powerOnMode, vmClassMode, extraConfig,
+// latencySensitivityLevels, txRxThreadModels, and the *Supported flags with
+// no ConfigTargetStatus counterpart (cpuLockedToMaxSupported,
+// memoryLockedToMaxSupported, hugePagesSupported, iommuSupported,
+// rssSupported, udpRSSSupported, lroSupported) -- are left untouched by
+// Merge.
+package configpolicysync
+
+import (
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	vimv1 "github.com/vmware-tanzu/vm-operator/external/vim/api/v1alpha1"
+)
+
+// Merge returns a copy of spec with its ConfigTarget-derived fields
+// replaced by the intersection of targets. Fields not derived from a
+// ConfigTarget are copied through from spec unmodified. If targets is
+// empty, spec is returned unmodified.
+func Merge(
+	spec vimv1.VirtualMachineConfigPolicySpec,
+	targets ...vimv1.ConfigTargetStatus) vimv1.VirtualMachineConfigPolicySpec {
+	if len(targets) == 0 {
+		return spec
+	}
+
+	agg := aggregate{
+		numCPUCores:            targets[0].NumCPUCores,
+		numNUMANodes:           targets[0].NumNumaNodes,
+		numSimultaneousThreads: targets[0].MaxSimultaneousThreads,
+		memory:                 quantityOrZero(targets[0].SupportedMaxMem),
+		smcPresent:             targets[0].SMCPresent,
+		sevSupported:           targets[0].SEVSupported,
+		sevSNPSupported:        targets[0].SEVSNPSupported,
+		tdxSupported:           targets[0].TDXSupported,
+		devices:                *targets[0].ConfigTargetDevices.DeepCopy(),
+	}
+
+	for _, t := range targets[1:] {
+		agg = agg.intersect(t)
+	}
+
+	out := spec
+	out.NumCPUCores = mergeIntRangeMax(out.NumCPUCores, agg.numCPUCores)
+	out.NumNUMANodes = mergeIntRangeMax(out.NumNUMANodes, agg.numNUMANodes)
+	out.NumSimultaneousThreads = mergeIntRangeMax(out.NumSimultaneousThreads, agg.numSimultaneousThreads)
+	out.Memory = mergeResourceQuantityRangeMax(out.Memory, agg.memory)
+	out.SMCPresent = agg.smcPresent
+	out.SEVSupported = agg.sevSupported
+	out.SEVSNPSupported = agg.sevSNPSupported
+	out.TDXSupported = agg.tdxSupported
+	out.ConfigTargetDevices = agg.devices
+
+	return out
+}
+
+// aggregate accumulates the fold-over-targets state used by Merge.
+type aggregate struct {
+	numCPUCores            int32
+	numNUMANodes           int32
+	numSimultaneousThreads int32
+	memory                 resource.Quantity
+
+	smcPresent      bool
+	sevSupported    bool
+	sevSNPSupported bool
+	tdxSupported    bool
+
+	devices vimv1.ConfigTargetDevices
+}
+
+// intersect folds t into agg, narrowing every field to what both agg and t
+// support.
+func (agg aggregate) intersect(t vimv1.ConfigTargetStatus) aggregate {
+	agg.numCPUCores = minInt32(agg.numCPUCores, t.NumCPUCores)
+	agg.numNUMANodes = minInt32(agg.numNUMANodes, t.NumNumaNodes)
+	agg.numSimultaneousThreads = minInt32(agg.numSimultaneousThreads, t.MaxSimultaneousThreads)
+	agg.memory = minQuantity(agg.memory, t.SupportedMaxMem)
+	agg.smcPresent = agg.smcPresent && t.SMCPresent
+	agg.sevSupported = agg.sevSupported && t.SEVSupported
+	agg.sevSNPSupported = agg.sevSNPSupported && t.SEVSNPSupported
+	agg.tdxSupported = agg.tdxSupported && t.TDXSupported
+	agg.devices = intersectConfigTargetDevices(agg.devices, t.ConfigTargetDevices)
+
+	return agg
+}
+
+// minInt32 returns the smaller of a and b. A zero value is treated as "no
+// data reported" and does not restrict the result, since ConfigTargetStatus
+// fields are all +optional and a target that has not finished populating
+// its status should not silently zero out an otherwise-healthy merge.
+func minInt32(a, b int32) int32 {
+	switch {
+	case a == 0:
+		return b
+	case b == 0:
+		return a
+	case a < b:
+		return a
+	default:
+		return b
+	}
+}
+
+// minQuantity returns the smaller of a and b. A nil/zero b is treated as
+// "no data reported" and does not restrict the result; see minInt32.
+func minQuantity(a resource.Quantity, b *resource.Quantity) resource.Quantity {
+	if b == nil || b.IsZero() {
+		return a
+	}
+
+	if a.IsZero() || b.Cmp(a) < 0 {
+		return b.DeepCopy()
+	}
+
+	return a
+}
+
+// quantityOrZero returns *q, or the zero Quantity if q is nil.
+func quantityOrZero(q *resource.Quantity) resource.Quantity {
+	if q == nil {
+		return resource.Quantity{}
+	}
+
+	return q.DeepCopy()
+}
+
+// mergeIntRangeMax returns a copy of existing with Max set to maxVal, or a
+// new IntRange{Max: maxVal} if existing is nil. Min is left untouched: it is
+// not derived from any ConfigTarget, and is a tenant-managed floor.
+func mergeIntRangeMax(existing *vimv1.IntRange, maxVal int32) *vimv1.IntRange {
+	out := vimv1.IntRange{Max: maxVal}
+	if existing != nil {
+		out.Min = existing.Min
+	}
+
+	return &out
+}
+
+// mergeResourceQuantityRangeMax returns a copy of existing with Max set to
+// maxVal, or a new ResourceQuantityRange{Max: maxVal} if existing is nil.
+// Min is left untouched; see mergeIntRangeMax.
+func mergeResourceQuantityRangeMax(
+	existing *vimv1.ResourceQuantityRange, maxVal resource.Quantity) *vimv1.ResourceQuantityRange {
+	out := vimv1.ResourceQuantityRange{Max: maxVal}
+	if existing != nil {
+		out.Min = existing.Min
+	}
+
+	return &out
+}
+
+// intersectConfigTargetDevices returns the ConfigTargetDevices categories
+// common to both a and b: for list fields, only entries that are, value for
+// value, present in both lists; for the single SGXTargetInfo pointer, the
+// shared value if both are equal, otherwise nil.
+func intersectConfigTargetDevices(a, b vimv1.ConfigTargetDevices) vimv1.ConfigTargetDevices {
+	return vimv1.ConfigTargetDevices{
+		CDROM:                     intersectDeepEqual(a.CDROM, b.CDROM),
+		Floppy:                    intersectDeepEqual(a.Floppy, b.Floppy),
+		Serial:                    intersectDeepEqual(a.Serial, b.Serial),
+		Parallel:                  intersectDeepEqual(a.Parallel, b.Parallel),
+		Sound:                     intersectDeepEqual(a.Sound, b.Sound),
+		USB:                       intersectDeepEqual(a.USB, b.USB),
+		PCIPassthrough:            intersectDeepEqual(a.PCIPassthrough, b.PCIPassthrough),
+		DynamicPassthroughDevices: intersectDeepEqual(a.DynamicPassthroughDevices, b.DynamicPassthroughDevices),
+		SRIOV:                     intersectDeepEqual(a.SRIOV, b.SRIOV),
+		VGPUDevice:                intersectDeepEqual(a.VGPUDevice, b.VGPUDevice),
+		VGPUProfile:               intersectDeepEqual(a.VGPUProfile, b.VGPUProfile),
+		SharedGPUPassthroughTypes: intersectDeepEqual(a.SharedGPUPassthroughTypes, b.SharedGPUPassthroughTypes),
+		SGXTargetInfo:             intersectPtr(a.SGXTargetInfo, b.SGXTargetInfo),
+		PrecisionClockInfo:        intersectDeepEqual(a.PrecisionClockInfo, b.PrecisionClockInfo),
+		VendorDeviceGroupInfo:     intersectDeepEqual(a.VendorDeviceGroupInfo, b.VendorDeviceGroupInfo),
+		DVXClassInfo:              intersectDeepEqual(a.DVXClassInfo, b.DVXClassInfo),
+		IDEDisks:                  intersectDeepEqual(a.IDEDisks, b.IDEDisks),
+		SCSIDisks:                 intersectDeepEqual(a.SCSIDisks, b.SCSIDisks),
+		SCSIPassthrough:           intersectDeepEqual(a.SCSIPassthrough, b.SCSIPassthrough),
+		VFlashModule:              intersectDeepEqual(a.VFlashModule, b.VFlashModule),
+	}
+}
+
+// intersectDeepEqual returns the elements of a that have an equal (per
+// apiequality.Semantic.DeepEqual) counterpart somewhere in b.
+func intersectDeepEqual[T any](a, b []T) []T {
+	if len(a) == 0 || len(b) == 0 {
+		return nil
+	}
+
+	out := make([]T, 0, len(a))
+
+	for _, av := range a {
+		for _, bv := range b {
+			if apiequality.Semantic.DeepEqual(av, bv) {
+				out = append(out, av)
+				break
+			}
+		}
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+
+	return out
+}
+
+// intersectPtr returns a if a and b are both non-nil and equal, else nil.
+func intersectPtr[T any](a, b *T) *T {
+	if a == nil || b == nil || !apiequality.Semantic.DeepEqual(a, b) {
+		return nil
+	}
+
+	return a
+}

--- a/pkg/util/configpolicysync/configpolicysync.go
+++ b/pkg/util/configpolicysync/configpolicysync.go
@@ -100,31 +100,28 @@ func (agg aggregate) intersect(t vimv1.ConfigTargetStatus) aggregate {
 	return agg
 }
 
-// minInt32 returns the smaller of a and b. A zero value is treated as "no
-// data reported" and does not restrict the result, since ConfigTargetStatus
-// fields are all +optional and a target that has not finished populating
-// its status should not silently zero out an otherwise-healthy merge.
+// minInt32 returns the smaller of a and b. Callers are expected to only pass
+// status from a Ready ConfigTarget (see the Reconciler's getConfigTargets),
+// so a zero value here is real reported data, not "not populated yet" --
+// e.g. a zero MaxSimultaneousThreads means the cluster does not support
+// HT/SMT, per VirtualMachineConfigPolicySpec's field docs.
 func minInt32(a, b int32) int32 {
-	switch {
-	case a == 0:
-		return b
-	case b == 0:
+	if a < b {
 		return a
-	case a < b:
-		return a
-	default:
-		return b
 	}
+
+	return b
 }
 
-// minQuantity returns the smaller of a and b. A nil/zero b is treated as
-// "no data reported" and does not restrict the result; see minInt32.
+// minQuantity returns the smaller of a and b. A nil b is treated as "not
+// reported by this ConfigTarget field" (e.g. SupportedMaxMem is +optional)
+// and does not restrict the result; a zero b is real data, see minInt32.
 func minQuantity(a resource.Quantity, b *resource.Quantity) resource.Quantity {
-	if b == nil || b.IsZero() {
+	if b == nil {
 		return a
 	}
 
-	if a.IsZero() || b.Cmp(a) < 0 {
+	if b.Cmp(a) < 0 {
 		return b.DeepCopy()
 	}
 

--- a/pkg/util/configpolicysync/configpolicysync.go
+++ b/pkg/util/configpolicysync/configpolicysync.go
@@ -22,6 +22,9 @@
 package configpolicysync
 
 import (
+	"errors"
+	"fmt"
+
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 
@@ -32,11 +35,19 @@ import (
 // replaced by the intersection of targets. Fields not derived from a
 // ConfigTarget are copied through from spec unmodified. If targets is
 // empty, spec is returned unmodified.
+//
+// A cluster's reported maximum can narrow as well as widen -- e.g. a
+// cluster loses hosts or is downgraded after an admin set a range field's
+// Min. If the resulting Max would drop below an existing, tenant-managed
+// Min, Merge returns spec unmodified and a non-nil error identifying the
+// inverted field(s) instead of silently producing a Min > Max range.
+// Callers must check the error and must not apply the returned spec when
+// it is non-nil.
 func Merge(
 	spec vimv1.VirtualMachineConfigPolicySpec,
-	targets ...vimv1.ConfigTargetStatus) vimv1.VirtualMachineConfigPolicySpec {
+	targets ...vimv1.ConfigTargetStatus) (vimv1.VirtualMachineConfigPolicySpec, error) {
 	if len(targets) == 0 {
-		return spec
+		return spec, nil
 	}
 
 	agg := aggregate{
@@ -66,7 +77,38 @@ func Merge(
 	out.TDXSupported = agg.tdxSupported
 	out.ConfigTargetDevices = agg.devices
 
-	return out
+	err := validateRanges(out)
+	if err != nil {
+		return spec, err
+	}
+
+	return out, nil
+}
+
+// validateRanges returns a non-nil error naming every range field on spec
+// whose Min exceeds its Max. This can only happen to a range field Merge
+// derives Max for: Min is tenant-managed and untouched by Merge, so a
+// cluster capability drop can push a synced Max below an existing Min.
+func validateRanges(spec vimv1.VirtualMachineConfigPolicySpec) error {
+	var errs []error
+
+	if r := spec.NumCPUCores; r != nil && r.Min > r.Max {
+		errs = append(errs, fmt.Errorf("numCPUCores: min (%d) exceeds max (%d)", r.Min, r.Max))
+	}
+
+	if r := spec.NumNUMANodes; r != nil && r.Min > r.Max {
+		errs = append(errs, fmt.Errorf("numNUMANodes: min (%d) exceeds max (%d)", r.Min, r.Max))
+	}
+
+	if r := spec.NumSimultaneousThreads; r != nil && r.Min > r.Max {
+		errs = append(errs, fmt.Errorf("numSimultaneousThreads: min (%d) exceeds max (%d)", r.Min, r.Max))
+	}
+
+	if r := spec.Memory; r != nil && r.Min.Cmp(r.Max) > 0 {
+		errs = append(errs, fmt.Errorf("memory: min (%s) exceeds max (%s)", r.Min.String(), r.Max.String()))
+	}
+
+	return errors.Join(errs...)
 }
 
 // aggregate accumulates the fold-over-targets state used by Merge.

--- a/pkg/util/configpolicysync/configpolicysync.go
+++ b/pkg/util/configpolicysync/configpolicysync.go
@@ -38,11 +38,12 @@ import (
 //
 // A cluster's reported maximum can narrow as well as widen -- e.g. a
 // cluster loses hosts or is downgraded after an admin set a range field's
-// Min. If the resulting Max would drop below an existing, tenant-managed
-// Min, Merge returns spec unmodified and a non-nil error identifying the
-// inverted field(s) instead of silently producing a Min > Max range.
-// Callers must check the error and must not apply the returned spec when
-// it is non-nil.
+// Min. If a range field's derived Max would drop below an existing,
+// tenant-managed Min, that field is left unchanged rather than publishing a
+// Min > Max range, and Merge returns a non-nil error naming it -- every
+// other field still converges normally, so one field in conflict does not
+// freeze the rest of the policy's sync. Callers should surface the error
+// (e.g. as a Ready=False condition) but must still apply the returned spec.
 func Merge(
 	spec vimv1.VirtualMachineConfigPolicySpec,
 	targets ...vimv1.ConfigTargetStatus) (vimv1.VirtualMachineConfigPolicySpec, error) {
@@ -54,7 +55,7 @@ func Merge(
 		numCPUCores:            targets[0].NumCPUCores,
 		numNUMANodes:           targets[0].NumNumaNodes,
 		numSimultaneousThreads: targets[0].MaxSimultaneousThreads,
-		memory:                 quantityOrZero(targets[0].SupportedMaxMem),
+		memory:                 quantityPtrCopy(targets[0].SupportedMaxMem),
 		smcPresent:             targets[0].SMCPresent,
 		sevSupported:           targets[0].SEVSupported,
 		sevSNPSupported:        targets[0].SEVSNPSupported,
@@ -67,48 +68,45 @@ func Merge(
 	}
 
 	out := spec
-	out.NumCPUCores = mergeIntRangeMax(out.NumCPUCores, agg.numCPUCores)
-	out.NumNUMANodes = mergeIntRangeMax(out.NumNUMANodes, agg.numNUMANodes)
-	out.NumSimultaneousThreads = mergeIntRangeMax(out.NumSimultaneousThreads, agg.numSimultaneousThreads)
-	out.Memory = mergeResourceQuantityRangeMax(out.Memory, agg.memory)
+
+	var errs []error
+
+	if r := mergeIntRangeMax(out.NumCPUCores, agg.numCPUCores); r.Min <= r.Max {
+		out.NumCPUCores = r
+	} else {
+		errs = append(errs, fmt.Errorf("numCPUCores: min (%d) exceeds cluster-reported max (%d); field left unchanged", r.Min, r.Max))
+	}
+
+	if r := mergeIntRangeMax(out.NumNUMANodes, agg.numNUMANodes); r.Min <= r.Max {
+		out.NumNUMANodes = r
+	} else {
+		errs = append(errs, fmt.Errorf("numNUMANodes: min (%d) exceeds cluster-reported max (%d); field left unchanged", r.Min, r.Max))
+	}
+
+	if r := mergeIntRangeMax(out.NumSimultaneousThreads, agg.numSimultaneousThreads); r.Min <= r.Max {
+		out.NumSimultaneousThreads = r
+	} else {
+		errs = append(errs, fmt.Errorf("numSimultaneousThreads: min (%d) exceeds cluster-reported max (%d); field left unchanged", r.Min, r.Max))
+	}
+
+	// A nil agg.memory means no target reported SupportedMaxMem -- leave
+	// Memory untouched rather than treating "no data" as a real zero.
+	if agg.memory != nil {
+		if r := mergeResourceQuantityRangeMax(out.Memory, *agg.memory); r.Min.Cmp(r.Max) <= 0 {
+			out.Memory = r
+		} else {
+			errs = append(errs, fmt.Errorf(
+				"memory: min (%s) exceeds cluster-reported max (%s); field left unchanged", r.Min.String(), r.Max.String()))
+		}
+	}
+
 	out.SMCPresent = agg.smcPresent
 	out.SEVSupported = agg.sevSupported
 	out.SEVSNPSupported = agg.sevSNPSupported
 	out.TDXSupported = agg.tdxSupported
 	out.ConfigTargetDevices = agg.devices
 
-	err := validateRanges(out)
-	if err != nil {
-		return spec, err
-	}
-
-	return out, nil
-}
-
-// validateRanges returns a non-nil error naming every range field on spec
-// whose Min exceeds its Max. This can only happen to a range field Merge
-// derives Max for: Min is tenant-managed and untouched by Merge, so a
-// cluster capability drop can push a synced Max below an existing Min.
-func validateRanges(spec vimv1.VirtualMachineConfigPolicySpec) error {
-	var errs []error
-
-	if r := spec.NumCPUCores; r != nil && r.Min > r.Max {
-		errs = append(errs, fmt.Errorf("numCPUCores: min (%d) exceeds max (%d)", r.Min, r.Max))
-	}
-
-	if r := spec.NumNUMANodes; r != nil && r.Min > r.Max {
-		errs = append(errs, fmt.Errorf("numNUMANodes: min (%d) exceeds max (%d)", r.Min, r.Max))
-	}
-
-	if r := spec.NumSimultaneousThreads; r != nil && r.Min > r.Max {
-		errs = append(errs, fmt.Errorf("numSimultaneousThreads: min (%d) exceeds max (%d)", r.Min, r.Max))
-	}
-
-	if r := spec.Memory; r != nil && r.Min.Cmp(r.Max) > 0 {
-		errs = append(errs, fmt.Errorf("memory: min (%s) exceeds max (%s)", r.Min.String(), r.Max.String()))
-	}
-
-	return errors.Join(errs...)
+	return out, errors.Join(errs...)
 }
 
 // aggregate accumulates the fold-over-targets state used by Merge.
@@ -116,7 +114,10 @@ type aggregate struct {
 	numCPUCores            int32
 	numNUMANodes           int32
 	numSimultaneousThreads int32
-	memory                 resource.Quantity
+
+	// memory is nil until some target reports SupportedMaxMem -- see
+	// minQuantityPtr.
+	memory *resource.Quantity
 
 	smcPresent      bool
 	sevSupported    bool
@@ -132,7 +133,7 @@ func (agg aggregate) intersect(t vimv1.ConfigTargetStatus) aggregate {
 	agg.numCPUCores = minInt32(agg.numCPUCores, t.NumCPUCores)
 	agg.numNUMANodes = minInt32(agg.numNUMANodes, t.NumNumaNodes)
 	agg.numSimultaneousThreads = minInt32(agg.numSimultaneousThreads, t.MaxSimultaneousThreads)
-	agg.memory = minQuantity(agg.memory, t.SupportedMaxMem)
+	agg.memory = minQuantityPtr(agg.memory, t.SupportedMaxMem)
 	agg.smcPresent = agg.smcPresent && t.SMCPresent
 	agg.sevSupported = agg.sevSupported && t.SEVSupported
 	agg.sevSNPSupported = agg.sevSNPSupported && t.SEVSNPSupported
@@ -155,28 +156,37 @@ func minInt32(a, b int32) int32 {
 	return b
 }
 
-// minQuantity returns the smaller of a and b. A nil b is treated as "not
-// reported by this ConfigTarget field" (e.g. SupportedMaxMem is +optional)
-// and does not restrict the result; a zero b is real data, see minInt32.
-func minQuantity(a resource.Quantity, b *resource.Quantity) resource.Quantity {
+// minQuantityPtr returns the smaller of a and b, treating either as "not
+// reported by this ConfigTarget field" (SupportedMaxMem is +optional) when
+// nil, rather than a real zero -- so seeding or folding in a target that
+// omitted the field never forces the result to zero and discards every
+// other target's real reported value. A zero, non-nil Quantity is real
+// data, see minInt32.
+func minQuantityPtr(a, b *resource.Quantity) *resource.Quantity {
+	if a == nil {
+		return quantityPtrCopy(b)
+	}
+
 	if b == nil {
 		return a
 	}
 
-	if b.Cmp(a) < 0 {
-		return b.DeepCopy()
+	if b.Cmp(*a) < 0 {
+		return quantityPtrCopy(b)
 	}
 
 	return a
 }
 
-// quantityOrZero returns *q, or the zero Quantity if q is nil.
-func quantityOrZero(q *resource.Quantity) resource.Quantity {
+// quantityPtrCopy returns a deep copy of q, or nil if q is nil.
+func quantityPtrCopy(q *resource.Quantity) *resource.Quantity {
 	if q == nil {
-		return resource.Quantity{}
+		return nil
 	}
 
-	return q.DeepCopy()
+	c := q.DeepCopy()
+
+	return &c
 }
 
 // mergeIntRangeMax returns a copy of existing with Max set to maxVal, or a

--- a/pkg/util/configpolicysync/configpolicysync_suite_test.go
+++ b/pkg/util/configpolicysync/configpolicysync_suite_test.go
@@ -1,0 +1,17 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package configpolicysync_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfigPolicySync(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ConfigPolicySync Test Suite")
+}

--- a/pkg/util/configpolicysync/configpolicysync_test.go
+++ b/pkg/util/configpolicysync/configpolicysync_test.go
@@ -141,15 +141,20 @@ var _ = Describe("Merge", Label(testlabels.API), func() {
 			Expect(merged.ConfigTargetDevices.CDROM).To(ConsistOf(shared))
 		})
 
-		It("treats a zero value on one target as no data, not as a restriction to zero", func() {
+		It("intersects a zero value on one target literally, as real reported data", func() {
+			// Merge's contract is that every target passed in has already
+			// been established as Ready by the caller (see the
+			// Reconciler's getConfigTargets) -- so a zero here is a real
+			// "this cluster does not support it," not "not populated yet,"
+			// and must narrow the intersection like any other value.
 			spec := vimv1.VirtualMachineConfigPolicySpec{}
 
 			merged := configpolicysync.Merge(spec,
 				vimv1.ConfigTargetStatus{NumCPUCores: 8},
-				vimv1.ConfigTargetStatus{}, // status not yet populated
+				vimv1.ConfigTargetStatus{NumCPUCores: 0},
 			)
 
-			Expect(merged.NumCPUCores.Max).To(Equal(int32(8)))
+			Expect(merged.NumCPUCores.Max).To(Equal(int32(0)))
 		})
 	})
 

--- a/pkg/util/configpolicysync/configpolicysync_test.go
+++ b/pkg/util/configpolicysync/configpolicysync_test.go
@@ -1,0 +1,174 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package configpolicysync_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	vimv1 "github.com/vmware-tanzu/vm-operator/external/vim/api/v1alpha1"
+
+	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/configpolicysync"
+)
+
+var _ = Describe("Merge", Label(testlabels.API), func() {
+	When("no targets are supplied", func() {
+		It("returns spec unchanged", func() {
+			spec := vimv1.VirtualMachineConfigPolicySpec{
+				Zone:       "zone-1",
+				CreateMode: vimv1.VirtualMachineConfigPolicyModeDeny,
+			}
+
+			Expect(configpolicysync.Merge(spec)).To(Equal(spec))
+		})
+	})
+
+	When("a single target is supplied", func() {
+		It("copies its capacity limits and security flags into spec, preserving non-derived fields", func() {
+			spec := vimv1.VirtualMachineConfigPolicySpec{
+				Zone:       "zone-1",
+				CreateMode: vimv1.VirtualMachineConfigPolicyModeDeny,
+				ExtraConfig: &vimv1.VirtualMachineConfigPolicyExtraConfigSpec{
+					Denied: []vimv1.VirtualMachineConfigPolicyExtraConfigKey{
+						{Type: vimv1.MatchTypeFixed, Key: "some.key"},
+					},
+				},
+			}
+
+			target := vimv1.ConfigTargetStatus{
+				NumCPUCores:            8,
+				NumNumaNodes:           2,
+				MaxSimultaneousThreads: 16,
+				SupportedMaxMem:        quantityPtr("64Gi"),
+				SMCPresent:             true,
+				SEVSupported:           true,
+			}
+
+			merged := configpolicysync.Merge(spec, target)
+
+			Expect(merged.Zone).To(Equal("zone-1"))
+			Expect(merged.CreateMode).To(Equal(vimv1.VirtualMachineConfigPolicyModeDeny))
+			Expect(merged.ExtraConfig).To(Equal(spec.ExtraConfig))
+
+			Expect(merged.NumCPUCores).ToNot(BeNil())
+			Expect(merged.NumCPUCores.Max).To(Equal(int32(8)))
+			Expect(merged.NumNUMANodes.Max).To(Equal(int32(2)))
+			Expect(merged.NumSimultaneousThreads.Max).To(Equal(int32(16)))
+			Expect(merged.Memory.Max.Equal(resource.MustParse("64Gi"))).To(BeTrue())
+			Expect(merged.SMCPresent).To(BeTrue())
+			Expect(merged.SEVSupported).To(BeTrue())
+			Expect(merged.SEVSNPSupported).To(BeFalse())
+			Expect(merged.TDXSupported).To(BeFalse())
+		})
+
+		It("preserves an existing Min on a range field", func() {
+			spec := vimv1.VirtualMachineConfigPolicySpec{
+				NumCPUCores: &vimv1.IntRange{Min: 2, Max: 4},
+			}
+
+			merged := configpolicysync.Merge(spec, vimv1.ConfigTargetStatus{NumCPUCores: 8})
+
+			Expect(merged.NumCPUCores.Min).To(Equal(int32(2)))
+			Expect(merged.NumCPUCores.Max).To(Equal(int32(8)))
+		})
+	})
+
+	When("multiple targets are supplied (multi-cluster zone)", func() {
+		It("intersects numeric ranges to the minimum of the per-target maxima", func() {
+			spec := vimv1.VirtualMachineConfigPolicySpec{}
+
+			merged := configpolicysync.Merge(spec,
+				vimv1.ConfigTargetStatus{NumCPUCores: 8, NumNumaNodes: 2, MaxSimultaneousThreads: 16},
+				vimv1.ConfigTargetStatus{NumCPUCores: 4, NumNumaNodes: 4, MaxSimultaneousThreads: 32},
+			)
+
+			Expect(merged.NumCPUCores.Max).To(Equal(int32(4)))
+			Expect(merged.NumNUMANodes.Max).To(Equal(int32(2)))
+			Expect(merged.NumSimultaneousThreads.Max).To(Equal(int32(16)))
+		})
+
+		It("intersects memory to the minimum of the per-target maxima", func() {
+			spec := vimv1.VirtualMachineConfigPolicySpec{}
+
+			merged := configpolicysync.Merge(spec,
+				vimv1.ConfigTargetStatus{SupportedMaxMem: quantityPtr("128Gi")},
+				vimv1.ConfigTargetStatus{SupportedMaxMem: quantityPtr("64Gi")},
+			)
+
+			Expect(merged.Memory.Max.Equal(resource.MustParse("64Gi"))).To(BeTrue())
+		})
+
+		It("ANDs boolean support flags", func() {
+			spec := vimv1.VirtualMachineConfigPolicySpec{}
+
+			merged := configpolicysync.Merge(spec,
+				vimv1.ConfigTargetStatus{SEVSupported: true, TDXSupported: true},
+				vimv1.ConfigTargetStatus{SEVSupported: true, TDXSupported: false},
+			)
+
+			Expect(merged.SEVSupported).To(BeTrue())
+			Expect(merged.TDXSupported).To(BeFalse())
+		})
+
+		It("intersects ConfigTargetDevices to entries common to every target", func() {
+			spec := vimv1.VirtualMachineConfigPolicySpec{}
+
+			shared := vimv1.VirtualMachineCdromInfo{
+				VirtualMachineTargetInfo: vimv1.VirtualMachineTargetInfo{Name: "cdrom-shared"},
+			}
+			onlyFirst := vimv1.VirtualMachineCdromInfo{
+				VirtualMachineTargetInfo: vimv1.VirtualMachineTargetInfo{Name: "cdrom-only-first"},
+			}
+
+			merged := configpolicysync.Merge(spec,
+				vimv1.ConfigTargetStatus{
+					ConfigTargetDevices: vimv1.ConfigTargetDevices{
+						CDROM: []vimv1.VirtualMachineCdromInfo{shared, onlyFirst},
+					},
+				},
+				vimv1.ConfigTargetStatus{
+					ConfigTargetDevices: vimv1.ConfigTargetDevices{
+						CDROM: []vimv1.VirtualMachineCdromInfo{shared},
+					},
+				},
+			)
+
+			Expect(merged.ConfigTargetDevices.CDROM).To(ConsistOf(shared))
+		})
+
+		It("treats a zero value on one target as no data, not as a restriction to zero", func() {
+			spec := vimv1.VirtualMachineConfigPolicySpec{}
+
+			merged := configpolicysync.Merge(spec,
+				vimv1.ConfigTargetStatus{NumCPUCores: 8},
+				vimv1.ConfigTargetStatus{}, // status not yet populated
+			)
+
+			Expect(merged.NumCPUCores.Max).To(Equal(int32(8)))
+		})
+	})
+
+	When("syncMode=Disabled fields are untouched", func() {
+		It("never sets fields that have no ConfigTarget source", func() {
+			spec := vimv1.VirtualMachineConfigPolicySpec{
+				LatencySensitivityLevels: []vimv1.LatencySensitivityLevel{vimv1.LatencySensitivityLevelHigh},
+				IOMMUSupported:           true,
+			}
+
+			merged := configpolicysync.Merge(spec, vimv1.ConfigTargetStatus{})
+
+			Expect(merged.LatencySensitivityLevels).To(Equal(spec.LatencySensitivityLevels))
+			Expect(merged.IOMMUSupported).To(BeTrue())
+		})
+	})
+})
+
+func quantityPtr(s string) *resource.Quantity {
+	q := resource.MustParse(s)
+	return &q
+}

--- a/pkg/util/configpolicysync/configpolicysync_test.go
+++ b/pkg/util/configpolicysync/configpolicysync_test.go
@@ -24,7 +24,9 @@ var _ = Describe("Merge", Label(testlabels.API), func() {
 				CreateMode: vimv1.VirtualMachineConfigPolicyModeDeny,
 			}
 
-			Expect(configpolicysync.Merge(spec)).To(Equal(spec))
+			merged, err := configpolicysync.Merge(spec)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(merged).To(Equal(spec))
 		})
 	})
 
@@ -49,7 +51,8 @@ var _ = Describe("Merge", Label(testlabels.API), func() {
 				SEVSupported:           true,
 			}
 
-			merged := configpolicysync.Merge(spec, target)
+			merged, err := configpolicysync.Merge(spec, target)
+			Expect(err).ToNot(HaveOccurred())
 
 			Expect(merged.Zone).To(Equal("zone-1"))
 			Expect(merged.CreateMode).To(Equal(vimv1.VirtualMachineConfigPolicyModeDeny))
@@ -71,10 +74,71 @@ var _ = Describe("Merge", Label(testlabels.API), func() {
 				NumCPUCores: &vimv1.IntRange{Min: 2, Max: 4},
 			}
 
-			merged := configpolicysync.Merge(spec, vimv1.ConfigTargetStatus{NumCPUCores: 8})
+			merged, err := configpolicysync.Merge(spec, vimv1.ConfigTargetStatus{NumCPUCores: 8})
+			Expect(err).ToNot(HaveOccurred())
 
 			Expect(merged.NumCPUCores.Min).To(Equal(int32(2)))
 			Expect(merged.NumCPUCores.Max).To(Equal(int32(8)))
+		})
+
+		It("narrows Max when the cluster's reported capability has shrunk", func() {
+			spec := vimv1.VirtualMachineConfigPolicySpec{
+				NumCPUCores:            &vimv1.IntRange{Min: 2, Max: 64},
+				NumNUMANodes:           &vimv1.IntRange{Min: 1, Max: 8},
+				NumSimultaneousThreads: &vimv1.IntRange{Min: 1, Max: 32},
+				Memory:                 &vimv1.ResourceQuantityRange{Min: resource.MustParse("1Gi"), Max: resource.MustParse("256Gi")},
+			}
+
+			merged, err := configpolicysync.Merge(spec, vimv1.ConfigTargetStatus{
+				NumCPUCores:            32,
+				NumNumaNodes:           4,
+				MaxSimultaneousThreads: 16,
+				SupportedMaxMem:        quantityPtr("128Gi"),
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(merged.NumCPUCores.Max).To(Equal(int32(32)), "must come down, not stay pinned to the old, wider Max")
+			Expect(merged.NumNUMANodes.Max).To(Equal(int32(4)))
+			Expect(merged.NumSimultaneousThreads.Max).To(Equal(int32(16)))
+			Expect(merged.Memory.Max.Equal(resource.MustParse("128Gi"))).To(BeTrue())
+
+			// Min is tenant intent and must survive a shrink untouched.
+			Expect(merged.NumCPUCores.Min).To(Equal(int32(2)))
+			Expect(merged.NumNUMANodes.Min).To(Equal(int32(1)))
+			Expect(merged.NumSimultaneousThreads.Min).To(Equal(int32(1)))
+			Expect(merged.Memory.Min.Equal(resource.MustParse("1Gi"))).To(BeTrue())
+		})
+
+		When("the cluster's reported capability has shrunk below an existing Min", func() {
+			It("rejects the sync instead of publishing an inverted range", func() {
+				spec := vimv1.VirtualMachineConfigPolicySpec{
+					NumCPUCores: &vimv1.IntRange{Min: 8, Max: 64},
+				}
+
+				_, err := configpolicysync.Merge(spec, vimv1.ConfigTargetStatus{NumCPUCores: 4})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("numCPUCores"))
+			})
+
+			It("leaves spec unmodified when rejecting", func() {
+				spec := vimv1.VirtualMachineConfigPolicySpec{
+					NumCPUCores: &vimv1.IntRange{Min: 8, Max: 64},
+				}
+
+				merged, err := configpolicysync.Merge(spec, vimv1.ConfigTargetStatus{NumCPUCores: 4})
+				Expect(err).To(HaveOccurred())
+				Expect(merged).To(Equal(spec))
+			})
+
+			It("rejects an inverted Memory range the same way", func() {
+				spec := vimv1.VirtualMachineConfigPolicySpec{
+					Memory: &vimv1.ResourceQuantityRange{Min: resource.MustParse("32Gi"), Max: resource.MustParse("256Gi")},
+				}
+
+				_, err := configpolicysync.Merge(spec, vimv1.ConfigTargetStatus{SupportedMaxMem: quantityPtr("16Gi")})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("memory"))
+			})
 		})
 	})
 
@@ -82,10 +146,11 @@ var _ = Describe("Merge", Label(testlabels.API), func() {
 		It("intersects numeric ranges to the minimum of the per-target maxima", func() {
 			spec := vimv1.VirtualMachineConfigPolicySpec{}
 
-			merged := configpolicysync.Merge(spec,
+			merged, err := configpolicysync.Merge(spec,
 				vimv1.ConfigTargetStatus{NumCPUCores: 8, NumNumaNodes: 2, MaxSimultaneousThreads: 16},
 				vimv1.ConfigTargetStatus{NumCPUCores: 4, NumNumaNodes: 4, MaxSimultaneousThreads: 32},
 			)
+			Expect(err).ToNot(HaveOccurred())
 
 			Expect(merged.NumCPUCores.Max).To(Equal(int32(4)))
 			Expect(merged.NumNUMANodes.Max).To(Equal(int32(2)))
@@ -95,10 +160,11 @@ var _ = Describe("Merge", Label(testlabels.API), func() {
 		It("intersects memory to the minimum of the per-target maxima", func() {
 			spec := vimv1.VirtualMachineConfigPolicySpec{}
 
-			merged := configpolicysync.Merge(spec,
+			merged, err := configpolicysync.Merge(spec,
 				vimv1.ConfigTargetStatus{SupportedMaxMem: quantityPtr("128Gi")},
 				vimv1.ConfigTargetStatus{SupportedMaxMem: quantityPtr("64Gi")},
 			)
+			Expect(err).ToNot(HaveOccurred())
 
 			Expect(merged.Memory.Max.Equal(resource.MustParse("64Gi"))).To(BeTrue())
 		})
@@ -106,10 +172,11 @@ var _ = Describe("Merge", Label(testlabels.API), func() {
 		It("ANDs boolean support flags", func() {
 			spec := vimv1.VirtualMachineConfigPolicySpec{}
 
-			merged := configpolicysync.Merge(spec,
+			merged, err := configpolicysync.Merge(spec,
 				vimv1.ConfigTargetStatus{SEVSupported: true, TDXSupported: true},
 				vimv1.ConfigTargetStatus{SEVSupported: true, TDXSupported: false},
 			)
+			Expect(err).ToNot(HaveOccurred())
 
 			Expect(merged.SEVSupported).To(BeTrue())
 			Expect(merged.TDXSupported).To(BeFalse())
@@ -125,7 +192,7 @@ var _ = Describe("Merge", Label(testlabels.API), func() {
 				VirtualMachineTargetInfo: vimv1.VirtualMachineTargetInfo{Name: "cdrom-only-first"},
 			}
 
-			merged := configpolicysync.Merge(spec,
+			merged, err := configpolicysync.Merge(spec,
 				vimv1.ConfigTargetStatus{
 					ConfigTargetDevices: vimv1.ConfigTargetDevices{
 						CDROM: []vimv1.VirtualMachineCdromInfo{shared, onlyFirst},
@@ -137,6 +204,7 @@ var _ = Describe("Merge", Label(testlabels.API), func() {
 					},
 				},
 			)
+			Expect(err).ToNot(HaveOccurred())
 
 			Expect(merged.ConfigTargetDevices.CDROM).To(ConsistOf(shared))
 		})
@@ -149,10 +217,11 @@ var _ = Describe("Merge", Label(testlabels.API), func() {
 			// and must narrow the intersection like any other value.
 			spec := vimv1.VirtualMachineConfigPolicySpec{}
 
-			merged := configpolicysync.Merge(spec,
+			merged, err := configpolicysync.Merge(spec,
 				vimv1.ConfigTargetStatus{NumCPUCores: 8},
 				vimv1.ConfigTargetStatus{NumCPUCores: 0},
 			)
+			Expect(err).ToNot(HaveOccurred())
 
 			Expect(merged.NumCPUCores.Max).To(Equal(int32(0)))
 		})
@@ -165,7 +234,8 @@ var _ = Describe("Merge", Label(testlabels.API), func() {
 				IOMMUSupported:           true,
 			}
 
-			merged := configpolicysync.Merge(spec, vimv1.ConfigTargetStatus{})
+			merged, err := configpolicysync.Merge(spec, vimv1.ConfigTargetStatus{})
+			Expect(err).ToNot(HaveOccurred())
 
 			Expect(merged.LatencySensitivityLevels).To(Equal(spec.LatencySensitivityLevels))
 			Expect(merged.IOMMUSupported).To(BeTrue())

--- a/pkg/util/configpolicysync/configpolicysync_test.go
+++ b/pkg/util/configpolicysync/configpolicysync_test.go
@@ -110,7 +110,7 @@ var _ = Describe("Merge", Label(testlabels.API), func() {
 		})
 
 		When("the cluster's reported capability has shrunk below an existing Min", func() {
-			It("rejects the sync instead of publishing an inverted range", func() {
+			It("reports an error naming the field instead of publishing an inverted range", func() {
 				spec := vimv1.VirtualMachineConfigPolicySpec{
 					NumCPUCores: &vimv1.IntRange{Min: 8, Max: 64},
 				}
@@ -120,24 +120,56 @@ var _ = Describe("Merge", Label(testlabels.API), func() {
 				Expect(err.Error()).To(ContainSubstring("numCPUCores"))
 			})
 
-			It("leaves spec unmodified when rejecting", func() {
+			It("leaves only the conflicting field unchanged", func() {
 				spec := vimv1.VirtualMachineConfigPolicySpec{
 					NumCPUCores: &vimv1.IntRange{Min: 8, Max: 64},
 				}
 
 				merged, err := configpolicysync.Merge(spec, vimv1.ConfigTargetStatus{NumCPUCores: 4})
 				Expect(err).To(HaveOccurred())
-				Expect(merged).To(Equal(spec))
+				Expect(merged.NumCPUCores).To(Equal(spec.NumCPUCores), "the conflicting field must not change")
 			})
 
-			It("rejects an inverted Memory range the same way", func() {
+			It("still converges every other field in the same call", func() {
+				spec := vimv1.VirtualMachineConfigPolicySpec{
+					NumCPUCores: &vimv1.IntRange{Min: 8, Max: 64},
+				}
+
+				merged, err := configpolicysync.Merge(spec, vimv1.ConfigTargetStatus{
+					NumCPUCores:     4,
+					SupportedMaxMem: quantityPtr("64Gi"),
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(merged.NumCPUCores).To(Equal(spec.NumCPUCores), "conflicting field stays as-is")
+				Expect(merged.Memory.Max.Equal(resource.MustParse("64Gi"))).To(BeTrue(),
+					"an unrelated field must still converge despite the NumCPUCores conflict")
+			})
+
+			It("rejects an inverted Memory range the same way, leaving only Memory unchanged", func() {
 				spec := vimv1.VirtualMachineConfigPolicySpec{
 					Memory: &vimv1.ResourceQuantityRange{Min: resource.MustParse("32Gi"), Max: resource.MustParse("256Gi")},
 				}
 
-				_, err := configpolicysync.Merge(spec, vimv1.ConfigTargetStatus{SupportedMaxMem: quantityPtr("16Gi")})
+				merged, err := configpolicysync.Merge(spec, vimv1.ConfigTargetStatus{
+					NumCPUCores:     4,
+					SupportedMaxMem: quantityPtr("16Gi"),
+				})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("memory"))
+				Expect(merged.Memory).To(Equal(spec.Memory))
+				Expect(merged.NumCPUCores.Max).To(Equal(int32(4)), "an unrelated field must still converge")
+			})
+
+			It("joins multiple field conflicts into a single error", func() {
+				spec := vimv1.VirtualMachineConfigPolicySpec{
+					NumCPUCores:  &vimv1.IntRange{Min: 8, Max: 64},
+					NumNUMANodes: &vimv1.IntRange{Min: 4, Max: 8},
+				}
+
+				_, err := configpolicysync.Merge(spec, vimv1.ConfigTargetStatus{NumCPUCores: 4, NumNumaNodes: 2})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("numCPUCores"))
+				Expect(err.Error()).To(ContainSubstring("numNUMANodes"))
 			})
 		})
 	})
@@ -207,6 +239,35 @@ var _ = Describe("Merge", Label(testlabels.API), func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(merged.ConfigTargetDevices.CDROM).To(ConsistOf(shared))
+		})
+
+		It("does not discard a later target's real memory value when an earlier target omits it", func() {
+			// SupportedMaxMem is +optional; a target that doesn't report it
+			// must not be treated as "this cluster supports zero bytes,"
+			// which would otherwise permanently floor the intersection at
+			// zero regardless of what any other target reports.
+			spec := vimv1.VirtualMachineConfigPolicySpec{}
+
+			merged, err := configpolicysync.Merge(spec,
+				vimv1.ConfigTargetStatus{SupportedMaxMem: nil},
+				vimv1.ConfigTargetStatus{SupportedMaxMem: quantityPtr("64Gi")},
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(merged.Memory).ToNot(BeNil())
+			Expect(merged.Memory.Max.Equal(resource.MustParse("64Gi"))).To(BeTrue())
+		})
+
+		It("leaves Memory untouched when no target reports SupportedMaxMem", func() {
+			spec := vimv1.VirtualMachineConfigPolicySpec{}
+
+			merged, err := configpolicysync.Merge(spec,
+				vimv1.ConfigTargetStatus{SupportedMaxMem: nil},
+				vimv1.ConfigTargetStatus{SupportedMaxMem: nil},
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(merged.Memory).To(BeNil())
 		})
 
 		It("intersects a zero value on one target literally, as real reported data", func() {

--- a/test/e2e/vmservice/config/wcp.yaml
+++ b/test/e2e/vmservice/config/wcp.yaml
@@ -83,6 +83,7 @@ intervals:
   default/wait-virtual-machine-service-endpoints: ["2m", "5s"]
   default/wait-virtual-machine-image-creation: ["10m", "5s"]
   default/consistent-virtual-machine-condition: ["30s", "5s"]
+  default/consistent-config-policy-spec: ["30s", "5s"]
   default/wait-virtual-machine-annotation-update: ["30s", "5s"]
   default/wait-virtual-machine-group-deletion: [ "60s", "5s" ]
   default/wait-virtual-machine-group-condition-update: [ "6m", "5s" ]
@@ -111,6 +112,7 @@ intervals:
   default/wait-policy-evaluation-update: ["3m", "10s"]
 
   default/wait-config-target-condition-update: ["5m", "10s"]
+  default/wait-config-policy-condition-update: ["5m", "10s"]
   default/wait-vm-config-options-creation: ["5m", "10s"]
   default/wait-vm-config-options-condition-update: ["5m", "10s"]
   default/wait-vm-guest-options-condition-update: ["5m", "10s"]

--- a/test/e2e/vmservice/vmservice/configpolicy/configpolicy.go
+++ b/test/e2e/vmservice/vmservice/configpolicy/configpolicy.go
@@ -385,12 +385,22 @@ func Spec(ctx context.Context, inputGetter func() SpecInput) {
 					z := &zoneList.Items[i]
 					Expect(z.Spec.ManagedVMs.ClusterMoIDs).ToNot(BeEmpty(),
 						"Zone %q has no cluster MoIDs in spec.managedVMs.clusterMoIDs", z.Name)
-
-					var ct vimv1.ConfigTarget
-					Expect(svClusterClient.Get(ctx,
-						ctrlclient.ObjectKey{Name: z.Spec.ManagedVMs.ClusterMoIDs[0]}, &ct)).To(Succeed())
+					clusterMoID := z.Spec.ManagedVMs.ClusterMoIDs[0]
 
 					Eventually(func(g Gomega) {
+						// Re-fetch the ConfigTarget on every poll, inside the
+						// Eventually, rather than once beforehand: fetching
+						// it outside would let this spec pass vacuously
+						// (comparing 0 == 0) if the ConfigTarget's own
+						// status hasn't finished populating yet.
+						var ct vimv1.ConfigTarget
+						g.Expect(svClusterClient.Get(ctx, ctrlclient.ObjectKey{Name: clusterMoID}, &ct)).To(Succeed())
+
+						ctCond := apimeta.FindStatusCondition(ct.Status.Conditions, vimv1.ReadyConditionType)
+						g.Expect(ctCond).ToNot(BeNil(), "ConfigTarget %q should have a Ready condition", ct.Name)
+						g.Expect(ctCond.Status).To(Equal(metav1.ConditionTrue),
+							"ConfigTarget %q should be Ready before its policy can converge", ct.Name)
+
 						policy := &vimv1.VirtualMachineConfigPolicy{}
 						g.Expect(svClusterClient.Get(ctx,
 							ctrlclient.ObjectKey{Name: z.Name, Namespace: input.WCPNamespaceName},
@@ -409,9 +419,41 @@ func Spec(ctx context.Context, inputGetter func() SpecInput) {
 							"VirtualMachineConfigPolicy %q spec.numCPUCores.max should equal ConfigTarget %q status.numCPUCores",
 							policy.Name, ct.Name)
 
+						g.Expect(policy.Spec.NumNUMANodes).ToNot(BeNil(),
+							"VirtualMachineConfigPolicy %q spec.numNUMANodes should be populated from ConfigTarget.status",
+							policy.Name)
+						g.Expect(policy.Spec.NumNUMANodes.Max).To(Equal(ct.Status.NumNumaNodes),
+							"VirtualMachineConfigPolicy %q spec.numNUMANodes.max should equal ConfigTarget %q status.numNumaNodes",
+							policy.Name, ct.Name)
+
+						g.Expect(policy.Spec.NumSimultaneousThreads).ToNot(BeNil(),
+							"VirtualMachineConfigPolicy %q spec.numSimultaneousThreads should be populated from ConfigTarget.status",
+							policy.Name)
+						g.Expect(policy.Spec.NumSimultaneousThreads.Max).To(Equal(ct.Status.MaxSimultaneousThreads),
+							"VirtualMachineConfigPolicy %q spec.numSimultaneousThreads.max should equal ConfigTarget %q status.maxSimultaneousThreads",
+							policy.Name, ct.Name)
+
 						g.Expect(policy.Spec.Memory).ToNot(BeNil(),
 							"VirtualMachineConfigPolicy %q spec.memory should be populated from ConfigTarget.status",
 							policy.Name)
+						if ct.Status.SupportedMaxMem != nil {
+							g.Expect(policy.Spec.Memory.Max.Equal(*ct.Status.SupportedMaxMem)).To(BeTrue(),
+								"VirtualMachineConfigPolicy %q spec.memory.max (%s) should equal ConfigTarget %q status.supportedMaxMem (%s)",
+								policy.Name, policy.Spec.Memory.Max.String(), ct.Name, ct.Status.SupportedMaxMem.String())
+						}
+
+						g.Expect(policy.Spec.SMCPresent).To(Equal(ct.Status.SMCPresent),
+							"VirtualMachineConfigPolicy %q spec.smcPresent should equal ConfigTarget %q status.smcPresent",
+							policy.Name, ct.Name)
+						g.Expect(policy.Spec.SEVSupported).To(Equal(ct.Status.SEVSupported),
+							"VirtualMachineConfigPolicy %q spec.sevSupported should equal ConfigTarget %q status.sevSupported",
+							policy.Name, ct.Name)
+						g.Expect(policy.Spec.SEVSNPSupported).To(Equal(ct.Status.SEVSNPSupported),
+							"VirtualMachineConfigPolicy %q spec.sevSNPSupported should equal ConfigTarget %q status.sevSNPSupported",
+							policy.Name, ct.Name)
+						g.Expect(policy.Spec.TDXSupported).To(Equal(ct.Status.TDXSupported),
+							"VirtualMachineConfigPolicy %q spec.tdxSupported should equal ConfigTarget %q status.tdxSupported",
+							policy.Name, ct.Name)
 					}, input.Config.GetIntervals("default", "wait-config-policy-condition-update")...).Should(Succeed())
 				}
 			})

--- a/test/e2e/vmservice/vmservice/configpolicy/configpolicy.go
+++ b/test/e2e/vmservice/vmservice/configpolicy/configpolicy.go
@@ -39,11 +39,12 @@ type SpecInput struct {
 }
 
 // Spec verifies the VirtualMachineConfigPolicy feature end-to-end.
-// Currently covers zone controller fan-out (S3) and the ConfigTarget
+// Currently covers zone controller fan-out (S3), the ConfigTarget
 // controller's cluster-scope capability discovery, including
-// status.maxHardwareVersion and non-SR-IOV device categories (S5.b/S5.c).
-// SR-IOV per-host enrichment, option enumeration (S6/S7), and policy
-// enforcement (S8/S9) will be added here.
+// status.maxHardwareVersion and non-SR-IOV device categories (S5.b/S5.c),
+// and the VirtualMachineConfigPolicy controller's sync from ConfigTarget
+// (S8). SR-IOV per-host enrichment, option enumeration (S6/S7), and VM
+// admission webhook policy enforcement (S9) will be added here.
 func Spec(ctx context.Context, inputGetter func() SpecInput) {
 	const specName = "vm-config-policy"
 
@@ -368,6 +369,94 @@ func Spec(ctx context.Context, inputGetter func() SpecInput) {
 					g.Expect(apierrors.IsNotFound(err)).To(BeTrue(),
 						"stale VirtualMachineConfigOptions %q should have been garbage-collected", stale.Name)
 				}, input.Config.GetIntervals("default", "wait-vm-config-options-deletion")...).Should(Succeed())
+			})
+	})
+
+	Context("When the VirtualMachineConfigPolicy controller syncs from ConfigTarget", func() {
+		It("Should populate policy spec from the zone's ConfigTarget capabilities",
+			Label("core-functional", "experimental"),
+			func() {
+				zoneList, err := utils.ListZonesByNamespace(ctx, svClusterClient, input.WCPNamespaceName)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(zoneList.Items).ToNot(BeEmpty(),
+					"expected at least one Zone in namespace %q", input.WCPNamespaceName)
+
+				for i := range zoneList.Items {
+					z := &zoneList.Items[i]
+					Expect(z.Spec.ManagedVMs.ClusterMoIDs).ToNot(BeEmpty(),
+						"Zone %q has no cluster MoIDs in spec.managedVMs.clusterMoIDs", z.Name)
+
+					var ct vimv1.ConfigTarget
+					Expect(svClusterClient.Get(ctx,
+						ctrlclient.ObjectKey{Name: z.Spec.ManagedVMs.ClusterMoIDs[0]}, &ct)).To(Succeed())
+
+					Eventually(func(g Gomega) {
+						policy := &vimv1.VirtualMachineConfigPolicy{}
+						g.Expect(svClusterClient.Get(ctx,
+							ctrlclient.ObjectKey{Name: z.Name, Namespace: input.WCPNamespaceName},
+							policy)).To(Succeed())
+
+						cond := apimeta.FindStatusCondition(policy.Status.Conditions, vimv1.ReadyConditionType)
+						g.Expect(cond).ToNot(BeNil(),
+							"VirtualMachineConfigPolicy %q should have a Ready condition", policy.Name)
+						g.Expect(cond.Status).To(Equal(metav1.ConditionTrue),
+							"VirtualMachineConfigPolicy %q should be Ready", policy.Name)
+
+						g.Expect(policy.Spec.NumCPUCores).ToNot(BeNil(),
+							"VirtualMachineConfigPolicy %q spec.numCPUCores should be populated from ConfigTarget.status",
+							policy.Name)
+						g.Expect(policy.Spec.NumCPUCores.Max).To(Equal(ct.Status.NumCPUCores),
+							"VirtualMachineConfigPolicy %q spec.numCPUCores.max should equal ConfigTarget %q status.numCPUCores",
+							policy.Name, ct.Name)
+
+						g.Expect(policy.Spec.Memory).ToNot(BeNil(),
+							"VirtualMachineConfigPolicy %q spec.memory should be populated from ConfigTarget.status",
+							policy.Name)
+					}, input.Config.GetIntervals("default", "wait-config-policy-condition-update")...).Should(Succeed())
+				}
+			})
+
+		It("Should stop syncing once spec.syncMode is set to Disabled",
+			Label("extended-functional", "experimental"),
+			func() {
+				zoneList, err := utils.ListZonesByNamespace(ctx, svClusterClient, input.WCPNamespaceName)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(zoneList.Items).ToNot(BeEmpty(),
+					"expected at least one Zone in namespace %q", input.WCPNamespaceName)
+				zoneName := zoneList.Items[0].Name
+
+				policy := &vimv1.VirtualMachineConfigPolicy{}
+				Expect(svClusterClient.Get(ctx,
+					ctrlclient.ObjectKey{Name: zoneName, Namespace: input.WCPNamespaceName},
+					policy)).To(Succeed())
+
+				DeferCleanup(func() {
+					Expect(svClusterClient.Get(ctx, ctrlclient.ObjectKeyFromObject(policy), policy)).To(Succeed())
+					policy.Spec.SyncMode = vimv1.VirtualMachineConfigPolicySyncModeConfigTarget
+					Expect(svClusterClient.Update(ctx, policy)).To(Succeed())
+				})
+
+				policy.Spec.SyncMode = vimv1.VirtualMachineConfigPolicySyncModeDisabled
+				Expect(svClusterClient.Update(ctx, policy)).To(Succeed())
+
+				Eventually(func(g Gomega) {
+					got := &vimv1.VirtualMachineConfigPolicy{}
+					g.Expect(svClusterClient.Get(ctx, ctrlclient.ObjectKeyFromObject(policy), got)).To(Succeed())
+
+					cond := apimeta.FindStatusCondition(got.Status.Conditions, vimv1.ReadyConditionType)
+					g.Expect(cond).ToNot(BeNil())
+					g.Expect(cond.Reason).To(Equal("SyncDisabled"))
+				}, input.Config.GetIntervals("default", "wait-config-policy-condition-update")...).Should(Succeed())
+
+				before := &vimv1.VirtualMachineConfigPolicy{}
+				Expect(svClusterClient.Get(ctx, ctrlclient.ObjectKeyFromObject(policy), before)).To(Succeed())
+
+				Consistently(func(g Gomega) {
+					got := &vimv1.VirtualMachineConfigPolicy{}
+					g.Expect(svClusterClient.Get(ctx, ctrlclient.ObjectKeyFromObject(policy), got)).To(Succeed())
+					g.Expect(got.Spec).To(Equal(before.Spec),
+						"VirtualMachineConfigPolicy %q spec must not change while syncMode=Disabled", got.Name)
+				}, input.Config.GetIntervals("default", "consistent-config-policy-spec")...).Should(Succeed())
 			})
 	})
 }


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Adds the `VirtualMachineConfigPolicy` sync controller, part of vmop-3745 (Story S8 / vmop-3770, vmop-3771, vmop-3772). When `spec.syncMode=ConfigTarget`, the controller mirrors the Zone's cluster capabilities (from `ConfigTarget.status`) into the policy's `spec` — min-of-maxima for numeric ranges, AND for boolean support flags, and set-intersection for device categories when a zone spans more than one cluster.

The controller watches both `ConfigTarget` and `Zone` (via field indexes on `VirtualMachineConfigPolicy.spec.zone` and `Zone.spec.managedVMs.clusterMoIDs`), so a capability change on either is reflected within one reconcile, per spec.md's requirement.

Ships with unit tests (including a hot-loop regression: a second reconcile against an unchanged ConfigTarget does not bump `resourceVersion`, checked against both the fake client and a real vcsim/envtest API server), vcsim integration tests, and an E2E extension of the existing `configpolicy` suite.

**Which issue(s) is/are addressed by this PR?**:

Fixes vmop-3770, Fixes vmop-3771, Fixes vmop-3772

**Are there any special notes for your reviewer**:

- The ConfigTarget→policy field-mapping logic lives in a new package, `pkg/util/configpolicysync/`, rather than the `pkg/vmconfig/policy/` path in the original task breakdown — that path is already used by an unrelated existing VM-tag/PolicyEvaluation reconciler. The name also deliberately avoids `pkg/util/configpolicy`, reserved by an unrelated, unmerged PR (#1738) for a different purpose (S9 enforcement matching).
- Cluster MoID derivation uses `zone.Spec.ManagedVMs.ClusterMoIDs` directly, matching what the merged Zone controller actually uses to create `ConfigTarget` objects — not the `spec.namespace.poolMoIDs`-based derivation described in `external/vim/doc/controller-workflows.md`, which is stale relative to the merged code.
- Does not depend on PR #1738 (S9 enforcement); built to merge cleanly with or without it.
- Independent of, but complements, #1783 (the validation webhook) — either can merge first. If they land out of order, `config/rbac/role.yaml` may need a manifest regeneration (`make generate-manifests`) rather than a hand-resolved merge conflict.

**Please add a release note if necessary**:

```release-note
Add a VirtualMachineConfigPolicy sync controller that mirrors vSphere cluster capabilities from ConfigTarget into the policy's spec.
```
