### PR TITLE
📖 Add vim.vmware.com partner integration guide

### DIFF
--- a/.sdd/specs/001-class-policy-resize/tasks.md
+++ b/.sdd/specs/001-class-policy-resize/tasks.md
@@ -37,10 +37,10 @@ Dependencies: none. All A-tasks may run in parallel `[P]`.
 
 ### Story S2 — Partner-facing integration doc (vmop-3739)
 
-- [ ] T020 [S2] Author `external/vim/doc/integration-guide.md` — pipeline diagram, role of each CRD, `ConfigTarget.status` capability surface (`maxHardwareVersion`, enriched `sriov`), per-host iteration inside the `ConfigTarget` controller, syncMode semantics, worked example of policy denial
-- [ ] T021 [S2] Link doc from public RTD site; review by PM and at least one downstream consumer team
+- [x] T020 [S2] Author `external/vim/doc/integration-guide.md` — pipeline diagram, role of each CRD, `ConfigTarget.status` capability surface, syncMode semantics, enforcement contract, worked example of policy denial. **Two bullets in this task's original scope were written against a design that was later retired and are documented as their opposite instead:** (1) "enriched `sriov`" — per T066c, `status.sriov` ships *empty*; SR-IOV enrichment is deferred to spec 003, and the guide tells consumers not to build on the field yet; (2) "per-host iteration inside the `ConfigTarget` controller (PropertyCollector RPC strategy, partial-failure handling)" — per the Story S4 retirement note below and T066b, there is no host enumeration and no `PropertyCollector` call; everything in `ConfigTarget.status` comes from the cluster's `EnvironmentBrowser`.
+- [~] T021 [S2] Link doc from public RTD site; review by PM and at least one downstream consumer team. **Not done, and not doable in the same change set.** `mkdocs.yml` sets `docs_dir: docs` with no include/monorepo plugin, so nothing under `external/vim/doc/` is reachable by the RTD build today — publishing requires either relocating the `external/vim/doc/` tree into `docs/`, adding an include plugin to `docs/requirements.txt`, or symlinking. That is a docs-site structural decision affecting all three `external/vim/doc/` pages, not just this one, and is tracked separately. The PM / downstream-consumer review half is a process step outside any PR.
 
-*Gate: T021 must be complete before Phase 2 code work begins.*
+*Gate: originally "T021 must be complete before Phase 2 code work begins." This gate was not honored — S3, S5, S6, S7, S8, and S9 all started and merged (or are in review) before S2 landed. Recorded as-happened rather than retro-justified.*
 
 ---
 

--- a/external/vim/README.md
+++ b/external/vim/README.md
@@ -5,6 +5,8 @@ This Go module contains the following directories:
 * [`./api`](./api) -- A Go module that contains the VIM Kubernetes APIs.
 * [`./pkg`](./pkg) -- Utilities for converting to/from the VIM Kubernetes APIs and the traditional VIM types.
 
-## Workflows
+## Documentation
 
-* [Using the environment browser APIs](./doc/environment_browser.md) reviews how `kubectl` users as well as graphical applications may leverage the VIM Kubernetes environment browser APIs to deploy workloads.
+* [Integration guide](./doc/integration-guide.md) -- the contract for teams consuming these APIs from outside VM Operator: what each resource guarantees, what is not populated yet, how `VirtualMachineConfigPolicy` is enforced, and what will reject a request.
+* [Deploying a VM](./doc/deploying-a-vm.md) -- how `kubectl` users and graphical applications leverage the VIM Kubernetes environment browser APIs to deploy workloads.
+* [Controller workflows](./doc/controller-workflows.md) -- how zone discovery fans out into cluster-scoped config metadata and guest option resources.

--- a/external/vim/doc/controller-workflows.md
+++ b/external/vim/doc/controller-workflows.md
@@ -13,8 +13,8 @@ There are two related pipelines:
 flowchart TB
   subgraph zone["Zone controller"]
     ZW["Watch Zone (namespace-scoped)"]
-    ZP["Read spec.namespace.poolMoIDs"]
-    ZC["Derive unique cluster MoIDs from pools"]
+    ZP["Read spec.managedVMs.clusterMoIDs"]
+    ZC["Take each unique cluster MoID"]
     ZCT["Create/patch ConfigTarget per cluster<br/>metadata.name = cluster MoID"]
     ZVMCP["Create/patch VirtualMachineConfigPolicy<br/>spec.zone = Zone metadata.name"]
     ZW --> ZP --> ZC --> ZCT
@@ -42,7 +42,7 @@ flowchart TB
   subgraph vmcp["VirtualMachineConfigPolicy controller"]
     VPW["Watch VirtualMachineConfigPolicy (namespace-scoped)"]
     VCHK{"spec.syncMode?"}
-    VSM["Read Zone + ConfigTarget<br/>(cluster MoID from pools)"]
+    VSM["Read Zone + ConfigTarget<br/>(cluster MoIDs from spec.managedVMs.clusterMoIDs)"]
     VPS["Patch policy spec from ConfigTarget status<br/>(limits, flags, ConfigTargetDevices)"]
     VDIS["Skip vSphere sync<br/>(admin/tenant-owned spec)"]
     VPW --> VCHK
@@ -57,7 +57,7 @@ flowchart TB
 
 Each `VirtualMachineGuestOptions` reconciliation updates `status.hardwareVersions` with one entry for the hardware version of the `VirtualMachineConfigOptions` being reconciled; reconciles of other hardware versions append their own entries (see the `VirtualMachineConfigOptions` controller section above).
 
-Dashed edges: (1) the `Zone` controller creates the namespaced policy object that the policy controller reconciles; (2) syncing policy spec requires a cluster `ConfigTarget` (created by the same reconcile chain) whose `metadata.name` is the cluster MoID derived from the zone’s `spec.namespace.poolMoIDs`, matching the `Zone` controller’s logic.
+Dashed edges: (1) the `Zone` controller creates the namespaced policy object that the policy controller reconciles; (2) syncing policy spec requires a cluster `ConfigTarget` (created by the same reconcile chain) whose `metadata.name` is a cluster MoID listed in the zone’s `spec.managedVMs.clusterMoIDs`, matching the `Zone` controller’s logic.
 
 ## vSphere API and Kubernetes writes
 
@@ -103,8 +103,8 @@ sequenceDiagram
 ### `Zone` controller
 
 1. `Zone` controller watches `Zone` resources in a namespace.
