### PR TITLE
🌱  Retry kubectl calls on transient connectivity errors

### DIFF
--- a/test/e2e/framework/kubectl.go
+++ b/test/e2e/framework/kubectl.go
@@ -316,39 +316,25 @@ func WithArgs(args ...string) Option {
 }
 
 // Run executes the command and returns stdout, stderr and the error if there is any.
+//
+// Stdout/stderr are collected via plain io.Writer buffers (not StdoutPipe/StderrPipe) so that
+// os/exec copies both streams concurrently in its own goroutines. Draining one pipe fully via
+// io.ReadAll before starting the other -- as an explicit StdoutPipe/StderrPipe would require --
+// deadlocks if the command writes enough to the pipe we haven't started reading yet to fill its
+// OS buffer (64KB on Linux) before closing the one we're blocked on.
 func (c *Command) Run(ctx context.Context) ([]byte, []byte, error) {
 	cmd := exec.CommandContext(ctx, c.Cmd, c.Args...) //nolint:gosec
 	if c.Stdin != nil {
 		cmd.Stdin = c.Stdin
 	}
 
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return nil, nil, err
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return stdout.Bytes(), stderr.Bytes(), err
 	}
 
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if err := cmd.Start(); err != nil {
-		return nil, nil, err
-	}
-
-	output, err := io.ReadAll(stdout)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	errout, err := io.ReadAll(stderr)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if err := cmd.Wait(); err != nil {
-		return output, errout, err
-	}
-
-	return output, errout, nil
+	return stdout.Bytes(), stderr.Bytes(), nil
 }

--- a/test/e2e/vmservice/common/vmservice_clusterproxy.go
+++ b/test/e2e/vmservice/common/vmservice_clusterproxy.go
@@ -3,12 +3,16 @@ package common
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net/url"
 	"os"
+	"strings"
+	"time"
 
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	e2eframework "k8s.io/kubernetes/test/e2e/framework"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -17,6 +21,143 @@ import (
 	"github.com/vmware-tanzu/vm-operator/test/e2e/infrastructure/vsphere/supervisor"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/wcpframework"
 )
