### PR TITLE
🐛 Fix vm-publish e2e test race condition and diagnostics

### DIFF
--- a/test/e2e/vmservice/config/wcp.yaml
+++ b/test/e2e/vmservice/config/wcp.yaml
@@ -62,7 +62,7 @@ intervals:
   default/wait-virtual-machine-group-deletion: [ "60s", "5s" ]
   default/wait-virtual-machine-group-condition-update: [ "6m", "5s" ]
   default/wait-virtual-machine-publish-request-creation: ["60s", "5s"]
-  default/wait-virtual-machine-publish-request-condition: ["6m", "5s"]
+  default/wait-virtual-machine-publish-request-condition: ["10m", "5s"]
   default/wait-virtual-machine-publish-request-upload-condition: ["20m", "5s"]
   default/wait-virtual-machine-publish-request-deletion: ["60s", "2s"]
   default/wait-virtual-machine-group-publish-request-condition: [ "6m", "5s" ]

--- a/test/e2e/vmservice/lib/vmoperator/vmoperator.go
+++ b/test/e2e/vmservice/lib/vmoperator/vmoperator.go
@@ -734,7 +734,7 @@ func VerifyVirtualMachinePublishRequestCondition(
 // VirtualMachineImage lookup). Waiting on Uploaded separately keeps that
 // slow, VC-side clone from having to fit inside the same short budget used
 // for Complete.
-func VerifyVirtualMachinePublishRequestUploaded(
+func WaitForVirtualMachinePublishRequestUploaded(
 	ctx context.Context,
 	config *config.E2EConfig,
 	client ctrlclient.Client,
@@ -758,7 +758,7 @@ func VerifyVirtualMachinePublishRequestUploaded(
 // VirtualMachineImage lookup for each child). Waiting on Uploaded here keeps
 // that slow, VC-side clone from having to fit inside the short budget used
 // for Complete.
-func VerifyVirtualMachineGroupPublishRequestImagesUploaded(
+func WaitForVirtualMachineGroupPublishRequestImagesUploaded(
 	ctx context.Context,
 	config *config.E2EConfig,
 	client ctrlclient.Client,

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_group_publishrequest.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_group_publishrequest.go
@@ -258,7 +258,7 @@ func VMGroupPublishRequestSpec(ctx context.Context, inputGetter func() VMGroupPu
 		// child's Uploaded condition on its own generous budget first so
 		// that slow, VC-side clone doesn't have to fit inside the shorter
 		// budget used for Complete.
-		vmoperator.VerifyVirtualMachineGroupPublishRequestImagesUploaded(
+		vmoperator.WaitForVirtualMachineGroupPublishRequestImagesUploaded(
 			ctx,
 			vmSvcE2EConfig,
 			vmSvcClusterProxy.GetClient(),

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_publishrequest.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_publishrequest.go
@@ -243,6 +243,7 @@ func VMPublishRequestSpec(ctx context.Context, inputGetter func() VMPublishReque
 					Type:   vmopv1.VirtualMachinePublishRequestConditionComplete,
 					Status: metav1.ConditionTrue,
 				}
+				vmoperator.WaitForVirtualMachinePublishRequestUploaded(ctx, config, svClusterClient, input.WCPNamespaceName, vmPublishRequestName)
 				vmoperator.VerifyVirtualMachinePublishRequestCondition(ctx, config, svClusterClient, input.WCPNamespaceName, vmPublishRequestName, vmPubCondition)
 
 				By("Duplicate TargetName should result in TargetItemAlreadyExistsReason condition", func() {
@@ -308,14 +309,14 @@ func VMPublishRequestSpec(ctx context.Context, inputGetter func() VMPublishReque
 				}
 
 				sourceVMName := fmt.Sprintf("%s-%s", vmPubSpecName+"-vapp-src", capiutil.RandomString(4))
-				createVMWithPromotionDisabled(ctx, svClusterClient, input.WCPNamespaceName, sourceVMName, sourceImageName, *clusterResources,
-					&vmopv1.VirtualMachineBootstrapSpec{
-						// LinuxPrep is needed here for the VM to get a valid IP address.
-						LinuxPrep: &vmopv1.VirtualMachineBootstrapLinuxPrepSpec{},
-						VAppConfig: &vmopv1.VirtualMachineBootstrapVAppConfigSpec{
-							Properties: sourceVAppProperties,
-						},
-					})
+				sourceBootstrapSpec := &vmopv1.VirtualMachineBootstrapSpec{
+					// LinuxPrep is needed here for the VM to get a valid IP address.
+					LinuxPrep: &vmopv1.VirtualMachineBootstrapLinuxPrepSpec{},
+					VAppConfig: &vmopv1.VirtualMachineBootstrapVAppConfigSpec{
+						Properties: sourceVAppProperties,
+					},
+				}
+				createVMWithPromotionDisabled(ctx, svClusterClient, input.WCPNamespaceName, sourceVMName, sourceImageName, *clusterResources, sourceBootstrapSpec)
 				vmoperator.WaitForVirtualMachineCreation(ctx, config, svClusterClient, input.WCPNamespaceName, sourceVMName)
 				DeferCleanup(func() {
 					vmoperator.DeleteVirtualMachine(ctx, svClusterClient, input.WCPNamespaceName, sourceVMName)
@@ -429,7 +430,7 @@ func VMPublishRequestSpec(ctx context.Context, inputGetter func() VMPublishReque
 				// than publishing to a Content Library (an OVF export). Wait for
 				// that clone on its own generous budget before waiting on Complete,
 				// which follows quickly once Uploaded=True.
-				vmoperator.VerifyVirtualMachinePublishRequestUploaded(ctx, config, svClusterClient, input.WCPNamespaceName, vmPublishRequestName)
+				vmoperator.WaitForVirtualMachinePublishRequestUploaded(ctx, config, svClusterClient, input.WCPNamespaceName, vmPublishRequestName)
 				vmoperator.VerifyVirtualMachinePublishRequestCondition(ctx, config, svClusterClient, input.WCPNamespaceName, vmPublishRequestName, metav1.Condition{
 					Type:   vmopv1.VirtualMachinePublishRequestConditionComplete,
 					Status: metav1.ConditionTrue,
@@ -559,7 +560,7 @@ func VMPublishRequestSpec(ctx context.Context, inputGetter func() VMPublishReque
 				By("Computing the VM's actual used storage from vCenter's file layout")
 				// Mirror the controller's own calculation (see checkContentLibraryQuota)
 				// so the expected requestedCapacity is built the same way the controller does.
-				vmmoid := vmoperator.GetVirtualMachineMOID(ctx, svClusterClient, input.WCPNamespaceName, input.LinuxVMName)
+				vmmoid := vmoperator.WaitForVirtualMachineMOID(ctx, config, svClusterClient, input.WCPNamespaceName, input.LinuxVMName)
 				vmMoRef := vimtypes.ManagedObjectReference{
 					Type:  string(vimtypes.ManagedObjectTypeVirtualMachine),
 					Value: vmmoid,
@@ -623,8 +624,7 @@ func generateVMBuilder(
 	}
 }
 
-// createVMWithPromotionDisabled creates a VirtualMachine with disk promotion
-// disabled once creation succeeds.
+// createVMWithPromotionDisabled creates a VirtualMachine with no online disk promotion.
 //
 // The VM is built as a typed struct rather than rendered YAML because
 // PromoteDisksMode does not exist before v1alpha4, so the v1alpha2 fixture
@@ -647,13 +647,10 @@ func createVMWithPromotionDisabled(
 			Name:      name,
 		},
 		Spec: vmopv1.VirtualMachineSpec{
-			ClassName:    clusterResources.VMClassName,
-			ImageName:    imageName,
-			StorageClass: clusterResources.StorageClassName,
-			PowerState:   vmopv1.VirtualMachinePowerStateOn,
-			Reserved: &vmopv1.VirtualMachineReservedSpec{
-				ResourcePolicyName: clusterResources.VMResourcePolicyName,
-			},
+			ClassName:        clusterResources.VMClassName,
+			ImageName:        imageName,
+			StorageClass:     clusterResources.StorageClassName,
+			PowerState:       vmopv1.VirtualMachinePowerStateOn,
 			PromoteDisksMode: vmopv1.VirtualMachinePromoteDisksModeDisabled,
 			Bootstrap:        bootstrap,
 		},

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_publishrequest.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_publishrequest.go
@@ -73,8 +73,9 @@ func VMPublishRequestSpec(ctx context.Context, inputGetter func() VMPublishReque
 			clusterResources *e2eConfig.Resources
 			vimClient        *vim25.Client
 
-			targetContentLibraryName string
-			vmPublishRequestName     string
+			targetContentLibraryName  string
+			vmPublishRequestName      string
+			deployedVMFromPublishName string
 		)
 
 		BeforeAll(func() {
@@ -104,11 +105,15 @@ func VMPublishRequestSpec(ctx context.Context, inputGetter func() VMPublishReque
 		BeforeEach(func() {
 			targetContentLibraryName = fmt.Sprintf("%s-%s-%s", vmPubSpecName, "content-library", capiutil.RandomString(4))
 			vmPublishRequestName = fmt.Sprintf("%s-%s", vmPubSpecName, capiutil.RandomString(4))
+			deployedVMFromPublishName = ""
 		})
 
 		AfterEach(func() {
 			if CurrentSpecReport().Failed() {
 				vmoperator.DescribeResourceIfExists(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), input.WCPNamespaceName, input.LinuxVMName, "vm")
+				if deployedVMFromPublishName != "" {
+					vmoperator.DescribeResourceIfExists(ctx, svClusterClient, clusterProxy.GetKubeconfigPath(), input.WCPNamespaceName, deployedVMFromPublishName, "vm")
+				}
 			}
 		})
 
@@ -280,6 +285,7 @@ func VMPublishRequestSpec(ctx context.Context, inputGetter func() VMPublishReque
 				// Use the published the vmi to deploy a new VM should succeed with VM powered on and IP assigned.
 				newVmName := fmt.Sprintf("%s-%s", vmPubSpecName+"-vm", capiutil.RandomString(4))
 				createVMWithPromotionDisabled(ctx, svClusterClient, input.WCPNamespaceName, newVmName, publishedImageCRName, *clusterResources, nil)
+				deployedVMFromPublishName = newVmName
 				vmoperator.WaitForVirtualMachineCreation(ctx, config, svClusterClient, input.WCPNamespaceName, newVmName)
 				vmoperator.DeleteVirtualMachine(ctx, svClusterClient, input.WCPNamespaceName, newVmName)
 			})
@@ -317,6 +323,7 @@ func VMPublishRequestSpec(ctx context.Context, inputGetter func() VMPublishReque
 					},
 				}
 				createVMWithPromotionDisabled(ctx, svClusterClient, input.WCPNamespaceName, sourceVMName, sourceImageName, *clusterResources, sourceBootstrapSpec)
+				deployedVMFromPublishName = sourceVMName
 				vmoperator.WaitForVirtualMachineCreation(ctx, config, svClusterClient, input.WCPNamespaceName, sourceVMName)
 				DeferCleanup(func() {
 					vmoperator.DeleteVirtualMachine(ctx, svClusterClient, input.WCPNamespaceName, sourceVMName)
@@ -341,6 +348,7 @@ func VMPublishRequestSpec(ctx context.Context, inputGetter func() VMPublishReque
 				deployedVMBuilder := generateVMBuilder(input.WCPNamespaceName, deployedVMName, publishedImageCRName, *clusterResources)
 				deployedVMYaml := manifestbuilders.GetVirtualMachineYamlA2(deployedVMBuilder)
 				Expect(clusterProxy.CreateWithArgs(ctx, deployedVMYaml)).NotTo(HaveOccurred(), "failed to create virtualmachine from the published image", string(deployedVMYaml))
+				deployedVMFromPublishName = deployedVMName
 				vmoperator.WaitForVirtualMachineCreation(ctx, config, svClusterClient, input.WCPNamespaceName, deployedVMName)
 				DeferCleanup(func() {
 					vmoperator.DeleteVirtualMachine(ctx, svClusterClient, input.WCPNamespaceName, deployedVMName)
@@ -446,7 +454,7 @@ func VMPublishRequestSpec(ctx context.Context, inputGetter func() VMPublishReque
 				// Deploy a new VM from the published image and verify it powers on with an IP.
 				newVmName := fmt.Sprintf("%s-%s", vmPubSpecName+"-vm", capiutil.RandomString(4))
 				createVMWithPromotionDisabled(ctx, svClusterClient, input.WCPNamespaceName, newVmName, publishedImageCRName, *clusterResources, nil)
-
+				deployedVMFromPublishName = newVmName
 				// Wait for the image cache on its own generous budget before
 				// waiting on the rest of VM creation, rather than sharing one
 				// 5-minute window across both: caching the just-published


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

- The "Requested Capacity Estimation" test was failing due to two issues:
Race condition: The test calls `GetVirtualMachineMOID()` on a shared source VM immediately after issuing a publish request, with no wait for VM placement. The helper is documented as requiring the VM to be placed (status.uniqueID populated), which happens during VM creation reconciliation. Under load or slow placement, the MOID would still be empty.
```
â€¢ [FAILED] [20.225 seconds]
Testing VM Services VIRTUAL-MACHINE VM-PUBLISH-REQUEST VirtualMachinePublishRequest Requested Capacity Estimation [It] should compute the requestedCapacity annotation from the VM's actual used storage, not its provisioned disk size [devops, viadmin, virtualmachine, vmservice, extended-functional]
/vm-operator/test/e2e/vmservice/vmservice/virtualmachine/vm_publishrequest.go:576

  [FAILED] Expected
      <string>: 
  not to be empty
  In [It] at: /vm-operator/test/e2e/vmservice/lib/vmoperator/vmoperator.go:526 @ 09/02/26 08:11:45.762
```

- Weak diagnostics: When deploy-from-published-image tests fail, the AfterEach() only dumps the source VM, not the deployed VM that actually failed, making RCA harder.
- Addessed the comments from this PR - https://github.com/vmware-tanzu/vm-operator/pull/1871

Fixes:
- Replace `GetVirtualMachineMOID()` (single-shot) with `WaitForVirtualMachineMOID()` (Eventually-polled) before reading vCenter properties, matching the pattern used elsewhere in the test suite.
- Increased the diskpromotion timeout as 6m time budget is  small for the overloaded setup. 
-  Hoist `deployedVMName` to Context scope, assign it at each VM deploy site, and dump it on failure so diagnostics capture the actual failed VM.

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #
vmop-4159

**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note

```