### PR TITLE
🐛 Update MapEthernetDevicesToSpecIdx for mixed network providers

### DIFF
--- a/pkg/providers/vsphere/network/devices.go
+++ b/pkg/providers/vsphere/network/devices.go
@@ -104,8 +104,15 @@ func UpdateVMClassEthCardFromDevice(
 	return nil
 }
 
-// MapEthernetDevicesToSpecIdx maps the VM's ethernet devices to the corresponding
-// entry in the VM's Spec.
+// MapEthernetDevicesToSpecIdx maps the VM's Ethernet cards to the corresponding entry
+// in the VM's Spec. The result of this is used only to populate the VM Status with the
+// interface spec name. Note that since we populate status very early in the VM reconcile,
+// the VM Spec.Network.Interface may have been changed which means there isn't an Ethernet
+// card added to this VM yet. Therefore, all this is best-effort, and we have to use some
+// additional bit of information from the interface spec CR to match it to the device if
+// there is one.
+// It would be nice if VM Tools would send down the interface name in the guest so we
+// could just show that instead.
 func MapEthernetDevicesToSpecIdx(
 	vmCtx pkgctx.VirtualMachineContext,
 	client ctrlclient.Client,
@@ -145,17 +152,27 @@ func findMatchingEthCardForInterfaceSpec(
 	interfaceSpec vmopv1.VirtualMachineNetworkInterfaceSpec,
 	ethCards object.VirtualDeviceList) int {
 
+	if !pkgcfg.FromContext(vmCtx).Features.PerNamespaceNetworkProvider {
+		if pkgcfg.FromContext(vmCtx).NetworkProviderType == pkgcfg.NetworkProviderTypeNamed {
+			return findMatchingEthCardNamed(vmCtx, client, interfaceSpec, ethCards)
+		}
+	}
+
 	matchingIdx := -1
 
-	switch pkgcfg.FromContext(vmCtx).NetworkProviderType {
-	case pkgcfg.NetworkProviderTypeVDS:
-		matchingIdx = findMatchingEthCardVDS(vmCtx, client, interfaceSpec, ethCards)
-	case pkgcfg.NetworkProviderTypeNSXT:
-		matchingIdx = findMatchingEthCardNSXT(vmCtx, client, interfaceSpec, ethCards)
-	case pkgcfg.NetworkProviderTypeVPC:
-		matchingIdx = findMatchingEthCardVPC(vmCtx, client, interfaceSpec, ethCards)
-	case pkgcfg.NetworkProviderTypeNamed:
-		matchingIdx = findMatchingEthCardNamed(vmCtx, client, interfaceSpec, ethCards)
+	// For this interface spec, try to find the Ethernet card that it most likely
+	// maps to. For an added/removed/changed interface, the device might not have
+	// been added yet so we have to use something derived from the interface spec
+	// to match it with a present device.
+	if group, err := getNetworkInterfaceAPIGroup(interfaceSpec); err == nil {
+		switch group {
+		case netopv1alpha1.SchemeGroupVersion.Group:
+			matchingIdx = findMatchingEthCardVDS(vmCtx, client, interfaceSpec, ethCards)
+		case ncpv1alpha1.SchemeGroupVersion.Group:
+			matchingIdx = findMatchingEthCardNSXT(vmCtx, client, interfaceSpec, ethCards)
+		case vpcv1alpha1.GroupVersion.Group:
+			matchingIdx = findMatchingEthCardVPC(vmCtx, client, interfaceSpec, ethCards)
+		}
 	}
 
 	return matchingIdx
@@ -167,25 +184,12 @@ func findMatchingEthCardVDS(
 	interfaceSpec vmopv1.VirtualMachineNetworkInterfaceSpec,
 	ethCards object.VirtualDeviceList) int {
 
-	var (
-		networkRefName string
-		networkRefType metav1.TypeMeta
-	)
-
-	if netRef := interfaceSpec.Network; netRef != nil {
-		// If Name is empty, NetOP will try to select the namespace default.
-		networkRefName = netRef.Name
-		networkRefType = netRef.TypeMeta
-	}
-
-	if kind := networkRefType.Kind; kind != "" && kind != "Network" {
-		return -1
-	}
+	networkName := interfaceSpec.Network.Name
 
 	netIf := &netopv1alpha1.NetworkInterface{}
 	netIfKey := types.NamespacedName{
 		Namespace: vmCtx.VM.Namespace,
-		Name:      NetOPCRName(vmCtx.VM.Name, networkRefName, interfaceSpec.Name, true),
+		Name:      NetOPCRName(vmCtx.VM.Name, networkName, interfaceSpec.Name, true),
 	}
 
 	// Check if a networkIf object exists with the older (v1a1) naming convention.
@@ -196,7 +200,7 @@ func findMatchingEthCardVDS(
 
 		// If NotFound set the netIf to the new v1a2 naming convention.
 		netIf.ObjectMeta = metav1.ObjectMeta{
-			Name:      NetOPCRName(vmCtx.VM.Name, networkRefName, interfaceSpec.Name, false),
+			Name:      NetOPCRName(vmCtx.VM.Name, networkName, interfaceSpec.Name, false),
 			Namespace: vmCtx.VM.Namespace,
 		}
 
@@ -224,13 +228,16 @@ func findMatchingEthCardNetOpNetIf(
 			continue
 		}
 
+		// TODO: For network migration when the NetworkID is a LogicalSwitchUUID,
+		// we'll need to match this like we do for NSXT/VPC.
+
 		ethCard := bEthCard.GetVirtualEthernetCard()
 		if id := netIf.Status.ExternalID; id != "" {
 			if ethCard.ExternalId != id {
 				continue
 			}
 		} else if ethCard.ExternalId != "" {
-			// This ethernet device has an external ID but the network interface CR does
+			// This Ethernet card has an external ID but the network interface CR does
 			// not. In VDS, the external ID is only set on newly created interface CRs so
 			// don't continue trying to match.
 			continue
@@ -266,36 +273,23 @@ func findMatchingEthCardNSXT(
 	interfaceSpec vmopv1.VirtualMachineNetworkInterfaceSpec,
 	ethCards object.VirtualDeviceList) int {
 
-	var (
-		networkRefName string
-		networkRefType metav1.TypeMeta
-	)
-
-	if netRef := interfaceSpec.Network; netRef != nil {
-		// If Name is empty, NCP will use the namespace default.
-		networkRefName = netRef.Name
-		networkRefType = netRef.TypeMeta
-	}
-
-	if kind := networkRefType.Kind; kind != "" && kind != "VirtualNetwork" {
-		return -1
-	}
+	networkName := interfaceSpec.Network.Name
 
 	vnetIf := &ncpv1alpha1.VirtualNetworkInterface{}
 	vnetIfKey := types.NamespacedName{
 		Namespace: vmCtx.VM.Namespace,
-		Name:      NCPCRName(vmCtx.VM.Name, networkRefName, interfaceSpec.Name, true),
+		Name:      NCPCRName(vmCtx.VM.Name, networkName, interfaceSpec.Name, true),
 	}
 
-	// check if a networkIf object exists with the older (v1a1) naming convention
+	// Check if a networkIf object exists with the older (v1a1) naming convention.
 	if err := client.Get(vmCtx, vnetIfKey, vnetIf); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return -1
 		}
 
-		// if notFound set the vnetIf to use the new v1a2 naming convention
+		// If NotFound set the vnetIf to use the new v1a2 naming convention.
 		vnetIf.ObjectMeta = metav1.ObjectMeta{
-			Name:      NCPCRName(vmCtx.VM.Name, networkRefName, interfaceSpec.Name, false),
+			Name:      NCPCRName(vmCtx.VM.Name, networkName, interfaceSpec.Name, false),
 			Namespace: vmCtx.VM.Namespace,
 		}
 
@@ -333,15 +327,10 @@ func findMatchingEthCardVPC(
 	interfaceSpec vmopv1.VirtualMachineNetworkInterfaceSpec,
 	ethCards object.VirtualDeviceList) int {
 
-	var networkRefName string
-	if netRef := interfaceSpec.Network; netRef != nil {
-		networkRefName = netRef.Name
-	}
-
 	subnetPort := &vpcv1alpha1.SubnetPort{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      VPCCRName(vmCtx.VM.Name, networkRefName, interfaceSpec.Name),
 			Namespace: vmCtx.VM.Namespace,
+			Name:      VPCCRName(vmCtx.VM.Name, interfaceSpec.Network.Name, interfaceSpec.Name),
 		},
 	}
 

--- a/pkg/providers/vsphere/network/devices_test.go
+++ b/pkg/providers/vsphere/network/devices_test.go
@@ -427,25 +427,29 @@ var _ = Describe("MapEthernetDevicesToSpecIdx", func() {
 						{
 							Name: "eth1",
 							Network: &vmopv1common.PartialObjectRef{
-								Name: networkName2,
+								Name:     networkName2,
+								TypeMeta: netOPNetworkTypeMeta,
 							},
 						},
 						{
 							Name: "eth0",
 							Network: &vmopv1common.PartialObjectRef{
-								Name: networkName1,
+								Name:     networkName1,
+								TypeMeta: netOPNetworkTypeMeta,
 							},
 						},
 						{
 							Name: "eth2",
 							Network: &vmopv1common.PartialObjectRef{
-								Name: networkName2,
+								Name:     networkName2,
+								TypeMeta: netOPNetworkTypeMeta,
 							},
 						},
 						{
 							Name: "eth3",
 							Network: &vmopv1common.PartialObjectRef{
-								Name: networkName3,
+								Name:     networkName3,
+								TypeMeta: netOPNetworkTypeMeta,
 							},
 							MACAddr: macAddress,
 						},
@@ -506,13 +510,15 @@ var _ = Describe("MapEthernetDevicesToSpecIdx", func() {
 						{
 							Name: "eth1",
 							Network: &vmopv1common.PartialObjectRef{
-								Name: networkName2,
+								Name:     networkName2,
+								TypeMeta: nsxtNetworkTypeMeta,
 							},
 						},
 						{
 							Name: "eth0",
 							Network: &vmopv1common.PartialObjectRef{
-								Name: networkName1,
+								Name:     networkName1,
+								TypeMeta: nsxtNetworkTypeMeta,
 							},
 						},
 					}
@@ -590,19 +596,22 @@ var _ = Describe("MapEthernetDevicesToSpecIdx", func() {
 						{
 							Name: "eth1",
 							Network: &vmopv1common.PartialObjectRef{
-								Name: networkName2,
+								Name:     networkName2,
+								TypeMeta: vpcNetworkTypeMeta,
 							},
 						},
 						{
 							Name: "eth2",
 							Network: &vmopv1common.PartialObjectRef{
-								Name: networkName3,
+								Name:     networkName3,
+								TypeMeta: vpcNetworkTypeMeta,
 							},
 						},
 						{
 							Name: "eth0",
 							Network: &vmopv1common.PartialObjectRef{
-								Name: networkName1,
+								Name:     networkName1,
+								TypeMeta: vpcNetworkTypeMeta,
 							},
 						},
 					}
@@ -648,7 +657,8 @@ var _ = Describe("MapEthernetDevicesToSpecIdx", func() {
 						{
 							Name: "eth0",
 							Network: &vmopv1common.PartialObjectRef{
-								Name: networkName,
+								Name:     networkName,
+								TypeMeta: vpcNetworkTypeMeta,
 							},
 						},
 					}
@@ -657,6 +667,171 @@ var _ = Describe("MapEthernetDevicesToSpecIdx", func() {
 				It("returns expected mapping", func() {
 					Expect(devKeyToIdx).To(HaveLen(1))
 					Expect(devKeyToIdx).To(HaveKeyWithValue(int32(4000), 0))
+				})
+			})
+		})
+
+		Context("Named", func() {
+			const networkName = "my-network"
+
+			BeforeEach(func() {
+				pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
+					config.NetworkProviderType = pkgcfg.NetworkProviderTypeNamed
+				})
+
+				dev1 := &vimtypes.VirtualVmxnet3{}
+				dev1.Key = 4000
+				dev1.Backing = &vimtypes.VirtualEthernetCardNetworkBackingInfo{
+					VirtualDeviceDeviceBackingInfo: vimtypes.VirtualDeviceDeviceBackingInfo{
+						DeviceName: networkName,
+					},
+				}
+				devices = append(devices, dev1)
+
+				// Note the interface's Network has no APIVersion/TypeMeta set,
+				// as is the case for a Named network.
+				vmCtx.VM.Spec.Network.Interfaces = []vmopv1.VirtualMachineNetworkInterfaceSpec{
+					{
+						Name: "eth0",
+						Network: &vmopv1common.PartialObjectRef{
+							Name: networkName,
+						},
+					},
+				}
+			})
+
+			Context("PerNamespaceNetworkProvider is disabled", func() {
+				BeforeEach(func() {
+					pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
+						config.Features.PerNamespaceNetworkProvider = false
+					})
+				})
+
+				It("matches by device name", func() {
+					Expect(devKeyToIdx).To(HaveLen(1))
+					Expect(devKeyToIdx).To(HaveKeyWithValue(int32(4000), 0))
+				})
+
+				Context("and the interface spec MACAddr does not match the device", func() {
+					BeforeEach(func() {
+						vmCtx.VM.Spec.Network.Interfaces[0].MACAddr = "aa:bb:cc:dd:ee:ff"
+					})
+
+					It("returns no mapping", func() {
+						Expect(devKeyToIdx).To(BeEmpty())
+					})
+				})
+			})
+
+			Context("PerNamespaceNetworkProvider is enabled", func() {
+				BeforeEach(func() {
+					pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
+						config.Features.PerNamespaceNetworkProvider = true
+					})
+				})
+
+				It("does not use the Named matcher and returns no mapping", func() {
+					// With PerNamespaceNetworkProvider enabled, dispatch is by
+					// the interface's API group. Since a Named network has no
+					// APIVersion set, no matcher applies.
+					Expect(devKeyToIdx).To(BeEmpty())
+				})
+			})
+		})
+
+		Context("Interface's Network has no recognized API group", func() {
+			BeforeEach(func() {
+				dev1 := &vimtypes.VirtualVmxnet3{}
+				dev1.Key = 4000
+				devices = append(devices, dev1)
+
+				vmCtx.VM.Spec.Network.Interfaces = []vmopv1.VirtualMachineNetworkInterfaceSpec{
+					{
+						Name: "eth0",
+						Network: &vmopv1common.PartialObjectRef{
+							Name: "some-network",
+							TypeMeta: metav1.TypeMeta{
+								APIVersion: "unknown.example.com/v1",
+							},
+						},
+					},
+				}
+			})
+
+			It("returns no mapping", func() {
+				Expect(devKeyToIdx).To(BeEmpty())
+			})
+		})
+
+		Context("Mixed VDS and VPC", func() {
+			BeforeEach(func() {
+				pkgcfg.SetContext(vmCtx, func(config *pkgcfg.Config) {
+					config.Features.PerNamespaceNetworkProvider = true
+				})
+			})
+
+			Context("Matches", func() {
+				const networkName1, networkName2 = "network-1", "network-2"
+				const backing1 = "dvpg-1"
+				const externalID2 = "extid-2"
+
+				BeforeEach(func() {
+					dev1 := &vimtypes.VirtualVmxnet3{}
+					dev1.Key = 4000
+					dev1.Backing = &vimtypes.VirtualEthernetCardDistributedVirtualPortBackingInfo{
+						Port: vimtypes.DistributedVirtualSwitchPortConnection{
+							PortgroupKey: backing1,
+						},
+					}
+					dev2 := &vimtypes.VirtualE1000e{}
+					dev2.Key = 4001
+					dev2.ExternalId = externalID2
+					devices = append(devices, dev1, dev2)
+
+					netIf1 := &netopv1alpha1.NetworkInterface{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      network.NetOPCRName(vmCtx.VM.Name, networkName1, "eth0", false),
+							Namespace: vmCtx.VM.Namespace,
+						},
+						Status: netopv1alpha1.NetworkInterfaceStatus{
+							NetworkID: backing1,
+						},
+					}
+					subnetPort2 := &vpcv1alpha1.SubnetPort{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      network.VPCCRName(vmCtx.VM.Name, networkName2, "eth1"),
+							Namespace: vmCtx.VM.Namespace,
+						},
+						Status: vpcv1alpha1.SubnetPortStatus{
+							Attachment: vpcv1alpha1.PortAttachment{
+								ID: externalID2,
+							},
+						},
+					}
+					initObjs = append(initObjs, netIf1, subnetPort2)
+
+					vmCtx.VM.Spec.Network.Interfaces = []vmopv1.VirtualMachineNetworkInterfaceSpec{
+						{
+							Name: "eth1",
+							Network: &vmopv1common.PartialObjectRef{
+								Name:     networkName2,
+								TypeMeta: vpcNetworkTypeMeta,
+							},
+						},
+						{
+							Name: "eth0",
+							Network: &vmopv1common.PartialObjectRef{
+								Name:     networkName1,
+								TypeMeta: netOPNetworkTypeMeta,
+							},
+						},
+					}
+				})
+
+				It("returns expected mapping", func() {
+					Expect(devKeyToIdx).To(HaveLen(2))
+					Expect(devKeyToIdx).To(HaveKeyWithValue(int32(4000), 1))
+					Expect(devKeyToIdx).To(HaveKeyWithValue(int32(4001), 0))
 				})
 			})
 		})


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

MapEthernetDevicesToSpecIdx was still using the network provider envvar, which does not support mixed network providers since a namespace may have a mix.Instead like is done for for when creating the network interface CRs, use the Network.APIVersion to lookup the CR for each interface.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # vmop-4023

**Are there any special notes for your reviewer**:

UTS smoke passed

**Please add a release note if necessary**:

```release-note
NONE
```