### PR TITLE
🐛 e2e: Serialize default KMS provider across concurrent jobs

### DIFF
--- a/test/e2e/infrastructure/vsphere/vcenter/storage.go
+++ b/test/e2e/infrastructure/vsphere/vcenter/storage.go
@@ -16,6 +16,7 @@ import (
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/soap"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 )
 
@@ -93,12 +94,7 @@ func GetOrCreateEncryptionStoragePolicy(ctx context.Context, client *vim25.Clien
 		}
 	}
 
-	profile, err := pbmClient.CreateProfile(ctx, *createSpec)
-	if err != nil {
-		return "", err
-	}
-
-	return profile.UniqueId, nil
+	return createPbmProfile(ctx, pbmClient, profileName, *createSpec)
 }
 
 // GetOrCreateEZTStoragePolicy Gets already created EZT (Eager Zeroed Thick)
@@ -161,12 +157,7 @@ func GetOrCreateEZTStoragePolicy(ctx context.Context, client *vim25.Client, prof
 		}
 	}
 
-	profile, err := pbmClient.CreateProfile(ctx, *createSpec)
-	if err != nil {
-		return "", err
-	}
-
-	return profile.UniqueId, nil
+	return createPbmProfile(ctx, pbmClient, profileName, *createSpec)
 }
 
 // GetOrCreateWorkerStoragePolicy returns an existing vSphere profile ID for profileName, or creates
@@ -217,12 +208,46 @@ func GetOrCreateWorkerStoragePolicy(ctx context.Context, client *vim25.Client, p
 		return "", errors.New("could not copy capability constraints from base WCP storage policy")
 	}
 
-	profile, err := pbmClient.CreateProfile(ctx, *createSpec)
+	return createPbmProfile(ctx, pbmClient, profileName, *createSpec)
+}
+
+// createPbmProfile creates a PBM profile from spec and returns
+// its ID. If a concurrent caller wins the create race (e.g. a sibling e2e
+// shard provisioning the same globally-named policy against the same shared
+// vCenter), the profile now exists, so its ID is resolved instead of failing.
+// All callers of this helper build their base capabilities from the same
+// e2e config resolved against the same shared testbed, so the winner's
+// profile is guaranteed to match what this caller would have created.
+func createPbmProfile(
+	ctx context.Context,
+	pbmClient *pbm.Client,
+	profileName string,
+	spec types.PbmCapabilityProfileCreateSpec) (string, error) {
+
+	profile, err := pbmClient.CreateProfile(ctx, spec)
 	if err != nil {
+		if isPbmDuplicateNameFault(err) {
+			return pbmClient.ProfileIDByName(ctx, profileName)
+		}
 		return "", err
 	}
 
 	return profile.UniqueId, nil
+}
+
+// isPbmDuplicateNameFault reports whether err is a PBM CreateProfile failure
+// because a profile with the requested name already exists.
+func isPbmDuplicateNameFault(err error) bool {
+	if !soap.IsSoapFault(err) {
+		return false
+	}
+
+	switch soap.ToSoapFault(err).VimFault().(type) {
+	case types.PbmDuplicateName, types.PbmDuplicateNameFault:
+		return true
+	default:
+		return false
+	}
 }
 
 // GetOrCreateVsanDirectStoragePolicyID Gets already created VSAN Direct Storage Policy ID or Creates one if not found.
@@ -260,12 +285,7 @@ func GetOrCreateVsanDirectStoragePolicyID(ctx context.Context, client *vim25.Cli
 		return "", err
 	}
 
-	profile, err := pbmClient.CreateProfile(ctx, *createSpec)
-	if err != nil {
-		return "", err
-	}
-
-	return profile.UniqueId, nil
+	return createPbmProfile(ctx, pbmClient, profileName, *createSpec)
 }
 
 // IsVSANDEnabledCluster checks if given wcp enabled cluster is enabled with vsand capability.

--- a/test/e2e/infrastructure/vsphere/vcenter/storage.go
+++ b/test/e2e/infrastructure/vsphere/vcenter/storage.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/vmware/govmomi/crypto"
-	"github.com/vmware/govmomi/fault"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/pbm"
 	"github.com/vmware/govmomi/pbm/types"
@@ -94,7 +93,12 @@ func GetOrCreateEncryptionStoragePolicy(ctx context.Context, client *vim25.Clien
 		}
 	}
 
-	return createPbmProfile(ctx, pbmClient, profileName, *createSpec)
+	profile, err := pbmClient.CreateProfile(ctx, *createSpec)
+	if err != nil {
+		return "", err
+	}
+
+	return profile.UniqueId, nil
 }
 
 // GetOrCreateEZTStoragePolicy Gets already created EZT (Eager Zeroed Thick)
