### PR TITLE
Fix vm-publish-request test failures

### DIFF
--- a/test/e2e/vmservice/config/wcp.yaml
+++ b/test/e2e/vmservice/config/wcp.yaml
@@ -58,6 +58,7 @@ intervals:
   default/wait-virtual-machine-group-condition-update: [ "6m", "5s" ]
   default/wait-virtual-machine-publish-request-creation: ["60s", "5s"]
   default/wait-virtual-machine-publish-request-condition: ["6m", "5s"]
+  default/wait-virtual-machine-publish-request-upload-condition: ["20m", "5s"]
   default/wait-virtual-machine-publish-request-deletion: ["60s", "2s"]
   default/wait-virtual-machine-group-publish-request-condition: [ "6m", "5s" ]
   default/wait-virtual-machine-group-publish-request-deletion: [ "60s", "2s" ]

--- a/test/e2e/vmservice/lib/vmoperator/vmoperator.go
+++ b/test/e2e/vmservice/lib/vmoperator/vmoperator.go
@@ -701,6 +701,57 @@ func VerifyVirtualMachinePublishRequestCondition(
 	}, config.GetIntervals("default", "wait-virtual-machine-publish-request-condition")...).Should(Succeed(), "Timed out waiting for Condition: %+v on VirtualMachinePublishRequest: %s", expectedCondition, vmPubName)
 }
 
+// VerifyVirtualMachinePublishRequestUploaded waits, on its own generous
+// budget, until the VirtualMachinePublishRequest reports Uploaded=True.
+// Publishing to an Inventory content library backs Uploaded by a vSphere
+// CloneVM_Task cloning the source VM as a template, which can take far
+// longer than the Complete condition that follows it (a fast, in-cluster
+// VirtualMachineImage lookup). Waiting on Uploaded separately keeps that
+// slow, VC-side clone from having to fit inside the same short budget used
+// for Complete.
+func VerifyVirtualMachinePublishRequestUploaded(
+	ctx context.Context,
+	config *config.E2EConfig,
+	client ctrlclient.Client,
+	ns, vmPubName string) {
+	Eventually(func(g Gomega) {
+		vmPub, err := utils.GetVirtualMachinePublishRequest(ctx, client, ns, vmPubName)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		actualCondition := meta.FindStatusCondition(vmPub.GetConditions(), vmopv1.VirtualMachinePublishRequestConditionUploaded)
+		g.Expect(actualCondition).ToNot(BeNil())
+		g.Expect(actualCondition.Status).Should(Equal(metav1.ConditionTrue))
+	}, config.GetIntervals("default", "wait-virtual-machine-publish-request-upload-condition")...).Should(Succeed(), "Timed out waiting for Uploaded=True on VirtualMachinePublishRequest: %s", vmPubName)
+}
+
+// VerifyVirtualMachineGroupPublishRequestImagesUploaded waits, on the same
+// generous budget as VerifyVirtualMachinePublishRequestUploaded, until every
+// VirtualMachinePublishRequest child tracked in status.images reports
+// Uploaded=True. Publishing to an Inventory content library backs Uploaded
+// by a vSphere CloneVM_Task per VM, which can take far longer than the
+// group's Complete condition that follows (a fast, in-cluster
+// VirtualMachineImage lookup for each child). Waiting on Uploaded here keeps
+// that slow, VC-side clone from having to fit inside the short budget used
+// for Complete.
+func VerifyVirtualMachineGroupPublishRequestImagesUploaded(
+	ctx context.Context,
+	config *config.E2EConfig,
+	client ctrlclient.Client,
+	ns, name string) {
+	Eventually(func(g Gomega) {
+		vmGroupPub, err := utils.GetVirtualMachineGroupPublishRequest(ctx, client, ns, name)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(vmGroupPub.Status.Images).ToNot(BeEmpty())
+		for _, image := range vmGroupPub.Status.Images {
+			actualCondition := meta.FindStatusCondition(image.Conditions, vmopv1.VirtualMachinePublishRequestConditionUploaded)
+			g.Expect(actualCondition).ToNot(BeNil(), "no Uploaded condition yet for %s", image.PublishRequestName)
+			g.Expect(actualCondition.Status).Should(Equal(metav1.ConditionTrue), "Uploaded not true yet for %s", image.PublishRequestName)
+		}
+	}, config.GetIntervals("default", "wait-virtual-machine-publish-request-upload-condition")...).Should(Succeed(),
+		"Timed out waiting for Uploaded=True on all VirtualMachineGroupPublishRequest images: %s", name)
+}
+
 // VerifyVirtualMachineGroupPublishRequestCompleted waits until the completed condition is true.
 func VerifyVirtualMachineGroupPublishRequestCompleted(
 	ctx context.Context,

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_group_publishrequest.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_group_publishrequest.go
@@ -248,6 +248,19 @@ func VMGroupPublishRequestSpec(ctx context.Context, inputGetter func() VMGroupPu
 			Target:          target,
 			VirtualMachines: vms,
 		}, "")
