### PR TITLE
🌱 Improve visibility of pending events during VM creation

### DIFF
--- a/controllers/virtualmachine/virtualmachine/virtualmachine_controller.go
+++ b/controllers/virtualmachine/virtualmachine/virtualmachine_controller.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -310,11 +311,28 @@ func NewReconciler(
 		Context:    ctx,
 		Client:     client,
 		Logger:     logger,
-		Recorder:   recorder,
+		Recorder:   &vmRecorderWrapper{Recorder: recorder},
 		VMProvider: vmProvider,
 		Prober:     prober,
 		vmMetrics:  metrics.NewVMMetrics(),
 	}
+}
+
+// vmRecorderWrapper wraps the Recorder to emit NoRequeueErrors as pending
+// instead of failures during create.
+type vmRecorderWrapper struct {
+	record.Recorder
+}
+
+func (v *vmRecorderWrapper) EmitEvent(object runtime.Object, opName string, err error, ignoreSuccess bool) {
+	if opName == "Create" {
+		if _, ok := errors.AsType[pkgerr.NoRequeueError](err); ok {
+			v.Warn(object, opName+"Pending", err.Error())
+			return
+		}
+	}
+
+	v.Recorder.EmitEvent(object, opName, err, ignoreSuccess)
 }
 
 // Reconciler reconciles a VirtualMachine object.
@@ -598,7 +616,6 @@ func (r *Reconciler) ReconcileNormal(ctx *pkgctx.VirtualMachineContext) (reterr 
 	}
 
 	if !controllerutil.ContainsFinalizer(ctx.VM, finalizerName) {
-
 		// If the object has the deprecated finalizer, remove it.
 		if updated := controllerutil.RemoveFinalizer(ctx.VM, deprecatedFinalizerName); updated {
 			ctx.Logger.V(5).Info("Removed deprecated finalizer", "finalizerName", deprecatedFinalizerName)
@@ -628,7 +645,7 @@ func (r *Reconciler) ReconcileNormal(ctx *pkgctx.VirtualMachineContext) (reterr 
 	if pkgcfg.FromContext(ctx).Features.FastDeploy {
 		// Do not proceed unless the VMI cache this VM needs is ready.
 		if !r.isVMICacheReady(ctx) {
-			return nil
+			return pkgerr.NoRequeueError{Message: "disk image cache is not ready"}
 		}
 	}
 
@@ -719,11 +736,11 @@ func (r *Reconciler) handleBlockingCreateErr(
 			// If the cache is not yet ready then do not return an error,
 			// but simultaneously, do not reflect a successful create. The
 			// VM will be requeued once the cache object is ready.
-			return nil
+			err = pkgerr.NoRequeueError{Message: "disk image cache is not ready"}
 		}
 	}
 
-	r.Recorder.EmitEvent(ctx.VM, "Create", filterNoRequeueErr(err), false)
+	r.Recorder.EmitEvent(ctx.VM, "Create", err, false)
 	return err
 }
 

--- a/controllers/virtualmachine/virtualmachine/virtualmachine_controller_unit_test.go
+++ b/controllers/virtualmachine/virtualmachine/virtualmachine_controller_unit_test.go
@@ -262,7 +262,7 @@ func unitTestsReconcile() {
 				expectEvents(ctx, "CreateSuccess")
 			})
 