@@ -157,7 +161,12 @@ func GetOrCreateEZTStoragePolicy(ctx context.Context, client *vim25.Client, prof
 		}
 	}
 
-	return createPbmProfile(ctx, pbmClient, profileName, *createSpec)
+	profile, err := pbmClient.CreateProfile(ctx, *createSpec)
+	if err != nil {
+		return "", err
+	}
+
+	return profile.UniqueId, nil
 }
 
 // GetOrCreateWorkerStoragePolicy returns an existing vSphere profile ID for profileName, or creates
@@ -208,44 +217,12 @@ func GetOrCreateWorkerStoragePolicy(ctx context.Context, client *vim25.Client, p
 		return "", errors.New("could not copy capability constraints from base WCP storage policy")
 	}
 
-	return createPbmProfile(ctx, pbmClient, profileName, *createSpec)
-}
-
-// createPbmProfile creates a PBM profile from spec and returns
-// its ID. If a concurrent caller wins the create race (e.g. a sibling e2e
-// shard provisioning the same globally-named policy against the same shared
-// vCenter), the profile now exists, so its ID is resolved instead of failing.
-// All callers of this helper build their base capabilities from the same
-// e2e config resolved against the same shared testbed, so the winner's
-// profile is guaranteed to match what this caller would have created.
-func createPbmProfile(
-	ctx context.Context,
-	pbmClient *pbm.Client,
-	profileName string,
-	spec types.PbmCapabilityProfileCreateSpec) (string, error) {
-
-	profile, err := pbmClient.CreateProfile(ctx, spec)
+	profile, err := pbmClient.CreateProfile(ctx, *createSpec)
 	if err != nil {
-		if isPbmDuplicateNameFault(err) {
-			return pbmClient.ProfileIDByName(ctx, profileName)
-		}
 		return "", err
 	}
 
 	return profile.UniqueId, nil
-}
-
-// isPbmDuplicateNameFault reports whether err is a PBM CreateProfile failure
-// because a profile with the requested name already exists.
-func isPbmDuplicateNameFault(err error) bool {
-	var dn *types.PbmDuplicateName
-	if _, ok := fault.As(err, &dn); ok {
-		return true
-	}
-
-	var dnf *types.PbmDuplicateNameFault
-	_, ok := fault.As(err, &dnf)
-	return ok
 }
 
 // GetOrCreateVsanDirectStoragePolicyID Gets already created VSAN Direct Storage Policy ID or Creates one if not found.
@@ -283,7 +260,12 @@ func GetOrCreateVsanDirectStoragePolicyID(ctx context.Context, client *vim25.Cli
 		return "", err
 	}
 
-	return createPbmProfile(ctx, pbmClient, profileName, *createSpec)
+	profile, err := pbmClient.CreateProfile(ctx, *createSpec)
+	if err != nil {
+		return "", err
+	}
+
+	return profile.UniqueId, nil
 }
 
 // IsVSANDEnabledCluster checks if given wcp enabled cluster is enabled with vsand capability.

--- a/test/e2e/infrastructure/vsphere/vcenter/storage.go
+++ b/test/e2e/infrastructure/vsphere/vcenter/storage.go
@@ -10,13 +10,13 @@ import (
 	"strings"
 
 	"github.com/vmware/govmomi/crypto"
+	"github.com/vmware/govmomi/fault"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/pbm"
 	"github.com/vmware/govmomi/pbm/types"
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/mo"
-	"github.com/vmware/govmomi/vim25/soap"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 )
 
