### PR TITLE
🌱 Add CLI flags for leader-election lease timing

### DIFF
--- a/main.go
+++ b/main.go
@@ -350,6 +350,27 @@ func initFlags() {
 		true,
 		"Enable the priority queue feature.",
 	)
+	flag.DurationVar(
+		&managerOpts.LeaseDuration,
+		"lease-duration",
+		pkgmgr.DefaultLeaseDuration,
+		"The duration non-leader candidates wait after observing a "+
+			"leadership renewal before attempting to acquire leadership "+
+			"of an unrenewed leader slot.",
+	)
+	flag.DurationVar(
+		&managerOpts.RenewDeadline,
+		"renew-deadline",
+		pkgmgr.DefaultRenewDeadline,
+		"The duration the acting leader retries refreshing leadership "+
+			"before giving it up.",
+	)
+	flag.DurationVar(
+		&managerOpts.RetryPeriod,
+		"retry-period",
+		pkgmgr.DefaultRetryPeriod,
+		"The duration leader election clients wait between tries of actions.",
+	)
 
 	logsv1.AddGoFlags(logOptions, flag.CommandLine)
 

--- a/pkg/manager/constants.go
+++ b/pkg/manager/constants.go
@@ -17,6 +17,18 @@ const (
 	// manager option.
 	DefaultSyncPeriod = time.Minute * 30
 
+	// DefaultLeaseDuration is the default value for the eponymous
+	// manager option.
+	DefaultLeaseDuration = 60 * time.Second
+
+	// DefaultRenewDeadline is the default value for the eponymous
+	// manager option.
+	DefaultRenewDeadline = 40 * time.Second
+
+	// DefaultRetryPeriod is the default value for the eponymous
+	// manager option.
+	DefaultRetryPeriod = 15 * time.Second
+
 	// DefaultMaxConcurrentReconciles is the default value for the eponymous
 	// manager option.
 	DefaultMaxConcurrentReconciles = 1

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -146,6 +146,10 @@ func New(ctx context.Context, opts Options) (Manager, error) {
 		LeaderElectionID:        opts.LeaderElectionID,
 		LeaderElectionNamespace: opts.PodNamespace,
 		NewCache:                opts.NewCache,
+
+		RetryPeriod:   &opts.RetryPeriod,
+		RenewDeadline: &opts.RenewDeadline,
+		LeaseDuration: &opts.LeaseDuration,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("unable to create manager: %w", err)

--- a/pkg/manager/options.go
+++ b/pkg/manager/options.go
@@ -41,6 +41,27 @@ var InitializeProvidersNoopFn InitializeProvidersFunc = func(_ *pkgctx.Controlle
 
 // Options describes the options used to create a new GCM manager.
 type Options struct {
+	// LeaseDuration is the duration that non-leader candidates will wait
+	// after observing a leadership renewal until attempting to acquire
+	// leadership of an unrenewed leader slot. This is effectively the
+	// maximum duration a leader can be stopped before another candidate
+	// takes over.
+	//
+	// Defaults to the eponymous constant in this package.
+	LeaseDuration time.Duration
+
+	// RenewDeadline is the duration that the acting leader will retry
+	// refreshing leadership before giving it up.
+	//
+	// Defaults to the eponymous constant in this package.
+	RenewDeadline time.Duration
+
+	// RetryPeriod is the duration leader election clients wait between
+	// tries of actions.
+	//
+	// Defaults to the eponymous constant in this package.
+	RetryPeriod time.Duration
+
 	// LeaderElectionEnabled is a flag that enables leader election.
 	LeaderElectionEnabled bool
 
@@ -254,5 +275,15 @@ func (o *Options) defaults() {
 
 	if o.AddToManager == nil {
 		o.AddToManager = AddToManagerNoopFn
+	}
+
+	if o.LeaseDuration == 0 {
+		o.LeaseDuration = DefaultLeaseDuration
+	}
+	if o.RenewDeadline == 0 {
+		o.RenewDeadline = DefaultRenewDeadline
+	}
+	if o.RetryPeriod == 0 {
+		o.RetryPeriod = DefaultRetryPeriod
 	}
 }


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

Expose the controller-runtime manager's leader-election lease timing as configurable Options fields and CLI flags instead of relying on the client-go defaults.

- Add LeaseDuration, RenewDeadline, and RetryPeriod fields to manager.Options, with defaults of 60s/40s/15s respectively.
- Wire the fields into ctrl.Options in manager.New so they take effect when leader election is enabled.
- Register --lease-duration, --renew-deadline, and --retry-period flags in main.go so operators can tune failover speed for their environment without a code change.

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:



Fixes `NA`


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note
Expose lease duration flags in the CLI.
```