### PR TITLE
Changs to use pre-existing KMS 

### DIFF
--- a/hack/e2e/kms.sh
+++ b/hack/e2e/kms.sh
@@ -47,7 +47,18 @@ find_gateway_ip() {
 }
 
 install() {
-  # gce2e-standard requires pykmip running on the gateway VM.
+  # Prefer a dedicated PyKMIP server supplied via testbedInfo.json (see
+  # setup-testbed-env.sh's _parse_pykmip_server / PYKMIP_HOST_* env vars) over
+  # installing pykmip on the external gateway VM discovered via govc.
+  local target_user="$1" target_ip="$2" target_password="$3"
+  if [ -n "${PYKMIP_HOST_IP:-}" ]; then
+    target_user="${PYKMIP_HOST_USERNAME:-root}"
+    target_ip="${PYKMIP_HOST_IP}"
+    target_password="${PYKMIP_HOST_PASSWORD:-}"
+    echo "Using dedicated PyKMIP server from testbedInfo.json: ${target_ip}"
+  fi
+
+  # gce2e-standard requires pykmip running on the target host.
   # Skip if already green (idempotent for parallel runners).
   if kms_is_green "gce2e-standard"; then
     echo "KMS provider gce2e-standard already green, skipping pykmip install"
@@ -59,9 +70,9 @@ install() {
               -keyout "$crt_dir"/pykmip-key.pem -out "$crt_dir"/pykmip-crt.pem
     fi
 
-    if [ -n "$2" ]; then
-      target="$1@$2"
-      password=$3
+    if [ -n "$target_ip" ]; then
+      target="$target_user@$target_ip"
+      password="$target_password"
 
       sshpass -p "$password" scp $SSH_OPTS "$crt_dir"/pykmip-*.pem "$script_dir"/install-pykmip.sh "$target":
       sshpass -p "$password" ssh -T $SSH_OPTS "$target" \
@@ -74,7 +85,7 @@ install() {
 
   # setup() configures vCenter key providers; kms_is_green checks inside
   # each block make it safe to call from multiple parallel runners.
-  setup "$2"
+  setup "$target_ip"
 }
 
 # kms_is_green returns 0 if the named provider already exists and has

--- a/hack/e2e/setup-testbed-env.sh
+++ b/hack/e2e/setup-testbed-env.sh
@@ -271,6 +271,35 @@ _parse_vc_credentials() {
 }
 
 # ---------------------------------------------------------------------------
+# _parse_pykmip_server
+#
+# Reads testbed_info (via _jq) and populates pykmip_ip, pykmip_username,
+# pykmip_password from a dedicated PyKMIP server VM, when the testbed
+# provisioned one (nimbus genericVm entry with type == "PyKMIPServer").
+#
+# When present, this takes priority over installing pykmip on the external
+# gateway VM (see _setup_gateway_and_proxy / kms.sh). Leaves pykmip_ip empty
+# when no such VM exists so callers fall back to the gateway-install path.
+# ---------------------------------------------------------------------------
+_parse_pykmip_server() {
+    pykmip_ip="" pykmip_username="" pykmip_password=""
+
+    if ! jq -e '.genericVm | type == "array" and length > 0' <<< "${testbed_info}" >/dev/null 2>&1; then
+        return 0
+    fi
+
+    pykmip_ip=$(_jq '[.genericVm[] | select(.type == "PyKMIPServer")][0] | .ip4 // .ip // ""')
+    if [[ -z "${pykmip_ip}" || "${pykmip_ip}" == "null" ]]; then
+        pykmip_ip=""
+        return 0
+    fi
+    pykmip_username=$(_jq '[.genericVm[] | select(.type == "PyKMIPServer")][0] | .username // "root"')
+    pykmip_password=$(_jq '[.genericVm[] | select(.type == "PyKMIPServer")][0] | .password // ""')
+
+    _log "PyKMIP server (testbedInfo.json): ${pykmip_ip} (user: ${pykmip_username})"
+}
+
+# ---------------------------------------------------------------------------
 # _export_common_vars
 #
 # Exports all standard test-framework environment variables derived from the
@@ -454,6 +483,7 @@ _setup_kubectl_vsphere() {
     fi
 
     rm -f vsphere-plugin.zip
+    rm -f "${extract_dir}/bin/kubectl"
     export PATH="${extract_dir}/bin:${PATH}"
     # When not sourced, emit PATH so the caller's shell gets it too.
     # Use a literal $PATH so the user's current PATH is spliced in at eval
@@ -537,6 +567,20 @@ _setup_gateway_and_proxy() {
     _export GOVC_URL      "${govc_url}"
     _export GOVC_INSECURE "true"
 
+    # Prefer a dedicated PyKMIP server supplied via testbedInfo.json (nimbus
+    # genericVm entry, type == "PyKMIPServer") over installing pykmip on the
+    # external gateway VM. When present, kms.sh installs/configures against
+    # that host directly and gce2e-standard is available regardless of
+    # whether the gateway VM itself is reachable.
+    local kms_mode="native-only"
+    if [[ -n "${pykmip_ip:-}" ]]; then
+        _export PYKMIP_HOST_IP       "${pykmip_ip}"
+        _export PYKMIP_HOST_USERNAME "${pykmip_username}"
+        _export PYKMIP_HOST_PASSWORD "${pykmip_password}"
+        _log "Using dedicated PyKMIP server from testbedInfo.json: ${pykmip_ip}"
+        kms_mode="full"
+    fi
+
     _log "Discovering gateway VM via govc..."
     local gateway_ip
     gateway_ip=$(GOVC_USERNAME="${vc_vim_username}" GOVC_PASSWORD="${vc_vim_password}" \
@@ -545,7 +589,7 @@ _setup_gateway_and_proxy() {
 
     if [[ -z "${gateway_ip:-}" || "${gateway_ip}" == "null" ]]; then
         _warn "Could not find gateway VM (may not be a VDS testbed)"
-        _setup_kms_providers "${script_dir}" "${govc_url}" "${mgmt_cidr}" "" "native-only"
+        _setup_kms_providers "${script_dir}" "${govc_url}" "${mgmt_cidr}" "" "${kms_mode}"
         return 0
     fi
 
@@ -553,7 +597,7 @@ _setup_gateway_and_proxy() {
 
     local _gw_password=""
     if ! _probe_gateway_ssh "${gateway_ip}"; then
-        _setup_kms_providers "${script_dir}" "${govc_url}" "${mgmt_cidr}" "" "native-only"
+        _setup_kms_providers "${script_dir}" "${govc_url}" "${mgmt_cidr}" "" "${kms_mode}"
         return 0
     fi
 
@@ -600,7 +644,7 @@ _setup_gateway_and_proxy() {
     _export GATEWAY_VM_PASSWORD "${_gw_password}"
     _log "✓ HTTP_PROXY=${gateway_ip}:3128  NO_PROXY=${no_proxy_val}"
 
-    _setup_kms_providers "${script_dir}" "${govc_url}" "${mgmt_cidr}" "${_gw_password}" "full"
+    _setup_kms_providers "${script_dir}" "${govc_url}" "${mgmt_cidr}" "${_gw_password}" "${kms_mode:-full}"
 }
 
 # ---------------------------------------------------------------------------
@@ -676,9 +720,11 @@ EOF
     local vc_url="" vc_root_password="" vc_root_old_password=""
     local vc_root_username="" vc_vim_username="" vc_vim_password=""
     local wcp_ip="" wcp_password=""
+    local pykmip_ip="" pykmip_username="" pykmip_password=""
 
     _load_testbed "${testbed_source}"  || return
     _parse_vc_credentials              || return
+    _parse_pykmip_server
     _export_common_vars
     _fetch_supervisor_access "${enable_e2e}" || return
 


### PR DESCRIPTION
pykmip on the external gateway VM discovered via govc, which is fragile (SSH probing, DNS fixes) and unavailable on testbeds without a reachable gateway. Newer testbedInfo.json deliverables provision a dedicated PyKMIP server VM (genericVm entry, type == "PyKMIPServer") with its own IP and credentials.

Changes:
- Add _parse_pykmip_server to setup-testbed-env.sh, extracting pykmip_ip/username/password from testbed_info.genericVm[] when a PyKMIPServer entry is present.
- When present, export PYKMIP_HOST_IP/USERNAME/PASSWORD and force gce2e-standard setup to "full" mode regardless of gateway VM reachability.
- Update kms.sh's install() to prefer PYKMIP_HOST_IP over the gateway VM args when set, installing/configuring pykmip against the dedicated testbed server instead.

Existing gateway-based install/discovery logic is left intact and still runs as a fallback for testbeds without a dedicated PyKMIP server VM.

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note

```