### PR TITLE
🌱 Remove unused worker storage policy from E2E suite

### DIFF
--- a/test/e2e/infrastructure/vsphere/vcenter/storage.go
+++ b/test/e2e/infrastructure/vsphere/vcenter/storage.go
@@ -160,57 +160,6 @@ func GetOrCreateEZTStoragePolicy(ctx context.Context, client *vim25.Client, prof
 	return createPbmProfile(ctx, pbmClient, profileName, *createSpec)
 }
 
-// GetOrCreateWorkerStoragePolicy returns an existing vSphere profile ID for profileName, or creates
-// a policy that duplicates the supervisor primary (WCP global) storage policy placement rules.
-// After creation, WCPSVC syncs a Kubernetes StorageClass; callers should wait for that object.
-// Pattern matches vks-gce2e EZT helper (duplicate base capabilities under a new name).
-func GetOrCreateWorkerStoragePolicy(ctx context.Context, client *vim25.Client, profileName, wcpProfileID string) (string, error) {
-	pbmClient, err := pbm.NewClient(ctx, client)
-	if err != nil {
-		return "", err
-	}
-
-	policyID, err := pbmClient.ProfileIDByName(ctx, profileName)
-	if err == nil {
-		return policyID, nil
-	}
-
-	if !strings.Contains(err.Error(), "no pbm profile found") {
-		return "", err
-	}
-
-	m, err := pbmClient.ProfileMap(ctx, wcpProfileID)
-	if err != nil {
-		return "", err
-	}
-
-	wcpProfile := m.Profile[0]
-
-	createSpec, err := pbm.CreateCapabilityProfileSpec(pbm.CapabilityProfileCreateSpec{
-		Name:           profileName,
-		SubProfileName: "Datastore placement",
-		Description:    "Worker storage profile (clone of WCP global capabilities) — " + wcpProfile.GetPbmProfile().Description,
-		CapabilityList: []pbm.Capability{},
-		Category:       string(types.PbmProfileCategoryEnumREQUIREMENT),
-	})
-	if err != nil {
-		return "", err
-	}
-
-	subProfile := &createSpec.Constraints.(*types.PbmCapabilitySubProfileConstraints).SubProfiles[0]
-	if p, ok := wcpProfile.(*types.PbmCapabilityProfile); ok {
-		if c, ok := p.Constraints.(*types.PbmCapabilitySubProfileConstraints); ok {
-			subProfile.Capability = append(subProfile.Capability, c.SubProfiles[0].Capability...)
-		}
-	}
-
-	if len(subProfile.Capability) == 0 {
-		return "", errors.New("could not copy capability constraints from base WCP storage policy")
-	}
-
-	return createPbmProfile(ctx, pbmClient, profileName, *createSpec)
-}
-
 // createPbmProfile creates a PBM profile from spec and returns
 // its ID. If a concurrent caller wins the create race (e.g. a sibling e2e
 // shard provisioning the same globally-named policy against the same shared

--- a/test/e2e/infrastructure/vsphere/wcp/namespaces.go
+++ b/test/e2e/infrastructure/vsphere/wcp/namespaces.go
@@ -11,14 +11,11 @@ import (
 
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	storagev1 "k8s.io/api/storage/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/vmware-tanzu/vm-operator/test/e2e/framework"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/infrastructure/vsphere/vcenter"
 )
 
