### PR TITLE
e2e: Fix flaky VM publish request specs

### DIFF
--- a/test/e2e/framework/retry_client.go
+++ b/test/e2e/framework/retry_client.go
@@ -49,6 +49,7 @@ var RetryableTransientErrSubstrings = []string{
 	"unexpected eof",
 	"broken pipe",
 	"http2: server sent goaway",
+	"http2: client connection lost",
 	"context deadline exceeded",
 	"no endpoints available for service",
 	"unable to connect to the server",

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_group_publishrequest.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_group_publishrequest.go
@@ -14,6 +14,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	capiutil "sigs.k8s.io/cluster-api/util"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -122,8 +123,21 @@ func VMGroupPublishRequestSpec(ctx context.Context, inputGetter func() VMGroupPu
 	}
 
 	createVMs := func() {
-		vmservice.DeployVMWithCloudInit(ctx, vmSvcClusterProxy, vmSvcE2EConfig, vmSvcClusterResources, vmSvcNamespace, vm1Name, vmChildGroupName, nil)
-		vmservice.DeployVMWithCloudInit(ctx, vmSvcClusterProxy, vmSvcE2EConfig, vmSvcClusterResources, vmSvcNamespace, vm0Name, vmGroupName, nil)
+		imageName := vmoperator.WaitForVirtualMachineImageName(
+			ctx,
+			&vmSvcE2EConfig.Config,
+			vmSvcClusterProxy.GetClient(),
+			vmSvcNamespace,
+			vmservice.GetDefaultImageDisplayName(vmSvcClusterResources))
+
+		for _, vm := range []*vmopv1.VirtualMachine{
+			newGroupMemberVM(vmSvcNamespace, vm1Name, vmChildGroupName, imageName, *vmSvcClusterResources),
+			newGroupMemberVM(vmSvcNamespace, vm0Name, vmGroupName, imageName, *vmSvcClusterResources),
+		} {
+			By(fmt.Sprintf("Creating VirtualMachine %s/%s in group %s", vm.Namespace, vm.Name, vm.Spec.GroupName))
+			Expect(vmSvcClusterProxy.GetClient().Create(ctx, vm)).To(Succeed(), "failed to create VirtualMachine %+v", vm)
+		}
+
 		vmoperator.VerifyVirtualMachineGroupLinked(ctx, vmSvcE2EConfig, vmSvcClusterProxy.GetClient(), vmSvcNamespace, vmGroupName, sets.New([]vmopv1.GroupMember{
 			{Kind: "VirtualMachine", Name: vm0Name},
 			{Kind: "VirtualMachineGroup", Name: vmChildGroupName},
@@ -308,4 +322,37 @@ func VMGroupPublishRequestSpec(ctx context.Context, inputGetter func() VMGroupPu
 		By("Deleting non admin user")
 		vcenter.DeleteUserOrFail(user)
 	})
+}
+
+// newGroupMemberVM returns a VirtualMachine that joins the named group.
+//
+// The VM is built as a typed struct rather than rendered YAML because
+// promoteDisksMode is not expressible through the shared v1alpha5 fixture, and
+// this spec needs it: the spec publishes the same VM twice, and after the first
+// publish's snapshot is removed a background PromoteDisks task starts on the
+// source VM. vCenter takes a snapshot internally to serve the second publish's
+// CreateOvf, that snapshot queues behind the promote, and on a loaded testbed
+// the publish call blocks for minutes before failing with
+// "Unable to create snapshot of VM". Disk provenance is irrelevant to the
+// subset-selection and publish-completion behavior under test here.
+//
+// Power state is intentionally left unset to match what the fixture rendered;
+// the API defaults it to PoweredOn on create.
+func newGroupMemberVM(
+	namespace, name, groupName, imageName string,
+	clusterResources e2eConfig.Resources) *vmopv1.VirtualMachine {
+
+	return &vmopv1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: vmopv1.VirtualMachineSpec{
+			GroupName:        groupName,
+			ClassName:        clusterResources.VMClassName,
+			StorageClass:     clusterResources.StorageClassName,
+			ImageName:        imageName,
+			PromoteDisksMode: vmopv1.VirtualMachinePromoteDisksModeDisabled,
+		},
+	}
 }

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_group_publishrequest.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_group_publishrequest.go
@@ -327,13 +327,14 @@ func VMGroupPublishRequestSpec(ctx context.Context, inputGetter func() VMGroupPu
 // newGroupMemberVM returns a VirtualMachine that joins the named group.
 //
 // The VM is built as a typed struct rather than rendered YAML because
-// promoteDisksMode is not expressible through the shared v1alpha5 fixture, and
-// this spec needs it: the spec publishes the same VM twice, and after the first
-// publish's snapshot is removed a background PromoteDisks task starts on the
-// source VM. vCenter takes a snapshot internally to serve the second publish's
-// CreateOvf, that snapshot queues behind the promote, and on a loaded testbed
-// the publish call blocks for minutes before failing with
-// "Unable to create snapshot of VM". Disk provenance is irrelevant to the
+// promoteDisksMode is not a field on the shared VirtualMachineYaml fixture, and
+// this spec needs it: the spec publishes the same VM three times, and the
+// second and third publishes land in the window where a background PromoteDisks
+// task is running on the source VM. Observed on a loaded testbed: the first
+// group publish (issued before promotion starts) completes in well under a
+// minute, while the next one, issued roughly a minute after the VMs were
+// created, never reports Complete and the spec times out. Disabling promotion
+// removes that collision; disk provenance is irrelevant to the
 // subset-selection and publish-completion behavior under test here.
 //
 // Power state is intentionally left unset to match what the fixture rendered;

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_publishrequest.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_publishrequest.go
@@ -278,10 +278,39 @@ func VMPublishRequestSpec(ctx context.Context, inputGetter func() VMPublishReque
 
 				By("Deploying a new VM from the published image")
 				// Use the published the vmi to deploy a new VM should succeed with VM powered on and IP assigned.
+				//
+				// The VM is built as a typed struct rather than rendered YAML
+				// because promoteDisksMode does not exist before v1alpha4, so
+				// the v1alpha2 fixture used elsewhere in this spec cannot set
+				// it -- the API server prunes fields absent from the requested
+				// version's schema.
 				newVmName := fmt.Sprintf("%s-%s", vmPubSpecName+"-vm", capiutil.RandomString(4))
-				newVMBuilder := generateVMBuilder(input.WCPNamespaceName, newVmName, publishedImageCRName, *clusterResources)
-				newVmYaml := manifestbuilders.GetVirtualMachineYamlA2(newVMBuilder)
-				Expect(clusterProxy.CreateWithArgs(ctx, newVmYaml)).NotTo(HaveOccurred(), "failed to create virtualmachine from the published image", string(newVmYaml))
+				newVM := &vmopv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: input.WCPNamespaceName,
+						Name:      newVmName,
+					},
+					Spec: vmopv1.VirtualMachineSpec{
+						ClassName:    clusterResources.VMClassName,
+						ImageName:    publishedImageCRName,
+						StorageClass: clusterResources.StorageClassName,
+						PowerState:   vmopv1.VirtualMachinePowerStateOn,
+						Reserved: &vmopv1.VirtualMachineReservedSpec{
+							ResourcePolicyName: clusterResources.VMResourcePolicyName,
+						},
+						// Suppress disk promotion so no background PromoteDisks
+						// task competes with the guest's first boot. A VM
+						// deployed from a freshly published image promotes off
+						// the image's parent disks, and on a loaded testbed that
+						// online promotion can run for minutes, delaying the
+						// guest reporting an IP past the wait-virtual-machine-vmip
+						// timeout. Disk provenance is irrelevant to the publish
+						// behavior under test here.
+						PromoteDisksMode: vmopv1.VirtualMachinePromoteDisksModeDisabled,
+					},
+				}
+				Expect(svClusterClient.Create(ctx, newVM)).To(Succeed(),
+					"failed to create virtualmachine from the published image %+v", newVM)
 				vmoperator.WaitForVirtualMachineCreation(ctx, config, svClusterClient, input.WCPNamespaceName, newVmName)
 				vmoperator.DeleteVirtualMachine(ctx, svClusterClient, input.WCPNamespaceName, newVmName)
 			})

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_publishrequest.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_publishrequest.go
@@ -298,14 +298,13 @@ func VMPublishRequestSpec(ctx context.Context, inputGetter func() VMPublishReque
 						Reserved: &vmopv1.VirtualMachineReservedSpec{
 							ResourcePolicyName: clusterResources.VMResourcePolicyName,
 						},
-						// Suppress disk promotion so no background PromoteDisks
-						// task competes with the guest's first boot. A VM
-						// deployed from a freshly published image promotes off
-						// the image's parent disks, and on a loaded testbed that
-						// online promotion can run for minutes, delaying the
-						// guest reporting an IP past the wait-virtual-machine-vmip
-						// timeout. Disk provenance is irrelevant to the publish
-						// behavior under test here.
+						// Disable disk promotion. This VM has timed out
+						// waiting for an IP on a loaded testbed, and a
+						// promote running against its first boot is the
+						// likeliest culprit, though the logs don't prove
+						// it. Nothing here cares where the disks came
+						// from, so there is no reason to leave promotion
+						// running.
 						PromoteDisksMode: vmopv1.VirtualMachinePromoteDisksModeDisabled,
 					},
 				}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

