### PR TITLE
🌱 Retriable controller runtime client for transient errors

### DIFF
--- a/test/e2e/framework/cluster_proxy.go
+++ b/test/e2e/framework/cluster_proxy.go
@@ -132,7 +132,12 @@ func (p *clusterProxy) GetScheme() *runtime.Scheme {
 	return p.scheme
 }
 
-// GetClient returns a controller-runtime client for the cluster.
+// GetClient returns a controller-runtime client for the cluster. The
+// returned client retries Get, Create, Update, Patch, Delete, and
+// DeleteAllOf on transient connectivity errors -- e.g. the conversion
+// webhook being briefly unreachable during a vm-operator pod rollout --
+// instead of failing an entire e2e spec on a single blip. See
+// NewRetryableClient.
 func (p *clusterProxy) GetClient() client.Client {
 	config := p.GetRESTConfig()
 
@@ -150,7 +155,7 @@ func (p *clusterProxy) GetClient() client.Client {
 		return c
 	}, 5*time.Minute, 10*time.Second).ShouldNot(BeNil(), "Failed to get controller-runtime client")
 
-	return c
+	return NewRetryableClient(c)
 }
 
 // GetClientSet returns a client-go client for the cluster.

--- a/test/e2e/framework/retry_client.go
+++ b/test/e2e/framework/retry_client.go
@@ -1,0 +1,221 @@
+// Copyright (c) 2026 Broadcom. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package framework
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	e2eframework "k8s.io/kubernetes/test/e2e/framework"
+)
+
+const (
+	// TransientRetryInterval and TransientRetryTimeout bound how long any e2e
+	// retry path -- the controller-runtime client retry below, and the
+	// kubectl-based retry in vmservice/common/vmservice_clusterproxy.go --
+	// keeps retrying a call that fails with a transient connectivity error,
+	// e.g. the conversion webhook being briefly unreachable during a
+	// vm-operator pod rollout, rather than a real admission/validation
+	// failure. Shared so both paths behave the same way against the same
+	// class of outage instead of drifting apart.
+	TransientRetryInterval = 15 * time.Second
+	TransientRetryTimeout  = 4 * time.Minute
+)
+
+// RetryableTransientErrSubstrings are lower-cased substrings of arbitrary
+// error/output text that indicate a transient failure talking to the
+// supervisor API server, or a webhook it calls out to, rather than a real
+// error that would just fail again.
+//
+// This is the single shared list for every e2e retry path that has to tell
+// "transient connectivity blip" apart from "real failure" -- both the
+// controller-runtime client retry below and the kubectl-based retry in
+// vmservice/common/vmservice_clusterproxy.go use it, so a new signature only
+// needs to be added once. The kubectl path matches it against raw
+// stdout/stderr text; IsRetryableTransientErrString below matches it against
+// a Go error's message for the client path.
+var RetryableTransientErrSubstrings = []string{
+	"dial tcp",
+	"connection refused",
+	"connection reset by peer",
+	"i/o timeout",
+	"tls handshake timeout",
+	"unexpected eof",
+	"broken pipe",
+	"http2: server sent goaway",
+	"context deadline exceeded",
+	"no endpoints available for service",
+	"unable to connect to the server",
+	"error trying to reach service",
+	"the server is currently unable to handle the request",
+}
+
+// IsRetryableTransientErrString reports whether msg contains one of
+// RetryableTransientErrSubstrings, case-insensitively.
+func IsRetryableTransientErrString(msg string) bool {
+	msg = strings.ToLower(msg)
+	for _, substr := range RetryableTransientErrSubstrings {
+		if strings.Contains(msg, substr) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isRetryableClientError reports whether err from a controller-runtime client
+// call looks like a transient connectivity failure -- as opposed to a real
+// error from the API server or an admission/validation webhook.
+//
+// A conversion webhook that is briefly unreachable surfaces as a typed
+// apierrors.IsInternalError (the API server wraps the dial failure in
+// "Internal error occurred: ..."), which is why that check comes first; the
+// substring list is the fallback for raw transport errors that never reach a
+// typed apierrors.APIStatus, e.g. the apiserver connection itself timing out.
+func isRetryableClientError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if apierrors.IsInternalError(err) || apierrors.IsServiceUnavailable(err) ||
+		apierrors.IsTimeout(err) || apierrors.IsServerTimeout(err) ||
+		apierrors.IsTooManyRequests(err) {
+		return true
+	}
+
+	if IsRetryableTransientErrString(err.Error()) {
+		return true
+	}
+
+	return false
+}
+
+// alreadySucceededFunc reports whether a retried write actually landed on a
+// previous attempt before its connection dropped, e.g. Create sees
+// AlreadyExists, Delete sees NotFound.
+type alreadySucceededFunc func(err error) bool
+
+func createAlreadySucceeded(err error) bool { return apierrors.IsAlreadyExists(err) }
+func deleteAlreadySucceeded(err error) bool { return apierrors.IsNotFound(err) }
+
+// retryOnTransientError runs fn, retrying every TransientRetryInterval for up
+// to TransientRetryTimeout, but only while fn's error is classified as a transient
+// connectivity failure by isRetryableClientError. Any other error is
+// returned immediately.
+//
+// succeeded, when non-nil, is checked on attempts after the first: if fn
+// fails but succeeded reports the write already landed (e.g. AlreadyExists on
+// a retried Create, NotFound on a retried Delete), the earlier failure is
+// treated as success rather than surfaced as a hard error -- the object may
+// have been persisted before the connection reporting the failure dropped.
+// On the first attempt, that same signal is a real failure (a name
+// collision, or a delete target that never existed) and is not suppressed.
+//
+// Update and Patch intentionally pass a nil succeeded: a Conflict on a
+// retried Update/Patch is ambiguous -- it can mean the earlier attempt
+// landed, or that someone else wrote to the object -- so it is surfaced as a
+// real error rather than guessed at. Call sites that mutate through
+// Update/Patch already re-fetch and retry at a higher level (see
+// lib/vmoperator), which self-heals a spurious conflict from this case.
+func retryOnTransientError(ctx context.Context, op string, succeeded alreadySucceededFunc, fn func() error) error {
+	var (
+		err     error
+		attempt int
+	)
+
+	start := time.Now()
+
+	pollErr := wait.PollUntilContextTimeout(ctx, TransientRetryInterval, TransientRetryTimeout, true,
+		func(pollCtx context.Context) (bool, error) {
+			attempt++
+
+			if pollCtx.Err() != nil {
+				err = pollCtx.Err()
+				return false, err
+			}
+
+			err = fn()
+			if err == nil {
+				return true, nil
+			}
+
+			if attempt > 1 && succeeded != nil && succeeded(err) {
+				e2eframework.Logf("controller-runtime %s: attempt %d landed before a transient error was reported, treating as success: %v",
+					op, attempt, err)
+				err = nil
+				return true, nil
+			}
+
+			if !isRetryableClientError(err) {
+				return false, err
+			}
+
+			e2eframework.Logf("controller-runtime %s: attempt %d failed with a transient error, retrying in %s (elapsed %s): %v",
+				op, attempt, TransientRetryInterval, time.Since(start).Round(time.Second), err)
+
+			return false, nil
+		})
+
+	if err != nil {
+		return err
+	}
+
+	return pollErr
+}
+
+// retryableClient wraps a controller-runtime client.Client so that Get,
+// Create, Update, Patch, Delete, and DeleteAllOf retry on transient
+// connectivity errors instead of failing an entire e2e spec on a single
+// blip. All other methods (List, Status, SubResource, Scheme, RESTMapper,
+// ...) pass through to the embedded client unmodified.
+type retryableClient struct {
+	client.Client
+}
+
+// NewRetryableClient wraps c with the retry behavior documented on
+// retryableClient.
+func NewRetryableClient(c client.Client) client.Client {
+	return &retryableClient{Client: c}
+}
+
+func (r *retryableClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	return retryOnTransientError(ctx, "get", nil, func() error {
+		return r.Client.Get(ctx, key, obj, opts...)
+	})
+}
+
+func (r *retryableClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	return retryOnTransientError(ctx, "create", createAlreadySucceeded, func() error {
+		return r.Client.Create(ctx, obj, opts...)
+	})
+}
+
+func (r *retryableClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	return retryOnTransientError(ctx, "update", nil, func() error {
+		return r.Client.Update(ctx, obj, opts...)
+	})
+}
+
+func (r *retryableClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	return retryOnTransientError(ctx, "patch", nil, func() error {
+		return r.Client.Patch(ctx, obj, patch, opts...)
+	})
+}
+
+func (r *retryableClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	return retryOnTransientError(ctx, "delete", deleteAlreadySucceeded, func() error {
+		return r.Client.Delete(ctx, obj, opts...)
+	})
+}
+
+func (r *retryableClient) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
+	return retryOnTransientError(ctx, "deleteAllOf", nil, func() error {
+		return r.Client.DeleteAllOf(ctx, obj, opts...)
+	})
+}

