### PR TITLE
:sparkles: Add spec for Veeam-backed backup/restore E2E tests

### DIFF
--- a/.sdd/INDEX.md
+++ b/.sdd/INDEX.md
@@ -36,6 +36,7 @@ Each spec lives under `specs/NNN-slug/`. Standard artifacts: `spec.md` (behavior
 | 003 | [compute-config-reconcile](specs/003-compute-config-reconcile/) | VM Compute Configuration Reconciliation | In Review | vmop-3388 |
 | 004 | [nic-extraconfig-reconcile](specs/004-nic-extraconfig-reconcile/) | NIC ExtraConfig Reconciler — E2E Coverage (`spec.md`/`plan.md` pending) | In Progress | vmop-3782 |
 | 005 | [ipv6-template-funcs](specs/005-ipv6-template-funcs/) | Differentiate IPv4/IPv6 vApp/Sysprep template functions (V1alpha6) | In Progress | vmop-1152 |
+| 006 | [veeam-e2e-backup-restore](specs/006-veeam-e2e-backup-restore/) | Use Veeam for Backup/Restore E2E Tests | Draft | vmop-4013 |
 
 ### Finding the right spec
 

--- a/.sdd/specs/006-veeam-e2e-backup-restore/research.md
+++ b/.sdd/specs/006-veeam-e2e-backup-restore/research.md
@@ -1,0 +1,129 @@
+# Research: Use Veeam for Backup/Restore E2E Tests
+
+- **Spec**: [`spec.md`](./spec.md)
+- **Epic**: vmop-4013
+
+## Current mimicry in the E2E suite
+
+All three restore workflows below are currently exercised in `test/e2e/vmservice/vmservice/viadmin/registervm.go`, backed by shared helpers in `test/e2e/vmservice/vmservice/util.go`. None of this is product code; it is E2E-only tooling that fakes what a VADP backup vendor would otherwise do to the vSphere VM.
+
+### Restore to new
+
+- `Context("RegisterVM Alarm", ...)` in `registervm.go` (and the general "Register VM with pre-existing VM CR" contexts) call `vmservice.DeleteVMResource(...)`, which:
+  1. Waits for VM Operator's own backup-state recording to catch up (`vmservice.WaitForBackupToComplete` / `waitForBackupToComplete`, `util.go:818`).
+  2. Powers off the VM and adds the `vmopv1.PauseAnnotation` annotation.
+  3. Calls `vmservice.UnregisterPVCVolumes` (`util.go:928`), which creates `CnsUnregisterVolume` objects per PVC to detach the Kubernetes/CNS side while leaving vSphere-side disks attached.
+  4. Deletes the Kubernetes `VirtualMachine` object and strips both `VMFinalizerName` and `VMFinalizerNameDeprecated` (`util.go:1004-1086`) so deletion completes without the controller re-adding the finalizer.
+- Net effect: the vSphere VM and its `vmservice.*` ExtraConfig (written continuously by VM Operator) are untouched; only the Kubernetes object is gone. This fakes "the VM was restored to a Supervisor that has no record of it."
+- `vmservice.InvokeRegisterVM` (`util.go:1090`) and `vmservice.VerifyPostRegisterVM` (`util.go:1112`) are then used unchanged to drive and verify registration — these are the parts that stay.
+
+### Restore to existing (in-place)
+
+- The two "Incremental Restore - Register VM..." contexts in `registervm.go` (lines ~224-348) do this in-line:
+  1. Create and power on a VM, wait for backup completion.
+  2. Power off, pause, and unregister PVCs (same helpers as above), but **do not delete the K8s object**.
+  3. Directly call `vmObj.Reconfigure(ctx, vmSpec)` on the vSphere VM with an `ExtraConfig` payload that sets `backupapi.VMResourceYAMLExtraConfigKey`, `backupapi.BackupVersionExtraConfigKey`, and (when PVCs are involved) `backupapi.PVCDiskDataExtraConfigKey` back to an **earlier, saved value** — i.e., the test hand-crafts "an older backup was restored" by overwriting ExtraConfig itself, rather than restoring anything.
+- `pkg/backup/api` (module `github.com/vmware-tanzu/vm-operator/pkg/backup/api`) defines the ExtraConfig key constants used here; this is the same contract a real VADP-restored VMX would need to preserve.
+
+### Disk-only restore
+
+- `Context("Restore disk only", ...)` in `registervm.go` (lines ~792-1068) is the most involved mimicry:
+  1. Creates a VM with a PVC-backed disk, waits for backup, powers off, pauses.
+  2. Resolves the disk's `VirtualDisk`/backing/datastore path via `govmomi` device introspection and the PVC → PV → CSI `VolumeHandle` chain.
+  3. Calls `vmObj.RemoveDevice(ctx, true, disk)` to detach the disk (`keepFiles=true`, so the VMDK stays on disk) — fakes "Veeam removed the disk from the VM to restore it."
+  4. Uses the datastore `FileManager` to `Copy` the VMDK to a new path under the VM's home directory, then `Delete`s the original — fakes "Veeam wrote the restored disk to a new location."
+  5. Calls `vmObj.AddDeviceWithProfile(ctx, profile, disk)` to reattach the disk from the new path.
+  6. Calls `vslm.NewObjectManager(vCenterClient).ReconcileDatastoreInventory(ctx, ds.Reference())` — this is the step that actually strips the FCD/CNS identity from the old disk, and is explicitly commented in the test as "emulating what Veeam's restore flow does."
+- `vmservice.InvokeRegisterVM` + `vmservice.VerifyPostRegisterVM` are again reused unchanged to drive and verify the resulting registration, expecting exactly one new `restored-*` PVC.
+
+### Shared verification/skip conventions worth preserving
+
+- FSS-style skips: `utils.IsFssEnabled(...)` gates `vmServiceBackupRestoreEnabled` / `incrementalRestoreEnabled` in `registervm.go`'s top-level `BeforeEach`. A Veeam-availability skip should follow the same shape (skip with a descriptive message, not fail).
+- `skipper.SkipUnlessInfraIs(input.Config.InfraConfig.InfraName, consts.WCP)` gates the whole spec on running against WCP infra; a Veeam server dependency would plausibly gate on a new infra/testbed capability in the same style.
+- Admin-privileged operations use `clusterProxy.NewAdminClusterProxy(ctx)` / `adminProxy.GetAdminClient()` because the regular supervisor-admin kubeconfig lacks RBAC on some API groups (e.g. `cns.vmware.com`). Any new Veeam-driven helper that needs elevated K8s access should follow the same pattern rather than widening RBAC for the default test user.
+
+## Spike: enable and confirm the VBR REST API on the existing appliance
+
+**Status: open, blocking.** This must be resolved before `plan.md` can commit to a concrete client design — every other Veeam-specific investigation item in this document assumes the REST API is reachable, and right now it is not confirmed to be.
+
+- Connectivity check performed 2026-08-10/11 against the existing VBR 12 appliance (internal test-infra host; address intentionally omitted from this repo — see the internal spike ticket `vmop-4030` for connection details):
+  - ICMP ping succeeds — the host is reachable on the network.
+  - TCP 3389 (RDP) — **open**. This is the access pattern currently used to manage the appliance (RDP in, open the VBR console).
+  - TCP 6160 (Veeam Installer Service) — **open**.
+  - TCP 9419 (VBR REST API default port) — **connection refused**.
+  - TCP 443, 9392, 9401, 10005 — all **connection refused**.
+- Refused (not timed-out/filtered) strongly suggests the `Veeam.Backup.RestAPI` Windows service is not running on the box, rather than a network firewall dropping the packets silently — a silent drop would more likely time out. This needs confirming on the box itself, not just inferring from the outside.
+- Whoever picks up implementation should, on the VBR appliance (via the existing RDP access — no SSH or other new access method is needed):
+  1. Open Windows **Services** and check whether `Veeam RESTful API Service` (exact name may vary by build) is present and running; start it if stopped, and set it to auto-start if this appliance is meant to stay available for E2E runs going forward.
+  2. Check **Windows Defender Firewall with Advanced Security** for an inbound allow rule for TCP `9419`; add one scoped to the CI runner's network if missing.
+  3. Once the service responds, re-run the connectivity check (`curl -k https://<vbr-host>:9419/api/swagger/ui/index.html`) and capture which `x-api-version` value(s) VBR 12 actually advertises via the Swagger UI, plus whether that endpoint is reachable from outside `localhost` (see the "403 for non-localhost" community report noted below) or needs the client to fall back to the try-newest/step-down strategy.
+  4. Authenticate with `x-api-version: 1.1-rev0` (the oldest VBR-12-era value we have direct spec evidence for — see "VeeamHub OSS evidence" below) and call `GET /api/v1/serverInfo` to capture the appliance's exact `buildVersion`. Then fetch that version's own Swagger document from the appliance and diff it against the vendored `1.1-rev0` spec in `veeamhub/veeam-vbr-sdk-go` to confirm whether disk-level restore and backup/restore-point deletion endpoints exist on our specific build (see "Open risk: disk-only restore may need a design change" below) — this determines whether `spec.md`'s disk-only restore and cleanup acceptance criteria need to change.
+- This spike is tracked as `vmop-4030` (VMSVC-4030), linked to the epic (`vmop-4013` / VMSVC-4013) via Epic Link, per [`sdd-standards.md`](../../memory/sdd-standards.md) "Tickets and wiki links."
+
+## Testbed and connectivity decisions
+
+- A Veeam Backup & Replication appliance already runs today, on a Windows Server VM, for manual/ad hoc use. It is not currently wired into any CI pipeline.
+- The pipeline will be extended to accept the Veeam appliance's address and credentials as parameters, each defaulting to the known existing instance's values when not supplied. This is deliberately low-friction: the appliance is treated as a test-infra dependency with a lower security bar than production credentials, so no Kubernetes Secret plumbing is required for this feature.
+- The appliance currently runs **VBR 12**. The REST API link referenced above (`vbr/13/rest/1.3-rev2`) is for VBR 13, which may not be what VBR 12 exposes. The test tooling must not hardcode a single API version; see "Version autodetection" below.
+
+## VeeamHub OSS evidence (concrete API surface, not just docs)
+
+A survey of `github.com/veeamhub` (2026-08-12) turned up a primary source that beats every public doc page consulted so far: **`veeamhub/veeam-vbr-sdk-go`** vendors Veeam's own `swagger.json` with `info.version: "1.1-rev0"` and `x-veeam-prev-version: "1.0-rev2"` — i.e. this is the actual VBR **12.0** REST spec, plus a generated Go client and runnable examples (`pkg/client/example_test.go`). `veeamhub/veeam-postman` independently corroborates the `1.1-rev0` ⇒ VBR 12.0 mapping and the on-appliance Swagger URLs. `veeamhub/powershell` (`BR-VBR13-PreUpgradeCheck/VBR13-PreUpgradeCheck.ps1`, `VSPC-HostedUsage/Set-HostedVbrJobAssignment.ps1`) demonstrates working auth/header code against real appliances. Dead ends: `veeam-python` (AWS/Azure assessment, unrelated), `veeam-terraform` (unrelated `x-api-version` hit), `veeam-vscan-security` (only references the Swagger UI URL), `moov` (docs-only; confirms disk streaming uses the **Data Integration API over iSCSI**, not REST).
+
+**Base URL confirmed as `https://<vbr-host>:9419`** (`example_test.go`) — the SDK's own README claims `:9398`, which is the legacy Enterprise Manager port and is wrong; do not follow that page.
+
+Concrete, code/spec-backed answers this surfaced (supersedes the doc-only version further down this file where they conflict):
+
+- **Create a job**: `POST /api/v1/jobs`, body is a full `JobSpec`/`BackupJobSpec` (`name`, `description`, `type:"Backup"`, `virtualMachines.includes[]`, `storage.backupRepositoryId` + `retentionPolicy`, `guestProcessing`, `schedule`). There is **no ad-hoc/"quick backup" endpoint** in 1.1-rev0 — set `schedule.runAutomatically:false` to get a job that only runs when explicitly started. Resolve the target VM's `objectId` via `GET /api/v1/inventory/vmware/hosts/{vcName}?nameFilter=<vmName>` and the repository id via `GET /api/v1/backupInfrastructure/repositories`.
+- **Trigger a backup run**: `POST /api/v1/jobs/{id}/start` with `JobStartSpec{performActiveFull, startChainedJobs}` → 201 `SessionModel{id, state, progressPercent, result}`. Poll `GET /api/v1/sessions/{id}`; logs at `GET /api/v1/sessions/{id}/logs`; `POST /api/v1/sessions/{id}/stop` to abort.
+- **Restore VM (restore-to-new)**: `POST /api/v1/restore/vmRestore/vmware/` (trailing slash matters), body `EntireViVMRestoreSpec` with `type: "Customized"` to rename — the new name goes in `folder.vmName`, and `folder.folder` must still be a full `VmwareObjectModel` (`name`/`type`/`hostName` all required) even when keeping the original vSphere folder. Restore point discovery chain: `GET /api/v1/backups` → `/api/v1/backups/{id}/objects` → `GET /api/v1/backupObjects/{id}/restorePoints`.
+- **Virtual disk restore — likely NOT available via REST on our appliance.** Enumerating all 97 paths in the 1.1-rev0 (VBR 12.0) spec, the only `/restore/*` paths are `instantRecovery/vmware/vm{...}`, `instantRecovery/vmware/fcd{...}`, and `vmRestore/vmware/`. **There is no disk-level restore endpoint.** `GET /api/v1/objectRestorePoints/{id}/disks` only lists disks, it does not restore one. This directly contradicts the "Restore-flow decisions" entry below, which was based on VBR 13's UI-guide docs. See "Open risk" callout right after this section.
+- **Cleanup is partial via REST**: `DELETE /api/v1/jobs/{id}` removes the job definition, but `/api/v1/backups`, `/api/v1/backups/{id}`, `/api/v1/backupObjects/*`, and `/api/v1/objectRestorePoints/*` are **GET-only** in 1.1-rev0 — there is no REST call to delete a backup or a restore point. Whether deleting the job also deletes its backup files (vs. orphaning them on the repository) is unverified and must be checked directly against the appliance.
+- **Auth mechanics, precisely**: `POST /api/oauth2/token` requires the `x-api-version` header even though the endpoint itself is unauthenticated (`security: []` in the spec) — this is a common integration mistake worth calling out explicitly in whatever client we write. Body: `grant_type=password&username=<u>&password=<p>` (form-encoded) → `{access_token, token_type, refresh_token, expires_in}`. **`expires_in` is 900 seconds (15 minutes)** — a VM restore can plausibly take longer than that, so the client MUST implement the refresh-token flow (`grant_type=refresh_token`) rather than assuming one token lasts a whole test. `POST /api/oauth2/logout` ends the session.
+- **Version discovery is circular, and community version-mapping tables disagree.** The on-appliance Swagger document itself lives at a version-scoped path (`/api/swagger/v1.1-rev0/swagger.json` style) — you cannot fetch "the" spec without already knowing (or guessing) the version segment; the practical use is the human-facing Swagger UI page, which lists what the appliance actually supports. `GET /api/v1/serverInfo` returns `buildVersion`, which can be mapped to a revision — but two VeeamHub sources disagree on that exact mapping (the SDK's own spec says VBR 12.0 = `1.1-rev0`; a PowerShell script in the same org's `powershell` repo comments VBR 12 = `1.2-rev0`, likely reflecting a later 12.x patch). **Do not trust a hardcoded version-to-build table; query the appliance's own `serverInfo`/Swagger UI at connect time.** There is also no version-specific error code in the `Error` schema — version negotiation by trial-and-error has to key off HTTP status/message text, not a structured error code.
+- **VBR 12 minor versions may add REST surface.** The 1.1-rev0 spec's job `type` enum is `["Backup"]` only, yet a VeeamHub PowerShell script pins `1.1-rev1` and queries a `CloudDirectorBackup` job type — meaning the REST surface changed within the VBR 12 line. Everything above about "not available" is proven only for 1.1-rev0/VBR 12.0; it must be re-verified against whatever `buildVersion` the actual appliance reports once the spike ticket (`vmop-4030`) gets the REST API reachable.
+
+### Open risk: disk-only restore may need a design change
+
+The "Restore-flow decisions" section below picked Veeam's "virtual disk restore" UI feature for the disk-only scenario, based on VBR 13's user guide. The VeeamHub evidence above says that feature has no REST endpoint in VBR 12.0's own spec. Until `vmop-4030` confirms our appliance's actual `buildVersion` and re-derives its Swagger spec, treat the disk-only restore acceptance criteria in `spec.md` as provisional. Fallback options if REST genuinely can't do disk-level restore on our appliance: (a) use REST's FCD instant-recovery endpoints (`POST /api/v1/restore/instantRecovery/vmware/fcd`, then `/migrate` to relocate it to a datastore) as the closest REST-native approximation, or (b) do a full VM restore via REST to a throwaway VM and then move/detach the one disk in vSphere — which reintroduces some of the manual-disk-manipulation mimicry this feature is meant to eliminate, so it should be a last resort, not the default plan.
+
+## Version autodetection
+
+- Goal (per `spec.md`): the connecting client detects, at connect time, which REST API version the target Veeam server actually supports, and uses the corresponding request shapes — avoiding a hard version coupling between the E2E pipeline and whatever VBR release happens to be running.
+- Confirmed mechanism (cross-referenced from Veeam's own REST API docs, VBR community/forum posts, and third-party write-ups; not yet verified against our own live VBR 12 appliance):
+  - The REST API is served over HTTPS on port `9419` (e.g. `https://<vbr-host>:9419/api/...`).
+  - Every request — including the token request itself — must carry an `x-api-version` header whose value is a `<major>.<minor>-rev<N>` string (e.g. `1.2-rev1`, `1.3-rev2`). Omitting it or naming an unsupported version produces a documented "Unsupported RESTAPI version" error.
+  - The server exposes a Swagger UI at `https://<vbr-host>:9419/api/swagger/ui/index.html` with a "Select a definition" dropdown that enumerates exactly which API version(s) that specific server instance supports. This is reachable pre-authentication and is the concrete answer to "how does a client discover what a given appliance supports without hardcoding a version" — the client can either parse this (or the underlying per-version Swagger/OpenAPI JSON document it references) to pick the newest version the server advertises, or fall back to a try-newest-then-step-down strategy against the "unsupported version" error if parsing the Swagger index turns out to be impractical.
+- Once the supported version is known, the client should select the newest mutually-supported version and pin the `x-api-version` header to it for the duration of a single client session (i.e., no re-detection mid-test-run).
+- Still to verify directly against the appliance before `plan.md` locks in a client design: the exact Swagger/OpenAPI document path(s) VBR 12 serves, the precise list of `x-api-version` values VBR 12 accepts (VBR 13's docs reference `1.1-rev0` through `1.3-rev2`; VBR 12 almost certainly supports an earlier, non-overlapping subset), and whether VBR 12's Swagger endpoint is reachable unauthenticated by default or requires a config change (one community forum thread reports a VBR instance returning 403 for the Swagger endpoint on anything but `localhost`, which would affect a remote E2E runner).
+
+## Restore-flow decisions
+
+- **Restore to new**: use Veeam's standard "Restore VM" action, targeting a new VM identity in the Supervisor namespace folder. Rejected alternative: "Instant VM Recovery" (boots directly from the backup repository) — its identity/registration implications diverge from what the current acceptance criteria (and the existing mimicked test) assume.
+- **Disk-only restore**: use Veeam's dedicated "virtual disk restore" action — https://helpcenter.veeam.com/docs/vbr/userguide/virtual_drive_recovery.html?ver=13 — which restores a single virtual disk directly. Rejected alternative: a full VM restore with everything except the target disk discarded, which would produce extra restore artifacts to track and clean up for no benefit. **Reopened**: this decision assumed VBR 13's documented UI feature has a REST equivalent; VeeamHub evidence for VBR 12.0's actual REST spec suggests it may not (see "Open risk" above). Treat as provisional until spike `vmop-4030` confirms against the real appliance.
+
+## Veeam Backup & Replication REST API
+
+- API reference (VBR 13, REST API 1.3-rev2): job creation endpoint — https://helpcenter.veeam.com/references/vbr/13/rest/1.3-rev2/tag/Jobs#operation/CreateJob
+- Login/token reference: https://helpcenter.veeam.com/references/vbr/13/rest/1.3-rev2/tag/Login
+- REST API reference index for all documented revisions: https://helpcenter.veeam.com/references/vbr/13/rest/1.3-rev2/ (this page's navigation lists sibling revisions `1.3-rev1`, `1.2-rev1`, `1.2-rev0`, `1.1-rev2`, `1.1-rev1`, `1.1-rev0` — the actual API reference content renders client-side, so a plain fetch only returns the page shell; the concrete auth/versioning facts below came from Veeam's other static doc pages, VBR community forum threads, and third-party write-ups, cross-referenced with each other).
+- Confirmed authentication flow: `POST https://<vbr-host>:9419/api/oauth2/token`, `Content-Type: application/x-www-form-urlencoded`, body `grant_type=password&username=<user>&password=<pass>` (domain credentials need the backslash URL-encoded), plus the mandatory `x-api-version` header (see "Version autodetection" above). Response contains `access_token` and `refresh_token`; subsequent requests carry `Authorization: Bearer <access_token>` and must still repeat the `x-api-version` header. Access tokens are short-lived; a refresh flow exists ("Using Refresh Token" in the docs nav) and should be used rather than re-authenticating with the password grant on every call.
+- Web UI walkthrough for vSphere backup job creation (useful for confirming REST payload shape by comparison with the UI flow): https://helpcenter.veeam.com/docs/vbr/userguide/backup_job_web.html?ver=13
+- Virtual disk restore (used for the disk-only scenario): https://helpcenter.veeam.com/docs/vbr/userguide/virtual_drive_recovery.html?ver=13 — this is a UI-guide link; the equivalent REST endpoint(s) still need to be located for whichever VBR version ends up in scope (see "Not yet investigated" below).
+- User-supplied high-level flow for this feature:
+  1. Create a temporary backup job via the REST API, named so it can be traced back to the CI pipeline run and target VM.
+  2. Take a backup via that job.
+  3. Change the VM's configuration (or delete it, for restore-to-new; or remove a disk, for disk-only restore) to set up the "needs restoring" state.
+  4. Restore the VM via the REST API.
+  5. Invoke the platform's manual VM registration API (`vmservice.InvokeRegisterVM` today).
+  6. Verify the result with existing verification helpers (`vmservice.VerifyPostRegisterVM` today).
+- Still not yet investigated against our actual appliance (candidates for follow-up spikes before `plan.md`; several of these are now answered *in general* by the VeeamHub evidence above but need confirming against our specific `buildVersion`):
+  - Our appliance's exact `x-api-version` and `buildVersion` (via `GET /api/v1/serverInfo` once reachable), and whether that build's REST surface matches the 1.1-rev0 spec vendored in `veeam-vbr-sdk-go` or a later 12.x revision with more endpoints.
+  - Whether our appliance's REST API genuinely has no disk-level restore endpoint (per the 1.1-rev0 evidence) — if confirmed, `spec.md`'s disk-only restore acceptance criteria need to pick one of the fallback approaches noted above instead of "virtual disk restore."
+  - Whether `DELETE /api/v1/jobs/{id}` also removes the job's backups/restore points on our appliance, or orphans them — determines whether the cleanup goal in `spec.md` is achievable via REST alone or needs a documented manual/PowerShell fallback.
+  - Whether the Swagger/discovery endpoint is reachable from the E2E runner's network path or only from `localhost` on the VBR appliance itself (see the 403-for-non-localhost forum report noted above) — if it's `localhost`-only by default, the version-autodetection goal needs the try-newest/bootstrap-with-`serverInfo` strategy above rather than parsing the Swagger UI remotely.
+  - How VBR's REST API reports job/task failure detail in practice (session `result`/`state` fields plus `GET /api/v1/sessions/{id}/logs`) — confirm this is enough to satisfy the "surface Veeam's own error" goal without needing to scrape the Veeam console.
+
+## Prior art referenced
+
+- `docs/guides/backup-restore/README.md` — the in-repo backup/restore guide already documents the intended production workflow (Sections 3–9) that this feature is meant to make the E2E suite actually exercise, including the restore-type detection logic (Section 4.3) and the hard limitations (Section 7) that any Veeam-driven restore must still respect (e.g., duplicate BIOS UUID, missing ExtraConfig, wrong namespace folder).

--- a/.sdd/specs/006-veeam-e2e-backup-restore/spec.md
+++ b/.sdd/specs/006-veeam-e2e-backup-restore/spec.md
@@ -1,0 +1,122 @@
+# Feature Specification: Use Veeam for Backup/Restore E2E Tests
+
+- **Feature branch**: [`features/use-veeam-for-backup-restore-tests`](../../../)
+  - **Fork**: `vmware-tanzu/vm-operator`
+  - **PR target**: `vmware-tanzu/vm-operator`
+- **Created**: 2026-08-07
+- **Status**: Draft
+- **Epic**: vmop-4013
+- **Spike (open)**: vmop-4030 — confirm the existing VBR appliance's REST API is enabled/reachable before implementation begins; see [`research.md`](./research.md) "Spike: enable and confirm the VBR REST API on the existing appliance."
+
+---
+
+## Summary
+
+The E2E suite that exercises VM Service backup/restore and manual VM registration does not exercise a real VADP backup vendor today. Each restore workflow it claims to cover is instead hand-mimicked directly against vSphere/CNS:
+
+- **Restore to new**: the Kubernetes representation of the VM is deleted while the underlying vSphere VM and its recorded state are left behind, to fake "the VM's Kubernetes object is gone but the VM was restored on vSphere."
+- **Restore to existing (in-place)**: the VM is paused and the state VM Operator itself recorded on the vSphere VM is directly overwritten to an older value, to fake "an older backup was restored over the current VM."
+- **Disk-only restore**: a virtual disk is relocated on the datastore and its cloud-native storage identity is manually stripped, to fake "a backup vendor restored just this one disk."
+
+Because none of these steps involve an actual backup/restore product, the tests have occasionally been shaped around the mechanics of the mimicry (specific device add/remove ordering, manually re-deriving storage inventory, manually keeping recorded state in sync) rather than around what a real VADP vendor actually produces on restore. Those mechanics do not occur, and would not need workarounds, in production.
+
+This feature replaces the mimicked backup/restore steps with real operations performed through Veeam Backup & Replication (VBR), driven by its REST API. Everything the suite already does to validate VM Operator's own behavior — waiting for backup state to be recorded, invoking the VM registration API, and verifying the resulting Kubernetes state after registration — is unaffected and continues to be used as-is. Only the steps that fabricate "a backup was taken" or "a restore happened" are replaced with the genuine equivalent.
+
+Background on the current mimicry, the VBR REST API, and prior art referenced while drafting this spec is recorded in [`research.md`](./research.md).
+
+---
+
+## Goals
+
+- E2E MUST create a real, dedicated Veeam backup job scoped to the specific test VM, rather than relying solely on VM Operator's own continuous state recording to simulate "a backup exists."
+- The backup job's name MUST be derivable from the CI pipeline run and the target VM name, so a job found in Veeam can be traced back to the E2E run and VM that created it.
+- E2E MUST trigger a real backup run of that job and wait for the backup to reach a successful terminal state before proceeding, replacing the current practice of treating VM Operator's own recorded state as the sole signal that "a backup exists to restore from."
+- For the **restore-to-new** scenario, E2E MUST use a real Veeam restore operation that produces a VM in the Supervisor namespace folder with no matching Kubernetes object, in place of the current mimicry of deleting the Kubernetes object while leaving the vSphere VM and its recorded state untouched.
+- For the **restore-to-existing (in-place)** scenario, E2E MUST use a real Veeam in-place VM restore in place of the current mimicry of directly overwriting the VM's recorded backup state to an older value.
+- For the **disk-only restore** scenario, E2E MUST use a real Veeam operation that restores a single virtual disk without restoring the whole VM, in place of the current mimicry of relocating a virtual disk and manually stripping its cloud-native storage identity. Which specific Veeam operation satisfies this (virtual disk restore vs. an FCD instant-recovery-and-migrate sequence) is not yet confirmed to be available via REST on the target appliance — see the open question below.
+- After each real Veeam restore, E2E MUST invoke the existing manual VM registration workflow against the restored VM, exactly as production operators are expected to when automatic registration is not used.
+- After registration completes, E2E MUST verify the resulting Kubernetes state using the suite's existing verification behavior (VM existence and power state, PVC/volume counts and naming, no errors surfaced) — this verification behavior is reused unchanged; only the mechanism that produces "a restored VM to register" is in scope for this feature.
+- E2E MUST clean up the temporary Veeam backup job it created — and any restore points or artifacts that job produced — whether the test passes or fails, so repeated CI runs do not accumulate orphaned Veeam jobs. If deleting the job does not, by itself, remove its backups/restore points on the target appliance, cleanup MUST take whatever additional step is needed to remove them rather than leaving orphaned backup data behind.
+- The pipeline MUST accept the target Veeam server's address as a parameter, defaulting to the pre-existing Veeam appliance used for manual testing today when the parameter is not supplied, so a run against a different Veeam instance does not require a code change.
+- The pipeline MUST accept Veeam server credentials as a parameter, defaulting to the pre-existing appliance's known credentials when not supplied.
+- E2E test tooling MUST detect, at connection time, which Veeam REST API version the configured server actually supports and use the corresponding request shapes, rather than assuming a single hardcoded API version — so the test suite keeps working across a Veeam appliance upgrade without a code change, and does not create a hard version coupling between the test pipeline and the Veeam appliance.
+- Tests MUST skip (not fail) with a clear message when the configured Veeam server is unreachable or does not expose a REST API version the tooling knows how to speak, mirroring the suite's existing skip-on-missing-capability conventions.
+- Failures returned by Veeam (job creation, backup run, restore run) MUST surface Veeam's own job/task identifier and reported error/status in the test failure message, so a failing E2E run is diagnosable from CI logs without needing interactive access to the Veeam server.
+
+## Non-goals
+
+- Testing Veeam Backup & Replication itself (its scheduling, retention, replication, or SureBackup features).
+- Provisioning, installing, or upgrading the Veeam server itself. A VBR appliance already runs (on a Windows Server VM) for manual use today; this feature only wires the existing pipeline to reach it (as a parameterized address/credentials pair) and does not change how that appliance is deployed or maintained.
+- Automatic registration (the platform's own background detection of a restored VM). This feature only changes how a backup/restore is *produced*; the existing tests that invoke manual registration continue to do so. Automatic-registration E2E coverage is a separate concern.
+- Cross-vCenter failover restore coverage.
+- Application-consistent / guest-quiesced backups, VSS integration, or pre/post backup scripts.
+- Support for any VADP vendor other than Veeam.
+- Changes to VM Operator's product behavior. This is an E2E-only change; if the work below uncovers an actual product defect, that defect is fixed in the same change set and called out explicitly rather than worked around in the test.
+
+---
+
+## User stories / acceptance criteria
+
+### Platform engineer — restore-to-new via real Veeam backup/restore
+
+- **Given** a VM Service VM with a real Veeam backup job and at least one successful backup run, **when** the E2E suite triggers a real Veeam restore that produces a VM in the Supervisor namespace folder without a matching Kubernetes object present, **then** invoking manual VM registration against that VM succeeds and produces the same post-registration state that the current mimicked test asserts.
+- **Given** the Veeam restore operation fails or times out, **when** the E2E test observes this, **then** the test fails with an error message that includes Veeam's job/task identifier and Veeam's reported failure reason, not just a generic timeout.
+
+### Platform engineer — restore-to-existing (in-place) via real Veeam backup/restore
+
+- **Given** a VM Service VM with an existing Kubernetes object and two successful Veeam backup runs (an older and a newer restore point), **when** the E2E suite triggers a real Veeam in-place restore to the older restore point, **then** the VM's recorded backup state on vSphere reflects the older restore point as a side effect of Veeam's own restore (not a hand-edited overwrite), and invoking manual VM registration against the existing VM succeeds, producing the same post-registration state the current mimicked test asserts (dangling volumes cleaned up, new restored volumes present).
+- **Given** the in-place restore is still in progress on Veeam's side, **when** manual VM registration is invoked too early, **then** the test either waits for Veeam's restore operation to reach a terminal state first (preferred) or captures and reports the resulting registration failure without masking it as a test infrastructure error.
+
+### Platform engineer — disk-only restore via real Veeam backup/restore
+
+- **Given** a VM Service VM with a persistent-volume-backed disk captured in a Veeam backup, **when** the E2E suite triggers a real Veeam operation scoped to that single disk (not the whole VM), **then** the disk's cloud-native storage identity is removed as an authentic side effect of Veeam's restore (not a manual workaround step), and invoking manual VM registration re-registers exactly that disk as a new restored volume, matching the count and shape asserted by the current mimicked test.
+
+### QA / CI maintainer — traceable, self-cleaning Veeam artifacts
+
+- **Given** an E2E pipeline run creates a Veeam backup job for a specific test VM, **when** the job is inspected in the Veeam console or via its API, **then** its name unambiguously identifies the CI pipeline run and the VM it targets.
+- **Given** an E2E test using Veeam completes (pass or fail), **when** the test's cleanup runs, **then** the Veeam backup job it created is deleted, and no restore point or job artifact is left behind for that run.
+- **Given** the configured testbed has no Veeam server available, **when** a Veeam-backed E2E test runs, **then** the test is skipped with a message naming the missing configuration, not failed.
+
+---
+
+## Edge cases
+
+- Two E2E runs targeting the same testbed concurrently must not collide on Veeam job names; job names must incorporate a value unique per run (e.g., pipeline run ID) in addition to the VM name.
+- A Veeam restore-to-new that targets a VM name already present in vSphere (but with no matching Kubernetes object) must not be confused with a duplicate-identity conflict; the platform's existing hard limitation on duplicate VM identity within a namespace still applies and is not something this feature works around.
+- If Veeam backup job creation succeeds but the backup run itself never starts (e.g., backup proxy exhaustion), the test must fail with a clear "backup run did not start" signal rather than hanging until the outer test-framework timeout.
+- Cleanup of the Veeam backup job must be attempted even when an assertion earlier in the test fails.
+- If the Veeam server is reachable but authentication fails (expired credentials, revoked API key), tests must skip or fail with a message that distinguishes "Veeam auth failure" from "Veeam unreachable" from "restore logic failure," so CI triage isn't spent chasing the wrong layer.
+
+---
+
+## Out of scope
+
+- Any change to VM Operator's product code or the platform's VM registration implementation.
+- Veeam job scheduling, retention policies, backup copy jobs, or scale-out repository configuration.
+- A general-purpose, reusable Veeam API client as a product/library deliverable — any client tooling produced here is test-only.
+- Load/scale testing of Veeam itself (number of concurrent jobs, throughput).
+- Windows-guest-specific VSS/application-aware backup validation.
+
+---
+
+## Open questions
+
+- [NEEDS CLARIFICATION: A connectivity check against the existing VBR appliance found port 9419 — VBR's default REST API port — refused, along with several other candidate ports; only RDP and the Veeam Installer Service port are open. This means the REST API is not currently reachable on that appliance. Tracked as spike vmop-4030; see `research.md` for the full connectivity finding and what needs to be checked/enabled on the VM. This blocks every other Veeam-specific investigation item below and must be resolved before `plan.md` can commit to a concrete client design.]
+- ~~Is a Veeam server already provisioned...~~ **Resolved**: a VBR appliance already runs on a Windows Server VM and is used manually today. The pipeline will be extended to accept its address as a parameter (defaulting to that known instance) rather than provisioning a new one.
+- ~~Which VBR release and REST API version should be targeted...~~ **Resolved**: the appliance in use today runs VBR 12, but the version MUST NOT be hardcoded — see the new version-autodetection goal above. `research.md` needs a follow-up investigation into what VBR 12's REST API actually exposes (VBR 12 predates the `1.3-rev2` surface documented for VBR 13) and how to detect API version/capability at connect time.
+- ~~How are Veeam service-account credentials distributed...~~ **Resolved**: credentials are a pipeline parameter, defaulting to the existing appliance's known credentials. No Kubernetes Secret plumbing is required for this feature; this is a lower-security-bar internal test appliance.
+- ~~Does "restore to new" mean Veeam's "restore VM" flow or an "instant recovery" flow?~~ **Resolved**: use Veeam's standard "Restore VM" action, targeting a new VM identity in the Supervisor namespace folder. This matches the acceptance criteria already written above.
+- [NEEDS CLARIFICATION: Should disk-only restore use Veeam's "virtual disk restore" UI feature, or an FCD instant-recovery-and-migrate REST sequence? Previously marked resolved in favor of "virtual disk restore," but a survey of Veeam's own vendored VBR 12.0 REST spec (`github.com/veeamhub/veeam-vbr-sdk-go`) found no disk-level restore endpoint in that spec — only `instantRecovery/vmware/{vm,fcd}` and `vmRestore/vmware/`. This may be specific to VBR 12.0 (12.x point releases have added REST surface before); it must be re-confirmed against our actual appliance's `buildVersion` under spike `vmop-4030` before `plan.md` commits to an approach. See `research.md` "Open risk: disk-only restore may need a design change."]
+- [NEEDS CLARIFICATION: Does `DELETE /api/v1/jobs/{id}` remove a job's backups and restore points on our appliance, or only the job definition (orphaning backup data)? Veeam's vendored VBR 12.0 REST spec exposes no delete operation for backups or restore points. If job deletion doesn't cascade, the cleanup goal above needs a concrete fallback mechanism, to be confirmed under spike `vmop-4030`.]
+
+---
+
+## Review & acceptance checklist
+
+- [ ] Every mimicked step currently in the E2E suite (deleting the Kubernetes VM object while leaving the vSphere VM behind, hand-overwriting recorded backup state, relocating and re-identifying a virtual disk) has a corresponding real-Veeam replacement described above.
+- [ ] Verification behavior that already validates VM Operator's own behavior (waiting for backup state, invoking registration, verifying post-registration state) is explicitly called out as reused, not replaced.
+- [ ] Job naming/traceability requirement is testable (a human can map a Veeam job back to a CI run and VM).
+- [ ] Cleanup behavior is specified for both pass and fail outcomes.
+- [ ] Skip-vs-fail behavior is specified for missing/unreachable/unauthenticated Veeam server.
+- [ ] All open `[NEEDS CLARIFICATION]` items are either resolved or explicitly blocking `tasks.md` until answered, per [`sdd-standards.md`](../../memory/sdd-standards.md).
+- [ ] Out-of-scope items are listed, including the explicit "no product code changes" boundary.

--- a/.sdd/specs/006-veeam-e2e-backup-restore/tasks.md
+++ b/.sdd/specs/006-veeam-e2e-backup-restore/tasks.md
@@ -1,0 +1,171 @@
+# Tasks: Use Veeam for Backup/Restore E2E Tests
+
+- **Spec**: [`spec.md`](./spec.md)
+- **Plan**: plan.md does not exist yet — this feature is E2E-tooling-only (no CRD/controller/webhook
+  surface), and the client design in Phase 2 is itself blocked on spike `vmop-4030`. See T002a below,
+  which authors `plan.md` once that spike answers the REST-surface questions; until then this task
+  list carries the technical decisions that would otherwise live there.
+- **Epic**: vmop-4013
+
+## Blocking spike (must resolve before Phase 2 starts)
+
+- [ ] T001 [vmop-4030] Spike: enable/confirm the VBR REST API on the existing appliance — start the
+      `Veeam RESTful API Service`, open firewall TCP 9419, confirm `GET /api/v1/serverInfo` and the
+      Swagger UI respond from the CI runner's network path (not just `localhost`). Record findings in
+      `research.md`. Blocks Phase 2 (T005-T010, T012).
+- [ ] T002 [vmop-4030] Spike: capture the appliance's exact `buildVersion` and `x-api-version`, diff its
+      live Swagger document against the vendored `veeamhub/veeam-vbr-sdk-go` `1.1-rev0` spec, and confirm
+      (a) whether a disk-level restore endpoint exists on this build, and (b) whether
+      `DELETE /api/v1/jobs/{id}` cascades to backups/restore points or orphans them. Update `research.md`
+      "Open risk: disk-only restore may need a design change" and resolve the two
+      `[NEEDS CLARIFICATION]` items in `spec.md` (or explicitly re-scope them) based on the answer.
+      Blocks T011 (cleanup fallback shape) and Phase 5 (T019-T021, disk-only restore).
+- [ ] T002a [vmop-4125] Author `plan.md` capturing the client design (package layout below), test
+      strategy, and confirmation that this feature has no `pkg/`/`api/` impact, now that T001/T002 have
+      resolved the open questions that were blocking it. This retires the note at the top of this file.
+
+## Phase 1 — Setup
+
+- [ ] T003 [P] [vmop-4126] Scaffold the Veeam client package `test/e2e/vmservice/lib/veeam/` (mirrors the existing
+      `test/e2e/vmservice/lib/vmoperator/` and `lib/csi/` shared-helper packages).
+- [ ] T004 [P] [vmop-4127] Add `VeeamConfig` (server address, credentials, defaults) to
+      `test/e2e/vmservice/config/config.go`, wired the same way `InfraConfig` is today, and add the
+      corresponding `veeamServerAddress`/`veeamUsername`/`veeamPassword` variable defaults (pointing at
+      the existing manual-test appliance) to `test/e2e/vmservice/config/wcp.yaml`, using the same
+      `${VAR:-default}` `expandEnv` convention already used for `STORAGE_CLASS` etc.
+
+## Phase 2 — Foundational (Veeam REST client)
+
+*Blocked on T001. (T011 additionally blocked on T002.)*
+
+- [ ] T005 [vmop-4128] Implement OAuth2 token client in `test/e2e/vmservice/lib/veeam/auth.go`:
+      `POST /api/oauth2/token` password grant with the mandatory `x-api-version` header, storing
+      `access_token`/`refresh_token`/`expires_in`, and a refresh-token flow invoked before the ~900s
+      access token would expire (a restore can outlast one token's lifetime per `research.md`).
+- [ ] T006 [vmop-4129] Implement API version autodetection in
+      `test/e2e/vmservice/lib/veeam/version.go`: query `GET /api/v1/serverInfo` (and/or the Swagger
+      index) at connect time, select the newest mutually-supported `x-api-version`, and pin it for the
+      client session. Return a typed "unsupported/unreachable" error the caller can turn into a Ginkgo
+      skip.
+- [ ] T007 [vmop-4130] Implement a Ginkgo skip helper in
+      `test/e2e/vmservice/vmservice/viadmin/registervm.go` (or a new
+      `test/e2e/vmservice/lib/veeam/skip.go`) that distinguishes "Veeam unreachable", "Veeam auth
+      failure", and "Veeam API version unsupported" per spec's edge case on triage clarity, following
+      the existing `utils.IsFssEnabled` / `skipper.SkipUnlessInfraIs` skip-not-fail convention noted in
+      `research.md`.
+- [ ] T008 [vmop-4131] Implement job naming and creation in `test/e2e/vmservice/lib/veeam/job.go`:
+      derive a job name from the CI pipeline run ID and target VM name (unique per concurrent run per
+      spec's edge case), resolve the VM's `objectId` via
+      `GET /api/v1/inventory/vmware/hosts/{vcName}?nameFilter=<vmName>`, resolve the repository id via
+      `GET /api/v1/backupInfrastructure/repositories`, and `POST /api/v1/jobs` with
+      `schedule.runAutomatically:false`.
+- [ ] T009 [vmop-4132] Implement backup run trigger/wait in `test/e2e/vmservice/lib/veeam/backup.go`:
+      `POST /api/v1/jobs/{id}/start`, poll `GET /api/v1/sessions/{id}` to a successful terminal state,
+      and on failure/timeout surface the session id, `state`, `result`, and
+      `GET /api/v1/sessions/{id}/logs` in the returned error (spec: "surface Veeam's own job/task
+      identifier and reported error/status"). Fail fast with a distinct "backup run did not start"
+      error if the session never leaves its initial state, rather than waiting out the suite's outer
+      timeout (spec edge case).
+- [ ] T010 [vmop-4133] Implement restore-point discovery in `test/e2e/vmservice/lib/veeam/restorepoint.go`:
+      `GET /api/v1/backups` → `/api/v1/backups/{id}/objects` → `GET /api/v1/backupObjects/{id}/restorePoints`,
+      exposing a way to pick the newest and the Nth-oldest restore point (needed by the in-place-restore
+      user story, which restores an older of two points).
+- [ ] T011 [vmop-4134] (Blocked on T002.) Implement job (and, per T002's findings, restore point/backup) cleanup in
+      `test/e2e/vmservice/lib/veeam/cleanup.go`, callable unconditionally from `DeferCleanup`/`AfterEach`
+      so it runs on both pass and fail (spec: "Cleanup ... must be attempted even when an assertion
+      earlier in the test fails").
+- [ ] T012 [P] [vmop-4135] Unit-style tests for the client package (name/version negotiation, error
+      surfacing, cleanup-always-runs contract) in `test/e2e/vmservice/lib/veeam/veeam_test.go`, using a
+      local `httptest` fake VBR server rather than a live appliance, plus the companion
+      `test/e2e/vmservice/lib/veeam/veeam_suite_test.go` holding just the `TestXxx(t *testing.T)`
+      entry point per `testing-standards.md`.
+
+## Phase 3 — User Story 1: restore-to-new via real Veeam backup/restore
+
+- [ ] T013 [US1] [vmop-4136] Implement `RestoreToNew` in `test/e2e/vmservice/lib/veeam/restore.go`:
+      `POST /api/v1/restore/vmRestore/vmware/` with `type: "Customized"`, targeting a new VM identity
+      in the Supervisor namespace folder, and wait for the restore session to reach a successful
+      terminal state (same session-polling/error-surfacing shape as T009).
+- [ ] T014 [US1] [vmop-4137] Replace the `vmservice.DeleteVMResource` mimicry in the "RegisterVM Alarm"
+      / "Register VM with pre-existing VM CR" contexts of
+      `test/e2e/vmservice/vmservice/viadmin/registervm.go` with: create job (T008) → run backup (T009)
+      → `RestoreToNew` (T013) → existing `vmservice.InvokeRegisterVM` / `vmservice.VerifyPostRegisterVM`
+      (unchanged, per spec's "reused as-is" requirement) → cleanup (T011).
+- [ ] T015 [US1] [vmop-4138] Add/extend the failing-restore assertion so a `RestoreToNew` failure or
+      timeout produces a test failure message containing Veeam's job/task id and reported failure
+      reason, per this user story's second acceptance criterion.
+
+## Phase 4 — User Story 2: restore-to-existing (in-place) via real Veeam backup/restore
+
+- [ ] T016 [US2] [vmop-4139] Implement `RestoreInPlace` in `test/e2e/vmservice/lib/veeam/restore.go`:
+      trigger Veeam's in-place VM restore against a specified (older) restore point id, and wait for
+      the restore session to reach a successful terminal state before returning.
+- [ ] T017 [US2] [vmop-4140] Replace the hand-crafted `vmObj.Reconfigure(...)` ExtraConfig overwrite in
+      the "Incremental Restore - Register VM..." contexts of `registervm.go` with: two backup runs via
+      the job from T008/T009 (older + newer restore point) → `RestoreInPlace` (T016) against the older
+      point → existing `vmservice.InvokeRegisterVM` / `vmservice.VerifyPostRegisterVM` → cleanup (T011).
+- [ ] T018 [US2] [vmop-4141] Ensure the test waits for the Veeam in-place restore's terminal state
+      before invoking manual registration (preferred path in the spec), and if registration is ever
+      invoked while Veeam is still restoring, capture and report that as a registration failure rather
+      than masking it as test-infrastructure flakiness.
+
+## Phase 5 — User Story 3: disk-only restore via real Veeam backup/restore
+
+*Blocked on T002's answer for which REST operation is available on the real appliance.*
+
+- [ ] T019 [US3] [vmop-4142] Once T002 resolves the approach, implement the chosen disk-only restore
+      operation in `test/e2e/vmservice/lib/veeam/restore.go` — either a virtual-disk-restore call, or
+      the FCD instant-recovery-then-migrate REST sequence
+      (`POST /api/v1/restore/instantRecovery/vmware/fcd` + its `/migrate` follow-up) per `research.md`'s
+      documented fallback — scoped to a single disk, not the whole VM.
+- [ ] T020 [US3] [vmop-4143] Replace the manual disk relocate/`ReconcileDatastoreInventory` mimicry in
+      the "Restore disk only" context of `registervm.go` with: job/backup (T008/T009) → the disk-only
+      restore from T019 → existing `vmservice.InvokeRegisterVM` / `vmservice.VerifyPostRegisterVM`,
+      asserting exactly one new `restored-*` PVC as today → cleanup (T011).
+- [ ] T021 [US3] [vmop-4144] If T002 determines no REST-native disk-level restore exists and the
+      full-VM-restore-then-manual-detach fallback (option (b) in `research.md`) must be used instead,
+      update `spec.md`'s disk-only restore acceptance criteria to match before merging this task, per
+      the SDD rule that a revealed wrong assumption updates the spec in the same PR.
+
+## Phase 6 — Pipeline parameterization and skip conventions
+
+- [ ] T022 [P] [vmop-4145] Wire the CI pipeline definition(s) to accept Veeam server address and
+      credentials as parameters, defaulting to the existing appliance's values, feeding
+      `VeeamConfig` (T004) via the same env-var-expansion mechanism as `E2E_KUBECONFIG_PATH` etc.
+- [ ] T023 [vmop-4146] Add a top-level `BeforeEach`/`skipper` gate in `registervm.go` that attempts
+      Veeam connect + version negotiation (T005/T006) once per spec run and skips (not fails) every
+      Veeam-backed context with a message naming the missing configuration when the server is
+      unreachable, unauthenticated, or on an unsupported API version, per the "QA / CI maintainer"
+      acceptance criteria.
+
+## Phase Final — Polish
+
+- [ ] T024 [vmop-4147] Update `test/e2e/README.md` with the new Veeam server/credential
+      parameters, the skip behavior, and how to point a local run at a different VBR instance.
+- [ ] T025 [vmop-4148] Update `docs/guides/backup-restore/README.md` if the real-Veeam E2E flow
+      surfaces any gap between documented production restore-type detection (Section 4.3) and what the
+      real appliance actually produces.
+- [ ] T027 Flip `spec.md` status from `Draft` to `Implemented` and check off every item in its
+      "Review & acceptance checklist" once all tasks above are complete and both
+      `[NEEDS CLARIFICATION]` markers are resolved.
+
+---
+
+## Traceability
+
+| Task(s) | Spec section |
+|---|---|
+| T001, T002 | Open questions (both `[NEEDS CLARIFICATION]` items) |
+| T005, T006, T023 | Goals: version autodetection, skip-not-fail |
+| T007, T009, T015 | Goals: surfacing Veeam's own job/task id and error on failure |
+| T008 | Goals: traceable job naming; Edge case: concurrent-run name collision |
+| T009 | Edge case: backup run never starts |
+| T011 | Goals/Edge case: cleanup on pass and fail, no orphaned artifacts |
+| T013-T015 | US1: restore-to-new |
+| T016-T018 | US2: restore-to-existing (in-place) |
+| T019-T021 | US3: disk-only restore |
+| T022 | Goals: pipeline-parameterized server address/credentials |
+
+All tasks above have been filed as stories under epic `vmop-4013` (`VMSVC-4013`), with
+`customfield_10830` set to the epic on each. See `vmop-4125` through `vmop-4148` (`VMSVC-4125`
+through `VMSVC-4148`).


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Add the SDD spec and research notes for replacing the E2E suite's mimicked backup/restore steps (CR deletion, ExtraConfig overwrites, disk relocation) with real backup and restore performed through Veeam Backup & Replication (VBR), driven by its REST API.

research.md records the VBR REST API mechanics confirmed so far (OAuth2 password-grant auth, the mandatory x-api-version header, Swagger-based version discovery) and the restore-flow decisions (Restore VM for restore-to-new, virtual disk restore for disk-only restore). A connectivity check found the REST API unreachable on the existing VBR appliance; that gap is tracked as spike vmop-4030 and referenced from the spec rather than blocking it outright.

Register the new spec in the SDD index. No product code changes; this is spec/research only, per e2e-sync-with-changes.md.


**Please add a release note if necessary**:

```release-note
Add spec for Veeam-backed backup/restore E2E tests
```