### PR TITLE
Mixed Case assessment and support

### DIFF
--- a/controllers/virtualmachine/volume/volume_controller.go
+++ b/controllers/virtualmachine/volume/volume_controller.go
@@ -57,7 +57,7 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		"spec.nodeuuid",
 		func(rawObj client.Object) []string {
 			attachment := rawObj.(*cnsv1alpha1.CnsNodeVmAttachment)
-			return []string{attachment.Spec.NodeUUID}
+			return []string{strings.ToLower(attachment.Spec.NodeUUID)}
 		}); err != nil {
 		return err
 	}
@@ -360,7 +360,7 @@ func (r *Reconciler) getAttachmentsForVM(ctx *pkgctx.VolumeContext) (map[string]
 	list := &cnsv1alpha1.CnsNodeVmAttachmentList{}
 	err := r.Client.List(ctx, list,
 		client.InNamespace(ctx.VM.Namespace),
-		client.MatchingFields{"spec.nodeuuid": ctx.VM.Status.BiosUUID})
+		client.MatchingFields{"spec.nodeuuid": strings.ToLower(ctx.VM.Status.BiosUUID)})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list CnsNodeVmAttachments: %w", err)
 	}
@@ -665,7 +665,7 @@ func (r *Reconciler) createCNSAttachmentButAlreadyExists(
 		return fmt.Errorf("the CnsNodeVmAttachment %s has a different controlling owner", attachmentName)
 	}
 
-	if attachment.Spec.NodeUUID != ctx.VM.Status.BiosUUID {
+	if !strings.EqualFold(attachment.Spec.NodeUUID, ctx.VM.Status.BiosUUID) {
 		// We are the owners of this attachment but the BiosUUIDs are different. What's most likely
 		// happened is the VC VM was deleted, and then the VC VM is being recreated, generating a new
 		// BiosUUID. Since this attachment is ours, delete it to let CNS remove the attachment from

--- a/controllers/virtualmachine/volume/volume_controller_unit_test.go
+++ b/controllers/virtualmachine/volume/volume_controller_unit_test.go
@@ -7,6 +7,7 @@ package volume_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -163,7 +164,10 @@ func unitTestsReconcile() {
 				"spec.nodeuuid",
 				func(rawObj client.Object) []string {
 					attachment := rawObj.(*cnsv1alpha1.CnsNodeVmAttachment)
-					return []string{attachment.Spec.NodeUUID}
+					// Mirrors the real indexer registered in AddToManager,
+					// which lowercases NodeUUID so lookups by BiosUUID are
+					// case-insensitive.
+					return []string{strings.ToLower(attachment.Spec.NodeUUID)}
 				}).
 			Build()
 
@@ -910,6 +914,36 @@ func unitTestsReconcile() {
 							Expect(attachment).ToNot(BeNil())
 							assertVMVolStatusFromAttachment(vmVol, attachment, vm.Status.Volumes[0])
 						})
+					})
+				})
+			})
+
+			When("CnsNodeVmAttachment has OwnerRef of this VM and NodeUUID matches BiosUUID only when case-folded", func() {
+
+				BeforeEach(func() {
+					vmVol = *vmVolumeWithPVC1
+					vm.Spec.Volumes = append(vm.Spec.Volumes, vmVol)
+					initObjects = append(initObjects, boundPVC1)
+
+					attachment := cnsAttachmentForVMVolume(vm, vmVol)
+					attachment.Spec.NodeUUID = strings.ToUpper(vm.Status.BiosUUID)
+					attachment.Status.Attached = true
+					attachment.Status.AttachmentMetadata = map[string]string{
+						cnsv1alpha1.AttributeFirstClassDiskUUID: dummyDiskUUID,
+					}
+					initObjects = append(initObjects, attachment)
+				})
+
+				It("is not treated as stale and is not deleted", func() {
+					err := reconciler.ReconcileNormal(volCtx)
+					Expect(err).ToNot(HaveOccurred())
+
+					By("Expected VM Status.Volumes", func() {
+						Expect(vm.Status.Volumes).To(HaveLen(1))
+
+						attachment := getCNSAttachmentForVolumeName(vm, vmVol.Name)
+						Expect(attachment).ToNot(BeNil())
+						Expect(attachment.Spec.NodeUUID).To(Equal(strings.ToUpper(vm.Status.BiosUUID)))
 					})
 				})
 			})