De-flakes the two VM publish E2E specs that failed together in a recent smoke run (VM-PUBLISH-REQUEST / CLS and VM-GROUP-PUBLISH-REQUEST). And fix another connection issue wrt the VM-PUBLISHREQUEST

Both failures are timeouts on a loaded testbed that correlate with background disk promotion running on the VM under test:
Failure 1
- VM-GROUP-PUBLISH-REQUEST — failed at VerifyVirtualMachineGroupPublishRequestCompleted (vmoperator.go:731): the subset publish never reported Complete within 360 s. The first group publish, issued before promotion begins, completed in ~30 s; the subset publish was issued about a minute after the member VMs were created — inside the promotion window implied by the source VM's timings — and hung.

Failure 2
- VM-PUBLISH-REQUEST / CLS Content Library — failed at WaitForVirtualMachineIP (vmoperator.go:204): the VM deployed from the freshly published image reached PoweredOn but reported no status.network.primaryIP4 for the full 300 s wait-virtual-machine-vmip window. In the same run, the source VM (promoteDisksMode: Online, the API default) flipped VirtualMachineGuestNetworkConfigSynced to True at the same second as VirtualMachineDiskPromotionSynced — i.e. the guest IP only surfaced once online promotion finished. A VM deployed from a just-published image promotes off cold, uncached parent disks, so that window is longer.

