### PR TITLE
e2e: Retry Subnet/SubnetSet delete on webhook rejection

### DIFF
--- a/test/e2e/vmservice/lib/vmoperator/vmoperator.go
+++ b/test/e2e/vmservice/lib/vmoperator/vmoperator.go
@@ -582,23 +582,52 @@ func DeleteVirtualMachine(ctx context.Context, client ctrlclient.Client, ns, vmN
 	Expect(client.Delete(ctx, vm)).Should(Succeed())
 }
 
-func DeleteSubnetOrSubnetSet(ctx context.Context, client ctrlclient.Client, ns, subnetName, kind string) {
-	var (
-		obj ctrlclient.Object
-		err error
-	)
+// DeleteVirtualMachineAndWait deletes the VirtualMachine and waits for it to
+// be gone. It is a no-op if the VM does not exist, so it can be registered
+// unconditionally in cleanup (e.g. via DeferCleanup).
+func DeleteVirtualMachineAndWait(ctx context.Context, config *config.E2EConfig, client ctrlclient.Client, ns, vmName string) {
+	vm, err := utils.GetVirtualMachine(ctx, client, ns, vmName)
+	if apierrors.IsNotFound(err) {
+		return
+	}
+	Expect(err).ToNot(HaveOccurred(), "failed to get VirtualMachine %s/%s", ns, vmName)
+	Expect(client.Delete(ctx, vm)).To(Succeed(), "failed to delete VirtualMachine %s/%s", ns, vmName)
+	WaitForVirtualMachineToBeDeleted(ctx, config, client, ns, vmName)
+}
+
+// DeleteSubnetOrSubnetSet deletes the Subnet or SubnetSet. It is a no-op if
+// the object does not exist. The delete is retried because a network cannot
+// be deleted until the SubnetPorts owned by a recently deleted VirtualMachine
+// have been garbage-collected.
+func DeleteSubnetOrSubnetSet(ctx context.Context, config *config.E2EConfig, client ctrlclient.Client, ns, subnetName, kind string) {
+	var getObj func() (ctrlclient.Object, error)
 
 	switch kind {
 	case "Subnet":
-		obj, err = utils.GetSubnet(ctx, client, ns, subnetName)
+		getObj = func() (ctrlclient.Object, error) { return utils.GetSubnet(ctx, client, ns, subnetName) }
 	case "SubnetSet":
-		obj, err = utils.GetSubnetSet(ctx, client, ns, subnetName)
+		getObj = func() (ctrlclient.Object, error) { return utils.GetSubnetSet(ctx, client, ns, subnetName) }
 	default:
-		err = fmt.Errorf("unsupported kind: %s", kind)
+		Expect(false).To(BeTrue(), "unsupported kind: %s", kind)
 	}
 
-	Expect(err).ToNot(HaveOccurred())
-	Expect(client.Delete(ctx, obj)).To(Succeed())
+	Eventually(func(g Gomega) {
+		obj, err := getObj()
+		if apierrors.IsNotFound(err) {
+			return
+		}
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(client.Delete(ctx, obj)).To(Succeed())
+	}, config.GetIntervals("default", "wait-subnet-deletion")...).Should(Succeed(), "Timed out deleting %s %s/%s", kind, ns, subnetName)
+}
+
+// DeleteSubnetOrSubnetSetAndWait deletes the Subnet or SubnetSet and waits
+// for it to be gone. It is a no-op if the object does not exist, so it can be
+// registered unconditionally in cleanup (e.g. via DeferCleanup).
+func DeleteSubnetOrSubnetSetAndWait(ctx context.Context, config *config.E2EConfig, client ctrlclient.Client, ns, subnetName, kind string) {
+	DeleteSubnetOrSubnetSet(ctx, config, client, ns, subnetName, kind)
+	WaitForSubnetOrSubnetSetToBeDeleted(ctx, config, client, ns, subnetName, kind)
 }
 
 // DescribeResourceIfExists logs the output of `kubectl describe <resource>` if the given resource exists.

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_networking.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_networking.go
@@ -216,7 +216,7 @@ func VMNetworkSpec(ctx context.Context, inputGetter func() VMNetworkSpecInput) {
 		vmservice.VerifySubnetOrSubnetSetCreation(ctx, config, svClusterClient, input.WCPNamespaceName, subnetSetName, utils.SubnetSetKind)
 
 		DeferCleanup(func() {
-			vmoperator.DeleteSubnetOrSubnetSet(ctx, svClusterClient, input.WCPNamespaceName, subnetSetName, utils.SubnetSetKind)
+			vmoperator.DeleteSubnetOrSubnetSet(ctx, config, svClusterClient, input.WCPNamespaceName, subnetSetName, utils.SubnetSetKind)
 			vmoperator.WaitForSubnetOrSubnetSetToBeDeleted(ctx, config, svClusterClient, input.WCPNamespaceName, subnetSetName, utils.SubnetSetKind)
 		})
 

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_vpcnetworking.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_vpcnetworking.go
@@ -36,62 +36,37 @@ type VMVPCSpecInput struct {
 	WCPNamespaceName string
 }
 
-const (
-	vpcAPIVersion     = "crd.nsx.vmware.com/v1alpha1"
-	subnetKind        = "Subnet"
-	subnetSetKind     = "SubnetSet"
-	subnetDHCPName    = "vmsvc-subnet-dhcp"
-	subnetSetDHCPName = "vmsvc-subnetset-dhcp"
-	subnetCIDRName    = "vmsvc-subnet-cidr"
-	subnetName        = "vmsvc-subnet-test-communication"
-	subnetSetCIDRName = "vmsvc-subnetset-cidr"
-	dhcpConfig        = "DHCP"
-	cidrConfig        = "CIDR"
-	nic1Name          = "subnet-dhcp-nic1"
-	nic2Name          = "subnetset-cidr-nic2"
-)
-
-func createSubnetOrSubnetSet(ctx context.Context, g Gomega, clusterProxy *common.VMServiceClusterProxy, kind, name, ns, networkConfigType string, private bool) {
-	GinkgoHelper()
-
-	sYaml := utils.CreateSubnetOrSubnetSetYaml(kind, name, ns, networkConfigType, private)
-	g.Expect(clusterProxy.CreateWithArgs(ctx, sYaml)).To(Succeed(), "failed to create the %s Subnet or SubnetSet: %s", dhcpConfig, string(sYaml))
-}
-
-func createSecurityPolicy(ctx context.Context, g Gomega, clusterProxy *common.VMServiceClusterProxy, name, ns string) {
-	GinkgoHelper()
-
-	sYaml := utils.CreateSecurityPolicyYaml(name, ns)
-	g.Expect(clusterProxy.CreateWithArgs(ctx, sYaml)).To(Succeed(), "failed to create SecurityPolicy: %s", string(sYaml))
-}
-
-func createSecret(ctx context.Context, g Gomega, clusterProxy *common.VMServiceClusterProxy, ns, secretName string) {
-	GinkgoHelper()
-	// Create and apply Secret yaml.
-	secret := manifestbuilders.Secret{
-		Namespace: ns,
-		Name:      secretName,
-	}
-	secretYaml := manifestbuilders.GetSecretYamlCloudConfig(secret)
-	g.Expect(clusterProxy.CreateWithArgs(ctx, secretYaml)).To(Succeed(), "failed to create secret: %s", string(secretYaml))
-}
-
-func createVM(ctx context.Context, g Gomega, clusterProxy *common.VMServiceClusterProxy, vmYaml []byte) {
-	GinkgoHelper()
-	g.Expect(clusterProxy.CreateWithArgs(ctx, vmYaml)).To(Succeed(), "failed to create virtualmachine: %s", string(vmYaml))
-}
-
-// Delete VM before deleting Subnet or SubnetSet.
-func deleteVMAndSubnet(ctx context.Context, config *e2eConfig.E2EConfig, svClusterClient ctrlclient.Client, namespace, vmName, subnetName, subnetKind string) {
-	vmoperator.DeleteVirtualMachine(ctx, svClusterClient, namespace, vmName)
-	vmoperator.WaitForVirtualMachineToBeDeleted(ctx, config, svClusterClient, namespace, vmName)
-	vmoperator.DeleteSubnetOrSubnetSet(ctx, svClusterClient, namespace, subnetName, subnetKind)
-	vmoperator.WaitForSubnetOrSubnetSetToBeDeleted(ctx, config, svClusterClient, namespace, subnetName, subnetKind)
-}
-
+// VMVPCSpec exercises VPC Subnet/SubnetSet-backed VM networking.
+//
+// clusterProxy.CreateWithArgs/ApplyWithArgs and the controller-runtime client
+// returned by GetClient already retry transient connectivity errors
+// internally (see framework/retry_client.go and
+// vmservice/common/vmservice_clusterproxy.go), so most creates below are
+// single-shot. Subnet, SubnetSet, VirtualMachine, and SecurityPolicy creates
+// are the exception and keep an explicit Eventually: their admission
+// webhooks (NSX operator, VM Operator) can reject with a real, non-transient
+// validation error simply because a referenced object -- a just-created
+// Subnet/SubnetSet, or the namespace's VPC/NSX projection -- has not
+// finished realizing yet. That is a distinct failure class from the
+// dial/timeout errors the lower-level retries classify as transient, so it
+// still needs to be ridden out here. These retried creates use
+// ApplyWithArgs rather than CreateWithArgs: CreateWithArgs only tolerates
+// AlreadyExists within its own internal retry attempts, so wrapping it in an
+// outer Eventually can surface a hard AlreadyExists failure if an earlier
+// outer attempt's write landed after a delayed/lost response -- Apply has
+// no such create-vs-update distinction to trip over.
 func VMVPCSpec(ctx context.Context, inputGetter func() VMVPCSpecInput) {
 	const (
 		specName = "vm-vpc-networking"
+
+		vpcAPIVersion     = "crd.nsx.vmware.com/v1alpha1"
+		subnetDHCPName    = "vmsvc-subnet-dhcp"
+		subnetSetDHCPName = "vmsvc-subnetset-dhcp"
+		subnetCIDRName    = "vmsvc-subnet-cidr"
+		subnetName        = "vmsvc-subnet-test-communication"
+		subnetSetCIDRName = "vmsvc-subnetset-cidr"
+		nic1Name          = "subnet-dhcp-nic1"
+		nic2Name          = "subnetset-cidr-nic2"
 	)
 
 	var (
@@ -105,13 +80,34 @@ func VMVPCSpec(ctx context.Context, inputGetter func() VMVPCSpecInput) {
 		v1a2vmParameters      manifestbuilders.VirtualMachineYaml
 		vm1Name               string
 		vm2Name               string
-		vm1IP                 string
-		vm2IP                 string
+		vm2Namespace          string
 		secretName            string
-		vmYaml                []byte
 		linuxImageDisplayName string
 		linuxVMIName          string
 	)
+
+	// createSubnetOrSubnetSet creates a Subnet or SubnetSet, retrying on a
+	// real (non-transient) validation error while its dependencies finish
+	// realizing; see the VMVPCSpec doc comment.
+	createSubnetOrSubnetSet := func(kind, name, ns, networkConfigType string, private bool) {
+		GinkgoHelper()
+
+		subnetYaml := utils.CreateSubnetOrSubnetSetYaml(kind, name, ns, networkConfigType, private)
+		Eventually(func(g Gomega) {
+			g.Expect(clusterProxy.ApplyWithArgs(ctx, subnetYaml)).To(Succeed(), "failed to create the %s %s/%s: %s", kind, ns, name, string(subnetYaml))
+		}, config.GetIntervals("default", "wait-subnet-creation")...).Should(Succeed(), "Timed out in creating %s %s/%s", kind, ns, name)
+	}
+
+	// createVM creates a VirtualMachine, retrying on a real (non-transient)
+	// validation error while its dependencies finish realizing; see the
+	// VMVPCSpec doc comment.
+	createVM := func(vmYaml []byte) {
+		GinkgoHelper()
+
+		Eventually(func(g Gomega) {
+			g.Expect(clusterProxy.ApplyWithArgs(ctx, vmYaml)).To(Succeed(), "failed to create virtualmachine: %s", string(vmYaml))
+		}, config.GetIntervals("default", "wait-virtual-machine-creation")...).Should(Succeed(), "Timed out in creating the VirtualMachine")
+	}
 
 	BeforeEach(func() {
 		input = inputGetter()
@@ -133,19 +129,20 @@ func VMVPCSpec(ctx context.Context, inputGetter func() VMVPCSpecInput) {
 		cancelPodWatches := framework.WatchPodLogsAndEventsInNamespaces(ctx, []string{config.GetVariable("VMOPNamespace")}, clusterProxy.GetRESTConfig(), filepath.Join(input.ArtifactFolder, specName))
 		DeferCleanup(cancelPodWatches)
 
-		linuxImageDisplayName = vmservice.GetDefaultImageDisplayName(clusterResources)
 		vm1Name = fmt.Sprintf("%s-%s", specName, capiutil.RandomString(4))
 		vm2Name = fmt.Sprintf("%s-%s", specName, capiutil.RandomString(4))
-
-		linuxVMIName = vmoperator.WaitForVirtualMachineImageName(ctx, &config.Config, svClusterClient, input.WCPNamespaceName, linuxImageDisplayName)
-		vm1IP = ""
-		vm2IP = ""
+		vm2Namespace = input.WCPNamespaceName
 		secretName = fmt.Sprintf("%s-%s", "secret", capiutil.RandomString(4))
 
-		Eventually(func(g Gomega) {
-			createSecret(ctx, g, clusterProxy, input.WCPNamespaceName, secretName)
-		}, config.GetIntervals("default", "wait-secret-creation")...).Should(Succeed(), "Timed out in creating the Secret")
+		secretYaml := manifestbuilders.GetSecretYamlCloudConfig(manifestbuilders.Secret{
+			Namespace: input.WCPNamespaceName,
+			Name:      secretName,
+		})
+		Expect(clusterProxy.CreateWithArgs(ctx, secretYaml)).To(Succeed(), "failed to create secret: %s", string(secretYaml))
 		vmservice.VerifySecretCreation(ctx, config, svClusterClient, input.WCPNamespaceName, secretName)
+
+		linuxImageDisplayName = vmservice.GetDefaultImageDisplayName(clusterResources)
+		linuxVMIName = vmoperator.WaitForVirtualMachineImageName(ctx, &config.Config, svClusterClient, input.WCPNamespaceName, linuxImageDisplayName)
 
 		v1a2vmParameters = manifestbuilders.VirtualMachineYaml{
 			Namespace:        input.WCPNamespaceName,
@@ -169,74 +166,53 @@ func VMVPCSpec(ctx context.Context, inputGetter func() VMVPCSpecInput) {
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
 			vmoperator.DescribeResourceIfExists(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), input.WCPNamespaceName, vm1Name, "vm")
-			vmoperator.DescribeResourceIfExists(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), input.WCPNamespaceName, vm2Name, "vm")
+			vmoperator.DescribeResourceIfExists(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), vm2Namespace, vm2Name, "vm")
 		}
 	})
 
-	AfterEach(func() {
-	})
-
 	Context("VPC DHCP should successfully create VMs", func() {
-		AfterEach(func() {
-			if vm1IP != "" {
-				deleteVMAndSubnet(ctx, config, svClusterClient, input.WCPNamespaceName, vm1Name, subnetDHCPName, subnetKind)
-			}
-
-			if vm2IP != "" {
-				deleteVMAndSubnet(ctx, config, svClusterClient, input.WCPNamespaceName, vm2Name, subnetSetDHCPName, subnetSetKind)
-			}
-		})
-
 		It("using customized DHCP Subnet/SubnetSet to assign valid ip addresses and ping each other", Label("smoke"), func() {
-			By("Creating VM1 using DHCP Private Subnet")
-			Eventually(func(g Gomega) {
-				createSubnetOrSubnetSet(ctx, g, clusterProxy, subnetKind, subnetDHCPName, input.WCPNamespaceName, dhcpConfig, true)
-			}, config.GetIntervals("default", "wait-subnet-creation")...).Should(Succeed(), "Timed out in creating Subnet")
-			vmservice.VerifySubnetOrSubnetSetCreation(ctx, config, svClusterClient, input.WCPNamespaceName, subnetDHCPName, subnetKind)
+			By("Creating a DHCP Private Subnet for VM1 and a DHCP Private SubnetSet for VM2")
+			createSubnetOrSubnetSet(utils.SubnetKind, subnetDHCPName, input.WCPNamespaceName, utils.DHCPConfig, true)
+			DeferCleanup(vmoperator.DeleteSubnetOrSubnetSetAndWait, ctx, config, svClusterClient, input.WCPNamespaceName, subnetDHCPName, utils.SubnetKind)
 
-			v1a2vmParameters.Name = vm1Name
-			v1a2vmParameters.NetworkA2 = manifestbuilders.NetworkA2{
+			createSubnetOrSubnetSet(utils.SubnetSetKind, subnetSetDHCPName, input.WCPNamespaceName, utils.DHCPConfig, true)
+			DeferCleanup(vmoperator.DeleteSubnetOrSubnetSetAndWait, ctx, config, svClusterClient, input.WCPNamespaceName, subnetSetDHCPName, utils.SubnetSetKind)
+
+			vmservice.VerifySubnetOrSubnetSetCreation(ctx, config, svClusterClient, input.WCPNamespaceName, subnetDHCPName, utils.SubnetKind)
+			vmservice.VerifySubnetOrSubnetSetCreation(ctx, config, svClusterClient, input.WCPNamespaceName, subnetSetDHCPName, utils.SubnetSetKind)
+
+			By("Creating VM1 using the DHCP Private Subnet and VM2 using the DHCP Private SubnetSet")
+			// vm1Params/vm2Params are shallow copies of v1a2vmParameters: only
+			// value fields (Name, Namespace, NetworkA2, ImageName) are set
+			// below, so the shared Bootstrap.CloudInit pointer is never
+			// mutated through either copy. Do not start writing through
+			// vmNParams.Bootstrap.* without giving it its own copy first.
+			vm1Params := v1a2vmParameters
+			vm1Params.Name = vm1Name
+			vm1Params.NetworkA2 = manifestbuilders.NetworkA2{
 				Interfaces: []manifestbuilders.InterfaceSpec{
-					{
-						Name:       subnetDHCPName,
-						Kind:       subnetKind,
-						APIVersion: vpcAPIVersion,
-					},
+					{Name: subnetDHCPName, Kind: utils.SubnetKind, APIVersion: vpcAPIVersion},
 				},
 			}
-			// Create v1alpha2 VM deployment yaml
-			vmYaml = manifestbuilders.GetVirtualMachineYamlA2(v1a2vmParameters)
+			createVM(manifestbuilders.GetVirtualMachineYamlA2(vm1Params))
+			DeferCleanup(vmoperator.DeleteVirtualMachineAndWait, ctx, config, svClusterClient, input.WCPNamespaceName, vm1Name)
 
-			Eventually(func(g Gomega) {
-				createVM(ctx, g, clusterProxy, vmYaml)
-			}, config.GetIntervals("default", "wait-virtual-machine-creation")...).Should(Succeed(), "Timed out in creating the VirtualMachine")
+			vm2Params := v1a2vmParameters
+			vm2Params.Name = vm2Name
+			vm2Params.NetworkA2 = manifestbuilders.NetworkA2{
+				Interfaces: []manifestbuilders.InterfaceSpec{
+					{Name: subnetSetDHCPName, Kind: utils.SubnetSetKind, APIVersion: vpcAPIVersion},
+				},
+			}
+			createVM(manifestbuilders.GetVirtualMachineYamlA2(vm2Params))
+			DeferCleanup(vmoperator.DeleteVirtualMachineAndWait, ctx, config, svClusterClient, input.WCPNamespaceName, vm2Name)
+
+			By("Waiting for both VMs to be created with IPs")
 			vmoperator.WaitForVirtualMachineCreation(ctx, config, svClusterClient, input.WCPNamespaceName, vm1Name)
-			vm1IP = vmoperator.GetVirtualMachineIP(ctx, svClusterClient, input.WCPNamespaceName, vm1Name)
-
-			By("Creating VM2 using DHCP Private SubnetSet")
-			Eventually(func(g Gomega) {
-				createSubnetOrSubnetSet(ctx, g, clusterProxy, subnetSetKind, subnetSetDHCPName, input.WCPNamespaceName, dhcpConfig, true)
-			}, config.GetIntervals("default", "wait-subnet-creation")...).Should(Succeed(), "Timed out in creating SubnetSet")
-			vmservice.VerifySubnetOrSubnetSetCreation(ctx, config, svClusterClient, input.WCPNamespaceName, subnetSetDHCPName, subnetSetKind)
-
-			v1a2vmParameters.Name = vm2Name
-			v1a2vmParameters.NetworkA2 = manifestbuilders.NetworkA2{
-				Interfaces: []manifestbuilders.InterfaceSpec{
-					{
-						Name:       subnetSetDHCPName,
-						Kind:       subnetSetKind,
-						APIVersion: vpcAPIVersion,
-					},
-				},
-			}
-			// Create v1alpha2 VM deployment yaml
-			vmYaml = manifestbuilders.GetVirtualMachineYamlA2(v1a2vmParameters)
-
-			Eventually(func(g Gomega) {
-				createVM(ctx, g, clusterProxy, vmYaml)
-			}, config.GetIntervals("default", "wait-virtual-machine-creation")...).Should(Succeed(), "Timed out in creating the VirtualMachine")
+			vm1IP := vmoperator.GetVirtualMachineIP(ctx, svClusterClient, input.WCPNamespaceName, vm1Name)
 			vmoperator.WaitForVirtualMachineCreation(ctx, config, svClusterClient, input.WCPNamespaceName, vm2Name)
-			vm2IP = vmoperator.GetVirtualMachineIP(ctx, svClusterClient, input.WCPNamespaceName, vm2Name)
+			vm2IP := vmoperator.GetVirtualMachineIP(ctx, svClusterClient, input.WCPNamespaceName, vm2Name)
 
 			By("In the same ns, two VMs on independent Private Subnet/SubnetSets should be able to communicate with each other")
 			verifyLoginAndPingVM(ctx, config, clusterProxy, svClusterClient, input.WCPNamespaceName, vm1IP, vm2IP)
@@ -244,66 +220,43 @@ func VMVPCSpec(ctx context.Context, inputGetter func() VMVPCSpecInput) {
 	})
 
 	Context("VPC CIDR should successfully create VM", func() {
-		AfterEach(func() {
-			if vm1IP != "" {
-				deleteVMAndSubnet(ctx, config, svClusterClient, input.WCPNamespaceName, vm1Name, subnetCIDRName, subnetKind)
-			}
-
-			if vm2IP != "" {
-				deleteVMAndSubnet(ctx, config, svClusterClient, input.WCPNamespaceName, vm2Name, subnetSetCIDRName, subnetSetKind)
-			}
-		})
-
 		It("using customized CIDR Subnet to assign valid ip address", func() {
-			By("Creating VM1 using CIDR Private Subnet")
-			Eventually(func(g Gomega) {
-				createSubnetOrSubnetSet(ctx, g, clusterProxy, subnetKind, subnetCIDRName, input.WCPNamespaceName, cidrConfig, true)
-			}, config.GetIntervals("default", "wait-subnet-creation")...).Should(Succeed(), "Timed out in creating Subnet")
-			vmservice.VerifySubnetOrSubnetSetCreation(ctx, config, svClusterClient, input.WCPNamespaceName, subnetCIDRName, subnetKind)
+			By("Creating a CIDR Private Subnet for VM1 and a CIDR Public SubnetSet for VM2")
+			createSubnetOrSubnetSet(utils.SubnetKind, subnetCIDRName, input.WCPNamespaceName, utils.CIDRConfig, true)
+			DeferCleanup(vmoperator.DeleteSubnetOrSubnetSetAndWait, ctx, config, svClusterClient, input.WCPNamespaceName, subnetCIDRName, utils.SubnetKind)
 
-			v1a2vmParameters.Name = vm1Name
-			v1a2vmParameters.NetworkA2 = manifestbuilders.NetworkA2{
+			createSubnetOrSubnetSet(utils.SubnetSetKind, subnetSetCIDRName, input.WCPNamespaceName, utils.CIDRConfig, false)
+			DeferCleanup(vmoperator.DeleteSubnetOrSubnetSetAndWait, ctx, config, svClusterClient, input.WCPNamespaceName, subnetSetCIDRName, utils.SubnetSetKind)
+
+			vmservice.VerifySubnetOrSubnetSetCreation(ctx, config, svClusterClient, input.WCPNamespaceName, subnetCIDRName, utils.SubnetKind)
+			vmservice.VerifySubnetOrSubnetSetCreation(ctx, config, svClusterClient, input.WCPNamespaceName, subnetSetCIDRName, utils.SubnetSetKind)
+
+			By("Creating VM1 using the CIDR Private Subnet and VM2 using the CIDR Public SubnetSet")
+			vm1Params := v1a2vmParameters
+			vm1Params.Name = vm1Name
+			vm1Params.NetworkA2 = manifestbuilders.NetworkA2{
 				Interfaces: []manifestbuilders.InterfaceSpec{
-					{
-						Name:       subnetCIDRName,
-						Kind:       subnetKind,
-						APIVersion: vpcAPIVersion,
-					},
+					{Name: subnetCIDRName, Kind: utils.SubnetKind, APIVersion: vpcAPIVersion},
 				},
 			}
-			// Create v1alpha2 VM deployment yaml
-			vmYaml = manifestbuilders.GetVirtualMachineYamlA2(v1a2vmParameters)
+			createVM(manifestbuilders.GetVirtualMachineYamlA2(vm1Params))
+			DeferCleanup(vmoperator.DeleteVirtualMachineAndWait, ctx, config, svClusterClient, input.WCPNamespaceName, vm1Name)
 
-			Eventually(func(g Gomega) {
-				createVM(ctx, g, clusterProxy, vmYaml)
-			}, config.GetIntervals("default", "wait-virtual-machine-creation")...).Should(Succeed(), "Timed out in creating the VirtualMachine")
+			vm2Params := v1a2vmParameters
+			vm2Params.Name = vm2Name
+			vm2Params.NetworkA2 = manifestbuilders.NetworkA2{
+				Interfaces: []manifestbuilders.InterfaceSpec{
+					{Name: subnetSetCIDRName, Kind: utils.SubnetSetKind, APIVersion: vpcAPIVersion},
+				},
+			}
+			createVM(manifestbuilders.GetVirtualMachineYamlA2(vm2Params))
+			DeferCleanup(vmoperator.DeleteVirtualMachineAndWait, ctx, config, svClusterClient, input.WCPNamespaceName, vm2Name)
+
+			By("Waiting for both VMs to be created with IPs")
 			vmoperator.WaitForVirtualMachineCreation(ctx, config, svClusterClient, input.WCPNamespaceName, vm1Name)
-			vm1IP = vmoperator.GetVirtualMachineIP(ctx, svClusterClient, input.WCPNamespaceName, vm1Name)
-
-			By("Creating VM2 using CIDR Public SubnetSet")
-			Eventually(func(g Gomega) {
-				createSubnetOrSubnetSet(ctx, g, clusterProxy, subnetSetKind, subnetSetCIDRName, input.WCPNamespaceName, cidrConfig, false)
-			}, config.GetIntervals("default", "wait-subnet-creation")...).Should(Succeed(), "Timed out in creating SubnetSet")
-			vmservice.VerifySubnetOrSubnetSetCreation(ctx, config, svClusterClient, input.WCPNamespaceName, subnetSetCIDRName, subnetSetKind)
-
-			v1a2vmParameters.Name = vm2Name
-			v1a2vmParameters.NetworkA2 = manifestbuilders.NetworkA2{
-				Interfaces: []manifestbuilders.InterfaceSpec{
-					{
-						Name:       subnetSetCIDRName,
-						Kind:       subnetSetKind,
-						APIVersion: vpcAPIVersion,
-					},
-				},
-			}
-			// Create v1alpha2 VM deployment yaml
-			vmYaml = manifestbuilders.GetVirtualMachineYamlA2(v1a2vmParameters)
-
-			Eventually(func(g Gomega) {
-				createVM(ctx, g, clusterProxy, vmYaml)
-			}, config.GetIntervals("default", "wait-virtual-machine-creation")...).Should(Succeed(), "Timed out in creating the VirtualMachine")
+			vm1IP := vmoperator.GetVirtualMachineIP(ctx, svClusterClient, input.WCPNamespaceName, vm1Name)
 			vmoperator.WaitForVirtualMachineCreation(ctx, config, svClusterClient, input.WCPNamespaceName, vm2Name)
-			vm2IP = vmoperator.GetVirtualMachineIP(ctx, svClusterClient, input.WCPNamespaceName, vm2Name)
+			vm2IP := vmoperator.GetVirtualMachineIP(ctx, svClusterClient, input.WCPNamespaceName, vm2Name)
 
 			By("In the same ns, two VMs on Private and Public Subnet/SubnetSets should be able to communicate with each other")
 			verifyLoginAndPingVM(ctx, config, clusterProxy, svClusterClient, input.WCPNamespaceName, vm1IP, vm2IP)
@@ -311,50 +264,26 @@ func VMVPCSpec(ctx context.Context, inputGetter func() VMVPCSpecInput) {
 	})
 
 	Context("VPC supports multiple NICs", func() {
-		AfterEach(func() {
-			if vm1IP != "" {
-				deleteVMAndSubnet(ctx, config, svClusterClient, input.WCPNamespaceName, vm1Name, nic1Name, subnetKind)
-			}
-			// Delete second SubnetSet
-			vmoperator.DeleteSubnetOrSubnetSet(ctx, svClusterClient, input.WCPNamespaceName, nic2Name, subnetSetKind)
-			vmoperator.WaitForSubnetOrSubnetSetToBeDeleted(ctx, config, svClusterClient, input.WCPNamespaceName, nic2Name, subnetSetKind)
-		})
-
 		It("VM deployment should succeed with 2 NICs", func() {
 			By("Creating VM with 2 NICs")
-			Eventually(func(g Gomega) {
-				createSubnetOrSubnetSet(ctx, g, clusterProxy, subnetKind, nic1Name, input.WCPNamespaceName, dhcpConfig, true)
-			}, config.GetIntervals("default", "wait-subnet-creation")...).Should(Succeed(), "Timed out in creating Subnet")
-			vmservice.VerifySubnetOrSubnetSetCreation(ctx, config, svClusterClient, input.WCPNamespaceName, nic1Name, subnetKind)
+			createSubnetOrSubnetSet(utils.SubnetKind, nic1Name, input.WCPNamespaceName, utils.DHCPConfig, true)
+			DeferCleanup(vmoperator.DeleteSubnetOrSubnetSetAndWait, ctx, config, svClusterClient, input.WCPNamespaceName, nic1Name, utils.SubnetKind)
+			vmservice.VerifySubnetOrSubnetSetCreation(ctx, config, svClusterClient, input.WCPNamespaceName, nic1Name, utils.SubnetKind)
 
-			Eventually(func(g Gomega) {
-				createSubnetOrSubnetSet(ctx, g, clusterProxy, subnetSetKind, nic2Name, input.WCPNamespaceName, cidrConfig, true)
-			}, config.GetIntervals("default", "wait-subnet-creation")...).Should(Succeed(), "Timed out in creating SubnetSet")
-			vmservice.VerifySubnetOrSubnetSetCreation(ctx, config, svClusterClient, input.WCPNamespaceName, nic2Name, subnetSetKind)
+			createSubnetOrSubnetSet(utils.SubnetSetKind, nic2Name, input.WCPNamespaceName, utils.CIDRConfig, true)
+			DeferCleanup(vmoperator.DeleteSubnetOrSubnetSetAndWait, ctx, config, svClusterClient, input.WCPNamespaceName, nic2Name, utils.SubnetSetKind)
+			vmservice.VerifySubnetOrSubnetSetCreation(ctx, config, svClusterClient, input.WCPNamespaceName, nic2Name, utils.SubnetSetKind)
 
 			v1a2vmParameters.Name = vm1Name
 			v1a2vmParameters.NetworkA2 = manifestbuilders.NetworkA2{
 				Interfaces: []manifestbuilders.InterfaceSpec{
-					{
-						Name:       nic1Name,
-						Kind:       subnetKind,
-						APIVersion: vpcAPIVersion,
-					},
-					{
-						Name:       nic2Name,
-						Kind:       subnetSetKind,
-						APIVersion: vpcAPIVersion,
-					},
+					{Name: nic1Name, Kind: utils.SubnetKind, APIVersion: vpcAPIVersion},
+					{Name: nic2Name, Kind: utils.SubnetSetKind, APIVersion: vpcAPIVersion},
 				},
 			}
-			// Create v1alpha2 VM deployment yaml
-			vmYaml = manifestbuilders.GetVirtualMachineWithMultiNetworkYamlA2(v1a2vmParameters)
-
-			Eventually(func(g Gomega) {
-				createVM(ctx, g, clusterProxy, vmYaml)
-			}, config.GetIntervals("default", "wait-virtual-machine-creation")...).Should(Succeed(), "Timed out in creating the VirtualMachine")
+			createVM(manifestbuilders.GetVirtualMachineWithMultiNetworkYamlA2(v1a2vmParameters))
+			DeferCleanup(vmoperator.DeleteVirtualMachineAndWait, ctx, config, svClusterClient, input.WCPNamespaceName, vm1Name)
 			vmoperator.WaitForVirtualMachineCreation(ctx, config, svClusterClient, input.WCPNamespaceName, vm1Name)
-			vm1IP = vmoperator.GetVirtualMachineIP(ctx, svClusterClient, input.WCPNamespaceName, vm1Name)
 		})
 	})
 
@@ -364,49 +293,25 @@ func VMVPCSpec(ctx context.Context, inputGetter func() VMVPCSpecInput) {
 			secondNamespaceCtx  wcpframework.NamespaceContext
 		)
 
-		AfterEach(func() {
-			if vm1IP != "" {
-				deleteVMAndSubnet(ctx, config, svClusterClient, input.WCPNamespaceName, vm1Name, subnetName, subnetKind)
-			}
-
-			if vm2IP != "" {
-				deleteVMAndSubnet(ctx, config, svClusterClient, secondNamespaceName, vm2Name, subnetName, subnetKind)
-			}
-			// Delete the second namespace if it was created.
-			if secondNamespaceCtx.GetNamespace() != nil {
-				clusterProxy.DeleteWCPNamespace(secondNamespaceCtx)
-			}
-		})
-
 		It("one VirtualMachine within Private Subnet can communicate to another VM in another ns within Public Subnet", func() {
 			By("Create VM1 using Private Subnet")
-			Eventually(func(g Gomega) {
-				createSubnetOrSubnetSet(ctx, g, clusterProxy, subnetKind, subnetName, input.WCPNamespaceName, cidrConfig, true)
-			}, config.GetIntervals("default", "wait-subnet-creation")...).Should(Succeed(), "Timed out in creating Subnet")
-			vmservice.VerifySubnetOrSubnetSetCreation(ctx, config, svClusterClient, input.WCPNamespaceName, subnetName, subnetKind)
+			createSubnetOrSubnetSet(utils.SubnetKind, subnetName, input.WCPNamespaceName, utils.CIDRConfig, true)
+			DeferCleanup(vmoperator.DeleteSubnetOrSubnetSetAndWait, ctx, config, svClusterClient, input.WCPNamespaceName, subnetName, utils.SubnetKind)
+			vmservice.VerifySubnetOrSubnetSetCreation(ctx, config, svClusterClient, input.WCPNamespaceName, subnetName, utils.SubnetKind)
 
 			v1a2vmParameters.Name = vm1Name
 			v1a2vmParameters.NetworkA2 = manifestbuilders.NetworkA2{
 				Interfaces: []manifestbuilders.InterfaceSpec{
-					{
-						Name:       subnetName,
-						Kind:       subnetKind,
-						APIVersion: vpcAPIVersion,
-					},
+					{Name: subnetName, Kind: utils.SubnetKind, APIVersion: vpcAPIVersion},
 				},
 			}
-			// Create v1alpha2 VM deployment yaml
-			vmYaml = manifestbuilders.GetVirtualMachineYamlA2(v1a2vmParameters)
-
-			Eventually(func(g Gomega) {
-				createVM(ctx, g, clusterProxy, vmYaml)
-			}, config.GetIntervals("default", "wait-virtual-machine-creation")...).Should(Succeed(), "Timed out in creating the VirtualMachine")
-			vmoperator.WaitForVirtualMachineCreation(ctx, config, svClusterClient, input.WCPNamespaceName, vm1Name)
-			vm1IP = vmoperator.GetVirtualMachineIP(ctx, svClusterClient, input.WCPNamespaceName, vm1Name)
+			createVM(manifestbuilders.GetVirtualMachineYamlA2(v1a2vmParameters))
+			DeferCleanup(vmoperator.DeleteVirtualMachineAndWait, ctx, config, svClusterClient, input.WCPNamespaceName, vm1Name)
 
 			By("Create a second namespace")
 
 			secondNamespaceName = fmt.Sprintf("%s-second", input.WCPNamespaceName)
+			vm2Namespace = secondNamespaceName
 			clID := vmservice.GetContentLibraryUUIDByName(consts.VMServiceCLName, wcpClient)
 			vmsvcSpecs := wcp.NewVMServiceSpecDetails([]string{clusterResources.VMClassName}, []string{clID})
 
@@ -414,49 +319,59 @@ func VMVPCSpec(ctx context.Context, inputGetter func() VMVPCSpecInput) {
 
 			secondNamespaceCtx, err = clusterProxy.CreateWCPNamespace(ctx, config, vmsvcSpecs, clusterResources.StorageClassName, secondNamespaceName, input.ArtifactFolder)
 			Expect(err).ToNot(HaveOccurred(), "Failed to create a second test WCP namespace")
+			DeferCleanup(clusterProxy.DeleteWCPNamespace, secondNamespaceCtx)
 			wcp.WaitForNamespaceReady(wcpClient, secondNamespaceName)
 
 			By("Wait for Linux VM Image to be available in the second namespace")
-
-			var vmImageName2 string
-
-			vmImageName2 = vmoperator.WaitForVirtualMachineImageName(ctx, &config.Config, svClusterClient, secondNamespaceName, linuxImageDisplayName)
+			vmImageName2 := vmoperator.WaitForVirtualMachineImageName(ctx, &config.Config, svClusterClient, secondNamespaceName, linuxImageDisplayName)
 			Expect(vmImageName2).NotTo(BeEmpty(), "VM Image CR name is empty for the second namespace")
 
+			// The second namespace was created moments ago: its RBAC/quota/NSX
+			// CRD projection onto the SV API server can lag behind
+			// WaitForNamespaceReady, which only observes the WCP-side config
+			// status. That is a second, namespace-readiness reason (on top of
+			// the general one in the VMVPCSpec doc comment) why this secret
+			// create keeps an explicit Eventually despite being a plain
+			// corev1 object.
 			By("Create a secret in the second namespace with cloud-init config")
+			secretYaml := manifestbuilders.GetSecretYamlCloudConfig(manifestbuilders.Secret{
+				Namespace: secondNamespaceName,
+				Name:      secretName,
+			})
 			Eventually(func(g Gomega) {
-				createSecret(ctx, g, clusterProxy, secondNamespaceName, secretName)
+				g.Expect(clusterProxy.ApplyWithArgs(ctx, secretYaml)).To(Succeed(), "failed to create secret: %s", string(secretYaml))
 			}, config.GetIntervals("default", "wait-secret-creation")...).Should(Succeed(), "Timed out in creating the Secret")
 			vmservice.VerifySecretCreation(ctx, config, svClusterClient, secondNamespaceName, secretName)
 
 			By("Create VM2 with a Public Subnet in the second ns")
 			// Create a Public subnet with the same name but in a different ns
-			Eventually(func(g Gomega) {
-				createSubnetOrSubnetSet(ctx, g, clusterProxy, subnetKind, subnetName, secondNamespaceName, cidrConfig, false)
-			}, config.GetIntervals("default", "wait-subnet-creation")...).Should(Succeed(), "Timed out in creating Subnet")
-			vmservice.VerifySubnetOrSubnetSetCreation(ctx, config, svClusterClient, secondNamespaceName, subnetName, subnetKind)
+			createSubnetOrSubnetSet(utils.SubnetKind, subnetName, secondNamespaceName, utils.CIDRConfig, false)
+			vmservice.VerifySubnetOrSubnetSetCreation(ctx, config, svClusterClient, secondNamespaceName, subnetName, utils.SubnetKind)
+			DeferCleanup(vmoperator.DeleteSubnetOrSubnetSetAndWait, ctx, config, svClusterClient, secondNamespaceName, subnetName, utils.SubnetKind)
 
-			v1a2vmParameters.Name = vm2Name
-			v1a2vmParameters.Namespace = secondNamespaceName
-			v1a2vmParameters.ImageName = vmImageName2
-			// Create v1alpha2 VM deployment yaml
-			vmYaml = manifestbuilders.GetVirtualMachineYamlA2(v1a2vmParameters)
-
-			Eventually(func(g Gomega) {
-				createVM(ctx, g, clusterProxy, vmYaml)
-			}, config.GetIntervals("default", "wait-virtual-machine-creation")...).Should(Succeed(), "Timed out in creating the VirtualMachine")
-			vmoperator.WaitForVirtualMachineCreation(ctx, config, svClusterClient, secondNamespaceName, vm2Name)
-			vm2IP = vmoperator.GetVirtualMachineIP(ctx, svClusterClient, secondNamespaceName, vm2Name)
+			vm2Parameters := v1a2vmParameters
+			vm2Parameters.Name = vm2Name
+			vm2Parameters.Namespace = secondNamespaceName
+			vm2Parameters.ImageName = vmImageName2
+			createVM(manifestbuilders.GetVirtualMachineYamlA2(vm2Parameters))
+			DeferCleanup(vmoperator.DeleteVirtualMachineAndWait, ctx, config, svClusterClient, secondNamespaceName, vm2Name)
 
 			By("Label VM2 and apply Security Policy that allows ingress")
 			Expect(vmservice.LabelVM(ctx, config, clusterProxy, vm2Name, secondNamespaceName, "role", "allow-ingress")).To(Succeed())
 
 			securityPolicyName := "allow-all-ingress"
+			securityPolicyYaml := utils.CreateSecurityPolicyYaml(securityPolicyName, secondNamespaceName)
 
 			Eventually(func(g Gomega) {
-				createSecurityPolicy(ctx, g, clusterProxy, securityPolicyName, secondNamespaceName)
+				g.Expect(clusterProxy.ApplyWithArgs(ctx, securityPolicyYaml)).To(Succeed(), "failed to create SecurityPolicy: %s", string(securityPolicyYaml))
 			}, config.GetIntervals("default", "wait-security-policy-creation")...).Should(Succeed(), "Timed out in creating SecurityPolicy")
 			vmservice.VerifySecurityPolicyCreation(ctx, config, svClusterClient, secondNamespaceName, securityPolicyName)
+
+			By("Wait for both VMs to be created with IPs")
+			vmoperator.WaitForVirtualMachineCreation(ctx, config, svClusterClient, input.WCPNamespaceName, vm1Name)
+			vm1IP := vmoperator.GetVirtualMachineIP(ctx, svClusterClient, input.WCPNamespaceName, vm1Name)
+			vmoperator.WaitForVirtualMachineCreation(ctx, config, svClusterClient, secondNamespaceName, vm2Name)
+			vm2IP := vmoperator.GetVirtualMachineIP(ctx, svClusterClient, secondNamespaceName, vm2Name)
 
 			By("VM1 on Private Subnet should now be able to ping VM2 on Public Subnet with Security Policy")
 			verifyLoginAndPingVM(ctx, config, clusterProxy, svClusterClient, input.WCPNamespaceName, vm1IP, vm2IP)


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

NSX's validating webhook rejects deleting a Subnet/SubnetSet while the SubnetPorts owned by a just-deleted VirtualMachine are still being garbage-collected, so a single-shot delete run right after removing its VM could fail outright. DeleteSubnetOrSubnetSet now retries the delete (treating NotFound as already-deleted) until the SubnetPorts clear.

While in this area:

- Add DeleteVirtualMachineAndWait and DeleteSubnetOrSubnetSetAndWait, combining the existing delete/wait pairs, and use them in vm_vpcnetworking.go instead of its own ad hoc get/delete/wait wrappers.
- Drop the outer Eventually around creates that the retrying clusterProxy client/kubectl calls already cover (#1839, #1844). Keep Eventually only around Subnet/SubnetSet/VM/SecurityPolicy creates, whose admission webhooks can reject with a real (non-transient) validation error while a referenced object is still realizing, and switch those retried creates to ApplyWithArgs so a retry can't surface a spurious AlreadyExists.
- Batch subnet/VM creation before waiting on VMs in the DHCP and CIDR contexts so the two VM boots overlap instead of serializing.
- Fix JustAfterEach describing VM2 in the wrong namespace in the cross-namespace context.

Verified all four VM-VPC specs pass against a real NSX-backed WCP testbed.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # vmop-4051


**Are there any special notes for your reviewer**:

```
Testing VM Services VIRTUAL-MACHINE VM-VPC VPC DHCP should successfully create VMs using customized DHCP Subnet/SubnetSet to assign valid ip addresses and ping each other [devops, viadmin, virtualmachine, vmservice, smoke]
/Users/bv/code/work/vm-operator-e2e/test/e2e/vmservice/vmservice/virtualmachine/vm_vpcnetworking.go:176
secret/secret-34dw created

  STEP: Verify that we have a Secret CRD @ 08/26/26 12:33:33.074
  STEP: Creating a DHCP Private Subnet for VM1 and a DHCP Private SubnetSet for VM2 @ 08/26/26 12:33:33.29
subnet.crd.nsx.vmware.com/vmsvc-subnet-dhcp created
....
Ran 4 of 186 Specs in 945.035 seconds
SUCCESS! -- 4 Passed | 0 Failed | 4 Pending | 178 Skipped
PASS
```

**Please add a release note if necessary**:

```release-note
NONE
```