### PR TITLE
Fix minor miss in KubeVM common types

### DIFF
--- a/external/kubevm/api/v1alpha1/common_types.go
+++ b/external/kubevm/api/v1alpha1/common_types.go
@@ -79,8 +79,6 @@ const (
 	PowerOpModeTrySoft PowerOpMode = "TrySoft"
 )
 
-// +kubebuilder:validation:Enum=Pending;Provisioning;Running;Stopping;Stopped;Suspended;Failed;Deleting
-
 // Condition types reported on a VirtualMachine.
 //
 // Conditions are where provider-dependent outcomes are reported, and this is a


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

minor miss in KubeVM common types

**Please add a release note if necessary**:

```release-note
NONE
```