### PR TITLE
🐛 Do not clear backfilled SubnetPort fields

### DIFF
--- a/pkg/providers/vsphere/network/network.go
+++ b/pkg/providers/vsphere/network/network.go
@@ -1125,8 +1125,13 @@ func createVPCNetworkInterface(
 		}
 
 		if pkgcfg.FromContext(ctx).Features.WorkloadIPv6 {
-			subnetPort.Spec.InterfaceIPType = IPAMModesToVPCInterfaceIPType(interfaceSpec.IPAMModes)
-			subnetPort.Spec.StaticIPAllocationType = DeriveStaticIPAllocationType(interfaceSpec)
+			// NSX Operator backfills these fields so don't clear if already set.
+			if ipType := IPAMModesToVPCInterfaceIPType(interfaceSpec.IPAMModes); ipType != "" {
+				subnetPort.Spec.InterfaceIPType = ipType
+			}
+			if ipAlloc := DeriveStaticIPAllocationType(interfaceSpec); ipAlloc != "" {
+				subnetPort.Spec.StaticIPAllocationType = ipAlloc
+			}
 		}
 
 		return nil

--- a/pkg/providers/vsphere/network/network_test.go
+++ b/pkg/providers/vsphere/network/network_test.go
@@ -1650,6 +1650,77 @@ var _ = Describe("CreateAndWaitForNetworkInterfaces", Label(testlabels.VCSim), f
 					})
 				})
 			})
+
+			Context("SubnetPort already has fields backfilled by NSX Operator", func() {
+				// NSX Operator backfills InterfaceIPType/StaticIPAllocationType on the
+				// SubnetPort in some cases. Our reconcile of the SubnetPort must not
+				// clear a previously backfilled value when the interfaceSpec does not
+				// itself derive a new, non-empty value for that field.
+				BeforeEach(func() {
+					initObjects = append(initObjects, &vpcv1alpha1.SubnetPort{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      network.VPCCRName(vm.Name, networkName, interfaceName),
+							Namespace: vm.Namespace,
+						},
+						Spec: vpcv1alpha1.SubnetPortSpec{
+							SubnetSet:              networkName,
+							InterfaceIPType:        vpcv1alpha1.IPAddressTypeIPv4IPv6,
+							StaticIPAllocationType: vpcv1alpha1.StaticIPAllocationTypeIPv4IPv6,
+						},
+					})
+				})
+
+				When("interfaceSpec has no IPAM modes or DHCP overrides", func() {
+					BeforeEach(func() {
+						networkSpec.Interfaces = []vmopv1.VirtualMachineNetworkInterfaceSpec{
+							{
+								Name:    interfaceName,
+								Network: &common.PartialObjectRef{Name: networkName, TypeMeta: vpcNetworkTypeMeta},
+							},
+						}
+					})
+
+					It("does not clear the already-set InterfaceIPType and StaticIPAllocationType", func() {
+						Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
+
+						subnetPort := &vpcv1alpha1.SubnetPort{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      network.VPCCRName(vm.Name, networkName, interfaceName),
+								Namespace: vm.Namespace,
+							},
+						}
+						Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(subnetPort), subnetPort)).To(Succeed())
+						Expect(subnetPort.Spec.InterfaceIPType).To(Equal(vpcv1alpha1.IPAddressTypeIPv4IPv6))
+						Expect(subnetPort.Spec.StaticIPAllocationType).To(Equal(vpcv1alpha1.StaticIPAllocationTypeIPv4IPv6))
+					})
+				})
+
+				When("interfaceSpec derives a new InterfaceIPType but no StaticIPAllocationType", func() {
+					BeforeEach(func() {
+						networkSpec.Interfaces = []vmopv1.VirtualMachineNetworkInterfaceSpec{
+							{
+								Name:      interfaceName,
+								Network:   &common.PartialObjectRef{Name: networkName, TypeMeta: vpcNetworkTypeMeta},
+								IPAMModes: []corev1.IPFamily{corev1.IPv4Protocol},
+							},
+						}
+					})
+
+					It("updates InterfaceIPType but preserves the already-set StaticIPAllocationType", func() {
+						Expect(err).To(MatchError(network.ErrNetworkInterfaceNotReady))
+
+						subnetPort := &vpcv1alpha1.SubnetPort{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      network.VPCCRName(vm.Name, networkName, interfaceName),
+								Namespace: vm.Namespace,
+							},
+						}
+						Expect(ctx.Client.Get(ctx, client.ObjectKeyFromObject(subnetPort), subnetPort)).To(Succeed())
+						Expect(subnetPort.Spec.InterfaceIPType).To(Equal(vpcv1alpha1.IPAddressTypeIPv4))
+						Expect(subnetPort.Spec.StaticIPAllocationType).To(Equal(vpcv1alpha1.StaticIPAllocationTypeIPv4IPv6))
+					})
+				})
+			})
 		})
 	})
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

NSX Operator backfills the InterfaceIPType and StaticIPAllocationType fields, so we should not clear them when the corresponding fields in the VM interface spec are not set.

This means that the fields cannot be cleared in the interface spec to get back the defaults. If we want to be slightly stricter, we could only set these fields when creating the SubnetPort.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # vmop-4001


**Are there any special notes for your reviewer**:



**Please add a release note if necessary**:


```release-note
NONE
```