+
+		// Publishing to an Inventory library clones each source VM as a
+		// template via vSphere's CloneVM_Task, which can take far longer
+		// than the group's Complete condition that follows. Wait for every
+		// child's Uploaded condition on its own generous budget first so
+		// that slow, VC-side clone doesn't have to fit inside the shorter
+		// budget used for Complete.
+		vmoperator.VerifyVirtualMachineGroupPublishRequestImagesUploaded(
+			ctx,
+			vmSvcE2EConfig,
+			vmSvcClusterProxy.GetClient(),
+			vmSvcNamespace,
+			groupPubName)
 		vmoperator.VerifyVirtualMachineGroupPublishRequestCompleted(
 			ctx,
 			vmSvcE2EConfig,

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_publishrequest.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_publishrequest.go
@@ -278,38 +278,8 @@ func VMPublishRequestSpec(ctx context.Context, inputGetter func() VMPublishReque
 
 				By("Deploying a new VM from the published image")
 				// Use the published the vmi to deploy a new VM should succeed with VM powered on and IP assigned.
-				//
-				// The VM is built as a typed struct rather than rendered YAML
-				// because promoteDisksMode does not exist before v1alpha4, so
-				// the v1alpha2 fixture used elsewhere in this spec cannot set
-				// it -- the API server prunes fields absent from the requested
-				// version's schema.
 				newVmName := fmt.Sprintf("%s-%s", vmPubSpecName+"-vm", capiutil.RandomString(4))
-				newVM := &vmopv1.VirtualMachine{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: input.WCPNamespaceName,
-						Name:      newVmName,
-					},
-					Spec: vmopv1.VirtualMachineSpec{
-						ClassName:    clusterResources.VMClassName,
-						ImageName:    publishedImageCRName,
-						StorageClass: clusterResources.StorageClassName,
-						PowerState:   vmopv1.VirtualMachinePowerStateOn,
-						Reserved: &vmopv1.VirtualMachineReservedSpec{
-							ResourcePolicyName: clusterResources.VMResourcePolicyName,
-						},
-						// Disable disk promotion. This VM has timed out
-						// waiting for an IP on a loaded testbed, and a
-						// promote running against its first boot is the
-						// likeliest culprit, though the logs don't prove
-						// it. Nothing here cares where the disks came
-						// from, so there is no reason to leave promotion
-						// running.
-						PromoteDisksMode: vmopv1.VirtualMachinePromoteDisksModeDisabled,
-					},
-				}
-				Expect(svClusterClient.Create(ctx, newVM)).To(Succeed(),
-					"failed to create virtualmachine from the published image %+v", newVM)
+				createVMWithPromotionDisabled(ctx, svClusterClient, input.WCPNamespaceName, newVmName, publishedImageCRName, *clusterResources, nil)
 				vmoperator.WaitForVirtualMachineCreation(ctx, config, svClusterClient, input.WCPNamespaceName, newVmName)
 				vmoperator.DeleteVirtualMachine(ctx, svClusterClient, input.WCPNamespaceName, newVmName)
 			})
@@ -340,42 +310,15 @@ func VMPublishRequestSpec(ctx context.Context, inputGetter func() VMPublishReque
 					sourceVAppProperties = append(sourceVAppProperties, vAppProp(p.Key, p.Value.Value))
 				}
 
-				// The source VM is built as a typed struct rather than rendered
-				// YAML because promoteDisksMode does not exist before v1alpha4,
-				// so the v1alpha2 fixture used elsewhere in this spec cannot set
-				// it -- the API server prunes fields absent from the requested
-				// version's schema.
 				sourceVMName := fmt.Sprintf("%s-%s", vmPubSpecName+"-vapp-src", capiutil.RandomString(4))