@@ -238,16 +238,14 @@ func createPbmProfile(
 // isPbmDuplicateNameFault reports whether err is a PBM CreateProfile failure
 // because a profile with the requested name already exists.
 func isPbmDuplicateNameFault(err error) bool {
-	if !soap.IsSoapFault(err) {
-		return false
+	var dn *types.PbmDuplicateName
+	if _, ok := fault.As(err, &dn); ok {
+		return true
 	}
 
-	switch soap.ToSoapFault(err).VimFault().(type) {
-	case types.PbmDuplicateName, types.PbmDuplicateNameFault:
-		return true
-	default:
-		return false
-	}
+	var dnf *types.PbmDuplicateNameFault
+	_, ok := fault.As(err, &dnf)
+	return ok
 }
 
 // GetOrCreateVsanDirectStoragePolicyID Gets already created VSAN Direct Storage Policy ID or Creates one if not found.

--- a/test/e2e/vmservice/common/scheme.go
+++ b/test/e2e/vmservice/common/scheme.go
@@ -5,6 +5,7 @@ package common
 
 import (
 	appsv1 "k8s.io/api/apps/v1"
+	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	storageV1 "k8s.io/api/storage/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -53,6 +54,11 @@ func addSchemes(sc *runtime.Scheme) {
 	err = storageV1.AddToScheme(sc)
 	if err != nil {
 		e2eframework.Failf("unable add storage v1 to scheme: %v", err)
+	}
+
+	err = coordinationv1.AddToScheme(sc)
+	if err != nil {
+		e2eframework.Failf("unable add coordination v1 to scheme: %v", err)
 	}
 
 	err = cnsv1alpha1.AddToScheme(sc)

--- a/test/e2e/vmservice/utils/kmslock.go
+++ b/test/e2e/vmservice/utils/kmslock.go
@@ -24,24 +24,15 @@ import (
 const (
 	// defaultKMSProviderLockName and defaultKMSProviderLockNamespace back a
 	// Lease used to serialize mutation of vCenter's default KMS provider
-	// across concurrently-running E2E jobs that target the same vCenter
-	// appliance.
+	// (CryptoManagerKmip.SetDefaultKmsCluster/GetDefaultKmsCluster called
+	// with entity=nil) across concurrently-running E2E jobs that target the
+	// same vCenter appliance — that setting is VC-wide, not scoped per
+	// namespace, session, or test.
 	//
-	// vCenter's default KMS provider (CryptoManagerKmip.SetDefaultKmsCluster
-	// / GetDefaultKmsCluster called with entity=nil) is a single, VC-wide
-	// setting — it is not scoped per-namespace, per-session, or per-test.
-	// Encryption specs save/restore it around each spec as if it were
-	// exclusively theirs; when two E2E jobs run encryption specs
-	// concurrently against the same vCenter, one job's cleanup can clear or
-	// overwrite the value the other job just set and is relying on,
-	// producing a spurious VirtualMachineEncryptionSynced=NoDefaultKeyProvider
-	// failure.
-	//
-	// The lock is a Lease in the target supervisor cluster rather than
-	// something stored in vCenter itself, because only jobs pointed at the
-	// same supervisor cluster/vCenter share that cluster's API server —
-	// which is exactly the set of jobs capable of racing on that vCenter's
-	// global setting.
+	// The lock lives in the target supervisor cluster rather than in
+	// vCenter itself because only jobs pointed at the same supervisor
+	// cluster/vCenter share that cluster's API server — exactly the set of
+	// jobs capable of racing on that vCenter's global setting.
 	defaultKMSProviderLockName      = "vmservice-e2e-default-kms-provider-lock"
 	defaultKMSProviderLockNamespace = "vmware-system-vmop"
 
@@ -115,8 +106,7 @@ func releaseKMSLease(ctx context.Context, c ctrlclient.Client, holder string) {
 		return
 	}
 	if ptr.DerefWithDefault(lease.Spec.HolderIdentity, "") != holder {
-		// Our lease already expired and another job reclaimed it; nothing
-		// to release.
+		// Lease already expired and another job reclaimed it.
 		return
 	}
 	if err := c.Delete(ctx, lease); err != nil {

--- a/test/e2e/vmservice/utils/kmslock.go
+++ b/test/e2e/vmservice/utils/kmslock.go
@@ -8,9 +8,9 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -37,36 +37,32 @@ const (
 	defaultKMSProviderLockName      = "vmservice-e2e-default-kms-provider-lock"
 	defaultKMSProviderLockNamespace = "vmware-system-vmop"
 
-	// defaultKMSProviderLockLeaseBuffer is subtracted from the Ginkgo suite's
-	// own --timeout to derive the lease duration (see
-	// defaultKMSProviderLockLeaseDuration), so a crashed holder is reclaimed
-	// with margin to spare before the suite itself would time out.
-	defaultKMSProviderLockLeaseBuffer = 5 * time.Minute
+	// defaultKMSProviderLockLeaseDuration bounds how long a holder that
+	// stops renewing (crash, panic, hard timeout) can block other jobs. A
+	// live holder never approaches this: it renews on
+	// defaultKMSProviderLockRenewInterval, well inside this window,
+	// regardless of how long its actual test work takes. Keeping this short
+	// and fixed - rather than derived from the suite's --timeout - means a
+	// dead holder is reclaimed in roughly this long, not in however long
+	// the suite's overall timeout happens to be.
+	defaultKMSProviderLockLeaseDuration = 90 * time.Second
 
-	// defaultKMSProviderLockLeaseDurationFloor is the minimum lease duration,
-	// used if the suite's --timeout is at or below
-	// defaultKMSProviderLockLeaseBuffer.
-	defaultKMSProviderLockLeaseDurationFloor = 5 * time.Minute
+	// defaultKMSProviderLockRenewInterval is how often a live holder
+	// refreshes the Lease's RenewTime. It must comfortably clear
+	// defaultKMSProviderLockLeaseDuration so transient API server hiccups
+	// don't cause a live holder to be mistaken for a dead one.
+	defaultKMSProviderLockRenewInterval = 30 * time.Second
 )
-
-// defaultKMSProviderLockLeaseDuration bounds how long a lock holder that
-// crashes or panics without releasing can block other jobs. It is derived
-// from the running suite's own Ginkgo --timeout (the same source
-// hack/e2e/run-e2e.sh sets via GINKGO_TIMEOUT) rather than a separately
-// maintained constant, so it always exceeds the slowest encryption spec's
-// full BeforeEach+It+AfterEach runtime by construction.
-func defaultKMSProviderLockLeaseDuration() time.Duration {
-	suiteConfig, _ := GinkgoConfiguration()
-	if d := suiteConfig.Timeout - defaultKMSProviderLockLeaseBuffer; d > defaultKMSProviderLockLeaseDurationFloor {
-		return d
-	}
-	return defaultKMSProviderLockLeaseDurationFloor
-}
 
 // AcquireDefaultKMSProviderLock blocks until this process holds the
 // exclusive lock on vCenter's default KMS provider setting, then returns a
 // function that releases it. Callers must arrange for the returned function
 // to run (e.g. via DeferCleanup) even if the calling spec fails.
+//
+// While held, the lock is kept alive by a background renewal loop, so a
+// live holder can run for as long as its test actually takes - the caller's
+// timeout only bounds how long to wait to *acquire* the lock, not how long
+// it may be held afterward.
 func AcquireDefaultKMSProviderLock(
 	ctx context.Context,
 	c ctrlclient.Client,
@@ -81,8 +77,64 @@ func AcquireDefaultKMSProviderLock(
 		"timed out waiting to acquire the default KMS provider lock (namespace %s, lease %s)",
 		defaultKMSProviderLockNamespace, defaultKMSProviderLockName)
 
+	stopRenewing := make(chan struct{})
+	var renewWG sync.WaitGroup
+	renewWG.Go(func() {
+		renewKMSLeaseUntilStopped(ctx, c, holder, stopRenewing)
+	})
+
 	return func() {
+		close(stopRenewing)
+		renewWG.Wait()
 		releaseKMSLease(ctx, c, holder)
+	}
+}
+
+// renewKMSLeaseUntilStopped refreshes the Lease's RenewTime on
+// defaultKMSProviderLockRenewInterval until stop is closed, keeping a live
+// holder from being mistaken for a dead one no matter how long its actual
+// work takes.
+func renewKMSLeaseUntilStopped(ctx context.Context, c ctrlclient.Client, holder string, stop <-chan struct{}) {
+	ticker := time.NewTicker(defaultKMSProviderLockRenewInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-stop:
+			return
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			renewKMSLease(ctx, c, holder)
+		}
+	}
+}
+
+// renewKMSLease refreshes the Lease's RenewTime if, and only if, it is still
+// held by holder. A failure here (lost race, transient API error) is
+// logged, not fatal: the next tick tries again, and if the Lease is
+// genuinely gone or held by someone else, the caller's own work will
+// eventually surface that as a correctness problem elsewhere rather than
+// silently corrupting vCenter's global setting.
+func renewKMSLease(ctx context.Context, c ctrlclient.Client, holder string) {
+	key := ctrlclient.ObjectKey{Namespace: defaultKMSProviderLockNamespace, Name: defaultKMSProviderLockName}
+
+	lease := &coordinationv1.Lease{}
+	if err := c.Get(ctx, key, lease); err != nil {
+		framework.Byf("WARNING: failed to read default KMS provider lock for renewal (holder %q): %v", holder, err)
+		return
+	}
+	if ptr.DerefWithDefault(lease.Spec.HolderIdentity, "") != holder {
+		framework.Byf("WARNING: default KMS provider lock no longer held by %q; another job may believe it holds it concurrently", holder)
+		return
+	}
+	lease.Spec.RenewTime = ptr.To(metav1.NowMicro())
+	// Update carries the Lease's resourceVersion, so a takeover that landed
+	// between our Get and Update (e.g. this Lease was judged expired just
+	// before this renewal) fails here with a conflict instead of silently
+	// overwriting the new holder's claim.
+	if err := c.Update(ctx, lease); err != nil {
+		framework.Byf("WARNING: failed to renew default KMS provider lock held by %q: %v", holder, err)
 	}
 }
 
@@ -104,7 +156,7 @@ func tryAcquireKMSLease(ctx context.Context, c ctrlclient.Client, holder string)
 		lease.Spec.HolderIdentity = ptr.To(holder)
 		lease.Spec.AcquireTime = ptr.To(now)
 		lease.Spec.RenewTime = ptr.To(now)
-		lease.Spec.LeaseDurationSeconds = ptr.To(int32(defaultKMSProviderLockLeaseDuration().Seconds()))
+		lease.Spec.LeaseDurationSeconds = ptr.To(int32(defaultKMSProviderLockLeaseDuration.Seconds()))
 		// Update carries the Lease's resourceVersion, so a concurrent
 		// takeover attempt by another job fails with a conflict here rather
 		// than both believing they hold the lock.
@@ -152,7 +204,7 @@ func newKMSLease(holder string) *coordinationv1.Lease {
 			HolderIdentity:       ptr.To(holder),
 			AcquireTime:          ptr.To(now),
 			RenewTime:            ptr.To(now),
-			LeaseDurationSeconds: ptr.To(int32(defaultKMSProviderLockLeaseDuration().Seconds())),
+			LeaseDurationSeconds: ptr.To(int32(defaultKMSProviderLockLeaseDuration.Seconds())),
 		},
 	}
 }

--- a/test/e2e/vmservice/utils/kmslock.go
+++ b/test/e2e/vmservice/utils/kmslock.go
@@ -1,0 +1,159 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	. "github.com/onsi/gomega"
+	coordinationv1 "k8s.io/api/coordination/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	capiutil "sigs.k8s.io/cluster-api/util"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
+	"github.com/vmware-tanzu/vm-operator/test/e2e/framework"
+)
+
+const (
+	// defaultKMSProviderLockName and defaultKMSProviderLockNamespace back a
+	// Lease used to serialize mutation of vCenter's default KMS provider
+	// across concurrently-running E2E jobs that target the same vCenter
+	// appliance.
+	//
+	// vCenter's default KMS provider (CryptoManagerKmip.SetDefaultKmsCluster
+	// / GetDefaultKmsCluster called with entity=nil) is a single, VC-wide
+	// setting — it is not scoped per-namespace, per-session, or per-test.
+	// Encryption specs save/restore it around each spec as if it were
+	// exclusively theirs; when two E2E jobs run encryption specs
+	// concurrently against the same vCenter, one job's cleanup can clear or
+	// overwrite the value the other job just set and is relying on,
+	// producing a spurious VirtualMachineEncryptionSynced=NoDefaultKeyProvider
+	// failure.
+	//
+	// The lock is a Lease in the target supervisor cluster rather than
+	// something stored in vCenter itself, because only jobs pointed at the
+	// same supervisor cluster/vCenter share that cluster's API server —
+	// which is exactly the set of jobs capable of racing on that vCenter's
+	// global setting.
+	defaultKMSProviderLockName      = "vmservice-e2e-default-kms-provider-lock"
+	defaultKMSProviderLockNamespace = "vmware-system-vmop"
+
+	// defaultKMSProviderLockLeaseDuration bounds how long a lock holder that
+	// crashes or panics without releasing can block other jobs. It must
+	// exceed the slowest encryption spec's full BeforeEach+It+AfterEach
+	// runtime.
+	defaultKMSProviderLockLeaseDuration = 15 * time.Minute
+)
+
+// AcquireDefaultKMSProviderLock blocks until this process holds the
+// exclusive lock on vCenter's default KMS provider setting, then returns a
+// function that releases it. Callers must arrange for the returned function
+// to run (e.g. via DeferCleanup) even if the calling spec fails.
+func AcquireDefaultKMSProviderLock(
+	ctx context.Context,
+	c ctrlclient.Client,
+	timeout time.Duration) func() {
+
+	holder := fmt.Sprintf("%s-%d-%s", kmsLockHostname(), os.Getpid(), capiutil.RandomString(6))
+
+	framework.Byf("Acquiring default KMS provider lock as %q", holder)
+	Eventually(func(g Gomega) {
+		g.Expect(tryAcquireKMSLease(ctx, c, holder)).To(Succeed())
+	}, timeout, 10*time.Second).Should(Succeed(),
+		"timed out waiting to acquire the default KMS provider lock (namespace %s, lease %s)",
+		defaultKMSProviderLockNamespace, defaultKMSProviderLockName)
+
+	return func() {
+		releaseKMSLease(ctx, c, holder)
+	}
+}
+
+// tryAcquireKMSLease makes a single attempt to create or take over the KMS
+// provider lock's Lease. A non-nil error (including "lock held by
+// <someone>") just means the caller should retry.
+func tryAcquireKMSLease(ctx context.Context, c ctrlclient.Client, holder string) error {
+	key := ctrlclient.ObjectKey{Namespace: defaultKMSProviderLockNamespace, Name: defaultKMSProviderLockName}
+
+	lease := &coordinationv1.Lease{}
+	err := c.Get(ctx, key, lease)
+	switch {
+	case apierrors.IsNotFound(err):
+		return c.Create(ctx, newKMSLease(holder))
+	case err != nil:
+		return err
+	case kmsLeaseExpired(lease):
+		now := metav1.NowMicro()
+		lease.Spec.HolderIdentity = ptr.To(holder)
+		lease.Spec.AcquireTime = ptr.To(now)
+		lease.Spec.RenewTime = ptr.To(now)
+		lease.Spec.LeaseDurationSeconds = ptr.To(int32(defaultKMSProviderLockLeaseDuration.Seconds()))
+		// Update carries the Lease's resourceVersion, so a concurrent
+		// takeover attempt by another job fails with a conflict here rather
+		// than both believing they hold the lock.
+		return c.Update(ctx, lease)
+	default:
+		return fmt.Errorf("lock held by %q", ptr.DerefWithDefault(lease.Spec.HolderIdentity, "<unknown>"))
+	}
+}
+
+// releaseKMSLease releases the lock if, and only if, it is still held by
+// holder. Deleting the Lease (rather than clearing HolderIdentity) lets the
+// next waiter acquire immediately instead of waiting out the lease
+// duration.
+func releaseKMSLease(ctx context.Context, c ctrlclient.Client, holder string) {
+	key := ctrlclient.ObjectKey{Namespace: defaultKMSProviderLockNamespace, Name: defaultKMSProviderLockName}
+
+	lease := &coordinationv1.Lease{}
+	if err := c.Get(ctx, key, lease); err != nil {
+		return
+	}
+	if ptr.DerefWithDefault(lease.Spec.HolderIdentity, "") != holder {
+		// Our lease already expired and another job reclaimed it; nothing
+		// to release.
+		return
+	}
+	if err := c.Delete(ctx, lease); err != nil {
+		framework.Byf("WARNING: failed to release default KMS provider lock held by %q: %v", holder, err)
+		return
+	}
+	framework.Byf("Released default KMS provider lock held by %q", holder)
+}
+
+func newKMSLease(holder string) *coordinationv1.Lease {
+	now := metav1.NowMicro()
+	return &coordinationv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultKMSProviderLockName,
+			Namespace: defaultKMSProviderLockNamespace,
+		},
+		Spec: coordinationv1.LeaseSpec{
+			HolderIdentity:       ptr.To(holder),
+			AcquireTime:          ptr.To(now),
+			RenewTime:            ptr.To(now),
+			LeaseDurationSeconds: ptr.To(int32(defaultKMSProviderLockLeaseDuration.Seconds())),
+		},
+	}
+}
+
+func kmsLeaseExpired(lease *coordinationv1.Lease) bool {
+	renew := lease.Spec.RenewTime
+	duration := ptr.DerefWithDefault(lease.Spec.LeaseDurationSeconds, 0)
+	if renew == nil || duration <= 0 {
+		return true
+	}
+	return time.Since(renew.Time) > time.Duration(duration)*time.Second
+}
+
+func kmsLockHostname() string {
+	if h, err := os.Hostname(); err == nil {
+		return h
+	}
+	return "unknown-host"
+}