Failure 3
- The VM-GROUP-PUBLISH-REQUEST test failed because a transient supervisor apiserver connectivity stall caused the kubectl create for the subset publish request to hang and die with http2: client connection lost, an error signature not yet covered by the e2e transient-retry classifier.

Changes:
- test/e2e/vmservice/vmservice/virtualmachine/vm_publishrequest.go — build the VM deployed from the published image as a typed vmopv1.VirtualMachine with promoteDisksMode: Disabled instead of the rendered v1alpha2 fixture. The fixture cannot express the field: promoteDisksMode does not exist before v1alpha4, so the API server prunes it from a v1alpha2 request. All other fields (class, image, storage class, reserved.resourcePolicyName, powerState: PoweredOn) match what the fixture rendered.
- test/e2e/vmservice/vmservice/virtualmachine/vm_group_publishrequest.go — create the group member VMs directly with promoteDisksMode: Disabled via a new package-level newGroupMemberVM helper, replacing vmservice.DeployVMWithCloudInit. No coverage is lost: that helper sets SecretName, which the v1a5singlevm.yaml.in template never references (it only reads .Bootstrap.*), so the cloud-config secret it created was never attached to the VMs — confirmed by the rendered YAML in the failing run, which has no bootstrap: stanza. The typed VM is field-equivalent plus promoteDisksMode.
-  Add "http2: client connection lost" to the e2e transient-error retry list so a lost HTTP/2 connection during kubectl create (as seen in the VM-GROUP-PUBLISH-REQUEST flake) gets retried instead of failing the test outright.

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #
vmop-4106

**Are there any special notes for your reviewer**:
On failure # 2, promotion holding back guest property updates is not provable from these logs
- promotion holding back guest property updates is not provable from these logs. What is observable is on the source VM, the only VM whose conditions were captured: across its entire promotion window (VirtualMachineDiskPromotionStarted True at 11:19:41 → VirtualMachineDiskPromotionSynced True at 11:21:05) there is no guest network update at all — VirtualMachineGuestNetworkConfigSynced stays unset and only flips True, with IPv4="172.26.0.114", at 11:21:05 as promotion completes. Whether promotion caused that quiet period or merely coincided with it cannot be told apart from this log, and the VM that actually failed the IP wait had no diagnostics captured, so its promotion state is unknown. Disabling promotion for this spec is therefore a precaution rather than a proven fix: the spec asserts publish and deploy behavior, disk provenance is irrelevant to that, and removing promotion costs no coverage here

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note

```