### PR TITLE
e2e: Propagate skip reason as syndrome on subtests

### DIFF
--- a/hack/e2e/run-e2e.sh
+++ b/hack/e2e/run-e2e.sh
@@ -59,12 +59,17 @@ fi
 # never intended to touch, making an intentionally-scoped run (e.g. smoke
 # only) look like most of the suite failed to execute. The latter two map to
 # "SKIPPED" since they were in scope but a runtime decision skipped them.
-# Failed specs also get a "syndrome" carrying Failure.Message, the callback
-# API's field for a short failure synopsis. Failure.Message is Gomega's full
-# failure output (often an object diff or YAML dump running well past 1024
-# characters), so it is truncated to the same 1024-character cap the
-# callback API enforces on "syndrome" fields — otherwise the callback POST
-# is rejected outright.
+# Any spec with a non-empty Failure.Message also gets a "syndrome" on its
+# subtest_details entry — the callback API's per-subtest field for a short
+# synopsis of why it failed or was skipped. This covers both failed specs
+# (the assertion/error message) and runtime-skipped specs (the Skip()
+# reason, e.g. "feature flag XYZ disabled"), giving a skip a propagated
+# reason instead of a bare "SKIPPED" with no context. Failure.Message is
+# Gomega's/Ginkgo's full output (often an object diff or YAML dump running
+# well past 1024 characters), so it is truncated to 1024 characters as a
+# hygiene measure matching the top-level "syndrome" field's documented cap,
+# even though the per-subtest field itself has no server-enforced length
+# limit.
 parse_json_report() {
     local json_file="${1}"
     jq '[.[0].SpecReports[] |
@@ -83,7 +88,7 @@ parse_json_report() {
                 else "INVALID"
                 end
             )
-        } + (if .State == "failed" and (.Failure.Message // "") != ""
+        } + (if (.Failure.Message // "") != ""
              then {syndrome: (.Failure.Message[0:1024])}
              else {} end)
     ]' "${json_file}"


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Follow-up to #1840, which fixed `parse_json_report` in `hack/e2e/run-e2e.sh` to drop label-filtered-out specs from the E2E callback's `subtest_details` instead of miscounting them as "Not_Run".

That fix left runtime-skipped specs (Ginkgo `Skip()` calls, e.g. a spec that bails out because a feature flag is disabled) reporting as a bare `SKIPPED` with no context on *why*. Ginkgo's JSON report already carries the skip reason in `Failure.Message` for these specs — this PR propagates it into the existing per-subtest `syndrome` field, the same field already used for `FAIL` entries.

**Which issue(s) is/are addressed by this PR?**

Fixes #

**Are there any special notes for your reviewer**:

Change is scoped to a single `jq` filter change in `parse_json_report` (removing the `.State == "failed" and` guard before the `syndrome` assignment) plus updated comments. Tested with:
- Synthetic JSON scenarios covering PASS / feature-flag-skipped (runtime `Skip()`) / FAIL / label-filtered-out specs — confirms the filtered-out spec is still dropped, the feature-flag skip now carries `syndrome: "feature flag XYZ disabled"`, and the FAIL entry is unaffected.
- `bash -n` and `shellcheck` — clean (only the pre-existing informational `SC1091` on the `callback.sh` source, unrelated to this change).

**Please add a release note if necessary**:

```release-note
NONE
```

— Faisal + Claude
