### PR TITLE
:sparkles: Bypass extension compat checks on VM Operator reconfigures

### DIFF
--- a/pkg/providers/vsphere/resources/vm.go
+++ b/pkg/providers/vsphere/resources/vm.go
@@ -13,10 +13,12 @@ import (
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 	pkgerr "github.com/vmware-tanzu/vm-operator/pkg/errors"
 	pkglog "github.com/vmware-tanzu/vm-operator/pkg/log"
 	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	taskutil "github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/task"
 	vmutil "github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/vm"
 )
@@ -80,6 +82,14 @@ func (vm *VirtualMachine) Reconfigure(
 	configSpec *vimtypes.VirtualMachineConfigSpec) (*vimtypes.TaskInfo, error) {
 
 	ctxop.MarkUpdate(ctx)
+
+	// VM Operator registered these constraints on the VM (see CreateConfigSpec
+	// and the extension compat constraint reconciler), so its own reconfigures
+	// must not be blocked by them. VM Operator holds the ExtensionCompat.Bypass
+	// privilege required for vpxd to honor this flag.
+	if pkgcfg.FromContext(ctx).Features.ExtensionCompatConstraint {
+		configSpec.SkipExtensionCompatibilityChecks = ptr.To(true)
+	}
 
 	logger := pkglog.FromContextOrDefault(ctx)
 	logger.Info("Reconfiguring VM", "configSpec", pkgutil.SafeConfigSpecToString(configSpec))

--- a/pkg/providers/vsphere/virtualmachine/cleanup.go
+++ b/pkg/providers/vsphere/virtualmachine/cleanup.go
@@ -17,6 +17,7 @@ import (
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgctx "github.com/vmware-tanzu/vm-operator/pkg/context"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmconfig/policy"
 )
 
@@ -56,6 +57,12 @@ func CleanupVMServiceState(
 	// Remove tag associations
 	if pkgcfg.FromContext(vmCtx).Features.VSpherePolicies {
 		removeTagAssociations(moVM.Config, &configSpec)
+	}
+
+	// Clear the extension compatibility constraints VM Operator registered,
+	// since it no longer manages this VM.
+	if pkgcfg.FromContext(vmCtx).Features.ExtensionCompatConstraint {
+		ClearConfigSpecExtensionCompatibilityConstraint(moVM.Config, &configSpec)
 	}
 
 	// Apply the configuration changes
@@ -179,10 +186,22 @@ func reconfigureVM(
 	vcVM *object.VirtualMachine,
 	configSpec vimtypes.VirtualMachineConfigSpec) error {
 
-	// Check if there are any changes to apply
-	if len(configSpec.ExtraConfig) == 0 && configSpec.ManagedBy == nil && len(configSpec.TagSpecs) == 0 {
+	// Check if there are any changes to apply. This must stay above the
+	// bypass gate below: setting the skip flag unconditionally would turn
+	// every no-op cleanup call into a real reconfigure task.
+	if len(configSpec.ExtraConfig) == 0 && configSpec.ManagedBy == nil &&
+		len(configSpec.TagSpecs) == 0 && configSpec.ExtensionCompatibilityConstraint == nil {
 		// No changes to apply
 		return nil
+	}
+
+	// VM Operator registered these constraints on the VM (see CreateConfigSpec
+	// and the extension compat constraint reconciler), so its own reconfigures
+	// -- including this one, which unsets managedBy as part of releasing the
+	// VM -- must not be blocked by them. VM Operator holds the
+	// ExtensionCompat.Bypass privilege required for vpxd to honor this flag.
+	if pkgcfg.FromContext(ctx).Features.ExtensionCompatConstraint {
+		configSpec.SkipExtensionCompatibilityChecks = ptr.To(true)
 	}
 
 	task, err := vcVM.Reconfigure(ctx, configSpec)

--- a/pkg/providers/vsphere/virtualmachine/cleanup_test.go
+++ b/pkg/providers/vsphere/virtualmachine/cleanup_test.go
@@ -186,6 +186,30 @@ func cleanupOnDeleteTests() {
 			})
 		})
 
+		Context("when the extension compat constraint feature is enabled", func() {
+			BeforeEach(func() {
+				initialExtraConfig = nil
+				initialManagedBy = &vimtypes.ManagedByInfo{
+					ExtensionKey: vmopv1.ManagedByExtensionKey,
+					Type:         vmopv1.ManagedByExtensionType,
+				}
+				pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+					config.Features.ExtensionCompatConstraint = true
+				})
+			})
+
+			It("bypasses compat checks and clears ManagedBy successfully", func() {
+				err := virtualmachine.CleanupVMServiceState(vmCtx, vcVM)
+				Expect(err).NotTo(HaveOccurred())
+
+				var moVM mo.VirtualMachine
+				err = vcVM.Properties(vmCtx, vcVM.Reference(), []string{"config"}, &moVM)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(moVM.Config).ToNot(BeNil())
+				Expect(moVM.Config.ManagedBy).To(BeNil())
+			})
+		})
+
 		Context("when VM has tag associations", func() {
 			var (
 				policyTag1ID string

--- a/pkg/providers/vsphere/virtualmachine/extensioncompatconstraint.go
+++ b/pkg/providers/vsphere/virtualmachine/extensioncompatconstraint.go
@@ -6,6 +6,8 @@ package virtualmachine
 
 import (
 	vimtypes "github.com/vmware/govmomi/vim25/types"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 )
 
 // extensionCompatConstraintKey identifies an extension compatibility
@@ -61,4 +63,32 @@ func UpdateConfigSpecExtensionCompatibilityConstraint(
 	}
 
 	configSpec.ExtensionCompatibilityConstraint = extensionCompatibilityConstraintSet()
+}
+
+// ClearConfigSpecExtensionCompatibilityConstraint removes the extension
+// compatibility constraints VM Operator registered on the VM. This should be
+// called when unregistering a VM from Supervisor (see CleanupVMServiceState),
+// since the constraints otherwise persist and continue to be enforced
+// against whatever manages the VM next.
+//
+// The constraint set is declared by the VM's managing extension as a whole
+// (see ManagedBy), not per-constraint, so it is only cleared when VM
+// Operator is still the managing extension.
+func ClearConfigSpecExtensionCompatibilityConstraint(
+	config *vimtypes.VirtualMachineConfigInfo,
+	configSpec *vimtypes.VirtualMachineConfigSpec) {
+
+	if config == nil || config.ExtensionCompatibilityConstraint == nil {
+		return
+	}
+
+	if config.ManagedBy == nil ||
+		config.ManagedBy.ExtensionKey != vmopv1.ManagedByExtensionKey ||
+		config.ManagedBy.Type != vmopv1.ManagedByExtensionType {
+		return
+	}
+
+	// A reconfigure's constraint set is a full-set-replace, so a non-nil,
+	// empty set clears the field.
+	configSpec.ExtensionCompatibilityConstraint = &vimtypes.VirtualMachineExtensionCompatibilityConstraintSet{}
 }

--- a/pkg/providers/vsphere/virtualmachine/extensioncompatconstraint_test.go
+++ b/pkg/providers/vsphere/virtualmachine/extensioncompatconstraint_test.go
@@ -10,6 +10,7 @@ import (
 
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/virtualmachine"
 )
 
@@ -150,6 +151,83 @@ var _ = Describe("UpdateConfigSpecExtensionCompatibilityConstraint", func() {
 
 		It("does not modify the ConfigSpec", func() {
 			Expect(configSpec.ExtensionCompatibilityConstraint).To(BeNil())
+		})
+	})
+})
+
+var _ = Describe("ClearConfigSpecExtensionCompatibilityConstraint", func() {
+
+	var (
+		config     *vimtypes.VirtualMachineConfigInfo
+		configSpec *vimtypes.VirtualMachineConfigSpec
+	)
+
+	BeforeEach(func() {
+		config = &vimtypes.VirtualMachineConfigInfo{
+			ManagedBy: &vimtypes.ManagedByInfo{
+				ExtensionKey: vmopv1.ManagedByExtensionKey,
+				Type:         vmopv1.ManagedByExtensionType,
+			},
+			ExtensionCompatibilityConstraint: &vimtypes.VirtualMachineExtensionCompatibilityConstraintSet{
+				Constraint: []vimtypes.VirtualMachineExtensionCompatibilityConstraint{
+					{ConstraintType: string(vimtypes.VirtualMachineExtensionCompatibilityConstraintTypeDEVICE)},
+				},
+			},
+		}
+		configSpec = &vimtypes.VirtualMachineConfigSpec{}
+	})
+
+	JustBeforeEach(func() {
+		virtualmachine.ClearConfigSpecExtensionCompatibilityConstraint(config, configSpec)
+	})
+
+	When("config is nil", func() {
+		BeforeEach(func() {
+			config = nil
+		})
+
+		It("does not modify the ConfigSpec", func() {
+			Expect(configSpec.ExtensionCompatibilityConstraint).To(BeNil())
+		})
+	})
+
+	When("config has no constraint set", func() {
+		BeforeEach(func() {
+			config.ExtensionCompatibilityConstraint = nil
+		})
+
+		It("does not modify the ConfigSpec", func() {
+			Expect(configSpec.ExtensionCompatibilityConstraint).To(BeNil())
+		})
+	})
+
+	When("config has a constraint set but is not managed by VM Operator", func() {
+		BeforeEach(func() {
+			config.ManagedBy = nil
+		})
+
+		It("does not modify the ConfigSpec", func() {
+			Expect(configSpec.ExtensionCompatibilityConstraint).To(BeNil())
+		})
+	})
+
+	When("config has a constraint set but is managed by a different extension", func() {
+		BeforeEach(func() {
+			config.ManagedBy = &vimtypes.ManagedByInfo{
+				ExtensionKey: "some.other.extension",
+				Type:         "someType",
+			}
+		})
+
+		It("does not modify the ConfigSpec", func() {
+			Expect(configSpec.ExtensionCompatibilityConstraint).To(BeNil())
+		})
+	})
+
+	When("config has a constraint set and is managed by VM Operator", func() {
+		It("sets a non-nil, empty constraint set on the ConfigSpec", func() {
+			Expect(configSpec.ExtensionCompatibilityConstraint).ToNot(BeNil())
+			Expect(configSpec.ExtensionCompatibilityConstraint.Constraint).To(BeEmpty())
 		})
 	})
 })

