### PR TITLE
fix guest-cutsomization failure

### DIFF
--- a/test/e2e/vmservice/config/wcp.yaml
+++ b/test/e2e/vmservice/config/wcp.yaml
@@ -111,3 +111,9 @@ intervals:
   # Empirically, Sysprep GOSC on this image reliably reports an IP in
   # 5.5-6 minutes so this spec needs a little more room.
   windows-sysprep/wait-virtual-machine-vmip: ["10m", "3s"]
+
+  # linux-guest-customization overrides apply only to specs that boot VMs
+  # with LinuxPrep guest customization (VMGOSCSpec's LinuxPrep and vAppConfig
+  # contexts). LinuxPrep customization triggers a guest network restart/reboot
+  # that can push the guest's IP report past the default 5m budget.
+  linux-guest-customization/wait-virtual-machine-vmip: ["8m", "3s"]

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_guestcustomization.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_guestcustomization.go
@@ -845,7 +845,34 @@ func VMGOSCSpec(ctx context.Context, inputGetter func() VMGOSCSpecInput) {
 			})
 
 			It("should successfully apply vAppConfig properties to VM", Label("experimental"), func() {
-				createAndVerifyVM(ctx, v1a2vmParameters, true)
+				// The IP wait is rolled inline rather than createAndVerifyVM /
+				// vmoperator.WaitForVirtualMachineIP so this spec can use the
+				// longer "linux-guest-customization" interval (see wcp.yaml)
+				// without changing that shared helper's timeout for every
+				// other caller -- the LinuxPrep customization used here
+				// triggers a guest network restart/reboot that can push the
+				// guest's IP report past the default budget, the same
+				// reasoning as the "windows-sysprep" override used for
+				// Sysprep VMs.
+				vmYaml = manifestbuilders.GetVirtualMachineYamlA2(v1a2vmParameters)
+				Expect(clusterProxy.CreateWithArgs(ctx, vmYaml)).To(Succeed(), "failed to create virtualmachine", string(vmYaml))
+
+				By(fmt.Sprintf("Verify that a single VirtualMachine '%s/%s' is created", input.WCPNamespaceName, vmName))
+				vmoperator.WaitForVirtualMachineToExist(ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
+				vmoperator.WaitForVirtualMachineConditionCreated(ctx, config, svClusterClient, input.WCPNamespaceName, vmName)
+				vmoperator.WaitForVirtualMachinePowerState(ctx, config, svClusterClient, input.WCPNamespaceName, vmName, string(vmopv1.VirtualMachinePowerStateOn))
+
+				By(fmt.Sprintf("Verify that an IP (ipv4) is allocated to the VirtualMachine '%s/%s'", input.WCPNamespaceName, vmName))
+				Eventually(func() bool {
+					vm, err := utils.GetVirtualMachine(ctx, svClusterClient, input.WCPNamespaceName, vmName)
+					if err != nil {
+						return false
+					}
+
+					return vm.Status.Network != nil &&
+						vm.Status.Network.PrimaryIP4 != "" &&
+						net.ParseIP(vm.Status.Network.PrimaryIP4).To4() != nil
+				}, config.GetIntervals("linux-guest-customization", "wait-virtual-machine-vmip")...).Should(BeTrue())
 
 				// Verify that the vAppConfig properties are actually applied to the VM
 				vmmoid := vmoperator.GetVirtualMachineMOID(ctx, svClusterClient, input.WCPNamespaceName, vmName)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

The VM-GUEST-CUSTOMIZATION vAppConfig > Multiple vAppConfigs specified E2E test times out after 5 minutes waiting for Status.Network.PrimaryIP4 even though guest customization completes successfully. LinuxPrep guest customization triggers a network restart/reboot in the guest OS, delaying VMware Tools' IP report back to vCenter. This mirrors the existing windows-sysprep interval override for Sysprep VMs, which face the same class of delay. The fix adds a linux-guest-customization interval bucket (8m) and inlines the IP-wait in the failing test to use it, without affecting other callers.

- Added linux-guest-customization/wait-virtual-machine-vmip: ["8m", "3s"] to test/e2e/vmservice/config/wcp.yaml
- Inlined VM creation and IP-wait logic in the failing It block (vm_guestcustomization.go:847) to use the longer interval, mirroring the existing pattern for Sysprep tests
- All other E2E tests remain unaffected; only this specific test path uses the extended timeout

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note

```