### PR TITLE
🌱 Use unique SSO username in publish-request E2E tests

### DIFF
--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_group_publishrequest.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_group_publishrequest.go
@@ -25,7 +25,6 @@ import (
 	"github.com/vmware-tanzu/vm-operator/test/e2e/infrastructure/vsphere/vcenter"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/infrastructure/vsphere/wcp"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/manifestbuilders"
-	"github.com/vmware-tanzu/vm-operator/test/e2e/testutils"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/common"
 	e2eConfig "github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/config"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/consts"
@@ -89,8 +88,7 @@ func VMGroupPublishRequestSpec(ctx context.Context, inputGetter func() VMGroupPu
 		)
 		Expect(err).NotTo(HaveOccurred())
 
-		sshCommandRunner, _, _ := testutils.GetHelpersFromKubeconfig(ctx, kubeConfig)
-		user, nonAdminClient = setupNonAdminUserForTests(ctx, vimClient, sshCommandRunner, vmSvcClusterProxy.GetClient(), vmSvcClusterProxy)
+		user, nonAdminClient = setupNonAdminUserForTests(ctx, vimClient, vmSvcClusterProxy)
 
 		inventoryFolderName := fmt.Sprintf("%s-%s-%s", vmPubSpecName, "folder", capiutil.RandomString(4))
 		inventoryCLName = fmt.Sprintf("%s-%s-%s", vmPubSpecName, "content-library", capiutil.RandomString(4))

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_publishrequest.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_publishrequest.go
@@ -30,7 +30,6 @@ import (
 	imgregv1a2 "github.com/vmware-tanzu/vm-operator/external/image-registry-operator/api/v1alpha2"
 	pkgconst "github.com/vmware-tanzu/vm-operator/pkg/constants"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/framework"
-	libssh "github.com/vmware-tanzu/vm-operator/test/e2e/infrastructure/vsphere/ssh"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/infrastructure/vsphere/testbed"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/infrastructure/vsphere/vcenter"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/infrastructure/vsphere/wcp"
@@ -366,7 +365,6 @@ func VMPublishRequestSpec(ctx context.Context, inputGetter func() VMPublishReque
 				inventoryFolder *object.Folder
 				inventoryCL     *imgregv1a2.ContentLibrary
 
-				user           *vcenter.User
 				nonAdminClient ctrlclient.Client
 			)
 
@@ -386,13 +384,12 @@ func VMPublishRequestSpec(ctx context.Context, inputGetter func() VMPublishReque
 				)
 				Expect(err).NotTo(HaveOccurred())
 
-				sshCommandRunner, _, _ := testutils.GetHelpersFromKubeconfig(ctx, kubeConfig)
-				user, nonAdminClient = setupNonAdminUserForTests(ctx, vimClient, sshCommandRunner, svClusterClient, clusterProxy)
-			})
-
-			AfterAll(func() {
-				By("Deleting non admin user")
-				vcenter.DeleteUserOrFail(user)
+				var user *vcenter.User
+				user, nonAdminClient = setupNonAdminUserForTests(ctx, vimClient, clusterProxy)
+				DeferCleanup(func() {
+					By("Deleting non admin user")
+					vcenter.DeleteUserOrFail(user)
+				})
 			})
 
 			BeforeEach(func() {
@@ -770,21 +767,22 @@ func validateContentLibraryV2(ctx context.Context, svClusterClient ctrlclient.Cl
 	}).WithTimeout(5 * time.Minute).Should(Succeed())
 }
 