--- a/test/e2e/vmservice/utils/kmslock.go
+++ b/test/e2e/vmservice/utils/kmslock.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"time"
 
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -36,12 +37,31 @@ const (
 	defaultKMSProviderLockName      = "vmservice-e2e-default-kms-provider-lock"
 	defaultKMSProviderLockNamespace = "vmware-system-vmop"
 
-	// defaultKMSProviderLockLeaseDuration bounds how long a lock holder that
-	// crashes or panics without releasing can block other jobs. It must
-	// exceed the slowest encryption spec's full BeforeEach+It+AfterEach
-	// runtime.
-	defaultKMSProviderLockLeaseDuration = 15 * time.Minute
+	// defaultKMSProviderLockLeaseBuffer is subtracted from the Ginkgo suite's
+	// own --timeout to derive the lease duration (see
+	// defaultKMSProviderLockLeaseDuration), so a crashed holder is reclaimed
+	// with margin to spare before the suite itself would time out.
+	defaultKMSProviderLockLeaseBuffer = 5 * time.Minute
+
+	// defaultKMSProviderLockLeaseDurationFloor is the minimum lease duration,
+	// used if the suite's --timeout is at or below
+	// defaultKMSProviderLockLeaseBuffer.
+	defaultKMSProviderLockLeaseDurationFloor = 5 * time.Minute
 )
