### PR TITLE
[x-port] [9.1.1] :bug: Only watch BatchAttach CRD if the SharedDisks cap is enabled

### DIFF
--- a/controllers/virtualmachine/virtualmachine/virtualmachine_controller.go
+++ b/controllers/virtualmachine/virtualmachine/virtualmachine_controller.go
@@ -200,12 +200,14 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 	// Watch CnsNodeVMBatchAttachment in order to account for the volume
 	// registration race outlined/fixed in
 	// https://github.com/vmware-tanzu/vm-operator/pull/1572.
-	builder = builder.Watches(
-		&cnsv1alpha1.CnsNodeVMBatchAttachment{},
-		handler.EnqueueRequestsFromMapFunc(
-			vmopv1util.CnsNodeVMBatchAttachmentToVirtualMachineMapper(ctx),
-		),
-	)
+	if pkgcfg.FromContext(ctx).Features.VMSharedDisks {
+		builder = builder.Watches(
+			&cnsv1alpha1.CnsNodeVMBatchAttachment{},
+			handler.EnqueueRequestsFromMapFunc(
+				vmopv1util.CnsNodeVMBatchAttachmentToVirtualMachineMapper(ctx),
+			),
+		)
+	}
 
 	return builder.Complete(r)
 }


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This is an x-port of #1773 from main branch.

We are unconditionally watching the batch attachment CRD which can cause issues due to the circular dependency between VM op and CSI for CRD installation.


**Please add a release note if necessary**:

```release-note
[x-port] [9.1.1] :bug: Only watch BatchAttach CRD if the SharedDisks cap is enabled
```