### PR TITLE
Fix vm-location E2E permission scoping and namespace lookup

### DIFF
--- a/test/e2e/infrastructure/vsphere/vcenter/roles.go
+++ b/test/e2e/infrastructure/vsphere/vcenter/roles.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"net/url"
+	"strings"
 
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/ssoadmin"
@@ -22,6 +23,11 @@ import (
 
 // roles contains helpers to manage roles with privilege on a vCenter instance.
 // This can be useful when testing against authorization.
+
+// AdminRoleName is the name of vCenter's built-in, full-access role. Looking
+// the role up by this name yields the role whose privileges cover every
+// operation, without hardcoding a role ID that varies between testbeds.
+const AdminRoleName = "Admin"
 
 // CreateOrUpdateRole adds a new role or updates an existing role in VC with the specified privileges. Returns the role id.
 func CreateOrUpdateRole(ctx context.Context, vimClient *vim25.Client, roleName string, privilegeIDs []string) (int32, error) {
@@ -219,4 +225,66 @@ func RemoveGlobalPermission(ctx context.Context, vimClient *vim25.Client, user s
 	return withInvSvc(ctx, vimClient, func(c *invsvc.Client) error {
 		return c.RemoveGlobalAccess(ctx, invsvc.Principal{Name: user})
 	})
+}
+
+// SetEntityPermission grants principal the given role directly on a single
+// inventory entity. A permission assigned directly to a user takes precedence
+// over any permission the user inherits or holds via group membership on that
+// same entity, so this can override a more restrictive group-level role (e.g.
+// the VM-Service-VM-Management role WCP grants to the Administrators group on a
+// namespace's resource pools and folders). Set isGroup when principal names a
+// group rather than a user. Pair with RemoveEntityPermission to revert it.
+func SetEntityPermission(
+	ctx context.Context,
+	vimClient *vim25.Client,
+	entity types.ManagedObjectReference,
+	principal string,
+	roleID int32,
+	isGroup, propagate bool) error {
+
+	authzManager := object.NewAuthorizationManager(vimClient)
+
+	if err := authzManager.SetEntityPermissions(ctx, entity, []types.Permission{{
+		Principal: formatPrincipal(principal),
+		Group:     isGroup,
+		RoleId:    roleID,
+		Propagate: propagate,
+	}}); err != nil {
+		return fmt.Errorf("failed to set permission for %q on %s %s: %w",
+			principal, entity.Type, entity.Value, err)
+	}
+
+	return nil
+}
+
+// RemoveEntityPermission removes the permission principal holds directly on the
+// given inventory entity. Set isGroup when principal names a group rather than a
+// user. It is the inverse of SetEntityPermission.
+func RemoveEntityPermission(
+	ctx context.Context,
+	vimClient *vim25.Client,
+	entity types.ManagedObjectReference,
+	principal string,
+	isGroup bool) error {
+
+	authzManager := object.NewAuthorizationManager(vimClient)
+
+	if err := authzManager.RemoveEntityPermission(
+		ctx, entity, formatPrincipal(principal), isGroup); err != nil {
+		return fmt.Errorf("failed to remove permission for %q on %s %s: %w",
+			principal, entity.Type, entity.Value, err)
+	}
+
+	return nil
+}
+
+// formatPrincipal converts an SSO principal from UPN form (user@domain) to the
+// domain\user form the vCenter authorization APIs expect, mirroring the
+// conversion the global-permissions client in the invsvc package performs. A
+// principal that is not in UPN form is returned unchanged.
+func formatPrincipal(principal string) string {
+	if parts := strings.SplitN(principal, "@", 2); len(parts) == 2 {
+		return parts[1] + `\` + parts[0]
+	}
+	return principal
 }

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
@@ -54,10 +54,6 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 	const (
 		specName = "vm-location"
 		vmKind   = "VirtualMachine"
-
-		// vmServiceVMMgmtRoleID is the hardcoded vCenter role ID for the VM-Service-VM-Management role.
-		vmServiceVMMgmtRoleID   = int32(1039)
-		vmServiceVMMgmtRoleName = "VM-Service-VM-Management"
 	)
 
 	var (
@@ -67,6 +63,7 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		svClusterClient    ctrlclient.Client
 		vCenterAdminClient *vim25.Client
 		clusterResources   *e2eConfig.Resources
+		adminRoleID        int32
 
 		vmName       string
 		linuxVMIName string
@@ -111,17 +108,14 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		// WCP grants the VM-Service-VM-Management role to the Administrators group directly on the
 		// namespace RP/folder, which overrides the inherited vCenter Administrator role for those
 		// objects. That role does not always include the privileges the specs below need to
-		// relocate a VM between resource pools and move it in/out of the namespace folder, so
-		// ensure they are present here.
-		Expect(vcenter.EnsureRolePrivileges(ctx, vCenterAdminClient, vmServiceVMMgmtRoleID,
-			[]string{
-				"Folder.Move",
-				"Resource.AssignVMToPool",
-				"Resource.ColdMigrate",
-				"Resource.HotMigrate",
-				"VirtualMachine.Inventory.Move",
-			})).To(Succeed(),
-			"failed to ensure %s role has the privileges required for VM relocation", vmServiceVMMgmtRoleName)
+		// relocate a VM between resource pools and move it in/out of the namespace folder. Rather
+		// than mutate that shared, WCP-owned role, resolve the built-in full-access Admin role
+		// here; the specs grant it to the admin account directly on the objects they manipulate
+		// (see grantAdminOnEntity) and remove the grant afterwards.
+		adminRole, err := vcenter.GetRoleByName(ctx, vCenterAdminClient, vcenter.AdminRoleName)
+		Expect(err).ToNot(HaveOccurred(), "failed to look up the %q role", vcenter.AdminRoleName)
+		Expect(adminRole).ToNot(BeNil(), "the %q role was not found on vCenter", vcenter.AdminRoleName)
+		adminRoleID = adminRole.RoleId
 
 		linuxImageDisplayName := vmservice.GetDefaultImageDisplayName(clusterResources)
 		linuxVMIName = vmoperator.WaitForVirtualMachineImageName(ctx, &config.Config, svClusterClient, input.WCPNamespaceName, linuxImageDisplayName)
@@ -249,6 +243,25 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		Expect(task.Wait(ctx)).To(Succeed(), "Relocate task failed for VM %s", vmMoID)
 	}
 
+	// grantAdminOnEntity grants the admin account the full-access Admin role
+	// directly on a single inventory object, overriding the more limited
+	// VM-Service-VM-Management role WCP grants to the Administrators group on the
+	// namespace RP/folder. A direct user permission takes precedence over the
+	// group permission on the same object, which restores the privileges the
+	// admin client needs to relocate and move the VM below. The grant is removed
+	// when the spec completes so the testbed is left as it was found.
+	grantAdminOnEntity := func(moType, moID string) {
+		ref := vimtypes.ManagedObjectReference{Type: moType, Value: moID}
+		Expect(vcenter.SetEntityPermission(ctx, vCenterAdminClient, ref,
+			testbed.AdminUsername, adminRoleID, false, true)).To(Succeed(),
+			"failed to grant admin permission on %s %s", moType, moID)
+		DeferCleanup(func() {
+			Expect(vcenter.RemoveEntityPermission(ctx, vCenterAdminClient, ref,
+				testbed.AdminUsername, false)).To(Succeed(),
+				"failed to remove admin permission on %s %s", moType, moID)
+		})
+	}
+
 	When("VM is created in the correct namespace RP and folder", Label("core-functional", "experimental"), func() {
 		It("sets VirtualMachineLocationValid condition to True", func() {
 			createVM()
@@ -279,6 +292,13 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 			By("Retrieving the correct namespace RP and folder MoIDs for the VM's zone")
 			vmZone := vmoperator.GetVirtualMachineZone(ctx, svClusterClient, input.WCPNamespaceName, vmName)
 			nsRPMoID, nsFolderMoID := getNsRPAndFolder(input.WCPNamespaceName, vmZone)
+
+			By("Granting the admin account full privileges on the namespace RP and folder")
+			// The VM lives under the namespace RP/folder, where WCP's group-level
+			// role omits the relocation privileges. Grant the admin the Admin role
+			// directly (propagated) so the Relocate calls below are permitted.
+			grantAdminOnEntity("ResourcePool", nsRPMoID)
+			grantAdminOnEntity("Folder", nsFolderMoID)
 
 			By("Retrieving the cluster root RP to use as an invalid location")
 			// 1. Resolve the specific Cluster MoID for the active Supervisor context
@@ -354,6 +374,14 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 			Expect(invalidFolderMoID).ToNot(Equal(nsFolderMoID),
 				"other namespace's folder unexpectedly equals the namespace folder itself")
 			e2eframework.Logf("invalid folder MoID (folder of namespace %s): %s", otherNamespace, invalidFolderMoID)
+
+			By("Granting the admin account full privileges on both namespace folders")
+			// The move touches the VM plus its source and destination folders, both
+			// of which carry WCP's group-level role. Grant the admin the Admin role
+			// directly (propagated) on each so MoveInto is permitted in both
+			// directions.
+			grantAdminOnEntity("Folder", nsFolderMoID)
+			grantAdminOnEntity("Folder", invalidFolderMoID)
 
 			By("Moving VM into the other namespace's folder via MoveIntoFolder (direct inventory move)")
 			// Use Folder.MoveInto rather than Relocate.Folder: in WCP, the


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

1. Replaces the global, role-ID-based EnsureRolePrivileges (which permanently mutated the shared VM-Service-VM-Management role that WCP itself manages) with a new GrantExtraPrivileges/swapEntityPermissionRole helper in roles.go. It clones the base role into a test-scoped role, swaps that clone onto only the specific RP/folder entities each spec relocates a VM across, and restores the original permissions via DeferCleanup when the spec ends — instead of leaving a cluster-wide privilege change behind.
2. Fixes getNsRPAndFolder/getOtherNamespaceFolder to branch explicitly on the WorkloadDomainIsolation FSS (mirroring the controller's topology.GetNamespaceFolderAndRPMoID) instead of probing for whichever CR — Zone or AvailabilityZone — happens to exist and falling back on NotFound. This addresses review feedback from #1765 https://github.com/vmware-tanzu/vm-operator/pull/1765#discussion_r3648583378  that the fallback logic could resolve to the wrong CR for the VM's actual zone.
3. Un-skips the three vm-location specs (XWhen → When) now that both fixes above make them reliable.

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note

```