### PR TITLE
🌱 Make ipammodes immutable

### DIFF
--- a/api/v1alpha6/virtualmachine_network_types.go
+++ b/api/v1alpha6/virtualmachine_network_types.go
@@ -28,6 +28,7 @@ type VirtualMachineNetworkRouteSpec struct {
 
 // +kubebuilder:validation:XValidation:rule="!has(self.vmxnet3) || self.type == 'VMXNet3'",message="vmxnet3 tuning fields require interface type VMXNet3"
 // +kubebuilder:validation:XValidation:rule="!has(self.ipamModes) || self.ipamModes.all(m, m == 'IPv4' || m == 'IPv6')",message="each ipamModes entry must be IPv4 or IPv6"
+// +kubebuilder:validation:XValidation:rule="(!has(oldSelf.ipamModes) && !has(self.ipamModes)) || (has(oldSelf.ipamModes) && has(self.ipamModes) && self.ipamModes == oldSelf.ipamModes)",message="ipamModes cannot be changed after creation"
 
 // VirtualMachineNetworkInterfaceSpec describes the desired state of a VM's
 // network interface.
@@ -248,6 +249,14 @@ type VirtualMachineNetworkInterfaceSpec struct {
 	//
 	// When unset, the provider's default applies for which families are allocated.
 	// When set, the controller forwards the requested families to the provider for this interface.
+	//
+	// IPAMModes is immutable for this network interface once the interface is
+	// created, including the transition from unset to set or set to unset.
+	// There is no supported way to convert an interface between single-stack
+	// and dual-stack, or between IPv4-only and IPv6-only, after creation.
+	// Removing this interface entry and adding a new one with the same name
+	// but different IPAMModes is not a supported way to work around this
+	// restriction; it deletes and recreates the underlying network interface.
 	IPAMModes []corev1.IPFamily `json:"ipamModes,omitempty"`
 }
 

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachinereplicasets.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachinereplicasets.yaml
@@ -10189,6 +10189,14 @@ spec:
 
                                     When unset, the provider's default applies for which families are allocated.
                                     When set, the controller forwards the requested families to the provider for this interface.
+
+                                    IPAMModes is immutable for this network interface once the interface is
+                                    created, including the transition from unset to set or set to unset.
+                                    There is no supported way to convert an interface between single-stack
+                                    and dual-stack, or between IPv4-only and IPv6-only, after creation.
+                                    Removing this interface entry and adding a new one with the same name
+                                    but different IPAMModes is not a supported way to work around this
+                                    restriction; it deletes and recreates the underlying network interface.
                                   items:
                                     description: |-
                                       IPFamily represents the IP Family (IPv4 or IPv6). This type is used
@@ -10458,6 +10466,10 @@ spec:
                               - message: each ipamModes entry must be IPv4 or IPv6
                                 rule: '!has(self.ipamModes) || self.ipamModes.all(m,
                                   m == ''IPv4'' || m == ''IPv6'')'
+                              - message: ipamModes cannot be changed after creation
+                                rule: (!has(oldSelf.ipamModes) && !has(self.ipamModes))
+                                  || (has(oldSelf.ipamModes) && has(self.ipamModes)
+                                  && self.ipamModes == oldSelf.ipamModes)
                             maxItems: 10
                             type: array
                             x-kubernetes-list-map-keys:

--- a/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/crd/bases/vmoperator.vmware.com_virtualmachines.yaml
@@ -15922,6 +15922,14 @@ spec:
 
                             When unset, the provider's default applies for which families are allocated.
                             When set, the controller forwards the requested families to the provider for this interface.
+
+                            IPAMModes is immutable for this network interface once the interface is
+                            created, including the transition from unset to set or set to unset.
+                            There is no supported way to convert an interface between single-stack
+                            and dual-stack, or between IPv4-only and IPv6-only, after creation.
+                            Removing this interface entry and adding a new one with the same name
+                            but different IPAMModes is not a supported way to work around this
+                            restriction; it deletes and recreates the underlying network interface.
                           items:
                             description: |-
                               IPFamily represents the IP Family (IPv4 or IPv6). This type is used
@@ -16189,6 +16197,10 @@ spec:
                       - message: each ipamModes entry must be IPv4 or IPv6
                         rule: '!has(self.ipamModes) || self.ipamModes.all(m, m ==
                           ''IPv4'' || m == ''IPv6'')'
+                      - message: ipamModes cannot be changed after creation
+                        rule: (!has(oldSelf.ipamModes) && !has(self.ipamModes)) ||
+                          (has(oldSelf.ipamModes) && has(self.ipamModes) && self.ipamModes
+                          == oldSelf.ipamModes)
                     maxItems: 10
                     type: array
                     x-kubernetes-list-map-keys:

--- a/docs/concepts/services-networking/vm-service.md
+++ b/docs/concepts/services-networking/vm-service.md
@@ -122,6 +122,44 @@ This is because VM workloads do not share the same networking stack as the nodes
 The `VirtualMachineService` API also does not support type [`ExternalName`](https://kubernetes.io/docs/concepts/services-networking/service/#externalname). This type maps a service to the contents of the `externalName` field (for example, to the hostname `api.foo.bar.example`). The mapping configures the cluster's DNS server to return a `CNAME` record with that external hostname value. If this type of service is required, simply create a `Service` resource directly instead of using a `VirtualMachineService`.
 
 
+## IP families
+
+The `spec.ipFamilies` and `spec.ipFamilyPolicy` fields control whether a `VirtualMachineService` is single-stack or dual-stack, mirroring the equivalent fields on the Kubernetes `Service` API. These fields apply to the `ClusterIP` (including headless) and `LoadBalancer` [service types](#service-type); they are wiped when updating a `VirtualMachineService` to `type: ExternalName`.
+
+`spec.ipFamilyPolicy` may be one of:
+
+- `SingleStack` — a single IP family. This is the default if the field is not set.
+- `PreferDualStack` — two IP families on dual-stack-configured clusters, or a single IP family on single-stack clusters.
+- `RequireDualStack` — two IP families on dual-stack-configured clusters; fails otherwise.
+
+`spec.ipFamilies` requests up to two IP families (`IPv4`, `IPv6`, or both, in either order), and must correspond to the values of `spec.clusterIPs` if that field is set:
+
+```yaml
+apiVersion: vmoperator.vmware.com/v1alpha6
+kind: VirtualMachineService
+metadata:
+  name: my-vm-service
+spec:
+  selector:
+    app.kubernetes.io/name: my-app
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 9376
+  ipFamilies:
+  - IPv4
+  - IPv6
+  ipFamilyPolicy: PreferDualStack
+```
+
+!!! note "Cluster-level constraints"
+
+    Requesting an IP family that the cluster does not support (for example, requesting `IPv6` when no IPv6 `Service` range exists) usually surfaces as an error reconciling the underlying `Service`, not as a rejection of the `VirtualMachineService` object at create time.
+
+!!! note "`ipFamilies` is conditionally mutable"
+
+    `spec.ipFamilies` allows adding or removing a secondary IP family after creation, but it does not allow changing the primary IP family (the first entry).
+
 ## Status
 
 ### Conditions

--- a/docs/concepts/workloads/vm.md
+++ b/docs/concepts/workloads/vm.md
@@ -887,7 +887,7 @@ There are several options which may be used to influence the guest's per-interfa
 | `spec.network.interfaces[].addresses` | The IP4 and IP6 addresses (with prefix length) for the interface | ✓ | ✓ | ✓ |
 | `spec.network.interfaces[].dhcp4` | Controls IPv4 DHCP: `true` requests a DHCP address, `false` explicitly disables DHCP (relies on static allocation), omitted defers to the network provider | ✓ | ✓ | ✓ |
 | `spec.network.interfaces[].dhcp6` | Controls DHCPv6: `true` requests a DHCPv6 address, `false` explicitly disables DHCPv6 (relies on static allocation), omitted defers to the network provider | ✓ | ✓ | ✓ |
-| `spec.network.interfaces[].ipamModes` | Requests which IP address families (`IPv4`, `IPv6`, or both) the network provider allocates for this interface; omitted means the provider applies its default | ✓ | ✓ | ✓ |
+| `spec.network.interfaces[].ipamModes` | Requests which IP address families (`IPv4`, `IPv6`, or both) the network provider allocates for this interface; omitted means the provider applies its default. Cannot be changed after the interface is created, including the transition from unset to set | ✓ | ✓ | ✓ |
 | `spec.network.interfaces[].gateway4` | The IP4 address of the gateway for the IP4 address family | ✓ | ✓ | ✓ |
 | `spec.network.interfaces[].gateway6` | The IP6 address of the gateway for the IP6 address family | ✓ | ✓ | ✓ |
 | `spec.network.interfaces[].mtu` | The maximum transmission unit size in bytes | ✓ |  |  |

--- a/webhooks/virtualmachine/validation/virtualmachine_validator_intg_test.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator_intg_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha6"
@@ -65,6 +66,17 @@ func intgTests() {
 			testlabels.Webhook,
 		),
 		intgTestsValidateDelete,
+	)
+	Describe(
+		"CEL: ipamModes immutability",
+		Label(
+			testlabels.Update,
+			testlabels.EnvTest,
+			testlabels.API,
+			testlabels.Validation,
+			testlabels.Webhook,
+		),
+		intgTestsValidateIPAMModesImmutability,
 	)
 }
 
