### PR TITLE
:sparkles: Include a guide for provider portability, add spec / tasks

### DIFF
--- a/.sdd/specs/006-vmop-kubevm-provider/plan.md
+++ b/.sdd/specs/006-vmop-kubevm-provider/plan.md
@@ -1,0 +1,230 @@
+# Implementation Plan: VM Operator as a KubeVM provider
+
+- **Spec**: [`spec.md`](./spec.md)
+- **Epic**: TBD
+- **Date**: 2026-08-31
+
+## Summary
+
+Add a generic-side core controller for `kube-vm.io/v1alpha1` `VirtualMachine` that adopts a VM Operator `VirtualMachine` as its infrastructure object and drives the generic object's status from fixed contract paths on it; add additive contract status fields to `vmoperator.vmware.com/v1alpha6` so those paths exist; and add the VM Operator side that resolves its own configuration from the owning generic object — a mutating-webhook step at create, and a small reconciler that keeps the desired power state in step. The delegation behaviour is behind a new `KubeVMProvider` feature gate, default off.
+
+## Technical context
+
+- **Go version**: root module `go 1.26.7`; `external/kubevm` deliberately floors at `go 1.23.0`.
+- **API version(s) touched**: `vmoperator.vmware.com/v1alpha6` gains three optional status fields and one condition-type constant; `v1alpha1`–`v1alpha5` gain conversion-restore handling for those fields. `kube-vm.io/v1alpha1` is unchanged.
+- **Modules touched**: root (`api/`, `webhooks/`, `controllers/`, `pkg/`, `config/`, `test/builder/`, `Makefile`, `go.mod`), and one new module for the core controller. `external/kubevm` itself gains no code.
+- **New dependencies**: root gains `github.com/vmware-tanzu/vm-operator/external/kubevm` via the existing `replace`-plus-zero-pseudo-version pattern used by the eleven other `external/*` and `pkg/*` sub-modules. Root is at `k8s.io/apimachinery v0.36.1` / `controller-runtime v0.24.0` against kubevm's floor of `v0.31.0` / `v0.19.0`; module resolution takes the higher, so the floor costs root nothing.
+- Every field path, function name and file reference below was checked against the repo. Items that could not be confirmed carry an `[UNVERIFIED]` marker.
+
+## Constitution check
+
+| Rule | Status | Notes |
+|------|--------|-------|
+| SDD artifacts under `.sdd/specs/NNN-slug/` | OK | `spec.md`, `plan.md`, `tasks.md` in this directory. |
+| Spec declares an epic | Deviation | Header carries `Epic: TBD` while `Status: Draft`, which `sdd-standards.md` permits. The epic must be filed before this spec merges. |
+| API compatibility | **Deviation** | Three optional status fields are added to a shipped CRD. See API / CRD strategy and Complexity tracking. |
+| New CRD markers, `make generate-manifests` | OK | No new CRD. Regeneration of the existing manifests and of `zz_generated.*` is a task. |
+| Thin controllers | OK | Mapping and linkage logic in `pkg/kubevm/`; the reconciler holds the loop, patch helper and watches only. |
+| Controllers only modify Status | **Deviation** | The VM Operator reconciler writes `spec.powerState` on the provider object. See Complexity tracking. |
+| Controllers must track `observedGeneration` and set `Ready` | OK | The core sets both on the generic object. |
+| Controllers for other API groups not directly in `controllers/` | OK | The generic-group controller lives in its own module. The VM Operator-side reconciler is `For(&vmopv1.VirtualMachine{})`, so `controllers/` is its correct home. |
+| Webhooks for other API groups not directly in `webhooks/` | OK | No webhook is added for the `kube-vm.io` group; the changes are inside the existing `vmoperator.vmware.com` mutating and validating webhooks. |
+| CEL preferred for simple structural rules | Deviation | Annotation immutability is enforced in Go, because CEL expresses "immutable once non-empty on one key of a map" poorly and `validateAnnotation` already owns annotation rules. |
+| Fan-in list-typed writes use an optimistic lock | OK | Owner references are patched with `client.MergeFromWithOptions(base, client.MergeFromWithOptimisticLock{})` and a skip-if-unchanged guard, because `controllers/virtualmachinegroup/virtualmachinegroup_controller.go:428` is a second writer of the same list via `controllerutil.SetOwnerReference`. |
+| Feature flag gets spec + plan + tasks | OK | This is that spec. |
+| One test file and one suite bootstrap per package | Partial | Honoured for all new packages. The existing `webhooks/virtualmachine/mutation` package still carries `virtualmachine_mutator_unit_test.go` and `virtualmachine_mutator_intg_test.go`; new coverage there goes into a new `virtualmachine_mutator_kubevm_test.go` registered into the existing `virtualmachine_mutator_suite_test.go`, rather than extending the legacy files. |
+| E2E in the same PR for Supervisor-observable changes | **Deviation** | See Complexity tracking. |
+| Sub-modules table in `constitution.md` | **Needs amendment** | `external/kubevm` is missing from the table, and the repo-layout section calls `external/` "vendored external API types", which is wrong for first-party code — the root `Makefile` already says so at lines 322–325 when it adds `./external/kubevm/` back into `GO_MOD_DIRS_TO_LINT`. Both need amending in the implementing PR, along with the new controller module. Not done here; this change set is limited to `spec.md` and `plan.md`. |
+| No internal ticket or wiki URLs | OK | `vmop-NNN` form only. |
+
+## Key decisions
+
+**1. The status contract is fixed paths the provider surfaces, not paths the core translates.** Cluster API works this way: `sigs.k8s.io/cluster-api@v1.11.0/internal/contract/` defines paths such as `{"status","ready"}` and `{"status","failureReason"}`, and CAPI core reads those exact paths on any infrastructure object with no per-provider adapter anywhere. The generic core does the same. Consequence: VM Operator has to publish at the contract paths rather than the core learning VM Operator's names. The one-pager's phrase "a thin status adapter" is what this decision moves — the adapter lives on the provider side, as fields, not in the core as code.
+
+**2. VM Operator therefore gains three additive status fields.** `status.addresses`, `status.providerID` and `status.providerMetadata` on `v1alpha6.VirtualMachineStatus`, all `+optional`. They duplicate information already reported under VM Operator's own names, which is a real cost, and they are written unconditionally rather than behind the gate — a contract is not something a provider satisfies only sometimes. This is the scope change against an earlier reading of this work as "no new fields", and it is recorded in the spec as such.
+
+**3. This limitation goes on the record.** Requiring contract status paths assumes the provider owns the provider object's type. A provider that reuses a third-party CRD can put the linkage annotation on it but cannot meaningfully write its status, so such a provider needs its own thin object to stand in front of the borrowed one. VM Operator owns its CRD, so this does not block the port.
+
+**4. Linkage requires mutual declaration.** The generic object's `spec.infrastructureRef` names the provider object (`+required`, and immutable via a `self == oldSelf` CEL rule). The provider object carries annotation `kube-vm.io/virtual-machine: <generic object name>`, same namespace. Adoption happens only when both agree. A one-sided reference produces a status message and no write of any kind. This costs one line of YAML and buys the guarantee that no generic object can conscript a provider object whose owner did not opt in.
+
+**5. The owner reference is a consequence of adoption, not its signal.** The core sets `controllerutil.SetControllerReference` after confirming mutual linkage, for garbage collection, and refuses to adopt when the provider object already carries a controller owner reference naming a different generic object. The precedent is `controllers/virtualmachinegroup/virtualmachinegroup_controller.go`: the member VM must carry `spec.groupName` matching the group (guard at lines 406–423, returning `NoRequeueError` with condition reason `NotMember`) *and* be reachable from the group's own membership before line 428 sets an owner reference. Two corrections to the design as briefed: the group-side list is `spec.bootOrder[].members`, not `spec.members`, and the call is `controllerutil.SetOwnerReference` — a plain owner reference, because a VM may be in a group and owned by something else. Our case wants the controller slot; the two coexist, since an object may have one controller reference and any number of plain ones.
+
+**6. Immutable-on-update fields are resolved once, in VM Operator's mutating webhook.** `validateImmutableFields` (`webhooks/virtualmachine/validation/virtualmachine_validator.go:2486`) makes `spec.storageClass` unconditionally immutable, `spec.image`/`spec.imageName` immutable via `validateImageOnUpdate` (:268), and `spec.className` immutable via `validateClassOnUpdate` (:722). Resolving these post-create is therefore impossible, so they are resolved at create. The mutating webhook is the right place because mutating webhooks run first, so `validateImageOnCreate` (:607) and `validateClassOnCreate` (:652) see a fully populated spec and no validation change is needed. One nuance the design as briefed does not capture: `validateClassOnUpdate` only enforces className immutability when neither `VMResize` nor `VMResizeCPUMemory` is enabled (:726–730), so class is not universally immutable. The plan still resolves it at create, because the demo cannot depend on a resize gate being on.
+
+**7. The mutable field is reasserted by the controller, every reconcile.** `spec.powerState` is copied from the generic object into the provider object on each reconcile, exactly as `updateMemberPowerState` (`virtualmachinegroup_controller.go:840`, assignment at :850) copies a group's power state onto its members, persisted with `client.MergeFrom` at :426. This is what makes precedence real: the generic object wins because the controller keeps saying so, and a hand-patch of the provider object's power state reverts on the next reconcile.
+
+**8. Values are persisted in the provider spec, not resolved in memory.** `kubectl get virtualmachines.vmoperator.vmware.com -o yaml` has to be truthful about what the VM was built from, and other tooling reads the object rather than recomputing it.
+
+**9. Ordering inside `Mutate()` is explicit, not a registered hook.** `MutateOnCreateFuncs` is a `sync.Map` (`virtualmachine_mutator.go:112`) iterated with `Range` at :306, and `sync.Map.Range` order is unspecified. Resolution must run before `SetDefaultPowerState` (:275, which defaults an empty power state to `PoweredOn`) and before `ResolveImageNameOnCreate` (:283, which resolves `spec.imageName` into `spec.image` and would otherwise deny a spec that has neither). So it is a direct call placed first in the `admissionv1.Create` branch, not a `MutateOnCreateFuncs.Store` entry.
+
+**10. Cross-group reads in the webhook bypass the cache by excluding the type.** `pkg/manager/manager.go` lines 107–127 already carry a `client.CacheOptions.DisableFor` list (`corev1.ConfigMap`, `corev1.Secret`, `appsv1.Deployment`); the generic `VirtualMachine` is added to it. Without that, the first admission request would lazily start an informer during a live call whose webhook has `failurePolicy: Fail`, and that informer never syncs if the CRD is absent. `mgr.GetAPIReader()` is the alternative and is used in three controllers (no webhooks today), but it would mean threading a second reader through `NewMutator(client)` and every test that constructs it. `DisableFor` also narrows the webhook's RBAC to `get`, where a cached read would need `list` and `watch`.
+
+**11. Provider objects are read as `unstructured`.** The core resolves the group and kind from `spec.infrastructureRef` and reads the contract paths out of an `unstructured.Unstructured`, importing no provider types. Version resolution uses the RESTMapper's preferred version for the group-kind. `[UNVERIFIED: the one-pager describes a contract version advertised through a well-known label on the provider CRD (line 319), and no label key constant exists anywhere in `external/kubevm`. Preferred-version resolution is a placeholder for this iteration and must be revisited when the contract version is defined.]`
+
+**12. The core controller lives in a new module nested under `external/kubevm/`.** `external/kubevm/go.mod` has exactly two direct dependencies (`k8s.io/apimachinery v0.31.0`, `sigs.k8s.io/controller-runtime v0.19.0`) and a header comment stating the low floor is deliberate so that providers importing the API types are not forced up a Kubernetes version. Adding a manager means `k8s.io/api` and `k8s.io/client-go`, neither of which is present today even transitively. Nesting the controller as `external/kubevm/controller/` rather than beside it keeps it moving with the API when the module relocates to its own repository, which its README says is expected. The core module must never depend on the root module.
+
+**13. Adoption of pre-existing VM Operator VMs is out of scope**, recorded as a non-goal with the intended future mechanism, not as an open question.
+
+## Project structure
+
+```
+api/v1alpha6/virtualmachine_types.go                — status.addresses, status.providerID, status.providerMetadata;
+                                                      VirtualMachineConditionUpToDate constant
+api/v1alpha1..v1alpha5/virtualmachine_conversion.go — restore-annotation handling for the three new fields
+api/v1alpha1..v1alpha5/zz_generated.conversion.go   — regenerated
+api/v1alpha6/zz_generated.deepcopy.go               — regenerated
+config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml — regenerated
+pkg/providers/vsphere/vmlifecycle/update_status.go  — publish the contract fields
+pkg/config/config.go                                — FeatureStates.KubeVMProvider
+pkg/config/env/env.go, pkg/config/env.go            — FSS_WCP_VMSERVICE_KUBEVM_PROVIDER wiring
+pkg/kubevm/                                         — NEW: annotation constant, mutual-linkage predicate,
+  link.go, mapping.go, *_test.go, kubevm_suite_test.go  owner-reference conflict check, the down-mappings
+controllers/virtualmachine/kubevmlink/              — NEW: power-state reassertion, UpToDate condition
+controllers/controllers.go                          — gate-conditional AddToManager
+webhooks/virtualmachine/mutation/
+  virtualmachine_mutator.go                           first call in the admissionv1.Create branch
+  virtualmachine_mutator_kubevm.go                    NEW: ResolveKubeVMParentOnCreate
+  virtualmachine_mutator_kubevm_test.go               NEW, registered into the existing suite file
+webhooks/virtualmachine/validation/
+  virtualmachine_validator.go                         annotation immutability inside validateAnnotation (:2636)
+pkg/manager/manager.go                              — scheme registration in New(); CacheOptions.DisableFor entry
+test/builder/fake.go                                — NewScheme() (:108) gains the kubevm group
+config/crd/external-crds/kube-vm.io_virtualmachines.yaml + README.md — CRD for root integration tests
+config/rbac/                                        — kube-vm.io/virtualmachines and .../status
+Makefile, go.mod                                    — generate-external-manifests stanza, lint dirs, replace + require
+hack/demo/kubevm/                                   — namespace pre-flight script, ordered demo manifests, runbook
+
+external/kubevm/controller/                         — NEW module (.../external/kubevm/controller)
+  go.mod, go.sum, main.go                             replace onto ../ ; never onto the root module
+  internal/controller/virtualmachine/*.go             adoption, linkage, owner ref, finalizer, deletion ordering
+  internal/contract/contract.go                       the fixed status paths, read from unstructured
+  config/crd/, hack/tools/                            stub provider CRD and this module's envtest tooling
+```
+
+## API / CRD strategy
+
+**Additive status fields on a shipped CRD.** `constitution.md` states that additive changes are not safe once an API has shipped, citing `kubernetes/kubernetes#111703` — a client that round-trips an object through an older schema drops fields it does not know. Three things reduce that exposure here, and none of them eliminates it, which is why this is recorded as a deviation rather than waved through. The fields live on the status subresource, whose only writer is VM Operator itself, always compiled against the current schema. They are `+optional` with `omitempty`, so an object that has never been through the new code is indistinguishable from one whose VM has no address yet. And the repo already has the machinery for the remaining case: `api/v1alpha5/virtualmachine_conversion.go` uses the Cluster API `utilconversion.MarshalData` / `UnmarshalData` restore-annotation pattern (`:213`, `:243`) precisely so that v1alpha6 fields with no v1alpha5 peer survive a round trip through an older served version. The three new fields are added to that restore path in each spoke. Expect `make generate-go-conversions` to need attention before it passes — `.sdd/specs/005-ipv6-template-funcs/plan.md` documents the same class of failure, where conversion-gen emits the partial `autoConvert_` function but withholds the public `Convert_` wrapper that a containing type's generated conversion still references by name.
+
+Fields added to `v1alpha6.VirtualMachineStatus`:
+
+| Field | Type | Source today |
+|---|---|---|
+| `addresses` | list of `{interface, type, address}`, `type` one of `InternalIP`/`ExternalIP`/`InternalDNS`/`ExternalDNS` | the same data that feeds `status.network.primaryIP4` in `updateGuestNetworkStatus` (`pkg/providers/vsphere/vmlifecycle/update_status.go:1201`, assignment at :1341) |
+| `providerID` | `string` | `status.instanceUUID`, set in `reconcileStatusPlatform` (:431) from `MoVM.Summary.Config.InstanceUuid` |
+| `providerMetadata` | `map[string]string` | `uniqueID` key from `status.uniqueID`, set in the same function from `MoVM.Self.Value` |
+
+`status.addresses` is a new VM Operator-side struct that is shape-compatible with the generic API's own address type, not a reuse of it. `api/` is its own module with its own deliberately low dependency floor, and making it depend on `external/kubevm` would be a larger change than the three fields; the contract is a wire shape, not a shared Go type.
+
+`status.powerState` already exists on VM Operator with the same field name and the same three values, so it is a contract path already satisfied and needs no work.
+
+Note the tension with an existing plan in the codebase: `reconcileStatusPlatform` carries `// TODO(v1alpha6): Deprecate and migrate these fields to the Provider status`, and `status.provider` (`VirtualMachineProviderStatus`, `api/v1alpha6/virtualmachine_types.go:1408`) already exists as a home for provider-reported facts. The contract requires a fixed path that is identical across providers, so the new fields go at the top level of status, not under `status.provider`. Reconciling the two is carried as an open question in the spec.
+
+One condition-type constant is added, `VirtualMachineConditionUpToDate = "UpToDate"`. Condition types are strings, not schema, so this is not a CRD change.
+
+Down-mapping. The generic `ObjectReference` requires all three of `apiGroup`, `kind` and `name`, so a boot-disk image reference must name its group explicitly.
+
+| Generic path | Provider path | Note |
+|---|---|---|
+| `spec.powerState` | `spec.powerState` | Identical enum values. No translation. |
+| `spec.instanceType.name` | `spec.className` | `spec.instanceType.resources` is not mapped. |
+| `spec.bootDisk.source.image.kind` | `spec.image.kind` | Must be `VirtualMachineImage` or `ClusterVirtualMachineImage`, else `validateImageOnCreate` (:644) rejects. |
+| `spec.bootDisk.source.image.name` | `spec.image.name` | |
+| `spec.bootDisk.storageClassName` | `spec.storageClass` | |
+
+Contract paths the core reads on the provider object, and where each lands on the generic object:
+
+| Contract path | Generic path |
+|---|---|
+| `status.addresses` | `status.addresses` |
+| `status.powerState` | `status.powerState` |
+| `status.providerID` | `status.providerID` |
+| `status.providerMetadata` | `status.providerMetadata` |
+| `status.conditions[type=Ready]` | `Ready` and `InfrastructureReady` conditions, plus the `status.ready` boolean |
+| `status.conditions[type=UpToDate]` | `UpToDate` condition |
+
+The core is the sole writer of the generic object's status.
+
+## Controller / webhook impact
+
+**Mutating webhook.** `ResolveKubeVMParentOnCreate(ctx, client, vm)` returns immediately unless the gate is on and the annotation is present. It Gets the named generic object, refuses if that object's `spec.infrastructureRef` does not name this VM in this namespace, then fills `spec.className`, `spec.image.kind`, `spec.image.name`, `spec.storageClass` and `spec.powerState` from the parent, only where the field is empty, so a user who set a value explicitly is not silently overwritten. It is called first in the `Create` branch of `Mutate()` (`virtualmachine_mutator.go:268`), ahead of the four existing create-time mutators.
+
+Because this is a synchronous admission check with no retry, **the generic object must exist before the provider object is created.** A refusal is an `admission.Denied`, not a requeue. The demo therefore applies two manifests in order, and the runbook says so.
+
+**Validating webhook.** `validateAnnotation` (`virtualmachine_validator.go:2636`) gains a rule making `kube-vm.io/virtual-machine` immutable once set. That function returns early for a privileged account (:2650), so a privileged caller can still change it; that matches the rest of the annotation rules and is not worked around.
+
+**Status publishing.** `reconcileStatusPlatform` (`update_status.go:431`) sets `status.providerID` and `status.providerMetadata["uniqueID"]` from the values it already reads; `updateGuestNetworkStatus` (:1201) appends the `InternalIP` entry to `status.addresses` from the same source that produces `primaryIP4` at :1341. Neither is gated.
+
+**New VM Operator reconciler.** `controllers/virtualmachine/kubevmlink`, `For(&vmopv1.VirtualMachine{})` with a `Watches` on the generic `VirtualMachine` mapping back to the provider object named by `spec.infrastructureRef`. Per reconcile: confirm the gate, confirm mutual linkage, reassert `spec.powerState`, and set the `UpToDate` condition false with reason `UnsupportedByProvider` when the parent's instance type, image reference or storage class no longer match what was persisted. It registers from `controllers/controllers.go` under the gate, following the existing `if pkgcfg.FromContext(ctx).Features.VMGroups` pattern at :81. Registering the watch only under the gate matters: `[UNVERIFIED: a Watches on a CRD that is not installed is expected to leave the informer unsynced and block manager start. Confirm empirically before relying on it — if it turns out to be tolerated, gating the watch is still the right default.]`
+
+**Core controller.** `For` the generic `VirtualMachine`. Per reconcile: add finalizer `kube-vm.io/virtualmachine`, confirm mutual linkage, set the controller owner reference with an optimistic-locked patch skipped when unchanged, read the contract paths off the provider object, write the generic status, and requeue while waiting for an address. On delete: delete the provider object, wait until it is gone, then drop the finalizer. It never writes the provider object's spec and never reads it.
+
+**Feature gate.** `FeatureStates.KubeVMProvider` in `pkg/config/config.go:191`, read from `FSS_WCP_VMSERVICE_KUBEVM_PROVIDER` via `setBool` in `pkg/config/env.go`. No entry in `pkg/config/default.go`, which only sets the five gates needing a non-zero default; `false` is the zero value and the wanted default.
+
+**Requeue delay while waiting for an address.** VM Operator's existing value is `PoweredOnVMHasIPRequeueDelay`, defaulted to `10 * time.Second` at `pkg/config/default.go:47`. It is a `Config` field, not a `const`, and lives in the root module's `pkgcfg`, which the core module cannot import. The core declares its own constant with the same value and a comment naming the origin. That duplication is the price of the core not depending on the root module.
+
+**RBAC.** Root manager: `get` on `kube-vm.io/virtualmachines` for the webhook, plus `list` and `watch` for the reconciler's cache-backed `Watches`. Core controller: full verbs on `kube-vm.io/virtualmachines` and its status, plus `get;list;watch;update;patch;delete` on the provider group, granted for the demo through a namespace-scoped ServiceAccount and Role.
+
+## Test strategy
+
+- **Unit** (`testlabels.Webhook` / `testlabels.Controller`, no infrastructure label): `pkg/kubevm` covers the down-mappings, the mutual-linkage predicate, and the owner-reference conflict check. `virtualmachine_mutator_kubevm_test.go` covers resolution with the gate off, with the annotation absent, with a one-sided reference, with a parent whose fields are partly empty, and with a user-set field that must not be overwritten. `update_status.go`'s existing tests gain assertions for the three contract fields. New coverage in the mutation package goes into a `_test.go` file registered into the existing `virtualmachine_mutator_suite_test.go`, not into its legacy `_unit_test.go` / `_intg_test.go` pair.
+- **Conversion**: round-trip tests for the three new status fields through each spoke version, extending the existing per-version `conversion_test.go` files in the `api/test` module, which drive `fuzztests.FuzzTestFuncInput` from `api/test/utilconversion/fuzztests`.
+- **Integration** (`testlabels.EnvTest`): the new reconciler's suite exercises power-state reassertion, revert-on-hand-patch, and `UpToDate=False` on an unsupported edit. Root integration tests load `config/crd/bases` as parsed objects and `config/crd/external-crds` as a directory (`test/builder/test_suite.go:302` and :311), so the generic CRD must be present in the latter for any of this to run.
+- **Integration, core module**: net-new harness. There is no `setup-envtest` target in the root Makefile; envtest binaries come from `hack/tools/Makefile` and `KUBEBUILDER_ASSETS` is exported once at `Makefile:74` pointing at `hack/tools/bin/$(GOHOSTOSARCH)`. The root harness is in the root module and is not importable from `external/kubevm/controller`, so that module needs its own tools directory, its own suite bootstrap, and a stub provider CRD — the core is duck-typed, so the stub only needs the contract status paths and an annotation.
+- **E2E**: none in this change set. Explicitly scoped as a follow-up and stated in the PR summary, which `e2e-sync-with-changes.md` permits. See Complexity tracking.
+- **Demo evidence**: a recorded run of the acceptance criteria in `spec.md`, driven by scripts under `hack/demo/kubevm/`. Because both CRDs claim short name `vm` — `api/v1alpha6/virtualmachine_types.go:1561` uses `shortName=vm`, `external/kubevm/api/v1alpha1/virtualmachine_types.go:660` uses `shortName=vm;vms` — every demo command uses fully qualified resource names.
+
+## Rollout / migration
+
+- **Feature flag**: `pkgcfg.Features.KubeVMProvider`, default `false`. With the gate off, the resolution step returns immediately and the reconciler is not registered, so an empty provider spec is rejected by `validateImageOnCreate` / `validateClassOnCreate` exactly as today. The three contract status fields are populated regardless of the gate; that is the one behaviour change that ships enabled.
+- **Removal criteria**: the gate stays until the generic API has a decided permanent home, adoption of pre-existing VMs works, and the duplication between the contract fields and VM Operator's own names is resolved. A follow-up spec covers each.
+- **Schema upgrade / backfill**: none needed. The new status fields populate on the next reconcile of each VM; a VM that has not reconciled since the upgrade simply has them absent, which is indistinguishable from a VM with no address yet.
+- **Partner comms**: the release note calls out the three new status fields, since anything reading VM Operator status sees them appear. The generic API itself is a strawman with no external consumers. `external/kubevm/README.md` records that its module path will change when it moves, and root taking a dependency on it makes that move a migration rather than a mechanical rename; that trade-off should be noted in the README in the implementing PR.
+
+## Risks
+
+| # | Risk | Handling |
+|---|---|---|
+| 1 | Both APIs default `powerState` to `PoweredOn` — the generic side via `+kubebuilder:default=PoweredOn`, VM Operator via `SetDefaultPowerState` (`virtualmachine_mutator.go:672`). Absence cannot signal delegation, and a defaulted value is indistinguishable from a user-set one. | Delegation is signalled by the annotation and the mutual reference, never by a field being empty. The controller reasserts unconditionally once linkage is confirmed, so which side originated the value stops mattering after the first reconcile. |
+| 2 | Post-create edits to instance type, image or storage class cannot be applied. | Report `UpToDate=False` with reason `UnsupportedByProvider` and keep reconciling. Never halt, never make the generic fields immutable to compensate. |
+| 3 | Conversion of the three new status fields to older served versions loses them, or breaks `make generate-go-conversions`. | Add them to the `utilconversion` restore path in each spoke's `virtualmachine_conversion.go` — all five of `api/v1alpha1`–`api/v1alpha5` have that file and already call both `MarshalData` and `UnmarshalData` — with round-trip tests. Budget for the codegen failure described in the 005 plan. |
+| 4 | A cross-group Get inside an admission webhook with a cache-backed client starts an informer during a live request under `failurePolicy: Fail`. | `client.CacheOptions.DisableFor` in `pkg/manager/manager.go`, with RBAC derived from that choice. |
+| 5 | `sync.Map.Range` ordering would make a registered mutation hook run at an unpredictable point relative to the four existing create-time mutators. | Explicit call, first in the `Create` branch. |
+| 6 | Owner references are a shared list and the VMGroup controller is a second writer (`virtualmachinegroup_controller.go:428`); a plain merge patch replaces list fields wholesale with no conflict detection. | `client.MergeFromWithOptimisticLock` plus a skip-if-unchanged guard using `apiequality.Semantic.DeepEqual`. |
+| 7 | A VM that is both a group member and kubevm-owned would have two controllers writing `spec.powerState`. | Out of scope. The reconciler refuses to engage and reports it when both `spec.groupName` and the kubevm annotation are set. |
+| 8 | The provider object is deleted directly. | The core never recreates it; it reports not-adopted and waits. Intended behaviour, and an acceptance criterion. |
+| 9 | Applying both manifests at once fails, because resolution is a synchronous admission check. | Two ordered manifests, generic object first, stated in the runbook. |
+| 10 | Scheme registration missed. | Two places need it: `pkg/manager/manager.go` `New()` (:60–97) and `test/builder/fake.go` `NewScheme()` (:108). `test/builder/test_suite.go` needs no change — it builds a bare `runtime.NewScheme()` at :405 and hands it to `pkgmgr.New`, which does the registration. |
+| 11 | The core module's envtest harness is net-new and easy to under-build. | Own `hack/tools`, own `setup-envtest`, own suite bootstrap, stub provider CRD. Its own task. |
+| 12 | The generic CRD is generated into `external/kubevm/config/crd/bases/` by the sub-module's own Makefile and is absent from `config/crd/external-crds/`, so root integration tests cannot see it. | New stanza in root `generate-external-manifests`, plus an entry in `config/crd/external-crds/README.md` under "Integration Test CRDs". The root stanzas use `paths=github.com/vmware-tanzu/vm-operator/external/<x>/...`, which only resolves once the module is in root `go.mod`. |
+| 13 | CI does not cover the new module. `GO_MOD_DIRS_TO_LINT` already adds `./external/kubevm/` (Makefile:322–325), but no GitHub workflow iterates sub-modules — `ci.yml`'s `build-image` job matrices over `.` and `test/e2e` only, and its `test` job matrices over packages within the root module. | Add the controller module to `GO_MOD_DIRS_TO_LINT` and add a `ci.yml` job that builds and tests it. Without the second, the module is unverified in CI. |
+| 14 | `kubectl get vm` is ambiguous once both CRDs are installed. | Fully qualified resource names in every demo command and script. |
+| 15 | **Demo environment. The largest risk, and a gate on the work.** Needs a Supervisor where a CRD can be installed, the gate can be enabled, and the core controller can run out-of-cluster against a namespace that already has a working VM class, ready image and associated storage class. | Confirm the environment before any demo-recording task starts; the spec carries this as a `[NEEDS CLARIFICATION]`. `vcsim` is not a fallback: it is root-module in-process Ginkgo, cannot be driven with kubectl, and its VMs run no guest, so no address is ever reported. |
+| 16 | A namespace that looks usable but is not, since most of these failures are asynchronous rather than at admission. | A pre-flight script. Verified: storage-class-to-namespace association *is* an admission check (`validateStorageFields`, :756, via `spqutil.IsStoragePolicyInNamespace`); image-name resolvability *is* checked, in the mutating webhook (`ResolveImageNameOnCreate`, :751, via `vmopv1util.ResolveImageName`, which resolves both namespaced `VirtualMachineImage` and cluster-scoped `ClusterVirtualMachineImage` and records the kind). But VM class existence is *not* — it surfaces later as `VirtualMachineClassReady=False`. Image readiness likewise surfaces as `VirtualMachineImageReady=False`, and default-network resolution happens in `AddDefaultNetworkInterface` (:567). The pre-flight must Get the class and check image readiness itself. |
+| 17 | Running the core controller with a cluster-admin kubeconfig makes it a privileged account. Twelve validator call sites branch on `ctx.IsPrivilegedAccount`, several of which *remove* checks a DevOps user would hit. | Prefer a namespace-scoped ServiceAccount; otherwise state the caveat on the recording. Carried as a `[NEEDS CLARIFICATION]` in the spec. |
+
+## Sequencing
+
+An ordered list a later agent can turn into `tasks.md`. Phase boundaries are where a reviewer can stop and see something work.
+
+**Phase 1 — Setup.** Confirm the demo environment (blocks Phase 5 only). Add `replace` and `require` for `external/kubevm` to the root `go.mod`. Register the generic scheme in `pkg/manager/manager.go` `New()` and in `test/builder/fake.go` `NewScheme()`, and add the type to `client.CacheOptions.DisableFor`. Add a kubevm stanza to root `generate-external-manifests`, copy the CRD into `config/crd/external-crds/`, and document it in that directory's README. Delete the orphan `+kubebuilder:validation:Enum=Pending;Provisioning;...` marker at `external/kubevm/api/v1alpha1/common_types.go:82`, which is attached to no type and generates nothing.
+
+**Phase 2 — Contract status fields.** Add `status.addresses`, `status.providerID` and `status.providerMetadata` to `v1alpha6.VirtualMachineStatus` plus the `VirtualMachineConditionUpToDate` constant; regenerate deepcopy, conversions and CRD manifests; add the three fields to each spoke's conversion restore path with round-trip tests; populate them in `reconcileStatusPlatform` and `updateGuestNetworkStatus` with unit-test assertions. This phase stands alone and can merge before anything else in this spec.
+
+**Phase 3 — Foundational.** Add `FeatureStates.KubeVMProvider`, its `env.VarName`, and its `setBool` wiring. Create `pkg/kubevm` with the annotation constant, the mutual-linkage predicate, the owner-reference conflict check, and the down-mappings, with unit tests. Add RBAC markers.
+
+**Phase 4 — VM Operator side.** Add `ResolveKubeVMParentOnCreate` and call it first in the `Create` branch of `Mutate()`, with tests in a new file registered into the existing mutation suite. Add annotation immutability to `validateAnnotation`, with tests. Add the `controllers/virtualmachine/kubevmlink` reconciler — power-state reassertion, `UpToDate` reporting, group-member refusal — register it under the gate in `controllers/controllers.go`, and cover it with unit and envtest specs. At the end of this phase, a hand-created generic object plus an empty-spec provider object produces a working VM, with nothing on the generic side yet doing adoption.
+
+**Phase 5 — Core controller.** Create the `external/kubevm/controller` module: `go.mod` with a `replace` onto the API module, `main.go`, `internal/contract` with the fixed paths, and the reconciler (finalizer, mutual-linkage check, owner reference, status from contract paths, requeue-for-address, ordered deletion). Build its envtest harness. Add the module to `GO_MOD_DIRS_TO_LINT` and to `ci.yml`. At the end of this phase the full lifecycle works end to end.
+
+**Phase 6 — Demo.** Write the namespace pre-flight script (class present; image present, `Ready`, and its kind recorded; storage class associated with the namespace; default network resolvable; relevant gates on). Write the ordered demo manifests and the runbook, using fully qualified resource names. Record the demo: create, address, power cycle, delete.
+
+**Phase Final — Polish.** Amend `constitution.md`: add `external/kubevm` and `external/kubevm/controller` to the sub-modules table, and correct the repo-layout description of `external/` so it no longer claims the directory holds only vendored API definitions. Note the module-path move in `external/kubevm/README.md`. File follow-up specs for E2E coverage, for resolving the duplication between the contract status fields and VM Operator's own names, and for adoption of pre-existing VMs.
+
+## Complexity tracking
+
+| Violation | Why needed | Simpler alternative rejected because |
+|-----------|------------|--------------------------------------|
+| `constitution.md` "API compatibility": three optional status fields are added to a shipped CRD, where the rule is that additive changes are not safe once an API has shipped. | The generic core must read one fixed set of paths for every provider, or it stops being generic. Cluster API's `internal/contract` package works exactly this way, with no per-provider adapter in core. VM Operator reports the same facts today under its own names, so the only way to satisfy the contract without putting VM Operator knowledge into the core is to publish at the contract paths. | Teaching the core to read `status.network.primaryIP4`, `status.instanceUUID` and `status.uniqueID` was rejected: it puts one provider's field names into the component whose whole purpose is not to have them, and every future provider would add another branch. Having VM Operator write the generic object's status directly was rejected because it creates a second writer on a subresource the core also owns, and it moves the adapter into a controller instead of into fields. A new API version was rejected as disproportionate for three optional, controller-written status fields on a version that is still the development hub, and the repo's existing `utilconversion` restore-annotation pattern already covers the round-trip case the rule is protecting against. |
+| `operator-best-practices.md` anti-pattern 2, "controllers should only modify Status": the VM Operator reconciler writes `spec.powerState` on the provider object, and the mutating webhook writes four more spec fields. | The delegated values have to be visible on the provider object; `kubectl get -o yaml` must be truthful about what the VM was built from, and other tooling reads the object rather than recomputing it. Three of the five fields are immutable after create in VM Operator, so there is no post-create window in which to apply them. The precedent already exists and was accepted for the same reason: `updateMemberPowerState` (`virtualmachinegroup_controller.go:840`) assigns `obj.Spec.PowerState = group.Spec.PowerState` at :850 and persists it with `client.MergeFrom` at :426. | Resolving the values in memory on the provider's read path was rejected: the object on the API server would then disagree with the VM that was actually built, which is the failure mode that makes a delegated API hard to debug. Putting the values only on the generic object and teaching every VM Operator read path to consult the parent was rejected as a far larger blast radius than a webhook plus one reconciler. |
+| `constitution.md` "Testing": E2E coverage does not ship in the same PR. | The delegation behaviour is gated off, so the only thing observable on a Supervisor at merge is three newly populated status fields, whose correctness is covered by unit and conversion tests. `e2e-sync-with-changes.md` permits deferral when the team explicitly scopes E2E as follow-up and says so in the PR summary, which this plan does. E2E for the gated behaviour also needs a testbed with the generic CRD installed and the gate on, which no CI testbed has today. | Writing E2E specs that skip unconditionally on every current testbed was rejected: an always-skipped spec is not coverage and would be rewritten once a capable testbed exists. Holding the whole change set until a testbed exists was rejected because it blocks the demo that is the point of the spec. |
+| `constitution.md` "Webhooks": annotation immutability is enforced in Go rather than CEL. | The rule is "immutable once non-empty" on one key inside `metadata.annotations`, which CEL expresses awkwardly, and `validateAnnotation` (:2636) already owns annotation rules. | A CEL transition rule on the annotation map was rejected because it would also have to permit every other annotation to change freely, and splitting annotation validation across CEL and Go makes the next annotation rule harder to place. |

