### PR TITLE
:bug: Skip shared-controller check for WSFC on create unless type is specified

### DIFF
--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_hardware.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_hardware.go
@@ -89,6 +89,13 @@ func createPvcsFromSpec(
 type testSpec struct {
 	pvcs     []manifestbuilders.PVC
 	hardware vmopv1.VirtualMachineHardwareSpec
+
+	// precreatePVCs, when true, creates the PVCs before the VirtualMachine
+	// instead of relying on the embedded PVC documents in the VM manifest.
+	// The VM manifest places the VirtualMachine document ahead of its PVCs,
+	// so admission would otherwise see the referenced PVC as not-yet-existing
+	// and skip PVC-dependent validation (e.g. ReadWriteMany sharing checks).
+	precreatePVCs bool
 }
 
 func waitForVMAndBatchAttach(
@@ -508,6 +515,16 @@ func VMHardwareSpec(ctx context.Context, inputGetter func() VMHardwareSpecInput)
 			func(specGetter func() testSpec) {
 				spec := specGetter()
 
+				if spec.precreatePVCs {
+					By("Pre-creating the PVCs so admission can resolve them when the VM is created")
+
+					for _, pvc := range spec.pvcs {
+						pvcYaml := manifestbuilders.GetPersistentVolumeClaimYaml(pvc)
+						pvcsYamls = append(pvcsYamls, pvcYaml)
+						Expect(clusterProxy.CreateWithArgs(ctx, pvcYaml)).To(Succeed(), "failed to create PVC %s", pvc.ClaimName)
+					}
+				}
+
 				vmYaml = manifestbuilders.GetVirtualMachineYamlA5(manifestbuilders.VirtualMachineYaml{
 					Namespace:        vmSvcNamespace,
 					Name:             vmName,
@@ -519,7 +536,14 @@ func VMHardwareSpec(ctx context.Context, inputGetter func() VMHardwareSpecInput)
 				})
 				vmYamls = append(vmYamls, vmYaml)
 
-				Expect(clusterProxy.CreateWithArgs(ctx, vmYaml)).To(Succeed(), "failed to create virtualmachine")
+				if spec.precreatePVCs {
+					// The VM manifest embeds the same PVC documents again; the VM
+					// is a genuine create, but re-declaring the pre-created PVCs
+					// must be an idempotent apply rather than a failing create.
+					Expect(clusterProxy.ApplyWithArgs(ctx, vmYaml)).To(Succeed(), "failed to create virtualmachine")
+				} else {
+					Expect(clusterProxy.CreateWithArgs(ctx, vmYaml)).To(Succeed(), "failed to create virtualmachine")
+				}
 
 				By("Waiting for the VirtualMachine to be created")
 
@@ -940,6 +964,34 @@ func VMHardwareSpec(ctx context.Context, inputGetter func() VMHardwareSpecInput)
 					pvcs: pvcs,
 				}
 			}),
+			Entry("create a virtual machine with a MicrosoftWSFC volume and no explicit controller",
+				func() testSpec {
+					// Create a volume with WSFC application mode and validate
+					// that a valid slot is assigned to the volume.
+					// Note that PVC must exist before we create the VM otherwise the
+					// validation webhook simply skips the validation.
+					vCenterClient = vcenter.NewVimClientFromKubeconfig(ctx, clusterProxy.GetKubeconfigPath())
+					defer vcenter.LogoutVimClient(vCenterClient)
+
+					isVSANEnabled, err := vcenter.IsVSANEnabledCluster(ctx, vCenterClient, clusterProxy.GetKubeconfigPath())
+					Expect(err).ToNot(HaveOccurred())
+					isVSANDEnabled, err := vcenter.IsVSANDEnabledCluster(ctx, vCenterClient, clusterProxy.GetKubeconfigPath())
+					Expect(err).ToNot(HaveOccurred())
+
+					if isVSANDEnabled || isVSANEnabled {
+						Skip("Skipping EZT storage profile tests as VSAN Datastore is present")
+					}
+
+					return testSpec{
+						precreatePVCs: true,
+						pvcs: createPvcsFromSpec(input, vmName, manifestbuilders.PVC{
+							StorageClassName: eztStorageProfileName,
+							AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
+							VolumeMode:       ptr.To(corev1.PersistentVolumeBlock),
+							ApplicationType:  vmopv1.VolumeApplicationTypeMicrosoftWSFC,
+						}, 1),
+					}
+				}),
 		)
 
 		Describe("Controller lifecycle", func() {

--- a/webhooks/virtualmachine/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator.go
@@ -1968,7 +1968,16 @@ func (v validator) validateSharedVolumesOrControllers(
 
 	// Rule 2 -- If the PVC is shared then the volume or controller must be
 	//           shared.
-	if pvcShared && !volShared && !controllerShared {
+	//
+	// Skip this check until a controller has actually been assigned to the
+	// volume (vol.ControllerType != ""). Controller placement is computed
+	// by the mutation webhook only after schema-upgrade backfill has
+	// populated spec.hardware.*Controllers from the VM's real,
+	// already-created state, so an unset ControllerType means placement is
+	// still pending, not invalid. Once a controller has been assigned,
+	// this rule still applies -- e.g. the user explicitly referenced an
+	// existing, non-shared controller.
+	if pvcShared && !volShared && vol.ControllerType != "" && !controllerShared {
 		allErrs = append(allErrs,
 			field.Invalid(
 				volPath.Child("sharingMode"),

--- a/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
@@ -498,6 +498,43 @@ func unitTestsValidateCreate() {
 					),
 				},
 			),
+			Entry("should allow MicrosoftWSFC volume with a ReadWriteMany PVC and no controller assignment",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						// At Create time, the VM's controller topology is not
+						// yet known -- it is only discovered once backfill
+						// runs on Update. A MicrosoftWSFC volume cannot be
+						// denied here for lacking a shared controller, since
+						// nothing can assign one yet.
+						pvc := &corev1.PersistentVolumeClaim{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "wsfc-rwx-pvc",
+								Namespace: ctx.vm.Namespace,
+							},
+							Spec: corev1.PersistentVolumeClaimSpec{
+								AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
+							},
+						}
+						Expect(ctx.Client.Create(ctx, pvc)).To(Succeed())
+
+						ctx.vm.Spec.Volumes = []vmopv1.VirtualMachineVolume{
+							{
+								Name: "wsfc-vol",
+								VirtualMachineVolumeSource: vmopv1.VirtualMachineVolumeSource{
+									PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
+										PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+											ClaimName: "wsfc-rwx-pvc",
+										},
+									},
+								},
+								ApplicationType: vmopv1.VolumeApplicationTypeMicrosoftWSFC,
+								DiskMode:        vmopv1.VolumeDiskModeIndependentPersistent,
+							},
+						}
+					},
+					expectAllowed: true,
+				},
+			),
 		)
 	})
 
