### PR TITLE
:sparkles: Add community and governance docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,127 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in the VM Operator project and our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at oss-coc@vmware.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,26 @@
 # Contributing to VM Operator
 
-It's still early days for VM Operator, but we would love to connect with people who are as passionate about Kubernetes and Virtual Machines as we are!
+We would love to connect with people who are as passionate about Kubernetes and Virtual Machines as we are!
 
 Please raise issues and feel free to open PRs.
 
 Any suggestions on usability, readability, clarity or architecture are all welcome.
 
-We will be building out the roadmap and starting a weekly design meeting soon!
+## Get involved
+
+- Join the [vm-operator-dev](https://groups.google.com/g/vm-operator-dev) mailing list for announcements and discussion.
+- Find us on Slack at [#ug-vmware](https://kubernetes.slack.com/messages/ug-vmware).
+- Attend a community meeting: see the [public calendar](https://calendar.google.com/calendar/embed?src=a71d7f1058d04da71b6209546308c54d9988ae4357812fa91188eed393d57618%40group.calendar.google.com&ctz=America%2FLos_Angeles) for the schedule and join via [Google Meet](http://meet.google.com/eoa-zodx-stt).
+- Review past discussion topics and meeting notes in the [community doc](https://docs.google.com/document/d/1MfTX2_F7rgtr_e55S5emv-OSmhenJhFMpdYqSIyED2w/edit?tab=t.0).
+
+## Project governance
+
+This project is governed as described in [GOVERNANCE.md](GOVERNANCE.md). The current maintainers are listed in [MAINTAINERS.md](MAINTAINERS.md).
+
+## Reporting security issues
+
+Please do not report security vulnerabilities through public GitHub issues. See [SECURITY.md](SECURITY.md) for how to report them responsibly.
+
+## Code of conduct
+
+Participation in this project is governed by the [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,57 @@
+# VM Operator Governance
+
+This document defines the project governance for VM Operator.
+
+## Overview
+
+VM Operator is committed to building an open, inclusive, productive, and self-governing open source community focused on enabling the management of virtual machines on Kubernetes. The community is governed by this document, with the goal of defining how community members can contribute and how decisions are made.
+
+## Code of Conduct
+
+VM Operator follows the [Code of Conduct](CODE_OF_CONDUCT.md), which all community members, maintainers, and contributors must adhere to.
+
+## Community Roles
+
+* **Users**: everyone who interacts with the project, e.g. via the mailing list, community meetings, issues, or discussions.
+* **Contributors**: anyone who contributes to the project, including code, documentation, tests, issues, or discussions.
+* **Maintainers**: contributors who have write access to the repository and are listed in [MAINTAINERS.md](MAINTAINERS.md). Maintainers are responsible for the overall health and direction of the project.
+
+## Decision Making
+
+VM Operator uses a **lazy consensus** model for day-to-day decisions:
+
+* Anyone can propose a change by opening a pull request or issue.
+* A pull request may be merged once it has approval from at least one maintainer and no maintainer has raised an unresolved objection.
+* Substantial changes (new APIs, breaking changes, or changes to project governance) should be raised as a proposal (issue or design doc linked from an issue) and discussed in a community meeting or the mailing list before implementation, per the Spec-Driven Development workflow described in `.sdd/`.
+* If consensus cannot be reached through discussion, a supermajority vote of maintainers decides the matter.
+
+## Becoming a Maintainer
+
+To become a maintainer, a contributor should:
+
+1. Have a sustained history of quality contributions (code, reviews, documentation, or community support) over a meaningful period of time.
+2. Demonstrate good judgment in code review and design discussion.
+3. Be nominated by an existing maintainer, with the nomination sent to the [mailing list](https://groups.google.com/g/vm-operator-dev) or raised in a community meeting.
+4. Receive no objections from existing maintainers within one week, or be approved by a supermajority vote of existing maintainers if an objection is raised.
+
+New maintainers are added to [MAINTAINERS.md](MAINTAINERS.md) and [CODEOWNERS](CODEOWNERS).
+
+## Removing a Maintainer
+
+Maintainers may step down at any time by opening a pull request removing themselves from [MAINTAINERS.md](MAINTAINERS.md) and [CODEOWNERS](CODEOWNERS).
+
+Maintainers who are inactive for an extended period (e.g. no reviews, commits, or community participation for six months) or who violate the [Code of Conduct](CODE_OF_CONDUCT.md) may be removed by a supermajority vote of the remaining maintainers.
+
+## Community Meetings
+
+The project holds regular community meetings, open to anyone. See the [public calendar](https://calendar.google.com/calendar/embed?src=a71d7f1058d04da71b6209546308c54d9988ae4357812fa91188eed393d57618%40group.calendar.google.com&ctz=America%2FLos_Angeles) for the schedule and join via [Google Meet](http://meet.google.com/eoa-zodx-stt). Agendas and notes are kept in the [community doc](https://docs.google.com/document/d/1MfTX2_F7rgtr_e55S5emv-OSmhenJhFMpdYqSIyED2w/edit?tab=t.0).
+
+## Communication Channels
+
+* Mailing list: [vm-operator-dev](https://groups.google.com/g/vm-operator-dev)
+* Slack: [#ug-vmware](https://kubernetes.slack.com/messages/ug-vmware)
+* Issues and pull requests: [GitHub](https://github.com/vmware-tanzu/vm-operator)
+
+## Amendments
+
+Changes to this governance document require approval from a supermajority of maintainers and should be discussed in a community meeting or on the mailing list before merging.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,14 @@
+# Maintainers
+
+This file lists the maintainers of the VM Operator project, in alphabetical order by GitHub handle. See [GOVERNANCE.md](GOVERNANCE.md) for what maintainers do and how this list changes.
+
+|GitHub handle                             |Organization|
+|------------------------------------------|------------|
+|[@akutz](https://github.com/akutz)        |Broadcom    |
+|[@aruneshpa](https://github.com/aruneshpa)|Broadcom    |
+|[@bryanv](https://github.com/bryanv)      |Broadcom    |
+
+
+## Becoming a maintainer
+
+See the maintainer nomination process in [GOVERNANCE.md](GOVERNANCE.md#becoming-a-maintainer).

--- a/README.md
+++ b/README.md
@@ -10,5 +10,7 @@ Please see the [documentation](https://vm-operator.rtfd.io) for more information
 
 ## Community
 - Find us on Slack at [#ug-vmware](https://kubernetes.slack.com/messages/ug-vmware)
-- Regular working group [meetings](https://docs.google.com/document/d/1B2oUAuNbYc8nXjRrN353Pt-mDPtwyLrBO3cok7BfV4s/edit?usp=sharing)
-- Reach out directly via VMware liaison [Ellen Mei](mailto:meie@vmware.com)
+- Join the [vm-operator-dev](https://groups.google.com/g/vm-operator-dev) mailing list for announcements and discussion
+- Community meetings are held regularly; see the [public calendar](https://calendar.google.com/calendar/embed?src=a71d7f1058d04da71b6209546308c54d9988ae4357812fa91188eed393d57618%40group.calendar.google.com&ctz=America%2FLos_Angeles) for the schedule and join via [Google Meet](http://meet.google.com/eoa-zodx-stt)
+- Meeting notes and discussion topics are tracked in the [community doc](https://docs.google.com/document/d/1MfTX2_F7rgtr_e55S5emv-OSmhenJhFMpdYqSIyED2w/edit?tab=t.0)
+- See [GOVERNANCE.md](GOVERNANCE.md) for how the project is governed and [MAINTAINERS.md](MAINTAINERS.md) for the current maintainers

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+The VM Operator maintainers take security issues seriously. We appreciate your efforts to responsibly disclose your findings.
+
+**Please do not report security vulnerabilities through public GitHub issues, discussions, or pull requests.**
+
+To report a vulnerability, please use one of the following private channels:
+
+* [GitHub Security Advisories](https://github.com/vmware-tanzu/vm-operator/security/advisories/new) for this repository (preferred). This creates a private discussion with maintainers and lets us coordinate a fix before public disclosure.
+
+Please include as much of the following as you can in your report:
+
+* A description of the vulnerability and its potential impact.
+* Steps to reproduce, or a proof-of-concept.
+* The affected version(s) or commit(s).
+* Any known mitigations.
+
+## Response
+
+Maintainers will acknowledge your report, investigate, and work with you on a coordinated disclosure timeline. We will credit reporters in the resulting advisory unless anonymity is requested.
+
+
+## Supported Versions
+
+VM Operator does not yet publish a formal support matrix. Security fixes are applied to the `main` branch; see the project's [releases](https://github.com/vmware-tanzu/vm-operator/releases) for available versions.


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Add GOVERNANCE.md, MAINTAINERS.md, and SECURITY.md, and update README.md and CONTRIBUTING.md, to establish the contributor and community-facing resources.

- GOVERNANCE.md documents the lazy-consensus decision model and the maintainer nomination/removal process.
- MAINTAINERS.md lists current maintainers.
- SECURITY.md defines a private vulnerability disclosure process via GitHub Security Advisories.
- README.md and CONTRIBUTING.md link the public community calendar, Google Meet, community notes doc, and vm-operator-dev mailing list, and point to the new governance/maintainers/security docs. The existing Slack channel reference is left unchanged.


**Please add a release note if necessary**:

```release-note
NONE
```