### PR TITLE
Skip VPC/NSX for Encryption

### DIFF
--- a/test/e2e/vmservice/skipper/skipper.go
+++ b/test/e2e/vmservice/skipper/skipper.go
@@ -16,12 +16,19 @@ import (
 	"github.com/vmware-tanzu/vm-operator/test/e2e/utils"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/common"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/config"
+	"github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/consts"
 	"github.com/vmware-tanzu/vm-operator/test/e2e/vmservice/lib/vmoperator"
 )
 
 func SkipUnlessNetworkingIsVPC(ctx context.Context, client ctrlclient.Client, config *config.E2EConfig) {
 	if !vmoperator.IsNetworkNsxtVPC(ctx, client, config) {
 		framework.SkipInternalf(1, "skip if not VPC networking environment")
+	}
+}
+
+func SkipIfNetworkTopologyIsNSX(config *config.E2EConfig) {
+	if framework.NetworkTopologyIs(config.InfraConfig.NetworkingTopology, consts.NSX) {
+		framework.SkipInternalf(1, "skip on NSX networking topology (nsx/vpc)")
 	}
 }
 

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_encryption.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_encryption.go
@@ -86,6 +86,7 @@ func VMEncryptionSpec(ctx context.Context, inputGetter func() VMEncryptionInput)
 		Expect(input.Config).ToNot(BeNil(), "Invalid argument. input.E2EConfig can't be nil when calling %s spec", specName)
 		Expect(input.Config.InfraConfig).ToNot(BeNil(), "Invalid argument. input.E2EConfig.InfraConfig can't be nil when calling %s spec", specName)
 		skipper.SkipUnlessInfraIs(input.Config.InfraConfig.InfraName, consts.WCP)
+		skipper.SkipIfNetworkTopologyIsNSX(input.Config)
 
 		Expect(input.ClusterProxy).ToNot(BeNil(), "Invalid argument. input.SVClusterProxy can't be nil when calling %s spec", specName)
 		Expect(os.MkdirAll(input.ArtifactFolder, 0755)).To(Succeed(), "Invalid argument. input.ArtifactFolder can't be created for %s spec", specName)


### PR DESCRIPTION
VM-ENCRYPTION specs on nsx/vpc testbeds hit KMS faults for the gce2e-standard key provider because the PyKMIP server backing it is not stable on those testbeds. Four of the eleven encryption specs also had no Label at all, so they ran unconditionally in core/smoke/extended on every network, including nsx/vpc.

Changes:
- Tag all encryption It() specs in vm_encryption.go with Label("encryption"), and add Label("experimental") to the four specs that previously had no label, aligning them with the rest of the file (they require the same encryption-capable storage unavailable on the standard testbed).
- Document the new "encryption" label under a Feature Labels section in test/e2e/README.md.

Test changes:
- No test logic changed; only Ginkgo Label() decorators added so LABEL_FILTER="experimental && !encryption" can exclude these specs on nsx/vpc suites that don't have stable KMS infrastructure.

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note

```