### PR TITLE
[x-port] [9.1] 🐛 Fix resource leaks during async VM create

### DIFF
--- a/pkg/providers/vsphere/vmprovider_vm.go
+++ b/pkg/providers/vsphere/vmprovider_vm.go
@@ -285,11 +285,17 @@ func (vs *vSphereVMProvider) createOrUpdateVirtualMachine(
 		decrementConcurrentCreatesFn()
 	}
 
+	var asyncCreateStarted bool
+	defer func() {
+		// If the async create go routine was started then it will call
+		// the cleanupFn when it is done.
+		if !asyncCreateStarted {
+			cleanupFn()
+		}
+	}()
+
 	createArgs, err := vs.getCreateArgs(vmCtx, client)
 	if err != nil {
-		// If getting the create args failed, the concurrent counter needs to be
-		// decremented before returning.
-		cleanupFn()
 		return nil, err
 	}
 
@@ -307,6 +313,8 @@ func (vs *vSphereVMProvider) createOrUpdateVirtualMachine(
 		createArgs,
 		chanErr,
 		cleanupFn)
+
+	asyncCreateStarted = true
 
 	// Return with the error channel. The VM will be re-enqueued once the create
 	// completes with success or failure.

--- a/pkg/providers/vsphere/vmprovider_vm.go
+++ b/pkg/providers/vsphere/vmprovider_vm.go
@@ -2133,7 +2133,7 @@ func (vs *vSphereVMProvider) vmCreateGetArgs(
 		return nil, err
 	}
 
-	err = vs.vmCreateGenConfigSpec(vmCtx, createArgs)
+	err = vs.vmCreateGenConfigSpec(vmCtx, vcClient, createArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -2395,6 +2395,7 @@ func (vs *vSphereVMProvider) vmCreateDoNetworking(
 
 func (vs *vSphereVMProvider) vmCreateGenConfigSpec(
 	vmCtx pkgctx.VirtualMachineContext,
+	vcClient *vcclient.Client,
 	createArgs *VMCreateArgs) error {
 
 	// TODO: This is a partial dupe of what's done in the update path in the remaining Session code. I got
@@ -2450,7 +2451,7 @@ func (vs *vSphereVMProvider) vmCreateGenConfigSpec(
 			if err := vmconfcrypto.Reconcile(
 				vmCtx,
 				vs.k8sClient,
-				vs.vcClient.VimClient(),
+				vcClient.VimClient(),
 				vmCtx.VM,
 				vmCtx.MoVM,
 				&createArgs.ConfigSpec); err != nil {
@@ -2463,7 +2464,7 @@ func (vs *vSphereVMProvider) vmCreateGenConfigSpec(
 	if err := vmconfbootoptions.Reconcile(
 		vmCtx,
 		vs.k8sClient,
-		vs.vcClient.VimClient(),
+		vcClient.VimClient(),
 		vmCtx.VM,
 		vmCtx.MoVM,
 		&createArgs.ConfigSpec); err != nil {

--- a/pkg/providers/vsphere/vmprovider_vm_group.go
+++ b/pkg/providers/vsphere/vmprovider_vm_group.go
@@ -221,7 +221,7 @@ func (vs *vSphereVMProvider) vmGroupGetVMPlacementConfigSpec(
 	vcClient *vcclient.Client,
 	createArgs *VMCreateArgs) (*vimtypes.VirtualMachineConfigSpec, error) {
 
-	if err := vs.vmCreateGenConfigSpec(vmCtx, createArgs); err != nil {
+	if err := vs.vmCreateGenConfigSpec(vmCtx, vcClient, createArgs); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION

**What does this PR do, and why is it needed?**

This fixes two issues during async VM create:
 - https://github.com/vmware-tanzu/vm-operator/pull/1504: fix NPE if the VC client creds change
 - https://github.com/vmware-tanzu/vm-operator/pull/1526: properly cleanup if async create panics

**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:


**Please add a release note if necessary**:


```release-note
Properly clean up if panic occurs during async VirtualMachine creation
```