### PR TITLE
✨ SAP config e2e test and status.hardware.memory conversion fix

### DIFF
--- a/pkg/providers/vsphere/virtualmachine/conversion.go
+++ b/pkg/providers/vsphere/virtualmachine/conversion.go
@@ -14,6 +14,12 @@ func MemoryQuantityToMb(q resource.Quantity) int64 {
 	return int64(math.Ceil(float64(q.Value()) / float64(1024*1024)))
 }
 
+// MbToBytes converts a vSphere MB-denominated value (always binary mebibytes)
+// into bytes, the inverse of MemoryQuantityToMb.
+func MbToBytes(mb int64) int64 {
+	return mb * 1024 * 1024
+}
+
 func CPUQuantityToMhz(q resource.Quantity, cpuFreqMhz uint64) int64 {
 	return int64(math.Ceil(float64(q.MilliValue()) * float64(cpuFreqMhz) / float64(1000)))
 }

--- a/pkg/providers/vsphere/virtualmachine/conversion_test.go
+++ b/pkg/providers/vsphere/virtualmachine/conversion_test.go
@@ -33,3 +33,19 @@ var _ = Describe("CPUQuantityToMhz", func() {
 		})
 	})
 })
+
+var _ = Describe("MbToBytes", func() {
+
+	Context("Convert vSphere MB (binary mebibytes) to bytes", func() {
+		It("is the inverse of MemoryQuantityToMb", func() {
+			q, err := resource.ParseQuantity("4Gi")
+			Expect(err).NotTo(HaveOccurred())
+			mb := virtualmachine.MemoryQuantityToMb(q)
+			Expect(virtualmachine.MbToBytes(mb)).Should(BeNumerically("==", q.Value()))
+		})
+
+		It("returns the binary byte count, not decimal", func() {
+			Expect(virtualmachine.MbToBytes(4096)).Should(BeNumerically("==", int64(4096*1024*1024)))
+		})
+	})
+})

