### PR TITLE
Error message standardization

### DIFF
--- a/controllers/virtualmachine/volume/volume_controller.go
+++ b/controllers/virtualmachine/volume/volume_controller.go
@@ -463,7 +463,7 @@ func (r *Reconciler) processAttachments(
 			// If hardware version is 0, which means we failed to parse the version from VM, then just assume that it
 			// is above minimal requirement.
 			if hardwareVersion.IsValid() && hardwareVersion < pkgconst.MinSupportedHWVersionForPVC {
-				retErr := fmt.Errorf("vm has an unsupported "+
+				retErr := fmt.Errorf("VM has an unsupported "+
 					"hardware version %d for PersistentVolumes. Minimum supported hardware version %d",
 					hardwareVersion, pkgconst.MinSupportedHWVersionForPVC)
 				r.recorder.EmitEvent(ctx.VM, "VolumeAttachment", retErr, true)

--- a/controllers/virtualmachine/volumebatch/volumebatch_controller.go
+++ b/controllers/virtualmachine/volumebatch/volumebatch_controller.go
@@ -968,7 +968,7 @@ func (r *Reconciler) validateHardwareVersion(ctx *pkgctx.VolumeContext) error {
 	// If hardware version is 0, which means we failed to parse the version
 	// from VM, then just assume that it is above minimal requirement.
 	if hardwareVersion.IsValid() && hardwareVersion < pkgconst.MinSupportedHWVersionForPVC {
-		retErr := fmt.Errorf("vm has an unsupported "+
+		retErr := fmt.Errorf("VM has an unsupported "+
 			"hardware version %d for PersistentVolumes. "+
 			"Minimum supported hardware version %d",
 			hardwareVersion, pkgconst.MinSupportedHWVersionForPVC)

--- a/controllers/virtualmachinegrouppublishrequest/virtualmachinegrouppublishrequest_controller.go
+++ b/controllers/virtualmachinegrouppublishrequest/virtualmachinegrouppublishrequest_controller.go
@@ -38,7 +38,7 @@ import (
 const (
 	finalizerName         = "vmoperator.vmware.com/virtualmachinegrouppublishrequest"
 	undefinedSpecErrorMsg = "spec.%s is undefined"
-	invalidSpecErrorMsg   = "webhooks failed to mutate/validate spec. please delete and create again."
+	invalidSpecErrorMsg   = "webhooks failed to mutate/validate spec. Please delete and create again."
 	delTTLMsg             = "%s vm group publish request due to TTL expired"
 )
 

--- a/controllers/virtualmachinegrouppublishrequest/virtualmachinegrouppublishrequest_controller_unit_test.go
+++ b/controllers/virtualmachinegrouppublishrequest/virtualmachinegrouppublishrequest_controller_unit_test.go
@@ -108,7 +108,7 @@ func unitTestsReconcile() {
 				Expect(vmGroupPubReq.Status.Conditions).To(HaveLen(1))
 				Expect(vmGroupPubReq.Status.Conditions[0].Status).To(Equal(metav1.ConditionFalse))
 				Expect(specErr).To(Equal(pkgerr.NoRequeueError{
-					Message: "webhooks failed to mutate/validate spec. please delete and create again.",
+					Message: "webhooks failed to mutate/validate spec. Please delete and create again.",
 				}))
 			})
 			BeforeEach(func() {

--- a/controllers/virtualmachinereplicaset/virtualmachinereplicaset_controller.go
+++ b/controllers/virtualmachinereplicaset/virtualmachinereplicaset_controller.go
@@ -500,7 +500,7 @@ func (r *Reconciler) syncReplicas(
 			}
 
 			log.V(5).Info("Created VM", "index", i+1, "totalVMsToBeCreated", diff)
-			r.Recorder.Eventf(rs, "SuccessfulCreate", "Created vm %q", vm.Name)
+			r.Recorder.Eventf(rs, "SuccessfulCreate", "Created VM %q", vm.Name)
 			vmList = append(vmList, vm)
 		}
 

--- a/pkg/providers/vsphere/virtualmachine/backup.go
+++ b/pkg/providers/vsphere/virtualmachine/backup.go
@@ -58,7 +58,7 @@ func BackupVirtualMachine(opts BackupVirtualMachineOptions) (result error) {
 				opts.VMCtx.VM,
 				vmopv1.VirtualMachineBackupUpToDateCondition,
 				vmopv1.VirtualMachineBackupFailedReason,
-				"Failed to backup VM. err: %v", result.Error(),
+				"Failed to back up VM. err: %v", result.Error(),
 			)
 		}
 	}()

--- a/pkg/providers/vsphere/virtualmachine/backup_test.go
+++ b/pkg/providers/vsphere/virtualmachine/backup_test.go
@@ -959,7 +959,7 @@ func backupTests() {
 							Expect(c).NotTo(BeNil())
 							Expect(c.Status).To(Equal(metav1.ConditionFalse))
 							Expect(c.Reason).To(Equal(vmopv1.VirtualMachineBackupFailedReason))
-							Expect(c.Message).To(Equal(`Failed to backup VM. err: strconv.ParseInt: parsing "invalid": invalid syntax`))
+							Expect(c.Message).To(Equal(`Failed to back up VM. err: strconv.ParseInt: parsing "invalid": invalid syntax`))
 						})
 					})
 
@@ -1004,7 +1004,7 @@ func backupTests() {
 							Expect(c).NotTo(BeNil())
 							Expect(c.Status).To(Equal(metav1.ConditionFalse))
 							Expect(c.Reason).To(Equal(vmopv1.VirtualMachineBackupFailedReason))
-							Expect(c.Message).To(Equal(`Failed to backup VM. err: strconv.ParseInt: parsing "invalid": invalid syntax`))
+							Expect(c.Message).To(Equal(`Failed to back up VM. err: strconv.ParseInt: parsing "invalid": invalid syntax`))
 						})
 					})
 				})

