### PR TITLE
✨ VM Provider VM tests should use fast deploy

### DIFF
--- a/pkg/providers/vsphere/vmprovider_test.go
+++ b/pkg/providers/vsphere/vmprovider_test.go
@@ -13,13 +13,18 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/vmware/govmomi/object"
+
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
+	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
@@ -182,4 +187,228 @@ func createOrUpdateVMAsync(
 
 	GinkgoLogr.Info("createOrUpdateVMAsync returned post channel", "err", err)
 	return err
+}
+
+// The helpers below implement the setup shared by the VM specs in
+// vmprovider_vm_*_test.go. A spec declares its own closure variables and Ginkgo
+// nodes so that the shape of its setup stays visible, but the bodies of those
+// nodes delegate here:
+//
+//	BeforeEach(func() {
+//		parentCtx = newVMTestParentContext()
+//		testConfig = newVMTestConfig()
+//		vmClass, vm = newVMTestObjects("test-vm")
+//		initObjects = nil
+//	})
+//
+//	JustBeforeEach(func() {
+//		ctx, vmProvider, nsInfo = setupVMTest(
+//			parentCtx, testConfig, vmClass, vm, initObjects...)
+//	})
+//
+//	AfterEach(func() {
+//		vmTestAfterEach(ctx, vm)
+//		ctx, vmProvider, vm, vmClass = nil, nil, nil, nil
+//		nsInfo = builder.WorkloadNamespaceInfo{}
+//	})
+//
+// Specs that need to interleave their own work — registering a vmconfig
+// reconciler, patching the VM class ConfigSpec, installing a vcsim handler —
+// call the finer-grained helpers (newVMTestContext, resolveVMTestImage,
+// createVMTestObjects) instead of setupVMTest.
+
+// newVMTestParentContext returns the parent context shared by the VM specs. It
+// is built in a BeforeEach rather than a JustBeforeEach so that a spec may
+// adjust the config or register vmconfig reconcilers on it before the vcsim
+// context is created.
+//
+// Fast Deploy is on, because that is how VM Operator deploys a VM on a modern
+// Supervisor; a spec that must exercise the legacy content library deploy path
+// calls disableFastDeploy.
+func newVMTestParentContext() context.Context {
+	parentCtx := pkgcfg.NewContextWithDefaultConfig()
+	parentCtx = ctxop.WithContext(parentCtx)
+	parentCtx = ovfcache.WithContext(parentCtx)
+	parentCtx = cource.WithContext(parentCtx)
+	pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
+		config.AsyncCreateEnabled = false
+		config.AsyncSignalEnabled = false
+		config.Features.FastDeploy = true
+	})
+	return parentCtx
+}
+
+// newVMTestConfig returns the vcsim configuration shared by the VM specs.
+func newVMTestConfig() builder.VCSimTestConfig {
+	return builder.VCSimTestConfig{
+		WithContentLibrary: true,
+	}
+}
+
+// newVMTestObjects returns the VM class and VM shared by the VM specs. The VM's
+// network is disabled so that a spec only pays for networking when it is
+// actually part of the behavior under test.
+func newVMTestObjects(
+	vmName string) (*vmopv1.VirtualMachineClass, *vmopv1.VirtualMachine) {
+
+	vmClass := builder.DummyVirtualMachineClassGenName()
+	vm := builder.DummyBasicVirtualMachine(vmName, "")
+
+	if vm.Spec.Network == nil {
+		vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
+	}
+	vm.Spec.Network.Disabled = true
+
+	return vmClass, vm
+}
+
+// newVMTestContext creates the vcsim test context and VM provider shared by the
+// VM specs, along with a workload namespace to deploy into.
+func newVMTestContext(
+	parentCtx context.Context,
+	testConfig builder.VCSimTestConfig,
+	initObjects ...client.Object) (
+	*builder.TestContextForVCSim,
+	providers.VirtualMachineProviderInterface,
+	builder.WorkloadNamespaceInfo) {
+
+	ctx := suite.NewTestContextForVCSimWithParentContext(parentCtx, testConfig, initObjects...)
+	pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
+		config.MaxDeployThreadsOnProvider = 1
+	})
+	vmProvider := vsphere.NewVSphereVMProviderFromClient(ctx, ctx.Client, ctx.Recorder)
+	nsInfo := ctx.CreateWorkloadNamespace()
+
+	return ctx, vmProvider, nsInfo
+}
+
+// resolveVMTestImage returns the image the VM specs deploy from. When the test
+// context has a content library, the image backed by its first library item is
+// used. Otherwise a VM from the vcsim inventory is used as the clone source,
+// which requires bypassing the content library provider check.
+func resolveVMTestImage(
+	ctx *builder.TestContextForVCSim,
+	testConfig builder.VCSimTestConfig) *vmopv1.ClusterVirtualMachineImage {
+
+	img := &vmopv1.ClusterVirtualMachineImage{}
+
+	if testConfig.WithContentLibrary {
+		ExpectWithOffset(1, ctx.Client.Get(
+			ctx,
+			client.ObjectKey{Name: ctx.ContentLibraryItem1Name},
+			img)).To(Succeed())
+
+		return img
+	}
+
+	// BMV: VM creation without a content library is broken - and has been for a
+	// long while - since we assume the VM image will always point to a content
+	// library item. Hack around that with this knob so we can continue to test
+	// the VM clone path.
+	vsphere.SkipVMImageCLProviderCheck = true
+
+	img = builder.DummyClusterVirtualMachineImage("DC0_C0_RP0_VM0")
+	ExpectWithOffset(1, ctx.Client.Create(ctx, img)).To(Succeed())
+	conditions.MarkTrue(img, vmopv1.ReadyConditionType)
+	ExpectWithOffset(1, ctx.Client.Status().Update(ctx, img)).To(Succeed())
+
+	return img
+}
+
+// createVMTestObjects creates the VM class and the VM in the workload
+// namespace, pointing the VM at the provided class and image and at the test
+// context's storage class.
+func createVMTestObjects(
+	ctx *builder.TestContextForVCSim,
+	nsInfo builder.WorkloadNamespaceInfo,
+	img *vmopv1.ClusterVirtualMachineImage,
+	vmClass *vmopv1.VirtualMachineClass,
+	vm *vmopv1.VirtualMachine) {
+
+	var className string
+	if vmClass != nil {
+		vmClass.Namespace = nsInfo.Namespace
+		ExpectWithOffset(1, ctx.Client.Create(ctx, vmClass)).To(Succeed())
+		className = vmClass.Name
+	}
+
+	vm.Namespace = nsInfo.Namespace
+	vm.Spec.ClassName = className
+	vm.Spec.ImageName = img.Name
+	vm.Spec.Image.Kind = cvmiKind
+	vm.Spec.Image.Name = img.Name
+	vm.Spec.StorageClass = ctx.StorageClassName
+
+	ExpectWithOffset(1, ctx.Client.Create(ctx, vm)).To(Succeed())
+}
+
+// setupVMTest performs the whole JustBeforeEach shared by the VM specs: it
+// creates the vcsim test context, VM provider, and workload namespace, then
+// creates the VM class and VM in that namespace. When Fast Deploy is enabled it
+// also reports the image's files as cached, since nothing else in a provider
+// test plays the part of the image cache controller.
+func setupVMTest(
+	parentCtx context.Context,
+	testConfig builder.VCSimTestConfig,
+	vmClass *vmopv1.VirtualMachineClass,
+	vm *vmopv1.VirtualMachine,
+	initObjects ...client.Object) (
+	*builder.TestContextForVCSim,
+	providers.VirtualMachineProviderInterface,
+	builder.WorkloadNamespaceInfo) {
+
+	ctx, vmProvider, nsInfo := newVMTestContext(parentCtx, testConfig, initObjects...)
+
+	img := resolveVMTestImage(ctx, testConfig)
+
+	if testConfig.WithContentLibrary && pkgcfg.FromContext(ctx).Features.FastDeploy {
+		ctx.MarkImageCacheReady(ctx.ContentLibraryItem1Cache)
+	}
+
+	createVMTestObjects(ctx, nsInfo, img, vmClass, vm)
+
+	return ctx, vmProvider, nsInfo
+}
+
+// disableFastDeploy turns Fast Deploy off for a spec that must exercise the
+// legacy content library deploy path — instance storage, for instance, which
+// Fast Deploy does not support. See
+// pkg/providers/vsphere/placement/zone_placement.go.
+func disableFastDeploy(parentCtx context.Context) {
+	pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
+		config.Features.FastDeploy = false
+	})
+}
+
+// pinVMToFirstZone places the VM into the first zone the test context created
+// by way of the topology label. It returns the zone's name and must be called
+// after the VM has been created.
+func pinVMToFirstZone(
+	ctx *builder.TestContextForVCSim,
+	vm *vmopv1.VirtualMachine) string {
+
+	zoneName := ctx.GetFirstZoneName()
+	vm.Labels[corev1.LabelTopologyZone] = zoneName
+	ExpectWithOffset(1, ctx.Client.Update(ctx, vm)).To(Succeed())
+
+	return zoneName
+}
+
+// vmTestAfterEach asserts the invariants shared by the VM specs and tears down
+// the test context.
+func vmTestAfterEach(
+	ctx *builder.TestContextForVCSim,
+	vm *vmopv1.VirtualMachine) {
+
+	vsphere.SkipVMImageCLProviderCheck = false
+
+	if vm != nil &&
+		!pkgcfg.FromContext(ctx).Features.BringYourOwnEncryptionKey {
+
+		By("Assert vm.Status.Crypto is nil when BYOK is disabled", func() {
+			ExpectWithOffset(1, vm.Status.Crypto).To(BeNil())
+		})
+	}
+
+	ctx.AfterEach()
 }

--- a/pkg/providers/vsphere/vmprovider_vm_cbt_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_cbt_test.go
@@ -12,20 +12,15 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/vmware/govmomi/simulator"
 	"github.com/vmware/govmomi/vim25/mo"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
-	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
-	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
-	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
-	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/internal"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
@@ -48,74 +43,29 @@ func vmCBTTests() {
 		testConfig  builder.VCSimTestConfig
 		ctx         *builder.TestContextForVCSim
 		vmProvider  providers.VirtualMachineProviderInterface
-		nsInfo      builder.WorkloadNamespaceInfo
 
 		vm      *vmopv1.VirtualMachine
 		vmClass *vmopv1.VirtualMachineClass
 	)
 
 	BeforeEach(func() {
-		parentCtx = pkgcfg.NewContextWithDefaultConfig()
-		parentCtx = ctxop.WithContext(parentCtx)
-		parentCtx = ovfcache.WithContext(parentCtx)
-		parentCtx = cource.WithContext(parentCtx)
-		pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
-			config.AsyncCreateEnabled = false
-			config.AsyncSignalEnabled = false
-		})
-		testConfig = builder.VCSimTestConfig{
-			WithContentLibrary: true,
-		}
+		parentCtx = newVMTestParentContext()
+		testConfig = newVMTestConfig()
 
-		vmClass = builder.DummyVirtualMachineClassGenName()
-		vm = builder.DummyBasicVirtualMachine("test-vm", "")
-
-		if vm.Spec.Network == nil {
-			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
-		}
-		vm.Spec.Network.Disabled = true
+		vmClass, vm = newVMTestObjects("test-vm")
 	})
 
 	JustBeforeEach(func() {
-		ctx = suite.NewTestContextForVCSimWithParentContext(
-			parentCtx, testConfig, initObjects...)
-		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-			config.MaxDeployThreadsOnProvider = 1
-		})
-		vmProvider = vsphere.NewVSphereVMProviderFromClient(
-			ctx, ctx.Client, ctx.Recorder)
-		nsInfo = ctx.CreateWorkloadNamespace()
-
-		vmClass.Namespace = nsInfo.Namespace
-		Expect(ctx.Client.Create(ctx, vmClass)).To(Succeed())
-
-		clusterVMI1 := &vmopv1.ClusterVirtualMachineImage{}
-
-		if testConfig.WithContentLibrary {
-			Expect(ctx.Client.Get(
-				ctx, client.ObjectKey{Name: ctx.ContentLibraryItem1Name},
-				clusterVMI1)).To(Succeed())
-		} else {
-			vsphere.SkipVMImageCLProviderCheck = true
-			clusterVMI1 = builder.DummyClusterVirtualMachineImage("DC0_C0_RP0_VM0")
-			Expect(ctx.Client.Create(ctx, clusterVMI1)).To(Succeed())
-			conditions.MarkTrue(clusterVMI1, vmopv1.ReadyConditionType)
-			Expect(ctx.Client.Status().Update(ctx, clusterVMI1)).To(Succeed())
-		}
-
-		vm.Namespace = nsInfo.Namespace
-		vm.Spec.ClassName = vmClass.Name
-		vm.Spec.ImageName = clusterVMI1.Name
-		vm.Spec.Image.Kind = cvmiKind
-		vm.Spec.Image.Name = clusterVMI1.Name
-		vm.Spec.StorageClass = ctx.StorageClassName
-
-		Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
+		ctx, vmProvider, _ = setupVMTest(
+			parentCtx, testConfig, vmClass, vm, initObjects...)
 	})
 
 	AfterEach(func() {
-		vsphere.SkipVMImageCLProviderCheck = false
-		ctx.AfterEach()
+		vmTestAfterEach(ctx, vm)
+
+		vmClass = nil
+		vm = nil
+
 		ctx = nil
 		initObjects = nil
 	})

--- a/pkg/providers/vsphere/vmprovider_vm_cleanup_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_cleanup_test.go
@@ -18,14 +18,8 @@ import (
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
-	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
-	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
-	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
-	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/constants"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
@@ -38,94 +32,37 @@ func vmCleanupTests() {
 		testConfig  builder.VCSimTestConfig
 		ctx         *builder.TestContextForVCSim
 		vmProvider  providers.VirtualMachineProviderInterface
-		nsInfo      builder.WorkloadNamespaceInfo
 
 		vm      *vmopv1.VirtualMachine
 		vmClass *vmopv1.VirtualMachineClass
 	)
 
 	BeforeEach(func() {
-		parentCtx = pkgcfg.NewContextWithDefaultConfig()
-		parentCtx = ctxop.WithContext(parentCtx)
-		parentCtx = ovfcache.WithContext(parentCtx)
-		parentCtx = cource.WithContext(parentCtx)
-		pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
-			config.AsyncCreateEnabled = false
-			config.AsyncSignalEnabled = false
-		})
-		testConfig = builder.VCSimTestConfig{
-			WithContentLibrary: true,
-		}
+		parentCtx = newVMTestParentContext()
+		testConfig = newVMTestConfig()
 
-		vmClass = builder.DummyVirtualMachineClassGenName()
-		vm = builder.DummyBasicVirtualMachine("test-vm", "")
-
-		if vm.Spec.Network == nil {
-			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
-		}
-		vm.Spec.Network.Disabled = true
+		vmClass, vm = newVMTestObjects("test-vm")
 
 		// Explicitly place the VM into one of the zones that the test context will create.
 		vm.Labels[corev1.LabelTopologyZone] = zoneName
 	})
 
 	JustBeforeEach(func() {
-		ctx = suite.NewTestContextForVCSimWithParentContext(
-			parentCtx, testConfig, initObjects...)
-		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-			config.MaxDeployThreadsOnProvider = 1
-		})
-		vmProvider = vsphere.NewVSphereVMProviderFromClient(
-			ctx, ctx.Client, ctx.Recorder)
-		nsInfo = ctx.CreateWorkloadNamespace()
-
-		vmClass.Namespace = nsInfo.Namespace
-		Expect(ctx.Client.Create(ctx, vmClass)).To(Succeed())
-
-		clusterVMI1 := &vmopv1.ClusterVirtualMachineImage{}
-
-		if testConfig.WithContentLibrary {
-			Expect(ctx.Client.Get(
-				ctx, client.ObjectKey{Name: ctx.ContentLibraryItem1Name},
-				clusterVMI1)).To(Succeed())
-		} else {
-			vsphere.SkipVMImageCLProviderCheck = true
-			clusterVMI1 = builder.DummyClusterVirtualMachineImage("DC0_C0_RP0_VM0")
-			Expect(ctx.Client.Create(ctx, clusterVMI1)).To(Succeed())
-			conditions.MarkTrue(clusterVMI1, vmopv1.ReadyConditionType)
-			Expect(ctx.Client.Status().Update(ctx, clusterVMI1)).To(Succeed())
-		}
-
-		vm.Namespace = nsInfo.Namespace
-		vm.Spec.ClassName = vmClass.Name
-		vm.Spec.ImageName = clusterVMI1.Name
-		vm.Spec.Image.Kind = cvmiKind
-		vm.Spec.Image.Name = clusterVMI1.Name
-		vm.Spec.StorageClass = ctx.StorageClassName
-
-		Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
+		ctx, vmProvider, _ = setupVMTest(
+			parentCtx, testConfig, vmClass, vm, initObjects...)
 
 		Expect(createOrUpdateVM(ctx, vmProvider, vm)).To(Succeed())
 	})
 
 	AfterEach(func() {
-		vsphere.SkipVMImageCLProviderCheck = false
-
-		if vm != nil &&
-			!pkgcfg.FromContext(ctx).Features.BringYourOwnEncryptionKey {
-			By("Assert vm.Status.Crypto is nil when BYOK is disabled", func() {
-				Expect(vm.Status.Crypto).To(BeNil())
-			})
-		}
+		vmTestAfterEach(ctx, vm)
 
 		vmClass = nil
 		vm = nil
 
-		ctx.AfterEach()
 		ctx = nil
 		initObjects = nil
 		vmProvider = nil
-		nsInfo = builder.WorkloadNamespaceInfo{}
 	})
 
 	It("successfully cleans up VM service state", func() {

--- a/pkg/providers/vsphere/vmprovider_vm_cns_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_cns_test.go
@@ -14,13 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
-	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
-	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
-	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
-	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
@@ -34,93 +28,34 @@ func vmCNSTests() {
 		testConfig  builder.VCSimTestConfig
 		ctx         *builder.TestContextForVCSim
 		vmProvider  providers.VirtualMachineProviderInterface
-		nsInfo      builder.WorkloadNamespaceInfo
 
 		vm      *vmopv1.VirtualMachine
 		vmClass *vmopv1.VirtualMachineClass
 	)
 
 	BeforeEach(func() {
-		parentCtx = pkgcfg.NewContextWithDefaultConfig()
-		parentCtx = ctxop.WithContext(parentCtx)
-		parentCtx = ovfcache.WithContext(parentCtx)
-		parentCtx = cource.WithContext(parentCtx)
-		pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
-			config.AsyncCreateEnabled = false
-			config.AsyncSignalEnabled = false
-		})
-		testConfig = builder.VCSimTestConfig{
-			WithContentLibrary: true,
-		}
+		parentCtx = newVMTestParentContext()
+		testConfig = newVMTestConfig()
 
-		vmClass = builder.DummyVirtualMachineClassGenName()
-		vm = builder.DummyBasicVirtualMachine("test-vm", "")
-
-		if vm.Spec.Network == nil {
-			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
-		}
-		vm.Spec.Network.Disabled = true
+		vmClass, vm = newVMTestObjects("test-vm")
 	})
 
 	JustBeforeEach(func() {
-		ctx = suite.NewTestContextForVCSimWithParentContext(
-			parentCtx, testConfig, initObjects...)
-		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-			config.MaxDeployThreadsOnProvider = 1
-		})
-		vmProvider = vsphere.NewVSphereVMProviderFromClient(
-			ctx, ctx.Client, ctx.Recorder)
-		nsInfo = ctx.CreateWorkloadNamespace()
+		ctx, vmProvider, _ = setupVMTest(
+			parentCtx, testConfig, vmClass, vm, initObjects...)
 
-		vmClass.Namespace = nsInfo.Namespace
-		Expect(ctx.Client.Create(ctx, vmClass)).To(Succeed())
-
-		clusterVMI1 := &vmopv1.ClusterVirtualMachineImage{}
-
-		if testConfig.WithContentLibrary {
-			Expect(ctx.Client.Get(
-				ctx, client.ObjectKey{Name: ctx.ContentLibraryItem1Name},
-				clusterVMI1)).To(Succeed())
-		} else {
-			vsphere.SkipVMImageCLProviderCheck = true
-			clusterVMI1 = builder.DummyClusterVirtualMachineImage("DC0_C0_RP0_VM0")
-			Expect(ctx.Client.Create(ctx, clusterVMI1)).To(Succeed())
-			conditions.MarkTrue(clusterVMI1, vmopv1.ReadyConditionType)
-			Expect(ctx.Client.Status().Update(ctx, clusterVMI1)).To(Succeed())
-		}
-
-		vm.Namespace = nsInfo.Namespace
-		vm.Spec.ClassName = vmClass.Name
-		vm.Spec.ImageName = clusterVMI1.Name
-		vm.Spec.Image.Kind = cvmiKind
-		vm.Spec.Image.Name = clusterVMI1.Name
-		vm.Spec.StorageClass = ctx.StorageClassName
-
-		Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
-
-		zoneName := ctx.GetFirstZoneName()
-		vm.Labels[corev1.LabelTopologyZone] = zoneName
-		Expect(ctx.Client.Update(ctx, vm)).To(Succeed())
+		pinVMToFirstZone(ctx, vm)
 	})
 
 	AfterEach(func() {
-		vsphere.SkipVMImageCLProviderCheck = false
-
-		if vm != nil &&
-			!pkgcfg.FromContext(ctx).Features.BringYourOwnEncryptionKey {
-			By("Assert vm.Status.Crypto is nil when BYOK is disabled", func() {
-				Expect(vm.Status.Crypto).To(BeNil())
-			})
-		}
+		vmTestAfterEach(ctx, vm)
 
 		vmClass = nil
 		vm = nil
 
-		ctx.AfterEach()
 		ctx = nil
 		initObjects = nil
 		vmProvider = nil
-		nsInfo = builder.WorkloadNamespaceInfo{}
 	})
 
 	It("CSI Volumes workflow", func() {

--- a/pkg/providers/vsphere/vmprovider_vm_configspec_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_configspec_test.go
@@ -18,6 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/google/uuid"
+
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/mo"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
@@ -27,13 +28,9 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgconst "github.com/vmware-tanzu/vm-operator/pkg/constants"
-	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
-	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/constants"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/virtualmachine"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
@@ -57,26 +54,10 @@ func vmConfigSpecTests() {
 	)
 
 	BeforeEach(func() {
-		parentCtx = pkgcfg.NewContextWithDefaultConfig()
-		parentCtx = ctxop.WithContext(parentCtx)
-		parentCtx = ovfcache.WithContext(parentCtx)
-		parentCtx = cource.WithContext(parentCtx)
-		pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
-			config.AsyncCreateEnabled = false
-			config.AsyncSignalEnabled = false
-		})
-		testConfig = builder.VCSimTestConfig{
-			WithContentLibrary: true,
-		}
+		parentCtx = newVMTestParentContext()
+		testConfig = newVMTestConfig()
 
-		vmClass = builder.DummyVirtualMachineClassGenName()
-		vm = builder.DummyBasicVirtualMachine("test-vm", "")
-
-		// Reduce diff from old tests: by default don't create an NIC.
-		if vm.Spec.Network == nil {
-			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
-		}
-		vm.Spec.Network.Disabled = true
+		vmClass, vm = newVMTestObjects("test-vm")
 
 		testConfig.WithNetworkEnv = builder.NetworkEnvNamed
 
@@ -102,42 +83,8 @@ func vmConfigSpecTests() {
 	})
 
 	JustBeforeEach(func() {
-		ctx = suite.NewTestContextForVCSimWithParentContext(parentCtx, testConfig, initObjects...)
-		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-			config.MaxDeployThreadsOnProvider = 1
-		})
-		vmProvider = vsphere.NewVSphereVMProviderFromClient(ctx, ctx.Client, ctx.Recorder)
-		nsInfo = ctx.CreateWorkloadNamespace()
-
-		vmClass.Namespace = nsInfo.Namespace
-		Expect(ctx.Client.Create(ctx, vmClass)).To(Succeed())
-
-		clusterVMI1 := &vmopv1.ClusterVirtualMachineImage{}
-
-		if testConfig.WithContentLibrary {
-			Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: ctx.ContentLibraryItem1Name}, clusterVMI1)).To(Succeed())
-
-		} else {
-			// BMV: VM creation without CL is broken - and has been for a long while - since we assume
-			// the VM Image will always point to a ContentLibrary item.
-			// Hack around that with this knob so we can continue to test the VM clone path.
-			vsphere.SkipVMImageCLProviderCheck = true
-
-			// Use the default VM created by vcsim as the source.
-			clusterVMI1 = builder.DummyClusterVirtualMachineImage("DC0_C0_RP0_VM0")
-			Expect(ctx.Client.Create(ctx, clusterVMI1)).To(Succeed())
-			conditions.MarkTrue(clusterVMI1, vmopv1.ReadyConditionType)
-			Expect(ctx.Client.Status().Update(ctx, clusterVMI1)).To(Succeed())
-		}
-
-		vm.Namespace = nsInfo.Namespace
-		vm.Spec.ClassName = vmClass.Name
-		vm.Spec.ImageName = clusterVMI1.Name
-		vm.Spec.Image.Kind = cvmiKind
-		vm.Spec.Image.Name = clusterVMI1.Name
-		vm.Spec.StorageClass = ctx.StorageClassName
-
-		Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
+		ctx, vmProvider, nsInfo = setupVMTest(
+			parentCtx, testConfig, vmClass, vm, initObjects...)
 
 		if configSpec != nil {
 			var w bytes.Buffer
@@ -168,19 +115,12 @@ func vmConfigSpecTests() {
 		vcVM = nil
 		configSpec = nil
 
-		vsphere.SkipVMImageCLProviderCheck = false
-
-		if vm != nil && !pkgcfg.FromContext(ctx).Features.BringYourOwnEncryptionKey {
-			By("Assert vm.Status.Crypto is nil when BYOK is disabled", func() {
-				Expect(vm.Status.Crypto).To(BeNil())
-			})
-		}
+		vmTestAfterEach(ctx, vm)
 
 		vmClass = nil
 		vm = nil
 		skipCreateOrUpdateVM = false
 
-		ctx.AfterEach()
 		ctx = nil
 		initObjects = nil
 		vmProvider = nil
@@ -918,17 +858,18 @@ func vmConfigSpecTests() {
 			}
 		})
 
