### PR TITLE
Fix e2e container permissions for dynamic submitter UIDs

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -160,6 +160,11 @@ COPY --chmod=755 kubectl /usr/local/bin/kubectl
 #
 # mts (GID 201): the group that both vmoperator and svc-vdm_stage0 belong to,
 # required for writing test artifacts to the NFS log directory after chmod g+w.
+#
+# chmod 1777 /home: some callers run this container as a dynamic, non-static
+# UID rather than the "vmoperator" user, so $HOME resolves to
+# /home/<uid> — a directory that doesn't exist and, without this, isn't
+# creatable by an arbitrary UID.
 RUN groupadd -g 201 mts && \
     groupadd -g 1000 vmoperator && \
     groupadd -g 2001835 svc-vdm_stage0 && \
@@ -168,11 +173,18 @@ RUN groupadd -g 201 mts && \
     useradd -u 1000 -g vmoperator -G mts -m -s /bin/bash vmoperator && \
     echo "svc-vdm_stage0 ALL=(ALL:ALL) NOPASSWD:ALL" >> /etc/sudoers && \
     echo "vmoperator ALL=(svc-vdm_stage0) NOPASSWD:ALL" >> /etc/sudoers && \
-    sed -i '/Defaults requiretty/d' /etc/sudoers
+    sed -i '/Defaults requiretty/d' /etc/sudoers && \
+    chmod 1777 /home
 
 # Create directories
+#
+# group mts, mode 775: setup-testbed-env.sh's kubectl-vsphere install does
+# "curl -o vsphere-plugin.zip" relative to the CWD ($WORKDIR), which a
+# dynamic, non-static UID (in the mts group, not the named "vmoperator"
+# group) can't write to otherwise.
 RUN mkdir -p /vm-operator && \
-    chown vmoperator:vmoperator /vm-operator
+    chown vmoperator:mts /vm-operator && \
+    chmod 775 /vm-operator
 
 WORKDIR /vm-operator
 

--- a/hack/e2e/wait-for-artifact-dir.sh
+++ b/hack/e2e/wait-for-artifact-dir.sh
@@ -2,12 +2,12 @@
 set -ex
 
 #
-# wait-for-artifact-dir.sh - Wait for RESULTSDIR to exist and make it writable
+# wait-for-artifact-dir.sh - Wait for RESULTSDIR to exist
 #
-# The UTS NFS log directory is created by the svc-vdm_stage0 service account.
-# This script waits for it to appear then uses "sudo -u svc-vdm_stage0 chmod g+w"
-# to make it group-writable. Both vmoperator and svc-vdm_stage0 are in the mts 
-# group (GID 201), so after chmod g+w the directory is writable by our container user.
+# The RESULTSDIR NFS mount is pre-created with g+w permissions already set,
+# so the vmoperator/svc-vdm_stage0 mts-group (GID 201) container user can
+# write logs directly once the directory appears, with no identity switch
+# needed.
 #
 # Usage:
 #   export RESULTSDIR=/cpbu/logs/user-logs/...
@@ -51,9 +51,6 @@ while [[ ! -d "$RESULTSDIR" ]]; do
 done
 
 echo "[wait-for-artifact-dir] Directory found: $RESULTSDIR (after ${elapsed}s)"
-sudo -u svc-vdm_stage0 chmod g+w "$RESULTSDIR"
-sudo -u svc-vdm_stage0 chmod -R g+w "$RESULTSDIR" || true
-echo "[wait-for-artifact-dir] Made directory group-writable: $RESULTSDIR"
 ls -la "$RESULTSDIR"
 touch "$RESULTSDIR/.marker.wait-for-artifact-dir.done"
 echo "[wait-for-artifact-dir] Marker created: $RESULTSDIR/.marker.wait-for-artifact-dir.done"


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Fixes e2e container permission issues that occur when the e2e image is run under a dynamic, non-static UID instead of the built-in `vmoperator` user. This broke two things: `$HOME` resolved to a non-existent, non-creatable `/home/<uid>` directory, and `kubectl-vsphere` plugin installation in `setup-testbed-env.sh` failed writing under `/vm-operator` because the non-static UID wasn't in the owning group. Also simplifies `wait-for-artifact-dir.sh` since the `RESULTSDIR` mount is now pre-created with group-write permissions, removing the need for a `sudo -u svc-vdm_stage0 chmod g+w` step.

**Which issue(s) is/are addressed by this PR?**

Fixes #

**Are there any special notes for your reviewer**:

None.

**Please add a release note if necessary**:

```release-note
NONE
```

There was a precheckin with this patch was run in internal repo and had a successful run.