-2. When `Zone` object is reconciled, its `spec.namespace.poolMoIDs` list is inspected to get a list of the resource pool IDs belonging to the zone.
-3. A unique set of vSphere cluster managed object IDs is derived from the list of the zone's pool IDs.
+2. When `Zone` object is reconciled, its `spec.managedVMs.clusterMoIDs` list is inspected to get the vSphere cluster managed object IDs belonging to the zone.
+3. That list is the unique set of vSphere cluster managed object IDs for the zone.
 4. For each of the unique cluster managed object IDs, the `Zone` controller creates or patches a cluster-scoped `ConfigTarget` resource with the `metadata.name` of the resource being the managed object ID of the cluster.
 5. The `Zone` controller creates or patches a namespace-scoped `VirtualMachineConfigPolicy` object for the given `Zone`. The `VirtualMachineConfigPolicy` field `spec.zone` records the name of the `Zone` to which the policy applies. If the resource does not already exist, then the `VirtualMachineConfigPolicy` field `spec.syncMode` is set to `ConfigTarget`.
 
@@ -127,7 +127,7 @@ sequenceDiagram
 3. If the value of `spec.syncMode` is `Disabled`, the controller does not copy data from vSphere into the policy; reconciliation may still update status (for example conditions). The policy **spec** is treated as operator-managed.
 4. If the value of `spec.syncMode` is `ConfigTarget`, the controller continues to reconcile the resource against the cluster `ConfigTarget`.
 5. The `VirtualMachineConfigPolicy` controller looks up the `Zone` resource named in `spec.zone`.
-6. Using the same pool-to-cluster derivation as the `Zone` controller, the controller obtains the vSphere cluster managed object ID(s) from the zone's `spec.namespace.poolMoIDs`. For each relevant cluster, it reads the cluster-scoped `ConfigTarget` whose `metadata.name` is that cluster MoID. Please note, today a Zone applied to a namespace maps to a single vSphere cluster. The other clusters are there strictly for infrastructure mobility / cluster decommissioning.
+6. Using the same derivation as the `Zone` controller, the controller obtains the vSphere cluster managed object ID(s) from the zone's `spec.managedVMs.clusterMoIDs`. For each relevant cluster, it reads the cluster-scoped `ConfigTarget` whose `metadata.name` is that cluster MoID. Please note, today a Zone applied to a namespace maps to a single vSphere cluster. The other clusters are there strictly for infrastructure mobility / cluster decommissioning.
 7. The `VirtualMachineConfigPolicy` controller maps the `ConfigTarget`'s **status** (numeric limits, feature flags, and the embedded device capability lists) into the policy's **spec**, which shares the `ConfigTargetDevices` shape and related fields (`numCPUCores`, `memory`, and so on). That gives namespaced consumers a single object for "what this zone allows," aligned with `vim.vm.ConfigTarget` after `QueryConfigTarget`.
 
 Additional **spec** fields on `VirtualMachineConfigPolicy` are not filled by vSphere sync; they are part of the policy contract for workloads and admission: `createMode`, `updateMode`, and `powerOnMode` (`Allow` vs `Deny`), `vmClassMode` (`AsPolicy` vs `AsConfig`), and optional `extraConfig` allow/deny lists. Defaults match the CRD (`syncMode` defaults to `ConfigTarget`, modes default to `Allow`, `vmClassMode` defaults to `AsPolicy`).

--- a/external/vim/doc/deploying-a-vm.md
+++ b/external/vim/doc/deploying-a-vm.md
@@ -144,6 +144,6 @@ sequenceDiagram
     Note over wh: createMode=Deny, so compliance is evaluated<br/>16Gi exceeds the zone's 8Gi per-VM ceiling
 
     wh-->>api: AdmissionResponse: denied