-		// FIXME: vcsim behavior needs to be closer to real VC here so there aren't dupes
 		It("Reconfigures the VM with all misc devices in ConfigSpec, including SCSI disk controller", func() {
 			var o mo.VirtualMachine
 			Expect(vcVM.Properties(ctx, vcVM.Reference(), nil, &o)).To(Succeed())
 
 			devList := object.VirtualDeviceList(o.Config.Hardware.Device)
 
-			// VM already has a default pointing device and the spec adds one more
-			// info about the default device is unknown to assert on
+			// Fast Deploy creates the VM from the ConfigSpec directly, so the
+			// VM has exactly the devices the class asked for. The content
+			// library deploy path instead left a vcsim-supplied default
+			// pointing device and video card behind alongside these.
 			pointingDev := devList.SelectByType(&vimtypes.VirtualPointingDevice{})
-			Expect(pointingDev).To(HaveLen(2))
+			Expect(pointingDev).To(HaveLen(1))
 			dev := pointingDev[0].GetVirtualDevice()
 			backing, ok := dev.Backing.(*vimtypes.VirtualPointingDeviceDeviceBackingInfo)
 			Expect(ok).Should(BeTrue())
@@ -946,10 +887,8 @@ func vmConfigSpecTests() {
 			dev = pciControllers[0].GetVirtualDevice()
 			Expect(dev.Key).To(Equal(int32(100)))
 
-			// VM already has a default video card and the spec adds one more
-			// info about the default device is unknown to assert on
 			video := devList.SelectByType(&vimtypes.VirtualMachineVideoCard{})
-			Expect(video).To(HaveLen(2))
+			Expect(video).To(HaveLen(1))
 			dev = video[0].GetVirtualDevice()
 			Expect(dev.Key).To(Equal(int32(500)))
 			Expect(dev.ControllerKey).To(Equal(int32(100)))

--- a/pkg/providers/vsphere/vmprovider_vm_connection_state_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_connection_state_test.go
@@ -12,7 +12,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/vmware/govmomi/simulator"
@@ -20,14 +19,8 @@ import (
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
-	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
-	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
-	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 	pkgerr "github.com/vmware-tanzu/vm-operator/pkg/errors"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
-	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
@@ -38,95 +31,34 @@ func vmConnectionStateTests() {
 		testConfig  builder.VCSimTestConfig
 		ctx         *builder.TestContextForVCSim
 		vmProvider  providers.VirtualMachineProviderInterface
-		nsInfo      builder.WorkloadNamespaceInfo
 
 		vm      *vmopv1.VirtualMachine
 		vmClass *vmopv1.VirtualMachineClass
-
-		zoneName string
 	)
 
 	BeforeEach(func() {
-		parentCtx = pkgcfg.NewContextWithDefaultConfig()
-		parentCtx = ctxop.WithContext(parentCtx)
-		parentCtx = ovfcache.WithContext(parentCtx)
-		parentCtx = cource.WithContext(parentCtx)
-		pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
-			config.AsyncCreateEnabled = false
-			config.AsyncSignalEnabled = false
-		})
-		testConfig = builder.VCSimTestConfig{
-			WithContentLibrary: true,
-		}
+		parentCtx = newVMTestParentContext()
+		testConfig = newVMTestConfig()
 
-		vmClass = builder.DummyVirtualMachineClassGenName()
-		vm = builder.DummyBasicVirtualMachine("test-vm", "")
-
-		if vm.Spec.Network == nil {
-			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
-		}
-		vm.Spec.Network.Disabled = true
+		vmClass, vm = newVMTestObjects("test-vm")
 	})
 
 	JustBeforeEach(func() {
-		ctx = suite.NewTestContextForVCSimWithParentContext(
-			parentCtx, testConfig, initObjects...)
-		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-			config.MaxDeployThreadsOnProvider = 1
-		})
-		vmProvider = vsphere.NewVSphereVMProviderFromClient(
-			ctx, ctx.Client, ctx.Recorder)
-		nsInfo = ctx.CreateWorkloadNamespace()
+		ctx, vmProvider, _ = setupVMTest(
+			parentCtx, testConfig, vmClass, vm, initObjects...)
 
-		vmClass.Namespace = nsInfo.Namespace
-		Expect(ctx.Client.Create(ctx, vmClass)).To(Succeed())
-
-		clusterVMI1 := &vmopv1.ClusterVirtualMachineImage{}
-
-		if testConfig.WithContentLibrary {
-			Expect(ctx.Client.Get(
-				ctx, client.ObjectKey{Name: ctx.ContentLibraryItem1Name},
-				clusterVMI1)).To(Succeed())
-		} else {
-			vsphere.SkipVMImageCLProviderCheck = true
-			clusterVMI1 = builder.DummyClusterVirtualMachineImage("DC0_C0_RP0_VM0")
-			Expect(ctx.Client.Create(ctx, clusterVMI1)).To(Succeed())
-			conditions.MarkTrue(clusterVMI1, vmopv1.ReadyConditionType)
-			Expect(ctx.Client.Status().Update(ctx, clusterVMI1)).To(Succeed())
-		}
-
-		vm.Namespace = nsInfo.Namespace
-		vm.Spec.ClassName = vmClass.Name
-		vm.Spec.ImageName = clusterVMI1.Name
-		vm.Spec.Image.Kind = cvmiKind
-		vm.Spec.Image.Name = clusterVMI1.Name
-		vm.Spec.StorageClass = ctx.StorageClassName
-
-		Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
-
-		zoneName = ctx.GetFirstZoneName()
-		vm.Labels[corev1.LabelTopologyZone] = zoneName
-		Expect(ctx.Client.Update(ctx, vm)).To(Succeed())
+		pinVMToFirstZone(ctx, vm)
 	})
 
 	AfterEach(func() {
-		vsphere.SkipVMImageCLProviderCheck = false
-
-		if vm != nil &&
-			!pkgcfg.FromContext(ctx).Features.BringYourOwnEncryptionKey {
-			By("Assert vm.Status.Crypto is nil when BYOK is disabled", func() {
-				Expect(vm.Status.Crypto).To(BeNil())
-			})
-		}
+		vmTestAfterEach(ctx, vm)
 
 		vmClass = nil
 		vm = nil
 
-		ctx.AfterEach()
 		ctx = nil
 		initObjects = nil
 		vmProvider = nil
-		nsInfo = builder.WorkloadNamespaceInfo{}
 	})
 
 	DescribeTable("VM is not connected",

--- a/pkg/providers/vsphere/vmprovider_vm_create_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_create_test.go
@@ -11,7 +11,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -24,13 +23,9 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
-	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
-	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/virtualmachine"
 	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
@@ -45,87 +40,28 @@ func vmCreateTests() {
 
 		vm      *vmopv1.VirtualMachine
 		vmClass *vmopv1.VirtualMachineClass
-
-		zoneName string
 	)
 
 	BeforeEach(func() {
-		parentCtx = pkgcfg.NewContextWithDefaultConfig()
-		parentCtx = ctxop.WithContext(parentCtx)
-		parentCtx = ovfcache.WithContext(parentCtx)
-		parentCtx = cource.WithContext(parentCtx)
-		pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
-			config.AsyncCreateEnabled = false
-			config.AsyncSignalEnabled = false
-		})
-		testConfig = builder.VCSimTestConfig{
-			WithContentLibrary: true,
-		}
+		parentCtx = newVMTestParentContext()
+		testConfig = newVMTestConfig()
 
-		vmClass = builder.DummyVirtualMachineClassGenName()
-		vm = builder.DummyBasicVirtualMachine("test-vm", "")
-
-		if vm.Spec.Network == nil {
-			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
-		}
-		vm.Spec.Network.Disabled = true
+		vmClass, vm = newVMTestObjects("test-vm")
 	})
 
 	JustBeforeEach(func() {
-		ctx = suite.NewTestContextForVCSimWithParentContext(
-			parentCtx, testConfig, initObjects...)
-		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-			config.MaxDeployThreadsOnProvider = 1
-		})
-		vmProvider = vsphere.NewVSphereVMProviderFromClient(
-			ctx, ctx.Client, ctx.Recorder)
-		nsInfo = ctx.CreateWorkloadNamespace()
+		ctx, vmProvider, nsInfo = setupVMTest(
+			parentCtx, testConfig, vmClass, vm, initObjects...)
 
-		vmClass.Namespace = nsInfo.Namespace
-		Expect(ctx.Client.Create(ctx, vmClass)).To(Succeed())
-
-		clusterVMI1 := &vmopv1.ClusterVirtualMachineImage{}
-
-		if testConfig.WithContentLibrary {
-			Expect(ctx.Client.Get(
-				ctx, client.ObjectKey{Name: ctx.ContentLibraryItem1Name},
-				clusterVMI1)).To(Succeed())
-		} else {
-			vsphere.SkipVMImageCLProviderCheck = true
-			clusterVMI1 = builder.DummyClusterVirtualMachineImage("DC0_C0_RP0_VM0")
-			Expect(ctx.Client.Create(ctx, clusterVMI1)).To(Succeed())
-			conditions.MarkTrue(clusterVMI1, vmopv1.ReadyConditionType)
-			Expect(ctx.Client.Status().Update(ctx, clusterVMI1)).To(Succeed())
-		}
-
-		vm.Namespace = nsInfo.Namespace
-		vm.Spec.ClassName = vmClass.Name
-		vm.Spec.ImageName = clusterVMI1.Name
-		vm.Spec.Image.Kind = cvmiKind
-		vm.Spec.Image.Name = clusterVMI1.Name
-		vm.Spec.StorageClass = ctx.StorageClassName
-
-		Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
-
-		zoneName = ctx.GetFirstZoneName()
-		vm.Labels[corev1.LabelTopologyZone] = zoneName
-		Expect(ctx.Client.Update(ctx, vm)).To(Succeed())
+		pinVMToFirstZone(ctx, vm)
 	})
 
 	AfterEach(func() {
-		vsphere.SkipVMImageCLProviderCheck = false
-
-		if vm != nil &&
-			!pkgcfg.FromContext(ctx).Features.BringYourOwnEncryptionKey {
-			By("Assert vm.Status.Crypto is nil when BYOK is disabled", func() {
-				Expect(vm.Status.Crypto).To(BeNil())
-			})
-		}
+		vmTestAfterEach(ctx, vm)
 
 		vmClass = nil
 		vm = nil
 
-		ctx.AfterEach()
 		ctx = nil
 		initObjects = nil
 		vmProvider = nil
@@ -266,7 +202,11 @@ func vmCreateTests() {
 					ctx *simulator.Context,
 					m *simulator.Method) (mo.Reference, vimtypes.BaseMethodFault) {
 
-					if m.Name == "ImportVApp" {
+					// Fault whichever call the configured deploy path
+					// makes: Fast Deploy creates the VM itself, while the
+					// content library path imports the OVF.
+					switch m.Name {
+					case "CreateVM_Task", "ImportVApp":
 						return nil, &vimtypes.InvalidRequest{}
 					}
 					return nil, nil
@@ -283,7 +223,8 @@ func vmCreateTests() {
 					g.Expect(c).ToNot(BeNil())
 					g.Expect(c.Status).To(Equal(metav1.ConditionFalse))
 					g.Expect(c.Reason).To(Equal("Error"))
-					g.Expect(c.Message).To(Equal("deploy error: ServerFaultCode: InvalidRequest"))
+					g.Expect(c.Message).To(Equal(
+						"failed to call create task: ServerFaultCode: InvalidRequest"))
 				}).Should(Succeed())
 			})
 		})

--- a/pkg/providers/vsphere/vmprovider_vm_crypto_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_crypto_test.go
@@ -11,7 +11,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -23,12 +22,8 @@ import (
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
-	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
-	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
 	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmconfig"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmconfig/crypto"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
@@ -50,25 +45,10 @@ func vmCryptoTests() {
 	)
 
 	BeforeEach(func() {
-		parentCtx = pkgcfg.NewContextWithDefaultConfig()
-		parentCtx = ctxop.WithContext(parentCtx)
-		parentCtx = ovfcache.WithContext(parentCtx)
-		parentCtx = cource.WithContext(parentCtx)
-		pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
-			config.AsyncCreateEnabled = false
-			config.AsyncSignalEnabled = false
-		})
-		testConfig = builder.VCSimTestConfig{
-			WithContentLibrary: true,
-		}
+		parentCtx = newVMTestParentContext()
+		testConfig = newVMTestConfig()
 
-		vmClass = builder.DummyVirtualMachineClassGenName()
-		vm = builder.DummyBasicVirtualMachine("test-vm", "")
-
-		if vm.Spec.Network == nil {
-			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
-		}
-		vm.Spec.Network.Disabled = true
+		vmClass, vm = newVMTestObjects("test-vm")
 
 		pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
 			config.Features.BringYourOwnEncryptionKey = true
@@ -80,44 +60,10 @@ func vmCryptoTests() {
 	})
 
 	JustBeforeEach(func() {
-		ctx = suite.NewTestContextForVCSimWithParentContext(
-			parentCtx, testConfig, initObjects...)
-		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-			config.MaxDeployThreadsOnProvider = 1
-		})
-		vmProvider = vsphere.NewVSphereVMProviderFromClient(
-			ctx, ctx.Client, ctx.Recorder)
-		nsInfo = ctx.CreateWorkloadNamespace()
+		ctx, vmProvider, nsInfo = setupVMTest(
+			parentCtx, testConfig, vmClass, vm, initObjects...)
 
