### PR TITLE
Bound RegisterVM disk-only-restore cleanup, repair FCD first & new fault type

### DIFF
--- a/test/e2e/vmservice/vmservice/viadmin/registervm.go
+++ b/test/e2e/vmservice/vmservice/viadmin/registervm.go
@@ -1052,7 +1052,8 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 			// Expect to fail w/ orphaned FCD
 			_, err = fcdManager.Retrieve(ctx, ds, disk.VDiskId.Id)
 			Expect(err).To(HaveOccurred())
-			Expect(fault.Is(err, &types.NotFound{})).To(BeTrue())
+			isOrphaned := fault.Is(err, &types.NotFound{}) || fault.Is(err, &types.FileNotFound{})
+			Expect(isOrphaned).To(BeTrue(), "expected NotFound or FileNotFound fault for orphaned FCD, got: %v", err)
 
 			// The Volume still exists
 			queryVolume()

--- a/test/e2e/vmservice/vmservice/viadmin/registervm.go
+++ b/test/e2e/vmservice/vmservice/viadmin/registervm.go
@@ -895,7 +895,7 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 			// Bounded so a broken vSphere-side disk state left behind by an earlier
 			// assertion failure in this spec fails cleanup fast instead of blocking
 			// the rest of the suite for hours.
-			DeferCleanup(deleteRegisteredVMAndPVCs, ctx, svClusterClient, clusterProxy, vmNamespace, vmName, vmYaml, NodeTimeout(3*time.Minute))
+			DeferCleanup(deleteRegisteredVMAndPVCs, svClusterClient, clusterProxy, vmNamespace, vmName, vmYaml, NodeTimeout(3*time.Minute))
 			// End create new VM
 
 			// Wait for IP, a valid moID and the PVC attachment.

--- a/test/e2e/vmservice/vmservice/viadmin/registervm.go
+++ b/test/e2e/vmservice/vmservice/viadmin/registervm.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"path"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -891,7 +892,10 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 			}
 			vmYaml := manifestbuilders.GetVirtualMachineYamlA2(vmParameters)
 			Expect(vmsvcClusterProxy.CreateWithArgs(ctx, vmYaml)).To(Succeed(), "failed to create Linux VM:\n%s", string(vmYaml))
-			DeferCleanup(deleteRegisteredVMAndPVCs, ctx, svClusterClient, clusterProxy, vmNamespace, vmName, vmYaml)
+			// Bounded so a broken vSphere-side disk state left behind by an earlier
+			// assertion failure in this spec fails cleanup fast instead of blocking
+			// the rest of the suite for hours.
+			DeferCleanup(deleteRegisteredVMAndPVCs, ctx, svClusterClient, clusterProxy, vmNamespace, vmName, vmYaml, NodeTimeout(3*time.Minute))
 			// End create new VM
 
 			// Wait for IP, a valid moID and the PVC attachment.
@@ -1021,6 +1025,24 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 			// "Delete" existing disk
 			Expect(vmObj.RemoveDevice(ctx, true, disk)).To(Succeed())
 			findDisk(Default, pvcNameA, false)
+
+			// If a later assertion in this spec fails before RegisterVM successfully
+			// re-registers this disk, the FCD catalog entry below is left dangling,
+			// pointing at a backing file that no longer exists at its original
+			// location. That dangling entry is what makes the outer VM/PVC
+			// DeferCleanup above hang for hours waiting on CNS/CSI to tear down
+			// storage that will never resolve cleanly. Best-effort force-remove it
+			// directly (runs before the outer cleanup since DeferCleanup is LIFO) so
+			// that cleanup isn't left waiting on it. A no-op if RegisterVM already
+			// reconciled this FCD away via the normal (passing) path.
+			origDatastore, origFCDID := ds, disk.VDiskId.Id
+			DeferCleanup(func(ctx context.Context) {
+				task, err := fcdManager.Delete(ctx, origDatastore, origFCDID)
+				if err != nil {
+					return
+				}
+				_ = task.Wait(ctx)
+			}, NodeTimeout(1*time.Minute))
 
 			// Create "new" disk
 			dstPath := object.DatastorePath{Datastore: vmPath.Datastore, Path: path.Join(vmHome, path.Base(datastorePath.Path))}


### PR DESCRIPTION
An assertion failure partway through the disk-only-restore spec (e.g. the FCD backing-file fault-type check) leaves the disk's original FCD catalog entry dangling: its backing file has already been moved/ deleted, but RegisterVM never ran to reconcile or re-register it. The outer DeferCleanup that deletes the VM and its PVCs then hangs for hours, since CNS/CSI retries indefinitely against an FCD stuck in this ambiguous state, and with no timeout on that DeferCleanup node, Ginkgo lets it run until the whole suite's grace period expires, blocking every later spec in the process.

Changes:
- Give the VM/PVC DeferCleanup a 3-minute NodeTimeout so a stuck cleanup fails fast instead of consuming the suite's timeout budget.
- Register a second, LIFO-earlier DeferCleanup right after the disk is detached that best-effort force-deletes the FCD catalog entry directly via fcdManager. This repairs the vSphere-side state before the VM/PVC cleanup runs, so CNS/CSI sees a clean NotFound instead of the ambiguous dangling-catalog state and doesn't get stuck retrying.

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note

```