### PR TITLE
🐛 Fix for vmi cache issue

### DIFF
--- a/test/e2e/vmservice/vmservice/viadmin/registervm.go
+++ b/test/e2e/vmservice/vmservice/viadmin/registervm.go
@@ -263,6 +263,11 @@ func VIAdminRegisterVMSpec(ctx context.Context, inputGetter func() VIAdminRegist
 			}
 
 			By("Get an existing VM Service VM MoID in Supervisor")
+			// Status.UniqueID is only set once the VM's vSphere create task completes,
+			// which is gated behind the same image-cache warm-up as Created. Wait for
+			// the shared warm-up VM's cache on its own budget first, since this Context
+			// runs before VM-LCM's BeforeEach gets a chance to do the same.
+			vmoperator.WaitForVirtualMachineImageCacheReady(ctx, config, svClusterClient, input.WCPNamespaceName, input.LinuxVMName)
 			vmoperator.WaitForVirtualMachineMOID(ctx, config, svClusterClient, input.WCPNamespaceName, input.LinuxVMName)
 			existingVM, err := utils.GetVirtualMachine(ctx, svClusterClient, input.WCPNamespaceName, input.LinuxVMName)
 			Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/vmservice/vmservice/virtualmachine/virtualmachinelcm.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/virtualmachinelcm.go