--- a/test/e2e/vmservice/common/vmservice_clusterproxy.go
+++ b/test/e2e/vmservice/common/vmservice_clusterproxy.go
@@ -22,52 +22,18 @@ import (
 	"github.com/vmware-tanzu/vm-operator/test/e2e/wcpframework"
 )
 
-const (
-	// kubectlRetryInterval and kubectlRetryTimeout bound how long
-	// CreateWithArgs, DeleteWithArgs, and ApplyWithArgs will keep retrying a
-	// kubectl call that fails with a transient connectivity error -- e.g. the
-	// conversion webhook being briefly unreachable during a vm-operator pod
-	// rollout -- rather than a real admission/validation failure.
-	kubectlRetryInterval = 15 * time.Second
-	kubectlRetryTimeout  = 4 * time.Minute
-)
-
-// retryableKubectlErrSubstrings are lower-cased substrings of stdout/stderr/
-// error text that indicate a transient failure talking to the supervisor API
-// server, or a webhook it calls out to, rather than a real admission or
-// validation error that would just fail again. Only these are retried.
-var retryableKubectlErrSubstrings = []string{
-	"dial tcp",
-	"connection refused",
-	"connection reset by peer",
-	"i/o timeout",
-	"tls handshake timeout",
-	"unexpected eof",
-	"broken pipe",
-	"http2: server sent goaway",
-	"context deadline exceeded",
-	"no endpoints available for service",
-	"unable to connect to the server",
-	"error trying to reach service",
-	"the server is currently unable to handle the request",
-}
-
 // isRetryableKubectlError reports whether stdout/stderr/err look like a
 // transient connectivity failure worth retrying, as opposed to a real error