--- a/pkg/util/vsphere/vm/power_state.go
+++ b/pkg/util/vsphere/vm/power_state.go
@@ -18,8 +18,10 @@ import (
 	"github.com/vmware/govmomi/vim25/mo"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 
+	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 	pkglog "github.com/vmware-tanzu/vm-operator/pkg/log"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	vspheretask "github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/task"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/vsphere/vm/internal"
 )
@@ -686,13 +688,24 @@ func setLastRestartTimeInExtraConfigAndWait(
 		"extraConfigKey", ExtraConfigKeyLastRestartTime,
 		"extraConfigValue", lastRestartTimeEpoch)
 
-	t, err := obj.Reconfigure(ctx, vimtypes.VirtualMachineConfigSpec{
+	configSpec := vimtypes.VirtualMachineConfigSpec{
 		ExtraConfig: []vimtypes.BaseOptionValue{
 			&vimtypes.OptionValue{
 				Key:   ExtraConfigKeyLastRestartTime,
 				Value: strconv.FormatInt(lastRestartTimeEpoch, 10),
 			},
-		}})
+		},
+	}
+
+	// VM Operator registered these constraints on the VM (see CreateConfigSpec
+	// and the extension compat constraint reconciler), so its own reconfigures
+	// must not be blocked by them. VM Operator holds the ExtensionCompat.Bypass
+	// privilege required for vpxd to honor this flag.
+	if pkgcfg.FromContext(ctx).Features.ExtensionCompatConstraint {
+		configSpec.SkipExtensionCompatibilityChecks = ptr.To(true)
+	}
+
+	t, err := obj.Reconfigure(ctx, configSpec)
 	if err != nil {
 		return fmt.Errorf(
 			"failed to invoke reconfigure that records extra config key=%s value=%v to vm %w",


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

VM Operator registers extension compatibility constraints on managed VMs (VMSVC-3778/3779), but without this change its own subsequent ReconfigVM_Task calls (PVC attach/detach, CPU/memory resize, NIC reconfiguration, last-restart-time bookkeeping, cleanup on delete) could be blocked by the very constraints it just set. VM Operator already holds the ExtensionCompat.Bypass privilege, so setting SkipExtensionCompatibilityChecks lets vpxd honor the bypass.

Gate the flag on Features.ExtensionCompatConstraint at every ReconfigVM_Task call site that reaches vCenter directly: resources.VirtualMachine.Reconfigure (covers backup, bootstrap, and session update paths), vm.setLastRestartTimeInExtraConfigAndWait, and virtualmachine.reconfigureVM used during VM cleanup. The last of these sets the flag after the existing no-op guard so an unchanged cleanup config spec still short-circuits without an extra reconfigure.

Also clear the registered constraint set itself when VM Operator unregisters a VM (CleanupVMServiceState), via the new ClearConfigSpecExtensionCompatibilityConstraint. A reconfigure's constraint set is a full-set-replace, so a non-nil empty set clears it; this rides along in the same bypassed Reconfigure call that already clears ManagedBy and ExtraConfig, so there is no ordering problem between clearing the constraint and being blocked by it. The clear only fires when ManagedBy still identifies VM Operator, since the constraint set is attributed to the VM's managing extension as a whole.

vmop-3780


**Please add a release note if necessary**:

```release-note
Bypass extension compat checks on VM Operator reconfigures
```