-		vmClass.Namespace = nsInfo.Namespace
-		Expect(ctx.Client.Create(ctx, vmClass)).To(Succeed())
-
-		clusterVMI1 := &vmopv1.ClusterVirtualMachineImage{}
-
-		if testConfig.WithContentLibrary {
-			Expect(ctx.Client.Get(
-				ctx, client.ObjectKey{Name: ctx.ContentLibraryItem1Name},
-				clusterVMI1)).To(Succeed())
-		} else {
-			vsphere.SkipVMImageCLProviderCheck = true
-			clusterVMI1 = builder.DummyClusterVirtualMachineImage("DC0_C0_RP0_VM0")
-			Expect(ctx.Client.Create(ctx, clusterVMI1)).To(Succeed())
-			conditions.MarkTrue(clusterVMI1, vmopv1.ReadyConditionType)
-			Expect(ctx.Client.Status().Update(ctx, clusterVMI1)).To(Succeed())
-		}
-
-		vm.Namespace = nsInfo.Namespace
-		vm.Spec.ClassName = vmClass.Name
-		vm.Spec.ImageName = clusterVMI1.Name
-		vm.Spec.Image.Kind = cvmiKind
-		vm.Spec.Image.Name = clusterVMI1.Name
-		vm.Spec.StorageClass = ctx.StorageClassName
-
-		Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
-
-		zoneName = ctx.GetFirstZoneName()
-		vm.Labels[corev1.LabelTopologyZone] = zoneName
-		Expect(ctx.Client.Update(ctx, vm)).To(Succeed())
+		zoneName = pinVMToFirstZone(ctx, vm)
 
 		var storageClass storagev1.StorageClass
 		Expect(ctx.Client.Get(
@@ -132,19 +78,11 @@ func vmCryptoTests() {
 	})
 
 	AfterEach(func() {
-		vsphere.SkipVMImageCLProviderCheck = false
-
-		if vm != nil &&
-			!pkgcfg.FromContext(ctx).Features.BringYourOwnEncryptionKey {
-			By("Assert vm.Status.Crypto is nil when BYOK is disabled", func() {
-				Expect(vm.Status.Crypto).To(BeNil())
-			})
-		}
+		vmTestAfterEach(ctx, vm)
 
 		vmClass = nil
 		vm = nil
 
-		ctx.AfterEach()
 		ctx = nil
 		initObjects = nil
 		vmProvider = nil
@@ -237,6 +175,7 @@ func vmCryptoTests() {
 						Expect(vm.Status.Crypto.Encrypted).To(HaveExactElements(
 							[]vmopv1.VirtualMachineEncryptionType{
 								vmopv1.VirtualMachineEncryptionTypeConfig,
+								vmopv1.VirtualMachineEncryptionTypeDisks,
 							}))
 						Expect(vm.Status.Crypto.ProviderID).To(Equal(ctx.NativeKeyProviderID))
 						Expect(vm.Status.Crypto.KeyID).ToNot(BeEmpty())
@@ -257,6 +196,7 @@ func vmCryptoTests() {
 						Expect(vm.Status.Crypto.Encrypted).To(HaveExactElements(
 							[]vmopv1.VirtualMachineEncryptionType{
 								vmopv1.VirtualMachineEncryptionTypeConfig,
+								vmopv1.VirtualMachineEncryptionTypeDisks,
 							}))
 						Expect(vm.Status.Crypto.ProviderID).To(Equal(ctx.NativeKeyProviderID))
 						Expect(vm.Status.Crypto.KeyID).ToNot(BeEmpty())
@@ -314,6 +254,7 @@ func vmCryptoTests() {
 							Expect(vm.Status.Crypto.Encrypted).To(HaveExactElements(
 								[]vmopv1.VirtualMachineEncryptionType{
 									vmopv1.VirtualMachineEncryptionTypeConfig,
+									vmopv1.VirtualMachineEncryptionTypeDisks,
 								}))
 							Expect(vm.Status.Crypto.ProviderID).To(Equal(ctx.NativeKeyProviderID))
 							Expect(vm.Status.Crypto.KeyID).ToNot(BeEmpty())
@@ -335,6 +276,7 @@ func vmCryptoTests() {
 					Expect(vm.Status.Crypto.Encrypted).To(HaveExactElements(
 						[]vmopv1.VirtualMachineEncryptionType{
 							vmopv1.VirtualMachineEncryptionTypeConfig,
+							vmopv1.VirtualMachineEncryptionTypeDisks,
 						}))
 					Expect(vm.Status.Crypto.ProviderID).To(Equal(ctx.EncryptionClass1ProviderID))
 					Expect(vm.Status.Crypto.KeyID).ToNot(BeEmpty())
@@ -355,6 +297,7 @@ func vmCryptoTests() {
 				Expect(vm.Status.Crypto.Encrypted).To(HaveExactElements(
 					[]vmopv1.VirtualMachineEncryptionType{
 						vmopv1.VirtualMachineEncryptionTypeConfig,
+						vmopv1.VirtualMachineEncryptionTypeDisks,
 					}))
 				Expect(vm.Status.Crypto.ProviderID).To(Equal(ctx.EncryptionClass1ProviderID))
 				Expect(vm.Status.Crypto.KeyID).To(Equal(nsInfo.EncryptionClass1KeyID))
@@ -392,6 +335,7 @@ func vmCryptoTests() {
 					Expect(vm.Status.Crypto.Encrypted).To(HaveExactElements(
 						[]vmopv1.VirtualMachineEncryptionType{
 							vmopv1.VirtualMachineEncryptionTypeConfig,
+							vmopv1.VirtualMachineEncryptionTypeDisks,
 						}))
 					Expect(vm.Status.Crypto.ProviderID).To(Equal(ctx.NativeKeyProviderID))
 					Expect(vm.Status.Crypto.KeyID).ToNot(BeEmpty())
@@ -412,6 +356,7 @@ func vmCryptoTests() {
 					Expect(vm.Status.Crypto.Encrypted).To(HaveExactElements(
 						[]vmopv1.VirtualMachineEncryptionType{
 							vmopv1.VirtualMachineEncryptionTypeConfig,
+							vmopv1.VirtualMachineEncryptionTypeDisks,
 						}))
 					Expect(vm.Status.Crypto.ProviderID).To(Equal(ctx.EncryptionClass1ProviderID))
 					Expect(vm.Status.Crypto.KeyID).ToNot(BeEmpty())
@@ -433,6 +378,7 @@ func vmCryptoTests() {
 				Expect(vm.Status.Crypto.Encrypted).To(HaveExactElements(
 					[]vmopv1.VirtualMachineEncryptionType{
 						vmopv1.VirtualMachineEncryptionTypeConfig,
+						vmopv1.VirtualMachineEncryptionTypeDisks,
 					}))
 				Expect(vm.Status.Crypto.ProviderID).To(Equal(ctx.EncryptionClass2ProviderID))
 				Expect(vm.Status.Crypto.KeyID).To(Equal(nsInfo.EncryptionClass2KeyID))
@@ -514,6 +460,7 @@ func vmCryptoTests() {
 					Expect(vm.Status.Crypto.Encrypted).To(HaveExactElements(
 						[]vmopv1.VirtualMachineEncryptionType{
 							vmopv1.VirtualMachineEncryptionTypeConfig,
+							vmopv1.VirtualMachineEncryptionTypeDisks,
 						}))
 					Expect(vm.Status.Crypto.ProviderID).To(Equal(ctx.NativeKeyProviderID))
 					Expect(vm.Status.Crypto.KeyID).ToNot(BeEmpty())
@@ -535,6 +482,7 @@ func vmCryptoTests() {
 					Expect(vm.Status.Crypto.Encrypted).To(HaveExactElements(
 						[]vmopv1.VirtualMachineEncryptionType{
 							vmopv1.VirtualMachineEncryptionTypeConfig,
+							vmopv1.VirtualMachineEncryptionTypeDisks,
 						}))
 					Expect(vm.Status.Crypto.ProviderID).To(Equal(ctx.EncryptionClass2ProviderID))
 					Expect(vm.Status.Crypto.KeyID).ToNot(BeEmpty())
@@ -557,6 +505,7 @@ func vmCryptoTests() {
 				Expect(vm.Status.Crypto.Encrypted).To(HaveExactElements(
 					[]vmopv1.VirtualMachineEncryptionType{
 						vmopv1.VirtualMachineEncryptionTypeConfig,
+						vmopv1.VirtualMachineEncryptionTypeDisks,
 					}))
 				Expect(vm.Status.Crypto.ProviderID).To(Equal(ctx.EncryptionClass2ProviderID))
 				Expect(vm.Status.Crypto.KeyID).To(Equal(nsInfo.EncryptionClass2KeyID))

--- a/pkg/providers/vsphere/vmprovider_vm_delete_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_delete_test.go
@@ -19,15 +19,10 @@ import (
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
-	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
-	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 	pkgerr "github.com/vmware-tanzu/vm-operator/pkg/errors"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
-	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/constants"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
@@ -40,89 +35,32 @@ func vmDeleteTests() {
 		testConfig  builder.VCSimTestConfig
 		ctx         *builder.TestContextForVCSim
 		vmProvider  providers.VirtualMachineProviderInterface
-		nsInfo      builder.WorkloadNamespaceInfo
 
 		vm      *vmopv1.VirtualMachine
 		vmClass *vmopv1.VirtualMachineClass
 	)
 
 	BeforeEach(func() {
-		parentCtx = pkgcfg.NewContextWithDefaultConfig()
-		parentCtx = ctxop.WithContext(parentCtx)
-		parentCtx = ovfcache.WithContext(parentCtx)
-		parentCtx = cource.WithContext(parentCtx)
-		pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
-			config.AsyncCreateEnabled = false
-			config.AsyncSignalEnabled = false
-		})
-		testConfig = builder.VCSimTestConfig{
-			WithContentLibrary: true,
-		}
+		parentCtx = newVMTestParentContext()
+		testConfig = newVMTestConfig()
 
-		vmClass = builder.DummyVirtualMachineClassGenName()
-		vm = builder.DummyBasicVirtualMachine("test-vm", "")
-
-		if vm.Spec.Network == nil {
-			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
-		}
-		vm.Spec.Network.Disabled = true
+		vmClass, vm = newVMTestObjects("test-vm")
 	})
 
 	JustBeforeEach(func() {
-		ctx = suite.NewTestContextForVCSimWithParentContext(
-			parentCtx, testConfig, initObjects...)
-		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-			config.MaxDeployThreadsOnProvider = 1
-		})
-		vmProvider = vsphere.NewVSphereVMProviderFromClient(
-			ctx, ctx.Client, ctx.Recorder)
-		nsInfo = ctx.CreateWorkloadNamespace()
-
-		vmClass.Namespace = nsInfo.Namespace
-		Expect(ctx.Client.Create(ctx, vmClass)).To(Succeed())
-
-		clusterVMI1 := &vmopv1.ClusterVirtualMachineImage{}
-
-		if testConfig.WithContentLibrary {
-			Expect(ctx.Client.Get(
-				ctx, client.ObjectKey{Name: ctx.ContentLibraryItem1Name},
-				clusterVMI1)).To(Succeed())
-		} else {
-			vsphere.SkipVMImageCLProviderCheck = true
-			clusterVMI1 = builder.DummyClusterVirtualMachineImage("DC0_C0_RP0_VM0")
-			Expect(ctx.Client.Create(ctx, clusterVMI1)).To(Succeed())
-			conditions.MarkTrue(clusterVMI1, vmopv1.ReadyConditionType)
-			Expect(ctx.Client.Status().Update(ctx, clusterVMI1)).To(Succeed())
-		}
-
-		vm.Namespace = nsInfo.Namespace
-		vm.Spec.ClassName = vmClass.Name
-		vm.Spec.ImageName = clusterVMI1.Name
-		vm.Spec.Image.Kind = cvmiKind
-		vm.Spec.Image.Name = clusterVMI1.Name
-		vm.Spec.StorageClass = ctx.StorageClassName
-
-		Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
+		ctx, vmProvider, _ = setupVMTest(
+			parentCtx, testConfig, vmClass, vm, initObjects...)
 	})
 
 	AfterEach(func() {
-		vsphere.SkipVMImageCLProviderCheck = false
-
-		if vm != nil &&
-			!pkgcfg.FromContext(ctx).Features.BringYourOwnEncryptionKey {
-			By("Assert vm.Status.Crypto is nil when BYOK is disabled", func() {
-				Expect(vm.Status.Crypto).To(BeNil())
-			})
-		}
+		vmTestAfterEach(ctx, vm)
 
 		vmClass = nil
 		vm = nil
 
-		ctx.AfterEach()
 		ctx = nil
 		initObjects = nil
 		vmProvider = nil
-		nsInfo = builder.WorkloadNamespaceInfo{}
 	})
 
 	BeforeEach(func() {

--- a/pkg/providers/vsphere/vmprovider_vm_disks_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_disks_test.go
@@ -12,19 +12,12 @@ import (
 	. "github.com/onsi/gomega/gstruct"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/vmware/govmomi/vim25/mo"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
-	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
-	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
-	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
-	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
@@ -35,95 +28,34 @@ func vmDisksTests() {
 		testConfig  builder.VCSimTestConfig
 		ctx         *builder.TestContextForVCSim
 		vmProvider  providers.VirtualMachineProviderInterface
-		nsInfo      builder.WorkloadNamespaceInfo
 
 		vm      *vmopv1.VirtualMachine
 		vmClass *vmopv1.VirtualMachineClass
-
-		zoneName string
 	)
 
 	BeforeEach(func() {
-		parentCtx = pkgcfg.NewContextWithDefaultConfig()
-		parentCtx = ctxop.WithContext(parentCtx)
-		parentCtx = ovfcache.WithContext(parentCtx)
-		parentCtx = cource.WithContext(parentCtx)
-		pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
-			config.AsyncCreateEnabled = false
-			config.AsyncSignalEnabled = false
-		})
-		testConfig = builder.VCSimTestConfig{
-			WithContentLibrary: true,
-		}
+		parentCtx = newVMTestParentContext()
+		testConfig = newVMTestConfig()
 
-		vmClass = builder.DummyVirtualMachineClassGenName()
-		vm = builder.DummyBasicVirtualMachine("test-vm", "")
-
-		if vm.Spec.Network == nil {
-			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
-		}
-		vm.Spec.Network.Disabled = true
+		vmClass, vm = newVMTestObjects("test-vm")
 	})
 
 	JustBeforeEach(func() {
-		ctx = suite.NewTestContextForVCSimWithParentContext(
-			parentCtx, testConfig, initObjects...)
-		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-			config.MaxDeployThreadsOnProvider = 1
-		})
-		vmProvider = vsphere.NewVSphereVMProviderFromClient(
-			ctx, ctx.Client, ctx.Recorder)
-		nsInfo = ctx.CreateWorkloadNamespace()
+		ctx, vmProvider, _ = setupVMTest(
+			parentCtx, testConfig, vmClass, vm, initObjects...)
 
-		vmClass.Namespace = nsInfo.Namespace
-		Expect(ctx.Client.Create(ctx, vmClass)).To(Succeed())
-
-		clusterVMI1 := &vmopv1.ClusterVirtualMachineImage{}
-
-		if testConfig.WithContentLibrary {
-			Expect(ctx.Client.Get(
-				ctx, client.ObjectKey{Name: ctx.ContentLibraryItem1Name},
-				clusterVMI1)).To(Succeed())
-		} else {
-			vsphere.SkipVMImageCLProviderCheck = true
-			clusterVMI1 = builder.DummyClusterVirtualMachineImage("DC0_C0_RP0_VM0")
-			Expect(ctx.Client.Create(ctx, clusterVMI1)).To(Succeed())
-			conditions.MarkTrue(clusterVMI1, vmopv1.ReadyConditionType)
-			Expect(ctx.Client.Status().Update(ctx, clusterVMI1)).To(Succeed())
-		}
-
-		vm.Namespace = nsInfo.Namespace
-		vm.Spec.ClassName = vmClass.Name
-		vm.Spec.ImageName = clusterVMI1.Name
-		vm.Spec.Image.Kind = cvmiKind
-		vm.Spec.Image.Name = clusterVMI1.Name
-		vm.Spec.StorageClass = ctx.StorageClassName
-
-		Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
-
-		zoneName = ctx.GetFirstZoneName()
-		vm.Labels[corev1.LabelTopologyZone] = zoneName
-		Expect(ctx.Client.Update(ctx, vm)).To(Succeed())
+		pinVMToFirstZone(ctx, vm)
 	})
 
 	AfterEach(func() {
-		vsphere.SkipVMImageCLProviderCheck = false
-
-		if vm != nil &&
-			!pkgcfg.FromContext(ctx).Features.BringYourOwnEncryptionKey {
-			By("Assert vm.Status.Crypto is nil when BYOK is disabled", func() {
-				Expect(vm.Status.Crypto).To(BeNil())
-			})
-		}
+		vmTestAfterEach(ctx, vm)
 
 		vmClass = nil
 		vm = nil
 
-		ctx.AfterEach()
 		ctx = nil
 		initObjects = nil
 		vmProvider = nil
-		nsInfo = builder.WorkloadNamespaceInfo{}
 	})
 
 	Context("VM has thin provisioning", func() {
@@ -141,7 +73,7 @@ func vmDisksTests() {
 			var o mo.VirtualMachine
 			Expect(vcVM.Properties(ctx, vcVM.Reference(), nil, &o)).To(Succeed())
 
-			_, backing := getVMHomeDisk(ctx, vcVM, o)
+			_, backing := getVMHomeDisk(o)
 			Expect(backing.ThinProvisioned).To(PointTo(BeTrue()))
 		})
 	})
@@ -159,7 +91,7 @@ func vmDisksTests() {
 			Expect(vcVM.Properties(ctx, vcVM.Reference(), nil, &o)).To(Succeed())
 
 			/* vcsim CL deploy has "thick" but that isn't reflected for this disk. */
-			_, backing := getVMHomeDisk(ctx, vcVM, o)
+			_, backing := getVMHomeDisk(o)
 			Expect(backing.ThinProvisioned).To(PointTo(BeFalse()))
 		})
 	})
@@ -180,7 +112,7 @@ func vmDisksTests() {
 			Expect(vcVM.Properties(ctx, vcVM.Reference(), nil, &o)).To(Succeed())
 
 			/* vcsim CL deploy has "eagerZeroedThick" but that isn't reflected for this disk. */
-			_, backing := getVMHomeDisk(ctx, vcVM, o)
+			_, backing := getVMHomeDisk(o)
 			Expect(backing.EagerlyScrub).To(PointTo(BeTrue()))
 		})
 	})
@@ -199,7 +131,7 @@ func vmDisksTests() {
 
 			var o mo.VirtualMachine
 			Expect(vcVM.Properties(ctx, vcVM.Reference(), nil, &o)).To(Succeed())
-			disk, _ := getVMHomeDisk(ctx, vcVM, o)
+			disk, _ := getVMHomeDisk(o)
 			Expect(disk.CapacityInBytes).To(BeEquivalentTo(newSize.Value()))
 		})
 	})

--- a/pkg/providers/vsphere/vmprovider_vm_extraconfig_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_extraconfig_test.go
@@ -11,22 +11,18 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/mo"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
-	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 	vmopv1common "github.com/vmware-tanzu/vm-operator/api/v1alpha6/common"
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
-	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
-	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
 	vsphereconst "github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/constants"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	vmopv1util "github.com/vmware-tanzu/vm-operator/pkg/util/vmopv1"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmconfig"
@@ -42,17 +38,13 @@ func vmExtraConfigTests() {
 		testConfig  builder.VCSimTestConfig
 		ctx         *builder.TestContextForVCSim
 		vmProvider  providers.VirtualMachineProviderInterface
-		nsInfo      builder.WorkloadNamespaceInfo
 
 		vm      *vmopv1.VirtualMachine
 		vmClass *vmopv1.VirtualMachineClass
 	)
 
 	BeforeEach(func() {
-		parentCtx = pkgcfg.NewContextWithDefaultConfig()
-		parentCtx = ctxop.WithContext(parentCtx)
-		parentCtx = ovfcache.WithContext(parentCtx)
-		parentCtx = cource.WithContext(parentCtx)
+		parentCtx = newVMTestParentContext()
 		// Set up vmconfig context so OnResult can be dispatched via the
 		// vmconfig framework when TelcoVMServiceAPI is enabled.
 		parentCtx = vmconfig.WithContext(parentCtx)
@@ -64,61 +56,27 @@ func vmExtraConfigTests() {
 			config.AsyncSignalEnabled = false
 			config.Features.TelcoVMServiceAPI = true
 		})
-		testConfig = builder.VCSimTestConfig{
-			WithContentLibrary: true,
-		}
+		testConfig = newVMTestConfig()
 
-		vmClass = builder.DummyVirtualMachineClassGenName()
-		vm = builder.DummyBasicVirtualMachine("test-vm", "")
-
-		if vm.Spec.Network == nil {
-			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
-		}
-		vm.Spec.Network.Disabled = true
+		vmClass, vm = newVMTestObjects("test-vm")
 	})
 
 	JustBeforeEach(func() {
-		ctx = suite.NewTestContextForVCSimWithParentContext(
-			parentCtx, testConfig, initObjects...)
-		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-			config.MaxDeployThreadsOnProvider = 1
-		})
-		vmProvider = vsphere.NewVSphereVMProviderFromClient(
-			ctx, ctx.Client, ctx.Recorder)
-		nsInfo = ctx.CreateWorkloadNamespace()
+		ctx, vmProvider, _ = setupVMTest(
+			parentCtx, testConfig, vmClass, vm, initObjects...)
 
-		vmClass.Namespace = nsInfo.Namespace
-		Expect(ctx.Client.Create(ctx, vmClass)).To(Succeed())
-
-		clusterVMI1 := &vmopv1.ClusterVirtualMachineImage{}
-		Expect(ctx.Client.Get(
-			ctx, client.ObjectKey{Name: ctx.ContentLibraryItem1Name},
-			clusterVMI1)).To(Succeed())
-
-		vm.Namespace = nsInfo.Namespace
-		vm.Spec.ClassName = vmClass.Name
-		vm.Spec.ImageName = clusterVMI1.Name
-		vm.Spec.Image.Kind = cvmiKind
-		vm.Spec.Image.Name = clusterVMI1.Name
-		vm.Spec.StorageClass = ctx.StorageClassName
-
-		Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
-
-		zoneName := ctx.GetFirstZoneName()
-		vm.Labels[corev1.LabelTopologyZone] = zoneName
-		Expect(ctx.Client.Update(ctx, vm)).To(Succeed())
+		pinVMToFirstZone(ctx, vm)
 	})
 
 	AfterEach(func() {
-		vsphere.SkipVMImageCLProviderCheck = false
+		vmTestAfterEach(ctx, vm)
 
 		vmClass = nil
 		vm = nil
-		ctx.AfterEach()
+
 		ctx = nil
 		initObjects = nil
 		vmProvider = nil
-		nsInfo = builder.WorkloadNamespaceInfo{}
 	})
 
 	// getECVal returns the string value of a vSphere ExtraConfig key, or "" if

--- a/pkg/providers/vsphere/vmprovider_vm_fast_deploy_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_fast_deploy_test.go
@@ -38,14 +38,10 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgconst "github.com/vmware-tanzu/vm-operator/pkg/constants"
-	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 	pkgerr "github.com/vmware-tanzu/vm-operator/pkg/errors"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
-	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
 	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
 	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 	"github.com/vmware-tanzu/vm-operator/test/testutil"
@@ -102,37 +98,22 @@ func vmFastDeployTests() {
 	)
 
 	BeforeEach(func() {
-		parentCtx = pkgcfg.NewContextWithDefaultConfig()
-		parentCtx = ctxop.WithContext(parentCtx)
-		parentCtx = ovfcache.WithContext(parentCtx)
-		parentCtx = cource.WithContext(parentCtx)
+		parentCtx = newVMTestParentContext()
 		pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
 			config.AsyncCreateEnabled = false
 			config.AsyncSignalEnabled = false
 			config.Features.FastDeploy = true
 		})
-		testConfig = builder.VCSimTestConfig{
-			WithContentLibrary: true,
-		}
+		testConfig = newVMTestConfig()
 
-		vmClass = builder.DummyVirtualMachineClassGenName()
-		vm = builder.DummyBasicVirtualMachine("test-vm", "")
-
-		if vm.Spec.Network == nil {
-			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
-		}
-		vm.Spec.Network.Disabled = true
+		vmClass, vm = newVMTestObjects("test-vm")
 
 		testConfig.WithNetworkEnv = builder.NetworkEnvNamed
 	})
 
 	JustBeforeEach(func() {
-		ctx = suite.NewTestContextForVCSimWithParentContext(parentCtx, testConfig, initObjects...)
-		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-			config.MaxDeployThreadsOnProvider = 1
-		})
-		vmProvider = vsphere.NewVSphereVMProviderFromClient(ctx, ctx.Client, ctx.Recorder)
-		nsInfo = ctx.CreateWorkloadNamespace()
+		ctx, vmProvider, nsInfo = newVMTestContext(
+			parentCtx, testConfig, initObjects...)
 		libMgr = library.NewManager(ctx.RestClient)
 
 		vmClass.Namespace = nsInfo.Namespace
@@ -205,20 +186,11 @@ func vmFastDeployTests() {
 	})
 
 	AfterEach(func() {
+		vmTestAfterEach(ctx, vm)
+
 		expectedDiskNamesFromCache = nil
-
-		if vm != nil &&
-			!pkgcfg.FromContext(ctx).Features.BringYourOwnEncryptionKey {
-
-			By("Assert vm.Status.Crypto is nil when BYOK is disabled", func() {
-				Expect(vm.Status.Crypto).To(BeNil())
-			})
-		}
-
 		libMgr = nil
 		configSpec = nil
-
-		vsphere.SkipVMImageCLProviderCheck = false
 
 		vmClass = nil
 		vm = nil
@@ -227,7 +199,6 @@ func vmFastDeployTests() {
 		extraConfig = nil
 		useEncryptedStorageClass = false
 
-		ctx.AfterEach()
 		ctx = nil
 		initObjects = nil
 		vmProvider = nil

--- a/pkg/providers/vsphere/vmprovider_vm_group_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_group_test.go
@@ -18,13 +18,10 @@ import (
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
-	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 	pkgerr "github.com/vmware-tanzu/vm-operator/pkg/errors"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
 	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
@@ -39,87 +36,28 @@ func vmGroupTests() {
 
 		vm      *vmopv1.VirtualMachine
 		vmClass *vmopv1.VirtualMachineClass
-
-		zoneName string
 	)
 
 	BeforeEach(func() {
-		parentCtx = pkgcfg.NewContextWithDefaultConfig()
-		parentCtx = ctxop.WithContext(parentCtx)
-		parentCtx = ovfcache.WithContext(parentCtx)
-		parentCtx = cource.WithContext(parentCtx)
-		pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
-			config.AsyncCreateEnabled = false
-			config.AsyncSignalEnabled = false
-		})
-		testConfig = builder.VCSimTestConfig{
-			WithContentLibrary: true,
-		}
+		parentCtx = newVMTestParentContext()
+		testConfig = newVMTestConfig()
 
-		vmClass = builder.DummyVirtualMachineClassGenName()
-		vm = builder.DummyBasicVirtualMachine("test-vm", "")
-
-		if vm.Spec.Network == nil {
-			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
-		}
-		vm.Spec.Network.Disabled = true
+		vmClass, vm = newVMTestObjects("test-vm")
 	})
 
 	JustBeforeEach(func() {
-		ctx = suite.NewTestContextForVCSimWithParentContext(
-			parentCtx, testConfig, initObjects...)
-		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-			config.MaxDeployThreadsOnProvider = 1
-		})
-		vmProvider = vsphere.NewVSphereVMProviderFromClient(
-			ctx, ctx.Client, ctx.Recorder)
-		nsInfo = ctx.CreateWorkloadNamespace()
+		ctx, vmProvider, nsInfo = setupVMTest(
+			parentCtx, testConfig, vmClass, vm, initObjects...)
 
-		vmClass.Namespace = nsInfo.Namespace
-		Expect(ctx.Client.Create(ctx, vmClass)).To(Succeed())
-
-		clusterVMI1 := &vmopv1.ClusterVirtualMachineImage{}
-
-		if testConfig.WithContentLibrary {
-			Expect(ctx.Client.Get(
-				ctx, client.ObjectKey{Name: ctx.ContentLibraryItem1Name},
-				clusterVMI1)).To(Succeed())
-		} else {
-			vsphere.SkipVMImageCLProviderCheck = true
-			clusterVMI1 = builder.DummyClusterVirtualMachineImage("DC0_C0_RP0_VM0")
-			Expect(ctx.Client.Create(ctx, clusterVMI1)).To(Succeed())
-			conditions.MarkTrue(clusterVMI1, vmopv1.ReadyConditionType)
-			Expect(ctx.Client.Status().Update(ctx, clusterVMI1)).To(Succeed())
-		}
-
-		vm.Namespace = nsInfo.Namespace
-		vm.Spec.ClassName = vmClass.Name
-		vm.Spec.ImageName = clusterVMI1.Name
-		vm.Spec.Image.Kind = cvmiKind
-		vm.Spec.Image.Name = clusterVMI1.Name
-		vm.Spec.StorageClass = ctx.StorageClassName
-
-		Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
-
-		zoneName = ctx.GetFirstZoneName()
-		vm.Labels[corev1.LabelTopologyZone] = zoneName
-		Expect(ctx.Client.Update(ctx, vm)).To(Succeed())
+		pinVMToFirstZone(ctx, vm)
 	})
 
 	AfterEach(func() {
-		vsphere.SkipVMImageCLProviderCheck = false
-
-		if vm != nil &&
-			!pkgcfg.FromContext(ctx).Features.BringYourOwnEncryptionKey {
-			By("Assert vm.Status.Crypto is nil when BYOK is disabled", func() {
-				Expect(vm.Status.Crypto).To(BeNil())
-			})
-		}
+		vmTestAfterEach(ctx, vm)
 
 		vmClass = nil
 		vm = nil
 
-		ctx.AfterEach()
 		ctx = nil
 		initObjects = nil
 		vmProvider = nil
@@ -249,9 +187,10 @@ func vmGroupTests() {
 								},
 							},
 							Placement: &vmopv1.VirtualMachinePlacementStatus{
-								Zone: groupZone,
-								Node: groupHost,
-								Pool: groupPool,
+								Zone:       groupZone,
+								Node:       groupHost,
+								Pool:       groupPool,
+								Datastores: ctx.GroupPlacementDatastores(),
 							},
 						},
 					}