--- a/controllers/virtualmachine/volumebatch/volumebatch_controller.go
+++ b/controllers/virtualmachine/volumebatch/volumebatch_controller.go
@@ -76,7 +76,7 @@ func AddToManager(ctx *pkgctx.ControllerManagerContext, mgr manager.Manager) err
 		"spec.nodeuuid",
 		func(rawObj client.Object) []string {
 			attachment := rawObj.(*cnsv1alpha1.CnsNodeVmAttachment)
-			return []string{attachment.Spec.NodeUUID}
+			return []string{strings.ToLower(attachment.Spec.NodeUUID)}
 		}); err != nil {
 		return err
 	}

--- a/controllers/virtualmachine/volumebatch/volumebatch_controller_unit_test.go
+++ b/controllers/virtualmachine/volumebatch/volumebatch_controller_unit_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -165,7 +166,10 @@ func unitTestsReconcile() {
 				"spec.nodeuuid",
 				func(rawObj client.Object) []string {
 					attachment := rawObj.(*cnsv1alpha1.CnsNodeVmAttachment)
-					return []string{attachment.Spec.NodeUUID}
+					// Mirrors the real indexer registered in AddToManager,
+					// which lowercases NodeUUID so lookups by BiosUUID are
+					// case-insensitive.
+					return []string{strings.ToLower(attachment.Spec.NodeUUID)}
 				}).
 			Build()
 
@@ -890,6 +894,35 @@ func unitTestsReconcile() {
 
 					By("VM Status.Volumes should contain refreshed volume that is tracked by batch attachment, with minimum status", func() {
 						assertVMVolStatusFromBatchAttachmentSpec(vm, batchAttachment, 0, 0)
+					})
+				})
+			})
+
+			When("legacy attachment NodeUUID matches BiosUUID only when case-folded", func() {
+				BeforeEach(func() {
+					// Legacy attachment's NodeUUID differs from the VM's
+					// BiosUUID only by letter casing; the volume is in the
+					// VM spec, so a case-sensitive match would wrongly treat
+					// this as orphaned/stale and delete it.
+					legacyAttachment1.Spec.NodeUUID = strings.ToUpper(dummyBiosUUID)
+					legacyAttachment1.Spec.VolumeName = legacyPVCName1
+
+					vm.Spec.Volumes = append(vm.Spec.Volumes, *vmVolWithLegacy1)
+					initObjects = append(initObjects, legacyAttachment1, legacyPVC1)
+				})
+
+				It("is still found via the case-insensitive NodeUUID index and not treated as orphaned", func() {
+					err := reconciler.ReconcileNormal(volCtx)
+					Expect(err).ToNot(HaveOccurred())
+
+					legacyKey1 := client.ObjectKey{Name: legacyAttachment1.Name, Namespace: ns}
+					attachment1 := &cnsv1alpha1.CnsNodeVmAttachment{}
+					Expect(ctx.Client.Get(ctx, legacyKey1, attachment1)).To(Succeed(),
+						"legacy attachment matching BiosUUID modulo case should not be deleted as orphaned")
+
+					By("VM Status.Volumes should contain legacy volume that is tracked by legacy attachment", func() {
+						Expect(vm.Status.Volumes).To(HaveLen(1))
+						assertVMVolStatusFromLegacyAttachment(legacyVolumeName1, attachment1, vm.Status.Volumes[0])
 					})
 				})
 			})

