### PR TITLE
Fix cross-datastore disk copy in RegisterVM disk-only test

### DIFF
--- a/test/e2e/vmservice/vmservice/viadmin/registervm.go
+++ b/test/e2e/vmservice/vmservice/viadmin/registervm.go
@@ -1024,8 +1024,8 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 			findDisk(Default, pvcNameA, false)
 
 			// Create "new" disk
-			dst := path.Join(vmHome, path.Base(datastorePath.Path))
-			Expect(fileManager.Copy(ctx, datastorePath.Path, dst)).To(Succeed())
+			dstPath := object.DatastorePath{Datastore: vmPath.Datastore, Path: path.Join(vmHome, path.Base(datastorePath.Path))}
+			Expect(fileManager.Copy(ctx, datastorePath.Path, dstPath.String())).To(Succeed())
 			Expect(fileManager.Delete(ctx, datastorePath.Path)).To(Succeed())
 
 			// Expect to fail w/ orphaned FCD
@@ -1037,8 +1037,7 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 			queryVolume()
 
 			// Attach new disk with storage profile (required for cns)
-			datastorePath.Path = dst
-			backing.FileName = datastorePath.String()
+			backing.FileName = dstPath.String()
 
 			profile := []types.BaseVirtualMachineProfileSpec{
 				&types.VirtualMachineDefinedProfileSpec{


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

The disk-only restore E2E test (`test/e2e/vmservice/vmservice/viadmin/registervm.go`) simulates an orphaned-FCD restore by copying the FCD's vmdk out of its own datastore and into the VM's home folder, then deleting the original. The destination path was built from `vmPath.Path` alone (dropping `vmPath.Datastore`), so it had no `[datastore]` prefix.

govmomi's `DatastoreFileManager.Path` defaults any unqualified name to the FileManager's own datastore — which here is the FCD's *source* datastore, not the VM's home datastore. When those two datastores differ (e.g. FCD on `vsanDatastore`, VM home on an NFS datastore), the copy silently targeted a non-existent folder on the wrong datastore and the task failed on real hardware.

**Which issue(s) is/are addressed by this PR?**:

Fixes #

**Are there any special notes for your reviewer**:

- Qualifies the destination path with `vmPath.Datastore` via `object.DatastorePath` so `Copy` resolves against the VM's actual home datastore.
- Reuses that same datastore-qualified path when setting `backing.FileName` to reattach the disk, instead of mutating the stale, vsan-scoped `datastorePath` variable in place.
- Test-only change; no product code touched.

**Please add a release note if necessary**:

```release-note

```