### PR TITLE
🐛 Improve the describe diagnostics on failure across the e2e suite

### DIFF
--- a/test/e2e/vmservice/lib/vmoperator/vmoperator.go
+++ b/test/e2e/vmservice/lib/vmoperator/vmoperator.go
@@ -588,6 +588,55 @@ func DescribeResourceIfExists(ctx context.Context, client ctrlclient.Client, kub
 	e2eframework.Logf("kubectl describe %s -n %s %s:\n%s", resource, ns, resourceName, stdout)
 }
 
+// DescribeObjectsOnFailure describes every instance of the vm-operator CR kinds tests
+// commonly create in ns, if the current spec failed — without depending on the caller
+// having tracked each resource's name/YAML correctly in an outer variable.
+func DescribeObjectsOnFailure(ctx context.Context, client ctrlclient.Client, kubeconfigPath, ns string) {
+	if !CurrentSpecReport().Failed() {
+		return
+	}
+
+	if ns == "" {
+		e2eframework.Logf("skipping vm-operator failure diagnostics: empty namespace")
+		return
+	}
+
+	// Typed List results don't have TypeMeta/Kind populated on their items (a
+	// well-known controller-runtime/client-go quirk), so each List is paired with
+	// the kubectl "resource" argument we pass to DescribeResourceIfExists below.
+	for _, entry := range []struct {
+		list ctrlclient.ObjectList
+		kind string
+	}{
+		{&vmopv1.VirtualMachineList{}, virtualMachineKind},
+		{&vmopv1.VirtualMachineGroupList{}, "VirtualMachineGroup"},
+		{&vmopv1.VirtualMachineGroupPublishRequestList{}, "VirtualMachineGroupPublishRequest"},
+		{&vmopv1.VirtualMachinePublishRequestList{}, "VirtualMachinePublishRequest"},
+		{&vmopv1.VirtualMachineServiceList{}, "VirtualMachineService"},
+		{&vmopv1.VirtualMachineSnapshotList{}, "VirtualMachineSnapshot"},
+		{&vmopv1.VirtualMachineWebConsoleRequestList{}, "VirtualMachineWebConsoleRequest"},
+	} {
+		if err := client.List(ctx, entry.list, ctrlclient.InNamespace(ns)); err != nil {
+			e2eframework.Logf("failed to list %s in %s for failure diagnostics: %v", entry.kind, ns, err)
+			continue
+		}
+
+		items, err := meta.ExtractList(entry.list)
+		if err != nil {
+			e2eframework.Logf("failed to extract %s items for failure diagnostics: %v", entry.kind, err)
+			continue
+		}
+
+		for _, item := range items {
+			accessor, err := meta.Accessor(item)
+			if err != nil {
+				continue
+			}
+			DescribeResourceIfExists(ctx, client, kubeconfigPath, ns, accessor.GetName(), entry.kind)
+		}
+	}
+}
+
 // Utility function to get a image k8s name given its display name.
 func WaitForVirtualMachineImageName(ctx context.Context, config *framework.Config,
 	client ctrlclient.Client, namespace, imageDisplayName string) string {

--- a/test/e2e/vmservice/vmservice/viadmin/registervm.go
+++ b/test/e2e/vmservice/vmservice/viadmin/registervm.go
@@ -148,6 +148,10 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 		incrementalRestoreEnabled = utils.IsFssEnabled(ctx, svClusterClient, config.GetVariable("VMOPNamespace"), config.GetVariable("VMOPDeploymentName"), config.GetVariable("VMOPManagerCommand"), config.GetVariable("EnvFSSIncrementalRestore"))
 	})
 
+	AfterEach(func() {
+		vmoperator.DescribeObjectsOnFailure(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), input.WCPNamespaceName)
+	})
+
 	Context("Authorization test", func() {
 		var (
 			vCenterHostname                    string

--- a/test/e2e/vmservice/vmservice/virtualmachine/virtualmachinelcm.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/virtualmachinelcm.go
@@ -124,9 +124,7 @@ func VMSpec(ctx context.Context, inputGetter func() VMSpecInput) {
 			vmNamespaceName = tmpNamespaceCtx.GetNamespace().Name
 		}
 
-		if CurrentSpecReport().Failed() {
-			vmoperator.DescribeResourceIfExists(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), vmNamespaceName, vmName, "vm")
-		}
+		vmoperator.DescribeObjectsOnFailure(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), vmNamespaceName)
 
 		// Delete the virtual machine if it was created.
 		if len(vmYaml) > 0 {

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_compute_config.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_compute_config.go
@@ -121,6 +121,10 @@ func VMComputeConfigSpec(ctx context.Context, inputGetter func() VMComputeConfig
 			config.InfraConfig.ManagementClusterConfig.Resources.PhotonImageDisplayName)
 	})
 
