### PR TITLE
Temporarily skipping the vm-location e2e tests

### DIFF
--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
@@ -249,7 +249,7 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		Expect(task.Wait(ctx)).To(Succeed(), "Relocate task failed for VM %s", vmMoID)
 	}
 
-	When("VM is created in the correct namespace RP and folder", Label("core-functional", "experimental"), func() {
+	XWhen("VM is created in the correct namespace RP and folder", Label("core-functional", "experimental"), func() {
 		It("sets VirtualMachineLocationValid condition to True", func() {
 			createVM()
 
@@ -261,7 +261,7 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		})
 	})
 
-	When("VM is moved outside the namespace RP hierarchy", Label("core-functional", "experimental"), func() {
+	XWhen("VM is moved outside the namespace RP hierarchy", Label("core-functional", "experimental"), func() {
 		It("sets condition False, then recovers to True when VM is returned to the correct location", func() {
 			By("Creating VM and waiting for it to reach Running state")
 			createVM()
@@ -321,7 +321,7 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		})
 	})
 
-	When("VM is moved outside the namespace Folder hierarchy", Label("core-functional", "experimental"), func() {
+	XWhen("VM is moved outside the namespace Folder hierarchy", Label("core-functional", "experimental"), func() {
 		It("sets condition False, then recovers to True when VM is returned to the correct location", func() {
 			By("Creating VM and waiting for it to reach Running state")
 			createVM()

--- a/test/e2e/vmservice/vmservice_test.go
+++ b/test/e2e/vmservice/vmservice_test.go
@@ -247,18 +247,6 @@ var _ = Describe("Testing VM Services", Label("devops"), Label("viadmin"), Label
 			})
 		})
 
-		Context("VM-LOCATION", func() {
-			virtualmachine.VMLocationSpec(context.TODO(), func() virtualmachine.VMLocationSpecInput {
-				return virtualmachine.VMLocationSpecInput{
-					ClusterProxy:     svClusterProxy,
-					Config:           config,
-					WCPClient:        wcpClient,
-					ArtifactFolder:   artifactFolder,
-					WCPNamespaceName: wcpNamespaceName,
-				}
-			})
-		})
-
 		Context("VM-EXTRACONFIG", func() {
 			virtualmachine.VMExtraConfigSpec(context.TODO(), func() virtualmachine.VMExtraConfigSpecInput {
 				return virtualmachine.VMExtraConfigSpecInput{

--- a/test/e2e/vmservice/vmservice_test.go
+++ b/test/e2e/vmservice/vmservice_test.go
@@ -247,6 +247,18 @@ var _ = Describe("Testing VM Services", Label("devops"), Label("viadmin"), Label
 			})
 		})
 
+		Context("VM-LOCATION", func() {
+			virtualmachine.VMLocationSpec(context.TODO(), func() virtualmachine.VMLocationSpecInput {
+				return virtualmachine.VMLocationSpecInput{
+					ClusterProxy:     svClusterProxy,
+					Config:           config,
+					WCPClient:        wcpClient,
+					ArtifactFolder:   artifactFolder,
+					WCPNamespaceName: wcpNamespaceName,
+				}
+			})
+		})
+
 		Context("VM-EXTRACONFIG", func() {
 			virtualmachine.VMExtraConfigSpec(context.TODO(), func() virtualmachine.VMExtraConfigSpecInput {
 				return virtualmachine.VMExtraConfigSpecInput{


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

1. vm-location tests are failing due to the failure in enabling necessary permissions on the RP/Folder.
2. This PR's intention is to block the vm-location tests execution temporarily  until we figure out a way to add necessary role and permission to relocate the VM to different location from the tests

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # vmsvc-3844

```
[PENDING]
Testing VM Services VIRTUAL-MACHINE VM-LOCATION when VM is created in the correct namespace RP and folder sets VirtualMachineLocationValid condition to True [devops, viadmin, virtualmachine, vmservice, core-functional, experimental]
[PENDING]
Testing VM Services VIRTUAL-MACHINE VM-LOCATION when VM is moved outside the namespace RP hierarchy sets condition False, then recovers to True when VM is returned to the correct location [devops, viadmin, virtualmachine, vmservice, core-functional, experimental]
[PENDING]
Testing VM Services VIRTUAL-MACHINE VM-LOCATION when VM is moved outside the namespace Folder hierarchy sets condition False, then recovers to True when VM is returned to the correct location [devops, viadmin, virtualmachine, vmservice, core-functional, experimental]

```
**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note

```