+
+// defaultKMSProviderLockLeaseDuration bounds how long a lock holder that
+// crashes or panics without releasing can block other jobs. It is derived
+// from the running suite's own Ginkgo --timeout (the same source
+// hack/e2e/run-e2e.sh sets via GINKGO_TIMEOUT) rather than a separately
+// maintained constant, so it always exceeds the slowest encryption spec's
+// full BeforeEach+It+AfterEach runtime by construction.
+func defaultKMSProviderLockLeaseDuration() time.Duration {
+	suiteConfig, _ := GinkgoConfiguration()
+	if d := suiteConfig.Timeout - defaultKMSProviderLockLeaseBuffer; d > defaultKMSProviderLockLeaseDurationFloor {
+		return d
+	}
+	return defaultKMSProviderLockLeaseDurationFloor
+}
 
 // AcquireDefaultKMSProviderLock blocks until this process holds the
 // exclusive lock on vCenter's default KMS provider setting, then returns a
@@ -84,7 +104,7 @@ func tryAcquireKMSLease(ctx context.Context, c ctrlclient.Client, holder string)
 		lease.Spec.HolderIdentity = ptr.To(holder)
 		lease.Spec.AcquireTime = ptr.To(now)
 		lease.Spec.RenewTime = ptr.To(now)