-func setupNonAdminUserForTests(ctx context.Context, vimClient *vim25.Client, sshCommandRunner libssh.SSHCommandRunner, _ ctrlclient.Client, svClusterProxy *common.VMServiceClusterProxy) (*vcenter.User, ctrlclient.Client) {
-	By("Creating non-admin user and assign it to SupervisorProviderAdministrators group")
+func setupNonAdminUserForTests(
+	ctx context.Context,
+	vimClient *vim25.Client,
+	svClusterProxy *common.VMServiceClusterProxy) (*vcenter.User, ctrlclient.Client) {
 
-	user, err := vcenter.CreateUserAndAssignToGrp(ctx, vimClient, sshCommandRunner, "gce2e-test-user", "Admin!23Admin", "SupervisorProviderAdministrators")
+	By("Creating non-admin user and assign it to SupervisorProviderAdministrators group")
+	sshCommandRunner, _, supervisorClusterIP := testutils.GetHelpersFromKubeconfig(ctx, svClusterProxy.GetKubeconfigPath())
+
+	username := "gce2e-test-user-" + capiutil.RandomString(4)
+	user, err := vcenter.CreateUserAndAssignToGrp(ctx, vimClient, sshCommandRunner, username, "Admin!23Admin", "SupervisorProviderAdministrators")
 	Expect(err).ToNot(HaveOccurred())
 
-	svClusterKubeConfig := svClusterProxy.GetKubeconfigPath()
-	_, _, supervisorClusterIP := testutils.GetHelpersFromKubeconfig(ctx, svClusterKubeConfig)
-
 	By("Logging in as non-admin user in supervisor")
-
 	kubectlPlugin := testutils.LoginWithUserWithRetry(user, supervisorClusterIP, "", "")
 
 	By("Creating a k8s client from the non-admin user kubeconfig")
-
 	restCfg, err := clientcmd.BuildConfigFromFlags("", kubectlPlugin.KubeconfigPath())
 	Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

Give each VirtualMachinePublishRequest/VirtualMachineGroupPublishRequest E2E run its own SSO test user (gce2e-test-user-<random>) instead of a fixed name, avoiding collisions between concurrent or overlapping test runs against the same vCenter.

Also simplify setupNonAdminUserForTests to derive the kubeconfig and SSH command runner from the cluster proxy it already receives, drop the now-unused sshCommandRunner/svClusterClient parameters, and switch non-admin user cleanup from AfterAll to DeferCleanup so it runs immediately after the block that creates the user.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

```
  Testing VM Services VIRTUAL-MACHINE VM-PUBLISH-REQUEST VirtualMachinePublishRequest                                                                                                                                                                                                                                                                                                               
    Inventory Content Library should publish the VM to an inventory library, deploy from                                                                                                                                                                                                                                                                                                            
    the published image, and reject a duplicate publish [devops, viadmin, virtualmachine, vmservice, smoke]                                                                                                                                                                                                                                                                                         
  ..../vm_publishrequest.go:456                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                                                                                    
    STEP: Creating non-admin user and assign it to SupervisorProviderAdministrators group @ 15:42:13.656                                                                                                                                                                                                                                                                                            
    STEP: Logging in as non-admin user in supervisor @ 15:44:05.319                                                                                                                                                                                                                                                                                                                                 
    STEP: logging in as the user @ 15:44:05.319                                                                                                                                                                                                                                                                                                                                                     
    STEP: Creating a k8s client from the non-admin user kubeconfig @ 15:44:11.493                                                                                                                                                                                                                                                                                                                   
    STEP: Checking if non-admin user kubeconfig is able to do basic operations @ 15:44:11.494                                                                                                                                                                                                                                                                                                       
    STEP: Creating library folder @ 15:44:11.856                                                                                                                                                                                                                                                                                                                                                    
    STEP: Creating an inventory content library @ 15:44:12.08                                                                                                                                                                                                                                                                                                                                       
  virtualmachinepublishrequest.vmoperator.vmware.com/vm-publish-4uvj created                                                                                                                                                                                                                                                                                                                        
  virtualmachine.vmoperator.vmware.com/vm-publish-vm-b8v5 created                                                                                                                                                                                                                                                                                                                                   
    STEP: Verify that a single VirtualMachine 'vmsvc-e2e-kr02si/vm-publish-vm-b8v5' is created                                                                                                                                                                                                                                                                                                      
    STEP: Waiting for vSphere VM to be created                                                                                                                                                                                                                                                                                                                                                      
    STEP: Waiting for VM power state to reach PoweredOn                                                                                                                                                                                                                                                                                                                                             
    STEP: Verify that an IP (ipv4) is allocated to the VirtualMachine 'vmsvc-e2e-kr02si/vm-publish-vm-b8v5'                                                                                                                                                                                                                                                                                         
  virtualmachinepublishrequest.vmoperator.vmware.com/vm-publish-cx2n created   # the duplicate publish, correctly rejected                                                                                                                                                                                                                                                                          
    STEP: Deleting non admin user @ 15:47:12.841                                                                                                                                                                                                                                                                                                                                                    
  • [308.651 seconds]                                                                                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                                                    
  Ran 1 of 182 Specs in 458.058 seconds                                                                                                                                                                                                                                                                                                                                                             
  SUCCESS! -- 1 Passed | 0 Failed | 7 Pending | 174 Skipped                                                                                                                                                                                                                                                                                                                                         
  PASS                                                                                                                                                                                                                                                                                                                                                                                              
...

...

  STEP: create a vm group publish with target inventory library should succeed @ 08/13/26 16:42:39.894
  STEP: Creating non-admin user and assign it to SupervisorProviderAdministrators group @ 08/13/26 16:42:40.264
Running command /usr/lib/vmware-vmafd/bin/dir-cli user find-by-name --account 'gce2e-test-user-3olp' --login 'Administrator@vsphere.local' --password '****'
  ... output: dir-cli failed. Error 1317: Operation failed with error ERROR_NO_SUCH_USER (1317)
Running command /usr/lib/vmware-vmafd/bin/dir-cli user create --account 'gce2e-test-user-3olp' --user-password '****' --first-name 'gce2e-test-user-3olp First name' --last-name 'gce2e-test-user-3olp Last name' --login 'Administrator@vsphere.local' --password '****'
  ... output: User account [gce2e-test-user-3olp] created successfully
Command output: User account [gce2e-test-user-3olp] created successfully

  STEP: Logging in as non-admin user in supervisor @ 08/13/26 16:44:58.183
  STEP: logging in as the user @ 08/13/26 16:44:58.183
  STEP: Creating a k8s client from the non-admin user kubeconfig @ 08/13/26 16:45:10.559
  STEP: Checking if non-admin user kubeconfig is able to do basic operations @ 08/13/26 16:45:10.56
  STEP: Creating library folder @ 08/13/26 16:45:10.989
  STEP: Creating an inventory content library @ 08/13/26 16:45:11.29
  I0813 16:45:11.662865   12015 util.go:1293] Create VirtualMachineGroupPublishRequest:
  I0813 16:45:12.374397   12015 vmoperator.go:720] VirtualMachineGroupPublishRequest vm-group-publish-lcq9-inventory Conditions:  [{Complete False 0 2026-08-13 16:45:12 -0500 CDT VirtualMachinePublishRequestsPending waiting 1 more vm publish requests to be completed}]
  I0813 16:46:33.683368   12015 vmoperator.go:720] VirtualMachineGroupPublishRequest vm-group-publish-lcq9-inventory Conditions:  [{Complete True 0 2026-08-13 16:46:29 -0500 CDT True }]
  STEP: set spec.TTLSecondsAfterFinished should delete the vm group publish request after TTL @ 08/13/26
  STEP: Deleting non admin user @ 08/13/26 16:46:34.605
Running command /usr/lib/vmware-vmafd/bin/dir-cli user find-by-name --account 'gce2e-test-user-3olp' --login 'Administrator@vsphere.local' --password '****'
  ... output: Account: gce2e-test-user-3olp
  UPN: gce2e-test-user-3olp@VSPHERE.LOCAL
Running command /usr/lib/vmware-vmafd/bin/dir-cli user delete --account 'gce2e-test-user-3olp' --login 'Administrator@vsphere.local' --password '****'
  ... output: User account [gce2e-test-user-3olp] deleted successfully

Ran 1 of 182 Specs in 687.676 seconds
SUCCESS! -- 1 Passed | 0 Failed | 7 Pending | 174 Skipped
PASS

```

UTS smoke

**Please add a release note if necessary**:

```release-note
NONE
```