### PR TITLE
✨ Add Dependabot config and post-update codegen workflow

### DIFF
--- a/.github/configs/labeler.yml
+++ b/.github/configs/labeler.yml
@@ -6,6 +6,7 @@ defaults: &defaults
     - ".*_generated.deepcopy.go"
     - ".*_generated.conversion.go"
     - "config\\/crd\\/bases\\/.*"
+    - "config\\/crd\\/external-crds\\/.*"
     - "docs\\/ref\\/api\\/v.*.md"
     - "go.sum"
 

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,50 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    open-pull-requests-limit: 10
+    # Update go.mod files stored in these directories daily
+    directories:
+      - "/"
+      - "/hack/tools"
+      - "/test/e2e"
+    schedule:
+      interval: "daily"
+    groups:
+      # Kubernetes Core, Extended Tools, and Controller Runtime
+      kubernetes-and-sigs:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+      # Go Standard Tools & Extension Libraries
+      golang-x-libs:
+        patterns:
+          - "golang.org/x/*"
+      # Go ci
+      golang-ci:
+        patterns:
+          - "github.com/golangci/*"
+      # Testing Frameworks (Ginkgo & Gomega)
+      testing-modules:
+        patterns:
+          - "github.com/onsi/ginkgo/*"
+          - "github.com/onsi/gomega"
+      # Telemetry, Observability & Metrics
+      observability-modules:
+        patterns:
+          - "github.com/prometheus/*"
+          - "go.opentelemetry.io/*"
+          - "go.uber.org/zap"
+      # Logs
+      log-modules:
+        patterns:
+          - "github.com/go-logr/*"
+      # Go other dependencies
+      go-other-dependencies:
+        patterns:
+          - "*"
+
+    ignore:
+      - dependency-name: "github.com/vmware-tanzu/image-registry-operator-api"
+      - dependency-name: "github.com/vmware-tanzu/net-operator-api"
+      - dependency-name: "github.com/vmware-tanzu/nsx-operator/pkg/apis"
+      - dependency-name: "github.com/vmware/govmomi"

--- a/.github/workflows/dependabot-codegen.yml
+++ b/.github/workflows/dependabot-codegen.yml
@@ -1,0 +1,60 @@
+name: dependabot-codegen
+
+# Dependabot only edits go.mod/go.sum. It never runs `make modules` (to
+# re-tidy every module in this multi-module repo) or `make generate` (to
+# regenerate CRDs, webhooks, RBAC, and Go sources), so a bumped dependency
+# can silently leave stale generated files behind, which then fails
+# verify-go-modules/verify-codegen in ci.yml. This workflow runs both right
+# after Dependabot opens or updates a PR and pushes any resulting changes
+# back onto the PR branch, so the PR arrives with generated output already
+# in sync with the bump.
+#
+# pull_request_target is required (not pull_request) so GITHUB_TOKEN keeps
+# the write permissions granted below instead of being downgraded to
+# read-only, which GitHub always does for pull_request runs triggered by
+# Dependabot. The workflow file itself still runs from the base branch;
+# only the checkout step below pulls in the PR's own head commit.
+on:
+  pull_request_target:
+    types:
+    - opened
+    - synchronize
+    - reopened
+
+jobs:
+  regenerate:
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - name: Check out PR head
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.event.pull_request.head.ref }}
+
+    - name: Install Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: 'go.mod'
+        cache: true
+        cache-dependency-path: '**/go.sum'
+
+    - name: Run go mod tidy across all modules
+      run: make modules
+
+    - name: Regenerate CRDs, webhooks, RBAC, and Go sources
+      run: make generate
+
+    - name: Commit and push regenerated files, if any
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        if git status --porcelain | grep -q .; then
+          git add -A
+          git commit -m "Regenerate code and tidy modules for dependency bump"
+          git push origin "HEAD:${{ github.event.pull_request.head.ref }}"
+        else
+          echo "No generated changes; nothing to push."
+        fi

--- a/.github/workflows/testing-needed.yml
+++ b/.github/workflows/testing-needed.yml
@@ -31,6 +31,7 @@ jobs:
               ':(exclude)*_generated.deepcopy.go' \
               ':(exclude)*_generated.conversion.go' \
               ':(exclude)config/crd/bases/*' \
+              ':(exclude)config/crd/external-crds/*' \
               ':(exclude)docs/ref/api/v.*.md' \
               ':(exclude)*go.sum' \
               | awk '{print $4+$6}')


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Configure Dependabot for gomod updates across the three go.mod directories in this multi-module repo (`/`, `/hack/tools`, `/test/e2e`), checked daily with up to 10 open PRs at a time. Related dependencies are grouped into single PRs (Kubernetes/sigs.k8s.io, golang.org/x, golangci, ginkgo/gomega, observability, go-logr, and a catch-all for everything else) to cut down on PR noise.
Modules that are vmware related (image-registry-operator-api, net-operator-api, nsx-operator, govmomi) must be bumped manually so they are ignored by dependabot.

Dependabot only edits go.mod/go.sum, so a bumped dependency can leave stale generated CRDs, webhooks, RBAC, or tidied modules behind, failing verify-go-modules/verify-codegen in CI. Add a workflow that runs `make modules` and `make generate` on Dependabot PRs and pushes the results back to the PR branch.

Also exclude config/crd/external-crds from the labeler and the testing-needed diff, matching the existing config/crd/bases exclusion, since both are generated output.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # vmop_3991

**Are there any special notes for your reviewer**:

This will synchronize the modules version across multiple go.mods in this repo. Checked daily with up to 10 open PRs at a time but eventually we can reduce this number after the first wave of updates.


**Please add a release note if necessary**:

```release-note

```