### PR TITLE
:sparkles: Functional verification TDS, plan and tasks for VM ReplicaSets

### DIFF
--- a/.sdd/specs/003-virtualmachinereplicaset/tasks.md
+++ b/.sdd/specs/003-virtualmachinereplicaset/tasks.md
@@ -1,0 +1,71 @@
+# Tasks: `VirtualMachineReplicaSet` Functional Test Coverage
+
+- **TDS**: [`tds.md`](./tds.md) — the acceptance-criteria source for this task list (in place of a `spec.md`; each task cites the TDS scenario number(s) it implements as `[SCn]`)
+- **Test plan**: [`test-plan.md`](./test-plan.md)
+- **Epic**: vmop-1701
+
+<!--
+TODO: fill in per-task [vmop-NNN] story/sub-task tags once filed under the
+epic, following the same deferral used in 002-vm-extraconfig-reconcile/tasks.md.
+vmop-1701 already tracks "Implement VirtualMachineReplicaSet API"; the one
+ticket that already exists (vmop-4017, for the TDS §19 Condition-on-adoption
+gap) is tagged below on the tasks it blocks.
+-->
+
+This task list decomposes `test-plan.md` into ordered, executable tasks. It is test-only for TDS scenarios that already pass or can be written against a genuine gap; three tasks are expected to produce an initially-failing (red) test that documents a real product gap rather than a test bug — see Phase Final.
+
+## Phase 1 — Setup
+
+- [ ] T001 Wire `unitTests` into the existing `suite.Register(t, "VirtualMachineReplicaSet controller suite", intgTests, nil)` call in `controllers/virtualmachinereplicaset/virtualmachinereplicaset_controller_suite_test.go` (currently `nil`) — blocks every unit-test task below.
+
+## Phase 2 — Foundational
+
+- [ ] T002 [P] Audit `webhooks/virtualmachinereplicaset/validation/virtualmachinereplicaset_validator_unit_test.go` and `_intg_test.go` for existing coverage of TDS scenarios 12 (negative replicas) and 13 (selector/template mismatch) to avoid duplicating specs in Phase 7.
+- [ ] T003 [P] Confirm the exact `make`/`ginkgo` invocation for each tier referenced in `test-plan.md`'s Verification section (unit, envtest integration, webhook, real-vCenter E2E) against `Makefile` and `test/e2e/README.md`; update `test-plan.md` if any command differs from what's documented there.
+
+## Phase 3 — Controller unit tests: core reconciliation
+
+- [ ] T004 [SC1,SC2,SC3,SC4,SC5,SC9,SC10] Create `controllers/virtualmachinereplicaset/virtualmachinereplicaset_controller_test.go` (external `_test` package, `Label(testlabels.Controller, testlabels.API)`, `builder.UnitTestContextForController` + `providerfake.VMProvider`, structured after `virtualmachinesnapshot_controller_unit_test.go`). Cover: create-from-scratch produces N owned VMs (SC1); default `spec.replicas=1` (SC2); explicit `spec.replicas=0` creates/leaves none (SC3); idempotent no-op reconcile (SC4); scale-to-zero-then-back-up creates fresh VMs, never reuses names (SC9); rapid successive `spec.replicas` edits converge to the final value without leaking VMs (SC10). Depends on T001.
+
+## Phase 4 — Controller unit tests: status & conditions
+
+- [ ] T005 [SC22,SC23,SC25,SC26,SC27,SC28,SC29] Extend `virtualmachinereplicaset_controller_test.go` (same file as T004, sequential — not `[P]` against T004/T006/T007): `status.replicas` always matches owned-VM count (SC22); `status.fullyLabeledReplicas` diverges from `status.replicas` on label drift (SC23); `VirtualMachinesCreated` reflects create-path failures via `providerfake` injected errors (SC25); `ReplicaFailure` condition on sustained failure to converge (SC26); `VirtualMachinesReady` aggregates readiness — resolve the `[NEEDS CLARIFICATION]` from the TDS by writing the test against the chosen condition state for the `spec.replicas=0` edge case and updating TDS §27 to remove the marker (SC27); `observedGeneration` only advances once the generation's spec is actually processed (SC28); `Resized` condition clears once converged (SC29). Depends on T004.
+
+## Phase 5 — Controller unit tests: template/selector/label semantics
+
+- [ ] T006 [SC14,SC15,SC16,SC30,SC31,SC34] Extend `virtualmachinereplicaset_controller_test.go` (same file, sequential after T005): selector edits don't retroactively relabel existing VMs (SC14); template spec edits don't mutate/recreate existing replicas (SC15); template metadata-label edits — resolve the `[NEEDS CLARIFICATION]` from the TDS by writing the test against the chosen behavior and updating TDS §16 to remove the marker (SC16); `vmoperator.vmware.com/replicaset-name` label correctness (SC30) and its ownership-vs-discoverability distinction (SC31); template `Spec` fields (e.g. `powerState`) pass through verbatim (SC34). Depends on T005.
+
+## Phase 6 — Controller unit tests: non-goal absence checks
+
+- [ ] T007 [SC35,SC36] Extend `virtualmachinereplicaset_controller_test.go` (same file, sequential after T006): assert no `ControllerRevision`-equivalent/rollout-status field exists on the type (SC35); assert `status.replicas` never changes except in response to an external `spec.replicas` edit, i.e. no built-in auto-scaling side effect (SC36). Depends on T006.
+
+## Phase 7 — Validation webhook tests
+
+- [ ] T008 [P] [SC12,SC13] In `webhooks/virtualmachinereplicaset/validation/`: add the negative-`spec.replicas` rejection case (SC12 — expected to fail today, no `+kubebuilder:validation:Minimum=0` or webhook rule exists; write it against the intended contract) to `virtualmachinereplicaset_validator_unit_test.go`; confirm/extend selector-vs-template-label mismatch coverage (SC13) per the T002 audit, adding only what's missing to `_unit_test.go`/`_intg_test.go`. Independent file from Phases 3–6, may run in parallel with them. Depends on T002.
+
+## Phase 8 — Controller integration tests: scaling & scale subresource
+
+- [ ] T009 [SC6,SC7,SC8,SC11,SC37] Extend `controllers/virtualmachinereplicaset/virtualmachinereplicaset_controller_intg_test.go` (envtest, existing `intgFakeVMProvider`): scale-up leaves original replicas untouched and sets `Resized`/`ScalingUp` (SC6); scale-down deletes the right count and sets `Resized`/`ScalingDown` (SC7); `deletePolicy: Random` scale-down invariants — deleted VM was owned, remaining VMs untouched, no assertion on *which* one is picked (SC8); editing the `/scale` subresource has identical effect to editing `spec.replicas` directly (SC11); replicas may legitimately co-locate on the same host/cluster module without error, since anti-affinity is out of scope (SC37). Depends on T001 (suite wiring already exists for intg tests; T001 is unit-only but kept as a dependency marker for ordering within this task list).
+
+## Phase 9 — Controller integration tests: ownership, orphans, GC, cross-namespace
+
+- [ ] T010 [SC17,SC18,SC20,SC21,SC33] [vmop-4017 for SC19] Extend the same `_intg_test.go` (sequential after T009): deleting the `VirtualMachineReplicaSet` cascades to owned VMs, best-effort given envtest can't run kube-controller-manager GC — document the limitation rather than asserting what envtest can't prove (SC17); deleting one owned VM directly triggers exactly one replacement (SC18); two `VirtualMachineReplicaSet`s with overlapping selectors never cross-delete each other's owned VMs (SC20); namespace-scoped selector matching — a same-labeled VM in a different namespace is never touched (SC21); a VM deleted by something other than the controller (competing controller, quota enforcement, manual `kubectl delete`) is treated identically to SC18 (SC33). **SC19** (a standalone VM matching the selector is adopted, and a `Condition` records the adoption): write the adoption-occurs half now; the `Condition` assertion is expected to fail until **vmop-4017** is implemented — do not weaken the assertion to make it pass. Depends on T009.
+
+## Phase 10 — Controller integration tests: readiness & finalizer draining
+
+- [ ] T011 [SC24,SC32,SC38] Extend the same `_intg_test.go` (sequential after T010): `status.readyReplicas` tracks each owned VM's `Ready` condition via `providerfake.SetCreateOrUpdateFunction` — **expected to fail** against the current stub that counts every filtered VM as ready regardless of actual status; write it against the intended contract, do not water it down (SC24); a slow-draining finalizer on a replica being scaled down doesn't cause the controller to overshoot `spec.replicas` with a premature replacement (SC32); a replica recreated after deletion gets a fresh generated name, never reusing the deleted replica's identity (SC38). Depends on T010.
+
+## Phase 11 — Mutation webhook baseline tests
+
+- [ ] T012 [P] Create `webhooks/virtualmachinereplicaset/mutation/virtualmachinereplicaset_mutator_unit_test.go` (new file, currently zero coverage) asserting the mutator's current no-op/pass-through behavior, so the eventual implementation of vmop-1827 has a regression baseline. Independent of all controller-file phases; may run in parallel with Phases 3–10.
+
+## Phase 12 — E2E smoke
+
+- [ ] T013 [P] [SC1,SC6,SC7,SC11,SC17 (thin slice)] Create `test/e2e/vmservice/virtualmachinereplicaset/` following the `test/e2e/vmservice/virtualmachine/` layout, registered from `test/e2e/vmservice/vmservice_test.go`; run against a **real vCenter/WCP cluster** per `test/e2e/README.md` (no vcsim path exists in this tier — see `test-plan.md`'s correction note): create with N replicas, scale up, scale down, delete, and confirm the VMs actually reach `PoweredOn`. Independent new package; may run in parallel with Phases 3–11.
+
+## Phase Final — Polish / triage
+
+- [ ] T014 Run the full suite (`make test` for unit + envtest integration + webhook tiers per T003's confirmed commands; the E2E suite from T013 against a real cluster) and confirm the **only** failures are the three known, intentionally-red assertions: SC19's Condition assertion (blocked on vmop-4017), SC24's readyReplicas assertion, SC12's negative-replicas assertion. Any other failure is a real test bug or a newly-discovered gap — fix or triage it, do not suppress it.
+- [ ] T015 File a follow-up `vmop-NNN` story/sub-task under epic vmop-1701 for the SC24 `status.readyReplicas` gap (the `// TODO: Figure out an equivalent of Ready condition...` in `virtualmachinereplicaset_controller.go`), linked via `customfield_10830`.
+- [ ] T016 File a follow-up `vmop-NNN` story/sub-task under epic vmop-1701 for the SC12 negative-`spec.replicas` validation gap, linked via `customfield_10830`.
+- [ ] T017 Update `test-plan.md` and `tds.md` with any deviations discovered during execution (per `.sdd/memory/sdd-standards.md`'s "spec is source of truth" rule) — including resolving TDS §16's and §27's `[NEEDS CLARIFICATION]` markers once T006 and T005 land, respectively.

--- a/.sdd/specs/003-virtualmachinereplicaset/tds.md
+++ b/.sdd/specs/003-virtualmachinereplicaset/tds.md
@@ -1,0 +1,246 @@
+# Functional Test Specification: `VirtualMachineReplicaSet`
+
+**Status**: Draft
+**Scope**: `VirtualMachineReplicaSet` only (`api/v1alpha6/virtualmachinereplicaset_types.go`). `VirtualMachineDeployment` and `VirtualMachineStatefulSet` are out of scope for this document — they build on top of the behavior specified here and should get their own TDS.
+**Source material**:
+
+- One Pager: *VM Service: Workload Management of VMs using Kubernetes Patterns* (Confluence page 1007649487)
+- Kubernetes `apps/v1` `ReplicaSet` (the pattern this API is explicitly modeled after)
+- KubeVirt `VirtualMachineInstanceReplicaSet` (`https://kubevirt.io/user-guide/user_workloads/replicaset/`) — the closest prior art for VM-shaped replicas rather than Pod-shaped replicas
+
+**Purpose of this document**: define the observable, user-facing contract for `VirtualMachineReplicaSet` in enough detail that a suite of tests written against these acceptance criteria — independent of any particular controller implementation — gives confidence the feature is safe to ship/switch on. This is written **before** looking at controller code, so it reflects intended behavior, not implemented behavior. Any test that fails against the real implementation is either a bug to fix or a deliberate deviation that must be called out and reconciled with this document.
+
+---
+
+## 1. API contract recap
+
+From `virtualmachinereplicaset_types.go`:
+
+| Field | Notes |
+|---|---|
+| `spec.replicas` (`*int32`, default `1`) | Desired replica count. Pointer so explicit `0` is distinguishable from unset. |
+| `spec.deletePolicy` (`string`, enum `Random`) | Only `Random` is a legal non-empty value today. |
+| `spec.selector` (`*metav1.LabelSelector`, required) | Must match `spec.template.metadata.labels`. |
+| `spec.template` (`VirtualMachineTemplateSpec`) | `metadata` (labels/annotations) + `spec` (`VirtualMachineSpec`) blueprint for replicas. |
+| `status.replicas` | Observed current replica count. |
+| `status.fullyLabeledReplicas` | Replicas whose labels match the template's labels. |
+| `status.readyReplicas` | Replicas whose owned `VirtualMachine`'s `Ready` condition is `True`. |
+| `status.observedGeneration` | Standard reconciler-freshness field. |
+| `status.conditions` | `VirtualMachinesCreated`, `VirtualMachinesReady`, `Resized` (reasons `ScalingUp`/`ScalingDown`), plus `ReplicaFailure` reason. |
+| Label `vmoperator.vmware.com/replicaset-name` | Applied by the controller to every owned `VirtualMachine`. |
+| Scale subresource | `specpath=.spec.replicas`, `statuspath=.status.replicas` — i.e. `kubectl scale` / HPA-style clients must work. |
+
+This is a **level-triggered controller over a fixed template**, not a rollout controller: there is no revision history, no rolling-update strategy, and no auto-scaling here — those are explicitly Non-Goals in the one-pager and belong to `VirtualMachineDeployment` (rollout) or are out of scope entirely (auto-scaling, affinity/anti-affinity, backup/restore).
+
+---
+
+## 2. Test categories and scenarios
+
+Each scenario is written as **Given / When / Then**, is implementation-agnostic, and states the expected outcome only in terms of the CR's spec/status and the set of `VirtualMachine` objects in the namespace.
+
+### 2.1 Basic reconciliation — bring actual state to desired state
+
+1. **Create with N replicas from scratch**
+   Given a new `VirtualMachineReplicaSet` with `spec.replicas=3`, a selector, and a template whose labels satisfy the selector.
+   When the object is created.
+   Then exactly 3 `VirtualMachine` objects exist in the namespace, each:
+   - has an owner reference to the `VirtualMachineReplicaSet`,
+   - carries all labels/annotations from `spec.template.metadata`,
+   - carries the `vmoperator.vmware.com/replicaset-name` label set to the ReplicaSet's name,
+   - has a `Spec` equal to `spec.template.spec`,
+   - has a unique, generated name (not a fixed/predictable suffix — no ordinal identity, unlike StatefulSet).
+   And `status.replicas == 3`, `status.fullyLabeledReplicas == 3`.
+
+2. **Default replicas**
+   Given a `VirtualMachineReplicaSet` created with `spec.replicas` unset.
+   Then the persisted object's `spec.replicas == 1` (CRD default) and exactly one `VirtualMachine` is created.
+
+3. **Explicit zero replicas**
+   Given `spec.replicas=0`.
+   Then no `VirtualMachine` objects are created (or, if some existed already from a previous higher replica count, all are deleted), and `status.replicas == 0`. The distinction between "explicit 0" and "unset" must not regress to defaulting.
+
+4. **Idempotent reconciliation / no-op steady state**
+   Given a `VirtualMachineReplicaSet` already at `status.replicas == spec.replicas` with all VMs healthy.
+   When the controller reconciles again with no external changes.
+   Then no `VirtualMachine` is created, deleted, or mutated, and `status.observedGeneration` remains aligned with `metadata.generation` (no spurious writes/conflicts).
+
+5. **Controller restart / resync produces the same result**
+   Given the same starting state as above, but the reconciliation is triggered by a full resync rather than a watch event (i.e., no assumption about create/update/delete event type — this is a level-triggered reconciler).
+   Then the resulting state is identical to scenario 4 — reconciliation must be safe to run from a cold cache.
+
+### 2.2 Scaling
+
+6. **Scale up**
+   Given a healthy `VirtualMachineReplicaSet` with `status.replicas == 2`.
+   When `spec.replicas` is updated to `5`.
+   Then 3 additional `VirtualMachine` objects are created (the original 2 are left untouched — not recreated), and eventually `status.replicas == 5`.
+   And a `Resized` condition is set with reason `ScalingUp` during the transition.
+
+7. **Scale down**
+   Given `status.replicas == 5`.
+   When `spec.replicas` is updated to `2`.
+   Then exactly 3 owned `VirtualMachine` objects are deleted and 2 remain, and eventually `status.replicas == 2`.
+   And a `Resized` condition is set with reason `ScalingDown` during the transition.
+
+8. **Scale-down selection honors `deletePolicy: Random`**
+   Given `deletePolicy: Random` and 5 replicas, some healthy and some unhealthy (e.g., one `VirtualMachine` is not yet `Ready`, or has a recent restart).
+   When scaling down by 1.
+   Then the implementation is free to pick any replica (that's what "Random" means) — the test should NOT assert a specific replica is deleted. Instead it should assert the **invariants** that must hold regardless of which one is chosen:
+   - exactly one fewer `VirtualMachine` exists afterward,
+   - the deleted VM is one that was actually owned by this ReplicaSet (never a foreign/unrelated VM),
+   - the remaining VMs are untouched (not recreated, not mutated).
+
+9. **Scale down to zero and back up**
+   Given a ReplicaSet scaled to 0 (all VMs deleted), then scaled back to 3.
+   Then 3 *new* `VirtualMachine` objects are created (no attempt to "resurrect" deleted VMs by name/UID), and `status.replicas == 3`.
+
+10. **Rapid successive scale changes ("flapping")**
+    Given `spec.replicas` is changed multiple times in quick succession (e.g., 1 → 5 → 2) before the controller fully converges on any intermediate value.
+    Then the controller eventually converges to match the **final** value of `spec.replicas` (2), without leaking extra VMs and without deleting more than necessary at any point (no thrashing that deletes and recreates VMs unnecessarily for the same desired count).
+
+11. **`kubectl scale` / scale subresource**
+    Given a `VirtualMachineReplicaSet`.
+    When a client updates only the `/scale` subresource (as `kubectl scale vmreplicaset foo --replicas=4` would), not the full object.
+    Then this has the identical effect as editing `spec.replicas` directly on the main resource, and `status.replicas` continues to reflect the scale subresource's status path.
+
+12. **Negative or absurd replica counts are rejected**
+    Given an attempt to set `spec.replicas = -1`.
+    Then the API server/webhook rejects the request (CRD/webhook validation), and no reconciliation is attempted against a negative count.
+
+### 2.3 Selector / template consistency
+
+13. **Selector must match template labels (webhook/validation)**
+    Given a `VirtualMachineReplicaSet` where `spec.selector` does not match `spec.template.metadata.labels`.
+    Then creation is rejected by validation with a clear error message — this must be caught at admission time, not discovered later as a silently-broken ReplicaSet. (KubeVirt's ReplicaSet notably does *not* enforce this and instead just logs errors while doing nothing useful; that is called out here explicitly as the behavior we do **not** want to replicate.)
+
+14. **Selector is immutable-in-effect / changing it doesn't retroactively relabel VMs**
+    Given a running ReplicaSet with 3 replicas matching selector A.
+    When `spec.selector` is changed to selector B (assuming the API allows the edit at all).
+    Then existing VMs are not relabeled to match B. If B no longer matches the existing VMs' labels, those VMs become unmanaged (orphaned relative to this ReplicaSet) and the controller creates *new* replicas matching B up to `spec.replicas`, rather than mutating live VM specs to satisfy the new selector. (Mutating a running `VirtualMachine`'s identity out from under a user would be a change with real blast radius — VMs are not disposable/ephemeral the way Pods are.)
+
+15. **Template spec changes do not retroactively update existing replicas**
+    Given a running ReplicaSet with 3 replicas created from template T1.
+    When `spec.template.spec` is edited to T2 (e.g., different VM class, different image).
+    Then the 3 existing `VirtualMachine` objects are **not** mutated/recreated as a side effect of the template edit alone (there is no rolling-update strategy on `ReplicaSet` itself — that's `VirtualMachineDeployment`'s job).
+    And any *subsequent* scale-up creates new replicas using T2, producing a (temporarily) heterogeneous set — this divergence is expected and must not be "corrected" by the ReplicaSet controller.
+
+16. **Template metadata (labels/annotations) changes: in-place propagation or not?**
+    `[NEEDS CLARIFICATION]` — Kubernetes Pod `ReplicaSet` never mutates existing Pods' labels/annotations after creation, only stamps them at creation time. Confirm expected behavior:
+    Given a running ReplicaSet with 3 replicas.
+    When `spec.template.metadata.labels` (a non-selector-breaking label) is edited.
+    Then either (a) existing VMs keep their original labels (Pod ReplicaSet parity — recommended default), or (b) labels are propagated in place. Whichever is chosen must be codified as a test and documented; silently doing (b) while other systems assume (a) resembles the risk called out for `VirtualMachineDeployment`'s metadata-only propagation, so mixing behavior between the two CRDs is confusing and should be an explicit, tested decision.
+
+### 2.4 Ownership, orphans, and adoption
+
+17. **Deleting the ReplicaSet cascades to its VMs**
+    Given a ReplicaSet with 3 owned VMs.
+    When the `VirtualMachineReplicaSet` is deleted (foreground or background deletion).
+    Then all 3 owned `VirtualMachine` objects are eventually deleted too (owner-reference-driven garbage collection), and no orphaned VMs remain with a dangling owner reference.
+
+18. **Deleting one managed VM triggers replacement**
+    Given a healthy ReplicaSet with 3 replicas.
+    When one owned `VirtualMachine` is deleted directly by a user/operator (bypassing the ReplicaSet).
+    Then the controller creates exactly one new `VirtualMachine` to restore `status.replicas == spec.replicas`, and `status.replicas` transiently reflects 2 before returning to 3.
+
+19. **A pre-existing VM that happens to match the selector *is* adopted, visibly**
+    Given a standalone `VirtualMachine` (no owner reference, created independently of any ReplicaSet) whose labels match a ReplicaSet's `spec.selector`.
+    When the `VirtualMachineReplicaSet` is created/reconciled.
+    Then the ReplicaSet **adopts** that VM (sets itself as controller owner reference) rather than leaving it permanently unmanaged. This supersedes the one-pager's "adoption is future work" framing: adoption here never relocates or reconfigures the VM — it is a pure ownership claim — so it does not run into the zone/placement-mobility limits that motivate deferring true affinity/relocation features. Adopting also keeps the controller self-healing (a ReplicaSet created after a matching standalone VM already exists should not get permanently stuck below its desired replica count). Concretely:
+    - the adopted VM counts toward `spec.replicas` (the controller does not create a redundant new VM if the adopted one alone satisfies the desired count),
+    - a **`Condition`** is set on the `VirtualMachineReplicaSet` recording that this replica was adopted rather than created (in addition to the existing `SuccessfulAdopt` Event, which is transient and not sufficient on its own — it doesn't survive being scrolled off and isn't visible via `kubectl describe`),
+    - the adopted VM's spec is *not* forced to match the template (same non-goal as scenario 15 — adoption doesn't imply conformance).
+    Tracked as vmop-4017 (epic vmop-1701) for the missing Condition — the test for this scenario is expected to fail on the Condition assertion until that ticket is implemented; that is intentional and should not be "fixed" by weakening the test.
+
+20. **Two ReplicaSets with overlapping selectors ("fighting over" VMs)**
+    Given two `VirtualMachineReplicaSet` objects whose selectors both match an overlapping set of labels.
+    Then this is a user-error scenario (same as upstream Kubernetes and KubeVirt): the test should assert the system does not corrupt state or crash-loop, and each ReplicaSet only ever deletes/creates VMs it actually owns (checked via owner reference), never a VM owned by the *other* ReplicaSet. A `Condition` surfacing this misconfiguration is desirable but the hard requirement is "no cross-ownership deletion."
+
+21. **Namespace scoping**
+    Given a `VirtualMachineReplicaSet` in namespace `ns-a` and a `VirtualMachine` with matching labels in namespace `ns-b`.
+    Then the ReplicaSet in `ns-a` never considers, counts, adopts, or deletes the VM in `ns-b` — selector matching is namespace-scoped, consistent with `VirtualMachine` and `ReplicaSet` both being namespaced resources.
+
+### 2.5 Status and conditions
+
+22. **`status.replicas` always reflects actual owned-VM count**
+    At every point across create/scale-up/scale-down/delete-and-replace scenarios above, `status.replicas` must equal the number of `VirtualMachine` objects currently owned by the ReplicaSet — never a stale or aspirational number.
+
+23. **`status.fullyLabeledReplicas` detects label drift on owned VMs**
+    Given a ReplicaSet with 3 owned VMs, then a user manually removes/changes a label on one owned VM so it no longer matches the template's labels (but the VM is still owned/not orphaned since ownership is by owner-reference, not by label).
+    Then `status.fullyLabeledReplicas` decreases to 2 while `status.replicas` remains 3 — these two fields must be able to diverge, and both must be independently observable.
+
+24. **`status.readyReplicas` tracks the owned VMs' `Ready` condition**
+    Given 3 owned VMs where 2 have `Ready=True` and 1 has `Ready=False` (e.g., still powering on or provisioning failed).
+    Then `status.readyReplicas == 2`. As the third VM's `Ready` condition flips to `True`, `status.readyReplicas` becomes 3 without any other spec change.
+
+25. **`VirtualMachinesCreated` condition reflects create-path failures**
+    Given a template that will fail to produce a valid `VirtualMachine` (e.g., references a nonexistent `VirtualMachineClass`, or otherwise fails admission when the controller tries to create it).
+    Then `VirtualMachinesCreated` is `False` with reason `VirtualMachineCreationFailed` and a message containing the underlying error, `status.replicas` reflects only the VMs that *did* get created (not the failed attempts), and the controller keeps retrying (does not give up permanently) — an amended template that fixes the error should let the ReplicaSet self-heal without requiring the object to be recreated.
+
+26. **`ReplicaFailure` condition surfaces ongoing failure to maintain desired count**
+    Given a scenario where a required replica keeps failing to become healthy (e.g., a class/image that always fails to power on, or a finalizer that blocks deletion of a replica the controller is trying to replace).
+    Then a condition/reason around `ReplicaFailure` is set, distinguishing "we are still trying and failing" from "everything converged."
+
+27. **`VirtualMachinesReady` condition aggregates readiness**
+    Given `status.readyReplicas < spec.replicas`.
+    Then `VirtualMachinesReady` is `False`. Once `status.readyReplicas == spec.replicas` (and `>= 1` if replicas is nonzero), it becomes `True`. For `spec.replicas == 0`, define and test the expected condition state explicitly (`[NEEDS CLARIFICATION]`: likely `True`/vacuously-ready, but must be codified rather than left ambiguous, since some Ready aggregations for empty sets choose `Unknown` instead).
+
+28. **`observedGeneration` freshness**
+    Given a spec edit (e.g., scale from 2 to 4).
+    Then `status.observedGeneration` only advances to the new `metadata.generation` once the controller has actually processed that generation's spec — a consumer polling status should never see `observedGeneration` matching the new generation while `status.replicas` still reflects the old desired count in a way inconsistent with "reconciliation has started."
+
+29. **`Resized` condition clears once converged**
+    Given a scale-up/down that has fully converged (actual == desired, all healthy).
+    Then the `Resized` condition either clears or transitions to a "not resizing"/steady state — it must not get stuck reporting `ScalingUp`/`ScalingDown` forever after convergence, since that would mislead anyone using it as a rollout-progress signal.
+
+### 2.6 Label / annotation propagation details
+
+30. **`vmoperator.vmware.com/replicaset-name` label is present and correct on every owned VM**
+    For every `VirtualMachine` created by a `VirtualMachineReplicaSet`, the label `vmoperator.vmware.com/replicaset-name` equals the ReplicaSet's `metadata.name`, and this label is also usable as a reliable way to `kubectl get vm -l vmoperator.vmware.com/replicaset-name=<name>` and get exactly the owned set (modulo the orphan/adoption caveats in §2.4).
+
+31. **User edits to that label on an owned VM don't break ownership tracking, but do break label-based discovery**
+    Given a user manually removes the `replicaset-name` label from an owned VM.
+    Then owner-reference-based operations (cascade delete, scale-down accounting via `status.replicas`) still work correctly since they don't depend on this label, but label-based tooling built on top of it will (correctly, expectedly) no longer find that VM — this is a documented limitation, not a bug, and the test differentiates "ownership" (owner ref, authoritative) from "discoverability" (label, best-effort).
+
+### 2.7 Interaction with `VirtualMachine` lifecycle
+
+32. **A replica's own finalizers don't stall the whole ReplicaSet**
+    Given a scale-down that needs to delete VM `x`, but `x` has a slow-draining finalizer (e.g., attached volume detachment in progress).
+    Then the ReplicaSet controller issues the delete and waits — it does not spin up a *replacement* replica while `x` is terminating in a way that would temporarily overshoot `spec.replicas` (unless `x`'s deletion is specifically what's being counted toward the decrease). Assert final convergence: once `x` fully terminates, `status.replicas == spec.replicas` and no more, no less.
+
+33. **A replica that is deleted by something other than the ReplicaSet (e.g., a competing controller, storage policy quota enforcement, or manual `kubectl delete`) is treated identically to any other missing replica**
+    This is really a restatement of scenario 18, but explicitly generalized: the controller has no special-cased logic keyed on *why* a VM disappeared — it is purely level-triggered on "count of currently-owned, live VirtualMachines vs. `spec.replicas`."
+
+34. **Power state / VM.Spec fields inside the template are passed through verbatim, not defaulted/mutated by the ReplicaSet controller**
+    Given `spec.template.spec.powerState = PoweredOn`.
+    Then every created replica's `Spec.PowerState` is exactly `PoweredOn` — the ReplicaSet controller must not impose its own opinion on fields that belong entirely to `VirtualMachineSpec`'s own webhook/defaulting; it is a pure stamping operation from template to instance.
+
+### 2.8 Explicit non-goals to assert as *absence* of behavior
+
+These deserve tests too — asserting a feature does **not** exist is how you catch scope creep or accidental behavior changes later:
+
+35. No rolling update / no revision history: confirm there is no `ControllerRevision`-equivalent, no rollout status, and no partial/staged replacement strategy anywhere in `VirtualMachineReplicaSet` — that belongs to `VirtualMachineDeployment`.
+
+36. No auto-scaling: `status.replicas` never changes in response to VM resource utilization; only external edits to `spec.replicas` change desired count. (An HPA *pointed at* the scale subresource is fine and expected to work per scenario 11 — that's an external actor, not built-in behavior.)
+
+37. No anti-affinity / spreading: replicas created by a `VirtualMachineReplicaSet` carry no implicit affinity or anti-affinity rules on placement — any host spreading is out of scope for this CRD per the one-pager's Non-Goals, so a test should confirm replicas can legitimately land on the same host/cluster module without the controller treating that as an error.
+
+38. No shared/stable storage or stable network identity: unlike `VirtualMachineStatefulSet`, replicas from a `VirtualMachineReplicaSet` get no per-ordinal PVC and no stable name/network identity — every replica's name is opaque/generated and interchangeable. A test recreating a replica should show the new replica has a *different* generated name, never reusing the deleted replica's identity.
+
+---
+
+## 3. Cross-cutting invariants (assert in every scenario where applicable)
+
+- **Owner reference is authoritative for ownership**, never labels alone (see §2.6).
+- **No VM outside the owned set is ever mutated or deleted** by a `VirtualMachineReplicaSet` reconcile, full stop — this is the single highest-value invariant to fuzz/property-test given how much of this feature is about counting and culling VMs.
+- **Idempotent / restart-safe**: every scenario should be repeatable by forcing a full re-reconcile (not just relying on incremental watch events) and observing no drift.
+- **`status.replicas` is a *measurement*, not a mirror of `spec.replicas`**: during any transition, they may legitimately differ; only at steady state must they converge.
+
+## 4. Suggested test-suite shape
+
+Per `.sdd/memory/testing-standards.md`, implement these as Ginkgo specs in `controllers/virtualmachinereplicaset/virtualmachinereplicaset_controller_test.go`, split by label. Note the three test tiers in this repo have distinct backing infrastructure and are not interchangeable:
+
+- **Unit** (`testlabels.Controller`) — fake client, no external infra: scenarios 1–16, 22–34 — fast, exhaustive edge cases on selector/template/status logic.
+- **Integration** (`testlabels.Controller`, `testlabels.EnvTest`) — real API server via `envtest`, fake `VMProvider`: scenarios 17–21 (ownership/GC needs real garbage collection semantics from envtest), 24 (readiness — driven via `providerfake.SetCreateOrUpdateFunction` setting the owned VM's `Ready` condition, not a real vSphere backend), 32 (finalizer draining). `testlabels.VCSim` (real vcsim-backed vSphere behavior via `test/builder`'s `TestContextForVCSim`) is **not** needed here: the `VirtualMachineReplicaSet` controller only creates/updates/deletes `VirtualMachine` CRs and never calls `pkg/providers/vsphere` directly — any vSphere-isms of an owned replica (power-on, disks, network) are already covered by the existing VM-level vcsim tests under `pkg/providers/vsphere/` (e.g. `vmprovider_vm_power_test.go`, `session_vm_update_test.go`). A new vcsim-tier test specifically for ReplicaSet would be redundant.
+- **E2E** (`test/e2e/vmservice/`) — runs against a **real vCenter/WCP cluster only** (`test/e2e/README.md`; no vcsim option exists in this tier): a thin smoke pass, labeled per the existing `smoke`/`core-functional` conventions, that creates/scales/deletes a `VirtualMachineReplicaSet` end-to-end and confirms VMs actually power on and the scale subresource works, per `.sdd/memory/e2e-sync-with-changes.md`.
+
+Once every scenario above has a passing, independent test (not derived from reading the controller's current code path, but from this contract), that is the bar for confidence that switching this feature on is safe.

--- a/.sdd/specs/003-virtualmachinereplicaset/test-plan.md
+++ b/.sdd/specs/003-virtualmachinereplicaset/test-plan.md
@@ -1,0 +1,72 @@
+# Plan: Implement `VirtualMachineReplicaSet` functional tests via AI, driven by the TDS
+
+## Context
+
+[`tds.md`](./tds.md) defines 38 Given/When/Then scenarios that specify the intended, implementation-independent behavior of `VirtualMachineReplicaSet`. The goal is to turn each scenario into a real, passing (or intentionally-flagged-failing) test, so that "all tests green" is a trustworthy signal that this feature is safe to switch on for users.
+
+Existing coverage today (verified by reading the code, not assumed):
+
+- `controllers/virtualmachinereplicaset/`: controller (`virtualmachinereplicaset_controller.go`), delete-policy helper (`virtualmachinereplicaset_delete_policy.go`), a suite file, and **only an integration (`envtest`) test file** (`_intg_test.go`) with 4 thin `It`s (create, scale up, scale down, delete/finalizer). **No unit test file exists.**
+- `webhooks/virtualmachinereplicaset/validation/`: validator + unit + intg tests already exist, covering selector/template label-match validation.
+- `webhooks/virtualmachinereplicaset/mutation/`: mutator exists but is a no-op stub (`// TODO` referencing vmop-1827) with **no test file at all**.
+- `test/e2e/`: **no coverage** of `VirtualMachineReplicaSet`.
+- `test/builder/dummies.go` already has `DummyVirtualMachineReplicaSet()` to reuse as a base fixture.
+
+**Important — real discrepancies found between the TDS and the current implementation, discovered by reading the controller code (not the TDS)**. These aren't test-writing details, they change what "correct" means:
+
+1. **Orphan adoption (TDS §19) — RESOLVED, code is correct.** The controller (`adoptOrphan`, `ReconcileNormal`) adopts any standalone VM with no controller owner ref that matches the selector. This is the intended, correct behavior, not a bug: adoption never relocates/reconfigures the VM (so it doesn't run into zone/placement-mobility limits), it matches the well-established Kubernetes `ReplicaSet` adoption pattern, and it keeps the controller self-healing instead of getting permanently stuck on a pre-existing matching VM. The one gap is **visibility**: today adoption only emits a transient `Event` (`SuccessfulAdopt`), with no persistent `Condition`, so there's no durable, `kubectl describe`-visible record that a given replica was adopted rather than created. Filed as **vmop-4017** under epic vmop-1701 to add a Condition on adoption. TDS §19 has been updated to assert adoption happens *and* that a Condition is set recording it — the test should currently fail on the Condition assertion until vmop-4017 lands, which is expected and desired (the test should stay red until the ticket is fixed, not be watered down). The competing-ReplicaSets case (TDS §20) is unaffected — that one still must surface a conflict rather than silently double-adopt.
+2. **`status.readyReplicas` (TDS §24)**: the code has a literal `// TODO: Figure out an equivalent of Ready condition...` and currently counts every filtered VM as ready regardless of actual `VirtualMachine.Status` readiness. TDS scenario 24 will fail against current code. This is a known, intentional gap — the test should be written to assert the *intended* contract and will fail until the TODO is implemented (or the test is labeled `Pending`/skipped with a tracking ticket, per team preference).
+3. **Negative replica validation (TDS §12)**: no CRD marker (`+kubebuilder:validation:Minimum=0`) or webhook rule rejects `spec.replicas = -1` today. This test is also expected to fail/expose a gap.
+
+These three are called out explicitly in the task list below rather than hidden — the point of this exercise is to surface exactly this kind of drift.
+
+## Approach
+
+Map the 38 TDS scenarios onto 4 concrete test surfaces, matching existing repo conventions (`.sdd/memory/testing-standards.md`), and implement them in ordered batches using subagents (one agent per batch, sequential batches so later batches can build on earlier fixtures/helpers). Each batch ends with running the real test suite so failures are triaged immediately (bug vs. TDS update vs. test bug), not batched up at the end.
+
+### Test surface mapping
+
+| Surface | File(s) | TDS scenarios | Why |
+|---|---|---|---|
+| Controller **unit** tests (new) | `controllers/virtualmachinereplicaset/virtualmachinereplicaset_controller_test.go` (new, following `virtualmachinesnapshot_controller_unit_test.go` as the template) | 1–5, 9, 10, 12(partial), 14, 15, 16, 22, 23, 25, 26, 27, 28, 29, 30, 31, 34, 35, 36 | Fast, exhaustive coverage of status/condition/label logic against a fake client — no envtest needed. |
+| Controller **integration** tests (extend existing) | `controllers/virtualmachinereplicaset/virtualmachinereplicaset_controller_intg_test.go` | 6, 7, 8, 11, 13(cross-check), 17, 18, 19 (resolved — see Context), 20, 21, 24, 32, 33, 37, 38 | Needs real API-server GC, real owner refs, real scale subresource, real cross-object interaction — exactly what the existing 4 tests already do a little of. |
+| Validation **webhook** tests (extend existing) | `webhooks/virtualmachinereplicaset/validation/virtualmachinereplicaset_validator_unit_test.go` / `_intg_test.go` | 12, 13 | Webhook already has a suite; add the negative-replicas case (currently likely absent — confirm and add) and confirm selector/template mismatch is fully covered (scenario 13 may already be covered — audit before adding duplicates). |
+| Mutation **webhook** tests (new) | `webhooks/virtualmachinereplicaset/mutation/virtualmachinereplicaset_mutator_unit_test.go` (new) | none directly from the 38, but needed for completeness since the mutator has zero tests today | Not in the original TDS scope, but flagged as a coverage gap while in the neighborhood; keep minimal (assert current no-op passthrough behavior) so it doesn't block the main effort. |
+| **E2E** smoke test (new) | `test/e2e/vmservice/virtualmachinereplicaset/` (new package, following `test/e2e/vmservice/virtualmachine/` layout) | thin slice of 1, 6, 7, 11, 17 | `test/e2e/` runs only against a **real vCenter/WCP cluster** (confirmed in `test/e2e/README.md` — no vcsim option in this tier). One end-to-end create/scale/delete pass, labeled per the existing `smoke`/`core-functional` conventions, per `.sdd/memory/e2e-sync-with-changes.md` — required because this is cluster-observable behavior. |
+
+Scenarios not explicitly listed above (e.g. 3, 4 defaulting) are folded into the unit-test batch's fixture setup rather than getting a dedicated bullet.
+
+**Correction — no new vcsim-tier test is being added.** vcsim-backed tests in this repo are a distinct, real-vSphere-simulator integration tier (`test/builder`'s `TestContextForVCSim`, `testlabels.VCSim`) that lives at the **provider** level (`pkg/providers/vsphere/**`, e.g. `vmprovider_vm_power_test.go`, `session_vm_update_test.go`) — that's where vSphere-isms (power state transitions, disks, networking) actually need a simulated vCenter. `VirtualMachineReplicaSet`'s controller (`controllers/virtualmachinereplicaset/virtualmachinereplicaset_controller.go`) never imports or calls `pkg/providers/vsphere` — it only creates/updates/deletes `VirtualMachine` CRs and counts/labels them; any vSphere-isms of an owned replica are already exercised by the existing VM-level vcsim tests. So the "Controller integration tests" row above uses plain `envtest` + the fake `VMProvider` (`testlabels.EnvTest`, no `testlabels.VCSim`), and the "E2E" row is the only tier that touches real vSphere behavior for this feature.
+
+### Batches (sequential; each is one subagent turn + a test run + triage)
+
+1. **Unit test scaffolding + core reconciliation** — create `virtualmachinereplicaset_controller_test.go` with suite wiring for unit tests (add `unitTests` to the existing `suite.Register` call in `virtualmachinereplicaset_controller_suite_test.go`, currently passing `nil`), using `builder.UnitTestContextForController` + `providerfake.VMProvider` per `testing-standards.md`. Implement scenarios 1–5, 9, 10.
+2. **Status & conditions** — scenarios 22, 23, 25, 26, 27, 28, 29 against the fake client, asserting `status.replicas`, `fullyLabeledReplicas`, conditions (`VirtualMachinesCreated`, `Resized`/`ScalingUp`/`ScalingDown`, `VirtualMachinesReady`, `ReplicaFailure`), `observedGeneration`.
+3. **Template/selector/label semantics** — scenarios 14, 15, 16, 30, 31, 34.
+4. **Negative/validation-adjacent unit cases** — scenario 12 unit-side assertion (reconciler should never act on a spec that shouldn't have passed validation) + audit/extend the validation webhook tests (scenarios 12, 13) in `webhooks/virtualmachinereplicaset/validation/`.
+5. **Non-goal absence checks** — scenarios 35, 36 (unit-level: no revision/rollout fields, no auto-scale side effects).
+6. **Integration: scaling & scale subresource** — extend `_intg_test.go` with scenarios 8, 11, 37, and the "flapping" scenario 10 at the envtest level if scenario 10's unit version doesn't fully cover real reconcile timing.
+7. **Integration: ownership, orphans, GC, cross-namespace** — scenarios 17 (best-effort — the existing suite already notes envtest can't run real GC; document this limitation rather than asserting something envtest can't prove), 18, 20, 21, 33, and **19 (resolved: assert adoption occurs — owner reference is set, VM is not duplicated — and assert a `Condition` records the adoption; the Condition assertion is expected to fail until vmop-4017 is implemented, which is intentional).**
+8. **Integration: readiness & finalizer draining** — scenarios 24 (expected to fail — write it against the intended contract, mark clearly, do not water it down to match the stub), 32, 38.
+9. **Mutation webhook baseline tests** — new `_unit_test.go` for the mutator, asserting current pass-through/no-op behavior (so future implementation of vmop-1827 has a regression baseline).
+10. **E2E smoke** — new `test/e2e/vmservice/virtualmachinereplicaset/` suite, run against a real vCenter/WCP cluster per `test/e2e/README.md` (no vcsim path exists here): create with N replicas, scale up, scale down, delete, confirm VMs actually reach `PoweredOn`.
+11. **Triage pass** — run the full suite, confirm the only failures are the three known, intentionally-red scenarios (§19's Condition assertion → vmop-4017, §24 readyReplicas stub, §12 negative-replicas), file follow-up tickets for §24 and §12 (vmop-4017 already filed for §19), and do not silently adjust any test to match broken behavior just to turn it green.
+
+### Key reused patterns (don't reinvent)
+
+- `test/builder.DummyVirtualMachineReplicaSet()` as the base fixture for unit tests; the existing `_intg_test.go`'s inline `rs := &vmopv1.VirtualMachineReplicaSet{...}` literal as the pattern for integration tests (or migrate it to the dummy builder for consistency — small win, call it out but don't force it if it causes churn).
+- `providerfake.SetCreateOrUpdateFunction` (already used in `_intg_test.go`) to control what happens when the fake provider creates/updates a `VirtualMachine`, e.g. to simulate a VM becoming `Ready` for scenario 24.
+- `virtualmachinesnapshot_controller_unit_test.go` as the structural template for the new unit test file (external `_test` package, `Describe`/`Context`/`When`/`It`, `Label(testlabels.Controller, testlabels.API)`, `BeforeEach`/`JustBeforeEach`/`AfterEach` with `ctx.AfterEach()`).
+- `pkg/constants/testlabels` labels: `Controller`, `EnvTest`, `API`, `Validation`, `Webhook` — use the existing combination on `Describe` blocks per file type.
+
+### Verification
+
+- Unit: `go test ./controllers/virtualmachinereplicaset/... -run TestVirtualMachine` (or the repo's `make test` / `ginkgo` target used elsewhere — confirm exact command from `Makefile`/README during batch 1).
+- Integration: same binary, but requires `envtest` binaries set up (`make test` should already handle this — verify).
+- Webhook: `go test ./webhooks/virtualmachinereplicaset/...`.
+- E2E: per `test/e2e/README.md`, run against a real vCenter/WCP cluster (`make test-e2e` / the `smoke`/`core-functional` Ginkgo-labeled targets — confirm exact target during batch 10; there is no vcsim-backed e2e target).
+- After each batch, run only that batch's package tests before moving on; run the full `make test` after batch 11 to catch cross-package regressions (e.g. the mapper function `VMToReplicaSets` touching other controllers' watch behavior is unlikely but worth a full run once).
+
+### Deliverable shape
+
+One PR (or a small stack) per batch or logical group of batches, each following `.sdd/memory/commit-message-standards.md` and `.sdd/memory/pull-request-standards.md`, calling out in the PR description which TDS scenario numbers are covered and which discovered gaps are being deliberately left red with a linked follow-up.


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This change contains the functional TDS, plan and tasks for the VirtualMachineReplicaSets feature.  The replica sets were implemented a while ago hidden behind a capability that is not yet enabled.  We need to verify the end-to-end functionality before we enable the feature.  This change contains the specs that will be used to drive the tests.


**Please add a release note if necessary**:

```release-note
NONE
```