-    api-->>kc: 403 Forbidden
+    api-->>kc: 422 Unprocessable Entity
     kc-->>User: Error: spec.resources.size.memory not allowed by the us-west-1 policy
 ```

--- a/external/vim/doc/deploying-a-vm.md
+++ b/external/vim/doc/deploying-a-vm.md
@@ -17,12 +17,12 @@ These APIs use predictable **`metadata.name`** values (and matching `spec` ident
 
 | Resource | Kind | `metadata.name` convention | Example names |
 |---|---|---|---|
-| **configtarget** | `ConfigTarget` | The vSphere cluster **managed object ID** (MoID) | `cluster-1`, `cluster-2`, `cluster-3` |
+| **configtarget** | `ConfigTarget` | The vSphere cluster **managed object ID** (MoID), which must match `^domain-c[0-9]+$` | `domain-c52`, `domain-c81` |
 | **vmconfigoption** | `VirtualMachineConfigOptions` | The **hardware version** string | `vmx-22`, `vmx-19` |
 | **vmguestoption** | `VirtualMachineGuestOptions` | **Lowercased** guest ID (DNS-safe label) | `otherlinux64`, `windows2022srv64` |
 | **vmconfigpolicy** | `VirtualMachineConfigPolicy` | The **zone** name for that policy | `us-east-1`, `us-west-2` |
 
-`kubectl` short names, where registered, are **`vmconfigoptions`**, **`vmguestoptions`**, and **`vmconfigpolicy`** (note the plural **s** on the first two). For `ConfigTarget`, the registered plural resource name is **`configtargets`** (for example `kubectl get configtargets cluster-1`); some clients also accept the singular form **`configtarget`**.
+The registered `kubectl` short names are **`vmconfigoptions`**, **`vmguestoptions`**, and **`vmconfigpolicy`** (note the plural **s** on the first two). `ConfigTarget` has no short name; use the plural resource name **`configtargets`** (for example `kubectl get configtargets domain-c52`), or the singular form **`configtarget`**.
 
 ## VirtualMachineConfigOptions
 
@@ -49,7 +49,7 @@ Clients typically combine **`VirtualMachineConfigOptions`** (hardware version + 
 
 ## ConfigTarget
 
-`ConfigTarget` is a **cluster-scoped** resource tied to a **single vSphere cluster**. The object is **named after that cluster’s MoID** (e.g., `cluster-1`). Its spec requires **`id`**, the same managed object ID. Status reflects **physical / pool-level** capacity from the vSphere `ConfigTarget` returned by `QueryConfigTarget`, for example:
+`ConfigTarget` is a **cluster-scoped** resource tied to a **single vSphere cluster**. The object is **named after that cluster’s MoID** (e.g., `domain-c52`). Its spec requires **`id`**, the same managed object ID. Status reflects **physical / pool-level** capacity from the vSphere `ConfigTarget` returned by `QueryConfigTarget`, for example:
 
 - Pool-wide CPU and core counts, NUMA node count, maximum SMT threads, and **`maxCPUsPerVM`** (cap on CPUs for one VM given cluster inventory).
 - Memory ceilings such as **`supportedMaxMem`** and **`maxMemOptimalPerf`**.
@@ -62,7 +62,9 @@ Clients typically combine **`VirtualMachineConfigOptions`** (hardware version + 
 
 `VirtualMachineConfigPolicy` is **namespace-scoped** (short name: `vmconfigpolicy`). It is **not** a projection of a single vSphere method; think of it as a **namespace-scoped companion to `ConfigTarget`** whose fields are interpreted **per virtual machine**.
 
-There is **one `VirtualMachineConfigPolicy` object per zone** in a namespace. Each object is **named after that zone** (for example `us-east-1`, `us-west-1`). If namespace `my-namespace-1` spans three zones—`us-west-1`, `us-east-1`, and `us-south-1`—then there are **three** policy objects in that namespace. Validators and placement-aware components **must consider every zone’s policy** when deciding whether a configuration is allowed: **all zone policies in the namespace are consulted**, and the outcome depends on whether **any** of them permits the requested VM configuration (for example, at least one zone allows the requested memory, CPU, devices, and ExtraConfig rules so the VM could legally run there). If **no** zone’s policy allows the request, admission or scheduling should reject it.
+There is **one `VirtualMachineConfigPolicy` object per zone** in a namespace. Each object is **named after that zone** (for example `us-east-1`, `us-west-1`). If namespace `my-namespace-1` spans three zones—`us-west-1`, `us-east-1`, and `us-south-1`—then there are **three** policy objects in that namespace.
+
+Enforcement resolves **exactly one** of them: the policy named after the VM's **assigned zone**, read from the VM's `topology.kubernetes.io/zone` label. A VM that has not yet been placed has no resolvable policy and is not enforced; enforcement resumes on the next update once placement sets the label. Placement-aware components that want to tell a user *which* zones could host a configuration must read every policy in the namespace and do that reasoning themselves — admission does not. See [`integration-guide.md`](./integration-guide.md) for the full enforcement contract.
 
 Where `ConfigTarget` status describes cluster inventory (for example, logical CPUs available to run workloads), policy fields such as **`memory`** (`ResourceQuantityRange`), **`numCPUCores`**, **`numNUMANodes`**, and **`numSimultaneousThreads`** (`IntRange`) express **what one VM is allowed to use under that zone’s policy**, not totals across hosts in the cluster.
 
@@ -103,9 +105,9 @@ The following scenario walks through how a user leverages these APIs when deploy
 
 6. The Kubernetes API server receives the `VirtualMachine` create request and routes it to the VM resource’s validation webhook.
 
-7. Namespace `my-namespace-1` has three zones, so there are three policies: **`VirtualMachineConfigPolicy`** objects **`us-west-1`**, **`us-east-1`**, and **`us-south-1`**. The webhook **lists or fetches every** `vmconfigpolicy` in the namespace and evaluates whether **any** zone’s policy permits the VM. Here, **`spec.memory.max`** is **8 Gi** **per VM** in **each** zone.
+7. The VM carries the label `topology.kubernetes.io/zone: us-west-1`, so the webhook fetches the single **`VirtualMachineConfigPolicy`** named **`us-west-1`** in `my-namespace-1`. That policy has **`spec.memory.max`** of **8 Gi** **per VM**, **`spec.createMode: Deny`**, and **`spec.vmClassMode: AsConfig`**.
 
-8. The request asks for **16 Gi**. **None** of the three zone policies allows that much memory for a single VM, so **no** zone would accept the configuration. The webhook rejects the request and the API server returns an error to `kubectl`.
+8. The request asks for **16 Gi**. Because `createMode` is `Deny`, the webhook evaluates compliance, finds the VM over the zone's ceiling, rejects the request, and the API server returns an error to `kubectl`. (Had `createMode` been left at its `Allow` default, the create would have been admitted regardless.)
 
 ```mermaid
 sequenceDiagram
@@ -115,7 +117,7 @@ sequenceDiagram
     participant wh as VM Validation Webhook
     participant vmco as VirtualMachineConfigOptions<br/>(vmx-22)
     participant vmgo as VirtualMachineGuestOptions<br/>(otherlinux64)
-    participant vcp as VirtualMachineConfigPolicy<br/>(per zone)
+    participant vcp as VirtualMachineConfigPolicy<br/>(us-west-1)
 
     User->>kc: kubectl get vmconfigoptions vmx-22 -oyaml
     kc->>api: GET .../virtualmachineconfigoptions/vmx-22
@@ -131,17 +133,17 @@ sequenceDiagram
     api-->>kc: YAML
     kc-->>User: supportedMinMem, recommendedMem, supportedNumDisks, ...
 
-    User->>kc: kubectl apply -f vm.yaml<br/>ns: my-namespace-1<br/>(guestID: OtherLinux64, hwVersion: vmx-22,<br/>memory: 16Gi, disks: 2)
+    User->>kc: kubectl apply -f vm.yaml<br/>ns: my-namespace-1<br/>zone label: us-west-1<br/>(guestID: OtherLinux64, hwVersion: vmx-22,<br/>memory: 16Gi, disks: 2)
     kc->>api: POST .../namespaces/my-namespace-1/virtualmachines
 
     api->>wh: AdmissionReview (CREATE VirtualMachine)
-    wh->>api: LIST .../namespaces/my-namespace-1/virtualmachineconfigpolicies
-    api->>vcp: read us-west-1, us-east-1, us-south-1
-    vcp-->>api: each spec.memory.max = 8Gi
+    wh->>api: GET .../namespaces/my-namespace-1/virtualmachineconfigpolicies/us-west-1
+    api->>vcp: read us-west-1
+    vcp-->>api: spec.createMode = Deny, spec.memory.max = 8Gi
 
-    Note over wh: All zone policies consulted<br/>no zone permits 16Gi per VM
+    Note over wh: createMode=Deny, so compliance is evaluated<br/>16Gi exceeds the zone's 8Gi per-VM ceiling
 
     wh-->>api: AdmissionResponse: denied
