### PR TITLE
e2e-test: Fix duplicate policy for concurrent runners

### DIFF
--- a/test/e2e/infrastructure/vsphere/vcenter/storage.go
+++ b/test/e2e/infrastructure/vsphere/vcenter/storage.go
@@ -16,6 +16,7 @@ import (
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/soap"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 )
 
@@ -93,12 +94,7 @@ func GetOrCreateEncryptionStoragePolicy(ctx context.Context, client *vim25.Clien
 		}
 	}
 
-	profile, err := pbmClient.CreateProfile(ctx, *createSpec)
-	if err != nil {
-		return "", err
-	}
-
-	return profile.UniqueId, nil
+	return createPbmProfile(ctx, pbmClient, profileName, *createSpec)
 }
 
 // GetOrCreateEZTStoragePolicy Gets already created EZT (Eager Zeroed Thick)
@@ -161,12 +157,7 @@ func GetOrCreateEZTStoragePolicy(ctx context.Context, client *vim25.Client, prof
 		}
 	}
 
-	profile, err := pbmClient.CreateProfile(ctx, *createSpec)
-	if err != nil {
-		return "", err
-	}
-
-	return profile.UniqueId, nil
+	return createPbmProfile(ctx, pbmClient, profileName, *createSpec)
 }
 
 // GetOrCreateWorkerStoragePolicy returns an existing vSphere profile ID for profileName, or creates
@@ -217,12 +208,46 @@ func GetOrCreateWorkerStoragePolicy(ctx context.Context, client *vim25.Client, p
 		return "", errors.New("could not copy capability constraints from base WCP storage policy")
 	}
 
-	profile, err := pbmClient.CreateProfile(ctx, *createSpec)
+	return createPbmProfile(ctx, pbmClient, profileName, *createSpec)
+}
+
+// createPbmProfile creates a PBM profile from spec and returns
+// its ID. If a concurrent caller wins the create race (e.g. a sibling e2e
+// shard provisioning the same globally-named policy against the same shared
+// vCenter), the profile now exists, so its ID is resolved instead of failing.
+// All callers of this helper build their base capabilities from the same
+// e2e config resolved against the same shared testbed, so the winner's
+// profile is guaranteed to match what this caller would have created.
+func createPbmProfile(
+	ctx context.Context,
+	pbmClient *pbm.Client,
+	profileName string,
+	spec types.PbmCapabilityProfileCreateSpec) (string, error) {
+
+	profile, err := pbmClient.CreateProfile(ctx, spec)
 	if err != nil {
+		if isPbmDuplicateNameFault(err) {
+			return pbmClient.ProfileIDByName(ctx, profileName)
+		}
 		return "", err
 	}
 
 	return profile.UniqueId, nil
+}
+
+// isPbmDuplicateNameFault reports whether err is a PBM CreateProfile failure
+// because a profile with the requested name already exists.
+func isPbmDuplicateNameFault(err error) bool {
+	if !soap.IsSoapFault(err) {
+		return false
+	}
+
+	switch soap.ToSoapFault(err).VimFault().(type) {
+	case types.PbmDuplicateName, types.PbmDuplicateNameFault:
+		return true
+	default:
+		return false
+	}
 }
 
 // GetOrCreateVsanDirectStoragePolicyID Gets already created VSAN Direct Storage Policy ID or Creates one if not found.
@@ -260,12 +285,7 @@ func GetOrCreateVsanDirectStoragePolicyID(ctx context.Context, client *vim25.Cli
 		return "", err
 	}
 
-	profile, err := pbmClient.CreateProfile(ctx, *createSpec)
-	if err != nil {
-		return "", err
-	}
-
-	return profile.UniqueId, nil
+	return createPbmProfile(ctx, pbmClient, profileName, *createSpec)
 }
 
 // IsVSANDEnabledCluster checks if given wcp enabled cluster is enabled with vsand capability.

--- a/test/e2e/infrastructure/vsphere/vcenter/storage.go
+++ b/test/e2e/infrastructure/vsphere/vcenter/storage.go
@@ -10,13 +10,13 @@ import (
 	"strings"
 
 	"github.com/vmware/govmomi/crypto"
+	"github.com/vmware/govmomi/fault"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/pbm"
 	"github.com/vmware/govmomi/pbm/types"
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/mo"
-	"github.com/vmware/govmomi/vim25/soap"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 )
 
@@ -238,16 +238,14 @@ func createPbmProfile(
 // isPbmDuplicateNameFault reports whether err is a PBM CreateProfile failure
 // because a profile with the requested name already exists.
 func isPbmDuplicateNameFault(err error) bool {
-	if !soap.IsSoapFault(err) {
-		return false
+	var dn *types.PbmDuplicateName
+	if _, ok := fault.As(err, &dn); ok {
+		return true
 	}
 
-	switch soap.ToSoapFault(err).VimFault().(type) {
-	case types.PbmDuplicateName, types.PbmDuplicateNameFault:
-		return true
-	default:
-		return false
-	}
+	var dnf *types.PbmDuplicateNameFault
+	_, ok := fault.As(err, &dnf)
+	return ok
 }
 
 // GetOrCreateVsanDirectStoragePolicyID Gets already created VSAN Direct Storage Policy ID or Creates one if not found.


### PR DESCRIPTION
The four Get-or-Create*StoragePolicy need duplicate check which fails immidately stopping the complete test.  

Confirmed via UTS runs 1115673, 1108771, and 1108764, where two sibling shards created their content libraries 60ms apart against the same vCenter. 

UTS run succeeded.

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note

```