@@ -478,9 +417,10 @@ func vmGroupTests() {
 								},
 							},
 							Placement: &vmopv1.VirtualMachinePlacementStatus{
-								Zone: placementZone,
-								Node: groupHost,
-								Pool: groupPool,
+								Zone:       placementZone,
+								Node:       groupHost,
+								Pool:       groupPool,
+								Datastores: ctx.GroupPlacementDatastores(),
 							},
 						},
 					}

--- a/pkg/providers/vsphere/vmprovider_vm_group_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_group_test.go
@@ -132,6 +132,7 @@ func vmGroupTests() {
 						{
 							Name: vm.Name,
 							Kind: "VirtualMachine",
+							UID:  vm.UID,
 							Conditions: []metav1.Condition{
 								{
 									Type:   vmopv1.VirtualMachineGroupMemberConditionPlacementReady,
@@ -180,6 +181,7 @@ func vmGroupTests() {
 						{
 							Name: vm.Name,
 							Kind: "VirtualMachine",
+							UID:  vm.UID,
 							Conditions: []metav1.Condition{
 								{
 									Type:   vmopv1.VirtualMachineGroupMemberConditionPlacementReady,
@@ -410,6 +412,7 @@ func vmGroupTests() {
 						{
 							Name: vm.Name,
 							Kind: "VirtualMachine",
+							UID:  vm.UID,
 							Conditions: []metav1.Condition{
 								{
 									Type:   vmopv1.VirtualMachineGroupMemberConditionPlacementReady,

--- a/pkg/providers/vsphere/vmprovider_vm_guest_heartbeat_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_guest_heartbeat_test.go
@@ -9,16 +9,11 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
-	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
-	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
-	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
-	"github.com/vmware-tanzu/vm-operator/pkg/providers"
-	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
-	"github.com/vmware-tanzu/vm-operator/test/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+	"github.com/vmware-tanzu/vm-operator/pkg/providers"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func vmGuestHeartbeatTests() {
@@ -28,89 +23,32 @@ func vmGuestHeartbeatTests() {
 		testConfig  builder.VCSimTestConfig
 		ctx         *builder.TestContextForVCSim
 		vmProvider  providers.VirtualMachineProviderInterface
-		nsInfo      builder.WorkloadNamespaceInfo
 
 		vm      *vmopv1.VirtualMachine
 		vmClass *vmopv1.VirtualMachineClass
 	)
 
 	BeforeEach(func() {
-		parentCtx = pkgcfg.NewContextWithDefaultConfig()
-		parentCtx = ctxop.WithContext(parentCtx)
-		parentCtx = ovfcache.WithContext(parentCtx)
-		parentCtx = cource.WithContext(parentCtx)
-		pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
-			config.AsyncCreateEnabled = false
-			config.AsyncSignalEnabled = false
-		})
-		testConfig = builder.VCSimTestConfig{
-			WithContentLibrary: true,
-		}
+		parentCtx = newVMTestParentContext()
+		testConfig = newVMTestConfig()
 
-		vmClass = builder.DummyVirtualMachineClassGenName()
-		vm = builder.DummyBasicVirtualMachine("test-vm", "")
-
-		if vm.Spec.Network == nil {
-			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
-		}
-		vm.Spec.Network.Disabled = true
+		vmClass, vm = newVMTestObjects("test-vm")
 	})
 
 	JustBeforeEach(func() {
-		ctx = suite.NewTestContextForVCSimWithParentContext(
-			parentCtx, testConfig, initObjects...)
-		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-			config.MaxDeployThreadsOnProvider = 1
-		})
-		vmProvider = vsphere.NewVSphereVMProviderFromClient(
-			ctx, ctx.Client, ctx.Recorder)
-		nsInfo = ctx.CreateWorkloadNamespace()
-
-		vmClass.Namespace = nsInfo.Namespace
-		Expect(ctx.Client.Create(ctx, vmClass)).To(Succeed())
-
-		clusterVMI1 := &vmopv1.ClusterVirtualMachineImage{}
-
-		if testConfig.WithContentLibrary {
-			Expect(ctx.Client.Get(
-				ctx, client.ObjectKey{Name: ctx.ContentLibraryItem1Name},
-				clusterVMI1)).To(Succeed())
-		} else {
-			vsphere.SkipVMImageCLProviderCheck = true
-			clusterVMI1 = builder.DummyClusterVirtualMachineImage("DC0_C0_RP0_VM0")
-			Expect(ctx.Client.Create(ctx, clusterVMI1)).To(Succeed())
-			conditions.MarkTrue(clusterVMI1, vmopv1.ReadyConditionType)
-			Expect(ctx.Client.Status().Update(ctx, clusterVMI1)).To(Succeed())
-		}
-
-		vm.Namespace = nsInfo.Namespace
-		vm.Spec.ClassName = vmClass.Name
-		vm.Spec.ImageName = clusterVMI1.Name
-		vm.Spec.Image.Kind = cvmiKind
-		vm.Spec.Image.Name = clusterVMI1.Name
-		vm.Spec.StorageClass = ctx.StorageClassName
-
-		Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
+		ctx, vmProvider, _ = setupVMTest(
+			parentCtx, testConfig, vmClass, vm, initObjects...)
 	})
 
 	AfterEach(func() {
-		vsphere.SkipVMImageCLProviderCheck = false
-
-		if vm != nil &&
-			!pkgcfg.FromContext(ctx).Features.BringYourOwnEncryptionKey {
-			By("Assert vm.Status.Crypto is nil when BYOK is disabled", func() {
-				Expect(vm.Status.Crypto).To(BeNil())
-			})
-		}
+		vmTestAfterEach(ctx, vm)
 
 		vmClass = nil
 		vm = nil
 
-		ctx.AfterEach()
 		ctx = nil
 		initObjects = nil
 		vmProvider = nil
-		nsInfo = builder.WorkloadNamespaceInfo{}
 	})
 
 	JustBeforeEach(func() {

--- a/pkg/providers/vsphere/vmprovider_vm_hardwareversion_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_hardwareversion_test.go
@@ -9,16 +9,11 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
-	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
-	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
-	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
-	"github.com/vmware-tanzu/vm-operator/pkg/providers"
-	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
-	"github.com/vmware-tanzu/vm-operator/test/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+	"github.com/vmware-tanzu/vm-operator/pkg/providers"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
 
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 )
@@ -30,89 +25,44 @@ func vmHardwareVersionTests() {
 		testConfig  builder.VCSimTestConfig
 		ctx         *builder.TestContextForVCSim
 		vmProvider  providers.VirtualMachineProviderInterface
-		nsInfo      builder.WorkloadNamespaceInfo
 
 		vm      *vmopv1.VirtualMachine
 		vmClass *vmopv1.VirtualMachineClass
 	)
 
 	BeforeEach(func() {
-		parentCtx = pkgcfg.NewContextWithDefaultConfig()
-		parentCtx = ctxop.WithContext(parentCtx)
-		parentCtx = ovfcache.WithContext(parentCtx)
-		parentCtx = cource.WithContext(parentCtx)
-		pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
-			config.AsyncCreateEnabled = false
-			config.AsyncSignalEnabled = false
-		})
-		testConfig = builder.VCSimTestConfig{
-			WithContentLibrary: true,
-		}
+		parentCtx = newVMTestParentContext()
+		testConfig = newVMTestConfig()
 
-		vmClass = builder.DummyVirtualMachineClassGenName()
-		vm = builder.DummyBasicVirtualMachine("test-vm", "")
-
-		if vm.Spec.Network == nil {
-			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
-		}
-		vm.Spec.Network.Disabled = true
+		vmClass, vm = newVMTestObjects("test-vm")
 	})
 
 	JustBeforeEach(func() {
-		ctx = suite.NewTestContextForVCSimWithParentContext(
-			parentCtx, testConfig, initObjects...)
-		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-			config.MaxDeployThreadsOnProvider = 1
-		})
-		vmProvider = vsphere.NewVSphereVMProviderFromClient(
-			ctx, ctx.Client, ctx.Recorder)
-		nsInfo = ctx.CreateWorkloadNamespace()
-
-		vmClass.Namespace = nsInfo.Namespace
-		Expect(ctx.Client.Create(ctx, vmClass)).To(Succeed())
-
-		clusterVMI1 := &vmopv1.ClusterVirtualMachineImage{}
-
-		if testConfig.WithContentLibrary {
-			Expect(ctx.Client.Get(
-				ctx, client.ObjectKey{Name: ctx.ContentLibraryItem1Name},
-				clusterVMI1)).To(Succeed())
-		} else {
-			vsphere.SkipVMImageCLProviderCheck = true
-			clusterVMI1 = builder.DummyClusterVirtualMachineImage("DC0_C0_RP0_VM0")
-			Expect(ctx.Client.Create(ctx, clusterVMI1)).To(Succeed())
-			conditions.MarkTrue(clusterVMI1, vmopv1.ReadyConditionType)
-			Expect(ctx.Client.Status().Update(ctx, clusterVMI1)).To(Succeed())
-		}
-
-		vm.Namespace = nsInfo.Namespace
-		vm.Spec.ClassName = vmClass.Name
-		vm.Spec.ImageName = clusterVMI1.Name
-		vm.Spec.Image.Kind = cvmiKind
-		vm.Spec.Image.Name = clusterVMI1.Name
-		vm.Spec.StorageClass = ctx.StorageClassName
-
-		Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
+		ctx, vmProvider, _ = setupVMTest(
+			parentCtx, testConfig, vmClass, vm, initObjects...)
 	})
 
 	AfterEach(func() {
-		vsphere.SkipVMImageCLProviderCheck = false
-
-		if vm != nil &&
-			!pkgcfg.FromContext(ctx).Features.BringYourOwnEncryptionKey {
-			By("Assert vm.Status.Crypto is nil when BYOK is disabled", func() {
-				Expect(vm.Status.Crypto).To(BeNil())
-			})
-		}
+		vmTestAfterEach(ctx, vm)
 
 		vmClass = nil
 		vm = nil
 
-		ctx.AfterEach()
 		ctx = nil
 		initObjects = nil
 		vmProvider = nil
-		nsInfo = builder.WorkloadNamespaceInfo{}
+	})
+
+	// The VM asks for a minimum hardware version so that the version under test
+	// is the one VM Operator chose. DetermineHardwareVersion picks no version at
+	// all unless the VM, its class, or its devices call for one; the platform
+	// then decides, and what it decides depends on the deploy path — the content
+	// library deploy applies the version the OVF declares, whereas a Fast Deploy
+	// create leaves it to the host.
+	const minHardwareVersion = 17
+
+	BeforeEach(func() {
+		vm.Spec.MinHardwareVersion = minHardwareVersion
 	})
 
 	JustBeforeEach(func() {
@@ -122,6 +72,6 @@ func vmHardwareVersionTests() {
 	It("should return the expected version", func() {
 		version, err := vmProvider.GetVirtualMachineHardwareVersion(ctx, vm)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(version).To(Equal(vimtypes.VMX9))
+		Expect(version).To(Equal(vimtypes.HardwareVersion(minHardwareVersion)))
 	})
 }

--- a/pkg/providers/vsphere/vmprovider_vm_instance_storage_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_instance_storage_test.go
@@ -11,18 +11,13 @@ import (
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
-	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
-	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/constants"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	vmopv1util "github.com/vmware-tanzu/vm-operator/pkg/util/vmopv1"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
@@ -34,99 +29,37 @@ func vmInstanceStorageTests() {
 		testConfig  builder.VCSimTestConfig
 		ctx         *builder.TestContextForVCSim
 		vmProvider  providers.VirtualMachineProviderInterface
-		nsInfo      builder.WorkloadNamespaceInfo
 
 		vm      *vmopv1.VirtualMachine
 		vmClass *vmopv1.VirtualMachineClass
-
-		zoneName string
 	)
 
 	BeforeEach(func() {
-		parentCtx = pkgcfg.NewContextWithDefaultConfig()
-		parentCtx = ctxop.WithContext(parentCtx)
-		parentCtx = ovfcache.WithContext(parentCtx)
-		parentCtx = cource.WithContext(parentCtx)
-		pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
-			config.AsyncCreateEnabled = false
-			config.AsyncSignalEnabled = false
-		})
-		testConfig = builder.VCSimTestConfig{
-			WithContentLibrary: true,
-		}
+		parentCtx = newVMTestParentContext()
+		// Fast Deploy does not support instance storage.
+		disableFastDeploy(parentCtx)
 
-		vmClass = builder.DummyVirtualMachineClassGenName()
-		vm = builder.DummyBasicVirtualMachine("test-vm", "")
+		testConfig = newVMTestConfig()
+		testConfig.WithInstanceStorage = true
 
-		if vm.Spec.Network == nil {
-			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
-		}
-		vm.Spec.Network.Disabled = true
+		vmClass, vm = newVMTestObjects("test-vm-instance-storage")
 	})
 
 	JustBeforeEach(func() {
-		ctx = suite.NewTestContextForVCSimWithParentContext(
-			parentCtx, testConfig, initObjects...)
-		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-			config.MaxDeployThreadsOnProvider = 1
-		})
-		vmProvider = vsphere.NewVSphereVMProviderFromClient(
-			ctx, ctx.Client, ctx.Recorder)
-		nsInfo = ctx.CreateWorkloadNamespace()
-
-		vmClass.Namespace = nsInfo.Namespace
-		Expect(ctx.Client.Create(ctx, vmClass)).To(Succeed())
-
-		clusterVMI1 := &vmopv1.ClusterVirtualMachineImage{}
-
-		if testConfig.WithContentLibrary {
-			Expect(ctx.Client.Get(
-				ctx, client.ObjectKey{Name: ctx.ContentLibraryItem1Name},
-				clusterVMI1)).To(Succeed())
-		} else {
-			vsphere.SkipVMImageCLProviderCheck = true
-			clusterVMI1 = builder.DummyClusterVirtualMachineImage("DC0_C0_RP0_VM0")
-			Expect(ctx.Client.Create(ctx, clusterVMI1)).To(Succeed())
-			conditions.MarkTrue(clusterVMI1, vmopv1.ReadyConditionType)
-			Expect(ctx.Client.Status().Update(ctx, clusterVMI1)).To(Succeed())
-		}
-
-		vm.Namespace = nsInfo.Namespace
-		vm.Spec.ClassName = vmClass.Name
-		vm.Spec.ImageName = clusterVMI1.Name
-		vm.Spec.Image.Kind = cvmiKind
-		vm.Spec.Image.Name = clusterVMI1.Name
-		vm.Spec.StorageClass = ctx.StorageClassName
-
-		Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
-
-		zoneName = ctx.GetFirstZoneName()
-		vm.Labels[corev1.LabelTopologyZone] = zoneName
-		Expect(ctx.Client.Update(ctx, vm)).To(Succeed())
+		ctx, vmProvider, _ = setupVMTest(
+			parentCtx, testConfig, vmClass, vm, initObjects...)
+		pinVMToFirstZone(ctx, vm)
 	})
 
 	AfterEach(func() {
-		vsphere.SkipVMImageCLProviderCheck = false
-
-		if vm != nil &&
-			!pkgcfg.FromContext(ctx).Features.BringYourOwnEncryptionKey {
-			By("Assert vm.Status.Crypto is nil when BYOK is disabled", func() {
-				Expect(vm.Status.Crypto).To(BeNil())
-			})
-		}
+		vmTestAfterEach(ctx, vm)
 
 		vmClass = nil
 		vm = nil
 
-		ctx.AfterEach()
 		ctx = nil
 		initObjects = nil
 		vmProvider = nil
-		nsInfo = builder.WorkloadNamespaceInfo{}
-	})
-
-	BeforeEach(func() {
-		testConfig.WithInstanceStorage = true
 	})
 
 	expectInstanceStorageVolumes := func(

--- a/pkg/providers/vsphere/vmprovider_vm_iso_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_iso_test.go
@@ -17,6 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/google/uuid"
+
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/simulator"
 	"github.com/vmware/govmomi/vapi/library"
@@ -26,13 +27,9 @@ import (
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
-	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 	pkgerr "github.com/vmware-tanzu/vm-operator/pkg/errors"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
-	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
 	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
@@ -45,53 +42,35 @@ func vmISOTests() {
 		ctx         *builder.TestContextForVCSim
 		vmProvider  providers.VirtualMachineProviderInterface
 		nsInfo      builder.WorkloadNamespaceInfo
+
+		vm      *vmopv1.VirtualMachine
+		vmClass *vmopv1.VirtualMachineClass
 	)
 
 	BeforeEach(func() {
-		parentCtx = pkgcfg.NewContextWithDefaultConfig()
-		parentCtx = ctxop.WithContext(parentCtx)
-		parentCtx = ovfcache.WithContext(parentCtx)
-		parentCtx = cource.WithContext(parentCtx)
-		pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
-			config.AsyncCreateEnabled = false
-			config.AsyncSignalEnabled = false
-		})
-		testConfig = builder.VCSimTestConfig{
-			WithContentLibrary: true,
-		}
+		parentCtx = newVMTestParentContext()
+		testConfig = newVMTestConfig()
 	})
 
 	JustBeforeEach(func() {
-		ctx = suite.NewTestContextForVCSimWithParentContext(parentCtx, testConfig, initObjects...)
-		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-			config.MaxDeployThreadsOnProvider = 1
-		})
-		vmProvider = vsphere.NewVSphereVMProviderFromClient(ctx, ctx.Client, ctx.Recorder)
-		nsInfo = ctx.CreateWorkloadNamespace()
+		ctx, vmProvider, nsInfo = newVMTestContext(
+			parentCtx, testConfig, initObjects...)
 	})
 
 	AfterEach(func() {
-		ctx.AfterEach()
+		vmTestAfterEach(ctx, vm)
+
+		vmClass = nil
+		vm = nil
+
 		ctx = nil
 		initObjects = nil
 		vmProvider = nil
 		nsInfo = builder.WorkloadNamespaceInfo{}
 	})
 
-	var (
-		vm      *vmopv1.VirtualMachine
-		vmClass *vmopv1.VirtualMachineClass
-	)
-
 	BeforeEach(func() {
-		vmClass = builder.DummyVirtualMachineClassGenName()
-		vm = builder.DummyBasicVirtualMachine("test-vm-iso", "")
-
-		// Reduce diff from old tests: by default don't create an NIC.
-		if vm.Spec.Network == nil {
-			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
-		}
-		vm.Spec.Network.Disabled = true
+		vmClass, vm = newVMTestObjects("test-vm-iso")
 	})
 
 	JustBeforeEach(func() {
@@ -126,6 +105,12 @@ func vmISOTests() {
 
 	Context("return config", func() {
 		JustBeforeEach(func() {
+			// Nothing in a provider test plays the part of the image cache
+			// controller, so report the ISO item's files as cached. The specs
+			// below that exercise the cache-not-ready paths build their own
+			// VirtualMachineImageCache instead.
+			ctx.MarkImageCacheReady(ctx.ContentLibraryIsoItemCache)
+
 			Expect(createOrUpdateVM(ctx, vmProvider, vm)).To(Succeed())
 		})
 

--- a/pkg/providers/vsphere/vmprovider_vm_location_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_location_test.go
@@ -11,7 +11,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -19,13 +18,9 @@ import (
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
-	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 	pkgerr "github.com/vmware-tanzu/vm-operator/pkg/errors"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
-	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
@@ -44,63 +39,25 @@ func vmLocationTests() {
 	)
 
 	BeforeEach(func() {
-		parentCtx = pkgcfg.NewContextWithDefaultConfig()
-		parentCtx = ctxop.WithContext(parentCtx)
-		parentCtx = ovfcache.WithContext(parentCtx)
-		parentCtx = cource.WithContext(parentCtx)
-		pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
-			config.AsyncCreateEnabled = false
-			config.AsyncSignalEnabled = false
-		})
-		testConfig = builder.VCSimTestConfig{
-			WithContentLibrary: true,
-		}
+		parentCtx = newVMTestParentContext()
+		testConfig = newVMTestConfig()
 
-		vmClass = builder.DummyVirtualMachineClassGenName()
-		vm = builder.DummyBasicVirtualMachine("test-vm", "")
-		if vm.Spec.Network == nil {
-			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
-		}
-		vm.Spec.Network.Disabled = true
+		vmClass, vm = newVMTestObjects("test-vm")
 	})
 
 	JustBeforeEach(func() {
-		ctx = suite.NewTestContextForVCSimWithParentContext(
-			parentCtx, testConfig, initObjects...)
-		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-			config.MaxDeployThreadsOnProvider = 1
-		})
-		vmProvider = vsphere.NewVSphereVMProviderFromClient(
-			ctx, ctx.Client, ctx.Recorder)
-		nsInfo = ctx.CreateWorkloadNamespace()
+		ctx, vmProvider, nsInfo = setupVMTest(
+			parentCtx, testConfig, vmClass, vm, initObjects...)
 
-		vmClass.Namespace = nsInfo.Namespace
-		Expect(ctx.Client.Create(ctx, vmClass)).To(Succeed())
-
-		clusterVMI1 := &vmopv1.ClusterVirtualMachineImage{}
-		Expect(ctx.Client.Get(
-			ctx, client.ObjectKey{Name: ctx.ContentLibraryItem1Name},
-			clusterVMI1)).To(Succeed())
-
-		vm.Namespace = nsInfo.Namespace
-		vm.Spec.ClassName = vmClass.Name
-		vm.Spec.ImageName = clusterVMI1.Name
-		vm.Spec.Image.Kind = cvmiKind
-		vm.Spec.Image.Name = clusterVMI1.Name
-		vm.Spec.StorageClass = ctx.StorageClassName
-
-		Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
-
-		zoneName := ctx.GetFirstZoneName()
-		vm.Labels[corev1.LabelTopologyZone] = zoneName
-		Expect(ctx.Client.Update(ctx, vm)).To(Succeed())
+		pinVMToFirstZone(ctx, vm)
 	})
 
 	AfterEach(func() {
+		vmTestAfterEach(ctx, vm)
+
 		vmClass = nil
 		vm = nil
 
-		ctx.AfterEach()
 		ctx = nil
 		initObjects = nil
 		vmProvider = nil

--- a/pkg/providers/vsphere/vmprovider_vm_metadata_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_metadata_test.go
@@ -10,16 +10,11 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
-	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
-	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
-	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
-	"github.com/vmware-tanzu/vm-operator/pkg/providers"
-	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
-	"github.com/vmware-tanzu/vm-operator/test/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+	"github.com/vmware-tanzu/vm-operator/pkg/providers"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,95 +29,34 @@ func vmMetadataTests() {
 		testConfig  builder.VCSimTestConfig
 		ctx         *builder.TestContextForVCSim
 		vmProvider  providers.VirtualMachineProviderInterface
-		nsInfo      builder.WorkloadNamespaceInfo
 
 		vm      *vmopv1.VirtualMachine
 		vmClass *vmopv1.VirtualMachineClass
-
-		zoneName string
 	)
 
 	BeforeEach(func() {
-		parentCtx = pkgcfg.NewContextWithDefaultConfig()
-		parentCtx = ctxop.WithContext(parentCtx)
-		parentCtx = ovfcache.WithContext(parentCtx)
-		parentCtx = cource.WithContext(parentCtx)
-		pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
-			config.AsyncCreateEnabled = false
-			config.AsyncSignalEnabled = false
-		})
-		testConfig = builder.VCSimTestConfig{
-			WithContentLibrary: true,
-		}
+		parentCtx = newVMTestParentContext()
+		testConfig = newVMTestConfig()
 
-		vmClass = builder.DummyVirtualMachineClassGenName()
-		vm = builder.DummyBasicVirtualMachine("test-vm", "")
-
-		if vm.Spec.Network == nil {
-			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
-		}
-		vm.Spec.Network.Disabled = true
+		vmClass, vm = newVMTestObjects("test-vm")
 	})
 
 	JustBeforeEach(func() {
-		ctx = suite.NewTestContextForVCSimWithParentContext(
-			parentCtx, testConfig, initObjects...)
-		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-			config.MaxDeployThreadsOnProvider = 1
-		})
-		vmProvider = vsphere.NewVSphereVMProviderFromClient(
-			ctx, ctx.Client, ctx.Recorder)
-		nsInfo = ctx.CreateWorkloadNamespace()
+		ctx, vmProvider, _ = setupVMTest(
+			parentCtx, testConfig, vmClass, vm, initObjects...)
 
-		vmClass.Namespace = nsInfo.Namespace
-		Expect(ctx.Client.Create(ctx, vmClass)).To(Succeed())
-
-		clusterVMI1 := &vmopv1.ClusterVirtualMachineImage{}
-
-		if testConfig.WithContentLibrary {
-			Expect(ctx.Client.Get(
-				ctx, client.ObjectKey{Name: ctx.ContentLibraryItem1Name},
-				clusterVMI1)).To(Succeed())
-		} else {
-			vsphere.SkipVMImageCLProviderCheck = true
-			clusterVMI1 = builder.DummyClusterVirtualMachineImage("DC0_C0_RP0_VM0")
-			Expect(ctx.Client.Create(ctx, clusterVMI1)).To(Succeed())
-			conditions.MarkTrue(clusterVMI1, vmopv1.ReadyConditionType)
-			Expect(ctx.Client.Status().Update(ctx, clusterVMI1)).To(Succeed())
-		}
-
-		vm.Namespace = nsInfo.Namespace
-		vm.Spec.ClassName = vmClass.Name
-		vm.Spec.ImageName = clusterVMI1.Name
-		vm.Spec.Image.Kind = cvmiKind
-		vm.Spec.Image.Name = clusterVMI1.Name
-		vm.Spec.StorageClass = ctx.StorageClassName
-
-		Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
-
-		zoneName = ctx.GetFirstZoneName()
-		vm.Labels[corev1.LabelTopologyZone] = zoneName
-		Expect(ctx.Client.Update(ctx, vm)).To(Succeed())
+		pinVMToFirstZone(ctx, vm)
 	})
 
 	AfterEach(func() {
-		vsphere.SkipVMImageCLProviderCheck = false
-
-		if vm != nil &&
-			!pkgcfg.FromContext(ctx).Features.BringYourOwnEncryptionKey {
-			By("Assert vm.Status.Crypto is nil when BYOK is disabled", func() {
-				Expect(vm.Status.Crypto).To(BeNil())
-			})
-		}
+		vmTestAfterEach(ctx, vm)
 
 		vmClass = nil
 		vm = nil
 
-		ctx.AfterEach()
 		ctx = nil
 		initObjects = nil
 		vmProvider = nil
-		nsInfo = builder.WorkloadNamespaceInfo{}
 	})
 
 	Context("ExtraConfig Transport", func() {

--- a/pkg/providers/vsphere/vmprovider_vm_misc_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_misc_test.go
@@ -9,7 +9,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/vmware/govmomi/vim25/mo"
@@ -17,12 +16,7 @@ import (
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
-	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
-	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
-	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
@@ -33,95 +27,34 @@ func vmMiscTests() {
 		testConfig  builder.VCSimTestConfig
 		ctx         *builder.TestContextForVCSim
 		vmProvider  providers.VirtualMachineProviderInterface
-		nsInfo      builder.WorkloadNamespaceInfo
 
 		vm      *vmopv1.VirtualMachine
 		vmClass *vmopv1.VirtualMachineClass
-
-		zoneName string
 	)
 
 	BeforeEach(func() {
-		parentCtx = pkgcfg.NewContextWithDefaultConfig()
-		parentCtx = ctxop.WithContext(parentCtx)
-		parentCtx = ovfcache.WithContext(parentCtx)
-		parentCtx = cource.WithContext(parentCtx)
-		pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
-			config.AsyncCreateEnabled = false
-			config.AsyncSignalEnabled = false
-		})
-		testConfig = builder.VCSimTestConfig{
-			WithContentLibrary: true,
-		}
+		parentCtx = newVMTestParentContext()
+		testConfig = newVMTestConfig()
 
-		vmClass = builder.DummyVirtualMachineClassGenName()
-		vm = builder.DummyBasicVirtualMachine("test-vm", "")
-
-		if vm.Spec.Network == nil {
-			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
-		}
-		vm.Spec.Network.Disabled = true
+		vmClass, vm = newVMTestObjects("test-vm")
 	})
 
 	JustBeforeEach(func() {
-		ctx = suite.NewTestContextForVCSimWithParentContext(
-			parentCtx, testConfig, initObjects...)
-		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-			config.MaxDeployThreadsOnProvider = 1
-		})
-		vmProvider = vsphere.NewVSphereVMProviderFromClient(
-			ctx, ctx.Client, ctx.Recorder)
-		nsInfo = ctx.CreateWorkloadNamespace()
+		ctx, vmProvider, _ = setupVMTest(
+			parentCtx, testConfig, vmClass, vm, initObjects...)
 
-		vmClass.Namespace = nsInfo.Namespace
-		Expect(ctx.Client.Create(ctx, vmClass)).To(Succeed())
-
-		clusterVMI1 := &vmopv1.ClusterVirtualMachineImage{}
-
-		if testConfig.WithContentLibrary {
-			Expect(ctx.Client.Get(
-				ctx, client.ObjectKey{Name: ctx.ContentLibraryItem1Name},
-				clusterVMI1)).To(Succeed())
-		} else {
-			vsphere.SkipVMImageCLProviderCheck = true
-			clusterVMI1 = builder.DummyClusterVirtualMachineImage("DC0_C0_RP0_VM0")
-			Expect(ctx.Client.Create(ctx, clusterVMI1)).To(Succeed())
-			conditions.MarkTrue(clusterVMI1, vmopv1.ReadyConditionType)
-			Expect(ctx.Client.Status().Update(ctx, clusterVMI1)).To(Succeed())
-		}
-
-		vm.Namespace = nsInfo.Namespace
-		vm.Spec.ClassName = vmClass.Name
-		vm.Spec.ImageName = clusterVMI1.Name
-		vm.Spec.Image.Kind = cvmiKind
-		vm.Spec.Image.Name = clusterVMI1.Name
-		vm.Spec.StorageClass = ctx.StorageClassName
-
-		Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
-
-		zoneName = ctx.GetFirstZoneName()
-		vm.Labels[corev1.LabelTopologyZone] = zoneName
-		Expect(ctx.Client.Update(ctx, vm)).To(Succeed())
+		pinVMToFirstZone(ctx, vm)
 	})
 
 	AfterEach(func() {
-		vsphere.SkipVMImageCLProviderCheck = false
-
-		if vm != nil &&
-			!pkgcfg.FromContext(ctx).Features.BringYourOwnEncryptionKey {
-			By("Assert vm.Status.Crypto is nil when BYOK is disabled", func() {
-				Expect(vm.Status.Crypto).To(BeNil())
-			})
-		}
+		vmTestAfterEach(ctx, vm)
 
 		vmClass = nil
 		vm = nil
 
-		ctx.AfterEach()
 		ctx = nil
 		initObjects = nil
 		vmProvider = nil
-		nsInfo = builder.WorkloadNamespaceInfo{}
 	})
 
 	It("Powers VM off", func() {

--- a/pkg/providers/vsphere/vmprovider_vm_network_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_network_test.go
@@ -16,13 +16,14 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/vmware/govmomi/object"
-	"github.com/vmware/govmomi/vim25/mo"
-	vimtypes "github.com/vmware/govmomi/vim25/types"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
 
 	netopv1alpha1 "github.com/vmware-tanzu/net-operator-api/api/v1alpha1"
 	vpcv1alpha1 "github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
@@ -33,14 +34,10 @@ import (
 	vmopv1common "github.com/vmware-tanzu/vm-operator/api/v1alpha6/common"
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
-	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
-	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/network"
 	"github.com/vmware-tanzu/vm-operator/pkg/util"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
 	netsetutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube/networksettings"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
@@ -69,88 +66,34 @@ func vmNetworkTests() {
 
 		vm      *vmopv1.VirtualMachine
 		vmClass *vmopv1.VirtualMachineClass
-
-		zoneName string
 	)
 
 	BeforeEach(func() {
-		parentCtx = pkgcfg.NewContextWithDefaultConfig()
-		parentCtx = ctxop.WithContext(parentCtx)
-		parentCtx = ovfcache.WithContext(parentCtx)
-		parentCtx = cource.WithContext(parentCtx)
+		parentCtx = newVMTestParentContext()
 		pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
-			config.AsyncCreateEnabled = false
-			config.AsyncSignalEnabled = false
 			config.MaxDeployThreadsOnProvider = 1
 		})
-		testConfig = builder.VCSimTestConfig{
-			WithContentLibrary: true,
-		}
+		testConfig = newVMTestConfig()
 
-		vmClass = builder.DummyVirtualMachineClassGenName()
-		vm = builder.DummyBasicVirtualMachine("test-vm", "")
+		vmClass, vm = newVMTestObjects("test-vm")
 
-		if vm.Spec.Network == nil {
-			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
-		}
+		// Networking is the behavior under test here.
 		vm.Spec.Network.Disabled = false
 	})
 
 	JustBeforeEach(func() {
-		ctx = suite.NewTestContextForVCSimWithParentContext(
-			parentCtx, testConfig, initObjects...)
-		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-			config.MaxDeployThreadsOnProvider = 1
-		})
-		vmProvider = vsphere.NewVSphereVMProviderFromClient(
-			ctx, ctx.Client, ctx.Recorder)
-		nsInfo = ctx.CreateWorkloadNamespace()
+		ctx, vmProvider, nsInfo = setupVMTest(
+			parentCtx, testConfig, vmClass, vm, initObjects...)
 
-		vmClass.Namespace = nsInfo.Namespace
-		Expect(ctx.Client.Create(ctx, vmClass)).To(Succeed())
-
-		clusterVMI1 := &vmopv1.ClusterVirtualMachineImage{}
-
-		if testConfig.WithContentLibrary {
-			Expect(ctx.Client.Get(
-				ctx, client.ObjectKey{Name: ctx.ContentLibraryItem1Name},
-				clusterVMI1)).To(Succeed())
-		} else {
-			vsphere.SkipVMImageCLProviderCheck = true
-			clusterVMI1 = builder.DummyClusterVirtualMachineImage("DC0_C0_RP0_VM0")
-			Expect(ctx.Client.Create(ctx, clusterVMI1)).To(Succeed())
-			conditions.MarkTrue(clusterVMI1, vmopv1.ReadyConditionType)
-			Expect(ctx.Client.Status().Update(ctx, clusterVMI1)).To(Succeed())
-		}
-
-		vm.Namespace = nsInfo.Namespace
-		vm.Spec.ClassName = vmClass.Name
-		vm.Spec.ImageName = clusterVMI1.Name
-		vm.Spec.Image.Kind = cvmiKind
-		vm.Spec.Image.Name = clusterVMI1.Name
-		vm.Spec.StorageClass = ctx.StorageClassName
-
-		Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
-
-		zoneName = ctx.GetFirstZoneName()
-		vm.Labels[corev1.LabelTopologyZone] = zoneName
-		Expect(ctx.Client.Update(ctx, vm)).To(Succeed())
+		pinVMToFirstZone(ctx, vm)
 	})
 
 	AfterEach(func() {
-		vsphere.SkipVMImageCLProviderCheck = false
-
-		if vm != nil &&
-			!pkgcfg.FromContext(ctx).Features.BringYourOwnEncryptionKey {
-			By("Assert vm.Status.Crypto is nil when BYOK is disabled", func() {
-				Expect(vm.Status.Crypto).To(BeNil())
-			})
-		}
+		vmTestAfterEach(ctx, vm)
 
 		vmClass = nil
 		vm = nil
 
-		ctx.AfterEach()
 		ctx = nil
 		initObjects = nil
 		vmProvider = nil

--- a/pkg/providers/vsphere/vmprovider_vm_npe_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_npe_test.go
@@ -10,17 +10,10 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
-	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
-	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
-	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
-	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
@@ -31,96 +24,35 @@ func vmNPETests() {
 		testConfig  builder.VCSimTestConfig
 		ctx         *builder.TestContextForVCSim
 		vmProvider  providers.VirtualMachineProviderInterface
-		nsInfo      builder.WorkloadNamespaceInfo
 
 		vm      *vmopv1.VirtualMachine
 		vmClass *vmopv1.VirtualMachineClass
-
-		zoneName string
 	)
 
 	BeforeEach(func() {
-		parentCtx = pkgcfg.NewContextWithDefaultConfig()
-		parentCtx = ctxop.WithContext(parentCtx)
-		parentCtx = ovfcache.WithContext(parentCtx)
-		parentCtx = cource.WithContext(parentCtx)
-		pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
-			config.AsyncCreateEnabled = false
-			config.AsyncSignalEnabled = false
-		})
-		testConfig = builder.VCSimTestConfig{
-			WithContentLibrary: true,
-			WithNetworkEnv:     builder.NetworkEnvVDS,
-		}
+		parentCtx = newVMTestParentContext()
+		testConfig = newVMTestConfig()
+		testConfig.WithNetworkEnv = builder.NetworkEnvVDS
 
-		vmClass = builder.DummyVirtualMachineClassGenName()
-		vm = builder.DummyBasicVirtualMachine("test-vm", "")
-
-		if vm.Spec.Network == nil {
-			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
-		}
-		vm.Spec.Network.Disabled = true
+		vmClass, vm = newVMTestObjects("test-vm")
 	})
 
 	JustBeforeEach(func() {
-		ctx = suite.NewTestContextForVCSimWithParentContext(
-			parentCtx, testConfig, initObjects...)
-		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-			config.MaxDeployThreadsOnProvider = 1
-		})
-		vmProvider = vsphere.NewVSphereVMProviderFromClient(
-			ctx, ctx.Client, ctx.Recorder)
-		nsInfo = ctx.CreateWorkloadNamespace()
+		ctx, vmProvider, _ = setupVMTest(
+			parentCtx, testConfig, vmClass, vm, initObjects...)
 
