### PR TITLE
fix test failure

### DIFF
--- a/pkg/vmconfig/diskpromo/diskpromo_reconciler.go
+++ b/pkg/vmconfig/diskpromo/diskpromo_reconciler.go
@@ -288,6 +288,21 @@ func (r reconciler) Reconcile(
 
 	switch vm.Spec.PromoteDisksMode {
 	case vmopv1.VirtualMachinePromoteDisksModeOnline:
+		if vm.Spec.PowerState == vmopv1.VirtualMachinePowerStateOff {
+			// Do not start a new online promotion when a power-off is
+			// desired. vCenter serializes tasks per-VM, so a freshly issued
+			// PromoteDisks task would stall the pending PowerOff behind it.
+			// Promotion resumes once the VM is powered back on.
+			pkgcond.MarkFalse(
+				vm,
+				vmopv1.VirtualMachineDiskPromotionSynced,
+				ReasonPending,
+				"Pending VM power-off")
+			logger.V(4).Info(
+				"Skipping online disk promotion while VM power-off is pending")
+			return nil
+		}
+
 		if moVM.Snapshot != nil && moVM.Snapshot.CurrentSnapshot != nil {
 			// Skip VMs that have snapshots.
 			pkgcond.MarkFalse(

--- a/pkg/vmconfig/diskpromo/diskpromo_reconciler_test.go
+++ b/pkg/vmconfig/diskpromo/diskpromo_reconciler_test.go
@@ -457,7 +457,26 @@ var _ = Describe("Reconcile", Label(testlabels.V1Alpha5), func() {
 						Expect(r.Reconcile(ctx, k8sClient, vimClient, vm, moVM, configSpec)).To(Succeed())
 					})
 
-					When("there is an error calling promote disks", func() {
+					When("spec.powerState is PoweredOff", func() {
+					BeforeEach(func() {
+						vm.Spec.PowerState = vmopv1.VirtualMachinePowerStateOff
+					})
+
+					It("should not promote disks", func() {
+						Expect(err).ToNot(HaveOccurred())
+
+						promoRef := getPromoTaskRef()
+						Expect(promoRef).To(BeNil())
+
+						c := conditions.Get(vm, vmopv1.VirtualMachineDiskPromotionSynced)
+						Expect(c).ToNot(BeNil())
+						Expect(c.Status).To(Equal(metav1.ConditionFalse))
+						Expect(c.Reason).To(Equal(diskpromo.ReasonPending))
+						Expect(c.Message).To(Equal("Pending VM power-off"))
+					})
+				})
+
+				When("there is an error calling promote disks", func() {
 						BeforeEach(func() {
 							reg.Handler = func(
 								ctx *simulator.Context,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**
```
Fixes a VM-LCM E2E test timeout (virtualmachinelcm.go:358) where a VM's power-off never completed within 300s.
â€¢ [FAILED] [469.499 seconds]
Testing VM Services VIRTUAL-MACHINE VM-LCM [It] Should create expected resources for a VirtualMachine from poweredOff to poweredOn [devops, viadmin, virtualmachine, vmservice, smoke]
/vm-operator/test/e2e/vmservice/vmservice/virtualmachine/virtualmachinelcm.go:358

  [FAILED] Timed out after 300.000s.
  Timed out waiting for VirtualMachines vm-lcm-5tvg PowerState to be updated to PoweredOff
  Expected
      <bool>: false
  to be true
  In [It] at: /vm-operator/test/e2e/vmservice/lib/vmoperator/vmoperator.go:506 @ 09/01/26 17:37:55.775
------------------------------
```

Root cause: the diskpromo reconciler only checked the VM's current power state before starting a new online PromoteDisks task, not the desired one. When spec.PowerState flipped to PoweredOff while the VM was still actually on, diskpromo kicked off a fresh promotion task anyway. That task appears to hold vCenter's per-VM task lock, serializing the subsequent PowerOff task behind it — the VM stayed PoweredOn until the test's wait budget expired.

Fix: diskpromo now skips starting a new online promotion when spec.PowerState == PoweredOff, marking the condition pending instead. This avoids ever racing a new promotion task against a pending power-off. Promotion resumes automatically once the VM is powered back on.

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note

```