-// from kubectl or the API server.
+// from kubectl or the API server. Shares its classification (and retry
+// interval/timeout, see retryKubectlOnTransientError below) with the
+// controller-runtime client retry in framework.NewRetryableClient, so both
+// paths recognize the same class of outage.
 func isRetryableKubectlError(stdout, stderr []byte, err error) bool {
 	if err == nil {
 		return false
 	}
 
-	msg := strings.ToLower(string(stdout) + " " + string(stderr) + " " + err.Error())
-	for _, substr := range retryableKubectlErrSubstrings {
-		if strings.Contains(msg, substr) {
-			return true
-		}
-	}
-
-	return false
+	return framework.IsRetryableTransientErrString(string(stdout) + " " + string(stderr) + " " + err.Error())
 }
 
 // alreadySucceededFunc reports whether a retried write actually landed on a
@@ -92,10 +58,11 @@ func kubectlDeleteAlreadySucceeded(_, stderr []byte) bool {
 	return strings.Contains(s, "NotFound") || strings.Contains(s, "not found")
 }
 
-// retryKubectlOnTransientError runs fn, retrying every kubectlRetryInterval
-// for up to kubectlRetryTimeout, but only while fn's error is classified as
-// a transient connectivity failure by isRetryableKubectlError. Any other
-// error is returned immediately.
+// retryKubectlOnTransientError runs fn, retrying every
+// framework.TransientRetryInterval for up to framework.TransientRetryTimeout,
+// but only while fn's error is classified as a transient connectivity
+// failure by isRetryableKubectlError. Any other error is returned
+// immediately.
 //
 // succeeded, when non-nil, is checked on attempts after the first: if fn
 // fails but succeeded reports the write already landed (e.g. AlreadyExists
