### PR TITLE
🌱 Use a unique kubeconfig file per local E2E run

### DIFF
--- a/.sdd/memory/e2e-testing.md
+++ b/.sdd/memory/e2e-testing.md
@@ -6,7 +6,7 @@
 
 ## Running tests
 
-**Environment setup** (kubeconfig under `~/.kube/wcp-config`, vars exported — see README for `testbedInfo.json` or a remote URL):
+**Environment setup** (kubeconfig written to a unique file, exported as `KUBECONFIG` and `E2E_KUBECONFIG_PATH`, so concurrent local runs don't stomp on each other's kubeconfig, vars exported — see README for `testbedInfo.json` or a remote URL):
 
 ```bash
 source ./hack/e2e/setup-testbed-env.sh <testbedInfo.json|URL> --e2e

--- a/hack/e2e/setup-testbed-env.sh
+++ b/hack/e2e/setup-testbed-env.sh
@@ -337,7 +337,7 @@ _decrypt_wcp_credentials() {
 # SSHes to vCenter to run decryptK8Pwd.py, downloads the supervisor kubeconfig,
 # and patches it to use the real supervisor IP (instead of 127.0.0.1).
 # Populates: wcp_ip, wcp_password (in _main's scope via dynamic scoping).
-# Exports:   KUBECONFIG
+# Exports:   KUBECONFIG, E2E_KUBECONFIG_PATH (--e2e only)
 # ---------------------------------------------------------------------------
 _fetch_supervisor_access() {
     local -r enable_e2e="$1"
@@ -383,8 +383,20 @@ _fetch_supervisor_access() {
     _log "Supervisor IP: ${wcp_ip}"
 
     mkdir -p "${HOME}/.kube"
-    local -r kubeconfig_dest="${HOME}/.kube/${vc_url}.kubeconfig"
-    local -r wcp_kubeconfig_dest="${HOME}/.kube/wcp-config"
+
+    # Unique-per-invocation filename, named for the supervisor (wcp_ip) this
+    # kubeconfig actually targets rather than the vCenter (vc_url) — the
+    # file is patched below to point at wcp_ip, not vc_url. The unique
+    # suffix means concurrent local runs — two testbeds, or two runs
+    # against the same testbed in separate terminals — each get their own
+    # file instead of one racing to overwrite the other's mid-run. This is
+    # the one file KUBECONFIG and (when --e2e is passed) E2E_KUBECONFIG_PATH
+    # both point at; see the Exports comment above.
+    local kubeconfig_dest
+    if ! kubeconfig_dest="$(mktemp "${HOME}/.kube/${wcp_ip}.kubeconfig.XXXXXX")"; then
+        _err "Failed to create a unique kubeconfig file under ${HOME}/.kube"
+        return 1
+    fi
 
     _log "Downloading kubeconfig to ${kubeconfig_dest}..."
     if ! _retry_with_backoff "${_KUBECONFIG_RETRY_ATTEMPTS}" "${_KUBECONFIG_RETRY_INITIAL_DELAY}" "SCP kubeconfig from supervisor" \
@@ -404,10 +416,15 @@ _fetch_supervisor_access() {
     _export KUBECONFIG "${kubeconfig_dest}"
 
     if [[ "${enable_e2e}" == "true" ]]; then
-        _log "Copying kubeconfig → ${wcp_kubeconfig_dest} (--e2e)"
-        cp "${kubeconfig_dest}" "${wcp_kubeconfig_dest}"
+        # Point the E2E test suite at the same unique kubeconfig file as
+        # KUBECONFIG (no separate copy needed — test/e2e/vmservice/config/
+        # wcp.yaml's kubeconfigPath reads E2E_KUBECONFIG_PATH first, falling
+        # back to the historical ~/.kube/wcp-config only for the manual,
+        # non-scripted flow documented in test/e2e/vmservice/README.md,
+        # which never goes through this script).
+        _export E2E_KUBECONFIG_PATH "${kubeconfig_dest}"
     else
-        _log "Skipping kubeconfig copy to ${wcp_kubeconfig_dest} (pass --e2e to enable)"
+        _log "Skipping E2E kubeconfig setup (pass --e2e to enable)"
     fi
 }
 
@@ -651,8 +668,9 @@ Arguments:
   TESTBED_SOURCE  Path to a local testbedinfo.json file or an HTTP(S) URL
 
 Options:
-  --e2e       Copy kubeconfig to ~/.kube/wcp-config, install kubectl-vsphere,
-              set up the squid HTTP proxy, and configure KMS key providers
+  --e2e       Also export KUBECONFIG as E2E_KUBECONFIG_PATH, install
+              kubectl-vsphere, set up the squid HTTP proxy, and configure
+              KMS key providers
   -h, --help  Show this help and exit
 
 Examples:
@@ -727,6 +745,7 @@ EOF
         _log "  VC_VIM_USERNAME (govc):     ${VC_VIM_USERNAME}"
         _log "  NETWORK:                    ${NETWORK}"
         _log "  KUBECONFIG:                 ${KUBECONFIG:-not set}"
+        _log "  E2E_KUBECONFIG_PATH:        ${E2E_KUBECONFIG_PATH:-not set}"
         _log "  SUPERVISOR_CLUSTER_IP:      ${SUPERVISOR_CLUSTER_IP}"
         _log "  HTTP_PROXY:                 ${HTTP_PROXY:-not set}"
         _log "  GATEWAY_IP:                 ${GATEWAY_IP:-not set}"

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -45,8 +45,11 @@ test/e2e/
 1. **Set up the env** for your WCP cluster:
 The following will export all the required environment variables
 required for the test and download the kubeconfig from the Supervisor cluster.
-The kubeconfig will be stored under the directory `~/.kube/<vcIp>.kubeconfig` 
-and copied to `~/.kube/wcp-config` which the E2E test reads from.
+The kubeconfig will be stored under a unique `~/.kube/<wcpIp>.kubeconfig.<random>`
+file (exported as both `KUBECONFIG` and, with `--e2e`, `E2E_KUBECONFIG_PATH`,
+which the E2E test reads from). The unique filename means concurrent local
+runs (e.g. against two testbeds, or two runs against the same testbed in
+separate terminals) won't stomp on each other's kubeconfig.
 
 ```bash
 source ./hack/e2e/setup-testbed-env.sh <testbedInfo.json> --e2e
