### PR TITLE
e2e: Drop filtered-out specs from callback subtest_details

### DIFF
--- a/hack/e2e/run-e2e.sh
+++ b/hack/e2e/run-e2e.sh
@@ -52,17 +52,23 @@ fi
 # Ginkgo's report distinguishes a spec that was excluded by the label/focus
 # filter (State "skipped" with no Failure) from one that called Skip() with a
 # reason at runtime (State "skipped" with a non-empty Failure.Message) or was
-# declared PIt/PDescribe (State "pending"); this maps the former to "Not_Run"
-# and the latter two to "SKIPPED" so the callback payload distinguishes
-# "never attempted" from "test logic decided to skip". Failed specs also get
-# a "syndrome" carrying Failure.Message, the callback API's field for a short
-# failure synopsis. Failure.Message is Gomega's full failure output (often an
-# object diff or YAML dump running well past 1024 characters), so it is
-# truncated to the same 1024-character cap the callback API enforces on
-# "syndrome" fields — otherwise the callback POST is rejected outright.
+# declared PIt/PDescribe (State "pending"); the former never executed at all
+# and is out of scope for this run (e.g. a "core"-labeled spec when only
+# "smoke" was requested), so it is dropped entirely rather than reported as
+# "Not_Run" — including it would pad the denominator with specs this run
+# never intended to touch, making an intentionally-scoped run (e.g. smoke
+# only) look like most of the suite failed to execute. The latter two map to
+# "SKIPPED" since they were in scope but a runtime decision skipped them.
+# Failed specs also get a "syndrome" carrying Failure.Message, the callback
+# API's field for a short failure synopsis. Failure.Message is Gomega's full
+# failure output (often an object diff or YAML dump running well past 1024
+# characters), so it is truncated to the same 1024-character cap the
+# callback API enforces on "syndrome" fields — otherwise the callback POST
+# is rejected outright.
 parse_json_report() {
     local json_file="${1}"
     jq '[.[0].SpecReports[] |
+        select(.State != "skipped" or (.Failure != null and .Failure.Message != "")) |
         ((.ContainerHierarchyTexts + [.LeafNodeText]) | map(select(. != "")) | join(" ")) as $fulltext |
         ("[" + .LeafNodeType + "]" + (if $fulltext != "" then " " + $fulltext else "" end)
             + (if (.LeafNodeLabels | length) > 0 then " [" + (.LeafNodeLabels | join(", ")) + "]" else "" end)
@@ -73,8 +79,7 @@ parse_json_report() {
                 if .State == "failed" then "FAIL"
                 elif .State == "passed" then "PASS"
                 elif .State == "pending" then "SKIPPED"
-                elif .State == "skipped" then
-                    (if (.Failure != null and .Failure.Message != "") then "SKIPPED" else "Not_Run" end)
+                elif .State == "skipped" then "SKIPPED"
                 else "INVALID"
                 end
             )


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

`hack/e2e/run-e2e.sh`'s `parse_json_report` builds the `subtest_details`
array posted to the E2E test callback URL from Ginkgo's `--json-report`
output. It included every spec compiled into the suite, even ones
excluded entirely by `--label-filter` (reported as `Not_Run`). A run
scoped to `LABEL_FILTER=smoke`, for example, still listed every
`core`-labeled spec in the payload as `Not_Run`, so the callback
consumer's pass-rate calculation saw a run that only executed a handful
of its "total" tests — reading as most of the suite having failed to
run, instead of those specs simply being out of scope for this run.

This drops specs that never executed at all (Ginkgo `State: "skipped"`
with no `Failure`, i.e. excluded by the label/focus filter) from the
reported list entirely, and collapses the remaining
pending/runtime-skipped states into a single `SKIPPED` result. A run
selecting 5 passing and 2 runtime-skipped (e.g. via `Skip()` for a
disabled feature flag) `smoke` specs, out of a suite that also has 10
filtered-out `core` specs, now reports `5 PASS + 2 SKIPPED = 7` total
instead of `5 PASS + 2 SKIPPED + 10 Not_Run = 17`.

The distinction between "excluded by filter" and "skipped at runtime"
relies on Ginkgo's own `SpecReport.MarshalJSON`, which omits the
`Failure` field entirely when it's the zero value (filter-excluded)
and populates `Failure.Message` when `Skip()` was called at runtime
(confirmed in `github.com/onsi/ginkgo/v2/types.SpecReport.MarshalJSON`
and `internal/failer.go`'s `Skip()`), so this only touches the reporting
logic — no behavior of the actual test run itself changes.

**Proof of testing**

Extracted `parse_json_report` into a standalone script and ran it
against synthetic Ginkgo JSON reports shaped to match Ginkgo's real
`MarshalJSON` output (`Failure` key entirely absent for filter-excluded
specs, present with a `Message` for runtime skips):

1. Exact motivating scenario — 5 `smoke` passes, 2 `smoke` specs
   runtime-skipped (feature flag), 10 `core` specs excluded by
   `--label-filter`:
   ```
   PASS: 5, SKIPPED: 2, total reported: 7   (previously: 17, with 10 "Not_Run")
   ```
2. Same scenario plus a failing `smoke` spec and a `PIt`-pending `smoke`
   spec, to confirm `FAIL`/pending handling is unaffected:
   ```
   PASS: 5, SKIPPED: 3, FAIL: 1, total reported: 9
   ```
3. Edge case — every spec filtered out (e.g. an empty label match):
   reports an empty `[]` rather than erroring.
4. Edge case — every spec passes, no skips/filters: reports `PASS: 3`
   as expected.
5. `bash -n hack/e2e/run-e2e.sh` and `shellcheck` both clean (only a
   pre-existing, unrelated `SC1091` info-level note about not
   following the sourced `callback.sh`).

**Which issue(s) is/are addressed by this PR?**:

Fixes #

**Are there any special notes for your reviewer**:

This only changes what gets reported to `TEST_CALLBACK_URL`
(`hack/e2e/run-e2e.sh` → `hack/e2e/callback.sh`); it does not change
which tests run, Ginkgo's exit code, or `test/e2e/vmservice` test code.
`TEST_CALLBACK_URL` is unset in local/default runs, so this is a no-op
outside of CI environments that configure the callback.

**Please add a release note if necessary**:

```release-note
None
```

— Faisal + Claude
