### PR TITLE
🐛 Flaky Test: CD-ROM disconnect fix

### DIFF
--- a/test/e2e/vmservice/vmservice/virtualmachine/virtualmachinelcm.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/virtualmachinelcm.go
@@ -741,19 +741,43 @@ func VMSpec(ctx context.Context, inputGetter func() VMSpecInput) {
 		cdromFileName := cdrom.Backing.(*types.VirtualCdromIsoBackingInfo).FileName
 		Expect(cdromFileName).To(Equal(clItem.Status.FileInfo[0].StorageURI))
 
-		By("Verifying CD-ROM can be disconnected from the VM")
-		// Use a host-forced (allowGuestControl=false) disconnect here: the guest
-		// is still sitting at the ISO's boot/installer screen with no VMware
-		// Tools running, so a guest-mediated disconnect (allowGuestControl=true)
-		// cannot get a guest ack and fails with msg.disk.onlineConnectFail. This
-		// step is only exercising the k8s-to-vSphere connection-state plumbing,
-		// not a guest-cooperative eject, so the host-forced path is the correct
-		// one to assert against.
+		// The guest is still sitting at the ISO's boot/installer screen with no
+		// VMware Tools running and is actively reading the CD-ROM, so vCenter
+		// raises a blocking "device is locked, force disconnect?" question on a
+		// live ReconfigVM to disconnect it -- guest-mediated
+		// (allowGuestControl=true) or host-forced (allowGuestControl=false)
+		// alike. Nothing answers that question, so the task hangs until
+		// vCenter's own timeout and then fails with msg.disk.onlineConnectFail.
+		// In practice a guest would unmount the media first (releasing the
+		// lock) and then a live disconnect succeeds with no question raised;
+		// since this test doesn't control the guest, it powers the VM off to
+		// disconnect the CD-ROM instead.
+		// TODO: vSphere also has a per-VM advanced option,
+		// cdrom.showIsoLockWarning=FALSE, that suppresses this question
+		// entirely and would allow a live disconnect. Consider surfacing that
+		// as a v1alpha6 CD-ROM option instead of requiring a power cycle.
+		// https://knowledge.broadcom.com/external/article?legacyId=2144053
+		By("Powering off the VM to safely disconnect the CD-ROM")
+		vmParameters.PowerState = poweredOffState
+		vmYaml = manifestbuilders.GetVirtualMachineYamlA3(vmParameters)
+		Expect(clusterProxy.ApplyWithArgs(ctx, vmYaml)).To(Succeed(), "failed to apply updated VM YAML to power off the VM %s", string(vmYaml))
+		vmoperator.WaitForVirtualMachinePowerState(ctx, config, svClusterClient, input.WCPNamespaceName, vmName, poweredOffState)
+
+		By("Verifying CD-ROM can be disconnected from the VM while powered off")
 		//nolint:staticcheck // VirtualMachineYaml (v1alpha3) still exposes deprecated Cdrom for this spec path.
 		vmParameters.Cdrom[0].Connected = false
 		vmParameters.Cdrom[0].AllowGuestControl = false
 		vmYaml = manifestbuilders.GetVirtualMachineYamlA3(vmParameters)
 		Expect(clusterProxy.ApplyWithArgs(ctx, vmYaml)).To(Succeed(), "failed to apply updated VM YAML with CD-ROM disconnected %s", string(vmYaml))
+		verifyCdromConnectionState(ctx, vmMoRef, propCollector, false, false)
+
+		By("Powering the VM back on")
+		vmParameters.PowerState = poweredOnState
+		vmYaml = manifestbuilders.GetVirtualMachineYamlA3(vmParameters)
+		Expect(clusterProxy.ApplyWithArgs(ctx, vmYaml)).To(Succeed(), "failed to apply updated VM YAML to power on the VM %s", string(vmYaml))
+		vmoperator.WaitForVirtualMachinePowerState(ctx, config, svClusterClient, input.WCPNamespaceName, vmName, poweredOnState)
+
+		By("Verifying CD-ROM did not auto-connect on power on")
 		verifyCdromConnectionState(ctx, vmMoRef, propCollector, false, false)
 
 		By("Verifying CD-ROM can be reconnected to the VM with allowGuestControl disabled")


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Fixes the ISO-deployed VM E2E test's CD-ROM disconnect step. The test was
live-disconnecting a CD-ROM (`Connected: false`) from a powered-on VM while
the guest was still actively reading the ISO (booting the live-installer
media, no VMware Tools running). vCenter raises a blocking "device is
locked, force disconnect?" question on that `ReconfigVM_Task`; nothing
answers it, so the task hangs until vCenter's own timeout and fails with
`msg.disk.onlineConnectFail`.

A prior attempt at this test worked around the symptom by switching to a
host-forced disconnect (`allowGuestControl: false`), assuming that path
wasn't subject to the guest ack. That assumption was wrong — the lock
question is raised regardless of `allowGuestControl`, so the failure
persisted.

The fix powers the VM off before applying the disconnect, verifies the
connection state while off, then powers back on and verifies the CD-ROM
does not auto-reconnect (`StartConnected` stays `false`). The existing
live-reconnect step (`Connected: true` while powered on) is left as-is,
since connecting media doesn't trigger the guest lock question — only
disconnecting a device the guest holds open does.

This is a test-only change; no product code was modified, since the
underlying behavior is a vCenter device-lock constraint, not a vm-operator
reconciliation defect.

A `TODO` comment notes a possible follow-up: vSphere's
`cdrom.showIsoLockWarning=FALSE` advanced option suppresses the lock
question and would allow a true live disconnect. That's left for a
separate change if we decide to expose it as a v1alpha6 CD-ROM option.

**Which issue(s) is/are addressed by this PR?**

Fixes #

**Are there any special notes for your reviewer**:

This addresses Bugzilla 3750874. The original Mobot triage classified this
as a product defect, but the root cause is a vCenter-side blocking
question (not something vm-operator's reconfigure logic can control
without adding VM-question-answering machinery), so the fix is scoped to
the E2E test's disconnect flow rather than `pkg/`/`api/`.