@@ -9169,6 +9206,50 @@ func unitTestsValidateUpdate() { //nolint:gocyclo
 						// All fields are already set by setControllerForPVC
 					},
 					expectAllowed: true,
+				},
+			),
+			Entry("should deny MicrosoftWSFC volume with a ReadWriteMany PVC assigned to a non-shared controller",
+				testParams{
+					setup: func(ctx *unitValidatingWebhookContext) {
+						// Once a controller has actually been assigned to
+						// the volume, Rule 2 still applies: a WSFC/RWX
+						// volume referencing a controller whose sharing mode
+						// is not Physical/Virtual must be denied.
+						pvc := &corev1.PersistentVolumeClaim{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "wsfc-rwx-pvc-update-2",
+								Namespace: ctx.vm.Namespace,
+							},
+							Spec: corev1.PersistentVolumeClaimSpec{
+								AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
+							},
+						}
+						Expect(ctx.Client.Create(ctx, pvc)).To(Succeed())
+
+						newVol := vmopv1.VirtualMachineVolume{
+							Name: newVolName,
+							VirtualMachineVolumeSource: vmopv1.VirtualMachineVolumeSource{
+								PersistentVolumeClaim: &vmopv1.PersistentVolumeClaimVolumeSource{
+									PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+										ClaimName: "wsfc-rwx-pvc-update-2",
+									},
+								},
+							},
+							ApplicationType: vmopv1.VolumeApplicationTypeMicrosoftWSFC,
+							DiskMode:        vmopv1.VolumeDiskModeIndependentPersistent,
+						}
+						ctx.vm.Spec.Volumes = append(ctx.vm.Spec.Volumes, newVol)
+						// setControllerForPVC (run below, since
+						// skipSetControllerForPVC is false) assigns this
+						// volume to a SharingMode=None SCSI controller,
+						// simulating a controller explicitly referenced by
+						// the user (or otherwise assigned) that is not
+						// shared.
+					},
+					expectAllowed: false,
+					validate: doValidateWithMsg(
+						"ReadWriteMany PVC must have a shared volume or controller",
+					),
 				},
 			),
 		)


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

MicrosoftWSFC and OracleRAC volumes backed by a ReadWriteMany PVC were denied on VirtualMachine create with "ReadWriteMany PVC must have a shared volume or controller". Controller placement (controllerType/controllerBusNumber/unitNumber) is only computed by the mutation webhook after schema-upgrade backfill has populated spec.hardware.*Controllers from the VM's real, already-created state, so on create the volume has no controller assigned yet and the rule had no way to ever be satisfied.

Skip the shared-volume-or-controller rule until a controller has actually been assigned to the volume (controllerType != ""). This still rejects an assigned-but-not-shared controller, it just no longer rejects a volume whose placement is still pending. Add unit tests covering the permissive create path and the denied path where an explicit controller is not shared, plus an e2e case that pre-creates the PVC so admission can resolve it and validate the WSFC volume is assigned a slot.



**Please add a release note if necessary**:

```release-note
Skip shared-controller check for WSFC on create
```