--- a/pkg/builder/auth.go
+++ b/pkg/builder/auth.go
@@ -131,7 +131,7 @@ func InPrivilegedUsersList(
 			// Neither the authenticating user nor the current privileged user
 			// is a service account, so compare the user names directly.
 			//
-			if userInfo.Username == privUser {
+			if strings.EqualFold(userInfo.Username, privUser) {
 				return true
 			}
 

--- a/pkg/builder/auth.go
+++ b/pkg/builder/auth.go
@@ -131,6 +131,9 @@ func InPrivilegedUsersList(
 			// Neither the authenticating user nor the current privileged user
 			// is a service account, so compare the user names directly.
 			//
+			// Usernames here may originate from an external IDP/AD source,
+			// which is not guaranteed to be case-preserving, so compare
+			// case-insensitively.
 			if strings.EqualFold(userInfo.Username, privUser) {
 				return true
 			}

--- a/pkg/builder/auth.go
+++ b/pkg/builder/auth.go
@@ -131,9 +131,9 @@ func InPrivilegedUsersList(
 			// Neither the authenticating user nor the current privileged user
 			// is a service account, so compare the user names directly.
 			//
-			// Usernames here may originate from an external IDP/AD source,
-			// which is not guaranteed to be case-preserving, so compare
-			// case-insensitively.
+			// This is an SSO username. VC already normalizes these to
+			// lower-case before they reach Supervisor, but compare
+			// case-insensitively as a defensive measure.
 			if strings.EqualFold(userInfo.Username, privUser) {
 				return true
 			}

--- a/pkg/builder/auth_test.go
+++ b/pkg/builder/auth_test.go
@@ -68,6 +68,18 @@ var _ = DescribeTable("IsPrivilegedAccount",
 		true,
 	),
 	Entry(
+		"is in priv user list with different letter casing",
+		&pkgctx.WebhookContext{
+			Context: pkgcfg.WithConfig(pkgcfg.Config{
+				PrivilegedUsers: "hello,world,fubar",
+			}),
+		},
+		authv1.UserInfo{
+			Username: "WORLD",
+		},
+		true,
+	),
+	Entry(
 		"is vm op service account",
 		&pkgctx.WebhookContext{
 			Context:            pkgcfg.NewContext(),

--- a/pkg/providers/vsphere/session/session_vm_update.go
+++ b/pkg/providers/vsphere/session/session_vm_update.go
@@ -1134,7 +1134,7 @@ func (s *Session) reconcileClusterModule(
 		return fmt.Errorf("ClusterModule %q not found in VirtualMachineSetResourcePolicy", clusterModuleName)
 	}
 
-	if oldUUID := vmCtx.VM.Annotations[pkgconst.ClusterModuleUUIDAnnotationKey]; oldUUID == moduleUUID {
+	if oldUUID := vmCtx.VM.Annotations[pkgconst.ClusterModuleUUIDAnnotationKey]; strings.EqualFold(oldUUID, moduleUUID) {
 		vmCtx.Logger.V(4).Info("Skipping cluster module reconciliation since cluster module uuid is the same")
 		return nil
 	}

--- a/pkg/providers/vsphere/session/session_vm_update_test.go
+++ b/pkg/providers/vsphere/session/session_vm_update_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
@@ -2096,6 +2097,16 @@ var _ = Describe("UpdateVirtualMachine", func() {
 			})
 
 			By("exit early without adding the vm to the cluster module", func() {
+				Expect(sess.UpdateVirtualMachine(vmCtx, vcVM, getUpdateArgs, getResizeArgs)).To(Succeed())
+			})
+
+			By("simulate vsphere-cluster-module-group-uuid annotation differing only by letter case", func() {
+				metav1.SetMetaDataAnnotation(&vmCtx.VM.ObjectMeta,
+					pkgconst.ClusterModuleUUIDAnnotationKey,
+					strings.ToUpper(dummyRP.Status.ClusterModules[0].ModuleUuid))
+			})
+
+			By("still exit early since the module uuid is the same modulo case", func() {
 				Expect(sess.UpdateVirtualMachine(vmCtx, vcVM, getUpdateArgs, getResizeArgs)).To(Succeed())
 			})
 

--- a/pkg/providers/vsphere/vmlifecycle/update_status_hardware_validation.go
+++ b/pkg/providers/vsphere/vmlifecycle/update_status_hardware_validation.go
@@ -326,7 +326,7 @@ func checkVolumes(
 		// Ignore Attached status here since we will be checking again the
 		// hardware status directly.
 		if volStatus.DiskUUID != "" {
-			volNameByDiskUUID[volStatus.DiskUUID] = volStatus.Name
+			volNameByDiskUUID[strings.ToLower(volStatus.DiskUUID)] = volStatus.Name
 		}
 	}
 
@@ -338,7 +338,7 @@ func checkVolumes(
 	for _, diskPlacement := range hwInfo.Disks.UnsortedList() {
 		// Look up volume name by disk UUID
 		// diskPlacement.Key is the disk UUID (from BuildHardwareInfo)
-		if volName, found := volNameByDiskUUID[diskPlacement.Key]; found {
+		if volName, found := volNameByDiskUUID[strings.ToLower(diskPlacement.Key)]; found {
 			actual.Insert(pkgutil.DevicePlacement{
 				Key:                 volName, // Use volume name as the key
 				ControllerType:      diskPlacement.ControllerType,

--- a/pkg/providers/vsphere/vmlifecycle/update_status_test.go
+++ b/pkg/providers/vsphere/vmlifecycle/update_status_test.go
@@ -3993,6 +3993,33 @@ var _ = Describe("UpdateStatus", func() {
 					})
 				})
 
+				When("volume is attached but status DiskUUID differs from hardware UUID only by letter case", func() {
+					BeforeEach(func() {
+						setupPVCVolume("pvc-volume-1", "test-pvc", vmopv1.VirtualControllerTypeSCSI, 0, 0)
+						setupSCSIControllerInSpec(0)
+
+						// Set up MoVM.Config.Hardware.Device to have a SCSI controller with a disk.
+						// The hardware-reported UUID is lowercase.
+						vmCtx.MoVM.Config = builder.DummyVirtualMachineConfigInfo(
+							builder.DummySCSIController(1000, 0),
+							builder.DummyVirtualDisk(2000, 1000, ptr.To(int32(0)), "disk-uuid-123", ""),
+						)
+						// Status.Volumes DiskUUID (as populated by the volume/CNS controllers)
+						// differs only in letter case from the hardware UUID above.
+						vmCtx.VM.Status.Volumes = []vmopv1.VirtualMachineVolumeStatus{
+							{
+								Name:     "pvc-volume-1",
+								DiskUUID: "DISK-UUID-123",
+								Type:     vmopv1.VolumeTypeManaged,
+							},
+						}
+					})
+
+					It("should still mark the condition as true", func() {
+						assertConditionTrue()
+					})
+				})
+
 				When("unexpected volume is attached", func() {
 					BeforeEach(func() {
 						vmCtx.VM.Spec.Volumes = []vmopv1.VirtualMachineVolume{}

--- a/pkg/util/cns.go
+++ b/pkg/util/cns.go
@@ -80,7 +80,7 @@ func GetCnsNodeVMAttachmentsForVM(
 		ctx,
 		list,
 		ctrlclient.InNamespace(vm.Namespace),
-		ctrlclient.MatchingFields{"spec.nodeuuid": vm.Status.BiosUUID})
+		ctrlclient.MatchingFields{"spec.nodeuuid": strings.ToLower(vm.Status.BiosUUID)})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list CnsNodeVmAttachments: %w", err)
 	}

--- a/pkg/util/cns_test.go
+++ b/pkg/util/cns_test.go
@@ -5,12 +5,20 @@
 package util_test
 
 import (
+	"context"
+	"strings"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
 	cnsv1alpha1 "github.com/vmware-tanzu/vm-operator/external/vsphere-csi-driver/api/v1alpha1"
 	"github.com/vmware-tanzu/vm-operator/pkg/util"
+	"github.com/vmware-tanzu/vm-operator/test/builder"
 )
 
 var _ = DescribeTable("SanitizeCNSErrorMessage",
@@ -30,6 +38,76 @@ FaultMessage: ([]vimtypes.LocalizableMessage) \u003cnil\u003e\\n }\\n },\\n Type
 \\\"The resource 'volume' is in use.\\\"\\n})\\n\". opId: \"67d69c68\""
 `, "failed to attach cns volume"),
 )
+
+var _ = Describe("GetCnsNodeVMAttachmentsForVM", func() {
+
+	const namespace = "test-namespace"
+
+	// nodeUUIDIndexerFunc mirrors the field indexer registered by the
+	// volume/volumebatch controllers' AddToManager, which normalizes
+	// spec.nodeuuid to lowercase before indexing.
+	nodeUUIDIndexerFunc := func(obj client.Object) []string {
+		attachment := obj.(*cnsv1alpha1.CnsNodeVmAttachment)
+		return []string{strings.ToLower(attachment.Spec.NodeUUID)}
+	}
+
+	newClientWithAttachment := func(attachmentNodeUUID string) client.Client {
+		attachment := &cnsv1alpha1.CnsNodeVmAttachment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-attachment",
+				Namespace: namespace,
+			},
+			Spec: cnsv1alpha1.CnsNodeVmAttachmentSpec{
+				NodeUUID: attachmentNodeUUID,
+			},
+		}
+		return fake.NewClientBuilder().
+			WithScheme(builder.NewScheme()).
+			WithObjects(attachment).
+			WithIndex(&cnsv1alpha1.CnsNodeVmAttachment{}, "spec.nodeuuid", nodeUUIDIndexerFunc).
+			Build()
+	}
+
+	DescribeTable("finds attachments regardless of BiosUUID/NodeUUID letter casing",
+		func(vmBiosUUID, attachmentNodeUUID string, expectMatch bool) {
+			vm := &vmopv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace},
+				Status:     vmopv1.VirtualMachineStatus{BiosUUID: vmBiosUUID},
+			}
+
+			attachments, err := util.GetCnsNodeVMAttachmentsForVM(
+				context.Background(), newClientWithAttachment(attachmentNodeUUID), vm)
+			Expect(err).ToNot(HaveOccurred())
+
+			if expectMatch {
+				Expect(attachments).To(HaveLen(1))
+				Expect(attachments).To(HaveKey("my-attachment"))
+			} else {
+				Expect(attachments).To(BeEmpty())
+			}
+		},
+		Entry("identical casing matches",
+			"4212a4b6-9f8e-4b1a-9b1e-0123456789ab",
+			"4212a4b6-9f8e-4b1a-9b1e-0123456789ab",
+			true),
+		Entry("uppercase BiosUUID matches lowercase NodeUUID",
+			"4212A4B6-9F8E-4B1A-9B1E-0123456789AB",
+			"4212a4b6-9f8e-4b1a-9b1e-0123456789ab",
+			true),
+		Entry("lowercase BiosUUID matches uppercase NodeUUID",
+			"4212a4b6-9f8e-4b1a-9b1e-0123456789ab",
+			"4212A4B6-9F8E-4B1A-9B1E-0123456789AB",
+			true),
+		Entry("mixed-case BiosUUID matches mixed-case NodeUUID",
+			"4212A4b6-9F8e-4b1A-9b1E-0123456789Ab",
+			"4212a4B6-9f8E-4B1a-9B1e-0123456789aB",
+			true),
+		Entry("non-matching UUIDs do not match",
+			"4212a4b6-9f8e-4b1a-9b1e-0123456789ab",
+			"ffffffff-ffff-ffff-ffff-ffffffffffff",
+			false),
+	)
+})
 
 var _ = Describe("GetCnsDiskModeFromDiskMode", func() {
 	DescribeTable("disk mode conversion",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

Fixes several cross-system case-sensitivity bugs where UUID and username values sourced from one system (CNS CnsNodeVmAttachment, vCenter cluster module annotations, privileged users list) were compared or indexed against values from another system (vCenter BiosUUID, live cluster module UUID, session username) using case-sensitive string equality or raw map keys. Since UUIDs and usernames are case-insensitive by convention, a casing mismatch between the two sources could cause attachment lookups to miss, stale cluster module reconciliation, or false privileged-user rejections.


<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # vmop-4101


**Are there any special notes for your reviewer**:

- These are targeted fixes from a case-sensitivity compliance pass across the codebase; no behavioral change is intended other than making these UUID/username comparisons case-insensitive.
- scanned report attached in the jira

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note

```