--- a/pkg/providers/vsphere/vmprovider_vm_crypto_test.go
+++ b/pkg/providers/vsphere/vmprovider_vm_crypto_test.go
@@ -399,7 +399,7 @@ func vmCryptoTests() {
 						Expect(c).ToNot(BeNil())
 						Expect(c.Status).To(Equal(metav1.ConditionFalse))
 						Expect(c.Reason).To(Equal("InvalidState"))
-						Expect(c.Message).To(Equal("Must use encryption storage class or have vTPM when encrypting vm"))
+						Expect(c.Message).To(Equal("Must use encryption storage class or have vTPM when encrypting the VM"))
 					})
 				})
 

--- a/pkg/util/vmopv1/vmgroup.go
+++ b/pkg/util/vmopv1/vmgroup.go
@@ -255,7 +255,7 @@ func PolicyEvalToVMToVMGroupMapperFunc(
 func RetrieveVMGroupMembers(ctx context.Context, c ctrlclient.Client,
 	vmGroupKey ctrlclient.ObjectKey, visitedGroups *sets.Set[string]) (sets.Set[string], error) {
 	if visitedGroups.Has(vmGroupKey.Name) {
-		return nil, fmt.Errorf("a loop is detected among groups: %q visisted", vmGroupKey.Name)
+		return nil, fmt.Errorf("a loop is detected among groups: %q visited", vmGroupKey.Name)
 	}
 	visitedGroups.Insert(vmGroupKey.Name)
 

--- a/pkg/util/vmopv1/vmgroup_test.go
+++ b/pkg/util/vmopv1/vmgroup_test.go
@@ -189,7 +189,7 @@ var _ = Describe("Validating RetrieveVMGroupMembers",
 				_, err := vmopv1util.RetrieveVMGroupMembers(ctx, ctx.Client,
 					ctrlclient.ObjectKeyFromObject(vmGroup), visitedGroups)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal(fmt.Sprintf("a loop is detected among groups: %q visisted", vmGroup.Name)))
+				Expect(err.Error()).To(Equal(fmt.Sprintf("a loop is detected among groups: %q visited", vmGroup.Name)))
 			})
 		})
 

--- a/pkg/vmconfig/crypto/crypto_reconciler.go
+++ b/pkg/vmconfig/crypto/crypto_reconciler.go
@@ -72,7 +72,7 @@ func SprintfStateNotSynced(op string, msgs ...string) string {
 			strings.Join(msgs[:len(msgs)-1], ", "),
 			msgs[len(msgs)-1])
 	}
-	return fmt.Sprintf("Must %s when %s vm", msg, op)
+	return fmt.Sprintf("Must %s when %s the VM", msg, op)
 }
 
 // Reason is the type used by reasons given to the condition