-		vmClass.Namespace = nsInfo.Namespace
-		Expect(ctx.Client.Create(ctx, vmClass)).To(Succeed())
-
-		clusterVMI1 := &vmopv1.ClusterVirtualMachineImage{}
-
-		if testConfig.WithContentLibrary {
-			Expect(ctx.Client.Get(
-				ctx, client.ObjectKey{Name: ctx.ContentLibraryItem1Name},
-				clusterVMI1)).To(Succeed())
-		} else {
-			vsphere.SkipVMImageCLProviderCheck = true
-			clusterVMI1 = builder.DummyClusterVirtualMachineImage("DC0_C0_RP0_VM0")
-			Expect(ctx.Client.Create(ctx, clusterVMI1)).To(Succeed())
-			conditions.MarkTrue(clusterVMI1, vmopv1.ReadyConditionType)
-			Expect(ctx.Client.Status().Update(ctx, clusterVMI1)).To(Succeed())
-		}
-
-		vm.Namespace = nsInfo.Namespace
-		vm.Spec.ClassName = vmClass.Name
-		vm.Spec.ImageName = clusterVMI1.Name
-		vm.Spec.Image.Kind = cvmiKind
-		vm.Spec.Image.Name = clusterVMI1.Name
-		vm.Spec.StorageClass = ctx.StorageClassName
-
-		Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
-
-		zoneName = ctx.GetFirstZoneName()
-		vm.Labels[corev1.LabelTopologyZone] = zoneName
-		Expect(ctx.Client.Update(ctx, vm)).To(Succeed())
+		pinVMToFirstZone(ctx, vm)
 	})
 
 	AfterEach(func() {
-		vsphere.SkipVMImageCLProviderCheck = false
-
-		if vm != nil &&
-			!pkgcfg.FromContext(ctx).Features.BringYourOwnEncryptionKey {
-			By("Assert vm.Status.Crypto is nil when BYOK is disabled", func() {
-				Expect(vm.Status.Crypto).To(BeNil())
-			})
-		}
+		vmTestAfterEach(ctx, vm)
 
 		vmClass = nil
 		vm = nil
 
-		ctx.AfterEach()
 		ctx = nil
 		initObjects = nil
 		vmProvider = nil
-		nsInfo = builder.WorkloadNamespaceInfo{}
 	})
 
 	DescribeTable("npe checks",

--- a/pkg/providers/vsphere/vmprovider_vm_pci_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_pci_test.go
@@ -9,7 +9,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/vmware/govmomi/object"
@@ -17,13 +16,7 @@ import (
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
-	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
-	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
-	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
-	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
@@ -34,35 +27,16 @@ func vmPCITests() {
 		testConfig  builder.VCSimTestConfig
 		ctx         *builder.TestContextForVCSim
 		vmProvider  providers.VirtualMachineProviderInterface
-		nsInfo      builder.WorkloadNamespaceInfo
 
 		vm      *vmopv1.VirtualMachine
 		vmClass *vmopv1.VirtualMachineClass
-
-		zoneName string
 	)
 
 	BeforeEach(func() {
-		parentCtx = pkgcfg.NewContextWithDefaultConfig()
-		parentCtx = ctxop.WithContext(parentCtx)
-		parentCtx = ovfcache.WithContext(parentCtx)
-		parentCtx = cource.WithContext(parentCtx)
-		pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
-			config.AsyncCreateEnabled = false
-			config.AsyncSignalEnabled = false
-		})
-		testConfig = builder.VCSimTestConfig{
-			WithContentLibrary: true,
-		}
+		parentCtx = newVMTestParentContext()
+		testConfig = newVMTestConfig()
 
-		vmClass = builder.DummyVirtualMachineClassGenName()
-		vm = builder.DummyBasicVirtualMachine("test-vm", "")
-
-		// Reduce diff from old tests: by default don't create an NIC.
-		if vm.Spec.Network == nil {
-			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
-		}
-		vm.Spec.Network.Disabled = true
+		vmClass, vm = newVMTestObjects("test-vm")
 
 		// For old behavior, we'll fallback to these standalone fields when the
 		// class does not have a ConfigSpec.
@@ -83,75 +57,23 @@ func vmPCITests() {
 	})
 
 	JustBeforeEach(func() {
-		ctx = suite.NewTestContextForVCSimWithParentContext(
-			parentCtx, testConfig, initObjects...)
-		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-			config.MaxDeployThreadsOnProvider = 1
-		})
-		vmProvider = vsphere.NewVSphereVMProviderFromClient(
-			ctx, ctx.Client, ctx.Recorder)
-		nsInfo = ctx.CreateWorkloadNamespace()
-
-		vmClass.Namespace = nsInfo.Namespace
-		Expect(ctx.Client.Create(ctx, vmClass)).To(Succeed())
-
-		clusterVMI1 := &vmopv1.ClusterVirtualMachineImage{}
-
-		if testConfig.WithContentLibrary {
-			Expect(ctx.Client.Get(
-				ctx, client.ObjectKey{
-					Name: ctx.ContentLibraryItem1Name,
-				}, clusterVMI1)).To(Succeed())
-
-		} else {
-			// BMV: VM creation without CL is broken - and has been for a long
-			// while - since we assume the VM Image will always point to a
-			// ContentLibrary item.
-			// Hack around that with this knob so we can continue to test the
-			// VM clone path.
-			vsphere.SkipVMImageCLProviderCheck = true
-
-			// Use the default VM created by vcsim as the source.
-			clusterVMI1 = builder.DummyClusterVirtualMachineImage("DC0_C0_RP0_VM0")
-			Expect(ctx.Client.Create(ctx, clusterVMI1)).To(Succeed())
-			conditions.MarkTrue(clusterVMI1, vmopv1.ReadyConditionType)
-			Expect(ctx.Client.Status().Update(ctx, clusterVMI1)).To(Succeed())
-		}
-
-		vm.Namespace = nsInfo.Namespace
-		vm.Spec.ClassName = vmClass.Name
-		vm.Spec.ImageName = clusterVMI1.Name
-		vm.Spec.Image.Kind = cvmiKind
-		vm.Spec.Image.Name = clusterVMI1.Name
-		vm.Spec.StorageClass = ctx.StorageClassName
-
-		Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
+		ctx, vmProvider, _ = setupVMTest(
+			parentCtx, testConfig, vmClass, vm, initObjects...)
 
 		// Explicitly place the VM into one of the zones that the test context
 		// will create.
-		zoneName = ctx.GetFirstZoneName()
-		vm.Labels[corev1.LabelTopologyZone] = zoneName
-		Expect(ctx.Client.Update(ctx, vm)).To(Succeed())
+		pinVMToFirstZone(ctx, vm)
 	})
 
 	AfterEach(func() {
-		vsphere.SkipVMImageCLProviderCheck = false
-
-		if vm != nil &&
-			!pkgcfg.FromContext(ctx).Features.BringYourOwnEncryptionKey {
-			By("Assert vm.Status.Crypto is nil when BYOK is disabled", func() {
-				Expect(vm.Status.Crypto).To(BeNil())
-			})
-		}
+		vmTestAfterEach(ctx, vm)
 
 		vmClass = nil
 		vm = nil
 
-		ctx.AfterEach()
 		ctx = nil
 		initObjects = nil
 		vmProvider = nil
-		nsInfo = builder.WorkloadNamespaceInfo{}
 	})
 
 	It("VM should have PCI devices from VM Class", func() {

--- a/pkg/providers/vsphere/vmprovider_vm_policy_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_policy_test.go
@@ -20,12 +20,8 @@ import (
 	vspherepolv1 "github.com/vmware-tanzu/vm-operator/external/vsphere-policy/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
-	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
-	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
 	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	vmconfpolicy "github.com/vmware-tanzu/vm-operator/pkg/vmconfig/policy"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
@@ -38,89 +34,32 @@ func vmPolicyTests() {
 		testConfig  builder.VCSimTestConfig
 		ctx         *builder.TestContextForVCSim
 		vmProvider  providers.VirtualMachineProviderInterface
-		nsInfo      builder.WorkloadNamespaceInfo
 
 		vm      *vmopv1.VirtualMachine
 		vmClass *vmopv1.VirtualMachineClass
 	)
 
 	BeforeEach(func() {
-		parentCtx = pkgcfg.NewContextWithDefaultConfig()
-		parentCtx = ctxop.WithContext(parentCtx)
-		parentCtx = ovfcache.WithContext(parentCtx)
-		parentCtx = cource.WithContext(parentCtx)
-		pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
-			config.AsyncCreateEnabled = false
-			config.AsyncSignalEnabled = false
-		})
-		testConfig = builder.VCSimTestConfig{
-			WithContentLibrary: true,
-		}
+		parentCtx = newVMTestParentContext()
+		testConfig = newVMTestConfig()
 
-		vmClass = builder.DummyVirtualMachineClassGenName()
-		vm = builder.DummyBasicVirtualMachine("test-vm", "")
-
-		if vm.Spec.Network == nil {
-			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
-		}
-		vm.Spec.Network.Disabled = true
+		vmClass, vm = newVMTestObjects("test-vm")
 	})
 
 	JustBeforeEach(func() {
-		ctx = suite.NewTestContextForVCSimWithParentContext(
-			parentCtx, testConfig, initObjects...)
-		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-			config.MaxDeployThreadsOnProvider = 1
-		})
-		vmProvider = vsphere.NewVSphereVMProviderFromClient(
-			ctx, ctx.Client, ctx.Recorder)
-		nsInfo = ctx.CreateWorkloadNamespace()
-
-		vmClass.Namespace = nsInfo.Namespace
-		Expect(ctx.Client.Create(ctx, vmClass)).To(Succeed())
-
-		clusterVMI1 := &vmopv1.ClusterVirtualMachineImage{}
-
-		if testConfig.WithContentLibrary {
-			Expect(ctx.Client.Get(
-				ctx, client.ObjectKey{Name: ctx.ContentLibraryItem1Name},
-				clusterVMI1)).To(Succeed())
-		} else {
-			vsphere.SkipVMImageCLProviderCheck = true
-			clusterVMI1 = builder.DummyClusterVirtualMachineImage("DC0_C0_RP0_VM0")
-			Expect(ctx.Client.Create(ctx, clusterVMI1)).To(Succeed())
-			conditions.MarkTrue(clusterVMI1, vmopv1.ReadyConditionType)
-			Expect(ctx.Client.Status().Update(ctx, clusterVMI1)).To(Succeed())
-		}
-
-		vm.Namespace = nsInfo.Namespace
-		vm.Spec.ClassName = vmClass.Name
-		vm.Spec.ImageName = clusterVMI1.Name
-		vm.Spec.Image.Kind = cvmiKind
-		vm.Spec.Image.Name = clusterVMI1.Name
-		vm.Spec.StorageClass = ctx.StorageClassName
-
-		Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
+		ctx, vmProvider, _ = setupVMTest(
+			parentCtx, testConfig, vmClass, vm, initObjects...)
 	})
 
 	AfterEach(func() {
-		vsphere.SkipVMImageCLProviderCheck = false
-
-		if vm != nil &&
-			!pkgcfg.FromContext(ctx).Features.BringYourOwnEncryptionKey {
-			By("Assert vm.Status.Crypto is nil when BYOK is disabled", func() {
-				Expect(vm.Status.Crypto).To(BeNil())
-			})
-		}
+		vmTestAfterEach(ctx, vm)
 
 		vmClass = nil
 		vm = nil
 
-		ctx.AfterEach()
 		ctx = nil
 		initObjects = nil
 		vmProvider = nil
-		nsInfo = builder.WorkloadNamespaceInfo{}
 	})
 
 	var (

--- a/pkg/providers/vsphere/vmprovider_vm_power_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_power_test.go
@@ -29,12 +29,9 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgconst "github.com/vmware-tanzu/vm-operator/pkg/constants"
-	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 	pkgerr "github.com/vmware-tanzu/vm-operator/pkg/errors"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 	"github.com/vmware-tanzu/vm-operator/test/testutil"
@@ -47,89 +44,32 @@ func vmPowerStateTests() {
 		testConfig  builder.VCSimTestConfig
 		ctx         *builder.TestContextForVCSim
 		vmProvider  providers.VirtualMachineProviderInterface
-		nsInfo      builder.WorkloadNamespaceInfo
 
 		vm      *vmopv1.VirtualMachine
 		vmClass *vmopv1.VirtualMachineClass
 	)
 
 	BeforeEach(func() {
-		parentCtx = pkgcfg.NewContextWithDefaultConfig()
-		parentCtx = ctxop.WithContext(parentCtx)
-		parentCtx = ovfcache.WithContext(parentCtx)
-		parentCtx = cource.WithContext(parentCtx)
-		pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
-			config.AsyncCreateEnabled = false
-			config.AsyncSignalEnabled = false
-		})
-		testConfig = builder.VCSimTestConfig{
-			WithContentLibrary: true,
-		}
+		parentCtx = newVMTestParentContext()
+		testConfig = newVMTestConfig()
 
-		vmClass = builder.DummyVirtualMachineClassGenName()
-		vm = builder.DummyBasicVirtualMachine("test-vm", "")
-
-		if vm.Spec.Network == nil {
-			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
-		}
-		vm.Spec.Network.Disabled = true
+		vmClass, vm = newVMTestObjects("test-vm")
 	})
 
 	JustBeforeEach(func() {
-		ctx = suite.NewTestContextForVCSimWithParentContext(
-			parentCtx, testConfig, initObjects...)
-		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-			config.MaxDeployThreadsOnProvider = 1
-		})
-		vmProvider = vsphere.NewVSphereVMProviderFromClient(
-			ctx, ctx.Client, ctx.Recorder)
-		nsInfo = ctx.CreateWorkloadNamespace()
-
-		vmClass.Namespace = nsInfo.Namespace
-		Expect(ctx.Client.Create(ctx, vmClass)).To(Succeed())
-
-		clusterVMI1 := &vmopv1.ClusterVirtualMachineImage{}
-
-		if testConfig.WithContentLibrary {
-			Expect(ctx.Client.Get(
-				ctx, client.ObjectKey{Name: ctx.ContentLibraryItem1Name},
-				clusterVMI1)).To(Succeed())
-		} else {
-			vsphere.SkipVMImageCLProviderCheck = true
-			clusterVMI1 = builder.DummyClusterVirtualMachineImage("DC0_C0_RP0_VM0")
-			Expect(ctx.Client.Create(ctx, clusterVMI1)).To(Succeed())
-			conditions.MarkTrue(clusterVMI1, vmopv1.ReadyConditionType)
-			Expect(ctx.Client.Status().Update(ctx, clusterVMI1)).To(Succeed())
-		}
-
-		vm.Namespace = nsInfo.Namespace
-		vm.Spec.ClassName = vmClass.Name
-		vm.Spec.ImageName = clusterVMI1.Name
-		vm.Spec.Image.Kind = cvmiKind
-		vm.Spec.Image.Name = clusterVMI1.Name
-		vm.Spec.StorageClass = ctx.StorageClassName
-
-		Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
+		ctx, vmProvider, _ = setupVMTest(
+			parentCtx, testConfig, vmClass, vm, initObjects...)
 	})
 
 	AfterEach(func() {
-		vsphere.SkipVMImageCLProviderCheck = false
-
-		if vm != nil &&
-			!pkgcfg.FromContext(ctx).Features.BringYourOwnEncryptionKey {
-			By("Assert vm.Status.Crypto is nil when BYOK is disabled", func() {
-				Expect(vm.Status.Crypto).To(BeNil())
-			})
-		}
+		vmTestAfterEach(ctx, vm)
 
 		vmClass = nil
 		vm = nil
 
-		ctx.AfterEach()
 		ctx = nil
 		initObjects = nil
 		vmProvider = nil
-		nsInfo = builder.WorkloadNamespaceInfo{}
 	})
 
 	getLastRestartTime := func(moVM mo.VirtualMachine) string {
@@ -636,19 +576,33 @@ func vmPowerStateTests() {
 			})
 
 			const (
-				oldDiskSizeBytes = int64(31457280)
 				newDiskSizeGi    = 20
 				newDiskSizeBytes = int64(newDiskSizeGi * 1024 * 1024 * 1024)
 			)
 