@@ -105,6 +105,12 @@ func VMSpec(ctx context.Context, inputGetter func() VMSpecInput) {
 
 		linuxVMIName = vmoperator.WaitForVirtualMachineImageName(ctx, &config.Config, svClusterClient, input.WCPNamespaceName, linuxImageDisplayName)
 
+		// Wait for the shared warm-up VM's image cache to be ready before any test in
+		// this suite creates its own VM against the same image/datastore/profile. This
+		// call is idempotent: only the first It pays the real wait, later Its resolve
+		// immediately once the condition is already True.
+		vmoperator.WaitForVirtualMachineImageCacheReady(ctx, config, svClusterClient, input.WCPNamespaceName, input.LinuxVMName)
+
 		cancelPodWatches := framework.WatchPodLogsAndEventsInNamespaces(ctx, []string{config.GetVariable("VMOPNamespace")}, clusterProxy.GetRESTConfig(), filepath.Join(input.ArtifactFolder, specName))
 		DeferCleanup(cancelPodWatches)
 

--- a/test/e2e/vmservice/vmservice/virtualmachine/vm_guestcustomization.go
+++ b/test/e2e/vmservice/vmservice/virtualmachine/vm_guestcustomization.go
@@ -47,6 +47,7 @@ type VMGOSCSpecInput struct {
 	WCPClient                 wcp.WorkloadManagementAPI
 	ArtifactFolder            string
 	WCPNamespaceName          string
+	LinuxVMName               string
 	WindowsServerVMName       string
 	WindowsInlineServerVMName string
 }
@@ -487,6 +488,7 @@ func VMGOSCSpec(ctx context.Context, inputGetter func() VMGOSCSpecInput) {
 
 		Expect(input.ClusterProxy).ToNot(BeNil(), "Invalid argument. input.SVClusterProxy can't be nil when calling %s spec", specName)
 		Expect(input.WCPNamespaceName).ToNot(BeEmpty(), "Invalid argument. input.WCPNamespaceName can't be empty when calling %s spec", specName)
+		Expect(input.LinuxVMName).ToNot(BeEmpty(), "Invalid argument. input.LinuxVMName can't be empty when calling %s spec", specName)
 		Expect(os.MkdirAll(input.ArtifactFolder, 0755)).To(Succeed(), "Invalid argument. input.ArtifactFolder can't be created for %s spec", specName)
 
 		config = input.Config
@@ -499,6 +501,12 @@ func VMGOSCSpec(ctx context.Context, inputGetter func() VMGOSCSpecInput) {
 		DeferCleanup(cancelPodWatches)
 
 		linuxImageDisplayName = vmservice.GetDefaultImageDisplayName(clusterResources)
+
+		// Wait for the shared warm-up VM's image cache to be ready before any test in
+		// this suite creates its own VM against the same image/datastore/profile. This
+		// call is idempotent: only the first It pays the real wait, later Its resolve
+		// immediately once the condition is already True.
+		vmoperator.WaitForVirtualMachineImageCacheReady(ctx, config, svClusterClient, input.WCPNamespaceName, input.LinuxVMName)
 
 		vmName = fmt.Sprintf("%s-%s", specName, capiutil.RandomString(4))
 		configMapName = fmt.Sprintf("%s-%s", "configmap", capiutil.RandomString(4))
@@ -985,6 +993,9 @@ func VMGOSCSpec(ctx context.Context, inputGetter func() VMGOSCSpecInput) {
 		verifyWindowsVMDeployed := func(ctx context.Context, config *e2eConfig.E2EConfig, svClusterClient ctrlclient.Client, ns, vmName string) {
 			By(fmt.Sprintf("Verify that a single VirtualMachine '%s/%s' is created", ns, vmName))
 			vmoperator.WaitForVirtualMachineToExist(ctx, config, svClusterClient, ns, vmName)
+			// This suite's warm-up VM is Windows-specific and isn't covered by the Linux
+			// image-cache wait above, so wait for it directly here on its own budget.
+			vmoperator.WaitForVirtualMachineImageCacheReady(ctx, config, svClusterClient, ns, vmName)
 			vmoperator.WaitForVirtualMachineConditionCreated(ctx, config, svClusterClient, ns, vmName)
 			vmoperator.WaitForVirtualMachinePowerState(ctx, config, svClusterClient, ns, vmName, string(vmopv1.VirtualMachinePowerStateOn))
 

--- a/test/e2e/vmservice/vmservice_test.go
+++ b/test/e2e/vmservice/vmservice_test.go
@@ -112,6 +112,7 @@ var _ = Describe("Testing VM Services", Label("devops"), Label("viadmin"), Label
 					WCPClient:                 wcpClient,
 					ArtifactFolder:            artifactFolder,
 					WCPNamespaceName:          wcpNamespaceName,
+					LinuxVMName:               linuxVMName,
 					WindowsServerVMName:       windowsServerVMName,
 					WindowsInlineServerVMName: windowsInlineServerVMName,
 				}


### PR DESCRIPTION
**What does this PR do, and why is it needed?**

Fixes a flaky e2e timeout (vmop-4120) where `VirtualMachineConditionCreated` never appears on a VM, timing out after 300s with a confusing "condition is nil" failure. The real cause is that the datastore-level image cache (FastDeploy) can take longer than the per-test 5-minute creation budget on a slow/stretched testbed — the shared warm-up VM created in `SynchronizedBeforeSuite` hadn't finished caching by the time downstream tests reused it.

This adds an explicit, idempotent wait for the shared warm-up VM's `VirtualMachineConditionImageCacheReady` condition, on its own 10-minute budget, in the three places that consume it before the cache is otherwise guaranteed to be warm:

- `virtualmachinelcm.go`: `BeforeEach`, before any VM-LCM test creates a VM against the shared Linux warm-up VM's image.
- `vm_guestcustomization.go`: `BeforeEach` for the Linux warm-up VM, and inside `verifyWindowsVMDeployed` for the separate Windows Sysprep warm-up VM.
- `registervm.go`: before `WaitForVirtualMachineMOID` on the shared warm-up VM, since `VI-ADMIN-RegisterVM` runs earlier in the suite than `VM-LCM`'s `BeforeEach`.

This intentionally does *not* touch the shared `WaitForVirtualMachineConditionCreated`/`WaitForVirtualMachineImageCacheReady` helpers in `vmoperator.go`: those already unconditionally require the condition, which is correct for their existing callers (ISO-cdrom VMs, freshly-published VMs) that are known to be FastDeploy-eligible. Making that check generic across every VM-creation call site would misfire on suites where a VM is legitimately downgraded to the legacy path per-VM (encrypted storage class without BYOK, instance storage present) even while the FastDeploy FSS is globally on — there is no reliable signal on the VM object to distinguish that from a genuine race, so this fix is scoped only to the specific warm-up VMs known not to hit those downgrade conditions.

Pipelines are successful.

**Which issue(s) is/are addressed by this PR?**

Fixes vmop-4120

**Are there any special notes for your reviewer**:

Scoped deliberately to the three call sites that reuse the shared warm-up VM(s), not a generic fix in the shared wait helpers — see rationale above for why a generic fix would risk false failures in VM-ENCRYPTION / instance-storage suites.

**Please add a release note if necessary**:

```release-note
NONE