### PR TITLE
🌱 e2e: Enable Windows Sysprep tests

### DIFF
--- a/test/e2e/fixtures/yaml/vmoperator/virtualmachines/singlevm.yaml.in
+++ b/test/e2e/fixtures/yaml/vmoperator/virtualmachines/singlevm.yaml.in
@@ -28,6 +28,9 @@ spec:
   resourcePolicyName: {{.ResourcePolicy}}
   {{end}}
   powerState: {{.PowerState}}
+  {{if .PowerOffMode}}
+  powerOffMode: {{.PowerOffMode}}
+  {{end}}
   {{if or .ConfigMapName .SecretName .Transport}}
   vmMetadata:
     {{if .ConfigMapName}}

--- a/test/e2e/fixtures/yaml/vmoperator/virtualmachines/v1a2singlevm.yaml.in
+++ b/test/e2e/fixtures/yaml/vmoperator/virtualmachines/v1a2singlevm.yaml.in
@@ -33,6 +33,9 @@ spec:
     resourcePolicyName: {{.ResourcePolicy}}
   {{end}}
   powerState: {{.PowerState}}
+  {{if .PowerOffMode}}
+  powerOffMode: {{.PowerOffMode}}
+  {{end}}
   {{if and .Bootstrap (or .Bootstrap.CloudInit .Bootstrap.Sysprep .Bootstrap.VAppConfig .Bootstrap.LinuxPrep)}}
   bootstrap:
     {{if .Bootstrap.CloudInit }}

--- a/test/e2e/manifestbuilders/virtualmachine.go
+++ b/test/e2e/manifestbuilders/virtualmachine.go
@@ -121,6 +121,7 @@ type VirtualMachineYaml struct {
 	ConfigMapName    string            `json:"config_map_name,omitempty"`
 	SecretName       string            `json:"secret_name,omitempty"`
 	PowerState       string            `json:"power_state,omitempty"`
+	PowerOffMode     string            `json:"power_off_mode,omitempty"`
 	Bootstrap        Bootstrap         `json:"bootstrap,omitempty"`
 	// Deprecated: For v1alpha5, use Hardware.Cdrom instead.
 	Cdrom               []Cdrom                            `json:"cdrom,omitempty"`

--- a/test/e2e/vmservice/config/wcp.yaml
+++ b/test/e2e/vmservice/config/wcp.yaml
@@ -100,3 +100,8 @@ intervals:
   default/wait-vm-compute-config-powerstate: ["3m", "10s"]
   default/wait-vm-extraconfig-synced:    ["5m", "10s"]
   default/wait-vm-nic-extra-config-synced: ["5m", "10s"]
+
+  # windows-sysprep overrides apply only to the Windows Sysprep spec.
+  # Empirically, Sysprep GOSC on this image reliably reports an IP in
+  # 5.5-6 minutes so this spec needs a little more room.
+  windows-sysprep/wait-virtual-machine-vmip: ["10m", "3s"]

--- a/test/e2e/vmservice/consts/consts.go
+++ b/test/e2e/vmservice/consts/consts.go
@@ -28,6 +28,12 @@ const (
 
 	JumpboxPodVMName = "jumpbox"
 
+	// WindowsSysprepLabel decorates the Windows guest-customization specs
+	// (see vm_guestcustomization.go's "Sysprep" Context) so the suite setup
+	// can preview the filtered spec tree and only precreate the Windows VM
+	// when a spec carrying this label will actually run.
+	WindowsSysprepLabel = "windows-sysprep"
+
 	// VM condition type strings used when waiting on backfill/registration lifecycle.
 	VMUnmanagedVolumesBackfilledCondition = "VirtualMachineUnmanagedVolumesBackfilled"
 	VMUnmanagedVolumesRegisteredCondition = "VirtualMachineUnmanagedVolumesRegistered"

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_guestcustomization.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_guestcustomization.go
@@ -42,12 +42,13 @@ import (
 )
 
 type VMGOSCSpecInput struct {
-	Config              *e2eConfig.E2EConfig
-	ClusterProxy        wcpframework.WCPClusterProxyInterface
-	WCPClient           wcp.WorkloadManagementAPI
-	ArtifactFolder      string
-	WCPNamespaceName    string
-	WindowsServerVMName string
+	Config                    *e2eConfig.E2EConfig
+	ClusterProxy              wcpframework.WCPClusterProxyInterface
+	WCPClient                 wcp.WorkloadManagementAPI
+	ArtifactFolder            string
+	WCPNamespaceName          string
+	WindowsServerVMName       string
+	WindowsInlineServerVMName string
 }
 
 // vAppProp builds a single vApp property key/value pair with a literal,
@@ -974,43 +975,71 @@ func VMGOSCSpec(ctx context.Context, inputGetter func() VMGOSCSpecInput) {
 		})
 	})
 
