### PR TITLE
:bug: Use controller owner refs to identify CnsRegisterVolumes owned by a VM

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -250,10 +250,6 @@ const (
 	// reconcile priority for an object.
 	ReconcilePriorityAnnotationKey = "vmoperator.vmware.com.protected/reconcile-priority"
 
-	// CreatedByLabel is the label key that indicates an object was
-	// created on behalf of a VM Operator VM. The value is the name of a VM.
-	CreatedByLabel = "vmoperator.vmware.com/created-by"
-
 	// NoUnmanagedVolumesRegisterAnnotationKey is the annotation to not create any CNSRegisterVolumes
 	// by skipping the unmanaged volume register reconcile.
 	NoUnmanagedVolumesRegisterAnnotationKey = "vmoperator.vmware.com/no-unmanaged-volumes-register"

--- a/pkg/providers/vsphere/vmprovider_vm_unmanaged_volumes_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_unmanaged_volumes_test.go
@@ -224,9 +224,6 @@ func vmUnmanagedVolumesTests() {
 			Expect(crv.Spec.DiskURLPath).ToNot(BeEmpty())
 			Expect(crv.Spec.AccessMode).To(Equal(corev1.ReadWriteOnce))
 
-			// Verify labels.
-			Expect(crv.Labels["vmoperator.vmware.com/created-by"]).To(Equal(vm.Name))
-
 			// Verify OwnerReference.
 			Expect(crv.OwnerReferences).To(HaveLen(1))
 			Expect(crv.OwnerReferences[0].Kind).To(Equal("VirtualMachine"))
@@ -465,9 +462,6 @@ func vmUnmanagedVolumesTests() {
 			Expect(crv.Spec.PvcName).To(Equal(claimName))
 			Expect(crv.Spec.DiskURLPath).ToNot(BeEmpty())
 			Expect(crv.Spec.AccessMode).To(Equal(corev1.ReadWriteOnce))
-
-			// Verify labels.
-			Expect(crv.Labels["vmoperator.vmware.com/created-by"]).To(Equal(vm.Name))
 
 			// Verify OwnerReference.
 			Expect(crv.OwnerReferences).To(HaveLen(1))

--- a/pkg/vmconfig/volumes/unmanaged/register/unmanagedvolumes_register.go
+++ b/pkg/vmconfig/volumes/unmanaged/register/unmanagedvolumes_register.go
@@ -707,7 +707,7 @@ func ensurePVCForUnmanagedDisk(
 		if !pkgcfg.FromContext(ctx).Features.VMSharedDisks {
 			volumeMode = corev1.PersistentVolumeFilesystem
 		}
-		obj.Spec.VolumeMode = ptr.To(volumeMode)
+		obj.Spec.VolumeMode = new(volumeMode)
 
 		// Set dataSourceRef to point to this VM.
 		obj.Spec.DataSourceRef = &expDSRef
@@ -822,94 +822,106 @@ func ensureCnsRegisterVolumeForDisk(
 	)
 
 	if err := k8sClient.Get(ctx, key, obj); err != nil {
-
 		if !apierrors.IsNotFound(err) {
 			return nil, fmt.Errorf(
 				"failed to get CnsRegisterVolume %s: %w", key, err)
 		}
-
-		//
-		// The CRV is not found, create a new one.
-		//
-		// Set the object metadata.
-		obj.Name = pvc.Name
-		obj.Namespace = vm.Namespace
-
-		obj.Labels = map[string]string{
-			pkgconst.CreatedByLabel: vm.Name,
-		}
-
-		// Set a ControllerOwnerRef on the CRV pointing back to the VM.
-		obj.OwnerReferences = []metav1.OwnerReference{
-			{
-				APIVersion:         vmopv1.GroupVersion.String(),
-				BlockOwnerDeletion: ptr.To(true),
-				Controller:         ptr.To(true),
-				Kind:               "VirtualMachine",
-				Name:               vm.Name,
-				UID:                vm.UID,
-			},
-		}
-
-		// Get the datastore URL for the provided file name.
-		finder := pkgctx.GetFinder(ctx)
-		if finder == nil {
-			return nil, errors.New("failed to get finder from context")
-		}
-		datastoreURL, err := pkgdatastore.GetDatastoreURLFromDatastorePath(
-			ctx,
-			pkgctx.GetFinder(ctx),
-			diskInfo.FileName)
-		if err != nil {
+	} else if metav1.IsControlledBy(obj, vm) {
+		// The CRV already exists and belongs to this VM instance.
+		return obj, nil
+	} else {
+		// A CnsRegisterVolume with this name exists but is not owned by
+		// this VM (e.g. an orphan left behind when its owning VM's
+		// controller owner reference was removed out-of-band before the
+		// VM was deleted). Trusting its Status.Registered would silently
+		// skip real registration for the current VM's disk, so delete the
+		// stale object and fall through to create a fresh one.
+		if err := k8sClient.Delete(ctx, obj); err != nil && !apierrors.IsNotFound(err) {
 			return nil, fmt.Errorf(
-				"failed to get datastore url for %q: %w",
-				diskInfo.FileName, err)
+				"failed to delete stale CnsRegisterVolume %s: %w", key, err)
+		}
+		*obj = cnsv1alpha1.CnsRegisterVolume{}
+	}
+
+	// Create a new CRV: either none existed, or the existing one was a
+	// stale, foreign object that was just deleted above.
+	//
+	// Set the object metadata.
+	obj.Name = pvc.Name
+	obj.Namespace = vm.Namespace
+
+	// Set a ControllerOwnerRef on the CRV pointing back to the VM. This
+	// owner ref, not a label, is what associates the CRV with the VM --
+	// VM names may exceed the 63-character limit for label values.
+	obj.OwnerReferences = []metav1.OwnerReference{
+		{
+			APIVersion:         vmopv1.GroupVersion.String(),
+			BlockOwnerDeletion: new(true),
+			Controller:         new(true),
+			Kind:               "VirtualMachine",
+			Name:               vm.Name,
+			UID:                vm.UID,
+		},
+	}
+
+	// Get the datastore URL for the provided file name.
+	finder := pkgctx.GetFinder(ctx)
+	if finder == nil {
+		return nil, errors.New("failed to get finder from context")
+	}
+	datastoreURL, err := pkgdatastore.GetDatastoreURLFromDatastorePath(
+		ctx,
+		finder,
+		diskInfo.FileName)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to get datastore url for %q: %w",
+			diskInfo.FileName, err)
+	}
+
+	var (
+		volumeMode    corev1.PersistentVolumeMode
+		vmSharedDisks = pkgcfg.FromContext(ctx).Features.VMSharedDisks
+	)
+
+	switch {
+	case pvc.Spec.VolumeMode != nil:
+		volumeMode = *pvc.Spec.VolumeMode
+
+		if !vmSharedDisks &&
+			volumeMode != corev1.PersistentVolumeFilesystem {
+			return nil, fmt.Errorf(
+				"volume mode %s not supported unless VMSharedDisks is enabled",
+				volumeMode)
 		}
 
-		var (
-			volumeMode    corev1.PersistentVolumeMode
-			vmSharedDisks = pkgcfg.FromContext(ctx).Features.VMSharedDisks
-		)
+	case !vmSharedDisks:
+		volumeMode = corev1.PersistentVolumeFilesystem
+	default:
+		volumeMode = corev1.PersistentVolumeBlock
+	}
 
-		switch {
-		case pvc.Spec.VolumeMode != nil:
-			volumeMode = *pvc.Spec.VolumeMode
+	obj.Spec = cnsv1alpha1.CnsRegisterVolumeSpec{
+		PvcName:     pvc.Name,
+		DiskURLPath: datastoreURL,
+		VolumeMode:  volumeMode,
+	}
 
-			if !vmSharedDisks &&
-				volumeMode != corev1.PersistentVolumeFilesystem {
-				return nil, fmt.Errorf(
-					"volume mode %s not supported unless VMSharedDisks is enabled",
-					volumeMode)
-			}
+	// Set the AccessMode to ReadWriteMany if the existing,
+	// underlying disk has a sharing mode set to MultiWriter. Otherwise init
+	// the AccessMode to ReadWriteOnce.
+	if diskInfo.Sharing == vimtypes.VirtualDiskSharingSharingMultiWriter {
+		obj.Spec.AccessMode = corev1.ReadWriteMany
+	} else {
+		obj.Spec.AccessMode = corev1.ReadWriteOnce
+	}
 
-		case !vmSharedDisks:
-			volumeMode = corev1.PersistentVolumeFilesystem
-		default:
-			volumeMode = corev1.PersistentVolumeBlock
-		}
+	// Set the disk backing type.
+	obj.Spec.BackingType = string(diskInfo.BackingType)
 
-		obj.Spec = cnsv1alpha1.CnsRegisterVolumeSpec{
-			PvcName:     pvc.Name,
-			DiskURLPath: datastoreURL,
-			VolumeMode:  volumeMode,
-		}
-
-		// Set the AccessMode to ReadWriteMany if the existing,
-		// underlying disk has a sharing mode set to MultiWriter. Otherwise init
-		// the AccessMode to ReadWriteOnce.
-		if diskInfo.Sharing == vimtypes.VirtualDiskSharingSharingMultiWriter {
-			obj.Spec.AccessMode = corev1.ReadWriteMany
-		} else {
-			obj.Spec.AccessMode = corev1.ReadWriteOnce
-		}
-
-		// Set the disk backing type.
-		obj.Spec.BackingType = string(diskInfo.BackingType)
-
-		// Create the CRV.
-		if err := k8sClient.Create(ctx, obj); err != nil {
-			return nil, fmt.Errorf("failed to create crv %s: %w", key, err)
-		}
+	// Create the CRV.
+	if err := k8sClient.Create(ctx, obj); err != nil {
+		return nil, fmt.Errorf("failed to create crv %s: %w", key, err)
 	}
 
 	return obj, nil
@@ -924,20 +936,22 @@ func cleanupCompletedCnsRegisterVolumesForVM(
 	k8sClient ctrlclient.Client,
 	vm *vmopv1.VirtualMachine) (bool, error) {
 
-	// List all CnsRegisterVolume objects for this VM.
+	// List all CnsRegisterVolume objects in the VM's namespace and filter to
+	// those owned by this VM.
 	crvList := &cnsv1alpha1.CnsRegisterVolumeList{}
 	if err := k8sClient.List(
 		ctx,
 		crvList,
-		ctrlclient.InNamespace(vm.Namespace),
-		ctrlclient.MatchingLabels{
-			pkgconst.CreatedByLabel: vm.Name,
-		}); err != nil {
+		ctrlclient.InNamespace(vm.Namespace)); err != nil {
 
 		return false, fmt.Errorf(
 			"failed to list CnsRegisterVolume objects for VM %s: %w",
 			vm.NamespacedName(), err)
 	}
+	crvList.Items = slices.DeleteFunc(crvList.Items,
+		func(crv cnsv1alpha1.CnsRegisterVolume) bool {
+			return !metav1.IsControlledBy(&crv, vm)
+		})
 
 	logger := pkglog.FromContextOrDefault(ctx).
 		WithName("cleanupCompletedCnsRegisterVolumesForVM")

--- a/pkg/vmconfig/volumes/unmanaged/register/unmanagedvolumes_register_test.go
+++ b/pkg/vmconfig/volumes/unmanaged/register/unmanagedvolumes_register_test.go
@@ -482,12 +482,82 @@ var _ = Describe("Reconcile", func() {
 							"%s/folder/vm1/regular-disk.vmdk?dcPath=%%2FDC0&dsName=LocalDS_0",
 							httpPrefix)))
 					Expect(crv.Spec.AccessMode).To(Equal(corev1.ReadWriteOnce))
-					Expect(crv.Labels["vmoperator.vmware.com/created-by"]).To(Equal(vm.Name))
 					Expect(crv.OwnerReferences).To(HaveLen(1))
 					Expect(crv.OwnerReferences[0].Kind).To(Equal("VirtualMachine"))
 					Expect(crv.OwnerReferences[0].Name).To(Equal(vm.Name))
 					Expect(*crv.OwnerReferences[0].Controller).To(BeTrue())
 					Expect(crv.Spec.BackingType).ToNot(BeEmpty())
+				})
+
+				It("should replace a CnsRegisterVolume owned by a different VM instead of trusting it", func() {
+					Expect(unmanagedvolsreg.Reconcile(
+						ctx,
+						k8sClient,
+						vimClient,
+						vm,
+						moVM,
+						configSpec)).To(MatchError(unmanagedvolsreg.ErrPendingRegister))
+
+					claimName := vmopv1util.FindByTargetID(
+						vmopv1.VirtualControllerTypeSCSI,
+						1, 0, vm.Spec.Volumes...).PersistentVolumeClaim.ClaimName
+
+					createBatchAttachWithPVCVolumeIDCacheMiss(ctx, k8sClient, vm, claimName)
+
+					// Simulate a stale CnsRegisterVolume left behind by a
+					// different VM instance that happened to produce the
+					// same deterministic PVC/CRV name (e.g. after its
+					// owning VM's controller owner ref was removed
+					// out-of-band prior to that VM's deletion).
+					staleCRV := &cnsv1alpha1.CnsRegisterVolume{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      claimName,
+							Namespace: vm.Namespace,
+							OwnerReferences: []metav1.OwnerReference{
+								{
+									APIVersion: vmopv1.GroupVersion.String(),
+									Kind:       "VirtualMachine",
+									Name:       "some-other-vm",
+									UID:        "11111111-1111-1111-1111-111111111111",
+									Controller: new(true),
+								},
+							},
+						},
+						Spec: cnsv1alpha1.CnsRegisterVolumeSpec{
+							PvcName:     claimName,
+							DiskURLPath: "[LocalDS_0] some-other-vm/stale-disk.vmdk",
+						},
+						Status: cnsv1alpha1.CnsRegisterVolumeStatus{
+							Registered: true,
+						},
+					}
+					Expect(k8sClient.Create(ctx, staleCRV)).To(Succeed())
+
+					Expect(unmanagedvolsreg.Reconcile(
+						ctx,
+						k8sClient,
+						vimClient,
+						vm,
+						moVM,
+						configSpec)).To(MatchError(unmanagedvolsreg.ErrPendingRegister))
+
+					crv := &cnsv1alpha1.CnsRegisterVolume{}
+					Expect(k8sClient.Get(ctx, ctrlclient.ObjectKey{
+						Namespace: vm.Namespace,
+						Name:      claimName,
+					}, crv)).To(Succeed())
+
+					// The stale, foreign object must have been replaced
+					// with a fresh one owned by this VM, not trusted as
+					// already-registered.
+					Expect(crv.OwnerReferences).To(HaveLen(1))
+					Expect(crv.OwnerReferences[0].Name).To(Equal(vm.Name))
+					Expect(crv.OwnerReferences[0].UID).To(Equal(vm.UID))
+					Expect(crv.Status.Registered).To(BeFalse())
+					Expect(crv.Spec.DiskURLPath).To(Equal(
+						fmt.Sprintf(
+							"%s/folder/vm1/regular-disk.vmdk?dcPath=%%2FDC0&dsName=LocalDS_0",
+							httpPrefix)))
 				})
 			})
 
