### PR TITLE
:sparkles: Reconcile stale extension compat constraints on VMs

### DIFF
--- a/pkg/providers/vsphere/session/session_vm_update.go
+++ b/pkg/providers/vsphere/session/session_vm_update.go
@@ -46,6 +46,7 @@ import (
 	vmconfcdrom "github.com/vmware-tanzu/vm-operator/pkg/vmconfig/cdrom"
 	vmconfcrypto "github.com/vmware-tanzu/vm-operator/pkg/vmconfig/crypto"
 	vmconfdiskpromo "github.com/vmware-tanzu/vm-operator/pkg/vmconfig/diskpromo"
+	vmconfextensioncompatconstraint "github.com/vmware-tanzu/vm-operator/pkg/vmconfig/extensioncompatconstraint"
 	vmconfextraconfig "github.com/vmware-tanzu/vm-operator/pkg/vmconfig/extraconfig"
 	vmconfnetworkextraconfig "github.com/vmware-tanzu/vm-operator/pkg/vmconfig/networkextraconfig"
 	vmconfpolicy "github.com/vmware-tanzu/vm-operator/pkg/vmconfig/policy"
@@ -1334,6 +1335,25 @@ func reconcileRegisterUnmanagedDisks(
 		configSpec)
 }
 
+func reconcileExtensionCompatConstraint(
+	ctx context.Context,
+	k8sClient ctrlclient.Client,
+	vm *vmopv1.VirtualMachine,
+	vcVM *object.VirtualMachine,
+	moVM mo.VirtualMachine,
+	configSpec *vimtypes.VirtualMachineConfigSpec) error {
+
+	pkglog.FromContextOrDefault(ctx).V(4).Info("Reconciling extension compat constraint")
+
+	return vmconfextensioncompatconstraint.Reconcile(
+		ctx,
+		k8sClient,
+		vcVM.Client(),
+		vm,
+		moVM,
+		configSpec)
+}
+
 func reconcileAnnotationsToExtraConfig(
 	ctx context.Context,
 	k8sClient ctrlclient.Client,
@@ -1518,6 +1538,19 @@ func doReconfigure(
 
 	if pkgcfg.FromContext(ctx).Features.AllDisksArePVCs {
 		if err := reconcileRegisterUnmanagedDisks(
+			ctx,
+			k8sClient,
+			vm,
+			vcVM,
+			moVM,
+			&configSpec); err != nil {
+
+			return err
+		}
+	}
+
+	if pkgcfg.FromContext(ctx).Features.ExtensionCompatConstraint {
+		if err := reconcileExtensionCompatConstraint(
 			ctx,
 			k8sClient,
 			vm,

--- a/pkg/providers/vsphere/virtualmachine/extensioncompatconstraint.go
+++ b/pkg/providers/vsphere/virtualmachine/extensioncompatconstraint.go
@@ -1,0 +1,64 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package virtualmachine
+
+import (
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+)
+
+// extensionCompatConstraintKey identifies an extension compatibility
+// constraint's identity on the wire: the (ConstraintType, ConstraintKind)
+// pair. ConstraintName is a descriptive label only and is deliberately
+// excluded from this key.
+type extensionCompatConstraintKey struct {
+	constraintType string
+	constraintKind string
+}
+
+// extensionCompatibilityConstraintSetMatches reports whether current already
+// contains exactly the desired set of INVARIANT constraints, ignoring
+// ConstraintName and the order of the Constraint slice.
+func extensionCompatibilityConstraintSetMatches(
+	current *vimtypes.VirtualMachineExtensionCompatibilityConstraintSet) bool {
+
+	desired := extensionCompatibilityConstraintSet().Constraint
+
+	if current == nil || len(current.Constraint) != len(desired) {
+		return false
+	}
+
+	currentKeys := make(map[extensionCompatConstraintKey]struct{}, len(current.Constraint))
+	for _, c := range current.Constraint {
+		currentKeys[extensionCompatConstraintKey{c.ConstraintType, c.ConstraintKind}] = struct{}{}
+	}
+
+	for _, c := range desired {
+		if _, ok := currentKeys[extensionCompatConstraintKey{c.ConstraintType, c.ConstraintKind}]; !ok {
+			return false
+		}
+	}
+
+	return true
+}
+
+// UpdateConfigSpecExtensionCompatibilityConstraint sets
+// configSpec.ExtensionCompatibilityConstraint to the desired set of 6
+// INVARIANT constraints if config's current set does not already match it.
+//
+// A reconfigure is a full-set-replace, so re-sending the full desired set
+// corrects any drift in one shot: missing constraints, stale leftovers from
+// an older desired set, or a set left behind by a snapshot revert (which
+// restores ConfigInfo.managedBy via the VMX delta chain but leaves
+// VCDB-backed constraints untouched).
+func UpdateConfigSpecExtensionCompatibilityConstraint(
+	config *vimtypes.VirtualMachineConfigInfo,
+	configSpec *vimtypes.VirtualMachineConfigSpec) {
+
+	if extensionCompatibilityConstraintSetMatches(config.ExtensionCompatibilityConstraint) {
+		return
+	}
+
+	configSpec.ExtensionCompatibilityConstraint = extensionCompatibilityConstraintSet()
+}

--- a/pkg/providers/vsphere/virtualmachine/extensioncompatconstraint_test.go
+++ b/pkg/providers/vsphere/virtualmachine/extensioncompatconstraint_test.go
@@ -1,0 +1,155 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package virtualmachine_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+
+	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/virtualmachine"
+)
+
+var _ = Describe("UpdateConfigSpecExtensionCompatibilityConstraint", func() {
+
+	newConstraint := func(
+		constraintType vimtypes.VirtualMachineExtensionCompatibilityConstraintType,
+		name string,
+	) vimtypes.VirtualMachineExtensionCompatibilityConstraint {
+		return vimtypes.VirtualMachineExtensionCompatibilityConstraint{
+			ConstraintName: name,
+			ConstraintType: string(constraintType),
+			ConstraintKind: string(vimtypes.VirtualMachineExtensionCompatibilityConstraintKindINVARIANT),
+		}
+	}
+
+	desiredConstraints := func(names ...string) []vimtypes.VirtualMachineExtensionCompatibilityConstraint {
+		types := []vimtypes.VirtualMachineExtensionCompatibilityConstraintType{
+			vimtypes.VirtualMachineExtensionCompatibilityConstraintTypeSERVICE,
+			vimtypes.VirtualMachineExtensionCompatibilityConstraintTypeFOLDER,
+			vimtypes.VirtualMachineExtensionCompatibilityConstraintTypePOOL,
+			vimtypes.VirtualMachineExtensionCompatibilityConstraintTypeVM_STORAGE_POLICY,
+			vimtypes.VirtualMachineExtensionCompatibilityConstraintTypeDISK_STORAGE_POLICY,
+			vimtypes.VirtualMachineExtensionCompatibilityConstraintTypeDEVICE,
+		}
+
+		out := make([]vimtypes.VirtualMachineExtensionCompatibilityConstraint, 0, len(types))
+		for i, t := range types {
+			name := ""
+			if i < len(names) {
+				name = names[i]
+			}
+			out = append(out, newConstraint(t, name))
+		}
+		return out
+	}
+
+	var (
+		config     *vimtypes.VirtualMachineConfigInfo
+		configSpec *vimtypes.VirtualMachineConfigSpec
+	)
+
+	BeforeEach(func() {
+		config = &vimtypes.VirtualMachineConfigInfo{}
+		configSpec = &vimtypes.VirtualMachineConfigSpec{}
+	})
+
+	JustBeforeEach(func() {
+		virtualmachine.UpdateConfigSpecExtensionCompatibilityConstraint(config, configSpec)
+	})
+
+	When("config has no extension compatibility constraint set", func() {
+		BeforeEach(func() {
+			config.ExtensionCompatibilityConstraint = nil
+		})
+
+		It("sets the full desired set on the ConfigSpec", func() {
+			Expect(configSpec.ExtensionCompatibilityConstraint).ToNot(BeNil())
+			Expect(configSpec.ExtensionCompatibilityConstraint.Constraint).To(HaveLen(6))
+		})
+	})
+
+	When("config has an empty constraint set", func() {
+		BeforeEach(func() {
+			config.ExtensionCompatibilityConstraint = &vimtypes.VirtualMachineExtensionCompatibilityConstraintSet{}
+		})
+
+		It("sets the full desired set on the ConfigSpec", func() {
+			Expect(configSpec.ExtensionCompatibilityConstraint).ToNot(BeNil())
+			Expect(configSpec.ExtensionCompatibilityConstraint.Constraint).To(HaveLen(6))
+		})
+	})
+
+	When("config is missing one of the desired constraints", func() {
+		BeforeEach(func() {
+			all := desiredConstraints()
+			config.ExtensionCompatibilityConstraint = &vimtypes.VirtualMachineExtensionCompatibilityConstraintSet{
+				Constraint: all[:5], // drop the last one (DEVICE)
+			}
+		})
+
+		It("re-sends the full desired set", func() {
+			Expect(configSpec.ExtensionCompatibilityConstraint).ToNot(BeNil())
+			Expect(configSpec.ExtensionCompatibilityConstraint.Constraint).To(HaveLen(6))
+		})
+	})
+
+	When("config has an extra, unexpected constraint", func() {
+		BeforeEach(func() {
+			all := desiredConstraints()
+			all = append(all, newConstraint("SOME_STALE_TYPE", "stale"))
+			config.ExtensionCompatibilityConstraint = &vimtypes.VirtualMachineExtensionCompatibilityConstraintSet{
+				Constraint: all,
+			}
+		})
+
+		It("re-sends the full desired set, dropping the stale entry", func() {
+			Expect(configSpec.ExtensionCompatibilityConstraint).ToNot(BeNil())
+			Expect(configSpec.ExtensionCompatibilityConstraint.Constraint).To(HaveLen(6))
+		})
+	})
+
+	When("config's constraints are in a different order than desired", func() {
+		BeforeEach(func() {
+			all := desiredConstraints()
+			reordered := make([]vimtypes.VirtualMachineExtensionCompatibilityConstraint, len(all))
+			copy(reordered, all)
+			reordered[0], reordered[len(reordered)-1] = reordered[len(reordered)-1], reordered[0]
+
+			config.ExtensionCompatibilityConstraint = &vimtypes.VirtualMachineExtensionCompatibilityConstraintSet{
+				Constraint: reordered,
+			}
+		})
+
+		It("does not modify the ConfigSpec", func() {
+			Expect(configSpec.ExtensionCompatibilityConstraint).To(BeNil())
+		})
+	})
+
+	When("config's constraints match but with different ConstraintName values", func() {
+		BeforeEach(func() {
+			config.ExtensionCompatibilityConstraint = &vimtypes.VirtualMachineExtensionCompatibilityConstraintSet{
+				Constraint: desiredConstraints("some", "other", "names", "than", "vm operator", "would use"),
+			}
+		})
+
+		It("does not modify the ConfigSpec, since ConstraintName is not part of identity", func() {
+			Expect(configSpec.ExtensionCompatibilityConstraint).To(BeNil())
+		})
+	})
+
+	When("config already has exactly the desired set", func() {
+		BeforeEach(func() {
+			config.ExtensionCompatibilityConstraint = &vimtypes.VirtualMachineExtensionCompatibilityConstraintSet{
+				Constraint: desiredConstraints(),
+			}
+		})
+
+		It("does not modify the ConfigSpec", func() {
+			Expect(configSpec.ExtensionCompatibilityConstraint).To(BeNil())
+		})
+	})
+})

--- a/pkg/vmconfig/extensioncompatconstraint/extensioncompatconstraint_reconciler.go
+++ b/pkg/vmconfig/extensioncompatconstraint/extensioncompatconstraint_reconciler.go
@@ -1,0 +1,86 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package extensioncompatconstraint
+
+import (
+	"context"
+
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/mo"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/virtualmachine"
+	"github.com/vmware-tanzu/vm-operator/pkg/vmconfig"
+)
+
+type reconciler struct{}
+
+var _ vmconfig.Reconciler = reconciler{}
+
+// New returns a new Reconciler for the VM's extension compatibility
+// constraint set.
+func New() vmconfig.Reconciler {
+	return reconciler{}
+}
+
+func Reconcile(
+	ctx context.Context,
+	k8sClient ctrlclient.Client,
+	vimClient *vim25.Client,
+	vm *vmopv1.VirtualMachine,
+	moVM mo.VirtualMachine,
+	configSpec *vimtypes.VirtualMachineConfigSpec) error {
+
+	return New().Reconcile(ctx, k8sClient, vimClient, vm, moVM, configSpec)
+}
+
+func (r reconciler) Name() string { return "extensioncompatconstraint" }
+
+func (r reconciler) OnResult(
+	_ context.Context,
+	_ *vmopv1.VirtualMachine,
+	_ mo.VirtualMachine,
+	_ error) error {
+
+	return nil
+}
+
+// Reconcile compares the VM's current extension compatibility constraint set
+// against the desired 6 INVARIANTs and, if they differ, sets the full desired
+// set on the ConfigSpec. Since a reconfigure is a full-set-replace, this one
+// path self-heals late-binding (VMs created before this capability was
+// enabled), post-upgrade drift (the desired set changed), and
+// post-snapshot-revert staleness (revert restores ConfigInfo.managedBy via
+// the VMX delta chain but leaves the VCDB-backed constraint rows untouched).
+func (r reconciler) Reconcile(
+	ctx context.Context,
+	_ ctrlclient.Client,
+	_ *vim25.Client,
+	vm *vmopv1.VirtualMachine,
+	moVM mo.VirtualMachine,
+	configSpec *vimtypes.VirtualMachineConfigSpec) error {
+
+	if ctx == nil {
+		panic("context is nil")
+	}
+	if vm == nil {
+		panic("vm is nil")
+	}
+	if configSpec == nil {
+		panic("configSpec is nil")
+	}
+
+	// No live VM config yet (e.g. during create before the VM exists in
+	// vSphere) -- nothing to compare against.
+	if moVM.Config == nil {
+		return nil
+	}
+
+	virtualmachine.UpdateConfigSpecExtensionCompatibilityConstraint(moVM.Config, configSpec)
+
+	return nil
+}

--- a/pkg/vmconfig/extensioncompatconstraint/extensioncompatconstraint_reconciler_suite_test.go
+++ b/pkg/vmconfig/extensioncompatconstraint/extensioncompatconstraint_reconciler_suite_test.go
@@ -1,0 +1,19 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package extensioncompatconstraint_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	_ "github.com/vmware-tanzu/vm-operator/test/builder/log"
+)
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ExtensionCompatConstraint Reconciler Test Suite")
+}

--- a/pkg/vmconfig/extensioncompatconstraint/extensioncompatconstraint_reconciler_test.go
+++ b/pkg/vmconfig/extensioncompatconstraint/extensioncompatconstraint_reconciler_test.go
@@ -1,0 +1,125 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: Apache-2.0
+
+package extensioncompatconstraint_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/vmware/govmomi/vim25/mo"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
+	"github.com/vmware-tanzu/vm-operator/pkg/vmconfig"
+	vmconfextensioncompatconstraint "github.com/vmware-tanzu/vm-operator/pkg/vmconfig/extensioncompatconstraint"
+)
+
+func makeVM() *vmopv1.VirtualMachine {
+	return &vmopv1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "vm"},
+	}
+}
+
+var _ = Describe("New", func() {
+	It("returns a non-nil Reconciler", func() {
+		Expect(vmconfextensioncompatconstraint.New()).ToNot(BeNil())
+	})
+	It("has name 'extensioncompatconstraint'", func() {
+		Expect(vmconfextensioncompatconstraint.New().Name()).To(Equal("extensioncompatconstraint"))
+	})
+})
+
+var _ = Describe("OnResult", func() {
+	It("is a no-op", func() {
+		r := vmconfextensioncompatconstraint.New()
+		Expect(r.OnResult(context.Background(), makeVM(), mo.VirtualMachine{}, nil)).To(Succeed())
+	})
+})
+
+var _ = Describe("Reconcile", func() {
+
+	var (
+		ctx        context.Context
+		vm         *vmopv1.VirtualMachine
+		moVM       mo.VirtualMachine
+		configSpec *vimtypes.VirtualMachineConfigSpec
+		r          vmconfig.Reconciler
+	)
+
+	BeforeEach(func() {
+		r = vmconfextensioncompatconstraint.New()
+		ctx = pkgcfg.NewContextWithDefaultConfig()
+		vm = makeVM()
+		moVM = mo.VirtualMachine{}
+		configSpec = &vimtypes.VirtualMachineConfigSpec{}
+	})
+
+	Context("a panic is expected", func() {
+		When("ctx is nil", func() {
+			JustBeforeEach(func() {
+				ctx = nil
+			})
+			It("panics", func() {
+				fn := func() {
+					_ = r.Reconcile(ctx, nil, nil, vm, moVM, configSpec)
+				}
+				Expect(fn).To(PanicWith("context is nil"))
+			})
+		})
+
+		When("vm is nil", func() {
+			JustBeforeEach(func() {
+				vm = nil
+			})
+			It("panics", func() {
+				fn := func() {
+					_ = r.Reconcile(ctx, nil, nil, vm, moVM, configSpec)
+				}
+				Expect(fn).To(PanicWith("vm is nil"))
+			})
+		})
+
+		When("configSpec is nil", func() {
+			JustBeforeEach(func() {
+				configSpec = nil
+			})
+			It("panics", func() {
+				fn := func() {
+					_ = r.Reconcile(ctx, nil, nil, vm, moVM, configSpec)
+				}
+				Expect(fn).To(PanicWith("configSpec is nil"))
+			})
+		})
+	})
+
+	When("moVM.Config is nil", func() {
+		BeforeEach(func() {
+			moVM = mo.VirtualMachine{}
+		})
+
+		It("does not modify the ConfigSpec", func() {
+			Expect(r.Reconcile(ctx, nil, nil, vm, moVM, configSpec)).To(Succeed())
+			Expect(configSpec.ExtensionCompatibilityConstraint).To(BeNil())
+		})
+	})
+
+	When("moVM.Config's constraint set does not match the desired set", func() {
+		BeforeEach(func() {
+			moVM = mo.VirtualMachine{
+				Config: &vimtypes.VirtualMachineConfigInfo{},
+			}
+		})
+
+		It("sets the full desired set on the ConfigSpec", func() {
+			Expect(r.Reconcile(ctx, nil, nil, vm, moVM, configSpec)).To(Succeed())
+			Expect(configSpec.ExtensionCompatibilityConstraint).ToNot(BeNil())
+			Expect(configSpec.ExtensionCompatibilityConstraint.Constraint).To(HaveLen(6))
+		})
+	})
+})


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Fold a generic, level-triggered check into the existing config reconfigure path: compare a VM's current
config.extensionCompatibilityConstraint set against the desired 6 INVARIANTs (ignoring the cosmetic ConstraintName and array order), and re-send the full desired set whenever they differ.

This is folded into doReconfigure's shared ConfigSpec rather than given its own standalone Reconfigure call, so it batches with other pending config changes into a single vCenter round trip. The trade-off is that reconcileConfig's existing verifyConnectionState check means this fix-up is skipped for VMs with a disconnected host, same as the rest of config reconciliation.

vmop-3779


**Please add a release note if necessary**:

```release-note
Reconcile stale extension compat constraints on VMs
```