-			It("Should emit a CreateSuccess event if ReconcileNormal causes a successful VM creation that returns a NoRequeueErr", func() {
+			It("Should emit a CreatePending event if ReconcileNormal returns a NoRequeueErr during create", func() {
 				providerfake.SetCreateOrUpdateFunction(
 					vmCtx,
 					fakeVMProvider,
@@ -273,7 +273,7 @@ func unitTestsReconcile() {
 				)
 				err := reconciler.ReconcileNormal(vmCtx)
 				Expect(pkgerr.IsNoRequeueError(err)).To(BeTrue())
-				expectEvents(ctx, "CreateSuccess")
+				expectEvents(ctx, "CreatePending")
 			})
 
 			It("Should emit CreateFailure event if ReconcileNormal causes a failed VM create", func() {
@@ -311,7 +311,7 @@ func unitTestsReconcile() {
 				expectEvents(ctx, "CreateSuccess")
 			})
 
-			It("Should emit a CreateSuccess event if ReconcileNormal causes a successful VM creation that returns a NoRequeueErr", func() {
+			It("Should emit a CreatePending event if ReconcileNormal returns a NoRequeueErr during create", func() {
 				providerfake.SetCreateOrUpdateFunction(
 					vmCtx,
 					fakeVMProvider,
@@ -322,7 +322,7 @@ func unitTestsReconcile() {
 				)
 				err := reconciler.ReconcileNormal(vmCtx)
 				Expect(pkgerr.IsNoRequeueError(err)).To(BeTrue())
-				expectEvents(ctx, "CreateSuccess")
+				expectEvents(ctx, "CreatePending")
 			})
 
 			It("Should emit CreateFailure event if ReconcileNormal causes a failed VM create", func() {


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Somewhat confusingly we could emit multiple CreateSuccess events during the VM creation process. Also, if we are waiting for the VMIC to be ready, the VM controller logs would not indicate that, making it unclear why a reconcile was a noop.

Change the suffix for NoRequeueErrors during create to be pending, since that error means we are just waiting for some external resource to be ready.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # vmop-4182

**Are there any special notes for your reviewer**:

Example:

```
$ k desc vm ...
  Warning  CreatePending  11s                virtualmachine-controller  error getting device for interface eth0: network interface is not ready
  Warning  CreatePending  11s                virtualmachine-controller  error getting device for interface eth0: network interface is not ready
  Warning  CreatePending  10s (x2 over 11s)  virtualmachine-controller  error getting device for interface eth0: network interface is not ready
  Warning  CreatePending  10s                virtualmachine-controller  disk image cache is not ready
  Normal   CreateSuccess  0s                 virtualmachine-controller  Create success
```

```
$ k logs ...
[pod/vmware-system-vmop-controller-manager-6745ffccff-82v8g/manager] I0910 18:42:39.263209       1 virtualmachine_controller.go:638] "Finished Reconciling VirtualMachine" logger="virtualmachine-controller" VirtualMachine="vmsvc-e2e-zvg016/vm22" reconcileID="3b101091-85c3-449b-97f9-d2a09a57b157" noRequeueReason="error getting device for interface eth0: network interface is not ready"
[pod/vmware-system-vmop-controller-manager-6745ffccff-82v8g/manager] I0910 18:42:39.523268       1 virtualmachine_controller.go:638] "Finished Reconciling VirtualMachine" logger="virtualmachine-controller" VirtualMachine="vmsvc-e2e-zvg016/vm22" reconcileID="ce13fe19-5759-4ec9-be42-1f281a1929f7" noRequeueReason="error getting device for interface eth0: network interface is not ready"
[pod/vmware-system-vmop-controller-manager-6745ffccff-82v8g/manager] I0910 18:42:39.568134       1 virtualmachine_controller.go:638] "Finished Reconciling VirtualMachine" logger="virtualmachine-controller" VirtualMachine="vmsvc-e2e-zvg016/vm22" reconcileID="9f4bfbac-4b9b-42fa-8641-74f45ac21ced" noRequeueReason="error getting device for interface eth0: network interface is not ready"
[pod/vmware-system-vmop-controller-manager-6745ffccff-82v8g/manager] I0910 18:42:40.771465       1 virtualmachine_controller.go:638] "Finished Reconciling VirtualMachine" logger="virtualmachine-controller" VirtualMachine="vmsvc-e2e-zvg016/vm22" reconcileID="2533451a-eb66-46af-a8a9-c0e1d38de3af" noRequeueReason="failed to reconcile vSphere policies for placement: failed to evaluate policy: VM vmsvc-e2e-zvg016/vm22 PolicyEvaluation vmsvc-e2e-zvg016/vm-vm22 still being evaluated: policy not ready"
[pod/vmware-system-vmop-controller-manager-6745ffccff-82v8g/manager] I0910 18:42:41.128275       1 virtualmachine_controller.go:638] "Finished Reconciling VirtualMachine" logger="virtualmachine-controller" VirtualMachine="vmsvc-e2e-zvg016/vm22" reconcileID="9817c649-3832-4329-8c4c-b0efd670f2b6" noRequeueReason="disk image cache is not ready"
[pod/vmware-system-vmop-controller-manager-6745ffccff-82v8g/manager] I0910 18:42:41.309880       1 virtualmachine_controller.go:638] "Finished Reconciling VirtualMachine" logger="virtualmachine-controller" VirtualMachine="vmsvc-e2e-zvg016/vm22" reconcileID="568f0b03-830d-4d18-a60f-02088a85a0d0" noRequeueReason="disk image cache is not ready"
[pod/vmware-system-vmop-controller-manager-6745ffccff-82v8g/manager] I0910 18:42:48.717270       1 virtualmachine_controller.go:638] "Finished Reconciling VirtualMachine" logger="virtualmachine-controller" VirtualMachine="vmsvc-e2e-zvg016/vm22" reconcileID="5368da99-249c-4b15-80f3-ee58eb0cddc6" noRequeueReason="disk image cache is not ready"
```

I agree the message for the network not ready "errors" need to be improved but would prefer to kick those to a later MR.

**Please add a release note if necessary**:

```release-note
NONE
```