-		lease.Spec.LeaseDurationSeconds = ptr.To(int32(defaultKMSProviderLockLeaseDuration.Seconds()))
+		lease.Spec.LeaseDurationSeconds = ptr.To(int32(defaultKMSProviderLockLeaseDuration().Seconds()))
 		// Update carries the Lease's resourceVersion, so a concurrent
 		// takeover attempt by another job fails with a conflict here rather
 		// than both believing they hold the lock.
@@ -109,7 +129,12 @@ func releaseKMSLease(ctx context.Context, c ctrlclient.Client, holder string) {
 		// Lease already expired and another job reclaimed it.
 		return
 	}
-	if err := c.Delete(ctx, lease); err != nil {
+	// Precondition the delete on the UID/resourceVersion we just read, so a
+	// take-over that lands between our Get and Delete (e.g. another job
+	// reclaiming an expired lease) fails this delete with a conflict instead
+	// of deleting a Lease it doesn't hold.
+	precondition := ctrlclient.Preconditions{UID: &lease.UID, ResourceVersion: &lease.ResourceVersion}
+	if err := c.Delete(ctx, lease, precondition); err != nil {
 		framework.Byf("WARNING: failed to release default KMS provider lock held by %q: %v", holder, err)
 		return
 	}
@@ -127,7 +152,7 @@ func newKMSLease(holder string) *coordinationv1.Lease {
 			HolderIdentity:       ptr.To(holder),
 			AcquireTime:          ptr.To(now),
 			RenewTime:            ptr.To(now),
-			LeaseDurationSeconds: ptr.To(int32(defaultKMSProviderLockLeaseDuration.Seconds())),
+			LeaseDurationSeconds: ptr.To(int32(defaultKMSProviderLockLeaseDuration().Seconds())),
 		},
 	}
 }

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_encryption.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_encryption.go
@@ -143,8 +143,13 @@ func VMEncryptionSpec(ctx context.Context, inputGetter func() VMEncryptionInput)
 		// vCenter's default KMS provider is VC-wide, not test-scoped;
 		// serialize this read-mutate-restore section against other E2E jobs
 		// on the same vCenter so a concurrent job's cleanup can't clobber