--- a/pkg/providers/vsphere/vmlifecycle/update_status.go
+++ b/pkg/providers/vsphere/vmlifecycle/update_status.go
@@ -274,12 +274,17 @@ func reconcileStatusHardware(
 
 		memStatus := &vmopv1.VirtualMachineMemoryAllocationStatus{}
 
-		b := memTotal * 1000 * 1000
-		memStatus.Total = kubeutil.BytesToResource(b)
+		// vSphere's MemoryMB (and MemoryAllocation.{Reservation,Limit}) are
+		// always binary mebibyte counts, not decimal megabytes — convert via
+		// virtualmachine.MbToBytes to match every other MemoryMB conversion
+		// in this codebase (e.g. pkg/util/vmopv1/compute_overwrite.go's
+		// desiredMemoryAllocation and the ConfigSpec.MemoryMB assignment), so
+		// status round-trips to the same byte value as spec.resources.size.memory.
+		memStatus.Total = kubeutil.BytesToResource(virtualmachine.MbToBytes(memTotal))
 
 		if a := config.MemoryAllocation; a != nil {
 			if res := a.Reservation; res != nil && *res > 0 {
-				memStatus.Reservation = kubeutil.BytesToResource(*res * 1000 * 1000)
+				memStatus.Reservation = kubeutil.BytesToResource(virtualmachine.MbToBytes(*res))
 			}
 		}
 
@@ -287,7 +292,7 @@ func reconcileStatusHardware(
 			if a := config.MemoryAllocation; a != nil {
 				// Nil or -1 Limit means unlimited in vSphere; only surface explicit positive limits.
 				if lim := a.Limit; lim != nil && *lim >= 0 {
-					memStatus.Limit = kubeutil.BytesToResource(*lim * 1000 * 1000)
+					memStatus.Limit = kubeutil.BytesToResource(virtualmachine.MbToBytes(*lim))
 				}
 			}
 

--- a/pkg/providers/vsphere/vmlifecycle/update_status_test.go
+++ b/pkg/providers/vsphere/vmlifecycle/update_status_test.go
@@ -5543,10 +5543,10 @@ var _ = Describe("Hardware status", func() {
 				Expect(vmCtx.VM.Status.Hardware.CPU.Reservation).To(Equal(int64(1000)))
 
 				Expect(vmCtx.VM.Status.Hardware.Memory.Total).ToNot(BeNil())
-				Expect(vmCtx.VM.Status.Hardware.Memory.Total.String()).To(Equal("2048M"))
+				Expect(vmCtx.VM.Status.Hardware.Memory.Total.String()).To(Equal("2Gi"))
 
 				Expect(vmCtx.VM.Status.Hardware.Memory.Reservation).ToNot(BeNil())
-				Expect(vmCtx.VM.Status.Hardware.Memory.Reservation.String()).To(Equal("1024M"))
+				Expect(vmCtx.VM.Status.Hardware.Memory.Reservation.String()).To(Equal("1Gi"))
 			})
 
 			When("CPU total is zero and allocation is nil", func() {
@@ -5730,13 +5730,13 @@ var _ = Describe("Hardware status", func() {
 
 			When("memory is larger than math.MaxInt32 bytes", func() {
 				BeforeEach(func() {
-					vmCtx.MoVM.Config.Hardware.MemoryMB = math.MaxInt32/(1000*1000) + 1
+					vmCtx.MoVM.Config.Hardware.MemoryMB = math.MaxInt32/(1024*1024) + 1
 				})
 
 				It("should set the memory status", func() {
 					err := vmlifecycle.ReconcileStatus(vmCtx, ctx.Client, vcVM, data)
 					Expect(err).ToNot(HaveOccurred())
-					Expect(vmCtx.VM.Status.Hardware.Memory.Total.String()).To(Equal("2148M"))
+					Expect(vmCtx.VM.Status.Hardware.Memory.Total.String()).To(Equal("2Gi"))
 				})
 			})
 			When("full compute configuration is set", func() {
@@ -5827,7 +5827,7 @@ var _ = Describe("Hardware status", func() {
 						mem := vmCtx.VM.Status.Hardware.Memory
 						Expect(mem).ToNot(BeNil())
 						Expect(mem.Limit).ToNot(BeNil())
-						Expect(mem.Limit.String()).To(Equal("2048M"))
+						Expect(mem.Limit.String()).To(Equal("2Gi"))
 						Expect(mem.ReservationLockedToMax).To(Equal(ptr.To(true)))
 						Expect(mem.HotAddEnabled).To(Equal(ptr.To(true)))
 					})

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_compute_config.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_compute_config.go
@@ -1395,9 +1395,10 @@ func VMComputeConfigSpec(ctx context.Context, inputGetter func() VMComputeConfig
 			By("Waiting for VM to be created and condition=True")
 			vmoperator.WaitForVirtualMachineConditionCreated(ctx, config, svClusterClient,
 				vmNamespace, vmName)
-			waitForComputeConfigSynced(ctx, svClusterClient, config,
+			condInitial := waitForComputeConfigSynced(ctx, svClusterClient, config,
 				types.NamespacedName{Namespace: vmNamespace, Name: vmName},
 				metav1.ConditionTrue, "")
+			Expect(condInitial).ToNot(BeNil())
 
 			By("Looking up host CpuMhz via govmomi for full CPU reservation")
 			vmObj, err := utils.GetVirtualMachine(ctx, svClusterClient, vmNamespace, vmName)
@@ -1441,7 +1442,7 @@ func VMComputeConfigSpec(ctx context.Context, inputGetter func() VMComputeConfig
 			By("Waiting for ComputeConfigSynced=True after latency sensitivity patch")
 			waitForComputeConfigSynced(ctx, svClusterClient, config,
 				types.NamespacedName{Namespace: vmNamespace, Name: vmName},
-				metav1.ConditionTrue, "")
+				metav1.ConditionTrue, "", condInitial.LastTransitionTime)
 
 			By("Asserting latencySensitivity and reservation in status")
 			Eventually(func(g Gomega) {
@@ -1487,9 +1488,10 @@ func VMComputeConfigSpec(ctx context.Context, inputGetter func() VMComputeConfig
 			By("Waiting for VM to be created and condition=True (powered-off)")
 			vmoperator.WaitForVirtualMachineConditionCreated(ctx, config, svClusterClient,
 				vmNamespace, vmName)
-			waitForComputeConfigSynced(ctx, svClusterClient, config,
+			condInitial := waitForComputeConfigSynced(ctx, svClusterClient, config,
 				types.NamespacedName{Namespace: vmNamespace, Name: vmName},
 				metav1.ConditionTrue, "")
+			Expect(condInitial).ToNot(BeNil())
 
 			By("Checking hardware version; skip if < 20")
 			vmObj, err := utils.GetVirtualMachine(ctx, svClusterClient, vmNamespace, vmName)
@@ -1516,7 +1518,7 @@ func VMComputeConfigSpec(ctx context.Context, inputGetter func() VMComputeConfig
 			By("Waiting for ComputeConfigSynced=True after vNUMA patch")
 			waitForComputeConfigSynced(ctx, svClusterClient, config,
 				types.NamespacedName{Namespace: vmNamespace, Name: vmName},
-				metav1.ConditionTrue, "")
+				metav1.ConditionTrue, "", condInitial.LastTransitionTime)
 
 			vmObj, err = utils.GetVirtualMachine(ctx, svClusterClient, vmNamespace, vmName)
 			Expect(err).ToNot(HaveOccurred())
@@ -1603,9 +1605,10 @@ func VMComputeConfigSpec(ctx context.Context, inputGetter func() VMComputeConfig
 			By("Waiting for VM to be created and condition=True (powered-off with hot-add flags applied)")
 			vmoperator.WaitForVirtualMachineConditionCreated(ctx, config, svClusterClient,
 				vmNamespace, vmName)
-			waitForComputeConfigSynced(ctx, svClusterClient, config,
+			condInitial := waitForComputeConfigSynced(ctx, svClusterClient, config,
 				types.NamespacedName{Namespace: vmNamespace, Name: vmName},
 				metav1.ConditionTrue, "")
+			Expect(condInitial).ToNot(BeNil())
 
 			By("Asserting hotAddEnabled=true in status before size patch")
 			Eventually(func(g Gomega) {
@@ -1639,7 +1642,7 @@ func VMComputeConfigSpec(ctx context.Context, inputGetter func() VMComputeConfig
 			By("Waiting for ComputeConfigSynced=True after size patch (VM powered-off; no power cycle needed)")
 			waitForComputeConfigSynced(ctx, svClusterClient, config,
 				types.NamespacedName{Namespace: vmNamespace, Name: vmName},
-				metav1.ConditionTrue, "")
+				metav1.ConditionTrue, "", condInitial.LastTransitionTime)
 
 			By("Powering on VM")
 			vmoperator.UpdateVirtualMachinePowerState(ctx, config, svClusterClient, vmNamespace, vmName, string(vmopv1.VirtualMachinePowerStateOn))
@@ -1657,7 +1660,7 @@ func VMComputeConfigSpec(ctx context.Context, inputGetter func() VMComputeConfig
 			}, config.GetIntervals("default", "wait-vm-compute-config-synced")...).
 				Should(Succeed(), "cpu size assertions failed for %s/%s", vmNamespace, vmName)
 
-			By("Asserting memory total = 3072M")
+			By("Asserting memory total = 3Gi")
 			Eventually(func(g Gomega) {
 				vm, err := utils.GetVirtualMachine(ctx, svClusterClient, vmNamespace, vmName)
 				g.Expect(err).ToNot(HaveOccurred())
@@ -1672,11 +1675,11 @@ func VMComputeConfigSpec(ctx context.Context, inputGetter func() VMComputeConfig
 					}())
 				g.Expect(mem).ToNot(BeNil())
 				g.Expect(mem.Total).ToNot(BeNil())
-				// vSphere reports memory in MB (treated as SI mega by the operator);
-				// 3Gi spec → 3072 vSphere MB → status stores 3072M.
-				want := resource.MustParse("3072M")
+				// vSphere's MemoryMB is a binary mebibyte count; 3Gi spec →
+				// 3072 vSphere MB → status stores 3Gi (exact round trip).
+				want := resource.MustParse("3Gi")
 				g.Expect(mem.Total.Equal(want)).To(BeTrue(),
-					"expected memory total=3072M, got %s", mem.Total.String())
+					"expected memory total=3Gi, got %s", mem.Total.String())
 			}, config.GetIntervals("default", "wait-vm-compute-config-synced")...).
 				Should(Succeed())
 		})

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_extraconfig.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_extraconfig.go
@@ -13,8 +13,11 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/mo"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	e2eframework "k8s.io/kubernetes/test/e2e/framework"
@@ -770,6 +773,216 @@ func VMExtraConfigSpec(ctx context.Context, inputGetter func() VMExtraConfigSpec
 			Expect(cond).NotTo(BeNil())
 			Expect(cond.Message).To(ContainSubstring(vmxHugePages),
 				"condition message should name the deferred PowerOff key")
+		})
+
+	// ── It block 10 ──────────────────────────────────────────────────────────
+	// A composite "SAP HANA profile" VM combining every VCFA compute
+	// advanced-parameter ask that has first-class or bag-key support:
+	// numa.vcpu.preferHT (first-class), sched.node{0-3}.affinity and
+	// smbios.assetTag (generic spec.advanced.extraConfig bag, since neither
+	// has a first-class field), ethernet0.ctxPerDev/pnicFeatures (first-class
+	// vmxnet3 fields), a 4-way vNUMA topology so the four sched.nodeX.affinity
+	// keys each bind to a real vNUMA client, and full CPU/memory reservation
+	// plus a full memory limit (spec.resources / memoryAdvanced). Exercises
+	// all three ExtraConfig-family reconcilers (VM-level, NIC-level,
+	// compute-config) on one VM. disk.enableUUID is asserted rather than set:
+	// it is a system-reserved key vm-operator sets unconditionally on every
+	// VM, not a user-configurable field. SVGA video memory has no VM Operator
+	// API today (no ExtraConfig key, no first-class field, no VM Class device
+	// knob) and is intentionally not covered here.
+	It("creates SAP HANA-profile VM with 4-way NUMA node affinity, asset tag, NIC tuning, and full compute reservation",
+		Label("extended-functional", "experimental"), func() {
+
+			if vCenterClient == nil {
+				Skip("govmomi vCenterClient not available — skipping SAP HANA profile test")
+			}
+
+			vmName := fmt.Sprintf("%s-sap-%s", specName, capiutil.RandomString(4))
+			vmKey := types.NamespacedName{Name: vmName, Namespace: input.WCPNamespaceName}
+			modePerQueue := vmopv1.TxContextThreadingModePerQueue
+			assetTag := "SAP-HANA-" + capiutil.RandomString(6)
+
+			By("Creating powered-off VM with PreferHT, NUMA scheduler affinity + asset tag bag keys, and NIC tuning")
+			vm := buildExtraConfigVM(buildExtraConfigVMOpts{
+				Name:         vmName,
+				Namespace:    input.WCPNamespaceName,
+				ClassName:    vmClassName,
+				ImageName:    linuxVMIName,
+				StorageClass: storageClass,
+				Advanced: &vmopv1.VirtualMachineAdvancedSpec{
+					PreferHTEnabled: ptr.To(true),
+					ExtraConfig: []vmopv1common.KeyValuePair{
+						{Key: "sched.node0.affinity", Value: "0"},
+						{Key: "sched.node1.affinity", Value: "1"},
+						{Key: "sched.node2.affinity", Value: "2"},
+						{Key: "sched.node3.affinity", Value: "3"},
+						{Key: "smbios.assetTag", Value: assetTag},
+					},
+				},
+			})
+			// vnumaNodeCount/coresPerSocket and the full CPU/memory reservation
+			// below all require power-off to apply; starting powered off avoids
+			// an extra power cycle mid-test. vnumaNodeCount also requires
+			// vmx-20+, so request it directly rather than skipping the test
+			// when the class/image default lands below that.
+			vm.Spec.PowerState = vmopv1.VirtualMachinePowerStateOff
+			vm.Spec.MinHardwareVersion = 20
+			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{
+				Interfaces: []vmopv1.VirtualMachineNetworkInterfaceSpec{
+					{
+						Name: "eth0",
+						Type: vmopv1.VirtualMachineNetworkInterfaceTypeVMXNet3,
+						VMXNet3: &vmopv1.VirtualMachineNetworkInterfaceVMXNet3Spec{
+							CtxPerDev: &modePerQueue,
+							PNICFeatures: []vmopv1.PNICQueueFeature{
+								vmopv1.PNICQueueFeatureReceiveSideScaling,
+							},
+						},
+					},
+				},
+			}
+			vm.Spec.MemoryAdvanced = &vmopv1.VirtualMachineMemoryAdvancedSpec{
+				ReservationLockedToMax: ptr.To(true),
+			}
+
+			Expect(svClusterClient.Create(ctx, vm)).To(Succeed(), "failed to create VM %s", vmName)
+			DeferCleanup(func() {
+				if !input.SkipCleanup {
+					vmoperator.DeleteVirtualMachine(ctx, svClusterClient, vmKey.Namespace, vmKey.Name)
+					vmoperator.WaitForVirtualMachineToBeDeleted(ctx, config, svClusterClient, vmKey.Namespace, vmKey.Name)
+				}
+			})
+
+			By("Waiting for VM to be created in vSphere (powered off)")
+			vmoperator.WaitForVirtualMachineConditionCreated(
+				ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
+
+			By("Waiting for ExtraConfigSynced=True (preferHT + NUMA scheduler affinity + asset tag)")
+			waitForExtraConfigSynced(ctx, svClusterClient, config, vmKey, metav1.ConditionTrue, "")
+
+			By("Waiting for NetworkConfigSynced=True (ctxPerDev + pnicFeatures)")
+			waitForNICExtraConfigSynced(ctx, svClusterClient, config, vmKey, metav1.ConditionTrue, "")
+
+			By("Waiting for ComputeConfigSynced=True (memoryAdvanced.reservationLockedToMax)")
+			waitForComputeConfigSynced(ctx, svClusterClient, config, vmKey, metav1.ConditionTrue, "")
+
+			// 4 vCPUs, CoresPerSocket=1 → 4 sockets, VNUMANodeCount=4 → one
+			// vNUMA client per socket, giving each of sched.node0-3.affinity a
+			// distinct vNUMA client to bind to.
+			By("Patching size.cpu=4 and vnumaNodeCount=4/coresPerSocket=1 while powered off")
+			latest := getExtraConfigVM(ctx, svClusterClient, vmKey)
+			patch := ctrlclient.MergeFrom(latest.DeepCopy())
+			latest.Spec.Resources = &vmopv1.VirtualMachineResourcesSpec{
+				Size: &vmopv1.VirtualMachineResourceQuantity{
+					CPU: ptr.To(resource.MustParse("4")),
+				},
+			}
+			latest.Spec.CPUAdvanced = &vmopv1.VirtualMachineCPUAdvancedSpec{
+				Topology: &vmopv1.VirtualMachineCPUTopologySpec{
+					CoresPerSocket: ptr.To(int32(1)),
+					VNUMANodeCount: ptr.To(int32(4)),
+				},
+			}
+			Expect(svClusterClient.Patch(ctx, latest, patch)).To(Succeed(),
+				"failed to patch VM %s size/topology", vmName)
+
+			By("Waiting for ComputeConfigSynced=True after size/topology patch")
+			waitForComputeConfigSynced(ctx, svClusterClient, config, vmKey, metav1.ConditionTrue, "")
+
+			vm = getExtraConfigVM(ctx, svClusterClient, vmKey)
+			vmMoRef := vimtypes.ManagedObjectReference{Type: "VirtualMachine", Value: vm.Status.UniqueID}
+
+			verifyCoresPerNumaNode := func(when string) {
+				By(fmt.Sprintf("Verifying coresPerNumaNode=1 via govmomi (%s)", when))
+				Eventually(func(g Gomega) {
+					var moVM mo.VirtualMachine
+					err := property.DefaultCollector(vCenterClient).RetrieveOne(
+						ctx, vmMoRef, []string{"config.numaInfo.coresPerNumaNode"}, &moVM,
+					)
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(moVM.Config).NotTo(BeNil())
+					g.Expect(moVM.Config.NumaInfo).NotTo(BeNil(),
+						"expected NumaInfo to be populated after vnumaNodeCount patch (%s)", when)
+					g.Expect(moVM.Config.NumaInfo.CoresPerNumaNode).NotTo(BeNil(),
+						"expected CoresPerNumaNode pointer to be set (%s)", when)
+					// 4 vCPUs / vnumaNodeCount=4 = 1 core per NUMA node.
+					g.Expect(*moVM.Config.NumaInfo.CoresPerNumaNode).To(BeEquivalentTo(int32(1)),
+						"expected coresPerNumaNode=1 (4 vCPUs / vnumaNodeCount=4) (%s)", when)
+				}, config.GetIntervals("default", "wait-vm-compute-config-synced")...).Should(Succeed(),
+					"timed out waiting for 4-way vNUMA config to be applied in vSphere for %s (%s)", vmKey, when)
+			}
+			verifyCoresPerNumaNode("powered off")
+
+			By("Looking up host CpuMhz via govmomi for full CPU reservation")
+			govVM := findVSphereVMByMOID(vCenterClient, vm.Status.UniqueID)
+			Expect(govVM).NotTo(BeNil())
+			host, err := govVM.HostSystem(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			var moHost mo.HostSystem
+			Expect(property.DefaultCollector(vCenterClient).RetrieveOne(
+				ctx, host.Reference(), []string{"summary.hardware"}, &moHost,
+			)).To(Succeed())
+			Expect(moHost.Summary.Hardware).NotTo(BeNil(), "host hardware summary not populated")
+			hostMHz := int64(moHost.Summary.Hardware.CpuMhz)
+			Expect(hostMHz).To(BeNumerically(">", 0), "host MHz should be positive")
+
+			cpuStatus := statusCPU(vm)
+			Expect(cpuStatus).NotTo(BeNil())
+			Expect(cpuStatus.Total).To(BeEquivalentTo(4), "expected size.cpu=4 to be reflected in status")
+			fullCPURes := int64(cpuStatus.Total) * hostMHz
+
+			memStatus := statusMemory(vm)
+			Expect(memStatus).NotTo(BeNil())
+			Expect(memStatus.Total).NotTo(BeNil())
+
+			By("Patching full CPU reservation and full memory limit")
+			latest = getExtraConfigVM(ctx, svClusterClient, vmKey)
+			patch = ctrlclient.MergeFrom(latest.DeepCopy())
+			latest.Spec.Resources.Requests = &vmopv1.VirtualMachineResourceQuantity{
+				CPU: ptr.To(resource.MustParse(fmt.Sprintf("%d", fullCPURes))),
+			}
+			latest.Spec.Resources.Limits = &vmopv1.VirtualMachineResourceQuantity{
+				Memory: memStatus.Total,
+			}
+			Expect(svClusterClient.Patch(ctx, latest, patch)).To(Succeed(),
+				"failed to patch VM %s full compute reservation", vmName)
+
+			By("Waiting for ComputeConfigSynced=True after full reservation/limit patch")
+			waitForComputeConfigSynced(ctx, svClusterClient, config, vmKey, metav1.ConditionTrue, "")
+
+			By("Powering on VM to confirm the vNUMA topology and reservations persist")
+			vmoperator.UpdateVirtualMachinePowerState(
+				ctx, config, svClusterClient, input.WCPNamespaceName, vmName, string(vmopv1.VirtualMachinePowerStateOn))
+			vmoperator.WaitForVirtualMachinePowerState(
+				ctx, config, svClusterClient, input.WCPNamespaceName, vmName, string(vmopv1.VirtualMachinePowerStateOn))
+
+			verifyCoresPerNumaNode("powered on")
+
+			By("Asserting every SAP HANA setting converged")
+			vm = getExtraConfigVM(ctx, svClusterClient, vmKey)
+			Expect(statusExtraConfigValue(vm, vmxPreferHT)).To(Equal("TRUE"))
+			Expect(statusExtraConfigValue(vm, "sched.node0.affinity")).To(Equal("0"))
+			Expect(statusExtraConfigValue(vm, "sched.node1.affinity")).To(Equal("1"))
+			Expect(statusExtraConfigValue(vm, "sched.node2.affinity")).To(Equal("2"))
+			Expect(statusExtraConfigValue(vm, "sched.node3.affinity")).To(Equal("3"))
+			Expect(statusExtraConfigValue(vm, "smbios.assetTag")).To(Equal(assetTag))
+			Expect(statusExtraConfigValue(vm, "ethernet0.ctxPerDev")).To(Equal("3"))
+			Expect(statusExtraConfigValue(vm, "ethernet0.pnicFeatures")).To(Equal("4"))
+			Expect(statusExtraConfigValue(vm, "disk.enableUUID")).To(Equal("TRUE"),
+				"disk.enableUUID is set unconditionally by vm-operator for every VM")
+
+			cpu := statusCPU(vm)
+			Expect(cpu).NotTo(BeNil())
+			Expect(cpu.Total).To(BeEquivalentTo(4))
+			Expect(cpu.Reservation).To(BeEquivalentTo(fullCPURes),
+				"expected CPU reservation=%d MHz", fullCPURes)
+			mem := statusMemory(vm)
+			Expect(mem).NotTo(BeNil())
+			Expect(mem.ReservationLockedToMax).NotTo(BeNil())
+			Expect(*mem.ReservationLockedToMax).To(BeTrue())
+			Expect(mem.Limit).NotTo(BeNil())
+			Expect(mem.Limit.Equal(*memStatus.Total)).To(BeTrue(),
+				"expected memory limit=%s (full size), got %s", memStatus.Total.String(), mem.Limit.String())
 		})
 }
 

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_extraconfig.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_extraconfig.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -545,7 +546,7 @@ func VMExtraConfigSpec(ctx context.Context, inputGetter func() VMExtraConfigSpec
 
 			vmoperator.WaitForVirtualMachineConditionCreated(
 				ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
-			waitForExtraConfigSynced(ctx, svClusterClient, config, vmKey, metav1.ConditionTrue, "")
+			condBaseline := waitForExtraConfigSynced(ctx, svClusterClient, config, vmKey, metav1.ConditionTrue, "")
 
 			By("Powering off VM cleanly via spec before destroy")
 			vmoperator.UpdateVirtualMachinePowerState(
@@ -593,8 +594,17 @@ func VMExtraConfigSpec(ctx context.Context, inputGetter func() VMExtraConfigSpec
 			vmoperator.WaitForVirtualMachineConditionCreated(
 				ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
 
+			// reconcileStatusExtraConfig (update_status.go) skips updating
+			// ExtraConfigSynced whenever moVM.Config is nil — i.e. for the
+			// entire window the vSphere VM is destroyed — so the condition
+			// sits unchanged at condBaseline's True the whole time. UniqueID
+			// changing doesn't prove otherwise: it's set by a separate patch
+			// in createVirtualMachineAsync, not by this same reconcile pass.
+			// Require LastTransitionTime to advance past condBaseline so this
+			// wait can't pass on that stale, pre-destroy True.
 			By("Waiting for ExtraConfigSynced=True on the recreated VM")
-			waitForExtraConfigSynced(ctx, svClusterClient, config, vmKey, metav1.ConditionTrue, "")
+			waitForExtraConfigSynced(ctx, svClusterClient, config, vmKey,
+				metav1.ConditionTrue, "", condBaseline.LastTransitionTime)
 
 			By("Asserting extraConfig is fully re-applied from spec on the recreated VM")
 			vm = getExtraConfigVM(ctx, svClusterClient, vmKey)
@@ -864,7 +874,7 @@ func VMExtraConfigSpec(ctx context.Context, inputGetter func() VMExtraConfigSpec
 			waitForNICExtraConfigSynced(ctx, svClusterClient, config, vmKey, metav1.ConditionTrue, "")
 
 			By("Waiting for ComputeConfigSynced=True (memoryAdvanced.reservationLockedToMax)")
-			waitForComputeConfigSynced(ctx, svClusterClient, config, vmKey, metav1.ConditionTrue, "")
+			condBaseline := waitForComputeConfigSynced(ctx, svClusterClient, config, vmKey, metav1.ConditionTrue, "")
 
 			// 4 vCPUs, CoresPerSocket=1 → 4 sockets, VNUMANodeCount=4 → one
 			// vNUMA client per socket, giving each of sched.node0-3.affinity a
@@ -886,9 +896,23 @@ func VMExtraConfigSpec(ctx context.Context, inputGetter func() VMExtraConfigSpec
 			Expect(svClusterClient.Patch(ctx, latest, patch)).To(Succeed(),
 				"failed to patch VM %s size/topology", vmName)
 
+			// condBaseline was already True (from the create-time
+			// reservationLockedToMax convergence) before this patch, so the
+			// condition status alone can't distinguish "still the old True"
+			// from "re-evaluated against the new spec and True again."
+			// Requiring LastTransitionTime to advance past condBaseline
+			// forces this wait to observe a reconcile that actually ran
+			// after the patch above.
 			By("Waiting for ComputeConfigSynced=True after size/topology patch")
-			waitForComputeConfigSynced(ctx, svClusterClient, config, vmKey, metav1.ConditionTrue, "")
+			condResize := waitForComputeConfigSynced(ctx, svClusterClient, config, vmKey,
+				metav1.ConditionTrue, "", condBaseline.LastTransitionTime)
 
+			// The reconcile that advances ComputeConfigSynced's
+			// LastTransitionTime past condBaseline computes status.hardware
+			// and the condition from the same live-config snapshot in the
+			// same patch (see reconcileStatusHardware/reconcileComputeConfigSynced
+			// in update_status.go), so this fetch is already consistent —
+			// no separate poll needed for cpu.Total.
 			vm = getExtraConfigVM(ctx, svClusterClient, vmKey)
 			vmMoRef := vimtypes.ManagedObjectReference{Type: "VirtualMachine", Value: vm.Status.UniqueID}
 
@@ -913,6 +937,11 @@ func VMExtraConfigSpec(ctx context.Context, inputGetter func() VMExtraConfigSpec
 			}
 			verifyCoresPerNumaNode("powered off")
 
+			cpuStatusAfterResize := statusCPU(vm)
+			Expect(cpuStatusAfterResize).NotTo(BeNil())
+			Expect(cpuStatusAfterResize.Total).To(BeEquivalentTo(4),
+				"expected size.cpu=4 to be reflected in status")
+
 			By("Looking up host CpuMhz via govmomi for full CPU reservation")
 			govVM := findVSphereVMByMOID(vCenterClient, vm.Status.UniqueID)
 			Expect(govVM).NotTo(BeNil())
@@ -926,10 +955,7 @@ func VMExtraConfigSpec(ctx context.Context, inputGetter func() VMExtraConfigSpec
 			hostMHz := int64(moHost.Summary.Hardware.CpuMhz)
 			Expect(hostMHz).To(BeNumerically(">", 0), "host MHz should be positive")
 
-			cpuStatus := statusCPU(vm)
-			Expect(cpuStatus).NotTo(BeNil())
-			Expect(cpuStatus.Total).To(BeEquivalentTo(4), "expected size.cpu=4 to be reflected in status")
-			fullCPURes := int64(cpuStatus.Total) * hostMHz
+			fullCPURes := int64(cpuStatusAfterResize.Total) * hostMHz
 
 			memStatus := statusMemory(vm)
 			Expect(memStatus).NotTo(BeNil())
@@ -947,8 +973,11 @@ func VMExtraConfigSpec(ctx context.Context, inputGetter func() VMExtraConfigSpec
 			Expect(svClusterClient.Patch(ctx, latest, patch)).To(Succeed(),
 				"failed to patch VM %s full compute reservation", vmName)
 
+			// Same race as above: condResize was already True before this
+			// patch, so require the condition to re-transition past it.
 			By("Waiting for ComputeConfigSynced=True after full reservation/limit patch")
-			waitForComputeConfigSynced(ctx, svClusterClient, config, vmKey, metav1.ConditionTrue, "")
+			waitForComputeConfigSynced(ctx, svClusterClient, config, vmKey,
+				metav1.ConditionTrue, "", condResize.LastTransitionTime)
 
 			By("Powering on VM to confirm the vNUMA topology and reservations persist")
 			vmoperator.UpdateVirtualMachinePowerState(
@@ -968,7 +997,29 @@ func VMExtraConfigSpec(ctx context.Context, inputGetter func() VMExtraConfigSpec
 			Expect(statusExtraConfigValue(vm, "smbios.assetTag")).To(Equal(assetTag))
 			Expect(statusExtraConfigValue(vm, "ethernet0.ctxPerDev")).To(Equal("3"))
 			Expect(statusExtraConfigValue(vm, "ethernet0.pnicFeatures")).To(Equal("4"))
-			Expect(statusExtraConfigValue(vm, "disk.enableUUID")).To(Equal("TRUE"),
+
+			// disk.enableUUID is set unconditionally by vm-operator on every VM,
+			// but it is neither a first-class field nor a spec.advanced.extraConfig
+			// bag key (it's system-reserved — users can't set it there either),
+			// so reconcileStatusExtraConfig never surfaces it in status.extraConfig.
+			// Verify it directly against the live vSphere config instead.
+			By("Asserting disk.enableUUID=TRUE directly against the live vSphere config")
+			var moVMFinal mo.VirtualMachine
+			Expect(property.DefaultCollector(vCenterClient).RetrieveOne(
+				ctx, vmMoRef, []string{"config.extraConfig"}, &moVMFinal,
+			)).To(Succeed())
+			Expect(moVMFinal.Config).NotTo(BeNil())
+			var diskUUID string
+			var diskUUIDFound bool
+			for _, ov := range moVMFinal.Config.ExtraConfig {
+				if kv := ov.GetOptionValue(); kv != nil && kv.Key == "disk.enableUUID" {
+					diskUUID, _ = kv.Value.(string)
+					diskUUIDFound = true
+					break
+				}
+			}
+			Expect(diskUUIDFound).To(BeTrue(), "expected disk.enableUUID to be set on the live VM")
+			Expect(diskUUID).To(Equal("TRUE"),
 				"disk.enableUUID is set unconditionally by vm-operator for every VM")
 
 			cpu := statusCPU(vm)
@@ -1034,6 +1085,7 @@ func waitForExtraConfigSynced(
 	vmKey types.NamespacedName,
 	wantStatus metav1.ConditionStatus,
 	wantReason string,
+	afterTime ...metav1.Time,
 ) *metav1.Condition {
 	desc := string(wantStatus)
 	if wantReason != "" {
@@ -1054,6 +1106,11 @@ func waitForExtraConfigSynced(
 		}
 		g.Expect(cond).NotTo(BeNil(),
 			"%s condition not yet present on VM %s", vmopv1.VirtualMachineExtraConfigSynced, vmKey)
+
+		if len(afterTime) > 0 {
+			g.Expect(cond.LastTransitionTime.After(afterTime[0].Time)).To(BeTrue(),
+				"condition lastTransitionTime not yet advanced past sentinel on %s", vmKey)
+		}
 		g.Expect(cond.Status).To(Equal(wantStatus),
 			"%s: got status=%s reason=%s message=%s",
 			vmopv1.VirtualMachineExtraConfigSynced, cond.Status, cond.Reason, cond.Message)
@@ -1066,6 +1123,11 @@ func waitForExtraConfigSynced(
 	}, config.GetIntervals("default", "wait-vm-extraconfig-synced")...).Should(Succeed(),
 		"timed out waiting for %s=%s on VM %s",
 		vmopv1.VirtualMachineExtraConfigSynced, desc, vmKey)
+
+	// metav1.Time has second-level granularity. Sleep 1s so a caller that
+	// captures matched.LastTransitionTime as a sentinel for a subsequent
+	// wait doesn't race a fast reconcile landing in the same second.
+	time.Sleep(time.Second)
 
 	return matched
 }


### PR DESCRIPTION
  **What does this PR do, and why is it needed?**

  Adds a composite "SAP HANA profile" E2E scenario to `VMComputeConfigSpec` (`test/e2e/vmservice/vmservice/virtualmachine/vm_extraconfig.go`) that creates a single VM covering every VCFA compute advanced-parameter request from the SAP HANA / VCD-to-VCFA migration requirements that VM Operator supports today, and fixes two bugs uncovered while writing it.

  **New E2E scenario**

  - `numa.vcpu.preferHT` — first-class `spec.advanced.preferHtEnabled`
  - `sched.node{0-3}.affinity` and `smbios.assetTag` — the generic `spec.advanced.extraConfig` bag, since neither has a first-class field
  - `ethernet0.ctxPerDev` / `ethernet0.pnicFeatures` — first-class `spec.network.interfaces[].vmxnet3` fields
  - A real 4-way vNUMA topology (`vnumaNodeCount: 4`, `coresPerSocket: 1`, `size.cpu: 4`, `minHardwareVersion: 20`) so each of the four `sched.nodeX.affinity` keys binds to an actual vNUMA client instead of being an inert ExtraConfig value — verified directly against vSphere via govmomi (`config.numaInfo.coresPerNumaNode`), both powered off and after power-on
  - Full CPU reservation (`spec.resources.requests.cpu`, derived from the host's `CpuMhz`) and a full memory limit (`spec.resources.limits.memory`), plus `memoryAdvanced.reservationLockedToMax` for the memory reservation guarantee
  - `disk.enableUUID` is asserted (not set) since it's a system-reserved key vm-operator sets unconditionally on every VM

  Not covered, by design: SVGA video memory amount has no VM Operator API today — no ExtraConfig key, no first-class field, no VM Class video device knob — so it isn't a test gap closeable with a test-only change.

  **Bug fix: `status.hardware.memory` used decimal instead of binary MB**

  `pkg/providers/vsphere/vmlifecycle/update_status.go` converted vSphere's `MemoryMB` (always true binary mebibytes) into `status.hardware.memory.{total,reservation,limit}` using `*1_000_000` (decimal mega) instead of binary math, under-reporting real memory by ~4.66% on every VM and contradicting every other MemoryMB conversion in this codebase (`pkg/util/vmopv1/compute_overwrite.go`'s `desiredMemoryAllocation`, the `ConfigSpec.MemoryMB` assignment). Added `virtualmachine.MbToBytes` next to its existing inverse `MemoryQuantityToMb` in `pkg/providers/vsphere/virtualmachine/conversion.go` (no such reverse utility existed anywhere), and fixed all three conversions to use it. Updated the tests that were pinned to the old, wrong values: `update_status_test.go` (4 assertions, including recalculating the `math.MaxInt32` boundary test for the new divisor) and `vm_compute_config.go` (a `"3072M"` round-trip assertion now correctly expects `"3Gi"` — an exact match instead of a lossy one). Added two small unit tests for `MbToBytes` in `conversion_test.go`.

  **Bug fix: condition waits racing against their own stale prior state**

  `waitForComputeConfigSynced` and `waitForExtraConfigSynced` support (or, for the latter, now support) an `afterTime` sentinel specifically to guard against this, but several call sites weren't using it: when a condition is already `True` before a patch, waiting for `True` again afterward with no sentinel can pass instantly on the stale, pre-patch value without ever confirming the reconciler processed the new spec. Fixed in the new SAP HANA scenario (two waits, threading `condBaseline`/`condResize.LastTransitionTime` forward) and in the existing `"re-applies extraConfig after the vSphere VM is destroyed out-of-band"` scenario, where `ExtraConfigSynced` sits untouched at its pre-destroy `True` for the entire window the underlying vSphere VM is gone (`reconcileStatusExtraConfig` skips updating it whenever `moVM.Config` is nil), and `status.uniqueID` changing doesn't prove otherwise since it's set by a separate patch in `createVirtualMachineAsync`. Added `afterTime ...metav1.Time` support to `waitForExtraConfigSynced` itself, matching the pattern already used by `waitForComputeConfigSynced`/`waitForNICExtraConfigSynced`.
already used by `waitForComputeConfigSynced`/`waitForNICExtraConfigSynced`.
already used by `waitForComputeConfigSynced`/`waitForNICExtraConfigSynced`.

**Which issue(s) is/are addressed by this PR?**

Fixes #

**Are there any special notes for your reviewer**:

- New scenario is labeled `extended-functional` and `experimental` (skips when `supports_telco_vm_service_api` is disabled or when the govmomi vCenter client isn't available), per `e2e-testing.md` — has not yet been run against a real Supervisor/vSphere cluster.
- The `status.hardware.memory` fix is a real behavior change for every VM, not test-only — flagging per `e2e-sync-with-changes.md`'s "found a potential bug while writing E2E tests" carve-out rather than scoping it to a separate PR, since the E2E test is what surfaced it and the fix needed the matching test updates in the same change set.

**Please add a release note if necessary**:

```release-note
Fix status.hardware.memory.{total,reservation,limit} under-reporting VM memory by ~4.66% due to a decimal/binary unit conversion bug.
``