--- a/pkg/vmconfig/crypto/crypto_reconciler_post_test.go
+++ b/pkg/vmconfig/crypto/crypto_reconciler_post_test.go
@@ -390,7 +390,7 @@ var _ = Describe("OnResult", Label(testlabels.Crypto), func() {
 					})
 					It("should return nil error and set a condition with the expected message", func() {
 						Expect(err).ToNot(HaveOccurred())
-						assertStateNotSynced(vm, "Must specify a key that can be located and not have encryption IO filter when updating unencrypted vm")
+						assertStateNotSynced(vm, "Must specify a key that can be located and not have encryption IO filter when updating unencrypted the VM")
 					})
 				})
 				When("there are three faults", func() {
@@ -425,7 +425,7 @@ var _ = Describe("OnResult", Label(testlabels.Crypto), func() {
 					})
 					It("should return nil error and set a condition with the expected message", func() {
 						Expect(err).ToNot(HaveOccurred())
-						assertStateNotSynced(vm, "Must specify a key that can be located, not have encryption IO filter, and be powered off when updating unencrypted vm")
+						assertStateNotSynced(vm, "Must specify a key that can be located, not have encryption IO filter, and be powered off when updating unencrypted the VM")
 					})
 				})
 			})

--- a/pkg/vmconfig/diskpromo/diskpromo_reconciler.go
+++ b/pkg/vmconfig/diskpromo/diskpromo_reconciler.go
@@ -282,7 +282,7 @@ func (r reconciler) Reconcile(
 			vm,
 			vmopv1.VirtualMachineDiskPromotionSynced,
 			ReasonPending,
-			"Cannot promote disks when VM has running task")
+			"Cannot promote disks when VM has a running task")
 		return nil
 	}
 
@@ -294,7 +294,7 @@ func (r reconciler) Reconcile(
 				vm,
 				vmopv1.VirtualMachineDiskPromotionSynced,
 				ReasonPending,
-				"Cannot online promote disks when VM has snapshot")
+				"Cannot online promote disks when VM has a snapshot")
 			logger.V(4).Info(
 				"Skipping online disk promotion for VM with snapshot(s)")
 			return nil

--- a/pkg/vmconfig/diskpromo/diskpromo_reconciler_test.go
+++ b/pkg/vmconfig/diskpromo/diskpromo_reconciler_test.go
@@ -857,7 +857,7 @@ var _ = Describe("Reconcile", Label(testlabels.V1Alpha5), func() {
 						Expect(c).ToNot(BeNil())
 						Expect(c.Status).To(Equal(metav1.ConditionFalse))
 						Expect(c.Reason).To(Equal(diskpromo.ReasonPending))
-						Expect(c.Message).To(Equal("Cannot promote disks when VM has running task"))
+						Expect(c.Message).To(Equal("Cannot promote disks when VM has a running task"))
 					})
 				})
 

--- a/webhooks/virtualmachine/mutation/virtualmachine_mutator.go
+++ b/webhooks/virtualmachine/mutation/virtualmachine_mutator.go
@@ -453,7 +453,7 @@ func SetNextRestartTime(
 			return false, field.Invalid(
 				field.NewPath("spec", "nextRestartTime"),
 				newVM.Spec.NextRestartTime,
-				"can only restart powered on vm")
+				"can only restart powered on VM")
 		}
 		newVM.Spec.NextRestartTime = time.Now().UTC().Format(time.RFC3339Nano)
 		return true, nil

--- a/webhooks/virtualmachine/mutation/virtualmachine_mutator_unit_test.go
+++ b/webhooks/virtualmachine/mutation/virtualmachine_mutator_unit_test.go
@@ -1104,7 +1104,7 @@ func unitTestsMutating() {
 						Expect(err.Error()).To(Equal(field.Invalid(
 							field.NewPath("spec", "nextRestartTime"),
 							"now",
-							"can only restart powered on vm").Error()))
+							"can only restart powered on VM").Error()))
 					})
 				})
 				Context("vm is suspended", func() {
@@ -1122,7 +1122,7 @@ func unitTestsMutating() {
 						Expect(err.Error()).To(Equal(field.Invalid(
 							field.NewPath("spec", "nextRestartTime"),
 							"now",
-							"can only restart powered on vm").Error()))
+							"can only restart powered on VM").Error()))
 					})
 				})
 			})

--- a/webhooks/virtualmachine/validation/virtualmachine_validator.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator.go
@@ -69,7 +69,7 @@ const (
 
 	readinessProbeOnlyOneAction                = "only one action can be specified"
 	tcpReadinessProbeNotAllowedVPC             = "VPC networking doesn't allow TCP readiness probe to be specified"
-	updatesNotAllowedWhenPowerOn               = "updates to this field is not allowed when VM power is on"
+	updatesNotAllowedWhenPowerOn               = "updates to this field are not allowed when VM power is on"
 	addingNewCdromNotAllowedWhenPowerOn        = "adding new CD-ROMs is not allowed when VM is powered on"
 	removingCdromNotAllowedWhenPowerOn         = "removing CD-ROMs is not allowed when VM is powered on"
 	removingBackfilledVolumeNotAllowed         = "removing volume backfilled from classic disk is not allowed"
@@ -153,7 +153,6 @@ var (
 		"vnet":                        true,
 		"wakeonpcktrcv":               true,
 	}
-
 )
 
 // +kubebuilder:webhook:verbs=create;update,path=/default-validate-vmoperator-vmware-com-v1alpha6-virtualmachine,mutating=false,failurePolicy=fail,groups=vmoperator.vmware.com,resources=virtualmachines,versions=v1alpha6,name=default.validating.virtualmachine.v1alpha6.vmoperator.vmware.com,sideEffects=None,admissionReviewVersions=v1;v1beta1