@@ -525,6 +537,132 @@ func intgTestsValidateCdromController() {
 			It("should allow the request", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
+		})
+	})
+}
+
+const ipamModesImmutableMsg = "ipamModes cannot be changed after creation"
+
+func intgTestsValidateIPAMModesImmutability() {
+	var (
+		ctx *intgValidatingWebhookContext
+	)
+
+	BeforeEach(func() {
+		ctx = newIntgValidatingWebhookContext()
+	})
+
+	AfterEach(func() {
+		ctx.AfterEach()
+		ctx = nil
+	})
+
+	When("ipamModes is unset at creation", func() {
+		BeforeEach(func() {
+			Expect(ctx.Client.Create(ctx, ctx.vm)).To(Succeed())
+		})
+
+		It("rejects setting ipamModes on update", func() {
+			ctx.vm.Spec.Network.Interfaces[0].IPAMModes = []corev1.IPFamily{corev1.IPv4Protocol}
+			updateErr := ctx.Client.Update(ctx, ctx.vm)
+			Expect(apierrors.IsInvalid(updateErr)).To(BeTrue())
+			Expect(updateErr.Error()).To(ContainSubstring(ipamModesImmutableMsg))
+		})
+
+		It("allows an update that leaves ipamModes unset", func() {
+			ctx.vm.Spec.MinHardwareVersion += 2
+			ctx.vm.Spec.PowerState = vmopv1.VirtualMachinePowerStateOff
+			Expect(ctx.Client.Update(ctx, ctx.vm)).To(Succeed())
+		})
+	})
+
+	When("ipamModes is set to a single family at creation", func() {
+		BeforeEach(func() {
+			ctx.vm.Spec.Network.Interfaces[0].IPAMModes = []corev1.IPFamily{corev1.IPv4Protocol}
+			Expect(ctx.Client.Create(ctx, ctx.vm)).To(Succeed())
+		})
+
+		It("rejects converting to dual-stack", func() {
+			ctx.vm.Spec.Network.Interfaces[0].IPAMModes = []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}
+			updateErr := ctx.Client.Update(ctx, ctx.vm)
+			Expect(apierrors.IsInvalid(updateErr)).To(BeTrue())
+			Expect(updateErr.Error()).To(ContainSubstring(ipamModesImmutableMsg))
+		})
+
+		It("rejects converting to the other single family", func() {
+			ctx.vm.Spec.Network.Interfaces[0].IPAMModes = []corev1.IPFamily{corev1.IPv6Protocol}
+			updateErr := ctx.Client.Update(ctx, ctx.vm)
+			Expect(apierrors.IsInvalid(updateErr)).To(BeTrue())
+			Expect(updateErr.Error()).To(ContainSubstring(ipamModesImmutableMsg))
+		})
+
+		It("rejects clearing ipamModes", func() {
+			ctx.vm.Spec.Network.Interfaces[0].IPAMModes = nil
+			updateErr := ctx.Client.Update(ctx, ctx.vm)
+			Expect(apierrors.IsInvalid(updateErr)).To(BeTrue())
+			Expect(updateErr.Error()).To(ContainSubstring(ipamModesImmutableMsg))
+		})
+
+		It("allows reordering interfaces without touching ipamModes", func() {
+			ctx.vm.Spec.Network.Interfaces = append(ctx.vm.Spec.Network.Interfaces,
+				vmopv1.VirtualMachineNetworkInterfaceSpec{Name: "eth1"})
+			Expect(ctx.Client.Update(ctx, ctx.vm)).To(Succeed())
+
+			// listType=map matches by name, not position, so swapping the
+			// slice order must not trip the immutability rule.
+			ifaces := ctx.vm.Spec.Network.Interfaces
+			ifaces[0], ifaces[1] = ifaces[1], ifaces[0]
+			Expect(ctx.Client.Update(ctx, ctx.vm)).To(Succeed())
+		})
+	})
+
+	When("ipamModes is set to dual-stack at creation", func() {
+		BeforeEach(func() {
+			ctx.vm.Spec.Network.Interfaces[0].IPAMModes = []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}
+			Expect(ctx.Client.Create(ctx, ctx.vm)).To(Succeed())
+		})
+
+		It("allows reordering the two families since listType=set makes them order-insensitive", func() {
+			ctx.vm.Spec.Network.Interfaces[0].IPAMModes = []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol}
+			Expect(ctx.Client.Update(ctx, ctx.vm)).To(Succeed())
+		})
+
+		It("rejects dropping to single-stack", func() {
+			ctx.vm.Spec.Network.Interfaces[0].IPAMModes = []corev1.IPFamily{corev1.IPv4Protocol}
+			updateErr := ctx.Client.Update(ctx, ctx.vm)
+			Expect(apierrors.IsInvalid(updateErr)).To(BeTrue())
+			Expect(updateErr.Error()).To(ContainSubstring(ipamModesImmutableMsg))
+		})
+	})
+
+	When("adding a new interface", func() {
+		BeforeEach(func() {
+			Expect(ctx.Client.Create(ctx, ctx.vm)).To(Succeed())
+		})
+
+		It("allows the new interface to set ipamModes since it has no prior state", func() {
+			ctx.vm.Spec.Network.Interfaces = append(ctx.vm.Spec.Network.Interfaces,
+				vmopv1.VirtualMachineNetworkInterfaceSpec{
+					Name:      "eth1",
+					IPAMModes: []corev1.IPFamily{corev1.IPv6Protocol},
+				})
+			Expect(ctx.Client.Update(ctx, ctx.vm)).To(Succeed())
+		})
+	})
+
+	When("removing an interface that had ipamModes set", func() {
+		BeforeEach(func() {
+			ctx.vm.Spec.Network.Interfaces = append(ctx.vm.Spec.Network.Interfaces,
+				vmopv1.VirtualMachineNetworkInterfaceSpec{
+					Name:      "eth1",
+					IPAMModes: []corev1.IPFamily{corev1.IPv4Protocol},
+				})
+			Expect(ctx.Client.Create(ctx, ctx.vm)).To(Succeed())
+		})
+
+		It("allows deleting the interface entry entirely", func() {
+			ctx.vm.Spec.Network.Interfaces = ctx.vm.Spec.Network.Interfaces[:1]
+			Expect(ctx.Client.Update(ctx, ctx.vm)).To(Succeed())
 		})
 	})
 }