@@ -118,7 +85,7 @@ func retryKubectlOnTransientError(
 
 	start := time.Now()
 
-	pollErr := wait.PollUntilContextTimeout(ctx, kubectlRetryInterval, kubectlRetryTimeout, true,
+	pollErr := wait.PollUntilContextTimeout(ctx, framework.TransientRetryInterval, framework.TransientRetryTimeout, true,
 		func(pollCtx context.Context) (bool, error) {
 			attempt++
 
@@ -144,7 +111,7 @@ func retryKubectlOnTransientError(
 			}
 
 			e2eframework.Logf("kubectl %s: attempt %d failed with a transient error, retrying in %s (elapsed %s): %v\nstderr: %s",
-				op, attempt, kubectlRetryInterval, time.Since(start).Round(time.Second), err, string(stderr))
+				op, attempt, framework.TransientRetryInterval, time.Since(start).Round(time.Second), err, string(stderr))
 
 			return false, nil
 		})
@@ -332,6 +299,9 @@ func (p *VMServiceClusterProxy) NewAdminClusterProxy(ctx context.Context) (*VMSe
 	return proxy, nil
 }
 
+// GetAdminClient returns a controller-runtime client for the cluster using the
+// admin identity. Like GetClient, the returned client retries on transient
+// connectivity errors; see framework.NewRetryableClient.
 func (p *VMServiceClusterProxy) GetAdminClient() (client.Client, error) {
 	config := p.GetRESTConfig()
 
@@ -341,7 +311,12 @@ func (p *VMServiceClusterProxy) GetAdminClient() (client.Client, error) {
 	config.Insecure = true
 	config.CAData = nil
 
-	return client.New(config, client.Options{Scheme: p.GetScheme()})
+	c, err := client.New(config, client.Options{Scheme: p.GetScheme()})
+	if err != nil {
+		return nil, err
+	}
+
+	return framework.NewRetryableClient(c), nil
 }
 
 func (p *VMServiceClusterProxy) Dispose(ctx context.Context) {

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_publishrequest.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_publishrequest.go
@@ -786,8 +786,9 @@ func setupNonAdminUserForTests(
 	restCfg, err := clientcmd.BuildConfigFromFlags("", kubectlPlugin.KubeconfigPath())
 	Expect(err).NotTo(HaveOccurred())
 
-	nonAdminClient, err := ctrlclient.New(restCfg, ctrlclient.Options{Scheme: svClusterProxy.GetScheme()})
+	rawNonAdminClient, err := ctrlclient.New(restCfg, ctrlclient.Options{Scheme: svClusterProxy.GetScheme()})
 	Expect(err).NotTo(HaveOccurred())
+	nonAdminClient := framework.NewRetryableClient(rawNonAdminClient)
 
 	By("Checking if non-admin user kubeconfig is able to do basic operations")
 


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Wraps every controller-runtime `client.Client` used by the vmservice e2e suite in a retrying decorator, so a single transient connectivity blip — e.g. the vm-operator conversion webhook being briefly unreachable while its pod restarts after losing leader election — no longer fails an entire spec. This is the controller-runtime-client counterpart to the kubectl-based retry in `#1839`: that PR retries `kubectl create/delete/apply`, this one retries the Go client's `Get`, `Create`, `Update`, `Patch`, `Delete`, and `DeleteAllOf`.

`retryingClient` (new, `test/e2e/framework/retry_client.go`) embeds `client.Client` and overrides only the mutating/read methods; `List`, `Status()`, `SubResource()`, `Scheme()`, `RESTMapper()`, etc. pass through unmodified. It retries every 15s for up to 4 minutes, but only on errors classified as transient: a dead conversion webhook surfaces as a typed `apierrors.IsInternalError`, so that check runs first, with a substring fallback (`dial tcp`, `connection refused`, `context deadline exceeded`, ...) for raw transport errors that never reach a typed `apierrors.APIStatus`. A real admission or validation error is returned immediately.

`Create` and `Delete` treat `AlreadyExists`/`NotFound` on a *retried* attempt (not the first) as success, since the write may have landed before the connection reporting failure dropped. `Update` and `Patch` intentionally get no such carve-out: a `Conflict` on retry is ambiguous — it can mean the earlier attempt landed, or that someone else wrote to the object — so it's surfaced as a real error. Call sites that mutate via `Update` already re-fetch and retry at a higher level (`lib/vmoperator`), which self-heals a spurious conflict from this case.

The wrapper is wired in at every client-construction path actually reachable from the suite: `clusterProxy.GetClient()` (the single chokepoint ~20 test files get their client from), `VMServiceClusterProxy.GetAdminClient()` (used by the admin-privileged flows in `util.go`, `registervm.go`, `configpolicy.go`), and the one-off non-admin test-user client in `vm_publishrequest.go`. No existing call site needed to change since `GetClient()`'s return type is unchanged. `workloadClusterProxy.GetClientNoExpect` was left untouched — it has no callers anywhere in the suite.

The retryable-error substring list and retry interval/timeout are exported (`framework.RetryableTransientErrSubstrings`, `framework.IsRetryableTransientErrString`, `framework.TransientRetryInterval`, `framework.TransientRetryTimeout`) so that once `#1839` merges, its kubectl-based classifier and constants can be pointed at these instead of maintaining a second copy.

**Which issue(s) is/are addressed by this PR?**:

Fixes #

**Are there any special notes for your reviewer**:

Depends on nothing from `#1839` to build or pass on its own — the two retry paths are independent today. Once `#1839` merges, a small follow-up here (or there) should collapse `vmservice_clusterproxy.go`'s `retryableKubectlErrSubstrings`/`kubectlRetryInterval`/`kubectlRetryTimeout` down to references to the exported `framework` symbols, dropping the duplicate list and constants.

**Please add a release note if necessary**:

```release-note
NONE