@@ -3661,7 +3660,6 @@ func isFirstClassVMAdvancedProperty(key string) bool {
 	_, ok := vmopv1util.AdvancedVMXKeyMap()[key]
 	return ok
 }
-
 
 func isSystemReservedNetworkDeviceProperty(key string) bool {
 	return systemReservedNetworkDeviceProperties[key]

--- a/webhooks/virtualmachine/validation/virtualmachine_validator_hardware_controllers_test.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator_hardware_controllers_test.go
@@ -967,7 +967,7 @@ func controllerValidationTests() {
 							}
 						},
 						expectAllowed: false,
-						validate:      doValidateWithMsg("spec.hardware.scsiControllers[0].sharingMode: Forbidden: updates to this field is not allowed when VM power is on"),
+						validate:      doValidateWithMsg("spec.hardware.scsiControllers[0].sharingMode: Forbidden: updates to this field are not allowed when VM power is on"),
 					},
 				),
 				Entry("should deny when scsiController type is updated",
@@ -989,7 +989,7 @@ func controllerValidationTests() {
 							}
 						},
 						expectAllowed: false,
-						validate:      doValidateWithMsg("spec.hardware.scsiControllers[0].type: Forbidden: updates to this field is not allowed when VM power is on"),
+						validate:      doValidateWithMsg("spec.hardware.scsiControllers[0].type: Forbidden: updates to this field are not allowed when VM power is on"),
 					},
 				),
 			)

--- a/webhooks/virtualmachine/validation/virtualmachine_validator_intg_test.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator_intg_test.go
@@ -327,7 +327,7 @@ func intgTestsValidateUpdate() {
 
 			It("rejects the request", func() {
 				expectedReason := field.Forbidden(field.NewPath("spec", "guestID"),
-					"updates to this field is not allowed when VM power is on").Error()
+					"updates to this field are not allowed when VM power is on").Error()
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring(expectedReason))
 			})
@@ -354,7 +354,7 @@ func intgTestsValidateUpdate() {
 
 			It("rejects the request", func() {
 				expectedReason := field.Forbidden(field.NewPath("spec", "hardware", "cdrom[0]", "image"),
-					"updates to this field is not allowed when VM power is on").Error()
+					"updates to this field are not allowed when VM power is on").Error()
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring(expectedReason))
 			})
@@ -511,7 +511,7 @@ func intgTestsValidateCdromController() {
 				Expect(err.Error()).To(ContainSubstring(field.NewPath("spec", "hardware", "cdrom[0]", "controllerType").String()))
 				Expect(err.Error()).To(ContainSubstring(field.NewPath("spec", "hardware", "cdrom[0]", "controllerBusNumber").String()))
 				Expect(err.Error()).To(ContainSubstring(field.NewPath("spec", "hardware", "cdrom[0]", "unitNumber").String()))
-				Expect(err.Error()).To(ContainSubstring("updates to this field is not allowed when VM power is on"))
+				Expect(err.Error()).To(ContainSubstring("updates to this field are not allowed when VM power is on"))
 			})
 		})
 

--- a/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator_unit_test.go
@@ -6586,7 +6586,7 @@ func unitTestsValidateUpdate() { //nolint:gocyclo
 						ctx.vm.Spec.PowerState = vmopv1.VirtualMachinePowerStateOn
 					},
 					validate: doValidateWithMsg(
-						`spec.guestID: Forbidden: updates to this field is not allowed when VM power is on`,
+						`spec.guestID: Forbidden: updates to this field are not allowed when VM power is on`,
 					),
 					expectAllowed: false,
 				},
@@ -6660,7 +6660,7 @@ func unitTestsValidateUpdate() { //nolint:gocyclo
 						ctx.vm.Spec.PowerState = vmopv1.VirtualMachinePowerStateOn
 					},
 					validate: doValidateWithMsg(
-						`spec.hardware.cdrom: Forbidden: updates to this field is not allowed when VM power is on`,
+						`spec.hardware.cdrom: Forbidden: updates to this field are not allowed when VM power is on`,
 					),
 					expectAllowed: false,
 				},