+			// deployedDiskSizeBytes is the boot disk's capacity as deployed. It
+			// is read from the VM rather than asserted against a constant,
+			// because the two deploy paths size the boot disk differently: Fast
+			// Deploy links it to the image's cached disk and inherits that
+			// disk's capacity, whereas the content library deploy applies the
+			// size the OVF descriptor declares.
+			var deployedDiskSizeBytes int64
+
+			// readBootDiskSizeBytes returns the capacity of the VM's only disk.
+			readBootDiskSizeBytes := func() int64 {
+				vmDevs := object.VirtualDeviceList(moVM.Config.Hardware.Device)
+				disks := vmDevs.SelectByType(&vimtypes.VirtualDisk{})
+				ExpectWithOffset(1, disks).To(HaveLen(1))
+				ExpectWithOffset(1, disks[0]).To(
+					BeAssignableToTypeOf(&vimtypes.VirtualDisk{}))
+				return disks[0].(*vimtypes.VirtualDisk).CapacityInBytes
+			}
+
 			When("the boot disk size is changed for non-ISO VMs", func() {
 				JustBeforeEach(func() {
-					vmDevs := object.VirtualDeviceList(moVM.Config.Hardware.Device)
-					disks := vmDevs.SelectByType(&vimtypes.VirtualDisk{})
-					Expect(disks).To(HaveLen(1))
-					Expect(disks[0]).To(BeAssignableToTypeOf(&vimtypes.VirtualDisk{}))
-					diskCapacityBytes := disks[0].(*vimtypes.VirtualDisk).CapacityInBytes
-					Expect(diskCapacityBytes).To(Equal(oldDiskSizeBytes))
+					Expect(readBootDiskSizeBytes()).To(
+						BeNumerically("<", newDiskSizeBytes),
+						"the VM must start smaller than the requested size")
 
 					q := resource.MustParse(fmt.Sprintf("%dGi", newDiskSizeGi))
 					vm.Spec.Advanced = &vmopv1.VirtualMachineAdvancedSpec{
@@ -664,12 +618,7 @@ func vmPowerStateTests() {
 					Expect(vm.Status.PowerState).To(Equal(vmopv1.VirtualMachinePowerStateOn))
 
 					Expect(vcVM.Properties(ctx, vcVM.Reference(), nil, &moVM)).To(Succeed())
-					vmDevs := object.VirtualDeviceList(moVM.Config.Hardware.Device)
-					disks := vmDevs.SelectByType(&vimtypes.VirtualDisk{})
-					Expect(disks).To(HaveLen(1))
-					Expect(disks[0]).To(BeAssignableToTypeOf(&vimtypes.VirtualDisk{}))
-					diskCapacityBytes := disks[0].(*vimtypes.VirtualDisk).CapacityInBytes
-					Expect(diskCapacityBytes).To(Equal(newDiskSizeBytes))
+					Expect(readBootDiskSizeBytes()).To(Equal(newDiskSizeBytes))
 				})
 			})
 
@@ -858,12 +807,10 @@ func vmPowerStateTests() {
 				When("the boot disk size is changed for VM with CD-ROM", func() {
 
 					JustBeforeEach(func() {
-						vmDevs := object.VirtualDeviceList(moVM.Config.Hardware.Device)
-						disks := vmDevs.SelectByType(&vimtypes.VirtualDisk{})
-						Expect(disks).To(HaveLen(1))
-						Expect(disks[0]).To(BeAssignableToTypeOf(&vimtypes.VirtualDisk{}))
-						diskCapacityBytes := disks[0].(*vimtypes.VirtualDisk).CapacityInBytes
-						Expect(diskCapacityBytes).To(Equal(oldDiskSizeBytes))
+						deployedDiskSizeBytes = readBootDiskSizeBytes()
+						Expect(deployedDiskSizeBytes).To(
+							BeNumerically("<", newDiskSizeBytes),
+							"the VM must start smaller than the requested size")
 
 						q := resource.MustParse(fmt.Sprintf("%dGi", newDiskSizeGi))
 						vm.Spec.Advanced = &vmopv1.VirtualMachineAdvancedSpec{
@@ -876,12 +823,7 @@ func vmPowerStateTests() {
 						Expect(vm.Status.PowerState).To(Equal(vmopv1.VirtualMachinePowerStateOn))
 						Expect(vcVM.Properties(ctx, vcVM.Reference(), nil, &moVM)).To(Succeed())
 
-						vmDevs := object.VirtualDeviceList(moVM.Config.Hardware.Device)
-						disks := vmDevs.SelectByType(&vimtypes.VirtualDisk{})
-						Expect(disks).To(HaveLen(1))
-						Expect(disks[0]).To(BeAssignableToTypeOf(&vimtypes.VirtualDisk{}))
-						diskCapacityBytes := disks[0].(*vimtypes.VirtualDisk).CapacityInBytes
-						Expect(diskCapacityBytes).To(Equal(oldDiskSizeBytes))
+						Expect(readBootDiskSizeBytes()).To(Equal(deployedDiskSizeBytes))
 					})
 				})
 			})

--- a/pkg/providers/vsphere/vmprovider_vm_resize_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_resize_test.go
@@ -11,11 +11,12 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/vmware/govmomi/vim25/mo"
-	vimtypes "github.com/vmware/govmomi/vim25/types"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/vmware/govmomi/vim25/mo"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
@@ -37,10 +38,8 @@ func vmResizeTests() {
 	)
 
 	BeforeEach(func() {
-		testConfig = builder.VCSimTestConfig{
-			WithContentLibrary: true,
-			WithNetworkEnv:     builder.NetworkEnvNamed,
-		}
+		testConfig = newVMTestConfig()
+		testConfig.WithNetworkEnv = builder.NetworkEnvNamed
 	})
 
 	JustBeforeEach(func() {

--- a/pkg/providers/vsphere/vmprovider_vm_setresourcepolicy_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_setresourcepolicy_test.go
@@ -19,12 +19,7 @@ import (
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
-	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
-	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
-	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
@@ -42,78 +37,23 @@ func vmSetResourcePolicyTests() {
 	)
 
 	BeforeEach(func() {
-		parentCtx = pkgcfg.NewContextWithDefaultConfig()
-		parentCtx = ctxop.WithContext(parentCtx)
-		parentCtx = ovfcache.WithContext(parentCtx)
-		parentCtx = cource.WithContext(parentCtx)
-		pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
-			config.AsyncCreateEnabled = false
-			config.AsyncSignalEnabled = false
-		})
-		testConfig = builder.VCSimTestConfig{
-			WithContentLibrary: true,
-		}
+		parentCtx = newVMTestParentContext()
+		testConfig = newVMTestConfig()
 
-		vmClass = builder.DummyVirtualMachineClassGenName()
-		vm = builder.DummyBasicVirtualMachine("test-vm", "")
-
-		if vm.Spec.Network == nil {
-			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
-		}
-		vm.Spec.Network.Disabled = true
+		vmClass, vm = newVMTestObjects("test-vm")
 	})
 
 	JustBeforeEach(func() {
-		ctx = suite.NewTestContextForVCSimWithParentContext(
-			parentCtx, testConfig, initObjects...)
-		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-			config.MaxDeployThreadsOnProvider = 1
-		})
-		vmProvider = vsphere.NewVSphereVMProviderFromClient(
-			ctx, ctx.Client, ctx.Recorder)
-		nsInfo = ctx.CreateWorkloadNamespace()
-
-		vmClass.Namespace = nsInfo.Namespace
-		Expect(ctx.Client.Create(ctx, vmClass)).To(Succeed())
-
-		clusterVMI1 := &vmopv1.ClusterVirtualMachineImage{}
-
-		if testConfig.WithContentLibrary {
-			Expect(ctx.Client.Get(
-				ctx, client.ObjectKey{Name: ctx.ContentLibraryItem1Name},
-				clusterVMI1)).To(Succeed())
-		} else {
-			vsphere.SkipVMImageCLProviderCheck = true
-			clusterVMI1 = builder.DummyClusterVirtualMachineImage("DC0_C0_RP0_VM0")
-			Expect(ctx.Client.Create(ctx, clusterVMI1)).To(Succeed())
-			conditions.MarkTrue(clusterVMI1, vmopv1.ReadyConditionType)
-			Expect(ctx.Client.Status().Update(ctx, clusterVMI1)).To(Succeed())
-		}
-
-		vm.Namespace = nsInfo.Namespace
-		vm.Spec.ClassName = vmClass.Name
-		vm.Spec.ImageName = clusterVMI1.Name
-		vm.Spec.Image.Kind = cvmiKind
-		vm.Spec.Image.Name = clusterVMI1.Name
-		vm.Spec.StorageClass = ctx.StorageClassName
-
-		Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
+		ctx, vmProvider, nsInfo = setupVMTest(
+			parentCtx, testConfig, vmClass, vm, initObjects...)
 	})
 
 	AfterEach(func() {
-		vsphere.SkipVMImageCLProviderCheck = false
-
-		if vm != nil &&
-			!pkgcfg.FromContext(ctx).Features.BringYourOwnEncryptionKey {
-			By("Assert vm.Status.Crypto is nil when BYOK is disabled", func() {
-				Expect(vm.Status.Crypto).To(BeNil())
-			})
-		}
+		vmTestAfterEach(ctx, vm)
 
 		vmClass = nil
 		vm = nil
 
-		ctx.AfterEach()
 		ctx = nil
 		initObjects = nil
 		vmProvider = nil

--- a/pkg/providers/vsphere/vmprovider_vm_snapshot_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_snapshot_test.go
@@ -11,7 +11,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -24,15 +23,12 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgconst "github.com/vmware-tanzu/vm-operator/pkg/constants"
-	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 	pkgerr "github.com/vmware-tanzu/vm-operator/pkg/errors"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere/virtualmachine"
 	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
 	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
@@ -47,87 +43,28 @@ func vmSnapshotTests() {
 
 		vm      *vmopv1.VirtualMachine
 		vmClass *vmopv1.VirtualMachineClass
-
-		zoneName string
 	)
 
 	BeforeEach(func() {
-		parentCtx = pkgcfg.NewContextWithDefaultConfig()
-		parentCtx = ctxop.WithContext(parentCtx)
-		parentCtx = ovfcache.WithContext(parentCtx)
-		parentCtx = cource.WithContext(parentCtx)
-		pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
-			config.AsyncCreateEnabled = false
-			config.AsyncSignalEnabled = false
-		})
-		testConfig = builder.VCSimTestConfig{
-			WithContentLibrary: true,
-		}
+		parentCtx = newVMTestParentContext()
+		testConfig = newVMTestConfig()
 
-		vmClass = builder.DummyVirtualMachineClassGenName()
-		vm = builder.DummyBasicVirtualMachine("test-vm", "")
-
-		if vm.Spec.Network == nil {
-			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
-		}
-		vm.Spec.Network.Disabled = true
+		vmClass, vm = newVMTestObjects("test-vm")
 	})
 
 	JustBeforeEach(func() {
-		ctx = suite.NewTestContextForVCSimWithParentContext(
-			parentCtx, testConfig, initObjects...)
-		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-			config.MaxDeployThreadsOnProvider = 1
-		})
-		vmProvider = vsphere.NewVSphereVMProviderFromClient(
-			ctx, ctx.Client, ctx.Recorder)
-		nsInfo = ctx.CreateWorkloadNamespace()
+		ctx, vmProvider, nsInfo = setupVMTest(
+			parentCtx, testConfig, vmClass, vm, initObjects...)
 
-		vmClass.Namespace = nsInfo.Namespace
-		Expect(ctx.Client.Create(ctx, vmClass)).To(Succeed())
-
-		clusterVMI1 := &vmopv1.ClusterVirtualMachineImage{}
-
-		if testConfig.WithContentLibrary {
-			Expect(ctx.Client.Get(
-				ctx, client.ObjectKey{Name: ctx.ContentLibraryItem1Name},
-				clusterVMI1)).To(Succeed())
-		} else {
-			vsphere.SkipVMImageCLProviderCheck = true
-			clusterVMI1 = builder.DummyClusterVirtualMachineImage("DC0_C0_RP0_VM0")
-			Expect(ctx.Client.Create(ctx, clusterVMI1)).To(Succeed())
-			conditions.MarkTrue(clusterVMI1, vmopv1.ReadyConditionType)
-			Expect(ctx.Client.Status().Update(ctx, clusterVMI1)).To(Succeed())
-		}
-
-		vm.Namespace = nsInfo.Namespace
-		vm.Spec.ClassName = vmClass.Name
-		vm.Spec.ImageName = clusterVMI1.Name
-		vm.Spec.Image.Kind = cvmiKind
-		vm.Spec.Image.Name = clusterVMI1.Name
-		vm.Spec.StorageClass = ctx.StorageClassName
-
-		Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
-
-		zoneName = ctx.GetFirstZoneName()
-		vm.Labels[corev1.LabelTopologyZone] = zoneName
-		Expect(ctx.Client.Update(ctx, vm)).To(Succeed())
+		pinVMToFirstZone(ctx, vm)
 	})
 
 	AfterEach(func() {
-		vsphere.SkipVMImageCLProviderCheck = false
-
-		if vm != nil &&
-			!pkgcfg.FromContext(ctx).Features.BringYourOwnEncryptionKey {
-			By("Assert vm.Status.Crypto is nil when BYOK is disabled", func() {
-				Expect(vm.Status.Crypto).To(BeNil())
-			})
-		}
+		vmTestAfterEach(ctx, vm)
 
 		vmClass = nil
 		vm = nil
 
-		ctx.AfterEach()
 		ctx = nil
 		initObjects = nil
 		vmProvider = nil

--- a/pkg/providers/vsphere/vmprovider_vm_storage_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_storage_test.go
@@ -21,12 +21,7 @@ import (
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
-	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
-	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
-	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
@@ -42,87 +37,28 @@ func vmStorageTests() {
 
 		vm      *vmopv1.VirtualMachine
 		vmClass *vmopv1.VirtualMachineClass
-
-		zoneName string
 	)
 
 	BeforeEach(func() {
-		parentCtx = pkgcfg.NewContextWithDefaultConfig()
-		parentCtx = ctxop.WithContext(parentCtx)
-		parentCtx = ovfcache.WithContext(parentCtx)
-		parentCtx = cource.WithContext(parentCtx)
-		pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
-			config.AsyncCreateEnabled = false
-			config.AsyncSignalEnabled = false
-		})
-		testConfig = builder.VCSimTestConfig{
-			WithContentLibrary: true,
-		}
+		parentCtx = newVMTestParentContext()
+		testConfig = newVMTestConfig()
 
-		vmClass = builder.DummyVirtualMachineClassGenName()
-		vm = builder.DummyBasicVirtualMachine("test-vm", "")
-
-		if vm.Spec.Network == nil {
-			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
-		}
-		vm.Spec.Network.Disabled = true
+		vmClass, vm = newVMTestObjects("test-vm")
 	})
 
 	JustBeforeEach(func() {
-		ctx = suite.NewTestContextForVCSimWithParentContext(
-			parentCtx, testConfig, initObjects...)
-		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-			config.MaxDeployThreadsOnProvider = 1
-		})
-		vmProvider = vsphere.NewVSphereVMProviderFromClient(
-			ctx, ctx.Client, ctx.Recorder)
-		nsInfo = ctx.CreateWorkloadNamespace()
+		ctx, vmProvider, nsInfo = setupVMTest(
+			parentCtx, testConfig, vmClass, vm, initObjects...)
 
-		vmClass.Namespace = nsInfo.Namespace
-		Expect(ctx.Client.Create(ctx, vmClass)).To(Succeed())
-
-		clusterVMI1 := &vmopv1.ClusterVirtualMachineImage{}
-
-		if testConfig.WithContentLibrary {
-			Expect(ctx.Client.Get(
-				ctx, client.ObjectKey{Name: ctx.ContentLibraryItem1Name},
-				clusterVMI1)).To(Succeed())
-		} else {
-			vsphere.SkipVMImageCLProviderCheck = true
-			clusterVMI1 = builder.DummyClusterVirtualMachineImage("DC0_C0_RP0_VM0")
-			Expect(ctx.Client.Create(ctx, clusterVMI1)).To(Succeed())
-			conditions.MarkTrue(clusterVMI1, vmopv1.ReadyConditionType)
-			Expect(ctx.Client.Status().Update(ctx, clusterVMI1)).To(Succeed())
-		}
-
-		vm.Namespace = nsInfo.Namespace
-		vm.Spec.ClassName = vmClass.Name
-		vm.Spec.ImageName = clusterVMI1.Name
-		vm.Spec.Image.Kind = cvmiKind
-		vm.Spec.Image.Name = clusterVMI1.Name
-		vm.Spec.StorageClass = ctx.StorageClassName
-
-		Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
-
-		zoneName = ctx.GetFirstZoneName()
-		vm.Labels[corev1.LabelTopologyZone] = zoneName
-		Expect(ctx.Client.Update(ctx, vm)).To(Succeed())
+		pinVMToFirstZone(ctx, vm)
 	})
 
 	AfterEach(func() {
-		vsphere.SkipVMImageCLProviderCheck = false
-
-		if vm != nil &&
-			!pkgcfg.FromContext(ctx).Features.BringYourOwnEncryptionKey {
-			By("Assert vm.Status.Crypto is nil when BYOK is disabled", func() {
-				Expect(vm.Status.Crypto).To(BeNil())
-			})
-		}
+		vmTestAfterEach(ctx, vm)
 
 		vmClass = nil
 		vm = nil
 
-		ctx.AfterEach()
 		ctx = nil
 		initObjects = nil
 		vmProvider = nil
@@ -145,6 +81,12 @@ func vmStorageTests() {
 	Context("Without Content Library", func() {
 		BeforeEach(func() {
 			testConfig.WithContentLibrary = false
+
+			// Fast Deploy locates an image's files through the image's
+			// VirtualMachineImageCache, which only exists for a content
+			// library item. Without a library the VM is cloned from a VM in
+			// the vcsim inventory, which is the legacy deploy path.
+			disableFastDeploy(parentCtx)
 		})
 
 		// TODO: Dedupe this with "Basic VM" above

--- a/pkg/providers/vsphere/vmprovider_vm_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_test.go
@@ -5,7 +5,7 @@
 package vsphere_test
 
 import (
-	"fmt"
+	"path"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -54,21 +54,26 @@ var _ = Describe("VirtualMachine", Label(testlabels.VCSim), func() {
 	Describe("Location", vmLocationTests)
 })
 
-// getVMHomeDisk gets the VM's "home" disk. It makes some assumptions about the backing and disk name.
+// getVMHomeDisk gets the VM's "home" disk, i.e. disk-0.vmdk in the VM's own
+// directory on the datastore.
+//
+// The directory is read from the VM's VMX path rather than built from the VM's
+// name, because the two deploy paths name it differently: the content library
+// deploy names the directory after the VM, whereas Fast Deploy names it after
+// the VM's UID. See vmCreatePathNameFromDatastoreRecommendation in
+// pkg/providers/vsphere/vmprovider_vm.go.
 func getVMHomeDisk(
-	ctx *builder.TestContextForVCSim,
-	vcVM *object.VirtualMachine,
 	o mo.VirtualMachine) (*vimtypes.VirtualDisk, *vimtypes.VirtualDiskFlatVer2BackingInfo) {
 
-	ExpectWithOffset(1, vcVM.Name()).ToNot(BeEmpty())
-	ExpectWithOffset(1, o.Datastore).ToNot(BeEmpty())
-	var dso mo.Datastore
-	ExpectWithOffset(1, vcVM.Properties(ctx, o.Datastore[0], nil, &dso)).To(Succeed())
+	ExpectWithOffset(1, o.Config).ToNot(BeNil())
+	ExpectWithOffset(1, o.Config.Files).ToNot(BeNil())
+	ExpectWithOffset(1, o.Config.Files.VmPathName).ToNot(BeEmpty())
 
 	devList := object.VirtualDeviceList(o.Config.Hardware.Device)
 	l := devList.SelectByBackingInfo(&vimtypes.VirtualDiskFlatVer2BackingInfo{
 		VirtualDeviceFileBackingInfo: vimtypes.VirtualDeviceFileBackingInfo{
-			FileName: fmt.Sprintf("[%s] %s/disk-0.vmdk", dso.Name, vcVM.Name()),
+			FileName: path.Join(
+				path.Dir(o.Config.Files.VmPathName), "disk-0.vmdk"),
 		},
 	})
 	ExpectWithOffset(1, l).To(HaveLen(1))

--- a/pkg/providers/vsphere/vmprovider_vm_unmanaged_volumes_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_unmanaged_volumes_test.go
@@ -11,6 +11,13 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/vmware/govmomi/object"
 	pbmmethods "github.com/vmware/govmomi/pbm/methods"
 	pbmsim "github.com/vmware/govmomi/pbm/simulator"
 	pbmtypes "github.com/vmware/govmomi/pbm/types"
@@ -19,23 +26,15 @@ import (
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/soap"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
-	corev1 "k8s.io/api/core/v1"
-	storagev1 "k8s.io/api/storage/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 	cnsv1alpha1 "github.com/vmware-tanzu/vm-operator/external/vsphere-csi-driver/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
-	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
 	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
 	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ptr"
 	"github.com/vmware-tanzu/vm-operator/pkg/vmconfig"
 	vmconfunmanagedvolsfil "github.com/vmware-tanzu/vm-operator/pkg/vmconfig/volumes/unmanaged/backfill"
@@ -59,10 +58,7 @@ func vmUnmanagedVolumesTests() {
 	)
 
 	BeforeEach(func() {
-		parentCtx = pkgcfg.NewContextWithDefaultConfig()
-		parentCtx = ctxop.WithContext(parentCtx)
-		parentCtx = ovfcache.WithContext(parentCtx)
-		parentCtx = cource.WithContext(parentCtx)
+		parentCtx = newVMTestParentContext()
 		parentCtx = vmconfig.WithContext(parentCtx)
 
 		// Enable AllDisksArePVCs feature
@@ -72,18 +68,9 @@ func vmUnmanagedVolumesTests() {
 			config.Features.AllDisksArePVCs = true
 		})
 
-		testConfig = builder.VCSimTestConfig{
-			WithContentLibrary: true,
-		}
+		testConfig = newVMTestConfig()
 
-		vmClass = builder.DummyVirtualMachineClassGenName()
-		vm = builder.DummyBasicVirtualMachine("test-vm", "")
-
-		// Disable network for simplicity
-		if vm.Spec.Network == nil {
-			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
-		}
-		vm.Spec.Network.Disabled = true
+		vmClass, vm = newVMTestObjects("test-vm")
 	})
 
 	JustBeforeEach(func() {
@@ -140,26 +127,15 @@ func vmUnmanagedVolumesTests() {
 		vmProvider = vsphere.NewVSphereVMProviderFromClient(ctx, ctx.Client, ctx.Recorder)
 		nsInfo = ctx.CreateWorkloadNamespace()
 
-		vmClass.Namespace = nsInfo.Namespace
-		Expect(ctx.Client.Create(ctx, vmClass)).To(Succeed())
-
-		clusterVMImage := &vmopv1.ClusterVirtualMachineImage{}
-		Expect(ctx.Client.Get(ctx, client.ObjectKey{Name: ctx.ContentLibraryItem1Name}, clusterVMImage)).To(Succeed())
-
-		vm.Namespace = nsInfo.Namespace
-		vm.Spec.ClassName = vmClass.Name
-		vm.Spec.ImageName = clusterVMImage.Name
-		vm.Spec.Image.Kind = cvmiKind
-		vm.Spec.Image.Name = clusterVMImage.Name
-		vm.Spec.StorageClass = ctx.StorageClassName
-
-		Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
+		createVMTestObjects(
+			ctx, nsInfo, resolveVMTestImage(ctx, testConfig), vmClass, vm)
 	})
 
 	AfterEach(func() {
+		vmTestAfterEach(ctx, vm)
+
 		vmClass = nil
 		vm = nil
-		ctx.AfterEach()
 		ctx = nil
 		initObjects = nil
 		vmProvider = nil
@@ -167,6 +143,13 @@ func vmUnmanagedVolumesTests() {
 	})
 
 	When("VM has unmanaged disks from vSphere", func() {
+		JustBeforeEach(func() {
+			// Nothing in a provider test plays the part of the image cache
+			// controller, so report the image's files as cached for Fast
+			// Deploy. The context below builds its own cache instead.
+			ctx.MarkImageCacheReady(ctx.ContentLibraryItem1Cache)
+		})
+
 		It("should backfill unmanaged disk into spec.volumes", func() {
 			Expect(createOrUpdateVM(ctx, vmProvider, vm)).
 				To(MatchError(vsphere.ErrRegisterVolumes))
@@ -196,7 +179,22 @@ func vmUnmanagedVolumesTests() {
 			Expect(pvc.Spec.DataSourceRef.Kind).To(Equal("VirtualMachine"))
 			Expect(pvc.Spec.DataSourceRef.Name).To(Equal(vm.Name))
 			Expect(pvc.Spec.AccessModes).To(ContainElement(corev1.ReadWriteOnce))
-			expectedStorage := *kubeutil.BytesToResource(31457280)
+
+			// The PVC is sized from the disk the VM actually has, which
+			// differs by deploy path: Fast Deploy links the boot disk to the
+			// image's cached VMDK and inherits its capacity, whereas the
+			// content library deploy applies the size the OVF declares.
+			Expect(vm.Status.UniqueID).ToNot(BeEmpty())
+			vcVM := ctx.GetVMFromMoID(vm.Status.UniqueID)
+			Expect(vcVM).ToNot(BeNil())
+			var moVM mo.VirtualMachine
+			Expect(vcVM.Properties(ctx, vcVM.Reference(), nil, &moVM)).To(Succeed())
+			vmDisks := object.VirtualDeviceList(moVM.Config.Hardware.Device).
+				SelectByType(&vimtypes.VirtualDisk{})
+			Expect(vmDisks).To(HaveLen(1))
+
+			expectedStorage := *kubeutil.BytesToResource(
+				vmDisks[0].(*vimtypes.VirtualDisk).CapacityInBytes)
 			Expect(pvc.Spec.Resources.Requests[corev1.ResourceStorage].Equal(expectedStorage)).To(BeTrue())
 
 			// Verify OwnerReference.

--- a/pkg/providers/vsphere/vmprovider_vm_upgrade_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_upgrade_test.go
@@ -9,18 +9,13 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
-	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
 	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
 	pkgconst "github.com/vmware-tanzu/vm-operator/pkg/constants"
-	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	vmopv1util "github.com/vmware-tanzu/vm-operator/pkg/util/vmopv1"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
@@ -32,95 +27,34 @@ func vmUpgradeTests() {
 		testConfig  builder.VCSimTestConfig
 		ctx         *builder.TestContextForVCSim
 		vmProvider  providers.VirtualMachineProviderInterface
-		nsInfo      builder.WorkloadNamespaceInfo
 
 		vm      *vmopv1.VirtualMachine
 		vmClass *vmopv1.VirtualMachineClass
-
-		zoneName string
 	)
 
 	BeforeEach(func() {
-		parentCtx = pkgcfg.NewContextWithDefaultConfig()
-		parentCtx = ctxop.WithContext(parentCtx)
-		parentCtx = ovfcache.WithContext(parentCtx)
-		parentCtx = cource.WithContext(parentCtx)
-		pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
-			config.AsyncCreateEnabled = false
-			config.AsyncSignalEnabled = false
-		})
-		testConfig = builder.VCSimTestConfig{
-			WithContentLibrary: true,
-		}
+		parentCtx = newVMTestParentContext()
+		testConfig = newVMTestConfig()
 
-		vmClass = builder.DummyVirtualMachineClassGenName()
-		vm = builder.DummyBasicVirtualMachine("test-vm", "")
-
-		if vm.Spec.Network == nil {
-			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
-		}
-		vm.Spec.Network.Disabled = true
+		vmClass, vm = newVMTestObjects("test-vm")
 	})
 
 	JustBeforeEach(func() {
-		ctx = suite.NewTestContextForVCSimWithParentContext(
-			parentCtx, testConfig, initObjects...)
-		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-			config.MaxDeployThreadsOnProvider = 1
-		})
-		vmProvider = vsphere.NewVSphereVMProviderFromClient(
-			ctx, ctx.Client, ctx.Recorder)
-		nsInfo = ctx.CreateWorkloadNamespace()
+		ctx, vmProvider, _ = setupVMTest(
+			parentCtx, testConfig, vmClass, vm, initObjects...)
 
-		vmClass.Namespace = nsInfo.Namespace
-		Expect(ctx.Client.Create(ctx, vmClass)).To(Succeed())
-
-		clusterVMI1 := &vmopv1.ClusterVirtualMachineImage{}
-
-		if testConfig.WithContentLibrary {
-			Expect(ctx.Client.Get(
-				ctx, client.ObjectKey{Name: ctx.ContentLibraryItem1Name},
-				clusterVMI1)).To(Succeed())
-		} else {
-			vsphere.SkipVMImageCLProviderCheck = true
-			clusterVMI1 = builder.DummyClusterVirtualMachineImage("DC0_C0_RP0_VM0")
-			Expect(ctx.Client.Create(ctx, clusterVMI1)).To(Succeed())
-			conditions.MarkTrue(clusterVMI1, vmopv1.ReadyConditionType)
-			Expect(ctx.Client.Status().Update(ctx, clusterVMI1)).To(Succeed())
-		}
-
-		vm.Namespace = nsInfo.Namespace
-		vm.Spec.ClassName = vmClass.Name
-		vm.Spec.ImageName = clusterVMI1.Name
-		vm.Spec.Image.Kind = cvmiKind
-		vm.Spec.Image.Name = clusterVMI1.Name
-		vm.Spec.StorageClass = ctx.StorageClassName
-
-		Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
-
-		zoneName = ctx.GetFirstZoneName()
-		vm.Labels[corev1.LabelTopologyZone] = zoneName
-		Expect(ctx.Client.Update(ctx, vm)).To(Succeed())
+		pinVMToFirstZone(ctx, vm)
 	})
 
 	AfterEach(func() {
-		vsphere.SkipVMImageCLProviderCheck = false
-
-		if vm != nil &&
-			!pkgcfg.FromContext(ctx).Features.BringYourOwnEncryptionKey {
-			By("Assert vm.Status.Crypto is nil when BYOK is disabled", func() {
-				Expect(vm.Status.Crypto).To(BeNil())
-			})
-		}
+		vmTestAfterEach(ctx, vm)
 
 		vmClass = nil
 		vm = nil
 
-		ctx.AfterEach()
 		ctx = nil
 		initObjects = nil
 		vmProvider = nil
-		nsInfo = builder.WorkloadNamespaceInfo{}
 	})
 
 	JustBeforeEach(func() {

--- a/pkg/providers/vsphere/vmprovider_vm_vks_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_vks_test.go
@@ -10,7 +10,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/vmware/govmomi/object"
@@ -18,15 +17,9 @@ import (
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 	backupapi "github.com/vmware-tanzu/vm-operator/pkg/backup/api"
-	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
-	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
-	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
-	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
 	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
 	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
@@ -37,7 +30,6 @@ func vmVKSTests() {
 		testConfig  builder.VCSimTestConfig
 		ctx         *builder.TestContextForVCSim
 		vmProvider  providers.VirtualMachineProviderInterface
-		nsInfo      builder.WorkloadNamespaceInfo
 
 		vm      *vmopv1.VirtualMachine
 		vmClass *vmopv1.VirtualMachineClass
@@ -46,71 +38,20 @@ func vmVKSTests() {
 		moVM mo.VirtualMachine
 
 		optIntoBackup bool
-
-		zoneName string
 	)
 
 	BeforeEach(func() {
-		parentCtx = pkgcfg.NewContextWithDefaultConfig()
-		parentCtx = ctxop.WithContext(parentCtx)
-		parentCtx = ovfcache.WithContext(parentCtx)
-		parentCtx = cource.WithContext(parentCtx)
-		pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
-			config.AsyncCreateEnabled = false
-			config.AsyncSignalEnabled = false
-		})
-		testConfig = builder.VCSimTestConfig{
-			WithContentLibrary: true,
-		}
+		parentCtx = newVMTestParentContext()
+		testConfig = newVMTestConfig()
 
-		vmClass = builder.DummyVirtualMachineClassGenName()
-		vm = builder.DummyBasicVirtualMachine("test-vm", "")
-
-		if vm.Spec.Network == nil {
-			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
-		}
-		vm.Spec.Network.Disabled = true
+		vmClass, vm = newVMTestObjects("test-vm")
 	})
 
 	JustBeforeEach(func() {
-		ctx = suite.NewTestContextForVCSimWithParentContext(
-			parentCtx, testConfig, initObjects...)
-		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-			config.MaxDeployThreadsOnProvider = 1
-		})
-		vmProvider = vsphere.NewVSphereVMProviderFromClient(
-			ctx, ctx.Client, ctx.Recorder)
-		nsInfo = ctx.CreateWorkloadNamespace()
+		ctx, vmProvider, _ = setupVMTest(
+			parentCtx, testConfig, vmClass, vm, initObjects...)
 
-		vmClass.Namespace = nsInfo.Namespace
-		Expect(ctx.Client.Create(ctx, vmClass)).To(Succeed())
-
-		clusterVMI1 := &vmopv1.ClusterVirtualMachineImage{}
-
-		if testConfig.WithContentLibrary {
-			Expect(ctx.Client.Get(
-				ctx, client.ObjectKey{Name: ctx.ContentLibraryItem1Name},
-				clusterVMI1)).To(Succeed())
-		} else {
-			vsphere.SkipVMImageCLProviderCheck = true
-			clusterVMI1 = builder.DummyClusterVirtualMachineImage("DC0_C0_RP0_VM0")
-			Expect(ctx.Client.Create(ctx, clusterVMI1)).To(Succeed())
-			conditions.MarkTrue(clusterVMI1, vmopv1.ReadyConditionType)
-			Expect(ctx.Client.Status().Update(ctx, clusterVMI1)).To(Succeed())
-		}
-
-		vm.Namespace = nsInfo.Namespace
-		vm.Spec.ClassName = vmClass.Name
-		vm.Spec.ImageName = clusterVMI1.Name
-		vm.Spec.Image.Kind = cvmiKind
-		vm.Spec.Image.Name = clusterVMI1.Name
-		vm.Spec.StorageClass = ctx.StorageClassName
-
-		Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
-
-		zoneName = ctx.GetFirstZoneName()
-		vm.Labels[corev1.LabelTopologyZone] = zoneName
-		Expect(ctx.Client.Update(ctx, vm)).To(Succeed())
+		pinVMToFirstZone(ctx, vm)
 
 		if vm.Labels == nil {
 			vm.Labels = make(map[string]string)
@@ -136,25 +77,16 @@ func vmVKSTests() {
 	AfterEach(func() {
 		optIntoBackup = false
 
-		vsphere.SkipVMImageCLProviderCheck = false
-
-		if vm != nil &&
-			!pkgcfg.FromContext(ctx).Features.BringYourOwnEncryptionKey {
-			By("Assert vm.Status.Crypto is nil when BYOK is disabled", func() {
-				Expect(vm.Status.Crypto).To(BeNil())
-			})
-		}
+		vmTestAfterEach(ctx, vm)
 
 		vmClass = nil
 		vm = nil
 		vcVM = nil
 		moVM = mo.VirtualMachine{}
 
-		ctx.AfterEach()
 		ctx = nil
 		initObjects = nil
 		vmProvider = nil
-		nsInfo = builder.WorkloadNamespaceInfo{}
 	})
 
 	It("should not have any backup ExtraConfig key", func() {

--- a/pkg/providers/vsphere/vmprovider_vm_webconsole_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_webconsole_test.go
@@ -9,16 +9,11 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
-	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
-	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
-	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
-	"github.com/vmware-tanzu/vm-operator/pkg/providers"
-	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
-	"github.com/vmware-tanzu/vm-operator/test/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+	"github.com/vmware-tanzu/vm-operator/pkg/providers"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 func vmWebConsoleTests() {
@@ -28,89 +23,32 @@ func vmWebConsoleTests() {
 		testConfig  builder.VCSimTestConfig
 		ctx         *builder.TestContextForVCSim
 		vmProvider  providers.VirtualMachineProviderInterface
-		nsInfo      builder.WorkloadNamespaceInfo
 
 		vm      *vmopv1.VirtualMachine
 		vmClass *vmopv1.VirtualMachineClass
 	)
 
 	BeforeEach(func() {
-		parentCtx = pkgcfg.NewContextWithDefaultConfig()
-		parentCtx = ctxop.WithContext(parentCtx)
-		parentCtx = ovfcache.WithContext(parentCtx)
-		parentCtx = cource.WithContext(parentCtx)
-		pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
-			config.AsyncCreateEnabled = false
-			config.AsyncSignalEnabled = false
-		})
-		testConfig = builder.VCSimTestConfig{
-			WithContentLibrary: true,
-		}
+		parentCtx = newVMTestParentContext()
+		testConfig = newVMTestConfig()
 
-		vmClass = builder.DummyVirtualMachineClassGenName()
-		vm = builder.DummyBasicVirtualMachine("test-vm", "")
-
-		if vm.Spec.Network == nil {
-			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
-		}
-		vm.Spec.Network.Disabled = true
+		vmClass, vm = newVMTestObjects("test-vm")
 	})
 
 	JustBeforeEach(func() {
-		ctx = suite.NewTestContextForVCSimWithParentContext(
-			parentCtx, testConfig, initObjects...)
-		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-			config.MaxDeployThreadsOnProvider = 1
-		})
-		vmProvider = vsphere.NewVSphereVMProviderFromClient(
-			ctx, ctx.Client, ctx.Recorder)
-		nsInfo = ctx.CreateWorkloadNamespace()
-
-		vmClass.Namespace = nsInfo.Namespace
-		Expect(ctx.Client.Create(ctx, vmClass)).To(Succeed())
-
-		clusterVMI1 := &vmopv1.ClusterVirtualMachineImage{}
-
-		if testConfig.WithContentLibrary {
-			Expect(ctx.Client.Get(
-				ctx, client.ObjectKey{Name: ctx.ContentLibraryItem1Name},
-				clusterVMI1)).To(Succeed())
-		} else {
-			vsphere.SkipVMImageCLProviderCheck = true
-			clusterVMI1 = builder.DummyClusterVirtualMachineImage("DC0_C0_RP0_VM0")
-			Expect(ctx.Client.Create(ctx, clusterVMI1)).To(Succeed())
-			conditions.MarkTrue(clusterVMI1, vmopv1.ReadyConditionType)
-			Expect(ctx.Client.Status().Update(ctx, clusterVMI1)).To(Succeed())
-		}
-
-		vm.Namespace = nsInfo.Namespace
-		vm.Spec.ClassName = vmClass.Name
-		vm.Spec.ImageName = clusterVMI1.Name
-		vm.Spec.Image.Kind = cvmiKind
-		vm.Spec.Image.Name = clusterVMI1.Name
-		vm.Spec.StorageClass = ctx.StorageClassName
-
-		Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
+		ctx, vmProvider, _ = setupVMTest(
+			parentCtx, testConfig, vmClass, vm, initObjects...)
 	})
 
 	AfterEach(func() {
-		vsphere.SkipVMImageCLProviderCheck = false
-
-		if vm != nil &&
-			!pkgcfg.FromContext(ctx).Features.BringYourOwnEncryptionKey {
-			By("Assert vm.Status.Crypto is nil when BYOK is disabled", func() {
-				Expect(vm.Status.Crypto).To(BeNil())
-			})
-		}
+		vmTestAfterEach(ctx, vm)
 
 		vmClass = nil
 		vm = nil
 
-		ctx.AfterEach()
 		ctx = nil
 		initObjects = nil
 		vmProvider = nil
-		nsInfo = builder.WorkloadNamespaceInfo{}
 	})
 
 	JustBeforeEach(func() {

--- a/pkg/providers/vsphere/vmprovider_vm_zone_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_zone_test.go
@@ -9,16 +9,11 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
-	"github.com/vmware-tanzu/vm-operator/pkg/conditions"
-	pkgcfg "github.com/vmware-tanzu/vm-operator/pkg/config"
-	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
-	"github.com/vmware-tanzu/vm-operator/pkg/providers"
-	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/kube/cource"
-	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
-	"github.com/vmware-tanzu/vm-operator/test/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
+	"github.com/vmware-tanzu/vm-operator/pkg/providers"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -30,7 +25,6 @@ func vmZoneTests() {
 		testConfig  builder.VCSimTestConfig
 		ctx         *builder.TestContextForVCSim
 		vmProvider  providers.VirtualMachineProviderInterface
-		nsInfo      builder.WorkloadNamespaceInfo
 
 		vm      *vmopv1.VirtualMachine
 		vmClass *vmopv1.VirtualMachineClass
@@ -39,86 +33,28 @@ func vmZoneTests() {
 	)
 
 	BeforeEach(func() {
-		parentCtx = pkgcfg.NewContextWithDefaultConfig()
-		parentCtx = ctxop.WithContext(parentCtx)
-		parentCtx = ovfcache.WithContext(parentCtx)
-		parentCtx = cource.WithContext(parentCtx)
-		pkgcfg.SetContext(parentCtx, func(config *pkgcfg.Config) {
-			config.AsyncCreateEnabled = false
-			config.AsyncSignalEnabled = false
-		})
-		testConfig = builder.VCSimTestConfig{
-			WithContentLibrary: true,
-		}
+		parentCtx = newVMTestParentContext()
+		testConfig = newVMTestConfig()
 
-		vmClass = builder.DummyVirtualMachineClassGenName()
-		vm = builder.DummyBasicVirtualMachine("test-vm", "")
-
-		if vm.Spec.Network == nil {
-			vm.Spec.Network = &vmopv1.VirtualMachineNetworkSpec{}
-		}
-		vm.Spec.Network.Disabled = true
+		vmClass, vm = newVMTestObjects("test-vm")
 	})
 
 	JustBeforeEach(func() {
-		ctx = suite.NewTestContextForVCSimWithParentContext(
-			parentCtx, testConfig, initObjects...)
-		pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-			config.MaxDeployThreadsOnProvider = 1
-		})
-		vmProvider = vsphere.NewVSphereVMProviderFromClient(
-			ctx, ctx.Client, ctx.Recorder)
-		nsInfo = ctx.CreateWorkloadNamespace()
+		ctx, vmProvider, _ = setupVMTest(
+			parentCtx, testConfig, vmClass, vm, initObjects...)
 
-		vmClass.Namespace = nsInfo.Namespace
-		Expect(ctx.Client.Create(ctx, vmClass)).To(Succeed())
-
-		clusterVMI1 := &vmopv1.ClusterVirtualMachineImage{}
-
-		if testConfig.WithContentLibrary {
-			Expect(ctx.Client.Get(
-				ctx, client.ObjectKey{Name: ctx.ContentLibraryItem1Name},
-				clusterVMI1)).To(Succeed())
-		} else {
-			vsphere.SkipVMImageCLProviderCheck = true
-			clusterVMI1 = builder.DummyClusterVirtualMachineImage("DC0_C0_RP0_VM0")
-			Expect(ctx.Client.Create(ctx, clusterVMI1)).To(Succeed())
-			conditions.MarkTrue(clusterVMI1, vmopv1.ReadyConditionType)
-			Expect(ctx.Client.Status().Update(ctx, clusterVMI1)).To(Succeed())
-		}
-
-		vm.Namespace = nsInfo.Namespace
-		vm.Spec.ClassName = vmClass.Name
-		vm.Spec.ImageName = clusterVMI1.Name
-		vm.Spec.Image.Kind = cvmiKind
-		vm.Spec.Image.Name = clusterVMI1.Name
-		vm.Spec.StorageClass = ctx.StorageClassName
-
-		Expect(ctx.Client.Create(ctx, vm)).To(Succeed())
-
-		zoneName = ctx.GetFirstZoneName()
-		vm.Labels[corev1.LabelTopologyZone] = zoneName
-		Expect(ctx.Client.Update(ctx, vm)).To(Succeed())
+		zoneName = pinVMToFirstZone(ctx, vm)
 	})
 
 	AfterEach(func() {
-		vsphere.SkipVMImageCLProviderCheck = false
-
-		if vm != nil &&
-			!pkgcfg.FromContext(ctx).Features.BringYourOwnEncryptionKey {
-			By("Assert vm.Status.Crypto is nil when BYOK is disabled", func() {
-				Expect(vm.Status.Crypto).To(BeNil())
-			})
-		}
+		vmTestAfterEach(ctx, vm)
 
 		vmClass = nil
 		vm = nil
 
-		ctx.AfterEach()
 		ctx = nil
 		initObjects = nil
 		vmProvider = nil
-		nsInfo = builder.WorkloadNamespaceInfo{}
 	})
 
 	It("Reverse lookups existing VM into correct zone", func() {

--- a/pkg/providers/vsphere/vmprovider_vmgroup_test.go
+++ b/pkg/providers/vsphere/vmprovider_vmgroup_test.go
@@ -5,6 +5,8 @@
 package vsphere_test
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -19,7 +21,6 @@ import (
 	"github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers"
 	"github.com/vmware-tanzu/vm-operator/pkg/providers/vsphere"
-	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
 	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
@@ -29,6 +30,7 @@ var _ = Describe(
 	Label(testlabels.Group), func() {
 
 		var (
+			parentCtx   context.Context
 			initObjects []client.Object
 			testConfig  builder.VCSimTestConfig
 			ctx         *builder.TestContextForVCSim
@@ -42,9 +44,8 @@ var _ = Describe(
 		)
 
 		BeforeEach(func() {
-			testConfig = builder.VCSimTestConfig{
-				WithContentLibrary: true,
-			}
+			parentCtx = newVMTestParentContext()
+			testConfig = newVMTestConfig()
 
 			vm1 = builder.DummyBasicVirtualMachine("group-placement-vm-1", "")
 			vm2 = builder.DummyBasicVirtualMachine("group-placement-vm-2", "")
@@ -64,16 +65,14 @@ var _ = Describe(
 		})
 
 		JustBeforeEach(func() {
-			ctx = suite.NewTestContextForVCSim(testConfig, initObjects...)
-			pkgcfg.SetContext(ctx, func(config *pkgcfg.Config) {
-				config.Features.FastDeploy = true
-			})
-			vmProvider = vsphere.NewVSphereVMProviderFromClient(ctx, ctx.Client, ctx.Recorder)
-			nsInfo = ctx.CreateWorkloadNamespace()
+			ctx, vmProvider, nsInfo = newVMTestContext(parentCtx, testConfig, initObjects...)
+			ctx.MarkImageCacheReady(ctx.ContentLibraryItem1Cache)
 
 			vmClass.Namespace = nsInfo.Namespace
 			Expect(ctx.Client.Create(ctx, vmClass)).To(Succeed())
 			Expect(ctx.Client.Status().Update(ctx, vmClass)).To(Succeed())
+
+			vmGroup.Namespace = nsInfo.Namespace
 
 			initVM := func(vm *vmopv1.VirtualMachine) {
 				vm.Namespace = nsInfo.Namespace
@@ -86,73 +85,6 @@ var _ = Describe(
 			}
 			initVM(vm1)
 			initVM(vm2)
-
-			vmGroup.Namespace = nsInfo.Namespace
-
-			{
-				// TODO: Put this test builder to reduce duplication.
-
-				vmic := vmopv1.VirtualMachineImageCache{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: pkgcfg.FromContext(ctx).PodNamespace,
-						Name:      pkgutil.VMIName(ctx.ContentLibraryItem1ID),
-					},
-				}
-				Expect(ctx.Client.Create(ctx, &vmic)).To(Succeed())
-
-				vmicm := corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: vmic.Namespace,
-						Name:      vmic.Name,
-					},
-					Data: map[string]string{
-						"value": ctx.ContentLibraryItem1YAML,
-					},
-				}
-				Expect(ctx.Client.Create(ctx, &vmicm)).To(Succeed())
-
-				vmic.Status = vmopv1.VirtualMachineImageCacheStatus{
-					OVF: &vmopv1.VirtualMachineImageCacheOVFStatus{
-						ConfigMapName:   vmic.Name,
-						ProviderVersion: ctx.ContentLibraryItem1Version,
-					},
-					Conditions: []metav1.Condition{
-						{
-							Type:   vmopv1.VirtualMachineImageCacheConditionHardwareReady,
-							Status: metav1.ConditionTrue,
-						},
-					},
-				}
-				Expect(ctx.Client.Status().Update(ctx, &vmic)).To(Succeed())
-
-				pkgcond.MarkTrue(
-					&vmic,
-					vmopv1.VirtualMachineImageCacheConditionFilesReady)
-				vmic.Status.Locations = []vmopv1.VirtualMachineImageCacheLocationStatus{
-					{
-						DatacenterID: ctx.Datacenter.Reference().Value,
-						DatastoreID:  ctx.Datastore.Reference().Value,
-						Files: []vmopv1.VirtualMachineImageCacheFileStatus{
-							{
-								ID:       ctx.ContentLibraryItem1Disk1Path,
-								Type:     vmopv1.VirtualMachineImageCacheFileTypeDisk,
-								DiskType: vmopv1.VolumeTypeClassic,
-							},
-							{
-								ID:   ctx.ContentLibraryItem1NVRAMPath,
-								Type: vmopv1.VirtualMachineImageCacheFileTypeOther,
-							},
-						},
-						Conditions: []metav1.Condition{
-							{
-								Type:   vmopv1.ReadyConditionType,
-								Status: metav1.ConditionTrue,
-							},
-						},
-					},
-				}
-				Expect(ctx.Client.Status().Update(ctx, &vmic)).To(Succeed())
-			}
 		})
 
 		AfterEach(func() {

--- a/test/builder/fake.go
+++ b/test/builder/fake.go
@@ -5,7 +5,12 @@
 package builder
 
 import (
+	"context"
+
+	"github.com/google/uuid"
+
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -44,6 +49,15 @@ func NewFakeClientWithInterceptors(
 	objs ...client.Object,
 ) client.Client {
 	scheme := NewScheme()
+
+	// Objects handed to WithObjects go straight into the tracker without
+	// passing through the Create interceptor below, so assign their UIDs here.
+	for _, obj := range objs {
+		ensureUID(obj)
+	}
+
+	funcs.Create = assignUIDOnCreate(funcs.Create)
+
 	return fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithInterceptorFuncs(funcs).
@@ -54,6 +68,44 @@ func NewFakeClientWithInterceptors(
 			kubeutil.VMSnapshotVMNameFieldIndex,
 			kubeutil.VMSnapshotVMNameIndexerFunc).
 		Build()
+}
+
+// assignUIDOnCreate wraps a Create interceptor so that every object created
+// through the fake client comes back with a UID, the way an object created
+// against a real API server does. The fake client assigns a resourceVersion but
+// no UID, which leaves code that derives a value from an object's UID — the
+// VM's directory on a datastore, a cloud-init instance ID, an owner reference —
+// looking at an empty string in tests but a real ID in production.
+//
+// A UID the caller set explicitly is left alone, since a spec that pins one is
+// usually asserting on it.
+func assignUIDOnCreate(next createFunc) createFunc {
+	return func(
+		ctx context.Context,
+		c client.WithWatch,
+		obj client.Object,
+		opts ...client.CreateOption) error {
+
+		ensureUID(obj)
+
+		if next != nil {
+			return next(ctx, c, obj, opts...)
+		}
+		return c.Create(ctx, obj, opts...)
+	}
+}
+
+type createFunc func(
+	ctx context.Context,
+	c client.WithWatch,
+	obj client.Object,
+	opts ...client.CreateOption) error
+
+// ensureUID assigns obj a unique UID if it does not already have one.
+func ensureUID(obj client.Object) {
+	if obj != nil && obj.GetUID() == "" {
+		obj.SetUID(types.UID(uuid.NewString()))
+	}
 }
 
 // KnownObjectTypes has the known VM operator types that will be

--- a/test/builder/vcsim_test_context.go
+++ b/test/builder/vcsim_test_context.go
@@ -30,6 +30,13 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
 	"github.com/vmware/govmomi"
 	vimcrypto "github.com/vmware/govmomi/crypto"
 	"github.com/vmware/govmomi/find"
@@ -43,12 +50,6 @@ import (
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/soap"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
-	corev1 "k8s.io/api/core/v1"
-	storagev1 "k8s.io/api/storage/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	// Blank import to make govmomi client aware of these bindings.
 	_ "github.com/vmware/govmomi/vapi/cluster/simulator"
@@ -75,6 +76,7 @@ import (
 	ctxop "github.com/vmware-tanzu/vm-operator/pkg/context/operation"
 	pkgmgr "github.com/vmware-tanzu/vm-operator/pkg/manager"
 	"github.com/vmware-tanzu/vm-operator/pkg/record"
+	pkgutil "github.com/vmware-tanzu/vm-operator/pkg/util"
 	kubeutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube"
 	netsetutil "github.com/vmware-tanzu/vm-operator/pkg/util/kube/networksettings"
 	"github.com/vmware-tanzu/vm-operator/pkg/util/ovfcache"
@@ -157,6 +159,40 @@ type VCSimTestConfig struct {
 	WithWorkloadIPv6 bool
 }
 
+// VCSimImageCacheFile is a file belonging to a content library item that a
+// VirtualMachineImageCache reports as cached on a datastore.
+type VCSimImageCacheFile struct {
+	// Name is how the item's descriptor refers to the file, for example the OVF
+	// disk href "disk0.vmdk". The Fast Deploy create path looks a disk's cached
+	// path up by this name. It is empty for a file the descriptor does not name,
+	// such as the item's NVRAM.
+	Name string
+
+	// Path is the file's datastore path.
+	Path string
+
+	// Disk is true when the file is a virtual disk.
+	Disk bool
+}
+
+// VCSimImageCacheItem describes the content library item that
+// MarkImageCacheReady builds a VirtualMachineImageCache for.
+type VCSimImageCacheItem struct {
+	// ID is the library item's ID, which is what an image reports as its
+	// status.providerItemID.
+	ID string
+
+	// Version is the library item's content version.
+	Version string
+
+	// OVFYAML is the marshaled OVF envelope stored in the cache's ConfigMap. It
+	// is empty for an ISO item, which has no OVF.
+	OVFYAML string
+
+	// Files are the item's cached files.
+	Files []VCSimImageCacheFile
+}
+
 // VCSimNetworkConfig describes the type and configuration of a network
 // to configure on vcsim.
 type VCSimNetworkConfig struct {
@@ -213,6 +249,12 @@ type TestContextForVCSim struct {
 	ContentLibraryIsoImageName   string
 	ContentLibraryIsoItemID      string
 	ContentLibraryIsoItemVersion string
+
+	// Descriptors for building a ready VirtualMachineImageCache for each
+	// content library item. See MarkImageCacheReady.
+	ContentLibraryItem1Cache   VCSimImageCacheItem
+	ContentLibraryItem2Cache   VCSimImageCacheItem
+	ContentLibraryIsoItemCache VCSimImageCacheItem
 
 	// When WithoutStorageClass is false:
 	StorageClassName          string
@@ -1073,6 +1115,131 @@ func (c *TestContextForVCSim) setupContentLibrary(config VCSimTestConfig) {
 	conditions.MarkTrue(clusterVMI3, vmopv1.ReadyConditionType)
 	Expect(c.Client.Status().Update(c, clusterVMI3)).To(Succeed())
 
+	c.ContentLibraryItem1Cache = VCSimImageCacheItem{
+		ID:      c.ContentLibraryItem1ID,
+		Version: c.ContentLibraryItem1Version,
+		OVFYAML: c.ContentLibraryItem1YAML,
+		Files: []VCSimImageCacheFile{
+			{Name: "disk0.vmdk", Path: c.ContentLibraryItem1Disk1Path, Disk: true},
+			{Path: c.ContentLibraryItem1NVRAMPath},
+		},
+	}
+
+	c.ContentLibraryItem2Cache = VCSimImageCacheItem{
+		ID:      c.ContentLibraryItem2ID,
+		Version: c.ContentLibraryItem2Version,
+		OVFYAML: c.ContentLibraryItem2YAML,
+		Files: []VCSimImageCacheFile{
+			{Name: "disk0.vmdk", Path: c.ContentLibraryItem2Disk1Path, Disk: true},
+			{Name: "disk1.vmdk", Path: c.ContentLibraryItem2Disk2Path, Disk: true},
+			{Name: "disk2.vmdk", Path: c.ContentLibraryItem2Disk3Path, Disk: true},
+			{Path: c.ContentLibraryItem2NVRAMPath},
+		},
+	}
+
+	// An ISO item has no OVF and no disks; the CD-ROM is backed by the library
+	// item directly.
+	c.ContentLibraryIsoItemCache = VCSimImageCacheItem{
+		ID:      c.ContentLibraryIsoItemID,
+		Version: c.ContentLibraryIsoItemVersion,
+	}
+}
+
+// MarkImageCacheReady creates the VirtualMachineImageCache resource that the
+// Fast Deploy create path consults to locate an image's cached files, along
+// with the ConfigMap holding the item's OVF envelope. The cache is marked
+// hardware-ready and files-ready at the test context's datacenter and
+// datastore, for both the plain and the encrypted storage profile, since a spec
+// may deploy from either storage class and the provider only accepts a location
+// whose profile matches the VM's.
+//
+// The library item is synced so that the files the cache names actually exist
+// on the datastore: the provider verifies each one with DatastoreFileExists
+// before it will use the cache.
+//
+// A spec exercising the cache-not-ready paths should build the
+// VirtualMachineImageCache itself rather than call this.
+func (c *TestContextForVCSim) MarkImageCacheReady(
+	item VCSimImageCacheItem) *vmopv1.VirtualMachineImageCache {
+
+	ExpectWithOffset(1, item.ID).ToNot(BeEmpty())
+
+	obj := &vmopv1.VirtualMachineImageCache{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: pkgcfg.FromContext(c).PodNamespace,
+			Name:      pkgutil.VMIName(item.ID),
+		},
+		Spec: vmopv1.VirtualMachineImageCacheSpec{
+			ProviderID:      item.ID,
+			ProviderVersion: item.Version,
+		},
+	}
+	ExpectWithOffset(1, c.Client.Create(c, obj)).To(Succeed())
+
+	if item.OVFYAML != "" {
+		ExpectWithOffset(1, c.Client.Create(c, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: obj.Namespace,
+				Name:      obj.Name,
+			},
+			Data: map[string]string{"value": item.OVFYAML},
+		})).To(Succeed())
+
+		obj.Status.OVF = &vmopv1.VirtualMachineImageCacheOVFStatus{
+			ConfigMapName:   obj.Name,
+			ProviderVersion: item.Version,
+		}
+	}
+
+	conditions.MarkTrue(obj, vmopv1.VirtualMachineImageCacheConditionHardwareReady)
+	conditions.MarkTrue(obj, vmopv1.VirtualMachineImageCacheConditionFilesReady)
+
+	files := make([]vmopv1.VirtualMachineImageCacheFileStatus, len(item.Files))
+	for i := range item.Files {
+		f := item.Files[i]
+		ExpectWithOffset(1, f.Path).ToNot(BeEmpty())
+
+		files[i] = vmopv1.VirtualMachineImageCacheFileStatus{
+			ID:   f.Path,
+			Name: f.Name,
+			Type: vmopv1.VirtualMachineImageCacheFileTypeOther,
+		}
+		if f.Disk {
+			files[i].Type = vmopv1.VirtualMachineImageCacheFileTypeDisk
+			files[i].DiskType = vmopv1.VolumeTypeClassic
+		}
+	}
+
+	for _, profileID := range []string{
+		c.StorageProfileID,
+		c.EncryptedStorageProfileID,
+	} {
+		if profileID == "" {
+			continue
+		}
+		obj.Status.Locations = append(
+			obj.Status.Locations,
+			vmopv1.VirtualMachineImageCacheLocationStatus{
+				DatacenterID: c.Datacenter.Reference().Value,
+				DatastoreID:  c.Datastore.Reference().Value,
+				ProfileID:    profileID,
+				Files:        files,
+				Conditions: []metav1.Condition{
+					{
+						Type:   vmopv1.ReadyConditionType,
+						Status: metav1.ConditionTrue,
+					},
+				},
+			})
+	}
+	ExpectWithOffset(1, c.Client.Status().Update(c, obj)).To(Succeed())
+
+	// The subscribed library is on-demand, so the item must be synced for its
+	// files to exist on the datastore.
+	libMgr := library.NewManager(c.RestClient)
+	ExpectWithOffset(1, libMgr.SyncLibraryItem(c, &library.Item{ID: item.ID}, true)).To(Succeed())
+
+	return obj
 }
 
 func (c *TestContextForVCSim) SimulatorContext() *simulator.Context {
@@ -1338,6 +1505,32 @@ func (c *TestContextForVCSim) setupAZs() {
 		Expect(c.Client.Create(c, az)).To(Succeed())
 		c.ZoneNames = append(c.ZoneNames, az.Name)
 		c.azCCRs[az.Name] = clusters
+	}
+}
+
+// GroupPlacementDatastores returns the datastore recommendations to store on a
+// VirtualMachineGroup member's placement status, describing the test context's
+// datastore as the home for the VM.
+//
+// In production the group placement controller records these alongside the
+// zone, node, and pool. A Fast Deploy create needs them, because it builds the
+// VM's files on the recommended datastore itself rather than handing the whole
+// job to the content library.
+func (c *TestContextForVCSim) GroupPlacementDatastores() []vmopv1.VirtualMachineGroupPlacementDatastoreStatus {
+	var props mo.Datastore
+	Expect(c.Datastore.Properties(
+		c,
+		c.Datastore.Reference(),
+		[]string{"name", "summary"},
+		&props)).To(Succeed())
+
+	return []vmopv1.VirtualMachineGroupPlacementDatastoreStatus{
+		{
+			Name:                             props.Name,
+			ID:                               c.Datastore.Reference().Value,
+			URL:                              props.Summary.Url,
+			TopLevelDirectoryCreateSupported: true,
+		},
 	}
 }
 


### PR DESCRIPTION


**What does this PR do, and why is it needed?**

Fast deploy is our default so the VM Provider tests should by default run with that feature enabled. Dedupe the repeated test context setup code so we have a single path to enable fast deploy.

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:


```release-note
NONE
```