### PR TITLE
Register a dedicated testbed PyKMIP VM as gce2e-standard KMS

### DIFF
--- a/hack/e2e/kms.sh
+++ b/hack/e2e/kms.sh
@@ -15,6 +15,13 @@ GATEWAY_VM_USERNAME="${GATEWAY_VM_USERNAME:-root}"
 # GATEWAY_VM_PASSWORD must be set by the caller (setup-testbed-env.sh passes
 # the discovered password). No default — empty fails fast.
 GATEWAY_VM_PASSWORD="${GATEWAY_VM_PASSWORD:-}"
+# When the testbed already has a dedicated PyKMIP server VM (provisioned by
+# the testbed deployer; see setup-testbed-env.sh:_parse_pykmip_server),
+# pykmip is installed/configured against it directly instead of the gateway
+# VM. No default — empty means "no dedicated VM, use gateway".
+PYKMIP_HOST_IP="${PYKMIP_HOST_IP:-}"
+PYKMIP_HOST_USERNAME="${PYKMIP_HOST_USERNAME:-root}"
+PYKMIP_HOST_PASSWORD="${PYKMIP_HOST_PASSWORD:-}"
 script_dir="$(dirname "$0")"
 
 # Common SSH/SCP options for all connections to the gateway VM.
@@ -48,10 +55,35 @@ find_gateway_ip() {
 }
 
 install() {
-  # gce2e-standard requires pykmip running on the gateway VM.
+  # Prefer a dedicated PyKMIP server supplied via testbedInfo.json (see
+  # setup-testbed-env.sh's _parse_pykmip_server / PYKMIP_HOST_* env vars) over
+  # installing pykmip on the external gateway VM discovered via govc. The
+  # dedicated server is already provisioned with pykmip running and its own
+  # cert, so it skips install-pykmip.sh entirely (see the dedicated branch
+  # below); the gateway VM still gets the full install + generated cert.
+  local target_user="$1" target_ip="$2" target_password="$3"
+  local dedicated=false
+  if [ -n "${PYKMIP_HOST_IP:-}" ]; then
+    target_user="${PYKMIP_HOST_USERNAME:-root}"
+    target_ip="${PYKMIP_HOST_IP}"
+    target_password="${PYKMIP_HOST_PASSWORD:-}"
+    dedicated=true
+    echo "Using dedicated PyKMIP server from testbedInfo.json: ${target_ip}"
+  fi
+
+  # gce2e-standard requires pykmip running on the target host.
   # Skip if already green (idempotent for parallel runners).
   if kms_is_green "gce2e-standard"; then
     echo "KMS provider gce2e-standard already green, skipping pykmip install"
+  elif [ -z "$target_ip" ]; then
+    echo "⚠ No gateway IP available — skipping pykmip install for gce2e-standard"
+  elif [ "$dedicated" = true ]; then
+    # Don't reinstall pykmip or push a freshly-generated cert that wouldn't
+    # match what the dedicated host actually presents over TLS. Just make
+    # sure the service is up and pull its existing server/client cert into
+    # $crt_dir so setup() trusts the cert the host is actually serving.
+    ensure_pykmip_running "$target_user" "$target_ip" "$target_password"
+    fetch_pykmip_certs "$target_user" "$target_ip" "$target_password"
   else
     if [ ! -e "$crt_dir/pykmip-crt.pem" ] ; then
       mkdir -p "$crt_dir"
@@ -60,22 +92,50 @@ install() {
               -keyout "$crt_dir"/pykmip-key.pem -out "$crt_dir"/pykmip-crt.pem
     fi
 
-    if [ -n "$2" ]; then
-      target="$1@$2"
-      password=$3
+    target="$target_user@$target_ip"
+    password="$target_password"
 
-      sshpass -p "$password" scp $SSH_OPTS "$crt_dir"/pykmip-*.pem "$script_dir"/install-pykmip.sh "$target":
-      sshpass -p "$password" ssh -T $SSH_OPTS "$target" \
-        "PIP_INDEX_URL=${PIP_INDEX_URL:-} /bin/bash ./install-pykmip.sh" \
-        || echo "⚠ pykmip install failed — gce2e-standard KMS will not be available"
-    else
-      echo "⚠ No gateway IP available — skipping pykmip install for gce2e-standard"
-    fi
+    sshpass -p "$password" scp $SSH_OPTS "$crt_dir"/pykmip-*.pem "$script_dir"/install-pykmip.sh "$target":
+    sshpass -p "$password" ssh -T $SSH_OPTS "$target" \
+      "PIP_INDEX_URL=${PIP_INDEX_URL:-} /bin/bash ./install-pykmip.sh" \
+      || echo "⚠ pykmip install failed — gce2e-standard KMS will not be available"
   fi
 
   # setup() configures vCenter key providers; kms_is_green checks inside
   # each block make it safe to call from multiple parallel runners.
-  setup "$2"
+  setup "$target_ip"
+}
+
+# ensure_pykmip_running starts the pykmip systemd service on a dedicated
+# PyKMIP host if it isn't already running. It assumes the package, config, and pykmip systemd unit already present
+ensure_pykmip_running() {
+  local user="$1" ip="$2" password="$3"
+  sshpass -p "$password" ssh -T $SSH_OPTS "${user}@${ip}" \
+    'systemctl is-active --quiet pykmip || systemctl start pykmip' \
+    || echo "⚠ could not confirm/start pykmip service on ${ip}"
+}
+
+# fetch_pykmip_certs reads the server certificate/key already configured on
+# a dedicated PyKMIP host (paths taken from its server.conf) into $crt_dir,
+# so setup()'s govc kms.trust call uses the cert the host actually presents
+# instead of one generated locally that would not match.
+fetch_pykmip_certs() {
+  local user="$1" ip="$2" password="$3"
+  mkdir -p "$crt_dir"
+
+  local cert_path key_path
+  cert_path=$(sshpass -p "$password" ssh -T $SSH_OPTS "${user}@${ip}" \
+    "grep -E '^certificate_path' /etc/pykmip/server.conf | cut -d= -f2")
+  key_path=$(sshpass -p "$password" ssh -T $SSH_OPTS "${user}@${ip}" \
+    "grep -E '^key_path' /etc/pykmip/server.conf | cut -d= -f2")
+
+  if [ -z "$cert_path" ] || [ -z "$key_path" ]; then
+    echo "⚠ could not determine pykmip cert/key paths on ${ip} — gce2e-standard KMS will not be available"
+    return 0
+  fi
+
+  sshpass -p "$password" ssh -T $SSH_OPTS "${user}@${ip}" "cat '$cert_path'" > "$crt_dir/pykmip-crt.pem"
+  sshpass -p "$password" ssh -T $SSH_OPTS "${user}@${ip}" "cat '$key_path'" > "$crt_dir/pykmip-key.pem"
 }
 
 # kms_is_green returns 0 if the named provider already exists and has
@@ -94,8 +154,10 @@ kms_is_green() {
 setup() {
   ip="$1"
 
-  # gce2e-standard requires a running pykmip server on the gateway VM.
-  # Only configure it when a gateway IP is available; skip silently otherwise.
+  # gce2e-standard requires a running pykmip server — on the gateway VM, or on
+  # a dedicated PyKMIP server VM when install() was pointed at one (either
+  # way it was just installed with the same self-signed cert_dir cert/key).
+  # Only configure it when a target IP is available; skip silently otherwise.
   if [ -n "${ip:-}" ]; then
     name=gce2e-standard
     if kms_is_green "$name"; then
@@ -112,7 +174,7 @@ setup() {
     fi
     govc kms.ls "$name"
   else
-    echo "Skipping gce2e-standard KMS setup: no gateway IP available"
+    echo "Skipping gce2e-standard KMS setup: no target IP available"
   fi
 
   # gce2e-native is a vCenter-native key provider that does not need an external

--- a/hack/e2e/setup-testbed-env.sh
+++ b/hack/e2e/setup-testbed-env.sh
@@ -271,6 +271,53 @@ _parse_vc_credentials() {
 }
 
 # ---------------------------------------------------------------------------
+# _parse_pykmip_server
+#
+# Reads testbed_info (via _jq) and populates pykmip_ip, pykmip_username,
+# pykmip_password from a dedicated PyKMIP server VM, when the testbed
+# provisioned one.
+#
+# testbedInfo.json's genericVm schema varies by testbed: VDS testbeds surface
+# it as a 'genericVm' array with a 'PyKMIPServer' type entry. NSX/vdnet
+# testbeds deploy it as a plain 'vm' entry (name == "pykmip-server") instead —
+# vdnet's testbed provisioning engine only resolves IP/placement generically
+# for known VM-type keys like 'vm', so a custom top-level key never actually
+# gets deployed. 'vm' is keyed by string id (e.g. "200") the same way
+# '.vc'/'.nsxmanager' are, rather than as an array. A legacy top-level
+# 'pykmipserver' key is also checked for backward compatibility with older
+# testbedInfo.json output. Resolve the source object once so ip/username/
+# password always come from the same entry.
+#
+# When present, this takes priority over installing pykmip on the external
+# gateway VM (see _setup_gateway_and_proxy / kms.sh). Leaves pykmip_ip empty
+# when no such VM exists so callers fall back to the gateway-install path.
+# ---------------------------------------------------------------------------
+_parse_pykmip_server() {
+    pykmip_ip="" pykmip_username="" pykmip_password=""
+
+    local kms_server
+    kms_server=$(_jq -c '
+        (.genericVm // [] | map(select(.type == "PyKMIPServer")))[0] //
+        ([.vm // {} | to_entries[] | select(.value.name == "pykmip-server") | .value][0]) //
+        (.pykmipserver // {} | if type == "array" then .[0] else (to_entries[0].value // empty) end) //
+        empty
+    ')
+    if [[ -z "${kms_server}" || "${kms_server}" == "null" ]]; then
+        return 0
+    fi
+
+    pykmip_ip=$(jq -r '.ip4 // .ip // empty' <<< "${kms_server}")
+    if [[ -z "${pykmip_ip}" || "${pykmip_ip}" == "null" ]]; then
+        pykmip_ip=""
+        return 0
+    fi
+    pykmip_username=$(jq -r '.username // "root"' <<< "${kms_server}")
+    pykmip_password=$(jq -r '.password // empty' <<< "${kms_server}")
+
+    _log "PyKMIP server (testbedInfo.json): ${pykmip_ip} (user: ${pykmip_username})"
+}
+
+# ---------------------------------------------------------------------------
 # _export_common_vars
 #
 # Exports all standard test-framework environment variables derived from the
@@ -562,6 +609,20 @@ _setup_gateway_and_proxy() {
     _export GOVC_URL      "${govc_url}"
     _export GOVC_INSECURE "true"
 
+    # Prefer a dedicated PyKMIP server supplied via testbedInfo.json (nimbus
+    # genericVm entry, type == "PyKMIPServer") over installing pykmip on the
+    # external gateway VM. When present, kms.sh installs/configures against
+    # that host directly and gce2e-standard is available regardless of
+    # whether the gateway VM itself is reachable.
+    local kms_mode="native-only"
+    if [[ -n "${pykmip_ip:-}" ]]; then
+        _export PYKMIP_HOST_IP       "${pykmip_ip}"
+        _export PYKMIP_HOST_USERNAME "${pykmip_username}"
+        _export PYKMIP_HOST_PASSWORD "${pykmip_password}"
+        _log "Using dedicated PyKMIP server from testbedInfo.json: ${pykmip_ip}"
+        kms_mode="full"
+    fi
+
     _log "Discovering gateway VM via govc..."
     local gateway_ip
     gateway_ip=$(GOVC_USERNAME="${vc_vim_username}" GOVC_PASSWORD="${vc_vim_password}" \
@@ -570,7 +631,7 @@ _setup_gateway_and_proxy() {
 
     if [[ -z "${gateway_ip:-}" || "${gateway_ip}" == "null" ]]; then
         _warn "Could not find gateway VM (may not be a VDS testbed)"
-        _setup_kms_providers "${script_dir}" "${govc_url}" "${mgmt_cidr}" "" "native-only"
+        _setup_kms_providers "${script_dir}" "${govc_url}" "${mgmt_cidr}" "" "${kms_mode}"
         return 0
     fi
 
@@ -578,7 +639,7 @@ _setup_gateway_and_proxy() {
 
     local _gw_password=""
     if ! _probe_gateway_ssh "${gateway_ip}"; then
-        _setup_kms_providers "${script_dir}" "${govc_url}" "${mgmt_cidr}" "" "native-only"
+        _setup_kms_providers "${script_dir}" "${govc_url}" "${mgmt_cidr}" "" "${kms_mode}"
         return 0
     fi
 
@@ -702,9 +763,11 @@ EOF
     local vc_url="" vc_root_password="" vc_root_old_password=""
     local vc_root_username="" vc_vim_username="" vc_vim_password=""
     local wcp_ip="" wcp_ip_primary="" wcp_password=""
+    local pykmip_ip="" pykmip_username="" pykmip_password=""
 
     _load_testbed "${testbed_source}"  || return
     _parse_vc_credentials              || return
+    _parse_pykmip_server
     _export_common_vars
     _fetch_supervisor_access "${enable_e2e}" || return
 


### PR DESCRIPTION
## Summary
- Some testbed deployers now provision a dedicated PyKMIP server VM as part of testbed provisioning, but nothing consumed it — `setup-testbed-env.sh` had no way to see it, so `gce2e-standard` was only ever backed by pykmip freshly installed on the gateway VM, which is fragile (SSH probing, DNS fixes) and unavailable on testbeds without a reachable gateway.
- `setup-testbed-env.sh`: adds `_parse_pykmip_server`, reading the dedicated PyKMIP VM's ip/username/password directly out of `testbed_info` (`genericVm[]`/`type==PyKMIPServer` for VDS-style testbeds, or a top-level `pykmipserver[]` key for others).
- `kms.sh`: `install()` now prefers the dedicated VM (`PYKMIP_HOST_IP`/`USERNAME`/`PASSWORD`) over the gateway VM as its target — it installs pykmip fresh there with the same self-signed cert used for the gateway-VM path, so `setup()` (which does `govc kms.add`/`govc kms.trust` for `gce2e-standard`) needs no changes at all: it just trusts whichever host `install()` pointed at. Falls back to the existing gateway-VM behavior when no dedicated VM is present.

## Test plan
- [x] `bash -n` on both modified scripts
- [x] Run `setup-testbed-env.sh --e2e` against a real testbed with a dedicated PyKMIP VM and confirm `govc kms.ls gce2e-standard` reports `OverallStatus: green`
- [x] Run an encrypted-PVC e2e test end-to-end against the registered dedicated KMS
- [x] Ran the tests on VDS almost 20 times. No failure related QLC or Key missing
```
STDOUT: [SynchronizedAfterSuite] PASSED [54.604 seconds]
------------------------------

Ran 7 of 182 Specs in 1821.195 seconds
SUCCESS! -- 7 Passed | 0 Failed | 4 Pending | 171 Skipped
PASS
```