@@ -134,6 +137,7 @@ The primary configuration is in `vmservice/config/wcp.yaml`:
 |----------|-------------|---------|------------------|
 | `NETWORK` | Networking topology (vds/nsx) | `vds` | ❌ |
 | `STORAGE_CLASS` | Storage class for VMs | `wcpglobal-storage-profile` | ❌ |
+| `E2E_KUBECONFIG_PATH` | Supervisor kubeconfig path (set by `setup-testbed-env.sh --e2e`; a unique file per invocation avoids concurrent local runs stomping on each other) | `~/.kube/wcp-config` | ❌ |
 | `E2E_NAMESPACE` | Fixed namespace for tests | Random namespace | ✅ |
 | `TEST_FOCUS` | Ginkgo focus pattern | All tests | ✅ |
 | `TEST_SKIP` | Ginkgo skip pattern | No skips | ✅ |

--- a/test/e2e/vmservice/config/config.go
+++ b/test/e2e/vmservice/config/config.go
@@ -87,24 +87,37 @@ func LoadE2EConfig(configPath string) *E2EConfig {
 	Expect(err).ToNot(HaveOccurred(), "failed to read the e2e test config file: %s", configPath)
 	Expect(configData).ToNot(BeEmpty(), "the e2e test config file should not be empty: %s", configPath)
 
-	configData = []byte(os.Expand(string(configData), func(v string) string {
-		parts := strings.SplitN(v, ":-", 2)
-		if val, ok := os.LookupEnv(parts[0]); ok && val != "" {
-			return val
-		}
-
-		if len(parts) == 2 {
-			return parts[1]
-		}
-
-		return ""
-	}))
+	configData = []byte(expandEnv(string(configData)))
 	config := &E2EConfig{}
 	Expect(yaml.Unmarshal(configData, config)).To(Succeed(), "failed to convert the e2e test config file to yaml")
 
 	Expect(config.Validate()).To(Succeed(), "The e2e test config file is not valid")
 
 	return config
+}
+
+// expandEnv substitutes "$NAME", "${NAME}", and "${NAME:-default}" references
+// in data with the named environment variable, falling back to default (or
+// the empty string, if no default is given) when the variable is unset or
+// empty. The default itself is expanded recursively, rather than substituted
+// verbatim, so a pattern like "${E2E_KUBECONFIG_PATH:-$HOME/.kube/wcp-config}"
+// still resolves $HOME when E2E_KUBECONFIG_PATH is unset.
+func expandEnv(data string) string {
+	var expandVar func(v string) string
+	expandVar = func(v string) string {
+		parts := strings.SplitN(v, ":-", 2)
+		if val, ok := os.LookupEnv(parts[0]); ok && val != "" {
+			return val
+		}
+
+		if len(parts) == 2 {
+			return os.Expand(parts[1], expandVar)
+		}
+
+		return ""
+	}
+
+	return os.Expand(data, expandVar)
 }
 
 func (c *E2EConfig) Validate() error {

--- a/test/e2e/vmservice/config/wcp.yaml
+++ b/test/e2e/vmservice/config/wcp.yaml
@@ -1,7 +1,7 @@
 ---
 infraConfig:
   infraName: "wcp"
-  kubeconfigPath: "$HOME/.kube/wcp-config"
+  kubeconfigPath: "${E2E_KUBECONFIG_PATH:-$HOME/.kube/wcp-config}"
   networkingTopology: "${NETWORK:-vds}"
   managementClusterConfig:
     managementClusterName: "wcp"


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

setup-testbed-env.sh --e2e wrote the supervisor kubeconfig to the fixed path ~/.kube/wcp-config, which test/e2e/vmservice/config/wcp.yaml always read from. Two concurrent local runs (two testbeds, or two runs against the same testbed in separate terminals) overwrote each other's kubeconfig mid-run.

Make setup-testbed-env.sh write a unique, mktemp-generated kubeconfig file per invocation, named after the supervisor IP (wcp_ip) it actually targets rather than the vCenter (vc_url). Export it as both KUBECONFIG (unchanged consumer) and the new E2E_KUBECONFIG_PATH. wcp.yaml's kubeconfigPath now reads E2E_KUBECONFIG_PATH first, falling back to the historical fixed path for the manual, non-scripted flow in test/e2e/vmservice/README.md that never goes through this script.

Extract the config loader's env-var expansion into a small, testable expandEnv helper and make it expand "${VAR:-default}" defaults recursively, since a plain os.Expand pass does not: without this, wcp.yaml's fallback "${E2E_KUBECONFIG_PATH:-$HOME/.kube/wcp-config}" would substitute the literal, unexpanded string "$HOME/.kube/wcp-config" whenever E2E_KUBECONFIG_PATH is unset.

Update test/e2e/README.md and .sdd/memory/e2e-testing.md to describe the new env var and file-naming scheme.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

UTS, local smoke passed, eg:

```
Downloading kubeconfig to /home/bv/.kube/10.163.11.149.kubeconfig.LKnCRT...
Warning: Permanently added '10.163.11.149' (ECDSA) to the list of known hosts.
...
  KUBECONFIG:                 /home/bv/.kube/10.163.11.149.kubeconfig.LKnCRT
  E2E_KUBECONFIG_PATH:        /home/bv/.kube/10.163.11.149.kubeconfig.LKnCRT
...
Running command: kubectl --kubeconfig /home/bv/.kube/10.163.11.149.kubeconfig.LKnCRT auth can-i get virtualmachineclass -A
```

**Please add a release note if necessary**:


```release-note
NONE
```