### PR TITLE
Fix vm-location E2E permission scoping and namespace lookup

### DIFF
--- a/test/e2e/infrastructure/vsphere/vcenter/roles.go
+++ b/test/e2e/infrastructure/vsphere/vcenter/roles.go
@@ -5,9 +5,11 @@ package vcenter
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net/url"
+	"slices"
 
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/ssoadmin"
@@ -77,35 +79,128 @@ func UpdateRole(ctx context.Context, vimClient *vim25.Client, roleID int32, role
 	return nil
 }
 
-// MergePrivileges returns the union of the given privilege lists, in the base
-// list's order followed by any privileges from extra not already present.
-func MergePrivileges(base []string, extra []string) []string {
-	have := make(map[string]struct{}, len(base))
-	for _, p := range base {
-		have[p] = struct{}{}
+// EnsureRolePrivileges makes sure the role with the given id grants at least the specified
+// privileges, without removing any privileges it already has. It is a no-op if the role
+// already grants every requested privilege.
+func EnsureRolePrivileges(ctx context.Context, vimClient *vim25.Client, roleID int32, privilegeIDs []string) error {
+	authzManager := object.NewAuthorizationManager(vimClient)
+
+	roleList, err := authzManager.RoleList(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list roles: %w", err)
 	}
 
-	merged := append([]string{}, base...)
-	for _, p := range extra {
-		if _, ok := have[p]; !ok {
+	role := roleList.ById(roleID)
+	if role == nil {
+		return fmt.Errorf("role %d not found", roleID)
+	}
+
+	merged := slices.Clone(role.Privilege)
+	for _, p := range privilegeIDs {
+		if !slices.Contains(merged, p) {
 			merged = append(merged, p)
-			have[p] = struct{}{}
 		}
 	}
 
-	return merged
+	if len(merged) == len(role.Privilege) {
+		return nil
+	}
+
+	if err := authzManager.UpdateRole(ctx, roleID, role.Name, merged); err != nil {
+		return fmt.Errorf("failed to update role %d (%s): %w", roleID, role.Name, err)
+	}
+
+	return nil
 }
 
-// SwapEntityPermissionRole finds the entity permission that currently grants fromRoleID and
+// GrantExtraPrivileges grants extraPrivileges, on top of the privileges the role named
+// baseRoleName already carries, to whichever principal currently holds baseRoleName on each
+// of the given entities.
+//
+// WCP pins roles such as VM-Service-VM-Management directly onto the objects it manages, and
+// that grant overrides whatever role those principals inherit from higher up the inventory.
+// Mutating the pinned role in place would affect every object it is granted on across the
+// whole vCenter, so this creates a role named tempRoleName and swaps it in for baseRoleName
+// on just the given entities instead.
+//
+// The temporary role starts as an exact clone of baseRoleName and only gains extraPrivileges
+// once every entity has been swapped over: vCenter refuses to grant a role carrying
+// privileges the acting principal does not already hold on that same entity, whereas editing
+// a role's definition afterwards is not subject to that check and takes effect on every
+// entity at once. Passing all the entities to a single call is therefore required -- granting
+// them across two calls would fail the check on the entities of the second call.
+//
+// The returned restore func reverts every swap and removes the temporary role. It is always
+// non-nil, including on error so that partial work can be unwound, so register it before
+// inspecting err. Callers must invoke it -- e.g. via DeferCleanup -- while their vCenter
+// session is still authenticated.
+func GrantExtraPrivileges(
+	ctx context.Context,
+	vimClient *vim25.Client,
+	baseRoleName, tempRoleName string,
+	extraPrivileges []string,
+	entities ...types.ManagedObjectReference,
+) (restore func(context.Context) error, err error) {
+	authzManager := object.NewAuthorizationManager(vimClient)
+
+	// A single RoleList serves both lookups below.
+	roleList, err := authzManager.RoleList(ctx)
+	if err != nil {
+		return func(context.Context) error { return nil }, fmt.Errorf("failed to list roles: %w", err)
+	}
+
+	baseRole := roleList.ByName(baseRoleName)
+	if baseRole == nil {
+		return func(context.Context) error { return nil }, fmt.Errorf("role %q not found", baseRoleName)
+	}
+
+	var tempRoleID int32
+	if existing := roleList.ByName(tempRoleName); existing != nil {
+		// Left behind by an interrupted run; reset it to the clone state.
+		tempRoleID = existing.RoleId
+		if err := authzManager.UpdateRole(ctx, tempRoleID, tempRoleName, baseRole.Privilege); err != nil {
+			return func(context.Context) error { return nil },
+				fmt.Errorf("failed to reset role %q: %w", tempRoleName, err)
+		}
+	} else if tempRoleID, err = authzManager.AddRole(ctx, tempRoleName, baseRole.Privilege); err != nil {
+		return func(context.Context) error { return nil },
+			fmt.Errorf("failed to create role %q: %w", tempRoleName, err)
+	}
+
+	var undos []func(context.Context) error
+	restore = func(ctx context.Context) error {
+		errs := make([]error, 0, len(undos)+1)
+		for _, undo := range undos {
+			errs = append(errs, undo(ctx))
+		}
+		errs = append(errs, RemoveRole(ctx, vimClient, tempRoleID))
+		return errors.Join(errs...)
+	}
+
+	for _, entity := range entities {
+		undo, err := swapEntityPermissionRole(ctx, vimClient, entity, baseRole.RoleId, tempRoleID)
+		if err != nil {
+			return restore, err
+		}
+		undos = append(undos, undo)
+	}
+
+	if err := EnsureRolePrivileges(ctx, vimClient, tempRoleID, extraPrivileges); err != nil {
+		return restore, fmt.Errorf("failed to add privileges to role %q: %w", tempRoleName, err)
+	}
+
+	return restore, nil
+}
+
+// swapEntityPermissionRole finds the entity permission that currently grants fromRoleID and
 // re-points it at toRoleID, leaving the principal, group, and propagate settings unchanged.
-// It returns a restore function that reverts the entity's permission back to fromRoleID;
-// callers must invoke it (e.g. via DeferCleanup) once toRoleID is no longer needed.
-func SwapEntityPermissionRole(
+// It returns a func that reverts the entity's permission back to fromRoleID.
+func swapEntityPermissionRole(
 	ctx context.Context,
 	vimClient *vim25.Client,
 	entity types.ManagedObjectReference,
 	fromRoleID, toRoleID int32,
-) (restore func(context.Context) error, err error) {
+) (func(context.Context) error, error) {
 	authzManager := object.NewAuthorizationManager(vimClient)
 
 	perms, err := authzManager.RetrieveEntityPermissions(ctx, entity, false)
@@ -113,18 +208,12 @@ func SwapEntityPermissionRole(
 		return nil, fmt.Errorf("failed to retrieve permissions on %s %s: %w", entity.Type, entity.Value, err)
 	}
 
-	idx := -1
-	for i := range perms {
-		if perms[i].RoleId == fromRoleID {
-			idx = i
-			break
-		}
-	}
-	if idx == -1 {
+	i := slices.IndexFunc(perms, func(p types.Permission) bool { return p.RoleId == fromRoleID })
+	if i < 0 {
 		return nil, fmt.Errorf("no permission granting role %d found on %s %s", fromRoleID, entity.Type, entity.Value)
 	}
 
-	original := perms[idx]
+	original := perms[i]
 	swapped := original
 	swapped.RoleId = toRoleID
 
@@ -132,11 +221,9 @@ func SwapEntityPermissionRole(
 		return nil, fmt.Errorf("failed to set role %d on %s %s: %w", toRoleID, entity.Type, entity.Value, err)
 	}
 
-	restore = func(ctx context.Context) error {
+	return func(ctx context.Context) error {
 		return authzManager.SetEntityPermissions(ctx, entity, []types.Permission{original})
-	}
-
-	return restore, nil
+	}, nil
 }
 
 // RemoveRole removes the role with specified id in VC.

--- a/test/e2e/infrastructure/vsphere/vcenter/roles.go
+++ b/test/e2e/infrastructure/vsphere/vcenter/roles.go
@@ -77,45 +77,66 @@ func UpdateRole(ctx context.Context, vimClient *vim25.Client, roleID int32, role
 	return nil
 }
 
-// EnsureRolePrivileges makes sure the role with the given id grants at least the specified
-// privileges, without removing any privileges it already has. It is a no-op if the role
-// already grants every requested privilege.
-func EnsureRolePrivileges(ctx context.Context, vimClient *vim25.Client, roleID int32, privilegeIDs []string) error {
-	authzManager := object.NewAuthorizationManager(vimClient)
-
-	roleList, err := authzManager.RoleList(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to list roles: %w", err)
-	}
-
-	role := roleList.ById(roleID)
-	if role == nil {
-		return fmt.Errorf("role %d not found", roleID)
-	}
-
-	have := make(map[string]struct{}, len(role.Privilege))
-	for _, p := range role.Privilege {
+// MergePrivileges returns the union of the given privilege lists, in the base
+// list's order followed by any privileges from extra not already present.
+func MergePrivileges(base []string, extra []string) []string {
+	have := make(map[string]struct{}, len(base))
+	for _, p := range base {
 		have[p] = struct{}{}
 	}
 
-	merged := role.Privilege
-	changed := false
-	for _, p := range privilegeIDs {
+	merged := append([]string{}, base...)
+	for _, p := range extra {
 		if _, ok := have[p]; !ok {
 			merged = append(merged, p)
-			changed = true
+			have[p] = struct{}{}
 		}
 	}
 
-	if !changed {
-		return nil
+	return merged
+}
+
+// SwapEntityPermissionRole finds the entity permission that currently grants fromRoleID and
+// re-points it at toRoleID, leaving the principal, group, and propagate settings unchanged.
+// It returns a restore function that reverts the entity's permission back to fromRoleID;
+// callers must invoke it (e.g. via DeferCleanup) once toRoleID is no longer needed.
+func SwapEntityPermissionRole(
+	ctx context.Context,
+	vimClient *vim25.Client,
+	entity types.ManagedObjectReference,
+	fromRoleID, toRoleID int32,
+) (restore func(context.Context) error, err error) {
+	authzManager := object.NewAuthorizationManager(vimClient)
+
+	perms, err := authzManager.RetrieveEntityPermissions(ctx, entity, false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve permissions on %s %s: %w", entity.Type, entity.Value, err)
 	}
 
-	if err := authzManager.UpdateRole(ctx, roleID, role.Name, merged); err != nil {
-		return fmt.Errorf("failed to update role %d (%s): %w", roleID, role.Name, err)
+	idx := -1
+	for i := range perms {
+		if perms[i].RoleId == fromRoleID {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		return nil, fmt.Errorf("no permission granting role %d found on %s %s", fromRoleID, entity.Type, entity.Value)
 	}
 
-	return nil
+	original := perms[idx]
+	swapped := original
+	swapped.RoleId = toRoleID
+
+	if err := authzManager.SetEntityPermissions(ctx, entity, []types.Permission{swapped}); err != nil {
+		return nil, fmt.Errorf("failed to set role %d on %s %s: %w", toRoleID, entity.Type, entity.Value, err)
+	}
+
+	restore = func(ctx context.Context) error {
+		return authzManager.SetEntityPermissions(ctx, entity, []types.Permission{original})
+	}
+
+	return restore, nil
 }
 
 // RemoveRole removes the role with specified id in VC.

--- a/test/e2e/infrastructure/vsphere/vcenter/roles.go
+++ b/test/e2e/infrastructure/vsphere/vcenter/roles.go
@@ -100,9 +100,8 @@ func GrantExtraPrivileges(
 		return noop, fmt.Errorf("role %q not found", baseRoleName)
 	}
 
-	// CreateOrUpdateRole resets tempRoleName to exactly baseRole's current privileges whether
-	// it is being created for the first time or left behind, possibly stale, by an interrupted
-	// run.
+	// CreateOrUpdateRole resets tempRoleName to exactly baseRole's current privileges,
+	// whether newly created or left stale by an interrupted run.
 	tempRoleID, err := CreateOrUpdateRole(ctx, vimClient, tempRoleName, baseRole.Privilege)
 	if err != nil {
 		return noop, fmt.Errorf("failed to create %q role: %w", tempRoleName, err)
@@ -114,7 +113,10 @@ func GrantExtraPrivileges(
 		for _, undo := range undos {
 			errs = append(errs, undo(ctx))
 		}
-		errs = append(errs, RemoveRole(ctx, vimClient, tempRoleID))
+		// failIfUsed=true: if an undo above failed, the permission still points at
+		// tempRoleID, and failIfUsed=false would have VC delete that permission along
+		// with the role -- erasing WCP's real grant instead of just leaking a temp role.
+		errs = append(errs, RemoveRole(ctx, vimClient, tempRoleID, true))
 		return errors.Join(errs...)
 	}
 
@@ -143,9 +145,9 @@ func GrantExtraPrivileges(
 	return restore, nil
 }
 
-// swapEntityPermissionRole finds the entity permission that currently grants fromRoleID and
-// re-points it at toRoleID, leaving the principal, group, and propagate settings unchanged.
-// It returns a func that reverts the entity's permission back to fromRoleID.
+// swapEntityPermissionRole finds the entity permissions that currently grant fromRoleID and
+// re-points them at toRoleID, leaving the principal, group, and propagate settings unchanged.
+// It returns a func that reverts those permissions back to fromRoleID.
 func swapEntityPermissionRole(
 	ctx context.Context,
 	vimClient *vim25.Client,
@@ -159,29 +161,45 @@ func swapEntityPermissionRole(
 		return nil, fmt.Errorf("failed to retrieve permissions on %s %s: %w", entity.Type, entity.Value, err)
 	}
 
-	i := slices.IndexFunc(perms, func(p types.Permission) bool { return p.RoleId == fromRoleID })
-	if i < 0 {
+	// Every permission granting fromRoleID is swapped, not just the first: WCP typically
+	// grants the role to a group, so the test account may reach the entity through any one
+	// of several group permissions. A permission already on toRoleID is a leftover from a
+	// run interrupted mid-swap; treat it as originally fromRoleID so the undo below still
+	// restores the pre-interruption state.
+	var originals, swapped []types.Permission
+	for _, p := range perms {
+		if p.RoleId != fromRoleID && p.RoleId != toRoleID {
+			continue
+		}
+
+		original := p
+		original.RoleId = fromRoleID
+		originals = append(originals, original)
+
+		s := p
+		s.RoleId = toRoleID
+		swapped = append(swapped, s)
+	}
+	if len(originals) == 0 {
 		return nil, fmt.Errorf("no permission granting role %d found on %s %s", fromRoleID, entity.Type, entity.Value)
 	}
 
-	original := perms[i]
-	swapped := original
-	swapped.RoleId = toRoleID
-
-	if err := authzManager.SetEntityPermissions(ctx, entity, []types.Permission{swapped}); err != nil {
+	if err := authzManager.SetEntityPermissions(ctx, entity, swapped); err != nil {
 		return nil, fmt.Errorf("failed to set role %d on %s %s: %w", toRoleID, entity.Type, entity.Value, err)
 	}
 
 	return func(ctx context.Context) error {
-		return authzManager.SetEntityPermissions(ctx, entity, []types.Permission{original})
+		return authzManager.SetEntityPermissions(ctx, entity, originals)
 	}, nil
 }
 
-// RemoveRole removes the role with specified id in VC.
-func RemoveRole(ctx context.Context, vimClient *vim25.Client, roleID int32) error {
+// RemoveRole removes the role with specified id in VC. When failIfUsed is true VC
+// rejects the removal if any permission still references the role; when false VC
+// deletes every permission that references it.
+func RemoveRole(ctx context.Context, vimClient *vim25.Client, roleID int32, failIfUsed bool) error {
 	authzManager := object.NewAuthorizationManager(vimClient)
 
-	err := authzManager.RemoveRole(ctx, roleID, false)
+	err := authzManager.RemoveRole(ctx, roleID, failIfUsed)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/infrastructure/vsphere/vcenter/roles.go
+++ b/test/e2e/infrastructure/vsphere/vcenter/roles.go
@@ -79,61 +79,10 @@ func UpdateRole(ctx context.Context, vimClient *vim25.Client, roleID int32, role
 	return nil
 }
 
-// EnsureRolePrivileges makes sure the role with the given id grants at least the specified
-// privileges, without removing any privileges it already has. It is a no-op if the role
-// already grants every requested privilege.
-func EnsureRolePrivileges(ctx context.Context, vimClient *vim25.Client, roleID int32, privilegeIDs []string) error {
-	authzManager := object.NewAuthorizationManager(vimClient)
-
-	roleList, err := authzManager.RoleList(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to list roles: %w", err)
-	}
-
-	role := roleList.ById(roleID)
-	if role == nil {
-		return fmt.Errorf("role %d not found", roleID)
-	}
-
-	merged := slices.Clone(role.Privilege)
-	for _, p := range privilegeIDs {
-		if !slices.Contains(merged, p) {
-			merged = append(merged, p)
-		}
-	}
-
-	if len(merged) == len(role.Privilege) {
-		return nil
-	}
-
-	if err := authzManager.UpdateRole(ctx, roleID, role.Name, merged); err != nil {
-		return fmt.Errorf("failed to update role %d (%s): %w", roleID, role.Name, err)
-	}
-
-	return nil
-}
-
-// GrantExtraPrivileges grants extraPrivileges, on top of the privileges the role named
-// baseRoleName already carries, to whichever principal currently holds baseRoleName on each
-// of the given entities.
-//
-// WCP pins roles such as VM-Service-VM-Management directly onto the objects it manages, and
-// that grant overrides whatever role those principals inherit from higher up the inventory.
-// Mutating the pinned role in place would affect every object it is granted on across the
-// whole vCenter, so this creates a role named tempRoleName and swaps it in for baseRoleName
-// on just the given entities instead.
-//
-// The temporary role starts as an exact clone of baseRoleName and only gains extraPrivileges
-// once every entity has been swapped over: vCenter refuses to grant a role carrying
-// privileges the acting principal does not already hold on that same entity, whereas editing
-// a role's definition afterwards is not subject to that check and takes effect on every
-// entity at once. Passing all the entities to a single call is therefore required -- granting
-// them across two calls would fail the check on the entities of the second call.
-//
-// The returned restore func reverts every swap and removes the temporary role. It is always
-// non-nil, including on error so that partial work can be unwound, so register it before
-// inspecting err. Callers must invoke it -- e.g. via DeferCleanup -- while their vCenter
-// session is still authenticated.
+// GrantExtraPrivileges grants extraPrivileges to whoever holds baseRoleName on each entity,
+// by cloning baseRoleName into tempRoleName, swapping that role onto every entity, then
+// adding extraPrivileges to the clone's definition (unlike SetEntityPermissions, a role edit
+// isn't checked for privilege escalation). restore (always non-nil) undoes everything.
 func GrantExtraPrivileges(
 	ctx context.Context,
 	vimClient *vim25.Client,
@@ -141,30 +90,22 @@ func GrantExtraPrivileges(
 	extraPrivileges []string,
 	entities ...types.ManagedObjectReference,
 ) (restore func(context.Context) error, err error) {
-	authzManager := object.NewAuthorizationManager(vimClient)
+	noop := func(context.Context) error { return nil }
 
-	// A single RoleList serves both lookups below.
-	roleList, err := authzManager.RoleList(ctx)
+	baseRole, err := GetRoleByName(ctx, vimClient, baseRoleName)
 	if err != nil {
-		return func(context.Context) error { return nil }, fmt.Errorf("failed to list roles: %w", err)
+		return noop, fmt.Errorf("failed to look up %q role: %w", baseRoleName, err)
 	}
-
-	baseRole := roleList.ByName(baseRoleName)
 	if baseRole == nil {
-		return func(context.Context) error { return nil }, fmt.Errorf("role %q not found", baseRoleName)
+		return noop, fmt.Errorf("role %q not found", baseRoleName)
 	}
 
-	var tempRoleID int32
-	if existing := roleList.ByName(tempRoleName); existing != nil {
-		// Left behind by an interrupted run; reset it to the clone state.
-		tempRoleID = existing.RoleId
-		if err := authzManager.UpdateRole(ctx, tempRoleID, tempRoleName, baseRole.Privilege); err != nil {
-			return func(context.Context) error { return nil },
-				fmt.Errorf("failed to reset role %q: %w", tempRoleName, err)
-		}
-	} else if tempRoleID, err = authzManager.AddRole(ctx, tempRoleName, baseRole.Privilege); err != nil {
-		return func(context.Context) error { return nil },
-			fmt.Errorf("failed to create role %q: %w", tempRoleName, err)
+	// CreateOrUpdateRole resets tempRoleName to exactly baseRole's current privileges whether
+	// it is being created for the first time or left behind, possibly stale, by an interrupted
+	// run.
+	tempRoleID, err := CreateOrUpdateRole(ctx, vimClient, tempRoleName, baseRole.Privilege)
+	if err != nil {
+		return noop, fmt.Errorf("failed to create %q role: %w", tempRoleName, err)
 	}
 
 	var undos []func(context.Context) error
@@ -185,8 +126,18 @@ func GrantExtraPrivileges(
 		undos = append(undos, undo)
 	}
 
-	if err := EnsureRolePrivileges(ctx, vimClient, tempRoleID, extraPrivileges); err != nil {
-		return restore, fmt.Errorf("failed to add privileges to role %q: %w", tempRoleName, err)
+	// tempRoleName currently holds exactly baseRole.Privilege (see CreateOrUpdateRole above),
+	// so merging against it here -- rather than re-reading the role back -- is sufficient.
+	merged := slices.Clone(baseRole.Privilege)
+	for _, p := range extraPrivileges {
+		if !slices.Contains(merged, p) {
+			merged = append(merged, p)
+		}
+	}
+	if len(merged) != len(baseRole.Privilege) {
+		if err := UpdateRole(ctx, vimClient, tempRoleID, tempRoleName, merged); err != nil {
+			return restore, fmt.Errorf("failed to add privileges to role %q: %w", tempRoleName, err)
+		}
 	}
 
 	return restore, nil

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
@@ -55,14 +55,12 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		specName = "vm-location"
 		vmKind   = "VirtualMachine"
 
-		// vmServiceVMMgmtRoleID is the hardcoded vCenter role ID for the VM-Service-VM-Management role.
-		vmServiceVMMgmtRoleID   = int32(1039)
+		// vmServiceVMMgmtRoleName is the vCenter role WCP grants to the Administrators group
+		// directly on the objects backing a Supervisor Namespace.
 		vmServiceVMMgmtRoleName = "VM-Service-VM-Management"
 
-		// relocateRoleName is a test-scoped role, created fresh for this spec, that grants
-		// the privileges required to relocate a VM between resource pools and folders. It is
-		// swapped in for vmServiceVMMgmtRoleID only on the specific entities under test,
-		// rather than mutating the shared vmServiceVMMgmtRoleName role in place.
+		// relocateRoleName is the test-scoped role that stands in for
+		// vmServiceVMMgmtRoleName on the entities each spec relocates a VM across.
 		relocateRoleName = "VM-Service-VM-Management-E2E-Relocate"
 	)
 
@@ -82,12 +80,8 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		vCenterAdminClient *vim25.Client
 		clusterResources   *e2eConfig.Resources
 
-		vmName                 string
-		linuxVMIName           string
-		relocateRoleID         int32
-		relocateRolePrivileges []string
-		relocateRoleUpgraded   bool
-		permissionRestores     []func(context.Context) error
+		vmName       string
+		linuxVMIName string
 	)
 
 	BeforeEach(func() {
@@ -125,34 +119,12 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		var err error
 		vCenterAdminClient, err = vcenter.NewVimClient(vCenterHostname, testbed.AdminUsername, testbed.AdminPassword)
 		Expect(err).ToNot(HaveOccurred(), "Failed to create vCenter admin client")
-
-		// WCP grants the VM-Service-VM-Management role to the Administrators group directly on the
-		// namespace RP/folder, which overrides the inherited vCenter Administrator role for those
-		// objects. That role does not always include the privileges the specs below need to
-		// relocate a VM between resource pools and move it in/out of the namespace folder.
-		// Rather than mutating the shared role in place, create a dedicated relocate role and
-		// swap it in for just the entities each spec touches; see grantRelocateRole and
-		// upgradeRelocateRole below.
-		//
-		// The role starts as an exact clone of the shared role's current privileges (a set the
-		// Administrators group already effectively holds on those entities), because vCenter
-		// blocks SetEntityPermissions from granting a role containing privileges the acting
-		// principal doesn't already have there -- granting a role with the relocate-only
-		// privileges already mixed in fails with "Permission ... denied" naming exactly those
-		// privileges. Once the clone is granted on every entity the spec needs it on,
-		// upgradeRelocateRole adds the relocate-only privileges to the role's own definition
-		// (a role-definition edit, not a fresh grant), which is not subject to that same-entity
-		// check and takes effect on all of those entities at once.
-		vmMgmtRole, err := vcenter.GetRoleByName(ctx, vCenterAdminClient, vmServiceVMMgmtRoleName)
-		Expect(err).ToNot(HaveOccurred(), "failed to look up %s role", vmServiceVMMgmtRoleName)
-		Expect(vmMgmtRole).ToNot(BeNil(), "%s role not found", vmServiceVMMgmtRoleName)
-
-		permissionRestores = nil
-		relocateRoleUpgraded = false
-		relocateRolePrivileges = vcenter.MergePrivileges(vmMgmtRole.Privilege, relocatePrivileges)
-
-		relocateRoleID, err = vcenter.CreateOrUpdateRole(ctx, vCenterAdminClient, relocateRoleName, vmMgmtRole.Privilege)
-		Expect(err).ToNot(HaveOccurred(), "failed to create %s role", relocateRoleName)
+		// Log out via DeferCleanup rather than AfterEach so that the permission cleanup
+		// registered later by grantRelocatePrivileges, which needs an authenticated session,
+		// runs first under Ginkgo's LIFO ordering.
+		DeferCleanup(func() {
+			vcenter.LogoutVimClient(vCenterAdminClient)
+		})
 
 		linuxImageDisplayName := vmservice.GetDefaultImageDisplayName(clusterResources)
 		linuxVMIName = vmoperator.WaitForVirtualMachineImageName(ctx, &config.Config, svClusterClient, input.WCPNamespaceName, linuxImageDisplayName)
@@ -161,18 +133,6 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 	})
 
 	AfterEach(func() {
-		// Undo the entity permission swaps and remove the temporary relocate role while
-		// vCenterAdminClient's session is still authenticated. DeferCleanup callbacks
-		// registered during BeforeEach/It run after this AfterEach, by which point
-		// LogoutVimClient below would have already invalidated the session.
-		for i := len(permissionRestores) - 1; i >= 0; i-- {
-			Expect(permissionRestores[i](ctx)).To(Succeed(), "failed to restore entity permission")
-		}
-		if relocateRoleID != 0 {
-			Expect(vcenter.RemoveRole(ctx, vCenterAdminClient, relocateRoleID)).To(Succeed(),
-				"failed to remove %s role", relocateRoleName)
-		}
-
 		if CurrentSpecReport().Failed() {
 			vmoperator.DescribeResourceIfExists(
 				ctx, svClusterClient,
@@ -181,7 +141,6 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		}
 
 		vmoperator.VerifyVMDeleted(ctx, svClusterClient, config, input.WCPNamespaceName, vmName)
-		vcenter.LogoutVimClient(vCenterAdminClient)
 	})
 
 	// getNsRPAndFolder returns the namespace RP and folder MoIDs for the given
@@ -292,36 +251,16 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		Expect(task.Wait(ctx)).To(Succeed(), "Relocate task failed for VM %s", vmMoID)
 	}
 
-	// grantRelocateRole swaps the relocate role in for vmServiceVMMgmtRoleID on the given
-	// entity for the remainder of the current spec. The restore function is recorded and
-	// invoked from AfterEach (not DeferCleanup) so it runs while the session is still
-	// authenticated.
-	//
-	// Call this for every entity a spec needs the relocate role on *before* calling
-	// upgradeRelocateRole: the swap only succeeds while the role's definition is still the
-	// base clone (see BeforeEach); upgrading first would make later swaps, onto entities that
-	// haven't been granted yet, fail the same escalation check on those entities.
-	grantRelocateRole := func(entity vimtypes.ManagedObjectReference) {
-		restore, err := vcenter.SwapEntityPermissionRole(ctx, vCenterAdminClient, entity,
-			vmServiceVMMgmtRoleID, relocateRoleID)
-		Expect(err).ToNot(HaveOccurred(),
-			"failed to grant relocate role on %s %s", entity.Type, entity.Value)
-		permissionRestores = append(permissionRestores, restore)
-	}
-
-	// upgradeRelocateRole adds the relocate-only privileges to the relocate role's definition.
-	// Call once, after every grantRelocateRole call for the current spec has completed: this
-	// is a role-definition edit rather than a fresh grant, so it takes effect immediately on
-	// every entity already granted the role, without re-triggering the escalation check that
-	// blocks a grant containing privileges not yet held on that specific entity.
-	upgradeRelocateRole := func() {
-		if relocateRoleUpgraded {
-			return
-		}
-		Expect(vcenter.UpdateRole(ctx, vCenterAdminClient, relocateRoleID, relocateRoleName,
-			relocateRolePrivileges)).To(Succeed(),
-			"failed to add relocate privileges to %s role", relocateRoleName)
-		relocateRoleUpgraded = true
+	// grantRelocatePrivileges gives the test's vCenter account the privileges it needs to
+	// relocate a VM across the given entities, reverting them when the spec ends. WCP pins
+	// vmServiceVMMgmtRoleName onto the objects backing a namespace, which shadows the
+	// inherited vCenter Administrator role there, so those privileges are not otherwise
+	// present. Pass every entity the spec touches in one call -- see GrantExtraPrivileges.
+	grantRelocatePrivileges := func(entities ...vimtypes.ManagedObjectReference) {
+		restore, err := vcenter.GrantExtraPrivileges(ctx, vCenterAdminClient,
+			vmServiceVMMgmtRoleName, relocateRoleName, relocatePrivileges, entities...)
+		DeferCleanup(restore)
+		Expect(err).ToNot(HaveOccurred(), "failed to grant privileges required for VM relocation")
 	}
 
 	When("VM is created in the correct namespace RP and folder", Label("core-functional", "experimental"), func() {
@@ -355,14 +294,13 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 			vmZone := vmoperator.GetVirtualMachineZone(ctx, svClusterClient, input.WCPNamespaceName, vmName)
 			nsRPMoID, nsFolderMoID := getNsRPAndFolder(input.WCPNamespaceName, vmZone)
 
-			By("Granting the relocate role on the namespace RP and folder")
+			By("Granting the privileges required to relocate the VM")
 			// Relocate needs Resource.* on the RP, but vCenter also checks
 			// VirtualMachine.Inventory.Move on the VM's parent folder even when the
-			// relocate spec leaves the folder unchanged -- and WCP pins role 1039 on the
-			// namespace folder too, so inherited Administrator does not cover it there.
-			grantRelocateRole(vimtypes.ManagedObjectReference{Type: "ResourcePool", Value: nsRPMoID})
-			grantRelocateRole(vimtypes.ManagedObjectReference{Type: "Folder", Value: nsFolderMoID})
-			upgradeRelocateRole()
+			// relocate spec leaves the folder unchanged.
+			grantRelocatePrivileges(
+				vimtypes.ManagedObjectReference{Type: "ResourcePool", Value: nsRPMoID},
+				vimtypes.ManagedObjectReference{Type: "Folder", Value: nsFolderMoID})
 
 			By("Retrieving the cluster root RP to use as an invalid location")
 			// 1. Resolve the specific Cluster MoID for the active Supervisor context
@@ -424,9 +362,6 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 			vmZone := vmoperator.GetVirtualMachineZone(ctx, svClusterClient, input.WCPNamespaceName, vmName)
 			_, nsFolderMoID := getNsRPAndFolder(input.WCPNamespaceName, vmZone)
 
-			By("Granting the relocate role on the namespace folder")
-			grantRelocateRole(vimtypes.ManagedObjectReference{Type: "Folder", Value: nsFolderMoID})
-
 			By("Retrieving another Supervisor Namespace's folder as the invalid folder location")
 			// A different namespace's folder always lies outside the 2-level hierarchy
 			// that validateVMFolder checks, so it reliably triggers the LocationMismatch.
@@ -442,9 +377,10 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 				"other namespace's folder unexpectedly equals the namespace folder itself")
 			e2eframework.Logf("invalid folder MoID (folder of namespace %s): %s", otherNamespace, invalidFolderMoID)
 
-			By("Granting the relocate role on the other namespace's folder")
-			grantRelocateRole(vimtypes.ManagedObjectReference{Type: "Folder", Value: invalidFolderMoID})
-			upgradeRelocateRole()
+			By("Granting the privileges required to move the VM between the two folders")
+			grantRelocatePrivileges(
+				vimtypes.ManagedObjectReference{Type: "Folder", Value: nsFolderMoID},
+				vimtypes.ManagedObjectReference{Type: "Folder", Value: invalidFolderMoID})
 
 			By("Moving VM into the other namespace's folder via MoveIntoFolder (direct inventory move)")
 			// Use Folder.MoveInto rather than Relocate.Folder: in WCP, the

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
@@ -29,7 +29,6 @@ import (
 	"github.com/vmware-tanzu/vm-operator/test/e2e/infrastructure/vsphere/vcenter"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/infrastructure/vsphere/wcp"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/manifestbuilders"
-	"github.com/vmware-tanzu/vm-operator/test/e2e/utils"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/common"
 	e2eConfig "github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/config"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/consts"
@@ -82,11 +81,6 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 
 		vmName       string
 		linuxVMIName string
-
-		// workloadDomainIsolationEnabled mirrors the WorkloadDomainIsolation FSS
-		// that topology.GetNamespaceFolderAndRPMoID branches on: Zone when
-		// enabled, AvailabilityZone when not.
-		workloadDomainIsolationEnabled bool
 	)
 
 	BeforeEach(func() {
@@ -118,10 +112,6 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 
 		svClusterClient = clusterProxy.GetClient()
 
-		workloadDomainIsolationEnabled = utils.IsFssEnabled(ctx, svClusterClient,
-			config.GetVariable("VMOPNamespace"), config.GetVariable("VMOPDeploymentName"),
-			config.GetVariable("VMOPManagerCommand"), config.GetVariable("EnvWorkloadIsolation"))
-
 		kubeconfigPath := clusterProxy.GetKubeconfigPath()
 		vCenterHostname := vcenter.GetVCPNIDFromKubeconfigFile(ctx, kubeconfigPath)
 
@@ -152,68 +142,44 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		vmoperator.VerifyVMDeleted(ctx, svClusterClient, config, input.WCPNamespaceName, vmName)
 	})
 
-	// getNsRPAndFolder returns the namespace RP and folder MoIDs for the given zone. It
-	// mirrors the controller's topology.GetNamespaceFolderAndRPMoID, branching on the same
-	// WorkloadDomainIsolation FSS rather than probing for whichever CR exists, since Zone
-	// and AvailabilityZone are never both live on the same cluster. The RP is per-zone, so
-	// zone must match the VM's status.zone or the resolved RP belongs to a different zone.
+	// getNsRPAndFolder returns the namespace RP and folder MoIDs for the given zone, read
+	// from Zone.Spec.ManagedVMs: the same fields topology.GetNamespaceFolderAndRPMoID
+	// returns and reconcileLocation validates the VM against. The AvailabilityZone that
+	// function falls back to when WorkloadDomainIsolation is off is deliberately not
+	// consulted -- this suite already requires namespaced Zones (see
+	// viadmin.VIAdminNamespaceRoleSpec), and an AvailabilityZone records a single namespace
+	// folder with no equivalent of Zone.Spec.ManagedVMs -- so a missing Zone fails the spec
+	// rather than resolving a value the controller would never have used. The RP is
+	// per-zone, so zone must match the VM's status.zone or the resolved RP belongs to a
+	// different zone.
 	getNsRPAndFolder := func(namespace, zone string) (rpMoID, folderMoID string) {
-		if workloadDomainIsolationEnabled {
-			z := &topologyv1.Zone{}
-			Expect(svClusterClient.Get(ctx, ctrlclient.ObjectKey{Namespace: namespace, Name: zone}, z)).
-				To(Succeed(), "failed to get Zone %s/%s", namespace, zone)
-			Expect(z.Spec.ManagedVMs.PoolMoIDs).ToNot(BeEmpty(),
-				"Zone %s/%s has no ManagedVMs.PoolMoIDs", namespace, zone)
-			e2eframework.Logf("resolved namespace RP from Zone %s: %s / %s",
-				z.Name, z.Spec.ManagedVMs.PoolMoIDs[0], z.Spec.ManagedVMs.FolderMoID)
-			return z.Spec.ManagedVMs.PoolMoIDs[0], z.Spec.ManagedVMs.FolderMoID
-		}
-
-		// WorkloadDomainIsolation disabled: the VM's status.zone is the
-		// cluster-scoped AvailabilityZone name.
-		az := &topologyv1.AvailabilityZone{}
-		Expect(svClusterClient.Get(ctx, ctrlclient.ObjectKey{Name: zone}, az)).
-			To(Succeed(), "failed to get AvailabilityZone %s", zone)
-
-		nsInfo, ok := az.Spec.Namespaces[namespace]
-		Expect(ok).To(BeTrue(),
-			"AvailabilityZone %s missing pool info for namespace %s", zone, namespace)
-		poolMoID := azNamespacePoolMoID(nsInfo)
-		Expect(poolMoID).ToNot(BeEmpty(),
-			"AvailabilityZone %s has no pool MoID for namespace %s", zone, namespace)
-		e2eframework.Logf("resolved namespace RP from AvailabilityZone %s: %s / %s",
-			az.Name, poolMoID, nsInfo.FolderMoId)
-		return poolMoID, nsInfo.FolderMoId
+		z := &topologyv1.Zone{}
+		Expect(svClusterClient.Get(ctx, ctrlclient.ObjectKey{Namespace: namespace, Name: zone}, z)).
+			To(Succeed(), "failed to get Zone %s/%s", namespace, zone)
+		Expect(z.Spec.ManagedVMs.PoolMoIDs).ToNot(BeEmpty(),
+			"Zone %s/%s has no ManagedVMs.PoolMoIDs", namespace, zone)
+		e2eframework.Logf("resolved namespace RP from Zone %s: %s / %s",
+			z.Name, z.Spec.ManagedVMs.PoolMoIDs[0], z.Spec.ManagedVMs.FolderMoID)
+		return z.Spec.ManagedVMs.PoolMoIDs[0], z.Spec.ManagedVMs.FolderMoID
 	}
 
-	// getOtherNamespaceFolder returns the folder MoID and name of a Supervisor Namespace other
-	// than the given one. WCP grants the VM-Service-VM-Management role directly on every
-	// namespace's own folder, so a different namespace's folder is a location that is both
-	// outside the given namespace's folder hierarchy and already permitted for the test's
-	// vCenter account -- unlike an arbitrary vCenter folder (e.g. the Datacenter's root VM
-	// folder), which WCP never grants permissions on.
+	// getOtherNamespaceFolder returns the managed-VMs folder MoID and namespace name of a
+	// Supervisor Namespace other than the given one, or ("", "") when the cluster has no
+	// other namespace. Another namespace's folder is the invalid location of choice because
+	// it lies outside the given namespace's folder hierarchy while still carrying a
+	// vmServiceVMMgmtRoleName permission for grantRelocatePrivileges to swap: WCP pins that
+	// role on the namespace folder, which today is the same object as the zone's
+	// Spec.ManagedVMs.FolderMoID. An arbitrary vCenter folder (e.g. the Datacenter's root VM
+	// folder) carries no such permission, so GrantExtraPrivileges would fail outright.
+	// Revisit if managed VMs ever move into a dedicated sub-folder under the namespace
+	// folder.
 	getOtherNamespaceFolder := func(namespace string) (folderMoID, otherNamespace string) {
-		if workloadDomainIsolationEnabled {
-			zoneList := &topologyv1.ZoneList{}
-			Expect(svClusterClient.List(ctx, zoneList)).To(Succeed(), "failed to list Zones")
+		zoneList := &topologyv1.ZoneList{}
+		Expect(svClusterClient.List(ctx, zoneList)).To(Succeed(), "failed to list Zones")
 
-			for _, z := range zoneList.Items {
-				if z.Namespace != namespace && len(z.Spec.ManagedVMs.PoolMoIDs) > 0 {
-					return z.Spec.ManagedVMs.FolderMoID, z.Namespace
-				}
-			}
-			return "", ""
-		}
-
-		azList := &topologyv1.AvailabilityZoneList{}
-		Expect(svClusterClient.List(ctx, azList)).
-			To(Succeed(), "failed to list AvailabilityZones")
-
-		for _, az := range azList.Items {
-			for ns, nsInfo := range az.Spec.Namespaces {
-				if ns != namespace && azNamespacePoolMoID(nsInfo) != "" {
-					return nsInfo.FolderMoId, ns
-				}
+		for _, z := range zoneList.Items {
+			if z.Namespace != namespace && len(z.Spec.ManagedVMs.PoolMoIDs) > 0 {
+				return z.Spec.ManagedVMs.FolderMoID, z.Namespace
 			}
 		}
 
@@ -440,15 +406,4 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 				})
 		})
 	})
-}
-
-// azNamespacePoolMoID returns the namespace RP MoID recorded in an AvailabilityZone's
-// NamespaceInfo, or the empty string if it records none. It mirrors the precedence in the
-// controller's topology.GetNamespaceFolderAndRPMoID: the plural PoolMoIDs wins over the older
-// singular PoolMoId, which is empty on a namespace spanning multiple ResourcePools.
-func azNamespacePoolMoID(nsInfo topologyv1.NamespaceInfo) string {
-	if len(nsInfo.PoolMoIDs) != 0 {
-		return nsInfo.PoolMoIDs[0]
-	}
-	return nsInfo.PoolMoId
 }

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
@@ -17,7 +17,6 @@ import (
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/mo"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	e2eframework "k8s.io/kubernetes/test/e2e/framework"
 	capiutil "sigs.k8s.io/cluster-api/util"
@@ -30,6 +29,7 @@ import (
 	"github.com/vmware-tanzu/vm-operator/test/e2e/infrastructure/vsphere/vcenter"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/infrastructure/vsphere/wcp"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/manifestbuilders"
+	"github.com/vmware-tanzu/vm-operator/test/e2e/utils"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/common"
 	e2eConfig "github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/config"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/consts"
@@ -82,6 +82,11 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 
 		vmName       string
 		linuxVMIName string
+
+		// workloadDomainIsolationEnabled mirrors the WorkloadDomainIsolation FSS
+		// that topology.GetNamespaceFolderAndRPMoID branches on: Zone when
+		// enabled, AvailabilityZone when not.
+		workloadDomainIsolationEnabled bool
 	)
 
 	BeforeEach(func() {
@@ -112,6 +117,10 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		DeferCleanup(cancelPodWatches)
 
 		svClusterClient = clusterProxy.GetClient()
+
+		workloadDomainIsolationEnabled = utils.IsFssEnabled(ctx, svClusterClient,
+			config.GetVariable("VMOPNamespace"), config.GetVariable("VMOPDeploymentName"),
+			config.GetVariable("VMOPManagerCommand"), config.GetVariable("EnvWorkloadIsolation"))
 
 		kubeconfigPath := clusterProxy.GetKubeconfigPath()
 		vCenterHostname := vcenter.GetVCPNIDFromKubeconfigFile(ctx, kubeconfigPath)
@@ -144,41 +153,36 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 	})
 
 	// getNsRPAndFolder returns the namespace RP and folder MoIDs for the given
-	// zone, mirroring the controller's topology.GetNamespaceFolderAndRPMoID:
-	// the namespaced Zone first, then the AvailabilityZone as fallback. The RP
-	// is per-zone, so zone must match the VM's status.zone or the resolved RP
-	// belongs to a different zone.
+	// zone. It mirrors the controller's topology.GetNamespaceFolderAndRPMoID,
+	// which resolves against Zone when WorkloadDomainIsolation is enabled and
+	// AvailabilityZone otherwise -- the two are never both live on the same
+	// cluster, so this branches on the same FSS rather than probing for
+	// whichever CR happens to exist. The RP is per-zone, so zone must match
+	// the VM's status.zone or the resolved RP belongs to a different zone.
 	getNsRPAndFolder := func(namespace, zone string) (rpMoID, folderMoID string) {
-		// A found Zone is authoritative: assert it carries a pool rather than
-		// falling through to the AvailabilityZone path, which would otherwise
-		// surface a misleading "AvailabilityZone not found" error.
-		z := &topologyv1.Zone{}
-		err := svClusterClient.Get(ctx, ctrlclient.ObjectKey{Namespace: namespace, Name: zone}, z)
-		if err == nil {
+		if workloadDomainIsolationEnabled {
+			z := &topologyv1.Zone{}
+			Expect(svClusterClient.Get(ctx, ctrlclient.ObjectKey{Namespace: namespace, Name: zone}, z)).
+				To(Succeed(), "failed to get Zone %s/%s", namespace, zone)
 			Expect(z.Spec.ManagedVMs.PoolMoIDs).ToNot(BeEmpty(),
 				"Zone %s/%s has no ManagedVMs.PoolMoIDs", namespace, zone)
 			e2eframework.Logf("resolved namespace RP from Zone %s: %s / %s",
 				z.Name, z.Spec.ManagedVMs.PoolMoIDs[0], z.Spec.ManagedVMs.FolderMoID)
 			return z.Spec.ManagedVMs.PoolMoIDs[0], z.Spec.ManagedVMs.FolderMoID
 		}
-		Expect(apierrors.IsNotFound(err)).To(BeTrue(), "failed to get Zone %s/%s", namespace, zone)
 
-		// Fallback for older, non-zonal configs (no Zone object), where the VM's
-		// status.zone is the cluster-scoped AvailabilityZone name.
+		// WorkloadDomainIsolation disabled: the VM's status.zone is the
+		// cluster-scoped AvailabilityZone name.
 		az := &topologyv1.AvailabilityZone{}
 		Expect(svClusterClient.Get(ctx, ctrlclient.ObjectKey{Name: zone}, az)).
 			To(Succeed(), "failed to get AvailabilityZone %s", zone)
 
-		if nsInfo, ok := az.Spec.Namespaces[namespace]; ok && nsInfo.PoolMoId != "" {
-			e2eframework.Logf("resolved namespace RP from AvailabilityZone %s: %s / %s",
-				az.Name, nsInfo.PoolMoId, nsInfo.FolderMoId)
-			return nsInfo.PoolMoId, nsInfo.FolderMoId
-		}
-
-		Fail(fmt.Sprintf(
-			"could not determine namespace RP and folder MoIDs for namespace %s in zone %s",
-			namespace, zone))
-		return "", ""
+		nsInfo, ok := az.Spec.Namespaces[namespace]
+		Expect(ok && nsInfo.PoolMoId != "").To(BeTrue(),
+			"AvailabilityZone %s missing pool info for namespace %s", zone, namespace)
+		e2eframework.Logf("resolved namespace RP from AvailabilityZone %s: %s / %s",
+			az.Name, nsInfo.PoolMoId, nsInfo.FolderMoId)
+		return nsInfo.PoolMoId, nsInfo.FolderMoId
 	}
 
 	// getOtherNamespaceFolder returns the folder MoID and name of a Supervisor Namespace other
@@ -188,16 +192,18 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 	// vCenter account -- unlike an arbitrary vCenter folder (e.g. the Datacenter's root VM
 	// folder), which WCP never grants permissions on.
 	getOtherNamespaceFolder := func(namespace string) (folderMoID, otherNamespace string) {
-		zoneList := &topologyv1.ZoneList{}
-		Expect(svClusterClient.List(ctx, zoneList)).To(Succeed(), "failed to list Zones")
+		if workloadDomainIsolationEnabled {
+			zoneList := &topologyv1.ZoneList{}
+			Expect(svClusterClient.List(ctx, zoneList)).To(Succeed(), "failed to list Zones")
 
-		for _, z := range zoneList.Items {
-			if z.Namespace != namespace && len(z.Spec.ManagedVMs.PoolMoIDs) > 0 {
-				return z.Spec.ManagedVMs.FolderMoID, z.Namespace
+			for _, z := range zoneList.Items {
+				if z.Namespace != namespace && len(z.Spec.ManagedVMs.PoolMoIDs) > 0 {
+					return z.Spec.ManagedVMs.FolderMoID, z.Namespace
+				}
 			}
+			return "", ""
 		}
 
-		// Fallback: AvailabilityZone.Spec.Namespaces (older cluster configurations).
 		azList := &topologyv1.AvailabilityZoneList{}
 		Expect(svClusterClient.List(ctx, azList)).
 			To(Succeed(), "failed to list AvailabilityZones")

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
@@ -152,13 +152,11 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		vmoperator.VerifyVMDeleted(ctx, svClusterClient, config, input.WCPNamespaceName, vmName)
 	})
 
-	// getNsRPAndFolder returns the namespace RP and folder MoIDs for the given
-	// zone. It mirrors the controller's topology.GetNamespaceFolderAndRPMoID,
-	// which resolves against Zone when WorkloadDomainIsolation is enabled and
-	// AvailabilityZone otherwise -- the two are never both live on the same
-	// cluster, so this branches on the same FSS rather than probing for
-	// whichever CR happens to exist. The RP is per-zone, so zone must match
-	// the VM's status.zone or the resolved RP belongs to a different zone.
+	// getNsRPAndFolder returns the namespace RP and folder MoIDs for the given zone. It
+	// mirrors the controller's topology.GetNamespaceFolderAndRPMoID, branching on the same
+	// WorkloadDomainIsolation FSS rather than probing for whichever CR exists, since Zone
+	// and AvailabilityZone are never both live on the same cluster. The RP is per-zone, so
+	// zone must match the VM's status.zone or the resolved RP belongs to a different zone.
 	getNsRPAndFolder := func(namespace, zone string) (rpMoID, folderMoID string) {
 		if workloadDomainIsolationEnabled {
 			z := &topologyv1.Zone{}
@@ -178,11 +176,14 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 			To(Succeed(), "failed to get AvailabilityZone %s", zone)
 
 		nsInfo, ok := az.Spec.Namespaces[namespace]
-		Expect(ok && nsInfo.PoolMoId != "").To(BeTrue(),
+		Expect(ok).To(BeTrue(),
 			"AvailabilityZone %s missing pool info for namespace %s", zone, namespace)
+		poolMoID := azNamespacePoolMoID(nsInfo)
+		Expect(poolMoID).ToNot(BeEmpty(),
+			"AvailabilityZone %s has no pool MoID for namespace %s", zone, namespace)
 		e2eframework.Logf("resolved namespace RP from AvailabilityZone %s: %s / %s",
-			az.Name, nsInfo.PoolMoId, nsInfo.FolderMoId)
-		return nsInfo.PoolMoId, nsInfo.FolderMoId
+			az.Name, poolMoID, nsInfo.FolderMoId)
+		return poolMoID, nsInfo.FolderMoId
 	}
 
 	// getOtherNamespaceFolder returns the folder MoID and name of a Supervisor Namespace other
@@ -210,7 +211,7 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 
 		for _, az := range azList.Items {
 			for ns, nsInfo := range az.Spec.Namespaces {
-				if ns != namespace && nsInfo.PoolMoId != "" {
+				if ns != namespace && azNamespacePoolMoID(nsInfo) != "" {
 					return nsInfo.FolderMoId, ns
 				}
 			}
@@ -260,7 +261,7 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 	// grantRelocatePrivileges grants the test's vCenter account the privileges needed to
 	// relocate a VM across the given entities, and reverts them when the spec ends. WCP pins
 	// vmServiceVMMgmtRoleName on namespace objects, shadowing the inherited Administrator
-	// role, so those privileges aren't otherwise present. Pass every entity in one call.
+	// role, so those privileges aren't otherwise present.
 	grantRelocatePrivileges := func(entities ...vimtypes.ManagedObjectReference) {
 		restore, err := vcenter.GrantExtraPrivileges(ctx, vCenterAdminClient,
 			vmServiceVMMgmtRoleName, relocateRoleName, relocatePrivileges, entities...)
@@ -439,4 +440,15 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 				})
 		})
 	})
+}
+
+// azNamespacePoolMoID returns the namespace RP MoID recorded in an AvailabilityZone's
+// NamespaceInfo, or the empty string if it records none. It mirrors the precedence in the
+// controller's topology.GetNamespaceFolderAndRPMoID: the plural PoolMoIDs wins over the older
+// singular PoolMoId, which is empty on a namespace spanning multiple ResourcePools.
+func azNamespacePoolMoID(nsInfo topologyv1.NamespaceInfo) string {
+	if len(nsInfo.PoolMoIDs) != 0 {
+		return nsInfo.PoolMoIDs[0]
+	}
+	return nsInfo.PoolMoId
 }

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
@@ -251,11 +251,10 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		Expect(task.Wait(ctx)).To(Succeed(), "Relocate task failed for VM %s", vmMoID)
 	}
 
-	// grantRelocatePrivileges gives the test's vCenter account the privileges it needs to
-	// relocate a VM across the given entities, reverting them when the spec ends. WCP pins
-	// vmServiceVMMgmtRoleName onto the objects backing a namespace, which shadows the
-	// inherited vCenter Administrator role there, so those privileges are not otherwise
-	// present. Pass every entity the spec touches in one call -- see GrantExtraPrivileges.
+	// grantRelocatePrivileges grants the test's vCenter account the privileges needed to
+	// relocate a VM across the given entities, and reverts them when the spec ends. WCP pins
+	// vmServiceVMMgmtRoleName on namespace objects, shadowing the inherited Administrator
+	// role, so those privileges aren't otherwise present. Pass every entity in one call.
 	grantRelocatePrivileges := func(entities ...vimtypes.ManagedObjectReference) {
 		restore, err := vcenter.GrantExtraPrivileges(ctx, vCenterAdminClient,
 			vmServiceVMMgmtRoleName, relocateRoleName, relocatePrivileges, entities...)

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
@@ -58,7 +58,21 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		// vmServiceVMMgmtRoleID is the hardcoded vCenter role ID for the VM-Service-VM-Management role.
 		vmServiceVMMgmtRoleID   = int32(1039)
 		vmServiceVMMgmtRoleName = "VM-Service-VM-Management"
+
+		// relocateRoleName is a test-scoped role, created fresh for this spec, that grants
+		// the privileges required to relocate a VM between resource pools and folders. It is
+		// swapped in for vmServiceVMMgmtRoleID only on the specific entities under test,
+		// rather than mutating the shared vmServiceVMMgmtRoleName role in place.
+		relocateRoleName = "VM-Service-VM-Management-E2E-Relocate"
 	)
+
+	relocatePrivileges := []string{
+		"Folder.Move",
+		"Resource.AssignVMToPool",
+		"Resource.ColdMigrate",
+		"Resource.HotMigrate",
+		"VirtualMachine.Inventory.Move",
+	}
 
 	var (
 		input              VMLocationSpecInput
@@ -68,8 +82,12 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		vCenterAdminClient *vim25.Client
 		clusterResources   *e2eConfig.Resources
 
-		vmName       string
-		linuxVMIName string
+		vmName                 string
+		linuxVMIName           string
+		relocateRoleID         int32
+		relocateRolePrivileges []string
+		relocateRoleUpgraded   bool
+		permissionRestores     []func(context.Context) error
 	)
 
 	BeforeEach(func() {
@@ -111,17 +129,30 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		// WCP grants the VM-Service-VM-Management role to the Administrators group directly on the
 		// namespace RP/folder, which overrides the inherited vCenter Administrator role for those
 		// objects. That role does not always include the privileges the specs below need to
-		// relocate a VM between resource pools and move it in/out of the namespace folder, so
-		// ensure they are present here.
-		Expect(vcenter.EnsureRolePrivileges(ctx, vCenterAdminClient, vmServiceVMMgmtRoleID,
-			[]string{
-				"Folder.Move",
-				"Resource.AssignVMToPool",
-				"Resource.ColdMigrate",
-				"Resource.HotMigrate",
-				"VirtualMachine.Inventory.Move",
-			})).To(Succeed(),
-			"failed to ensure %s role has the privileges required for VM relocation", vmServiceVMMgmtRoleName)
+		// relocate a VM between resource pools and move it in/out of the namespace folder.
+		// Rather than mutating the shared role in place, create a dedicated relocate role and
+		// swap it in for just the entities each spec touches; see grantRelocateRole and
+		// upgradeRelocateRole below.
+		//
+		// The role starts as an exact clone of the shared role's current privileges (a set the
+		// Administrators group already effectively holds on those entities), because vCenter
+		// blocks SetEntityPermissions from granting a role containing privileges the acting
+		// principal doesn't already have there -- granting a role with the relocate-only
+		// privileges already mixed in fails with "Permission ... denied" naming exactly those
+		// privileges. Once the clone is granted on every entity the spec needs it on,
+		// upgradeRelocateRole adds the relocate-only privileges to the role's own definition
+		// (a role-definition edit, not a fresh grant), which is not subject to that same-entity
+		// check and takes effect on all of those entities at once.
+		vmMgmtRole, err := vcenter.GetRoleByName(ctx, vCenterAdminClient, vmServiceVMMgmtRoleName)
+		Expect(err).ToNot(HaveOccurred(), "failed to look up %s role", vmServiceVMMgmtRoleName)
+		Expect(vmMgmtRole).ToNot(BeNil(), "%s role not found", vmServiceVMMgmtRoleName)
+
+		permissionRestores = nil
+		relocateRoleUpgraded = false
+		relocateRolePrivileges = vcenter.MergePrivileges(vmMgmtRole.Privilege, relocatePrivileges)
+
+		relocateRoleID, err = vcenter.CreateOrUpdateRole(ctx, vCenterAdminClient, relocateRoleName, vmMgmtRole.Privilege)
+		Expect(err).ToNot(HaveOccurred(), "failed to create %s role", relocateRoleName)
 
 		linuxImageDisplayName := vmservice.GetDefaultImageDisplayName(clusterResources)
 		linuxVMIName = vmoperator.WaitForVirtualMachineImageName(ctx, &config.Config, svClusterClient, input.WCPNamespaceName, linuxImageDisplayName)
@@ -130,6 +161,18 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 	})
 
 	AfterEach(func() {
+		// Undo the entity permission swaps and remove the temporary relocate role while
+		// vCenterAdminClient's session is still authenticated. DeferCleanup callbacks
+		// registered during BeforeEach/It run after this AfterEach, by which point
+		// LogoutVimClient below would have already invalidated the session.
+		for i := len(permissionRestores) - 1; i >= 0; i-- {
+			Expect(permissionRestores[i](ctx)).To(Succeed(), "failed to restore entity permission")
+		}
+		if relocateRoleID != 0 {
+			Expect(vcenter.RemoveRole(ctx, vCenterAdminClient, relocateRoleID)).To(Succeed(),
+				"failed to remove %s role", relocateRoleName)
+		}
+
 		if CurrentSpecReport().Failed() {
 			vmoperator.DescribeResourceIfExists(
 				ctx, svClusterClient,
@@ -249,7 +292,39 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		Expect(task.Wait(ctx)).To(Succeed(), "Relocate task failed for VM %s", vmMoID)
 	}
 
-	XWhen("VM is created in the correct namespace RP and folder", Label("core-functional", "experimental"), func() {
+	// grantRelocateRole swaps the relocate role in for vmServiceVMMgmtRoleID on the given
+	// entity for the remainder of the current spec. The restore function is recorded and
+	// invoked from AfterEach (not DeferCleanup) so it runs while the session is still
+	// authenticated.
+	//
+	// Call this for every entity a spec needs the relocate role on *before* calling
+	// upgradeRelocateRole: the swap only succeeds while the role's definition is still the
+	// base clone (see BeforeEach); upgrading first would make later swaps, onto entities that
+	// haven't been granted yet, fail the same escalation check on those entities.
+	grantRelocateRole := func(entity vimtypes.ManagedObjectReference) {
+		restore, err := vcenter.SwapEntityPermissionRole(ctx, vCenterAdminClient, entity,
+			vmServiceVMMgmtRoleID, relocateRoleID)
+		Expect(err).ToNot(HaveOccurred(),
+			"failed to grant relocate role on %s %s", entity.Type, entity.Value)
+		permissionRestores = append(permissionRestores, restore)
+	}
+
+	// upgradeRelocateRole adds the relocate-only privileges to the relocate role's definition.
+	// Call once, after every grantRelocateRole call for the current spec has completed: this
+	// is a role-definition edit rather than a fresh grant, so it takes effect immediately on
+	// every entity already granted the role, without re-triggering the escalation check that
+	// blocks a grant containing privileges not yet held on that specific entity.
+	upgradeRelocateRole := func() {
+		if relocateRoleUpgraded {
+			return
+		}
+		Expect(vcenter.UpdateRole(ctx, vCenterAdminClient, relocateRoleID, relocateRoleName,
+			relocateRolePrivileges)).To(Succeed(),
+			"failed to add relocate privileges to %s role", relocateRoleName)
+		relocateRoleUpgraded = true
+	}
+
+	When("VM is created in the correct namespace RP and folder", Label("core-functional", "experimental"), func() {
 		It("sets VirtualMachineLocationValid condition to True", func() {
 			createVM()
 
@@ -261,7 +336,7 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		})
 	})
 
-	XWhen("VM is moved outside the namespace RP hierarchy", Label("core-functional", "experimental"), func() {
+	When("VM is moved outside the namespace RP hierarchy", Label("core-functional", "experimental"), func() {
 		It("sets condition False, then recovers to True when VM is returned to the correct location", func() {
 			By("Creating VM and waiting for it to reach Running state")
 			createVM()
@@ -279,6 +354,15 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 			By("Retrieving the correct namespace RP and folder MoIDs for the VM's zone")
 			vmZone := vmoperator.GetVirtualMachineZone(ctx, svClusterClient, input.WCPNamespaceName, vmName)
 			nsRPMoID, nsFolderMoID := getNsRPAndFolder(input.WCPNamespaceName, vmZone)
+
+			By("Granting the relocate role on the namespace RP and folder")
+			// Relocate needs Resource.* on the RP, but vCenter also checks
+			// VirtualMachine.Inventory.Move on the VM's parent folder even when the
+			// relocate spec leaves the folder unchanged -- and WCP pins role 1039 on the
+			// namespace folder too, so inherited Administrator does not cover it there.
+			grantRelocateRole(vimtypes.ManagedObjectReference{Type: "ResourcePool", Value: nsRPMoID})
+			grantRelocateRole(vimtypes.ManagedObjectReference{Type: "Folder", Value: nsFolderMoID})
+			upgradeRelocateRole()
 
 			By("Retrieving the cluster root RP to use as an invalid location")
 			// 1. Resolve the specific Cluster MoID for the active Supervisor context
@@ -321,7 +405,7 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 		})
 	})
 
-	XWhen("VM is moved outside the namespace Folder hierarchy", Label("core-functional", "experimental"), func() {
+	When("VM is moved outside the namespace Folder hierarchy", Label("core-functional", "experimental"), func() {
 		It("sets condition False, then recovers to True when VM is returned to the correct location", func() {
 			By("Creating VM and waiting for it to reach Running state")
 			createVM()
@@ -340,6 +424,9 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 			vmZone := vmoperator.GetVirtualMachineZone(ctx, svClusterClient, input.WCPNamespaceName, vmName)
 			_, nsFolderMoID := getNsRPAndFolder(input.WCPNamespaceName, vmZone)
 
+			By("Granting the relocate role on the namespace folder")
+			grantRelocateRole(vimtypes.ManagedObjectReference{Type: "Folder", Value: nsFolderMoID})
+
 			By("Retrieving another Supervisor Namespace's folder as the invalid folder location")
 			// A different namespace's folder always lies outside the 2-level hierarchy
 			// that validateVMFolder checks, so it reliably triggers the LocationMismatch.
@@ -354,6 +441,10 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 			Expect(invalidFolderMoID).ToNot(Equal(nsFolderMoID),
 				"other namespace's folder unexpectedly equals the namespace folder itself")
 			e2eframework.Logf("invalid folder MoID (folder of namespace %s): %s", otherNamespace, invalidFolderMoID)
+
+			By("Granting the relocate role on the other namespace's folder")
+			grantRelocateRole(vimtypes.ManagedObjectReference{Type: "Folder", Value: invalidFolderMoID})
+			upgradeRelocateRole()
 
 			By("Moving VM into the other namespace's folder via MoveIntoFolder (direct inventory move)")
 			// Use Folder.MoveInto rather than Relocate.Folder: in WCP, the


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

- Replaces the global, role-ID-based EnsureRolePrivileges (which permanently mutated the shared VM-Service-VM-Management role that WCP itself manages) with a new GrantExtraPrivileges/swapEntityPermissionRole helper in roles.go. It clones the base role into a test-scoped role, swaps that clone onto only the specific RP/folder entities each spec relocates a VM across, and restores the original permissions via DeferCleanup when the spec ends — instead of leaving a cluster-wide privilege change behind.
- Drops the AvailabilityZone lookup from getNsRPAndFolder/getOtherNamespaceFolder entirely. Both now read Zone.Spec.ManagedVMs — the same fields the controller's topology.GetNamespaceFolderAndRPMoID returns and reconcileLocation validates the VM against — and a missing Zone fails the spec rather than silently resolving a value the controller would never have used. This addresses review feedback on https://github.com/vmware-tanzu/vm-operator/pull/1765#discussion_r3648583378 that the AvailabilityZone CR should no longer be used for this. 
- Un-skips the three vm-location specs (XWhen → When) now that both fixes above make them reliable.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # vmop-4033


**Are there any special notes for your reviewer**:

Ran UTS postcheckin against the changes and got a successfull run for these tests

**Please add a release note if necessary**:

```release-note
NONE
```
