### PR TITLE
e2e: Inline support bundle collection option

### DIFF
--- a/hack/e2e/collect-support-bundle.sh
+++ b/hack/e2e/collect-support-bundle.sh
@@ -12,6 +12,10 @@
 #
 # Environment variable overrides:
 #   RESULTSDIR   Default output directory when --output-dir is not passed.
+#
+# This is a best-effort diagnostic step, not a test: any runtime failure to
+# obtain or download a bundle exits 0 so it never fails the caller's
+# pipeline. Only invocation errors (bad/missing flags) exit non-zero.
 
 set -uo pipefail
 
@@ -68,9 +72,9 @@ if [[ -n "${TESTBED_BLOB_URL}" ]]; then
     TESTBED_TMP="$(mktemp /tmp/testbedInfo.XXXXXX.json)"
     _raw_tmp="$(mktemp /tmp/testbedInfo-raw.XXXXXX.json)"
     if ! curl -sf "${TESTBED_BLOB_URL}" -o "${_raw_tmp}"; then
-        _err "Failed to fetch testbedInfo from ${TESTBED_BLOB_URL}"
+        _warn "Failed to fetch testbedInfo from ${TESTBED_BLOB_URL}; skipping WCP bundle"
         rm -f "${_raw_tmp}"
-        exit 1
+        exit 0
     fi
     # Unwrap deliverable_blob if present (UTS test_blob API format); otherwise
     # the URL points directly to the raw testbedInfo.json in the logs directory.
@@ -82,7 +86,7 @@ if [[ -n "${TESTBED_BLOB_URL}" ]]; then
     rm -f "${_raw_tmp}"
     TESTBED_INFO_JSON="${TESTBED_TMP}"
 elif [[ -n "${TESTBED_INFO_JSON}" ]]; then
-    [[ -f "${TESTBED_INFO_JSON}" ]] || { _err "File not found: ${TESTBED_INFO_JSON}"; exit 1; }
+    [[ -f "${TESTBED_INFO_JSON}" ]] || { _warn "File not found: ${TESTBED_INFO_JSON}; skipping WCP bundle"; exit 0; }
 else
     _err "Either --testbed-info-json or --testbed-blob-url is required"
     usage; exit 1