-				sourceVM := &vmopv1.VirtualMachine{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      sourceVMName,
-						Namespace: input.WCPNamespaceName,
-					},
-					Spec: vmopv1.VirtualMachineSpec{
-						ClassName:    clusterResources.VMClassName,
-						ImageName:    sourceImageName,
-						StorageClass: clusterResources.StorageClassName,
-						PowerState:   vmopv1.VirtualMachinePowerStateOn,
-						Reserved: &vmopv1.VirtualMachineReservedSpec{
-							ResourcePolicyName: clusterResources.VMResourcePolicyName,
+				createVMWithPromotionDisabled(ctx, svClusterClient, input.WCPNamespaceName, sourceVMName, sourceImageName, *clusterResources,
+					&vmopv1.VirtualMachineBootstrapSpec{
+						// LinuxPrep is needed here for the VM to get a valid IP address.
+						LinuxPrep: &vmopv1.VirtualMachineBootstrapLinuxPrepSpec{},
+						VAppConfig: &vmopv1.VirtualMachineBootstrapVAppConfigSpec{
+							Properties: sourceVAppProperties,
 						},
-						// Suppress disk promotion so no background PromoteDisks
-						// task can leave the OVF capture queued past this spec's
-						// publish timeout. Publish has no dependency on disk
-						// promotion, and disk provenance is irrelevant to the
-						// vAppConfig behavior under test here.
-						PromoteDisksMode: vmopv1.VirtualMachinePromoteDisksModeDisabled,
-						Bootstrap: &vmopv1.VirtualMachineBootstrapSpec{
-							// LinuxPrep is needed here for the VM to get a valid IP address.
-							LinuxPrep: &vmopv1.VirtualMachineBootstrapLinuxPrepSpec{},
-							VAppConfig: &vmopv1.VirtualMachineBootstrapVAppConfigSpec{
-								Properties: sourceVAppProperties,
-							},
-						},
-					},
-				}
-				Expect(svClusterClient.Create(ctx, sourceVM)).To(Succeed(),
-					"failed to create source virtualmachine with vAppConfig %+v", sourceVM)
+					})
 				vmoperator.WaitForVirtualMachineCreation(ctx, config, svClusterClient, input.WCPNamespaceName, sourceVMName)
 				DeferCleanup(func() {
 					vmoperator.DeleteVirtualMachine(ctx, svClusterClient, input.WCPNamespaceName, sourceVMName)
@@ -483,6 +426,13 @@ func VMPublishRequestSpec(ctx context.Context, inputGetter func() VMPublishReque
 				// Publish the VM to the inventory library.
 				vmPubReqBuilder := generateVMPublishRequestBuilder(input.WCPNamespaceName, vmPublishRequestName, input.LinuxVMName, vmPubTargetItemName, inventoryCL.Name)
 				createVMPublishRequest(ctx, *config, svClusterClient, *clusterProxy, vmPubReqBuilder)
+
+				// Publishing to an Inventory library clones the source VM as a
+				// template via vSphere's CloneVM_Task, which can take far longer
+				// than publishing to a Content Library (an OVF export). Wait for
+				// that clone on its own generous budget before waiting on Complete,
+				// which follows quickly once Uploaded=True.
+				vmoperator.VerifyVirtualMachinePublishRequestUploaded(ctx, config, svClusterClient, input.WCPNamespaceName, vmPublishRequestName)
 				vmoperator.VerifyVirtualMachinePublishRequestCondition(ctx, config, svClusterClient, input.WCPNamespaceName, vmPublishRequestName, metav1.Condition{
 					Type:   vmopv1.VirtualMachinePublishRequestConditionComplete,
 					Status: metav1.ConditionTrue,
@@ -497,10 +447,19 @@ func VMPublishRequestSpec(ctx context.Context, inputGetter func() VMPublishReque
 
 				// Deploy a new VM from the published image and verify it powers on with an IP.
 				newVmName := fmt.Sprintf("%s-%s", vmPubSpecName+"-vm", capiutil.RandomString(4))
-				newVMBuilder := generateVMBuilder(input.WCPNamespaceName, newVmName, publishedImageCRName, *clusterResources)
-				newVmYaml := manifestbuilders.GetVirtualMachineYamlA2(newVMBuilder)
-				Expect(clusterProxy.CreateWithArgs(ctx, newVmYaml)).NotTo(HaveOccurred(), "failed to create virtualmachine from the published image", string(newVmYaml))
-				vmoperator.WaitForVirtualMachineCreation(ctx, config, svClusterClient, input.WCPNamespaceName, newVmName)
+				createVMWithPromotionDisabled(ctx, svClusterClient, input.WCPNamespaceName, newVmName, publishedImageCRName, *clusterResources, nil)
+
+				// Wait for the image cache on its own generous budget before
+				// waiting on the rest of VM creation, rather than sharing one
+				// 5-minute window across both: caching the just-published
+				// item onto a datastore can take several minutes, and
+				// placement recommending a different datastore mid-flight
+				// forces a second, equally slow cache copy.
+				vmoperator.WaitForVirtualMachineToExist(ctx, config, svClusterClient, input.WCPNamespaceName, newVmName)
+				vmoperator.WaitForVirtualMachineImageCacheReady(ctx, config, svClusterClient, input.WCPNamespaceName, newVmName)
+				vmoperator.WaitForVirtualMachineConditionCreated(ctx, config, svClusterClient, input.WCPNamespaceName, newVmName)
+				vmoperator.WaitForVirtualMachinePowerState(ctx, config, svClusterClient, input.WCPNamespaceName, newVmName, string(vmopv1.VirtualMachinePowerStateOn))
+				vmoperator.WaitForVirtualMachineIP(ctx, config, svClusterClient, input.WCPNamespaceName, newVmName)
 				vmoperator.DeleteVirtualMachine(ctx, svClusterClient, input.WCPNamespaceName, newVmName)
 
 				// Clean up the first publish request; the published item remains in the inventory library.
@@ -665,6 +624,46 @@ func generateVMBuilder(
 		ResourcePolicy:   clusterResources.VMResourcePolicyName,
 		PowerState:       "PoweredOn",
 	}
+}
+
+// createVMWithPromotionDisabled creates a VirtualMachine with disk promotion
+// disabled and returns it once creation succeeds.
+//
+// The VM is built as a typed struct rather than rendered YAML because
+// PromoteDisksMode does not exist before v1alpha4, so the v1alpha2 fixture
+// used elsewhere in this spec cannot set it -- the API server prunes fields
+// absent from the requested version's schema.
+//
+// Nothing in these specs cares where a VM's disks came from, and leaving
+// promotion running risks a background PromoteDisks task colliding with a
+// deployed VM's first boot, or with a soon-to-be-published source VM's OVF
+// capture, on a loaded testbed.
+func createVMWithPromotionDisabled(
+	ctx context.Context,
+	svClusterClient ctrlclient.Client,
+	namespace, name, imageName string,
+	clusterResources e2eConfig.Resources,
+	bootstrap *vmopv1.VirtualMachineBootstrapSpec) *vmopv1.VirtualMachine {
+	vm := &vmopv1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: vmopv1.VirtualMachineSpec{
+			ClassName:    clusterResources.VMClassName,
+			ImageName:    imageName,
+			StorageClass: clusterResources.StorageClassName,
+			PowerState:   vmopv1.VirtualMachinePowerStateOn,
+			Reserved: &vmopv1.VirtualMachineReservedSpec{
+				ResourcePolicyName: clusterResources.VMResourcePolicyName,
+			},
+			PromoteDisksMode: vmopv1.VirtualMachinePromoteDisksModeDisabled,
+			Bootstrap:        bootstrap,
+		},
+	}
+	Expect(svClusterClient.Create(ctx, vm)).To(Succeed(),
+		"failed to create virtualmachine %q with disk promotion disabled", name)
+	return vm
 }
 
 func generateVMPublishRequestBuilder(

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_publishrequest.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_publishrequest.go
@@ -627,7 +627,7 @@ func generateVMBuilder(
 }
 
 // createVMWithPromotionDisabled creates a VirtualMachine with disk promotion
-// disabled and returns it once creation succeeds.
+// disabled once creation succeeds.
 //
 // The VM is built as a typed struct rather than rendered YAML because
 // PromoteDisksMode does not exist before v1alpha4, so the v1alpha2 fixture
@@ -643,7 +643,7 @@ func createVMWithPromotionDisabled(
 	svClusterClient ctrlclient.Client,
 	namespace, name, imageName string,
 	clusterResources e2eConfig.Resources,
-	bootstrap *vmopv1.VirtualMachineBootstrapSpec) *vmopv1.VirtualMachine {
+	bootstrap *vmopv1.VirtualMachineBootstrapSpec) {
 	vm := &vmopv1.VirtualMachine{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
@@ -663,7 +663,6 @@ func createVMWithPromotionDisabled(
 	}
 	Expect(svClusterClient.Create(ctx, vm)).To(Succeed(),
 		"failed to create virtualmachine %q with disk promotion disabled", name)
-	return vm
 }
 
 func generateVMPublishRequestBuilder(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

**FAILURE 1:**
â€¢ [FAILED] [541.159 seconds]
```
Testing VM Services VIRTUAL-MACHINE VM-PUBLISH-REQUEST VirtualMachinePublishRequest Inventory Content Library [It] should publish the VM to an inventory library, deploy from the published image, and reject a duplicate publish [devops, viadmin, virtualmachine, vmservice, smoke]
/vm-operator/test/e2e/vmservice/vmservice/virtualmachine/vm_publishrequest.go:482
[FAILED] Timed out after 300.002s.
  Timed out waiting for VirtualMachine vm-publish-vm-wk8f to be created on VC
  The function passed to Eventually failed at /vm-operator/test/e2e/vmservice/lib/vmoperator/vmoperator.go:91 with:
  Expected
      <*v1.Condition | 0x0>: nil
  not to be nil
  In [It] at: /vm-operator/test/e2e/vmservice/lib/vmoperator/vmoperator.go:95 @ 09/01/26 02:00:54.655
```
**RCA:**
During the disk copy to the first datastore (~2.5 min), the reconcile loop runs again and gets a different recommendation because vCenter's storage balancer saw the copy finish and rebalanced. vm-operator copies the disk again to the new datastore (~2.5 min). Two copies take ~5 minutes, exceeding the test's 5-minute timeout before the VM is even created.
**Fix:**
Split the deploy wait into two stages with separate timeouts:
- Wait for image cache to finish (10 minutes)
- Wait for VM creation (5 minutes)


**FAILURE 2:**
```
â€¢ [FAILED] [1005.467 seconds]
Testing VM Services VIRTUAL-MACHINE VM-PUBLISH-REQUEST VirtualMachinePublishRequest Inventory Content Library [It] should publish the VM to an inventory library, deploy from the published image, and reject a duplicate publish [devops, viadmin, virtualmachine, vmservice, smoke]
/vm-operator/test/e2e/vmservice/vmservice/virtualmachine/vm_publishrequest.go:482
  [FAILED] Timed out after 360.001s.
  Timed out waiting for Condition: {Type:Complete Status:True ObservedGeneration:0 LastTransitionTime:0001-01-01 00:00:00 +0000 UTC Reason: Message:} on VirtualMachinePublishRequest: vm-publish-27j8
  The function passed to Eventually failed at /vm-operator/test/e2e/vmservice/lib/vmoperator/vmoperator.go:696 with:
  Expected
      <v1.ConditionStatus>: False
  to equal
      <v1.ConditionStatus>: True
  In [It] at: /vm-operator/test/e2e/vmservice/lib/vmoperator/vmoperator.go:701 @ 09/01/26 01:36:20.203
```
**RCA:**
Publishing to an Inventory library uses vSphere's CloneVM_Task (full VM-to-template clone), which took ~16m in this run — far longer than the fast OVF-export path used for regular content libraries. The test's Complete=True wait only budgeted 6m, so it timed out before the clone (a legitimate, error-free vSphere operation) finished.
**Fix:**
Split the wait into two stages matching the controller's own Uploaded → Complete conditions — wait for Uploaded=True on a new 20m budget (covers the slow clone), then Complete=True on the existing 6m budget (covers only the fast completion check that follows). Also disabled disk promotion on the VM deployed from the published image (already done for the CLS spec) to remove a second possible source of first-boot flakiness, and extracted the now-3x-duplicated typed-VM-with-promotion-disabled struct into a shared helper.


**FAILURE 3:**
```
STDOUT: â€¢ [FAILED] [729.429 seconds]
Testing VM Services VIRTUAL-MACHINE VM-GROUP-PUBLISH-REQUEST [It] should succeed when vm group publish request with created with proper inputs [devops, viadmin, virtualmachine, vmservice, smoke]
/vm-operator/test/e2e/vmservice/vmservice/virtualmachine/vm_group_publishrequest.go:274
  [FAILED] Timed out after 360.000s.
  Timed out waiting for VirtualMachineGroupPublishRequest to be completed
  Expected
      <bool>: false
  to be true
  In [It] at: /vm-operator/test/e2e/vmservice/lib/vmoperator/vmoperator.go:731 @ 09/01/26 02:01:04.937
```

**RCA:**
 Publishing a VM/VM group to an inventory library uses vSphere's CloneVM_Task (slow, ~8.5 min), while CLS-backed libraries use CreateOVF (fast). Both specs waited on Complete under a 6-minute budget, causing timeout even though the publish succeeded — just past the test deadline.
**Fix:**
Added VerifyVirtualMachinePublishRequestUploaded and VerifyVirtualMachineGroupPublishRequestImagesUploaded helpers that wait for Uploaded=True on a generous 20-minute budget before the existing Complete waits.
Introduced createVMWithPromotionDisabled to prevent disk-promotion collisions during VM creation.

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # vmop-4149


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    6. If a release note is not required, please write "NONE".
-->

```release-note

```