+	AfterEach(func() {
+		vmoperator.DescribeObjectsOnFailure(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), vmNamespace)
+	})
+
 	It("creates VM with hot-pluggable allocation and verifies condition True after live update",
 		Label("core-functional", "experimental"), func() {
 

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_encryption.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_encryption.go
@@ -145,9 +145,7 @@ func VMEncryptionSpec(ctx context.Context, inputGetter func() VMEncryptionInput)
 	})
 
 	AfterEach(func() {
-		if CurrentSpecReport().Failed() {
-			vmoperator.DescribeResourceIfExists(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), tmpNamespaceName, vmName, "vm")
-		}
+		vmoperator.DescribeObjectsOnFailure(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), tmpNamespaceName)
 		// Delete the virtual machine if it was created.
 		if len(vmYaml) > 0 {
 			Expect(clusterProxy.DeleteWithArgs(ctx, vmYaml)).To(Succeed(), "failed to delete virtualmachine")

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_extraconfig.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_extraconfig.go
@@ -128,6 +128,10 @@ func VMExtraConfigSpec(ctx context.Context, inputGetter func() VMExtraConfigSpec
 			input.WCPNamespaceName, linuxImageDisplayName)
 	})
 
+	AfterEach(func() {
+		vmoperator.DescribeObjectsOnFailure(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), input.WCPNamespaceName)
+	})
+
 	// ── It block 1: phases 1-2 ────────────────────────────────────────────────
 	// Creates a VM with PowerCycle first-class fields and two bag keys, waits for
 	// ExtraConfigSynced=True, then exercises bag key CRUD and verifies status.extraConfig

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_group.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_group.go
@@ -111,14 +111,7 @@ func VMGroupSpec(ctx context.Context, inputGetter func() VMGroupSpecInput) {
 	})
 
 	AfterEach(func() {
-		if CurrentSpecReport().Failed() {
-			vmoperator.DescribeResourceIfExists(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), input.WCPNamespaceName, vmgRootName, vmgKind)
-			vmoperator.DescribeResourceIfExists(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), input.WCPNamespaceName, vmgChildName, vmgKind)
-
-			for _, vmName := range vmMemberNames {
-				vmoperator.DescribeResourceIfExists(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), input.WCPNamespaceName, vmName, vmKind)
-			}
-		}
+		vmoperator.DescribeObjectsOnFailure(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), input.WCPNamespaceName)
 
 		// Delete the root VirtualMachineGroup if created.
 		if len(vmgRootYaml) > 0 {
@@ -867,6 +860,7 @@ func VMGroupSpec(ctx context.Context, inputGetter func() VMGroupSpecInput) {
 
 		AfterEach(func() {
 			if tmpNamespaceName != "" {
+				vmoperator.DescribeObjectsOnFailure(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), tmpNamespaceName)
 				clusterProxy.DeleteWCPNamespace(tmpNamespaceCtx)
 				tmpNamespaceName = ""
 			}
@@ -1472,6 +1466,7 @@ func VMGroupSpec(ctx context.Context, inputGetter func() VMGroupSpecInput) {
 
 		AfterEach(func() {
 			if tmpNamespaceName != "" {
+				vmoperator.DescribeObjectsOnFailure(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), tmpNamespaceName)
 				clusterProxy.DeleteWCPNamespace(tmpNamespaceCtx)
 				tmpNamespaceName = ""
 			}

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_group_publishrequest.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_group_publishrequest.go
@@ -221,6 +221,8 @@ func VMGroupPublishRequestSpec(ctx context.Context, inputGetter func() VMGroupPu
 	}
 
 	AfterEach(func() {
+		vmoperator.DescribeObjectsOnFailure(ctx, vmSvcClusterProxy.GetClient(), vmSvcClusterProxy.GetKubeconfigPath(), vmSvcNamespace)
+
 		if skipCleanup {
 			return
 		}

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_guestcustomization.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_guestcustomization.go
@@ -533,9 +533,7 @@ func VMGOSCSpec(ctx context.Context, inputGetter func() VMGOSCSpecInput) {
 	})
 
 	AfterEach(func() {
-		if CurrentSpecReport().Failed() {
-			vmoperator.DescribeResourceIfExists(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), input.WCPNamespaceName, vmName, "vm")
-		}
+		vmoperator.DescribeObjectsOnFailure(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), input.WCPNamespaceName)
 
 		if skipCleanup {
 			return

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_hardware.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_hardware.go
@@ -458,6 +458,8 @@ func VMHardwareSpec(ctx context.Context, inputGetter func() VMHardwareSpecInput)
 		})
 
 		AfterEach(func() {
+			vmoperator.DescribeObjectsOnFailure(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), vmSvcNamespace)
+
 			if CurrentSpecReport().Failed() {
 				By("Logging Virtual Machines and Batch Attachments after failure")
 
@@ -2034,6 +2036,8 @@ func VMHardwareSpec(ctx context.Context, inputGetter func() VMHardwareSpecInput)
 			})
 
 			AfterEach(func() {
+				vmoperator.DescribeObjectsOnFailure(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), vmSvcNamespace)
+
 				CleanupBrownfieldVM(ctx, BrownfieldVMCleanupInput{
 					VCenterAdminClient: vCenterAdminClient,
 					BrownfieldVMName:   brownfieldVMName,

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_location.go
@@ -130,12 +130,7 @@ func VMLocationSpec(ctx context.Context, inputGetter func() VMLocationSpecInput)
 	})
 
 	AfterEach(func() {
-		if CurrentSpecReport().Failed() {
-			vmoperator.DescribeResourceIfExists(
-				ctx, svClusterClient,
-				clusterProxy.GetKubeconfigPath(),
-				input.WCPNamespaceName, vmName, vmKind)
-		}
+		vmoperator.DescribeObjectsOnFailure(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), input.WCPNamespaceName)
 
 		vmoperator.VerifyVMDeleted(ctx, svClusterClient, config, input.WCPNamespaceName, vmName)
 		vcenter.LogoutVimClient(vCenterAdminClient)

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_longevity.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_longevity.go
@@ -111,8 +111,8 @@ func VMLongevitySpec(ctx context.Context, inputGetter func() VMLongevityInput) {
 	AfterEach(func() {
 		if CurrentSpecReport().Failed() {
 			vmoperator.DescribeResourceIfExists(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), input.WCPNamespaceName, vmClassName, "vmclass")
-			vmoperator.DescribeResourceIfExists(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), input.WCPNamespaceName, vmName, "vm")
 		}
+		vmoperator.DescribeObjectsOnFailure(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), input.WCPNamespaceName)
 
 		// Delete and verify the virtual machine doesn't exist.
 		if len(vmYaml) > 0 {

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_multipleclusters.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_multipleclusters.go
@@ -78,9 +78,7 @@ func VMMultipleClusterSpec(ctx context.Context, inputGetter func() VMMultipleClu
 	})
 
 	AfterEach(func() {
-		if CurrentSpecReport().Failed() {
-			vmoperator.DescribeResourceIfExists(ctx, svClusterClient, input.ClusterProxy.GetKubeconfigPath(), input.WCPNamespaceName, vmName, "vm")
-		}
+		vmoperator.DescribeObjectsOnFailure(ctx, svClusterClient, input.ClusterProxy.GetKubeconfigPath(), input.WCPNamespaceName)
 
 		// Delete the virtual machine
 		vmoperator.DeleteVirtualMachine(ctx, svClusterClient, input.WCPNamespaceName, vmName)

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_networking.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_networking.go
@@ -111,9 +111,7 @@ func VMNetworkSpec(ctx context.Context, inputGetter func() VMNetworkSpecInput) {
 			vmNamespaceName = tmpNamespaceCtx.GetNamespace().Name
 		}
 
-		if CurrentSpecReport().Failed() {
-			vmoperator.DescribeResourceIfExists(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), vmNamespaceName, vmName, "vm")
-		}
+		vmoperator.DescribeObjectsOnFailure(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), vmNamespaceName)
 
 		// Delete the virtual machine if it was created.
 		if len(vmYaml) > 0 {

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_nic_extra_config.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_nic_extra_config.go
@@ -377,6 +377,10 @@ func VMNICExtraConfigSpec(ctx context.Context, inputGetter func() VMNICExtraConf
 		linuxVMIName = vmoperator.WaitForVirtualMachineImageName(ctx, &config.Config, svClusterClient, vmNamespace, linuxImageDisplayName)
 	})
 
+	AfterEach(func() {
+		vmoperator.DescribeObjectsOnFailure(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), vmNamespace)
+	})
+
 	It("creates VM with live-mode ExtraConfig and verifies both coalescingScheme and coalescingParams",
 		Label("core-functional", "experimental"), func() {
 			vmName := "nic-ec-live-" + capiutil.RandomString(5)

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_publishrequest.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_publishrequest.go
@@ -108,9 +108,7 @@ func VMPublishRequestSpec(ctx context.Context, inputGetter func() VMPublishReque
 		})
 
 		AfterEach(func() {
-			if CurrentSpecReport().Failed() {
-				vmoperator.DescribeResourceIfExists(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), input.WCPNamespaceName, input.LinuxVMName, "vm")
-			}
+			vmoperator.DescribeObjectsOnFailure(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), input.WCPNamespaceName)
 		})
 
 		Context("CLS Content Library", Ordered, func() {

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_snapshot.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_snapshot.go
@@ -116,6 +116,8 @@ func VMSnapshotSpec(ctx context.Context, inputGetter func() VMSnapshotSpecInput)
 	})
 
 	AfterEach(func() {
+		vmoperator.DescribeObjectsOnFailure(ctx, svClusterClient, vmSvcClusterProxy.GetKubeconfigPath(), vmSvcNamespace)
+
 		if skipCleanup {
 			return
 		}

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_vpcnetworking.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_vpcnetworking.go
@@ -167,12 +167,9 @@ func VMVPCSpec(ctx context.Context, inputGetter func() VMVPCSpecInput) {
 		}
 	})
 
-	// Describe the VMs if the test failed before they are deleted.
+	// Describe the VMs (and other vm-operator CRs) if the test failed before they are deleted.
 	JustAfterEach(func() {
-		if CurrentSpecReport().Failed() {
-			vmoperator.DescribeResourceIfExists(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), input.WCPNamespaceName, vm1Name, "vm")
-			vmoperator.DescribeResourceIfExists(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), input.WCPNamespaceName, vm2Name, "vm")
-		}
+		vmoperator.DescribeObjectsOnFailure(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), input.WCPNamespaceName)
 	})
 
 	AfterEach(func() {
@@ -367,6 +364,10 @@ func VMVPCSpec(ctx context.Context, inputGetter func() VMVPCSpecInput) {
 		)
 
 		AfterEach(func() {
+			if secondNamespaceCtx.GetNamespace() != nil {
+				vmoperator.DescribeObjectsOnFailure(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), secondNamespaceName)
+			}
+
 			if vm1IP != "" {
 				deleteVMAndSubnet(ctx, config, svClusterClient, input.WCPNamespaceName, vm1Name, subnetName, subnetKind)
 			}

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_webconsolerequest.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_webconsolerequest.go
@@ -79,8 +79,11 @@ func VMWebConsoleRequestSpec(ctx context.Context, inputGetter func() VMWebConsol
 
 	AfterEach(func() {
 		if CurrentSpecReport().Failed() {
+			// resourceName can be the legacy v1a1 "webconsolerequests" resource, which
+			// isn't a vm-operator v1alpha6 CR and so isn't covered by DescribeObjectsOnFailure.
 			vmoperator.DescribeResourceIfExists(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), input.WCPNamespaceName, webconsoleName, resourceName)
 		}
+		vmoperator.DescribeObjectsOnFailure(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), input.WCPNamespaceName)
 	})
 
 	Context("Create web console request CR", func() {

--- a/test/e2e/vmservice/vmservice/virtualmachineservice/virtualmachineservice.go
+++ b/test/e2e/vmservice/vmservice/virtualmachineservice/virtualmachineservice.go
@@ -29,11 +29,6 @@ import (
 	"github.com/vmware-tanzu/vm-operator/test/e2e/wcpframework"
 )
 
-const (
-	virtualMachineKind        = "VirtualMachine"
-	virtualMachineServiceKind = "VirtualMachineService"
-)
-
 type SpecInput struct {
 	Config           *e2eConfig.E2EConfig
 	ClusterProxy     wcpframework.WCPClusterProxyInterface
@@ -86,12 +81,7 @@ func VirtualMachineServiceSpec(ctx context.Context, inputGetter func() SpecInput
 	})
 
 	AfterEach(func() {
-		if CurrentSpecReport().Failed() {
-			vmoperator.DescribeResourceIfExists(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), input.WCPNamespaceName, vmServiceName, virtualMachineServiceKind)
-			for _, vmName := range vmNames {
-				vmoperator.DescribeResourceIfExists(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), input.WCPNamespaceName, vmName, virtualMachineKind)
-			}
-		}
+		vmoperator.DescribeObjectsOnFailure(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), input.WCPNamespaceName)
 
 		Expect(ctrlclient.IgnoreNotFound(svClusterClient.Delete(ctx, &vmopv1.VirtualMachineService{
 			ObjectMeta: metav1.ObjectMeta{Name: vmServiceName, Namespace: input.WCPNamespaceName},


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Add `vmoperator.DescribeObjectsOnFailure`, an AfterEach-callable helper that lists every vm-operator object e2e tests upon failure commonly create, instead of relying on an outer variable (vmYaml/vmName) that can be stale, reassigned to a different resource, or never set for the specific object that actually failed.

Roll this out as a single AfterEach call across the ~19 spec files that create these resources. Files that only touch cluster-scoped or non-vm-operator resources (VM classes, content libraries, plain namespaces) are left unchanged.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # vmop_3782245


**Are there any special notes for your reviewer**:

There will be more PRs to standardize some practices across the AfterEach of the suites.

**Please add a release note if necessary**:

```release-note

```