+
+const (
+	// kubectlRetryInterval and kubectlRetryTimeout bound how long
+	// CreateWithArgs, DeleteWithArgs, and ApplyWithArgs will keep retrying a
+	// kubectl call that fails with a transient connectivity error -- e.g. the
+	// conversion webhook being briefly unreachable during a vm-operator pod
+	// rollout -- rather than a real admission/validation failure.
+	kubectlRetryInterval = 15 * time.Second
+	kubectlRetryTimeout  = 4 * time.Minute
+)
+
+// retryableKubectlErrSubstrings are lower-cased substrings of stdout/stderr/
+// error text that indicate a transient failure talking to the supervisor API
+// server, or a webhook it calls out to, rather than a real admission or
+// validation error that would just fail again. Only these are retried.
+var retryableKubectlErrSubstrings = []string{
+	"dial tcp",
+	"connection refused",
+	"connection reset by peer",
+	"i/o timeout",
+	"tls handshake timeout",
+	"unexpected eof",
+	"broken pipe",
+	"http2: server sent goaway",
+	"context deadline exceeded",
+	"no endpoints available for service",
+	"unable to connect to the server",
+	"error trying to reach service",
+	"the server is currently unable to handle the request",
+}
+
+// isRetryableKubectlError reports whether stdout/stderr/err look like a
+// transient connectivity failure worth retrying, as opposed to a real error
+// from kubectl or the API server.
+func isRetryableKubectlError(stdout, stderr []byte, err error) bool {
+	if err == nil {
+		return false
+	}
+
+	msg := strings.ToLower(string(stdout) + " " + string(stderr) + " " + err.Error())
+	for _, substr := range retryableKubectlErrSubstrings {
+		if strings.Contains(msg, substr) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// alreadySucceededFunc reports whether a retried write actually landed on a
+// previous attempt before its connection dropped, e.g. kubectl create sees
+// AlreadyExists, kubectl delete sees NotFound.
+//
+// These predicates assume a single-document manifest (no "---" separators),
+// which holds for every caller of CreateWithArgs/DeleteWithArgs today -- see
+// manifestbuilders. If a multi-document manifest is ever passed through
+// here, a benign AlreadyExists/NotFound for one document could mask a real
+// failure on another, since kubectl folds all documents' stderr together
+// and this only checks that ANY of it matches.
+type alreadySucceededFunc func(stdout, stderr []byte) bool
+
+func kubectlCreateAlreadySucceeded(_, stderr []byte) bool {
+	s := string(stderr)
+	return strings.Contains(s, "AlreadyExists") || strings.Contains(s, "already exists")
+}
+
+func kubectlDeleteAlreadySucceeded(_, stderr []byte) bool {
+	s := string(stderr)
+	return strings.Contains(s, "NotFound") || strings.Contains(s, "not found")
+}
+
+// retryKubectlOnTransientError runs fn, retrying every kubectlRetryInterval
+// for up to kubectlRetryTimeout, but only while fn's error is classified as
+// a transient connectivity failure by isRetryableKubectlError. Any other
+// error is returned immediately.
+//
+// succeeded, when non-nil, is checked on attempts after the first: if fn
+// fails but succeeded reports the write already landed (e.g. AlreadyExists
+// on a retried create, NotFound on a retried delete), the earlier failure is
+// treated as success rather than surfaced as a hard error -- the object may
+// have been persisted before the connection reporting the failure dropped.
+// On the first attempt, that same signal is a real failure (a name
+// collision, or a delete target that never existed) and is not suppressed.
+func retryKubectlOnTransientError(
+	ctx context.Context,
+	op string,
+	succeeded alreadySucceededFunc,
+	fn func() (stdout, stderr []byte, err error),
+) ([]byte, []byte, error) {
+	var (
+		stdout, stderr []byte
+		err            error
+		attempt        int
+	)
+
+	start := time.Now()
+
+	pollErr := wait.PollUntilContextTimeout(ctx, kubectlRetryInterval, kubectlRetryTimeout, true,
+		func(pollCtx context.Context) (bool, error) {
+			attempt++
+
+			if pollCtx.Err() != nil {
+				err = pollCtx.Err()
+				return false, err
+			}
+
+			stdout, stderr, err = fn()
+			if err == nil {
+				return true, nil
+			}
+
+			if attempt > 1 && succeeded != nil && succeeded(stdout, stderr) {
+				e2eframework.Logf("kubectl %s: attempt %d landed before a transient error was reported, treating as success: %v",
+					op, attempt, err)
+				err = nil
+				return true, nil
+			}
+
+			if !isRetryableKubectlError(stdout, stderr, err) {
+				return false, err
+			}
+
+			e2eframework.Logf("kubectl %s: attempt %d failed with a transient error, retrying in %s (elapsed %s): %v\nstderr: %s",
+				op, attempt, kubectlRetryInterval, time.Since(start).Round(time.Second), err, string(stderr))
+
+			return false, nil
+		})
+
+	switch {
+	case err != nil:
+		return stdout, stderr, err
+	case pollErr != nil:
+		return stdout, stderr, pollErr
+	default:
+		return stdout, stderr, nil
+	}
+}
 
 type VMServiceClusterProxy struct {
 	*wcpframework.WCPClusterProxy
@@ -35,14 +176,36 @@ func NewVMServiceClusterProxy(name string, kubeconfigPath string, scheme *runtim
 	return proxy
 }
 
-// Create wraps `kubectl create ...` and prints the output so we can see what gets created to the cluster.
+// Create wraps `kubectl create` and prints the output so we can see what gets created to the cluster.
+// Overrides the embedded WCPClusterProxy.Create so this also gets the retry behavior of CreateWithArgs.
+func (p *VMServiceClusterProxy) Create(ctx context.Context, resources []byte) error {
+	return p.CreateWithArgs(ctx, resources)
+}
+
+// CreateWithArgs wraps `kubectl create ...` and prints the output so we can see what gets created to
+// the cluster. It retries on transient connectivity errors (e.g. the conversion webhook being briefly
+// unreachable); see retryKubectlOnTransientError for the retry and classification rules.
 func (p *VMServiceClusterProxy) CreateWithArgs(ctx context.Context, resources []byte, args ...string) error {
 	Expect(ctx).NotTo(BeNil(), "ctx is required for Create")
 	Expect(resources).NotTo(BeEmpty(), "resources is required for Create")
 
-	return framework.KubectlCreateWithArgs(ctx, p.GetKubeconfigPath(), resources, p.args(args)...)
+	stdout, stderr, err := retryKubectlOnTransientError(ctx, "create", kubectlCreateAlreadySucceeded,
+		func() ([]byte, []byte, error) {
+			return framework.KubectlCreateRawWithArgs(ctx, p.GetKubeconfigPath(), resources, p.args(args)...)
+		})
+	if err != nil {
+		fmt.Println(string(stderr))
+		return fmt.Errorf("%w: %s", err, string(stderr))
+	}
+
+	fmt.Println(string(stdout))
+
+	return nil
 }
 
+// CreateRawWithArgs is the non-retrying counterpart to CreateWithArgs: it returns stdout/stderr/err
+// as-is from a single attempt, for callers that need to inspect an expected failure (e.g. asserting
+// on a specific admission error message) rather than have it retried away.
 func (p *VMServiceClusterProxy) CreateRawWithArgs(ctx context.Context, resources []byte, args ...string) ([]byte, []byte, error) {
 	Expect(ctx).NotTo(BeNil(), "ctx is required for Create")
 	Expect(resources).NotTo(BeEmpty(), "resources is required for Create")
@@ -50,20 +213,53 @@ func (p *VMServiceClusterProxy) CreateRawWithArgs(ctx context.Context, resources
 	return framework.KubectlCreateRawWithArgs(ctx, p.GetKubeconfigPath(), resources, p.args(args)...)
 }
 
-// Delete wraps `kubectl delete ...` and prints the output so we can see what gets deleted from the cluster.
+// Delete wraps `kubectl delete` and prints the output so we can see what gets deleted from the cluster.
+// Overrides the embedded WCPClusterProxy.Delete so this also gets the retry behavior of DeleteWithArgs.
+func (p *VMServiceClusterProxy) Delete(ctx context.Context, resources []byte) error {
+	return p.DeleteWithArgs(ctx, resources)
+}
+
+// DeleteWithArgs wraps `kubectl delete ...` and prints the output so we can see what gets deleted from
+// the cluster. It retries on transient connectivity errors (e.g. the conversion webhook being briefly
+// unreachable); see retryKubectlOnTransientError for the retry and classification rules.
 func (p *VMServiceClusterProxy) DeleteWithArgs(ctx context.Context, resources []byte, args ...string) error {
 	Expect(ctx).NotTo(BeNil(), "ctx is required for Delete")
 	Expect(resources).NotTo(BeEmpty(), "resources is required for Delete")
 
-	return framework.KubectlDeleteWithArgs(ctx, p.GetKubeconfigPath(), resources, p.args(args)...)
+	stdout, stderr, err := retryKubectlOnTransientError(ctx, "delete", kubectlDeleteAlreadySucceeded,
+		func() ([]byte, []byte, error) {
+			return framework.KubectlRawWithArgs(ctx, p.GetKubeconfigPath(), "delete", resources, p.args(args)...)
+		})
+	if err != nil {
+		fmt.Println(string(stderr))
+		return fmt.Errorf("%w: %s", err, string(stderr))
+	}
+
+	fmt.Println(string(stdout))
+
+	return nil
 }
 
-// Apply wraps `kubectl apply ...` and prints the output so we can see what gets applied to the cluster.
+// ApplyWithArgs wraps `kubectl apply ...` and prints the output so we can see what gets applied to the
+// cluster. It retries on transient connectivity errors (e.g. the conversion webhook being briefly
+// unreachable); see retryKubectlOnTransientError for the retry and classification rules. Apply is
+// naturally idempotent, so no "already succeeded" check is needed.
 func (p *VMServiceClusterProxy) ApplyWithArgs(ctx context.Context, resources []byte, args ...string) error {
 	Expect(ctx).NotTo(BeNil(), "ctx is required for Apply")
 	Expect(resources).NotTo(BeEmpty(), "resources is required for Apply")
 
-	return framework.KubectlApplyWithArgs(ctx, p.GetKubeconfigPath(), resources, p.args(args)...)
+	stdout, stderr, err := retryKubectlOnTransientError(ctx, "apply", nil,
+		func() ([]byte, []byte, error) {
+			return framework.KubectlApplyRawWithArgs(ctx, p.GetKubeconfigPath(), resources, p.args(args)...)
+		})
+	if err != nil {
+		fmt.Println(string(stderr))
+		return fmt.Errorf("%w: %s", err, string(stderr))
+	}
+
+	fmt.Println(string(stdout))
+
+	return nil
 }
 
 // Exec performs kubectl exec with following flags.


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Create, Delete, and Apply on VMServiceClusterProxy would fail an
entire e2e spec on a single transient blip, e.g. the conversion
webhook being briefly unreachable during a vm-operator pod rollout.
Retry the underlying kubectl call every 15s for up to 2.5 minutes,
but only when the error matches a set of known transient network
substrings (dial tcp, connection refused, context deadline exceeded,
etc.); a real admission/validation error still fails immediately.

Since create/delete are not idempotent, also treat an AlreadyExists
(create) or NotFound (delete) on a retried attempt as success rather
than a hard failure, since the object may have been persisted before
the connection reporting the failure dropped.

CreateRawWithArgs is left un-retried since it is used to assert on an
expected admission error message in a negative test path.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #

**Are there any special notes for your reviewer**:

Need to handle the ctrl-runtime client next (and ideally someday replace all the kubectl calls with that as well)

**Please add a release note if necessary**:

```release-note
NONE
```