-    api-->>kc: 422 Unprocessable Entity
-    kc-->>User: Error: memory not allowed by any zone policy in namespace
+    api-->>kc: 403 Forbidden
+    kc-->>User: Error: spec.resources.size.memory not allowed by the us-west-1 policy
 ```

--- a/external/vim/doc/integration-guide.md
+++ b/external/vim/doc/integration-guide.md
@@ -90,13 +90,18 @@ Two things about this graph matter to consumers:
 `status` holds the cluster's aggregate capability. The fields most consumers want:
 
 - `maxHardwareVersion` — the highest hardware version creatable on at least one host in the cluster, computed as the maximum `key` among `QueryConfigOptionDescriptor` results with `createSupported == true`. This is the cheap answer to "is this VM's hardware version feasible here" without reading per-host anything.
-- `defaultHardwareVersion` — the cluster's default.
 - `numCPUs`, `numCPUCores`, `numNumaNodes`, `maxCPUsPerVM`, `maxSimultaneousThreads`.
-- `supportedMaxMem`, `maxMemOptimalPerf`, `availablePersistentMemoryReservation`.
+- `supportedMaxMem`, `maxMemOptimalPerf`, `availablePersistentMemoryReservation`. Each is omitted rather than zeroed when the cluster does not report it, so distinguish "absent" from "zero".
 - `smcPresent`, `sevSupported`, `sevSnpSupported`, `tdxSupported`.
 - The inlined `ConfigTargetDevices` device categories: CD-ROM, floppy, serial, parallel, sound, USB, PCI passthrough, dynamic passthrough, vGPU device and profile, shared GPU passthrough types, SGX, precision clock, vendor device groups, DVX classes, IDE and SCSI disks, SCSI passthrough, and vFlash module.
 
-**`status.sriov` is not populated today.** SR-IOV enrichment requires per-host iteration and is deferred; the field ships empty and any SR-IOV entries nested inside the PCI-passthrough union are excluded as well. Do not build an SR-IOV feature on this field yet — it will start returning data in a later release, which is a behavior change even though it is not an API change.
+Three fields exist on `ConfigTargetStatus` but **are never written today**, and always read as their zero value:
+
+- `sriov` — SR-IOV enrichment requires per-host iteration and is deferred to a later release; SR-IOV entries nested inside the PCI-passthrough union are excluded as well.
+- `defaultHardwareVersion` — use `maxHardwareVersion`, or read the per-version `VirtualMachineConfigOptions` objects.
+- `vMotionBandwidth`.
+
+Do not build on any of them yet. They will start returning data in a later release, which is a behavior change for a consumer that treats the zero value as meaningful, even though it is not an API change.
 
 `status.conditions` carries a `Ready` condition. When it is not `True` the reason is one of `ClusterNotFound`, `QueryConfigTargetFailed`, or `QueryConfigOptionDescriptorFailed`, and the status shown is the last successful query's data, not current data.
 
@@ -203,7 +208,7 @@ Range semantics: for `numCPUCores`, `memory`, and `hardwareVersions`, a zero `Mi
 
 ### What a denial looks like
 
-Admission denials come back as field errors on the specific offending path — `spec.advanced.extraConfig[2].key`, `spec.resources.size.memory`, `spec.minHardwareVersion`, and so on — with every violation reported at once rather than one per round trip.
+Admission denials come back as HTTP 422, with field errors on the specific offending path — `spec.advanced.extraConfig[2].key`, `spec.resources.size.memory`, `spec.minHardwareVersion`, and so on — every violation reported at once rather than one per round trip, joined into a single reason string with `, `.
 
 The power-on path is different. It always sets a `VirtualMachineConfigPolicyVerified` condition on the `VirtualMachine`, and consumers should read that rather than inferring compliance from anything else:
 
@@ -263,14 +268,17 @@ spec:
       value: "..."
 ```
 
-The webhook resolves `us-west-1` from the zone label, sees `createMode: Deny`, evaluates the spec, and rejects with both violations at once:
+The webhook resolves `us-west-1` from the zone label, sees `createMode: Deny`, evaluates the spec, and rejects with both violations at once. The denial is an HTTP 422 from `default.validating.virtualmachine.v1alpha6.vmoperator.vmware.com`, whose reason is every field error joined with `, `:
 
 ```