@@ -77,9 +74,6 @@ type NamespaceCreateInput struct {
 	Client                 ctrlclient.Client
 	WCPClient              WorkloadManagementAPI
 	StorageClassName       string
-	WorkerStorageClassName string
-	// Config supplies loaded e2e intervals (wcp.yaml); nil uses built-in defaults for worker StorageClass wait only.
-	Config                 framework.ConfigInterface
 	VMServiceSpec          VMServiceSpecDetails
 	Zone                   string
 	SupervisorID           string
@@ -141,106 +135,6 @@ func GetNamespace(ctx context.Context, input NamespaceGetInput) (*corev1.Namespa
 // defaultNamespaceStorageQuotaMiB is the default per-policy quota (MiB) used when associating storage with a WCP namespace.
 const defaultNamespaceStorageQuotaMiB = int64(1024 * 500)
 
-// EnsureWorkerKubernetesStorageClassIfMissing duplicates the primary WCP storage policy on vSphere when the
-// worker-named StorageClass is missing from the supervisor, then waits for WCPSVC to sync the StorageClass.
-// Wait/poll intervals use built-in defaults (NamespaceCreateInput.Config drives config when creating a namespace).
-//
-// When namespace and wcpClient are set, the worker storage policy is also associated with that supervisor namespace
-// (via SetNamespaceStorageSpecs) if it is not already present. Use this for pre-provisioned namespaces that were
-// created before the worker StorageClass existed.
-func EnsureWorkerKubernetesStorageClassIfMissing(
-	ctx context.Context,
-	kubeconfigPath string,
-	client kubernetes.Interface,
-	primaryStorageClass *storagev1.StorageClass,
-	workerStorageClassName string,
-	cfg framework.ConfigInterface,
-	namespace string,
-	wcpClient WorkloadManagementAPI) *storagev1.StorageClass {
-	if workerStorageClassName == "" {
-		return nil
-	}
-
-	sc, err := client.StorageV1().StorageClasses().Get(ctx, workerStorageClassName, metav1.GetOptions{})
-	if err == nil {
-		Expect(sc.Parameters).NotTo(BeNil())
-		policyID, ok := sc.Parameters["storagePolicyID"]
-		Expect(ok).To(BeTrue(), "worker storage class must expose storagePolicyID for namespace association")
-		ensureNamespaceAssociatesWorkerStoragePolicyByID(wcpClient, namespace, policyID)
-
-		return sc
-	}
-
-	if !apierrors.IsNotFound(err) {
-		Expect(err).NotTo(HaveOccurred())
-	}
-
-	Expect(primaryStorageClass.Parameters).NotTo(BeNil())
-	basePolicyID, ok := primaryStorageClass.Parameters["storagePolicyID"]
-	Expect(ok).To(BeTrue(), "primary storage class must expose storagePolicyID for cloning worker policy")
-	Expect(basePolicyID).NotTo(BeEmpty())
-
-	vimClient := vcenter.NewVimClientFromKubeconfig(ctx, kubeconfigPath)
-	defer vcenter.LogoutVimClient(vimClient)
-
-	workerPolicyID, createErr := vcenter.GetOrCreateWorkerStoragePolicy(ctx, vimClient, workerStorageClassName, basePolicyID)
-	Expect(createErr).NotTo(HaveOccurred(), "failed to create or resolve worker storage policy %q", workerStorageClassName)
-	ensureNamespaceAssociatesWorkerStoragePolicyByID(wcpClient, namespace, workerPolicyID)
-
-	sc = waitForWorkerStorageClass(ctx, client, workerStorageClassName, cfg)
-
-	return sc
-}
-
-// ensureNamespaceAssociatesWorkerStoragePolicyByID appends the worker policy to the namespace storage
-// specs when missing. The policy ID must be passed directly so this can be called before the
-// Kubernetes StorageClass object exists (WCPSVC only syncs the StorageClass after the association).
-func ensureNamespaceAssociatesWorkerStoragePolicyByID(
-	wcpClient WorkloadManagementAPI,
-	namespace string,
-	workerPolicyID string) {
-	if namespace == "" || wcpClient == nil || workerPolicyID == "" {
-		return
-	}
-
-	details, err := wcpClient.GetNamespace(namespace)
-	Expect(err).NotTo(HaveOccurred(), "get wcp namespace failed for storage policy sync %q", namespace)
-
-	for _, s := range details.VMStorageSpec {
-		if s.Policy == workerPolicyID {
-			return
-		}
-	}
-
-	limit := defaultNamespaceStorageQuotaMiB
-	if len(details.VMStorageSpec) > 0 && details.VMStorageSpec[0].Limit > 0 {
-		limit = details.VMStorageSpec[0].Limit
-	}
-
-	merged := append(append([]StorageSpec(nil), details.VMStorageSpec...),
-		StorageSpec{Policy: workerPolicyID, Limit: limit})
-	Expect(wcpClient.SetNamespaceStorageSpecs(namespace, merged)).NotTo(HaveOccurred(),
-		"failed to associate worker storage policy with namespace %q", namespace)
-	WaitForNamespaceReady(wcpClient, namespace)
-}
-
-// waitForWorkerStorageClass polls until the StorageClass appears after vSphere policy creation (WCPSVC sync).
-func waitForWorkerStorageClass(ctx context.Context, client kubernetes.Interface, name string, cfg framework.ConfigInterface) *storagev1.StorageClass {
-	var sc *storagev1.StorageClass
-
-	Eventually(func() error {
-		var err error
-
-		sc, err = client.StorageV1().StorageClasses().Get(ctx, name, metav1.GetOptions{})
-
-		return err
-	}, cfg.GetIntervals("default", "wait-storage-class-ready")...).Should(Succeed(),
-		"timed out waiting for StorageClass %q after ensuring worker storage policy on vCenter", name)
-	Expect(sc).NotTo(BeNil())
-
-	return sc
-}
-
 // CreateNamespace creates a WCP kubernetes namespace object using DCLI client.
 func CreateNamespace(ctx context.Context, input NamespaceCreateInput) (*corev1.Namespace, context.CancelFunc) {
 	wcpClient := input.WCPClient
@@ -278,16 +172,6 @@ func CreateNamespace(ctx context.Context, input NamespaceCreateInput) (*corev1.N
 
 	Expect(err).NotTo(HaveOccurred())
 	WaitForNamespaceReady(wcpClient, namespaceForTest)
-
-	if input.WorkerStorageClassName != "" {
-		workerStorageClass := EnsureWorkerKubernetesStorageClassIfMissing(ctx, input.Kubeconfig, svClientSet,
-			storageClass, input.WorkerStorageClassName, input.Config, namespaceForTest, wcpClient)
-
-		Expect(workerStorageClass).NotTo(BeNil())
-		Expect(workerStorageClass.Parameters).NotTo(BeNil())
-		_, ok = workerStorageClass.Parameters["storagePolicyID"]
-		Expect(ok).To(BeTrue(), "supervisor storage class must have a corresponding storage policy ID")
-	}
 
 	_, cancelWatches := context.WithCancel(ctx)
 	ns, err := GetCorev1Namespace(ctx, input.Client, namespaceForTest)

--- a/test/e2e/vmservice/README.md
+++ b/test/e2e/vmservice/README.md
@@ -16,33 +16,19 @@ From the VC UI,
 
 ### 2. Storage Classes
 
-The e2e tests require two storage policies to be created beforehand:
-- `wcpglobal_storage_profile` exists or create one
-- `worker-storagepolicy` 
+The e2e tests require the `wcpglobal_storage_profile` storage policy to exist beforehand.
+Testbed provision jobs will automatically create it.
 
-Testbeds created using the `dev-integ-vds` already have the `wcpglobal_storage_profile`, 
-so you would need to only create the `worker-storagepolicy`.
-
-#### Option 1: Create missing policy
-
-Run the following script which creates the `worker-storagepolicy` for you.
-```bash
-GOVC_PASSWORD="${SSH_PASSWORD}" ./hack/managestoragepolicy.sh create "${VCSA_IP}"
-```
-
-#### Option 2: From VC UI
-
+From the VC UI:
 - Left pane > Policies and Profiles
 - VM Storage Policies from the left lane
 - Confirm `wcpglobal_storage_profile` exists or create one
     - K8s compliant name must be `wcpglobal-storage-profile`
-- Create `worker-storagepolicy` 
-    - K8s compliant name must be `worker-storagepolicy`
-- Add both policies to any namespace in the Supervisor cluster. 
+- Add the policy to any namespace in the Supervisor cluster.
 This will add the storage policy CRD to the cluster which is a cluster resource.
     - Supervisor > Select any namespace
     - Storage > Edit button
-    - Select both storage policies
+    - Select the storage policy
 
 ## Running tests
 

--- a/test/e2e/vmservice/config/config.go
+++ b/test/e2e/vmservice/config/config.go
@@ -45,7 +45,6 @@ type Resources struct {
 	WindowsImageDisplayName       string `json:"windowsImageDisplayName,omitempty"`
 	EncryptedImageDisplayName     string `json:"encryptedImageDisplayName,omitempty"`
 	StorageClassName              string `json:"storageClassName,omitempty"`
-	WorkerStorageClassName        string `json:"workerStorageClassName,omitempty"`
 	VMClassName                   string `json:"vmClassName,omitempty"`
 	VMResourcePolicyName          string `json:"vmResourcePolicyName,omitempty"`
 	ContentLibrarySubscriptionURL string `json:"contentLibrarySubscriptionURL,omitempty"`

--- a/test/e2e/vmservice/config/kind.yaml
+++ b/test/e2e/vmservice/config/kind.yaml
@@ -57,5 +57,4 @@ intervals:
   default/wait-subnet-deletion: ["6m", "10s"]
   default/wait-security-policy-creation: ["2m", "10s"]
   default/wait-pvc-attachment: ["5m", "10s"]
-  default/wait-worker-storage-class: ["15m", "15s"]
   default/wait-jumpbox-sshpass-ready: ["30m", "10s"]

--- a/test/e2e/vmservice/config/wcp.yaml
+++ b/test/e2e/vmservice/config/wcp.yaml
@@ -10,7 +10,6 @@ infraConfig:
       windowsImageDisplayName: "windows-server2022-efi-tools"
       encryptedImageDisplayName: "${ENCRYPTED_IMAGE_DISPLAY_NAME:-photon-5.0-encrypted}"
       storageClassName: "${STORAGE_CLASS:-wcpglobal-storage-profile}"
-      workerStorageClassName: "${WORKER_STORAGE_CLASS:-worker-storagepolicy}"
       vmClassName: "best-effort-small"
       vmResourcePolicyName: ""
       contentLibrarySubscriptionURL: "${CONTENT_LIBRARY_SUBSCRIPTION_URL:-https://wp-content-pstg.broadcom.com/vmsvc/lib.json}"

--- a/test/e2e/vmservice/vmservice/viadmin/contentlibraries.go
+++ b/test/e2e/vmservice/vmservice/viadmin/contentlibraries.go
@@ -61,7 +61,6 @@ func VIAdminCLSpec(ctx context.Context, inputGetter func() VIAdminCLSpecInput) {
 		// Therefore, we are not using the default namespace and creating a new one for each test spec.
 		nsContext, err = clusterProxy.CreateWCPNamespace(ctx, config, vmsvcSpecs,
 			config.InfraConfig.ManagementClusterConfig.Resources.StorageClassName,
-			config.InfraConfig.ManagementClusterConfig.Resources.WorkerStorageClassName,
 			fmt.Sprintf("%s-%s", specName, capiutil.RandomString(6)),
 			input.ArtifactFolder)
 		Expect(err).NotTo(HaveOccurred(), "failed to create wcp namespace")

--- a/test/e2e/vmservice/vmservice/viadmin/namespaces.go
+++ b/test/e2e/vmservice/vmservice/viadmin/namespaces.go
@@ -10,10 +10,11 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
-	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	capiutil "sigs.k8s.io/cluster-api/util"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	topologyv1 "github.com/vmware-tanzu/vm-operator/external/tanzu-topology/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/infrastructure/vsphere/vcenter"
@@ -61,7 +62,6 @@ func VIAdminNamespaceRoleSpec(ctx context.Context, inputGetter func() VIAdminNam
 
 		nsContext, err = clusterProxy.CreateWCPNamespace(ctx, config, vmsvcSpecs,
 			config.InfraConfig.ManagementClusterConfig.Resources.StorageClassName,
-			config.InfraConfig.ManagementClusterConfig.Resources.WorkerStorageClassName,
 			fmt.Sprintf("%s-%s", nsRoleSpecName, capiutil.RandomString(6)),
 			input.ArtifactFolder)
 		Expect(err).NotTo(HaveOccurred(), "failed to create wcp namespace")

--- a/test/e2e/vmservice/vmservice/virtualmachine/virtualmachinelcm.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/virtualmachinelcm.go
@@ -426,7 +426,7 @@ func VMSpec(ctx context.Context, inputGetter func() VMSpecInput) {
 		vmClassNames := []string{clusterResources.VMClassName}
 		vmsvcSpecs := wcp.NewVMServiceSpecDetails(vmClassNames, clIDs)
 		var err error
-		tmpNamespaceCtx, err = clusterProxy.CreateWCPNamespace(ctx, config, vmsvcSpecs, clusterResources.StorageClassName, clusterResources.WorkerStorageClassName, tmpNamespaceName, input.ArtifactFolder)
+		tmpNamespaceCtx, err = clusterProxy.CreateWCPNamespace(ctx, config, vmsvcSpecs, clusterResources.StorageClassName, tmpNamespaceName, input.ArtifactFolder)
 		Expect(err).NotTo(HaveOccurred(), "failed to create wcp namespace")
 		wcp.WaitForNamespaceReady(wcpClient, tmpNamespaceName)
 
@@ -456,7 +456,7 @@ func VMSpec(ctx context.Context, inputGetter func() VMSpecInput) {
 		wcp.WaitForNamespaceDeleted(wcpClient, tmpNamespaceName)
 
 		// Recreate the namespace with the same name and spec.
-		tmpNamespaceCtx, err = clusterProxy.CreateWCPNamespace(ctx, config, vmsvcSpecs, clusterResources.StorageClassName, clusterResources.WorkerStorageClassName, tmpNamespaceName, input.ArtifactFolder)
+		tmpNamespaceCtx, err = clusterProxy.CreateWCPNamespace(ctx, config, vmsvcSpecs, clusterResources.StorageClassName, tmpNamespaceName, input.ArtifactFolder)
 		Expect(err).ToNot(HaveOccurred(), "failed to create wcp namespace")
 		wcp.WaitForNamespaceReady(wcpClient, tmpNamespaceName)
 
@@ -526,7 +526,7 @@ func VMSpec(ctx context.Context, inputGetter func() VMSpecInput) {
 		vmsvcSpecs := wcp.NewVMServiceSpecDetails(vmClassNames, clIDs)
 		// Not assigning to the tmpNamespaceCtx because no VMs will be deployed in this namespace.
 		// So that in AfterEach, it will delete the VM from the correct namespace (input.WCPNamespaceName).
-		newNamespaceCtx, err := clusterProxy.CreateWCPNamespace(ctx, config, vmsvcSpecs, clusterResources.StorageClassName, clusterResources.WorkerStorageClassName, newNamespaceName, input.ArtifactFolder)
+		newNamespaceCtx, err := clusterProxy.CreateWCPNamespace(ctx, config, vmsvcSpecs, clusterResources.StorageClassName, newNamespaceName, input.ArtifactFolder)
 		Expect(err).ToNot(HaveOccurred(), "failed to create wcp namespace")
 		wcp.WaitForNamespaceReady(wcpClient, newNamespaceName)
 
@@ -589,7 +589,7 @@ func VMSpec(ctx context.Context, inputGetter func() VMSpecInput) {
 		clIDs := []string{vmserviceCLID}
 		vmClassNames := []string{clusterResources.VMClassName}
 		vmsvcSpecs := wcp.NewVMServiceSpecDetails(vmClassNames, clIDs)
-		tmpNamespaceCtx, err = clusterProxy.CreateWCPNamespace(ctx, config, vmsvcSpecs, clusterResources.StorageClassName, clusterResources.WorkerStorageClassName, tmpNamespaceName, input.ArtifactFolder)
+		tmpNamespaceCtx, err = clusterProxy.CreateWCPNamespace(ctx, config, vmsvcSpecs, clusterResources.StorageClassName, tmpNamespaceName, input.ArtifactFolder)
 		Expect(err).NotTo(HaveOccurred(), "failed to create wcp namespace %s", tmpNamespaceName)
 		wcp.WaitForNamespaceReady(wcpClient, tmpNamespaceName)
 
@@ -876,7 +876,7 @@ func VMSpec(ctx context.Context, inputGetter func() VMSpecInput) {
 			clIDs := []string{vmserviceCLID}
 			vmClassNames := []string{clusterResources.VMClassName}
 			vmsvcSpecs := wcp.NewVMServiceSpecDetails(vmClassNames, clIDs)
-			tmpNamespaceCtx, err = clusterProxy.CreateWCPNamespace(ctx, config, vmsvcSpecs, clusterResources.StorageClassName, clusterResources.WorkerStorageClassName, tmpNamespaceName, input.ArtifactFolder)
+			tmpNamespaceCtx, err = clusterProxy.CreateWCPNamespace(ctx, config, vmsvcSpecs, clusterResources.StorageClassName, tmpNamespaceName, input.ArtifactFolder)
 			Expect(err).NotTo(HaveOccurred(), "failed to create wcp namespace")
 			wcp.WaitForNamespaceReady(wcpClient, tmpNamespaceName)
 
@@ -1105,7 +1105,7 @@ func VMSpec(ctx context.Context, inputGetter func() VMSpecInput) {
 			vmClassNames := []string{clusterResources.VMClassName}
 			vmsvcSpecs := wcp.NewVMServiceSpecDetails(vmClassNames, clIDs)
 			var err error
-			tmpNamespaceCtx, err = clusterProxy.CreateWCPNamespace(ctx, config, vmsvcSpecs, clusterResources.StorageClassName, clusterResources.WorkerStorageClassName, tmpNamespaceName, input.ArtifactFolder)
+			tmpNamespaceCtx, err = clusterProxy.CreateWCPNamespace(ctx, config, vmsvcSpecs, clusterResources.StorageClassName, tmpNamespaceName, input.ArtifactFolder)
 			Expect(err).NotTo(HaveOccurred(), "failed to create wcp namespace")
 			wcp.WaitForNamespaceReady(wcpClient, tmpNamespaceName)
 

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_encryption.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_encryption.go
@@ -126,7 +126,7 @@ func VMEncryptionSpec(ctx context.Context, inputGetter func() VMEncryptionInput)
 		vmsvcSpecs := wcp.NewVMServiceSpecDetails(vmClassNames, clIDs)
 
 		tmpNamespaceName = fmt.Sprintf("%s-ns-%s", specName, capiutil.RandomString(4))
-		tmpNamespaceCtx, err = clusterProxy.CreateWCPNamespace(ctx, config, vmsvcSpecs, clusterResources.StorageClassName, clusterResources.WorkerStorageClassName, tmpNamespaceName, input.ArtifactFolder)
+		tmpNamespaceCtx, err = clusterProxy.CreateWCPNamespace(ctx, config, vmsvcSpecs, clusterResources.StorageClassName, tmpNamespaceName, input.ArtifactFolder)
 		Expect(err).NotTo(HaveOccurred(), "failed to create wcp namespace %s", tmpNamespaceName)
 
 		wcp.WaitForNamespaceReady(wcpClient, tmpNamespaceName)

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_group.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_group.go
@@ -831,7 +831,7 @@ func VMGroupSpec(ctx context.Context, inputGetter func() VMGroupSpecInput) {
 			clIDs := []string{vmserviceCLID}
 			vmClassNames := []string{clusterResources.VMClassName}
 			vmsvcSpecs := wcp.NewVMServiceSpecDetails(vmClassNames, clIDs)
-			tmpNamespaceCtx, err = clusterProxy.CreateWCPNamespace(ctx, config, vmsvcSpecs, clusterResources.StorageClassName, clusterResources.WorkerStorageClassName, fmt.Sprintf("%s-%s", specName, capiutil.RandomString(6)), input.ArtifactFolder)
+			tmpNamespaceCtx, err = clusterProxy.CreateWCPNamespace(ctx, config, vmsvcSpecs, clusterResources.StorageClassName, fmt.Sprintf("%s-%s", specName, capiutil.RandomString(6)), input.ArtifactFolder)
 			Expect(err).ToNot(HaveOccurred(), "failed to create wcp namespace")
 			Expect(tmpNamespaceCtx.GetNamespace()).ToNot(BeNil(), "namespace should not be nil")
 			tmpNamespaceName = tmpNamespaceCtx.GetNamespace().Name
@@ -1435,7 +1435,7 @@ func VMGroupSpec(ctx context.Context, inputGetter func() VMGroupSpecInput) {
 			clIDs := []string{vmserviceCLID}
 			vmClassNames := []string{clusterResources.VMClassName}
 			vmsvcSpecs := wcp.NewVMServiceSpecDetails(vmClassNames, clIDs)
-			tmpNamespaceCtx, err = clusterProxy.CreateWCPNamespace(ctx, config, vmsvcSpecs, clusterResources.StorageClassName, clusterResources.WorkerStorageClassName, fmt.Sprintf("%s-%s", specName, capiutil.RandomString(6)), input.ArtifactFolder)
+			tmpNamespaceCtx, err = clusterProxy.CreateWCPNamespace(ctx, config, vmsvcSpecs, clusterResources.StorageClassName, fmt.Sprintf("%s-%s", specName, capiutil.RandomString(6)), input.ArtifactFolder)
 			Expect(err).ToNot(HaveOccurred(), "failed to create wcp namespace")
 			Expect(tmpNamespaceCtx.GetNamespace()).ToNot(BeNil(), "namespace should not be nil")
 			tmpNamespaceName = tmpNamespaceCtx.GetNamespace().Name

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_longevity.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_longevity.go
@@ -89,7 +89,7 @@ func VMLongevitySpec(ctx context.Context, inputGetter func() VMLongevityInput) {
 
 		if _, err := wcpClient.GetNamespace(secondNamespaceName); err != nil {
 			vmsvcSpecs := wcp.NewVMServiceSpecDetails([]string{}, []string{})
-			secondNSContext, err = clusterProxy.CreateWCPNamespace(ctx, config, vmsvcSpecs, clusterResources.StorageClassName, clusterResources.WorkerStorageClassName, secondNamespaceName, input.ArtifactFolder)
+			secondNSContext, err = clusterProxy.CreateWCPNamespace(ctx, config, vmsvcSpecs, clusterResources.StorageClassName, secondNamespaceName, input.ArtifactFolder)
 			Expect(err).ToNot(HaveOccurred(), "Failed to create a second test WCP namespace")
 			wcp.WaitForNamespaceReady(wcpClient, secondNamespaceName)
 		}

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_vpcnetworking.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_vpcnetworking.go
@@ -414,7 +414,7 @@ func VMVPCSpec(ctx context.Context, inputGetter func() VMVPCSpecInput) {
 
 			var err error
 
-			secondNamespaceCtx, err = clusterProxy.CreateWCPNamespace(ctx, config, vmsvcSpecs, clusterResources.StorageClassName, clusterResources.WorkerStorageClassName, secondNamespaceName, input.ArtifactFolder)
+			secondNamespaceCtx, err = clusterProxy.CreateWCPNamespace(ctx, config, vmsvcSpecs, clusterResources.StorageClassName, secondNamespaceName, input.ArtifactFolder)
 			Expect(err).ToNot(HaveOccurred(), "Failed to create a second test WCP namespace")
 			wcp.WaitForNamespaceReady(wcpClient, secondNamespaceName)
 

--- a/test/e2e/vmservice/vmservice_suite_test.go
+++ b/test/e2e/vmservice/vmservice_suite_test.go
@@ -8,7 +8,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"regexp"
 	"strings"
 	"testing"
 
@@ -23,7 +22,6 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	conformancetestdata "k8s.io/kubernetes/test/conformance/testdata"
@@ -35,14 +33,14 @@ import (
 	"github.com/vmware-tanzu/vm-operator/test/e2e/framework"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/infrastructure/vsphere/vcenter"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/infrastructure/vsphere/wcp"
-	
+
 	"github.com/vmware-tanzu/vm-operator/test/e2e/manifestbuilders"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/utils"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/common"
-	vmserviceutils "github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/utils"
 	e2eConfig "github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/config"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/consts"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/lib/vmoperator"
+	vmserviceutils "github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/utils"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/vmservice"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/wcpframework"
 )
@@ -56,7 +54,6 @@ var (
 	echoPodLogs                 bool
 	skipCleanup                 bool
 	workloadIsolationFSSEnabled bool
-	vksTesting                  bool
 	configFilePath              string
 	artifactFolder              string
 	skipTests                   string
@@ -146,7 +143,6 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 
 	vmClassName := config.InfraConfig.ManagementClusterConfig.Resources.VMClassName
 	storageClassName := config.InfraConfig.ManagementClusterConfig.Resources.StorageClassName
-	workerStorageClassName := config.InfraConfig.ManagementClusterConfig.Resources.WorkerStorageClassName
 
 	if wcpNamespaceName == "" {
 		wcpNamespaceName = config.GetVariable("E2ENamespace")
@@ -154,25 +150,18 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 
 	if wcpNamespaceName == "" {
 		namespaceName := fmt.Sprintf("%s-%s", testSuiteName, capiutil.RandomString(6))
-		wcpNamespaceCtx = createWCPNamespaceCtx(ctx, namespaceName, consts.VMServiceCLName, vmClassName, storageClassName, workerStorageClassName)
+		wcpNamespaceCtx = createWCPNamespaceCtx(ctx, namespaceName, consts.VMServiceCLName, vmClassName, storageClassName)
 		wcpNamespaceName = wcpNamespaceCtx.GetNamespace().Name
 		wcp.WaitForNamespaceReady(wcpClient, wcpNamespaceName)
 	} else {
 		_, err := wcpClient.GetNamespace(wcpNamespaceName)
 		if err != nil {
 			framework.Byf("Namespace %q does not exist, creating it", wcpNamespaceName)
-			wcpNamespaceCtx = createWCPNamespaceCtx(ctx, wcpNamespaceName, consts.VMServiceCLName, vmClassName, storageClassName, workerStorageClassName)
+			wcpNamespaceCtx = createWCPNamespaceCtx(ctx, wcpNamespaceName, consts.VMServiceCLName, vmClassName, storageClassName)
 			wcp.WaitForNamespaceReady(wcpClient, wcpNamespaceName)
 		} else {
 			framework.Byf("Namespace %q already exists, skipping creation", wcpNamespaceName)
 		}
-	}
-
-	if workerStorageClassName != "" {
-		svClient := svClusterProxy.GetClientSet()
-		primarySC, err := svClient.StorageV1().StorageClasses().Get(ctx, storageClassName, metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred(), "primary storage class %q must exist for worker StorageClass setup", storageClassName)
-		wcp.EnsureWorkerKubernetesStorageClassIfMissing(ctx, kubeconfigPath, svClient, primarySC, workerStorageClassName, config, wcpNamespaceName, wcpClient)
 	}
 
 	By("Ensure the storage class is available in the WCP namespace")
@@ -186,14 +175,8 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		config.GetVariable("EnvFSSPodVMOnStretchedSupervisor"),
 	)
 	utils.EnsureStorageClassInNamespace(ctx, svClusterProxy.GetClient(),
-		wcpNamespaceName, storageClassName, podVMOnStretchedSupervisorEnabled, 
+		wcpNamespaceName, storageClassName, podVMOnStretchedSupervisorEnabled,
 		*config)
-
-	if workerStorageClassName != "" {
-		utils.EnsureStorageClassInNamespace(ctx, svClusterProxy.GetClient(), 
-			wcpNamespaceName, workerStorageClassName, 
-			podVMOnStretchedSupervisorEnabled, *config)
-	}
 
 	By("Ensure the VM Class is available in the WCP namespace")
 	Expect(vmservice.EnsureVMClassPresent(wcpClient, vmClassName)).To(Succeed())
@@ -265,20 +248,10 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		config.GetVariable("VMOPNamespace"), config.GetVariable("VMOPDeploymentName"),
 		config.GetVariable("VMOPManagerCommand"), config.GetVariable("EnvWorkloadIsolation"))
 
-	stretchedTestbed := false
-
 	if workloadIsolationFSSEnabled && os.Getenv("STRETCHED_SUPERVISOR") == "true" {
 		supervisorID := vcenter.GetSupervisorIDFromKubeconfig(ctx, kubeconfigPath)
 		err := svClusterProxy.CreateMissingZoneBindingsWithSupervisor(supervisorID, []string{"zone-2", "zone-3"})
 		Expect(err).ToNot(HaveOccurred(), "failed to update zone bindings with supervisor")
-
-		// The VKS test we're using doesn't work with stretched since it does not set the
-		// zones on the worker pools.
-		stretchedTestbed = true
-	}
-
-	if !checkSkipVKSTests(skipTests) && !stretchedTestbed {
-		vksTesting = true
 	}
 
 	return []byte(
@@ -352,10 +325,10 @@ func setupSupervisorClusterProxy(kubeconfigPath string, sc *runtime.Scheme, conf
 }
 
 // createWCPNamespaceCtx creates a WCP namespace with the default associations.
-func createWCPNamespaceCtx(ctx context.Context, name, clName, vmClassName, storageClassName, workerStorageClassName string) wcpframework.NamespaceContext {
+func createWCPNamespaceCtx(ctx context.Context, name, clName, vmClassName, storageClassName string) wcpframework.NamespaceContext {
 	clID := vmservice.GetContentLibraryUUIDByName(clName, wcpClient)
 	vmsvcSpecs := wcp.NewVMServiceSpecDetails([]string{vmClassName}, []string{clID})
-	wcpNamespaceCtx, err := svClusterProxy.CreateWCPNamespace(ctx, config, vmsvcSpecs, storageClassName, workerStorageClassName, name, artifactFolder)
+	wcpNamespaceCtx, err := svClusterProxy.CreateWCPNamespace(ctx, config, vmsvcSpecs, storageClassName, name, artifactFolder)
 	Expect(err).ToNot(HaveOccurred(), "Failed to create the test WCP namespace")
 
 	return wcpNamespaceCtx
@@ -483,16 +456,6 @@ func deployVMWithCloudInit(ctx context.Context, ns, vmName, vmiName string) {
 	}
 	vmYaml := manifestbuilders.GetVirtualMachineYaml(vmParameters)
 	Expect(vmsvcClusterProxy.CreateWithArgs(ctx, vmYaml)).To(Succeed(), "failed to create VM:\n%s", string(vmYaml))
-}
-
-func checkSkipVKSTests(skipStr string) bool {
-	if skipStr == "" {
-		return false
-	}
-
-	skippedTests := regexp.MustCompile(`\bVKS\b`)
-	// If 'VKS' is specified in test-skip, then do not create a VKS cluster.
-	return skippedTests.MatchString(skipStr)
 }
 
 func deployJumpboxPodVM(ctx context.Context) {

--- a/test/e2e/wcpframework/wcp_cluster_proxy.go
+++ b/test/e2e/wcpframework/wcp_cluster_proxy.go
@@ -41,7 +41,7 @@ type WCPClusterProxyInterface interface {
 	framework.ClusterProxyInterface
 	CreateWCPNamespace(ctx context.Context, config framework.ConfigInterface,
 		vmsvcSpecs wcp.VMServiceSpecDetails,
-		scName, wscName, nsName, artifactFolder string) (NamespaceContext, error)
+		scName, nsName, artifactFolder string) (NamespaceContext, error)
 	UpdateNamespaceWithZones(ctx context.Context, namespaceName string, zones []string, svClusterClient ctrlclient.Client) (ZoneContext, error)
 	DeleteZonesFromNamespace(ctx context.Context, namespaceName string, zones []string, svClusterClient ctrlclient.Client) error
 	GetZonesBoundWithSupervisor(supervisorID string) (wcp.ZoneList, error)
@@ -51,7 +51,7 @@ type WCPClusterProxyInterface interface {
 	ListVSphereZones() (wcp.VSphereZoneList, error)
 	CreateWCPNamespaceWithNetwork(ctx context.Context, config framework.ConfigInterface,
 		vmsvcSpecs wcp.VMServiceSpecDetails,
-		scName, wscName, nsName, artifactFolder string, network wcp.NameSpaceNetworkInfo) (NamespaceContext, error)
+		scName, nsName, artifactFolder string, network wcp.NameSpaceNetworkInfo) (NamespaceContext, error)
 	CreateWCPNamespaceWithVMReservation(ctx context.Context, nsName, scName, zone, supervisorID string, vmsvcSpecs wcp.VMServiceSpecDetails, vmClassNameToReservedCount map[string]int) (NamespaceContext, error)
 	DeleteWCPNamespace(nsCtx NamespaceContext)
 }
@@ -93,21 +93,19 @@ func (w *WCPClusterProxy) GetWorkloadManagementAPI() wcp.WorkloadManagementAPI {
 // CreateWCPNamespace applies wcp api to create a namespace in wcp cluster with the given specs.
 func (w *WCPClusterProxy) CreateWCPNamespace(ctx context.Context, config framework.ConfigInterface,
 	vmsvcSpecs wcp.VMServiceSpecDetails,
-	scName, wscName, nsName, artifactFolder string) (NamespaceContext, error) {
+	scName, nsName, artifactFolder string) (NamespaceContext, error) {
 	// we need to create namespace with vm class and bind it
 	// the CR of vm class will get deleted if the namespace owning it gets deleted
 	// we can assume that vcenter has default vm classes names present
 	namespace, cancelNsWatches := wcp.CreateNamespace(ctx, wcp.NamespaceCreateInput{
-		SpecName:               nsName,
-		ClientSet:              w.ClusterProxyInterface.GetClientSet(),
-		Client:                 w.ClusterProxyInterface.GetClient(),
-		Kubeconfig:             w.ClusterProxyInterface.GetKubeconfigPath(),
-		StorageClassName:       scName,
-		WorkerStorageClassName: wscName,
-		Config:                 config,
-		WCPClient:              w.wcpAPI,
-		ArtifactFolder:         artifactFolder,
-		VMServiceSpec:          vmsvcSpecs,
+		SpecName:         nsName,
+		ClientSet:        w.ClusterProxyInterface.GetClientSet(),
+		Client:           w.ClusterProxyInterface.GetClient(),
+		Kubeconfig:       w.ClusterProxyInterface.GetKubeconfigPath(),
+		StorageClassName: scName,
+		WCPClient:        w.wcpAPI,
+		ArtifactFolder:   artifactFolder,
+		VMServiceSpec:    vmsvcSpecs,
 	})
 
 	return NamespaceContext{
@@ -235,22 +233,20 @@ func (w *WCPClusterProxy) DeleteZonesFromNamespace(ctx context.Context, nsName s
 // CreateWCPNamespaceWithNetwork applies wcp api to create a namespace in wcp cluster with the given specs.
 func (w *WCPClusterProxy) CreateWCPNamespaceWithNetwork(ctx context.Context, config framework.ConfigInterface,
 	vmsvcSpecs wcp.VMServiceSpecDetails,
-	scName, wscName, nsName, artifactFolder string, network wcp.NameSpaceNetworkInfo) (NamespaceContext, error) {
+	scName, nsName, artifactFolder string, network wcp.NameSpaceNetworkInfo) (NamespaceContext, error) {
 	// we need to create namespace with vm class and bind it
 	// the CR of vm class will get deleted if the namespace owning it gets deleted
 	// we can assume that vcenter has default vm classes names present
 	namespace, cancelNsWatches := wcp.CreateNamespace(ctx, wcp.NamespaceCreateInput{
-		SpecName:               nsName,
-		ClientSet:              w.ClusterProxyInterface.GetClientSet(),
-		Client:                 w.ClusterProxyInterface.GetClient(),
-		Kubeconfig:             w.ClusterProxyInterface.GetKubeconfigPath(),
-		StorageClassName:       scName,
-		WorkerStorageClassName: wscName,
-		Config:                 config,
-		WCPClient:              w.wcpAPI,
-		ArtifactFolder:         artifactFolder,
-		VMServiceSpec:          vmsvcSpecs,
-		Network:                &network,
+		SpecName:         nsName,
+		ClientSet:        w.ClusterProxyInterface.GetClientSet(),
+		Client:           w.ClusterProxyInterface.GetClient(),
+		Kubeconfig:       w.ClusterProxyInterface.GetKubeconfigPath(),
+		StorageClassName: scName,
+		WCPClient:        w.wcpAPI,
+		ArtifactFolder:   artifactFolder,
+		VMServiceSpec:    vmsvcSpecs,
+		Network:          &network,
 	})
 
 	return NamespaceContext{
@@ -342,7 +338,7 @@ func (s *SimulatedWCPClusterProxy) applyWithArgs(ctx context.Context, resources 
 // CreateWCPNamespace in simulatedwcpcluster type implements how to create a wcp namespace in kind cluster.
 func (s *SimulatedWCPClusterProxy) CreateWCPNamespaceWithNetwork(ctx context.Context, config framework.ConfigInterface,
 	vmsvcSpecs wcp.VMServiceSpecDetails,
-	scName, wscName, nsName, artifactFolder string, network wcp.NameSpaceNetworkInfo) (NamespaceContext, error) {
+	scName, nsName, artifactFolder string, network wcp.NameSpaceNetworkInfo) (NamespaceContext, error) {
 	return NamespaceContext{}, nil
 }
 
@@ -359,7 +355,7 @@ func (s *SimulatedWCPClusterProxy) CreateWCPNamespaceWithVMReservation(
 // CreateWCPNamespace in simulatedwcpcluster type implements how to create a wcp namespace in kind cluster.
 func (s *SimulatedWCPClusterProxy) CreateWCPNamespace(ctx context.Context, config framework.ConfigInterface,
 	vmsvcSpecs wcp.VMServiceSpecDetails,
-	scName, wscName, nsName, artifactFolder string) (NamespaceContext, error) {
+	scName, nsName, artifactFolder string) (NamespaceContext, error) {
 	namespace, cancelWatches := framework.CreateNamespaceAndWatchEvents(ctx, framework.CreateNamespaceAndWatchEventsInput{
 		Creator:   s.ClusterProxyInterface.GetClient(),
 		ClientSet: s.ClusterProxyInterface.GetClientSet(),


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

No test ever exercised the worker-storagepolicy StorageClass as a VM or PVC storage class; it was only created and asserted into existence by its own setup path, which had already broken the suite twice on concurrent runs (BZ 3773589). Drop the config field/default, the vCenter policy helper, the namespace association plumbing, and every call site that threaded it through, and update the README's now-stale setup instructions.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

UTS smoke passed

**Please add a release note if necessary**:

```release-note
NONE
```