@@ -6685,7 +6685,7 @@ func unitTestsValidateUpdate() { //nolint:gocyclo
 						ctx.vm.Spec.PowerState = vmopv1.VirtualMachinePowerStateOn
 					},
 					validate: doValidateWithMsg(
-						`spec.hardware.cdrom: Forbidden: updates to this field is not allowed when VM power is on`,
+						`spec.hardware.cdrom: Forbidden: updates to this field are not allowed when VM power is on`,
 					),
 					expectAllowed: false,
 				},
@@ -6721,7 +6721,7 @@ func unitTestsValidateUpdate() { //nolint:gocyclo
 						ctx.vm.Spec.PowerState = vmopv1.VirtualMachinePowerStateOn
 					},
 					validate: doValidateWithMsg(
-						`spec.hardware.cdrom: Forbidden: updates to this field is not allowed when VM power is on`,
+						`spec.hardware.cdrom: Forbidden: updates to this field are not allowed when VM power is on`,
 					),
 					expectAllowed: false,
 				},
@@ -6750,7 +6750,7 @@ func unitTestsValidateUpdate() { //nolint:gocyclo
 						ctx.vm.Spec.PowerState = vmopv1.VirtualMachinePowerStateOn
 					},
 					validate: doValidateWithMsg(
-						`spec.hardware.cdrom[0].image: Forbidden: updates to this field is not allowed when VM power is on`,
+						`spec.hardware.cdrom[0].image: Forbidden: updates to this field are not allowed when VM power is on`,
 					),
 					expectAllowed: false,
 				},
@@ -6826,9 +6826,9 @@ func unitTestsValidateUpdate() { //nolint:gocyclo
 						ctx.vm.Spec.Hardware.Cdrom[0].UnitNumber = ptr.To(int32(1))
 					},
 					validate: doValidateWithMsg(
-						`spec.hardware.cdrom[0].controllerType: Forbidden: updates to this field is not allowed when VM power is on`,
-						`spec.hardware.cdrom[0].controllerBusNumber: Forbidden: updates to this field is not allowed when VM power is on`,
-						`spec.hardware.cdrom[0].unitNumber: Forbidden: updates to this field is not allowed when VM power is on`,
+						`spec.hardware.cdrom[0].controllerType: Forbidden: updates to this field are not allowed when VM power is on`,
+						`spec.hardware.cdrom[0].controllerBusNumber: Forbidden: updates to this field are not allowed when VM power is on`,
+						`spec.hardware.cdrom[0].unitNumber: Forbidden: updates to this field are not allowed when VM power is on`,
 					),
 					expectAllowed: false,
 				},
@@ -6900,7 +6900,7 @@ func unitTestsValidateUpdate() { //nolint:gocyclo
 					},
 					expectAllowed: false,
 					validate: doValidateWithMsg(
-						"spec.bootOptions: Forbidden: updates to this field is not allowed when VM power is on",
+						"spec.bootOptions: Forbidden: updates to this field are not allowed when VM power is on",
 					),
 				},
 			),
@@ -6960,7 +6960,7 @@ func unitTestsValidateUpdate() { //nolint:gocyclo
 					},
 					expectAllowed: false,
 					validate: doValidateWithMsg(
-						"spec.bootOptions: Forbidden: updates to this field is not allowed when VM power is on",
+						"spec.bootOptions: Forbidden: updates to this field are not allowed when VM power is on",
 					),
 				},
 			),
@@ -7026,7 +7026,7 @@ func unitTestsValidateUpdate() { //nolint:gocyclo
 					},
 					expectAllowed: false,
 					validate: doValidateWithMsg(
-						"spec.bootOptions: Forbidden: updates to this field is not allowed when VM power is on",
+						"spec.bootOptions: Forbidden: updates to this field are not allowed when VM power is on",
 					),
 				},
 			),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

Fixes grammar, spelling, and capitalization defects in error/condition/event messages surfaced to users and operators (via admission responses, Kubernetes Events, and status Conditions). Found during a 9.1.2 error-message audit scoped to customer-facing grammar and formatting issues. 

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # vmop-4100


**Are there any special notes for your reviewer**:

All changes are string-literal-only; no behavior, API, or logic changes. No new tests added since these are message-text-only fixes with no new branches to cover.

<!-- Anything else you would like the reviewers to know about this PR. -->
- scanned report attached in the jira

**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note

```