### PR TITLE
    🐛 Fix Multi Datastore for RestoreDiskOnly tests

### DIFF
--- a/test/e2e/vmservice/vmservice/viadmin/registervm.go
+++ b/test/e2e/vmservice/vmservice/viadmin/registervm.go
@@ -1091,6 +1091,11 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 			dir = path.Dir(datastorePath.Path)
 			Expect(dir).To(Equal(vmHome))
 
+			// The restored disk now lives on the VM's home datastore rather than the
+			// original (e.g. vsan) datastore, so ds must be rebound before validating
+			// the FCD backing below.
+			ds = object.NewDatastore(vCenterClient, *backing.Datastore)
+
 			// Validate FCD backing is restored
 			_, err = fcdManager.Retrieve(ctx, ds, disk.VDiskId.Id)
 			Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/vmservice/vmservice/viadmin/registervm.go
+++ b/test/e2e/vmservice/vmservice/viadmin/registervm.go
@@ -960,7 +960,6 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 
 			findDisk := func(g Gomega, pvcName string, shouldExist bool) {
 				volumeHandle := getVolumeHandle(g, pvcName, vmNamespace)
-
 				deviceList, err := vmObj.Device(ctx)
 				g.Expect(err).ToNot(HaveOccurred())
 
@@ -973,7 +972,7 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 							disk = device.(*types.VirtualDisk)
 							backing = disk.Backing.(*types.VirtualDiskFlatVer2BackingInfo)
 							found = datastorePath.FromString(backing.FileName)
-
+							g.Expect(datastorePath.FromString(backing.FileName)).To(BeTrue(), "failed to parse datastore path %q", backing.FileName)
 							break
 						}
 					}
@@ -1024,8 +1023,8 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 			findDisk(Default, pvcNameA, false)
 
 			// Create "new" disk
-			dst := path.Join(vmHome, path.Base(datastorePath.Path))
-			Expect(fileManager.Copy(ctx, datastorePath.Path, dst)).To(Succeed())
+			dstPath := object.DatastorePath{Datastore: vmPath.Datastore, Path: path.Join(vmHome, path.Base(datastorePath.Path))}
+			Expect(fileManager.Copy(ctx, datastorePath.Path, dstPath.String())).To(Succeed())
 			Expect(fileManager.Delete(ctx, datastorePath.Path)).To(Succeed())
 
 			// Expect to fail w/ orphaned FCD
@@ -1037,8 +1036,7 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 			queryVolume()
 
 			// Attach new disk with storage profile (required for cns)
-			datastorePath.Path = dst
-			backing.FileName = datastorePath.String()
+			backing.FileName = dstPath.String()
 
 			profile := []types.BaseVirtualMachineProfileSpec{
 				&types.VirtualMachineDefinedProfileSpec{


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

RegisterVM Restore Disk Only makes few assumptions which seems fine till there is only homogenous datastore types. But if they storage policy is tagged multiple datastore environment nfs, vSAN and VMFS,  then the code breaks in FileManager `Copy`. Changes below fixes that makes the overall stability of this test not depending on placement

- Refresh DS incase the datastore of vmHome and PVC is not the same.
- Copy the full datastore path including datastore types.

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

- Ran multiple UTS runs to verify for multiple combinations vmHome and PVC A in different datastores.
- Ran VDS UTS tests to confirm this doesn't break that.


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note

```