-	Context("Sysprep", func() {
-		BeforeEach(func() {
-			// The Windows server VM was deployed during the suite setup and will be deleted in the suite teardown.
-			skipCleanup = true
+	Context("Sysprep", Label(consts.WindowsSysprepLabel, "experimental"), func() {
 
-			// Skip if WCP_Windows_Sysprep FSS not enabled
-			skipper.SkipUnlessWindowsFSSEnabled(ctx, svClusterClient, config)
-		})
+		// verifyWindowsVMDeployed waits for vmName to exist, power on, and report a
+		// real IPv4 address, shared by both Sysprep Contexts above.
+		//
+		// The IP wait is rolled inline rather than vmoperator.WaitForVirtualMachineIP
+		// so these specs can use the longer "windows-sysprep" interval (see wcp.yaml)
+		// without changing that shared helper's timeout for every other caller, and
+		// so a guest falling back to an APIPA (169.254.0.0/16) self-assigned address
+		// -- which vmoperator.WaitForVirtualMachineIP would otherwise accept as a
+		// real IP -- is treated as still-waiting rather than success.
+		verifyWindowsVMDeployed := func(ctx context.Context, config *e2eConfig.E2EConfig, svClusterClient ctrlclient.Client, ns, vmName string) {
+			By(fmt.Sprintf("Verify that a single VirtualMachine '%s/%s' is created", ns, vmName))
+			vmoperator.WaitForVirtualMachineToExist(ctx, config, svClusterClient, ns, vmName)
+			vmoperator.WaitForVirtualMachineConditionCreated(ctx, config, svClusterClient, ns, vmName)
+			vmoperator.WaitForVirtualMachinePowerState(ctx, config, svClusterClient, ns, vmName, string(vmopv1.VirtualMachinePowerStateOn))
 
+			By(fmt.Sprintf("Verify that an IP (ipv4) is allocated to the VirtualMachine '%s/%s'", ns, vmName))
+			Eventually(func(g Gomega) {
+				vm, err := utils.GetVirtualMachine(ctx, svClusterClient, ns, vmName)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(vm).ToNot(BeNil())
+
+				g.Expect(vm.Status.Network).ToNot(BeNil())
+				g.Expect(vm.Status.Network.PrimaryIP4).ToNot(BeEmpty())
+				ip := net.ParseIP(vm.Status.Network.PrimaryIP4).To4()
+				g.Expect(ip).ToNot(BeNil())
+				g.Expect(ip.IsLinkLocalUnicast()).To(BeFalse())
+			}, config.GetIntervals("windows-sysprep", "wait-virtual-machine-vmip")...).Should(Succeed())
+		}
+
+		// Register-from-backup isn't Windows-specific -- it's already
+		// covered by the Linux specs above -- and re-verifying it here
+		// only adds several more minutes to an already slow spec.
 		When("raw Sysprep data is used", func() {
-			// TODO: VMSVC-2789: Re-enable this once we've fixed PR 3531430
-			XIt("should successfully deploy VM and be able to register VM from backup", func() {
+			It("should successfully deploy VM", func() {
 				// The VM is already created during the suite setup.
 				vmName = input.WindowsServerVMName
 				Expect(vmName).ToNot(BeEmpty())
-				vmoperator.WaitForVirtualMachineCreation(ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
 
-				if vmServiceBackupRestoreEnabled {
-					vmservice.VerifyRegisterVMOnlyClassicDisk(ctx, vmName, input.WCPNamespaceName, nil, clusterProxy, config, svClusterClient, wcpClient)
+				// Set vmYaml so the VM gets cleaned up.
+				vmParameters = manifestbuilders.VirtualMachineYaml{
+					Name:      vmName,
+					Namespace: input.WCPNamespaceName,
 				}
+				vmYaml = manifestbuilders.GetVirtualMachineYaml(vmParameters)
+
+				verifyWindowsVMDeployed(ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
 			})
 		})
 
 		When("Inline Sysprep is used", func() {
-			BeforeEach(func() {
-				skipper.SkipUnlessV1a2FSSEnabled(ctx, svClusterClient, config)
-			})
-			// TODO: VMSVC-2789: Re-enable this once we've fixed PR 3531430
-			XIt("should successfully deploy VM and be able to register VM from backup", func() {
+			It("should successfully deploy VM", func() {
 				// The VM is already created during the suite setup.
-				vmName = input.WindowsServerVMName + "-a2"
+				vmName = input.WindowsInlineServerVMName
 				Expect(vmName).ToNot(BeEmpty())
-				vmoperator.WaitForVirtualMachineCreation(ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
 
-				if vmServiceBackupRestoreEnabled {
-					vmservice.VerifyRegisterVMOnlyClassicDisk(ctx, vmName, input.WCPNamespaceName, nil, clusterProxy, config, svClusterClient, wcpClient)
+				// Set vmYaml so the VM gets cleaned up.
+				vmParameters = manifestbuilders.VirtualMachineYaml{
+					Name:      vmName,
+					Namespace: input.WCPNamespaceName,
 				}
+				vmYaml = manifestbuilders.GetVirtualMachineYaml(vmParameters)
+
+				verifyWindowsVMDeployed(ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
 			})
 		})
 	})

--- a/test/e2e/vmservice/vmservice_suite_test.go
+++ b/test/e2e/vmservice/vmservice_suite_test.go
@@ -8,16 +8,18 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 
 	// Configure testing.
 	. "github.com/onsi/ginkgo/v2"
+	ginkgotypes "github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/gomega"
 
 	// Configure logging.
 	logs "github.com/sirupsen/logrus"
-	klog "k8s.io/klog/v2"
+	"k8s.io/klog/v2"
 	_ "k8s.io/kubernetes/test/e2e/framework"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -61,11 +63,19 @@ var (
 	testSuiteName               string
 	wcpNamespaceName            string
 	windowsServerVMName         string
+	windowsInlineServerVMName   string
 	linuxVMName                 string
 	config                      *e2eConfig.E2EConfig
 	svClusterProxy              wcpframework.WCPClusterProxyInterface
 	wcpClient                   wcp.WorkloadManagementAPI
 	wcpNamespaceCtx             wcpframework.NamespaceContext
+
+	// windowsSysprepSpecsWillRun is computed from a Ginkgo spec preview
+	// before RunSpecs is called and records whether any spec labeled
+	// consts.WindowsSysprepLabel will actually be run given the current
+	// focus/skip/label-filter configuration. It gates the (expensive)
+	// Windows VM precreation in SynchronizedBeforeSuite below.
+	windowsSysprepSpecsWillRun bool
 )
 
 func init() {
@@ -99,6 +109,20 @@ func TestVMService(t *testing.T) {
 	logs.SetOutput(GinkgoWriter)
 
 	defer klog.Flush()
+
+	// Preview the filtered spec tree (honoring -ginkgo.focus/-skip/-label-filter)
+	// before any spec runs, so suite setup below can skip precreating the Windows
+	// VM when nothing that needs it will actually run. PreviewSpecs must be called
+	// before RunSpecs; it cannot be called once the suite is running.
+	for _, specReport := range PreviewSpecs("VM Service E2E suite").SpecReports {
+		if !specReport.State.Is(ginkgotypes.SpecStatePassed) {
+			continue
+		}
+		if slices.Contains(specReport.Labels(), consts.WindowsSysprepLabel) {
+			windowsSysprepSpecsWillRun = true
+			break
+		}
+	}
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "VM Service E2E suite")
@@ -214,9 +238,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		// We only deploy the VM here and not block to wait for it to be ready.
 		deployVMWithCloudInit(ctx, wcpNamespaceName, linuxVMName, photonVMIName)
 
-		if fssEnabled := utils.IsFssEnabled(ctx, svClusterProxy.GetClient(),
-			config.GetVariable("VMOPNamespace"), config.GetVariable("VMOPDeploymentName"),
-			config.GetVariable("VMOPManagerCommand"), config.GetVariable("EnvFSSWindowsSysprep")); fssEnabled {
+		if windowsSysprepSpecsWillRun {
 			// The Windows VM deployment and customization could take a while to complete.
 			// We only deploy the VM here and skip checking the VM status.
 			// The actual verification will be done in vm_guestcustomization spec.
@@ -233,6 +255,10 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 			// the format specified in RFC-1034, Section 3.5 for DNS labels.
 			windowsServerVMName = fmt.Sprintf("%s-%s", "windows", capiutil.RandomString(4))
 			deployWindowsVMWithSysprep(ctx, wcpNamespaceName, windowsServerVMName, windowsVMIName)
+
+			By("Deploying a Windows VM with inline Sysprep config")
+			windowsInlineServerVMName = fmt.Sprintf("%s-%s", "windows2", capiutil.RandomString(4))
+			deployWindowsVMWithInlineSysprep(ctx, wcpNamespaceName, windowsInlineServerVMName, windowsVMIName)
 		}
 	}
 
@@ -335,7 +361,6 @@ func createWCPNamespaceCtx(ctx context.Context, name, clName, vmClassName, stora
 }
 
 // deployWindowsVMWithSysprep deploys a Windows VM with the minimal Sysprep config passed.
-// If WCP_VMService_v1alpha2 is enabled, it additionally deploys a v1a2 Windows VM with the same Sysprep config.
 func deployWindowsVMWithSysprep(ctx context.Context, ns, vmName, vmiName string) {
 	vmsvcClusterProxy := svClusterProxy.(*common.VMServiceClusterProxy)
 	secretName := "sysprep-data"
@@ -366,22 +391,29 @@ func deployWindowsVMWithSysprep(ctx context.Context, ns, vmName, vmiName string)
 		Transport:        "Sysprep",
 		SecretName:       secretName,
 		PowerState:       "poweredOn",
+		PowerOffMode:     "Hard",
 	}
 	vmYaml := manifestbuilders.GetVirtualMachineYaml(vmParameters)
-	Expect(vmsvcClusterProxy.CreateWithArgs(ctx, vmYaml)).To(Succeed(), "failed to create v1alpha1 Windows VM", string(vmYaml))
+	Expect(vmsvcClusterProxy.CreateWithArgs(ctx, vmYaml)).To(Succeed(), "failed to create Windows VM", string(vmYaml))
+}
 
-	if utils.IsFssEnabled(ctx, svClusterProxy.GetClient(),
-		config.GetVariable("VMOPNamespace"), config.GetVariable("VMOPDeploymentName"),
-		config.GetVariable("VMOPManagerCommand"), config.GetVariable("EnvFSSV1alpha2")) {
-		secretName = "inline-sysprep-data"
-		secret = manifestbuilders.Secret{
-			Namespace: ns,
-			Name:      secretName,
-		}
-		secretYaml = manifestbuilders.GetSecretYamlInlineSysprepData(secret)
-		Expect(vmsvcClusterProxy.CreateWithArgs(ctx, secretYaml)).To(Succeed(), "failed to create the Secret with Sysprep data", string(secretYaml))
+// deployWindowsVMWithInlineSysprep deploys a Windows VM whose Sysprep answer
+// file is specified inline in spec.bootstrap.sysprep.sysprep, rather than via
+// a Secret referenced through rawSysprep (see deployWindowsVMWithSysprep).
+// This exercises the v1alpha2 API and the inline-Sysprep-data path.
+func deployWindowsVMWithInlineSysprep(ctx context.Context, ns, vmName, vmiName string) {
+	vmsvcClusterProxy := svClusterProxy.(*common.VMServiceClusterProxy)
 
-		inlinedSysprep := fmt.Sprintf(`
+	secretName := "inline-sysprep-data"
+	secret := manifestbuilders.Secret{
+		Namespace: ns,
+		Name:      secretName,
+	}
+
+	secretYaml := manifestbuilders.GetSecretYamlInlineSysprepData(secret)
+	Expect(vmsvcClusterProxy.ApplyWithArgs(ctx, secretYaml)).To(Succeed(), "failed to create the Secret with inline Sysprep data", string(secretYaml))
+
+	inlinedSysprep := fmt.Sprintf(`
         guiUnattended:
           autoLogon: true
           autoLogonCount: 1
@@ -401,24 +433,23 @@ func deployWindowsVMWithSysprep(ctx context.Context, ns, vmName, vmiName string)
         userData:
           fullName: "First User"
           orgName: "Broadcom"`, secretName)
-		// Keep Windows VM name under 15 chars so hostName inherited from vmName can adhere to
-		// the format specified in RFC-1034, Section 3.5 for DNS labels.
-		v1a2vmParameters := manifestbuilders.VirtualMachineYaml{
-			Namespace:        ns,
-			Name:             vmName + "-a2",
-			VMClassName:      config.InfraConfig.ManagementClusterConfig.Resources.VMClassName,
-			StorageClassName: config.InfraConfig.ManagementClusterConfig.Resources.StorageClassName,
-			ImageName:        vmiName,
-			PowerState:       "PoweredOn",
-			Bootstrap: manifestbuilders.Bootstrap{
-				Sysprep: &manifestbuilders.Sysprep{
-					Sysprep: &inlinedSysprep,
-				},
+
+	vmParameters := manifestbuilders.VirtualMachineYaml{
+		Namespace:        ns,
+		Name:             vmName,
+		VMClassName:      config.InfraConfig.ManagementClusterConfig.Resources.VMClassName,
+		StorageClassName: config.InfraConfig.ManagementClusterConfig.Resources.StorageClassName,
+		ImageName:        vmiName,
+		PowerState:       "PoweredOn",
+		PowerOffMode:     "Hard",
+		Bootstrap: manifestbuilders.Bootstrap{
+			Sysprep: &manifestbuilders.Sysprep{
+				Sysprep: new(inlinedSysprep),
 			},
-		}
-		vmYaml := manifestbuilders.GetVirtualMachineYamlA2(v1a2vmParameters)
-		Expect(vmsvcClusterProxy.CreateWithArgs(ctx, vmYaml)).To(Succeed(), "failed to create v1alpha2 Windows VM", string(vmYaml))
+		},
 	}
+	vmYaml := manifestbuilders.GetVirtualMachineYamlA2(vmParameters)
+	Expect(vmsvcClusterProxy.CreateWithArgs(ctx, vmYaml)).To(Succeed(), "failed to create Windows VM with inline Sysprep", string(vmYaml))
 }
 
 // deployVMWithCloudInit deploys a VM with the default cloud-init config passed.

--- a/test/e2e/vmservice/vmservice_test.go
+++ b/test/e2e/vmservice/vmservice_test.go
@@ -106,12 +106,13 @@ var _ = Describe("Testing VM Services", Label("devops"), Label("viadmin"), Label
 		Context("VM-GUEST-CUSTOMIZATION", func() {
 			virtualmachine.VMGOSCSpec(context.TODO(), func() virtualmachine.VMGOSCSpecInput {
 				return virtualmachine.VMGOSCSpecInput{
-					ClusterProxy:        svClusterProxy,
-					Config:              config,
-					WCPClient:           wcpClient,
-					ArtifactFolder:      artifactFolder,
-					WCPNamespaceName:    wcpNamespaceName,
-					WindowsServerVMName: windowsServerVMName,
+					ClusterProxy:              svClusterProxy,
+					Config:                    config,
+					WCPClient:                 wcpClient,
+					ArtifactFolder:            artifactFolder,
+					WCPNamespaceName:          wcpNamespaceName,
+					WindowsServerVMName:       windowsServerVMName,
+					WindowsInlineServerVMName: windowsInlineServerVMName,
 				}
 			})
 		})


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Re-enable the Windows Sysprep guest-customization tests

Investigation found the underlying Sysprep GOSC flow was never actually broken -- it just reliably takes a longer than the suite's default wait-virtual-machine-vmip budget to report an IP. A "windows-sysprep" scoped interval override handles that without slowing down every other spec's timeout. The IP wait also now rejects APIPA (169.254.0.0/16) self-assigned addresses, which the shared helper would otherwise accept as success.

Other changes:

- Gate the (expensive) Windows VM precreation in suite setup on a Ginkgo PreviewSpecs check, so it's skipped whenever no windows-sysprep-labeled spec will actually run.

- Precreate a second Windows VM using inline Sysprep data (GetSecretYamlInlineSysprepData) and add a matching spec.

- Drop the register-from-backup re-verification for Windows; it is already covered by the Linux specs and only slowed this spec down.

- Set PowerOffMode: Hard and reuse the shared per-spec AfterEach cleanup path instead of relying on suite-level namespace teardown, which doesn't reliably run (its "skip on failure" check doesn't reflect this spec's own pass/fail, and it's skipped entirely when the namespace is reused rather than freshly created).

- Label both specs "experimental" until validated more broadly.

Verified passing against a real WCP/vSphere testbed.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # vmop-4121


**Are there any special notes for your reviewer**:

UTS experimental passes

**Please add a release note if necessary**:

```release-note
NONE
```