@@ -119,8 +123,8 @@ IFS=$'\t' read -r VC_IP VC_VIM_USER VC_VIM_PWD < <(_jq '
 ')
 
 if [[ -z "${VC_IP}" || -z "${VC_VIM_USER}" || -z "${VC_VIM_PWD}" ]]; then
-    _err "Could not extract VC IP or vim credentials from testbedInfo.json"
-    exit 1
+    _warn "Could not extract VC IP or vim credentials from testbedInfo.json; skipping WCP bundle"
+    exit 0
 fi
 
 _log "Collecting WCP support bundle from VC ${VC_IP}..."

--- a/hack/e2e/collect-support-bundle.sh
+++ b/hack/e2e/collect-support-bundle.sh
@@ -24,6 +24,14 @@ TESTBED_INFO_JSON=""
 TESTBED_BLOB_URL=""
 OUTPUT_DIR="${RESULTSDIR:-/tmp/support-bundles}"
 
+# WCP allows only one support-bundle generation in flight per supervisor/
+# cluster; a request made while another is running fails until it completes.
+# Multiple pipelines (or multiple test suites within one pipeline) can now
+# collect bundles from the same VC around the same time, so retry on failure
+# instead of giving up immediately. ~10 minutes of total wait by default.
+SUPPORT_BUNDLE_RETRY_ATTEMPTS="${SUPPORT_BUNDLE_RETRY_ATTEMPTS:-20}"
+SUPPORT_BUNDLE_RETRY_INTERVAL_SECONDS="${SUPPORT_BUNDLE_RETRY_INTERVAL_SECONDS:-30}"
+
 usage() {
     cat >&2 <<EOF
 Usage: ${SCRIPT_NAME} [OPTIONS]
@@ -137,6 +145,35 @@ BUNDLE_URL=""
 BUNDLE_TOKEN=""
 
 # ---------------------------------------------------------------------------
+# Request a support bundle, retrying while another collection is already in
+# progress on this VC. Prints the response body on success (HTTP 2xx and a
+# recognizable bundle field); returns non-zero once retries are exhausted.
+# ---------------------------------------------------------------------------
+request_support_bundle() {
+    local url="$1"
+    local attempt=1 response http_code body
+
+    while (( attempt <= SUPPORT_BUNDLE_RETRY_ATTEMPTS )); do
+        response=$(curl -sk -w '\n%{http_code}' --max-time 30 -X POST \
+            -H "vmware-api-session-id: ${VC_SESSION}" "${url}")
+        http_code=$(printf '%s' "${response}" | tail -1)
+        body=$(printf '%s' "${response}" | sed '$d')
+
+        if [[ "${http_code}" == "20"* ]] && printf '%s' "${body}" | jq -e '.url // .support_bundle_token // empty' >/dev/null 2>&1; then
+            printf '%s' "${body}"
+            return 0
+        fi
+
+        _warn "Support bundle request attempt ${attempt}/${SUPPORT_BUNDLE_RETRY_ATTEMPTS} on ${VC_IP} did not return a bundle (HTTP ${http_code}); another collection may be in progress. Retrying in ${SUPPORT_BUNDLE_RETRY_INTERVAL_SECONDS}s..."
+        sleep "${SUPPORT_BUNDLE_RETRY_INTERVAL_SECONDS}"
+        ((attempt++))
+    done
+
+    _warn "Gave up requesting a support bundle from ${VC_IP} after ${SUPPORT_BUNDLE_RETRY_ATTEMPTS} attempts"
+    return 1
+}
+
+# ---------------------------------------------------------------------------
 # v2 API: supervisors endpoint (vSphere 8.0+)
 # ---------------------------------------------------------------------------
 SUPERVISOR_ID=$(curl -sk --max-time 30 -H "vmware-api-session-id: ${VC_SESSION}" \
@@ -145,9 +182,7 @@ SUPERVISOR_ID=$(curl -sk --max-time 30 -H "vmware-api-session-id: ${VC_SESSION}"
 
 if [[ -n "${SUPERVISOR_ID}" ]]; then
     _log "Getting WCP bundle for supervisor ${SUPERVISOR_ID} (v2 API)..."
-    BUNDLE_INFO=$(curl -sk --max-time 30 -X POST \
-        -H "vmware-api-session-id: ${VC_SESSION}" \
-        "https://${VC_IP}/api/vcenter/namespace-management/supervisors/${SUPERVISOR_ID}/support-bundles")
+    BUNDLE_INFO=$(request_support_bundle "https://${VC_IP}/api/vcenter/namespace-management/supervisors/${SUPERVISOR_ID}/support-bundles") || BUNDLE_INFO='{}'
     BUNDLE_URL=$(echo "${BUNDLE_INFO}" | jq -r '.url // empty')
     BUNDLE_TOKEN=$(echo "${BUNDLE_INFO}" | jq -r '.support_bundle_token.token // empty')
 else
@@ -159,10 +194,7 @@ else
         | jq -r 'if type == "array" then .[0].cluster // empty else empty end')
     if [[ -n "${CLUSTER_ID}" ]]; then
         _log "Getting WCP bundle for cluster ${CLUSTER_ID} (v1 API)..."
-        BUNDLE_INFO=$(curl -sk --max-time 30 -X POST \
-            -H "vmware-api-session-id: ${VC_SESSION}" \
-            "https://${VC_IP}/api/vcenter/namespace-management/clusters/${CLUSTER_ID}/support-bundle" \
-            || echo '{}')
+        BUNDLE_INFO=$(request_support_bundle "https://${VC_IP}/api/vcenter/namespace-management/clusters/${CLUSTER_ID}/support-bundle") || BUNDLE_INFO='{}'
         BUNDLE_URL=$(echo "${BUNDLE_INFO}" | jq -r '.url // empty')
         BUNDLE_TOKEN=$(echo "${BUNDLE_INFO}" | jq -r '.wcp_support_bundle_token.token // empty')
     else

--- a/hack/e2e/run-e2e.sh
+++ b/hack/e2e/run-e2e.sh
@@ -138,6 +138,9 @@ REPORT_DIR="${ARTIFACT_FOLDER}"
 # before the container scheduler force-kills the process.
 GINKGO_TIMEOUT="${GINKGO_TIMEOUT:-2h}"
 
+# See "Optionally collect a WCP support bundle" below.
+COLLECT_SUPPORT_BUNDLE_MODE="${COLLECT_SUPPORT_BUNDLE_MODE:-off}"
+
 # Disable color output in CI env.
 export GINKGO_NO_COLOR=${TEST_CALLBACK_URL:+TRUE}
 
@@ -191,6 +194,28 @@ else
     "$GINKGO_BIN" "${GINKGO_ARGS[@]}" ./test/e2e/vmservice/... -- $E2E_ARGS || E2E_EXIT=$?
 fi
 
-# 6. Report result, then propagate the original exit code
+# 6. Report result first so autotriage sees the outcome without waiting on
+# the slower step below.
 report_result "${E2E_EXIT}" "${REPORT_DIR}/report.json"
+
+# 7. Optionally collect a WCP support bundle from this suite's own pod,
+# right after its tests finish, instead of waiting on a separate downstream
+# job once every suite in the pipeline is done. Off by default (e.g. local
+# runs); CI sets COLLECT_SUPPORT_BUNDLE_MODE via e2e job env_vars.
+#   off         - never collect (default)
+#   on-failure  - collect only when E2E_EXIT is non-zero
+#   always      - collect regardless of outcome
+if [ "${COLLECT_SUPPORT_BUNDLE_MODE}" = "always" ] || \
+   { [ "${COLLECT_SUPPORT_BUNDLE_MODE}" = "on-failure" ] && [ "${E2E_EXIT}" -ne 0 ]; }; then
+    if [ -n "${TESTBED_DATA_URL:-}" ] && [ -f "${_SCRIPT_DIR}/collect-support-bundle.sh" ]; then
+        echo "[run-e2e] Collecting support bundle (COLLECT_SUPPORT_BUNDLE_MODE=${COLLECT_SUPPORT_BUNDLE_MODE})..."
+        "${_SCRIPT_DIR}/collect-support-bundle.sh" --testbed-blob-url "${TESTBED_DATA_URL}" --output-dir "${ARTIFACT_FOLDER}" \
+            || echo "[run-e2e] WARNING: support bundle collection failed; continuing" >&2
+    else
+        echo "[run-e2e] WARNING: COLLECT_SUPPORT_BUNDLE_MODE=${COLLECT_SUPPORT_BUNDLE_MODE} but TESTBED_DATA_URL is unset; skipping" >&2
+    fi
+fi
+
+# 8. Propagate the test suite's own exit code — bundle collection above never
+# affects it.
 exit "${E2E_EXIT}"


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Adds a fast-path for collecting a WCP support bundle immediately after an
E2E suite finishes, instead of only via the separate downstream
`collect-support-bundle-*` UTS job that waits for every suite in the
pipeline to complete.

1. `collect-support-bundle.sh`: WCP only allows one support-bundle
   generation in flight per supervisor/cluster. The trigger request now
   retries with backoff instead of giving up on the first non-2xx/missing-
   bundle response, since bundle collection can now be requested from
   multiple places (parallel suites, or this inline path plus the
   existing downstream job) against the same VC around the same time.
2. `run-e2e.sh`: new opt-in `COLLECT_SUPPORT_BUNDLE_MODE` env var
   (`off` default / `on-failure` / `always`). When enabled, collects a
   bundle right after the suite's own result is reported, using the
   pod's own `TESTBED_DATA_URL`. Never affects the suite's exit code.

This is phase 1 of a two-phase change (companion CI-config PR in
`cayman_vm-operator` wires `COLLECT_SUPPORT_BUNDLE_MODE=on-failure` into
the e2e job definitions). The existing standalone
`collect-support-bundle-*` UTS jobs are untouched and keep running as
today's crash-resilience backstop; removing them is a deliberately
separate follow-up once this inline path has soaked, since they're
UTS-scheduled independent of whether an e2e pod survives to run its own
post-test step.

**Which issue(s) is/are addressed by this PR?**

Fixes #

**Are there any special notes for your reviewer**:

Local runs are unaffected — `COLLECT_SUPPORT_BUNDLE_MODE` defaults to
`off`, so this is a no-op until CI opts in via env var.

**Please add a release note if necessary**:

```release-note
NONE
```

— Faisal + Claude