@@ -608,7 +678,6 @@ var _ = Describe("Reconcile", func() {
 							"%s/folder/vm1/multiwriter-disk.vmdk?dcPath=%%2FDC0&dsName=LocalDS_0",
 							httpPrefix)))
 					Expect(crv.Spec.AccessMode).To(Equal(corev1.ReadWriteMany))
-					Expect(crv.Labels["vmoperator.vmware.com/created-by"]).To(Equal(vm.Name))
 					Expect(crv.OwnerReferences).To(HaveLen(1))
 					Expect(crv.OwnerReferences[0].Kind).To(Equal("VirtualMachine"))
 					Expect(crv.OwnerReferences[0].Name).To(Equal(vm.Name))
@@ -1057,9 +1126,6 @@ var _ = Describe("Reconcile", func() {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "my-vm-134e95b6",
 							Namespace: vm.Namespace,
-							Labels: map[string]string{
-								"vmoperator.vmware.com/created-by": vm.Name,
-							},
 							OwnerReferences: []metav1.OwnerReference{
 								{
 									APIVersion: vmopv1.GroupVersion.String(),
@@ -2162,9 +2228,6 @@ var _ = Describe("Reconcile", func() {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "my-vm-9eb41331",
 							Namespace: vm.Namespace,
-							Labels: map[string]string{
-								"vmoperator.vmware.com/created-by": vm.Name,
-							},
 							OwnerReferences: []metav1.OwnerReference{
 								{
 									APIVersion: vmopv1.GroupVersion.String(),
@@ -2298,8 +2361,14 @@ var _ = Describe("Reconcile", func() {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "my-vm-1aeeec80",
 							Namespace: vm.Namespace,
-							Labels: map[string]string{
-								pkgconst.CreatedByLabel: vm.Name,
+							OwnerReferences: []metav1.OwnerReference{
+								{
+									APIVersion: vmopv1.GroupVersion.String(),
+									Kind:       "VirtualMachine",
+									Name:       vm.Name,
+									UID:        vm.UID,
+									Controller: ptr.To(true),
+								},
 							},
 						},
 						Spec: cnsv1alpha1.CnsRegisterVolumeSpec{

--- a/test/e2e/vmservice/lib/vmoperator/vmoperator.go
+++ b/test/e2e/vmservice/lib/vmoperator/vmoperator.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"net"
 	"reflect"
+	"slices"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -1263,8 +1264,8 @@ func EventuallyBootDiskStoragePolicyMatchesVMStorageClass(
 }
 
 // WaitForVMCnsRegisterVolumesRegistered waits until every CnsRegisterVolume
-// owned by the given VM (identified by label vmoperator.vmware.com/created-by)
-// has status.registered=true.
+// owned by the given VM (identified by its controller owner reference) has
+// status.registered=true.
 //
 // This must be called before creating a VirtualMachineSnapshot when the
 // AllDisksArePVCs feature is enabled. If a snapshot is taken while a
@@ -1290,19 +1291,23 @@ func WaitForVMCnsRegisterVolumesRegistered(
 
 	By(fmt.Sprintf("Waiting for all CnsRegisterVolumes to be registered for VM %s/%s", ns, vmName))
 	Eventually(func(g Gomega) bool {
+		vm := &vmopv1.VirtualMachine{}
+		if err := client.Get(ctx, ctrlclient.ObjectKey{Namespace: ns, Name: vmName}, vm); err != nil {
+			e2eframework.Logf("retry: failed to get VirtualMachine %s/%s: %v", ns, vmName, err)
+			return false
+		}
+
 		crvList := &unstructured.UnstructuredList{}
 		crvList.SetGroupVersionKind(crvGVK)
 
-		err := client.List(ctx, crvList,
-			ctrlclient.InNamespace(ns),
-			ctrlclient.MatchingLabels{
-				"vmoperator.vmware.com/created-by": vmName,
-			},
-		)
-		if err != nil {
+		if err := client.List(ctx, crvList, ctrlclient.InNamespace(ns)); err != nil {
 			e2eframework.Logf("retry: failed to list CnsRegisterVolumes for VM %s/%s: %v", ns, vmName, err)
 			return false
 		}
+
+		crvList.Items = slices.DeleteFunc(crvList.Items, func(crv unstructured.Unstructured) bool {
+			return !metav1.IsControlledBy(&crv, vm)
+		})
 
 		if len(crvList.Items) == 0 {
 			// No CRVs for this VM — either FCD-backed image or registration


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Currently, we use "created-by" label on the CRV resource to identify the resources that was created to register the classic disks of a VM as PVC -- what we call unmanaged disk registration.

This has a flaw.  Because Kubernetes restricts the length of the value of the label to 63 whereas the object names can be up to 254 characters long.  This means, classic disks of any VM that has name exceeding 63 characters can never complete registration thereby blocking a lot of day-2 workflows on the disk (e.g., expanding the disk).

This change fixes this bug by changing the lookup to use ownerRef on the CRV that is set by the controller.  Since the CRV can't be edited by the developer user, it's safe to assume that no one can remove the OwnerRef from the CRV.

While here, also fix a bug where we would silently adopt an existing CRV by name if one existed (from a prior VM).  We now delete those and re-create new ones for the current VM.  This will have a consequence of the FCD being deleted if the CRV mapped a disk, but I would argue that explicitly deleting and re-creating it is the correct contract here.


**Please add a release note if necessary**:

```release-note
Use controller owner refs to identify CnsRegisterVolumes owned by a VM
```