-		// the default provider this spec depends on mid-flight.
-		DeferCleanup(vmserviceutils.AcquireDefaultKMSProviderLock(ctx, svClusterClient, 10*time.Minute))
+		// the default provider this spec depends on mid-flight. The lock is
+		// kept alive by a renewal loop while held, so this timeout only
+		// bounds how long to wait for other jobs' encryption specs ahead in
+		// line to finish and release it, not how long any one spec may hold
+		// it - 25m comfortably covers a few queued specs at their observed
+		// several-minute runtimes.
+		DeferCleanup(vmserviceutils.AcquireDefaultKMSProviderLock(ctx, svClusterClient, 25*time.Minute))
 
 		defaultKeyProviderID, err = cryptoManager.GetDefaultKmsClusterID(ctx, nil, true)
 		Expect(err).NotTo(HaveOccurred(), "failed to get default Key Provider ID")

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_encryption.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_encryption.go
@@ -140,12 +140,10 @@ func VMEncryptionSpec(ctx context.Context, inputGetter func() VMEncryptionInput)
 			To(Succeed(), "failed to ensure encryption storage in namespace %s",
 				tmpNamespaceName)
 
-		// vCenter's default KMS provider is a single VC-wide setting, not
-		// scoped per-test. Serialize the read-mutate-restore critical
-		// section below (through AfterEach's restore) against any other
-		// E2E job pointed at the same vCenter, so a concurrent job's
-		// cleanup cannot clobber the default provider this spec depends on
-		// mid-flight. See VMSVC-4007.
+		// vCenter's default KMS provider is VC-wide, not test-scoped;
+		// serialize this read-mutate-restore section against other E2E jobs
+		// on the same vCenter so a concurrent job's cleanup can't clobber
+		// the default provider this spec depends on mid-flight.
 		DeferCleanup(vmserviceutils.AcquireDefaultKMSProviderLock(ctx, svClusterClient, 10*time.Minute))
 
 		defaultKeyProviderID, err = cryptoManager.GetDefaultKmsClusterID(ctx, nil, true)

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_encryption.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_encryption.go
@@ -140,6 +140,14 @@ func VMEncryptionSpec(ctx context.Context, inputGetter func() VMEncryptionInput)
 			To(Succeed(), "failed to ensure encryption storage in namespace %s",
 				tmpNamespaceName)
 