--- a/.sdd/specs/006-vmop-kubevm-provider/spec.md
+++ b/.sdd/specs/006-vmop-kubevm-provider/spec.md
@@ -1,0 +1,85 @@
+# Feature Specification: VM Operator as a KubeVM provider
+
+- **Feature branch**: [`vmop-kubevm-provider`](../../..)
+  - **Fork**: N/A
+  - **PR target**: `vmware-tanzu/vm-operator`
+- **Created**: 2026-08-31
+- **Status**: Draft
+- **Epic**: TBD
+- **Design docs**: `external/kubevm/docs/one-pager-kubevm-generic-api.md`
+
+---
+
+A user drives a VM's whole lifecycle — create, get an address, power off, power on, delete — through the generic `kube-vm.io/v1alpha1` `VirtualMachine` object, with VM Operator's own `VirtualMachine` acting as the provider object behind it. A minimal field set only. The acceptance evidence is a short recorded demo on a Supervisor.
+
+## Goals
+
+- MUST let a DevOps user create a generic `VirtualMachine` that names a VM Operator `VirtualMachine` as its infrastructure object, and have the VM come up without the user setting a VM class, image, or storage class on the provider object.
+- MUST make the generic object the single place the user edits for the delegated fields. A change to the generic object's desired power state MUST reach the backend VM; a hand-edit of the same field on the provider object MUST be reverted.
+- MUST report the backend VM's observed state on the generic object: its address, its power state, its platform identifier, and whether it is ready.
+- MUST have VM Operator publish that observed state on its own object at the fixed field paths the generic status contract defines, so the generic core reads the same paths for every provider and contains no VM Operator-specific code.
+- MUST require both objects to name each other before any of this engages. A generic object that points at a provider object which does not point back MUST NOT cause adoption and MUST NOT cause any write to the provider object.
+- MUST persist the delegated values in the provider object's spec, so that reading the provider object shows what the VM was actually built from.
+- MUST accept a post-create edit to a generic field that the provider cannot apply, report that it was not applied with reason `UnsupportedByProvider`, and keep reconciling everything else.
+- MUST be off by default. The delegation behaviour engages only when a feature gate is enabled and mutual linkage is confirmed.
+- MUST leave every existing VM Operator behaviour unchanged when the gate is off or when a VM Operator `VirtualMachine` has no generic owner.
+
+## Non-goals
+
+- Does not support the full generic API. Only the four spec values and four status values listed under "Delegated fields" are mapped. Every other generic field is ignored in this iteration; nothing is silently approximated.
+- Does not support adoption of a pre-existing VM Operator `VirtualMachine` that was created before the generic object. Both objects are created together in this iteration. The intended future mechanism is an explicit annotation gesture on the existing provider object plus an import step that back-fills the generic object's spec at create time, so the generic spec is truthful about a VM it did not provision.
+- Does not apply post-create edits to the generic fields that map onto VM Operator fields which are immutable after create — sizing, image, and storage class. Such an edit is accepted by the API and reported as not applied. The generic fields are deliberately **not** made immutable to compensate, because a future VM Operator that can resize should not require an API break to allow the edit.
+- Does not recreate a provider object that the user deletes directly. The generic object reports that it has no adopted infrastructure and waits.
+- Does not add data disks, additional network interfaces, static addressing, cloud-init bootstrap, SSH keys, tags, failure domains, or spot scheduling.
+- Does not add a second reconciler for suspend. `Suspended` is a legal value in both APIs and passes through, but is not part of the demo or the acceptance criteria.
+- Does not introduce a provider-specific API group (for example `infrastructure.vsphere.kube-vm.io`). VM Operator's existing `vmoperator.vmware.com` `VirtualMachine` is the provider object.
+- Does not remove or rename any existing VM Operator status field. The contract fields are added alongside the ones that carry the same information under VM Operator's own names today.
+- Does not ship E2E coverage in the same change set. E2E is explicitly scoped as a follow-up and is stated as such in the PR summary.
+
+## Delegated fields
+
+The generic object owns four values. The user sets them there and nowhere else.
+
+| Generic spec path | Applied |
+|---|---|
+| `spec.powerState` | On every reconcile, for as long as the objects are linked |
+| `spec.instanceType.name` | Once, when the VM is created |
+| `spec.bootDisk.source.image` (its kind and name) | Once, when the VM is created |
+| `spec.bootDisk.storageClassName` | Once, when the VM is created |
+
+Power state values are spelled identically in both APIs (`PoweredOn`, `PoweredOff`, `Suspended`), so a user sees the same word wherever they look.
+
+The generic object reports four values back, plus readiness: the guest's address as an entry of type `InternalIP` in `status.addresses`, the observed power state in `status.powerState`, the platform's identifier for the VM in `status.providerID`, any further provider-reported facts in `status.providerMetadata`, and readiness as both the `Ready` condition and the `status.ready` boolean.
+
+## Scope note: this adds fields to a published VM Operator API
+
+The generic core must not contain provider-specific code, so the observed values above are read from fixed contract paths that every provider surfaces on its own object. VM Operator reports the same information today under its own names, so it gains new, optional, additive status fields at the contract paths: `status.addresses`, `status.providerID`, and `status.providerMetadata`. These are written by VM Operator's normal status reconciliation, are not gated, and duplicate information already present elsewhere in the same status. This is an API change to a shipped CRD and is treated as one — see `plan.md`.
+
+## User stories / acceptance criteria
+
+### DevOps user
+
+- **Given** a namespace with a working VM class, a ready image, and an associated storage class, **when** the user applies a generic `VirtualMachine` carrying only a power state, an instance type name, a boot disk image reference and a storage class name, followed by a VM Operator `VirtualMachine` in the same namespace whose spec is empty and which carries the back-reference annotation, **then** the VM is created and both objects report ready.
+- **Given** that VM, **when** the user reads the provider object, **then** its spec shows the class, image and storage class the VM was built from — not an empty spec.
+- **Given** that VM, **when** the user reads the generic object's status, **then** it carries the VM's address as an `InternalIP` entry, its observed power state, its platform identifier, and `ready: true`.
+- **Given** that VM, **when** the user sets the generic object's desired power state to `PoweredOff`, **then** the backend VM powers off and both objects report the new observed power state; **and when** the user sets it back to `PoweredOn`, **then** the VM powers on again.
+- **Given** that VM, **when** the user hand-edits the desired power state on the provider object only, **then** the value is restored to the generic object's value on the next reconcile.
+- **Given** that VM, **when** the user changes the instance type name on the generic object, **then** the request is accepted, the backend VM is unchanged, and the generic object reports `UpToDate` false with reason `UnsupportedByProvider` — reconciliation of everything else continues.
+- **Given** that VM, **when** the user deletes the generic object, **then** the provider object and the backend VM are deleted, and the generic object goes away only after the provider object has gone.
+- **Given** that VM, **when** the user deletes the provider object directly, **then** the generic object reports that it has no adopted infrastructure and waits; nothing is recreated.
+- **Given** a generic object that names a provider object which does not carry the back-reference annotation, **when** the user applies it, **then** nothing is adopted, no field on the provider object is written, and the generic object says why it is waiting.
+- **Given** a provider object that carries the back-reference annotation, **when** the user tries to change that annotation to name a different generic object, **then** the change is rejected.
+- **Given** a provider object already owned by one generic object, **when** a second generic object names it, **then** the second generic object refuses to adopt it and says so.
+
+### Platform engineer
+
+- **Given** the feature gate is off, **when** a generic `VirtualMachine` and a matching provider object are applied, **then** no field on the provider object's spec is written by anyone and the existing VM Operator behaviour is unchanged — an empty provider spec fails VM Operator's own create-time validation exactly as it does today.
+- **Given** the feature gate is off, **when** any VM Operator `VirtualMachine` is created and operated normally, **then** its behaviour is unchanged in every respect except that its status also reports the address, platform identifier and provider metadata at the contract paths.
+- **Given** a VM Operator `VirtualMachine` read through an older API version, **when** the contract status fields are populated, **then** they survive a round trip back to the current version rather than being silently lost.
+
+## Open questions
+
+- [NEEDS CLARIFICATION: Demo environment. This work needs a Supervisor where a new CRD can be installed, the feature gate can be turned on, and the generic controller can be run out-of-cluster against a namespace that already has a working VM class, ready image, and associated storage class. Until an environment meeting all of those is confirmed, the demo-recording work cannot start. There is no acceptable fallback: the in-process vSphere simulator harness cannot be driven with kubectl and its VMs run no guest, so no address is ever reported.]
+- [NEEDS CLARIFICATION: Whether the generic controller should run under a namespace-scoped ServiceAccount for the demo. Running it with a cluster-admin kubeconfig makes it a privileged account, which bypasses validations a normal DevOps user would hit, so the demo would not demonstrate the user's actual experience. A namespace-scoped ServiceAccount is preferred; if the environment cannot provide one, the caveat has to be stated on the recording.]
+- [NEEDS CLARIFICATION: Whether the contract status fields should eventually replace VM Operator's existing equivalents rather than sit beside them. There is already a `TODO(v1alpha6)` in the status reconciler proposing that the existing identifier fields migrate into a provider sub-struct, which pulls in the opposite direction. Deciding this is out of scope here but should not be left open indefinitely, because three fields reporting the same fact is a maintenance cost.]
+- [NEEDS CLARIFICATION: Whether the generic object's image reference kind — namespaced `VirtualMachineImage` versus cluster-scoped `ClusterVirtualMachineImage` — should be validated at admission on the generic side. The generic boot disk source is immutable, so a user who names the wrong kind has to delete and recreate the generic object. Deferred, because the generic API server cannot resolve a provider-owned kind without importing provider code.]

--- a/.sdd/specs/006-vmop-kubevm-provider/tasks.md
+++ b/.sdd/specs/006-vmop-kubevm-provider/tasks.md
@@ -1,0 +1,109 @@
+# Tasks: VM Operator as a KubeVM provider
+
+- **Spec**: [`spec.md`](./spec.md)
+- **Plan**: [`plan.md`](./plan.md)
+- **Epic**: [TICKET NEEDED]
+
+## Phase 1 — Demo environment and namespace pre-flight
+
+- [ ] T001 [TICKET NEEDED] Confirm and record a Supervisor demo environment where a new CRD can be installed, `FSS_WCP_VMSERVICE_KUBEVM_PROVIDER` can be set, and an out-of-cluster controller can reach the API server, naming the cluster and namespace (`hack/demo/kubevm/README.md`)
+- [ ] T002 [TICKET NEEDED] Decide whether the core controller runs under a namespace-scoped ServiceAccount or a cluster-admin kubeconfig for the demo, and record the decision and the RBAC it implies, resolving the second spec open question (`hack/demo/kubevm/README.md`)
+- [ ] T003 [TICKET NEEDED] Write `preflight.sh` with a check that Gets the named `VirtualMachineClass` in the namespace and fails when it is absent, since class existence is not an admission check (`hack/demo/kubevm/preflight.sh`)
+- [ ] T004 [TICKET NEEDED] Add a pre-flight check that resolves the image name to either a namespaced `VirtualMachineImage` or a cluster-scoped `ClusterVirtualMachineImage`, asserts its `Ready` condition is true, and prints the resolved kind (`hack/demo/kubevm/preflight.sh`)
+- [ ] T005 [TICKET NEEDED] Add a pre-flight check that the named storage class has a storage policy associated with the namespace, matching what `validateStorageFields` enforces at admission (`hack/demo/kubevm/preflight.sh`)
+- [ ] T006 [TICKET NEEDED] Add a pre-flight check that a default network is resolvable in the namespace for the configured network provider, matching what `AddDefaultNetworkInterface` does at admission (`hack/demo/kubevm/preflight.sh`)
+- [ ] T007 [TICKET NEEDED] Add a pre-flight step that prints the enabled VM Operator feature gates read from the deployment environment (`hack/demo/kubevm/preflight.sh`)
+- [ ] T008 [TICKET NEEDED] Run the pre-flight script against the demo namespace and record the resolved image kind in the environment notes, because the generic `bootDisk.source` is immutable and a wrong kind requires recreating the generic object (`hack/demo/kubevm/README.md`)
+
+## Phase 2 — Contract status fields on `vmoperator.vmware.com/v1alpha6`
+
+- [ ] T009 [TICKET NEEDED] Add a `VirtualMachineAddress` struct with `interface`, `type` and `address` fields and an `InternalIP;ExternalIP;InternalDNS;ExternalDNS` enum marker on `type` (`api/v1alpha6/virtualmachine_types.go`)
+- [ ] T010 [TICKET NEEDED] Add optional `Addresses []VirtualMachineAddress`, `ProviderID string` and `ProviderMetadata map[string]string` fields to `VirtualMachineStatus` (`api/v1alpha6/virtualmachine_types.go`)
+- [ ] T011 [TICKET NEEDED] Add the `VirtualMachineConditionUpToDate = "UpToDate"` condition-type constant (`api/v1alpha6/virtualmachine_types.go`)
+- [ ] T012 [TICKET NEEDED] Run `make generate` and commit the regenerated deepcopy and CRD manifest (`api/v1alpha6/zz_generated.deepcopy.go`, `config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml`)
+- [ ] T013 [TICKET NEEDED] Run `make generate-go-conversions` and confirm each spoke's existing hand-written `Convert_v1alpha6_VirtualMachineStatus_To_v1alphaN_VirtualMachineStatus` wrapper still compiles against the regenerated `autoConvert_` function (`api/v1alpha1/virtualmachine_conversion.go`, `api/v1alpha2/virtualmachine_conversion.go`, `api/v1alpha3/virtualmachine_conversion.go`, `api/v1alpha4/virtualmachine_conversion.go`, `api/v1alpha5/virtualmachine_conversion.go`)
+- [ ] T014 [TICKET NEEDED] Confirm each spoke's `ConvertTo` restores the three fields through its existing `dst.Status = restored.Status` assignment and record that no per-field restore code is needed (`api/v1alpha1/virtualmachine_conversion.go`, `api/v1alpha2/virtualmachine_conversion.go`, `api/v1alpha3/virtualmachine_conversion.go`, `api/v1alpha4/virtualmachine_conversion.go`, `api/v1alpha5/virtualmachine_conversion.go`)
+- [ ] T015 [TICKET NEEDED] Run each spoke's whole-object `SpokeHubSpoke` and `HubSpokeHub` fuzz round-trip and confirm the three new status fields survive, adding a fuzzer override only if one fails (`api/test/v1alpha1/conversion_test.go`, `api/test/v1alpha2/conversion_test.go`, `api/test/v1alpha3/conversion_test.go`, `api/test/v1alpha4/conversion_test.go`, `api/test/v1alpha5/conversion_test.go`)
+- [ ] T016 [TICKET NEEDED] Set `status.providerID` from `MoVM.Summary.Config.InstanceUuid` and `status.providerMetadata["uniqueID"]` from `MoVM.Self.Value` in `reconcileStatusPlatform`, ungated (`pkg/providers/vsphere/vmlifecycle/update_status.go`)
+- [ ] T017 [TICKET NEEDED] Populate a single `InternalIP` entry in `status.addresses` in `updateGuestNetworkStatus` from the same value that produces `status.network.primaryIP4`, ungated (`pkg/providers/vsphere/vmlifecycle/update_status.go`)
+- [ ] T018 [TICKET NEEDED] Add unit assertions for `status.providerID`, `status.providerMetadata` and `status.addresses` to the existing status tests (`pkg/providers/vsphere/vmlifecycle/update_status_test.go`)
+- [ ] T019 [TICKET NEEDED] Run `make verify-codegen`, `make lint-go-full` and the `api` and `vmprovider-vmlifecycle` test targets on this phase alone to confirm it merges independently (`Makefile`)
+
+## Phase 3 — Feature gate, scheme registration and module wiring
+
+- [ ] T020 [TICKET NEEDED] Add `KubeVMProvider bool` to `FeatureStates` with no entry in `default.go`, so the zero value is the default (`pkg/config/config.go`)
+- [ ] T021 [TICKET NEEDED] Add the `FSS_WCP_VMSERVICE_KUBEVM_PROVIDER` variable name (`pkg/config/env/env.go`)
+- [ ] T022 [TICKET NEEDED] Wire the variable to `Features.KubeVMProvider` with `setBool` (`pkg/config/env.go`)
+- [ ] T023 [TICKET NEEDED] Add a test asserting the new variable name and its default-off behaviour (`pkg/config/env/env_test.go`)
+- [ ] T024 [TICKET NEEDED] Add the `replace` and `require` entries for `github.com/vmware-tanzu/vm-operator/external/kubevm` using the zero-pseudo-version pattern, in the same change as the first import so `go mod tidy` does not drop them (`go.mod`)
+- [ ] T025 [TICKET NEEDED] Register `kubevmv1a1.AddToScheme` in `pkg/manager/manager.go` `New()` and add the generic `VirtualMachine` to `client.CacheOptions.DisableFor` under the same condition, because `newClient` resolves a GVK for every `DisableFor` entry and errors on a type absent from the scheme (`pkg/manager/manager.go`)
+- [ ] T026 [TICKET NEEDED] Confirm the root integration suite starts the manager with the gate both off and on, exercising the scheme and `DisableFor` coupling through the existing `pkgmgr.New` call (`test/builder/test_suite.go`)
+- [ ] T027 [TICKET NEEDED] Add the kubevm group to `NewScheme()` (`test/builder/fake.go`)
+- [ ] T028 [TICKET NEEDED] Add the generic `VirtualMachine` to `KnownObjectTypes()` so the fake client enforces the spec/status split on it (`test/builder/fake.go`)
+- [ ] T029 [TICKET NEEDED] Add a `generate-external-manifests` stanza with `paths=github.com/vmware-tanzu/vm-operator/external/kubevm/...` (`Makefile`)
+- [ ] T030 [TICKET NEEDED] Run the new stanza and commit the generated generic CRD (`config/crd/external-crds/kube-vm.io_virtualmachines.yaml`)
+- [ ] T031 [TICKET NEEDED] Add the generic CRD to the "Integration Test CRDs" list (`config/crd/external-crds/README.md`)
+- [ ] T032 [TICKET NEEDED] Add RBAC markers for `get` on `kube-vm.io/virtualmachines` for the webhook and `list;watch` for the reconciler, and regenerate the role (`config/rbac/role.yaml`)
+
+## Phase 4 — `pkg/kubevm` helpers
+
+- [ ] T033 [TICKET NEEDED] Add the `kube-vm.io/virtual-machine` annotation key constant (`pkg/kubevm/link.go`)
+- [ ] T034 [TICKET NEEDED] Add a mutual-linkage predicate that returns true only when the provider object's annotation names the generic object and the generic object's `spec.infrastructureRef` names the provider object by group, kind and name in the same namespace (`pkg/kubevm/link.go`)
+- [ ] T035 [TICKET NEEDED] Add an owner-reference conflict check that reports when the provider object already carries a controller owner reference naming a different generic object (`pkg/kubevm/link.go`)
+- [ ] T036 [TICKET NEEDED] Add the down-mapping functions for `instanceType.name` to `className`, `bootDisk.source.image` kind and name to `spec.image`, `bootDisk.storageClassName` to `spec.storageClass`, and `powerState` to `spec.powerState` (`pkg/kubevm/mapping.go`)
+- [ ] T037 [TICKET NEEDED] Add the suite bootstrap for the package (`pkg/kubevm/kubevm_suite_test.go`)
+- [ ] T038 [TICKET NEEDED] Add unit tests for the linkage predicate, the conflict check and the down-mappings (`pkg/kubevm/kubevm_test.go`)
+
+## Phase 5 — VM Operator side
+
+- [ ] T039 [TICKET NEEDED] Spike: start a manager in envtest with a `Watches` on the generic `VirtualMachine` while the CRD is absent, observe whether the manager blocks on cache sync or starts, and record the result and whether the watch stays gate-conditional (`.sdd/specs/006-vmop-kubevm-provider/research.md`)
+- [ ] T040 [TICKET NEEDED] Add `ResolveKubeVMParentOnCreate` that returns immediately unless the gate is on and the annotation is present, Gets the named generic object, refuses when its `spec.infrastructureRef` does not name this VM in this namespace, and otherwise fills `spec.className`, `spec.image.kind`, `spec.image.name`, `spec.storageClass` and `spec.powerState` only where empty (`webhooks/virtualmachine/mutation/virtualmachine_mutator_kubevm.go`)
+- [ ] T041 [TICKET NEEDED] Call `ResolveKubeVMParentOnCreate` first in the `admissionv1.Create` branch of `Mutate()`, ahead of `AddDefaultNetworkInterface`, as a direct call rather than a `MutateOnCreateFuncs` entry (`webhooks/virtualmachine/mutation/virtualmachine_mutator.go`)
+- [ ] T042 [TICKET NEEDED] Add unit tests for resolution with the gate off, the annotation absent, a one-sided reference, a parent with partly empty fields, and a user-set field that must not be overwritten, in a new file registered into the existing suite (`webhooks/virtualmachine/mutation/virtualmachine_mutator_kubevm_test.go`, `webhooks/virtualmachine/mutation/virtualmachine_mutator_suite_test.go`)
+- [ ] T043 [TICKET NEEDED] Add a rule to `validateAnnotation` making `kube-vm.io/virtual-machine` immutable once set for non-privileged callers (`webhooks/virtualmachine/validation/virtualmachine_validator.go`)
+- [ ] T044 [TICKET NEEDED] Add unit tests for the annotation immutability rule, including the privileged-account bypass, in a new file registered into the existing suite (`webhooks/virtualmachine/validation/virtualmachine_validator_kubevm_test.go`, `webhooks/virtualmachine/validation/virtualmachine_validator_suite_test.go`)
+- [ ] T045 [TICKET NEEDED] Add the reconciler skeleton with `For(&vmopv1.VirtualMachine{})`, `AddToManager`, and a `Watches` on the generic `VirtualMachine` mapping to the provider object named by `spec.infrastructureRef` (`controllers/virtualmachine/kubevmlink/kubevmlink_controller.go`)
+- [ ] T046 [TICKET NEEDED] Reassert `spec.powerState` from the generic object on every reconcile once mutual linkage is confirmed, persisted with `client.MergeFrom` (`controllers/virtualmachine/kubevmlink/kubevmlink_controller.go`)
+- [ ] T047 [TICKET NEEDED] Set `UpToDate=False` with reason `UnsupportedByProvider` when the generic object's instance type, image reference or storage class no longer match the values persisted in the provider spec, and keep reconciling (`controllers/virtualmachine/kubevmlink/kubevmlink_controller.go`)
+- [ ] T048 [TICKET NEEDED] Refuse to engage and report it when the VM has both `spec.groupName` and the kubevm annotation set (`controllers/virtualmachine/kubevmlink/kubevmlink_controller.go`)
+- [ ] T049 [TICKET NEEDED] Register the reconciler under `Features.KubeVMProvider` (`controllers/controllers.go`)
+- [ ] T050 [TICKET NEEDED] Add the suite bootstrap for the reconciler package (`controllers/virtualmachine/kubevmlink/kubevmlink_controller_suite_test.go`)
+- [ ] T051 [TICKET NEEDED] Add unit tests labelled `testlabels.Controller` for gate-off, one-sided linkage, power-state reassertion and the group-member refusal (`controllers/virtualmachine/kubevmlink/kubevmlink_controller_test.go`)
+- [ ] T052 [TICKET NEEDED] Add integration specs labelled `testlabels.EnvTest` for power-state reassertion, revert of a hand-patched provider power state, and `UpToDate=False` on an unsupported edit (`controllers/virtualmachine/kubevmlink/kubevmlink_controller_test.go`)
+
+## Phase 6 — Core controller module
+
+- [ ] T053 [TICKET NEEDED] Spike: search `external/kubevm` for a contract-version label key, check what the one-pager specifies, and record whether the core resolves the provider version from a CRD label or from the RESTMapper's preferred version in this iteration (`.sdd/specs/006-vmop-kubevm-provider/research.md`)
+- [ ] T054 [TICKET NEEDED] Create the module with a `replace` onto `../` and no dependency on the root module (`external/kubevm/controller/go.mod`, `external/kubevm/controller/go.sum`)
+- [ ] T055 [TICKET NEEDED] Add the fixed contract status paths and unstructured readers for `status.addresses`, `status.powerState`, `status.providerID`, `status.providerMetadata` and the `Ready` and `UpToDate` conditions (`external/kubevm/controller/internal/contract/contract.go`)
+- [ ] T056 [TICKET NEEDED] Add unit tests for the contract readers against an `unstructured.Unstructured` fixture (`external/kubevm/controller/internal/contract/contract_test.go`)
+- [ ] T057 [TICKET NEEDED] Add `main.go` that builds a manager, registers the generic scheme, and starts the reconciler (`external/kubevm/controller/main.go`)
+- [ ] T058 [TICKET NEEDED] Add the reconciler with `For` the generic `VirtualMachine` and the `kube-vm.io/virtualmachine` finalizer (`external/kubevm/controller/internal/controller/virtualmachine/virtualmachine_controller.go`)
+- [ ] T059 [TICKET NEEDED] Resolve the provider object's group-version-kind from `spec.infrastructureRef` using the decision recorded in T053 and Get it as `unstructured`, never creating it (`external/kubevm/controller/internal/controller/virtualmachine/virtualmachine_controller.go`)
+- [ ] T060 [TICKET NEEDED] Confirm mutual linkage and refuse adoption when the provider object already carries a controller owner reference naming a different generic object (`external/kubevm/controller/internal/controller/virtualmachine/virtualmachine_controller.go`)
+- [ ] T061 [TICKET NEEDED] Set the controller owner reference with `client.MergeFromWithOptions(base, client.MergeFromWithOptimisticLock{})`, skipped when `apiequality.Semantic.DeepEqual` reports the list unchanged (`external/kubevm/controller/internal/controller/virtualmachine/virtualmachine_controller.go`)
+- [ ] T062 [TICKET NEEDED] Write the generic status from the contract paths, including `status.ready`, the `Ready` and `InfrastructureReady` conditions, `UpToDate`, and `observedGeneration` (`external/kubevm/controller/internal/controller/virtualmachine/virtualmachine_controller.go`)
+- [ ] T063 [TICKET NEEDED] Add a package constant of 10 seconds for the requeue delay while waiting for an address, with a comment naming `PoweredOnVMHasIPRequeueDelay` as its origin (`external/kubevm/controller/internal/controller/virtualmachine/virtualmachine_controller.go`)
+- [ ] T064 [TICKET NEEDED] Delete the provider object on generic-object deletion and drop the finalizer only after the provider object is gone (`external/kubevm/controller/internal/controller/virtualmachine/virtualmachine_controller.go`)
+- [ ] T065 [TICKET NEEDED] Add the module's own envtest tooling with a `setup-envtest` target and `KUBEBUILDER_ASSETS` export (`external/kubevm/controller/hack/tools/Makefile`, `external/kubevm/controller/Makefile`)
+- [ ] T066 [TICKET NEEDED] Add a stub provider CRD carrying only the contract status paths and the linkage annotation, for the module's envtest environment (`external/kubevm/controller/config/crd/stub-provider.yaml`)
+- [ ] T067 [TICKET NEEDED] Add the module's suite bootstrap loading both the generic CRD and the stub provider CRD (`external/kubevm/controller/internal/controller/virtualmachine/virtualmachine_controller_suite_test.go`)
+- [ ] T068 [TICKET NEEDED] Add integration specs labelled `testlabels.EnvTest` for adoption on mutual linkage, no write on a one-sided reference, status mirrored from the contract paths, refusal on an existing conflicting controller owner reference, no recreation when the provider object is deleted directly, and ordered deletion (`external/kubevm/controller/internal/controller/virtualmachine/virtualmachine_controller_test.go`)
+- [ ] T069 [TICKET NEEDED] Add `./external/kubevm/controller/` to `GO_MOD_DIRS_TO_LINT`, which the `filter-out ./external%` rule otherwise excludes (`Makefile`)
+- [ ] T070 [TICKET NEEDED] Add a CI job that builds, lints and tests the new module, since the existing `build-image` and `test` matrices cover only the root module and `test/e2e` (`.github/workflows/ci.yml`)
+
+## Phase 7 — Demo
+
+- [ ] T071 [TICKET NEEDED] Write the generic `VirtualMachine` manifest, applied first, using the image kind recorded in T008 (`hack/demo/kubevm/01-generic-vm.yaml`)
+- [ ] T072 [TICKET NEEDED] Write the empty-spec provider `VirtualMachine` manifest carrying the back-reference annotation, applied second (`hack/demo/kubevm/02-provider-vm.yaml`)
+- [ ] T073 [TICKET NEEDED] Write the RBAC manifests for the core controller's ServiceAccount as decided in T002 (`hack/demo/kubevm/rbac.yaml`)
+- [ ] T074 [TICKET NEEDED] Write the runbook covering the ordered apply, why order matters, and fully qualified resource names throughout because both CRDs claim the `vm` short name (`hack/demo/kubevm/README.md`)
+- [ ] T075 [TICKET NEEDED] Record the demo covering create, address reported, power off, power on, hand-edit reverted, unsupported edit reported, and delete (`hack/demo/kubevm/README.md`)
+
+## Phase Final — Housekeeping
+
+- [ ] T076 [TICKET NEEDED] Add `external/kubevm/` and `external/kubevm/controller/` to the sub-modules table (`.sdd/memory/constitution.md`)
+- [ ] T077 [TICKET NEEDED] Amend the repository-layout section so `external/` is no longer described only as vendored API definitions (`.sdd/memory/constitution.md`)
+- [ ] T078 [TICKET NEEDED] Note that the root module now depends on this module, so the expected move to its own repository becomes a migration rather than a rename (`external/kubevm/README.md`)
+- [ ] T079 [TICKET NEEDED] File follow-up specs for E2E coverage, for resolving the duplication between the contract status fields and VM Operator's own identifier fields, and for adoption of pre-existing VM Operator VMs (`.sdd/specs/006-vmop-kubevm-provider/plan.md`)
+- [ ] T080 [TICKET NEEDED] Update the module README with what the demo proves and what it does not — no E2E, no adoption of pre-existing VMs, no resize, four spec fields and four status fields only (`external/kubevm/README.md`)

--- a/external/kubevm/api/v1alpha1/common_types.go
+++ b/external/kubevm/api/v1alpha1/common_types.go
@@ -79,8 +79,6 @@ const (
 	PowerOpModeTrySoft PowerOpMode = "TrySoft"
 )
 
-// +kubebuilder:validation:Enum=Pending;Provisioning;Running;Stopping;Stopped;Suspended;Failed;Deleting
-
 // Condition types reported on a VirtualMachine.
 //
 // Conditions are where provider-dependent outcomes are reported, and this is a

--- a/external/kubevm/docs/one-pager-kubevm-generic-api.md
+++ b/external/kubevm/docs/one-pager-kubevm-generic-api.md
@@ -53,7 +53,8 @@ KubeVM is intended to complement KubeVirt, not to replace it: it addresses the h
 The proposal introduces a new API group, `kube-vm.io`, whose central resource is a `VirtualMachine` supported by a small set of companion types for sizing, images, networking, and snapshots.
 The design deliberately places the common surface — everything that is shared across backends — in the generic API, so that a provider needs to contribute only the settings that are unique to its platform.
 A machine is bound to its backend through a Cluster-API-style `spec.infrastructureRef`, and the generic layer observes the backend exclusively through a duck-typed status contract: a small, fixed set of well-known status fields — provider identifier, readiness, and network addresses — that the contract *requires* each provider to surface at agreed field paths.
-The generic core reads only those paths and imports no provider code; a provider whose native status differs (VM Operator, for instance, exposes equivalent information under its own field names today) satisfies the contract through a thin status adapter rather than by changing the core.
+The generic core reads only those paths and imports no provider code, so it needs no per-provider translation and does not change when a provider is added.
+A provider whose native status already carries the same information under its own field names — as VM Operator does today — publishes the contract fields on its own object alongside them.
 Settling the exact contract — the canonical `providerID` form in particular — is part of defining the API.
 A generic controller reconciles the `VirtualMachine` against its provider object, and each provider contributes a controller that translates the resolved intent into calls against its platform.
 To keep the generic API from degenerating into the union of every vendor's feature set, a field is promoted into the portable core only once at least two providers converge on a common shape for it; until then it stays on the provider object where it originated.
@@ -280,7 +281,9 @@ Note that this leaves a real gap rather than a theoretical one: Windows guests o
 ### Controllers
 
 The generic controller reconciles the `VirtualMachine` against its provider object.
-It drives the desired state onto that object, reads the backend's observed state through the duck-typed status contract — a fixed set of well-known fields the contract requires each provider to surface at agreed paths, mapped by a thin per-provider adapter where the provider's native status uses different names (as VM Operator's does today) — and rolls the provider identifier, readiness, and network addresses up into the generic machine's status.
+It does not write the provider object's spec.
+Configuration reaches the platform because the provider reads the generic object it is linked to, which keeps platform-specific translation on the provider side where the platform knowledge already is.
+The generic controller resolves the reference, adopts the object, reads the backend's observed state through the duck-typed status contract — a fixed set of well-known fields each provider surfaces at agreed paths on its own object — and rolls the provider identifier, readiness, and network addresses up into the generic machine's status.
 It also owns the lifecycle concerns that belong to the portable object, including finalizers, status conditions, and backoff on transient failure.
 Because it interacts with the backend solely through the infrastructure reference and the status contract, the generic controller imports no provider code, and each provider evolves independently behind that contract.
 
@@ -301,7 +304,9 @@ It was architected to be provider-agnostic from the outset — all vSphere-speci
 One reconciliation to be explicit about, because it differs from the illustrative examples above.
 Those examples show a bespoke, capability-only `VSphereVirtualMachine` provider object for clarity.
 The vSphere realization is expected to differ: the provider object would be **VM Operator's own `vmoperator.vmware.com/VirtualMachine` CRD, reused directly** — a full-featured, and therefore *thick*, object — rather than a slim bespoke type.
-Reusing the native CRD buys day-one parity with everything VM Operator already does, at the cost of a thick provider object managed through a layered-override model, where the generic object supplies a baseline and the provider object may override it.
+Reusing the native CRD buys day-one parity with everything VM Operator already does, at the cost of a thick provider object.
+Fields the generic API owns are resolved by VM Operator from the generic object and persisted into its own spec: those that are immutable once set are resolved when the machine is created, and power state is kept in step on every reconcile.
+The generic object is authoritative for those fields, so a direct edit to them on the provider object is reverted on the next reconcile, in the same way an edit to a Pod owned by a Deployment is.
 In other words, "thin provider object" is the aspiration the generic API is built toward and is realistic for greenfield cloud providers; a mature platform's provider may reasonably trade thinness for parity.
 This is also the strongest argument that the design generalizes: it has to accommodate a provider whose native API is richer than the portable core, not only providers built to fit it.
 

--- a/external/kubevm/docs/provider-porting-guide.md
+++ b/external/kubevm/docs/provider-porting-guide.md
@@ -1,0 +1,311 @@
+# KubeVM Provider Porting Guide
+
+This describes what a provider has to implement to serve KubeVM `VirtualMachine` objects, and then walks through the vSphere port as a concrete example.
+
+Part 1 is the provider contract and applies to every provider. Part 2 is specific to VM Operator on vSphere; skip it if you are not working on that port.
+
+The API types are in [`api/v1alpha1`](../api/v1alpha1). The design rationale is in [`one-pager-kubevm-generic-api.md`](one-pager-kubevm-generic-api.md).
+
+## Part 1: the provider contract
+
+### Object model
+
+A portable `kube-vm.io/v1alpha1` `VirtualMachine` holds configuration that means the same thing on every platform. It binds to one backend through `spec.infrastructureRef`, which names a provider-owned object by `apiGroup`, `kind`, and `name` in the same namespace. There is no version in the reference: the group and kind identify the resource, and the served version is resolved at runtime, so a provider can roll its API forward without rewriting every object that points at it.
+
+The provider object carries platform-specific configuration only. Anything portable belongs on the generic object.
+
+You do not have to create a new CRD. The provider object can be an existing type you already ship. That is the case for the vSphere port, which uses VM Operator's own `VirtualMachine`.
+
+### Write direction
+
+This is the rule that everything else follows from.
+
+- The generic core never writes the provider object's spec. It does a `Get`, reads status at contract paths, sets an owner reference, and manages finalizers and deletion ordering. This matches Cluster API, whose core `Machine` controller gets the infrastructure object and errors if it is absent rather than creating it.
+- The core reads provider **status** at contract-defined paths. It never reads or interprets provider **spec**, because doing so would require knowing platform-specific field names.
+- The provider resolves its configuration by reading the owning generic object. Providers importing the core API is normal; Cluster API ships `util.GetOwnerMachine` for exactly this.
+- The core never imports provider code. The dependency runs one way: provider module depends on the core API module.
+
+### Linkage requires both sides to agree
+
+Adoption happens only when the generic object and the provider object each name the other.
+
+Generic side: `spec.infrastructureRef` names the provider object. It is immutable, enforced by CEL (`self == oldSelf`) in [`virtualmachine_types.go`](../api/v1alpha1/virtualmachine_types.go).
+
+Provider side: the annotation `kube-vm.io/virtual-machine: <name>` on the provider object, naming the generic object in the same namespace. It should be immutable once set.
+
+A one-sided reference must never cause adoption. On mismatch the core writes nothing to the provider object and reports a not-adopted condition on the generic object.
+
+The owner reference follows from confirmed linkage. The core sets it after both sides check out, for garbage collection. It is not the adoption signal; treating it as one would be self-certifying, since the core is the thing that writes it.
+
+If the provider object already carries a controller owner reference from a different generic object, refuse and report it. Never take it over.
+
+The reason for two-sided declaration is that VMs hold state. With a one-sided reference, anyone who can create a generic `VirtualMachine` could point it at a running VM and reconfigure it. Deployments adopt Pods by label selector, which is safe because Pods are disposable and a wrongly adopted Pod is replaced rather than mutated in place.
+
+There is precedent in VM Operator. A `VirtualMachineGroup` only takes ownership of a VM when the VM sets `spec.groupName` to the group's name **and** the group lists the VM in one of its boot order groups, at `spec.bootOrder[].members`. See the `GroupName` field doc in `api/v1alpha6/virtualmachine_types.go` (lines 1193-1204) and `virtualmachinegroup_types.go` lines 14 and 50. The controller walks the group's member list and checks `obj.GetGroupName() != ctx.VMGroup.Name` before setting the owner reference (`controllers/virtualmachinegroup/virtualmachinegroup_controller.go:406`).
+
+An annotation rather than a spec field, because the provider object may be a CRD whose schema the provider does not control, and requiring a spec field would rule that case out. The contract already uses metadata normatively: the contract version a provider satisfies is advertised as a label on its CRD. A spec field is more discoverable, and promoting the annotation to a field later is a non-breaking migration, so this can change.
+
+### Minimal object pair
+
+```yaml
+apiVersion: kube-vm.io/v1alpha1
+kind: VirtualMachine
+metadata:
+  name: web-01
+  namespace: team-a
+spec:
+  powerState: PoweredOn
+  instanceType:
+    name: small
+  bootDisk:
+    source:
+      image:
+        apiGroup: infrastructure.example.com
+        kind: ExampleImage
+        name: ubuntu-2204
+    storageClassName: fast
+  infrastructureRef:
+    apiGroup: infrastructure.example.com
+    kind: ExampleVirtualMachine
+    name: web-01
+```
+
+```yaml
+apiVersion: infrastructure.example.com/v1alpha1
+kind: ExampleVirtualMachine
+metadata:
+  name: web-01
+  namespace: team-a
+  annotations:
+    kube-vm.io/virtual-machine: web-01
+spec: {}
+```
+
+The provider object's spec is empty on submission. The provider's mutating webhook fills in the fields it needs from the parent.
+
+### Field handling depends on whether the provider's field is mutable
+
+**Immutable on the provider.** Resolve once, at create, in the provider's mutating webhook, by reading the parent and writing the value into the provider object's spec.
+
+**Mutable on the provider.** The provider's own controller copies the parent's value into the provider spec on every reconcile. VM Operator already does this shape for group members: `updateMemberPowerState` assigns `obj.Spec.PowerState = group.Spec.PowerState` (`virtualmachinegroup_controller.go:842-850`), persisted with the patch at line 426.
+
+Either way, **persist the value into the provider object's spec.** Do not resolve it in memory at reconcile time. `kubectl get -o yaml` on the provider object has to show what the VM will actually do. Other controllers read that object, and GitOps diffing, backup and restore, and audit all assume the spec is truthful.
+
+This deviates from the usual guidance that a controller should only write status. The trade-off is deliberate and the VM Operator group controller already accepted it for the same shape.
+
+### Precedence
+
+The generic object wins for the fields it owns. That is enforced by the provider controller reasserting the value on every reconcile, not by a policy. A user who hand-patches a delegated field on the provider object sees it revert on the next reconcile, the same as editing a Pod owned by a Deployment.
+
+There is no conflict-resolution policy, no condition vocabulary for conflicts, and nothing that can deadlock.
+
+### Status contract
+
+The core reads a fixed set of paths off the provider object as `unstructured`. It knows nothing about the provider's native field names. Every provider is obliged to surface these paths and populate them from whatever its platform gives it.
+
+| Contract path on provider object | Generic status field |
+|---|---|
+| `status.addresses[]`, entries typed `InternalIP` / `ExternalIP` | `status.addresses[]` |
+| `status.powerState` | `status.powerState` |
+| `status.providerID` | `status.providerID` |
+| `status.providerMetadata` | `status.providerMetadata` |
+| `Ready` condition in `status.conditions` | `Ready` condition |
+
+Readiness travels through the `Ready` condition. The core mirrors it onto the generic object and also sets the generic `status.ready` boolean from it. That boolean is a plain field on `VirtualMachineStatus`, separate from conditions, and the core has to set it; tools that read only `status.ready` are common. Providers do not need a boolean of their own.
+
+`status.providerMetadata` is a `map[string]string` for observed facts with no portable equivalent. The core copies it wholesale and never reads a value back into a reconcile decision, so a provider can add keys without negotiating a schema change.
+
+For `providerID`, pick a stable, globally unique identifier the platform already gives you. Do not invent a URI scheme. A managed-object reference or similar handle that is unique only within one management endpoint is not good enough, since a cluster can face more than one.
+
+Sketch of the adapter, on the core side:
+
+```go
+var infra unstructured.Unstructured
+infra.SetGroupVersionKind(gvk) // resolved from apiGroup + kind at runtime
+if err := c.Get(ctx, key, &infra); err != nil {
+    return err // never create it
+}
+
+providerID, _, _ := unstructured.NestedString(infra.Object, "status", "providerID")
+powerState, _, _ := unstructured.NestedString(infra.Object, "status", "powerState")
+addrs, _, _ := unstructured.NestedSlice(infra.Object, "status", "addresses")
+meta, _, _ := unstructured.NestedStringMap(infra.Object, "status", "providerMetadata")
+```
+
+### Feature gating
+
+Put the provider's KubeVM behaviour behind a feature gate, default off. Nothing changes for existing users until the gate is on, and the gate plus the annotation together keep the new code path to a single conditional branch.
+
+### Corner cases
+
+**Both sides default the same field.** The generic API defaults `spec.powerState` to `PoweredOn` (`+kubebuilder:default=PoweredOn`). Most providers default their equivalent too. So "field is empty" cannot mean "delegated to the parent", and you cannot tell a user-set value from a defaulted one by inspection. Do not build a conflict rule on presence or absence. "Empty means delegated" is also not portable, since a provider whose field is required cannot express it.
+
+**Post-create edits the provider cannot apply.** The generic API may accept an edit that is immutable on your platform. Report it with `UpToDate=False`, reason `UnsupportedByProvider`, and keep reconciling everything else. Never stop reconciling a live VM over one unappliable field. Do not make the generic field immutable because your platform's is: EC2 can change instance type while the instance is stopped, and pinning the portable API to the strictest platform would be wrong.
+
+**Adopting a VM that already exists.** Supported and intended. An operator adds the annotation to an existing provider object and creates a generic object whose immutable fields match the provider object's current values. An import flow can back-fill the generic spec from the provider object at create time so the two agree by construction. Adoption cannot change immutable fields, so a mismatch has to be rejected, not reconciled.
+
+**Someone deletes the provider object.** The core does `Get` only and never recreates it. It reports a not-adopted condition and waits. This is intended behaviour, not a bug.
+
+**Short name collision.** The generic CRD declares `shortName=vm;vms` and VM Operator's declares `shortName=vm`, so `kubectl get vm` is ambiguous once both are installed. Use fully qualified resource names in scripts and documentation: `virtualmachines.kube-vm.io` and `virtualmachines.vmoperator.vmware.com`.
+
+**Module dependency direction.** Your module depends on the core API module; the core never depends on yours. The core API module keeps its Kubernetes dependency floor deliberately low because providers import it, so do not expect it to track your own dependency versions. If provider and core live in one repository during development, wire them with a `replace` directive. The root `go.mod` in this repository already does that for the other `external/*` modules (lines 5-16). Note there is no `replace` for `external/kubevm` today, because nothing in the parent build imports it yet.
+
+## Part 2: the vSphere port (VM Operator)
+
+The provider object is VM Operator's existing `vmoperator.vmware.com` `VirtualMachine`. No new CRD.
+
+### Feature gate
+
+Add a gate to `FeatureStates` in `pkg/config/config.go` (the struct is at line 191), default off. The resolution path engages only when the gate is on and the annotation is present.
+
+### The object pair, vSphere flavour
+
+```yaml
+apiVersion: kube-vm.io/v1alpha1
+kind: VirtualMachine
+metadata:
+  name: web-01
+  namespace: team-a
+spec:
+  powerState: PoweredOn
+  instanceType:
+    name: best-effort-small
+  bootDisk:
+    source:
+      image:
+        apiGroup: vmoperator.vmware.com
+        kind: VirtualMachineImage
+        name: vmi-0a0044d7c690bcbea
+    storageClassName: wcpglobal-storage-profile
+  infrastructureRef:
+    apiGroup: vmoperator.vmware.com
+    kind: VirtualMachine
+    name: web-01
+```
+
+```yaml
+apiVersion: vmoperator.vmware.com/v1alpha6
+kind: VirtualMachine
+metadata:
+  name: web-01
+  namespace: team-a
+  annotations:
+    kube-vm.io/virtual-machine: web-01
+spec: {}
+```
+
+The sample in `config/samples/virtualmachine.yaml` in this module instead shows a dedicated `VSphereVirtualMachine` type in its own group. That is a hypothetical shape for a provider that ships a new CRD. The port uses VM Operator's existing type.
+
+### Fields that move down
+
+| Generic | vSphere provider | Mutability |
+|---|---|---|
+| `spec.powerState` | `spec.powerState` | mutable, reasserted each reconcile |
+| `spec.instanceType.name` | `spec.className` | resolved at create; immutable afterwards unless a resize feature gate is enabled |
+| `spec.bootDisk.source.image.kind` | `spec.image.kind` | immutable, resolved at create |
+| `spec.bootDisk.source.image.name` | `spec.image.name` | immutable, resolved at create |
+| `spec.bootDisk.storageClassName` | `spec.storageClass` | immutable, resolved at create |
+
+Power state values are identical on both sides. The generic `PowerState` enum spells them `PoweredOn`, `PoweredOff`, `Suspended` to match `VirtualMachinePowerState`, so there is no value mapping.
+
+Field names verified in `api/v1alpha6/virtualmachine_types.go`: `spec.className` (881), `spec.image` (827, a `VirtualMachineImageRef` with `kind` and `name`), `spec.storageClass` (922), `spec.powerState` (963).
+
+The field set is deliberately small. The detailed fields are expected to change as more providers engage, so the first version moves five values and no more.
+
+### Status fields to add
+
+VM Operator's `VirtualMachineStatus` today has `powerState` (1436), `network.primaryIP4` (`virtualmachine_network_types.go:866`), `uniqueID` (1460), `instanceUUID` (1473), and `conditions` (1440). It has no `addresses`, no `providerID`, and no `providerMetadata`. The port has to add those three contract paths and populate them from the values it already has.
+
+| Contract path to add | Populated from |
+|---|---|
+| `status.addresses[]`, one entry typed `InternalIP` | `status.network.primaryIP4` |
+| `status.providerID` | `status.instanceUUID` |
+| `status.providerMetadata["uniqueID"]` | `status.uniqueID` |
+
+`status.powerState` and the `Ready` condition (`api/v1alpha6/condition_consts.go:9`) already sit at the contract paths and need no work.
+
+`providerID` comes from `status.instanceUUID`, not `status.uniqueID`. `uniqueID` is set to `vmCtx.MoVM.Self.Value` (`pkg/providers/vsphere/vmlifecycle/update_status.go:438`), a vSphere managed-object reference that is unique within one vCenter but not globally, so it is not usable as `providerID`. It is still worth surfacing, which is what the `providerMetadata` entry is for. `instanceUUID` is set from `Summary.Config.InstanceUuid` two lines below and is the stable UUID.
+
+### Resolution belongs in the mutating webhook
+
+The validating webhook requires `spec.image` and `spec.className` to be non-empty on create: see `validateImageOnCreate` (`webhooks/virtualmachine/validation/virtualmachine_validator.go:607`, `field.Required` when `vm.Spec.Image == nil`) and `validateClassOnCreate` (line 652, `field.Required` on `spec.className` for a classless VM unless the import gate is on). A provider object submitted with an empty spec would be rejected before any controller ran.
+
+Mutating webhooks run before validating webhooks, so resolving in the mutator means the object that reaches validation is an ordinary VM Operator `VirtualMachine` and no validation changes are needed.
+
+The empty spec is schema-valid. The v1alpha6 schema in `config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml` has no `required` list at spec level, so `spec: {}` is accepted by the API server.
+
+### Ordering the mutations
+
+Resolution has to be an explicit call in `mutator.Mutate`, placed before VM Operator's own defaulting and resolution steps: `SetDefaultPowerState`, `SetDefaultCdromImgKindOnCreate`, `ResolveImageNameOnCreate`, and `ResolveClassAndClassName` (`webhooks/virtualmachine/mutation/virtualmachine_mutator.go:272-295`).
+
+Do not register it through `MutateOnCreateFuncs`. That is a `sync.Map` (line 112) iterated with `Range` at line 305, and `sync.Map` iteration order is unspecified, so registration there cannot guarantee resolution runs first.
+
+`SetDefaultPowerState` (line 672) sets `spec.powerState` to `VirtualMachinePowerStateOn` when it is empty. That is the concrete instance of both sides defaulting the same field: once it runs you cannot distinguish a value from the parent, a value from the user, and a value from this defaulter.
+
+### Reading the parent from inside the webhook
+
+```go
+// The parent's name comes from the annotation on the provider object.
+parentName := vm.Annotations["kube-vm.io/virtual-machine"]
+if parentName == "" {
+    return false, nil // not a KubeVM-managed VM
+}
+
+var parent kubevmv1a1.VirtualMachine
+key := ctrlclient.ObjectKey{Namespace: vm.Namespace, Name: parentName}
+if err := apiReader.Get(ctx, key, &parent); err != nil {
+    return false, err
+}
+
+// Mutual declaration: the parent must point back at this object.
+ref := parent.Spec.InfrastructureRef
+if ref.APIGroup != vmopv1.GroupName || ref.Kind != "VirtualMachine" || ref.Name != vm.Name {
+    return false, fmt.Errorf("%s does not reference this object", parentName)
+}
+
+vm.Spec.ClassName = parent.Spec.InstanceType.Name
+// ... remaining create-time fields
+```
+
+Use the uncached reader, `mgr.GetAPIReader()`. A manager's default client is cache-backed, and the first `Get` of a type it has never seen lazily starts an informer. Inside a live admission request with `failurePolicy: Fail`, that request blocks waiting for cache sync, and it never succeeds if the CRD is not installed at all. Three VM Operator controllers already take the uncached reader for their own reasons, including `controllers/virtualmachinegroup/virtualmachinegroup_controller.go:62`.
+
+The alternative is to exclude the type from the cache via `client.CacheOptions.DisableFor` in `pkg/manager/manager.go` (lines 108-109), which already lists `ConfigMap`, `Secret`, and `Deployment`.
+
+There is also an RBAC consequence. A cache-backed client needs `list` and `watch` on the type, not just `get`, over the cache's configured scope. `GetNamespaceCacheConfigs` (`pkg/manager/cache.go:107`) returns `nil` and therefore a cluster-wide cache when no watch namespace is set. The uncached reader needs only `get`.
+
+### Patching owner references
+
+Owner references are a shared list, and a plain merge patch replaces a list wholesale with no `resourceVersion` precondition, so it can silently drop a concurrent writer's entry with no error to trigger a retry. There is a second writer to that list on VM Operator VMs: the group controller calls `controllerutil.SetOwnerReference` on member VMs (`virtualmachinegroup_controller.go:428`).
+
+Patch with an optimistic lock and skip the write when nothing changed:
+
+```go
+base := obj.DeepCopy()
+// set the owner reference on obj ...
+if !apiequality.Semantic.DeepEqual(base.OwnerReferences, obj.OwnerReferences) {
+    if err := c.Patch(ctx, obj,
+        client.MergeFromWithOptions(base, client.MergeFromWithOptimisticLock{})); err != nil {
+        return err
+    }
+}
+```
+
+Compare with `apiequality.Semantic.DeepEqual` from `k8s.io/apimachinery/pkg/api/equality`, not `reflect.DeepEqual`, which false-diffs on types like `resource.Quantity` and would defeat the skip guard.
+
+### Waiting for an address
+
+Provisioning and guest boot take time, and an address only appears once VM Tools reports one. Requeue with a delay instead of hot-looping. VM Operator already has a constant for this case: `PoweredOnVMHasIPRequeueDelay`, 10 seconds (`pkg/config/default.go:47`), used at `controllers/virtualmachine/virtualmachine/virtualmachine_controller.go:503`.
+
+### Scheme registration
+
+Register the core API types in three places:
+
+- `pkg/manager/manager.go`, alongside the other `AddToScheme` calls at lines 64-96, gated on the feature gate as `imgregv1` and `vimv1` are.
+- `test/builder/fake.go`, in the `AddToScheme` block at lines 110-118, for unit tests using the fake client. Add the type to `KnownObjectTypes` (line 63) so the fake client enforces the spec/status split.
+- For envtest integration tests, drop the generic CRD into `config/crd/external-crds/`, which `test/builder/test_suite.go:310` loads as `CRDDirectoryPaths`.
+
+## Open items
+
+- The contract version label key is described in the API doc comments but is not yet defined as a constant in this module.
+- There is no conformance test suite holding a provider to the status contract.
+- The core controller does not exist in this module yet. This module is API types and generation only.


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

This change includes a document that will help existing hyperscalers / hypervisors port their virtual machine APIs to KubeVM.  The document tries to propose how to handle disambiguation between fields that are shared between the KubeVM API surface and the provider.

While here, also include the SDD (Spec Driven Development) spec, plan and tasks files.

Also update the one pager and the types with a minor miss.

**Please add a release note if necessary**:

```release-note
Include a guide for provider portability, add spec / tasks
```