### PR TITLE
[x-port] [9.1.2] ✨ Distroless: Adopt minimal Photon bottom-up image build without rpm packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,15 @@
-ARG BASE_IMAGE=gcr.io/distroless/base-debian12
+ARG BASE_IMAGE=mirror.gcr.io/library/photon:5.0
 
 # Copy the controller-manager into a thin image
 FROM ${BASE_IMAGE}
 
+## --------------------------------------
+## Cleanup (Distroless image)
+## --------------------------------------
+
+RUN tdnf makecache && tdnf -y update && \
+    rm /etc/tdnf/protected.d/tdnf.conf && tdnf -y autoremove photon-repos tdnf && \
+    rm -rf /var/cache/tdnf /usr/lib/{rpm,tdnf} /usr/lib/sysimage/{rpm,tdnf} /etc/{rpm,tdnf}
 
 ## --------------------------------------
 ## Environment variables

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,47 @@
 ARG BASE_IMAGE=mirror.gcr.io/library/photon:5.0
 
-# Copy the controller-manager into a thin image
-FROM ${BASE_IMAGE}
-
 ## --------------------------------------
-## Cleanup (Distroless image)
+## Build a minimal root filesystem (bottom-up)
 ## --------------------------------------
 
-RUN tdnf makecache && tdnf -y update && \
-    rm /etc/tdnf/protected.d/tdnf.conf && tdnf -y autoremove photon-repos tdnf && \
-    rm -rf /var/cache/tdnf /usr/lib/{rpm,tdnf} /usr/lib/sysimage/{rpm,tdnf} /etc/{rpm,tdnf}
+FROM ${BASE_IMAGE} AS installer
+
+RUN mkdir -p /installroot
+
+# For distroless, we just need the files from filesystem,
+# ca-certificates-pki, glibc, and glibc-libs, which are
+# pre-installed on most curated base images including
+# internal+external Photon builds. 
+# glibc/glibc-libs are required because manager is 
+# built internally with CGO_ENABLED=1 and
+# GOEXPERIMENT=boringcrypto for FIPS compliance
+# so it is dynamically linked against libc, not static.
+# Copy their files straight out of the live root
+# filesystem using tdnf's own package queries, which
+# needs no extra package and no network access.
+
+RUN set -eo pipefail; \
+    for pkg in filesystem ca-certificates-pki glibc glibc-libs; do \
+            tdnf --disablerepo="*" list installed "$pkg" >/dev/null 2>&1 \
+                # if any missing package, fail the build
+                || { echo "missing package: $pkg" >&2; exit 1; }; \
+            tdnf --disablerepo="*" repoquery --installed --list "$pkg" \
+                | while read -r f; do if [ -e "$f" ]; then echo "$f"; fi; done \
+                | cpio -pdm /installroot; \
+    done
+
+## --------------------------------------
+## Copy the controller-manager into a thin image
+## --------------------------------------
+
+FROM scratch
 
 ## --------------------------------------
 ## Environment variables
 ## --------------------------------------
 
+ARG TARGETOS
+ARG TARGETARCH
 ENV GOOS=${TARGETOS}
 ENV GOARCH=${TARGETARCH}
 
@@ -42,11 +69,20 @@ LABEL branch="${BUILD_BRANCH}" \
 
 
 ## --------------------------------------
+## Minimal root filesystem (CA bundle + glibc, no tdnf/rpm/shell)
+## --------------------------------------
+
+COPY --from=installer /installroot /
+
+
+## --------------------------------------
 ## Copy the binaries from the builder
 ## --------------------------------------
 
 WORKDIR /
 COPY ./bin/manager .
 COPY ./bin/web-console-validator .
-USER nobody
+# No /etc/passwd on the image
+# we need to use UID instead of nobody
+USER 65534:65534
 ENTRYPOINT ["/manager"]

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ WEBHOOK_ROOT      ?= $(MANIFEST_ROOT)/webhook
 RBAC_ROOT         ?= $(MANIFEST_ROOT)/rbac
 
 # Image URL to use all building/pushing image targets
-BASE_IMAGE ?= gcr.io/distroless/base-debian12
+BASE_IMAGE ?= mirror.gcr.io/library/photon:5.0
 IMAGE ?= vmoperator-controller
 IMAGE_TAG ?= latest
 IMG ?= ${IMAGE}:${IMAGE_TAG}


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Crossport of
- https://github.com/vmware-tanzu/vm-operator/pull/1616
- https://github.com/vmware-tanzu/vm-operator/pull/1739

Switches the manager image base from `gcr.io/distroless/base-debian12` to `mirror.gcr.io/library/photon:5.0` (#1616), then replaces the tdnf-update-based cleanup with a two-stage, bottom-up minimal Photon rootfs build (#1739). An `installer` stage copies only `filesystem`, `ca-certificates-pki`, `glibc`, and `glibc-libs` out of the live root filesystem via tdnf's installed-package queries piped through `cpio`, needing no network access and failing the build if any of those packages is missing. The final image is built `FROM scratch`, copying in that minimal rootfs plus the binaries, and runs as UID/GID 65534 instead of `USER nobody` (no `/etc/passwd` on the image).

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # vmop_3785596

**Are there any special notes for your reviewer**:

Direct crossport of the two linked upstream PRs; no adaptation was needed beyond resolving the merge onto the release/vc-9.1.0 base.

**Please add a release note if necessary**:

```release-note
Docker images contain the very minimum for controller execution and no longer contain bash or any other libraries (with the exception of glibc and glibc-libs).
```