-Error from server (Forbidden): error when creating "vm.yaml":
-admission webhook "default.validating.virtualmachine.v1alpha6.vmoperator.vmware.com" denied the request:
-spec.resources.size.memory: Invalid value: "16Gi": memory 16Gi exceeds the maximum of 8Gi allowed by policy
-spec.advanced.extraConfig[0].key: Forbidden: extraConfig key "guestinfo.metadata" is denied by policy
+spec.resources.size.memory: Invalid value: "16Gi": memory 16Gi
+exceeds the maximum 8Gi supported by the namespace's
+VirtualMachineConfigPolicy, spec.advanced.extraConfig[0].key:
+Forbidden: guestinfo.metadata: denied by the namespace's
+VirtualMachineConfigPolicy
 ```
+
+(Line breaks added for readability — the real reason is one line.)
 
 Change either `createMode` to `Allow` or the VM to fit, and the create succeeds. Note that with `createMode: Allow` and `powerOnMode: Deny` the same VM would be admitted and then refused at power-on instead — the pre-flight answer for a UI is to read the policy, not to submit and see.
 
@@ -295,7 +303,7 @@ Rejections that come from admission webhooks:
 
 ## Compatibility notes
 
-- **Do not depend on `status.sriov`.** It is empty today and will become populated.
+- **Do not depend on `status.sriov`, `status.defaultHardwareVersion`, or `status.vMotionBandwidth`.** They are unwritten today and will become populated.
 - **Do not depend on absence of enforcement.** A namespace whose policies are all at the `Allow` default enforces nothing today; an administrator flipping one mode to `Deny` changes that with no API change and no notice to your component.
 - **Do not derive a cluster MoID from a policy.** Go through `Zone.spec.managedVMs.clusterMoIDs`. An earlier design derived it from `spec.namespace.poolMoIDs`; that is not what the controllers do.
 - **Do not treat `VirtualMachineGuestOptions.metadata.name` as the guest ID.** It is a lossy, truncated transform. Use `spec.id`.

--- a/external/vim/doc/integration-guide.md
+++ b/external/vim/doc/integration-guide.md
@@ -1,0 +1,302 @@
+# Integration guide
+
+This guide is for teams that consume the `vim.vmware.com` APIs from outside VM Operator — UI and CLI surfaces, placement and quota tooling, and anything that needs to answer "what can this zone actually run?" before a `VirtualMachine` is submitted.
+
+It describes the four `vim.vmware.com` CRDs, how VM Operator populates them, and how `VirtualMachineConfigPolicy` is enforced against a `VirtualMachine`. For the narrative walkthrough of the reconcile chain see [`controller-workflows.md`](./controller-workflows.md); for a resource-by-resource field tour see [`deploying-a-vm.md`](./deploying-a-vm.md). This document is the integration contract: what you can rely on, what is not populated yet, and what will reject your request.
+
+## Status and enablement
+
+The whole feature is behind a single Supervisor capability:
+
+```
+supports_vm_service_vm_config_policy
+```
+
+While that capability is deactivated, VM Operator does not register the `vim.vmware.com` scheme, does not run any of the controllers below, and does not enforce policy on `VirtualMachine` admission or power-on. The CRDs may still be installed on the cluster — installation is unconditional — so **the presence of the CRDs is not a signal that the feature is on**. Detect enablement from the capability, or from whether a `ConfigTarget` for your cluster exists and is `Ready`.
+
+The API version is `v1alpha1`. It is alpha: fields may be added, and unpopulated fields may start being populated, without a version bump.
+
+## The four resources
+
+| Kind | Scope | Plural / short name | `metadata.name` | Written by | Derived from |
+|---|---|---|---|---|---|
+| `ConfigTarget` | Cluster | `configtargets` | vSphere cluster MoID, e.g. `domain-c52` | Zone controller (creates), `ConfigTarget` controller (status) | `EnvironmentBrowser.QueryConfigTarget` + `QueryConfigOptionDescriptor` |
+| `VirtualMachineConfigOptions` | Cluster | `virtualmachineconfigoptions` / `vmconfigoptions` | Hardware version, e.g. `vmx-22` | `ConfigTarget` controller (creates), `VirtualMachineConfigOptions` controller (status) | `EnvironmentBrowser.QueryConfigOptionEx` |
+| `VirtualMachineGuestOptions` | Cluster | `virtualmachineguestoptions` / `vmguestoptions` | DNS-safe form of the guest ID, e.g. `otherlinux64` | `VirtualMachineConfigOptions` controller | `QueryConfigOptionEx` guest OS descriptors |
+| `VirtualMachineConfigPolicy` | Namespaced | `virtualmachineconfigpolicies` / `vmconfigpolicy` | Zone name, e.g. `us-west-1` | Zone controller (creates), `VirtualMachineConfigPolicy` controller (syncs spec) | `ConfigTarget.status`, plus admin/tenant-authored fields |
+
+`ConfigTarget` has no registered short name; use `configtargets`.
+
+All four are **owned by VM Operator**. Treat `ConfigTarget`, `VirtualMachineConfigOptions`, and `VirtualMachineGuestOptions` as strictly read-only from outside the operator: they are recreated and their status overwritten on every reconcile. `VirtualMachineConfigPolicy` is the one object an administrator is expected to edit, and only the fields called out in [Which policy fields are yours](#which-policy-fields-are-yours).
+
+## The pipeline
+
+```mermaid
+flowchart TB
+  subgraph zone["Zone controller"]
+    ZW["Watch Zone (namespace-scoped)"]
+    ZC["Read spec.managedVMs.clusterMoIDs"]
+    ZCT["Create/patch ConfigTarget per cluster MoID<br/>metadata.name = cluster MoID"]
+    ZVMCP["Create/patch VirtualMachineConfigPolicy<br/>metadata.name = Zone name, spec.zone = Zone name"]
+    ZW --> ZC --> ZCT
+    ZW --> ZVMCP
+  end
+
+  subgraph ct["ConfigTarget controller"]
+    CTW["Watch ConfigTarget (cluster-scoped)"]
+    QCT["QueryConfigTarget → status device categories, CPU/memory ceilings, security flags"]
+    QCOD["QueryConfigOptionDescriptor → hardware version keys, status.maxHardwareVersion"]
+    CTO["Create/patch VirtualMachineConfigOptions per version<br/>metadata.name = e.g. vmx-22"]
+    CTW --> QCT
+    CTW --> QCOD --> CTO
+  end
+
+  subgraph vmco["VirtualMachineConfigOptions controller"]
+    VW["Watch VirtualMachineConfigOptions (cluster-scoped)"]
+    QCOE["QueryConfigOptionEx for that hardware version"]
+    VST["Fill status; collect guest OS IDs → status.guestIDs"]
+    VGO["Create/patch VirtualMachineGuestOptions per guest ID<br/>upsert one status.hardwareVersions entry"]
+    VW --> QCOE --> VST --> VGO
+  end
+
+  subgraph vmcp["VirtualMachineConfigPolicy controller"]
+    VPW["Watch VirtualMachineConfigPolicy (namespace-scoped)"]
+    VCHK{"spec.syncMode?"}
+    VSM["Resolve Zone → cluster MoIDs → Ready ConfigTarget(s)"]
+    VPS["Patch policy spec with the intersection of those ConfigTarget statuses"]
+    VDIS["Leave spec untouched<br/>(admin-owned)"]
+    VPW --> VCHK
+    VCHK -->|ConfigTarget| VSM --> VPS
+    VCHK -->|Disabled| VDIS
+  end
+
+  ZCT --> CTW
+  CTO --> VW
+  ZVMCP --> VPW
+  ZCT -.->|"ConfigTarget status feeds the sync"| VSM
+```
+
+Two things about this graph matter to consumers:
+
+- **Everything is level-triggered and eventually consistent.** A hardware version added to a cluster shows up as a new `VirtualMachineConfigOptions`, then as new `status.hardwareVersions` entries on the affected `VirtualMachineGuestOptions`, then — for `syncMode=ConfigTarget` policies — as a widened `spec` on the zone's policy. Do not assume these land in the same instant. Gate on the `Ready` condition of the object you are reading.
+- **The `ConfigTarget` controller queries the cluster's `EnvironmentBrowser` only.** It does not enumerate hosts and makes no `PropertyCollector` calls. Everything in `ConfigTarget.status` is cluster-aggregate data.
+
+## Reading cluster capability
+
+### ConfigTarget
+
+`metadata.name` is the cluster MoID and is validated by a CEL rule on the CRD: it must match `^domain-c[0-9]+$`. `spec.id` carries the same MoID and is immutable after create.
+
+`status` holds the cluster's aggregate capability. The fields most consumers want:
+
+- `maxHardwareVersion` — the highest hardware version creatable on at least one host in the cluster, computed as the maximum `key` among `QueryConfigOptionDescriptor` results with `createSupported == true`. This is the cheap answer to "is this VM's hardware version feasible here" without reading per-host anything.
+- `defaultHardwareVersion` — the cluster's default.
+- `numCPUs`, `numCPUCores`, `numNumaNodes`, `maxCPUsPerVM`, `maxSimultaneousThreads`.
+- `supportedMaxMem`, `maxMemOptimalPerf`, `availablePersistentMemoryReservation`.
+- `smcPresent`, `sevSupported`, `sevSnpSupported`, `tdxSupported`.
+- The inlined `ConfigTargetDevices` device categories: CD-ROM, floppy, serial, parallel, sound, USB, PCI passthrough, dynamic passthrough, vGPU device and profile, shared GPU passthrough types, SGX, precision clock, vendor device groups, DVX classes, IDE and SCSI disks, SCSI passthrough, and vFlash module.
+
+**`status.sriov` is not populated today.** SR-IOV enrichment requires per-host iteration and is deferred; the field ships empty and any SR-IOV entries nested inside the PCI-passthrough union are excluded as well. Do not build an SR-IOV feature on this field yet — it will start returning data in a later release, which is a behavior change even though it is not an API change.
+
+`status.conditions` carries a `Ready` condition. When it is not `True` the reason is one of `ClusterNotFound`, `QueryConfigTargetFailed`, or `QueryConfigOptionDescriptorFailed`, and the status shown is the last successful query's data, not current data.
+
+### VirtualMachineConfigOptions and VirtualMachineGuestOptions
+
+`VirtualMachineConfigOptions` is one object per hardware version supported by the cluster; `metadata.name` must equal `spec.hardwareVersion` and must match `^vmx-[0-9]+$` (both CEL rules on the CRD; `spec.hardwareVersion` is immutable).
+
+`VirtualMachineGuestOptions` is one object per guest OS ID, named after the DNS-safe transform of the guest ID: lowercased, runs of non-DNS-safe characters collapsed to a hyphen, trimmed, truncated to 63 characters. Its `spec.id` carries the canonical, correctly-cased guest identifier — **match on `spec.id`, not on the object name**, which is lossy by construction.
+
+`VirtualMachineGuestOptions.status.hardwareVersions` is a listMap keyed by `hardwareVersion`, with one entry contributed by each `VirtualMachineConfigOptions` that reports the guest. Entries are garbage-collected when a hardware version stops reporting the guest, and the object is deleted when its last entry goes away. So a guest OS present in this list for `vmx-22` is genuinely supported on `vmx-22` right now, not merely at some point in the past.
+
+The pair is meant to be read together: `VirtualMachineConfigOptions` for the hardware-version-level device and capability matrix, `VirtualMachineGuestOptions` for the guest-specific limits at that hardware version.
+
+## VirtualMachineConfigPolicy
+
+One policy per zone per namespace, named after the zone. A namespace spanning three zones has three policy objects.
+
+### syncMode
+
+`spec.syncMode` decides who owns the capability portion of the spec. It defaults to `ConfigTarget` and is only defaulted on create — the Zone controller will not reset it afterwards.
+
+- **`ConfigTarget`** — the `VirtualMachineConfigPolicy` controller resolves `spec.zone` to a `Zone`, reads `spec.managedVMs.clusterMoIDs`, loads the matching `ConfigTarget` objects, and writes the intersection of their statuses into the policy's **spec**. Every cluster behind the zone must have a `Ready` `ConfigTarget`; if any does not, the controller writes nothing and marks the policy not `Ready`.
+- **`Disabled`** — no vSphere data is copied. The spec is entirely administrator-managed. `Ready` is set `True` with reason `SyncDisabled`.
+
+Today a zone applied to a namespace maps to a single vSphere cluster; the multi-cluster path exists for infrastructure mobility and cluster decommissioning. When it is exercised, the merge is an intersection: minimum of numeric maxima, logical AND of boolean support flags, and, for device categories, only descriptors present value-for-value on every `ConfigTarget`.
+
+Only the `Max` side of a range field is synced. `Min` is a tenant-managed floor and is never touched. If a cluster's capability shrinks far enough that a synced `Max` would drop below an administrator-set `Min`, the controller refuses the whole write rather than publish an inverted range, and marks `Ready=False` with reason `InvalidRange`.
+
+### Which policy fields are yours
+
+Synced from `ConfigTarget` when `syncMode=ConfigTarget` — **do not hand-edit these, they will be overwritten**:
+
+`numCPUCores.max`, `numNUMANodes.max`, `numSimultaneousThreads.max`, `memory.max`, `smcPresent`, `sevSupported`, `sevSnpSupported`, `tdxSupported`, and the inlined `ConfigTargetDevices` fields.
+
+Administrator-owned in both sync modes:
+
+`createMode`, `updateMode`, `powerOnMode`, `vmClassMode`, `extraConfig`, `latencySensitivityLevels`, `txRxThreadModels`, the `Min` side of every range, and the support flags that have no `ConfigTarget` counterpart: `cpuLockedToMaxSupported`, `memoryLockedToMaxSupported`, `hugePagesSupported`, `iommuSupported`, `rssSupported`, `udpRSSSupported`, `lroSupported`.
+
+### Ready condition reasons
+
+| Reason | Meaning |
+|---|---|
+| *(none, `Ready=True`)* | Spec reflects a successful sync from every cluster behind the zone. |
+| `SyncDisabled` | `syncMode=Disabled`; spec is administrator-managed and is not stale by definition. |
+| `ZoneNotFound` | `spec.zone` does not resolve to a `Zone` in this namespace. |
+| `ConfigTargetNotFound` | The zone lists a cluster MoID with no `ConfigTarget` object. |
+| `ConfigTargetNotReady` | One or more of the zone's `ConfigTarget`s are not `Ready`. |
+| `InvalidRange` | A synced `Max` would have fallen below an administrator-set `Min`; the sync was refused. |
+
+A policy that is not `Ready` still has a usable spec — the last known-good sync — and **is still enforced**. Enforcing a possibly-stale ceiling is deliberate: the alternative is either failing open or denying every request in the namespace over one flapping `ConfigTarget`. The staleness is logged at each enforcement point and, on the power-on path, appended to the condition message on the `VirtualMachine`.
+
+## Enforcement
+
+There are two enforcement points, sharing one matcher so they cannot drift:
+
+1. **`VirtualMachine` admission webhook** — evaluates the VM's *desired spec* on create, update, and power-on transitions.
+2. **vSphere power-on reconcile** — evaluates the VM's *actual, live vSphere `ConfigInfo`* immediately before powering on. This catches a VM that was compliant when last reconfigured but whose governing policy has since tightened.
+
+### Which policy governs a VM
+
+The policy is resolved by the VM's **assigned zone**: the value of the `topology.kubernetes.io/zone` label on the `VirtualMachine`, used as the name of a `VirtualMachineConfigPolicy` in the VM's namespace. It is a single `Get`.
+
+Two consequences worth designing around:
+
+- **A VM that has not yet been placed is not enforced.** With no zone label there is no resolvable policy, so admission returns no error. Enforcement resumes on the next update once placement sets the label.
+- **Enforcement is against one zone, not "any zone that would accept it."** If your tooling wants to tell a user which zones could host a configuration, it must read every `VirtualMachineConfigPolicy` in the namespace itself; the webhook will not do that reasoning for it.
+
+If no policy object exists for the VM's zone, nothing is enforced.
+
+### When enforcement actually runs
+
+The three modes are independent gates, each defaulting to `Allow`. Compliance is only evaluated when a mode that applies to *this* request is set to `Deny`:
+
+| Request | Gated by |
+|---|---|
+| Create, VM not powered on | `createMode` |
+| Create, `spec.powerState: PoweredOn` | `createMode` **or** `powerOnMode` |
+| Update, no power-state change | `updateMode` |
+| Update that flips the VM to `PoweredOn` | `updateMode` **or** `powerOnMode` |
+| Power-on reconcile (live config) | `powerOnMode` |
+
+`powerOnMode=Deny` therefore lets an administrator leave create and update alone while still refusing to power on a non-compliant VM. **With all three modes at their `Allow` default, a policy enforces nothing** — it is purely a published description of the zone's capability.
+
+`spec.vmClassMode` gates this one level higher and defaults to `AsPolicy`, which means a VM whose configuration derives from a VM Class bypasses the policy entirely. Only `vmClassMode=AsConfig` subjects a VM with a `spec.className` to policy evaluation. This default preserves pre-feature behavior.
+
+### What is checked
+
+| Policy field | VM spec field | Live `ConfigInfo` |
+|---|---|---|
+| `extraConfig.allowed` / `.denied` | `spec.advanced.extraConfig[].key` | `config.extraConfig[].key` |
+| `hardwareVersions` (min/max) | `spec.minHardwareVersion` | `config.version` |
+| `numCPUCores` | `spec.resources.size.cpu` | `config.hardware.numCPU` |
+| `memory` | `spec.resources.size.memory` | `config.hardware.memoryMB` |
+| `numNUMANodes` | `spec.cpuAdvanced.topology.vnumaNodeCount` | *not checked* |
+| `iommuSupported` | `spec.cpuAdvanced.iommuEnabled` | `config.flags.vvtdEnabled` |
+| `memoryLockedToMaxSupported` | `spec.memoryAdvanced.reservationLockedToMax` | `config.memoryReservationLockedToMax` |
+| `hugePagesSupported` | `spec.advanced.hugePages1GEnabled` | *not checked* |
+
+Not enforced by either point, despite being present on the policy spec: `smcPresent`, `sevSupported`, `sevSnpSupported`, `tdxSupported`, `cpuLockedToMaxSupported` (host/cluster capabilities, not VM settings a config can violate), `numSimultaneousThreads` (no unambiguous VM spec counterpart), `latencySensitivityLevels` (the `vmoperator.vmware.com` and `vim.vmware.com` enums do not map one-to-one), the per-NIC properties `rssSupported`, `udpRSSSupported`, `lroSupported`, `txRxThreadModels`, and the `ConfigTargetDevices` device categories. A consumer that wants to warn on those must do it itself.
+
+Range semantics: for `numCPUCores`, `memory`, and `hardwareVersions`, a zero `Min` means no minimum and a zero `Max` means no maximum. `numNUMANodes` is the exception — a synced `Max` of zero is real data meaning the cluster reports no NUMA support, and is enforced as such.
+
+`extraConfig` matching: each entry has a `type` of `Fixed`, `Regex`, or `Glob`, defaulting to `Glob`. A key matching any `denied` entry is rejected; `denied` beats `allowed`. If `allowed` is non-empty, a key matching nothing in it is also rejected. A malformed pattern is treated as a non-match rather than failing the request.
+
+### What a denial looks like
+
+Admission denials come back as field errors on the specific offending path — `spec.advanced.extraConfig[2].key`, `spec.resources.size.memory`, `spec.minHardwareVersion`, and so on — with every violation reported at once rather than one per round trip.
+
+The power-on path is different. It always sets a `VirtualMachineConfigPolicyVerified` condition on the `VirtualMachine`, and consumers should read that rather than inferring compliance from anything else:
+
+- `True` — the live configuration complies.
+- `False`, reason `NotVerified` — it does not. If `powerOnMode` is not `Deny` the VM still powers on; the condition is the only signal.
+- *Absent* — no policy governs the VM: it is unplaced, its zone has no policy, or `vmClassMode=AsPolicy` exempts it.
+
+When `powerOnMode=Deny` and the live config is non-compliant, the power-on is refused as a terminal (non-requeueing) error. Fixing the VM or relaxing the policy triggers a fresh reconcile; there is no retry loop in between.
+
+### Worked example: denying an oversized VM
+
+Namespace `my-namespace-1`, zone `us-west-1`. The zone's cluster reports 8 GiB as its per-VM memory ceiling, and the administrator has set `createMode: Deny`:
+
+```yaml
+apiVersion: vim.vmware.com/v1alpha1
+kind: VirtualMachineConfigPolicy
+metadata:
+  name: us-west-1
+  namespace: my-namespace-1
+spec:
+  zone: us-west-1
+  syncMode: ConfigTarget   # memory.max below is synced, not hand-written
+  createMode: Deny
+  vmClassMode: AsConfig    # required, or a VM with a spec.className is exempt
+  memory:
+    max: 8Gi
+  extraConfig:
+    denied:
+    - type: Glob
+      key: "guestinfo.*"
+status:
+  conditions:
+  - type: Ready
+    status: "True"
+```
+
+A `VirtualMachine` created in that namespace, already placed in `us-west-1`, asking for 16 GiB:
+
+```yaml
+apiVersion: vmoperator.vmware.com/v1alpha6
+kind: VirtualMachine
+metadata:
+  name: my-vm
+  namespace: my-namespace-1
+  labels:
+    topology.kubernetes.io/zone: us-west-1
+spec:
+  className: best-effort-large
+  imageName: vmi-0a0044d7c690bcbea
+  storageClass: wcpglobal-storage-profile
+  resources:
+    size:
+      memory: 16Gi
+  advanced:
+    extraConfig:
+    - key: guestinfo.metadata
+      value: "..."
+```
+
+The webhook resolves `us-west-1` from the zone label, sees `createMode: Deny`, evaluates the spec, and rejects with both violations at once:
+
+```
+Error from server (Forbidden): error when creating "vm.yaml":
+admission webhook "default.validating.virtualmachine.v1alpha6.vmoperator.vmware.com" denied the request:
+spec.resources.size.memory: Invalid value: "16Gi": memory 16Gi exceeds the maximum of 8Gi allowed by policy
+spec.advanced.extraConfig[0].key: Forbidden: extraConfig key "guestinfo.metadata" is denied by policy
+```
+
+Change either `createMode` to `Allow` or the VM to fit, and the create succeeds. Note that with `createMode: Allow` and `powerOnMode: Deny` the same VM would be admitted and then refused at power-on instead — the pre-flight answer for a UI is to read the policy, not to submit and see.
+
+## Validation you will hit
+
+Rejections that come from the API server's CEL rules, before any webhook runs:
+
+| Object | Rule |
+|---|---|
+| `ConfigTarget` | `spec.id` immutable, `spec.id.id` non-empty, `metadata.name` matches `^domain-c[0-9]+$` |
+| `VirtualMachineConfigOptions` | `spec.hardwareVersion` immutable, matches `^vmx-[0-9]+$`, and equals `metadata.name` |
+| `VirtualMachineGuestOptions` | `spec.id` immutable and non-empty |
+
+Rejections that come from admission webhooks:
+
+| Object | Rule |
+|---|---|
+| `VirtualMachineGuestOptions` | `metadata.name` must equal the DNS-safe transform of `spec.id` |
+| `VirtualMachineConfigPolicy` | `spec.zone` must reference an existing `Zone` in the same namespace; every `extraConfig` `allowed`/`denied` entry must have a non-empty key |
+
+`ConfigTarget` and `VirtualMachineConfigOptions` have no validating webhook — every check they need is expressible in CEL and lives on the CRD.
+
+## Compatibility notes
+
+- **Do not depend on `status.sriov`.** It is empty today and will become populated.
+- **Do not depend on absence of enforcement.** A namespace whose policies are all at the `Allow` default enforces nothing today; an administrator flipping one mode to `Deny` changes that with no API change and no notice to your component.
+- **Do not derive a cluster MoID from a policy.** Go through `Zone.spec.managedVMs.clusterMoIDs`. An earlier design derived it from `spec.namespace.poolMoIDs`; that is not what the controllers do.
+- **Do not treat `VirtualMachineGuestOptions.metadata.name` as the guest ID.** It is a lossy, truncated transform. Use `spec.id`.
+- **Read the `Ready` condition before trusting any status or synced spec.** Every object here publishes last-known-good data when its upstream query fails.


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Authors `external/vim/doc/integration-guide.md`, the partner-facing integration doc for the `vim.vmware.com` APIs (vmop-3739, Story S2 of vmop-3331). The audience is teams consuming these APIs from outside VM Operator — UI/CLI surfaces, placement and quota tooling — so it is written as a contract rather than a tour: what you can rely on, what is not populated yet, and what will reject your request.

Contents:

- The capability gate (`supports_vm_service_vm_config_policy`), and why CRD presence is *not* a signal the feature is on.
- The four CRDs: scope, plural/short names, `metadata.name` conventions, who writes them, what they derive from.
- The reconcile pipeline (corrected mermaid), with the eventual-consistency and `Ready`-gating caveats a consumer needs.
- The `ConfigTarget.status` capability surface, including `maxHardwareVersion` and an explicit "do not build on `status.sriov`, it is empty today" warning.
- `VirtualMachineConfigPolicy`: `syncMode` semantics, which spec fields are synced vs. administrator-owned, the multi-cluster intersection merge, the `Min > Max` refusal, and every `Ready` condition reason.
- The enforcement contract: both enforcement points, the per-mode gating table, the full checked/not-checked field matrix, range and `extraConfig` matching semantics, and what a denial looks like on each path.
- A worked policy-denial example, end to end.
- The CEL rules and webhook rules a caller will hit.

**Written against the merged end state of the stack.** The guide describes behavior from five PRs still in review, so it should merge after them:

| PR | Behavior documented |
|---|---|
| #1738 | Both enforcement points, `spec.hardwareVersions`, the `VirtualMachineConfigPolicyVerified` condition |
| #1783 | `VirtualMachineConfigPolicy` validation webhook |
| #1784 | Sync controller, intersection merge, `Ready` reasons |
| #1785 | CEL migration; `configtarget` / `virtualmachineconfigoptions` webhooks removed |
| #1782, #1789 | `VirtualMachineGuestOptions` GC semantics |

Marked draft for that reason. Nothing here needs to change if those merge as-is; if #1738's enforcement shifts in review, the "Enforcement" section is one contiguous block to amend.

**Three corrections to the sibling docs**

Writing this surfaced claims in `controller-workflows.md` and `deploying-a-vm.md` that the merged code contradicts. Fixed here rather than propagated into a new partner-facing doc:

1. **Cluster MoID derivation.** Both docs derived cluster MoIDs from the Zone's `spec.namespace.poolMoIDs`. The merged Zone controller and the sync controller in #1784 both use `spec.managedVMs.clusterMoIDs`. Fixed in the mermaid node text and in the prose of both controller sections.
2. **`ConfigTarget` name examples.** `deploying-a-vm.md` used `cluster-1` / `cluster-2`. #1785 adds a CEL rule requiring `^domain-c[0-9]+$`, so those examples would be rejected by the API server. Now `domain-c52`.
3. **Enforcement scope — the substantive one.** `deploying-a-vm.md` stated that admission lists *every* `VirtualMachineConfigPolicy` in the namespace and denies only if *no* zone permits the VM. #1738 does the opposite: it resolves exactly one policy, named after the VM's assigned `topology.kubernetes.io/zone` label, via a single `Get`, and a VM with no zone label is not enforced at all. Its worked example and sequence diagram are rewritten to match, and the guide calls out that any-zone reasoning is the consumer's job, not admission's.

Also fixes `external/vim/README.md`, which linked to a `doc/environment_browser.md` that has never existed, and now links the three real pages.

**Which issue(s) is/are addressed by this PR?**

Addresses vmop-3739.

**Are there any special notes for your reviewer**:

- Docs-only. No `pkg/`, `api/`, or `test/` changes.
- **T021 is deliberately left open.** It asks to link the guide from the public RTD site, but `mkdocs.yml` sets `docs_dir: docs` with no include/monorepo plugin, so nothing under `external/vim/doc/` is reachable by the RTD build today — that is true of all three pages there, not just this one. Publishing means relocating the tree into `docs/`, adding a build dependency, or symlinking: a docs-site structural decision worth its own change. T021's other half (review by PM and a downstream consumer team) is a process step no PR can close. `tasks.md` records both.
- **Two bullets of T020's original scope are documented as their opposite**, because the design they described was retired. The task asked for "enriched `sriov`" and "per-host iteration inside the `ConfigTarget` controller (PropertyCollector RPC strategy, partial-failure handling)". Per T066b/T066c and the Story S4 closure, there is no host enumeration, no `PropertyCollector` call, and `status.sriov` ships empty pending spec 003. The guide says so plainly and warns consumers off the field; `tasks.md` records the divergence.

**Please add a release note if necessary**:

```release-note
NONE
```