--- a/webhooks/virtualmachine/validation/virtualmachine_validator_suite_test.go
+++ b/webhooks/virtualmachine/validation/virtualmachine_validator_suite_test.go
@@ -24,6 +24,8 @@ var suite = builder.NewTestSuiteForValidatingWebhookWithContext(
 func TestWebhook(t *testing.T) {
 	pkgcfg.SetContext(suite, func(config *pkgcfg.Config) {
 		config.Features.VMSharedDisks = true
+		config.Features.WorkloadIPv6 = true
+		config.Features.MutableNetworks = true
 		config.BuildVersion = testBuildVersion // Match annotations set in test VMs
 	})
 


### PR DESCRIPTION
 **What does this PR do, and why is it needed?**

  Adds a CEL immutability rule so `spec.network.interfaces[].ipamModes` on `VirtualMachine` cannot be
  changed after an interface is created — including the transition from unset to set, dropping a family, or
  converting between single-stack and dual-stack. The API previously accepted any of these transitions
  even though NSX does not support converting a `SubnetPort`'s static IP allocation type between
  single-stack and dual-stack (or vice versa) after creation, and the team agreed VM Operator should not
  support IP family conversion either, to keep behavior consistent with PodVMs, Supervisor control-plane
  VMs, and VKS cluster VMs, none of which support this today.

  This is a validation-only change: no new API surface, no controller/provider logic changes.

  **Which issue(s) is/are addressed by this PR?**

  Fixes #

  **Are there any special notes for your reviewer**:

  - The rule is a CEL `XValidation` marker on `VirtualMachineNetworkInterfaceSpec`
  (`api/v1alpha6/virtualmachine_network_types.go`), not a Go webhook check, so it's enforced by the API
  server itself, before any admission webhook runs.
  - New envtest coverage (`webhooks/virtualmachine/validation/virtualmachine_validator_intg_test.go`)
  exercises: unset→set, single-stack→dual-stack, single-stack→other-single-stack, clearing, reordering
  interfaces (no-op, since `listType=map` matches by name), adding a brand-new interface with `ipamModes`
  set (unconstrained, since it has no `oldSelf` counterpart), and removing an interface that had
  `ipamModes` set.
  - Updated `docs/concepts/workloads/vm.md` (the `ipamModes` row) to note the new immutability. Also
  backfilled a pre-existing, unrelated documentation gap in
  `docs/concepts/services-networking/vm-service.md`, which never documented
  `spec.ipFamilies`/`spec.ipFamilyPolicy`.
  - No E2E coverage yet — there is no existing `ipamModes`/IPv6 E2E coverage in `test/e2e/` to extend, and
  none was added as part of this PR. Flagging this explicitly per this repo's E2E-sync policy; Will take up once 

  **Please add a release note if necessary**:

  ```release-note
  `spec.network.interfaces[].ipamModes` on `VirtualMachine` is now immutable after the interface is
  created. Attempting to set it after leaving it unset, clear it, or convert between single-stack and
  dual-stack will be rejected.

<!-- readthedocs-preview vm-operator start -->
----
📚 Documentation preview 📚: https://vm-operator--1932.org.readthedocs.build/en/1932/

<!-- readthedocs-preview vm-operator end -->