+		// vCenter's default KMS provider is a single VC-wide setting, not
+		// scoped per-test. Serialize the read-mutate-restore critical
+		// section below (through AfterEach's restore) against any other
+		// E2E job pointed at the same vCenter, so a concurrent job's
+		// cleanup cannot clobber the default provider this spec depends on
+		// mid-flight. See VMSVC-4007.
+		DeferCleanup(vmserviceutils.AcquireDefaultKMSProviderLock(ctx, svClusterClient, 10*time.Minute))
+
 		defaultKeyProviderID, err = cryptoManager.GetDefaultKmsClusterID(ctx, nil, true)
 		Expect(err).NotTo(HaveOccurred(), "failed to get default Key Provider ID")
 	})


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

vCenter's default KMS provider (`CryptoManagerKmip.SetDefaultKmsCluster`
/ `GetDefaultKmsCluster` called with `entity=nil`) is a single, VC-wide
setting — it is not scoped per-namespace, per-session, or per-test. The
`vm_encryption.go` E2E specs save and restore this value in
`BeforeEach`/`AfterEach` as if each test owned it exclusively. When two
E2E jobs run encryption specs concurrently against the same vCenter
appliance, one job's cleanup can clear or overwrite the default the
other job just set and is relying on, producing a spurious
`VirtualMachineEncryptionSynced=NoDefaultKeyProvider` failure and
timeout partway through VM creation.

This was root-caused from two UTS builds (1132205 and 1132208) that
ran encryption specs concurrently against the same shared vCenter: the
first build's `AfterEach` cleared the global default KMS provider 3
seconds before the second build's vTPM spec tried to create its VM,
which then failed because vm-operator correctly saw no default
provider configured.

This PR adds a distributed lock backed by a Kubernetes `Lease` in the
target supervisor cluster's `vmware-system-vmop` namespace, held for
the full read-mutate-restore window (from `BeforeEach`'s read of the
current default through `AfterEach`'s restore, via `DeferCleanup`), so
only one job at a time can mutate the default KMS provider for a given
vCenter appliance.

Changes:
- Add `AcquireDefaultKMSProviderLock` in
  `test/e2e/vmservice/utils/kmslock.go`: an optimistic-concurrency
  create-or-take-over `Lease` lock with a bounded TTL so a crashed
  holder cannot permanently block other jobs.
- Wire the lock into `vm_encryption.go`'s `BeforeEach`, released after
  `AfterEach` restores the original default provider.
- Register `coordination/v1` in the shared e2e scheme
  (`vmservice/common/scheme.go`) so controller-runtime clients can
  read/write `Lease` objects — this was previously missing and caused
  the lock to fail with `no kind is registered for the type v1.Lease`.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #

**Are there any special notes for your reviewer**:
UTS precheckin succeeded for all environment. Ran the encryption tests.

This is a test-infrastructure-only change (`test/e2e/**`); no product
(`pkg/`, `api/`) code is touched. Verified with `go build ./...`,
`go vet`, and `gofmt` on the e2e module; also validated live against a
real WCP testbed running the `vm_encryption.go` specs (surfaced and
fixed the missing `coordination/v1` scheme registration in the
process).

**Please add a release note if necessary**:

```release-note
NONE
```
